### PR TITLE
fix: Update sleeptime agent's persona block, not primary agent

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -250,10 +250,9 @@ export async function createAgent(
         const groupAgent = await client.agents.retrieve(groupAgentId);
         if (groupAgent.agent_type === "sleeptime_agent") {
           // Update the persona block on the SLEEPTIME agent, not the primary agent
-          await client.agents.blocks.modify("persona", {
+          await client.agents.blocks.modify("memory_persona", {
             agent_id: groupAgentId,
             value: SLEEPTIME_MEMORY_PERSONA,
-            label: "memory_persona",
             description:
               "Instructions for the sleep-time memory management agent",
           });


### PR DESCRIPTION
## Problem

PR #90 added a sleeptime memory management persona, but it was being set on the **PRIMARY agent** instead of the **sleeptime agent**.

This meant:
- ❌ Primary agent got memory management instructions (wrong!)
- ❌ Sleeptime agent got default persona (wrong!)

## Root Cause

```typescript
// Line 242-246 in create.ts (BEFORE)
await client.agents.blocks.modify("memory_persona", {
  agent_id: agent.id,  // ❌ This is the PRIMARY agent!
  value: SLEEPTIME_MEMORY_PERSONA,
  ...
});
```

## Solution

1. **Retrieve agent with `managed_group` included** to access group members
2. **Find sleeptime agent** by checking `agent_type === 'sleeptime_agent'`
3. **Update persona block on sleeptime agent**, not primary

```typescript
// Get full agent with managed group
const fullAgent = await client.agents.retrieve(agent.id, {
  include: ["agent.managed_group"],
});

// Find sleeptime agent in the group
for (const groupAgentId of fullAgent.managed_group.agent_ids) {
  const groupAgent = await client.agents.retrieve(groupAgentId);
  if (groupAgent.agent_type === "sleeptime_agent") {
    // Update the RIGHT agent
    await client.agents.blocks.modify("persona", {
      agent_id: groupAgentId,  // ✅ Sleeptime agent!
      value: SLEEPTIME_MEMORY_PERSONA,
      ...
    });
    break;
  }
}
```

## Verified via API

Tested with agent `agent-1b8a0e3f-e3ca-49d0-ad58-08e3c4263283`:

```json
{
  "managed_group": {
    "manager_agent_id": "agent-1b8a0e3f...",  // Primary agent
    "agent_ids": ["agent-319ce182..."]          // Sleeptime agent
  }
}
```

Sleeptime agent has `agent_type: "sleeptime_agent"`.

## Testing

- ✅ Lint passes
- ✅ Type check passes
- ✅ Only updates persona when creating NEW blocks (respects `newGlobalBlockIds.persona`)

Fixes #90

👾 Generated with [Letta Code](https://letta.com)