### PR TITLE
fix: cache pending approval denials on ESC interrupt

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2234,7 +2234,19 @@ export default function App({
       }
       refreshDerived();
 
-      // Clear any pending approvals since we're cancelling
+      // Cache any pending approvals as denials to send with the next message
+      // This tells the server "I'm rejecting these approvals" so it doesn't stay stuck waiting
+      if (pendingApprovals.length > 0) {
+        const denialResults = pendingApprovals.map((approval) => ({
+          type: "approval" as const,
+          tool_call_id: approval.toolCallId,
+          approve: false,
+          reason: "User interrupted the stream",
+        }));
+        setQueuedApprovalResults(denialResults);
+      }
+
+      // Clear local approval state
       setPendingApprovals([]);
       setApprovalContexts([]);
       setApprovalResults([]);
@@ -2282,6 +2294,7 @@ export default function App({
     isExecutingTool,
     refreshDerived,
     setStreaming,
+    pendingApprovals,
   ]);
 
   // Keep ref to latest processConversation to avoid circular deps in useEffect


### PR DESCRIPTION
When user presses ESC during a pending approval prompt, the client was clearing local approval state but not informing the server. This left the server stuck waiting for an approval response, causing the app to brick when the user tried to send a new message.

Now we cache pending approvals as denial results in queuedApprovalResults before clearing local state. When the user sends their next message, the denial is sent first, clearing the server's pending state.

This follows the same pattern already used by "Cancel all" (line 5152) and queue-cancel handlers (lines 1493, 1728).

🐛 Generated with [Letta Code](https://letta.com)