### PR TITLE
fix: generate plan file path when entering plan mode via tab cycling

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -22,7 +22,7 @@ import type { AgentProvenance } from "../agent/create";
 import { sendMessageStream } from "../agent/message";
 import { SessionStats } from "../agent/stats";
 import type { ApprovalContext } from "../permissions/analyzer";
-import { permissionMode } from "../permissions/mode";
+import { type PermissionMode, permissionMode } from "../permissions/mode";
 import { updateProjectSettings } from "../settings";
 import { settingsManager } from "../settings-manager";
 import { telemetry } from "../telemetry";
@@ -4310,6 +4310,17 @@ DO NOT respond to these messages or otherwise consider them in your response unl
     permissionMode.getMode(),
   );
 
+  // Handle permission mode changes from the Input component (e.g., shift+tab cycling)
+  const handlePermissionModeChange = useCallback((mode: PermissionMode) => {
+    // When entering plan mode via tab cycling, generate and set the plan file path
+    if (mode === "plan") {
+      const planPath = generatePlanFilePath();
+      permissionMode.setPlanFilePath(planPath);
+    }
+    // permissionMode.setMode() is called in InputRich.tsx before this callback
+    setUiPermissionMode(mode);
+  }, []);
+
   const handlePlanApprove = useCallback(
     async (acceptEdits: boolean = false) => {
       const currentIndex = approvalResults.length;
@@ -4762,7 +4773,7 @@ Plan file path: ${planFilePath}`;
               onSubmit={onSubmit}
               onBashSubmit={handleBashSubmit}
               permissionMode={uiPermissionMode}
-              onPermissionModeChange={setUiPermissionMode}
+              onPermissionModeChange={handlePermissionModeChange}
               onExit={handleExit}
               onInterrupt={handleInterrupt}
               interruptRequested={interruptRequested}


### PR DESCRIPTION
When entering plan mode via shift+tab cycling, the plan file path was not being set, causing "Plan file path: not set" errors when trying to write a plan or exit plan mode.

Added handlePermissionModeChange callback that generates and sets the plan file path when mode changes to "plan", matching the behavior of the EnterPlanMode tool approval flow.

🤖 Generated with [Letta Code](https://letta.com)