### PR TITLE
fix: pre-load skills for subagents and fix dev-mode spawning

### DIFF
--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -75,9 +75,9 @@ All subsequent file operations target the worktree:
 
 ### Phase 2: Review Recent Conversation History
 
-Use the `searching-messages` skill (pre-loaded in
-`<loaded_skills>`) to search via `letta messages search`
-and `letta messages list`.
+Use `letta messages search` and `letta messages list`
+(documented in `<loaded_skills>` below) to search the
+parent agent's conversation history.
 
 **Sliding window through recent history:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,6 +437,7 @@ async function main(): Promise<void> {
         "include-partial-messages": { type: "boolean" },
         "from-agent": { type: "string" },
         skills: { type: "string" },
+        "pre-load-skills": { type: "string" },
         sleeptime: { type: "boolean" },
         "from-af": { type: "string" },
 


### PR DESCRIPTION
The reflection subagent couldn't access conversation history because:
1. The `skills:` field in subagent configs was parsed but never acted on
2. The reflection prompt claimed skills were "pre-loaded" but they weren't
3. In dev mode, subagents fell back to the global `letta` binary instead of the dev source

Changes:
- Add --pre-load-skills flag to headless mode that reads skill SKILL.md content and injects it as <loaded_skills> XML in the first user message
- Wire config.skills through manager.ts to pass --pre-load-skills to subagent CLI args
- Fix dev-mode subagent spawning to use process.execPath (bun) with the .ts script path instead of falling back to global letta binary
- Update reflection.md prompt to match actual injection mechanism
- Register --pre-load-skills in index.ts parseArgs to prevent rejection

👾 Generated with [Letta Code](https://letta.com)