### PR TITLE
fix: auto toolset detect chatgpt_oauth as codex

### DIFF
--- a/src/tests/tools/model-provider-detection.test.ts
+++ b/src/tests/tools/model-provider-detection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isOpenAIModel } from "../../tools/manager";
+import { deriveToolsetFromModel } from "../../tools/toolset";
 
 describe("isOpenAIModel", () => {
   test("detects openai handles", () => {
@@ -10,11 +11,21 @@ describe("isOpenAIModel", () => {
     expect(isOpenAIModel("chatgpt-plus-pro/gpt-5.3-codex")).toBe(true);
   });
 
+  test("detects chatgpt_oauth handles", () => {
+    expect(isOpenAIModel("chatgpt_oauth/gpt-5.3-codex")).toBe(true);
+  });
+
   test("detects chatgpt-plus-pro model ids via models.json metadata", () => {
     expect(isOpenAIModel("gpt-5.3-codex-plus-pro-high")).toBe(true);
   });
 
   test("does not detect anthropic handles", () => {
     expect(isOpenAIModel("anthropic/claude-sonnet-4-6")).toBe(false);
+  });
+});
+
+describe("deriveToolsetFromModel", () => {
+  test("maps chatgpt_oauth handles to codex toolset", () => {
+    expect(deriveToolsetFromModel("chatgpt_oauth/gpt-5.3-codex")).toBe("codex");
   });
 });

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -898,14 +898,16 @@ export function isOpenAIModel(modelIdentifier: string): boolean {
   if (info?.handle && typeof info.handle === "string") {
     return (
       info.handle.startsWith("openai/") ||
-      info.handle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`)
+      info.handle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`) ||
+      info.handle.startsWith("chatgpt_oauth/")
     );
   }
   // Fallback: treat raw handle-style identifiers as OpenAI for openai/*
   // and ChatGPT OAuth Codex provider handles.
   return (
     modelIdentifier.startsWith("openai/") ||
-    modelIdentifier.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`)
+    modelIdentifier.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`) ||
+    modelIdentifier.startsWith("chatgpt_oauth/")
   );
 }
 


### PR DESCRIPTION
## Summary
- classify `chatgpt_oauth/*` model handles as OpenAI/Codex in `isOpenAIModel`
- fixes auto toolset resolution for ChatGPT OAuth sessions so they map to Codex instead of Claude
- add regression tests for both provider detection and toolset derivation

## Validation
- bun test src/tests/tools/model-provider-detection.test.ts
- bun run typecheck
- pre-commit checks (`bun run scripts/check.js`) on commit
