### PR TITLE
feat: persist toolset mode and add auto option

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -89,11 +89,10 @@ import {
   analyzeToolApproval,
   checkToolPermission,
   executeTool,
-  isGeminiModel,
-  isOpenAIModel,
   savePermissionRule,
   type ToolExecutionResult,
 } from "../tools/manager";
+import type { ToolsetName, ToolsetPreference } from "../tools/toolset";
 import { debugLog, debugWarn } from "../utils/debug";
 import {
   handleMcpAdd,
@@ -1239,13 +1238,7 @@ export default function App({
       }
     | {
         type: "switch_toolset";
-        toolsetId:
-          | "codex"
-          | "codex_snake"
-          | "default"
-          | "gemini"
-          | "gemini_snake"
-          | "none";
+        toolsetId: ToolsetPreference;
         commandId?: string;
       }
     | { type: "switch_system"; promptId: string; commandId?: string }
@@ -1263,15 +1256,11 @@ export default function App({
   const [currentSystemPromptId, setCurrentSystemPromptId] = useState<
     string | null
   >("default");
-  const [currentToolset, setCurrentToolset] = useState<
-    | "codex"
-    | "codex_snake"
-    | "default"
-    | "gemini"
-    | "gemini_snake"
-    | "none"
-    | null
-  >(null);
+  const [currentToolset, setCurrentToolset] = useState<ToolsetName | null>(
+    null,
+  );
+  const [currentToolsetPreference, setCurrentToolsetPreference] =
+    useState<ToolsetPreference>("auto");
   const [llmConfig, setLlmConfig] = useState<LlmConfig | null>(null);
   const llmConfigRef = useRef(llmConfig);
   useEffect(() => {
@@ -1279,7 +1268,7 @@ export default function App({
   }, [llmConfig]);
   const [currentModelId, setCurrentModelId] = useState<string | null>(null);
   // Full model handle for API calls (e.g., "anthropic/claude-sonnet-4-5-20251101")
-  const [_currentModelHandle, setCurrentModelHandle] = useState<string | null>(
+  const [currentModelHandle, setCurrentModelHandle] = useState<string | null>(
     null,
   );
   // Derive agentName from agentState (single source of truth)
@@ -2669,14 +2658,27 @@ export default function App({
           // Store full handle for API calls (e.g., compaction)
           setCurrentModelHandle(agentModelHandle || null);
 
-          // Derive toolset from agent's model (not persisted, computed on resume)
-          if (agentModelHandle) {
-            const derivedToolset = isOpenAIModel(agentModelHandle)
-              ? "codex"
-              : isGeminiModel(agentModelHandle)
-                ? "gemini"
-                : "default";
-            setCurrentToolset(derivedToolset);
+          const persistedToolsetPreference =
+            settingsManager.getToolsetPreference(agentId);
+          setCurrentToolsetPreference(persistedToolsetPreference);
+
+          if (persistedToolsetPreference === "auto") {
+            if (agentModelHandle) {
+              const { switchToolsetForModel } = await import(
+                "../tools/toolset"
+              );
+              const derivedToolset = await switchToolsetForModel(
+                agentModelHandle,
+                agentId,
+              );
+              setCurrentToolset(derivedToolset);
+            } else {
+              setCurrentToolset(null);
+            }
+          } else {
+            const { forceToolsetSwitch } = await import("../tools/toolset");
+            await forceToolsetSwitch(persistedToolsetPreference, agentId);
+            setCurrentToolset(persistedToolsetPreference);
           }
         } catch (error) {
           console.error("Error fetching agent config:", error);
@@ -5126,6 +5128,13 @@ export default function App({
         setAgentId(targetAgentId);
         setAgentState(agent);
         setLlmConfig(agent.llm_config);
+        const agentModelHandle =
+          agent.llm_config.model_endpoint_type && agent.llm_config.model
+            ? agent.llm_config.model_endpoint_type +
+              "/" +
+              agent.llm_config.model
+            : (agent.llm_config.model ?? null);
+        setCurrentModelHandle(agentModelHandle);
         setConversationId(targetConversationId);
 
         // Ensure bootstrap reminders are re-injected on the first user turn
@@ -5260,6 +5269,13 @@ export default function App({
         setAgentId(agent.id);
         setAgentState(agent);
         setLlmConfig(agent.llm_config);
+        const agentModelHandle =
+          agent.llm_config.model_endpoint_type && agent.llm_config.model
+            ? agent.llm_config.model_endpoint_type +
+              "/" +
+              agent.llm_config.model
+            : (agent.llm_config.model ?? null);
+        setCurrentModelHandle(agentModelHandle);
 
         // Reset context token tracking for new agent
         resetContextHistory(contextTrackerRef.current);
@@ -9763,42 +9779,42 @@ ${SYSTEM_REMINDER_CLOSE}
 
           // Reset context token tracking since different models have different tokenizers
           resetContextHistory(contextTrackerRef.current);
+          setCurrentModelHandle(modelHandle);
 
-          const { isOpenAIModel, isGeminiModel } = await import(
-            "../tools/manager"
-          );
-          const targetToolset:
-            | "codex"
-            | "codex_snake"
-            | "default"
-            | "gemini"
-            | "gemini_snake"
-            | "none" = isOpenAIModel(modelHandle)
-            ? "codex"
-            : isGeminiModel(modelHandle)
-              ? "gemini"
-              : "default";
+          const persistedToolsetPreference =
+            settingsManager.getToolsetPreference(agentId);
+          let toolsetNoticeLine: string | null = null;
 
-          let toolsetName:
-            | "codex"
-            | "codex_snake"
-            | "default"
-            | "gemini"
-            | "gemini_snake"
-            | "none"
-            | null = null;
-          if (currentToolset !== targetToolset) {
+          if (persistedToolsetPreference === "auto") {
             const { switchToolsetForModel } = await import("../tools/toolset");
-            toolsetName = await switchToolsetForModel(modelHandle, agentId);
+            const toolsetName = await switchToolsetForModel(
+              modelHandle,
+              agentId,
+            );
+            setCurrentToolsetPreference("auto");
             setCurrentToolset(toolsetName);
+            toolsetNoticeLine =
+              "Auto toolset selected: switched to " +
+              toolsetName +
+              ". Use /toolset to set a manual override.";
+          } else {
+            const { forceToolsetSwitch } = await import("../tools/toolset");
+            if (currentToolset !== persistedToolsetPreference) {
+              await forceToolsetSwitch(persistedToolsetPreference, agentId);
+              setCurrentToolset(persistedToolsetPreference);
+            }
+            setCurrentToolsetPreference(persistedToolsetPreference);
+            toolsetNoticeLine =
+              "Manual toolset override remains active: " +
+              persistedToolsetPreference +
+              ".";
           }
 
-          const autoToolsetLine = toolsetName
-            ? `Automatically switched toolset to ${toolsetName}. Use /toolset to change back if desired.\nConsider switching to a different system prompt using /system to match.`
-            : null;
           const outputLines = [
-            `Switched to ${model.label}${reasoningLevel ? ` (${reasoningLevel} reasoning)` : ""}`,
-            ...(autoToolsetLine ? [autoToolsetLine] : []),
+            "Switched to " +
+              model.label +
+              (reasoningLevel ? ` (${reasoningLevel} reasoning)` : ""),
+            ...(toolsetNoticeLine ? [toolsetNoticeLine] : []),
           ].join("\n");
 
           cmd.finish(outputLines, true);
@@ -9990,16 +10006,7 @@ ${SYSTEM_REMINDER_CLOSE}
   );
 
   const handleToolsetSelect = useCallback(
-    async (
-      toolsetId:
-        | "codex"
-        | "codex_snake"
-        | "default"
-        | "gemini"
-        | "gemini_snake"
-        | "none",
-      commandId?: string | null,
-    ) => {
+    async (toolsetId: ToolsetPreference, commandId?: string | null) => {
       const overlayCommand = commandId
         ? commandRunner.getHandle(commandId, "/toolset")
         : consumeOverlayCommand("toolset");
@@ -10028,20 +10035,51 @@ ${SYSTEM_REMINDER_CLOSE}
       await withCommandLock(async () => {
         const cmd =
           overlayCommand ??
-          commandRunner.start(
-            "/toolset",
-            `Switching toolset to ${toolsetId}...`,
-          );
+          commandRunner.start("/toolset", "Switching toolset...");
         cmd.update({
-          output: `Switching toolset to ${toolsetId}...`,
+          output: "Switching toolset...",
           phase: "running",
         });
 
         try {
-          const { forceToolsetSwitch } = await import("../tools/toolset");
+          const { forceToolsetSwitch, switchToolsetForModel } = await import(
+            "../tools/toolset"
+          );
+
+          if (toolsetId === "auto") {
+            const modelHandle =
+              currentModelHandle ??
+              (llmConfig?.model_endpoint_type && llmConfig?.model
+                ? `${llmConfig.model_endpoint_type}/${llmConfig.model}`
+                : (llmConfig?.model ?? null));
+            if (!modelHandle) {
+              throw new Error(
+                "Could not determine current model for auto toolset",
+              );
+            }
+
+            const derivedToolset = await switchToolsetForModel(
+              modelHandle,
+              agentId,
+            );
+            settingsManager.setToolsetPreference(agentId, "auto");
+            setCurrentToolsetPreference("auto");
+            setCurrentToolset(derivedToolset);
+            cmd.finish(
+              `Toolset mode set to auto (currently ${derivedToolset}).`,
+              true,
+            );
+            return;
+          }
+
           await forceToolsetSwitch(toolsetId, agentId);
+          settingsManager.setToolsetPreference(agentId, toolsetId);
+          setCurrentToolsetPreference(toolsetId);
           setCurrentToolset(toolsetId);
-          cmd.finish(`Switched toolset to ${toolsetId}`, true);
+          cmd.finish(
+            `Switched toolset to ${toolsetId} (manual override)`,
+            true,
+          );
         } catch (error) {
           const errorDetails = formatErrorDetails(error, agentId);
           cmd.fail(`Failed to switch toolset: ${errorDetails}`);
@@ -10052,7 +10090,9 @@ ${SYSTEM_REMINDER_CLOSE}
       agentId,
       commandRunner,
       consumeOverlayCommand,
+      currentModelHandle,
       isAgentBusy,
+      llmConfig,
       withCommandLock,
     ],
   );
@@ -11307,6 +11347,7 @@ Plan file path: ${planFilePath}`;
             {activeOverlay === "toolset" && (
               <ToolsetSelector
                 currentToolset={currentToolset ?? undefined}
+                currentPreference={currentToolsetPreference}
                 onSelect={handleToolsetSelect}
                 onCancel={closeOverlay}
               />

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -47,6 +47,14 @@ export interface AgentSettings {
   baseUrl?: string; // undefined = Letta API (api.letta.com)
   pinned?: boolean; // true if agent is pinned
   memfs?: boolean; // true if memory filesystem is enabled
+  toolset?:
+    | "auto"
+    | "codex"
+    | "codex_snake"
+    | "default"
+    | "gemini"
+    | "gemini_snake"
+    | "none"; // toolset mode for this agent (manual override or auto)
 }
 
 export interface Settings {
@@ -1317,10 +1325,15 @@ class SettingsManager {
         pinned: updates.pinned !== undefined ? updates.pinned : existing.pinned,
         // Use nullish coalescing for memfs (undefined = keep existing)
         memfs: updates.memfs !== undefined ? updates.memfs : existing.memfs,
+        // Use nullish coalescing for toolset (undefined = keep existing)
+        toolset:
+          updates.toolset !== undefined ? updates.toolset : existing.toolset,
       };
       // Clean up undefined/false values
       if (!updated.pinned) delete updated.pinned;
       if (!updated.memfs) delete updated.memfs;
+      if (!updated.toolset || updated.toolset === "auto")
+        delete updated.toolset;
       if (!updated.baseUrl) delete updated.baseUrl;
       agents[idx] = updated;
     } else {
@@ -1333,6 +1346,8 @@ class SettingsManager {
       // Clean up undefined/false values
       if (!newAgent.pinned) delete newAgent.pinned;
       if (!newAgent.memfs) delete newAgent.memfs;
+      if (!newAgent.toolset || newAgent.toolset === "auto")
+        delete newAgent.toolset;
       if (!newAgent.baseUrl) delete newAgent.baseUrl;
       agents.push(newAgent);
     }
@@ -1352,6 +1367,40 @@ class SettingsManager {
    */
   setMemfsEnabled(agentId: string, enabled: boolean): void {
     this.upsertAgentSettings(agentId, { memfs: enabled });
+  }
+
+  /**
+   * Get toolset preference for an agent on the current server.
+   * Defaults to "auto" when no manual override is stored.
+   */
+  getToolsetPreference(
+    agentId: string,
+  ):
+    | "auto"
+    | "codex"
+    | "codex_snake"
+    | "default"
+    | "gemini"
+    | "gemini_snake"
+    | "none" {
+    return this.getAgentSettings(agentId)?.toolset ?? "auto";
+  }
+
+  /**
+   * Set toolset preference for an agent on the current server.
+   */
+  setToolsetPreference(
+    agentId: string,
+    preference:
+      | "auto"
+      | "codex"
+      | "codex_snake"
+      | "default"
+      | "gemini"
+      | "gemini_snake"
+      | "none",
+  ): void {
+    this.upsertAgentSettings(agentId, { toolset: preference });
   }
 
   /**

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -977,3 +977,37 @@ describe("Settings Manager - Agents Array Migration", () => {
     expect(settingsManager.isMemfsEnabled("agent-persist-test")).toBe(true);
   });
 });
+
+describe("Settings Manager - Toolset Preferences", () => {
+  test("getToolsetPreference defaults to auto", async () => {
+    await settingsManager.initialize();
+
+    expect(settingsManager.getToolsetPreference("agent-unset")).toBe("auto");
+  });
+
+  test("setToolsetPreference stores and clears manual override", async () => {
+    await settingsManager.initialize();
+
+    settingsManager.setToolsetPreference("agent-toolset", "codex");
+    expect(settingsManager.getToolsetPreference("agent-toolset")).toBe("codex");
+
+    settingsManager.setToolsetPreference("agent-toolset", "auto");
+    expect(settingsManager.getToolsetPreference("agent-toolset")).toBe("auto");
+  });
+
+  test("setToolsetPreference persists to disk", async () => {
+    await settingsManager.initialize();
+
+    settingsManager.setToolsetPreference("agent-toolset-persist", "gemini");
+
+    // Wait for async persist
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await settingsManager.reset();
+    await settingsManager.initialize();
+
+    expect(settingsManager.getToolsetPreference("agent-toolset-persist")).toBe(
+      "gemini",
+    );
+  });
+});

--- a/src/tests/startup-flow.test.ts
+++ b/src/tests/startup-flow.test.ts
@@ -140,4 +140,15 @@ describe("Startup Flow - Smoke", () => {
     expect(result.stderr).toContain("Missing LETTA_API_KEY");
     expect(result.stderr).not.toContain("No recent session found");
   });
+
+  test("--toolset auto is accepted", async () => {
+    const result = await runCli(
+      ["--new-agent", "--toolset", "auto", "-p", "Say OK"],
+      {
+        expectExit: 1,
+      },
+    );
+    expect(result.stderr).toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Invalid toolset");
+  });
 });

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -5,6 +5,7 @@ import {
   clearToolsWithLock,
   GEMINI_PASCAL_TOOLS,
   getToolNames,
+  isGeminiModel,
   isOpenAIModel,
   loadSpecificTools,
   loadTools,
@@ -35,6 +36,18 @@ export type ToolsetName =
   | "gemini"
   | "gemini_snake"
   | "none";
+export type ToolsetPreference = ToolsetName | "auto";
+
+export function deriveToolsetFromModel(
+  modelIdentifier: string,
+): "codex" | "gemini" | "default" {
+  const resolvedModel = resolveModel(modelIdentifier) ?? modelIdentifier;
+  return isOpenAIModel(resolvedModel)
+    ? "codex"
+    : isGeminiModel(resolvedModel)
+      ? "gemini"
+      : "default";
+}
 
 /**
  * Ensures the correct memory tool is attached to the agent based on the model.
@@ -248,11 +261,6 @@ export async function forceToolsetSwitch(
   const useMemoryPatch =
     toolsetName === "codex" || toolsetName === "codex_snake";
   await ensureCorrectMemoryTool(agentId, modelForLoading, useMemoryPatch);
-
-  // NOTE: Toolset is not persisted. On resume, we derive from agent's model.
-  // If we want to persist explicit toolset overrides in the future, add:
-  //   agentToolsets: Record<string, ToolsetName> to Settings (global, since agent IDs are UUIDs)
-  // and save here: settingsManager.updateSettings({ agentToolsets: { ...current, [agentId]: toolsetName } })
 }
 
 /**
@@ -293,13 +301,6 @@ export async function switchToolsetForModel(
   // Ensure base memory tool is correct for the model
   await ensureCorrectMemoryTool(agentId, resolvedModel);
 
-  const { isGeminiModel } = await import("./manager");
-  const toolsetName = isOpenAIModel(resolvedModel)
-    ? "codex"
-    : isGeminiModel(resolvedModel)
-      ? "gemini"
-      : "default";
-
-  // NOTE: Toolset is derived from model, not persisted. See comment in forceToolsetSwitch.
+  const toolsetName = deriveToolsetFromModel(resolvedModel);
   return toolsetName;
 }


### PR DESCRIPTION
## Summary
- persist per-agent toolset preference in settings (same agent settings path used by memfs)
- add auto as the default toolset mode, with manual toolset selection as an override
- update /toolset selector to show Auto first and render Auto (current - X) when active
- keep model-driven toolset switching only when preference is auto; preserve manual override across model changes
- allow --toolset auto in CLI argument validation/help text
- add tests for toolset preference persistence and startup parsing of --toolset auto

## Validation
- bun test src/tests/settings-manager.test.ts src/tests/startup-flow.test.ts
- bun run typecheck
- pre-commit check script (lint + typecheck) ran during commit
