### PR TITLE
feat: support query prefill in /search command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -876,6 +876,7 @@ export default function App({
     | null;
   const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>(null);
   const [feedbackPrefill, setFeedbackPrefill] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
   const [modelSelectorOptions, setModelSelectorOptions] = useState<{
     filterProvider?: string;
     forceRefresh?: boolean;
@@ -883,6 +884,7 @@ export default function App({
   const closeOverlay = useCallback(() => {
     setActiveOverlay(null);
     setFeedbackPrefill("");
+    setSearchQuery("");
     setModelSelectorOptions({});
   }, []);
 
@@ -4957,7 +4959,11 @@ export default function App({
         }
 
         // Special handling for /search command - show message search
-        if (msg.trim() === "/search") {
+        if (trimmed.startsWith("/search")) {
+          // Extract optional query after /search
+          const [, ...rest] = trimmed.split(/\s+/);
+          const query = rest.join(" ").trim();
+          setSearchQuery(query);
           setActiveOverlay("search");
           return { submitted: true };
         }
@@ -8462,7 +8468,10 @@ Plan file path: ${planFilePath}`;
 
             {/* Message Search - conditionally mounted as overlay */}
             {activeOverlay === "search" && (
-              <MessageSearch onClose={closeOverlay} />
+              <MessageSearch
+                onClose={closeOverlay}
+                initialQuery={searchQuery || undefined}
+              />
             )}
 
             {/* Feedback Dialog - conditionally mounted as overlay */}

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -61,7 +61,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/search": {
-    desc: "Search messages across all agents",
+    desc: "Search messages across all agents (/search [query])",
     order: 16,
     handler: () => {
       // Handled specially in App.tsx to show message search

--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -9,6 +9,7 @@ import { colors } from "./colors";
 
 interface MessageSearchProps {
   onClose: () => void;
+  initialQuery?: string;
 }
 
 const DISPLAY_PAGE_SIZE = 5;
@@ -109,10 +110,10 @@ function getMessageText(msg: MessageSearchResponse[number]): string {
   return `[${msg.message_type || "unknown"}]`;
 }
 
-export function MessageSearch({ onClose }: MessageSearchProps) {
+export function MessageSearch({ onClose, initialQuery }: MessageSearchProps) {
   const terminalWidth = useTerminalWidth();
-  const [searchInput, setSearchInput] = useState("");
-  const [activeQuery, setActiveQuery] = useState("");
+  const [searchInput, setSearchInput] = useState(initialQuery ?? "");
+  const [activeQuery, setActiveQuery] = useState(initialQuery ?? "");
   const [searchMode, setSearchMode] = useState<SearchMode>("hybrid");
   const [results, setResults] = useState<MessageSearchResponse>([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Allow `/search <query>` to open the search page with the query prefilled and auto-executed, similar to how /remember handles args.

🐾 Generated with [Letta Code](https://letta.com)