### PR TITLE
fix(retry): add ChatGPT connection error patterns to retriable error detection

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -500,7 +500,7 @@ async function isRetriableError(
         "api_error", // Anthropic SDK error type field
         "Network error", // Transient network failures during streaming
         "Connection error during", // Peer disconnections, incomplete chunked reads (Anthropic, ChatGPT streaming)
-      ]
+      ];
       if (
         llmProviderPatterns.some((pattern) => detail.includes(pattern)) &&
         !is4xxError


### PR DESCRIPTION
## Summary
- Added `"ChatGPT API error: upstream connect error"` to `llmProviderPatterns` in `isRetriableError` to catch ChatGPT upstream connect errors (e.g. `INTERNAL_SERVER_ERROR: ChatGPT server error: upstream connect error or disconnect/reset before headers`)
- Broadened `"Connection error during Anthropic streaming"` to `"Connection error during"` to catch peer disconnection errors from any LLM provider, not just Anthropic (e.g. `Connection error during streaming: peer closed connection without sending complete message body`)

These errors were not being retried because: the SDK converts the SSE `event: error` into a thrown `APIError`, which overrides the server's `stop_reason: "llm_api_error"` to a generic `"error"`. The fallback metadata check then relies on pattern matching the error detail, which was missing patterns for ChatGPT-specific errors.

## Test plan
- [ ] Verify ChatGPT upstream connect errors trigger automatic retry (up to 3 attempts)
- [ ] Verify non-Anthropic streaming connection errors (peer disconnections) trigger retry
- [ ] Verify existing Anthropic connection error retries still work (substring match)
- [ ] Verify 4xx client errors are still excluded from retry