### PR TITLE
fix: Markdown render spacing

### DIFF
--- a/src/cli/components/MarkdownDisplay.tsx
+++ b/src/cli/components/MarkdownDisplay.tsx
@@ -109,11 +109,7 @@ export const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({
         );
       }
 
-      contentBlocks.push(
-        <Box key={key}>
-          {headerElement}
-        </Box>,
-      );
+      contentBlocks.push(<Box key={key}>{headerElement}</Box>);
       return;
     }
 


### PR DESCRIPTION
Remove extra spacing from markdown renders