### PR TITLE
fix: ensure tool return text wrapping respects left column padding

### DIFF
--- a/src/cli/components/PlanRenderer.tsx
+++ b/src/cli/components/PlanRenderer.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type React from "react";
+import { useTerminalWidth } from "../hooks/useTerminalWidth.js";
 import { colors } from "./colors.js";
 
 interface PlanItem {
@@ -16,14 +17,22 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
   plan,
   explanation,
 }) => {
+  const columns = useTerminalWidth();
+  const prefixWidth = 5; // "  ⎿  " or "     "
+  const contentWidth = Math.max(0, columns - prefixWidth);
+
   return (
     <Box flexDirection="column">
       {explanation && (
-        <Box>
-          <Text>{"  ⎿  "}</Text>
-          <Text italic dimColor>
-            {explanation}
-          </Text>
+        <Box flexDirection="row">
+          <Box width={prefixWidth} flexShrink={0}>
+            <Text>{"  ⎿  "}</Text>
+          </Box>
+          <Box flexGrow={1} width={contentWidth}>
+            <Text italic dimColor wrap="wrap">
+              {explanation}
+            </Text>
+          </Box>
         </Box>
       )}
       {plan.map((item, index) => {
@@ -34,21 +43,21 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
         if (item.status === "completed") {
           // Green with strikethrough
           textElement = (
-            <Text color={colors.todo.completed} strikethrough>
+            <Text color={colors.todo.completed} strikethrough wrap="wrap">
               {checkbox} {item.step}
             </Text>
           );
         } else if (item.status === "in_progress") {
           // Blue bold
           textElement = (
-            <Text color={colors.todo.inProgress} bold>
+            <Text color={colors.todo.inProgress} bold wrap="wrap">
               {checkbox} {item.step}
             </Text>
           );
         } else {
           // Plain text for pending
           textElement = (
-            <Text>
+            <Text wrap="wrap">
               {checkbox} {item.step}
             </Text>
           );
@@ -58,9 +67,13 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
         const prefix = index === 0 && !explanation ? "  ⎿  " : "     ";
 
         return (
-          <Box key={`${index}-${item.step.slice(0, 20)}`}>
-            <Text>{prefix}</Text>
-            {textElement}
+          <Box key={`${index}-${item.step.slice(0, 20)}`} flexDirection="row">
+            <Box width={prefixWidth} flexShrink={0}>
+              <Text>{prefix}</Text>
+            </Box>
+            <Box flexGrow={1} width={contentWidth}>
+              {textElement}
+            </Box>
           </Box>
         );
       })}

--- a/src/cli/components/TodoRenderer.tsx
+++ b/src/cli/components/TodoRenderer.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type React from "react";
+import { useTerminalWidth } from "../hooks/useTerminalWidth.js";
 import { colors } from "./colors.js";
 
 interface TodoItem {
@@ -14,6 +15,10 @@ interface TodoRendererProps {
 }
 
 export const TodoRenderer: React.FC<TodoRendererProps> = ({ todos }) => {
+  const columns = useTerminalWidth();
+  const prefixWidth = 5; // "  ⎿  " or "     "
+  const contentWidth = Math.max(0, columns - prefixWidth);
+
   return (
     <Box flexDirection="column">
       {todos.map((todo, index) => {
@@ -24,21 +29,21 @@ export const TodoRenderer: React.FC<TodoRendererProps> = ({ todos }) => {
         if (todo.status === "completed") {
           // Green with strikethrough
           textElement = (
-            <Text color={colors.todo.completed} strikethrough>
+            <Text color={colors.todo.completed} strikethrough wrap="wrap">
               {checkbox} {todo.content}
             </Text>
           );
         } else if (todo.status === "in_progress") {
           // Blue bold (like code formatting)
           textElement = (
-            <Text color={colors.todo.inProgress} bold>
+            <Text color={colors.todo.inProgress} bold wrap="wrap">
               {checkbox} {todo.content}
             </Text>
           );
         } else {
           // Plain text for pending
           textElement = (
-            <Text>
+            <Text wrap="wrap">
               {checkbox} {todo.content}
             </Text>
           );
@@ -48,9 +53,13 @@ export const TodoRenderer: React.FC<TodoRendererProps> = ({ todos }) => {
         const prefix = index === 0 ? "  ⎿  " : "     ";
 
         return (
-          <Box key={todo.id || index}>
-            <Text>{prefix}</Text>
-            {textElement}
+          <Box key={todo.id || index} flexDirection="row">
+            <Box width={prefixWidth} flexShrink={0}>
+              <Text>{prefix}</Text>
+            </Box>
+            <Box flexGrow={1} width={contentWidth}>
+              {textElement}
+            </Box>
           </Box>
         );
       })}


### PR DESCRIPTION
Use two-column layout with explicit widths in diff renderers so wrapped lines stay aligned instead of going to column 0. Also wrap word-diff fragments in parent <Text> element for proper text flow.

Affected components:
- MemoryDiffRenderer (memory tool diffs)
- DiffRenderer (file edit/write diffs)
- TodoRenderer (todo list items)
- PlanRenderer (plan items)

🐾 Generated with [Letta Code](https://letta.com)