### PR TITLE
feat: align headless bidirectional queueing with TUI runtime

### DIFF
--- a/src/cli/helpers/messageQueueBridge.ts
+++ b/src/cli/helpers/messageQueueBridge.ts
@@ -15,6 +15,8 @@ export type QueuedMessage = {
 
 type QueueAdder = (message: QueuedMessage) => void;
 
+// Global bridge is intentionally single-consumer. Each process runs either
+// one TUI App instance or one headless bidirectional loop.
 let queueAdder: QueueAdder | null = null;
 const pendingMessages: QueuedMessage[] = [];
 const MAX_PENDING_MESSAGES = 10;

--- a/src/tests/headless/queueing.test.ts
+++ b/src/tests/headless/queueing.test.ts
@@ -60,6 +60,7 @@ describe("headless bidirectional queue wiring", () => {
 
     expect(source).toContain("setMessageQueueAdder((queuedMessage) =>");
     expect(source).toContain("serializeQueuedMessageAsUserLine");
+    expect(source).toContain("_queuedKind");
     expect(source).toContain("setMessageQueueAdder(null)");
   });
 });


### PR DESCRIPTION
## Summary
- connect headless bidirectional mode to the same `messageQueueBridge` used by the TUI task runtime
- route background `Task`/subagent notifications into the bidirectional input queue as synthetic user turns
- coalesce already-buffered user inputs into a single turn payload (parity with TUI dequeue batching behavior)
- add queue merge helpers (`mergeBidirectionalQueuedInput`) and dedicated headless tests

## Why
Bidirectional/headless previously had a simpler line-by-line loop that did not consume the TUI message queue bridge, so background task notifications were not naturally enqueued through the same robust path. This change brings headless queue behavior closer to the TUI runtime model.

## Validation
- `bun test src/tests/headless/queueing.test.ts src/tests/headless/skills-reminder.test.ts src/tests/headless/approval-recovery-wiring.test.ts`
- `bun run check`
