### PR TITLE
feat: add /plan command and allow gh commands in plan mode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4818,6 +4818,27 @@ export default function App({
           return { submitted: true };
         }
 
+        // Special handling for /plan command - enter plan mode
+        if (trimmed === "/plan") {
+          // Generate plan file path and enter plan mode
+          const planPath = generatePlanFilePath();
+          permissionMode.setPlanFilePath(planPath);
+          permissionMode.setMode("plan");
+          setUiPermissionMode("plan");
+
+          // Add status message to transcript
+          const statusId = uid("status");
+          buffersRef.current.byId.set(statusId, {
+            kind: "status",
+            id: statusId,
+            lines: [`Plan mode enabled. Plan file: ${planPath}`],
+          });
+          buffersRef.current.order.push(statusId);
+          refreshDerived();
+
+          return { submitted: true };
+        }
+
         // Special handling for /init command - initialize agent memory
         if (trimmed === "/init") {
           // Check for pending approvals before sending

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -68,9 +68,17 @@ export const commands: Record<string, Command> = {
       return "Opening message search...";
     },
   },
+  "/plan": {
+    desc: "Enter plan mode",
+    order: 17,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Entering plan mode...";
+    },
+  },
   "/clear": {
     desc: "Start a new conversation (keep agent memory)",
-    order: 17,
+    order: 18,
     handler: () => {
       // Handled specially in App.tsx to create new conversation
       return "Starting new conversation...";
@@ -78,7 +86,7 @@ export const commands: Record<string, Command> = {
   },
   "/clear-messages": {
     desc: "Reset all agent messages (destructive)",
-    order: 18,
+    order: 19,
     hidden: true, // Advanced command, not shown in autocomplete
     handler: () => {
       // Handled specially in App.tsx to reset agent messages

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -61,6 +61,70 @@ describe("isReadOnlyShellCommand", () => {
     });
   });
 
+  describe("gh commands", () => {
+    test("allows read-only gh pr commands", () => {
+      expect(isReadOnlyShellCommand("gh pr list")).toBe(true);
+      expect(isReadOnlyShellCommand("gh pr view 123")).toBe(true);
+      expect(isReadOnlyShellCommand("gh pr diff 123")).toBe(true);
+      expect(isReadOnlyShellCommand("gh pr checks 123")).toBe(true);
+      expect(isReadOnlyShellCommand("gh pr status")).toBe(true);
+      expect(
+        isReadOnlyShellCommand(
+          "gh pr list --state merged --limit 20 --json number,title",
+        ),
+      ).toBe(true);
+    });
+
+    test("blocks write gh pr commands", () => {
+      expect(isReadOnlyShellCommand("gh pr create")).toBe(false);
+      expect(isReadOnlyShellCommand("gh pr merge 123")).toBe(false);
+      expect(isReadOnlyShellCommand("gh pr close 123")).toBe(false);
+      expect(isReadOnlyShellCommand("gh pr edit 123")).toBe(false);
+    });
+
+    test("allows read-only gh issue commands", () => {
+      expect(isReadOnlyShellCommand("gh issue list")).toBe(true);
+      expect(isReadOnlyShellCommand("gh issue view 123")).toBe(true);
+      expect(isReadOnlyShellCommand("gh issue status")).toBe(true);
+    });
+
+    test("blocks write gh issue commands", () => {
+      expect(isReadOnlyShellCommand("gh issue create")).toBe(false);
+      expect(isReadOnlyShellCommand("gh issue close 123")).toBe(false);
+    });
+
+    test("allows gh search commands", () => {
+      expect(isReadOnlyShellCommand("gh search repos letta")).toBe(true);
+      expect(isReadOnlyShellCommand("gh search issues bug")).toBe(true);
+      expect(isReadOnlyShellCommand("gh search prs fix")).toBe(true);
+    });
+
+    test("allows gh api commands", () => {
+      expect(isReadOnlyShellCommand("gh api repos/owner/repo")).toBe(true);
+      expect(
+        isReadOnlyShellCommand("gh api repos/owner/repo/pulls/123/comments"),
+      ).toBe(true);
+    });
+
+    test("allows gh status command", () => {
+      expect(isReadOnlyShellCommand("gh status")).toBe(true);
+    });
+
+    test("blocks unsafe gh categories", () => {
+      expect(isReadOnlyShellCommand("gh auth login")).toBe(false);
+      expect(isReadOnlyShellCommand("gh config set")).toBe(false);
+      expect(isReadOnlyShellCommand("gh secret set")).toBe(false);
+    });
+
+    test("blocks bare gh", () => {
+      expect(isReadOnlyShellCommand("gh")).toBe(false);
+    });
+
+    test("blocks gh with unknown category", () => {
+      expect(isReadOnlyShellCommand("gh unknown")).toBe(false);
+    });
+  });
+
   describe("find command", () => {
     test("allows safe find", () => {
       expect(isReadOnlyShellCommand("find . -name '*.js'")).toBe(true);


### PR DESCRIPTION
- Add /plan slash command to enter plan mode from the CLI
- Add SAFE_GH_COMMANDS allowlist for GitHub CLI commands in plan mode
  - Allows read-only commands: pr list/view/diff, issue list/view, repo list/view, run list/view, search, api, status
  - Blocks write commands: pr create/merge, issue create/close, etc.
- Add comprehensive tests for gh command permission checking

🐾 Generated with [Letta Code](https://letta.com)