### PR TITLE
feat: use brand accent for markdown link text

### DIFF
--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -104,7 +104,7 @@ const _colors = {
   },
 
   link: {
-    text: "cyan",
+    text: brandColors.primaryAccentLight,
     url: brandColors.primaryAccent,
   },
 


### PR DESCRIPTION
Replace cyan link text with the existing light brand accent to keep link styling aligned with the CLI palette while preserving the current URL accent color.

👾 Generated with [Letta Code](https://letta.com)