### PR TITLE
fix: auto-create missing skills blocks when resuming older agents

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -16,7 +16,7 @@ import {
 import { getClient } from "./agent/client";
 import { initializeLoadedSkillsFlag, setAgentContext } from "./agent/context";
 import { createAgent } from "./agent/create";
-import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
+import { ensureSkillsBlocks, ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import { sendMessageStream } from "./agent/message";
 import { getModelUpdateArgs } from "./agent/model";
 import { SessionStats } from "./agent/stats";
@@ -528,6 +528,12 @@ export async function handleHeadlessCommand(
     agentId: agent.id,
     conversationId,
   });
+
+  // Ensure the agent has the required skills blocks (for backwards compatibility)
+  const createdBlocks = await ensureSkillsBlocks(agent.id);
+  if (createdBlocks.length > 0) {
+    console.log("Created missing skills blocks for agent compatibility");
+  }
 
   // Set agent context for tools that need it (e.g., Skill tool, Task tool)
   setAgentContext(agent.id, skillsDirectory);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { getResumeData, type ResumeData } from "./agent/check-approval";
 import { getClient } from "./agent/client";
 import { initializeLoadedSkillsFlag, setAgentContext } from "./agent/context";
 import type { AgentProvenance } from "./agent/create";
-import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
+import { ensureSkillsBlocks, ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import { LETTA_CLOUD_API_URL } from "./auth/oauth";
 import { ConversationSelector } from "./cli/components/ConversationSelector";
 import type { ApprovalRequest } from "./cli/helpers/stream";
@@ -1226,6 +1226,12 @@ async function main(): Promise<void> {
         // Save agent ID to both project and global settings
         settingsManager.updateLocalProjectSettings({ lastAgent: agent.id });
         settingsManager.updateSettings({ lastAgent: agent.id });
+
+        // Ensure the agent has the required skills blocks (for backwards compatibility)
+        const createdBlocks = await ensureSkillsBlocks(agent.id);
+        if (createdBlocks.length > 0) {
+          console.log("Created missing skills blocks for agent compatibility");
+        }
 
         // Set agent context for tools that need it (e.g., Skill tool)
         setAgentContext(agent.id, skillsDirectory);


### PR DESCRIPTION
When resuming an agent created before skills were added, the CLI would crash with a 400 error because `conversations.create()` tried to isolate blocks that didn't exist. Now we detect missing skills/loaded_skills blocks and auto-create them with default values before any operations.

🤖 Generated with [Letta Code](https://letta.com)