### PR TITLE
fix: Tool name mismatch

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -289,23 +289,29 @@ export async function loadSpecificTools(toolNames: string[]): Promise<void> {
       continue;
     }
 
-    const definition = TOOL_DEFINITIONS[name as ToolName];
+    // Map server-facing name to our internal tool name
+    const internalName = getInternalToolName(name);
+
+    const definition = TOOL_DEFINITIONS[internalName as ToolName];
     if (!definition) {
-      console.warn(`Tool ${name} not found in definitions, skipping`);
+      console.warn(
+        `Tool ${name} (internal: ${internalName}) not found in definitions, skipping`,
+      );
       continue;
     }
 
     if (!definition.impl) {
-      throw new Error(`Tool implementation not found for ${name}`);
+      throw new Error(`Tool implementation not found for ${internalName}`);
     }
 
     const toolSchema: ToolSchema = {
-      name,
+      name: internalName,
       description: definition.description,
       input_schema: definition.schema,
     };
 
-    toolRegistry.set(name, {
+    // Register under the internal name so later lookups using mapping succeed
+    toolRegistry.set(internalName, {
       schema: toolSchema,
       fn: definition.impl,
     });
@@ -730,7 +736,9 @@ export function getToolSchemas(): ToolSchema[] {
  * @returns The tool schema or undefined if not found
  */
 export function getToolSchema(name: string): ToolSchema | undefined {
-  return toolRegistry.get(name)?.schema;
+  // Accept either server-facing or internal names
+  const internalName = getInternalToolName(name);
+  return toolRegistry.get(internalName)?.schema;
 }
 
 /**


### PR DESCRIPTION
Letta code has two notions of tool names: external eg. "read_file" and internal "read_file_gemini"

On resume or targeted loads, we were looking up by the external name, so definitions weren’t found and tools didn’t register correctly.

Example before:
```

  The user wants just reading tests, and I've been using the read_file tool. There's no need for a todo since they didn't specify a file. They liked my earlier approach of just picking one, so I could call read_file on a small arbitrary
  file, like test.txt. I'll go ahead and use the tool for that. It's straightforward, and I want to keep it concise for the user!

● Read(file_path="/Users/kevinlin/Documents/letta-code/test.txt", offset=1, limit=40, mode="slice", indentation={5 props})
  ⎿  Tool not found: read_file. Available tools: shell, update_plan, read_file, grep_files, apply_patch, list_dir, shell_command

● Read(file_path="/Users/kevinlin/Documents/letta-code/test.txt", offset=1, limit=40, mode="slice", indentation={5 props})
  ⎿  Tool not found: read_file. Available tools: shell, update_plan, read_file, grep_files, apply_patch, list_dir, shell_command

● Read tool is momentarily unavailable; please try another action or check tool hooks/config.

```

After:
```
● Read tool is momentarily unavailable; please try another action or check tool hooks/config.

> try reading a file

● Read(file_path="/Users/kevinlin/Documents/letta-code/README.md", offset=0, limit=20)
  ⎿   2→
      3→A self-improving, stateful coding agent that can learn from experience and improve with use.
      4→…

● Read /Users/kevinlin/Documents/letta-code/README.md (first ~20 lines).

```