### PR TITLE
feat: auto-generate changelog in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,8 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
           body: |
-            Release ${{ steps.version.outputs.tag }}
-            
             Changes from ${{ steps.version.outputs.old_version }} to ${{ steps.version.outputs.new_version }}
+          generate_release_notes: true
           files: letta.js
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
## Summary

- Enable `generate_release_notes: true` in the release workflow so GitHub automatically lists merged PRs and contributors in each release
- Removes redundant "Release vX.Y.Z" from the body (already in the release title) and keeps the version diff line as a header

After this change, releases will include a full list of merged PRs and new contributors instead of just "Changes from X to Y".

Inspired by #701 — this is a minimal version that works without requiring PR labels or additional config. Label-based categories can be layered on later once a labeling workflow is in place.

👾 Generated with [Letta Code](https://letta.com)