### PR TITLE
fix: bash mode input locking, ESC cancellation, and no timeout

### DIFF
--- a/src/cli/components/BashCommandMessage.tsx
+++ b/src/cli/components/BashCommandMessage.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { memo } from "react";
+import { INTERRUPTED_BY_USER } from "../../constants";
 import type { StreamingState } from "../helpers/accumulator";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { BlinkDot } from "./BlinkDot.js";
@@ -60,13 +61,26 @@ export const BashCommandMessage = memo(
 
         {/* Streaming output during execution */}
         {line.phase === "running" && line.streaming && (
-          <StreamingOutputDisplay streaming={line.streaming} />
+          <StreamingOutputDisplay
+            streaming={line.streaming}
+            showInterruptHint
+          />
         )}
 
         {/* Full output after completion (no collapse for bash mode) */}
-        {line.phase === "finished" && line.output && (
-          <CollapsedOutputDisplay output={line.output} maxLines={Infinity} />
-        )}
+        {line.phase === "finished" &&
+          line.output &&
+          (line.output === INTERRUPTED_BY_USER ? (
+            // Red styling for interrupted commands (LET-7199)
+            <Box flexDirection="row">
+              <Box width={5} flexShrink={0}>
+                <Text>{"  ⎿  "}</Text>
+              </Box>
+              <Text color={colors.status.interrupt}>{INTERRUPTED_BY_USER}</Text>
+            </Box>
+          ) : (
+            <CollapsedOutputDisplay output={line.output} maxLines={Infinity} />
+          ))}
 
         {/* Fallback: show output when phase is undefined (legacy bash commands before streaming) */}
         {!line.phase && line.output && (

--- a/src/cli/components/StreamingOutputDisplay.tsx
+++ b/src/cli/components/StreamingOutputDisplay.tsx
@@ -4,6 +4,8 @@ import type { StreamingState } from "../helpers/accumulator";
 
 interface StreamingOutputDisplayProps {
   streaming: StreamingState;
+  /** Show "(esc to interrupt)" hint - used by bash mode (LET-7199) */
+  showInterruptHint?: boolean;
 }
 
 /**
@@ -11,7 +13,7 @@ interface StreamingOutputDisplayProps {
  * Shows a rolling window of the last 5 lines with elapsed time.
  */
 export const StreamingOutputDisplay = memo(
-  ({ streaming }: StreamingOutputDisplayProps) => {
+  ({ streaming, showInterruptHint }: StreamingOutputDisplayProps) => {
     // Force re-render every second for elapsed timer
     const [, forceUpdate] = useState(0);
     useEffect(() => {
@@ -24,10 +26,13 @@ export const StreamingOutputDisplay = memo(
     const hiddenCount = Math.max(0, totalLineCount - tailLines.length);
 
     const firstLine = tailLines[0];
+    const interruptHint = showInterruptHint ? " (esc to interrupt)" : "";
     if (!firstLine) {
       return (
         <Box>
-          <Text dimColor>{`  ⎿  Running... (${elapsed}s)`}</Text>
+          <Text
+            dimColor
+          >{`  ⎿  Running... (${elapsed}s)${interruptHint}`}</Text>
         </Box>
       );
     }
@@ -59,7 +64,7 @@ export const StreamingOutputDisplay = memo(
         {/* Hidden count + elapsed time */}
         {hiddenCount > 0 && (
           <Text dimColor>
-            {"     "}… +{hiddenCount} more lines ({elapsed}s)
+            {"     "}… +{hiddenCount} more lines ({elapsed}s){interruptHint}
           </Text>
         )}
       </Box>

--- a/src/tools/impl/shellRunner.ts
+++ b/src/tools/impl/shellRunner.ts
@@ -42,10 +42,13 @@ export function spawnWithLauncher(
     let timedOut = false;
     let killTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      childProcess.kill("SIGTERM");
-    }, options.timeoutMs);
+    // Only set timeout if timeoutMs > 0 (0 means no timeout)
+    const timeoutId = options.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          childProcess.kill("SIGTERM");
+        }, options.timeoutMs)
+      : null;
 
     const abortHandler = () => {
       childProcess.kill("SIGTERM");
@@ -72,7 +75,7 @@ export function spawnWithLauncher(
     });
 
     childProcess.on("error", (err: NodeJS.ErrnoException) => {
-      clearTimeout(timeoutId);
+      if (timeoutId) clearTimeout(timeoutId);
       if (killTimer) {
         clearTimeout(killTimer);
         killTimer = null;
@@ -92,7 +95,7 @@ export function spawnWithLauncher(
     });
 
     childProcess.on("close", (code) => {
-      clearTimeout(timeoutId);
+      if (timeoutId) clearTimeout(timeoutId);
       if (killTimer) {
         clearTimeout(killTimer);
         killTimer = null;


### PR DESCRIPTION
- Add input locking while bash command is running (prevents concurrent commands)
- Add ESC key handling to interrupt running bash commands
- Remove 30s timeout (user must ESC to cancel long-running commands)
- Show "(esc to interrupt)" hint next to running timer
- Show "(Command completed with no output)" for empty successful commands
- Style "Interrupted by user" in red (matching client-side tool styling)

Fixes LET-7199

🤖 Generated with [Letta Code](https://letta.com)