### PR TITLE
feat: add agent description and show in /resume

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -51,7 +51,7 @@ export interface CreateAgentResult {
 }
 
 export async function createAgent(
-  name = "letta-cli-agent",
+  name = "letta-code-agent",
   model?: string,
   embeddingModel = "openai/text-embedding-3-small",
   updateArgs?: Record<string, unknown>,
@@ -342,6 +342,7 @@ export async function createAgent(
     agent_type: "letta_v1_agent" as AgentType,
     system: systemPrompt,
     name,
+    description: `Letta Code agent created in ${process.cwd()}`,
     embedding: embeddingModel,
     model: modelHandle,
     context_window_limit: contextWindow,

--- a/src/cli/components/ResumeSelector.tsx
+++ b/src/cli/components/ResumeSelector.tsx
@@ -11,7 +11,7 @@ interface ResumeSelectorProps {
   onCancel: () => void;
 }
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 5;
 
 /**
  * Format a relative time string from a date
@@ -274,7 +274,13 @@ export function ResumeSelector({
                   <Text color={colors.selector.itemCurrent}> (current)</Text>
                 )}
               </Box>
-              {/* Row 2: Metadata (dimmed) */}
+              {/* Row 2: Description */}
+              <Box flexDirection="row" marginLeft={2}>
+                <Text dimColor italic>
+                  {agent.description || "No description"}
+                </Text>
+              </Box>
+              {/* Row 3: Metadata (dimmed) */}
               <Box flexDirection="row" marginLeft={2}>
                 <Text dimColor>
                   {relativeTime} · {blockCount} memory block


### PR DESCRIPTION
- Set default description on agent creation: "Letta Code agent created in {pwd}"
- Display description in /resume selector (shows "No description" if empty)
- Reduce page size from 10 to 5 agents for better readability

🐾 Generated with [Letta Code](https://letta.com)