### PR TITLE
fix(cli): let lowercase d type in /agents search

### DIFF
--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -615,7 +615,7 @@ export function AgentSelector({
         }
         loadPinnedAgents();
       }
-    } else if (input === "d" || input === "D") {
+    } else if (input === "D") {
       // Delete agent - open confirmation
       let selectedAgent: AgentState | null = null;
       let selectedAgentId: string | null = null;
@@ -937,7 +937,7 @@ export function AgentSelector({
               : activeTab === "letta-code"
                 ? `Page ${lettaCodePage + 1}${lettaCodeHasMore ? "+" : `/${lettaCodeTotalPages || 1}`}${lettaCodeLoadingMore ? " (loading...)" : ""}`
                 : `Page ${allPage + 1}${allHasMore ? "+" : `/${allTotalPages || 1}`}${allLoadingMore ? " (loading...)" : ""}`;
-          const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · D delete${activeTab === "pinned" ? " · P unpin" : ""}${onCreateNewAgent ? " · N new" : ""} · Esc cancel`;
+          const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? " · P unpin" : ""}${onCreateNewAgent ? " · N new" : ""} · Esc cancel`;
 
           return (
             <Box flexDirection="column">

--- a/src/tests/cli/agent-selector-shortcuts.test.ts
+++ b/src/tests/cli/agent-selector-shortcuts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("agent selector shortcuts", () => {
+  test("uses Shift+D for delete so lowercase d can be typed in search", () => {
+    const selectorPath = fileURLToPath(
+      new URL("../../cli/components/AgentSelector.tsx", import.meta.url),
+    );
+    const source = readFileSync(selectorPath, "utf-8");
+
+    expect(source).toContain('} else if (input === "D") {');
+    expect(source).not.toContain('input === "d" || input === "D"');
+
+    const deleteShortcutIndex = source.indexOf('} else if (input === "D") {');
+    const searchTypingIndex = source.indexOf(
+      '} else if (activeTab !== "pinned" && input && !key.ctrl && !key.meta) {',
+    );
+
+    expect(deleteShortcutIndex).toBeGreaterThanOrEqual(0);
+    expect(searchTypingIndex).toBeGreaterThan(deleteShortcutIndex);
+    expect(source).toContain("Shift+D delete");
+  });
+});


### PR DESCRIPTION
## Why

In `/agents`, typing a lowercase `d` should start a search query, but it was interpreted as the delete shortcut. This made searching for agent names containing `d` frustrating and error-prone.

## What

- Changed delete shortcut in `AgentSelector` from `d/D` to `Shift+D` (`D` only)
- Updated footer hint text to show `Shift+D delete`
- Added a regression test to lock this behavior:
  - `src/tests/cli/agent-selector-shortcuts.test.ts`

This keeps delete available while preserving normal lowercase typing behavior in search.
