### PR TITLE
fix: update CI matrix from GLM 4.6 to GLM 4.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         # Note: gemini-3-flash temporarily disabled due to instability
-        model: [gpt-5-minimal, gpt-4.1, sonnet-4.5, gemini-pro, glm-4.6, haiku]
+        model: [gpt-5-minimal, gpt-4.1, sonnet-4.5, gemini-pro, glm-4.7, haiku]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Updates CI test matrix from GLM 4.6 to GLM 4.7

## Why
GLM 4.6 has been consistently flaking in CI tests (#437).

## Test plan
- CI will run with GLM 4.7 instead of GLM 4.6

Closes #437

🐾 Generated with [Letta Code](https://letta.com)