### PR TITLE
fix: use system-reminder tags for conversation switch context

### DIFF
--- a/src/cli/helpers/conversationSwitchAlert.ts
+++ b/src/cli/helpers/conversationSwitchAlert.ts
@@ -1,7 +1,5 @@
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
-
-const SYSTEM_ALERT_OPEN = "<system-alert>";
-const SYSTEM_ALERT_CLOSE = "</system-alert>";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 
 const MAX_HISTORY_MESSAGES = 8;
 const MAX_MESSAGE_CHARS = 500;
@@ -83,7 +81,7 @@ export function buildConversationSwitchAlert(
     parts.push("Review the in-context messages for full conversation history.");
   }
 
-  return `${SYSTEM_ALERT_OPEN}\n${parts.join("\n")}\n${SYSTEM_ALERT_CLOSE}\n\n`;
+  return `${SYSTEM_REMINDER_OPEN}\n${parts.join("\n")}\n${SYSTEM_REMINDER_CLOSE}\n\n`;
 }
 
 function pushConversationMeta(

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -59,7 +59,7 @@ export interface Settings {
   reflectionTrigger: "off" | "step-count" | "compaction-event";
   reflectionBehavior: "reminder" | "auto-launch";
   reflectionStepCount: number;
-  conversationSwitchAlertEnabled: boolean; // Send system-alert when switching conversations/agents
+  conversationSwitchAlertEnabled: boolean; // Send system-reminder when switching conversations/agents
   globalSharedBlockIds: Record<string, string>; // DEPRECATED: kept for backwards compat
   profiles?: Record<string, string>; // DEPRECATED: old format, kept for migration
   pinnedAgents?: string[]; // DEPRECATED: kept for backwards compat, use pinnedAgentsByServer

--- a/src/tests/cli/conversationSwitchAlert.test.ts
+++ b/src/tests/cli/conversationSwitchAlert.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { buildConversationSwitchAlert } from "../../cli/helpers/conversationSwitchAlert";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+
+describe("conversationSwitchAlert", () => {
+  test("wraps conversation switch context in system-reminder tags", () => {
+    const alert = buildConversationSwitchAlert({
+      origin: "resume-selector",
+      conversationId: "conv-123",
+      isDefault: false,
+      messageCount: 14,
+      summary: "Bugfix thread",
+    });
+
+    expect(alert).toContain(SYSTEM_REMINDER_OPEN);
+    expect(alert).toContain(SYSTEM_REMINDER_CLOSE);
+    expect(alert).not.toContain("<system-alert>");
+    expect(alert).not.toContain("</system-alert>");
+    expect(alert).toContain("Conversation resumed via /resume selector.");
+    expect(alert).toContain("Conversation: conv-123 (14 messages)");
+  });
+});


### PR DESCRIPTION
## Summary
- switch conversation-switch helper output from `<system-alert>` to `SYSTEM_REMINDER_OPEN/CLOSE`
- align settings comment with actual behavior (`system-reminder`)
- add regression test covering reminder tag wrapping

## Why
PR #910 introduced conversation switch context injection, but wrapped it in `<system-alert>`. Most reminder parsing/rendering/filtering paths in the CLI key off `<system-reminder>`, so the injected block was not treated consistently with other system reminders.

## Validation
- bun test src/tests/cli/conversationSwitchAlert.test.ts src/tests/cli/memoryReminder.test.ts
- bun run typecheck
- bun run scripts/check.js (pre-commit hook)
