### PR TITLE
fix(cli): move /memfs lower in command autocomplete order

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -63,7 +63,7 @@ export const commands: Record<string, Command> = {
   "/memfs": {
     desc: "Manage filesystem-backed memory (/memfs [enable|disable|sync|reset])",
     args: "[enable|disable|sync|reset]",
-    order: 15.5,
+    order: 27.5, // Advanced feature, near /toolset
     handler: () => {
       // Handled specially in App.tsx
       return "Managing memory filesystem...";


### PR DESCRIPTION
/memfs is an advanced feature that users shouldn't need frequently. Move it from order 15.5 (page 1) to order 27.5 (near /toolset).

👾 Generated with [Letta Code](https://letta.com)