### PR TITLE
TUI: show subagent reasoning effort

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -225,16 +225,34 @@ function recordToolCall(
  * Handle an init event from the subagent stream
  */
 function handleInitEvent(
-  event: { agent_id?: string; conversation_id?: string },
+  event: {
+    agent_id?: string;
+    conversation_id?: string;
+    reasoning_effort?: string | null;
+  },
   state: ExecutionState,
   baseURL: string,
   subagentId: string,
 ): void {
+  const next: Parameters<typeof updateSubagent>[1] = {};
+
   if (event.agent_id) {
     state.agentId = event.agent_id;
     const agentURL = `${baseURL}/agents/${event.agent_id}`;
-    updateSubagent(subagentId, { agentURL });
+    next.agentURL = agentURL;
   }
+
+  if (
+    typeof event.reasoning_effort === "string" ||
+    event.reasoning_effort === null
+  ) {
+    next.reasoningEffort = event.reasoning_effort;
+  }
+
+  if (Object.keys(next).length > 0) {
+    updateSubagent(subagentId, next);
+  }
+
   if (event.conversation_id) {
     state.conversationId = event.conversation_id;
   }

--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -82,7 +82,10 @@ const AgentRow = memo(
       agent.totalTokens,
       isRunning,
     );
-    const modelDisplay = getSubagentModelDisplay(agent.model);
+    const modelDisplay = getSubagentModelDisplay(
+      agent.model,
+      agent.reasoningEffort,
+    );
     const lastTool = agent.toolCalls[agent.toolCalls.length - 1];
 
     // Condensed mode: simplified view to reduce re-renders when overflowing
@@ -110,6 +113,11 @@ const AgentRow = memo(
               {modelDisplay && (
                 <>
                   <Text dimColor>{` · ${modelDisplay.label}`}</Text>
+                  {modelDisplay.reasoningEffortLabel && (
+                    <Text
+                      dimColor
+                    >{`-${modelDisplay.reasoningEffortLabel}`}</Text>
+                  )}
                   {modelDisplay.isByokProvider && (
                     <Text
                       color={
@@ -166,6 +174,11 @@ const AgentRow = memo(
             {modelDisplay && (
               <>
                 <Text dimColor>{` · ${modelDisplay.label}`}</Text>
+                {modelDisplay.reasoningEffortLabel && (
+                  <Text
+                    dimColor
+                  >{`-${modelDisplay.reasoningEffortLabel}`}</Text>
+                )}
                 {modelDisplay.isByokProvider && (
                   <Text
                     color={

--- a/src/cli/components/SubagentGroupStatic.tsx
+++ b/src/cli/components/SubagentGroupStatic.tsx
@@ -38,6 +38,7 @@ export interface StaticSubagent {
   agentURL: string | null;
   error?: string;
   model?: string;
+  reasoningEffort?: string | null;
   isBackground?: boolean;
 }
 
@@ -63,7 +64,10 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
   const isRunning = agent.status === "running";
   const shouldDim = isRunning && !agent.isBackground;
   const stats = formatStats(agent.toolCount, agent.totalTokens, isRunning);
-  const modelDisplay = getSubagentModelDisplay(agent.model);
+  const modelDisplay = getSubagentModelDisplay(
+    agent.model,
+    agent.reasoningEffort,
+  );
 
   return (
     <Box flexDirection="column">
@@ -84,6 +88,9 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
           {modelDisplay && (
             <>
               <Text dimColor>{` · ${modelDisplay.label}`}</Text>
+              {modelDisplay.reasoningEffortLabel && (
+                <Text dimColor>{`-${modelDisplay.reasoningEffortLabel}`}</Text>
+              )}
               {modelDisplay.isByokProvider && (
                 <Text
                   color={

--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -178,9 +178,7 @@ const ENCRYPTED_CONTENT_HINT = [
  * Walk the error object to find the `detail` string containing the encrypted content error.
  * Handles both direct (e.detail) and nested (e.error.error.detail) structures.
  */
-function findEncryptedContentDetail(
-  e: unknown,
-): string | undefined {
+function findEncryptedContentDetail(e: unknown): string | undefined {
   if (typeof e !== "object" || e === null) return undefined;
   const obj = e as Record<string, unknown>;
 

--- a/src/cli/helpers/subagentAggregation.ts
+++ b/src/cli/helpers/subagentAggregation.ts
@@ -138,6 +138,7 @@ export function createSubagentGroupItem(
         agentURL: subagent.agentURL,
         error: subagent.error,
         model: subagent.model,
+        reasoningEffort: subagent.reasoningEffort,
         isBackground: subagent.isBackground,
       });
     }

--- a/src/cli/helpers/subagentDisplay.ts
+++ b/src/cli/helpers/subagentDisplay.ts
@@ -53,6 +53,7 @@ export interface SubagentModelDisplay {
   label: string;
   isByokProvider: boolean;
   isOpenAICodexProvider: boolean;
+  reasoningEffortLabel?: string;
 }
 
 /**
@@ -61,6 +62,7 @@ export interface SubagentModelDisplay {
  */
 export function getSubagentModelDisplay(
   model: string | undefined,
+  reasoningEffort?: string | null,
 ): SubagentModelDisplay | null {
   if (!model) return null;
 
@@ -74,9 +76,28 @@ export function getSubagentModelDisplay(
   const label =
     getModelShortName(normalized) ?? normalized.split("/").pop() ?? normalized;
 
+  const effort = typeof reasoningEffort === "string" ? reasoningEffort : null;
+  const effortLabel =
+    effort === "none" || !effort
+      ? undefined
+      : effort === "minimal"
+        ? "min"
+        : effort === "medium"
+          ? "med"
+          : effort === "med"
+            ? "med"
+            : effort === "low"
+              ? "low"
+              : effort === "high"
+                ? "high"
+                : effort === "xhigh"
+                  ? "xhigh"
+                  : undefined;
+
   return {
     label,
     isByokProvider,
     isOpenAICodexProvider,
+    reasoningEffortLabel: effortLabel,
   };
 }

--- a/src/cli/helpers/subagentState.ts
+++ b/src/cli/helpers/subagentState.ts
@@ -27,6 +27,7 @@ export interface SubagentState {
   durationMs: number;
   error?: string;
   model?: string;
+  reasoningEffort?: string | null;
   startTime: number;
   toolCallId?: string; // Links this subagent to its parent Task tool call
   isBackground?: boolean; // True if running in background (fire-and-forget)
@@ -121,6 +122,7 @@ export function registerSubagent(
     toolCalls: [],
     totalTokens: 0,
     durationMs: 0,
+    reasoningEffort: null,
     startTime: Date.now(),
     toolCallId,
     isBackground,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -850,6 +850,9 @@ export async function handleHeadlessCommand(
       agent_id: agent.id,
       conversation_id: conversationId,
       model: agent.llm_config?.model ?? "",
+      reasoning_effort: (
+        agent.llm_config as { reasoning_effort?: string | null } | undefined
+      )?.reasoning_effort,
       tools:
         agent.tools?.map((t) => t.name).filter((n): n is string => !!n) || [],
       cwd: process.cwd(),
@@ -1862,6 +1865,9 @@ async function runBidirectionalMode(
     agent_id: agent.id,
     conversation_id: conversationId,
     model: agent.llm_config?.model,
+    reasoning_effort: (
+      agent.llm_config as { reasoning_effort?: string | null } | undefined
+    )?.reasoning_effort,
     tools: agent.tools?.map((t) => t.name) || [],
     cwd: process.cwd(),
     uuid: `init-${agent.id}`,

--- a/src/tests/cli/subagentDisplay.test.ts
+++ b/src/tests/cli/subagentDisplay.test.ts
@@ -2,43 +2,92 @@ import { describe, expect, test } from "bun:test";
 import { getSubagentModelDisplay } from "../../cli/helpers/subagentDisplay";
 
 describe("getSubagentModelDisplay", () => {
+  test("includes reasoning effort label when provided", () => {
+    const display = getSubagentModelDisplay("openai/gpt-5.2", "xhigh");
+    expect(display).toEqual({
+      label: "GPT-5.2",
+      isByokProvider: false,
+      isOpenAICodexProvider: false,
+      reasoningEffortLabel: "xhigh",
+    });
+  });
+
+  test("includes minimal reasoning effort label", () => {
+    const display = getSubagentModelDisplay("openai/gpt-5.2", "minimal");
+    expect(display).toEqual({
+      label: "GPT-5.2",
+      isByokProvider: false,
+      isOpenAICodexProvider: false,
+      reasoningEffortLabel: "min",
+    });
+  });
+
+  test("does not show unknown reasoning effort values", () => {
+    const display = getSubagentModelDisplay("openai/gpt-5.2", "superhigh");
+    expect(display).toEqual({
+      label: "GPT-5.2",
+      isByokProvider: false,
+      isOpenAICodexProvider: false,
+      reasoningEffortLabel: undefined,
+    });
+  });
+
+  test("does not show none reasoning effort", () => {
+    const display = getSubagentModelDisplay("openai/gpt-5.2", "none");
+    expect(display).toEqual({
+      label: "GPT-5.2",
+      isByokProvider: false,
+      isOpenAICodexProvider: false,
+      reasoningEffortLabel: undefined,
+    });
+  });
+
   test("formats known model IDs using short labels", () => {
-    const display = getSubagentModelDisplay("haiku");
+    const display = getSubagentModelDisplay("haiku", null);
     expect(display).toEqual({
       label: "Haiku 4.5",
       isByokProvider: false,
       isOpenAICodexProvider: false,
+      reasoningEffortLabel: undefined,
     });
   });
 
   test("formats non-BYOK handles using short labels", () => {
     const display = getSubagentModelDisplay(
       "anthropic/claude-haiku-4-5-20251001",
+      null,
     );
     expect(display).toEqual({
       label: "Haiku 4.5",
       isByokProvider: false,
       isOpenAICodexProvider: false,
+      reasoningEffortLabel: undefined,
     });
   });
 
   test("marks lc-* handles as BYOK", () => {
     const display = getSubagentModelDisplay(
       "lc-anthropic/claude-haiku-4-5-20251001",
+      null,
     );
     expect(display).toEqual({
       label: "claude-haiku-4-5-20251001",
       isByokProvider: true,
       isOpenAICodexProvider: false,
+      reasoningEffortLabel: undefined,
     });
   });
 
   test("marks chatgpt-plus-pro handles as BYOK", () => {
-    const display = getSubagentModelDisplay("chatgpt-plus-pro/gpt-5.2-codex");
+    const display = getSubagentModelDisplay(
+      "chatgpt-plus-pro/gpt-5.2-codex",
+      null,
+    );
     expect(display).toEqual({
       label: "GPT-5.2 Codex",
       isByokProvider: true,
       isOpenAICodexProvider: true,
+      reasoningEffortLabel: undefined,
     });
   });
 });

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -83,6 +83,7 @@ export interface SystemInitMessage extends MessageEnvelope {
   agent_id: string;
   conversation_id: string;
   model: string;
+  reasoning_effort?: string | null;
   tools: string[];
   cwd: string;
   mcp_servers: Array<{ name: string; status: string }>;


### PR DESCRIPTION
This adds a small reasoning-effort suffix to Task-spawned subagents in the TUI (e.g. `GPT-5.3 Codex-med`).

Why
- When Task spawns multiple subagents, it is hard to tell which reasoning tier each one actually ran with.

Behavior
- Displays `-min`, `-low`, `-med`, `-high`, or `-xhigh` next to the subagent model label.
- Hides the suffix when `reasoning_effort` is unset/unknown or explicitly `none`.
- Works for non-reasoning models (no suffix shown).

Correctness
- Uses the *actual* subagent `reasoning_effort` from the headless `system:init` event, which is emitted from the created agent's `llm_config.reasoning_effort` (server source of truth), not the local subagent config.

Implementation
- `src/types/protocol.ts`: add optional `reasoning_effort` to `SystemInitMessage`.
- `src/headless.ts`: include `reasoning_effort` in the init event payload.
- `src/agent/subagents/manager.ts`: capture `reasoning_effort` from the subagent init event and store it.
- `src/cli/helpers/subagentState.ts`: track `reasoningEffort` in `SubagentState`.
- `src/cli/components/SubagentGroupDisplay.tsx` and `src/cli/components/SubagentGroupStatic.tsx`: render the suffix when present.

Tests
- Update `src/tests/cli/subagentDisplay.test.ts`.

Test plan
- `bun run check`
- `bun test src/tests/cli/subagentDisplay.test.ts`
- `bun test src/integration-tests/headless-input-format.test.ts -t "Task tool with explore subagent works"`