### PR TITLE
feat: add truncation to Task tool output and auto-cleanup overflow files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -362,6 +362,16 @@ async function main(): Promise<void> {
     // Silently ignore update failures
   });
 
+  // Clean up old overflow files (non-blocking, 24h retention)
+  const { cleanupOldOverflowFiles } = await import("./tools/impl/overflow");
+  Promise.resolve().then(() => {
+    try {
+      cleanupOldOverflowFiles(process.cwd());
+    } catch {
+      // Silently ignore cleanup failures
+    }
+  });
+
   // Parse command-line arguments (Bun-idiomatic approach using parseArgs)
   // Preprocess args to support --conv as alias for --conversation
   const processedArgs = process.argv.map((arg) =>

--- a/src/tools/impl/truncation.ts
+++ b/src/tools/impl/truncation.ts
@@ -10,6 +10,7 @@ import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
 export const LIMITS = {
   // Command output limits
   BASH_OUTPUT_CHARS: 30_000, // 30K characters for bash/shell output
+  TASK_OUTPUT_CHARS: 30_000, // 30K characters for subagent task output
 
   // File reading limits
   READ_MAX_LINES: 2_000, // Max lines per file read


### PR DESCRIPTION
## Summary

- Add 30K character limit to Task tool output (same as Bash tool)
- When truncated, writes full output to overflow file with notice pointing to it
- Make `cleanupOldOverflowFiles` robust (handles errors, skips subdirectories)
- Run cleanup on CLI startup (non-blocking, 24h retention)
- Add test for subdirectory handling in cleanup

Closes #585 - the reported "front-truncation" was likely server-side truncation of very long Task outputs. With client-side truncation + overflow files, users will get the truncated output with a pointer to the full content.

🐾 Generated with [Letta Code](https://letta.com)