### PR TITLE
feat: add skill for migrating from Codex and Claude Code

### DIFF
--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -181,6 +181,28 @@ If the user says "take as long as you need" or explicitly wants deep research, u
 - Config files (.eslintrc, tsconfig.json, .prettierrc)
 - CI/CD configs (.github/workflows/, .gitlab-ci.yml)
 
+**Historical session research** (Claude Code / Codex):
+The user may have previous coding sessions from Claude Code (`~/.claude/`) or OpenAI Codex (`~/.codex/`) that contain valuable context about this project. This can reveal:
+- What problems they've worked on before
+- Their coding patterns and preferences
+- Project-specific knowledge from past sessions
+
+To check for and search historical data:
+```bash
+# Check if history exists
+ls ~/.claude/projects 2>/dev/null && echo "Claude Code history found"
+ls ~/.codex/sessions 2>/dev/null && echo "Codex history found"
+
+# Find sessions for this project (Claude - encode path)
+ENCODED=$(pwd | sed 's|/|-|g')
+ls ~/.claude/projects/$ENCODED/ 2>/dev/null
+
+# Search prompts mentioning this project
+cat ~/.claude/history.jsonl | jq -r "select(.project | contains(\"$(basename $(pwd))\")) | .display" | head -20
+```
+
+For detailed guidance on searching historical sessions, load the `migrating-from-codex-and-claude-code` skill which includes ready-to-use scripts.
+
 **Git-based research** (if in a git repo):
 - `git log --oneline -20` - Recent commit history and patterns
 - `git branch -a` - Branching strategy
