### PR TITLE
Added .agents detection for custom subagents

### DIFF
--- a/src/cli/components/SubagentManager.tsx
+++ b/src/cli/components/SubagentManager.tsx
@@ -10,6 +10,7 @@ import {
   GLOBAL_AGENTS_DIR,
   getAllSubagentConfigs,
   getBuiltinSubagentNames,
+  LEGACY_AGENTS_DIR,
   type SubagentConfig,
 } from "../../agent/subagents";
 import { colors } from "./colors";
@@ -137,7 +138,8 @@ export function SubagentManager({ onClose }: SubagentManagerProps) {
       )}
 
       <Text dimColor>
-        To add custom subagents, create .md files in {AGENTS_DIR}/ (project) or{" "}
+        To add custom subagents, create .md files in {AGENTS_DIR}/ (project,
+        preferred), {LEGACY_AGENTS_DIR}/ (project, legacy), or{" "}
         {GLOBAL_AGENTS_DIR}/ (global)
       </Text>
       <Text dimColor>Press ESC or Enter to close</Text>

--- a/src/tests/agent/subagent-discovery.test.ts
+++ b/src/tests/agent/subagent-discovery.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearSubagentConfigCache,
+  discoverSubagents,
+  getAllSubagentConfigs,
+} from "../../agent/subagents";
+
+async function writeSubagent(
+  directory: string,
+  filename: string,
+  name: string,
+  description: string,
+): Promise<void> {
+  await mkdir(directory, { recursive: true });
+  const content = `---
+name: ${name}
+description: ${description}
+---
+You are ${name}.
+`;
+  await writeFile(join(directory, filename), content, "utf-8");
+}
+
+describe("subagent discovery", () => {
+  const testDirs: string[] = [];
+
+  afterEach(async () => {
+    clearSubagentConfigCache();
+    for (const dir of testDirs.splice(0, testDirs.length)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("discovers project subagents from .agents", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "letta-subagents-"));
+    testDirs.push(projectDir);
+
+    const uniqueName = `custom-agent-${Date.now()}`;
+    await writeSubagent(
+      join(projectDir, ".agents"),
+      "custom.md",
+      uniqueName,
+      "project-level agent",
+    );
+
+    const { subagents } = await discoverSubagents(projectDir);
+    const discovered = subagents.find((s) => s.name === uniqueName);
+    expect(discovered).toBeDefined();
+    expect(discovered?.description).toBe("project-level agent");
+  });
+
+  test(".agents overrides legacy .letta/agents with the same name", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "letta-subagents-"));
+    testDirs.push(projectDir);
+
+    const uniqueName = `override-agent-${Date.now()}`;
+    await writeSubagent(
+      join(projectDir, ".letta/agents"),
+      "legacy.md",
+      uniqueName,
+      "legacy description",
+    );
+    await writeSubagent(
+      join(projectDir, ".agents"),
+      "project.md",
+      uniqueName,
+      "preferred description",
+    );
+
+    const configs = await getAllSubagentConfigs(projectDir);
+    expect(configs[uniqueName]).toBeDefined();
+    expect(configs[uniqueName]?.description).toBe("preferred description");
+  });
+
+  test("recursively discovers nested markdown files under .agents", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "letta-subagents-"));
+    testDirs.push(projectDir);
+
+    const uniqueName = `nested-agent-${Date.now()}`;
+    await writeSubagent(
+      join(projectDir, ".agents/team/research"),
+      "nested.md",
+      uniqueName,
+      "nested description",
+    );
+
+    const { subagents } = await discoverSubagents(projectDir);
+    expect(subagents.some((s) => s.name === uniqueName)).toBe(true);
+  });
+
+  test("follows symlinked directories under .agents", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "letta-subagents-"));
+    const sharedDir = await mkdtemp(join(tmpdir(), "letta-shared-agents-"));
+    testDirs.push(projectDir, sharedDir);
+
+    const uniqueName = `symlink-agent-${Date.now()}`;
+    await writeSubagent(
+      sharedDir,
+      "shared.md",
+      uniqueName,
+      "symlinked description",
+    );
+
+    const agentsDir = join(projectDir, ".agents");
+    await mkdir(agentsDir, { recursive: true });
+    await symlink(sharedDir, join(agentsDir, "shared"), "dir");
+
+    const { subagents } = await discoverSubagents(projectDir);
+    const discovered = subagents.find((s) => s.name === uniqueName);
+    expect(discovered).toBeDefined();
+    expect(discovered?.description).toBe("symlinked description");
+  });
+});


### PR DESCRIPTION
Response to https://github.com/letta-ai/letta-code/issues/801

- .agents is now the preferred project folder for custom subagents.
- Legacy .letta/agents still works.

- Agent discovery order is now:
~/.letta/agents (global) --> .letta/agents (legacy project) --> .agents (project, highest priority)


- Project discovery supports nested folders + symlinks.
- Global discovery stays non-recursive (to avoid pulling in unrelated markdown).
- /subagents helper text updated.
- Added tests for agents detection
