### PR TITLE
fix: patch server-side tools showing up as interrupted

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -72,6 +72,7 @@ export type Buffers = {
   lastOtid: string | null; // Track the last otid to detect transitions
   pendingRefresh?: boolean; // Track throttled refresh state
   interrupted?: boolean; // Track if stream was interrupted by user (skip stale refreshes)
+  commitGeneration?: number; // Incremented when resuming from error to invalidate pending refreshes
   usage: {
     promptTokens: number;
     completionTokens: number;
@@ -90,6 +91,7 @@ export function createBuffers(): Buffers {
     pendingToolByRun: new Map(),
     toolCallIdToLineId: new Map(),
     lastOtid: null,
+    commitGeneration: 0,
     usage: {
       promptTokens: 0,
       completionTokens: 0,

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -336,6 +336,9 @@ export async function drainStreamWithResume(
       // Reset interrupted flag so resumed chunks can be processed by onChunk.
       // Without this, tool_return_message for server-side tools (web_search, fetch_webpage)
       // would be silently ignored, showing "Interrupted by user" even on successful resume.
+      // Increment commitGeneration to invalidate any pending setTimeout refreshes that would
+      // commit the stale "Interrupted by user" state before the resume stream completes.
+      buffers.commitGeneration = (buffers.commitGeneration || 0) + 1;
       buffers.interrupted = false;
 
       // Resume from Redis where we left off


### PR DESCRIPTION
patch but where (1) markIncompleteToolsAsCancelled marks server-side tools as 'Interrupted by user', (2) A pending setTimeout(..., 16) (from any previous chunk) will fire (3) Resume resets interrupted = false BEFORE the await (4)  The setTimeout sees interrupted=false and commits the stale 'interrupted' state (5) Resume stream returns tool_return_message AFTER the line is committed. The fix: Added a commitGeneration counter that: (1) Is incremented when resuming from errors (stream.ts:341) (2) Is captured when scheduling setTimeout (App.tsx:811) (3) Is checked when setTimeout fires - if generation changed, skip the refresh (App.tsx:820)