@@ -227,13 +249,15 @@ You should ask these questions at the start (bundle them together in one AskUser
 1. **Research depth**: "Standard or deep research (comprehensive, as long as needed)?"
 2. **Identity**: "Which contributor are you?" (You can often infer this from git logs - e.g., if git shows "cpacker" as a top contributor, ask "Are you cpacker?")
 3. **Related repos**: "Are there other repositories I should know about and consider in my research?" (e.g., backend monorepo, shared libraries)
-4. **Memory updates**: "How often should I check if I should update my memory?" with options "Frequent (every 3-5 turns)" and "Occasional (every 8-10 turns)". This should be a binary question with "Memory" as the header.
-5. **Communication style**: "Terse or detailed responses?"
-6. **Any specific rules**: "Rules I should always follow?"
+4. **Historical sessions**: "Should I search your Claude Code or Codex history for context about this project?" (Check if `~/.claude` or `~/.codex` exist first - only ask if they do)
+5. **Memory updates**: "How often should I check if I should update my memory?" with options "Frequent (every 3-5 turns)" and "Occasional (every 8-10 turns)". This should be a binary question with "Memory" as the header.
+6. **Communication style**: "Terse or detailed responses?"
+7. **Any specific rules**: "Rules I should always follow?"
 
 **Why these matter:**
 - Identity lets you correlate git history to the user (their commits, PRs, coding style)
 - Related repos provide crucial context (many projects span multiple repos)
+- Historical sessions from Claude Code/Codex can reveal past work, preferences, and project knowledge the user has already discussed with other AI assistants
 - Workflow/communication style should be stored in the `human` block
 - Rules go in `persona` block
 

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/SKILL.md
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: Migrating from Codex and Claude Code
+description: Find and search historical conversation data from Claude Code and OpenAI Codex CLIs. Use when you need to understand a user's coding patterns, learn about a project from past sessions, or bootstrap agent memory from historical context.
+---
+
+# Migrating from Codex and Claude Code
+
+This skill helps you discover, search, and extract useful information from historical Claude Code and OpenAI Codex conversations stored on the user's machine.
+
+## When to Use This Skill
+
+- During `/init` to bootstrap agent memory with project context
+- When the user asks about their previous coding sessions
+- To understand coding patterns, preferences, or project history
+- To find context about a specific project or problem the user worked on before
+
+## Scripts
+
+This skill includes ready-to-use scripts for common operations:
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/detect.sh` | Detect available history and show summary |
+| `scripts/list-sessions.sh` | List sessions for a project |
+| `scripts/search.sh` | Search across all history by keyword |
+| `scripts/view-session.sh` | View a session in readable format |
+
+### Quick Start
+
+```bash
+# Detect what history data exists
+./scripts/detect.sh
+
+# List sessions for current project
+./scripts/list-sessions.sh claude
+./scripts/list-sessions.sh codex
+
+# Search for a keyword across all history
+./scripts/search.sh "database migration"
+./scripts/search.sh "auth" --claude --project /path/to/project
+
+# View a specific session
+./scripts/view-session.sh ~/.claude/projects/-path-to-project/session.jsonl
+./scripts/view-session.sh session.jsonl --tools --thinking
+```
+
+## Data Locations
+
+### Claude Code (`~/.claude/`)
+
+| Path | Contents |
+|------|----------|
+| `history.jsonl` | Global prompt history (all projects) - **always available** |
+| `projects/<encoded-path>/` | Per-project conversation sessions - **may not exist for older projects** |
+| `projects/<encoded-path>/sessions-index.json` | Quick session metadata lookup |
+| `projects/<encoded-path>/<session-uuid>.jsonl` | Full conversation history |
+| `settings.json` | User preferences (model, plugins) |
+
+**Path Encoding**: Claude encodes project paths by replacing `/` with `-`:
+- `/Users/foo/repos/myproject` → `-Users-foo-repos-myproject`
+
+**Important**: Session files may not exist for older projects (cleaned up or not persisted). In this case, `history.jsonl` still contains the user's prompts but not full conversations. The scripts will automatically fall back to searching history.jsonl.
+
+### OpenAI Codex (`~/.codex/`)
+
+| Path | Contents |
+|------|----------|
+| `history.jsonl` | Global prompt history |
+| `sessions/<year>/<month>/<day>/rollout-*.jsonl` | Session files by date |
+| `config.toml` | User config (model, trusted projects) |
+
+## Quick Searches
+
+### Find Sessions for Current Project
+
+```bash
+# For Claude Code - encode current path
+ENCODED=$(pwd | sed 's|/|-|g')
+ls ~/.claude/projects/$ENCODED/ 2>/dev/null
+
+# Check sessions index for quick metadata
+cat ~/.claude/projects/$ENCODED/sessions-index.json 2>/dev/null | jq '.entries[] | {firstPrompt, messageCount, modified}'
+
+# If session files don't exist, search history.jsonl instead
+cat ~/.claude/history.jsonl | jq --arg p "$(pwd)" 'select(.project == $p)'
+```
+
+### Search by Project Name (Fallback)
+
+When session files don't exist (older/cleaned up projects), search history.jsonl:
+
+```bash
+# Search by exact project path
+cat ~/.claude/history.jsonl | jq 'select(.project == "/path/to/project")'
+
+# Search by project name (partial match)
+cat ~/.claude/history.jsonl | jq 'select(.project | contains("project-name"))'
+
+# List all prompts for a project
+cat ~/.claude/history.jsonl | jq -r 'select(.project | contains("myproject")) | "\(.timestamp / 1000 | strftime("%Y-%m-%d %H:%M"))  \(.display[0:80])..."'
+```
+
+### Search Prompt History
+
+```bash
+# Claude - search all prompts
+cat ~/.claude/history.jsonl | jq 'select(.display | test("keyword"; "i"))' 
+
+# Codex - search all prompts
+cat ~/.codex/history.jsonl | jq 'select(.text | test("keyword"; "i"))'
+```
+
+### Find User Messages in Sessions
+
+```bash
+# Claude - extract user messages from a session
+cat ~/.claude/projects/<path>/<session>.jsonl | jq 'select(.type == "user") | .message.content'
+
+# Codex - extract user messages from a session  
+cat ~/.codex/sessions/<path>/rollout-*.jsonl | jq 'select(.type == "event_msg" and .payload.type == "user_message") | .payload.message'
+```
+
+### Analyze Tool Usage Patterns
+
+```bash
+# Claude - what tools does the user's assistant use most?
+cat ~/.claude/projects/<path>/<session>.jsonl | jq 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name' | sort | uniq -c | sort -rn
+
+# Codex - tool usage
+cat ~/.codex/sessions/<path>/rollout-*.jsonl | jq 'select(.type == "response_item" and .payload.type == "function_call") | .payload.name' | sort | uniq -c | sort -rn
+```
+
+## Extracting Context for Memory Blocks
+
+### Projects the User Has Worked On
+
+```bash
+# Claude - list all projects with activity counts
+cat ~/.claude/history.jsonl | jq -s 'group_by(.project) | map({project: .[0].project, count: length}) | sort_by(-.count)'
+```
+
+### Recent Session Summaries
+
+Claude sessions may contain summary entries:
+```bash
+cat ~/.claude/projects/<path>/<session>.jsonl | jq 'select(.type == "summary") | .summary'
+```
+
+### Common Workflows/Commands
+
+Look for patterns in Bash tool calls:
+```bash
+cat ~/.claude/projects/<path>/<session>.jsonl | jq 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "Bash") | .input.command' | head -20
+```
+
+## Populating Memory Blocks
+
+When using historical data to populate memory blocks:
+
+1. **`human` block**: Add insights about:
+   - Projects they work on frequently
+   - Coding preferences (tools, languages, frameworks)
+   - Communication style (concise vs detailed)
+
+2. **`project` block**: Add context about:
+   - Tech stack (detected from tool calls)
+   - Common commands (build, test, lint)
+   - File patterns frequently accessed
+
+## Detailed Format Documentation
+
+For complete format specifications, see:
+- [references/claude-format.md](references/claude-format.md) - Claude Code JSONL structure
+- [references/codex-format.md](references/codex-format.md) - OpenAI Codex JSONL structure

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/references/claude-format.md
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/references/claude-format.md
@@ -1,0 +1,220 @@
+# Claude Code Data Format Reference
+
+## Directory Structure
+
+```
+~/.claude/
+├── history.jsonl              # Global prompt history
+├── projects/                  # Per-project data
+│   └── -Users-...-<path>/     # Encoded directory paths
+│       ├── sessions-index.json    # Quick session metadata
+│       ├── <session-uuid>.jsonl   # Full conversation sessions
+│       └── agent-<id>.jsonl       # Agent-specific sessions
+├── settings.json              # User preferences
+├── statsig/                   # Analytics
+└── debug/                     # Debug logs
+```
+
+## Path Encoding
+
+Claude encodes project paths by replacing `/` with `-`:
+```
+/Users/username/repos/myproject → -Users-username-repos-myproject
+```
+
+To encode a path programmatically:
+```bash
+ENCODED=$(pwd | sed 's|/|-|g')
+```
+
+## Global History (`history.jsonl`)
+
+Each line is a JSON object representing a user prompt:
+
+```json
+{
+  "display": "fix this test: npm run test:unit",
+  "pastedContents": {},
+  "timestamp": 1759105062139,
+  "project": "/Users/username/repos/myproject",
+  "sessionId": "0fd6a5d1-c1e4-494f-82d6-9391ccc1797d"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `display` | The user's prompt text |
+| `pastedContents` | Any pasted content (files, images) |
+| `timestamp` | Unix timestamp in milliseconds |
+| `project` | Working directory path |
+| `sessionId` | Links to session file |
+
+## Sessions Index (`sessions-index.json`)
+
+Quick metadata lookup without parsing full session files:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "sessionId": "0fd6a5d1-c1e4-494f-82d6-9391ccc1797d",
+      "fullPath": "/Users/username/.claude/projects/-Users-sarah-repos-myproject/0fd6a5d1-....jsonl",
+      "fileMtime": 1768524387632,
+      "firstPrompt": "fix the failing test in auth.ts",
+      "messageCount": 14,
+      "created": "2026-01-16T00:39:26.583Z",
+      "modified": "2026-01-16T00:46:27.609Z",
+      "gitBranch": "feature/auth-fix",
+      "projectPath": "/Users/username/repos/myproject",
+      "isSidechain": false
+    }
+  ]
+}
+```
+
+## Session Files (`<session-uuid>.jsonl`)
+
+Each line is a JSON object. Message types:
+
+### User Message
+
+```json
+{
+  "type": "user",
+  "uuid": "8705b595-71fb-4a97-be0b-edc2fe934724",
+  "parentUuid": null,
+  "sessionId": "079c7831-6083-4b29-9fe2-534da46f2585",
+  "cwd": "/Users/username/repos/myproject",
+  "gitBranch": "main",
+  "timestamp": "2025-12-23T03:01:20.501Z",
+  "message": {
+    "role": "user",
+    "content": "please help me fix the lint errors"
+  }
+}
+```
+
+### User Message with Tool Results
+
+When responding to tool calls, content is an array:
+
+```json
+{
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01FTU3GpL9GpoJXd8WitDSd2",
+        "content": "Exit code 0\nChecked 265 files...",
+        "is_error": false
+      }
+    ]
+  }
+}
+```
+
+### Assistant Message
+
+Content is always an array with multiple block types:
+
+```json
+{
+  "type": "assistant",
+  "uuid": "64064220-5503-44f1-8f3c-d6862b249309",
+  "parentUuid": "8705b595-71fb-4a97-be0b-edc2fe934724",
+  "message": {
+    "role": "assistant",
+    "model": "claude-opus-4-5-20251101",
+    "content": [
+      {
+        "type": "thinking",
+        "thinking": "The user wants me to fix linting errors. Let me first run the lint command.",
+        "signature": "EowCCkY..."
+      },
+      {
+        "type": "text",
+        "text": "I'll run the linter to see what errors exist:"
+      },
+      {
+        "type": "tool_use",
+        "id": "toolu_01FTU3GpL9GpoJXd8WitDSd2",
+        "name": "Bash",
+        "input": {
+          "command": "bun run lint",
+          "description": "Run linter"
+        }
+      }
+    ],
+    "usage": {
+      "input_tokens": 10,
+      "cache_creation_input_tokens": 4691,
+      "cache_read_input_tokens": 14987,
+      "output_tokens": 3
+    }
+  }
+}
+```
+
+### Content Block Types
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `thinking` | `thinking`, `signature` | Chain-of-thought reasoning |
+| `text` | `text` | Final response text |
+| `tool_use` | `id`, `name`, `input` | Tool invocation |
+
+### Summary Entry
+
+Auto-generated conversation summaries:
+
+```json
+{
+  "type": "summary",
+  "summary": "Fixed bun lint formatting issue in TypeScript file",
+  "leafUuid": "25a01498-6c60-463b-b127-4e383daa97a5"
+}
+```
+
+### File History Snapshot
+
+Tracks file state at message time:
+
+```json
+{
+  "type": "file-history-snapshot",
+  "messageId": "8705b595-71fb-4a97-be0b-edc2fe934724",
+  "snapshot": {
+    "trackedFileBackups": {},
+    "timestamp": "2025-12-23T03:01:20.507Z"
+  }
+}
+```
+
+## Common Queries
+
+### Extract all user prompts from a session
+```bash
+cat session.jsonl | jq 'select(.type == "user" and (.message.content | type == "string")) | .message.content'
+```
+
+### Extract all tool calls
+```bash
+cat session.jsonl | jq 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | {name, input}'
+```
+
+### Get conversation flow (user → assistant pairs)
+```bash
+cat session.jsonl | jq -c 'select(.type == "user" or .type == "assistant") | {type, content: (.message.content | if type == "string" then . else .[0] end)}'
+```
+
+### Find sessions by tool usage
+```bash
+for f in ~/.claude/projects/*/*.jsonl; do
+  if cat "$f" | jq -e 'select(.type == "assistant") | .message.content[]? | select(.name == "Bash")' > /dev/null 2>&1; then
+    echo "$f"
+  fi
+done
+```

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/references/codex-format.md
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/references/codex-format.md
@@ -1,0 +1,288 @@
+# OpenAI Codex Data Format Reference
+
+## Directory Structure
+
+```
+~/.codex/
+├── history.jsonl              # Global prompt history
+├── sessions/                  # Session data by date
+│   └── <year>/<month>/<day>/
+│       └── rollout-<timestamp>-<session-id>.jsonl
+├── config.toml                # User configuration
+├── auth.json                  # Authentication
+├── skills/                    # User-defined skills
+└── log/                       # Debug logs
+```
+
+## Global History (`history.jsonl`)
+
+Each line is a JSON object representing a user prompt:
+
+```json
+{
+  "session_id": "019b109f-bc18-7291-9cbf-10cbe0c51250",
+  "ts": 1765510477,
+  "text": "help me find places in our code where we might have idle transactions"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `session_id` | Links to session file |
+| `ts` | Unix timestamp in seconds |
+| `text` | The user's prompt text |
+
+## Session Files (`rollout-<timestamp>-<session-id>.jsonl`)
+
+Each line is a JSON object with `timestamp`, `type`, and `payload`:
+
+### Record Types
+
+| Type | Payload Types | Description |
+|------|--------------|-------------|
+| `session_meta` | - | Session metadata |
+| `response_item` | `message`, `function_call`, `function_call_output`, `reasoning`, `ghost_snapshot` | Conversation items |
+| `event_msg` | `user_message`, `agent_reasoning`, `agent_message`, `token_count` | Events |
+| `turn_context` | - | Per-turn metadata |
+
+### Session Meta
+
+First entry in each session file:
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:22.511Z",
+  "type": "session_meta",
+  "payload": {
+    "id": "019b109f-bc18-7291-9cbf-10cbe0c51250",
+    "timestamp": "2025-12-12T03:34:22.488Z",
+    "cwd": "/Users/username/repos/myproject",
+    "originator": "codex_cli_rs",
+    "cli_version": "0.71.0",
+    "instructions": null,
+    "source": "cli",
+    "model_provider": "openai",
+    "git": {
+      "commit_hash": "68039c606f8c5010a57068005025740b77155782",
+      "branch": "main",
+      "repository_url": "git@github.com:org/repo.git"
+    }
+  }
+}
+```
+
+### User Message
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:37.406Z",
+  "type": "response_item",
+  "payload": {
+    "type": "message",
+    "role": "user",
+    "content": [
+      {
+        "type": "input_text",
+        "text": "help me find the bug in auth.ts"
+      }
+    ]
+  }
+}
+```
+
+### User Message Event
+
+Raw user input (often duplicates response_item):
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:37.406Z",
+  "type": "event_msg",
+  "payload": {
+    "type": "user_message",
+    "message": "help me find the bug in auth.ts",
+    "images": []
+  }
+}
+```
+
+### Assistant Message
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:45.073Z",
+  "type": "response_item",
+  "payload": {
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "output_text",
+        "text": "I'll search for potential issues in the auth module."
+      }
+    ]
+  }
+}
+```
+
+### Agent Reasoning
+
+Thinking/planning text:
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:45.004Z",
+  "type": "event_msg",
+  "payload": {
+    "type": "agent_reasoning",
+    "text": "**Searching for transaction patterns**\n\nI need to find patterns where..."
+  }
+}
+```
+
+### Reasoning Summary
+
+Structured thinking with summary:
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:45.005Z",
+  "type": "response_item",
+  "payload": {
+    "type": "reasoning",
+    "summary": [
+      {
+        "type": "summary_text",
+        "text": "**Searching for transaction patterns**\n\nI need to find..."
+      }
+    ],
+    "content": null,
+    "encrypted_content": "gAAAAABpO41U..."
+  }
+}
+```
+
+### Function Call (Tool Use)
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:46.462Z",
+  "type": "response_item",
+  "payload": {
+    "type": "function_call",
+    "name": "shell_command",
+    "arguments": "{\"command\":\"rg -n \\\"blocks_agents\\\" .\",\"workdir\":\"/Users/username/repos/myproject\"}",
+    "call_id": "call_z83FuakeMWWlIpMhf2YpkLVA"
+  }
+}
+```
+
+### Function Call Output (Tool Result)
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:49.538Z",
+  "type": "response_item",
+  "payload": {
+    "type": "function_call_output",
+    "call_id": "call_z83FuakeMWWlIpMhf2YpkLVA",
+    "output": "Exit code: 0\nWall time: 0 seconds\nOutput:\n./src/orm/blocks_agents.py:10:..."
+  }
+}
+```
+
+### Turn Context
+
+Metadata about each conversation turn:
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:49.539Z",
+  "type": "turn_context",
+  "payload": {
+    "cwd": "/Users/username/repos/myproject",
+    "approval_policy": "on-request",
+    "sandbox_policy": {
+      "type": "workspace-write",
+      "network_access": false
+    },
+    "model": "gpt-5.2",
+    "effort": "medium",
+    "summary": "auto"
+  }
+}
+```
+
+### Token Count
+
+Usage statistics:
+
+```json
+{
+  "timestamp": "2025-12-12T03:34:49.130Z",
+  "type": "event_msg",
+  "payload": {
+    "type": "token_count",
+    "info": {
+      "total_token_usage": {
+        "input_tokens": 8414,
+        "cached_input_tokens": 1152,
+        "output_tokens": 688,
+        "reasoning_output_tokens": 231,
+        "total_tokens": 9102
+      },
+      "model_context_window": 258400
+    }
+  }
+}
+```
+
+## Configuration (`config.toml`)
+
+```toml
+model = "gpt-5.2-codex"
+model_reasoning_effort = "medium"
+
+[projects."/Users/username/repos/myproject"]
+trust_level = "trusted"
+
+[history]
+persistence = "save-all"
+```
+
+## Common Queries
+
+### Extract all user messages from a session
+```bash
+cat rollout-*.jsonl | jq 'select(.type == "event_msg" and .payload.type == "user_message") | .payload.message'
+```
+
+### Extract all function calls
+```bash
+cat rollout-*.jsonl | jq 'select(.type == "response_item" and .payload.type == "function_call") | {name: .payload.name, args: .payload.arguments}'
+```
+
+### Get session metadata
+```bash
+cat rollout-*.jsonl | jq 'select(.type == "session_meta") | .payload'
+```
+
+### Count tool usage by name
+```bash
+cat rollout-*.jsonl | jq 'select(.type == "response_item" and .payload.type == "function_call") | .payload.name' | sort | uniq -c | sort -rn
+```
+
+### Find sessions by working directory
+```bash
+for f in ~/.codex/sessions/*/*/*/*rollout*.jsonl; do
+  cwd=$(cat "$f" | jq -r 'select(.type == "session_meta") | .payload.cwd' 2>/dev/null)
+  if [[ "$cwd" == "/Users/username/repos/myproject"* ]]; then
+    echo "$f"
+  fi
+done
+```
+
+### Extract reasoning/thinking
+```bash
+cat rollout-*.jsonl | jq 'select(.type == "event_msg" and .payload.type == "agent_reasoning") | .payload.text'
+```

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/detect.sh
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/detect.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Detect available Claude Code and Codex history data
+# Usage: ./detect.sh [project-path]
+
+set -e
+
+PROJECT_PATH="${1:-$(pwd)}"
+
+echo "=== History Data Detection ==="
+echo ""
+
+# Claude Code
+if [[ -d "$HOME/.claude" ]]; then
+    echo "Claude Code: FOUND"
+    echo "  Location: ~/.claude/"
+    
+    # Count global prompts
+    if [[ -f "$HOME/.claude/history.jsonl" ]]; then
+        PROMPT_COUNT=$(wc -l < "$HOME/.claude/history.jsonl" | tr -d ' ')
+        echo "  Global prompts: $PROMPT_COUNT"
+    fi
+    
+    # Count projects
+    if [[ -d "$HOME/.claude/projects" ]]; then
+        PROJECT_COUNT=$(ls -1 "$HOME/.claude/projects" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  Projects: $PROJECT_COUNT"
+        
+        # Check for current project
+        ENCODED=$(echo "$PROJECT_PATH" | sed 's|/|-|g')
+        if [[ -d "$HOME/.claude/projects/$ENCODED" ]]; then
+            SESSION_COUNT=$(ls -1 "$HOME/.claude/projects/$ENCODED"/*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+            echo "  Current project sessions: $SESSION_COUNT"
+            
+            # Show sessions index if available
+            if [[ -f "$HOME/.claude/projects/$ENCODED/sessions-index.json" ]]; then
+                echo ""
+                echo "  Recent sessions in this project:"
+                jq -r '.entries | sort_by(.modified) | reverse | .[0:5][] | "    \(.modified[0:10]) - \(.firstPrompt[0:60])..."' \
+                    "$HOME/.claude/projects/$ENCODED/sessions-index.json" 2>/dev/null || true
+            fi
+        else
+            echo "  Current project: No sessions found"
+        fi
+    fi
+    
+    # Total size
+    SIZE=$(du -sh "$HOME/.claude/projects" 2>/dev/null | cut -f1)
+    echo "  Total size: $SIZE"
+else
+    echo "Claude Code: NOT FOUND"
+fi
+
+echo ""
+
+# Codex
+if [[ -d "$HOME/.codex" ]]; then
+    echo "Codex: FOUND"
+    echo "  Location: ~/.codex/"
+    
+    # Count global prompts
+    if [[ -f "$HOME/.codex/history.jsonl" ]]; then
+        PROMPT_COUNT=$(wc -l < "$HOME/.codex/history.jsonl" | tr -d ' ')
+        echo "  Global prompts: $PROMPT_COUNT"
+    fi
+    
+    # Count sessions
+    if [[ -d "$HOME/.codex/sessions" ]]; then
+        SESSION_COUNT=$(find "$HOME/.codex/sessions" -name "*.jsonl" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  Total sessions: $SESSION_COUNT"
+        
+        # Check for sessions matching current project
+        MATCHING=0
+        for f in $(find "$HOME/.codex/sessions" -name "*.jsonl" 2>/dev/null); do
+            CWD=$(head -1 "$f" | jq -r '.payload.cwd // empty' 2>/dev/null)
+            if [[ "$CWD" == "$PROJECT_PATH"* ]]; then
+                ((MATCHING++)) || true
+            fi
+        done
+        echo "  Current project sessions: $MATCHING"
+    fi
+    
+    # Total size
+    SIZE=$(du -sh "$HOME/.codex/sessions" 2>/dev/null | cut -f1)
+    echo "  Total size: $SIZE"
+    
+    # Show config
+    if [[ -f "$HOME/.codex/config.toml" ]]; then
+        MODEL=$(grep "^model" "$HOME/.codex/config.toml" 2>/dev/null | head -1 | cut -d'"' -f2)
+        if [[ -n "$MODEL" ]]; then
+            echo "  Configured model: $MODEL"
+        fi
+    fi
+else
+    echo "Codex: NOT FOUND"
+fi
+
+echo ""
+echo "=== Summary ==="
+[[ -d "$HOME/.claude" ]] && echo "Run: ./list-sessions.sh claude [project-path]"
+[[ -d "$HOME/.codex" ]] && echo "Run: ./list-sessions.sh codex [project-path]"

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/list-sessions.sh
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/list-sessions.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# List sessions for a project from Claude Code or Codex
+# Usage: ./list-sessions.sh <claude|codex> [project-path]
+
+set -e
+
+SOURCE="${1:-claude}"
+PROJECT_PATH="${2:-$(pwd)}"
+
+if [[ "$SOURCE" == "claude" ]]; then
+    ENCODED=$(echo "$PROJECT_PATH" | sed 's|/|-|g')
+    PROJECT_DIR="$HOME/.claude/projects/$ENCODED"
+    
+    echo "=== Claude Code Sessions ==="
+    echo "Project: $PROJECT_PATH"
+    echo ""
+    
+    if [[ -d "$PROJECT_DIR" ]]; then
+        # Session files exist - use them
+        echo "Source: Session files"
+        echo ""
+        
+        # Use sessions-index.json if available (faster)
+        if [[ -f "$PROJECT_DIR/sessions-index.json" ]]; then
+            jq -r '.entries | sort_by(.modified) | reverse | .[] | "\(.modified[0:19])  msgs:\(.messageCount|tostring|.[0:4])  \(.firstPrompt[0:70])..."' \
+                "$PROJECT_DIR/sessions-index.json"
+        else
+            # Fall back to parsing each file
+            for f in "$PROJECT_DIR"/*.jsonl; do
+                [[ -f "$f" ]] || continue
+                BASENAME=$(basename "$f")
+                FIRST_PROMPT=$(jq -r 'select(.type == "user") | .message.content | if type == "string" then . else .[0].text // .[0].content // "?" end' "$f" 2>/dev/null | head -1 | cut -c1-70)
+                MSG_COUNT=$(grep -c '"type"' "$f" 2>/dev/null || echo "?")
+                MTIME=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$f" 2>/dev/null || stat -c "%y" "$f" 2>/dev/null | cut -c1-16)
+                echo "$MTIME  msgs:$MSG_COUNT  $FIRST_PROMPT..."
+                echo "  -> $BASENAME"
+            done
+        fi
+    else
+        # No session files - fall back to history.jsonl
+        echo "Source: history.jsonl (session files not found)"
+        echo "Note: Only prompts available, not full conversations"
+        echo ""
+        
+        if [[ -f "$HOME/.claude/history.jsonl" ]]; then
+            MATCHES=$(jq -r --arg proj "$PROJECT_PATH" '
+                select(.project == $proj) | 
+                "\(.timestamp / 1000 | strftime("%Y-%m-%d %H:%M"))  \(.display[0:70])..."
+            ' "$HOME/.claude/history.jsonl" 2>/dev/null)
+            
+            if [[ -n "$MATCHES" ]]; then
+                echo "$MATCHES"
+            else
+                echo "No prompts found for this exact project path."
+                echo "Try searching with a partial match:"
+                echo "  cat ~/.claude/history.jsonl | jq 'select(.project | contains(\"$(basename "$PROJECT_PATH")\"))'"
+            fi
+        else
+            echo "No history.jsonl found"
+        fi
+    fi
+
+elif [[ "$SOURCE" == "codex" ]]; then
+    echo "=== Codex Sessions ==="
+    echo "Project: $PROJECT_PATH"
+    echo ""
+    
+    FOUND=0
+    for f in $(find "$HOME/.codex/sessions" -name "*.jsonl" 2>/dev/null | sort -r); do
+        CWD=$(head -1 "$f" | jq -r '.payload.cwd // empty' 2>/dev/null)
+        if [[ "$CWD" == "$PROJECT_PATH"* ]]; then
+            ((FOUND++)) || true
+            BASENAME=$(basename "$f")
+            FIRST_PROMPT=$(jq -r 'select(.type == "event_msg" and .payload.type == "user_message") | .payload.message' "$f" 2>/dev/null | head -1 | cut -c1-70)
+            TIMESTAMP=$(echo "$BASENAME" | sed 's/rollout-//' | cut -c1-19 | tr 'T' ' ')
+            echo "$TIMESTAMP  $FIRST_PROMPT..."
+            echo "  -> $f"
+        fi
+    done
+    
+    if [[ $FOUND -eq 0 ]]; then
+        echo "No Codex sessions found for: $PROJECT_PATH"
+    fi
+else
+    echo "Usage: ./list-sessions.sh <claude|codex> [project-path]"
+    exit 1
+fi

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/search.sh
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/search.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Search across Claude Code and Codex history
+# Usage: ./search.sh <keyword> [--claude|--codex|--both] [--project path]
+
+set -e
+
+KEYWORD=""
+SOURCE="both"
+PROJECT_FILTER=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --claude) SOURCE="claude"; shift ;;
+        --codex) SOURCE="codex"; shift ;;
+        --both) SOURCE="both"; shift ;;
+        --project) PROJECT_FILTER="$2"; shift 2 ;;
+        -*) echo "Unknown option: $1"; exit 1 ;;
+        *) KEYWORD="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$KEYWORD" ]]; then
+    echo "Usage: ./search.sh <keyword> [--claude|--codex|--both] [--project path]"
+    echo ""
+    echo "Examples:"
+    echo "  ./search.sh 'database migration'"
+    echo "  ./search.sh 'test' --claude"
+    echo "  ./search.sh 'auth' --project /path/to/project"
+    exit 1
+fi
+
+echo "=== Searching for: $KEYWORD ==="
+echo ""
+
+# Search Claude Code
+if [[ "$SOURCE" == "claude" || "$SOURCE" == "both" ]] && [[ -d "$HOME/.claude" ]]; then
+    echo "--- Claude Code Results ---"
+    
+    # Search global history (always available, even when session files are deleted)
+    if [[ -f "$HOME/.claude/history.jsonl" ]]; then
+        echo "Prompt history (history.jsonl):"
+        if [[ -n "$PROJECT_FILTER" ]]; then
+            RESULTS=$(jq -r --arg kw "$KEYWORD" --arg proj "$PROJECT_FILTER" '
+                select((.display | test($kw; "i")) and (.project | startswith($proj))) | 
+                "\(.timestamp / 1000 | strftime("%Y-%m-%d %H:%M"))  \(.display[0:80])..."
+            ' "$HOME/.claude/history.jsonl" 2>/dev/null | head -30)
+        else
+            RESULTS=$(jq -r --arg kw "$KEYWORD" '
+                select(.display | test($kw; "i")) | 
+                "\(.timestamp / 1000 | strftime("%Y-%m-%d %H:%M"))  \(.project | split("/") | .[-1]):  \(.display[0:70])..."
+            ' "$HOME/.claude/history.jsonl" 2>/dev/null | head -30)
+        fi
+        if [[ -n "$RESULTS" ]]; then
+            echo "$RESULTS"
+        else
+            echo "  No matches in prompt history"
+        fi
+        echo ""
+    fi
+    
+    # Search session files
+    echo ""
+    echo "Session matches:"
+    for PROJECT_DIR in "$HOME/.claude/projects"/*; do
+        [[ -d "$PROJECT_DIR" ]] || continue
+        
+        # Apply project filter if specified
+        if [[ -n "$PROJECT_FILTER" ]]; then
+            DECODED=$(basename "$PROJECT_DIR" | sed 's/-/\//g')
+            [[ "$DECODED" == "$PROJECT_FILTER"* ]] || continue
+        fi
+        
+        for f in "$PROJECT_DIR"/*.jsonl; do
+            [[ -f "$f" ]] || continue
+            [[ "$(basename "$f")" == "sessions-index.json" ]] && continue
+            
+            # Search user messages (string content only)
+            MATCHES=$(jq -r --arg kw "$KEYWORD" '
+                select(.type == "user" and (.message.content | type == "string")) | 
+                .message.content |
+                select(test($kw; "i"))
+            ' "$f" 2>/dev/null | head -3)
+            
+            if [[ -n "$MATCHES" ]]; then
+                PROJECT_NAME=$(basename "$PROJECT_DIR" | sed 's/-/\//g' | rev | cut -c1-50 | rev)
+                echo ""
+                echo "  Project: ...$PROJECT_NAME"
+                echo "  Session: $(basename "$f")"
+                echo "$MATCHES" | while read -r line; do
+                    echo "    > ${line:0:80}..."
+                done
+            fi
+        done
+    done
+    echo ""
+fi
+
+# Search Codex
+if [[ "$SOURCE" == "codex" || "$SOURCE" == "both" ]] && [[ -d "$HOME/.codex" ]]; then
+    echo "--- Codex Results ---"
+    
+    # Search global history
+    if [[ -f "$HOME/.codex/history.jsonl" ]]; then
+        RESULTS=$(jq -r --arg kw "$KEYWORD" 'select(.text | test($kw; "i")) | "\(.ts | strftime("%Y-%m-%d %H:%M"))  \(.text[0:100])...\n"' "$HOME/.codex/history.jsonl" 2>/dev/null | head -20)
+        if [[ -n "$RESULTS" ]]; then
+            echo "Global history matches:"
+            echo "$RESULTS"
+        fi
+    fi
+    
+    # Search session files
+    echo "Session matches:"
+    for f in $(find "$HOME/.codex/sessions" -name "*.jsonl" 2>/dev/null); do
+        # Apply project filter if specified
+        if [[ -n "$PROJECT_FILTER" ]]; then
+            CWD=$(head -1 "$f" | jq -r '.payload.cwd // empty' 2>/dev/null)
+            [[ "$CWD" == "$PROJECT_FILTER"* ]] || continue
+        fi
+        
+        MATCHES=$(jq -r --arg kw "$KEYWORD" '
+            select(.type == "event_msg" and .payload.type == "user_message") |
+            .payload.message |
+            select(test($kw; "i"))
+        ' "$f" 2>/dev/null | head -3)
+        
+        if [[ -n "$MATCHES" ]]; then
+            echo ""
+            echo "  File: $(basename "$f")"
+            CWD=$(head -1 "$f" | jq -r '.payload.cwd // "?"' 2>/dev/null)
+            echo "  Project: $CWD"
+            echo "$MATCHES" | while read -r line; do
+                echo "    ${line:0:100}..."
+            done
+        fi
+    done
+fi

--- a/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/view-session.sh
+++ b/src/skills/builtin/migrating-from-codex-and-claude-code/scripts/view-session.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# View a session file in readable format
+# Usage: ./view-session.sh <session-file> [--tools] [--thinking]
+
+set -e
+
+SESSION_FILE="$1"
+SHOW_TOOLS=false
+SHOW_THINKING=false
+
+# Parse flags
+shift || true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tools) SHOW_TOOLS=true; shift ;;
+        --thinking) SHOW_THINKING=true; shift ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -z "$SESSION_FILE" || ! -f "$SESSION_FILE" ]]; then
+    echo "Usage: ./view-session.sh <session-file> [--tools] [--thinking]"
+    echo ""
+    echo "Options:"
+    echo "  --tools     Show tool calls and results"
+    echo "  --thinking  Show assistant thinking/reasoning"
+    exit 1
+fi
+
+# Detect format (Claude vs Codex)
+FIRST_LINE=$(head -1 "$SESSION_FILE")
+if echo "$FIRST_LINE" | jq -e '.type == "session_meta"' > /dev/null 2>&1; then
+    FORMAT="codex"
+elif echo "$FIRST_LINE" | jq -e '.type' > /dev/null 2>&1; then
+    FORMAT="claude"
+else
+    echo "Unknown session format"
+    exit 1
+fi
+
+echo "=== Session Viewer ==="
+echo "File: $SESSION_FILE"
+echo "Format: $FORMAT"
+echo ""
+
+if [[ "$FORMAT" == "claude" ]]; then
+    # Claude format
+    jq -r --argjson tools "$SHOW_TOOLS" --argjson thinking "$SHOW_THINKING" '
+        if .type == "user" then
+            .message.content |
+            if type == "string" then
+                ">>> USER:\n\(.)\n"
+            elif .[0].type == "tool_result" then
+                if $tools then
+                    ">>> TOOL RESULT (\(.[0].tool_use_id[0:20])):\n\(.[0].content[0:500])...\n"
+                else
+                    empty
+                end
+            else
+                ">>> USER:\n\(.[0].text // .[0].content // "?")\n"
+            end
+        elif .type == "assistant" then
+            .message.content | map(
+                if .type == "text" then
+                    "<<< ASSISTANT:\n\(.text)\n"
+                elif .type == "thinking" and $thinking then
+                    "<<< THINKING:\n\(.thinking[0:300])...\n"
+                elif .type == "tool_use" and $tools then
+                    "<<< TOOL: \(.name)\n\(.input | tostring[0:200])...\n"
+                else
+                    empty
+                end
+            ) | join("\n")
+        elif .type == "summary" then
+            "=== SUMMARY: \(.summary) ===\n"
+        else
+            empty
+        end
+    ' "$SESSION_FILE"
+    
+elif [[ "$FORMAT" == "codex" ]]; then
+    # Codex format
+    
+    # Show session metadata
+    jq -r 'select(.type == "session_meta") | "Project: \(.payload.cwd)\nModel: \(.payload.model_provider // "?")\nBranch: \(.payload.git.branch // "?")\n"' "$SESSION_FILE" | head -5
+    echo "---"
+    echo ""
+    
+    jq -r --argjson tools "$SHOW_TOOLS" --argjson thinking "$SHOW_THINKING" '
+        if .type == "event_msg" and .payload.type == "user_message" then
+            ">>> USER:\n\(.payload.message)\n"
+        elif .type == "response_item" and .payload.type == "message" and .payload.role == "assistant" then
+            .payload.content | map(
+                if .type == "output_text" then
+                    "<<< ASSISTANT:\n\(.text)\n"
+                else
+                    empty
+                end
+            ) | join("\n")
+        elif .type == "event_msg" and .payload.type == "agent_reasoning" and $thinking then
+            "<<< THINKING:\n\(.payload.text[0:300])...\n"
+        elif .type == "response_item" and .payload.type == "function_call" and $tools then
+            "<<< TOOL: \(.payload.name)\n\(.payload.arguments[0:200])...\n"
+        elif .type == "response_item" and .payload.type == "function_call_output" and $tools then
+            ">>> TOOL RESULT:\n\(.payload.output[0:500])...\n"
+        else
+            empty
+        end
+    ' "$SESSION_FILE"
+fi


### PR DESCRIPTION
Adds a new bundled skill that helps agents discover and search historical conversation data from Claude Code (~/.claude) and OpenAI Codex (~/.codex).

Includes:
- Detection scripts to find available history
- Search scripts with fallback to history.jsonl when session files don't exist
- Session viewer for readable output
- Format documentation for both JSONL structures

Also updates initializing-memory skill to recommend searching historical sessions during /init.

🤖 Generated with [Letta Code](https://letta.com)