### PR TITLE
fix: improve hooks TUI - Enter to delete, better spacing

### DIFF
--- a/src/cli/components/HooksManager.tsx
+++ b/src/cli/components/HooksManager.tsx
@@ -310,13 +310,11 @@ export const HooksManager = memo(function HooksManager({
             setNewCommand("");
           }
         } else {
-          // Could add edit functionality here
+          // Delete selected hook
+          setDeleteHookIndex(selectedIndex - 1);
+          setDeleteConfirmIndex(1); // Default to No
+          setScreen("delete-confirm");
         }
-      } else if ((input === "d" || input === "D") && selectedIndex > 0) {
-        // Delete selected hook
-        setDeleteHookIndex(selectedIndex - 1);
-        setDeleteConfirmIndex(1); // Default to No
-        setScreen("delete-confirm");
       } else if (key.escape) {
         setScreen("events");
         setSelectedIndex(0);
@@ -468,7 +466,7 @@ export const HooksManager = memo(function HooksManager({
           // Both types have hooks array
           const command = "hooks" in hook ? hook.hooks[0]?.command || "" : "";
           const truncatedCommand =
-            command.length > 30 ? `${command.slice(0, 27)}...` : command;
+            command.length > 50 ? `${command.slice(0, 47)}...` : command;
 
           return (
             <Text key={`${hook.source}-${index}`}>
@@ -476,8 +474,10 @@ export const HooksManager = memo(function HooksManager({
                 {prefix} {index + 2}.{" "}
               </Text>
               <Text color="cyan">{sourceLabel}</Text>
-              {matcherPattern !== null && (
+              {matcherPattern !== null ? (
                 <Text> {matcherPattern.padEnd(12)} </Text>
+              ) : (
+                <Text> </Text>
               )}
               <Text dimColor>{truncatedCommand}</Text>
             </Text>
@@ -485,7 +485,7 @@ export const HooksManager = memo(function HooksManager({
         })}
 
         <Text> </Text>
-        <Text dimColor>Enter to select · d to delete · esc to go back</Text>
+        <Text dimColor>Enter to select · esc to go back</Text>
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- Enter on existing hooks now opens delete confirmation (was previously a no-op)
- Removed `d` key shortcut for deletion to simplify UX and match other TUI patterns
- Fixed spacing between `[Local]` and command for hooks without matchers
- Increased command truncation limit from 30 to 50 characters for better visibility

## Test plan
- [ ] Open `/hooks` TUI
- [ ] Navigate to a hook event with existing hooks
- [ ] Verify Enter on existing hook opens delete confirmation
- [ ] Verify `d` key no longer triggers delete
- [ ] Verify spacing is correct for hooks without matchers (e.g., Stop hooks)
- [ ] Verify longer commands display more characters before truncation

🐾 Generated with [Letta Code](https://letta.com)