### PR TITLE
fix(cli): clean up /usage command formatting

### DIFF
--- a/src/cli/components/SessionStats.tsx
+++ b/src/cli/components/SessionStats.tsx
@@ -59,11 +59,12 @@ export function formatUsageStats({
     const toDollars = (credits: number) => (credits / 1000).toFixed(2);
 
     outputLines.push(
-      `Available credits:     ◎${formatNumber(totalCredits)} ($${toDollars(totalCredits)})       Plan: [${balance.billing_tier}]`,
-      `  Monthly credits:     ◎${formatNumber(monthlyCredits)} ($${toDollars(monthlyCredits)})`,
-      `  Purchased credits:   ◎${formatNumber(purchasedCredits)} ($${toDollars(purchasedCredits)})`,
-      "",
+      `Plan: [${balance.billing_tier}]`,
       "https://app.letta.com/settings/organization/usage",
+      "",
+      `Available credits:     ◎${formatNumber(totalCredits)} ($${toDollars(totalCredits)})`,
+      `Monthly credits:       ◎${formatNumber(monthlyCredits)} ($${toDollars(monthlyCredits)})`,
+      `Purchased credits:     ◎${formatNumber(purchasedCredits)} ($${toDollars(purchasedCredits)})`,
     );
   }
 


### PR DESCRIPTION
- Move Plan and URL above credits breakdown
- Align all credit lines at same indentation level
- Remove nested indentation for Monthly/Purchased credits

👾 Generated with [Letta Code](https://letta.com)