### PR TITLE
fix: correct help text for letta --new flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ BEHAVIOR
 EXAMPLES
   # when installed as an executable
   letta                    # Show profile selector or create new
-  letta --new              # Create new agent directly
+  letta --new              # Create new conversation
   letta --agent agent_123  # Open specific agent
 
   # inside the interactive session


### PR DESCRIPTION
Fixed incorrect example in help text that said `letta --new` creates a new agent directly. The correct behavior is that it creates a new conversation for concurrent sessions. Creating a new agent is done with `--new-agent` flag.

🐾 Generated with [Letta Code](https://letta.com)