### PR TITLE
feat: add image reading support to Read tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@letta-ai/letta-client": "^1.6.8",
+    "@letta-ai/letta-client": "^1.7.2",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",
     "open": "^10.2.0",
@@ -43,6 +43,7 @@
     "@types/bun": "latest",
     "@types/diff": "^8.0.0",
     "@types/picomatch": "^4.0.2",
+    "@types/react": "^19.2.9",
     "diff": "^8.0.2",
     "husky": "9.1.7",
     "ink": "^5.0.0",

--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -3,12 +3,32 @@
 import * as path from "node:path";
 import type {
   ApprovalReturn,
+  TextContent,
   ToolReturn,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { INTERRUPTED_BY_USER } from "../constants";
-import { executeTool, type ToolExecutionResult } from "../tools/manager";
+import {
+  executeTool,
+  type ToolExecutionResult,
+  type ToolReturnContent,
+} from "../tools/manager";
+
+/**
+ * Extract displayable text from tool return content (for UI display).
+ * Multimodal content returns the text parts concatenated.
+ */
+export function getDisplayableToolReturn(content: ToolReturnContent): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  // Extract text from multimodal content
+  return content
+    .filter((part): part is TextContent => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
 
 /**
  * Tools that are safe to execute in parallel (read-only or independent).
@@ -235,13 +255,14 @@ async function executeSingleDecision(
       );
 
       // Update UI if callback provided (interactive mode)
+      // Note: UI display uses text-only version, backend gets full multimodal content
       if (onChunk) {
         onChunk({
           message_type: "tool_return_message",
           id: "dummy",
           date: new Date().toISOString(),
           tool_call_id: decision.approval.toolCallId,
-          tool_return: toolResult.toolReturn,
+          tool_return: getDisplayableToolReturn(toolResult.toolReturn),
           status: toolResult.status,
           stdout: toolResult.stdout,
           stderr: toolResult.stderr,
@@ -251,7 +272,7 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: toolResult.toolReturn,
+        tool_return: toolResult.toolReturn, // Full multimodal content for backend
         status: toolResult.status,
         stdout: toolResult.stdout,
         stderr: toolResult.stderr,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -26,6 +26,7 @@ import {
 import {
   type ApprovalResult,
   executeAutoAllowedTools,
+  getDisplayableToolReturn,
 } from "../agent/approval-execution";
 import {
   buildApprovalRecoveryMessage,
@@ -7333,7 +7334,7 @@ DO NOT respond to these messages or otherwise consider them in your response unl
           id: "dummy",
           date: new Date().toISOString(),
           tool_call_id: approval.toolCallId,
-          tool_return: toolResult.toolReturn,
+          tool_return: getDisplayableToolReturn(toolResult.toolReturn),
           status: toolResult.status,
           stdout: toolResult.stdout,
           stderr: toolResult.stderr,

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -594,12 +594,30 @@ export const ToolCallMessage = memo(
         }
       }
 
-      // Check if this is a file read tool - show line count summary
+      // Check if this is a file read tool - show line count or image summary
       if (
         isFileReadTool(rawName) &&
         line.resultOk !== false &&
         line.resultText
       ) {
+        // Check if this is an image result (starts with "[Image: filename]")
+        const isImageResult = line.resultText.startsWith("[Image: ");
+
+        if (isImageResult) {
+          return (
+            <Box flexDirection="row">
+              <Box width={prefixWidth} flexShrink={0}>
+                <Text>{prefix}</Text>
+              </Box>
+              <Box flexGrow={1} width={contentWidth}>
+                <Text>
+                  Read <Text bold>1</Text> image
+                </Text>
+              </Box>
+            </Box>
+          );
+        }
+
         // Count lines in the result (the content returned by Read tool)
         const lineCount = line.resultText.split("\n").length;
         return (
@@ -609,7 +627,8 @@ export const ToolCallMessage = memo(
             </Box>
             <Box flexGrow={1} width={contentWidth}>
               <Text>
-                Read <Text bold>{lineCount}</Text> lines
+                Read <Text bold>{lineCount}</Text> line
+                {lineCount !== 1 ? "s" : ""}
               </Text>
             </Box>
           </Box>

--- a/src/tools/descriptions/Read.md
+++ b/src/tools/descriptions/Read.md
@@ -9,6 +9,8 @@ Usage:
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated
 - Results are returned using cat -n format, with line numbers starting at 1
+- This tool allows Letta Code to read images (PNG, JPG, JPEG, GIF, WEBP, BMP). When reading an image file the contents are presented visually as Letta Code is a multimodal LLM. Large images are automatically resized to fit within API limits.
+- You will regularly be asked to read screenshots. If the user provides a path to a screenshot, ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths.
 - This tool can only read files, not directories. To read a directory, use the ls command via Bash.
 - You can call multiple tools in a single response. It is always better to speculatively read multiple potentially useful files in parallel.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.

--- a/src/tools/impl/ReadFileGemini.ts
+++ b/src/tools/impl/ReadFileGemini.ts
@@ -3,12 +3,27 @@
  * Uses Gemini's exact schema and description
  */
 
-import { read } from "./Read";
+import type { TextContent } from "@letta-ai/letta-client/resources/agents/messages";
+import { read, type ToolReturnContent } from "./Read";
 
 interface ReadFileGeminiArgs {
   file_path: string;
   offset?: number;
   limit?: number;
+}
+
+/**
+ * Extract text from tool return content (for Gemini wrapper)
+ */
+function extractText(content: ToolReturnContent): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  // Extract text from multimodal content (Gemini doesn't support images via this tool)
+  return content
+    .filter((part): part is TextContent => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
 }
 
 export async function read_file_gemini(
@@ -24,6 +39,6 @@ export async function read_file_gemini(
 
   const result = await read(lettaArgs);
 
-  // Read returns { content: string }
-  return { message: result.content };
+  // Read returns { content: ToolReturnContent } - extract text for Gemini
+  return { message: extractText(result.content) };
 }

--- a/src/tools/impl/ReadLSP.ts
+++ b/src/tools/impl/ReadLSP.ts
@@ -2,7 +2,7 @@
  * LSP-enhanced Read tool - wraps the base Read tool and adds LSP diagnostics
  * This is used when LETTA_ENABLE_LSP is set
  */
-import { read as baseRead } from "./Read.js";
+import { read as baseRead, type ToolReturnContent } from "./Read.js";
 
 // Format a single diagnostic in opencode style: "ERROR [line:col] message"
 function formatDiagnostic(diag: {
@@ -30,7 +30,7 @@ interface ReadLSPArgs {
 }
 
 interface ReadLSPResult {
-  content: string;
+  content: ToolReturnContent;
 }
 
 export async function read_lsp(args: ReadLSPArgs): Promise<ReadLSPResult> {
@@ -39,6 +39,11 @@ export async function read_lsp(args: ReadLSPArgs): Promise<ReadLSPResult> {
 
   // Skip LSP if not enabled (shouldn't happen since we only load this when enabled)
   if (!process.env.LETTA_ENABLE_LSP) {
+    return result;
+  }
+
+  // If content is multimodal (image), skip LSP processing - only applies to text files
+  if (typeof result.content !== "string") {
     return result;
   }
 


### PR DESCRIPTION
Re-implements image reading using proper SDK support for multimodal tool returns. The Read tool now detects image files by extension and returns them as structured ImageContent alongside text context.

Key changes:
- Update @letta-ai/letta-client to 1.7.2 (adds image support in ToolReturn.tool_return)
- Read tool detects images (PNG, JPG, JPEG, GIF, WEBP, BMP) and returns base64 with auto-resizing
- ToolExecutionResult.toolReturn now supports string | Array<TextContent | ImageContent>
- UI extracts text for display while backend receives full multimodal content
- Fixed pluralization: "Read 1 line" vs "Read N lines", "Read 1 image" for images

Unlike the previous implementation (#603), this approach uses the native SDK support instead of queueing images in a separate registry.

👾 Generated with [Letta Code](https://letta.com)