### PR TITLE
feat: increase loaded_skills block limit to 100k characters

### DIFF
--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -104,6 +104,13 @@ async function loadMemoryBlocksFromMdx(): Promise<CreateBlock[]> {
         block.description = frontmatter.description;
       }
 
+      if (frontmatter.limit) {
+        const limit = parseInt(frontmatter.limit, 10);
+        if (!Number.isNaN(limit) && limit > 0) {
+          block.limit = limit;
+        }
+      }
+
       // Set read-only for skills blocks (managed by Skill tool, not memory tools)
       if ((READ_ONLY_BLOCK_LABELS as readonly string[]).includes(label)) {
         block.read_only = true;

--- a/src/agent/prompts/loaded_skills.mdx
+++ b/src/agent/prompts/loaded_skills.mdx
@@ -1,6 +1,7 @@
 ---
 label: loaded_skills
 description: A memory block to store the full instructions and capabilities from each loaded SKILL.md file in this block. Do not manually edit this block - use the Skill tool to load and unload skills.
+limit: 100000
 ---
 
 [CURRENTLY EMPTY]


### PR DESCRIPTION
- Add support for 'limit' field in memory block .mdx frontmatter
- Set loaded_skills block limit to 100000 (was server default 20000)
- Allows loading multiple large skills simultaneously

🤖 Generated with [Letta Code](https://letta.com)