### PR TITLE
feat: improve tool denial error message display

### DIFF
--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -186,6 +186,13 @@ export const ToolCallMessage = memo(({ line }: { line: ToolCallLine }) => {
       // Not JSON, use raw text
     }
 
+    // Format tool denial errors more user-friendly
+    if (isError && displayText.includes("request to call tool denied")) {
+      const match = displayText.match(/User reason: (.+)$/);
+      const reason = match ? match[1] : "(empty)";
+      displayText = `User rejected the tool call with reason: ${reason}`;
+    }
+
     return (
       <Box flexDirection="row">
         <Box width={prefixWidth} flexShrink={0}>


### PR DESCRIPTION
Changed tool denial error display from:
  "Error: request to call tool denied. User reason: {reason}"

To:
  "User rejected the tool call with reason: {reason}"

Makes it clearer for CLI users that they rejected the tool call, rather than looking like a system error. Shows "(empty)" if no reason provided.

👾 Generated with [Letta Code](https://letta.com)