### PR TITLE
fix: use context-accurate cancel labels instead of hardcoded "Interrupted by user"

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -101,7 +101,7 @@ export async function drainStream(
       // Check if stream was aborted
       if (abortSignal?.aborted) {
         stopReason = "cancelled";
-        markIncompleteToolsAsCancelled(buffers);
+        markIncompleteToolsAsCancelled(buffers, true, "user_interrupt");
         queueMicrotask(refresh);
         break;
       }
@@ -135,7 +135,7 @@ export async function drainStream(
       // Check abort signal before processing - don't add data after interrupt
       if (abortSignal?.aborted) {
         stopReason = "cancelled";
-        markIncompleteToolsAsCancelled(buffers);
+        markIncompleteToolsAsCancelled(buffers, true, "user_interrupt");
         queueMicrotask(refresh);
         break;
       }
@@ -172,7 +172,7 @@ export async function drainStream(
 
     // Set error stop reason so drainStreamWithResume can try to reconnect
     stopReason = "error";
-    markIncompleteToolsAsCancelled(buffers);
+    markIncompleteToolsAsCancelled(buffers, true, "stream_error");
     queueMicrotask(refresh);
   } finally {
     // Clean up abort listener
@@ -189,7 +189,7 @@ export async function drainStream(
   // (SDK returns gracefully on abort), mark as cancelled
   if (abortedViaListener && !stopReason) {
     stopReason = "cancelled";
-    markIncompleteToolsAsCancelled(buffers);
+    markIncompleteToolsAsCancelled(buffers, true, "user_interrupt");
     queueMicrotask(refresh);
   }
 
@@ -200,7 +200,7 @@ export async function drainStream(
 
   // Mark incomplete tool calls as cancelled if stream was cancelled
   if (stopReason === "cancelled") {
-    markIncompleteToolsAsCancelled(buffers);
+    markIncompleteToolsAsCancelled(buffers, true, "user_interrupt");
   }
 
   // Mark the final line as finished now that stream has ended

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1460,7 +1460,7 @@ export async function handleHeadlessCommand(
       }
 
       // Mark incomplete tool calls as cancelled to prevent stuck state
-      markIncompleteToolsAsCancelled(buffers);
+      markIncompleteToolsAsCancelled(buffers, true, "stream_error");
 
       // Extract error details from buffers if available
       const errorLines = toLines(buffers).filter(
@@ -1518,7 +1518,7 @@ export async function handleHeadlessCommand(
     }
   } catch (error) {
     // Mark incomplete tool calls as cancelled
-    markIncompleteToolsAsCancelled(buffers);
+    markIncompleteToolsAsCancelled(buffers, true, "stream_error");
 
     // Use comprehensive error formatting (same as TUI mode)
     const errorDetails = formatErrorDetails(error, agent.id);


### PR DESCRIPTION
Made the hotfix so "Interrupted by user" only appears on real user interrupts by adding explicit cancellation reasons and wiring them through all call sites. This keeps the existing behavior (tools get marked finished) but replaces the hardcoded label with context-accurate text for stream errors, internal cancels, and approval cancels.

Details:

- Added CancelReason and a reason→text mapping in src/cli/helpers/accumulator.ts, then updated markIncompleteToolsAsCancelled to accept the reason and use the mapped label.
- Updated all call sites to pass the correct reason:
    - User ESC/abort flows now pass user_interrupt (e.g., src/cli/App.tsx:3006, src/cli/helpers/ stream.ts:104).
    - Stream errors now pass stream_error (e.g., src/cli/helpers/stream.ts:175, src/cli/ App.tsx:2781).
    - Approval cancellation uses approval_cancel (e.g., src/cli/App.tsx:6826).
    - Internal stale cleanup uses internal_cancel (e.g., src/cli/App.tsx:1740, src/cli/ App.tsx:7387).
    - Headless error paths use stream_error (src/headless.ts:1463, src/headless.ts:1521).

🐾 Generated with [Letta Code](https://letta.com)