### PR TITLE
fix: subagent display spacing and extra newline

### DIFF
--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -64,7 +64,7 @@ interface AgentRowProps {
 const AgentRow = memo(({ agent, isLast, expanded }: AgentRowProps) => {
   const { treeChar, continueChar } = getTreeChars(isLast);
   const columns = useTerminalWidth();
-  const gutterWidth = 6; // tree char (1) + " ⎿  " (5)
+  const gutterWidth = 7; // continueChar (3) + " ⎿  " (4)
   const contentWidth = Math.max(0, columns - gutterWidth);
 
   const getDotElement = () => {
@@ -105,17 +105,9 @@ const AgentRow = memo(({ agent, isLast, expanded }: AgentRowProps) => {
       {/* Subagent URL */}
       {agent.agentURL && (
         <Box flexDirection="row">
-          <Box width={gutterWidth} flexShrink={0}>
-            <Text>
-              <Text color={colors.subagent.treeChar}>{continueChar}</Text>
-              <Text dimColor>{" ⎿  "}</Text>
-            </Text>
-          </Box>
-          <Box flexGrow={1} width={contentWidth}>
-            <Text wrap="wrap" dimColor>
-              Subagent: {agent.agentURL}
-            </Text>
-          </Box>
+          <Text color={colors.subagent.treeChar}>{continueChar}</Text>
+          <Text dimColor>{" ⎿  Subagent: "}</Text>
+          <Text dimColor>{agent.agentURL}</Text>
         </Box>
       )}
 
@@ -198,7 +190,7 @@ const GroupHeader = memo(
     return (
       <Box flexDirection="row">
         {allCompleted ? (
-          <Text color={dotColor}>⏺</Text>
+          <Text color={dotColor}>●</Text>
         ) : (
           <BlinkDot color={colors.subagent.header} />
         )}

--- a/src/cli/components/SubagentGroupStatic.tsx
+++ b/src/cli/components/SubagentGroupStatic.tsx
@@ -51,7 +51,7 @@ interface AgentRowProps {
 const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
   const { treeChar, continueChar } = getTreeChars(isLast);
   const columns = useTerminalWidth();
-  const gutterWidth = 6; // tree char (1) + " ⎿  " (5)
+  const gutterWidth = 7; // continueChar (3) + " ⎿  " (4)
   const contentWidth = Math.max(0, columns - gutterWidth);
 
   const dotColor =
@@ -76,17 +76,9 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
       {/* Subagent URL */}
       {agent.agentURL && (
         <Box flexDirection="row">
-          <Box width={gutterWidth} flexShrink={0}>
-            <Text>
-              <Text color={colors.subagent.treeChar}>{continueChar}</Text>
-              <Text dimColor>{" ⎿  "}</Text>
-            </Text>
-          </Box>
-          <Box flexGrow={1} width={contentWidth}>
-            <Text wrap="wrap" dimColor>
-              Subagent: {agent.agentURL}
-            </Text>
-          </Box>
+          <Text color={colors.subagent.treeChar}>{continueChar}</Text>
+          <Text dimColor>{" ⎿  Subagent: "}</Text>
+          <Text dimColor>{agent.agentURL}</Text>
         </Box>
       )}
 
@@ -141,7 +133,7 @@ export const SubagentGroupStatic = memo(
       <Box flexDirection="column">
         {/* Header */}
         <Box flexDirection="row">
-          <Text color={dotColor}>⏺</Text>
+          <Text color={dotColor}>●</Text>
           <Text color={colors.subagent.header}> {statusText}</Text>
         </Box>
 


### PR DESCRIPTION
- Fixed gutterWidth from 6 to 7 (continueChar is 3 chars, not 1)
- Simplified URL row to match status row pattern - removed Box wrappers that were causing an extra blank line between URL and status
- Changed header dot from ⏺ (2 columns) to ● (1 column) to fix spacing
- Both Display and Static components now use consistent simple layout

🐛 Generated with [Letta Code](https://letta.com)