### PR TITLE
feat: simplify new agent intro message with /init tip

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4185,19 +4185,17 @@ Plan file path: ${planFilePath}`;
         ? agentState?.name
           ? `Resumed **${agentState.name}**`
           : "Resumed agent"
-        : "Created a new agent (use /pin to save, /pinned or /resume to switch)";
+        : "Creating a new agent (use /pin to save)";
 
-      const agentNameLine =
-        !continueSession && agentState?.name
-          ? `→ Agent: ${agentState.name} (use /rename to rename)`
-          : "";
-
-      const statusLines = [
-        resumedMessage,
-        agentNameLine,
-        ...hints,
-        agentUrl ? `→ ${agentUrl}` : "",
-      ].filter(Boolean);
+      const statusLines = continueSession
+        ? [resumedMessage, ...hints, agentUrl ? `→ ${agentUrl}` : ""].filter(
+            Boolean,
+          )
+        : [
+            resumedMessage,
+            agentUrl ? `→ ${agentUrl}` : "",
+            "→ Tip: use /init to initialize your agent's memory system!",
+          ].filter(Boolean);
 
       buffersRef.current.byId.set(statusId, {
         kind: "status",

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -60,7 +60,7 @@ type LoadingState =
 export function getAgentStatusHints(
   continueSession: boolean,
   agentState?: Letta.AgentState | null,
-  agentProvenance?: AgentProvenance | null,
+  _agentProvenance?: AgentProvenance | null,
 ): string[] {
   const hints: string[] = [];
 
@@ -81,14 +81,6 @@ export function getAgentStatusHints(
     }
     hints.push("→ To create a new agent, use --new");
     return hints;
-  }
-
-  // For new agents, show initialized memory blocks
-  if (agentProvenance) {
-    const blockLabels = agentProvenance.blocks.map((b) => b.label);
-    if (blockLabels.length > 0) {
-      hints.push(`→ Initialized memory blocks: ${blockLabels.join(", ")}`);
-    }
   }
 
   return hints;


### PR DESCRIPTION
- Change header to 'Creating a new agent (use /pin to save)'
- Show ADE link as second line
- Add tip about /init command for memory initialization
- Remove verbose memory blocks list from intro

🤖 Generated with [Letta Code](https://letta.com)