### PR TITLE
fix: always fetch detailed error info from server when run_id exists

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -985,7 +985,7 @@ export default function App({
             approvals,
             apiDurationMs,
             lastRunId,
-            streamError,
+            fallbackError,
           } = await drainStreamWithResume(
             stream,
             buffersRef.current,
@@ -1411,8 +1411,10 @@ export default function App({
 
           // Track the error in telemetry
           telemetry.trackError(
-            streamError ? "StreamError" : stopReason || "unknown_stop_reason",
-            streamError || `Stream stopped with reason: ${stopReason}`,
+            fallbackError
+              ? "FallbackError"
+              : stopReason || "unknown_stop_reason",
+            fallbackError || `Stream stopped with reason: ${stopReason}`,
             "message_stream",
             {
               modelId: currentModelId || undefined,
@@ -1421,10 +1423,11 @@ export default function App({
           );
 
           // If we have a client-side stream error (e.g., JSON parse error), show it directly
-          if (streamError) {
+          // Fallback error: no run_id available, show whatever error message we have
+          if (fallbackError) {
             const errorMsg = lastRunId
-              ? `Stream error: ${streamError}\n(run_id: ${lastRunId})`
-              : `Stream error: ${streamError}`;
+              ? `Stream error: ${fallbackError}\n(run_id: ${lastRunId})`
+              : `Stream error: ${fallbackError}`;
             appendError(errorMsg, true); // Skip telemetry - already tracked above
             setStreaming(false);
             refreshDerived();


### PR DESCRIPTION
Previously, stream errors would show generic messages like "An error occurred during agent execution" even when detailed error info was available on the server.

Changes:
- Capture run_id from stream chunks independently (don't require seq_id)
- Extract run_id from APIError.error when catching stream exceptions
- Only set fallbackError when no run_id is available
- Rename streamError -> fallbackError to clarify its purpose

Now when a server error occurs during streaming, we always fetch the detailed error from the run metadata, which includes type, message, and detail fields.

🐾 Generated with [Letta Code](https://letta.com)