### PR TITLE
feat: shift+enter multi-line input support

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -939,7 +939,6 @@ export default function App({
   );
 
   // Core streaming function - iterative loop that processes conversation turns
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refs read .current dynamically
   const processConversation = useCallback(
     async (
       initialInput: Array<MessageCreate | ApprovalCreate>,

--- a/src/cli/components/HelpDialog.tsx
+++ b/src/cli/components/HelpDialog.tsx
@@ -69,6 +69,8 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
       { keys: "Tab", description: "Autocomplete command or file path" },
       { keys: "↓", description: "Navigate down / next command in history" },
       { keys: "↑", description: "Navigate up / previous command in history" },
+      { keys: "Shift+Enter", description: "Insert newline (multi-line input)" },
+      { keys: "Opt+Enter", description: "Insert newline (alternative)" },
       {
         keys: "Ctrl+C",
         description: "Interrupt operation / exit (double press)",

--- a/src/cli/utils/kittyProtocolDetector.ts
+++ b/src/cli/utils/kittyProtocolDetector.ts
@@ -1,0 +1,147 @@
+/**
+ * Detects and enables Kitty keyboard protocol support.
+ * Based on gemini-cli's implementation.
+ * See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+ */
+import * as fs from "node:fs";
+
+let detectionComplete = false;
+let kittySupported = false;
+let kittyEnabled = false;
+
+const DEBUG = process.env.LETTA_DEBUG_KITTY === "1";
+
+/**
+ * Detects Kitty keyboard protocol support.
+ * This function should be called once at app startup, before rendering.
+ */
+export async function detectAndEnableKittyProtocol(): Promise<void> {
+  if (detectionComplete) {
+    return;
+  }
+
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      detectionComplete = true;
+      resolve();
+      return;
+    }
+
+    const originalRawMode = process.stdin.isRaw;
+    if (!originalRawMode) {
+      process.stdin.setRawMode(true);
+    }
+
+    let responseBuffer = "";
+    let progressiveEnhancementReceived = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const finish = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      process.stdin.removeListener("data", handleData);
+      if (!originalRawMode) {
+        process.stdin.setRawMode(false);
+      }
+
+      // If the terminal explicitly answered the progressive enhancement query,
+      // treat it as supported.
+      if (progressiveEnhancementReceived) kittySupported = true;
+
+      // Best-effort: even when the query isn't supported (common in xterm.js),
+      // enabling may still work. So we enable whenever we're on a TTY.
+      // If unsupported, terminals will just ignore the escape.
+      if (process.stdout.isTTY) {
+        if (DEBUG) {
+          // eslint-disable-next-line no-console
+          console.error("[kitty] enabling protocol");
+        }
+
+        enableKittyKeyboardProtocol();
+        process.on("exit", disableKittyKeyboardProtocol);
+        process.on("SIGTERM", disableKittyKeyboardProtocol);
+        process.on("SIGINT", disableKittyKeyboardProtocol);
+      } else if (DEBUG && !kittySupported) {
+        // eslint-disable-next-line no-console
+        console.error(
+          "[kitty] protocol query unsupported; enabled anyway (best-effort)",
+        );
+      }
+
+      detectionComplete = true;
+      resolve();
+    };
+
+    const handleData = (data: Buffer) => {
+      if (timeoutId === undefined) {
+        // Race condition. We have already timed out.
+        return;
+      }
+      responseBuffer += data.toString();
+
+      if (DEBUG) {
+        // eslint-disable-next-line no-console
+        console.error("[kitty] rx:", JSON.stringify(data.toString()));
+      }
+
+      // Check for progressive enhancement response (CSI ? <flags> u)
+      if (responseBuffer.includes("\x1b[?") && responseBuffer.includes("u")) {
+        progressiveEnhancementReceived = true;
+        // Give more time to get the full set of kitty responses
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(finish, 1000);
+      }
+
+      // Check for device attributes response (CSI ? <attrs> c)
+      if (responseBuffer.includes("\x1b[?") && responseBuffer.includes("c")) {
+        // If we also got progressive enhancement, we can be confident.
+        if (progressiveEnhancementReceived) kittySupported = true;
+
+        finish();
+      }
+    };
+
+    process.stdin.on("data", handleData);
+
+    // Query progressive enhancement and device attributes.
+    // Many terminals (including VS Code/xterm.js) will only start reporting
+    // enhanced keys after this handshake.
+    if (DEBUG) {
+      // eslint-disable-next-line no-console
+      console.error("[kitty] querying support");
+    }
+    fs.writeSync(process.stdout.fd, "\x1b[?u\x1b[c");
+
+    // Timeout after 200ms
+    timeoutId = setTimeout(finish, 200);
+  });
+}
+
+export function isKittyProtocolEnabled(): boolean {
+  return kittyEnabled;
+}
+
+function enableKittyKeyboardProtocol() {
+  try {
+    // Enable keyboard progressive enhancement flags.
+    // Use 7 (=1|2|4): DISAMBIGUATE_ESCAPE_CODES | REPORT_EVENT_TYPES | REPORT_ALTERNATE_KEYS
+    // This matches what crossterm-based TUIs (e.g., codex) request.
+    fs.writeSync(process.stdout.fd, "\x1b[>7u");
+    kittyEnabled = true;
+  } catch {
+    // Ignore errors
+  }
+}
+
+function disableKittyKeyboardProtocol() {
+  try {
+    if (kittyEnabled) {
+      fs.writeSync(process.stdout.fd, "\x1b[<u");
+      kittyEnabled = false;
+    }
+  } catch {
+    // Ignore errors
+  }
+}

