### PR TITLE
feat: add --name/-n option to resume agent by name

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5412,7 +5412,14 @@ Plan file path: ${planFilePath}`;
                   })}
                 </Text>
                 <Text dimColor>Resume this agent with:</Text>
-                <Text color={colors.link.url}>letta --agent {agentId}</Text>
+                <Text color={colors.link.url}>
+                  {/* Show -n "name" if agent has name and is pinned, otherwise --agent */}
+                  {agentName &&
+                  (settingsManager.getLocalPinnedAgents().includes(agentId) ||
+                    settingsManager.getGlobalPinnedAgents().includes(agentId))
+                    ? `letta -n "${agentName}"`
+                    : `letta --agent ${agentId}`}
+                </Text>
               </Box>
             )}
 


### PR DESCRIPTION
Adds a new CLI option to resume an agent by name from pinned agents:
- `letta --name "Big Chungus"` or `letta -n bananagram`
- Case-insensitive exact matching
- Searches both local and global pinned agents
- If multiple agents match, picks most recently used (LRU)
- Shows helpful error with available agents if no match found

Also updates exit message to show `letta -n "name"` instead of `letta --agent <id>` when the agent has a name and is pinned.

🤖 Generated with [Letta Code](https://letta.com)