### PR TITLE
Fix hard-to-read dark blue color in H2 headings

### DIFF
--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -68,19 +68,19 @@ export const colors = {
     header: brandColors.primaryAccent,
   },
 
-  // Code and markdown elements
+  // Code and markdown elements (use terminal theme colors)
   code: {
-    inline: brandColors.statusSuccess,
+    inline: "green",
   },
 
   link: {
-    text: brandColors.primaryAccent,
-    url: brandColors.primaryAccent,
+    text: "cyan",
+    url: "blue",
   },
 
   heading: {
-    primary: brandColors.primaryAccent,
-    secondary: brandColors.primaryAccentLight,
+    primary: "cyan",
+    secondary: "blue",
   },
 
   // Status indicators


### PR DESCRIPTION
## Summary

Converts all markdown elements to use terminal theme colors instead of hardcoded hex colors for better accessibility and adaptation to user's terminal theme.

## Problem

Markdown content was using hardcoded brand colors that didn't adapt to terminal themes:
- H2 headings used very dark blue (`#0707AC`) which was hard to read on dark backgrounds
- All markdown elements (headings, code, links) used fixed hex colors regardless of terminal theme

## Solution

Changed all markdown elements to use terminal theme colors:
- **H1 headings**: `cyan` (was `#8C8CF9`)
- **H2 headings**: `blue` (was `#0707AC`)
- **H3+ headings**: default terminal color (no color specified)
- **Inline code**: `green` (was `#64CF64`)
- **Link text**: `cyan` (was `#8C8CF9`)
- **Link URLs**: `blue` (was `#8C8CF9`)

## Benefits

- ✅ Adapts to user's terminal theme (light/dark mode)
- ✅ Better accessibility across different terminal setups
- ✅ Consistent with semantic colors (errors, diffs, warnings)
- ✅ No more readability issues on dark backgrounds

## Color Strategy (Updated)

**Brand colors (hex)**: UI chrome elements only (borders, prompts, status indicators)
**Terminal theme colors**: All content including markdown (headings, code, links, diffs, errors)

This ensures content is always readable while maintaining Letta branding in the UI chrome.

## Testing

- ✅ Build passes
- ✅ Lint passes  
- ✅ Visually tested with markdown content
- ✅ Colors adapt to terminal theme

👾 Generated with [Letta Code](https://letta.com)
