### PR TITLE
fix: simplify disconnect success message

### DIFF
--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -387,8 +387,7 @@ export async function handleDisconnect(
       cmdId,
       msg,
       `✓ Disconnected from Claude OAuth.\n\n` +
-        `Provider '${ANTHROPIC_PROVIDER_NAME}' removed from Letta.\n` +
-        `Your OAuth tokens have been removed from ~/.letta/settings.json`,
+        `Provider '${ANTHROPIC_PROVIDER_NAME}' removed from Letta.`,
       true,
       "finished",
     );


### PR DESCRIPTION
## Summary
- Remove redundant OAuth token location message from `/disconnect` output

## Before
```
✓ Disconnected from Claude OAuth.

Provider 'claude-pro-max' removed from Letta.
Your OAuth tokens have been removed from ~/.letta/settings.json
```

## After
```
✓ Disconnected from Claude OAuth.

Provider 'claude-pro-max' removed from Letta.
```