### PR TITLE
feat: task tool: include subagent agent_id in output

### DIFF
--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -70,7 +70,16 @@ export async function task(args: TaskArgs): Promise<string> {
       return `Error: ${result.error || "Subagent execution failed"}`;
     }
 
-    return result.report;
+    // Include stable subagent metadata so orchestrators can attribute results.
+    // Keep the tool return type as a string for compatibility.
+    const header = [
+      `subagent_type=${subagent_type}`,
+      result.agentId ? `agent_id=${result.agentId}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return `${header}\n\n${result.report}`;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     completeSubagent(subagentId, { success: false, error: errorMessage });


### PR DESCRIPTION
Expose the spawned subagent's `agent_id` in Task tool output so orchestrators can attribute results and build stable run indexes.

Change (minimal):
- Prefix Task output with `subagent_type=<...> agent_id=<...>` followed by the existing report text.
- Keep returning a string for compatibility; no URL logic.

Issue: #339

Disclosure: Co-authored using Letta Code with GPT-5.2.