### PR TITLE
refactor: use constants for system-reminder tags

### DIFF
--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -1,10 +1,7 @@
 import { Text } from "ink";
 import { memo } from "react";
 import stringWidth from "string-width";
-import {
-  SYSTEM_REMINDER_CLOSE,
-  SYSTEM_REMINDER_OPEN,
-} from "../../constants";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors, hexToBgAnsi, hexToFgAnsi } from "./colors";
 


### PR DESCRIPTION
## Summary
- Use `SYSTEM_REMINDER_OPEN` and `SYSTEM_REMINDER_CLOSE` from `constants.ts` instead of hardcoded strings in `splitSystemReminderBlocks()`
- Ensures consistency with the rest of the codebase that uses these constants

## Test plan
- [ ] Verify user messages still display correctly with system-reminder blocks