### PR TITLE
feat: Task subagents: allow overriding spawned letta executable

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -382,8 +382,10 @@ async function executeSubagent(
   try {
     const cliArgs = buildSubagentArgs(type, config, model, userPrompt);
 
-    // Spawn letta in headless mode with stream-json output
-    const proc = spawn("letta", cliArgs, {
+    // Spawn Letta Code in headless mode.
+    // Some environments may have a different `letta` binary earlier in PATH.
+    const lettaCmd = process.env.LETTA_CODE_BIN || "letta";
+    const proc = spawn(lettaCmd, cliArgs, {
       cwd: process.cwd(),
       env: process.env,
     });


### PR DESCRIPTION
Fixes a common PATH collision issue where `letta` does not resolve to Letta Code.

Change (minimal):
- When spawning Task subagents, use `process.env.LETTA_CODE_BIN ?? "letta"` as the spawn command.

No behavior changes unless `LETTA_CODE_BIN` is set.

Issue: #338

Disclosure: Co-authored using Letta Code with GPT-5.2.