### PR TITLE
feat: add pretty preview for LS tool in approval dialog

### DIFF
--- a/src/cli/components/ApprovalDialogRich.tsx
+++ b/src/cli/components/ApprovalDialogRich.tsx
@@ -82,6 +82,23 @@ const DynamicPreview: React.FC<DynamicPreviewProps> = ({
     );
   }
 
+  if (t === "ls") {
+    const pathVal = parsedArgs?.path;
+    const path = typeof pathVal === "string" ? pathVal : "(current directory)";
+    const ignoreVal = parsedArgs?.ignore;
+    const ignore =
+      Array.isArray(ignoreVal) && ignoreVal.length > 0
+        ? ` (ignoring: ${ignoreVal.join(", ")})`
+        : "";
+
+    return (
+      <Box flexDirection="column" paddingLeft={2}>
+        <Text>List files in: {path}</Text>
+        {ignore ? <Text dimColor>{ignore}</Text> : null}
+      </Box>
+    );
+  }
+
   // File edit previews: write/edit/multi_edit
   if ((t === "write" || t === "edit" || t === "multiedit") && parsedArgs) {
     try {


### PR DESCRIPTION
Instead of showing raw JSON for LS tool approvals, now displays:
- "List files in: {path}"
- "(ignoring: pattern1, pattern2)" if ignore patterns exist

Matches the clean preview style used for Bash commands.

👾 Generated with [Letta Code](https://letta.com)