### PR TITLE
fix: Fix subagents not inheriting parent's tool permission rules

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -130,6 +130,17 @@ export async function handleHeadlessCommand(
     }
   }
 
+  // Set CLI permission overrides if provided (inherited from parent agent)
+  if (values.allowedTools || values.disallowedTools) {
+    const { cliPermissions } = await import("./permissions/cli");
+    if (values.allowedTools) {
+      cliPermissions.setAllowedTools(values.allowedTools as string);
+    }
+    if (values.disallowedTools) {
+      cliPermissions.setDisallowedTools(values.disallowedTools as string);
+    }
+  }
+
   // Check for input-format early - if stream-json, we don't need a prompt
   const inputFormat = values["input-format"] as string | undefined;
   const isBidirectionalMode = inputFormat === "stream-json";


### PR DESCRIPTION
The --allowedTools and --disallowedTools flags were being parsed in headless mode but never applied. This meant subagents spawned via the Task tool couldn't inherit their parent's permission grants, causing edits to fail silently (subagents can't request approval).

🐛 Generated with [Letta Code](https://letta.com)