### PR TITLE
fix: Tab completion for slash commands

### DIFF
--- a/src/cli/components/InputAssist.tsx
+++ b/src/cli/components/InputAssist.tsx
@@ -40,7 +40,11 @@ export function InputAssist({
     if (!showFileAutocomplete && !showCommandAutocomplete) {
       onAutocompleteActiveChange(false);
     }
-  }, [showFileAutocomplete, showCommandAutocomplete, onAutocompleteActiveChange]);
+  }, [
+    showFileAutocomplete,
+    showCommandAutocomplete,
+    onAutocompleteActiveChange,
+  ]);
 
   // Show file autocomplete when @ is present
   if (showFileAutocomplete) {


### PR DESCRIPTION
## Summary

- Fix bug where `Enter` key stops working after using `Tab` to autocomplete a slash command
- Reset `isAutocompleteActive` state when no autocomplete is being shown