### PR TITLE
fix: clear stale queued approvals after successful approval flow

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3935,6 +3935,9 @@ export default function App({
             { type: "approval", approvals: allResults },
           ]);
           toolResultsInFlightRef.current = false;
+
+          // Clear any stale queued results from previous interrupts.
+          queueApprovalResults(null);
         }
       } finally {
         if (shouldTrackAutoAllowed) {
@@ -6864,6 +6867,12 @@ DO NOT respond to these messages or otherwise consider them in your response unl
             },
           ]);
           toolResultsInFlightRef.current = false;
+
+          // Clear any stale queued results from previous interrupts.
+          // This approval flow supersedes any previously queued results - if we don't
+          // clear them here, they persist with matching generation and get sent on the
+          // next onSubmit, causing "Invalid tool call IDs" errors.
+          queueApprovalResults(null);
         }
       } finally {
         // Always release the execution guard, even if an error occurred


### PR DESCRIPTION
When an interrupt occurred during tool execution, approval results were queued with the current generation for later submission. However, if the user then went through a different approval flow (via dialog or auto-allowed), the stale queued results persisted because:

1. sendAllResults builds its own allResults from current state
2. It never checks or clears queuedApprovalResults
3. The queue is only consumed in onSubmit

This caused "Invalid tool call IDs" errors when the user eventually sent a message - the stale results (with matching generation) were sent instead of results for the current pending tool.

Fix: Clear queuedApprovalResults after processConversation succeeds in:
- sendAllResults (user approval via dialog)
- checkPendingApprovalsForSlashCommand (auto-allowed before slash commands)

The auto-allowed path in processConversation already had this fix.

🤖 Generated with [Letta Code](https://letta.com)