### PR TITLE
chore: modify explore agent description for clarity

### DIFF
--- a/src/agent/subagents/builtin/explore.md
+++ b/src/agent/subagents/builtin/explore.md
@@ -1,6 +1,6 @@
 ---
 name: explore
-description: Fast agent for codebase exploration - finding files, searching code, understanding structure
+description: Fast agent for codebase exploration - finding files, searching code, understanding structure. (Read-Only)
 tools: Glob, Grep, Read, LS, TaskOutput
 model: haiku
 memoryBlocks: human, persona


### PR DESCRIPTION
Updated the description to indicate the agent is read-only.