### PR TITLE
fix(cli): handle malformed AskUserQuestion data from LLM

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9264,10 +9264,13 @@ ${SYSTEM_REMINDER_CLOSE}
       parseMemoryPreference(questions, answers);
 
       // Format the answer string like Claude Code does
-      const answerParts = questions.map((q) => {
-        const answer = answers[q.question] || "";
-        return `"${q.question}"="${answer}"`;
-      });
+      // Filter out malformed questions (LLM might send invalid data)
+      const answerParts = questions
+        .filter((q) => q.question)
+        .map((q) => {
+          const answer = answers[q.question] || "";
+          return `"${q.question}"="${answer}"`;
+        });
       const toolReturn = `User has answered your questions: ${answerParts.join(", ")}. You can now continue with the user's answers in mind.`;
 
       const precomputedResult: ToolExecutionResult = {

--- a/src/cli/helpers/memoryReminder.ts
+++ b/src/cli/helpers/memoryReminder.ts
@@ -60,6 +60,8 @@ export function parseMemoryPreference(
   answers: Record<string, string>,
 ): boolean {
   for (const q of questions) {
+    // Skip malformed questions (LLM might send invalid data)
+    if (!q.question) continue;
     const questionLower = q.question.toLowerCase();
     const headerLower = q.header?.toLowerCase() || "";
 


### PR DESCRIPTION
Add defensive checks for questions with undefined `question` field. The LLM might send invalid JSON where questions are missing required fields.

- Skip malformed questions in parseMemoryPreference
- Filter out malformed questions when formatting answer parts

👾 Generated with [Letta Code](https://letta.com)