### PR TITLE
fix: Default agent creation on first bootup

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -73,7 +73,7 @@ async function addTagToAgent(
 /**
  * Create a fresh default Memo agent and pin it globally.
  * Always creates a new agent — does NOT search by tag to avoid picking up
- * agents created by CI or other users on shared Letta Cloud orgs.
+ * agents created by other users on shared Letta Cloud orgs.
  *
  * Respects `createDefaultAgents` setting (defaults to true).
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1267,7 +1267,7 @@ async function main(): Promise<void> {
         if (wouldShowSelector && globalPinned.length === 0) {
           // New user with no pinned agents - create a fresh Memo agent
           // NOTE: Always creates a new agent (no server-side tag lookup) to avoid
-          // picking up agents created by CI or other users on shared orgs.
+          // picking up agents created by other users on shared orgs.
           const { ensureDefaultAgents } = await import("./agent/defaults");
           try {
             const memoAgent = await ensureDefaultAgents(client);


### PR DESCRIPTION
## Summary

- Fix default agent selection to always create a fresh Memo agent on first bootup instead of reusing an existing one from the server
- Remove server-side tag lookup (`findDefaultAgent`) that caused fresh installs to pick up agents created by other users on the same Letta Cloud org
- Remove fire-and-forget `ensureDefaultAgents` call for existing users (unnecessary — they already have pinned agents)
- Remove `hasOnlyDefaultAgents` auto-select logic that bypassed the agent selector

###  Problem

On first bootup, `ensureDefaultAgents()` searched the entire Letta Cloud org for any agent tagged `default:memo`. Since CI tests share the same account and create Memo agents, a fresh install would silently reuse a CI-created agent (e.g., agent-7b28c5bf-...) instead of creating a new one.