### PR TITLE
fix: Remove duplicate current model in model selector

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3262,6 +3262,7 @@ Plan file path: ${planFilePath}`;
                     ? `${llmConfig.model_endpoint_type}/${llmConfig.model}`
                     : undefined
                 }
+                currentEnableReasoner={llmConfig?.enable_reasoner}
                 onSelect={handleModelSelect}
                 onCancel={() => setModelSelectorOpen(false)}
               />

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -16,12 +16,14 @@ type UiModel = {
 
 interface ModelSelectorProps {
   currentModel?: string;
+  currentEnableReasoner?: boolean;
   onSelect: (modelId: string) => void;
   onCancel: () => void;
 }
 
 export function ModelSelector({
   currentModel,
+  currentEnableReasoner,
   onSelect,
   onCancel,
 }: ModelSelectorProps) {
@@ -85,7 +87,26 @@ export function ModelSelector({
       <Box flexDirection="column">
         {visibleModels.map((model, index) => {
           const isSelected = index === selectedIndex;
-          const isCurrent = model.handle === currentModel;
+
+          // Check if this model is current by comparing handle and relevant settings
+          let isCurrent = model.handle === currentModel;
+
+          // For models with the same handle, also check specific configuration settings
+          if (isCurrent && model.handle?.startsWith("anthropic/")) {
+            // For Anthropic models, check enable_reasoner setting
+            const modelEnableReasoner = model.updateArgs?.enable_reasoner;
+
+            // If the model explicitly sets enable_reasoner, check if it matches current settings
+            if (modelEnableReasoner !== undefined) {
+              // Model has explicit enable_reasoner setting, compare with current
+              isCurrent =
+                isCurrent && modelEnableReasoner === currentEnableReasoner;
+            } else {
+              // If model doesn't explicitly set enable_reasoner, it defaults to enabled (or undefined)
+              // It's current if currentEnableReasoner is not explicitly false
+              isCurrent = isCurrent && currentEnableReasoner !== false;
+            }
+          }
 
           return (
             <Box key={model.id} flexDirection="row" gap={1}>


### PR DESCRIPTION
Multiple models get shown as current because we do not compare model reasoning settings
<img width="899" height="96" alt="Screenshot 2025-12-12 at 4 20 58 PM" src="https://github.com/user-attachments/assets/327a083d-efa8-4eb2-9238-cbf99bdbe6a3" />
