### PR TITLE
chore: hide /compact command from autocomplete

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -40,6 +40,7 @@ export const commands: Record<string, Command> = {
   },
   "/compact": {
     desc: "Summarize conversation history (compaction)",
+    hidden: true,
     handler: () => {
       // Handled specially in App.tsx to access client and agent ID
       return "Compacting conversation...";


### PR DESCRIPTION
The /compact command is still functional but won't show in the command bar suggestions.

🤖 Generated with [Letta Code](https://letta.com)