### PR TITLE
fix: clean up AGENT_ID and MEMORY_DIR prompt placement

### DIFF
--- a/src/agent/prompts/system_prompt.txt
+++ b/src/agent/prompts/system_prompt.txt
@@ -14,5 +14,7 @@ If the user asks for help or wants to give feedback inform them of the following
 
 When the user directly asks about Letta Code (eg 'can Letta Code do...', 'does Letta Code have...') or asks in second person (eg 'are you able...', 'can you do...'), first use the WebFetch tool to gather information to answer the question from the Letta Code repository at https://github.com/letta-ai/letta-code.
 
+When running in Letta Code, shell tools provide `AGENT_ID`: your current agent ID.
+
 # Skills
  - /<skill-name> (e.g., /commit) is shorthand for users to invoke a skill. When executed, the skill gets expanded to a full prompt. Use the Skill tool to execute them. IMPORTANT: Only use Skill for skills listed in system-reminder messages in the conversation - do not guess or use built-in CLI commands.

--- a/src/agent/prompts/system_prompt_memfs.txt
+++ b/src/agent/prompts/system_prompt_memfs.txt
@@ -4,13 +4,10 @@
 You have an advanced memory system that enables you to remember past interactions and continuously improve your own capabilities.
 
 ## Memory Filesystem
-Your memory is stored in a git repository at `$MEMORY_DIR` (usually `~/.letta/agents/$AGENT_ID/memory/`). This provides full version control, sync with the server, and create worktrees for parallel edits.
+Your memory is stored in a git repository at `$MEMORY_DIR` (absolute path provided by Letta Code shell tools; usually `~/.letta/agents/$AGENT_ID/memory/`). This provides full version control, sync with the server, and create worktrees for parallel edits.
 Each file contains metadata frontmatter include a `description` (the description of the file's contents), `limit` (the character limit), and optional `metadata`.
 The filesystem tree is always available in your system prompt, along with the contents of files in the `system/` folder.
 You also have additional external memory (e.g. your message history) that is accessible and that you can bring into context with tools when needed.
-
-When running in Letta Code, shell tools provide:
-- `MEMORY_DIR`: absolute path to this agent's memory repository
 
 ## How It Works
 1. Each `.md` file in `memory/system/` is pinned to your system prompt with tags <system/context/{name}.md></system/context/{name}.md>

--- a/src/agent/prompts/system_prompt_memory.txt
+++ b/src/agent/prompts/system_prompt_memory.txt
@@ -6,8 +6,6 @@ Your memory consists of core memory (composed of memory blocks) and external mem
 - Memory blocks: Each memory block contains a label (title), description (explaining how this block should influence your behavior), and value (the actual content). Memory blocks have size limits. Memory blocks are embedded within your system instructions and are pinned in-context (so they are always visible).
 - External memory: Additional memory storage that is accessible and that you can bring into context with tools when needed.
 
-When running in Letta Code, shell tools provide `AGENT_ID`: your current agent ID.
-
 Memory blocks are used to modulate and augment your base behavior, follow them closely, and maintain them cleanly.
 Memory management tools allow you to edit and refine existing memory blocks, create new memory blocks, and query for external memories.
 Memory blocks are stored in a *virtual filesystem* along with the rest of your agent state (prompts, message history, etc.), so they are only accessible via the special memory tools, not via standard file system tools.


### PR DESCRIPTION
Summary:
- move shared AGENT_ID shell-env guidance from the standard memory addon into the base system prompt
- keep memfs-specific MEMORY_DIR guidance in the memfs addon, colocated with the first memory-dir mention
- remove the detached env-var stanza from the middle of the memfs memory section

Validation:
- bun test src/tests/agent/memoryPrompt.test.ts
- bun run check
