### PR TITLE
fix: increase EventEmitter limit

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -2,7 +2,6 @@
 import { Box, Text, useInput } from "ink";
 import SpinnerLib from "ink-spinner";
 import { type ComponentType, useEffect, useRef, useState } from "react";
-import { stdin } from "process";
 import { LETTA_CLOUD_API_URL } from "../../auth/oauth";
 import type { PermissionMode } from "../../permissions/mode";
 import { permissionMode } from "../../permissions/mode";
@@ -14,10 +13,6 @@ import { InputAssist } from "./InputAssist";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { QueuedMessages } from "./QueuedMessages";
 import { ShimmerText } from "./ShimmerText";
-
-// Increase max listeners to accommodate multiple useInput hooks
-// (5 in this component + autocomplete components)
-stdin.setMaxListeners(20);
 
 // Type assertion for ink-spinner compatibility
 const Spinner = SpinnerLib as ComponentType<{ type?: string }>;

--- a/vendor/ink/build/components/App.js
+++ b/vendor/ink/build/components/App.js
@@ -24,7 +24,12 @@ export default class App extends PureComponent {
         error: undefined,
     };
     rawModeEnabledCount = 0;
-    internal_eventEmitter = new EventEmitter();
+    // Increase max listeners to accommodate multiple useInput hooks across components
+    internal_eventEmitter = (() => {
+        const emitter = new EventEmitter();
+        emitter.setMaxListeners(20);
+        return emitter;
+    })();
     isRawModeSupported() {
         return this.props.stdin.isTTY;
     }


### PR DESCRIPTION
## Summary
- Fixed the `MaxListenersExceededWarning` that still appeared after #235 by setting `setMaxListeners(20)` on Ink's `internal_eventEmitter`
- Removed the ineffective fix from `InputRich.tsx` that was targeting the wrong `EventEmitter`