### PR TITLE
feat: add multiline input support with Shift+Enter and backslash+Enter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",

--- a/src/cli/components/HelpDialog.tsx
+++ b/src/cli/components/HelpDialog.tsx
@@ -51,6 +51,15 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
       { keys: "Tab", description: "Autocomplete command or file path" },
       { keys: "↓", description: "Navigate down / next command in history" },
       { keys: "↑", description: "Navigate up / previous command in history" },
+      { keys: "\\+Enter", description: "Insert newline (most reliable)" },
+      {
+        keys: "Ctrl+J",
+        description: "Insert newline in message (multiline input)",
+      },
+      {
+        keys: "Shift+Enter",
+        description: "Insert newline (if terminal supports it)",
+      },
       {
         keys: "Ctrl+C",
         description: "Interrupt operation / exit (double press)",

--- a/src/tests/cli/multiline-input.test.ts
+++ b/src/tests/cli/multiline-input.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+
+/**
+ * Tests for multiline input functionality
+ *
+ * Multiline input is supported via:
+ * 1. Shift+Enter - inserts a newline character
+ * 2. Backslash+Enter - removes trailing backslash and inserts newline
+ *
+ * These tests verify the sanitization and display logic for multiline text.
+ */
+
+/** Helper function from PasteAwareTextInput.tsx */
+function sanitizeForDisplay(text: string): string {
+  return text.replace(/\r\n|\r|\n/g, "↵");
+}
+
+test("sanitizeForDisplay converts single newline to ↵", () => {
+  const text = "Hello\nWorld";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("Hello↵World");
+});
+
+test("sanitizeForDisplay converts multiple newlines to ↵", () => {
+  const text = "Line 1\nLine 2\nLine 3";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("Line 1↵Line 2↵Line 3");
+});
+
+test("sanitizeForDisplay handles CRLF (Windows)", () => {
+  const text = "Windows\r\nStyle";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("Windows↵Style");
+});
+
+test("sanitizeForDisplay handles CR (old Mac)", () => {
+  const text = "Old\rMac";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("Old↵Mac");
+});
+
+test("sanitizeForDisplay preserves text without newlines", () => {
+  const text = "No newlines here";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("No newlines here");
+});
+
+test("sanitizeForDisplay handles empty string", () => {
+  const text = "";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("");
+});
+
+test("sanitizeForDisplay handles text with only newlines", () => {
+  const text = "\n\n\n";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("↵↵↵");
+});
+
+test("sanitizeForDisplay handles mixed line endings", () => {
+  const text = "Unix\nWindows\r\nOld Mac\rMixed";
+  const result = sanitizeForDisplay(text);
+  expect(result).toBe("Unix↵Windows↵Old Mac↵Mixed");
+});
+
+/**
+ * Integration test scenarios (documented for manual testing):
+ *
+ * 1. Type "Hello" then press Shift+Enter, type "World" then Enter
+ *    - Display should show: "Hello↵World"
+ *    - Actual message sent: "Hello\nWorld" (with real newline)
+ *
+ * 2. Type "Line 1\" then press Enter
+ *    - Display should show: "Line 1↵"
+ *    - Actual message sent: "Line 1\n" (backslash removed, newline added)
+ *
+ * 3. Type "Regular" then press Enter (no Shift, no backslash)
+ *    - Message should submit immediately with "Regular"
+ *
+ * 4. Type "Multiple" Shift+Enter "Lines" Shift+Enter "Here" then Enter
+ *    - Display: "Multiple↵Lines↵Here"
+ *    - Actual: "Multiple\nLines\nHere"
+ */


### PR DESCRIPTION
## Summary

- **Shift+Enter**: Inserts a newline in the message (detected via raw terminal escape sequences for cross-terminal compatibility)
- **Backslash+Enter**: Removes trailing backslash and inserts newline (most reliable method)
- **Ctrl+J**: Alternative newline insertion (standard Unix binding)

This enables users to compose multiline messages before sending, aligning with standard UX patterns found in Slack, Discord, ChatGPT, Claude Code, Gemini CLI, and other modern chat interfaces.

## Implementation Details

- Modified vendored ink-text-input to render multiple lines using Ink Box component
- Added raw stdin handling in PasteAwareTextInput to detect Shift+Enter escape sequences across different terminals (kitty protocol, xterm modifyOtherKeys, etc.)
- Actual submitted messages contain real newlines for proper formatting
- Added keyboard shortcuts to /help dialog

## Test plan

- [x] Lint and typecheck pass (bun run check)
- [x] All 466 tests pass (bun test)
- [x] Manual testing: Shift+Enter creates new line in input
- [x] Manual testing: Backslash+Enter creates new line in input
- [x] Manual testing: Ctrl+J creates new line in input
- [x] Manual testing: Regular Enter still submits message
- [x] Manual testing: /help shows new keyboard shortcuts

👾 Generated with [Letta Code](https://letta.com)