### PR TITLE
fix: add provider_type for OpenRouter models in model_settings

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -27,8 +27,9 @@ function buildModelSettings(
   const isOpenAI = modelHandle.startsWith("openai/");
   const isAnthropic = modelHandle.startsWith("anthropic/");
   const isGoogleAI = modelHandle.startsWith("google_ai/");
+  const isOpenRouter = modelHandle.startsWith("openrouter/");
 
-  if (isOpenAI) {
+  if (isOpenAI || isOpenRouter) {
     const openaiSettings: OpenAIModelSettings = {
       provider_type: "openai",
       parallel_tool_calls: true,


### PR DESCRIPTION
OpenRouter models (e.g., glm-4.6) were returning { parallel_tool_calls: true } without the required provider_type discriminator, causing 422 validation errors from the Letta API. OpenRouter models now use provider_type: 'openai'.

Fixes glm-4.6 unit test failure in CI.

👾 Generated with [Letta Code](https://letta.com)