### PR TITLE
feat: add Claude Haiku 4.5 to model selector

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -15,6 +15,13 @@
     "updateArgs": { "contextWindow": 200000 }
   },
   {
+    "id": "haiku",
+    "handle": "anthropic/claude-haiku-4-5-20251001",
+    "label": "Claude Haiku 4.5",
+    "description": "Anthropic's fastest model",
+    "updateArgs": { "contextWindow": 200000 }
+  },
+  {
     "id": "gpt-5-codex",
     "handle": "openai/gpt-5-codex",
     "label": "GPT-5-Codex",


### PR DESCRIPTION
## Summary
Adds Claude Haiku 4.5 (haiku-4-5-20251001) to the available models dropdown in the model selector.

## Changes
- Added new Haiku 4.5 model entry to `src/models.json`
- Model appears between Opus 4.1 and GPT-5-Codex in the selector

## Test plan
- Run the app and verify Haiku 4.5 appears in the model selector
- Switch to the Haiku model using `/model haiku` command and verify it works

🐙 Generated with [Letta Code](https://letta.com)