### PR TITLE
fix: only inject interrupt recovery after real user interrupts

### DIFF
--- a/src/agent/prompts/approval_recovery_alert.txt
+++ b/src/agent/prompts/approval_recovery_alert.txt
@@ -1,1 +1,1 @@
-<system-alert>Automated keep-alive ping. Ignore this message and continue from where you stopped.</system-alert>
+<system-reminder>Automated keep-alive ping. Ignore this message and continue from where you stopped.</system-reminder>

--- a/src/agent/prompts/interrupt_recovery_alert.txt
+++ b/src/agent/prompts/interrupt_recovery_alert.txt
@@ -1,1 +1,1 @@
-<system-alert>The user interrupted the active stream.</system-alert>
+<system-reminder>The user interrupted the active stream.</system-reminder>

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -4,7 +4,7 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getClient } from "../../agent/client";
-import { SYSTEM_REMINDER_OPEN } from "../../constants";
+import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
@@ -93,7 +93,12 @@ function extractUserMessagePreview(message: Message): string | null {
       const part = content[i];
       if (part?.type === "text" && part.text) {
         // Skip system-reminder blocks
-        if (part.text.startsWith(SYSTEM_REMINDER_OPEN)) continue;
+        if (
+          part.text.startsWith(SYSTEM_REMINDER_OPEN) ||
+          part.text.startsWith(SYSTEM_ALERT_OPEN)
+        ) {
+          continue;
+        }
         textToShow = part.text;
         break;
       }

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -1,6 +1,11 @@
 import { memo } from "react";
 import stringWidth from "string-width";
-import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+import {
+  SYSTEM_ALERT_CLOSE,
+  SYSTEM_ALERT_OPEN,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../constants";
 import { extractTaskNotificationsForDisplay } from "../helpers/taskNotifications";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors, hexToBgAnsi, hexToFgAnsi } from "./colors";
@@ -53,15 +58,20 @@ export function splitSystemReminderBlocks(
   text: string,
 ): Array<{ text: string; isSystemReminder: boolean }> {
   const blocks: Array<{ text: string; isSystemReminder: boolean }> = [];
-  const tagOpen = SYSTEM_REMINDER_OPEN;
-  const tagClose = SYSTEM_REMINDER_CLOSE;
+  const tags = [
+    { open: SYSTEM_REMINDER_OPEN, close: SYSTEM_REMINDER_CLOSE },
+    { open: SYSTEM_ALERT_OPEN, close: SYSTEM_ALERT_CLOSE }, // legacy
+  ];
 
   let remaining = text;
 
   while (remaining.length > 0) {
-    const openIdx = remaining.indexOf(tagOpen);
+    const nextTag = tags
+      .map((tag) => ({ ...tag, idx: remaining.indexOf(tag.open) }))
+      .filter((tag) => tag.idx >= 0)
+      .sort((a, b) => a.idx - b.idx)[0];
 
-    if (openIdx === -1) {
+    if (!nextTag) {
       // No more system-reminder tags, rest is user content
       if (remaining.trim()) {
         blocks.push({ text: remaining.trim(), isSystemReminder: false });
@@ -70,7 +80,7 @@ export function splitSystemReminderBlocks(
     }
 
     // Find the closing tag
-    const closeIdx = remaining.indexOf(tagClose, openIdx);
+    const closeIdx = remaining.indexOf(nextTag.close, nextTag.idx);
     if (closeIdx === -1) {
       // Malformed/incomplete tag - treat the whole remainder as literal user text.
       const literal = remaining.trim();
@@ -81,18 +91,21 @@ export function splitSystemReminderBlocks(
     }
 
     // Content before the tag is user content
-    if (openIdx > 0) {
-      const before = remaining.slice(0, openIdx).trim();
+    if (nextTag.idx > 0) {
+      const before = remaining.slice(0, nextTag.idx).trim();
       if (before) {
         blocks.push({ text: before, isSystemReminder: false });
       }
     }
 
     // Extract the full system-reminder block (including tags)
-    const sysBlock = remaining.slice(openIdx, closeIdx + tagClose.length);
+    const sysBlock = remaining.slice(
+      nextTag.idx,
+      closeIdx + nextTag.close.length,
+    );
     blocks.push({ text: sysBlock, isSystemReminder: true });
 
-    remaining = remaining.slice(closeIdx + tagClose.length);
+    remaining = remaining.slice(closeIdx + nextTag.close.length);
   }
 
   return blocks;

--- a/src/cli/helpers/backfill.ts
+++ b/src/cli/helpers/backfill.ts
@@ -5,7 +5,12 @@ import type {
   Message,
   TextContent,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+import {
+  SYSTEM_ALERT_CLOSE,
+  SYSTEM_ALERT_OPEN,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../constants";
 import type { Buffers } from "./accumulator";
 import { extractTaskNotificationsForDisplay } from "./taskNotifications";
 
@@ -41,13 +46,17 @@ function normalizeLineEndings(s: string): string {
   return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
-function removeSystemReminderBlocks(text: string): string {
+function removeSystemContextBlocks(text: string): string {
   return text
     .replace(
       new RegExp(
         `${SYSTEM_REMINDER_OPEN}[\\s\\S]*?${SYSTEM_REMINDER_CLOSE}`,
         "g",
       ),
+      "",
+    )
+    .replace(
+      new RegExp(`${SYSTEM_ALERT_OPEN}[\\s\\S]*?${SYSTEM_ALERT_CLOSE}`, "g"),
       "",
     )
     .trim();
@@ -102,7 +111,7 @@ function renderUserContentParts(
   // Parts are joined with newlines so each appears as a separate line
   if (typeof parts === "string") {
     const normalized = normalizeLineEndings(parts);
-    return clip(removeSystemReminderBlocks(normalized), CLIP_CHAR_LIMIT_TEXT);
+    return clip(removeSystemContextBlocks(normalized), CLIP_CHAR_LIMIT_TEXT);
   }
 
   const rendered: string[] = [];
@@ -111,7 +120,7 @@ function renderUserContentParts(
       const text = p.text || "";
       // Normalize line endings (\r\n and \r -> \n) to prevent terminal garbling
       const normalized = normalizeLineEndings(text);
-      const withoutSystemReminders = removeSystemReminderBlocks(normalized);
+      const withoutSystemReminders = removeSystemContextBlocks(normalized);
       if (!withoutSystemReminders) continue;
       rendered.push(clip(withoutSystemReminders, CLIP_CHAR_LIMIT_TEXT));
     } else if (p.type === "image") {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,10 @@ export const INTERRUPTED_BY_USER = "Interrupted by user";
 export const SYSTEM_REMINDER_TAG = "system-reminder";
 export const SYSTEM_REMINDER_OPEN = `<${SYSTEM_REMINDER_TAG}>`;
 export const SYSTEM_REMINDER_CLOSE = `</${SYSTEM_REMINDER_TAG}>`;
+// Legacy tag kept for parsing/backward compatibility with older saved messages.
+export const SYSTEM_ALERT_TAG = "system-alert";
+export const SYSTEM_ALERT_OPEN = `<${SYSTEM_ALERT_TAG}>`;
+export const SYSTEM_ALERT_CLOSE = `</${SYSTEM_ALERT_TAG}>`;
 
 /**
  * How often (in turns) to check for memfs sync conflicts, even without

--- a/src/tests/cli/backfill-system-reminder.test.ts
+++ b/src/tests/cli/backfill-system-reminder.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { backfillBuffers } from "../../cli/helpers/backfill";
-import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+import {
+  SYSTEM_ALERT_CLOSE,
+  SYSTEM_ALERT_OPEN,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../constants";
 
 function userMessage(
   id: string,
@@ -64,5 +69,21 @@ describe("backfill system-reminder handling", () => {
 
     expect(buffers.byId.get("u3")).toBeUndefined();
     expect(buffers.order).toHaveLength(0);
+  });
+
+  test("hides legacy system-alert blocks from backfill", () => {
+    const buffers = createBuffers();
+    const history = [
+      userMessage(
+        "u4",
+        `${SYSTEM_ALERT_OPEN}The user interrupted the active stream.${SYSTEM_ALERT_CLOSE}\n\nhello :D`,
+      ),
+    ];
+
+    backfillBuffers(buffers, history);
+
+    const line = buffers.byId.get("u4");
+    expect(line?.kind).toBe("user");
+    expect(line && "text" in line ? line.text : "").toBe("hello :D");
   });
 });

--- a/src/tests/cli/interrupt-recovery-wiring.test.ts
+++ b/src/tests/cli/interrupt-recovery-wiring.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("interrupt recovery alert wiring", () => {
+  test("gates alert injection on explicit user interrupt state", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    expect(source).toContain("pendingInterruptRecoveryConversationIdRef");
+    expect(source).toContain("canInjectInterruptRecovery");
+    expect(source).toContain(
+      "pendingInterruptRecoveryConversationIdRef.current ===",
+    );
+    expect(source).toContain(
+      "pendingInterruptRecoveryConversationIdRef.current = null;",
+    );
+  });
+});

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -18,4 +18,13 @@ describe("splitSystemReminderBlocks", () => {
     expect(blocks.some((b) => b.text.includes("before"))).toBe(true);
     expect(blocks.some((b) => b.text.includes("after"))).toBe(true);
   });
+
+  test("detects legacy system-alert blocks as system context", () => {
+    const blocks = splitSystemReminderBlocks(
+      "before\n<system-alert>alert</system-alert>\nafter",
+    );
+
+    expect(blocks.some((b) => b.isSystemReminder)).toBe(true);
+    expect(blocks.some((b) => b.text.includes("<system-alert>"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- gate interrupt recovery alert injection on an explicit user interrupt signal (same conversation only)
- standardize generated recovery alerts to `<system-reminder>`
- parse and hide legacy `<system-alert>` blocks in backfill/static rendering and preview filtering
- strip both `<system-reminder>` and `<system-alert>` blocks in input restore paths
- convert permission mode change context injection to `<system-reminder>` for consistency

## Root cause
The retry/recovery path in `App.tsx` prepended `INTERRUPT_RECOVERY_ALERT` whenever `lastSentInputRef` existed and contained user messages, even if the previous turn failed due to timeout/network error (not a user interrupt).

That caused cases like:
- first prompt times out
- user sends a new prompt
- client injects "The user interrupted the active stream" anyway

## Behavior change
Now the recovery alert is injected only if the previous turn was actually interrupted by the user via interrupt handling.

## Backcompat
Older conversations can still contain `<system-alert>` content blocks. Rendering/backfill now treats these as system context and hides them similarly to `<system-reminder>` blocks.

## Validation
- `bun test src/tests/cli/backfill-system-reminder.test.ts src/tests/cli/userMessageRich.test.ts src/tests/cli/interrupt-recovery-wiring.test.ts src/tests/cli/conversationSwitchAlert.test.ts`
- `bun run typecheck`
- `bun run scripts/check.js`
