### PR TITLE
fix: patch bug in approve plan mode (handle empty toolArgs for tools with no parameters)

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -215,10 +215,12 @@ export async function drainStream(
 
     // Include ALL tool_call_ids - don't filter out incomplete entries
     // Missing name/args will be handled by denial logic in App.tsx
+    // Default empty toolArgs to "{}" - empty string causes JSON.parse("") to fail
+    // This happens for tools with no parameters (e.g., EnterPlanMode, ExitPlanMode)
     approvals = allPending.map((a) => ({
       toolCallId: a.toolCallId,
       toolName: a.toolName || "",
-      toolArgs: a.toolArgs || "",
+      toolArgs: a.toolArgs || "{}",
     }));
 
     if (approvals.length === 0) {


### PR DESCRIPTION
Root cause: For tools with empty schemas (EnterPlanMode, ExitPlanMode), the server doesn't send an `arguments` field in the stream. This caused toolArgs to remain as "" (empty string), and JSON.parse("") throws "JSON Parse error: Unexpected EOF".

Fixes:
1. stream.ts: Default empty toolArgs to "{}" when packaging approvals
2. approval-execution.ts: Add EnterPlanMode/ExitPlanMode to PARALLEL_SAFE_TOOLS (they don't need resource key extraction, avoiding the parse entirely)
3. approval-execution.ts: Wrap remaining JSON.parse calls in try/catch

🐾 Generated with [Letta Code](https://letta.com)