### PR TITLE
fix: add number key support to approval dialogs

### DIFF
--- a/src/cli/components/InlineBashApproval.tsx
+++ b/src/cli/components/InlineBashApproval.tsx
@@ -114,6 +114,17 @@ export const InlineBashApproval = memo(
         if (key.escape) {
           // Cancel (queue denial, return to input)
           onCancel?.();
+          return;
+        }
+
+        // Number keys for quick selection (only for fixed options, not custom text input)
+        if (input === "1") {
+          onApprove();
+          return;
+        }
+        if (input === "2" && allowPersistence) {
+          onApproveAlways("project");
+          return;
         }
       },
       { isActive: isFocused },

--- a/src/cli/components/InlineFileEditApproval.tsx
+++ b/src/cli/components/InlineFileEditApproval.tsx
@@ -276,6 +276,20 @@ export const InlineFileEditApproval = memo(
         }
         if (key.escape) {
           onCancel?.();
+          return;
+        }
+
+        // Number keys for quick selection (only for fixed options, not custom text input)
+        if (input === "1") {
+          onApprove(diffsToPass.size > 0 ? diffsToPass : undefined);
+          return;
+        }
+        if (input === "2" && allowPersistence) {
+          onApproveAlways(
+            "project",
+            diffsToPass.size > 0 ? diffsToPass : undefined,
+          );
+          return;
         }
       },
       { isActive: isFocused },

--- a/src/cli/components/InlineGenericApproval.tsx
+++ b/src/cli/components/InlineGenericApproval.tsx
@@ -127,6 +127,17 @@ export const InlineGenericApproval = memo(
         }
         if (key.escape) {
           onCancel?.();
+          return;
+        }
+
+        // Number keys for quick selection (only for fixed options, not custom text input)
+        if (input === "1") {
+          onApprove();
+          return;
+        }
+        if (input === "2" && allowPersistence) {
+          onApproveAlways("project");
+          return;
         }
       },
       { isActive: isFocused },

--- a/src/cli/components/InlineTaskApproval.tsx
+++ b/src/cli/components/InlineTaskApproval.tsx
@@ -109,6 +109,17 @@ export const InlineTaskApproval = memo(
         }
         if (key.escape) {
           onCancel?.();
+          return;
+        }
+
+        // Number keys for quick selection (only for fixed options, not custom text input)
+        if (input === "1") {
+          onApprove();
+          return;
+        }
+        if (input === "2" && allowPersistence) {
+          onApproveAlways("session");
+          return;
         }
       },
       { isActive: isFocused },

--- a/src/cli/components/StaticPlanApproval.tsx
+++ b/src/cli/components/StaticPlanApproval.tsx
@@ -100,6 +100,17 @@ export const StaticPlanApproval = memo(
         }
         if (key.escape) {
           onKeepPlanning("User cancelled");
+          return;
+        }
+
+        // Number keys for quick selection (only for fixed options, not custom text input)
+        if (input === "1") {
+          onApproveAndAcceptEdits();
+          return;
+        }
+        if (input === "2") {
+          onApprove();
+          return;
         }
       },
       { isActive: isFocused },


### PR DESCRIPTION
Adds the ability to press 1, 2, etc. to quickly select options in approval dialogs instead of having to use arrow keys + Enter.

Affected components:
- InlineBashApproval
- InlineFileEditApproval
- InlineTaskApproval
- InlineGenericApproval
- StaticPlanApproval

Fixes #819

👾 Generated with [Letta Code](https://letta.com)