### PR TITLE
fix: improve skill loading feedback to prevent subagent hallucination

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -16,7 +16,7 @@ You are a subagent launched via the Task tool to search conversation history. Yo
 Skill({ command: "load", skills: ["searching-messages"] })
 ```
 
-The skill content will appear in your loaded_skills block with script paths and search strategies.
+After loading, your `loaded_skills` memory block contains the full instructions with ready-to-use bash commands. Follow them directly - do not search for files or guess at commands.
 
 ### Step 2: Search the parent agent's history
 

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -324,7 +324,9 @@ export async function skill(args: SkillArgs): Promise<SkillResult> {
 
         // Now we can report success
         for (const skillId of preparedSkills) {
-          results.push(`"${skillId}" loaded`);
+          results.push(
+            `"${skillId}" loaded. Contents have been placed into your memory - check your 'loaded_skills' block for instructions.`,
+          );
         }
 
         // Update the cached flag


### PR DESCRIPTION
- Skill tool now returns explicit message directing agent to check loaded_skills block
- Updated recall subagent prompt to emphasize following loaded instructions directly

🐛 Generated with [Letta Code](https://letta.com)