### PR TITLE
fix: improve parallel tool approval UX with sequential review

### DIFF
--- a/src/cli/components/ApprovalDialogRich.tsx
+++ b/src/cli/components/ApprovalDialogRich.tsx
@@ -440,7 +440,9 @@ export const ApprovalDialog = memo(function ApprovalDialog({
             {progress.total - (progress.current - 1)} remaining)
           </Text>
         )}
-        {isExecuting && <Text dimColor>Executing tool...</Text>}
+        {isExecuting && progress && progress.total > 1 && (
+          <Text dimColor>Executing tool...</Text>
+        )}
         <Box height={1} />
 
         {/* Dynamic per-tool renderer (indented) */}


### PR DESCRIPTION
Implements sequential approval flow for parallel tool calls where the user reviews one tool at a time instead of all at once. Changes approval to a two-phase process: collect all decisions first, then execute approved tools in batch.

Key improvements:
- Sequential approval UI with progress indicator (e.g., "Tool 2 of 5")
- Shows "(X reviewed, Y remaining)" for better progress tracking
- Two-phase flow: collect decisions → execute all approved tools
- Removes "Executing tool..." during approval phase for cleaner UX
- Fixes state reset bug when moving between tools (denial reason persisting)
- Fixes display order for denials to show in correct sequence
- Fixes "remaining" count off-by-one error
- Improves header text: shows "3 tools require approval (5 total)" when some auto-executed
- Error handling for failed tool execution during batch phase

👾 Generated with [Letta Code](https://letta.com)