### PR TITLE
feat: align TaskOutput UX with Bash output

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -16,7 +16,7 @@ import { extractCompactionSummary } from "./backfill";
 import type { ContextTracker } from "./contextTracker";
 import { MAX_CONTEXT_HISTORY } from "./contextTracker";
 import { findLastSafeSplitPoint } from "./markdownSplit";
-import { isShellTool } from "./toolNameMapping";
+import { isShellOutputTool } from "./toolNameMapping";
 
 type CompactionSummaryMessageChunk = {
   message_type: "summary_message";
@@ -1207,7 +1207,7 @@ export function setToolCallsRunning(b: Buffers, toolCallIds: string[]): void {
       const line = b.byId.get(lineId);
       if (line && line.kind === "tool_call") {
         const shouldSeedStreaming =
-          line.name && isShellTool(line.name) && !line.streaming;
+          line.name && isShellOutputTool(line.name) && !line.streaming;
         b.byId.set(lineId, {
           ...line,
           phase: "running",

--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -272,6 +272,14 @@ export function formatArgsDisplay(
             return { display, parsed };
           }
 
+          // TaskOutput: show task id with optional non-blocking marker
+          if (toolName.toLowerCase() === "taskoutput" && parsed.task_id) {
+            const taskId = String(parsed.task_id);
+            const isNonBlocking = parsed.block === false;
+            display = isNonBlocking ? `(non-blocking) ${taskId}` : taskId;
+            return { display, parsed };
+          }
+
           // Shell/Bash tools: show just the command
           if (isShellTool(toolName) && parsed.command) {
             // Handle both string and array command formats

--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -68,9 +68,8 @@ export function getDisplayToolName(rawName: string): string {
   if (rawName === "Replace" || rawName === "replace") return "Update";
   if (rawName === "WriteFile" || rawName === "write_file") return "Write";
   if (rawName === "KillBash") return "Kill Bash";
-  if (rawName === "BashOutput" || rawName === "TaskOutput") {
-    return "Shell Output";
-  }
+  if (rawName === "BashOutput") return "Shell Output";
+  if (rawName === "TaskOutput") return "Task Output";
   if (rawName === "MultiEdit") return "Update";
 
   // No mapping found, return as-is
@@ -213,6 +212,15 @@ export function isShellTool(name: string): boolean {
     n === "run_shell_command" ||
     n === "runshellcommand"
   );
+}
+
+/**
+ * Checks if a tool should use shell-style streaming output rendering.
+ * Includes shell command tools plus TaskOutput/BashOutput pollers.
+ */
+export function isShellOutputTool(name: string): boolean {
+  const n = name.toLowerCase();
+  return isShellTool(name) || n === "taskoutput" || n === "bashoutput";
 }
 
 /**

--- a/src/tests/cli/toolNameMapping.test.ts
+++ b/src/tests/cli/toolNameMapping.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { isMemoryTool } from "../../cli/helpers/toolNameMapping";
+import {
+  getDisplayToolName,
+  isMemoryTool,
+  isShellOutputTool,
+} from "../../cli/helpers/toolNameMapping";
 
 describe("toolNameMapping.isMemoryTool", () => {
   test("recognizes all supported memory tool names", () => {
@@ -13,5 +17,18 @@ describe("toolNameMapping.isMemoryTool", () => {
   test("returns false for non-memory tools", () => {
     expect(isMemoryTool("bash")).toBe(false);
     expect(isMemoryTool("web_search")).toBe(false);
+  });
+});
+
+describe("toolNameMapping task output mappings", () => {
+  test("uses distinct display labels for shell output and task output", () => {
+    expect(getDisplayToolName("BashOutput")).toBe("Shell Output");
+    expect(getDisplayToolName("TaskOutput")).toBe("Task Output");
+  });
+
+  test("treats TaskOutput as shell-style output for streaming UI", () => {
+    expect(isShellOutputTool("TaskOutput")).toBe(true);
+    expect(isShellOutputTool("BashOutput")).toBe(true);
+    expect(isShellOutputTool("Task")).toBe(false);
   });
 });

--- a/src/tools/impl/BashOutput.ts
+++ b/src/tools/impl/BashOutput.ts
@@ -7,11 +7,81 @@ interface GetTaskOutputArgs {
   block?: boolean;
   timeout?: number;
   filter?: string;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+  runningMessageWhenNonBlocking?: boolean;
 }
 
 interface GetTaskOutputResult {
   message: string;
   status?: "running" | "completed" | "failed";
+}
+
+const POLL_INTERVAL_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function emitNewProcessOutput(
+  proc: typeof backgroundProcesses extends Map<string, infer V> ? V : never,
+  onOutput: (chunk: string, stream: "stdout" | "stderr") => void,
+  indexes: { stdout: number; stderr: number },
+  filter?: string,
+): { stdout: number; stderr: number } {
+  const next = { ...indexes };
+
+  if (proc.stdout.length > next.stdout) {
+    const newStdoutLines = proc.stdout.slice(next.stdout);
+    const filtered = filter
+      ? newStdoutLines.filter((line) => line.includes(filter))
+      : newStdoutLines;
+    if (filtered.length > 0) {
+      onOutput(`${filtered.join("\n")}\n`, "stdout");
+    }
+    next.stdout = proc.stdout.length;
+  }
+
+  if (proc.stderr.length > next.stderr) {
+    const newStderrLines = proc.stderr.slice(next.stderr);
+    const filtered = filter
+      ? newStderrLines.filter((line) => line.includes(filter))
+      : newStderrLines;
+    if (filtered.length > 0) {
+      onOutput(`${filtered.join("\n")}\n`, "stderr");
+    }
+    next.stderr = proc.stderr.length;
+  }
+
+  return next;
+}
+
+function emitNewBackgroundTaskOutput(
+  task: typeof backgroundTasks extends Map<string, infer V> ? V : never,
+  onOutput: (chunk: string, stream: "stdout" | "stderr") => void,
+  cursor: { outputIndex: number; emittedError?: string },
+  filter?: string,
+): { outputIndex: number; emittedError?: string } {
+  const next = { ...cursor };
+
+  if (task.output.length > next.outputIndex) {
+    const newOutputLines = task.output.slice(next.outputIndex);
+    const filtered = filter
+      ? newOutputLines.filter((line) => line.includes(filter))
+      : newOutputLines;
+    if (filtered.length > 0) {
+      onOutput(`${filtered.join("\n")}\n`, "stdout");
+    }
+    next.outputIndex = task.output.length;
+  }
+
+  if (task.error && task.error !== next.emittedError) {
+    if (!filter || task.error.includes(filter)) {
+      onOutput(`[error] ${task.error}\n`, "stderr");
+    }
+    next.emittedError = task.error;
+  }
+
+  return next;
 }
 
 /**
@@ -22,18 +92,41 @@ interface GetTaskOutputResult {
 export async function getTaskOutput(
   args: GetTaskOutputArgs,
 ): Promise<GetTaskOutputResult> {
-  const { task_id, block = false, timeout = 30000, filter } = args;
+  const {
+    task_id,
+    block = false,
+    timeout = 30000,
+    filter,
+    onOutput,
+    runningMessageWhenNonBlocking = false,
+  } = args;
 
   // Check backgroundProcesses first (for Bash background commands)
   const proc = backgroundProcesses.get(task_id);
   if (proc) {
-    return getProcessOutput(task_id, proc, block, timeout, filter);
+    return getProcessOutput(
+      task_id,
+      proc,
+      block,
+      timeout,
+      filter,
+      onOutput,
+      runningMessageWhenNonBlocking,
+    );
   }
 
   // Check backgroundTasks (for Task background subagents)
   const task = backgroundTasks.get(task_id);
   if (task) {
-    return getBackgroundTaskOutput(task_id, task, block, timeout, filter);
+    return getBackgroundTaskOutput(
+      task_id,
+      task,
+      block,
+      timeout,
+      filter,
+      onOutput,
+      runningMessageWhenNonBlocking,
+    );
   }
 
   return { message: `No background process found with ID: ${task_id}` };
@@ -48,28 +141,51 @@ async function getProcessOutput(
   block: boolean,
   timeout: number,
   filter?: string,
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void,
+  runningMessageWhenNonBlocking?: boolean,
 ): Promise<GetTaskOutputResult> {
-  // If blocking, wait for process to complete (or timeout)
+  // If blocking, wait for process to complete (or timeout) while streaming deltas.
   if (block && proc.status === "running") {
     const startTime = Date.now();
-    await new Promise<void>((resolve) => {
-      const checkInterval = setInterval(() => {
-        const currentProc = backgroundProcesses.get(task_id);
-        if (!currentProc || currentProc.status !== "running") {
-          clearInterval(checkInterval);
-          resolve();
-        } else if (Date.now() - startTime >= timeout) {
-          clearInterval(checkInterval);
-          resolve();
-        }
-      }, 100); // Check every 100ms
-    });
+    let cursor = { stdout: 0, stderr: 0 };
+
+    if (onOutput) {
+      cursor = emitNewProcessOutput(proc, onOutput, cursor, filter);
+    }
+
+    while (Date.now() - startTime < timeout) {
+      const currentProc = backgroundProcesses.get(task_id);
+      if (!currentProc) break;
+
+      if (onOutput) {
+        cursor = emitNewProcessOutput(currentProc, onOutput, cursor, filter);
+      }
+
+      if (currentProc.status !== "running") {
+        break;
+      }
+
+      await sleep(POLL_INTERVAL_MS);
+    }
+
+    const finalProc = backgroundProcesses.get(task_id);
+    if (finalProc && onOutput) {
+      emitNewProcessOutput(finalProc, onOutput, cursor, filter);
+    }
   }
 
   // Re-fetch in case status changed while waiting
   const currentProc = backgroundProcesses.get(task_id);
   if (!currentProc) {
     return { message: `Process ${task_id} no longer exists` };
+  }
+
+  if (
+    !block &&
+    runningMessageWhenNonBlocking &&
+    currentProc.status === "running"
+  ) {
+    return { message: "Task is still running...", status: "running" };
   }
 
   const stdout = currentProc.stdout.join("\n");
@@ -109,28 +225,58 @@ async function getBackgroundTaskOutput(
   block: boolean,
   timeout: number,
   filter?: string,
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void,
+  runningMessageWhenNonBlocking?: boolean,
 ): Promise<GetTaskOutputResult> {
-  // If blocking, wait for task to complete (or timeout)
+  // If blocking, wait for task to complete (or timeout) while streaming deltas.
   if (block && task.status === "running") {
     const startTime = Date.now();
-    await new Promise<void>((resolve) => {
-      const checkInterval = setInterval(() => {
-        const currentTask = backgroundTasks.get(task_id);
-        if (!currentTask || currentTask.status !== "running") {
-          clearInterval(checkInterval);
-          resolve();
-        } else if (Date.now() - startTime >= timeout) {
-          clearInterval(checkInterval);
-          resolve();
-        }
-      }, 100); // Check every 100ms
-    });
+    let cursor: { outputIndex: number; emittedError?: string } = {
+      outputIndex: 0,
+    };
+
+    if (onOutput) {
+      cursor = emitNewBackgroundTaskOutput(task, onOutput, cursor, filter);
+    }
+
+    while (Date.now() - startTime < timeout) {
+      const currentTask = backgroundTasks.get(task_id);
+      if (!currentTask) break;
+
+      if (onOutput) {
+        cursor = emitNewBackgroundTaskOutput(
+          currentTask,
+          onOutput,
+          cursor,
+          filter,
+        );
+      }
+
+      if (currentTask.status !== "running") {
+        break;
+      }
+
+      await sleep(POLL_INTERVAL_MS);
+    }
+
+    const finalTask = backgroundTasks.get(task_id);
+    if (finalTask && onOutput) {
+      emitNewBackgroundTaskOutput(finalTask, onOutput, cursor, filter);
+    }
   }
 
   // Re-fetch in case status changed while waiting
   const currentTask = backgroundTasks.get(task_id);
   if (!currentTask) {
     return { message: `Task ${task_id} no longer exists` };
+  }
+
+  if (
+    !block &&
+    runningMessageWhenNonBlocking &&
+    currentTask.status === "running"
+  ) {
+    return { message: "Task is still running...", status: "running" };
   }
 
   let text = currentTask.output.join("\n");

--- a/src/tools/impl/TaskOutput.ts
+++ b/src/tools/impl/TaskOutput.ts
@@ -5,6 +5,7 @@ interface TaskOutputArgs {
   task_id: string;
   block?: boolean;
   timeout?: number;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
 }
 
 interface TaskOutputResult {
@@ -20,11 +21,13 @@ export async function task_output(
   args: TaskOutputArgs,
 ): Promise<TaskOutputResult> {
   validateRequiredParams(args, ["task_id"], "TaskOutput");
-  const { task_id, block = true, timeout = 30000 } = args;
+  const { task_id, block = true, timeout = 30000, onOutput } = args;
 
   return getTaskOutput({
     task_id,
     block,
     timeout,
+    onOutput,
+    runningMessageWhenNonBlocking: true,
   });
 }

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -15,6 +15,8 @@ import { TOOL_DEFINITIONS, type ToolName } from "./toolDefinitions";
 export const TOOL_NAMES = Object.keys(TOOL_DEFINITIONS) as ToolName[];
 const STREAMING_SHELL_TOOLS = new Set([
   "Bash",
+  "BashOutput",
+  "TaskOutput",
   "shell_command",
   "ShellCommand",
   "shell",
@@ -110,6 +112,8 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "EnterPlanMode",
   "ExitPlanMode",
   "Task",
+  "TaskOutput",
+  "TaskStop",
   "Skill",
   // Standard Codex tools
   "ShellCommand",


### PR DESCRIPTION
## Summary
- align `TaskOutput` with the existing Bash output UX pipeline so blocking calls can stream incremental output via `onOutput`
- improve TaskOutput presentation in the TUI (`Task Output`, non-blocking arg format, shell-style running/collapsed output)
- avoid showing raw JSON payloads for non-blocking running status in collapsed output (show message text instead)
- add codex Pascal toolset parity by including `TaskOutput` and `TaskStop` in `OPENAI_PASCAL_TOOLS`

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test src/tests/tools/task-output.test.ts src/tests/tools/task-background.test.ts src/tests/cli/toolNameMapping.test.ts`

## Notes
- This reuses the existing shared `getTaskOutput` core and shell streaming UI path; it does not introduce a separate renderer or duplicate Bash execution logic.
