### PR TITLE
chore: add dependabot config for letta-client updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@letta-ai/letta-client"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps):"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to track `@letta-ai/letta-client` for daily version updates
- Scoped to only this dependency to avoid noise from other packages
- PRs will be labeled `dependencies` and use `chore(deps):` commit prefix

👾 Generated with [Letta Code](https://letta.com)