### PR TITLE
fix: update isolated blocks in conversation context for Skill tool

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -7,6 +7,7 @@ interface AgentContext {
   agentId: string | null;
   skillsDirectory: string | null;
   hasLoadedSkills: boolean;
+  conversationId: string | null;
 }
 
 // Use globalThis to ensure singleton across bundle
@@ -24,6 +25,7 @@ function getContext(): AgentContext {
       agentId: null,
       skillsDirectory: null,
       hasLoadedSkills: false,
+      conversationId: null,
     };
   }
   return global[CONTEXT_KEY];
@@ -84,6 +86,22 @@ export function hasLoadedSkills(): boolean {
  */
 export function setHasLoadedSkills(loaded: boolean): void {
   context.hasLoadedSkills = loaded;
+}
+
+/**
+ * Set the current conversation ID
+ * @param conversationId - The conversation ID, or null to clear
+ */
+export function setConversationId(conversationId: string | null): void {
+  context.conversationId = conversationId;
+}
+
+/**
+ * Get the current conversation ID
+ * @returns The conversation ID or null if not set
+ */
+export function getConversationId(): string | null {
+  return context.conversationId;
 }
 
 /**

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -16,7 +16,11 @@ import {
   isConversationBusyError,
 } from "./agent/approval-recovery";
 import { getClient } from "./agent/client";
-import { initializeLoadedSkillsFlag, setAgentContext } from "./agent/context";
+import {
+  initializeLoadedSkillsFlag,
+  setAgentContext,
+  setConversationId,
+} from "./agent/context";
 import { createAgent } from "./agent/create";
 import { ensureSkillsBlocks, ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import { sendMessageStream } from "./agent/message";
@@ -658,6 +662,9 @@ export async function handleHeadlessCommand(
     conversationId = "default";
   }
   markMilestone("HEADLESS_CONVERSATION_READY");
+
+  // Set conversation ID in context for tools (e.g., Skill tool) to access
+  setConversationId(conversationId);
 
   // Save session (agent + conversation) to both project and global settings
   // Skip for subagents - they shouldn't pollute the LRU settings

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { getResumeData, type ResumeData } from "./agent/check-approval";
 import { getClient } from "./agent/client";
-import { initializeLoadedSkillsFlag, setAgentContext } from "./agent/context";
+import {
+  initializeLoadedSkillsFlag,
+  setAgentContext,
+  setConversationId as setContextConversationId,
+} from "./agent/context";
 import type { AgentProvenance } from "./agent/create";
 import { INCOGNITO_TAG, MEMO_TAG } from "./agent/defaults";
 import { ensureSkillsBlocks, ISOLATED_BLOCK_LABELS } from "./agent/memory";
@@ -1767,6 +1771,8 @@ async function main(): Promise<void> {
         setAgentId(agent.id);
         setAgentState(agent);
         setConversationId(conversationIdToUse);
+        // Also set in global context for tools (e.g., Skill tool) to access
+        setContextConversationId(conversationIdToUse);
         setLoadingState("ready");
       }
 


### PR DESCRIPTION
When skills/loaded_skills blocks are isolated per-conversation, the Skill tool was updating the agent-level block instead of the conversation's isolated copy. This caused skill content to never appear in the agent's context after loading.

Changes:
- Add conversationId to agent context (context.ts)
- Set conversationId when starting sessions (headless.ts, index.ts)
- Add helpers to resolve and update isolated blocks (Skill.ts)
- Cache isolated block IDs to avoid repeated API calls
- Safe fallback to agent-level blocks on any error

🐾 Generated with [Letta Code](https://letta.com)