### PR TITLE
feat: rename --from-af to --import and /download to /export

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -339,6 +339,7 @@ const NON_STATE_COMMANDS = new Set([
   "/search",
   "/memory",
   "/feedback",
+  "/export",
   "/download",
 ]);
 
@@ -6970,11 +6971,11 @@ export default function App({
           return { submitted: true };
         }
 
-        // Special handling for /download command - download agent file
-        if (msg.trim() === "/download") {
+        // Special handling for /export command (also accepts legacy /download)
+        if (msg.trim() === "/export" || msg.trim() === "/download") {
           const cmd = commandRunner.start(
             msg.trim(),
-            "Downloading agent file...",
+            "Exporting agent file...",
           );
 
           setCommandRunning(true);
@@ -7042,7 +7043,7 @@ export default function App({
             writeFileSync(fileName, JSON.stringify(fileContent, null, 2));
 
             // Build success message
-            let summary = `AgentFile downloaded to ${fileName}`;
+            let summary = `AgentFile exported to ${fileName}`;
             if (skills.length > 0) {
               summary += `\n📦 Included ${skills.length} skill(s): ${skills.map((s) => s.name).join(", ")}`;
             }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -135,12 +135,12 @@ export const commands: Record<string, Command> = {
       return "Updating description...";
     },
   },
-  "/download": {
-    desc: "Download AgentFile (.af)",
+  "/export": {
+    desc: "Export AgentFile (.af)",
     order: 26,
     handler: () => {
       // Handled specially in App.tsx to access agent ID and client
-      return "Downloading agent file...";
+      return "Exporting agent file...";
     },
   },
   "/toolset": {
@@ -392,6 +392,13 @@ export const commands: Record<string, Command> = {
     hidden: true, // Alias for /agents (opens to Pinned tab)
     handler: () => {
       return "Opening agent browser...";
+    },
+  },
+  "/download": {
+    desc: "Export AgentFile (.af)",
+    hidden: true, // Legacy alias for /export
+    handler: () => {
+      return "Exporting agent file...";
     },
   },
 };

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -100,9 +100,9 @@ describe("Startup Flow - Invalid Inputs", () => {
     { timeout: 70000 },
   );
 
-  test("--from-af with nonexistent file shows error", async () => {
+  test("--import with nonexistent file shows error", async () => {
     const result = await runCli(
-      ["--from-af", "/nonexistent/path/agent.af", "-p", "test"],
+      ["--import", "/nonexistent/path/agent.af", "-p", "test"],
       { expectExit: 1 },
     );
     expect(result.stderr).toContain("not found");

--- a/src/tests/startup-flow.test.ts
+++ b/src/tests/startup-flow.test.ts
@@ -104,13 +104,13 @@ describe("Startup Flow - Flag Conflicts", () => {
     );
   });
 
-  test("--conversation conflicts with --from-af", async () => {
+  test("--conversation conflicts with --import", async () => {
     const result = await runCli(
-      ["--conversation", "conv-123", "--from-af", "test.af"],
+      ["--conversation", "conv-123", "--import", "test.af"],
       { expectExit: 1 },
     );
     expect(result.stderr).toContain(
-      "--conversation cannot be used with --from-af",
+      "--conversation cannot be used with --import",
     );
   });
 


### PR DESCRIPTION
## Summary
- Renames `--from-af` CLI flag to `--import` for cleaner agent file import UX (`letta --import <file.af>`)
- Renames `/download` slash command to `/export` for consistency
- Old names (`--from-af`, `/download`) kept as hidden aliases for backward compatibility

## Test plan
- [ ] Verify `letta --import agent.af` works to import an agent file
- [ ] Verify `letta --from-af agent.af` still works (backward compat)
- [ ] Verify `/export` exports the agent file in interactive mode
- [ ] Verify `/download` still works as alias
- [ ] Run `npm test` to confirm startup-flow tests pass with updated flag names

🐾 Generated with [Letta Code](https://letta.com)