### PR TITLE
fix: use const for globalPinned

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1078,7 +1078,7 @@ async function main(): Promise<void> {
         // Load settings
         await settingsManager.loadLocalProjectSettings();
         const localSettings = settingsManager.getLocalProjectSettings();
-        let globalPinned = settingsManager.getGlobalPinnedAgents();
+        const globalPinned = settingsManager.getGlobalPinnedAgents();
         const client = await getClient();
 
         // For self-hosted servers, pre-fetch available models


### PR DESCRIPTION
## Summary
- Change `let` to `const` for `globalPinned` variable since it's never reassigned
- Fixes Biome lint warning

## Test plan
- [x] `bun run check` passes

🐾 Generated with [Letta Code](https://letta.com)