### PR TITLE
feat: show conversation resume hint in exit stats

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7462,6 +7462,11 @@ Plan file path: ${planFilePath}`;
                     ? `letta -n "${agentName}"`
                     : `letta --agent ${agentId}`}
                 </Text>
+                <Text> </Text>
+                <Text dimColor>Resume this conversation with:</Text>
+                <Text color={colors.link.url}>
+                  {`letta --conv ${conversationId}`}
+                </Text>
               </Box>
             )}
 


### PR DESCRIPTION
Add "Resume this conversation with: letta --conv <id>" to the exit stats display, making it easier for users to continue a specific conversation.

🤖 Generated with [Letta Code](https://letta.com)