### PR TITLE
fix: reconcile memfs/standard prompt sections safely

### DIFF
--- a/src/agent/memoryPrompt.ts
+++ b/src/agent/memoryPrompt.ts
@@ -1,0 +1,201 @@
+import {
+  SYSTEM_PROMPT_MEMFS_ADDON,
+  SYSTEM_PROMPT_MEMORY_ADDON,
+} from "./promptAssets";
+
+export type MemoryPromptMode = "standard" | "memfs";
+
+export interface MemoryPromptDrift {
+  code:
+    | "legacy_memory_language_with_memfs"
+    | "memfs_language_with_standard_mode"
+    | "orphan_memfs_fragment";
+  message: string;
+}
+
+interface Heading {
+  level: number;
+  title: string;
+  startOffset: number;
+}
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
+function scanHeadingsOutsideFences(text: string): Heading[] {
+  const lines = text.split("\n");
+  const headings: Heading[] = [];
+  let inFence = false;
+  let fenceToken = "";
+  let offset = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    const fenceMatch = trimmed.match(/^(```+|~~~+)/);
+    if (fenceMatch) {
+      const token = fenceMatch[1] ?? fenceMatch[0] ?? "";
+      const tokenChar = token.startsWith("`") ? "`" : "~";
+      if (!inFence) {
+        inFence = true;
+        fenceToken = tokenChar;
+      } else if (fenceToken === tokenChar) {
+        inFence = false;
+        fenceToken = "";
+      }
+    }
+
+    if (!inFence) {
+      const headingMatch = line.match(/^\s*(#{1,6})\s+(.+?)\s*$/);
+      if (headingMatch) {
+        const hashes = headingMatch[1] ?? "";
+        const rawTitle = headingMatch[2] ?? "";
+        if (hashes && rawTitle) {
+          const level = hashes.length;
+          const title = rawTitle.replace(/\s+#*$/, "").trim();
+          headings.push({
+            level,
+            title,
+            startOffset: offset,
+          });
+        }
+      }
+    }
+
+    offset += line.length + 1;
+  }
+
+  return headings;
+}
+
+function stripHeadingSections(
+  text: string,
+  shouldStrip: (heading: Heading) => boolean,
+): string {
+  let current = text;
+  while (true) {
+    const headings = scanHeadingsOutsideFences(current);
+    const target = headings.find(shouldStrip);
+    if (!target) {
+      return current;
+    }
+
+    const nextHeading = headings.find(
+      (heading) =>
+        heading.startOffset > target.startOffset &&
+        heading.level <= target.level,
+    );
+    const end = nextHeading ? nextHeading.startOffset : current.length;
+    current = `${current.slice(0, target.startOffset)}${current.slice(end)}`;
+  }
+}
+
+function getMemfsTailFragment(): string {
+  const tailAnchor = "# See what changed";
+  const start = SYSTEM_PROMPT_MEMFS_ADDON.indexOf(tailAnchor);
+  if (start === -1) return "";
+  return SYSTEM_PROMPT_MEMFS_ADDON.slice(start).trim();
+}
+
+function stripExactAddon(text: string, addon: string): string {
+  const trimmedAddon = addon.trim();
+  if (!trimmedAddon) return text;
+  let current = text;
+  while (current.includes(trimmedAddon)) {
+    current = current.replace(trimmedAddon, "");
+  }
+  return current;
+}
+
+function stripOrphanMemfsTail(text: string): string {
+  const tail = getMemfsTailFragment();
+  if (!tail) return text;
+  let current = text;
+  while (current.includes(tail)) {
+    current = current.replace(tail, "");
+  }
+  return current;
+}
+
+function compactBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
+export function stripManagedMemorySections(systemPrompt: string): string {
+  let current = normalizeNewlines(systemPrompt);
+
+  // Strip exact current addons first (fast path).
+  current = stripExactAddon(current, SYSTEM_PROMPT_MEMORY_ADDON);
+  current = stripExactAddon(current, SYSTEM_PROMPT_MEMFS_ADDON);
+
+  // Strip known orphan fragment produced by the old regex bug.
+  current = stripOrphanMemfsTail(current);
+
+  // Strip legacy/variant memory sections by markdown heading parsing.
+  current = stripHeadingSections(
+    current,
+    (heading) => heading.title === "Memory",
+  );
+  current = stripHeadingSections(current, (heading) =>
+    heading.title.startsWith("Memory Filesystem"),
+  );
+
+  return compactBlankLines(current);
+}
+
+export function reconcileMemoryPrompt(
+  systemPrompt: string,
+  mode: MemoryPromptMode,
+): string {
+  const base = stripManagedMemorySections(systemPrompt).trimEnd();
+  const addon =
+    mode === "memfs"
+      ? SYSTEM_PROMPT_MEMFS_ADDON.trimStart()
+      : SYSTEM_PROMPT_MEMORY_ADDON.trimStart();
+  return `${base}\n\n${addon}`.trim();
+}
+
+export function detectMemoryPromptDrift(
+  systemPrompt: string,
+  expectedMode: MemoryPromptMode,
+): MemoryPromptDrift[] {
+  const prompt = normalizeNewlines(systemPrompt);
+  const drifts: MemoryPromptDrift[] = [];
+
+  const hasLegacyMemoryLanguage = prompt.includes(
+    "Your memory consists of core memory (composed of memory blocks)",
+  );
+  const hasMemfsLanguage =
+    prompt.includes("## Memory Filesystem") ||
+    prompt.includes("Your memory is stored in a git repository at");
+  const hasOrphanFragment =
+    prompt.includes("# See what changed") &&
+    prompt.includes("git add system/") &&
+    prompt.includes('git commit -m "<type>: <what changed>"');
+
+  if (expectedMode === "memfs" && hasLegacyMemoryLanguage) {
+    drifts.push({
+      code: "legacy_memory_language_with_memfs",
+      message:
+        "System prompt contains legacy memory-block language while memfs is enabled.",
+    });
+  }
+
+  if (expectedMode === "standard" && hasMemfsLanguage) {
+    drifts.push({
+      code: "memfs_language_with_standard_mode",
+      message:
+        "System prompt contains Memory Filesystem language while memfs is disabled.",
+    });
+  }
+
+  if (hasOrphanFragment && !hasMemfsLanguage) {
+    drifts.push({
+      code: "orphan_memfs_fragment",
+      message:
+        "System prompt contains orphaned memfs sync fragment without a full memfs section.",
+    });
+  }
+
+  return drifts;
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9732,13 +9732,8 @@ ${SYSTEM_REMINDER_CLOSE}
             phase: "running",
           });
 
-          const { updateAgentSystemPromptRaw } = await import(
-            "../agent/modify"
-          );
-          const result = await updateAgentSystemPromptRaw(
-            agentId,
-            prompt.content,
-          );
+          const { updateAgentSystemPrompt } = await import("../agent/modify");
+          const result = await updateAgentSystemPrompt(agentId, promptId);
 
           if (result.success) {
             setCurrentSystemPromptId(promptId);

--- a/src/tests/agent/memoryPrompt.integration.test.ts
+++ b/src/tests/agent/memoryPrompt.integration.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { getClient } from "../../agent/client";
+import { createAgent } from "../../agent/create";
+import { updateAgentSystemPromptMemfs } from "../../agent/modify";
+import {
+  SYSTEM_PROMPT_MEMFS_ADDON,
+  SYSTEM_PROMPT_MEMORY_ADDON,
+} from "../../agent/promptAssets";
+
+const describeIntegration = process.env.LETTA_API_KEY
+  ? describe
+  : describe.skip;
+
+function expectedPrompt(base: string, addon: string): string {
+  return `${base.trimEnd()}\n\n${addon.trimStart()}`.trim();
+}
+
+describeIntegration("memory prompt integration", () => {
+  const createdAgentIds: string[] = [];
+
+  beforeAll(() => {
+    // Avoid polluting user's normal local LRU state in integration runs.
+    process.env.LETTA_CODE_AGENT_ROLE = "subagent";
+  });
+
+  afterAll(async () => {
+    const client = await getClient();
+    for (const agentId of createdAgentIds) {
+      try {
+        await client.agents.delete(agentId);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  });
+
+  test(
+    "new agent prompt is exact for memfs enabled and disabled modes",
+    async () => {
+      const base = [
+        "You are a test agent.",
+        "Follow user instructions precisely.",
+      ].join("\n");
+
+      const created = await createAgent({
+        name: `prompt-memfs-${Date.now()}`,
+        systemPromptCustom: base,
+        memoryPromptMode: "memfs",
+      });
+      createdAgentIds.push(created.agent.id);
+
+      const client = await getClient();
+
+      const expectedMemfs = expectedPrompt(base, SYSTEM_PROMPT_MEMFS_ADDON);
+      let fetched = await client.agents.retrieve(created.agent.id);
+      expect(fetched.system).toBe(expectedMemfs);
+      expect((fetched.system.match(/## Memory Filesystem/g) || []).length).toBe(
+        1,
+      );
+      expect((fetched.system.match(/# See what changed/g) || []).length).toBe(
+        1,
+      );
+
+      const enableAgain = await updateAgentSystemPromptMemfs(
+        created.agent.id,
+        true,
+      );
+      expect(enableAgain.success).toBe(true);
+      fetched = await client.agents.retrieve(created.agent.id);
+      expect(fetched.system).toBe(expectedMemfs);
+
+      const disable = await updateAgentSystemPromptMemfs(
+        created.agent.id,
+        false,
+      );
+      expect(disable.success).toBe(true);
+      const expectedStandard = expectedPrompt(base, SYSTEM_PROMPT_MEMORY_ADDON);
+      fetched = await client.agents.retrieve(created.agent.id);
+      expect(fetched.system).toBe(expectedStandard);
+      expect(fetched.system).not.toContain("## Memory Filesystem");
+      expect(fetched.system).toContain(
+        "Your memory consists of core memory (composed of memory blocks)",
+      );
+
+      const reEnable = await updateAgentSystemPromptMemfs(
+        created.agent.id,
+        true,
+      );
+      expect(reEnable.success).toBe(true);
+      fetched = await client.agents.retrieve(created.agent.id);
+      expect(fetched.system).toBe(expectedMemfs);
+      expect((fetched.system.match(/# See what changed/g) || []).length).toBe(
+        1,
+      );
+    },
+    { timeout: 120000 },
+  );
+});

--- a/src/tests/agent/memoryPrompt.test.ts
+++ b/src/tests/agent/memoryPrompt.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  detectMemoryPromptDrift,
+  reconcileMemoryPrompt,
+} from "../../agent/memoryPrompt";
+import {
+  SYSTEM_PROMPT_MEMFS_ADDON,
+  SYSTEM_PROMPT_MEMORY_ADDON,
+} from "../../agent/promptAssets";
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  return haystack.split(needle).length - 1;
+}
+
+describe("memoryPrompt reconciler", () => {
+  test("replaces existing standard memory section with memfs section", () => {
+    const base = "You are a test agent.";
+    const standard = `${base}\n\n${SYSTEM_PROMPT_MEMORY_ADDON.trimStart()}`;
+
+    const reconciled = reconcileMemoryPrompt(standard, "memfs");
+
+    expect(reconciled).toContain("## Memory Filesystem");
+    expect(reconciled).not.toContain(
+      "Your memory consists of core memory (composed of memory blocks)",
+    );
+    expect(countOccurrences(reconciled, "## Memory Filesystem")).toBe(1);
+  });
+
+  test("does not leave orphan memfs sync fragment when switching from memfs to standard", () => {
+    const base = "You are a test agent.";
+    const memfs = `${base}\n\n${SYSTEM_PROMPT_MEMFS_ADDON.trimStart()}`;
+
+    const reconciled = reconcileMemoryPrompt(memfs, "standard");
+
+    expect(reconciled).toContain(
+      "Your memory consists of core memory (composed of memory blocks)",
+    );
+    expect(reconciled).not.toContain("## Memory Filesystem");
+    expect(reconciled).not.toContain("# See what changed");
+    expect(reconciled).not.toContain('git commit -m "<type>: <what changed>"');
+  });
+
+  test("cleans orphan memfs tail fragment before rebuilding target mode", () => {
+    const tailStart = SYSTEM_PROMPT_MEMFS_ADDON.indexOf("# See what changed");
+    expect(tailStart).toBeGreaterThanOrEqual(0);
+    const orphanTail = SYSTEM_PROMPT_MEMFS_ADDON.slice(tailStart).trim();
+
+    const drifted = `Header text\n\n${orphanTail}`;
+    const drifts = detectMemoryPromptDrift(drifted, "standard");
+    expect(drifts.some((d) => d.code === "orphan_memfs_fragment")).toBe(true);
+
+    const reconciled = reconcileMemoryPrompt(drifted, "standard");
+    expect(reconciled).toContain(
+      "Your memory consists of core memory (composed of memory blocks)",
+    );
+    expect(reconciled).not.toContain("# See what changed");
+  });
+
+  test("memfs reconciliation is idempotent and keeps single syncing section", () => {
+    const base = "You are a test agent.";
+    const once = reconcileMemoryPrompt(base, "memfs");
+    const twice = reconcileMemoryPrompt(once, "memfs");
+
+    expect(twice).toBe(once);
+    expect(countOccurrences(twice, "## Syncing")).toBe(1);
+    expect(countOccurrences(twice, "# See what changed")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes memfs/system-prompt mode drift by replacing fragile regex swapping with a deterministic prompt reconciler.

Root cause:
- The old stripping logic in updateAgentSystemPromptMemfs matched markdown headings with regex.
- It could treat # ... inside fenced code blocks as real headings (for example # See what changed in the memfs sync snippet), which could leave orphan prompt fragments or mixed memfs/legacy sections.

What changed:
- Added src/agent/memoryPrompt.ts as the single compiler/reconciler for managed memory prompt sections:
  - strips managed sections safely (markdown-aware, fence-aware)
  - removes known orphan memfs sync fragments
  - rebuilds canonical standard vs memfs section deterministically
- Wired reconciler into all relevant paths:
  - agent creation (createAgent)
  - memfs toggles (updateAgentSystemPromptMemfs)
  - system preset switches (updateAgentSystemPrompt, /system path)
- Hardened memfs flag application order in applyMemfsFlags:
  - reconcile prompt first, then persist local memfs setting
- Avoided create-time memfs flip/flop:
  - when explicit --memfs/--no-memfs is provided, new-agent flow skips default auto-enable behavior.

## Validation
Automated:
- bun test src/tests/agent/memoryPrompt.test.ts (new unit regression coverage)
- bun run check (lint + typecheck)
- Added API integration test:
  - src/tests/agent/memoryPrompt.integration.test.ts
  - verifies exact canonical prompt text for memfs enabled/disabled and toggle idempotency.

Manual end-to-end (headless create/toggle against Letta API):
- --new-agent --memfs: memfs section present, legacy memory-block language absent, # See what changed count = 1
- --new-agent --no-memfs: inverse expectations pass
- Toggle same agent memfs -> standard -> memfs: expectations pass at each step
