### PR TITLE
feat: add /download command to export agent file locally

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -85,6 +85,13 @@ export const commands: Record<string, Command> = {
       return "Opening toolset selector...";
     },
   },
+  "/download": {
+    desc: "Download agent file locally",
+    handler: () => {
+      // Handled specially in App.tsx to access agent ID and client
+      return "Downloading agent file...";
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
Adds a new CLI command that uses the agents.exportFile endpoint to download the current agent's configuration to {agent_id}.af in the current directory.

👾 Generated with [Letta Code](https://letta.com)