### PR TITLE
fix: invalid tool call ID recovery and system-reminder tag centralization

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -13,7 +13,11 @@ import {
   addToolCall,
   updateSubagent,
 } from "../../cli/helpers/subagentState.js";
-import { INTERRUPTED_BY_USER } from "../../constants";
+import {
+  INTERRUPTED_BY_USER,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../constants";
 import { cliPermissions } from "../../permissions/cli";
 import { permissionMode } from "../../permissions/mode";
 import { sessionPermissions } from "../../permissions/session";
@@ -643,11 +647,11 @@ function buildDeploySystemReminder(
       ? "read-only tools (Read, Glob, Grep)"
       : "local tools (Bash, Read, Write, Edit, etc.)";
 
-  return `<system-reminder>
+  return `${SYSTEM_REMINDER_OPEN}
 This task is from "${senderAgentName}" (agent ID: ${senderAgentId}), which deployed you as a subagent inside the Letta Code CLI (docs.letta.com/letta-code).
 You have access to ${toolDescription} in their codebase.
 Your final message will be returned to the caller.
-</system-reminder>
+${SYSTEM_REMINDER_CLOSE}
 
 `;
 }

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -4,6 +4,7 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import { Box, Text, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getClient } from "../../agent/client";
+import { SYSTEM_REMINDER_OPEN } from "../../constants";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
@@ -85,7 +86,7 @@ function extractUserMessagePreview(message: Message): string | null {
       const part = content[i];
       if (part?.type === "text" && part.text) {
         // Skip system-reminder blocks
-        if (part.text.startsWith("<system-reminder>")) continue;
+        if (part.text.startsWith(SYSTEM_REMINDER_OPEN)) continue;
         textToShow = part.text;
         break;
       }

--- a/src/cli/helpers/sessionContext.ts
+++ b/src/cli/helpers/sessionContext.ts
@@ -4,6 +4,7 @@
 import { execSync } from "node:child_process";
 import { platform } from "node:os";
 import { LETTA_CLOUD_API_URL } from "../../auth/oauth";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
 
@@ -194,7 +195,7 @@ export function buildSessionContext(options: SessionContextOptions): string {
     }
 
     // Build the context
-    let context = `<system-reminder>
+    let context = `${SYSTEM_REMINDER_OPEN}
 This is an automated message providing context about the user's environment.
 The user has just initiated a new connection via the [Letta Code CLI client](https://docs.letta.com/letta-code/index.md).
 
@@ -242,7 +243,7 @@ ${gitInfo.status}
 - **Agent description**: ${agentInfo.description || "(no description)"} (the user can change this with /description)
 - **Last message**: ${lastRunInfo}
 - **Server location**: ${actualServerUrl}
-</system-reminder>`;
+${SYSTEM_REMINDER_CLOSE}`;
 
     return context;
   } catch {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,13 @@ export const DEFAULT_AGENT_NAME = "Nameless Agent";
 export const INTERRUPTED_BY_USER = "Interrupted by user";
 
 /**
+ * XML tag used to wrap system reminder content injected into messages
+ */
+export const SYSTEM_REMINDER_TAG = "system-reminder";
+export const SYSTEM_REMINDER_OPEN = `<${SYSTEM_REMINDER_TAG}>`;
+export const SYSTEM_REMINDER_CLOSE = `</${SYSTEM_REMINDER_TAG}>`;
+
+/**
  * Status bar thresholds - only show indicators when values exceed these
  */
 // Show token count after 100 estimated tokens (shows exact count until 1k, then compact)

--- a/src/skills/builtin/messaging-agents/scripts/continue-conversation.ts
+++ b/src/skills/builtin/messaging-agents/scripts/continue-conversation.ts
@@ -22,6 +22,10 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../../../constants";
 
 // Use createRequire for @letta-ai/letta-client so NODE_PATH is respected
 // (ES module imports don't respect NODE_PATH, but require does)
@@ -92,11 +96,11 @@ function buildSystemReminder(
   senderAgentName: string,
   senderAgentId: string,
 ): string {
-  return `<system-reminder>
+  return `${SYSTEM_REMINDER_OPEN}
 This message is from "${senderAgentName}" (agent ID: ${senderAgentId}), an agent currently running inside the Letta Code CLI (docs.letta.com/letta-code).
 The sender will only see the final message you generate (not tool calls or reasoning).
 If you need to share detailed information, include it in your response text.
-</system-reminder>
+${SYSTEM_REMINDER_CLOSE}
 
 `;
 }

--- a/src/skills/builtin/messaging-agents/scripts/start-conversation.ts
+++ b/src/skills/builtin/messaging-agents/scripts/start-conversation.ts
@@ -22,6 +22,10 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../../../constants";
 
 // Use createRequire for @letta-ai/letta-client so NODE_PATH is respected
 // (ES module imports don't respect NODE_PATH, but require does)
@@ -92,11 +96,11 @@ function buildSystemReminder(
   senderAgentName: string,
   senderAgentId: string,
 ): string {
-  return `<system-reminder>
+  return `${SYSTEM_REMINDER_OPEN}
 This message is from "${senderAgentName}" (agent ID: ${senderAgentId}), an agent currently running inside the Letta Code CLI (docs.letta.com/letta-code).
 The sender will only see the final message you generate (not tool calls or reasoning).
 If you need to share detailed information, include it in your response text.
-</system-reminder>
+${SYSTEM_REMINDER_CLOSE}
 
 `;
 }

--- a/src/tests/approval-recovery.test.ts
+++ b/src/tests/approval-recovery.test.ts
@@ -3,6 +3,7 @@ import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   isApprovalPendingError,
   isApprovalStateDesyncError,
+  isInvalidToolCallIdsError,
 } from "../agent/approval-recovery";
 import { extractApprovals } from "../agent/check-approval";
 
@@ -31,6 +32,21 @@ describe("isApprovalStateDesyncError", () => {
     expect(isApprovalStateDesyncError(detail)).toBe(true);
   });
 
+  test("detects invalid tool call IDs error", () => {
+    const detail =
+      "Invalid tool call IDs: Expected ['tc_abc123'], got ['tc_xyz789']";
+    expect(isApprovalStateDesyncError(detail)).toBe(true);
+  });
+
+  test("detects invalid tool call IDs error case-insensitively", () => {
+    expect(
+      isApprovalStateDesyncError("INVALID TOOL CALL IDS: Expected X, got Y"),
+    ).toBe(true);
+    expect(isApprovalStateDesyncError("invalid tool call ids: mismatch")).toBe(
+      true,
+    );
+  });
+
   test("returns false for unrelated errors", () => {
     expect(isApprovalStateDesyncError("Connection timeout")).toBe(false);
     expect(isApprovalStateDesyncError("Internal server error")).toBe(false);
@@ -41,6 +57,43 @@ describe("isApprovalStateDesyncError", () => {
     expect(isApprovalStateDesyncError(undefined)).toBe(false);
     expect(isApprovalStateDesyncError(123)).toBe(false);
     expect(isApprovalStateDesyncError({ error: "test" })).toBe(false);
+  });
+});
+
+describe("isInvalidToolCallIdsError", () => {
+  test("detects invalid tool call IDs error", () => {
+    const detail =
+      "Invalid tool call IDs: Expected ['tc_abc123'], got ['tc_xyz789']";
+    expect(isInvalidToolCallIdsError(detail)).toBe(true);
+  });
+
+  test("detects invalid tool call IDs error case-insensitively", () => {
+    expect(
+      isInvalidToolCallIdsError("INVALID TOOL CALL IDS: Expected X, got Y"),
+    ).toBe(true);
+    expect(isInvalidToolCallIdsError("invalid tool call ids: mismatch")).toBe(
+      true,
+    );
+  });
+
+  test("returns false for 'no tool call awaiting' error", () => {
+    // This is a different desync type - server has NO pending approvals
+    expect(
+      isInvalidToolCallIdsError("No tool call is currently awaiting approval"),
+    ).toBe(false);
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isInvalidToolCallIdsError("Connection timeout")).toBe(false);
+    expect(isInvalidToolCallIdsError("Internal server error")).toBe(false);
+    expect(isInvalidToolCallIdsError("Rate limit exceeded")).toBe(false);
+  });
+
+  test("returns false for non-string input", () => {
+    expect(isInvalidToolCallIdsError(null)).toBe(false);
+    expect(isInvalidToolCallIdsError(undefined)).toBe(false);
+    expect(isInvalidToolCallIdsError(123)).toBe(false);
+    expect(isInvalidToolCallIdsError({ error: "test" })).toBe(false);
   });
 });
 

--- a/src/tests/skills/messaging-agents-scripts.test.ts
+++ b/src/tests/skills/messaging-agents-scripts.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type Letta from "@letta-ai/letta-client";
+import { SYSTEM_REMINDER_OPEN } from "../../constants";
 import { continueConversation } from "../../skills/builtin/messaging-agents/scripts/continue-conversation";
 import { startConversation } from "../../skills/builtin/messaging-agents/scripts/start-conversation";
 
@@ -98,7 +99,7 @@ describe("start-conversation", () => {
 
     // Check message was sent with system reminder
     expect(mockMessageCreate).toHaveBeenCalledWith(mockConversation.id, {
-      input: expect.stringContaining("<system-reminder>"),
+      input: expect.stringContaining(SYSTEM_REMINDER_OPEN),
     });
     expect(mockMessageCreate).toHaveBeenCalledWith(mockConversation.id, {
       input: expect.stringContaining("Hello!"),
@@ -217,7 +218,7 @@ describe("continue-conversation", () => {
 
     // Check message was sent with system reminder
     expect(mockMessageCreate).toHaveBeenCalledWith(mockConversation.id, {
-      input: expect.stringContaining("<system-reminder>"),
+      input: expect.stringContaining(SYSTEM_REMINDER_OPEN),
     });
     expect(mockMessageCreate).toHaveBeenCalledWith(mockConversation.id, {
       input: expect.stringContaining("Follow-up question"),

--- a/src/tests/tools/read.test.ts
+++ b/src/tests/tools/read.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { SYSTEM_REMINDER_OPEN } from "../../constants";
 import { read } from "../../tools/impl/Read";
 import { TestDirectory } from "../helpers/testFs";
 
@@ -115,7 +116,7 @@ export default box;
 
     const result = await read({ file_path: file });
 
-    expect(result.content).toContain("<system-reminder>");
+    expect(result.content).toContain(SYSTEM_REMINDER_OPEN);
     expect(result.content).toContain("empty contents");
   });
 
@@ -125,7 +126,7 @@ export default box;
 
     const result = await read({ file_path: file });
 
-    expect(result.content).toContain("<system-reminder>");
+    expect(result.content).toContain(SYSTEM_REMINDER_OPEN);
     expect(result.content).toContain("empty contents");
   });
 });

--- a/src/tools/impl/Read.ts
+++ b/src/tools/impl/Read.ts
@@ -6,6 +6,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import { LETTA_CLOUD_API_URL } from "../../auth/oauth.js";
 import { resizeImageIfNeeded } from "../../cli/helpers/imageResize.js";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { settingsManager } from "../../settings-manager.js";
 import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
 import { LIMITS } from "./truncation.js";
@@ -249,7 +250,7 @@ export async function read(args: ReadArgs): Promise<ReadResult> {
     const content = await fs.readFile(resolvedPath, "utf-8");
     if (content.trim() === "") {
       return {
-        content: `<system-reminder>\nThe file ${resolvedPath} exists but has empty contents.\n</system-reminder>`,
+        content: `${SYSTEM_REMINDER_OPEN}\nThe file ${resolvedPath} exists but has empty contents.\n${SYSTEM_REMINDER_CLOSE}`,
       };
     }
     const formattedContent = formatWithLineNumbers(

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -205,7 +205,10 @@ export interface RetryMessage extends MessageEnvelope {
 export interface RecoveryMessage extends MessageEnvelope {
   type: "recovery";
   /** Type of recovery performed */
-  recovery_type: "approval_pending" | "approval_desync";
+  recovery_type:
+    | "approval_pending"
+    | "approval_desync"
+    | "invalid_tool_call_ids";
   /** Human-readable description of what happened */
   message: string;
   run_id?: string;


### PR DESCRIPTION
- Added invalid tool call ID recovery: detect "Invalid tool call IDs" errors, fetch actual pending approvals, clear stale approval state, restore the user's message, and show the fetched approvals (pre‑stream + post‑stream).
    - Also added the same recovery path in headless mode.
    - Added tests + protocol union update for the new recovery type.
- Hardened queued approval behavior: clear queued approvals when resyncing, and keep approval state consistent.
- Centralized system‑reminder tags: added SYSTEM_REMINDER_TAG/OPEN/CLOSE in src/constants.ts, replaced hardcoded tags across CLI, session context, subagents, tools, and messaging scripts, and updated tests.
- Improved restore input filtering: now strips system‑reminder blocks from both string and array content when restoring input, so we don't re‑inject internal reminders.

👾 Generated with [Letta Code](https://letta.com)