### PR TITLE
fix: replace console.warn with debugWarn for EAGER_CANCEL timeout

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -72,7 +72,7 @@ import {
   savePermissionRule,
   type ToolExecutionResult,
 } from "../tools/manager";
-import { debugLog } from "../utils/debug";
+import { debugLog, debugWarn } from "../utils/debug";
 import {
   handleMcpAdd,
   handleMcpUsage,
@@ -3290,7 +3290,7 @@ export default function App({
       // Set timeout as safety net in case server doesn't respond
       const abortTimeoutId = setTimeout(() => {
         if (abortControllerRef.current) {
-          console.warn("[EAGER_CANCEL] Forcing abort after 30s timeout");
+          debugWarn("EAGER_CANCEL", "Forcing abort after 30s timeout");
           abortControllerRef.current.abort();
           abortControllerRef.current = null;
         }


### PR DESCRIPTION
## Summary
- Replaces accidental `console.warn` with `debugWarn` for the eager cancel timeout message
- Now only logs when `LETTA_DEBUG=1` is set, avoiding noise in user terminal

👾 Generated with [Letta Code](https://letta.com)