### PR TITLE
fix: remove extra newline above SubagentGroupDisplay during execution

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5727,7 +5727,7 @@ Plan file path: ${planFilePath}`;
   ]);
 
   return (
-    <Box key={resumeKey} flexDirection="column" gap={1}>
+    <Box key={resumeKey} flexDirection="column">
       <Static
         key={staticRenderEpoch}
         items={staticItems}
@@ -5776,7 +5776,7 @@ Plan file path: ${planFilePath}`;
         )}
       </Static>
 
-      <Box flexDirection="column" gap={1}>
+      <Box flexDirection="column">
         {/* Loading screen / intro text */}
         {loadingState !== "ready" && (
           <WelcomeScreen
@@ -6131,7 +6131,7 @@ Plan file path: ${planFilePath}`;
             )}
 
             {/* Input row - always mounted to preserve state */}
-            <Box marginTop={liveItems.length > 0 ? 0 : 1}>
+            <Box marginTop={1}>
               <Input
                 visible={
                   !showExitStats &&


### PR DESCRIPTION
Removes gap={1} from outer and inner Box containers which was causing double-spacing above SubagentGroupDisplay while tasks were running. Also makes Input marginTop consistent (always 1).

🤖 Generated with [Letta Code](https://letta.com)