### PR TITLE
perf: use hash-based caching for toolset swap upserts

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -5,6 +5,19 @@ import { LETTA_CLOUD_API_URL, refreshAccessToken } from "../auth/oauth";
 import { ensureAnthropicProviderToken } from "../providers/anthropic-provider";
 import { settingsManager } from "../settings-manager";
 
+/**
+ * Get the current Letta server URL from environment or settings.
+ * Used for cache keys and API operations.
+ */
+export function getServerUrl(): string {
+  const settings = settingsManager.getSettings();
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    LETTA_CLOUD_API_URL
+  );
+}
+
 export async function getClient() {
   const settings = settingsManager.getSettings();
 


### PR DESCRIPTION
Previously, toolset switching always re-uploaded all tools to the server unconditionally, vs startup already used hash-based caching via upsertToolsIfNeeded() to skip redundant uploads.

This change updates forceToolsetSwitch() and switchToolsetForModel() to use the same caching mechanism. Tools are only re-uploaded when the hash of loaded tools differs from the cached hash for the server URL.

Also adds getServerUrl() helper to client.ts to avoid duplicating the URL resolution logic.

🤖 Generated with [Letta Code](https://letta.com)