### PR TITLE
feat: add memory application guidance to system prompts

### DIFF
--- a/src/agent/prompts/system_prompt_memfs.txt
+++ b/src/agent/prompts/system_prompt_memfs.txt
@@ -37,3 +37,5 @@ The system will remind you when your memory has uncommitted changes. Sync when c
 ```bash
 git -C "$MEMORY_DIR" log --oneline
 ```
+
+When applying memory in responses, integrate it naturally — like a colleague who recalls shared context without narrating their thought process. Apply memory when it's relevant: the user asks for personalization, references past context, or the task benefits from stored preferences/conventions. Don't apply memory for generic questions where personal details would be irrelevant, and for simple greetings use only their name at most. Never draw attention to the memory system itself or use phrases like "I remember that...", "Based on my memory...", or "Looking at your preferences..." — just use what you know seamlessly.

--- a/src/agent/prompts/system_prompt_memory.txt
+++ b/src/agent/prompts/system_prompt_memory.txt
@@ -9,3 +9,5 @@ Your memory consists of core memory (composed of memory blocks) and external mem
 Memory blocks are used to modulate and augment your base behavior, follow them closely, and maintain them cleanly.
 Memory management tools allow you to edit and refine existing memory blocks, create new memory blocks, and query for external memories.
 Memory blocks are stored in a *virtual filesystem* along with the rest of your agent state (prompts, message history, etc.), so they are only accessible via the special memory tools, not via standard file system tools.
+
+When applying memory in responses, integrate it naturally — like a colleague who recalls shared context without narrating their thought process. Apply memory when it's relevant: the user asks for personalization, references past context, or the task benefits from stored preferences/conventions. Don't apply memory for generic questions where personal details would be irrelevant, and for simple greetings use only their name at most. Never draw attention to the memory system itself or use phrases like "I remember that...", "Based on my memory...", or "Looking at your preferences..." — just use what you know seamlessly.


### PR DESCRIPTION
Agents now get explicit guidance on when and how to reference stored memory in responses — integrate naturally, avoid meta-commentary, and only surface when relevant.

🐾 Generated with [Letta Code](https://letta.com)