### PR TITLE
feat(ui): align subagent status dots, headers, and dimming with runni…

### DIFF
--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -72,6 +72,7 @@ const AgentRow = memo(
     const contentWidth = Math.max(0, columns - gutterWidth);
 
     const isRunning = agent.status === "pending" || agent.status === "running";
+    const shouldDim = isRunning && !agent.isBackground;
     const stats = formatStats(
       agent.toolCalls.length,
       agent.totalTokens,
@@ -94,7 +95,9 @@ const AgentRow = memo(
                 {"   "}
                 {treeChar}{" "}
               </Text>
-              <Text bold>{agent.description}</Text>
+              <Text bold={!shouldDim} dimColor={shouldDim}>
+                {agent.description}
+              </Text>
               <Text dimColor>
                 {" · "}
                 {agent.type.toLowerCase()}
@@ -133,7 +136,9 @@ const AgentRow = memo(
               {"   "}
               {treeChar}{" "}
             </Text>
-            <Text bold>{agent.description}</Text>
+            <Text bold={!shouldDim} dimColor={shouldDim}>
+              {agent.description}
+            </Text>
             <Text dimColor>
               {" · "}
               {agent.type.toLowerCase()}
@@ -245,16 +250,16 @@ interface GroupHeaderProps {
 
 const GroupHeader = memo(
   ({ count, allCompleted, hasErrors, expanded }: GroupHeaderProps) => {
-    const statusText = allCompleted
-      ? `Ran ${count} subagent${count !== 1 ? "s" : ""}`
-      : `Running ${count} subagent${count !== 1 ? "s" : ""}…`;
-
     const hint = expanded ? "(ctrl+o to collapse)" : "(ctrl+o to expand)";
 
-    // Use error color for dot if any subagent errored
     const dotColor = hasErrors
       ? colors.subagent.error
       : colors.subagent.completed;
+    const runningDotColor = hasErrors
+      ? colors.subagent.error
+      : colors.tool.pending;
+    const label = allCompleted ? "Ran" : "Running";
+    const suffix = count !== 1 ? "agents" : "agent";
 
     return (
       <Box flexDirection="row">
@@ -262,10 +267,13 @@ const GroupHeader = memo(
           <Text color={dotColor}>●</Text>
         ) : (
           // BlinkDot now gets shouldAnimate from AnimationContext
-          <BlinkDot color={colors.subagent.header} />
+          <BlinkDot color={runningDotColor} />
         )}
-        <Text color={colors.subagent.header}> {statusText} </Text>
-        <Text color={colors.subagent.hint}>{hint}</Text>
+        <Text>
+          {" "}
+          {label} <Text bold>{count}</Text> {suffix}
+        </Text>
+        <Text color={colors.subagent.hint}> {hint}</Text>
       </Box>
     );
   },

--- a/src/cli/components/SubagentGroupStatic.tsx
+++ b/src/cli/components/SubagentGroupStatic.tsx
@@ -56,7 +56,9 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
   const gutterWidth = 8; // indent (3) + continueChar (2) + status indent (3)
   const contentWidth = Math.max(0, columns - gutterWidth);
 
-  const stats = formatStats(agent.toolCount, agent.totalTokens);
+  const isRunning = agent.status === "running";
+  const shouldDim = isRunning && !agent.isBackground;
+  const stats = formatStats(agent.toolCount, agent.totalTokens, isRunning);
 
   return (
     <Box flexDirection="column">
@@ -67,7 +69,9 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
             {"   "}
             {treeChar}{" "}
           </Text>
-          <Text bold>{agent.description}</Text>
+          <Text bold={!shouldDim} dimColor={shouldDim}>
+            {agent.description}
+          </Text>
           <Text dimColor>
             {" · "}
             {agent.type.toLowerCase()}
@@ -143,20 +147,27 @@ export const SubagentGroupStatic = memo(
       return null;
     }
 
-    const statusText = `Ran ${agents.length} subagent${agents.length !== 1 ? "s" : ""}`;
     const hasErrors = agents.some((a) => a.status === "error");
+    const hasRunning = agents.some((a) => a.status === "running");
+    const label = hasRunning ? "Running" : "Ran";
+    const suffix = agents.length !== 1 ? "agents" : "agent";
 
     // Use error color for dot if any subagent errored
     const dotColor = hasErrors
       ? colors.subagent.error
-      : colors.subagent.completed;
+      : hasRunning
+        ? colors.tool.pending
+        : colors.subagent.completed;
 
     return (
       <Box flexDirection="column">
         {/* Header */}
         <Box flexDirection="row">
           <Text color={dotColor}>●</Text>
-          <Text color={colors.subagent.header}> {statusText}</Text>
+          <Text>
+            {" "}
+            {label} <Text bold>{agents.length}</Text> {suffix}
+          </Text>
         </Box>
 
         {/* Agent rows */}


### PR DESCRIPTION
…ng states

- Match tool-call dot semantics (static grey → blinking grey → green done) for subagent groups
- Replace blue headers with "Running/Ran N agents" and bold the count
- Dim only foreground-running subagent rows; background-running rows stay white
- Ensure running/approval phases don't flash pre-approval and preserve args rendering

👾 Generated with [Letta Code](https://letta.com)