### PR TITLE
fix: prevent subagents from polluting LRU settings

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -529,15 +529,19 @@ export async function handleHeadlessCommand(
   }
 
   // Save session (agent + conversation) to both project and global settings
-  await settingsManager.loadLocalProjectSettings();
-  settingsManager.setLocalLastSession(
-    { agentId: agent.id, conversationId },
-    process.cwd(),
-  );
-  settingsManager.setGlobalLastSession({
-    agentId: agent.id,
-    conversationId,
-  });
+  // Skip for subagents - they shouldn't pollute the LRU settings
+  const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
+  if (!isSubagent) {
+    await settingsManager.loadLocalProjectSettings();
+    settingsManager.setLocalLastSession(
+      { agentId: agent.id, conversationId },
+      process.cwd(),
+    );
+    settingsManager.setGlobalLastSession({
+      agentId: agent.id,
+      conversationId,
+    });
+  }
 
   // Ensure the agent has the required skills blocks (for backwards compatibility)
   const createdBlocks = await ensureSkillsBlocks(agent.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1458,14 +1458,18 @@ async function main(): Promise<void> {
         }
 
         // Save the session (agent + conversation) to settings
-        settingsManager.setLocalLastSession(
-          { agentId: agent.id, conversationId: conversationIdToUse },
-          process.cwd(),
-        );
-        settingsManager.setGlobalLastSession({
-          agentId: agent.id,
-          conversationId: conversationIdToUse,
-        });
+        // Skip for subagents - they shouldn't pollute the LRU settings
+        const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
+        if (!isSubagent) {
+          settingsManager.setLocalLastSession(
+            { agentId: agent.id, conversationId: conversationIdToUse },
+            process.cwd(),
+          );
+          settingsManager.setGlobalLastSession({
+            agentId: agent.id,
+            conversationId: conversationIdToUse,
+          });
+        }
 
         setAgentId(agent.id);
         setAgentState(agent);


### PR DESCRIPTION
Subagents spawned via the Task tool were updating the lastSession in settings.json, causing the CLI to boot into "Nameless Agent" instead of the user's actual agent on next startup.

Now checks LETTA_CODE_AGENT_ROLE env var before saving session - subagents skip the LRU save entirely.

👾 Generated with [Letta Code](https://letta.com)