### PR TITLE
feat: prompt to resume global pinned agent in fresh directories (#358)

### DIFF
--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -51,6 +51,7 @@ type LoadingState =
   | "importing"
   | "initializing"
   | "checking"
+  | "selecting_global"
   | "ready";
 
 /**


### PR DESCRIPTION
When starting Letta Code in a directory without a .letta folder, if the user has global pinned agents, show a selector asking which agent to use instead of silently creating a new one. This encourages users to bring existing stateful agents to new projects.

- Add selecting_global loading state and render ProfileSelectionInline
- Auto-pin selected agent to the project for future sessions
- Add freshRepoMode prop to hide redundant "(global)" labels
- Bypass selector for --new, --agent, --from-af, --continue flags

🤖 Generated with [Letta Code](https://letta.com)