### PR TITLE
fix: allow @ file selection during search debounce

### DIFF
--- a/src/cli/components/FileAutocomplete.tsx
+++ b/src/cli/components/FileAutocomplete.tsx
@@ -68,7 +68,6 @@ export function FileAutocomplete({
     maxVisible: 10,
     onSelect: onSelect ? (item) => onSelect(item.path) : undefined,
     manageActiveState: false, // We manage active state manually due to async loading
-    disabled: isLoading,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Previously, Tab/Enter were blocked during the 300ms search debounce because `disabled: isLoading` was passed to the navigation hook. This prevented users from selecting visible matches while typing.

🐛 Generated with [Letta Code](https://letta.com)