### PR TITLE
fix: include plan file path in plan mode denial messages

### DIFF
--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -116,10 +116,21 @@ export function checkPermission(
   const modeOverride = permissionMode.checkModeOverride(toolName, toolArgs);
   if (modeOverride) {
     const currentMode = permissionMode.getMode();
+    // Include plan file path and guidance in denial message for plan mode
+    let reason = `Permission mode: ${currentMode}`;
+    if (currentMode === "plan" && modeOverride === "deny") {
+      const planFilePath = permissionMode.getPlanFilePath();
+      if (planFilePath) {
+        reason =
+          `Plan mode is active. You can only use read-only tools (Read, Grep, Glob, etc.) and write to the plan file. ` +
+          `Write your plan to: ${planFilePath}. ` +
+          `Use ExitPlanMode when your plan is ready for user approval.`;
+      }
+    }
     return {
       decision: modeOverride,
       matchedRule: `${currentMode} mode`,
-      reason: `Permission mode: ${currentMode}`,
+      reason,
     };
   }
 


### PR DESCRIPTION
When plan mode denies a tool, the error message now includes guidance about what tools are allowed and where to write the plan file. This helps when plan mode is activated mid-conversation via tab-cycling.

👾 Generated with [Letta Code](https://letta.com)