### PR TITLE
fix: await token persistence to prevent authentication loop

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -100,6 +100,10 @@ export function SetupUI({ onComplete }: SetupUIProps) {
               tokenExpiresAt: now + tokens.expires_in * 1000,
             });
 
+            // Wait for all pending writes (keychain, disk) to complete before continuing
+            // This prevents a race condition where main() validation runs before tokens are persisted
+            await settingsManager.flush();
+
             setMode("done");
             setTimeout(() => onComplete(), 1000);
           } catch (err) {


### PR DESCRIPTION
Race condition where OAuth setup would complete before tokens were written to keychain, causing immediate validation failure and infinite setup loop.

Fix: Added await settingsManager.flush() after updateSettings() to ensure all async writes complete before recursive main() call validates credentials.