### PR TITLE
fix: add retry for Anthropic streaming connection errors

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -255,6 +255,7 @@ async function isRetriableError(
         "overloaded", // anthropic_client.py:753 - used for LLMProviderOverloaded
         "api_error", // Anthropic SDK error type field
         "Network error", // Transient network failures during streaming
+        "Connection error during Anthropic streaming", // Peer disconnections, incomplete chunked reads
       ];
       if (llmProviderPatterns.some((pattern) => detail.includes(pattern))) {
         return true;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1173,6 +1173,7 @@ export async function handleHeadlessCommand(
             "overloaded", // anthropic_client.py:753 - used for LLMProviderOverloaded
             "api_error", // Anthropic SDK error type field
             "Network error", // Transient network failures during streaming
+            "Connection error during Anthropic streaming", // Peer disconnections, incomplete chunked reads
           ];
           const isLlmErrorFromDetail = llmProviderPatterns.some((pattern) =>
             detail.includes(pattern),


### PR DESCRIPTION
Add "Connection error during Anthropic streaming" to retriable error patterns. This handles transient errors when Anthropic's server closes the connection mid-stream (e.g., "peer closed connection without sending complete message body").

🐾 Generated with [Letta Code](https://letta.com)