### PR TITLE
fix: Update skill unload logic

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -112,8 +112,8 @@ export async function initializeLoadedSkillsFlag(): Promise<void> {
       { agent_id: context.agentId },
     );
     const value = loadedSkillsBlock?.value?.trim() || "";
-    // Consider empty or placeholder as no skills loaded
-    context.hasLoadedSkills = value !== "" && value !== "[CURRENTLY EMPTY]";
+    // Check for actual skill content (skills are formatted with "# Skill:" headers)
+    context.hasLoadedSkills = value.includes("# Skill:");
   } catch {
     // Block doesn't exist, no skills loaded
     context.hasLoadedSkills = false;


### PR DESCRIPTION
Changed the `hasLoadedSkills` detection logic to check for actual skill content (`# Skill:` headers) rather than checking against specific placeholder strings. This fixes the issue where the `skill_unload_reminder` was incorrectly shown when the loaded_skills block contained text like `[No skills currently loaded]` that wasn't the expected `[CURRENTLY EMPTY]` placeholder.