### PR TITLE
fix: show model selector on self-hosted when default model unavailable

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -12,6 +12,7 @@ import { getClient } from "./client";
 import { getDefaultMemoryBlocks } from "./memory";
 import {
   formatAvailableModels,
+  getDefaultModel,
   getModelUpdateArgs,
   resolveModel,
 } from "./model";
@@ -120,8 +121,8 @@ export async function createAgent(
     }
     modelHandle = resolved;
   } else {
-    // Use default model
-    modelHandle = "anthropic/claude-sonnet-4-5-20250929";
+    // Use default model from models.json
+    modelHandle = getDefaultModel();
   }
 
   const client = await getClient();

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -305,10 +305,6 @@ function ProfileSelectionUI({
           <Text bold color={colors.selector.title}>
             Select a model
           </Text>
-          <Text dimColor>
-            The default model ({defaultModelHandle || "unknown"}) is not
-            available on this server.
-          </Text>
 
           {showModelSearch && (
             <Box>


### PR DESCRIPTION
## Summary

On self-hosted servers without the default Anthropic model (`anthropic/claude-sonnet-4-5-20250929`), the app would crash with "model not found". This PR fixes that by:

- Using `getDefaultModel()` instead of hardcoding the Anthropic model
- Skipping auto-creation of default agents when the default model isn't available
- Showing an interactive model selector so users can pick from available models
- Removing the redundant "default model not available" message from the UI

## Test plan

- [x] Start letta-code with `LETTA_BASE_URL=http://localhost:8283` pointing to a self-hosted server without Anthropic models
- [x] Verify model selector appears instead of crash
- [x] Verify user can select a model and create an agent

Fixes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)