### PR TITLE
fix: normalize path separators in isMemoryDirCommand for Windows

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -289,34 +289,48 @@ function extractDashCArgument(tokens: string[]): string | undefined {
 function getAllowedMemoryPrefixes(agentId: string): string[] {
   const home = homedir();
   const prefixes: string[] = [
-    resolve(home, ".letta", "agents", agentId, "memory"),
-    resolve(home, ".letta", "agents", agentId, "memory-worktrees"),
+    normalizeSeparators(resolve(home, ".letta", "agents", agentId, "memory")),
+    normalizeSeparators(
+      resolve(home, ".letta", "agents", agentId, "memory-worktrees"),
+    ),
   ];
   const parentId = process.env.LETTA_PARENT_AGENT_ID;
   if (parentId && parentId !== agentId) {
     prefixes.push(
-      resolve(home, ".letta", "agents", parentId, "memory"),
-      resolve(home, ".letta", "agents", parentId, "memory-worktrees"),
+      normalizeSeparators(
+        resolve(home, ".letta", "agents", parentId, "memory"),
+      ),
+      normalizeSeparators(
+        resolve(home, ".letta", "agents", parentId, "memory-worktrees"),
+      ),
     );
   }
   return prefixes;
 }
 
 /**
+ * Normalize a path to forward slashes (for consistent comparison on Windows).
+ */
+function normalizeSeparators(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
  * Resolve a path that may contain ~ or $HOME to an absolute path.
+ * Always returns forward slashes for cross-platform consistency.
  */
 function expandPath(p: string): string {
   const home = homedir();
   if (p.startsWith("~/")) {
-    return resolve(home, p.slice(2));
+    return normalizeSeparators(resolve(home, p.slice(2)));
   }
   if (p.startsWith("$HOME/")) {
-    return resolve(home, p.slice(6));
+    return normalizeSeparators(resolve(home, p.slice(6)));
   }
   if (p.startsWith('"$HOME/')) {
-    return resolve(home, p.slice(7).replace(/"$/, ""));
+    return normalizeSeparators(resolve(home, p.slice(7).replace(/"$/, "")));
   }
-  return resolve(p);
+  return normalizeSeparators(resolve(p));
 }
 
 /**

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -248,7 +248,8 @@ describe("isReadOnlyShellCommand", () => {
 
 describe("isMemoryDirCommand", () => {
   const AGENT_ID = "agent-test-abc123";
-  const home = homedir();
+  // Normalize to forward slashes for shell command strings (even on Windows)
+  const home = homedir().replace(/\\/g, "/");
   const memDir = `${home}/.letta/agents/${AGENT_ID}/memory`;
   const worktreeDir = `${home}/.letta/agents/${AGENT_ID}/memory-worktrees`;
 


### PR DESCRIPTION
On Windows, resolve() produces backslash paths while shell command strings use forward slashes, causing path comparison to always fail. Normalize all paths to forward slashes for consistent cross-platform matching.

👾 Generated with [Letta Code](https://letta.com)