### PR TITLE
feat: rename /resume to /agents with backwards-compatible alias

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -785,7 +785,7 @@ export default function App({
         `Connecting to last used agent in ${shortCwd}`,
         agentState?.name ? `→ Agent: ${agentState.name}` : "",
         agentUrl ? `→ ${agentUrl}` : "",
-        "→ Use /pinned or /resume to switch agents",
+        "→ Use /pinned or /agents to switch agents",
       ].filter(Boolean);
       buffersRef.current.byId.set(statusId, {
         kind: "status",
@@ -2565,7 +2565,7 @@ export default function App({
           return { submitted: true };
         }
 
-        // Special handling for /resume command - show session resume selector
+        // Special handling for /agents command - show agent selector (/resume is hidden alias)
         if (msg.trim() === "/agents" || msg.trim() === "/resume") {
           setActiveOverlay("resume");
           return { submitted: true };

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -132,8 +132,16 @@ export const commands: Record<string, Command> = {
       return "Processing memory request...";
     },
   },
+  "/agents": {
+    desc: "Browse and switch to another agent",
+    handler: () => {
+      // Handled specially in App.tsx to show agent selector
+      return "Opening agent selector...";
+    },
+  },
   "/resume": {
     desc: "Browse and switch to another agent",
+    hidden: true, // Backwards compatibility alias for /agents
     handler: () => {
       // Handled specially in App.tsx to show agent selector
       return "Opening agent selector...";


### PR DESCRIPTION
- /agents is now the primary command for browsing and switching agents
- /resume remains as a hidden alias for backwards compatibility
- Updated hint message to reference /agents

👾 Generated with [Letta Code](https://letta.com)