### PR TITLE
fix: prevent UserPromptSubmit hook from firing repeatedly on dequeue

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4501,7 +4501,9 @@ export default function App({
         // Trigger dequeue effect now that processConversation is no longer active.
         // The dequeue effect checks abortControllerRef (a ref, not state), so it
         // won't re-run on its own — bump dequeueEpoch to force re-evaluation.
-        if (messageQueueRef.current.length > 0) {
+        // Only bump for normal completions — if stale (ESC was pressed), the user
+        // cancelled and queued messages should NOT be auto-submitted.
+        if (!isStale && messageQueueRef.current.length > 0) {
           setDequeueEpoch((e) => e + 1);
         }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `UserPromptSubmit` hooks fire tens-to-hundreds of times in rapid succession when a queued message is dequeued after `processConversation` finishes.

Also fixes a regression where ESC cancel would not prevent queued messages from auto-submitting (requiring a second cancel).

## Root Cause

A state/ref mismatch between the **dequeue effect** and **`isAgentBusy()`** creates a tight dequeue → re-queue loop that fires hooks on every iteration.

**Dequeue effect** (line 8309) gates on *state* values:
```
!streaming && !commandRunning && !isExecutingTool && ...
```

**`isAgentBusy()`** (line 1486) additionally checks a *ref*:
```
abortControllerRef.current !== null
```

The dequeue effect doesn't check `abortControllerRef`, so it can fire while `processConversation` is still active.

### The loop

When a user submits a message while the agent is streaming, it gets queued. When `end_turn` fires:

1. `setStreaming(false)` at line 3409 — React schedules re-render
2. `await runStopHooks()` at line 3442 — yields to React
3. React re-renders with `streaming = false`. **`abortControllerRef.current` is still non-null** (only cleared at line 4499 in the `finally` block)
4. Dequeue effect fires: `!streaming && messageQueue.length > 0` → all conditions pass
5. Calls `setMessageQueue([])` then `onSubmitRef.current(msg)` (no await — fire-and-forget)
6. Inside `onSubmit`: `await runUserPromptSubmitHooks()` → **hooks fire**
7. After hooks: `isAgentBusy()` returns true (`abortControllerRef` still set)
8. Message gets re-queued at line 5469
9. `messageQueue` changes → dequeue effect re-runs → **back to step 4**

Each iteration ≈ 20-40ms (hook shell command + React render overhead). The window lasts from `setStreaming(false)` until the `finally` block clears `abortControllerRef`. With stop hooks taking 1-2+ seconds, this produces 50-200+ hook firings.

## How the Queuing/Dequeuing System Works

### Queue lifecycle

1. **Enqueue**: When a user submits a message while `isAgentBusy()` returns true, `onSubmit` adds it to `messageQueue` state (line 5469) and returns early. The user's input is cleared.

2. **Dequeue**: A `useEffect` (line 8301) watches `messageQueue`, `streaming`, `pendingApprovals`, `commandRunning`, `isExecutingTool`, `anySelectorOpen`, and `dequeueEpoch`. When all blocking conditions clear, it concatenates queued messages, clears the queue, and calls `onSubmitRef.current(concatenatedMessage)` without `await`.

3. **Task notifications**: Non-React code (e.g., background tasks) can add to the queue via `messageQueueBridge`, which calls `setMessageQueue` + bumps `dequeueEpoch`.

### Why refs need epoch bumps

The dequeue effect's dependency array only includes state values. Ref changes (`userCancelledRef`, `waitingForQueueCancelRef`, and now `abortControllerRef`) don't trigger re-evaluation. When a ref changes in a way that should unblock dequeue, `dequeueEpoch` must be bumped to force the effect to re-run.

## Fix

Three changes:

1. **Dequeue guard**: Add `!abortControllerRef.current` to the dequeue effect conditions — prevents dequeue while `processConversation` is still active

2. **Epoch bump in `finally`**: After clearing `abortControllerRef.current` in the `finally` block, bump `dequeueEpoch` if messages are queued — ensures dequeue re-evaluates once it's safe

3. **Gate epoch bump on `!isStale`**: Only bump the epoch for normal completions, not ESC-cancelled conversations. When the user presses ESC, `handleInterrupt` bumps `conversationGenerationRef` which makes the `processConversation` finally block detect `isStale = true`. Without this gate, the epoch bump would cause queued messages to auto-submit after ESC, requiring the user to cancel twice (once for the stream, once for the queued message). With the gate, ESC cancels both the active stream and leaves queued messages inert, preserving the original cancel semantics.

### ESC + queued message flow

**Before fix (on main):**
- ESC → `handleInterrupt` sets `userCancelledRef=true`, clears `abortControllerRef`
- `finally` runs, no epoch bump → nothing triggers dequeue after `userCancelledRef` clears
- Queued message stays inert ✅

**After fix (without `!isStale` gate):**
- ESC → same as above
- `finally` bumps epoch → dequeue fires but blocked by `userCancelledRef`
- After 50ms timeout, `userCancelledRef` clears → if epoch bump and timeout batch in same render, dequeue fires → queued message auto-submits ❌

**After fix (with `!isStale` gate):**
- ESC → same as above
- `finally` sees `isStale=true` → skips epoch bump → queued message stays inert ✅
- When user submits a new message, `onSubmit` bumps epoch naturally → queued messages dequeue after the new message completes (same behavior as main)

### Safety validation

Every code path through `processConversation` clears `abortControllerRef` via the `finally` block:

| Scenario | `abortControllerRef` cleared? | Messages stuck? |
|---|---|---|
| Normal `end_turn` | Yes (finally block) | No — epoch bump triggers dequeue |
| Stop hook blocked re-entry | Yes (finally runs before `setTimeout` re-entry fires) | No |
| `requires_approval` early return | Yes (finally runs despite early return) | No |
| Error/catch paths | Yes (all flow through finally) | No |
| ESC interrupt (`handleInterrupt`) | Yes (cleared immediately at line 4683) | No — queued messages stay inert, dequeue on next user message |
| `sendAllResults` approval callback | Yes (re-entry's finally clears its own controller) | No |

## Test plan

- [ ] Submit a message while the agent is streaming → message should queue, then dequeue and process once (with one hook firing) after the turn ends
- [ ] Verify `UserPromptSubmit` hooks fire exactly once per dequeued message, not hundreds of times
- [ ] Verify task notifications queued during streaming are processed after the turn ends
- [ ] Verify ESC during streaming with a queued message cancels BOTH the stream and the queued message (single ESC, no double-cancel needed)
- [ ] Verify ESC during streaming properly clears state and allows subsequent dequeue on next user message
- [ ] Verify Stop hook blocked flow still re-enters conversation correctly