### PR TITLE
fix(tui): handle malformed AskUserQuestion by falling through to generic approval

### DIFF
--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -289,16 +289,20 @@ export const ApprovalSwitch = memo(
     }
 
     // 5. AskUserQuestion → InlineQuestionApproval
+    // Guard: only render specialized UI if questions are valid, otherwise fall through
+    // to InlineGenericApproval (matches pattern for Bash/Task with malformed args)
     if (toolName === "AskUserQuestion" && onQuestionSubmit) {
       const questions = getQuestions(approval);
-      return (
-        <InlineQuestionApproval
-          questions={questions}
-          onSubmit={onQuestionSubmit}
-          onCancel={onCancel}
-          isFocused={isFocused}
-        />
-      );
+      if (questions.length > 0) {
+        return (
+          <InlineQuestionApproval
+            questions={questions}
+            onSubmit={onQuestionSubmit}
+            onCancel={onCancel}
+            isFocused={isFocused}
+          />
+        );
+      }
     }
 
     // 6. Task tool → InlineTaskApproval

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -91,17 +91,7 @@ export const InlineQuestionApproval = memo(
 
     useInput(
       (input, key) => {
-        if (!isFocused) return;
-
-        // If the tool call is malformed (e.g. AskUserQuestion with an empty questions
-        // array), we still want a way for the user to escape/cancel so the TUI doesn't
-        // appear to hang with the input footer hidden.
-        if (!currentQuestion) {
-          if ((key.ctrl && input === "c") || key.escape || key.return) {
-            onCancel?.();
-          }
-          return;
-        }
+        if (!isFocused || !currentQuestion) return;
 
         // CTRL-C: cancel
         if (key.ctrl && input === "c") {
@@ -313,29 +303,7 @@ export const InlineQuestionApproval = memo(
       ? "Enter to toggle · Arrow to navigate · Esc to cancel"
       : "Enter to select · Arrow to navigate · Esc to cancel";
 
-    if (!currentQuestion) {
-      // Render a minimal, cancel-able UI for malformed AskUserQuestion approvals.
-      // This prevents the approval UI from returning null which would leave the user
-      // stuck with the input footer hidden.
-      const solidLine = SOLID_LINE.repeat(Math.max(columns, 10));
-      return (
-        <Box flexDirection="column">
-          <Text dimColor>{solidLine}</Text>
-          <Text bold color={colors.approval.header}>
-            Question (invalid request)
-          </Text>
-          <Box height={1} />
-          <Box paddingLeft={2} flexDirection="column">
-            <Text dimColor>
-              AskUserQuestion was called with no questions. Press Esc to cancel.
-            </Text>
-          </Box>
-          <Box marginTop={1}>
-            <Text dimColor>Esc to cancel · Enter to cancel</Text>
-          </Box>
-        </Box>
-      );
-    }
+    if (!currentQuestion) return null;
 
     return (
       <Box flexDirection="column">


### PR DESCRIPTION
Supersedes #793 with a simpler approach.

## Problem
When `AskUserQuestion` is called with an empty `questions` array (malformed), the TUI hangs because `InlineQuestionApproval` returns `null` when there's no current question.

## Solution
Follow the existing pattern used by Bash/Task: if args are malformed, fall through to `InlineGenericApproval`. User can then:
- **Approve** → tool validation fails with `Error: questions must be a non-empty array`
- **Cancel** → approval cancelled

This is simpler and consistent with how other tools handle malformed args - no special error UI needed.

## Changes
- `ApprovalSwitch.tsx`: Add `questions.length > 0` guard (matches Bash/Task pattern)

Thanks to @paulbettner for identifying the issue in #793!

👾 Generated with [Letta Code](https://letta.com)