### PR TITLE
fix: use conversation-scoped cancel instead of agent-scoped

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@letta-ai/letta-client": "1.6.7",
+        "@letta-ai/letta-client": "^1.6.8",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "open": "^10.2.0",
@@ -36,7 +36,7 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.6.7", "", {}, "sha512-BFpD9s7G+XnZY6fd5mjQfSc9ua9uCM11sNI/nKAZougk5dKK3FwS1RofxUfuLPX0/mNteyivSL2/SYiwBszyRw=="],
+    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.6.8", "", {}, "sha512-FscN1/c03uGByxD2nnnQ6/DMch234UQVlZJcoamU7ElFqv0ESNXb/3zpjL/SreTEUqk7IzrAp2bw5u/ILMt0UA=="],
 
     "@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@letta-ai/letta-client": "1.6.7",
+    "@letta-ai/letta-client": "^1.6.8",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",
     "open": "^10.2.0"

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2799,7 +2799,9 @@ export default function App({
       // Send cancel request to backend asynchronously (fire-and-forget)
       // Don't wait for it or show errors since user already got feedback
       getClient()
-        .then((client) => client.agents.messages.cancel(agentId))
+        .then((client) =>
+          client.conversations.cancel(conversationIdRef.current),
+        )
         .catch(() => {
           // Silently ignore - cancellation already happened client-side
         });
@@ -2818,7 +2820,7 @@ export default function App({
       setInterruptRequested(true);
       try {
         const client = await getClient();
-        await client.agents.messages.cancel(agentId);
+        await client.conversations.cancel(conversationIdRef.current);
 
         if (abortControllerRef.current) {
           abortControllerRef.current.abort();
@@ -3400,7 +3402,9 @@ export default function App({
 
             // Send cancel request to backend (fire-and-forget)
             getClient()
-              .then((client) => client.agents.messages.cancel(agentId))
+              .then((client) =>
+                client.conversations.cancel(conversationIdRef.current),
+              )
               .then(() => {})
               .catch(() => {
                 // Reset flag if cancel fails


### PR DESCRIPTION
Previously, pressing ESC to interrupt called `client.agents.messages.cancel(agentId)` which cancels ALL active runs for the agent across ALL conversations. This means interrupting one conversation would also cancel any other concurrent conversations.

Now uses `client.conversations.cancel(conversationId)` which only cancels the specific conversation's run, leaving other conversations unaffected.

Also bumps @letta-ai/letta-client to 1.6.8 which adds the conversations.cancel() API.

🤖 Generated with [Letta Code](https://letta.com)