### PR TITLE
fix: make memory sync reminder more actionable (LET-7407)

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7549,13 +7549,15 @@ MEMORY SYNC: Your memory directory has uncommitted changes or is ahead of the re
 
 ${gitStatus.summary}
 
-To sync:
+Sync when convenient by running these commands:
 \`\`\`bash
 cd ~/.letta/agents/${agentId}/memory
 git add system/
 git commit -m "<type>: <what changed>"
 git push
 \`\`\`
+
+You should do this soon to avoid losing memory updates. It only takes a few seconds.
 ${SYSTEM_REMINDER_CLOSE}
 `;
         // Clear after injecting so it doesn't repeat


### PR DESCRIPTION
## Summary
- Makes the memory git sync system reminder more directive so the agent is encouraged to actually commit and push

## Before
```
<system-reminder>
MEMORY SYNC: Your memory directory has uncommitted changes or is ahead of the remote.

7 uncommitted change(s), local commits not pushed to remote

To sync:

cd ~/.letta/agents/<agent-id>/memory
git add system/
git commit -m "<type>: <what changed>"
git push

</system-reminder>
```

## After
```
<system-reminder>
MEMORY SYNC: Your memory directory has uncommitted changes or is ahead of the remote.

7 uncommitted change(s), local commits not pushed to remote

Sync when convenient by running these commands:

cd ~/.letta/agents/<agent-id>/memory
git add system/
git commit -m "<type>: <what changed>"
git push

You should do this soon to avoid losing memory updates. It only takes a few seconds.
</system-reminder>
```

Resolves LET-7407

👾 Generated with [Letta Code](https://letta.com)