### PR TITLE
fix: send Anthropic effort in model_settings and read it for display

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -70,6 +70,14 @@ function buildModelSettings(
       provider_type: "anthropic",
       parallel_tool_calls: true,
     };
+    // Map reasoning_effort to Anthropic's effort field (controls token spending via output_config)
+    const effort = updateArgs?.reasoning_effort;
+    if (effort === "low" || effort === "medium" || effort === "high") {
+      anthropicSettings.effort = effort;
+    } else if (effort === "xhigh") {
+      // "max" is valid on the backend but the SDK type hasn't caught up yet
+      (anthropicSettings as Record<string, unknown>).effort = "max";
+    }
     // Build thinking config if either enable_reasoner or max_reasoning_tokens is specified
     if (
       updateArgs?.enable_reasoner !== undefined ||
@@ -126,6 +134,13 @@ function buildModelSettings(
       provider_type: "bedrock",
       parallel_tool_calls: true,
     };
+    // Map reasoning_effort to Anthropic's effort field (Bedrock runs Claude models)
+    const effort = updateArgs?.reasoning_effort;
+    if (effort === "low" || effort === "medium" || effort === "high") {
+      bedrockSettings.effort = effort;
+    } else if (effort === "xhigh") {
+      bedrockSettings.effort = "max";
+    }
     // Build thinking config if either enable_reasoner or max_reasoning_tokens is specified
     if (
       updateArgs?.enable_reasoner !== undefined ||


### PR DESCRIPTION
## Summary

- `buildModelSettings()` never set the `effort` field on `AnthropicModelSettings`, so the backend never received it — `llm_config.effort` was always null for Anthropic agents, and the "(high)" label never appeared in the status bar
- The display code only read `llm_config.reasoning_effort` (the OpenAI field), never the Anthropic-specific `effort` field
- Now maps `reasoning_effort` → `effort` in the Anthropic and Bedrock branches (`low`/`medium`/`high` direct, `xhigh` → `"max"` via cast since SDK type lags backend)
- Derives `currentReasoningEffort` from `model_settings` (non-deprecated) with provider-aware logic, falling back to `llm_config` for backwards compat

👾 Generated with [Letta Code](https://letta.com)