### PR TITLE
fix(tui): show elapsed time for running shell tools

### DIFF
--- a/src/cli/components/StreamingOutputDisplay.tsx
+++ b/src/cli/components/StreamingOutputDisplay.tsx
@@ -68,6 +68,13 @@ export const StreamingOutputDisplay = memo(
             {"     "}… +{hiddenCount} more lines ({elapsed}s){interruptHint}
           </Text>
         )}
+
+        {/* Always show elapsed while running, even if output is short */}
+        {hiddenCount === 0 && (
+          <Text dimColor>
+            {"     "}({elapsed}s){interruptHint}
+          </Text>
+        )}
       </Box>
     );
   },

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -21,6 +21,7 @@ import {
   isPatchTool,
   isPlanTool,
   isSearchTool,
+  isShellTool,
   isTaskTool,
   isTodoTool,
 } from "../helpers/toolNameMapping.js";
@@ -61,22 +62,6 @@ type ToolCallLine = {
   phase: "streaming" | "ready" | "running" | "finished";
   streaming?: StreamingState;
 };
-
-/**
- * Check if tool is a shell/bash tool that supports streaming output
- */
-function isShellTool(name: string): boolean {
-  const shellTools = [
-    "Bash",
-    "Shell",
-    "shell",
-    "shell_command",
-    "run_shell_command",
-    "RunShellCommand",
-    "ShellCommand",
-  ];
-  return shellTools.includes(name);
-}
 
 /**
  * ToolCallMessageRich - Rich formatting version with old layout logic


### PR DESCRIPTION
## Problem
Running shell tools (ShellCommand/shell_command/bash) only showed an elapsed timer when there was no output yet, or when output exceeded the tail window ("+N more lines").

If a command produced a small amount of output (<= 5 lines) and kept running, there was no elapsed indicator, making it hard to tell whether it was still progressing.

Also, ToolCallMessageRich duplicated shell-tool detection and missed the lowercase "bash" tool name, so streaming output/timers could be skipped.

## Fix
- Always show an elapsed line while a shell tool is running, even when output is short.
- Use the canonical isShellTool helper for ToolCallMessageRich (avoid duplication; includes lowercase bash).

## Test plan
- [ ] Trigger a long-running ShellCommand that prints a line early (e.g., "rg ... | head" on a large repo) and confirm the UI keeps showing "(Xs)" while it runs.
- [ ] Trigger a bash tool call and confirm streaming output renders as a shell tool.

Generated with Letta Code