### PR TITLE
feat: allow read-only shell commands in plan mode

### DIFF
--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -1,6 +1,8 @@
 // src/permissions/mode.ts
 // Permission mode management (default, acceptEdits, plan, bypassPermissions)
 
+import { isReadOnlyShellCommand } from "./readOnlyShell";
+
 export type PermissionMode =
   | "default"
   | "acceptEdits"
@@ -191,6 +193,23 @@ class PermissionModeManager {
           }
 
           if (planFilePath && targetPath && targetPath === planFilePath) {
+            return "allow";
+          }
+        }
+
+        // Allow read-only shell commands (ls, git status, git log, etc.)
+        const shellTools = [
+          "Bash",
+          "shell",
+          "Shell",
+          "shell_command",
+          "ShellCommand",
+          "run_shell_command",
+          "RunShellCommand",
+        ];
+        if (shellTools.includes(toolName)) {
+          const command = toolArgs?.command as string | string[] | undefined;
+          if (command && isReadOnlyShellCommand(command)) {
             return "allow";
           }
         }


### PR DESCRIPTION
Git read commands (status, diff, log, show, branch, tag, remote) and other read-only shell commands (ls, cat, grep, etc.) are now allowed in plan mode. This leverages the existing isReadOnlyShellCommand logic.

🤖 Generated with [Letta Code](https://letta.com)