### PR TITLE
fix: add include option when retrieving agents for memory blocks

### DIFF
--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -49,7 +49,9 @@ export function MemoryTabViewer({
     const fetchBlocks = async () => {
       try {
         const client = await getClient();
-        const agent = await client.agents.retrieve(agentId);
+        const agent = await client.agents.retrieve(agentId, {
+          include: ["agent.blocks"],
+        });
         setFreshBlocks(agent.memory?.blocks || []);
       } catch (error) {
         console.error("Failed to fetch memory blocks:", error);

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -120,7 +120,9 @@ function ProfileSelectionUI({
       const fetchedOptions = await Promise.all(
         optionsToFetch.map(async (opt) => {
           try {
-            const agent = await client.agents.retrieve(opt.agentId);
+            const agent = await client.agents.retrieve(opt.agentId, {
+              include: ["agent.blocks"],
+            });
             return { ...opt, agent };
           } catch {
             return { ...opt, agent: null };


### PR DESCRIPTION
## Summary
- Add `include: ["agent.blocks"]` to `agents.retrieve()` calls in MemoryTabViewer and profile-selection
- Fixes issue where memory blocks show as empty when using SDK 1.0+ against Letta Server 0.13.0+

## Problem
Letta Server 0.13.0 introduced SDK version detection that defaults `include_relationships = []` for SDK 1.0+ clients. This means memory blocks are no longer returned by default - clients must explicitly request them via the `include` parameter.

Two components were affected:
- `/memory` command showed "No memory blocks attached" even when blocks exist
- Profile selector showed "0 memory blocks" for all agents

## Test plan
- [x] Verified fix against local Letta Server 0.16.2
- [x] Without `include`: 0 blocks returned
- [x] With `include: ["agent.blocks"]`: 8 blocks returned
- [x] Tested `/memory` command displays blocks correctly
- [x] Tested profile selector shows correct block count

🤖 Generated with [Claude Code](https://claude.ai/code)