### PR TITLE
fix: auto-approve reflection subagent task without HITL prompt

### DIFF
--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -410,6 +410,8 @@ const READ_ONLY_SUBAGENT_TYPES = new Set([
   "Plan",
   "recall", // Conversation history search - Skill, Bash, Read, TaskOutput
   "Recall",
+  "reflection", // Memory reflection - reads history, writes to agent's own memory files
+  "Reflection",
 ]);
 
 /**


### PR DESCRIPTION
The reflection subagent only reads conversation history and writes to the agent's own memory files — it doesn't modify user code. Add it to READ_ONLY_SUBAGENT_TYPES so it launches without requiring manual approval each time.

👾 Generated with [Letta Code](https://letta.com)