### PR TITLE
fix: remove userCancelledViaESC check that broke all tool approvals

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5370,13 +5370,11 @@ DO NOT respond to these messages or otherwise consider them in your response unl
         refreshDerived();
 
         const wasAborted = approvalAbortController.signal.aborted;
-        // Distinguish between ESC (user cancelled) vs queue-cancel (new message sent):
-        // - ESC: handleInterrupt nulls abortControllerRef.current
-        // - Queue-cancel: abortControllerRef.current still exists
-        // The 50ms userCancelledRef timeout is too short for long-running tools (subagents),
-        // so we check if abortControllerRef was nulled instead.
-        const userCancelledViaESC = abortControllerRef.current === null;
-        const userCancelled = userCancelledRef.current || userCancelledViaESC;
+        // Check if user cancelled via ESC. We use wasAborted (toolAbortController was aborted)
+        // as the primary signal, plus userCancelledRef for cancellations that happen just before
+        // tools complete. Note: we can't use `abortControllerRef.current === null` because
+        // abortControllerRef is also null in the normal approval flow (no stream running).
+        const userCancelled = userCancelledRef.current;
 
         if (wasAborted || userCancelled) {
           // Queue results to send alongside the next user message (if not cancelled entirely)


### PR DESCRIPTION
## Summary

- Fixes critical regression from #506 where all tool approvals hang
- The `abortControllerRef.current === null` check fires during normal approval flow (not just ESC)
- Removes the problematic check; relies on `wasAborted` and `userCancelledRef` instead

## Root Cause

When the approval dialog is shown, `processConversation` returns and sets `abortControllerRef.current = null` in its finally block. So when the user approves and `sendAllResults` runs, the check `abortControllerRef.current === null` is true, causing the code to incorrectly think ESC was pressed.

## Test plan

- [x] Build passes
- [x] Lint passes  
- [x] Typecheck passes
- [ ] Manual test: approve a tool call (Read, Bash, etc.) - should continue instead of hanging
- [ ] Manual test: answer AskUserQuestion - should continue instead of hanging
- [ ] Manual test: ESC during subagent execution - should still cancel properly

🐛 Generated with [Letta Code](https://letta.com)