### PR TITLE
fix: use model_settings instead of deprecated llm_config for agent updates

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -235,12 +235,7 @@ export async function createAgent(
     const otherArgs = { ...updateArgs } as Record<string, unknown>;
     delete (otherArgs as Record<string, unknown>).context_window;
     if (Object.keys(otherArgs).length > 0) {
-      await updateAgentLLMConfig(
-        agent.id,
-        modelHandle,
-        otherArgs,
-        true, // preserve parallel_tool_calls
-      );
+      await updateAgentLLMConfig(agent.id, modelHandle, otherArgs);
     }
   }
 


### PR DESCRIPTION
Migrates from the deprecated llm_config field to the new model_settings field when updating agent model configuration. Changes:

- Use model_settings with provider-specific settings (OpenAIModelSettings, AnthropicModelSettings) instead of merging into llm_config
- Use context_window_limit instead of context_window in llm_config
- Map reasoning_effort to model_settings.reasoning for OpenAI models
- Map enable_reasoner to model_settings.thinking for Anthropic models
- Simplify to single API call instead of two-step update

👾 Generated with [Letta Code](https://letta.com)