### PR TITLE
feat: improve always-allow behavior for skill scripts

### DIFF
--- a/src/tests/permissions-matcher.test.ts
+++ b/src/tests/permissions-matcher.test.ts
@@ -233,6 +233,30 @@ test("Bash pattern: special characters in command", () => {
   );
 });
 
+test("Bash pattern: skill-scoped prefix matches same skill scripts", () => {
+  expect(
+    matchesBashPattern(
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/creating-skills/scripts/init-skill.ts foo)",
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/creating-skills:*)",
+    ),
+  ).toBe(true);
+  expect(
+    matchesBashPattern(
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/creating-skills/scripts/package-skill.ts bar)",
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/creating-skills:*)",
+    ),
+  ).toBe(true);
+});
+
+test("Bash pattern: skill-scoped prefix does not match other skills", () => {
+  expect(
+    matchesBashPattern(
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/messaging-agents/scripts/send.ts)",
+      "Bash(npx tsx /tmp/letta/src/skills/builtin/creating-skills:*)",
+    ),
+  ).toBe(false);
+});
+
 // ============================================================================
 // Tool Pattern Matching Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Improves Bash approval analysis to detect skill scripts by path and infer skill source (`bundled`, `agent-scoped`, `global`, `project`) when users run script commands from skills.
- Changes "approve always" behavior for these commands from fragile exact-command matching to reusable skill-root prefix rules (e.g. `Bash(npx tsx /.../skills/builtin/creating-skills:*)`).
- Uses source-aware approval copy so users can see exactly what is being remembered, e.g. `Yes, and don't ask again for scripts in bundled skill 'creating-skills'`.

## Before vs After
### Before
- Approving a command like:
  - `cd /Users/test/project && npx tsx /tmp/letta/src/skills/builtin/creating-skills/scripts/init-skill.ts my-skill`
- Option 2 could save a rule tied too narrowly to that exact command string.
- Follow-up commands in the same skill (for example `package-skill.ts`) could still trigger another approval prompt.

### After
- The same command now produces a reusable rule scoped to the skill root:
  - `Bash(cd /Users/test/project && npx tsx /tmp/letta/src/skills/builtin/creating-skills:*)`
- Follow-up scripts in the same skill match that rule and are auto-allowed as expected.
- Approval text communicates scope clearly, with source-specific labels:
  - `Yes, and don't ask again for scripts in bundled skill 'creating-skills'`
  - `Yes, and don't ask again for scripts in agent-scoped skill 'finding-agents'`
  - `Yes, and don't ask again for scripts in global skill 'messaging-agents'`
  - `Yes, and don't ask again for scripts in project skill 'workflow/agent-tools'`

## What to expect
- Users invoking scripts from known skill locations should see more ergonomic, predictable option-2 behavior.
- Dangerous command safeguards remain unchanged: commands containing dangerous operations/flags still disable persistence (`allowPersistence: false`).
- Existing non-skill Bash approval behavior remains the same.

## Validation
- `bun test src/tests/permissions-analyzer.test.ts src/tests/permissions-matcher.test.ts`
- `bun run lint`
- Repo check hook (`bun run scripts/check.js`) passed during commit

## Files changed
- `src/permissions/analyzer.ts`
- `src/tests/permissions-analyzer.test.ts`
- `src/tests/permissions-matcher.test.ts`

👾 Generated with [Letta Code](https://letta.com)