### PR TITLE
refactor: rename model id from 'default' to 'sonnet-4.5'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [gpt-5-minimal, gpt-4.1, default, gemini-pro, glm-4.6, haiku]
+        model: [gpt-5-minimal, gpt-4.1, sonnet-4.5, gemini-pro, glm-4.6, haiku]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Application-wide constants
+ */
+
+/**
+ * Default model ID to use when no model is specified
+ */
+export const DEFAULT_MODEL_ID = "sonnet-4.5";

--- a/src/models.json
+++ b/src/models.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "default",
+    "id": "sonnet-4.5",
     "handle": "anthropic/claude-sonnet-4-5-20250929",
     "label": "Claude Sonnet 4.5 (default)",
     "description": "The recommended default model (currently Sonnet 4.5)",


### PR DESCRIPTION
- Changed model id from "default" to "sonnet-4.5" in models.json
- Created src/constants.ts with DEFAULT_MODEL_ID constant
- Updated CI workflow matrix to use "sonnet-4.5" instead of "default"
- Model resolution still works via isDefault flag

This makes the model id more explicit and maintainable while keeping backward compatibility through getDefaultModel().

👾 Generated with [Letta Code](https://letta.com)