### PR TITLE
fix: skip empty reasoning blocks in static commit

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -533,6 +533,11 @@ export default function App({
         continue;
       }
       if ("phase" in ln && ln.phase === "finished") {
+        // Skip empty reasoning blocks to prevent stray "Thinking..." indicators
+        if (ln.kind === "reasoning" && (!ln.text || ln.text.trim() === "")) {
+          emittedIdsRef.current.add(id);
+          continue;
+        }
         emittedIdsRef.current.add(id);
         newlyCommitted.push({ ...ln });
       }


### PR DESCRIPTION
## Summary
- Fixes stray "✻ Thinking…" indicators appearing after responses complete
- Filters out empty reasoning blocks before committing them to static items

## Root Cause
Some providers (especially Gemini) emit reasoning blocks that get marked as `phase: "finished"` but contain empty or whitespace-only text. These empty blocks were being committed to the static transcript, causing the "Thinking..." header to appear without any content.

## Test Plan
- [ ] Test with Gemini models that previously showed the bug
- [ ] Verify thinking indicator disappears after response completes
- [ ] Ensure valid reasoning blocks (with content) still display correctly

👾 Generated with [Letta Code](https://letta.com)