### PR TITLE
feat: allow Skill tool in plan mode for load/unload/refresh commands

### DIFF
--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -214,6 +214,15 @@ class PermissionModeManager {
           }
         }
 
+        // Allow Skill tool with read-only commands (load, unload, refresh)
+        // These commands only modify memory blocks, not files
+        if (toolName === "Skill" || toolName === "skill") {
+          const command = toolArgs?.command as string | undefined;
+          if (command && ["load", "unload", "refresh"].includes(command)) {
+            return "allow";
+          }
+        }
+
         // Allow read-only shell commands (ls, git status, git log, etc.)
         const shellTools = [
           "Bash",


### PR DESCRIPTION
Allow the Skill tool to be used in plan mode when the command is one of:
- `load` - Adds skill content to memory (read-only)
- `unload` - Removes skill content from memory (read-only)
- `refresh` - Re-scans skills directory (read-only)

Fixes #500

Generated with [Letta Code](https://letta.com)