### PR TITLE
feat: add /remember command for quick memory updates

### DIFF
--- a/src/agent/promptAssets.ts
+++ b/src/agent/promptAssets.ts
@@ -14,6 +14,7 @@ import personaEmptyPrompt from "./prompts/persona_empty.mdx";
 import personaKawaiiPrompt from "./prompts/persona_kawaii.mdx";
 import planModeReminder from "./prompts/plan_mode_reminder.txt";
 import projectPrompt from "./prompts/project.mdx";
+import rememberPrompt from "./prompts/remember.md";
 import skillCreatorModePrompt from "./prompts/skill_creator_mode.md";
 import skillUnloadReminder from "./prompts/skill_unload_reminder.txt";
 import skillsPrompt from "./prompts/skills.mdx";
@@ -25,6 +26,7 @@ export const PLAN_MODE_REMINDER = planModeReminder;
 export const SKILL_UNLOAD_REMINDER = skillUnloadReminder;
 export const INITIALIZE_PROMPT = initializePrompt;
 export const SKILL_CREATOR_PROMPT = skillCreatorModePrompt;
+export const REMEMBER_PROMPT = rememberPrompt;
 
 export const MEMORY_PROMPTS: Record<string, string> = {
   "persona.mdx": personaPrompt,

--- a/src/agent/prompts/remember.md
+++ b/src/agent/prompts/remember.md
@@ -1,0 +1,29 @@
+# Memory Request
+
+The user has invoked the `/remember` command, which indicates they want you to commit something to memory.
+
+## What This Means
+
+The user wants you to use your memory tools to remember information from the conversation. This could be:
+
+- **A correction**: "You need to run the linter BEFORE committing" → they want you to remember this workflow
+- **A preference**: "I prefer tabs over spaces" → store in the appropriate memory block
+- **A fact**: "The API key is stored in .env.local" → project-specific knowledge
+- **A rule**: "Never push directly to main" → behavioral guideline
+
+## Your Task
+
+1. **Identify what to remember**: Look at the recent conversation context. What did the user say that they want you to remember? If they provided text after `/remember`, that's what they want remembered. If after analyzing it is still unclear, you can ask the user to clarify or provide more context.
+
+2. **Determine the right memory block**: Use your memory tools to store the information in the appropriate memory block. Different agents may have different configurations of memory blocks. Use your judgement to determine the most appropriate memory block (or blocks) to edit. Consider creating a new block is no relevant block exists.
+
+3. **Confirm the update**: After updating memory, briefly confirm what you remembered and where you stored it.
+
+## Guidelines
+
+- Be concise - distill the information to its essence
+- Avoid duplicates - check if similar information already exists
+- Match existing formatting of memory blocks (bullets, sections, etc.)
+- If unclear what to remember, ask the user to clarify
+
+Remember: Your memory blocks persist across sessions. What you store now will influence your future behavior.

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -120,6 +120,13 @@ export const commands: Record<string, Command> = {
       return "Starting skill creation...";
     },
   },
+  "/remember": {
+    desc: "Remember something from the conversation (optionally: /remember <what to remember>)",
+    handler: () => {
+      // Handled specially in App.tsx to trigger memory update
+      return "Processing memory request...";
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
Adds a new slash command that triggers the agent to commit information to memory. Supports optional text argument (e.g., `/remember lint first`) which gets appended after the system reminder prompt.

🐾 Generated with [Letta Code](https://letta.com)