### PR TITLE
fix: clear abortControllerRef after EAGER_CANCEL interrupt

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1448,6 +1448,7 @@ export default function App({
       // Abort the stream via abort signal
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
+        abortControllerRef.current = null; // Clear ref so isAgentBusy() returns false
       }
 
       // Set cancellation flag to prevent processConversation from starting


### PR DESCRIPTION
After aborting a stream with EAGER_CANCEL, the abortControllerRef was left set (though aborted), causing isAgentBusy() to return true. This led to an infinite loop when entering a new message:

1. User interrupts stream (EAGER_CANCEL)
2. streaming=false but abortControllerRef still set
3. User enters message, isAgentBusy() returns true
4. Message gets queued instead of processed
5. Dequeue effect fires, calls onSubmit
6. isAgentBusy() still true, message re-queued
7. Infinite loop -> 'Maximum update depth exceeded'

Fix: Set abortControllerRef.current = null immediately after abort() in the EAGER_CANCEL path, consistent with the finally block cleanup.

🤖 Generated with [Letta Code](https://letta.com)