### PR TITLE
feat: add anonymized device_id for telemetry

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -23,11 +23,7 @@ export async function getClient() {
     if (expiresAt - now < 5 * 60 * 1000) {
       try {
         // Get or generate device ID (should always exist, but fallback just in case)
-        let deviceId = settings.deviceId;
-        if (!deviceId) {
-          deviceId = crypto.randomUUID();
-          settingsManager.updateSettings({ deviceId });
-        }
+        const deviceId = settingsManager.getOrCreateDeviceId();
         const deviceName = hostname();
 
         const tokens = await refreshAccessToken(

--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -72,11 +72,7 @@ export function SetupUI({ onComplete }: SetupUIProps) {
       }
 
       // Get or generate device ID
-      let deviceId = settingsManager.getSetting("deviceId");
-      if (!deviceId) {
-        deviceId = crypto.randomUUID();
-        settingsManager.updateSettings({ deviceId });
-      }
+      const deviceId = settingsManager.getOrCreateDeviceId();
       const deviceName = hostname();
 
       // Start polling in background

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -123,6 +123,19 @@ class SettingsManager {
   }
 
   /**
+   * Get or create device ID (generates UUID if not exists)
+   */
+  getOrCreateDeviceId(): string {
+    const settings = this.getSettings();
+    let deviceId = settings.deviceId;
+    if (!deviceId) {
+      deviceId = crypto.randomUUID();
+      this.updateSettings({ deviceId });
+    }
+    return deviceId;
+  }
+
+  /**
    * Update settings (synchronous in-memory, async persist)
    */
   updateSettings(updates: Partial<Settings>): void {


### PR DESCRIPTION
- Centralize device ID logic in settingsManager.getOrCreateDeviceId()
- Generate random UUID (not hardware fingerprint) for privacy
- Initialize device_id on telemetry startup for all users
- Add device_id to all events and X-Letta-Code-Device-ID header
- Persist in ~/.letta/settings.json across sessions

👾 Generated with [Letta Code](https://letta.com)