### PR TITLE
fix: compact plan and todo tool header args

### DIFF
--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -7,12 +7,18 @@ import {
   isFileReadTool,
   isFileWriteTool,
   isPatchTool,
+  isPlanTool,
   isShellTool,
+  isTodoTool,
 } from "./toolNameMapping.js";
 
 // Small helpers
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null;
+
+function formatItemCount(count: number): string {
+  return `${String(count)} item${count === 1 ? "" : "s"}`;
+}
 
 /**
  * Formats a file path for display (matches Claude Code style):
@@ -277,6 +283,18 @@ export function formatArgsDisplay(
             const taskId = String(parsed.task_id);
             const isNonBlocking = parsed.block === false;
             display = isNonBlocking ? `(non-blocking) ${taskId}` : taskId;
+            return { display, parsed };
+          }
+
+          // Plan tools: only show compact plan item count.
+          if (isPlanTool(toolName) && Array.isArray(parsed.plan)) {
+            display = formatItemCount(parsed.plan.length);
+            return { display, parsed };
+          }
+
+          // Todo tools: only show compact todo item count.
+          if (isTodoTool(toolName) && Array.isArray(parsed.todos)) {
+            display = formatItemCount(parsed.todos.length);
             return { display, parsed };
           }
 

--- a/src/tests/cli/formatArgsDisplay.test.ts
+++ b/src/tests/cli/formatArgsDisplay.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { formatArgsDisplay } from "../../cli/helpers/formatArgsDisplay";
+
+describe("formatArgsDisplay compact plan/todo headers", () => {
+  test("shows only plan item count for update_plan", () => {
+    const args = JSON.stringify({
+      explanation: "Investigating restart regression",
+      plan: [
+        { step: "Step 1", status: "pending" },
+        { step: "Step 2", status: "pending" },
+        { step: "Step 3", status: "pending" },
+      ],
+    });
+
+    expect(formatArgsDisplay(args, "update_plan").display).toBe("3 items");
+  });
+
+  test("handles singular plan item count for UpdatePlan", () => {
+    const args = JSON.stringify({
+      explanation: "One-step fix",
+      plan: [{ step: "Step 1", status: "pending" }],
+    });
+
+    expect(formatArgsDisplay(args, "UpdatePlan").display).toBe("1 item");
+  });
+
+  test("shows only todo item count for TODO tools", () => {
+    const args = JSON.stringify({
+      todos: [
+        { content: "First", status: "pending" },
+        { content: "Second", status: "in_progress" },
+      ],
+      note: "extra metadata",
+    });
+
+    expect(formatArgsDisplay(args, "TodoWrite").display).toBe("2 items");
+    expect(formatArgsDisplay(args, "write_todos").display).toBe("2 items");
+  });
+});


### PR DESCRIPTION
## Summary
- make plan/todo tool-call arg labels compact in transcript headers
- render update_plan / UpdatePlan as item counts only (example: Planning(3 items))
- render todo tools as item counts only (example: TODO(3 items))
- add tests for snake_case and PascalCase plan/todo variants

## Validation
- bun test src/tests/cli/formatArgsDisplay.test.ts
- bun run typecheck
- bunx --bun @biomejs/biome@2.2.5 check src/cli/helpers/formatArgsDisplay.ts src/tests/cli/formatArgsDisplay.test.ts
