### PR TITLE
fix: statusline command parsing, rendering keys, and stale execution

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -310,9 +310,9 @@ const InputFooter = memo(function InputFooter({
         {hideFooterContent ? (
           <Text>{" ".repeat(rightColumnWidth)}</Text>
         ) : statusLineRight ? (
-          statusLineRight.split("\n").map((line) => (
-            <Text key={line} wrap="truncate-end">
-              {parseOsc8Line(line, line)}
+          statusLineRight.split("\n").map((line, i) => (
+            <Text key={`${i}-${line}`} wrap="truncate-end">
+              {parseOsc8Line(line, `r${i}`)}
             </Text>
           ))
         ) : (

--- a/src/cli/hooks/useConfigurableStatusLine.ts
+++ b/src/cli/hooks/useConfigurableStatusLine.ts
@@ -110,6 +110,9 @@ export function useConfigurableStatusLine(
 
     if (!config) {
       configRef.current = null;
+      // Abort any in-flight execution so stale results don't surface.
+      abortRef.current?.abort();
+      abortRef.current = null;
       setActive(false);
       setText("");
       setRightText("");


### PR DESCRIPTION
## Summary
- Fix `/statusline` argument parsing to preserve spaces in commands (use `indexOf` instead of `split`)
- Fix scope flag (`-l`/`-p`) extraction using regex match instead of `endsWith`
- Load project settings before updating for `set`/`clear` subcommands
- Handle missing config in `enable` subcommand gracefully instead of silently succeeding
- Fix duplicate React keys in status line footer rendering
- Abort in-flight status line execution when config is cleared to prevent stale results

## Test plan
- [ ] Run `/statusline set "echo hello world" -l` and verify the full command is preserved
- [ ] Run `/statusline enable` with no config set and verify error message
- [ ] Clear status line config and verify no stale output appears
- [ ] Verify status line rendering with duplicate lines doesn't produce React key warnings