### PR TITLE
fix(ui): show full Task prompt in approval dialogs

### DIFF
--- a/src/cli/components/ApprovalDialogRich.tsx
+++ b/src/cli/components/ApprovalDialogRich.tsx
@@ -343,12 +343,8 @@ const DynamicPreview: React.FC<DynamicPreviewProps> = ({
     const model =
       typeof parsedArgs?.model === "string" ? parsedArgs.model : undefined;
 
-    // Truncate long prompts for preview (show first ~200 chars)
-    const maxPromptLength = 200;
-    const promptPreview =
-      prompt.length > maxPromptLength
-        ? `${prompt.slice(0, maxPromptLength)}...`
-        : prompt;
+    // Show full prompt - users need to see what the task will do
+    const promptPreview = prompt;
 
     return (
       <Box flexDirection="column" paddingLeft={2}>

--- a/src/cli/components/InlineTaskApproval.tsx
+++ b/src/cli/components/InlineTaskApproval.tsx
@@ -129,8 +129,8 @@ export const InlineTaskApproval = memo(
     const memoizedTaskContent = useMemo(() => {
       const { subagentType, description, prompt, model } = taskInfo;
 
-      // Truncate prompt if too long (show first ~200 chars)
-      const truncatedPrompt = truncate(prompt, 300);
+      // Show full prompt - users need to see what the task will do
+      const truncatedPrompt = prompt;
 
       return (
         <>


### PR DESCRIPTION
## Summary

Remove truncation from Task approval dialogs so users can see the complete prompt before making approval decisions.

**Before:** Prompts truncated to 200-300 characters with "..." at the end
**After:** Full prompt displayed with text wrapping

## Changes

- `InlineTaskApproval.tsx`: Removed 300 character truncation
- `ApprovalDialogRich.tsx`: Removed 200 character truncation

## Why

Users need to see the full Task prompt to make informed decisions about whether to approve. Critical information at the end of prompts was being hidden, which could lead to approving tasks without understanding their full scope.

## Test Plan

- [x] Tested with long prompts (1000+ chars) - full text displays
- [x] Text wraps correctly within terminal width
- [x] Verified in both approval dialog variants

Written by Cameron ◯ Letta Code

"Transparency is the currency of trust." - Unknown