### PR TITLE
fix(footer): prevent merged clickable links in agent info bar

### DIFF
--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -79,27 +79,29 @@ export const AgentInfoBar = memo(function AgentInfoBar({
         )}
       </Box>
 
-      {/* Alien + Links */}
+      {/* Alien + ADE link / server URL */}
       <Box>
         <Text color={colors.footer.agentName}>{alienLines[1]}</Text>
         {isCloudUser && adeUrl && !isTmux && (
-          <>
-            <Link url={adeUrl}>
-              <Text>Open in ADE ↗</Text>
-            </Link>
-            <Text dimColor>· </Text>
-          </>
+          <Link url={adeUrl}>
+            <Text>Open in ADE ↗</Text>
+          </Link>
         )}
         {isCloudUser && adeUrl && isTmux && (
-          <Text dimColor>Open in ADE: {adeUrl} · </Text>
-        )}
-        {isCloudUser && (
-          <Link url="https://app.letta.com/settings/organization/usage">
-            <Text>View usage ↗</Text>
-          </Link>
+          <Text dimColor>Open in ADE: {adeUrl}</Text>
         )}
         {!isCloudUser && <Text dimColor>{serverUrl}</Text>}
       </Box>
+
+      {/* Usage link on its own line to avoid terminal URL auto-link merging */}
+      {isCloudUser && (
+        <Box>
+          <Text>{"          "}</Text>
+          <Link url="https://app.letta.com/settings/organization/usage">
+            <Text>View usage ↗</Text>
+          </Link>
+        </Box>
+      )}
 
       {/* Alien + Agent ID */}
       <Box>


### PR DESCRIPTION
## Summary

This PR fixes malformed footer links caused by rendering two links on the same row in `AgentInfoBar`:

- `Open in ADE`
- `View usage`

In environments where `ink-link` falls back to plain-text URLs (instead of OSC 8 hyperlinks), terminal auto-linkers can merge adjacent URL fragments into one broken target (for example: `https://app.letta.com/settings/organization/usage2ead-7fdf-...`).

## What changed

- Keep existing URLs unchanged
- Render `View usage` on its own row (separate from `Open in ADE`)
- Preserve existing non-cloud footer semantics:
  - row 1: ADE link (cloud) or server URL (non-cloud)
  - row 2: agent ID
  - row 3: conversation ID / default conversation
- Keep tmux behavior unchanged

## Why this is safe

- No URL/path logic changes
- No API/model/tooling behavior changes
- Single-file UI-only change: `src/cli/components/AgentInfoBar.tsx`

## Validation

- `bun run lint` passes
- `bun run build` passes
- Reproduced malformed combined URL before change; no merged link after separating rows
