### PR TITLE
fix: prevent approval from reappearing after interrupt during execution

### DIFF
--- a/src/cli/components/StreamingOutputDisplay.tsx
+++ b/src/cli/components/StreamingOutputDisplay.tsx
@@ -23,10 +23,13 @@ export const StreamingOutputDisplay = memo(
     const { tailLines, totalLineCount } = streaming;
     const hiddenCount = Math.max(0, totalLineCount - tailLines.length);
 
-    // No output yet - don't show anything
     const firstLine = tailLines[0];
     if (!firstLine) {
-      return null;
+      return (
+        <Box>
+          <Text dimColor>{`  ⎿  Running... (${elapsed}s)`}</Text>
+        </Box>
+      );
     }
 
     return (


### PR DESCRIPTION
When a user approves a tool and then interrupts during execution (ESC), the approval would reappear on the next message because the server was never notified about the interruption.

Root cause: If bash execution hangs (e.g., process ignores SIGTERM), executeApprovalBatch never returns, so results were never queued.

Changes:
- Track executing tool call IDs in a ref during sendAllResults
- Queue tool results immediately in handleInterrupt (don't wait for hung execution to complete)
- Add interruptQueuedRef to prevent double-queueing
- Add SIGKILL fallback in Bash.ts if SIGTERM doesn't kill process
- Show "Running... (Xs)" for shell commands with no output yet

🐾 Generated with [Letta Code](https://letta.com)