### PR TITLE
fix: don't extern sharp, even if unused

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,13 +17,11 @@ const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
 const version = pkg.version;
 const useMagick = Bun.env.USE_MAGICK;
 const features = []
-const externalDeps = []
 
 console.log(`📦 Building Letta Code v${version}...`);
 if (useMagick) {
   console.log(`🪄 Using magick variant of imageResize...`);
   features.push("USE_MAGICK")
-  externalDeps.push("sharp")
 }
 
 await Bun.build({
@@ -48,7 +46,6 @@ await Bun.build({
     ".txt": "text",
   },
   features: features,
-  external: externalDeps,
 });
 
 // Add shebang to output file


### PR DESCRIPTION
@cpacker sorry about this -- my changes worked in my working directory, but not as a global install. This fixes that issue