### PR TITLE
docs: Add /rename command to interactive commands list

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ letta --agent <id> --unlink    # Remove Letta Code tools from agent, then start 
 While in a session, you can use these commands:
 - `/agent` - Show current agent link
 - `/model` - Switch models
+- `/rename` - Rename the current agent
 - `/stream` - Toggle token streaming on/off
 - `/link` - Attach Letta Code tools to current agent (enables Read, Write, Edit, Bash, etc.)
 - `/unlink` - Remove Letta Code tools from current agent


### PR DESCRIPTION
Added missing /rename command to the README's interactive commands section.

All slash commands from registry.ts are now documented:
- /agent, /model, /rename, /stream, /link, /unlink, /clear, /exit, /logout