### PR TITLE
fix: restore pending approvals when using /resume command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4409,6 +4409,33 @@ export default function App({
                   setStaticItems([separator, successItem]);
                   setLines(toLines(buffersRef.current));
                 }
+
+                // Restore pending approvals if any (fixes #540 for /resume command)
+                if (resumeData.pendingApprovals.length > 0) {
+                  setPendingApprovals(resumeData.pendingApprovals);
+
+                  // Analyze approval contexts (same logic as startup)
+                  try {
+                    const contexts = await Promise.all(
+                      resumeData.pendingApprovals.map(async (approval) => {
+                        const parsedArgs = safeJsonParseOr<
+                          Record<string, unknown>
+                        >(approval.toolArgs, {});
+                        return await analyzeToolApproval(
+                          approval.toolName,
+                          parsedArgs,
+                        );
+                      }),
+                    );
+                    setApprovalContexts(contexts);
+                  } catch (approvalError) {
+                    // If analysis fails, leave context as null (will show basic options)
+                    console.error(
+                      "Failed to analyze resume approvals:",
+                      approvalError,
+                    );
+                  }
+                }
               }
             } catch (error) {
               const errorCmdId = uid("cmd");
@@ -7511,6 +7538,35 @@ Plan file path: ${planFilePath}`;
                         };
                         setStaticItems([separator, successItem]);
                         setLines(toLines(buffersRef.current));
+                      }
+
+                      // Restore pending approvals if any (fixes #540 for ConversationSelector)
+                      if (resumeData.pendingApprovals.length > 0) {
+                        setPendingApprovals(resumeData.pendingApprovals);
+
+                        // Analyze approval contexts (same logic as startup)
+                        try {
+                          const contexts = await Promise.all(
+                            resumeData.pendingApprovals.map(
+                              async (approval) => {
+                                const parsedArgs = safeJsonParseOr<
+                                  Record<string, unknown>
+                                >(approval.toolArgs, {});
+                                return await analyzeToolApproval(
+                                  approval.toolName,
+                                  parsedArgs,
+                                );
+                              },
+                            ),
+                          );
+                          setApprovalContexts(contexts);
+                        } catch (approvalError) {
+                          // If analysis fails, leave context as null (will show basic options)
+                          console.error(
+                            "Failed to analyze resume approvals:",
+                            approvalError,
+                          );
+                        }
                       }
                     }
                   } catch (error) {


### PR DESCRIPTION
The /resume command and ConversationSelector were calling getResumeData() but only using messageHistory, ignoring pendingApprovals. This caused the approval UI to not appear when resuming a conversation that had a pending tool approval.

Added setPendingApprovals() calls to both /resume paths to restore approval state correctly.

🐾 Generated with [Letta Code](https://letta.com)