### PR TITLE
feat: add usage command

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -25,9 +25,9 @@ export const commands: Record<string, Command> = {
     },
   },
   "/exit": {
-    desc: "Exit and show session stats",
+    desc: "Exit this session",
     handler: () => {
-      // Handled specially in App.tsx to show stats
+      // Handled specially in App.tsx
       return "Exiting...";
     },
   },
@@ -178,6 +178,13 @@ export const commands: Record<string, Command> = {
     handler: () => {
       // Handled specially in App.tsx to open memory viewer
       return "Opening memory viewer...";
+    },
+  },
+  "/usage": {
+    desc: "Show session usage statistics and balance",
+    handler: () => {
+      // Handled specially in App.tsx to display usage stats
+      return "Fetching usage statistics...";
     },
   },
 };

--- a/src/cli/components/CommandMessage.tsx
+++ b/src/cli/components/CommandMessage.tsx
@@ -12,6 +12,7 @@ type CommandLine = {
   output: string;
   phase?: "running" | "finished";
   success?: boolean;
+  dimOutput?: boolean;
 };
 
 /**
@@ -63,7 +64,7 @@ export const CommandMessage = memo(({ line }: { line: CommandLine }) => {
             <Text>{"  ⎿  "}</Text>
           </Box>
           <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-            <MarkdownDisplay text={line.output} />
+            <MarkdownDisplay text={line.output} dimColor={line.dimOutput} />
           </Box>
         </Box>
       )}

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -44,6 +44,7 @@ export type Line =
       output: string;
       phase?: "running" | "finished";
       success?: boolean;
+      dimOutput?: boolean;
     }
   | {
       kind: "status";


### PR DESCRIPTION
```
● /usage
  ⎿ Total duration (API):  0ms
     Total duration (wall): 6.5s
     Session usage:         0 steps, 0 input, 0 output

     Available credits:     $9.23       Plan: [enterprise]
       Monthly credits:     $0.00
       Purchased credits:   $9.23


● /exit
  ⎿  See ya!


──────────────────────────────────────────────────────────────────────────────────────────
>  
──────────────────────────────────────────────────────────────────────────────────────────
Press / for commands or @ for files         Letta Code v0.7.0 [claude-sonnet-4-5-20250929]

caren@caren-mac letta-code % 
```