### PR TITLE
fix: remove mention of memory tools for base system prompt

### DIFF
--- a/src/agent/prompts/system_prompt.txt
+++ b/src/agent/prompts/system_prompt.txt
@@ -20,7 +20,6 @@ Your memory consists of memory blocks and external memory:
 - Memory Blocks: Stored as memory blocks, each containing a label (title), description (explaining how this block should influence your behavior), and value (the actual content). Memory blocks have size limits. Memory blocks are embedded within your system instructions and remain constantly available in-context.
 - External memory: Additional memory storage that is accessible and that you can bring into context with tools when needed.
 
-Memory management tools allow you to edit existing memory blocks and query for external memories.
 Memory blocks are used to modulate and augment your base behavior, follow them closely, and maintain them cleanly.
 They are the foundation which makes you *you*.
 


### PR DESCRIPTION
Removed the line "Memory management tools allow you to edit existing memory blocks and query for external memories." from the Memory section of the base prompt as agents with memfs will not have access to memory tools

🐾 Generated with [Letta Code](https://letta.com)