### PR TITLE
fix: only build after install on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "check": "bun run scripts/check.js",
     "dev": "bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts",
     "build": "node scripts/postinstall-patches.js && bun run build.js",
-    "prepare": "bun run build",
+    "prepublishOnly": "bun run build",
     "postinstall": "node scripts/postinstall-patches.js"
   },
   "lint-staged": {


### PR DESCRIPTION
Right now, `bun i`/`npm i` will build the project, which isn't (or at least shouldn't be) desired behavior during development/packaging, given installing deps and building the project should be separated parts of the workflow(s). This makes that extra build step only run on publish, still ensuring build artifacts are fresh when releasing to npm.