### PR TITLE
fix: pass conversation_id to /download command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -6711,7 +6711,17 @@ export default function App({
 
           try {
             const client = await getClient();
-            const fileContent = await client.agents.exportFile(agentId);
+
+            // Pass conversation_id if we're in a specific conversation (not default)
+            const exportParams: { conversation_id?: string } = {};
+            if (conversationId !== "default") {
+              exportParams.conversation_id = conversationId;
+            }
+
+            const fileContent = await client.agents.exportFile(
+              agentId,
+              exportParams,
+            );
             const fileName = `${agentId}.af`;
             writeFileSync(fileName, JSON.stringify(fileContent, null, 2));
 


### PR DESCRIPTION
## Summary

Fixes bug where `/download` always exports the agent's global message history instead of the current conversation's messages.

## Problem

When running `/download` in a specific conversation, the exported .af file contained the agent's entire global message history instead of just the messages from the current conversation.

**Root cause:** Not passing `conversation_id` parameter to `exportFile()` API call.

## Fix

Pass `conversation_id` to `exportFile()` when in a specific conversation (not "default").

**Before:**
```typescript
const fileContent = await client.agents.exportFile(agentId);
```

**After:**
```typescript
const exportParams: { conversation_id?: string } = {};
if (conversationId !== "default") {
  exportParams.conversation_id = conversationId;
}
const fileContent = await client.agents.exportFile(agentId, exportParams);
```

## Behavior

**In default conversation:**
- `/download` → Exports global message history ✅

**In specific conversation (conv-abc123):**
- `/download` → Exports only this conversation's messages ✅

## Test Plan

- [ ] Run `/download` in default conversation, verify global history exported
- [ ] Start new conversation with `/new`, run `/download`, verify only new conversation messages exported
- [ ] Switch between conversations with `/resume`, verify each exports correct messages

👾 Generated with [Letta Code](https://letta.com)