### PR TITLE
fix: make toolset switching atomic to prevent tool desync race

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -8,7 +8,10 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import { getClientToolsFromRegistry } from "../tools/manager";
+import {
+  getClientToolsFromRegistry,
+  waitForToolsetReady,
+} from "../tools/manager";
 import { isTimingsEnabled } from "../utils/timing";
 import { getClient } from "./client";
 
@@ -41,6 +44,10 @@ export async function sendMessageStream(
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;
 
   const client = await getClient();
+
+  // Wait for any in-progress toolset switch to complete before reading tools
+  // This prevents sending messages with stale tools during a switch
+  await waitForToolsetReady();
 
   let stream: Stream<LettaStreamingResponse>;
 


### PR DESCRIPTION
When switching toolsets via /toolset, the registry was cleared synchronously then tools loaded asynchronously. Messages could be sent during this window with stale/partial tools, causing parallel tool calls to have mixed success/failure ("Tool not found" for some).

Changes:
- Add replaceRegistry() helper for atomic clear+populate
- Add switch lock mechanism (acquireSwitchLock/releaseSwitchLock) with ref-counting to handle overlapping switches
- Export waitForToolsetReady() and await it in sendMessageStream() before reading tools
- Add clearToolsWithLock() for forceToolsetSwitch("none") case

👾 Generated with [Letta Code](https://letta.com)