### PR TITLE
feat: remove queue timeout, wait for tool completion

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1369,14 +1369,6 @@ export default function App({
     }
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (queueAppendTimeoutRef.current) {
-        clearTimeout(queueAppendTimeoutRef.current);
-      }
-    };
-  }, []);
-
   // Show exit stats on exit (double Ctrl+C)
   const [showExitStats, setShowExitStats] = useState(false);
 
@@ -1440,8 +1432,6 @@ export default function App({
     restoreQueueOnCancelRef.current = restoreQueueOnCancel;
   }, [restoreQueueOnCancel]);
 
-  const queueAppendTimeoutRef = useRef<NodeJS.Timeout | null>(null); // 15s append mode timeout
-
   // Cache last sent input - cleared on successful completion, remains if interrupted
   const lastSentInputRef = useRef<Array<MessageCreate | ApprovalCreate> | null>(
     null,
@@ -1490,13 +1480,9 @@ export default function App({
     [],
   );
 
-  // Consume queued messages for appending to tool results (clears queue + timeout)
+  // Consume queued messages for appending to tool results (clears queue)
   const consumeQueuedMessages = useCallback((): QueuedMessage[] | null => {
     if (messageQueueRef.current.length === 0) return null;
-    if (queueAppendTimeoutRef.current) {
-      clearTimeout(queueAppendTimeoutRef.current);
-      queueAppendTimeoutRef.current = null;
-    }
     const messages = [...messageQueueRef.current];
     setMessageQueue([]);
     return messages;
@@ -5426,50 +5412,7 @@ export default function App({
             { kind: "user", text: msg },
           ];
 
-          const isSlashCommand = msg.startsWith("/");
-
-          // Regular messages: use append mode (wait 15s for tools, then append to API call)
-          if (
-            !isSlashCommand &&
-            streamingRef.current &&
-            !waitingForQueueCancelRef.current &&
-            !queueAppendTimeoutRef.current
-          ) {
-            queueAppendTimeoutRef.current = setTimeout(() => {
-              if (messageQueueRef.current.length === 0) {
-                queueAppendTimeoutRef.current = null;
-                return;
-              }
-              queueAppendTimeoutRef.current = null;
-
-              // 15s expired - fall back to cancel
-              waitingForQueueCancelRef.current = true;
-              queueSnapshotRef.current = [...messageQueueRef.current];
-              if (toolAbortControllerRef.current) {
-                toolAbortControllerRef.current.abort();
-              }
-              getClient()
-                .then((client) => {
-                  if (conversationIdRef.current === "default") {
-                    return client.agents.messages.cancel(agentIdRef.current);
-                  }
-                  return client.conversations.cancel(conversationIdRef.current);
-                })
-                .catch(() => {
-                  waitingForQueueCancelRef.current = false;
-                });
-              setTimeout(() => {
-                if (
-                  waitingForQueueCancelRef.current &&
-                  abortControllerRef.current
-                ) {
-                  abortControllerRef.current.abort();
-                  waitingForQueueCancelRef.current = false;
-                  queueSnapshotRef.current = [];
-                }
-              }, 3000);
-            }, 15000);
-          }
+          // Regular messages: queue and wait for tool completion
 
           return newQueue;
         });


### PR DESCRIPTION
Removes 15-second timeout that cancelled long-running tools when messages were queued.

**Before:**
- Queue message while tool running → 15s timeout starts
- If tool runs >15s → Cancel operation, process queued messages
- Quick tools → Append queued messages to next turn

**After:**
- Queue message while tool running → Wait indefinitely
- Tool completes (any duration) → Append queued messages to next turn
- No forced cancellation for long-running tools

This allows tools like large file operations, network requests, or complex searches to complete naturally without interruption.

**Changes:**
- Removed `queueAppendTimeoutRef` timeout logic (-47 lines)
- Simplified `consumeQueuedMessages()` (no timeout clearing)
- Queue now waits for tool completion regardless of duration

**Testing:** All existing tests pass