### PR TITLE
feat: restore previous permission mode when exiting plan mode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9559,9 +9559,11 @@ ${SYSTEM_REMINDER_CLOSE}
       lastPlanFilePathRef.current = planFilePath;
 
       // Exit plan mode
-      const newMode = acceptEdits ? "acceptEdits" : "default";
-      permissionMode.setMode(newMode);
-      setUiPermissionMode(newMode);
+      const restoreMode = acceptEdits
+        ? "acceptEdits"
+        : (permissionMode.getModeBeforePlan() ?? "default");
+      permissionMode.setMode(restoreMode);
+      setUiPermissionMode(restoreMode);
 
       try {
         // Execute ExitPlanMode tool to get the result

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -452,3 +452,20 @@ test("Permission mode takes precedence over CLI allowedTools", () => {
   // Clean up
   cliPermissions.clear();
 });
+
+test("plan mode - remembers and restores previous mode", () => {
+  permissionMode.setMode("bypassPermissions");
+  expect(permissionMode.getMode()).toBe("bypassPermissions");
+
+  // Enter plan mode - should remember prior mode.
+  permissionMode.setMode("plan");
+  expect(permissionMode.getMode()).toBe("plan");
+  expect(permissionMode.getModeBeforePlan()).toBe("bypassPermissions");
+
+  // Exit plan mode by restoring previous mode.
+  permissionMode.setMode(permissionMode.getModeBeforePlan() ?? "default");
+  expect(permissionMode.getMode()).toBe("bypassPermissions");
+
+  // Once we leave plan mode, the remembered mode is consumed.
+  expect(permissionMode.getModeBeforePlan()).toBe(null);
+});


### PR DESCRIPTION
## Problem
Plan mode is a temporary permission mode. Today, approving ExitPlanMode always returns the client to `default` (or `acceptEdits`), even if the user had previously set another mode like `bypassPermissions` (YOLO).

## Fix
- Track the mode that was active immediately before entering plan mode.
- When ExitPlanMode is approved, restore that previous mode (unless the user explicitly selects `acceptEdits`).

Implementation details:
- Store `permissionModeBeforePlan` in the permission mode singleton.
- Update the ExitPlanMode approval handler to restore the remembered mode.

## Tests
- Add a unit test verifying plan mode remembers and restores the previous permission mode.