### PR TITLE
fix: clarify Task max_turns default guidance

### DIFF
--- a/src/tools/schemas/Task.json
+++ b/src/tools/schemas/Task.json
@@ -32,7 +32,7 @@
     "max_turns": {
       "type": "integer",
       "exclusiveMinimum": 0,
-      "description": "Maximum number of agentic turns (API round-trips) before stopping."
+      "description": "Maximum number of agentic turns (API round-trips) before stopping. Defaults to unlimited (recommended for most use cases)."
     }
   },
   "required": ["description", "prompt", "subagent_type"],


### PR DESCRIPTION
## Summary
- update Task schema description for max_turns
- explicitly state this parameter defaults to unlimited
- recommend leaving it unset for most use cases so parent agents do not over-constrain subagents

## Why
Some models were overusing max_turns when calling Task. This wording makes the intended default behavior explicit in the tool schema itself.

## Validation
- bun run scripts/check.js (ran via commit hook)
