### PR TITLE
fix(cli): preserve spacing in thinking/assistant blocks during streaming

### DIFF
--- a/src/cli/components/AssistantMessageRich.tsx
+++ b/src/cli/components/AssistantMessageRich.tsx
@@ -5,12 +5,12 @@ import { MarkdownDisplay } from "./MarkdownDisplay.js";
 import { Text } from "./Text";
 
 // Helper function to normalize text - copied from old codebase
+// NOTE: Less aggressive than before to preserve spacing when content is split across chunks
 const normalize = (s: string) =>
   s
     .replace(/\r\n/g, "\n")
-    .replace(/[ \t]+$/gm, "")
     .replace(/\n{3,}/g, "\n\n")
-    .replace(/^\n+|\n+$/g, "");
+    .replace(/^\n+/g, ""); // Only trim leading newlines, preserve trailing ones
 
 type AssistantLine = {
   kind: "assistant";

--- a/src/cli/components/ReasoningMessageRich.tsx
+++ b/src/cli/components/ReasoningMessageRich.tsx
@@ -5,12 +5,12 @@ import { MarkdownDisplay } from "./MarkdownDisplay.js";
 import { Text } from "./Text";
 
 // Helper function to normalize text - copied from old codebase
+// NOTE: Less aggressive than before to preserve spacing when content is split across chunks
 const normalize = (s: string) =>
   s
     .replace(/\r\n/g, "\n")
-    .replace(/[ \t]+$/gm, "")
     .replace(/\n{3,}/g, "\n\n")
-    .replace(/^\n+|\n+$/g, "");
+    .replace(/^\n+/g, ""); // Only trim leading newlines, preserve trailing ones
 
 type ReasoningLine = {
   kind: "reasoning";


### PR DESCRIPTION
The normalize() function was removing trailing spaces and newlines from text chunks, causing visual concatenation issues when content is split at paragraph boundaries during streaming. This resulted in missing spaces and words running together in thinking blocks.

The fix makes normalization less aggressive by preserving trailing whitespace, which is essential for proper spacing between continuation chunks.

👾 Generated with [Letta Code](https://letta.com)