### PR TITLE
fix: backcompat for init/defrag

### DIFF
--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -14,11 +14,7 @@ export const GLOBAL_BLOCK_LABELS = ["persona", "human"] as const;
 /**
  * Block labels that are stored per-project (local to the current directory).
  */
-export const PROJECT_BLOCK_LABELS = [
-  "skills",
-  "loaded_skills",
-  "memory_filesystem",
-] as const;
+export const PROJECT_BLOCK_LABELS = ["skills", "loaded_skills"] as const;
 
 /**
  * All available memory block labels (derived from global + project blocks)

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -6705,16 +6705,21 @@ ${recentCommits}
             refreshDerived();
 
             // Send trigger message instructing agent to load the initializing-memory skill
-            const initMessage = `${SYSTEM_REMINDER_OPEN}
-The user has requested memory initialization via /init.
-
+            // Only include memfs path if memfs is enabled for this agent
+            const memfsSection = settingsManager.isMemfsEnabled(agentId)
+              ? `
 ## Memory Filesystem Location
 
 Your memory blocks are synchronized with the filesystem at:
 \`~/.letta/agents/${agentId}/memory/\`
 
 Use this path when working with memory files during initialization.
+`
+              : "";
 
+            const initMessage = `${SYSTEM_REMINDER_OPEN}
+The user has requested memory initialization via /init.
+${memfsSection}
 ## 1. Load the initializing-memory skill
 
 First, check your \`loaded_skills\` memory block. If the \`initializing-memory\` skill is not already loaded:

--- a/src/skills/builtin/defragmenting-memory/SKILL.md
+++ b/src/skills/builtin/defragmenting-memory/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: defragmenting-memory
-description: Decomposes and reorganizes agent memory blocks into focused, single-purpose components. Use when memory has large multi-topic blocks, redundancy, or poor organization. Works directly on memfs files — memory sync handles propagation to the API.
+description: Decomposes and reorganizes agent memory blocks into focused, single-purpose components. Use when memory has large multi-topic blocks, redundancy, or poor organization.
 ---
 
 # Memory Defragmentation Skill
+
+> **Requires Memory Filesystem (memfs)**
+>
+> This skill works by directly editing memory files on disk. It requires the memory filesystem feature to be enabled.
+>
+> **To check:** Look for a `memory_filesystem` block in your system prompt. If it shows a tree structure of `/memory/system/` and `/memory/user/`, memfs is enabled.
+>
+> **To enable:** Ask the user to run `/memfs enable`, then reload the CLI.
 
 This skill helps you maintain clean, well-organized memory blocks by:
 1. Creating a safety backup of the memfs directory


### PR DESCRIPTION
- /init command now only includes memfs path section when memfs is enabled
- Removed memory_filesystem from PROJECT_BLOCK_LABELS so new agents without memfs don't get an unused block (created on-demand when enabled)
- Updated defragmenting-memory skill to clearly state memfs requirement

👾 Generated with [Letta Code](https://letta.com)