### PR TITLE
fix: migrate metadata references from BashOutput to TaskOutput

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -73,8 +73,8 @@ const PARALLEL_SAFE_TOOLS = new Set([
   "conversation_search",
   "web_search",
   "fetch_webpage",
-  // Background shell output (read-only check)
-  "BashOutput",
+  // Background task output (read-only check)
+  "TaskOutput",
   // Task spawns independent subagents
   "Task",
   // Plan mode tools (no parameters, no file operations)

--- a/src/agent/subagents/builtin/explore.md
+++ b/src/agent/subagents/builtin/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast agent for codebase exploration - finding files, searching code, understanding structure
-tools: Glob, Grep, Read, LS, BashOutput
+tools: Glob, Grep, Read, LS, TaskOutput
 model: haiku
 memoryBlocks: human, persona
 mode: stateless

--- a/src/agent/subagents/builtin/general-purpose.md
+++ b/src/agent/subagents/builtin/general-purpose.md
@@ -1,7 +1,7 @@
 ---
 name: general-purpose
 description: Full-capability agent for research, planning, and implementation
-tools: Bash, BashOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+tools: Bash, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: sonnet-4.5
 memoryBlocks: all
 mode: stateful

--- a/src/agent/subagents/builtin/plan.md
+++ b/src/agent/subagents/builtin/plan.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Planning agent that breaks down complex tasks into actionable steps
-tools: Glob, Grep, Read, LS, BashOutput
+tools: Glob, Grep, Read, LS, TaskOutput
 model: opus
 memoryBlocks: all
 mode: stateless

--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -1,7 +1,7 @@
 ---
 name: recall
 description: Search conversation history to recall past discussions, decisions, and context
-tools: Bash, Read, BashOutput
+tools: Bash, Read, TaskOutput
 model: opus
 memoryBlocks: none
 mode: stateless

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -1,7 +1,7 @@
 ---
 name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
-tools: Read, Edit, Write, Glob, Grep, Bash, BashOutput
+tools: Read, Edit, Write, Glob, Grep, Bash, TaskOutput
 model: sonnet-4.5
 memoryBlocks: none
 skills: searching-messages

--- a/src/cli/components/HooksManager.tsx
+++ b/src/cli/components/HooksManager.tsx
@@ -99,7 +99,7 @@ const FALLBACK_TOOL_NAMES = [
   "Skill",
   "EnterPlanMode",
   "ExitPlanMode",
-  "BashOutput",
+  "TaskOutput",
   "KillBash",
 ];
 

--- a/src/cli/components/ToolsetSelector.tsx
+++ b/src/cli/components/ToolsetSelector.tsx
@@ -31,7 +31,7 @@ const toolsets: ToolsetOption[] = [
     description: "Toolset optimized for Claude models",
     tools: [
       "Bash",
-      "BashOutput",
+      "TaskOutput",
       "Edit",
       "Glob",
       "Grep",

--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -68,7 +68,9 @@ export function getDisplayToolName(rawName: string): string {
   if (rawName === "Replace" || rawName === "replace") return "Update";
   if (rawName === "WriteFile" || rawName === "write_file") return "Write";
   if (rawName === "KillBash") return "Kill Bash";
-  if (rawName === "BashOutput") return "Shell Output";
+  if (rawName === "BashOutput" || rawName === "TaskOutput") {
+    return "Shell Output";
+  }
   if (rawName === "MultiEdit") return "Update";
 
   // No mapping found, return as-is

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -400,15 +400,15 @@ function matchesPattern(
 
 /**
  * Subagent types that are read-only and safe to auto-approve.
- * These only have access to read-only tools (Glob, Grep, Read, LS, BashOutput).
+ * These only have access to read-only tools (Glob, Grep, Read, LS, TaskOutput).
  * See: src/agent/subagents/builtin/*.md for definitions
  */
 const READ_ONLY_SUBAGENT_TYPES = new Set([
-  "explore", // Codebase exploration - Glob, Grep, Read, LS, BashOutput
+  "explore", // Codebase exploration - Glob, Grep, Read, LS, TaskOutput
   "Explore",
-  "plan", // Planning agent - Glob, Grep, Read, LS, BashOutput
+  "plan", // Planning agent - Glob, Grep, Read, LS, TaskOutput
   "Plan",
-  "recall", // Conversation history search - Skill, Bash, Read, BashOutput
+  "recall", // Conversation history search - Skill, Bash, Read, TaskOutput
   "Recall",
 ]);
 
@@ -428,7 +428,7 @@ function getDefaultDecision(
     "Glob",
     "Grep",
     "TodoWrite",
-    "BashOutput",
+    "TaskOutput",
     "LS",
     // Codex toolset (snake_case) - tools that don't require approval
     "read_file",

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -239,7 +239,7 @@ class PermissionModeManager {
         }
 
         // Allow Task tool with read-only subagent types
-        // These subagents only have access to read-only tools (Glob, Grep, Read, LS, BashOutput)
+        // These subagents only have access to read-only tools (Glob, Grep, Read, LS, TaskOutput)
         const readOnlySubagentTypes = new Set([
           "explore",
           "Explore",


### PR DESCRIPTION
## Summary
- replace `BashOutput` with `TaskOutput` in subagent tool manifests
- update permission metadata and auto-allow comments/lists to match `TaskOutput`
- update CLI metadata (toolset selector, hooks fallback, display mapping) for `TaskOutput`

## Validation
- `npm run lint`
- `npx tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)