### PR TITLE
fix: drop option for max turns from task

### DIFF
--- a/src/tools/schemas/Task.json
+++ b/src/tools/schemas/Task.json
@@ -28,11 +28,6 @@
     "conversation_id": {
       "type": "string",
       "description": "Resume from an existing conversation. Does NOT require agent_id (conversation IDs are unique and encode the agent)."
-    },
-    "max_turns": {
-      "type": "integer",
-      "exclusiveMinimum": 0,
-      "description": "Maximum number of agentic turns (API round-trips) before stopping. Defaults to unlimited (recommended for most use cases)."
     }
   },
   "required": ["description", "prompt", "subagent_type"],


### PR DESCRIPTION
Codex constantly violates the guidance and wastes subagent cycles by capping the length