### PR TITLE
test: skip GitHub integration test on CI

### DIFF
--- a/src/tests/agent/import-skills.test.ts
+++ b/src/tests/agent/import-skills.test.ts
@@ -190,26 +190,29 @@ describe("skills extraction from .af files", () => {
     expect(extracted).toEqual([]);
   });
 
-  test("fetches skill from remote source_url (integration)", async () => {
-    const afContent = {
-      agents: [],
-      blocks: [],
-      sources: [],
-      tools: [],
-      mcp_servers: [],
-      skills: [
-        {
-          name: "imessage",
-          source_url: "letta-ai/skills/main/tools/imessage",
-        },
-      ],
-    };
+  test.skipIf(process.env.CI === "true")(
+    "fetches skill from remote source_url (integration)",
+    async () => {
+      const afContent = {
+        agents: [],
+        blocks: [],
+        sources: [],
+        tools: [],
+        mcp_servers: [],
+        skills: [
+          {
+            name: "imessage",
+            source_url: "letta-ai/skills/main/tools/imessage",
+          },
+        ],
+      };
 
-    writeFileSync(afPath, JSON.stringify(afContent, null, 2));
+      writeFileSync(afPath, JSON.stringify(afContent, null, 2));
 
-    const extracted = await extractSkillsFromAf(afPath, skillsDir);
+      const extracted = await extractSkillsFromAf(afPath, skillsDir);
 
-    expect(extracted).toEqual(["imessage"]);
-    expect(existsSync(join(skillsDir, "imessage", "SKILL.md"))).toBe(true);
-  });
+      expect(extracted).toEqual(["imessage"]);
+      expect(existsSync(join(skillsDir, "imessage", "SKILL.md"))).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
Follow-up to #823 - fixes CI test failures from GitHub rate limits.

**Issue:**
CI runners hit GitHub API rate limits (60 req/hr unauthenticated) when running the integration test, causing failures.

**Fix:**
Skip remote fetch test when `CI=true` environment variable is set.

**Testing:** 
- **Local**: Integration test runs (authenticated via gh CLI or within limits)
- **CI**: Integration test skipped (avoids rate limit errors)

**Changes:**
- Wrap integration test with `test.skipIf(process.env.CI === 'true')`
- Feature still fully tested (5 other import tests + 5 export tests)
- Integration test validates actual GitHub fetching locally

Small follow-up to ensure CI passes reliably.