### PR TITLE
fix(retry): broaden ChatGPT error pattern to catch all ChatGPT API errors

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -494,7 +494,7 @@ async function isRetriableError(
       const llmProviderPatterns = [
         "Anthropic API error", // anthropic_client.py:759
         "OpenAI API error", // openai_client.py:1034
-        "ChatGPT API error: upstream connect error", // chatgpt_oauth_client.py - upstream connect errors
+        "ChatGPT API error", // chatgpt_oauth_client.py - upstream connect errors
         "Google Vertex API error", // google_vertex_client.py:848
         "overloaded", // anthropic_client.py:753 - used for LLMProviderOverloaded
         "api_error", // Anthropic SDK error type field


### PR DESCRIPTION
## Summary
- Broadens `"ChatGPT API error: upstream connect error"` to `"ChatGPT API error"` so all ChatGPT API errors are caught as retriable, not just upstream connect errors.

Follow-up to #977.

## Test plan
- [ ] Verify ChatGPT API errors (upstream connect, rate limits, timeouts) trigger automatic retry