### PR TITLE
feat: add refresh command to Task tool

### DIFF
--- a/src/tools/descriptions/Task.md
+++ b/src/tools/descriptions/Task.md
@@ -6,11 +6,21 @@ The Task tool launches specialized agents (subprocesses) that autonomously handl
 
 ## Usage
 
-When using the Task tool, you must specify:
+The Task tool supports two commands:
+
+### Run (default)
+Launch a subagent to perform a task. Parameters:
 - **subagent_type**: Which specialized agent to use (see Available Agents section)
 - **prompt**: Detailed, self-contained instructions for the agent (agents cannot ask questions mid-execution)
 - **description**: Short 3-5 word summary for tracking
 - **model** (optional): Override the model for this agent
+
+### Refresh
+Re-scan the `.letta/agents/` directories to discover new or updated custom subagents:
+```typescript
+Task({ command: "refresh" })
+```
+Use this after creating or modifying custom subagent definitions.
 
 ## When to use this tool:
 

--- a/src/tools/schemas/Task.json
+++ b/src/tools/schemas/Task.json
@@ -1,24 +1,28 @@
 {
   "type": "object",
   "properties": {
+    "command": {
+      "type": "string",
+      "enum": ["run", "refresh"],
+      "description": "The operation to perform: \"run\" to spawn a subagent (default), \"refresh\" to re-scan the .letta/agents/ directories and update the available subagents list"
+    },
     "subagent_type": {
       "type": "string",
-      "description": "The type of specialized agent to use. Available agents are discovered from .letta/agents/ directory."
+      "description": "The type of specialized agent to use. Available agents are discovered from .letta/agents/ directory. Required for \"run\" command."
     },
     "prompt": {
       "type": "string",
-      "description": "The task for the agent to perform"
+      "description": "The task for the agent to perform. Required for \"run\" command."
     },
     "description": {
       "type": "string",
-      "description": "A short (3-5 word) description of the task"
+      "description": "A short (3-5 word) description of the task. Required for \"run\" command."
     },
     "model": {
       "type": "string",
       "description": "Optional model to use for this agent. If not specified, uses the recommended model for the subagent type."
     }
   },
-  "required": ["subagent_type", "prompt", "description"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }


### PR DESCRIPTION
## Summary
- Add `refresh` command to Task tool to re-discover custom subagents from `.letta/agents/` directories
- Matches the pattern used by the Skill tool's refresh command
- Enables creating new subagents without restarting the CLI

## Test plan
- [x] Create a custom subagent in `.letta/agents/`
- [x] Run `Task({ command: "refresh" })` 
- [x] Verify new subagent is discoverable and runnable
- [x] TypeScript compiles without errors
- [x] Build succeeds

Written by Cameron ◯ Letta Code

"The only way to do great work is to love what you do." - Steve Jobs