### PR TITLE
fix: show actual agent skills directory in extraction message

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -512,8 +512,10 @@ export async function handleHeadlessCommand(
 
     // Display extracted skills summary
     if (result.skills && result.skills.length > 0) {
+      const { getAgentSkillsDir } = await import("./agent/skills");
+      const skillsDir = getAgentSkillsDir(agent.id);
       console.log(
-        `📦 Extracted ${result.skills.length} skill${result.skills.length === 1 ? "" : "s"} to .skills/: ${result.skills.join(", ")}`,
+        `📦 Extracted ${result.skills.length} skill${result.skills.length === 1 ? "" : "s"} to ${skillsDir}: ${result.skills.join(", ")}`,
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1476,8 +1476,10 @@ async function main(): Promise<void> {
 
           // Display extracted skills summary
           if (result.skills && result.skills.length > 0) {
+            const { getAgentSkillsDir } = await import("./agent/skills");
+            const skillsDir = getAgentSkillsDir(agent.id);
             console.log(
-              `\n📦 Extracted ${result.skills.length} skill${result.skills.length === 1 ? "" : "s"} to .skills/: ${result.skills.join(", ")}\n`,
+              `\n📦 Extracted ${result.skills.length} skill${result.skills.length === 1 ? "" : "s"} to ${skillsDir}: ${result.skills.join(", ")}\n`,
             );
           }
         }


### PR DESCRIPTION
Changes extraction message to display actual destination path instead of generic .skills/.

**Before:**
```
📦 Extracted 2 skills to .skills/: slack, adding-models
```

**After:**
```
📦 Extracted 2 skills to ~/.letta/agents/agent-abc123/skills/: slack, adding-models
```

**Changes:**
- src/index.ts: Use `getAgentSkillsDir(agent.id)` for path
- src/headless.ts: Use `getAgentSkillsDir(agent.id)` for path

Shows users the exact location where skills were extracted, making it easier to find and verify the imported skills.