### PR TITLE
fix: handle browser open errors gracefully in OAuth flow

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -58,10 +58,17 @@ export function SetupUI({ onComplete }: SetupUIProps) {
       // Auto-open browser
       try {
         const { default: open } = await import("open");
-        await open(deviceData.verification_uri_complete);
+        // Use wait: true to properly catch errors when opener command doesn't exist
+        const subprocess = await open(deviceData.verification_uri_complete, {
+          wait: false,
+        });
+        // Handle errors from the spawned process (e.g., xdg-open not found in containers)
+        subprocess.on("error", () => {
+          // Silently ignore - user can still manually visit the URL shown above
+        });
       } catch (openErr) {
         // If auto-open fails, user can still manually visit the URL
-        console.error("Failed to auto-open browser:", openErr);
+        // This handles cases like missing opener commands in containers
       }
 
       // Get or generate device ID


### PR DESCRIPTION
When running in containers or environments without a browser opener (xdg-open, etc.), the open() call would spawn a child process that later emits an unhandled error event, crashing the CLI.

Now we attach an error handler to the subprocess to silently catch these errors. The URL is still displayed so users can manually visit it to complete authentication.

Fixes crash: 'Error: spawn xdg-open ENOENT'

🤖 Generated with [Letta Code](https://letta.com)