### PR TITLE
feat: add skill source controls and headless reminder settings

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -3,10 +3,13 @@
  * This allows tools to access the current agent ID without threading it through params.
  */
 
+import { ALL_SKILL_SOURCES } from "./skillSources";
+import type { SkillSource } from "./skills";
+
 interface AgentContext {
   agentId: string | null;
   skillsDirectory: string | null;
-  noSkills: boolean;
+  skillSources: SkillSource[];
   conversationId: string | null;
 }
 
@@ -24,7 +27,7 @@ function getContext(): AgentContext {
     global[CONTEXT_KEY] = {
       agentId: null,
       skillsDirectory: null,
-      noSkills: false,
+      skillSources: [...ALL_SKILL_SOURCES],
       conversationId: null,
     };
   }
@@ -37,16 +40,17 @@ const context = getContext();
  * Set the current agent context
  * @param agentId - The agent ID
  * @param skillsDirectory - Optional skills directory path
- * @param noSkills - Whether to skip bundled skills
+ * @param skillSources - Enabled skill sources for this session
  */
 export function setAgentContext(
   agentId: string,
   skillsDirectory?: string,
-  noSkills?: boolean,
+  skillSources?: SkillSource[],
 ): void {
   context.agentId = agentId;
   context.skillsDirectory = skillsDirectory || null;
-  context.noSkills = noSkills ?? false;
+  context.skillSources =
+    skillSources !== undefined ? [...skillSources] : [...ALL_SKILL_SOURCES];
 }
 
 /**
@@ -76,10 +80,17 @@ export function getSkillsDirectory(): string | null {
 }
 
 /**
- * Get whether bundled skills should be skipped
+ * Get enabled skill sources for discovery/injection.
+ */
+export function getSkillSources(): SkillSource[] {
+  return [...context.skillSources];
+}
+
+/**
+ * Backwards-compat helper: returns true when bundled skills are disabled.
  */
 export function getNoSkills(): boolean {
-  return context.noSkills;
+  return !context.skillSources.includes("bundled");
 }
 
 /**

--- a/src/agent/skillSources.ts
+++ b/src/agent/skillSources.ts
@@ -1,0 +1,82 @@
+import type { SkillSource } from "./skills";
+
+export const ALL_SKILL_SOURCES: SkillSource[] = [
+  "bundled",
+  "global",
+  "agent",
+  "project",
+];
+
+export type SkillSourceSpecifier = SkillSource | "all";
+
+export type SkillSourceSelectionInput = {
+  skillSourcesRaw?: string;
+  noSkills?: boolean;
+  noBundledSkills?: boolean;
+};
+
+const VALID_SKILL_SOURCE_SPECIFIERS: SkillSourceSpecifier[] = [
+  "all",
+  ...ALL_SKILL_SOURCES,
+];
+
+function isSkillSource(value: string): value is SkillSource {
+  return ALL_SKILL_SOURCES.includes(value as SkillSource);
+}
+
+function normalizeSkillSources(sources: SkillSource[]): SkillSource[] {
+  const sourceSet = new Set(sources);
+  return ALL_SKILL_SOURCES.filter((source) => sourceSet.has(source));
+}
+
+export function parseSkillSourcesList(skillSourcesRaw: string): SkillSource[] {
+  const tokens = skillSourcesRaw
+    .split(",")
+    .map((source) => source.trim())
+    .filter((source) => source.length > 0);
+
+  if (tokens.length === 0) {
+    throw new Error(
+      "--skill-sources must include at least one source (e.g. bundled,project)",
+    );
+  }
+
+  const sources: SkillSource[] = [];
+  for (const token of tokens) {
+    const source = token as SkillSourceSpecifier;
+    if (!VALID_SKILL_SOURCE_SPECIFIERS.includes(source)) {
+      throw new Error(
+        `Invalid skill source "${token}". Valid values: ${VALID_SKILL_SOURCE_SPECIFIERS.join(", ")}`,
+      );
+    }
+
+    if (source === "all") {
+      sources.push(...ALL_SKILL_SOURCES);
+      continue;
+    }
+
+    if (isSkillSource(source)) {
+      sources.push(source);
+    }
+  }
+
+  return normalizeSkillSources(sources);
+}
+
+export function resolveSkillSourcesSelection(
+  input: SkillSourceSelectionInput,
+): SkillSource[] {
+  if (input.noSkills) {
+    return [];
+  }
+
+  const configuredSources = input.skillSourcesRaw
+    ? parseSkillSourcesList(input.skillSourcesRaw)
+    : [...ALL_SKILL_SOURCES];
+
+  const filteredSources = input.noBundledSkills
+    ? configuredSources.filter((source) => source !== "bundled")
+    : configuredSources;
+
+  return normalizeSkillSources(filteredSources);
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -806,6 +806,7 @@ export default function App({
   showCompactions = false,
   agentProvenance = null,
   releaseNotes = null,
+  sessionContextReminderEnabled = true,
 }: {
   agentId: string;
   agentState?: AgentState | null;
@@ -825,6 +826,7 @@ export default function App({
   showCompactions?: boolean;
   agentProvenance?: AgentProvenance | null;
   releaseNotes?: string | null; // Markdown release notes to display above header
+  sessionContextReminderEnabled?: boolean;
 }) {
   // Warm the model-access cache in the background so /model is fast on first open.
   useEffect(() => {
@@ -8016,7 +8018,11 @@ ${SYSTEM_REMINDER_CLOSE}`;
       const sessionContextEnabled = settingsManager.getSetting(
         "sessionContextEnabled",
       );
-      if (!hasSentSessionContextRef.current && sessionContextEnabled) {
+      if (
+        !hasSentSessionContextRef.current &&
+        sessionContextEnabled &&
+        sessionContextReminderEnabled
+      ) {
         const { buildSessionContext } = await import(
           "./helpers/sessionContext"
         );
@@ -8168,7 +8174,7 @@ ${SYSTEM_REMINDER_CLOSE}
           SKILLS_DIR: defaultDir,
           formatSkillsAsSystemReminder,
         } = await import("../agent/skills");
-        const { getSkillsDirectory, getNoSkills } = await import(
+        const { getSkillsDirectory, getSkillSources } = await import(
           "../agent/context"
         );
 
@@ -8181,7 +8187,7 @@ ${SYSTEM_REMINDER_CLOSE}
           const skillsDir =
             getSkillsDirectory() || join(process.cwd(), defaultDir);
           const { skills } = await discover(skillsDir, agentId, {
-            skipBundled: getNoSkills(),
+            sources: getSkillSources(),
           });
           latestSkills = skills;
         } catch {
@@ -8895,6 +8901,7 @@ ${SYSTEM_REMINDER_CLOSE}
       pendingRalphConfig,
       openTrajectorySegment,
       resetTrajectoryBases,
+      sessionContextReminderEnabled,
       appendTaskNotificationEvents,
     ],
   );

--- a/src/cli/components/SkillsDialog.tsx
+++ b/src/cli/components/SkillsDialog.tsx
@@ -52,14 +52,14 @@ export function SkillsDialog({ onClose, agentId }: SkillsDialogProps) {
         const { discoverSkills, SKILLS_DIR } = await import(
           "../../agent/skills"
         );
-        const { getSkillsDirectory, getNoSkills } = await import(
+        const { getSkillsDirectory, getSkillSources } = await import(
           "../../agent/context"
         );
         const { join } = await import("node:path");
         const skillsDir =
           getSkillsDirectory() || join(process.cwd(), SKILLS_DIR);
         const result = await discoverSkills(skillsDir, agentId, {
-          skipBundled: getNoSkills(),
+          sources: getSkillSources(),
         });
         setSkills(result.skills);
       } catch {

--- a/src/tests/agent/skill-sources.test.ts
+++ b/src/tests/agent/skill-sources.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ALL_SKILL_SOURCES,
+  parseSkillSourcesList,
+  resolveSkillSourcesSelection,
+} from "../../agent/skillSources";
+
+describe("skill source selection", () => {
+  test("defaults to all sources", () => {
+    expect(resolveSkillSourcesSelection({})).toEqual(ALL_SKILL_SOURCES);
+  });
+
+  test("--no-skills disables all sources", () => {
+    expect(
+      resolveSkillSourcesSelection({
+        noSkills: true,
+      }),
+    ).toEqual([]);
+  });
+
+  test("--no-bundled-skills removes bundled from default set", () => {
+    expect(
+      resolveSkillSourcesSelection({
+        noBundledSkills: true,
+      }),
+    ).toEqual(["global", "agent", "project"]);
+  });
+
+  test("--skill-sources accepts explicit subsets and normalizes order", () => {
+    expect(parseSkillSourcesList("project,global")).toEqual([
+      "global",
+      "project",
+    ]);
+  });
+
+  test("--skill-sources supports all keyword", () => {
+    expect(parseSkillSourcesList("all,project")).toEqual(ALL_SKILL_SOURCES);
+  });
+
+  test("throws for invalid source", () => {
+    expect(() => parseSkillSourcesList("project,unknown")).toThrow(
+      'Invalid skill source "unknown"',
+    );
+  });
+
+  test("throws for empty --skill-sources value", () => {
+    expect(() => parseSkillSourcesList(" , ")).toThrow(
+      "--skill-sources must include at least one source",
+    );
+  });
+});

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -89,6 +89,11 @@ export interface SystemInitMessage extends MessageEnvelope {
   permission_mode: string;
   slash_commands: string[];
   memfs_enabled?: boolean;
+  skill_sources?: Array<"bundled" | "global" | "agent" | "project">;
+  system_info_reminder_enabled?: boolean;
+  reflection_trigger?: "off" | "step-count" | "compaction-event";
+  reflection_behavior?: "reminder" | "auto-launch";
+  reflection_step_count?: number;
   // output_style omitted - Letta Code doesn't have output styles feature
 }
 


### PR DESCRIPTION
## Summary
- add a canonical skill source selection model (`bundled|global|agent|project`) with list-based resolution helpers
- change CLI semantics so `--no-skills` disables all sources, add `--no-bundled-skills`, and add canonical `--skill-sources`
- thread resolved skill sources through interactive + headless skills discovery/reminder injection
- add `--no-system-info-reminder` and gate interactive session context injection via app prop
- add headless sleeptime parity flags (`--reflection-trigger`, `--reflection-behavior`, `--reflection-step-count`) and persist updates using the same settings flow as `/sleeptime`
- include effective runtime settings in headless `system.init` and `initialize` control responses

## Validation
- bun run lint
- bun run typecheck
- bun test src/tests/agent/skill-sources.test.ts src/tests/headless/skills-reminder.test.ts src/tests/session-context.test.ts
- bun test src/tests/startup-flow.test.ts

## Notes
- fixes the `--no-skills` semantics to match "disable all skill sources"
- keeps `discoverSkills(..., { skipBundled })` backward-compatible while introducing `sources`
