### PR TITLE
fix: drop conversation_search from default toolset

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -43,7 +43,7 @@ export const DEFAULT_AGENT_CONFIGS: Record<string, CreateAgentOptions> = {
     name: "Incognito",
     description: INCOGNITO_DESCRIPTION,
     initBlocks: [], // No personal memory blocks
-    baseTools: ["web_search", "conversation_search", "fetch_webpage"], // No memory tool
+    baseTools: ["web_search", "fetch_webpage"], // No memory tool
   },
 };
 


### PR DESCRIPTION
Remove conversation_search from the incognito agent's baseTools (the only agent config that explicitly included it). The default create path already didn't include it. Only web_search and fetch_webpage remain as default server-side tools.

👾 Generated with [Letta Code](https://letta.com)