### PR TITLE
feat: remove conversation_search from main agent default tools

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -136,7 +136,6 @@ export async function createAgent(
   const defaultBaseTools = options.baseTools ?? [
     baseMemoryTool,
     "web_search",
-    "conversation_search",
     "fetch_webpage",
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ OPTIONS
   --new                 Create new conversation (for concurrent sessions)
   --new-agent           Create new agent directly (skip profile selection)
   --init-blocks <list>  Comma-separated memory blocks to initialize when using --new-agent (e.g., "persona,skills")
-  --base-tools <list>   Comma-separated base tools to attach when using --new-agent (e.g., "memory,web_search,conversation_search")
+  --base-tools <list>   Comma-separated base tools to attach when using --new-agent (e.g., "memory,web_search,fetch_webpage")
   -a, --agent <id>      Use a specific agent ID
   -n, --name <name>     Resume agent by name (from pinned agents, case-insensitive)
   -m, --model <id>      Model ID or handle (e.g., "opus-4.5" or "anthropic/claude-opus-4-5")


### PR DESCRIPTION
## Summary
- Removes `conversation_search` from the default base tools for main agents
- Main agents should use the `recall` skill instead (which spawns a subagent with conversation_search access)
- Subagents still retain `conversation_search` access for direct searching
- Updates CLI help text example to reflect new defaults

## Test plan
- [ ] Create a new agent and verify it doesn't have `conversation_search` in its tools
- [ ] Verify subagents still have access to `conversation_search`
- [ ] Test that `--base-tools` flag can still add `conversation_search` if needed

🤖 Generated with [Letta Code](https://letta.com)