### PR TITLE
feat: add support for default conversation via --conv default

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -18,6 +18,10 @@ export const STREAM_REQUEST_START_TIME = Symbol("streamRequestStartTime");
 /**
  * Send a message to a conversation and return a streaming response.
  * Uses the conversations API for proper message isolation per session.
+ *
+ * For the "default" conversation (agent's primary message history without
+ * an explicit conversation object), pass conversationId="default" and
+ * provide agentId in opts. This uses the agents messages API instead.
  */
 export async function sendMessageStream(
   conversationId: string,
@@ -25,7 +29,7 @@ export async function sendMessageStream(
   opts: {
     streamTokens?: boolean;
     background?: boolean;
-    // add more later: includePings, request timeouts, etc.
+    agentId?: string; // Required when conversationId is "default"
   } = { streamTokens: true, background: true },
   // TODO: Re-enable once issues are resolved - disabled retries were causing problems
   // Disable SDK retries by default - state management happens outside the stream,
@@ -37,17 +41,47 @@ export async function sendMessageStream(
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;
 
   const client = await getClient();
-  const stream = await client.conversations.messages.create(
-    conversationId,
-    {
-      messages: messages,
-      streaming: true,
-      stream_tokens: opts.streamTokens ?? true,
-      background: opts.background ?? true,
-      client_tools: getClientToolsFromRegistry(),
-    },
-    requestOptions,
-  );
+
+  let stream: Stream<LettaStreamingResponse>;
+
+  if (process.env.DEBUG) {
+    console.log(
+      `[DEBUG] sendMessageStream: conversationId=${conversationId}, useAgentsRoute=${conversationId === "default"}`,
+    );
+  }
+
+  if (conversationId === "default") {
+    // Use agents route for default conversation (agent's primary message history)
+    if (!opts.agentId) {
+      throw new Error(
+        "agentId is required in opts when using default conversation",
+      );
+    }
+    stream = await client.agents.messages.create(
+      opts.agentId,
+      {
+        messages: messages,
+        streaming: true,
+        stream_tokens: opts.streamTokens ?? true,
+        background: opts.background ?? true,
+        client_tools: getClientToolsFromRegistry(),
+      },
+      requestOptions,
+    );
+  } else {
+    // Use conversations route for explicit conversations
+    stream = await client.conversations.messages.create(
+      conversationId,
+      {
+        messages: messages,
+        streaming: true,
+        stream_tokens: opts.streamTokens ?? true,
+        background: opts.background ?? true,
+        client_tools: getClientToolsFromRegistry(),
+      },
+      requestOptions,
+    );
+  }
 
   // Attach start time to stream for TTFT calculation in drainStream
   if (requestStartTime !== undefined) {

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1729,6 +1729,7 @@ export default function App({
             stream = await sendMessageStream(
               conversationIdRef.current,
               currentInput,
+              { agentId: agentIdRef.current },
             );
           } catch (preStreamError) {
             // Check if this is a pre-stream approval desync error

--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -79,7 +79,7 @@ export const AgentInfoBar = memo(function AgentInfoBar({
         <Text dimColor>{"  "}</Text>
         {isCloudUser && (
           <Link
-            url={`https://app.letta.com/agents/${agentId}${conversationId ? `?conversation=${conversationId}` : ""}`}
+            url={`https://app.letta.com/agents/${agentId}${conversationId && conversationId !== "default" ? `?conversation=${conversationId}` : ""}`}
           >
             <Text>Open in ADE ↗</Text>
           </Link>


### PR DESCRIPTION
Adds ability to access an agent's primary message history (the "default" conversation) without creating an explicit conversation object.

Changes:
- sendMessageStream: branches on "default" to use agents API route
- check-approval: uses conversation_id=default param, sorts messages by date
- index.ts/headless.ts: --conv default flag, --conv agent-xxx shorthand
- ConversationSelector: shows default conversation at top of /resume list
- AgentInfoBar: omits ?conversation= param in ADE link for default

Fixes during review:
- Initialize messages=[] when backfill disabled (agent API path)
- Add conversation_id=default filter to ConversationSelector fetch

🐾 Generated with [Letta Code](https://letta.com)