### PR TITLE
update message search link to point to message

### DIFF
--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -360,9 +360,15 @@ export function MessageSearch({ onClose }: MessageSearchProps) {
                     </Text>
                     {agentId && (
                       <>
-                        <Text dimColor> · agent: </Text>
+                        <Text dimColor> · </Text>
                         <Link
                           url={`https://app.letta.com/projects/default-project/agents/${agentId}?searchTerm=${encodeURIComponent(activeQuery)}&messageId=${msgId}`}
+                        >
+                          <Text color={colors.link.text}>view message</Text>
+                        </Link>
+                        <Text dimColor> · agent: </Text>
+                        <Link
+                          url={`https://app.letta.com/projects/default-project/agents/${agentId}`}
                         >
                           <Text color={colors.link.text}>{agentId}</Text>
                         </Link>


### PR DESCRIPTION
blocked by https://github.com/letta-ai/letta-cloud/pull/7104 (which persists the query params to URL)

message search results now can directly link to the search panel for that agent

<img width="1501" height="379" alt="Screenshot 2025-12-15 at 6 14 53 PM" src="https://github.com/user-attachments/assets/238e1d9f-6da6-4edd-921c-261659bd8d5b" />
