### PR TITLE
feat: show line count summary for Read tool results

### DIFF
--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -13,6 +13,7 @@ import {
 import {
   getDisplayToolName,
   isFileEditTool,
+  isFileReadTool,
   isFileWriteTool,
   isMemoryTool,
   isPatchTool,
@@ -545,6 +546,28 @@ export const ToolCallMessage = memo(
         } catch {
           // If parsing fails, fall through to regular handling
         }
+      }
+
+      // Check if this is a file read tool - show line count summary
+      if (
+        isFileReadTool(rawName) &&
+        line.resultOk !== false &&
+        line.resultText
+      ) {
+        // Count lines in the result (the content returned by Read tool)
+        const lineCount = line.resultText.split("\n").length;
+        return (
+          <Box flexDirection="row">
+            <Box width={prefixWidth} flexShrink={0}>
+              <Text>{prefix}</Text>
+            </Box>
+            <Box flexGrow={1} width={contentWidth}>
+              <Text>
+                Read <Text bold>{lineCount}</Text> lines
+              </Text>
+            </Box>
+          </Box>
+        );
       }
 
       // Regular result handling


### PR DESCRIPTION
Instead of showing raw file content in tool results, display a concise "Read N lines" summary with the line count bolded. Applies to all Read tool variants: Read, read_file, read_file_gemini, ReadManyFiles, etc.

🐛 Generated with [Letta Code](https://letta.com)