### PR TITLE
fix: resolve shell command sandbox bypass and unauthorized file access

### DIFF
--- a/src/tests/permissions_security.test.ts
+++ b/src/tests/permissions_security.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import {
+  isMemoryDirCommand,
+  isReadOnlyShellCommand,
+} from "../permissions/readOnlyShell";
+
+test("FIX: isReadOnlyShellCommand should not auto-approve reading sensitive files", () => {
+  // These used to return true, now should return false
+  expect(isReadOnlyShellCommand("cat /etc/passwd")).toBe(false);
+  expect(isReadOnlyShellCommand("grep secret /etc/shadow")).toBe(false);
+  expect(isReadOnlyShellCommand("head -n 20 ../../../.ssh/id_rsa")).toBe(false);
+
+  // Normal safe commands should still work
+  expect(isReadOnlyShellCommand("ls")).toBe(true);
+  expect(isReadOnlyShellCommand("cat README.md")).toBe(true);
+});
+
+test("FIX: isMemoryDirCommand should not allow command injection via cd bypass", () => {
+  const agentId = "agent123";
+  const home = homedir();
+  const memoryDir = resolve(home, ".letta", "agents", agentId, "memory");
+
+  // This command starts with cd to memory dir, then tries to delete root
+  const dangerousCommand = `cd ${memoryDir} && rm -rf /`;
+
+  expect(isMemoryDirCommand(dangerousCommand, agentId)).toBe(false);
+
+  // Safe commands in memory dir should still work
+  expect(isMemoryDirCommand(`cd ${memoryDir} && ls`, agentId)).toBe(true);
+  expect(isMemoryDirCommand(`cd ${memoryDir} && git status`, agentId)).toBe(
+    true,
+  );
+});


### PR DESCRIPTION
Updating the shell command permission logic fixes a couple of security-related issues I found in the sandbox.

Chained commands starting with `cd` into a memory directory were previously bypassing subsequent validation. Even with `MEMORY_DIR_APPROVE_ALL` enabled, ensuring that command segments don't use absolute paths or parent directory references is vital to prevent escaping the intended scope. All path-like tokens in these segments are now validated.

Refining the "always safe" command list was also necessary. While commands like `cat`, `grep`, or `head` are read-only, they lacked path validation, which could allow reading sensitive system files via absolute paths. A conservative check has been added to prevent auto-approval if any argument looks like an absolute path or a traversal attempt.

Robustness of the sandbox is improved while maintaining the "auto-approve" convenience for standard, scoped operations. Regression tests are included in `src/tests/permissions_security.test.ts`.

Verification was done locally using `bun test`.