### PR TITLE
docs: remove `letta-code-bin` AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Community maintained packages are available for Arch Linux users on the [AUR](ht
 ```bash
 yay -S letta-code # release
 yay -S letta-code-git # nightly
-yay -S letta-code-bin # prebuilt release
 ```
 
 ---


### PR DESCRIPTION
The -bin package is marked for deletion on the AUR due to 0.14.0 having a specific build variable to make AUR builds work, meaning the pre-distributed release version doesn't work for packaging.