### PR TITLE
feat: show specific retry messages for known LLM provider errors

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -178,6 +178,7 @@ import {
 import { setErrorContext } from "./helpers/errorContext";
 import {
   formatErrorDetails,
+  getRetryStatusMessage,
   isEncryptedContentError,
 } from "./helpers/errorFormatter";
 import { formatCompact } from "./helpers/format";
@@ -4365,9 +4366,7 @@ export default function App({
 
             // Show subtle grey status message
             const statusId = uid("status");
-            const statusLines = [
-              "Unexpected downstream LLM API error, retrying...",
-            ];
+            const statusLines = [getRetryStatusMessage(detailFromRun)];
             buffersRef.current.byId.set(statusId, {
               kind: "status",
               id: statusId,

--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -433,6 +433,25 @@ export function formatErrorDetails(
   return String(e);
 }
 
+const DEFAULT_RETRY_MESSAGE =
+  "Unexpected downstream LLM API error, retrying...";
+
+/**
+ * Return a user-facing status message for a retriable LLM API error.
+ * Matches known provider error patterns from the run's error detail and
+ * returns a specific message; falls back to a generic one otherwise.
+ */
+export function getRetryStatusMessage(
+  errorDetail: string | null | undefined,
+): string {
+  if (!errorDetail) return DEFAULT_RETRY_MESSAGE;
+
+  if (errorDetail.includes("Anthropic API is overloaded"))
+    return "Anthropic API is overloaded, retrying...";
+
+  return DEFAULT_RETRY_MESSAGE;
+}
+
 /**
  * Create a terminal hyperlink to the agent with run ID displayed
  */


### PR DESCRIPTION
## Summary
- Adds `getRetryStatusMessage()` to `errorFormatter.ts` that maps run error details to user-facing retry messages
- When Anthropic API is overloaded, shows "Anthropic API is overloaded, retrying..." instead of the generic "Unexpected downstream LLM API error, retrying..."
- Extensible for future provider-specific messages (OpenAI, Google Vertex, etc.)

## Test plan
- [ ] Trigger an Anthropic overloaded error and verify the status message shows "Anthropic API is overloaded, retrying..."
- [ ] Trigger a non-overloaded LLM API error and verify the generic "Unexpected downstream LLM API error, retrying..." still shows