### PR TITLE
fix: edge case for if the in-context messages are cleared with a pending approval 

### DIFF
--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -133,7 +133,10 @@ export async function getResumeData(
       const lastStopReason = (agent as { last_stop_reason?: string })
         .last_stop_reason;
       if (lastStopReason === "requires_approval") {
-        debugWarn("check-approval", `Agent last_stop_reason: ${lastStopReason}`);
+        debugWarn(
+          "check-approval",
+          `Agent last_stop_reason: ${lastStopReason}`,
+        );
         debugWarn(
           "check-approval",
           `Message to check: ${messageToCheck.id} (type: ${messageToCheck.message_type})`,
@@ -172,7 +175,9 @@ export async function getResumeData(
         };
         pendingApprovals = toolCalls
           .filter(
-            (tc: ToolCallEntry): tc is ToolCallEntry & { tool_call_id: string } =>
+            (
+              tc: ToolCallEntry,
+            ): tc is ToolCallEntry & { tool_call_id: string } =>
               !!tc && !!tc.tool_call_id,
           )
           .map((tc: ToolCallEntry & { tool_call_id: string }) => ({


### PR DESCRIPTION
 The problem:
  1. If agent.message_ids is cleared, inContextLastMessageId becomes null
  2. The desync check is skipped because it requires inContextLastMessageId to be truthy
  3. The code falls back to checking cursorLastMessage (the last message from the cursor/history)
  4. If that cursor message is still an approval_request_message, letta-code will incorrectly think there's a pending approval

Solution: Assume there is no approval (do NOT fall back to messages[-1]) 