### PR TITLE
fix: improve diff text visibility on wrapped lines

### DIFF
--- a/src/cli/components/AdvancedDiffRenderer.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.tsx
@@ -158,6 +158,7 @@ function Line({
                   return (
                     <Text
                       key={`${kind}-${i}-${p.value.substring(0, 10)}`}
+                      backgroundColor={bgLine}
                       color={colors.diff.textOnDark}
                     >
                       {p.value}
@@ -181,6 +182,7 @@ function Line({
                   return (
                     <Text
                       key={`${kind}-${i}-${p.value.substring(0, 10)}`}
+                      backgroundColor={bgLine}
                       color={colors.diff.textOnDark}
                     >
                       {p.value}

--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -145,7 +145,7 @@ export const colors = {
     removedWordBg: "#7a2d2d",
     contextLineBg: undefined,
     textOnDark: "white",
-    textOnHighlight: "black",
+    textOnHighlight: "white",
     symbolAdd: "green",
     symbolRemove: "red",
     symbolContext: undefined,


### PR DESCRIPTION
- Change textOnHighlight from black to white for better visibility
- Add explicit backgroundColor to unchanged text segments to prevent dim text on wrapped portions

Note: Highlighted word background (bgWord) still not preserved on wrap due to Ink limitation with nested Text + wrap="wrap". Text is readable, just missing the lighter highlight background on wrapped portions.

🤖 Generated with [Letta Code](https://letta.com)