### PR TITLE
fix: patch OOM issue

### DIFF
--- a/src/cli/components/ApprovalDialogRich.tsx
+++ b/src/cli/components/ApprovalDialogRich.tsx
@@ -288,6 +288,8 @@ export const ApprovalDialog = memo(function ApprovalDialog({
   }, [progress, approvalContext, onApproveAll, onApproveAlways]);
 
   useInput((_input, key) => {
+    if (isExecuting) return;
+
     if (isEnteringReason) {
       // When entering reason, only handle enter/escape
       if (key.return) {


### PR DESCRIPTION
- Prevent duplicate tool execution during approvals: approval handlers now guard re-entry with isExecutingTool, the approval dialog
    ignores input while executing, and we block new submits while a batch is running.
- Clear the approval dialog immediately after a decision and run approved tools using a snapshot, so the UI no longer sits on the
    approval screen during long runs.
- Mark streaming true while client-side tools execute to keep the thinking/lock state consistent with server-side runs.