### PR TITLE
fix: Add missing return statement and closing brace in /mcp command handler

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -33,6 +33,11 @@ import {
   savePermissionRule,
 } from "../tools/manager";
 import {
+  handleMcpAdd,
+  handleMcpUsage,
+  type McpCommandContext,
+} from "./commands/mcp";
+import {
   addCommandResult,
   handlePin,
   handleProfileDelete,
@@ -42,11 +47,6 @@ import {
   type ProfileCommandContext,
   validateProfileLoad,
 } from "./commands/profile";
-import {
-  handleMcpAdd,
-  handleMcpUsage,
-  type McpCommandContext,
-} from "./commands/mcp";
 import { AgentSelector } from "./components/AgentSelector";
 import { ApprovalDialog } from "./components/ApprovalDialogRich";
 import { AssistantMessage } from "./components/AssistantMessageRich";
@@ -1791,6 +1791,8 @@ export default function App({
 
           // Unknown subcommand
           handleMcpUsage(mcpCtx, msg);
+          return { submitted: true };
+        }
 
         // Special handling for /help command - opens help dialog
         if (trimmed === "/help") {
@@ -4658,7 +4660,8 @@ Plan file path: ${planFilePath}`;
                     kind: "command",
                     id: cmdId,
                     input: "/mcp",
-                    output: "Use /mcp add --transport <http|sse|stdio> <name> <url|command> [...] to add a new server",
+                    output:
+                      "Use /mcp add --transport <http|sse|stdio> <name> <url|command> [...] to add a new server",
                     phase: "finished",
                     success: true,
                   });

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -2,9 +2,9 @@
 // MCP server command handlers
 
 import type {
-  CreateStreamableHTTPMcpServer,
   CreateSseMcpServer,
   CreateStdioMcpServer,
+  CreateStreamableHTTPMcpServer,
 } from "@letta-ai/letta-client/resources/mcp-servers/mcp-servers";
 import { getClient } from "../../agent/client";
 import type { Buffers, Line } from "../helpers/accumulator";
@@ -77,11 +77,11 @@ function parseCommandArgs(commandStr: string): string[] {
   let current = "";
   let inQuotes = false;
   let quoteChar = "";
-  
+
   for (let i = 0; i < commandStr.length; i++) {
     const char = commandStr[i];
     if (!char) continue; // Skip if undefined (shouldn't happen but type safety)
-    
+
     if ((char === '"' || char === "'") && !inQuotes) {
       // Start of quoted string
       inQuotes = true;
@@ -101,12 +101,12 @@ function parseCommandArgs(commandStr: string): string[] {
       current += char;
     }
   }
-  
+
   // Add final argument if any
   if (current) {
     args.push(current);
   }
-  
+
   return args;
 }
 
@@ -127,7 +127,7 @@ function parseMcpAddArgs(parts: string[]): McpAddArgs | null {
   let name: string | null = null;
   let url: string | null = null;
   let command: string | null = null;
-  let args: string[] = [];
+  const args: string[] = [];
   const headers: Record<string, string> = {};
   let authToken: string | null = null;
 
@@ -153,9 +153,9 @@ function parseMcpAddArgs(parts: string[]): McpAddArgs | null {
         // Parse "key: value" or "key=value"
         const colonMatch = headerValue.match(/^([^:]+):\s*(.+)$/);
         const equalsMatch = headerValue.match(/^([^=]+)=(.+)$/);
-        if (colonMatch && colonMatch[1] && colonMatch[2]) {
+        if (colonMatch?.[1] && colonMatch[2]) {
           headers[colonMatch[1].trim()] = colonMatch[2].trim();
-        } else if (equalsMatch && equalsMatch[1] && equalsMatch[2]) {
+        } else if (equalsMatch?.[1] && equalsMatch[2]) {
           headers[equalsMatch[1].trim()] = equalsMatch[2].trim();
         }
       }
@@ -194,14 +194,14 @@ function parseMcpAddArgs(parts: string[]): McpAddArgs | null {
     return null;
   }
 
-  return { 
-    transport, 
-    name, 
-    url: url || null, 
-    command: command || null, 
-    args, 
-    headers, 
-    authToken: authToken || null 
+  return {
+    transport,
+    name,
+    url: url || null,
+    command: command || null,
+    args,
+    headers,
+    authToken: authToken || null,
   };
 }
 
@@ -220,7 +220,7 @@ export async function handleMcpAdd(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      "Usage: /mcp add --transport <http|sse|stdio> <name> <url|command> [--header \"key: value\"] [--auth token]\n\nExamples:\n  /mcp add --transport http notion https://mcp.notion.com/mcp\n  /mcp add --transport http secure-api https://api.example.com/mcp --header \"Authorization: Bearer token\"",
+      'Usage: /mcp add --transport <http|sse|stdio> <name> <url|command> [--header "key: value"] [--auth token]\n\nExamples:\n  /mcp add --transport http notion https://mcp.notion.com/mcp\n  /mcp add --transport http secure-api https://api.example.com/mcp --header "Authorization: Bearer token"',
       false,
     );
     return;
@@ -253,7 +253,8 @@ export async function handleMcpAdd(
         mcp_server_type: "streamable_http",
         server_url: args.url,
         auth_token: args.authToken,
-        custom_headers: Object.keys(args.headers).length > 0 ? args.headers : null,
+        custom_headers:
+          Object.keys(args.headers).length > 0 ? args.headers : null,
       };
     } else if (args.transport === "sse") {
       if (!args.url) {
@@ -263,7 +264,8 @@ export async function handleMcpAdd(
         mcp_server_type: "sse",
         server_url: args.url,
         auth_token: args.authToken,
-        custom_headers: Object.keys(args.headers).length > 0 ? args.headers : null,
+        custom_headers:
+          Object.keys(args.headers).length > 0 ? args.headers : null,
       };
     } else {
       // stdio
@@ -307,10 +309,10 @@ export async function handleMcpAdd(
 
     try {
       await client.mcpServers.refresh(server.id);
-      
+
       // Get tool count
       const tools = await client.mcpServers.tools.list(server.id);
-      
+
       updateCommandResult(
         ctx.buffersRef,
         ctx.refreshDerived,
@@ -321,7 +323,8 @@ export async function handleMcpAdd(
       );
     } catch (refreshErr) {
       // If refresh fails, still show success but warn about tools
-      const errorMsg = refreshErr instanceof Error ? refreshErr.message : "Unknown error";
+      const errorMsg =
+        refreshErr instanceof Error ? refreshErr.message : "Unknown error";
       updateCommandResult(
         ctx.buffersRef,
         ctx.refreshDerived,
@@ -352,7 +355,7 @@ export function handleMcpUsage(ctx: McpCommandContext, msg: string): void {
     ctx.buffersRef,
     ctx.refreshDerived,
     msg,
-    "Usage: /mcp [add ...]\n  /mcp - list MCP servers\n  /mcp add --transport <http|sse|stdio> <name> <url|command> [...] - add a new server\n\nExamples:\n  /mcp add --transport http notion https://mcp.notion.com/mcp\n  /mcp add --transport http api https://api.example.com --header \"Authorization: Bearer token\"",
+    'Usage: /mcp [add ...]\n  /mcp - list MCP servers\n  /mcp add --transport <http|sse|stdio> <name> <url|command> [...] - add a new server\n\nExamples:\n  /mcp add --transport http notion https://mcp.notion.com/mcp\n  /mcp add --transport http api https://api.example.com --header "Authorization: Bearer token"',
     false,
   );
 }


### PR DESCRIPTION
## Summary

Fixes critical syntax error introduced in PR #302 that prevented the build from completing.

**Error:** `Unexpected , at /Users/cameron/letta/letta-code/src/cli/App.tsx:3325:6`

## Root Cause

The `/mcp` command handler (added in #302) was missing:
- `return { submitted: true };` statement after `handleMcpUsage()` call (line 1793)
- Closing brace `}` for the `/mcp` if block that starts at line 1767

This caused the subsequent `/help` if statement to be incorrectly parsed as part of the `/mcp` block, creating a syntax error.

## Changes

### Critical Fix
- **src/cli/App.tsx:1794-1795** - Added missing return statement and closing brace

### Linting Fixes
Applied auto-fixes for code touched by PR #302:
- **Import organization** in App.tsx, mcp.ts, McpSelector.tsx
- **Optional chain usage** in mcp.ts (colonMatch?.[1], equalsMatch?.[1])
- **Unused import removal** in McpSelector.tsx (McpServerListResponse)
- **Code formatting** (whitespace, line breaks, arrow function formatting)

## Testing

- ✅ Build completes successfully (`bun run build`)
- ✅ All linting checks pass
- ✅ All type checks pass

## Impact

This is a **critical fix** - the main branch is currently unbuildable without this patch.

Written by Cameron ◯ Letta Code

"Sometimes the smallest punctuation makes all the difference."
