### PR TITLE
fix: Task tool subagent spawn and isolated block labels

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -3,7 +3,7 @@ name: recall
 description: Search conversation history to recall past discussions, decisions, and context
 tools: Skill, Bash, Read, BashOutput
 model: haiku
-memoryBlocks: human, persona
+memoryBlocks: human, persona, skills, loaded_skills
 mode: stateless
 ---
 

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -308,7 +308,7 @@ function buildSubagentArgs(
   userPrompt: string,
 ): string[] {
   const args: string[] = [
-    "--new",
+    "--new-agent",
     "--system",
     type,
     "--model",

--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -290,7 +290,7 @@ export const SubagentGroupDisplay = memo(() => {
   const hasErrors = agents.some((a) => a.status === "error");
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" marginTop={1}>
       <GroupHeader
         count={agents.length}
         allCompleted={allCompleted}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -471,6 +471,16 @@ export async function handleHeadlessCommand(
   // Determine which conversation to use
   let conversationId: string;
 
+  // Only isolate blocks that actually exist on this agent
+  // If initBlocks is undefined, agent has default blocks (all ISOLATED_BLOCK_LABELS exist)
+  // If initBlocks is defined, only isolate blocks that are in both lists
+  const isolatedBlockLabels: string[] =
+    initBlocks === undefined
+      ? [...ISOLATED_BLOCK_LABELS]
+      : ISOLATED_BLOCK_LABELS.filter((label) =>
+          initBlocks.includes(label as string),
+        );
+
   if (specifiedConversationId) {
     // User specified a conversation to resume
     try {
@@ -496,7 +506,7 @@ export async function handleHeadlessCommand(
         // Conversation no longer exists, create new
         const conversation = await client.conversations.create({
           agent_id: agent.id,
-          isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
+          isolated_block_labels: isolatedBlockLabels,
         });
         conversationId = conversation.id;
       }
@@ -504,7 +514,7 @@ export async function handleHeadlessCommand(
       // No matching session, create new conversation
       const conversation = await client.conversations.create({
         agent_id: agent.id,
-        isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
+        isolated_block_labels: isolatedBlockLabels,
       });
       conversationId = conversation.id;
     }
@@ -513,7 +523,7 @@ export async function handleHeadlessCommand(
     // This ensures isolated message history per CLI invocation
     const conversation = await client.conversations.create({
       agent_id: agent.id,
-      isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
+      isolated_block_labels: isolatedBlockLabels,
     });
     conversationId = conversation.id;
   }


### PR DESCRIPTION
- Fix --new to --new-agent in manager.ts after CLI flag rename
- Add skills/loaded_skills to recall subagent memoryBlocks (uses Skill tool)
- Dynamically compute isolated_block_labels based on initBlocks
  - Only isolate blocks that actually exist on the agent
  - Fixes 400 error when creating conversations for agents without skills blocks
- Add marginTop to SubagentGroupDisplay for consistent spacing
- Add CI test for Task tool with explore subagent

🐾 Generated with [Letta Code](https://letta.com)