### PR TITLE
feat: add stdio MCP server support for client-side tool execution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@letta-ai/letta-code",
       "dependencies": {
         "@letta-ai/letta-client": "^1.7.6",
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "open": "^10.2.0",
@@ -36,6 +37,8 @@
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -93,6 +96,8 @@
 
     "@letta-ai/letta-client": ["@letta-ai/letta-client@1.7.6", "", {}, "sha512-C/f03uE3TJdgfHk/8rRBxzWvY0YHCYAlrePHcTd0CRHMo++0TA1OTcgiCF+EFVDVYGzfPSeMpqgAZTNvD9r9GQ=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+
     "@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
 
     "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
@@ -105,7 +110,13 @@
 
     "@vscode/ripgrep": ["@vscode/ripgrep@1.17.0", "", { "dependencies": { "https-proxy-agent": "^7.0.2", "proxy-from-env": "^1.1.0", "yauzl": "^2.9.2" } }, "sha512-mBRKm+ASPkUcw4o9aAgfbusIu6H4Sdhw09bjeP1YOBFTJEZAnrnk6WZwzv8NEjgC82f7ILvhmb1WIElSugea6g=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
 
@@ -115,6 +126,8 @@
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
@@ -122,6 +135,12 @@
     "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -139,7 +158,19 @@
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -151,35 +182,91 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "es-toolkit": ["es-toolkit@1.41.0", "", {}, "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
 
@@ -188,6 +275,8 @@
     "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
 
     "ink-text-input": ["ink-text-input@5.0.1", "", { "dependencies": { "chalk": "^5.2.0", "type-fest": "^3.6.1" }, "peerDependencies": { "ink": "^4.0.0", "react": "^18.0.0" } }, "sha512-crnsYJalG4EhneOFnr/q+Kzw1RgmXI2KsBaLFE6mpiIKxAtJLUnvygOF2IUKO8z4nwkSkveGRBMd81RoYdRSag=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -199,9 +288,19 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "lint-staged": ["lint-staged@16.2.4", "", { "dependencies": { "commander": "^14.0.1", "listr2": "^9.0.4", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-Pkyr/wd90oAyXk98i/2KwfkIhoYQUMtss769FIT9hFM5ogYZwrk+GRE46yKXSg2ZGhcJ1p38Gf5gmI5Ohjg2yg=="],
 
@@ -213,7 +312,17 @@
 
     "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -227,13 +336,29 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -241,29 +366,65 @@
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
 
     "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
@@ -279,17 +440,29 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -300,6 +473,10 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.7.6",
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",
     "open": "^10.2.0",

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -65,6 +65,14 @@ export function getCurrentAgentId(): string {
 }
 
 /**
+ * Try to get the current agent ID without throwing
+ * @returns The agent ID or null if not set
+ */
+export function tryGetCurrentAgentId(): string | null {
+  return context.agentId;
+}
+
+/**
  * Get the skills directory path
  * @returns The skills directory path or null if not set
  */

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -24,12 +24,6 @@ import {
 } from "./agent/context";
 import { createAgent } from "./agent/create";
 import { ensureSkillsBlocks, ISOLATED_BLOCK_LABELS } from "./agent/memory";
-import {
-  ensureMemoryFilesystemBlock,
-  formatMemorySyncSummary,
-  syncMemoryFilesystem,
-  updateMemoryFilesystemBlock,
-} from "./agent/memoryFilesystem";
 import { sendMessageStream } from "./agent/message";
 import { getModelUpdateArgs } from "./agent/model";
 import { SessionStats } from "./agent/stats";
@@ -586,36 +580,6 @@ export async function handleHeadlessCommand(
     }
   }
 
-  // Sync filesystem-backed memory before creating conversations (only if memfs is enabled)
-  if (settingsManager.isMemfsEnabled(agent.id)) {
-    try {
-      await ensureMemoryFilesystemBlock(agent.id);
-      const syncResult = await syncMemoryFilesystem(agent.id);
-      if (syncResult.conflicts.length > 0) {
-        console.error(
-          `Memory filesystem sync conflicts detected (${syncResult.conflicts.length}). Run in interactive mode to resolve.`,
-        );
-        process.exit(1);
-      }
-      await updateMemoryFilesystemBlock(agent.id);
-      if (
-        syncResult.updatedBlocks.length > 0 ||
-        syncResult.createdBlocks.length > 0 ||
-        syncResult.deletedBlocks.length > 0 ||
-        syncResult.updatedFiles.length > 0 ||
-        syncResult.createdFiles.length > 0 ||
-        syncResult.deletedFiles.length > 0
-      ) {
-        console.log(formatMemorySyncSummary(syncResult));
-      }
-    } catch (error) {
-      console.error(
-        `Memory filesystem sync failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      process.exit(1);
-    }
-  }
-
   // Determine which blocks to isolate for the conversation
   let isolatedBlockLabels: string[] = [];
   if (!noSkillsFlag) {
@@ -715,6 +679,19 @@ export async function handleHeadlessCommand(
   // Set agent context for tools that need it (e.g., Skill tool, Task tool)
   setAgentContext(agent.id, skillsDirectory);
 
+  // Sync MCP tools for stdio server support (fire-and-forget)
+  // This enables client-side execution of stdio MCP tools
+  (async () => {
+    try {
+      const { mcpToolTracker } = await import("./mcp/tracker");
+      await mcpToolTracker.sync(agent.id);
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to sync MCP tools: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  })();
+
   // Skills-related fire-and-forget operations (skip for subagents/--no-skills)
   if (!noSkillsFlag && !isSubagent) {
     // Fire-and-forget: Initialize loaded skills flag (LET-7101)
@@ -776,8 +753,8 @@ export async function handleHeadlessCommand(
     return;
   }
 
-  // Create buffers to accumulate stream (pass agent.id for server-side tool hooks)
-  const buffers = createBuffers(agent.id);
+  // Create buffers to accumulate stream
+  const buffers = createBuffers();
 
   // Initialize session stats
   const sessionStats = new SessionStats();
@@ -947,11 +924,7 @@ export async function handleHeadlessCommand(
           // no-op
         }
       } else {
-        await drainStreamWithResume(
-          approvalStream,
-          createBuffers(agent.id),
-          () => {},
-        );
+        await drainStreamWithResume(approvalStream, createBuffers(), () => {});
       }
     }
   };
@@ -1800,6 +1773,10 @@ export async function handleHeadlessCommand(
   // Report all milestones at the end for latency audit
   markMilestone("HEADLESS_COMPLETE");
   reportAllMilestones();
+
+  // Cleanup stdio MCP connections
+  const { cleanupStdioConnections } = await import("./mcp/executor");
+  await cleanupStdioConnections();
 }
 
 /**
@@ -2033,7 +2010,7 @@ async function runBidirectionalMode(
       currentAbortController = new AbortController();
 
       try {
-        const buffers = createBuffers(agent.id);
+        const buffers = createBuffers();
         const startTime = performance.now();
         let numTurns = 0;
 
@@ -2323,5 +2300,8 @@ async function runBidirectionalMode(
   }
 
   // Stdin closed, exit gracefully
+  // Cleanup stdio MCP connections
+  const { cleanupStdioConnections } = await import("./mcp/executor");
+  await cleanupStdioConnections();
   process.exit(0);
 }

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,183 @@
+# MCP (Model Context Protocol) Stdio Support
+
+This module enables client-side execution of stdio MCP servers in Letta Code.
+
+## Overview
+
+MCP servers can run in three transport modes:
+
+1. **HTTP/Streamable HTTP** - Server runs remotely, tools execute server-side ✅ Already supported
+2. **SSE (Server-Sent Events)** - Server runs remotely, tools execute server-side ✅ Already supported
+3. **Stdio** - Server runs locally via subprocess, tools execute client-side ✅ **NEW**
+
+Since Letta agents run on the server, stdio MCP servers cannot be executed server-side. This module solves that by:
+
+1. Running stdio MCP servers as client-side subprocesses
+2. Intercepting tool calls for stdio servers
+3. Executing them locally via the MCP SDK
+4. Returning results to the Letta server
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│         Letta Code CLI (Client)         │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │   stdio-client.ts               │   │
+│  │   - Manages stdio subprocesses  │   │
+│  │   - MCP SDK client connections  │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │   tracker.ts                    │   │
+│  │   - Maps tools → servers        │   │
+│  │   - Identifies stdio tools      │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │   executor.ts                   │   │
+│  │   - Intercepts tool calls       │   │
+│  │   - Routes stdio tools locally  │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+└─────────────────────────────────────────┘
+              │
+              │ API calls (non-stdio tools)
+              ↓
+┌─────────────────────────────────────────┐
+│         Letta Server (Backend)          │
+│                                         │
+│  - Manages agents & conversations       │
+│  - Executes HTTP/SSE MCP tools         │
+│  - Stores results                       │
+└─────────────────────────────────────────┘
+```
+
+## Usage
+
+### Adding a Stdio MCP Server
+
+```bash
+# Interactive mode
+letta
+/mcp add --transport stdio npx-mcp npx @modelcontextprotocol/server-everything
+
+# Or use the connect wizard (with OAuth support)
+/mcp connect
+```
+
+### Example: Filesystem MCP Server
+
+```bash
+# Add the official filesystem MCP server
+/mcp add --transport stdio filesystem npx @modelcontextprotocol/server-filesystem /path/to/directory
+
+# The server will run as: npx @modelcontextprotocol/server-filesystem /path/to/directory
+# Tools are automatically discovered and synced
+```
+
+### How It Works
+
+1. **Server Registration**: Stdio servers are registered with the Letta backend (same as HTTP/SSE)
+2. **Client-Side Sync**: On agent initialization, `mcpToolTracker.sync()` fetches all MCP servers and tools
+3. **Subprocess Spawning**: For stdio servers, `stdioClientManager` spawns the subprocess and establishes MCP connection
+4. **Tool Call Interception**: When a tool is called, `executeStdioMcpTool()` checks if it's a stdio tool
+5. **Local Execution**: If stdio, the tool is executed client-side via MCP SDK
+6. **Result Return**: Result is formatted and returned as if it came from the server
+
+## API Reference
+
+### `stdioClientManager`
+
+Manages stdio MCP server connections.
+
+```typescript
+import { stdioClientManager } from "./mcp";
+
+// Connect to a server
+await stdioClientManager.connect({
+  serverId: "server-123",
+  serverName: "my-server",
+  command: "npx",
+  args: ["@modelcontextprotocol/server-filesystem", "/path"],
+});
+
+// Execute a tool
+const result = await stdioClientManager.executeTool(
+  "server-123",
+  "read_file",
+  { path: "example.txt" },
+);
+
+// Disconnect
+await stdioClientManager.disconnect("server-123");
+```
+
+### `mcpToolTracker`
+
+Tracks tool-to-server mappings.
+
+```typescript
+import { mcpToolTracker } from "./mcp";
+
+// Sync tools from backend
+await mcpToolTracker.sync(agentId);
+
+// Check if a tool is from a stdio server
+if (mcpToolTracker.isStdioTool("read_file")) {
+  // Execute client-side
+}
+
+// Get server ID for a tool
+const serverId = mcpToolTracker.getToolServerId("read_file");
+```
+
+### `executeStdioMcpTool`
+
+Intercepts and executes stdio MCP tools.
+
+```typescript
+import { executeStdioMcpTool } from "./mcp";
+
+// Returns null if not a stdio tool
+const result = await executeStdioMcpTool("read_file", {
+  path: "example.txt",
+});
+
+if (result !== null) {
+  // Was a stdio tool, executed client-side
+  console.log(result.toolReturn);
+}
+```
+
+## Error Handling
+
+Stdio MCP execution includes robust error handling:
+
+- **Connection Failures**: Logged to stderr, execution fails gracefully
+- **Tool Execution Errors**: Returned as error status with message
+- **Process Crashes**: Detected and logged, connection marked as failed
+- **Cleanup**: All subprocesses cleaned up on exit
+
+## Limitations
+
+1. **Client-Side Only**: Stdio servers only work in CLI/desktop mode, not in web-based UIs
+2. **No OAuth**: Stdio servers don't support OAuth (they run locally)
+3. **Process Management**: Long-running servers are subprocess children of the CLI
+
+## Future Enhancements
+
+- [ ] Auto-restart crashed stdio servers
+- [ ] Health checks for stdio connections
+- [ ] Stdio server output logging/debugging
+- [ ] Support for stdio server environment variables
+- [ ] Shared stdio connections across agents
+
+## Related Files
+
+- `src/mcp/stdio-client.ts` - Stdio subprocess manager
+- `src/mcp/tracker.ts` - Tool-to-server mapping tracker
+- `src/mcp/executor.ts` - Client-side execution logic
+- `src/tools/manager.ts` - Modified to intercept stdio tools
+- `src/headless.ts` - Sync and cleanup integration

--- a/src/mcp/example.ts
+++ b/src/mcp/example.ts
@@ -1,0 +1,188 @@
+// src/mcp/example.ts
+// Example usage of stdio MCP client-side execution
+// This file demonstrates how to use the MCP stdio support programmatically
+
+import { cleanupStdioConnections, executeStdioMcpTool } from "./executor";
+import { stdioClientManager } from "./stdio-client";
+import { mcpToolTracker } from "./tracker";
+
+/**
+ * Example 1: Direct stdio client usage
+ * Use this when you want full control over the MCP connection
+ */
+async function example1_DirectClient() {
+  // Connect to a stdio MCP server
+  await stdioClientManager.connect({
+    serverId: "filesystem-local",
+    serverName: "Filesystem",
+    command: "npx",
+    args: [
+      "@modelcontextprotocol/server-filesystem",
+      "/Users/yourusername/Documents",
+    ],
+  });
+
+  // List available tools
+  const tools = await stdioClientManager.listTools("filesystem-local");
+  console.log("Available tools:", tools.map((t) => t.name));
+
+  // Execute a tool
+  const result = await stdioClientManager.executeTool(
+    "filesystem-local",
+    "read_file",
+    { path: "example.txt" },
+  );
+  console.log("Result:", result);
+
+  // Cleanup
+  await stdioClientManager.disconnect("filesystem-local");
+}
+
+/**
+ * Example 2: Using the tracker (recommended)
+ * Use this when you want to work with tools registered in Letta
+ */
+async function example2_WithTracker() {
+  const agentId = "agent-123"; // Your agent ID
+
+  // Sync tools from Letta backend
+  // This automatically connects to all stdio servers
+  await mcpToolTracker.sync(agentId);
+
+  // Check if a tool is from a stdio server
+  const isStdio = mcpToolTracker.isStdioTool("read_file");
+  console.log("Is stdio tool:", isStdio);
+
+  // Get server ID for a tool
+  const serverId = mcpToolTracker.getToolServerId("read_file");
+  console.log("Server ID:", serverId);
+
+  // Execute the tool (automatically routes to correct server)
+  if (serverId) {
+    const result = await stdioClientManager.executeTool(serverId, "read_file", {
+      path: "example.txt",
+    });
+    console.log("Result:", result);
+  }
+
+  // Cleanup all connections
+  await cleanupStdioConnections();
+}
+
+/**
+ * Example 3: Using the executor (highest level)
+ * Use this for seamless integration with existing tool execution
+ */
+async function example3_WithExecutor() {
+  const agentId = "agent-123"; // Your agent ID
+
+  // Sync tools
+  await mcpToolTracker.sync(agentId);
+
+  // Execute a tool - automatically detects if it's stdio and routes appropriately
+  const result = await executeStdioMcpTool("read_file", {
+    path: "example.txt",
+  });
+
+  if (result !== null) {
+    // Tool was executed client-side
+    console.log("Stdio result:", result);
+  } else {
+    // Tool is not a stdio tool (would be executed server-side)
+    console.log("Not a stdio tool");
+  }
+
+  // Cleanup
+  await cleanupStdioConnections();
+}
+
+/**
+ * Example 4: Error handling
+ */
+async function example4_ErrorHandling() {
+  try {
+    await stdioClientManager.connect({
+      serverId: "test-server",
+      serverName: "Test",
+      command: "invalid-command", // This will fail
+      args: [],
+    });
+  } catch (error) {
+    console.error("Connection failed:", error);
+    // Error is logged to stderr and thrown
+  }
+
+  try {
+    const result = await stdioClientManager.executeTool(
+      "nonexistent-server",
+      "some_tool",
+      {},
+    );
+  } catch (error) {
+    console.error("Tool execution failed:", error);
+    // Error message: "Stdio MCP server not connected: nonexistent-server"
+  }
+}
+
+/**
+ * Example 5: Multiple servers
+ */
+async function example5_MultipleServers() {
+  // Connect to multiple stdio servers
+  await stdioClientManager.connect({
+    serverId: "filesystem",
+    serverName: "Filesystem",
+    command: "npx",
+    args: ["@modelcontextprotocol/server-filesystem", "/data"],
+  });
+
+  await stdioClientManager.connect({
+    serverId: "postgres",
+    serverName: "PostgreSQL",
+    command: "npx",
+    args: [
+      "@modelcontextprotocol/server-postgres",
+      "postgresql://localhost/mydb",
+    ],
+  });
+
+  // Get all connected servers
+  const servers = stdioClientManager.getConnectedServers();
+  console.log("Connected servers:", servers);
+
+  // Execute tools on different servers
+  const fileResult = await stdioClientManager.executeTool(
+    "filesystem",
+    "read_file",
+    { path: "data.txt" },
+  );
+
+  const dbResult = await stdioClientManager.executeTool(
+    "postgres",
+    "query",
+    { sql: "SELECT * FROM users LIMIT 10" },
+  );
+
+  console.log("File result:", fileResult);
+  console.log("DB result:", dbResult);
+
+  // Cleanup all
+  await cleanupStdioConnections();
+}
+
+// Run examples (comment out the ones you don't want to run)
+if (import.meta.main) {
+  // example1_DirectClient();
+  // example2_WithTracker();
+  // example3_WithExecutor();
+  // example4_ErrorHandling();
+  // example5_MultipleServers();
+}
+
+export {
+  example1_DirectClient,
+  example2_WithTracker,
+  example3_WithExecutor,
+  example4_ErrorHandling,
+  example5_MultipleServers,
+};

--- a/src/mcp/executor.ts
+++ b/src/mcp/executor.ts
@@ -1,0 +1,104 @@
+// src/mcp/executor.ts
+// Client-side execution of stdio MCP tools
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolExecutionResult } from "../tools/manager";
+import { stdioClientManager } from "./stdio-client";
+import { mcpToolTracker } from "./tracker";
+
+/**
+ * Convert MCP CallToolResult to Letta ToolExecutionResult format.
+ */
+function convertMcpResult(mcpResult: CallToolResult): ToolExecutionResult {
+  // Extract text content from MCP result
+  let textContent = "";
+  const contentArray = Array.isArray(mcpResult.content)
+    ? mcpResult.content
+    : [mcpResult.content];
+
+  for (const item of contentArray) {
+    if (item.type === "text") {
+      textContent += item.text;
+    } else if (item.type === "image") {
+      // For images, include a reference
+      textContent += `[Image: ${item.data.substring(0, 50)}...]`;
+    } else if (item.type === "resource") {
+      // For resources, include the URI
+      textContent += `[Resource: ${item.resource.uri}]`;
+    }
+  }
+
+  return {
+    toolReturn: textContent || "(empty response)",
+    status: mcpResult.isError ? "error" : "success",
+    stdout: undefined,
+    stderr: mcpResult.isError ? textContent : undefined,
+  };
+}
+
+/**
+ * Execute a tool client-side if it belongs to a stdio MCP server.
+ * Returns null if the tool is not a stdio MCP tool (caller should execute server-side).
+ *
+ * @param toolName Tool name
+ * @param args Tool arguments
+ * @returns ToolExecutionResult if stdio tool, null otherwise
+ */
+export async function executeStdioMcpTool(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<ToolExecutionResult | null> {
+  // Check if this is a stdio MCP tool
+  if (!mcpToolTracker.isStdioTool(toolName)) {
+    return null;
+  }
+
+  const serverId = mcpToolTracker.getToolServerId(toolName);
+  if (!serverId) {
+    throw new Error(`[mcp] Could not find server for stdio tool: ${toolName}`);
+  }
+
+  // Ensure client is connected
+  if (!stdioClientManager.isConnected(serverId)) {
+    const serverConfig = mcpToolTracker.getStdioServer(serverId);
+    if (!serverConfig) {
+      throw new Error(`[mcp] Could not find config for server: ${serverId}`);
+    }
+
+    await stdioClientManager.connect({
+      serverId,
+      serverName: serverConfig.name,
+      command: serverConfig.command,
+      args: serverConfig.args,
+    });
+  }
+
+  // Execute the tool
+  try {
+    console.error(
+      `[mcp] Executing stdio tool client-side: ${toolName} (server: ${serverId})`,
+    );
+    const mcpResult = await stdioClientManager.executeTool(
+      serverId,
+      toolName,
+      args,
+    );
+    return convertMcpResult(mcpResult);
+  } catch (error) {
+    const errorMessage = `[mcp] Stdio tool execution failed: ${error instanceof Error ? error.message : String(error)}`;
+    console.error(errorMessage);
+    return {
+      toolReturn: errorMessage,
+      status: "error",
+      stderr: errorMessage,
+    };
+  }
+}
+
+/**
+ * Cleanup all stdio MCP connections.
+ * Call this on graceful shutdown.
+ */
+export async function cleanupStdioConnections(): Promise<void> {
+  await stdioClientManager.disconnectAll();
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,13 @@
+// src/mcp/index.ts
+// MCP (Model Context Protocol) support for Letta Code
+
+export { stdioClientManager } from "./stdio-client";
+export { mcpToolTracker } from "./tracker";
+export { executeStdioMcpTool, cleanupStdioConnections } from "./executor";
+export { localMcpConfig } from "./local-config";
+export {
+  registerMcpToolsWithServer,
+  unregisterMcpToolsFromServer,
+  isMcpToolRegisteredWithServer,
+  getMcpServerIdForTool,
+} from "./server-registration";

--- a/src/mcp/local-config.ts
+++ b/src/mcp/local-config.ts
@@ -1,0 +1,166 @@
+// src/mcp/local-config.ts
+// Local-only stdio MCP server configuration (not synced to Letta server)
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+interface StdioServerConfig {
+  id: string;
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+interface LocalMcpConfig {
+  stdioServers: StdioServerConfig[];
+}
+
+const CONFIG_DIR = join(homedir(), ".letta");
+const MCP_CONFIG_FILE = join(CONFIG_DIR, "mcp-stdio.json");
+
+/**
+ * Manages local-only stdio MCP server configurations.
+ * These are stored client-side and never sent to the Letta server.
+ */
+class LocalMcpConfigManager {
+  private config: LocalMcpConfig | null = null;
+
+  /**
+   * Load local config from disk.
+   */
+  private loadConfig(): LocalMcpConfig {
+    if (this.config) return this.config;
+
+    // Ensure config directory exists
+    if (!existsSync(CONFIG_DIR)) {
+      mkdirSync(CONFIG_DIR, { recursive: true });
+    }
+
+    // Load or create config file
+    if (existsSync(MCP_CONFIG_FILE)) {
+      try {
+        const content = readFileSync(MCP_CONFIG_FILE, "utf-8");
+        this.config = JSON.parse(content);
+      } catch (error) {
+        console.error(
+          `[mcp] Failed to load config: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        this.config = { stdioServers: [] };
+      }
+    } else {
+      this.config = { stdioServers: [] };
+      this.saveConfig();
+    }
+
+    return this.config;
+  }
+
+  /**
+   * Save config to disk.
+   */
+  private saveConfig(): void {
+    if (!this.config) return;
+
+    try {
+      writeFileSync(MCP_CONFIG_FILE, JSON.stringify(this.config, null, 2));
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to save config: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Add a stdio server to local config.
+   */
+  addStdioServer(config: StdioServerConfig): void {
+    const currentConfig = this.loadConfig();
+
+    // Check if server already exists
+    const existing = currentConfig.stdioServers.find(
+      (s) => s.id === config.id || s.name === config.name,
+    );
+    if (existing) {
+      throw new Error(
+        `Stdio server with name "${config.name}" already exists`,
+      );
+    }
+
+    currentConfig.stdioServers.push(config);
+    this.saveConfig();
+
+    console.error(`[mcp] Added local stdio server: ${config.name}`);
+  }
+
+  /**
+   * Remove a stdio server from local config.
+   */
+  removeStdioServer(idOrName: string): boolean {
+    const currentConfig = this.loadConfig();
+    const initialLength = currentConfig.stdioServers.length;
+
+    currentConfig.stdioServers = currentConfig.stdioServers.filter(
+      (s) => s.id !== idOrName && s.name !== idOrName,
+    );
+
+    if (currentConfig.stdioServers.length < initialLength) {
+      this.saveConfig();
+      console.error(`[mcp] Removed local stdio server: ${idOrName}`);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get all stdio servers.
+   */
+  getStdioServers(): StdioServerConfig[] {
+    return this.loadConfig().stdioServers;
+  }
+
+  /**
+   * Get a specific stdio server by ID or name.
+   */
+  getStdioServer(idOrName: string): StdioServerConfig | null {
+    const servers = this.loadConfig().stdioServers;
+    return (
+      servers.find((s) => s.id === idOrName || s.name === idOrName) || null
+    );
+  }
+
+  /**
+   * Update a stdio server config.
+   */
+  updateStdioServer(
+    idOrName: string,
+    updates: Partial<Omit<StdioServerConfig, "id">>,
+  ): boolean {
+    const currentConfig = this.loadConfig();
+    const server = currentConfig.stdioServers.find(
+      (s) => s.id === idOrName || s.name === idOrName,
+    );
+
+    if (!server) return false;
+
+    Object.assign(server, updates);
+    this.saveConfig();
+
+    console.error(`[mcp] Updated local stdio server: ${server.name}`);
+    return true;
+  }
+
+  /**
+   * Clear all stdio servers.
+   */
+  clearAll(): void {
+    this.config = { stdioServers: [] };
+    this.saveConfig();
+    console.error("[mcp] Cleared all local stdio servers");
+  }
+}
+
+// Singleton instance
+export const localMcpConfig = new LocalMcpConfigManager();

--- a/src/mcp/server-registration.ts
+++ b/src/mcp/server-registration.ts
@@ -21,7 +21,7 @@ export async function registerMcpToolsWithServer(
   serverId: string,
   serverName: string,
   tools: McpToolSchema[],
-  maxTools: number = 9, // Limit to avoid hitting quota (account limit is 10)
+  maxTools: number = 7, // Limit to avoid hitting quota (account limit is 10)
 ): Promise<{ registered: string[]; errors: Array<{ tool: string; error: string }> }> {
   const client = await getClient();
   const registered: string[] = [];

--- a/src/mcp/server-registration.ts
+++ b/src/mcp/server-registration.ts
@@ -1,0 +1,263 @@
+// src/mcp/server-registration.ts
+// Server-aware MCP tool registration (following the design document)
+
+import type { Tool } from "@letta-ai/letta-client/resources/tools";
+import { getClient } from "../agent/client";
+import { localMcpConfig } from "./local-config";
+import { stdioClientManager } from "./stdio-client";
+
+interface McpToolSchema {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/**
+ * Register stdio MCP tools with Letta Cloud as CLIENT_MCP type.
+ * This follows the design document approach where the server knows about MCP tools.
+ */
+export async function registerMcpToolsWithServer(
+  agentId: string,
+  serverId: string,
+  serverName: string,
+  tools: McpToolSchema[],
+  maxTools: number = 9, // Limit to avoid hitting quota (account limit is 10)
+): Promise<{ registered: string[]; errors: Array<{ tool: string; error: string }> }> {
+  const client = await getClient();
+  const registered: string[] = [];
+  const errors: Array<{ tool: string; error: string }> = [];
+
+  // Limit tools to avoid quota issues
+  const toolsToRegister = tools.slice(0, maxTools);
+  console.error(`[mcp] Registering ${toolsToRegister.length}/${tools.length} tools (limit: ${maxTools})`);
+
+  for (const tool of toolsToRegister) {
+    try {
+      // Sanitize tool name for Python function name (replace hyphens with underscores)
+      const pythonName = sanitizeToolName(tool.name);
+
+      // Generate source code (name is derived from function name in source_code)
+      const sourceCode = generateMcpToolSourceCode(tool, pythonName, serverId);
+
+      // Convert MCP schema to Letta format
+      const description = tool.description
+        ? `[MCP:${serverName}] ${tool.description}`
+        : `MCP tool from ${serverName}`;
+
+      // Register with Letta Cloud
+      // Letta extracts name from json_schema.name (NOT from source_code parsing!)
+      // See: letta/services/tool_manager.py - create_or_update_tool_async
+      const createdTool = await client.tools.create({
+        source_code: sourceCode,
+        description: description,
+        tags: ["mcp", "client-side", serverName, `mcp-server:${serverId}`],
+        source_type: "python",
+        // REQUIRE APPROVAL so the tool goes through the approval flow
+        // This allows our CLI to intercept and execute client-side
+        default_requires_approval: true,
+        // IMPORTANT: json_schema MUST have 'name' at root level for Letta to use it!
+        // The 'parameters' object contains the actual input schema
+        json_schema: {
+          name: pythonName, // <-- THIS IS THE KEY! Letta uses json_schema.name
+          // Nested parameters object - this is what the agent sees
+          parameters: {
+            type: "object",
+            properties: tool.inputSchema.properties || {},
+            required: (tool.inputSchema.required as string[]) || [],
+          },
+          // MCP metadata (custom fields)
+          "x-mcp-server": serverId,
+          "x-mcp-server-name": serverName,
+          "x-is-mcp": true,
+          "x-mcp-original-name": tool.name, // Store original name with hyphens
+        },
+      });
+
+      // Attach tool to agent
+      await client.agents.tools.attach(createdTool.id, {
+        agent_id: agentId,
+      });
+
+      registered.push(tool.name);
+      console.error(
+        `[mcp] Registered tool with server: ${tool.name} → ${pythonName} (${createdTool.id})`,
+      );
+    } catch (error) {
+      const errorMsg =
+        error instanceof Error ? error.message : String(error);
+      errors.push({ tool: tool.name, error: errorMsg });
+      console.error(
+        `[mcp] Failed to register tool ${tool.name}: ${errorMsg}`,
+      );
+    }
+  }
+
+  return { registered, errors };
+}
+
+/**
+ * Sanitize tool name for Python function naming.
+ * Converts hyphens to underscores and ensures valid Python identifier.
+ */
+function sanitizeToolName(name: string): string {
+  // Replace hyphens and other invalid chars with underscores
+  let sanitized = name.replace(/[-]/g, "_");
+  
+  // Ensure starts with letter or underscore
+  if (!/^[a-zA-Z_]/.test(sanitized)) {
+    sanitized = `mcp_${sanitized}`;
+  }
+  
+  // Replace any remaining invalid characters
+  sanitized = sanitized.replace(/[^a-zA-Z0-9_]/g, "_");
+  
+  return sanitized;
+}
+
+/**
+ * Generate stub source code for MCP tool.
+ * Must be minimal and parseable by Letta's Python parser.
+ * The function name becomes the tool name in Letta.
+ */
+function generateMcpToolSourceCode(
+  mcpTool: McpToolSchema,
+  pythonName: string,
+  _serverId: string,
+): string {
+  // Letta's Python parser is very strict.
+  // Use the absolute simplest one-liner format that definitely works.
+  // ALWAYS use **kwargs to ensure consistent parsing.
+  // Single-line format avoids any indentation/newline issues.
+  const desc = (mcpTool.description || "MCP tool").slice(0, 50).replace(/["\n\r]/g, " ");
+  
+  // Simplest valid Python function with docstring
+  return `def ${pythonName}(**kwargs):\n    """${desc}"""\n    pass`;
+}
+
+/**
+ * Unregister MCP tools from the server when removing a stdio server.
+ */
+export async function unregisterMcpToolsFromServer(
+  agentId: string,
+  serverId: string,
+): Promise<void> {
+  const client = await getClient();
+
+  try {
+    // Get all tools for the agent
+    const agentTools = await client.agents.tools.list(agentId);
+
+    // Filter tools that belong to this MCP server
+    const mcpTools = agentTools.items?.filter((tool) => {
+      const schema = tool.json_schema as Record<string, unknown>;
+      return schema?.["x-mcp-server"] === serverId;
+    });
+
+    if (!mcpTools || mcpTools.length === 0) {
+      console.error(
+        `[mcp] No tools found for server ${serverId} to unregister`,
+      );
+      return;
+    }
+
+    // Detach and delete each tool
+    for (const tool of mcpTools) {
+      if (!tool.id) continue;
+
+      try {
+        // Detach from agent
+        await client.agents.tools.delete(agentId, tool.id);
+
+        // Delete the tool
+        await client.tools.delete(tool.id);
+
+        console.error(`[mcp] Unregistered tool: ${tool.name}`);
+      } catch (error) {
+        console.error(
+          `[mcp] Failed to unregister tool ${tool.name}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  } catch (error) {
+    console.error(
+      `[mcp] Failed to unregister tools for server ${serverId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Check if a tool is registered as an MCP tool with the server.
+ */
+export async function isMcpToolRegisteredWithServer(
+  agentId: string,
+  toolName: string,
+): Promise<boolean> {
+  try {
+    const client = await getClient();
+    const agentTools = await client.agents.tools.list(agentId);
+
+    const tool = agentTools.items?.find((t) => t.name === toolName);
+    if (!tool) return false;
+
+    const schema = tool.json_schema as Record<string, unknown>;
+    return schema?.["x-is-mcp"] === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the MCP server ID for a registered tool.
+ * Handles both original MCP names (with hyphens) and sanitized Python names.
+ */
+export async function getMcpServerIdForTool(
+  agentId: string,
+  toolName: string,
+): Promise<string | null> {
+  const info = await getMcpToolInfo(agentId, toolName);
+  return info?.serverId ?? null;
+}
+
+/**
+ * Get full MCP tool info including the original tool name.
+ * This is needed because Python-safe names (get_env) differ from MCP names (get-env).
+ */
+export async function getMcpToolInfo(
+  agentId: string,
+  toolName: string,
+): Promise<{ serverId: string; originalName: string } | null> {
+  try {
+    const client = await getClient();
+    const agentTools = await client.agents.tools.list(agentId);
+
+    // Try to find by Python name first
+    let tool = agentTools.items?.find((t) => t.name === toolName);
+    
+    // If not found, try sanitized version
+    if (!tool) {
+      const sanitized = sanitizeToolName(toolName);
+      tool = agentTools.items?.find((t) => t.name === sanitized);
+    }
+    
+    // If still not found, try finding by original MCP name in schema
+    if (!tool) {
+      tool = agentTools.items?.find((t) => {
+        const schema = t.json_schema as Record<string, unknown>;
+        return schema?.["x-mcp-original-name"] === toolName;
+      });
+    }
+
+    if (!tool) return null;
+
+    const schema = tool.json_schema as Record<string, unknown>;
+    const serverId = schema?.["x-mcp-server"] as string;
+    // Use original name if stored, otherwise fall back to the Python name
+    const originalName = (schema?.["x-mcp-original-name"] as string) || toolName;
+    
+    if (!serverId) return null;
+    
+    return { serverId, originalName };
+  } catch {
+    return null;
+  }
+}

--- a/src/mcp/server-registration.ts
+++ b/src/mcp/server-registration.ts
@@ -21,7 +21,7 @@ export async function registerMcpToolsWithServer(
   serverId: string,
   serverName: string,
   tools: McpToolSchema[],
-  maxTools: number = 7, // Limit to avoid hitting quota (account limit is 10)
+  maxTools: number = 9, // Limit tools registered per MCP server
 ): Promise<{ registered: string[]; errors: Array<{ tool: string; error: string }> }> {
   const client = await getClient();
   const registered: string[] = [];

--- a/src/mcp/stdio-client.ts
+++ b/src/mcp/stdio-client.ts
@@ -1,0 +1,221 @@
+// src/mcp/stdio-client.ts
+// Client-side stdio MCP server manager
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+interface StdioServerConfig {
+  serverId: string;
+  serverName: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * Manages client-side stdio MCP connections.
+ * Each stdio server runs as a subprocess and communicates via stdin/stdout.
+ */
+class StdioClientManager {
+  private clients = new Map<string, Client>();
+  private transports = new Map<string, StdioClientTransport>();
+  private configs = new Map<string, StdioServerConfig>();
+  private initializationPromises = new Map<string, Promise<void>>();
+
+  /**
+   * Register and connect to a stdio MCP server.
+   * @param config Server configuration
+   */
+  async connect(config: StdioServerConfig): Promise<void> {
+    // If already connected, skip
+    if (this.clients.has(config.serverId)) {
+      return;
+    }
+
+    // If initialization in progress, wait for it
+    const existingInit = this.initializationPromises.get(config.serverId);
+    if (existingInit) {
+      return existingInit;
+    }
+
+    // Start new initialization
+    const initPromise = this._initializeConnection(config);
+    this.initializationPromises.set(config.serverId, initPromise);
+
+    try {
+      await initPromise;
+    } finally {
+      this.initializationPromises.delete(config.serverId);
+    }
+  }
+
+  private async _initializeConnection(
+    config: StdioServerConfig,
+  ): Promise<void> {
+    try {
+      // Create transport (which will spawn the process internally)
+      const transport = new StdioClientTransport({
+        command: config.command,
+        args: config.args,
+        env: config.env,
+      });
+
+      // Create client
+      const client = new Client(
+        {
+          name: "letta-code",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {},
+        },
+      );
+
+      // Connect
+      await client.connect(transport);
+
+      // Store
+      this.clients.set(config.serverId, client);
+      this.transports.set(config.serverId, transport);
+      this.configs.set(config.serverId, config);
+
+      console.error(
+        `[mcp] Connected to stdio server: ${config.serverName} (${config.serverId})`,
+      );
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to connect to ${config.serverName}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Execute a tool on a stdio MCP server.
+   * @param serverId Server ID
+   * @param toolName Tool name
+   * @param args Tool arguments
+   * @returns Tool execution result
+   */
+  async executeTool(
+    serverId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const client = this.clients.get(serverId);
+    if (!client) {
+      throw new Error(
+        `[mcp] Stdio MCP server not connected: ${serverId}. Call connect() first.`,
+      );
+    }
+
+    try {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: args,
+      });
+      return result;
+    } catch (error) {
+      console.error(
+        `[mcp] Tool execution failed for ${toolName}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * List tools available from a stdio server.
+   * @param serverId Server ID
+   * @returns Array of tool information
+   */
+  async listTools(serverId: string): Promise<
+    Array<{
+      name: string;
+      description?: string;
+      inputSchema: Record<string, unknown>;
+    }>
+  > {
+    const client = this.clients.get(serverId);
+    if (!client) {
+      throw new Error(
+        `[mcp] Stdio MCP server not connected: ${serverId}. Call connect() first.`,
+      );
+    }
+
+    try {
+      const response = await client.listTools();
+      return response.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      }));
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to list tools: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from a stdio server.
+   * @param serverId Server ID
+   */
+  async disconnect(serverId: string): Promise<void> {
+    const client = this.clients.get(serverId);
+    const transport = this.transports.get(serverId);
+
+    if (client) {
+      try {
+        await client.close();
+      } catch (error) {
+        console.error(
+          `[mcp] Error closing client: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (transport) {
+      try {
+        await transport.close();
+      } catch (error) {
+        console.error(
+          `[mcp] Error closing transport: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    this.clients.delete(serverId);
+    this.transports.delete(serverId);
+    this.configs.delete(serverId);
+
+    console.error(`[mcp] Disconnected from stdio server: ${serverId}`);
+  }
+
+  /**
+   * Disconnect from all stdio servers.
+   */
+  async disconnectAll(): Promise<void> {
+    const serverIds = Array.from(this.clients.keys());
+    await Promise.all(serverIds.map((id) => this.disconnect(id)));
+  }
+
+  /**
+   * Check if a server is connected.
+   * @param serverId Server ID
+   */
+  isConnected(serverId: string): boolean {
+    return this.clients.has(serverId);
+  }
+
+  /**
+   * Get all connected server IDs.
+   */
+  getConnectedServers(): string[] {
+    return Array.from(this.clients.keys());
+  }
+}
+
+// Singleton instance
+export const stdioClientManager = new StdioClientManager();

--- a/src/mcp/tracker.ts
+++ b/src/mcp/tracker.ts
@@ -1,0 +1,312 @@
+// src/mcp/tracker.ts
+// Tracks which tools belong to stdio MCP servers for client-side execution
+
+import type {
+  SseMcpServer,
+  StdioMcpServer,
+  StreamableHTTPMcpServer,
+} from "@letta-ai/letta-client/resources/mcp-servers/mcp-servers";
+import { getClient } from "../agent/client";
+import { localMcpConfig } from "./local-config";
+import { stdioClientManager } from "./stdio-client";
+
+type McpServer = StreamableHTTPMcpServer | SseMcpServer | StdioMcpServer;
+
+interface ToolServerMapping {
+  toolId: string;
+  toolName: string;
+  serverId: string;
+  serverName: string;
+  serverType: "streamable_http" | "sse" | "stdio" | "stdio_local";
+}
+
+/**
+ * Manages the mapping between tools and their MCP servers.
+ * Used to identify which tools need client-side execution (stdio servers).
+ */
+class McpToolTracker {
+  private toolMappings = new Map<string, ToolServerMapping>();
+  private stdioServers = new Map<
+    string,
+    { name: string; command: string; args: string[] }
+  >();
+  private lastSync: number | null = null;
+  private syncPromise: Promise<void> | null = null;
+
+  /**
+   * Sync tool mappings from the Letta server.
+   * This should be called after agent initialization or when MCP servers change.
+   */
+  async sync(agentId: string): Promise<void> {
+    // If sync is in progress, wait for it
+    if (this.syncPromise) {
+      return this.syncPromise;
+    }
+
+    this.syncPromise = this._performSync(agentId);
+    try {
+      await this.syncPromise;
+    } finally {
+      this.syncPromise = null;
+    }
+  }
+
+  private async _performSync(agentId: string): Promise<void> {
+    try {
+      const client = await getClient();
+
+      // Fetch all MCP servers
+      const servers = await client.mcpServers.list();
+
+      // Clear existing mappings
+      this.toolMappings.clear();
+      this.stdioServers.clear();
+
+      // For each server, fetch its tools and build mappings
+      for (const server of servers) {
+        if (!server.id) continue;
+
+        try {
+          const tools = await client.mcpServers.tools.list(server.id);
+
+          for (const tool of tools) {
+            if (!tool.id || !tool.name) continue;
+
+            this.toolMappings.set(tool.name, {
+              toolId: tool.id,
+              toolName: tool.name,
+              serverId: server.id,
+              serverName: server.server_name,
+              serverType: server.mcp_server_type,
+            });
+          }
+
+          // Track stdio servers for client-side execution
+          if (server.mcp_server_type === "stdio" && "command" in server) {
+            this.stdioServers.set(server.id, {
+              name: server.server_name,
+              command: server.command,
+              args: server.args,
+            });
+
+            // Ensure stdio client is connected
+            await stdioClientManager.connect({
+              serverId: server.id,
+              serverName: server.server_name,
+              command: server.command,
+              args: server.args,
+            });
+          }
+        } catch (error) {
+          console.error(
+            `[mcp] Failed to sync tools for server ${server.server_name}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      // Load server-registered MCP tools (design document approach)
+      await this.syncServerRegisteredMcpTools(agentId);
+
+      // Also load local-only stdio servers (fallback/privacy approach)
+      await this.syncLocalStdioServers();
+
+      this.lastSync = Date.now();
+      console.error(
+        `[mcp] Synced ${this.toolMappings.size} MCP tools (${this.stdioServers.size} stdio servers)`,
+      );
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to sync MCP tools: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Sync server-registered MCP tools (design document approach).
+   * These are tools registered with Letta Cloud that are marked as MCP tools.
+   */
+  private async syncServerRegisteredMcpTools(agentId: string): Promise<void> {
+    try {
+      // Skip if agent ID is invalid (e.g., "loading" placeholder)
+      if (!agentId || agentId === "loading" || !agentId.startsWith("agent-")) {
+        console.error(
+          `[mcp] Skipping server-registered MCP sync: invalid agent ID (${agentId})`,
+        );
+        return;
+      }
+
+      const client = await getClient();
+
+      // Fetch agent's tools
+      const agentTools = await client.agents.tools.list(agentId);
+
+      // Find tools with MCP metadata
+      for (const tool of agentTools.items || []) {
+        const schema = tool.json_schema as Record<string, unknown>;
+        const isMcp = schema?.["x-is-mcp"] === true;
+        const serverId = schema?.["x-mcp-server"] as string | undefined;
+        const serverName =
+          (schema?.["x-mcp-server-name"] as string | undefined) || "unknown";
+
+        if (isMcp && serverId && tool.name) {
+          // Check if this stdio server is in our local config
+          const localServer = localMcpConfig.getStdioServer(serverId);
+
+          if (localServer) {
+            // Ensure subprocess is connected
+            if (!stdioClientManager.isConnected(serverId)) {
+              await stdioClientManager.connect({
+                serverId: localServer.id,
+                serverName: localServer.name,
+                command: localServer.command,
+                args: localServer.args,
+                env: localServer.env,
+              });
+            }
+
+            // Add to mappings
+            this.toolMappings.set(tool.name, {
+              toolId: tool.id || `mcp-${serverId}-${tool.name}`,
+              toolName: tool.name,
+              serverId: serverId,
+              serverName: serverName,
+              serverType: "stdio", // Server-registered stdio
+            });
+
+            this.stdioServers.set(serverId, {
+              name: serverName,
+              command: localServer.command,
+              args: localServer.args,
+            });
+          } else {
+            console.error(
+              `[mcp] Found server-registered MCP tool "${tool.name}" but local config missing for server ${serverId}`,
+            );
+          }
+        }
+      }
+
+      const mcpToolCount = Array.from(this.toolMappings.values()).filter(
+        (m) => m.serverType === "stdio",
+      ).length;
+
+      if (mcpToolCount > 0) {
+        console.error(
+          `[mcp] Synced ${mcpToolCount} server-registered MCP tools`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        `[mcp] Failed to sync server-registered MCP tools: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Sync local-only stdio servers (not registered with Letta backend).
+   * These are managed entirely client-side (privacy-focused approach).
+   */
+  private async syncLocalStdioServers(): Promise<void> {
+    const localServers = localMcpConfig.getStdioServers();
+
+    for (const server of localServers) {
+      // Skip servers that are already synced from server-registered MCP tools
+      if (this.stdioServers.has(server.id)) {
+        continue;
+      }
+
+      try {
+        // Connect to the stdio server
+        await stdioClientManager.connect({
+          serverId: server.id,
+          serverName: server.name,
+          command: server.command,
+          args: server.args,
+          env: server.env,
+        });
+
+        // List tools from the server
+        const tools = await stdioClientManager.listTools(server.id);
+
+        // Add mappings for each tool
+        for (const tool of tools) {
+          // Only add if not already mapped (server-registered takes precedence)
+          if (!this.toolMappings.has(tool.name)) {
+            this.toolMappings.set(tool.name, {
+              toolId: `local-${server.id}-${tool.name}`,
+              toolName: tool.name,
+              serverId: server.id,
+              serverName: server.name,
+              serverType: "stdio_local", // Mark as local-only
+            });
+          }
+        }
+
+        console.error(
+          `[mcp] Loaded ${tools.length} tools from local stdio server: ${server.name}`,
+        );
+      } catch (error) {
+        console.error(
+          `[mcp] Failed to sync local stdio server ${server.name}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if a tool belongs to a stdio MCP server (requires client-side execution).
+   * @param toolName Tool name
+   * @returns true if the tool is from a stdio server (local or remote)
+   */
+  isStdioTool(toolName: string): boolean {
+    const mapping = this.toolMappings.get(toolName);
+    return (
+      mapping?.serverType === "stdio" || mapping?.serverType === "stdio_local"
+    );
+  }
+
+  /**
+   * Get the server ID for a tool.
+   * @param toolName Tool name
+   * @returns Server ID or null if not found
+   */
+  getToolServerId(toolName: string): string | null {
+    return this.toolMappings.get(toolName)?.serverId ?? null;
+  }
+
+  /**
+   * Get all stdio server IDs.
+   */
+  getStdioServerIds(): string[] {
+    return Array.from(this.stdioServers.keys());
+  }
+
+  /**
+   * Get stdio server config by ID.
+   */
+  getStdioServer(
+    serverId: string,
+  ): { name: string; command: string; args: string[] } | null {
+    return this.stdioServers.get(serverId) ?? null;
+  }
+
+  /**
+   * Check if sync is needed (no sync yet or stale).
+   */
+  needsSync(): boolean {
+    if (!this.lastSync) return true;
+    // Consider stale after 5 minutes
+    return Date.now() - this.lastSync > 5 * 60 * 1000;
+  }
+
+  /**
+   * Force a resync (useful after adding/removing MCP servers).
+   */
+  invalidate(): void {
+    this.lastSync = null;
+  }
+}
+
+// Singleton instance
+export const mcpToolTracker = new McpToolTracker();


### PR DESCRIPTION
## Summary

Implements #150 - adds support for connecting stdio MCP servers through client-side tool execution.

Since agents run on Letta Cloud, they can connect to `http` and `sse` MCP servers directly. This PR enables `stdio` server support by executing tools client-side via the CLI.

### How it works

1. User adds stdio server: `/mcp add --transport stdio <name> <command> [args...]`
2. CLI spawns the MCP server as a local subprocess
3. Tools are registered with Letta Cloud (with `require_approval=true`)
4. When agent calls a tool, CLI intercepts the approval request
5. CLI executes tool locally via stdio and returns result to server

### Changes

- Add `src/mcp/` module for managing stdio server connections
- Update `src/cli/commands/mcp.ts` with stdio server registration
- Update `src/agent/approval-execution.ts` for client-side MCP tool execution
- Update `src/headless.ts` for MCP initialization and cleanup

## Test plan
```bash
# Add stdio MCP server
/mcp add --transport stdio test npx @modelcontextprotocol/server-everything

# Test tools
echo "hello"
get environment variables
calculate sum of 10 and 25
```

## Demo

All 9 tools from `@modelcontextprotocol/server-everything` tested successfully:
- echo, get_env, get_annotated_message, get_sum, get_tiny_image
- get_structured_content, get_resource_reference, get_resource_links, gzip_file_as_resource

Closes #150