### PR TITLE
fix: use subtle gray background for user message highlight on dark terminals

### DIFF
--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -209,8 +209,8 @@ export const colors = {
   get userMessage() {
     const theme = getTerminalTheme();
     return {
-      background: theme === "light" ? "#dcddf2" : "#ffffff", // light purple for light, white for dark
-      text: theme === "light" ? undefined : "#000000", // black text for dark terminals
+      background: theme === "light" ? "#dcddf2" : "#2d2d2d", // light purple for light, subtle gray for dark
+      text: undefined, // use default terminal text color
     };
   },
 };


### PR DESCRIPTION
The previous white background (#ffffff) with black text was too bright on dark terminals. Now uses a subtle dark gray (#2d2d2d) with the default terminal text color, which gives light text on a subtle background.

Light mode unchanged (light purple #dcddf2).

👾 Generated with [Letta Code](https://letta.com)