### PR TITLE
fix: include command prefix in bash permission patterns for complex c…

### DIFF
--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -356,10 +356,17 @@ function analyzeBashApproval(
 
         if (subcommand === "run" && thirdPart) {
           const fullCommand = `${segmentBase} ${subcommand} ${thirdPart}`;
+          // Include the prefix part (everything before the package manager command)
+          const beforePackageManager = command.substring(
+            0,
+            command.indexOf(segmentBase),
+          );
+          const pattern = `${beforePackageManager}${fullCommand}:*`;
+
           return {
-            recommendedRule: `Bash(${fullCommand}:*)`,
-            ruleDescription: `'${fullCommand}' commands`,
-            approveAlwaysText: `Yes, and don't ask again for '${fullCommand}' commands in this project`,
+            recommendedRule: `Bash(${pattern})`,
+            ruleDescription: `'${beforePackageManager}${fullCommand}' commands`,
+            approveAlwaysText: `Yes, and don't ask again for '${beforePackageManager}${fullCommand}' commands in this project`,
             defaultScope: "project",
             allowPersistence: true,
             safetyLevel: "safe",
@@ -368,10 +375,17 @@ function analyzeBashApproval(
 
         if (subcommand) {
           const fullCommand = `${segmentBase} ${subcommand}`;
+          // Include the prefix part (everything before the package manager command)
+          const beforePackageManager = command.substring(
+            0,
+            command.indexOf(segmentBase),
+          );
+          const pattern = `${beforePackageManager}${fullCommand}:*`;
+
           return {
-            recommendedRule: `Bash(${fullCommand}:*)`,
-            ruleDescription: `'${fullCommand}' commands`,
-            approveAlwaysText: `Yes, and don't ask again for '${fullCommand}' commands in this project`,
+            recommendedRule: `Bash(${pattern})`,
+            ruleDescription: `'${beforePackageManager}${fullCommand}' commands`,
+            approveAlwaysText: `Yes, and don't ask again for '${beforePackageManager}${fullCommand}' commands in this project`,
             defaultScope: "project",
             allowPersistence: true,
             safetyLevel: "safe",


### PR DESCRIPTION
…ommands

When approving commands like "cd /path && npm run test", the permission pattern now correctly includes the full prefix (e.g., "cd /path && npm run test:*") instead of just "npm run test:*", matching the existing behavior for git commands.

This fixes the issue where "approve always" wouldn't match commands that had a cd or other prefix before the package manager command.

👾 Generated with [Letta Code](https://letta.com)