### PR TITLE
feat: Tag Task-spawned agents with role:subagent

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -206,6 +206,11 @@ export async function createAgent(
   const systemPromptContent = await resolveSystemPrompt(systemPromptId);
 
   // Create agent with all block IDs (existing + newly created)
+  const tags = ["origin:letta-code"];
+  if (process.env.LETTA_CODE_AGENT_ROLE === "subagent") {
+    tags.push("role:subagent");
+  }
+
   const agent = await client.agents.create({
     agent_type: "letta_v1_agent" as AgentType,
     system: systemPromptContent,
@@ -216,7 +221,7 @@ export async function createAgent(
     context_window_limit: contextWindow,
     tools: toolNames,
     block_ids: blockIds,
-    tags: ["origin:letta-code"],
+    tags,
     // should be default off, but just in case
     include_base_tools: false,
     include_base_tool_rules: false,

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -385,7 +385,11 @@ async function executeSubagent(
     // Spawn letta in headless mode with stream-json output
     const proc = spawn("letta", cliArgs, {
       cwd: process.cwd(),
-      env: process.env,
+      env: {
+        ...process.env,
+        // Tag Task-spawned agents for easy filtering.
+        LETTA_CODE_AGENT_ROLE: "subagent",
+      },
     });
 
     // Set up abort handler to kill the child process


### PR DESCRIPTION
Problem:
Task-spawned subagents are not tagged distinctly from primary agents, making filtering difficult.

Change (minimal):
- When spawning Task subagents, set `LETTA_CODE_AGENT_ROLE=subagent` in the child process environment.
- When creating a new agent, append `role:subagent` to tags when `LETTA_CODE_AGENT_ROLE=subagent`.

No naming changes. No lineage tags.

Fixes #342

Disclosure: Co-authored using Letta Code with GPT-5.2.