### PR TITLE
fix: fix stale memory command

### DIFF
--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -99,7 +99,9 @@ export function MemoryTabViewer({
 
     if (key.leftArrow) {
       const prevIndex =
-        selectedTabIndex === 0 ? displayBlocks.length - 1 : selectedTabIndex - 1;
+        selectedTabIndex === 0
+          ? displayBlocks.length - 1
+          : selectedTabIndex - 1;
       switchTab(prevIndex);
       return;
     }


### PR DESCRIPTION
Fixes stale memory display in the /memory CLI command by fetching fresh memory blocks from the API on component mount