### PR TITLE
fix: prevent post-cancel chunks from rendering after ESC interrupt

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1095,8 +1095,13 @@ export default function App({
           sessionStatsRef.current.endTurn(apiDurationMs);
           sessionStatsRef.current.updateUsageFromBuffers(buffersRef.current);
 
-          // Immediate refresh after stream completes to show final state
-          refreshDerived();
+          const wasInterrupted = !!buffersRef.current.interrupted;
+
+          // Immediate refresh after stream completes to show final state unless
+          // the user already cancelled (handleInterrupt rendered the UI).
+          if (!wasInterrupted) {
+            refreshDerived();
+          }
 
           // Case 1: Turn ended normally
           if (stopReason === "end_turn") {

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -219,6 +219,13 @@ function extractTextPart(v: unknown): string {
 
 // Feed one SDK chunk; mutate buffers in place.
 export function onChunk(b: Buffers, chunk: LettaStreamingResponse) {
+  // Skip processing if stream was interrupted mid-turn. handleInterrupt already
+  // rendered the cancellation state, so we should ignore any buffered chunks
+  // that arrive before drainStream exits.
+  if (b.interrupted) {
+    return;
+  }
+
   // TODO remove once SDK v1 has proper typing for in-stream errors
   // Check for streaming error objects (not typed in SDK but emitted by backend)
   // Note: Error handling moved to catch blocks in App.tsx and headless.ts

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -71,6 +71,9 @@ export async function drainStream(
   } else if (abortSignal?.aborted) {
     // Already aborted before we started
     abortedViaListener = true;
+    if (stream.controller && !stream.controller.signal.aborted) {
+      stream.controller.abort();
+    }
   }
 
   try {


### PR DESCRIPTION
When user presses ESC to cancel a streaming response, the spinner would disappear but content could continue appearing due to a race condition:

1. handleInterrupt sets interrupted=true and renders cancelled state
2. drainStream loop may still yield buffered chunks from SDK
3. Line 1099 refreshDerived() was called unconditionally after drain, re-rendering all buffer data including post-abort chunks

This commit adds three defensive fixes:

- Add `interrupted` check to onChunk() to skip buffered chunks after cancel
- Guard refreshDerived() at line 1099 to skip when wasInterrupted=true
- Abort SDK stream controller when signal is already aborted (edge case)

🐾 Generated with [Letta Code](https://letta.com)