### PR TITLE
fix: make cursor visible on newline characters in multi-line input

### DIFF
--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -74,7 +74,13 @@ function TextInput({ value: originalValue, placeholder = '', focus = true, mask,
         renderedValue = value.length > 0 ? '' : chalk.inverse(' ');
         let i = 0;
         for (const char of value) {
-            renderedValue += i >= cursorOffset - cursorActualWidth && i <= cursorOffset ? chalk.inverse(char) : char;
+            const isCursorPosition = i >= cursorOffset - cursorActualWidth && i <= cursorOffset;
+            if (isCursorPosition && char === '\n') {
+                // Newline at cursor: show inverted space (visible cursor) then the newline
+                renderedValue += chalk.inverse(' ') + char;
+            } else {
+                renderedValue += isCursorPosition ? chalk.inverse(char) : char;
+            }
             i++;
         }
         if (value.length > 0 && cursorOffset === value.length) {


### PR DESCRIPTION
When navigating multi-line input (created with Shift+Enter), the cursor would become invisible when positioned on `\n` characters because `chalk.inverse('\n')` produces no visible output.

Fix: render an inverted space before the newline character to show a visible cursor block at the end of the line.

Fixes #687

👾 Generated with [Letta Code](https://letta.com)