### PR TITLE
fix: simplify startup memory block message

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3737,8 +3737,8 @@ Plan file path: ${planFilePath}`;
       const statusLines = [
         resumedMessage,
         agentNameLine,
-        agentUrl ? `→ ${agentUrl}` : "",
         ...hints,
+        agentUrl ? `→ ${agentUrl}` : "",
       ].filter(Boolean);
 
       buffersRef.current.byId.set(statusId, {

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -3,7 +3,6 @@ import type { Letta } from "@letta-ai/letta-client";
 import { Box, Text } from "ink";
 
 import type { AgentProvenance } from "../../agent/create";
-import { isProjectBlock } from "../../agent/memory";
 import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
@@ -84,45 +83,11 @@ export function getAgentStatusHints(
     return hints;
   }
 
-  // For new agents with provenance, show block sources
+  // For new agents, show initialized memory blocks
   if (agentProvenance) {
-    // Blocks reused from existing storage
-    const reusedGlobalBlocks = agentProvenance.blocks
-      .filter((b) => b.source === "global")
-      .map((b) => b.label);
-    const reusedProjectBlocks = agentProvenance.blocks
-      .filter((b) => b.source === "project")
-      .map((b) => b.label);
-
-    // New blocks - categorize by where they'll be stored
-    // (project blocks → .letta/, others → ~/.letta/)
-    const newBlocks = agentProvenance.blocks.filter((b) => b.source === "new");
-    const newGlobalBlocks = newBlocks
-      .filter((b) => !isProjectBlock(b.label))
-      .map((b) => b.label);
-    const newProjectBlocks = newBlocks
-      .filter((b) => isProjectBlock(b.label))
-      .map((b) => b.label);
-
-    if (reusedGlobalBlocks.length > 0) {
-      hints.push(
-        `→ Reusing from global (~/.letta/): ${reusedGlobalBlocks.join(", ")}`,
-      );
-    }
-    if (newGlobalBlocks.length > 0) {
-      hints.push(
-        `→ Created in global (~/.letta/): ${newGlobalBlocks.join(", ")}`,
-      );
-    }
-    if (reusedProjectBlocks.length > 0) {
-      hints.push(
-        `→ Reusing from project (.letta/): ${reusedProjectBlocks.join(", ")}`,
-      );
-    }
-    if (newProjectBlocks.length > 0) {
-      hints.push(
-        `→ Created in project (.letta/): ${newProjectBlocks.join(", ")}`,
-      );
+    const blockLabels = agentProvenance.blocks.map((b) => b.label);
+    if (blockLabels.length > 0) {
+      hints.push(`→ Initialized memory blocks: ${blockLabels.join(", ")}`);
     }
   }
 


### PR DESCRIPTION
- Remove outdated global/project split messaging (we no longer persist block IDs for sharing)
- Show simple 'Initialized memory blocks: ...' instead
- Move memory blocks line above agent URL link

🤖 Generated with [Letta Code](https://letta.com)