### PR TITLE
fix: make ADE links work in tmux

### DIFF
--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -22,6 +22,7 @@ export const AgentInfoBar = memo(function AgentInfoBar({
   serverUrl,
   conversationId,
 }: AgentInfoBarProps) {
+  const isTmux = Boolean(process.env.TMUX);
   // Check if current agent is pinned
   const isPinned = useMemo(() => {
     if (!agentId) return false;
@@ -31,6 +32,10 @@ export const AgentInfoBar = memo(function AgentInfoBar({
   }, [agentId]);
 
   const isCloudUser = serverUrl?.includes("api.letta.com");
+  const adeUrl =
+    agentId && agentId !== "loading"
+      ? `https://app.letta.com/agents/${agentId}${conversationId && conversationId !== "default" ? `?conversation=${conversationId}` : ""}`
+      : "";
   const showBottomBar = agentId && agentId !== "loading";
 
   if (!showBottomBar) {
@@ -77,13 +82,12 @@ export const AgentInfoBar = memo(function AgentInfoBar({
       </Box>
       <Box>
         <Text dimColor>{"  "}</Text>
-        {isCloudUser && (
-          <Link
-            url={`https://app.letta.com/agents/${agentId}${conversationId && conversationId !== "default" ? `?conversation=${conversationId}` : ""}`}
-          >
+        {isCloudUser && adeUrl && !isTmux && (
+          <Link url={adeUrl}>
             <Text>Open in ADE ↗</Text>
           </Link>
         )}
+        {isCloudUser && adeUrl && isTmux && <Text>Open in ADE: {adeUrl}</Text>}
         {isCloudUser && <Text dimColor>{" · "}</Text>}
         {isCloudUser && (
           <Link url="https://app.letta.com/settings/organization/usage">

--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -37,6 +37,7 @@ export function MemoryTabViewer({
 }: MemoryTabViewerProps) {
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+  const isTmux = Boolean(process.env.TMUX);
   const adeUrl = `https://app.letta.com/agents/${agentId}?view=memory${conversationId ? `&conversation=${conversationId}` : ""}`;
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -256,9 +257,12 @@ export function MemoryTabViewer({
         </Text>
         <Box>
           <Text dimColor>{"  "}←→/Tab switch · ↑↓ scroll · </Text>
-          <Link url={adeUrl}>
-            <Text dimColor>Edit in ADE</Text>
-          </Link>
+          {!isTmux && (
+            <Link url={adeUrl}>
+              <Text dimColor>Edit in ADE</Text>
+            </Link>
+          )}
+          {isTmux && <Text dimColor>Edit in ADE: {adeUrl}</Text>}
           <Text dimColor> · Esc cancel</Text>
         </Box>
       </Box>


### PR DESCRIPTION
Render plain ADE URLs when TMUX is detected so terminals can click them while preserving OSC-8 links outside tmux.

👾 Generated with [Letta Code](https://letta.com)