### PR TITLE
test: add xhigh coverage for shared-handle model tier selection

### DIFF
--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -11,6 +11,11 @@ describe("getModelInfoForLlmConfig", () => {
 
     const none = getModelInfoForLlmConfig(handle, { reasoning_effort: "none" });
     expect(none?.id).toBe("gpt-5.2-none");
+
+    const xhigh = getModelInfoForLlmConfig(handle, {
+      reasoning_effort: "xhigh",
+    });
+    expect(xhigh?.id).toBe("gpt-5.2-xhigh");
   });
 
   test("falls back to first handle match when effort missing", () => {


### PR DESCRIPTION
## Summary
- add test coverage for `reasoning_effort: \"xhigh\"` in `getModelInfoForLlmConfig`
- ensure `/model` tier selection remains correct for all configured GPT-5.2 reasoning levels

## Test plan
- [x] `bun test src/tests/model-tier-selection.test.ts`

👾 Generated with [Letta Code](https://letta.com)