### PR TITLE
fix: reset interrupted flag before retry to prevent silent stream drops

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1902,6 +1902,9 @@ export default function App({
                 (id) => id !== statusId,
               );
               refreshDerived();
+
+              // Reset interrupted flag so retry stream chunks are processed
+              buffersRef.current.interrupted = false;
               continue;
             }
 
@@ -1965,6 +1968,8 @@ export default function App({
             refreshDerived();
 
             if (!cancelled) {
+              // Reset interrupted flag so retry stream chunks are processed
+              buffersRef.current.interrupted = false;
               // Retry by continuing the while loop (same currentInput)
               continue;
             }


### PR DESCRIPTION
When a stream error occurred, markIncompleteToolsAsCancelled() set buffers.interrupted = true. On retry via continue, this flag was never reset, causing onChunk() to silently drop ALL chunks from the retry stream. This made approval desync recovery appear to hang silently - the recovery message was sent but all response chunks were ignored.

The interrupted flag was only reset at the start of processConversation (line 1248), not between retry iterations within the while loop.

Manual "keep going" worked because it triggered a fresh processConversation call which reset the flag.

🤖 Generated with [Letta Code](https://letta.com)