### PR TITLE
fix(permissions): normalize path separators for Windows compatibility

### DIFF
--- a/src/tests/permissions-matcher.test.ts
+++ b/src/tests/permissions-matcher.test.ts
@@ -263,3 +263,65 @@ test("Tool pattern: case sensitivity", () => {
   expect(matchesToolPattern("WebFetch", "webfetch")).toBe(false);
   expect(matchesToolPattern("WebFetch", "WebFetch")).toBe(true);
 });
+
+// ============================================================================
+// Windows Path Normalization Tests (Issue #790)
+// These test that backslash paths work correctly for glob matching
+// ============================================================================
+
+test("File pattern: Windows-style backslashes in pattern", () => {
+  // Pattern with backslashes should match forward-slash paths
+  expect(
+    matchesFilePattern(
+      "Edit(.skills/obsidian-mcp/scripts/foo.js)",
+      "Edit(.skills\\obsidian-mcp\\scripts/**)",
+      "/project",
+    ),
+  ).toBe(true);
+});
+
+test("File pattern: Windows-style backslashes in query", () => {
+  // Query with backslashes should match forward-slash patterns
+  expect(
+    matchesFilePattern(
+      "Edit(.skills\\obsidian-mcp\\scripts\\foo.js)",
+      "Edit(.skills/obsidian-mcp/scripts/**)",
+      "/project",
+    ),
+  ).toBe(true);
+});
+
+test("File pattern: Windows-style backslashes in both", () => {
+  // Both using backslashes should still match
+  expect(
+    matchesFilePattern(
+      "Edit(.skills\\obsidian-mcp\\scripts\\foo.js)",
+      "Edit(.skills\\obsidian-mcp\\scripts\\**)",
+      "/project",
+    ),
+  ).toBe(true);
+});
+
+test("File pattern: Edit(**) matches any path with backslashes", () => {
+  // The ** glob should match everything, even with Windows paths
+  // Note: minimatch requires dot:true to match dot-prefixed paths with **
+  // so we test with a non-dot path here
+  expect(
+    matchesFilePattern(
+      "Edit(skills\\obsidian-mcp\\scripts\\foo.js)",
+      "Edit(**)",
+      "D:\\Coding\\Project",
+    ),
+  ).toBe(true);
+});
+
+test("File pattern: Windows absolute path in working directory", () => {
+  // Windows-style working directory should work
+  expect(
+    matchesFilePattern(
+      "Edit(src/file.ts)",
+      "Edit(src/**)",
+      "D:\\Coding\\Project",
+    ),
+  ).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Fixes permission rule matching on Windows where backslash paths weren't matching glob patterns
- `minimatch` expects forward slashes, but Windows paths use backslashes
- User settings may contain escaped backslashes (e.g., `.skills\\dir\\**`)
- `path.resolve()` produces backslash paths on Windows

## Changes
- Add `normalizePath()` helper that converts backslashes to forward slashes
- Normalize file paths, glob patterns, and working directory before matching
- Add 5 unit tests for Windows path handling

## Testing
Tests verify that:
- Patterns with backslashes match forward-slash paths
- Paths with backslashes match forward-slash patterns  
- Both using backslashes still match
- `**` glob works with Windows-style paths
- Windows absolute working directories work

Fixes #790

👾 Generated with [Letta Code](https://letta.com)