### PR TITLE
fix: disable hidden SDK retries for streaming POSTs

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -34,11 +34,9 @@ export async function sendMessageStream(
     background?: boolean;
     agentId?: string; // Required when conversationId is "default"
   } = { streamTokens: true, background: true },
-  // TODO: Re-enable once issues are resolved - disabled retries were causing problems
   // Disable SDK retries by default - state management happens outside the stream,
   // so retries would violate idempotency and create race conditions
-  // requestOptions: { maxRetries?: number } = { maxRetries: 0 },
-  requestOptions: { maxRetries?: number } = {},
+  requestOptions: { maxRetries?: number } = { maxRetries: 0 },
 ): Promise<Stream<LettaStreamingResponse>> {
   // Capture request start time for TTFT measurement when timings are enabled
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;


### PR DESCRIPTION
## Summary
- set sendMessageStream default requestOptions.maxRetries to 0
- remove stale commented default that left SDK retries effectively enabled

## Why
- streaming message POSTs are non-idempotent
- retries are handled in Letta Code recovery logic; SDK auto-retry can duplicate turns and create busy races

## Risk / rollout
- intended as C2 and should merge after C1 retry-classification validation window
- rollback is a one-line revert in src/agent/message.ts

## Validation
- bun run lint
- bun run typecheck
