### PR TITLE
fix: reduce image resize limit to 2000px for many-image requests

### DIFF
--- a/src/cli/helpers/clipboard.ts
+++ b/src/cli/helpers/clipboard.ts
@@ -236,7 +236,7 @@ const UTI_TO_MEDIA_TYPE: Record<string, string> = {
 /**
  * Import image from macOS clipboard, resize if needed, return placeholder.
  * Uses temp file approach to avoid stdout buffer limits.
- * Resizes large images to fit within API limits (2048x2048).
+ * Resizes large images to fit within API limits (2000x2000).
  */
 export async function tryImportClipboardImageMac(): Promise<ClipboardImageResult> {
   if (process.platform !== "darwin") return null;

--- a/src/cli/helpers/imageResize.ts
+++ b/src/cli/helpers/imageResize.ts
@@ -2,10 +2,10 @@
 // Follows Codex CLI's approach (codex-rs/utils/image/src/lib.rs)
 import sharp from "sharp";
 
-// Conservative limits that work with Anthropic's API (max 8000x8000)
-// Codex uses 2048x768, we use 2048x2048 for more flexibility with tall screenshots
-export const MAX_IMAGE_WIDTH = 2048;
-export const MAX_IMAGE_HEIGHT = 2048;
+// Anthropic limits: 8000x8000 for single images, but 2000x2000 for many-image requests
+// We use 2000 to stay safe when conversation history accumulates multiple images
+export const MAX_IMAGE_WIDTH = 2000;
+export const MAX_IMAGE_HEIGHT = 2000;
 
 export interface ResizeResult {
   data: string; // base64 encoded


### PR DESCRIPTION
Anthropic's API has a stricter 2000px limit when >20 images are in a request (vs 8000px for single images). Our 2048px limit was breaking when conversations accumulated images over time.

🐾 Generated with [Letta Code](https://letta.com)