### PR TITLE
fix: include command prefix in bash permission patterns for complex commands (rebase of #68)

### DIFF
--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -378,10 +378,17 @@ function analyzeBashApproval(
 
         if (subcommand === "run" && thirdPart) {
           const fullCommand = `${segmentBase} ${subcommand} ${thirdPart}`;
+          // Include the prefix part (everything before the package manager command)
+          const beforePackageManager = command.substring(
+            0,
+            command.indexOf(segmentBase),
+          );
+          const pattern = `${beforePackageManager}${fullCommand}:*`;
+
           return {
-            recommendedRule: `Bash(${fullCommand}:*)`,
-            ruleDescription: `'${fullCommand}' commands`,
-            approveAlwaysText: `Yes, and don't ask again for '${fullCommand}' commands in this project`,
+            recommendedRule: `Bash(${pattern})`,
+            ruleDescription: `'${beforePackageManager}${fullCommand}' commands`,
+            approveAlwaysText: `Yes, and don't ask again for '${beforePackageManager}${fullCommand}' commands in this project`,
             defaultScope: "project",
             allowPersistence: true,
             safetyLevel: "safe",
@@ -390,10 +397,17 @@ function analyzeBashApproval(
 
         if (subcommand) {
           const fullCommand = `${segmentBase} ${subcommand}`;
+          // Include the prefix part (everything before the package manager command)
+          const beforePackageManager = command.substring(
+            0,
+            command.indexOf(segmentBase),
+          );
+          const pattern = `${beforePackageManager}${fullCommand}:*`;
+
           return {
-            recommendedRule: `Bash(${fullCommand}:*)`,
-            ruleDescription: `'${fullCommand}' commands`,
-            approveAlwaysText: `Yes, and don't ask again for '${fullCommand}' commands in this project`,
+            recommendedRule: `Bash(${pattern})`,
+            ruleDescription: `'${beforePackageManager}${fullCommand}' commands`,
+            approveAlwaysText: `Yes, and don't ask again for '${beforePackageManager}${fullCommand}' commands in this project`,
             defaultScope: "project",
             allowPersistence: true,
             safetyLevel: "safe",


### PR DESCRIPTION
This PR rebases the original fix from https://github.com/letta-ai/letta-code/pull/68 onto the latest main and keeps the change minimal.\n\n**What this does**\n- Updates bash permission analysis so that when a package manager command (e.g. `npm run test`) is prefixed by another command (e.g. `cd /path && npm run test`), the generated approval pattern includes the full prefix segment, matching how git commands are already handled.\n- Ensures that "approve always" rules actually match future commands that include the same prefix and subcommand.\n\n**Implementation**\n- In `src/permissions/analyzer.ts`, when detecting package manager `run` subcommands, compute `beforePackageManager` as the portion of the bash command before the package manager segment, and include it in the generated rule pattern and user-facing description.\n- Applies this logic both for `run <script> <args>` and `run <script>` cases.\n\n**Validation**\n- Ran `bun run lint` (Biome) on this branch: passes.\n- Ran `bun run build`: passes after installing dependencies with `bun install`.\n\nThis is intentionally a small, targeted change to make the original PR easy to merge while preserving its behavior.