### PR TITLE
ci: make deploy manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
-name: Release
+name: Bump version and release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       version_type:
@@ -17,8 +14,6 @@ jobs:
     environment: npm-publish
     permissions:
       contents: write
-    # Skip if this is a version bump commit to avoid infinite loop
-    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'chore: bump version')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Making the deploy manual (though still an easy action button in `Actions`) to clear up GitHub feed spam.