### PR TITLE
fix: align codex plus-pro routing and gpt-5.3-codex defaults

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -193,7 +193,7 @@
     "description": "GPT-5.3 Codex (no reasoning) via ChatGPT Plus/Pro",
     "updateArgs": {
       "reasoning_effort": "none",
-      "verbosity": "medium",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000
     }
@@ -205,7 +205,7 @@
     "description": "GPT-5.3 Codex (low reasoning) via ChatGPT Plus/Pro",
     "updateArgs": {
       "reasoning_effort": "low",
-      "verbosity": "medium",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000
     }
@@ -217,7 +217,7 @@
     "description": "GPT-5.3 Codex (med reasoning) via ChatGPT Plus/Pro",
     "updateArgs": {
       "reasoning_effort": "medium",
-      "verbosity": "medium",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000
     }
@@ -230,7 +230,7 @@
     "isFeatured": true,
     "updateArgs": {
       "reasoning_effort": "high",
-      "verbosity": "medium",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000
     }
@@ -242,7 +242,7 @@
     "description": "GPT-5.3 Codex (max reasoning) via ChatGPT Plus/Pro",
     "updateArgs": {
       "reasoning_effort": "xhigh",
-      "verbosity": "medium",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000
     }

--- a/src/tests/cli/subagentDisplay.test.ts
+++ b/src/tests/cli/subagentDisplay.test.ts
@@ -27,7 +27,7 @@ describe("getSubagentModelDisplay", () => {
       "lc-anthropic/claude-haiku-4-5-20251001",
     );
     expect(display).toEqual({
-      label: "claude-haiku-4-5-20251001",
+      label: "Haiku 4.5",
       isByokProvider: true,
       isOpenAICodexProvider: false,
     });

--- a/src/tests/tools/model-provider-detection.test.ts
+++ b/src/tests/tools/model-provider-detection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { isOpenAIModel } from "../../tools/manager";
+
+describe("isOpenAIModel", () => {
+  test("detects openai handles", () => {
+    expect(isOpenAIModel("openai/gpt-5.2-codex")).toBe(true);
+  });
+
+  test("detects chatgpt-plus-pro handles", () => {
+    expect(isOpenAIModel("chatgpt-plus-pro/gpt-5.3-codex")).toBe(true);
+  });
+
+  test("detects chatgpt-plus-pro model ids via models.json metadata", () => {
+    expect(isOpenAIModel("gpt-5.3-codex-plus-pro-high")).toBe(true);
+  });
+
+  test("does not detect anthropic handles", () => {
+    expect(isOpenAIModel("anthropic/claude-sonnet-4-6")).toBe(false);
+  });
+});

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -7,6 +7,7 @@ import {
   runPostToolUseHooks,
   runPreToolUseHooks,
 } from "../hooks";
+import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import { telemetry } from "../telemetry";
 import { debugLog } from "../utils/debug";
 import { TOOL_DEFINITIONS, type ToolName } from "./toolDefinitions";
@@ -805,10 +806,17 @@ export async function loadTools(modelIdentifier?: string): Promise<void> {
 export function isOpenAIModel(modelIdentifier: string): boolean {
   const info = getModelInfo(modelIdentifier);
   if (info?.handle && typeof info.handle === "string") {
-    return info.handle.startsWith("openai/");
+    return (
+      info.handle.startsWith("openai/") ||
+      info.handle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`)
+    );
   }
-  // Fallback: treat raw handle-style identifiers as OpenAI if they start with openai/
-  return modelIdentifier.startsWith("openai/");
+  // Fallback: treat raw handle-style identifiers as OpenAI for openai/*
+  // and ChatGPT OAuth Codex provider handles.
+  return (
+    modelIdentifier.startsWith("openai/") ||
+    modelIdentifier.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`)
+  );
 }
 
 export function isGeminiModel(modelIdentifier: string): boolean {


### PR DESCRIPTION
## Summary
- fix CI regression in src/tests/cli/subagentDisplay.test.ts to match current model alias behavior for lc-* handles
- update isOpenAIModel to treat chatgpt-plus-pro/* as OpenAI-family for auto codex toolset routing
- set GPT-5.3 Codex Plus/Pro tier defaults to verbosity: low (none/low/medium/high/xhigh)
- add unit tests covering OpenAI provider detection for both openai/* and chatgpt-plus-pro/*

## Validation
- bun test src/tests/cli/subagentDisplay.test.ts src/tests/tools/model-provider-detection.test.ts
- bun test src/tests/model-tier-selection.test.ts
- bun test src/tests/agent/subagent-model-resolution.test.ts
- bun run typecheck
- bun run lint

## Notes
- Full bun test in this sandbox still fails on existing integration tests that require broader runtime permissions/environment; targeted suites above pass.