### PR TITLE
fix(cli): clip oversized shell tool output in collapsed tool results

### DIFF
--- a/src/cli/components/CollapsedOutputDisplay.tsx
+++ b/src/cli/components/CollapsedOutputDisplay.tsx
@@ -10,6 +10,7 @@ const PREFIX_WIDTH = 5; // "  ⎿  " or "     "
 interface CollapsedOutputDisplayProps {
   output: string; // Full output from completion
   maxLines?: number; // Max lines to show before collapsing (Infinity = show all)
+  maxChars?: number; // Max chars to show before clipping
 }
 
 /**
@@ -22,12 +23,24 @@ export const CollapsedOutputDisplay = memo(
   ({
     output,
     maxLines = DEFAULT_COLLAPSED_LINES,
+    maxChars,
   }: CollapsedOutputDisplayProps) => {
     const columns = useTerminalWidth();
     const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
 
+    let displayOutput = output;
+    let clippedByChars = false;
+    if (
+      typeof maxChars === "number" &&
+      maxChars > 0 &&
+      output.length > maxChars
+    ) {
+      displayOutput = `${output.slice(0, maxChars)}…`;
+      clippedByChars = true;
+    }
+
     // Keep empty lines for accurate display (don't filter them out)
-    const lines = output.split("\n");
+    const lines = displayOutput.split("\n");
     // Remove trailing empty line from final newline
     if (lines.length > 0 && lines[lines.length - 1] === "") {
       lines.pop();
@@ -72,6 +85,17 @@ export const CollapsedOutputDisplay = memo(
             </Box>
             <Box flexGrow={1} width={contentWidth}>
               <Text dimColor>… +{hiddenCount} lines</Text>
+            </Box>
+          </Box>
+        )}
+        {/* Character clipping hint */}
+        {clippedByChars && (
+          <Box flexDirection="row">
+            <Box width={PREFIX_WIDTH} flexShrink={0}>
+              <Text>{"     "}</Text>
+            </Box>
+            <Box flexGrow={1} width={contentWidth}>
+              <Text dimColor>… output clipped</Text>
             </Box>
           </Box>
         )}

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -855,7 +855,7 @@ export const ToolCallMessage = memo(
           line.phase === "finished" &&
           line.resultText &&
           line.resultOk !== false && (
-            <CollapsedOutputDisplay output={line.resultText} />
+            <CollapsedOutputDisplay output={line.resultText} maxChars={300} />
           )}
 
         {/* Tool result for non-shell tools or shell tool errors */}


### PR DESCRIPTION
## Summary
- add optional `maxChars` clipping support to `CollapsedOutputDisplay`
- apply `maxChars={300}` for shell tool success output in `ToolCallMessageRich`
- preserve existing line-based collapse behavior while preventing giant single-line blobs from overwhelming transcript rendering

## Test plan
- [x] Run `bunx --bun @biomejs/biome@2.2.5 check src`
- [x] Run `tsc --noEmit`
- [ ] Reproduce with large single-line shell tool output and verify collapsed output is clipped with hint

👾 Generated with [Letta Code](https://letta.com)