### PR TITLE
revert: PR #638 bash abort controller

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -118,7 +118,6 @@ EventEmitter.defaultMaxListeners = 20;
 export function Input({
   visible = true,
   streaming,
-  bashRunning = false,
   tokenCount,
   thinkingMessage,
   onSubmit,
@@ -146,7 +145,6 @@ export function Input({
 }: {
   visible?: boolean;
   streaming: boolean;
-  bashRunning?: boolean;
   tokenCount: number;
   thinkingMessage: string;
   onSubmit: (message?: string) => Promise<{ submitted: boolean }>;
@@ -277,22 +275,22 @@ export function Input({
     onEscapeCancel();
   });
 
-  // Handle escape key for interrupt (when streaming or bash running) or double-escape-to-clear (when not)
+  // Handle escape key for interrupt (when streaming) or double-escape-to-clear (when not)
   useInput((_input, key) => {
     if (!visible) return;
     // Debug logging for escape key detection
     if (process.env.LETTA_DEBUG_KEYS === "1" && key.escape) {
       // eslint-disable-next-line no-console
       console.error(
-        `[debug:InputRich:escape] escape=${key.escape} visible=${visible} onEscapeCancel=${!!onEscapeCancel} streaming=${streaming} bashRunning=${bashRunning}`,
+        `[debug:InputRich:escape] escape=${key.escape} visible=${visible} onEscapeCancel=${!!onEscapeCancel} streaming=${streaming}`,
       );
     }
     // Skip if onEscapeCancel is provided - handled by the confirmation handler above
     if (onEscapeCancel) return;
 
     if (key.escape) {
-      // When streaming or bash command running, use Esc to interrupt
-      if ((streaming || bashRunning) && onInterrupt && !interruptRequested) {
+      // When streaming, use Esc to interrupt
+      if (streaming && onInterrupt && !interruptRequested) {
         onInterrupt();
         // Don't load queued messages into input - let the dequeue effect
         // in App.tsx process them automatically after the interrupt completes.
@@ -321,15 +319,9 @@ export function Input({
   useInput((input, key) => {
     if (!visible) return;
 
-    // Handle CTRL-C
+    // Handle CTRL-C for double-ctrl-c-to-exit
+    // In bash mode, CTRL-C wipes input but doesn't exit bash mode
     if (input === "c" && key.ctrl) {
-      // If bash command or streaming is running, interrupt it (like normal terminal)
-      if ((bashRunning || streaming) && onInterrupt && !interruptRequested) {
-        onInterrupt();
-        return;
-      }
-
-      // Otherwise, double-ctrl-c-to-exit behavior
       if (ctrlCPressed) {
         // Second CTRL-C - call onExit callback which handles stats and exit
         if (onExit) onExit();


### PR DESCRIPTION
## Summary
- Properly reverts PR #638 (fix: cancellation for running bash commands)
- PR #640 only partially reverted #638 (only App.tsx, missed InputRich.tsx changes)

## Changes reverted
- `bashRunning` state and `setBashRunning` 
- `bashAbortControllerRef`
- Bash abort check in `handleInterrupt`
- Abort controller creation in `handleBashSubmit`
- `signal` parameter passed to `spawnCommand`
- `isAbort` check in catch block
- `bashRunning` prop in InputRich.tsx
- Escape and Ctrl+C interrupt handlers for bash commands

## Test plan
- Verify bash mode commands still work (without cancellation support)
- Verify agent streaming cancellation still works with Escape