### PR TITLE
feat: surface memfs_enabled in headless init message

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -872,6 +872,7 @@ export async function handleHeadlessCommand(
       mcp_servers: [],
       permission_mode: "",
       slash_commands: [],
+      memfs_enabled: settingsManager.isMemfsEnabled(agent.id),
       uuid: `init-${agent.id}`,
     };
     console.log(JSON.stringify(initEvent));
@@ -1935,6 +1936,7 @@ async function runBidirectionalMode(
     model: agent.llm_config?.model,
     tools: availableTools,
     cwd: process.cwd(),
+    memfs_enabled: settingsManager.isMemfsEnabled(agent.id),
     uuid: `init-${agent.id}`,
   };
   console.log(JSON.stringify(initEvent));

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -88,6 +88,7 @@ export interface SystemInitMessage extends MessageEnvelope {
   mcp_servers: Array<{ name: string; status: string }>;
   permission_mode: string;
   slash_commands: string[];
+  memfs_enabled?: boolean;
   // output_style omitted - Letta Code doesn't have output styles feature
 }
 


### PR DESCRIPTION
## Summary
- Adds `memfs_enabled?: boolean` to `SystemInitMessage` in the protocol types
- Sets `memfs_enabled` in both headless init event locations (stream-json and bidirectional modes)
- Companion PR: letta-ai/letta-code-sdk (adds `memfs` option and maps the init field)

## Context
The SDK needs to know whether memfs is active for an agent. This adds the field to the wire protocol's init message so the SDK can surface it as `memfsEnabled` on `SDKInitMessage`.

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed locally)
- [ ] Test that init message includes `memfs_enabled: true` when memfs is enabled for an agent
- [ ] Test that init message includes `memfs_enabled: false` when memfs is not enabled
- [ ] Verify existing headless tests still pass

Written by Cameron and Letta Code

"The palest ink is better than the best memory." -- Chinese proverb