### PR TITLE
feat: add --memfs / --no-memfs CLI flags

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -120,6 +120,8 @@ export async function handleHeadlessCommand(
       "base-tools": { type: "string" },
       "from-af": { type: "string" },
       "no-skills": { type: "boolean" },
+      memfs: { type: "boolean" },
+      "no-memfs": { type: "boolean" },
     },
     strict: false,
     allowPositionals: true,
@@ -235,6 +237,8 @@ export async function handleHeadlessCommand(
   const initBlocksRaw = values["init-blocks"] as string | undefined;
   const baseToolsRaw = values["base-tools"] as string | undefined;
   const sleeptimeFlag = (values.sleeptime as boolean | undefined) ?? undefined;
+  const memfsFlag = values.memfs as boolean | undefined;
+  const noMemfsFlag = values["no-memfs"] as boolean | undefined;
   const fromAfFile = values["from-af"] as string | undefined;
 
   // Handle --conv {agent-id} shorthand: --conv agent-xyz → --agent agent-xyz --conv default
@@ -583,6 +587,13 @@ export async function handleHeadlessCommand(
     if (createdBlocks.length > 0) {
       console.log("Created missing skills blocks for agent compatibility");
     }
+  }
+
+  // Apply memfs flag if specified
+  if (memfsFlag) {
+    settingsManager.setMemfsEnabled(agent.id, true);
+  } else if (noMemfsFlag) {
+    settingsManager.setMemfsEnabled(agent.id, false);
   }
 
   // Sync filesystem-backed memory before creating conversations (only if memfs is enabled)

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ OPTIONS
   --skills <path>       Custom path to skills directory (default: .skills in current directory)
   --sleeptime           Enable sleeptime memory management (only for new agents)
   --from-af <path>      Create agent from an AgentFile (.af) template
+  --memfs               Enable memory filesystem for this agent
+  --no-memfs            Disable memory filesystem for this agent
 
 BEHAVIOR
   On startup, Letta Code checks for saved profiles:
@@ -409,6 +411,8 @@ async function main(): Promise<void> {
         sleeptime: { type: "boolean" },
         "from-af": { type: "string" },
         "no-skills": { type: "boolean" },
+        memfs: { type: "boolean" },
+        "no-memfs": { type: "boolean" },
       },
       strict: true,
       allowPositionals: true,
@@ -518,6 +522,8 @@ async function main(): Promise<void> {
   const specifiedToolset = (values.toolset as string | undefined) ?? undefined;
   const skillsDirectory = (values.skills as string | undefined) ?? undefined;
   const sleeptimeFlag = (values.sleeptime as boolean | undefined) ?? undefined;
+  const memfsFlag = values.memfs as boolean | undefined;
+  const noMemfsFlag = values["no-memfs"] as boolean | undefined;
   const fromAfFile = values["from-af"] as string | undefined;
   const isHeadless = values.prompt || values.run || !process.stdin.isTTY;
 
@@ -1589,6 +1595,13 @@ async function main(): Promise<void> {
 
         // Set agent context for tools that need it (e.g., Skill tool)
         setAgentContext(agent.id, skillsDirectory);
+
+        // Apply memfs flag if specified
+        if (memfsFlag) {
+          settingsManager.setMemfsEnabled(agent.id, true);
+        } else if (noMemfsFlag) {
+          settingsManager.setMemfsEnabled(agent.id, false);
+        }
 
         // Fire-and-forget: Initialize loaded skills flag (LET-7101)
         // Don't await - this is just for the skill unload reminder


### PR DESCRIPTION
## Summary

- Add `--memfs` flag to enable memory filesystem for an agent
- Add `--no-memfs` flag to disable memory filesystem for an agent

This is plumbing only - default behavior unchanged (memfs still off by default). Next PR will change defaults to enable memfs by default for new agents.

🐾 Generated with [Letta Code](https://letta.com)