### PR TITLE
Add fetch_web to default tool list

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -29,6 +29,7 @@ export async function createAgent(
     "memory",
     "web_search",
     "conversation_search",
+    "fetch_web",
   ];
 
   // Load memory blocks from .mdx files


### PR DESCRIPTION
## Summary
- Adds `fetch_web` to the default tool list when creating new Letta Code CLI agents
- This gives agents web fetching capabilities out of the box alongside existing tools like `web_search` and `conversation_search`

## Test plan
- Create a new agent and verify it has access to the `fetch_web` tool

👾 Generated with [Letta Code](https://letta.com)