### PR TITLE
fix(cli): use white text on active tab highlight across all selectors

### DIFF
--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -663,7 +663,7 @@ export function AgentSelector({
             backgroundColor={
               isActive ? colors.selector.itemHighlighted : undefined
             }
-            color={isActive ? "black" : undefined}
+            color={isActive ? "white" : undefined}
             bold={isActive}
           >
             {` ${tab.label} `}

--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -406,7 +406,7 @@ export function MemfsTreeViewer({
                   backgroundColor={
                     isSelected ? colors.selector.itemHighlighted : undefined
                   }
-                  color={isSelected ? "black" : undefined}
+                  color={isSelected ? "white" : undefined}
                 >
                   {prefix}
                 </Text>

--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -135,7 +135,7 @@ export function MemoryTabViewer({
             backgroundColor={
               isActive ? colors.selector.itemHighlighted : undefined
             }
-            color={isActive ? "black" : undefined}
+            color={isActive ? "white" : undefined}
             bold={isActive}
           >
             {` ${block.label} `}

--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -500,7 +500,7 @@ export function MessageSearch({
                       backgroundColor={
                         isActive ? colors.selector.itemHighlighted : undefined
                       }
-                      color={isActive ? "black" : undefined}
+                      color={isActive ? "white" : undefined}
                       bold={isActive}
                     >
                       {` ${getRangeLabel(range)} `}
@@ -522,7 +522,7 @@ export function MessageSearch({
                       backgroundColor={
                         isActive ? colors.selector.itemHighlighted : undefined
                       }
-                      color={isActive ? "black" : undefined}
+                      color={isActive ? "white" : undefined}
                       bold={isActive}
                     >
                       {` ${mode} `}

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -576,7 +576,7 @@ export function ModelSelector({
             backgroundColor={
               isActive ? colors.selector.itemHighlighted : undefined
             }
-            color={isActive ? "black" : undefined}
+            color={isActive ? "white" : undefined}
             bold={isActive}
           >
             {` ${getCategoryLabel(cat)} `}

--- a/src/cli/components/SkillsDialog.tsx
+++ b/src/cli/components/SkillsDialog.tsx
@@ -167,7 +167,7 @@ export function SkillsDialog({ onClose, agentId }: SkillsDialogProps) {
             backgroundColor={
               isActive ? colors.selector.itemHighlighted : undefined
             }
-            color={isActive ? "black" : undefined}
+            color={isActive ? "white" : undefined}
             bold={isActive}
           >
             {` ${getTabLabel(tab)} `}


### PR DESCRIPTION
## Summary

- Active tab labels were rendering with `color="black"` on the blue highlight background, making them appear dim/grey and hard to read
- Changed to `color="white"` in all 6 places the pattern appears: `ModelSelector`, `AgentSelector`, `MessageSearch` (×2), `SkillsDialog`, `MemoryTabViewer`, `MemfsTreeViewer`

👾 Generated with [Letta Code](https://letta.com)