### PR TITLE
fix: /pinned bugs

### DIFF
--- a/src/cli/components/ProfileSelector.tsx
+++ b/src/cli/components/ProfileSelector.tsx
@@ -292,7 +292,11 @@ export const ProfileSelector = memo(function ProfileSelector({
             const displayId = truncateAgentId(profile.agentId, availableForId);
 
             return (
-              <Box key={profile.agentId} flexDirection="column" marginBottom={1}>
+              <Box
+                key={profile.agentId}
+                flexDirection="column"
+                marginBottom={1}
+              >
                 {/* Row 1: Selection indicator, profile name, and ID */}
                 <Box flexDirection="row">
                   <Text


### PR DESCRIPTION
##  Summary

  - Fix React duplicate key warning in /pinned UI by using agent ID instead of name as key
  - Show pinned agent scope (project vs global) in the UI
  - Fix `P` key to properly unpin agents instead of toggling between scopes