### PR TITLE
fix: -m flag now correctly applies model variants with same handle

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -540,18 +540,13 @@ export async function handleHeadlessCommand(
         process.exit(1);
       }
 
-      // Optimization: Skip update if agent is already using the specified model
-      const currentModel = agent.llm_config?.model;
-      const currentEndpointType = agent.llm_config?.model_endpoint_type;
-      const currentHandle = `${currentEndpointType}/${currentModel}`;
-
-      if (currentHandle !== modelHandle) {
-        const { updateAgentLLMConfig } = await import("./agent/modify");
-        const updateArgs = getModelUpdateArgs(model);
-        await updateAgentLLMConfig(agent.id, modelHandle, updateArgs);
-        // Refresh agent state after model update
-        agent = await client.agents.retrieve(agent.id);
-      }
+      // Always apply model update - different model IDs can share the same
+      // handle but have different settings (e.g., gpt-5.2-medium vs gpt-5.2-xhigh)
+      const { updateAgentLLMConfig } = await import("./agent/modify");
+      const updateArgs = getModelUpdateArgs(model);
+      await updateAgentLLMConfig(agent.id, modelHandle, updateArgs);
+      // Refresh agent state after model update
+      agent = await client.agents.retrieve(agent.id);
     }
 
     if (systemPromptPreset) {


### PR DESCRIPTION
## Summary

- Fixes the `-m` / `--model` flag not working when switching between model variants that share the same handle (e.g., `gpt-5.2-medium` → `gpt-5.2-xhigh`)
- Removed a premature optimization that compared only handles, missing different `updateArgs` like `reasoning_effort`
- No impact on default startup (fix only affects paths where `-m` is explicitly passed)

Fixes #675

👾 Generated with [Letta Code](https://letta.com)