### PR TITLE
fix: prevent premature cancellation of server-side tools in mixed execution

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1776,11 +1776,16 @@ export default function App({
         // If we're sending a new message, old pending state is no longer relevant
         // Pass false to avoid setting interrupted=true, which causes race conditions
         // with concurrent processConversation calls reading the flag
-        markIncompleteToolsAsCancelled(
-          buffersRef.current,
-          false,
-          "internal_cancel",
-        );
+        // IMPORTANT: Skip this when allowReentry=true (continuing after tool execution)
+        // because server-side tools (like memory) may still be pending and their results
+        // will arrive in this stream. Cancelling them prematurely shows "Cancelled" in UI.
+        if (!allowReentry) {
+          markIncompleteToolsAsCancelled(
+            buffersRef.current,
+            false,
+            "internal_cancel",
+          );
+        }
         // Reset interrupted flag since we're starting a fresh stream
         buffersRef.current.interrupted = false;
 


### PR DESCRIPTION
When parallel tool calls include both client-side (approval-required) and server-side (auto-executed) tools, the server-side tool's result was incorrectly shown as "Cancelled".

Root cause: markIncompleteToolsAsCancelled() was called at the start of every processConversation call, including when continuing after tool execution (allowReentry=true). Server-side tools don't execute until we respond to the approval request, so their results arrive in the second stream. Cancelling them before that stream processes their results caused the "Cancelled" display.

Fix: Only call markIncompleteToolsAsCancelled when starting a new user turn (allowReentry=false), not when continuing after tool execution.

Fixes LET-7134

👾 Generated with [Letta Code](https://letta.com)