### PR TITLE
feat: add learning and meta-cognitive thinking verbs

### DIFF
--- a/src/cli/helpers/thinkingMessages.ts
+++ b/src/cli/helpers/thinkingMessages.ts
@@ -32,6 +32,15 @@ const THINKING_VERBS = [
   "rendering",
   "executing",
   "initializing",
+  "absolutely right",
+  "thinking about thinking",
+  "metathinking",
+  "learning",
+  "adapting",
+  "evolving",
+  "remembering",
+  "absorbing",
+  "internalizing",
 ] as const;
 
 // Get a random thinking verb (e.g., "thinking", "processing")

--- a/src/tests/cli/thinkingMessages.test.ts
+++ b/src/tests/cli/thinkingMessages.test.ts
@@ -5,31 +5,31 @@ describe("Thinking messages", () => {
   test("returns formatted message with agent name", () => {
     const message = getRandomThinkingMessage("Letta");
 
-    // Should be in format "Letta is <verb>ing"
-    expect(message).toMatch(/^Letta is \w+$/);
+    // Should be in format "Letta is <verb/phrase>"
+    expect(message).toMatch(/^Letta is .+$/);
     expect(message.startsWith("Letta is ")).toBe(true);
   });
 
   test("returns capitalized verb without agent name", () => {
     const message = getRandomThinkingMessage();
 
-    // Should be a capitalized verb (e.g., "Thinking", "Processing")
-    expect(message).toMatch(/^[A-Z][a-z]+$/);
+    // Should be a capitalized verb/phrase (e.g., "Thinking", "Processing", "Absolutely right")
+    expect(message).toMatch(/^[A-Z].+$/);
     expect(message[0]).toMatch(/[A-Z]/);
   });
 
   test("handles null agent name", () => {
     const message = getRandomThinkingMessage(null);
 
-    // Should fall back to capitalized verb
-    expect(message).toMatch(/^[A-Z][a-z]+$/);
+    // Should fall back to capitalized verb/phrase
+    expect(message).toMatch(/^[A-Z].+$/);
   });
 
   test("handles empty string agent name", () => {
     const message = getRandomThinkingMessage("");
 
-    // Should fall back to capitalized verb (empty string is falsy)
-    expect(message).toMatch(/^[A-Z][a-z]+$/);
+    // Should fall back to capitalized verb/phrase (empty string is falsy)
+    expect(message).toMatch(/^[A-Z].+$/);
   });
 
   test("generates different messages on multiple calls", () => {


### PR DESCRIPTION
## Summary
Adds new thinking verbs that emphasize Letta's core capabilities around learning and memory.

## New Verbs

**Meta/self-aware:**
- "thinking about thinking"
- "metathinking"

**Learning-related (core to Letta):**
- "learning"
- "adapting"
- "evolving"
- "remembering"
- "absorbing"
- "internalizing"

**Bonus:**
- "absolutely right" (playful confidence)

## Examples

Now you'll see messages like:
- "Letta Code is thinking about thinking..."
- "Letta Code is remembering..."
- "Letta Code is absolutely right..."
- "Letta Code is evolving..."

## Changes

- Updated `THINKING_VERBS` array in `src/cli/helpers/thinkingMessages.ts`
- Relaxed test regex patterns to support multi-word phrases (changed from `/^[A-Z][a-z]+$/` to `/^[A-Z].+$/`)
- All tests passing ✅

Written by Cameron ◯ Letta Code

"We shape our tools and thereafter our tools shape us." - Marshall McLuhan