### PR TITLE
fix(cli): reset logo to flat frame when loading completes

### DIFF
--- a/src/cli/components/AnimatedLogo.tsx
+++ b/src/cli/components/AnimatedLogo.tsx
@@ -124,13 +124,16 @@ function getSnapshot(): number {
 
 interface AnimatedLogoProps {
   color?: string;
+  /** When false, show static frame 0 (flat logo). Defaults to true. */
+  animate?: boolean;
 }
 
 export function AnimatedLogo({
   color = colors.welcome.accent,
+  animate = true,
 }: AnimatedLogoProps) {
   const tick = useSyncExternalStore(subscribe, getSnapshot);
-  const frame = tick % logoFrames.length;
+  const frame = animate ? tick % logoFrames.length : 0;
 
   const logoLines = logoFrames[frame]?.split("\n") ?? [];
 

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -117,7 +117,10 @@ export function WelcomeScreen({
     <Box flexDirection="row" marginTop={1}>
       {/* Left column: Logo */}
       <Box flexDirection="column" paddingLeft={1} paddingRight={2}>
-        <AnimatedLogo color={colors.welcome.accent} />
+        <AnimatedLogo
+          color={colors.welcome.accent}
+          animate={loadingState !== "ready"}
+        />
       </Box>
 
       {/* Right column: Text info */}


### PR DESCRIPTION
When the welcome screen was captured in scrollback history, the animated logo would freeze on whatever frame it was displaying. Now it shows the flat front-facing logo (frame 0) once loading finishes.

👾 Generated with [Letta Code](https://letta.com)