### PR TITLE
fix: reset isLoading state in file autocomplete early-return paths

### DIFF
--- a/src/cli/components/FileAutocomplete.tsx
+++ b/src/cli/components/FileAutocomplete.tsx
@@ -81,6 +81,7 @@ export function FileAutocomplete({
 
     if (!result) {
       setMatches([]);
+      setIsLoading(false);
       onActiveChange?.(false);
       return;
     }
@@ -96,6 +97,7 @@ export function FileAutocomplete({
       // Always hide if there's more non-whitespace content after, or another @
       if (afterSpace.trim().length > 0 || afterSpace.includes("@")) {
         setMatches([]);
+        setIsLoading(false);
         onActiveChange?.(false);
         return;
       }
@@ -107,12 +109,14 @@ export function FileAutocomplete({
         if (matches[0]?.path !== query) {
           setMatches([{ path: query, type: "file" }]);
         }
+        setIsLoading(false);
         onActiveChange?.(false); // Don't block Enter key
         return;
       }
 
       // No valid selection was made, hide
       setMatches([]);
+      setIsLoading(false);
       onActiveChange?.(false);
       return;
     }
@@ -138,6 +142,7 @@ export function FileAutocomplete({
     // Check if it's a URL pattern (no debounce)
     if (query.startsWith("http://") || query.startsWith("https://")) {
       setMatches([{ path: query, type: "url" }]);
+      setIsLoading(false);
       onActiveChange?.(true);
       return;
     }


### PR DESCRIPTION
The file autocomplete UI would stay visible showing "Searching..." even after the cursor moved past the @ reference. This happened because multiple early-return code paths cleared matches and called onActiveChange(false) but didn't reset isLoading to false.

The render condition `matches.length === 0 && !isLoading` would fail since isLoading was still true, causing the component to render the loading state instead of returning null.

🐛 Generated with [Letta Code](https://letta.com)