### PR TITLE
fix: clarify /clear command output message

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4512,7 +4512,8 @@ export default function App({
               kind: "command",
               id: cmdId,
               input: msg,
-              output: "Agent's in-context messages cleared & moved to conversation history",
+              output:
+                "Agent's in-context messages cleared & moved to conversation history",
               phase: "finished",
               success: true,
             });

--- a/src/cli/helpers/shellAliases.ts
+++ b/src/cli/helpers/shellAliases.ts
@@ -74,7 +74,7 @@ function parseAliasesFromFile(filePath: string): Map<string, string> {
       const funcMatch =
         trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\)\s*\{?/) ||
         trimmed.match(/^function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\{?/);
-      if (funcMatch && funcMatch[1]) {
+      if (funcMatch?.[1]) {
         functionName = funcMatch[1];
         functionBody = `${line}\n`;
         braceDepth =

--- a/src/tests/approval-recovery.test.ts
+++ b/src/tests/approval-recovery.test.ts
@@ -124,8 +124,8 @@ describe("extractApprovals", () => {
     const result = extractApprovals(msg);
 
     expect(result.pendingApprovals).toHaveLength(1);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-1");
-    expect(result.pendingApprovals[0]!.toolName).toBe("Bash");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-1");
+    expect(result.pendingApprovals[0]?.toolName).toBe("Bash");
     expect(result.pendingApproval?.toolCallId).toBe("call-1");
   });
 
@@ -153,12 +153,12 @@ describe("extractApprovals", () => {
     const result = extractApprovals(msg);
 
     expect(result.pendingApprovals).toHaveLength(3);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-1");
-    expect(result.pendingApprovals[0]!.toolName).toBe("Bash");
-    expect(result.pendingApprovals[1]!.toolCallId).toBe("call-2");
-    expect(result.pendingApprovals[1]!.toolName).toBe("web_search");
-    expect(result.pendingApprovals[2]!.toolCallId).toBe("call-3");
-    expect(result.pendingApprovals[2]!.toolName).toBe("Read");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-1");
+    expect(result.pendingApprovals[0]?.toolName).toBe("Bash");
+    expect(result.pendingApprovals[1]?.toolCallId).toBe("call-2");
+    expect(result.pendingApprovals[1]?.toolName).toBe("web_search");
+    expect(result.pendingApprovals[2]?.toolCallId).toBe("call-3");
+    expect(result.pendingApprovals[2]?.toolName).toBe("Read");
     // pendingApproval is deprecated, should be first item
     expect(result.pendingApproval?.toolCallId).toBe("call-1");
   });
@@ -175,8 +175,8 @@ describe("extractApprovals", () => {
     const result = extractApprovals(msg);
 
     expect(result.pendingApprovals).toHaveLength(1);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-legacy");
-    expect(result.pendingApprovals[0]!.toolName).toBe("Write");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-legacy");
+    expect(result.pendingApprovals[0]?.toolName).toBe("Write");
   });
 
   test("prefers tool_calls array over deprecated tool_call", () => {
@@ -193,7 +193,7 @@ describe("extractApprovals", () => {
 
     // Should use tool_calls, not tool_call
     expect(result.pendingApprovals).toHaveLength(1);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-new");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-new");
   });
 
   test("filters out tool calls without tool_call_id", () => {
@@ -210,8 +210,8 @@ describe("extractApprovals", () => {
 
     // Should only include entries with valid tool_call_id
     expect(result.pendingApprovals).toHaveLength(2);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-valid");
-    expect(result.pendingApprovals[1]!.toolCallId).toBe("call-valid-2");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-valid");
+    expect(result.pendingApprovals[1]?.toolCallId).toBe("call-valid-2");
   });
 
   test("returns empty array when no tool calls present", () => {
@@ -231,9 +231,9 @@ describe("extractApprovals", () => {
     const result = extractApprovals(msg);
 
     expect(result.pendingApprovals).toHaveLength(1);
-    expect(result.pendingApprovals[0]!.toolCallId).toBe("call-minimal");
-    expect(result.pendingApprovals[0]!.toolName).toBe("");
-    expect(result.pendingApprovals[0]!.toolArgs).toBe("");
+    expect(result.pendingApprovals[0]?.toolCallId).toBe("call-minimal");
+    expect(result.pendingApprovals[0]?.toolName).toBe("");
+    expect(result.pendingApprovals[0]?.toolArgs).toBe("");
   });
 });
 

--- a/src/tests/lazy-approval-recovery.test.ts
+++ b/src/tests/lazy-approval-recovery.test.ts
@@ -33,7 +33,7 @@ interface StreamMessage {
   subtype?: string;
   message_type?: string;
   stop_reason?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: index signature for arbitrary JSON fields
   [key: string]: any;
 }
 


### PR DESCRIPTION
Clarifies that messages are moved to conversation history, not deleted.

👾 Generated with [Letta Code](https://letta.com)