### PR TITLE
fix: test keychain cleanup deletes real credentials

### DIFF
--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -19,6 +19,7 @@ import {
   deleteSecureTokens,
   isKeychainAvailable,
   keychainAvailablePrecompute,
+  setServiceName,
 } from "../utils/secrets.js";
 
 // Store original HOME to restore after tests
@@ -27,6 +28,9 @@ let testHomeDir: string;
 let testProjectDir: string;
 
 beforeEach(async () => {
+  // Use a test-specific keychain service name to avoid deleting real credentials
+  setServiceName("letta-code-test");
+
   // Reset settings manager FIRST before changing HOME
   await settingsManager.reset();
 
@@ -49,6 +53,9 @@ afterEach(async () => {
 
   // Restore original HOME AFTER reset completes
   process.env.HOME = originalHome;
+
+  // Restore the real service name
+  setServiceName("letta-code");
 });
 
 // ============================================================================

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -14,9 +14,16 @@ try {
   secretsAvailable = false;
 }
 
-const SERVICE_NAME = "letta-code";
+let SERVICE_NAME = "letta-code";
 const API_KEY_NAME = "letta-api-key";
 const REFRESH_TOKEN_NAME = "letta-refresh-token";
+
+/**
+ * Override the keychain service name (useful for tests to avoid touching real credentials)
+ */
+export function setServiceName(name: string): void {
+  SERVICE_NAME = name;
+}
 
 // Note: When secrets API is unavailable (Node.js), tokens will be managed
 // by the settings manager which falls back to storing in the settings file


### PR DESCRIPTION
## Summary
- Tests in `settings-manager.test.ts` called `deleteSecureTokens()` with the production service name `"letta-code"`, deleting real keychain entries
- Added `setServiceName()` export to `src/utils/secrets.ts` so the service name is overridable
- Tests now use `"letta-code-test"` as the keychain service name, restoring `"letta-code"` in afterEach

## Test plan
- [x] `bun test src/tests/settings-manager.test.ts` — 45/45 pass
- [ ] Verify real keychain entries are untouched after running the test suite