### PR TITLE
fix: reset conversation routing after /agents new agent creation

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5248,6 +5248,19 @@ export default function App({
         // Update project settings with new agent
         await updateProjectSettings({ lastAgent: agent.id });
 
+        // New agents always start on their default conversation route.
+        // Persist this explicitly so routing and resume state do not retain
+        // a previous agent's non-default conversation id.
+        const targetConversationId = "default";
+        settingsManager.setLocalLastSession(
+          { agentId: agent.id, conversationId: targetConversationId },
+          process.cwd(),
+        );
+        settingsManager.setGlobalLastSession({
+          agentId: agent.id,
+          conversationId: targetConversationId,
+        });
+
         // Build success message with hints
         const agentUrl = `https://app.letta.com/projects/default-project/agents/${agent.id}`;
         const successOutput = [
@@ -5287,6 +5300,24 @@ export default function App({
               agent.llm_config.model
             : (agent.llm_config.model ?? null);
         setCurrentModelHandle(agentModelHandle);
+        setConversationId(targetConversationId);
+
+        // Set conversation switch context for new agent switch
+        pendingConversationSwitchRef.current = {
+          origin: "agent-switch",
+          conversationId: targetConversationId,
+          isDefault: true,
+          agentSwitchContext: {
+            name: agent.name || agent.id,
+            description: agent.description ?? undefined,
+            model: agentModelHandle
+              ? (await import("../agent/model")).getModelDisplayName(
+                  agentModelHandle,
+                ) || agentModelHandle
+              : "unknown",
+            blockCount: agent.blocks?.length ?? 0,
+          },
+        };
 
         // Reset context token tracking for new agent
         resetContextHistory(contextTrackerRef.current);

--- a/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
+++ b/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
@@ -42,9 +42,30 @@ describe("bootstrap reminder reset wiring", () => {
       const anchorIndex = source.indexOf(anchor);
       expect(anchorIndex).toBeGreaterThanOrEqual(0);
 
+      const windowStart = Math.max(0, anchorIndex - 2500);
       const windowEnd = Math.min(source.length, anchorIndex + 5000);
-      const scoped = source.slice(anchorIndex, windowEnd);
+      const scoped = source.slice(windowStart, windowEnd);
       expect(scoped).toContain("resetBootstrapReminderState();");
     }
+  });
+
+  test("new-agent creation flow resets routing to default conversation", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    const anchor = 'const inputCmd = "/new";';
+    const anchorIndex = source.indexOf(anchor);
+    expect(anchorIndex).toBeGreaterThanOrEqual(0);
+
+    const windowEnd = Math.min(source.length, anchorIndex + 8000);
+    const scoped = source.slice(anchorIndex, windowEnd);
+
+    expect(scoped).toContain('const targetConversationId = "default";');
+    expect(scoped).toContain("setConversationId(targetConversationId);");
+    expect(scoped).toContain("settingsManager.setLocalLastSession(");
+    expect(scoped).toContain("settingsManager.setGlobalLastSession({");
+    expect(scoped).toContain("conversationId: targetConversationId");
   });
 });


### PR DESCRIPTION
## Summary
- reset the `/agents` new-agent creation flow to explicitly switch routing to the new agent's `default` conversation
- persist local/global last-session state with `conversationId: "default"` for the newly created agent to prevent stale conversation routing
- add regression wiring assertions in `bootstrap-reminders-reset-wiring.test.ts` for new-agent conversation reset behavior

## Test plan
- [x] bun run fix
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run check
- [x] bun test src/tests/cli/bootstrap-reminders-reset-wiring.test.ts

👾 Generated with [Letta Code](https://letta.com)