### PR TITLE
fix: remove hardcoded embedding model, let server use default

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -75,7 +75,7 @@ export interface CreateAgentOptions {
 export async function createAgent(
   nameOrOptions: string | CreateAgentOptions = DEFAULT_AGENT_NAME,
   model?: string,
-  embeddingModel = "openai/text-embedding-3-small",
+  embeddingModel?: string,
   updateArgs?: Record<string, unknown>,
   skillsDirectory?: string,
   parallelToolCalls = true,
@@ -104,8 +104,7 @@ export async function createAgent(
   }
 
   const name = options.name ?? DEFAULT_AGENT_NAME;
-  const embeddingModelVal =
-    options.embeddingModel ?? "openai/text-embedding-3-small";
+  const embeddingModelVal = options.embeddingModel;
   const parallelToolCallsVal = options.parallelToolCalls ?? true;
   const enableSleeptimeVal = options.enableSleeptime ?? false;
 
@@ -318,7 +317,7 @@ export async function createAgent(
     system: systemPromptContent,
     name,
     description: agentDescription,
-    embedding: embeddingModelVal,
+    embedding: embeddingModelVal || undefined,
     model: modelHandle,
     context_window_limit: contextWindow,
     tools: toolNames,


### PR DESCRIPTION
## Summary

- Remove hardcoded `openai/text-embedding-3-small` embedding model from `createAgent()`
- Let the server use its configured default embedding model instead
- Only pass `embedding` parameter to API if explicitly specified by user

This is a simpler, focused fix compared to the larger #313 which added model selection UI.

Fixes #566

🤖 Generated with [Letta Code](https://letta.com)