### PR TITLE
fix(cli): consistent loading state layout during startup

### DIFF
--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -57,6 +57,7 @@ async function getAuthMethod(): Promise<"url" | "api-key" | "oauth"> {
 }
 
 type LoadingState =
+  | "loading_profiles"
   | "assembling"
   | "importing"
   | "initializing"
@@ -146,6 +147,8 @@ function getLoadingMessage(
   continueSession: boolean,
 ): string {
   switch (loadingState) {
+    case "loading_profiles":
+      return "Loading pinned agents...";
     case "initializing":
       return continueSession ? "Resuming agent..." : "Creating agent...";
     case "assembling":

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -284,7 +284,7 @@ function ProfileSelectionUI({
     <Box flexDirection="column">
       {/* Welcome Screen */}
       <WelcomeScreen
-        loadingState="ready"
+        loadingState={loading ? "loading_profiles" : "ready"}
         continueSession={false}
         agentState={null}
         agentProvenance={null}
@@ -298,9 +298,7 @@ function ProfileSelectionUI({
         </>
       )}
 
-      {loading ? (
-        <Text dimColor>Loading pinned agents...</Text>
-      ) : selectingModel && serverModelsForNewAgent ? (
+      {loading ? null : selectingModel && serverModelsForNewAgent ? (
         // Model selection mode
         <Box flexDirection="column" gap={1}>
           <Text bold color={colors.selector.title}>


### PR DESCRIPTION
- Move "Loading pinned agents..." from below logo to right side (same position as other loading states like "Assembling tools...")
- Add shared module-level ticker for AnimatedLogo using useSyncExternalStore so animation stays in sync across component tree transitions (no snap reset)

👾 Generated with [Letta Code](https://letta.com)