--- a/src/cli/utils/terminalKeybindingInstaller.ts
+++ b/src/cli/utils/terminalKeybindingInstaller.ts
@@ -1,0 +1,326 @@
+/**
+ * Terminal keybinding installer for VS Code/Cursor/Windsurf
+ * Installs Shift+Enter keybinding that sends ESC+CR for multi-line input
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+
+export type TerminalType = "vscode" | "cursor" | "windsurf" | null;
+
+interface VSCodeKeybinding {
+  key: string;
+  command: string;
+  args?: Record<string, unknown>;
+  when?: string;
+}
+
+/**
+ * Detect terminal type from environment variables
+ */
+export function detectTerminalType(): TerminalType {
+  // Check for Cursor first (it sets TERM_PROGRAM=vscode for compatibility)
+  if (process.env.CURSOR_TRACE_ID || process.env.CURSOR_CHANNEL) {
+    return "cursor";
+  }
+
+  // Check for Windsurf
+  if (process.env.WINDSURF_TRACE_ID || process.env.WINDSURF_CHANNEL) {
+    return "windsurf";
+  }
+
+  const termProgram = process.env.TERM_PROGRAM?.toLowerCase();
+
+  if (termProgram === "vscode") return "vscode";
+  if (termProgram === "cursor") return "cursor";
+  if (termProgram === "windsurf") return "windsurf";
+
+  // Fallback checks
+  if (process.env.VSCODE_INJECTION === "1") return "vscode";
+
+  return null;
+}
+
+/**
+ * Check if running in a VS Code-like terminal (xterm.js-based)
+ */
+export function isVSCodeLikeTerminal(): boolean {
+  return detectTerminalType() !== null;
+}
+
+/**
+ * Get platform-specific path to keybindings.json
+ */
+export function getKeybindingsPath(terminal: TerminalType): string | null {
+  if (!terminal) return null;
+
+  const appName = {
+    vscode: "Code",
+    cursor: "Cursor",
+    windsurf: "Windsurf",
+  }[terminal];
+
+  const os = platform();
+
+  if (os === "darwin") {
+    return join(
+      homedir(),
+      "Library",
+      "Application Support",
+      appName,
+      "User",
+      "keybindings.json",
+    );
+  }
+
+  if (os === "win32") {
+    const appData = process.env.APPDATA;
+    if (!appData) return null;
+    return join(appData, appName, "User", "keybindings.json");
+  }
+
+  if (os === "linux") {
+    return join(homedir(), ".config", appName, "User", "keybindings.json");
+  }
+
+  return null;
+}
+
+/**
+ * The keybinding we install - Shift+Enter sends ESC+CR
+ */
+const SHIFT_ENTER_KEYBINDING: VSCodeKeybinding = {
+  key: "shift+enter",
+  command: "workbench.action.terminal.sendSequence",
+  args: { text: "\u001b\r" },
+  when: "terminalFocus",
+};
+
+/**
+ * Strip single-line and multi-line comments from JSONC
+ * Also handles trailing commas
+ */
+function stripJsonComments(jsonc: string): string {
+  // Remove single-line comments (// ...)
+  let result = jsonc.replace(/\/\/.*$/gm, "");
+
+  // Remove multi-line comments (/* ... */)
+  result = result.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // Remove trailing commas before ] or }
+  result = result.replace(/,(\s*[}\]])/g, "$1");
+
+  return result;
+}
+
+/**
+ * Parse keybindings.json (handles JSONC with comments)
+ */
+function parseKeybindings(content: string): VSCodeKeybinding[] | null {
+  try {
+    const stripped = stripJsonComments(content);
+    const parsed = JSON.parse(stripped);
+    if (!Array.isArray(parsed)) return null;
+    return parsed as VSCodeKeybinding[];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if our Shift+Enter keybinding already exists
+ */
+export function keybindingExists(keybindingsPath: string): boolean {
+  if (!existsSync(keybindingsPath)) return false;
+
+  try {
+    const content = readFileSync(keybindingsPath, { encoding: "utf-8" });
+    const keybindings = parseKeybindings(content);
+
+    if (!keybindings) return false;
+
+    return keybindings.some(
+      (kb) =>
+        kb.key?.toLowerCase() === "shift+enter" &&
+        kb.command === "workbench.action.terminal.sendSequence" &&
+        kb.when?.includes("terminalFocus"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create backup of keybindings.json
+ */
+function createBackup(keybindingsPath: string): string | null {
+  if (!existsSync(keybindingsPath)) return null;
+
+  const backupPath = `${keybindingsPath}.letta-backup`;
+  try {
+    copyFileSync(keybindingsPath, backupPath);
+    return backupPath;
+  } catch {
+    // Backup failed, but we can continue without it
+    return null;
+  }
+}
+
+export interface InstallResult {
+  success: boolean;
+  error?: string;
+  backupPath?: string;
+  alreadyExists?: boolean;
+}
+
+/**
+ * Install the Shift+Enter keybinding
+ */
+export function installKeybinding(keybindingsPath: string): InstallResult {
+  try {
+    // Check if already exists
+    if (keybindingExists(keybindingsPath)) {
+      return { success: true, alreadyExists: true };
+    }
+
+    // Ensure parent directory exists
+    const parentDir = dirname(keybindingsPath);
+    if (!existsSync(parentDir)) {
+      mkdirSync(parentDir, { recursive: true });
+    }
+
+    let keybindings: VSCodeKeybinding[] = [];
+    let backupPath: string | null = null;
+
+    // Read existing keybindings if file exists
+    if (existsSync(keybindingsPath)) {
+      backupPath = createBackup(keybindingsPath);
+
+      const content = readFileSync(keybindingsPath, { encoding: "utf-8" });
+      const parsed = parseKeybindings(content);
+
+      if (parsed === null) {
+        return {
+          success: false,
+          error: `Could not parse ${keybindingsPath}. Please fix syntax errors and try again.`,
+        };
+      }
+
+      keybindings = parsed;
+    }
+
+    // Add our keybinding
+    keybindings.push(SHIFT_ENTER_KEYBINDING);
+
+    // Write back
+    const newContent = `${JSON.stringify(keybindings, null, 2)}\n`;
+    writeFileSync(keybindingsPath, newContent, { encoding: "utf-8" });
+
+    return {
+      success: true,
+      backupPath: backupPath ?? undefined,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: `Failed to install keybinding: ${message}`,
+    };
+  }
+}
+
+/**
+ * Remove the Shift+Enter keybinding we installed
+ */
+export function removeKeybinding(keybindingsPath: string): InstallResult {
+  try {
+    if (!existsSync(keybindingsPath)) {
+      return { success: true }; // Nothing to remove
+    }
+
+    const content = readFileSync(keybindingsPath, { encoding: "utf-8" });
+    const keybindings = parseKeybindings(content);
+
+    if (!keybindings) {
+      return {
+        success: false,
+        error: `Could not parse ${keybindingsPath}`,
+      };
+    }
+
+    // Filter out our keybinding
+    const filtered = keybindings.filter(
+      (kb) =>
+        !(
+          kb.key?.toLowerCase() === "shift+enter" &&
+          kb.command === "workbench.action.terminal.sendSequence" &&
+          kb.when?.includes("terminalFocus")
+        ),
+    );
+
+    // Write back
+    const newContent = `${JSON.stringify(filtered, null, 2)}\n`;
+    writeFileSync(keybindingsPath, newContent, { encoding: "utf-8" });
+
+    return { success: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: `Failed to remove keybinding: ${message}`,
+    };
+  }
+}
+
+/**
+ * Convenience function to install keybinding for current terminal
+ */
+export function installKeybindingForCurrentTerminal(): InstallResult {
+  const terminal = detectTerminalType();
+  if (!terminal) {
+    return {
+      success: false,
+      error: "Not running in a VS Code-like terminal",
+    };
+  }
+
+  const path = getKeybindingsPath(terminal);
+  if (!path) {
+    return {
+      success: false,
+      error: `Could not determine keybindings.json path for ${terminal}`,
+    };
+  }
+
+  return installKeybinding(path);
+}
+
+/**
+ * Convenience function to remove keybinding for current terminal
+ */
+export function removeKeybindingForCurrentTerminal(): InstallResult {
+  const terminal = detectTerminalType();
+  if (!terminal) {
+    return {
+      success: false,
+      error: "Not running in a VS Code-like terminal",
+    };
+  }
+
+  const path = getKeybindingsPath(terminal);
+  if (!path) {
+    return {
+      success: false,
+      error: `Could not determine keybindings.json path for ${terminal}`,
+    };
+  }
+
+  return removeKeybinding(path);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,9 @@ export interface Settings {
   globalSharedBlockIds: Record<string, string>; // label -> blockId mapping (persona, human; style moved to project settings)
   permissions?: PermissionRules;
   env?: Record<string, string>;
+  // Shift+Enter keybinding state (for VS Code/Cursor/Windsurf)
+  // Tracks if we've auto-installed the keybinding (or if user already had it)
+  shiftEnterKeybindingInstalled?: boolean;
 }
 
 export interface ProjectSettings {

--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -14,6 +14,9 @@ function isControlSequence(input, key) {
     if (key.tab || (key.ctrl && input === 'c')) return true;
     if (key.shift && key.tab) return true;
 
+    // Modifier+Enter - handled by parent for newline insertion
+    if (key.return && (key.shift || key.meta || key.ctrl)) return true;
+
     // Ctrl+W (delete word) - handled by parent component
     if (key.ctrl && (input === 'w' || input === 'W')) return true;
 


### PR DESCRIPTION
Adds multi-line input via Shift+Enter across all major terminals:

- VS Code/Cursor/Windsurf: Auto-installs keybinding on first startup
- Native terminals (Kitty/Ghostty): Handles kitty keyboard protocol
- iTerm2: Works via Option as Meta (built-in)
- WezTerm: Works with `enable_kitty_keyboard = true` in config

👾 Generated with [Letta Code](https://letta.com)