### PR TITLE
Add origin:letta-code tag to CLI-created agents

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -145,6 +145,7 @@ export async function createAgent(
     context_window_limit: 200_000,
     tools: toolNames,
     block_ids: blockIds,
+    tags: ["origin:letta-code"],
     // should be default off, but just in case
     include_base_tools: false,
     include_base_tool_rules: false,


### PR DESCRIPTION
## Summary
- Adds `origin:letta-code` tag to agents created through Letta Code CLI
- This helps identify and filter agents by their creation source (CLI vs ADE vs other interfaces)

## Test plan
- Create a new agent via CLI and verify it has the `origin:letta-code` tag
- Check agent details in the ADE or via API to confirm tag is present

👾 Generated with [Letta Code](https://letta.com)