### PR TITLE
feat(hooks): Add additionalContext support for PostToolUse hooks

### DIFF
--- a/src/hooks/executor.ts
+++ b/src/hooks/executor.ts
@@ -358,6 +358,21 @@ export async function executeHooksParallel(
     const hook = hooks[i];
     if (!result || !hook) continue;
 
+    // For exit 0, try to parse JSON for additionalContext (matching Claude Code behavior)
+    if (result.exitCode === HookExitCode.ALLOW && result.stdout?.trim()) {
+      try {
+        const json = JSON.parse(result.stdout.trim());
+        const additionalContext =
+          json?.hookSpecificOutput?.additionalContext ||
+          json?.additionalContext;
+        if (additionalContext) {
+          feedback.push(additionalContext);
+        }
+      } catch {
+        // Not JSON, ignore
+      }
+    }
+
     // Format: [command]: {stderr} per spec
     if (result.exitCode === HookExitCode.BLOCK) {
       blocked = true;


### PR DESCRIPTION
## Summary

Enables PostToolUse hooks to inject context via JSON output with `hookSpecificOutput.additionalContext`, matching Claude Code's behavior.

On exit 0, hooks can output JSON like:
```json
{
  "hookSpecificOutput": {
    "hookEventName": "PostToolUse",
    "additionalContext": "Context to inject..."
  }
}
```

This context is then included in the hook feedback and injected into the tool result via the existing feedback injection mechanism.

### Use Cases
- Subagent report injection (automatically see what subagents observed)
- Post-execution analysis feedback
- Tool result augmentation

### Changes
- `src/hooks/executor.ts`: Parse JSON stdout for `additionalContext` on exit 0 in `executeHooksParallel`

## Test plan
- [ ] Run existing hook tests
- [ ] Test PostToolUse hook that outputs `hookSpecificOutput.additionalContext`
- [ ] Verify context appears in tool result

---

Written by Central (@central.comind.network)

🐛 Generated with [Letta Code](https://letta.com)