### PR TITLE
feat: add startup status messages showing agent provenance

### DIFF
--- a/src/cli/components/StatusMessage.tsx
+++ b/src/cli/components/StatusMessage.tsx
@@ -1,0 +1,41 @@
+import { Box, Text } from "ink";
+import { memo } from "react";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+
+type StatusLine = {
+  kind: "status";
+  id: string;
+  lines: string[];
+};
+
+/**
+ * StatusMessage - Displays multi-line status messages
+ *
+ * Used for agent provenance info at startup, showing:
+ * - Whether agent is resumed or newly created
+ * - Where memory blocks came from (global/project/new)
+ *
+ * Layout matches ErrorMessage with a left column icon (grey circle)
+ */
+export const StatusMessage = memo(({ line }: { line: StatusLine }) => {
+  const columns = useTerminalWidth();
+  const contentWidth = Math.max(0, columns - 2);
+
+  return (
+    <Box flexDirection="column">
+      {line.lines.map((text, idx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: Static status lines never reorder
+        <Box key={idx} flexDirection="row">
+          <Box width={2} flexShrink={0}>
+            <Text dimColor>{idx === 0 ? "●" : " "}</Text>
+          </Box>
+          <Box flexGrow={1} width={contentWidth}>
+            <Text dimColor>{text}</Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+});
+
+StatusMessage.displayName = "StatusMessage";

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -44,6 +44,11 @@ export type Line =
       output: string;
       phase?: "running" | "finished";
       success?: boolean;
+    }
+  | {
+      kind: "status";
+      id: string;
+      lines: string[]; // Multi-line status message with arrow formatting
     };
 
 // Top-level state object for all streaming events

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -142,7 +142,7 @@ export async function handleHeadlessCommand(
   // Priority 2: Check if --new flag was passed (skip all resume logic)
   if (!agent && forceNew) {
     const updateArgs = getModelUpdateArgs(model);
-    agent = await createAgent(
+    const result = await createAgent(
       undefined,
       model,
       undefined,
@@ -155,6 +155,7 @@ export async function handleHeadlessCommand(
       initBlocks,
       baseTools,
     );
+    agent = result.agent;
   }
 
   // Priority 3: Try to resume from project settings (.letta/settings.local.json)
@@ -186,7 +187,7 @@ export async function handleHeadlessCommand(
   // Priority 5: Create a new agent
   if (!agent) {
     const updateArgs = getModelUpdateArgs(model);
-    agent = await createAgent(
+    const result = await createAgent(
       undefined,
       model,
       undefined,
@@ -199,6 +200,7 @@ export async function handleHeadlessCommand(
       undefined,
       undefined,
     );
+    agent = result.agent;
   }
 
   // Save agent ID to both project and global settings

--- a/src/tests/agent/init-blocks.test.ts
+++ b/src/tests/agent/init-blocks.test.ts
@@ -54,7 +54,7 @@ describeOrSkip("createAgent init-blocks filtering", () => {
   test(
     "only requested memory blocks are created/registered",
     async () => {
-      const agent = await createAgent(
+      const { agent } = await createAgent(
         "init-blocks-test",
         undefined,
         "openai/text-embedding-3-small",

--- a/src/tests/message.smoke.ts
+++ b/src/tests/message.smoke.ts
@@ -14,7 +14,7 @@ async function main() {
   }
 
   console.log("🧠  Creating test agent...");
-  const agent = await createAgent("smoke-agent", "openai/gpt-4.1");
+  const { agent } = await createAgent("smoke-agent", "openai/gpt-4.1");
   console.log(`✅  Agent created: ${agent.id}`);
 
   console.log("💬  Sending test message...");

--- a/src/tests/test-image-send.ts
+++ b/src/tests/test-image-send.ts
@@ -12,7 +12,7 @@ async function main() {
 
   // Create agent
   console.log("\nCreating test agent...");
-  const agent = await createAgent("image-test-agent");
+  const { agent } = await createAgent("image-test-agent");
   console.log("Agent created:", agent.id);
 
   // Read image


### PR DESCRIPTION
Add informative status lines at startup that show:
- Whether agent is resumed or newly created
- Where memory blocks came from (global ~/.letta/ vs project .letta/)
- Hint to use --new for creating a new agent when resuming

Status messages appear as transcript lines (like errors) with a grey circle prefix, after backfilled history or at session start.

🤖 Generated with [Letta Code](https://letta.com)