### PR TITLE
fix: add auto-notification guidance to background task return value

### DIFF
--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -426,7 +426,14 @@ export async function task(args: TaskArgs): Promise<string> {
 
     await waitForBackgroundSubagentLink(subagentId, null, signal);
 
-    return `Task running in background with ID: ${taskId}\nOutput file: ${outputFile}`;
+    // Extract Letta agent ID from subagent state (available after link resolves)
+    const linkedAgent = getSubagentSnapshot().agents.find(
+      (a) => a.id === subagentId,
+    );
+    const agentId = linkedAgent?.agentURL?.split("/agents/")[1] ?? null;
+    const agentIdLine = agentId ? `\nAgent ID: ${agentId}` : "";
+
+    return `Task running in background with task ID: ${taskId}${agentIdLine}\nOutput file: ${outputFile}\n\nYou will be notified automatically when this task completes — a <task-notification> message will be delivered with the result. No need to poll, sleep-wait, or check the output file. Just continue with your current work.`;
   }
 
   // Register subagent with state store for UI display (foreground path)


### PR DESCRIPTION
Models were wasting turns polling background subagents with Bash(sleep) loops or repeated Read(outputFile) calls. The harness already delivers a <task-notification> message automatically on completion, but the return value didn't mention this.

Now the background Task return includes:
- Explicit "you will be notified automatically" message
- The Letta agent ID (extracted after subagent link resolves)
- Guidance that polling/sleep-waiting is unnecessary

👾 Generated with [Letta Code](https://letta.com)