### PR TITLE
fix: prevent stale stream updates after interrupt

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -62,6 +62,7 @@ export type Buffers = {
   toolCallIdToLineId: Map<string, string>;
   lastOtid: string | null; // Track the last otid to detect transitions
   pendingRefresh?: boolean; // Track throttled refresh state
+  interrupted?: boolean; // Track if stream was interrupted by user (skip stale refreshes)
   usage: {
     promptTokens: number;
     completionTokens: number;
@@ -162,6 +163,9 @@ export function markCurrentLineAsFinished(b: Buffers) {
  * This prevents blinking tool calls from staying in progress state.
  */
 export function markIncompleteToolsAsCancelled(b: Buffers) {
+  // Mark buffer as interrupted to skip stale throttled refreshes
+  b.interrupted = true;
+
   for (const [id, line] of b.byId.entries()) {
     if (line.kind === "tool_call" && line.phase !== "finished") {
       const updatedLine = {

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -141,16 +141,16 @@ export async function drainStream(
       }
     }
 
-    onChunk(buffers, chunk);
-    queueMicrotask(refresh);
-
-    // Check abort signal again after processing chunk (for eager cancellation)
+    // Check abort signal before processing - don't add data after interrupt
     if (abortSignal?.aborted) {
       stopReason = "cancelled";
       markIncompleteToolsAsCancelled(buffers);
       queueMicrotask(refresh);
       break;
     }
+
+    onChunk(buffers, chunk);
+    queueMicrotask(refresh);
 
     if (chunk.message_type === "stop_reason") {
       stopReason = chunk.stop_reason;


### PR DESCRIPTION
When user interrupts a stream and quickly opens an overlay (like /model), stream data could still appear above the overlay due to race conditions.

Changes:
- Add interrupted flag to Buffers, set when stream is cancelled
- Throttled refresh checks flag and skips if interrupted
- Move abort check BEFORE onChunk in drainStream
- Clear interrupted flag when starting new stream

🤖 Generated with [Letta Code](https://letta.com)