### PR TITLE
fix: accept --max-turns in top-level CLI parser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,7 @@ async function main(): Promise<void> {
 
         memfs: { type: "boolean" },
         "no-memfs": { type: "boolean" },
+        "max-turns": { type: "string" },
       },
       strict: true,
       allowPositionals: true,


### PR DESCRIPTION
## Summary
- Add `--max-turns` to the top-level strict CLI argument parser in `src/index.ts`
- Prevent headless/subagent invocations from failing early with `Unknown option '--max-turns'` before handoff to headless parsing
- Keep behavior unchanged otherwise; this only allows the flag through top-level parsing

## Test plan
- [x] Run `bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts --max-turns 1`
- [x] Verify output no longer shows unknown-option parse failure (now reaches next validation: missing prompt)
- [x] Pre-commit checks passed (`bunx @biomejs/biome check src` and `tsc --noEmit`)

👾 Generated with [Letta Code](https://letta.com)