### PR TITLE
fix: Append memFS system prompt based on CLI flags

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -670,9 +670,17 @@ export async function handleHeadlessCommand(
   }
 
   // Ensure agent's system prompt includes/excludes memfs section to match setting
-  if (memfsFlag || noMemfsFlag || (isNewlyCreatedAgent && !isSubagent) || (specifiedAgentId && !isSubagent)) {
+  if (
+    memfsFlag ||
+    noMemfsFlag ||
+    (isNewlyCreatedAgent && !isSubagent) ||
+    (specifiedAgentId && !isSubagent)
+  ) {
     const { updateAgentSystemPromptMemfs } = await import("./agent/modify");
-    await updateAgentSystemPromptMemfs(agent.id, settingsManager.isMemfsEnabled(agent.id));
+    await updateAgentSystemPromptMemfs(
+      agent.id,
+      settingsManager.isMemfsEnabled(agent.id),
+    );
   }
 
   // Sync filesystem-backed memory before creating conversations (only if memfs is enabled)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1651,8 +1651,13 @@ async function main(): Promise<void> {
 
         // Ensure agent's system prompt includes/excludes memfs section to match setting
         if (memfsFlag || noMemfsFlag || (isNewlyCreatedAgent && !isSubagent)) {
-          const { updateAgentSystemPromptMemfs } = await import("./agent/modify");
-          await updateAgentSystemPromptMemfs(agent.id, settingsManager.isMemfsEnabled(agent.id));
+          const { updateAgentSystemPromptMemfs } = await import(
+            "./agent/modify"
+          );
+          await updateAgentSystemPromptMemfs(
+            agent.id,
+            settingsManager.isMemfsEnabled(agent.id),
+          );
         }
 
         // Fire-and-forget: Initialize loaded skills flag (LET-7101)


### PR DESCRIPTION
## Summary

- Agents getting memfs enabled (via flags or by default) weren't getting the memfs documentation in their system prompt — it was only injected via `/memfs enable`
- Call `updateAgentSystemPromptMemfs()` after the existing settings block in both index.ts and headless.ts