### PR TITLE
feat: auto-generate changelog in GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,51 @@
+# Configuration for automatically generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - bot
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: "🚀 New Features"
+      labels:
+        - feat
+        - feature
+        - enhancement
+
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+        - bugfix
+
+    - title: "📚 Documentation"
+      labels:
+        - docs
+        - documentation
+
+    - title: "🧪 Tests"
+      labels:
+        - test
+        - tests
+        - testing
+
+    - title: "🔧 Maintenance"
+      labels:
+        - chore
+        - maintenance
+        - refactor
+        - cleanup
+
+    - title: "⬆️ Dependencies"
+      labels:
+        - dependencies
+        - deps
+
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,10 @@ jobs:
           name: Release ${{ steps.version.outputs.tag }}
           body: |
             Release ${{ steps.version.outputs.tag }}
-            
+
             Changes from ${{ steps.version.outputs.old_version }} to ${{ steps.version.outputs.new_version }}
+          generate_release_notes: true
+          append_body: true
           files: letta.js
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
## Summary

Currently, release notes only show the version bump without any details about what changed:

```
Release v0.13.11

Changes from 0.13.10 to 0.13.11
```

This makes it difficult for users to understand what's new in each release.

## Changes

### 1. Enable auto-generated release notes (`.github/workflows/release.yml`)
- Added `generate_release_notes: true` to include PRs and commits automatically
- Added `append_body: true` to keep the existing header while appending the changelog

### 2. Configure changelog categories (`.github/release.yml`)
- 🚀 **New Features** - `feat`, `feature`, `enhancement`
- 🐛 **Bug Fixes** - `bug`, `fix`, `bugfix`
- 📚 **Documentation** - `docs`, `documentation`
- 🧪 **Tests** - `test`, `tests`, `testing`
- 🔧 **Maintenance** - `chore`, `maintenance`, `refactor`, `cleanup`
- ⬆️ **Dependencies** - `dependencies`, `deps`
- Excludes dependabot PRs and PRs labeled `skip-changelog`

## Result

After this change, releases will look like:

```markdown
Release v0.13.12

Changes from 0.13.11 to 0.13.12

## 🚀 New Features
* feat: add new model support by @user in #123

## 🐛 Bug Fixes
* fix: memory sync issue by @user in #124

**Full Changelog**: https://github.com/letta-ai/letta-code/compare/v0.13.11...v0.13.12
```

## Note

For the categories to work, PRs need to have the appropriate labels. PRs without labels will appear under "Other Changes".

## Test plan

- [ ] Verify the workflow file syntax is valid
- [ ] Trigger a test release (or dry-run) to confirm the changelog is generated correctly

🐙 Generated with [Letta Code](https://letta.com)