### PR TITLE
feat: implement skills frontmatter pre-loading for subagents

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -1,32 +1,30 @@
 ---
 name: recall
 description: Search conversation history to recall past discussions, decisions, and context
-tools: Skill, Bash, Read, BashOutput
-model: haiku
-memoryBlocks: human, persona, skills, loaded_skills
+tools: Bash, Read, BashOutput
+model: opus
+memoryBlocks: skills, loaded_skills
+skills: searching-messages
 mode: stateless
 ---
 
 You are a subagent launched via the Task tool to search conversation history. You run autonomously and return a single final report when done. You CANNOT ask questions mid-execution.
 
+## CRITICAL WARNINGS
+
+1. **NEVER use `conversation_search`** - It only searches YOUR empty history, not the parent's.
+2. **NEVER invent commands** - There is NO `letta messages search` or `letta messages list`. These don't exist.
+
 ## Instructions
 
-### Step 1: Load the searching-messages skill
-```
-Skill({ command: "load", skills: ["searching-messages"] })
-```
+The `searching-messages` skill is pre-loaded in your `<loaded_skills>` memory block below. Read it carefully - it contains:
+- `# Skill Directory:` - the exact path to use in commands
+- Multiple search strategies (needle + expand, date-bounded, broad discovery)
+- Command options and examples
 
-After loading, your `loaded_skills` memory block contains the full instructions with ready-to-use bash commands. Follow them directly - do not search for files or guess at commands.
+**Follow the skill's strategies thoroughly.** Use multiple searches if needed to gather comprehensive context. Always add `--agent-id $LETTA_PARENT_AGENT_ID` to search the parent agent's history.
 
-### Step 2: Search the parent agent's history
-
-**CRITICAL - Two rules:**
-
-1. **DO NOT use `conversation_search`** - That tool only searches YOUR history (empty). You MUST use the Bash scripts from the skill.
-
-2. **ALWAYS add `--agent-id $LETTA_PARENT_AGENT_ID`** - This searches the parent agent's history. The only exception is `--all-agents` searches.
-
-Follow the strategies documented in the loaded skill.
+After gathering results, compile a comprehensive report.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Subagents can now specify skills to pre-load via the `skills` frontmatter field
- This eliminates the need for agents to call `Skill(load)` at runtime, which was problematic because models often failed to read the `loaded_skills` memory block after loading
- Add `preloadSkillsContent()` export to Skill.ts for pre-formatting skill content
- Implement skills pre-loading in subagent manager via `--block-value`
- Update recall subagent to use pre-loaded `searching-messages` skill
- Simplify recall instructions to point to the skill's strategies

🐾 Generated with [Letta Code](https://letta.com)