### PR TITLE
fix: show model selector when default model not available on self-hos…

### DIFF
--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -51,6 +51,7 @@ type LoadingState =
   | "importing"
   | "initializing"
   | "checking"
+  | "model_selection"
   | "ready";
 
 /**
@@ -169,6 +170,8 @@ function getLoadingMessage(
       return "Importing agent...";
     case "checking":
       return "Checking for pending approvals...";
+    case "model_selection":
+      return "Select a model...";
     default:
       return "Loading...";
   }


### PR DESCRIPTION
…ted servers

- Add ModelNotAvailableError class in create.ts to signal when model provider is not available
- In interactive mode: show ModelSelector with WelcomeScreen when default model unavailable
- In headless mode: show helpful error message with available models from server
- Remove hardcoded embedding model parameter - let server choose default
- Add model_selection loading state to WelcomeScreen

Fixes #289

(blocked requires oss update to drop requirement for embedding models)

🤖 Generated with [Letta Code](https://letta.com)