### PR TITLE
fix: restore exit stats on double Ctrl+C

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -457,6 +457,9 @@ export default function App({
   // Session stats tracking
   const sessionStatsRef = useRef(new SessionStats());
 
+  // Show exit stats on exit (double Ctrl+C)
+  const [showExitStats, setShowExitStats] = useState(false);
+
   // Track if we've sent the session context for this CLI session
   const hasSentSessionContextRef = useRef(false);
 
@@ -1352,7 +1355,8 @@ export default function App({
 
   const handleExit = useCallback(() => {
     saveLastAgentBeforeExit();
-    // Give React time to render the goodbye message, then exit
+    setShowExitStats(true);
+    // Give React time to render the stats, then exit
     setTimeout(() => {
       process.exit(0);
     }, 100);
@@ -4292,9 +4296,26 @@ Plan file path: ${planFilePath}`;
             {/* Ensure 1 blank line above input when there are no live items */}
             {liveItems.length === 0 && <Box height={1} />}
 
+            {/* Exit stats - shown when exiting via double Ctrl+C */}
+            {showExitStats && (
+              <Box flexDirection="column">
+                <Text dimColor>
+                  {formatUsageStats({
+                    stats: sessionStatsRef.current.getSnapshot(),
+                  })}
+                </Text>
+                <Text dimColor>Resume this agent with:</Text>
+                <Text color="blue">letta --agent {agentId}</Text>
+              </Box>
+            )}
+
             {/* Input row - always mounted to preserve state */}
             <Input
-              visible={pendingApprovals.length === 0 && !anySelectorOpen}
+              visible={
+                !showExitStats &&
+                pendingApprovals.length === 0 &&
+                !anySelectorOpen
+              }
               streaming={
                 streaming && !abortControllerRef.current?.signal.aborted
               }


### PR DESCRIPTION
<img width="379" height="158" alt="image" src="https://github.com/user-attachments/assets/b118d282-2d29-40c3-8fab-22967751f55c" />

- Add back showExitStats state that was removed in usage command PR
- Display session stats when exiting via double Ctrl+C
- Show 'Resume this agent with: letta --agent {id}' hint in blue

🤖 Generated with [Letta Code](https://letta.com)