### PR TITLE
feat: add word-based navigation and deletion shortcuts to input

### DIFF
--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -10,8 +10,8 @@ function isControlSequence(input, key) {
     // Pasted content is handled separately
     if (key?.isPasted) return true;
 
-    // Standard control keys
-    if (key.escape || key.tab || (key.ctrl && input === 'c')) return true;
+    // Standard control keys (but NOT plain escape - apps may need it for shortcuts)
+    if (key.tab || (key.ctrl && input === 'c')) return true;
     if (key.shift && key.tab) return true;
 
     // Ctrl+W (delete word) - handled by parent component
@@ -20,8 +20,9 @@ function isControlSequence(input, key) {
     // Option+Arrow escape sequences: Ink parses \x1bb as meta=true, input='b'
     if (key.meta && (input === 'b' || input === 'B' || input === 'f' || input === 'F')) return true;
 
-    // Any raw escape sequence starting with \x1b (CSI sequences, Option+Delete, etc.)
-    if (input && typeof input === 'string' && input.startsWith('\x1b')) return true;
+    // Filter specific escape sequences that would insert garbage, but allow plain ESC through
+    // CSI sequences (ESC[...), Option+Delete (ESC + DEL), and other multi-char escape sequences
+    if (input && typeof input === 'string' && input.startsWith('\x1b') && input.length > 1) return true;
 
     return false;
 }


### PR DESCRIPTION
## Summary
Adds word-based editing shortcuts to the input field, matching standard shell/editor behavior:

### Navigation
- **Option+Left**: jump to the beginning of the previous word
- **Option+Right**: jump to the beginning of the next word

### Deletion
- **Option+Delete**: delete the previous word
- **Ctrl+Delete**: delete all text (instant clear)

This brings the Letta Code input field closer to standard terminal emulator and text editor behavior, making it more intuitive for power users.

## Implementation Details
- Added helper functions `findPreviousWordBoundary()` and `findNextWordBoundary()` to calculate word boundaries
- Added `useInput` hook in `PasteAwareTextInput` component to intercept keyboard shortcuts
- Uses existing cursor positioning mechanism (`setNudgeCursorOffset` and `caretOffsetRef`)
- Word boundaries are defined as transitions between whitespace and non-whitespace characters
- Handles both `displayValue` and `actualValue` for consistency with paste placeholder system

## Keyboard Mapping Notes
In terminal applications, keyboard events are mapped as:
- **Option key** → `key.meta` (works for word operations)
- **Ctrl key** → `key.ctrl` (works for delete all)
- **Cmd key** → Not available (intercepted by terminal emulator for terminal-level shortcuts)

This is why we use Ctrl+Delete instead of Cmd+Delete - terminal emulators don't pass Cmd key events to applications.

## Test Plan
- [ ] Build and run `letta` CLI
- [ ] Type a multi-word message like: `hello world test navigation`
- [ ] **Navigation**: Use Option+Left/Right to jump between words
- [ ] **Word deletion**: Use Option+Delete to delete previous word
- [ ] **Clear all**: Use Ctrl+Delete to clear entire input
- [ ] Verify cursor lands at correct positions
- [ ] Test edge cases: beginning/end of input, multiple spaces, empty input

## Notes
- Existing shortcuts remain: double-Esc to clear, Ctrl+C to clear+exit
- Complements existing Ctrl+A (jump to start) and Ctrl+E (jump to end) from base input component

👾 Generated with [Letta Code](https://letta.com)
