### PR TITLE
fix: replace low-contrast blue with primaryAccent color

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -57,6 +57,7 @@ import { ApprovalDialog } from "./components/ApprovalDialogRich";
 import { AssistantMessage } from "./components/AssistantMessageRich";
 import { BashCommandMessage } from "./components/BashCommandMessage";
 import { CommandMessage } from "./components/CommandMessage";
+import { colors } from "./components/colors";
 import { EnterPlanModeDialog } from "./components/EnterPlanModeDialog";
 import { ErrorMessage } from "./components/ErrorMessageRich";
 import { FeedbackDialog } from "./components/FeedbackDialog";
@@ -5082,7 +5083,7 @@ Plan file path: ${planFilePath}`;
                   })}
                 </Text>
                 <Text dimColor>Resume this agent with:</Text>
-                <Text color="blue">letta --agent {agentId}</Text>
+                <Text color={colors.link.url}>letta --agent {agentId}</Text>
               </Box>
             )}
 

--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -75,12 +75,12 @@ export const colors = {
 
   link: {
     text: "cyan",
-    url: "blue",
+    url: brandColors.primaryAccent,
   },
 
   heading: {
     primary: "cyan",
-    secondary: "blue",
+    secondary: brandColors.primaryAccent,
   },
 
   // Status indicators
@@ -134,7 +134,7 @@ export const colors = {
   // Info/modal views
   info: {
     border: brandColors.primaryAccent,
-    prompt: "blue",
+    prompt: brandColors.primaryAccent,
   },
 
   // Diff rendering


### PR DESCRIPTION
The terminal "blue" color has poor contrast on dark backgrounds in iTerm2. Replace all uses with brandColors.primaryAccent (#8C8CF9) which is more visible.

Changed:
- link.url
- heading.secondary
- info.prompt
- hardcoded blue in App.tsx

🐾 Generated with [Letta Code](https://letta.com)