### PR TITLE
fix: reset interrupted flag before stream resume

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -332,6 +332,12 @@ export async function drainStreamWithResume(
 
     try {
       const client = await getClient();
+
+      // Reset interrupted flag so resumed chunks can be processed by onChunk.
+      // Without this, tool_return_message for server-side tools (web_search, fetch_webpage)
+      // would be silently ignored, showing "Interrupted by user" even on successful resume.
+      buffers.interrupted = false;
+
       // Resume from Redis where we left off
       const resumeStream = await client.runs.messages.stream(result.lastRunId, {
         starting_after: result.lastSeqId,


### PR DESCRIPTION
Server-side tools (web_search, fetch_webpage) were showing "Interrupted by user" even when they completed successfully. This happened because:

1. Stream error occurred → markIncompleteToolsAsCancelled set interrupted=true and resultText="Interrupted by user"
2. Stream resume succeeded, but resumed chunks were ignored by onChunk because interrupted was still true
3. Tool results stayed as "Interrupted by user" even though backend had the actual results

The fix resets interrupted=false before attempting resume, allowing tool_return_message chunks to be processed and overwrite the placeholder.

🐾 Generated with [Letta Code](https://letta.com)