### PR TITLE
feat: add Kimi K2 Thinking model

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -345,6 +345,15 @@
     }
   },
   {
+    "id": "kimi-k2-thinking",
+    "handle": "openrouter/moonshotai/kimi-k2-thinking",
+    "label": "Kimi K2 Thinking",
+    "description": "Kimi's K2 model with advanced thinking capabilities",
+    "updateArgs": {
+      "context_window": 256000
+    }
+  },
+  {
     "id": "deepseek-chat-v3.1",
     "handle": "openrouter/deepseek/deepseek-chat-v3.1",
     "label": "DeepSeek Chat V3.1",


### PR DESCRIPTION
Add support for Moonshot AI's Kimi K2 Thinking model via OpenRouter. This model features advanced thinking capabilities with a 256K context window.

Model configuration:
- ID: kimi-k2-thinking
- Handle: openrouter/moonshotai/kimi-k2-thinking
- Context window: 256,000 tokens

👾 Generated with [Letta Code](https://letta.com)