### PR TITLE
feat: add missing core tools to codex and gemini toolsets

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -95,6 +95,13 @@ export const GEMINI_DEFAULT_TOOLS: ToolName[] = [
 
 // PascalCase toolsets (codex-2 and gemini-2) for consistency with Skill tool naming
 export const OPENAI_PASCAL_TOOLS: ToolName[] = [
+  // Additional Letta Code tools
+  "AskUserQuestion",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "Task",
+  "Skill",
+  // Standard Codex tools
   "ShellCommand",
   "Shell",
   "ReadFile",
@@ -102,10 +109,16 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "GrepFiles",
   "ApplyPatch",
   "UpdatePlan",
-  "Skill",
 ];
 
 export const GEMINI_PASCAL_TOOLS: ToolName[] = [
+  // Additional Letta Code tools
+  "AskUserQuestion",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "Skill",
+  "Task",
+  // Standard Gemini tools
   "RunShellCommand",
   "ReadFileGemini",
   "ListDirectory",
@@ -115,7 +128,6 @@ export const GEMINI_PASCAL_TOOLS: ToolName[] = [
   "WriteFileGemini",
   "WriteTodos",
   "ReadManyFiles",
-  "Skill",
 ];
 
 // Tool permissions configuration


### PR DESCRIPTION
Add AskUserQuestion, EnterPlanMode, ExitPlanMode, and Task to both OPENAI_PASCAL_TOOLS (codex) and GEMINI_PASCAL_TOOLS (gemini) toolsets.

These tools are essential for:
- AskUserQuestion: Asking clarifying questions to users
- EnterPlanMode/ExitPlanMode: Plan mode functionality
- Task: Spawning subagents

🤖 Generated with [Letta Code](https://letta.com)