### PR TITLE
fix: refresh model preset settings on resume

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -877,8 +877,9 @@ export async function handleHeadlessCommand(
     (!forceNew && !fromAfFile)
   );
 
-  // If resuming, refresh model settings from presets and apply optional
-  // command-line overrides (model/system prompt).
+  // If resuming, always refresh model settings from presets to keep
+  // preset-derived fields in sync, then apply optional command-line
+  // overrides (model/system prompt).
   if (isResumingAgent) {
     const { updateAgentLLMConfig } = await import("./agent/modify");
 
@@ -900,13 +901,31 @@ export async function handleHeadlessCommand(
       const { getModelPresetUpdateForAgent } = await import("./agent/model");
       const presetRefresh = getModelPresetUpdateForAgent(agent);
       if (presetRefresh) {
-        await updateAgentLLMConfig(
-          agent.id,
-          presetRefresh.modelHandle,
-          presetRefresh.updateArgs,
-        );
-        // Refresh agent state after model update
-        agent = await client.agents.retrieve(agent.id);
+        // Resume preset refresh is intentionally scoped for now.
+        // We only force-refresh max_output_tokens + parallel_tool_calls.
+        // Other preset fields available in models.json (for example:
+        // context_window, reasoning_effort, enable_reasoner,
+        // max_reasoning_tokens, verbosity, temperature,
+        // thinking_budget) are intentionally not auto-applied yet.
+        const resumeRefreshUpdateArgs: Record<string, unknown> = {};
+        if (typeof presetRefresh.updateArgs.max_output_tokens === "number") {
+          resumeRefreshUpdateArgs.max_output_tokens =
+            presetRefresh.updateArgs.max_output_tokens;
+        }
+        if (typeof presetRefresh.updateArgs.parallel_tool_calls === "boolean") {
+          resumeRefreshUpdateArgs.parallel_tool_calls =
+            presetRefresh.updateArgs.parallel_tool_calls;
+        }
+
+        if (Object.keys(resumeRefreshUpdateArgs).length > 0) {
+          await updateAgentLLMConfig(
+            agent.id,
+            presetRefresh.modelHandle,
+            resumeRefreshUpdateArgs,
+          );
+          // Refresh agent state after model update
+          agent = await client.agents.retrieve(agent.id);
+        }
       }
     }
 

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -21,7 +21,10 @@ describe("model preset refresh wiring", () => {
     const source = readFileSync(path, "utf-8");
 
     const start = source.indexOf("export async function updateAgentLLMConfig(");
-    const end = source.indexOf("export interface SystemPromptUpdateResult", start);
+    const end = source.indexOf(
+      "export interface SystemPromptUpdateResult",
+      start,
+    );
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     const updateSegment = source.slice(start, end);
@@ -35,6 +38,44 @@ describe("model preset refresh wiring", () => {
     );
     expect(source).not.toContain(
       'hasUpdateArg(updateArgs, "parallel_tool_calls")',
+    );
+  });
+
+  test("interactive resume flow refreshes model preset without explicit --model", () => {
+    const path = fileURLToPath(new URL("../../index.ts", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain("if (resuming)");
+    expect(source).toContain("getModelPresetUpdateForAgent");
+    expect(source).toContain(
+      "const presetRefresh = getModelPresetUpdateForAgent(agent)",
+    );
+    expect(source).toContain("resumeRefreshUpdateArgs");
+    expect(source).toContain("presetRefresh.updateArgs.max_output_tokens");
+    expect(source).toContain("presetRefresh.updateArgs.parallel_tool_calls");
+    expect(source).toContain("await updateAgentLLMConfig(");
+    expect(source).toContain("presetRefresh.modelHandle");
+    expect(source).not.toContain(
+      "await updateAgentLLMConfig(\n                agent.id,\n                presetRefresh.modelHandle,\n                presetRefresh.updateArgs,",
+    );
+  });
+
+  test("headless resume flow refreshes model preset without explicit --model", () => {
+    const path = fileURLToPath(new URL("../../headless.ts", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain("if (isResumingAgent)");
+    expect(source).toContain("getModelPresetUpdateForAgent");
+    expect(source).toContain(
+      "const presetRefresh = getModelPresetUpdateForAgent(agent)",
+    );
+    expect(source).toContain("resumeRefreshUpdateArgs");
+    expect(source).toContain("presetRefresh.updateArgs.max_output_tokens");
+    expect(source).toContain("presetRefresh.updateArgs.parallel_tool_calls");
+    expect(source).toContain("await updateAgentLLMConfig(");
+    expect(source).toContain("presetRefresh.modelHandle");
+    expect(source).not.toContain(
+      "await updateAgentLLMConfig(\n          agent.id,\n          presetRefresh.modelHandle,\n          presetRefresh.updateArgs,",
     );
   });
 });

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -62,17 +62,4 @@ describe("approval recovery wiring", () => {
     expect(segment).toContain("client.agents.messages.cancel");
     expect(segment).toContain("client.conversations.cancel");
   });
-
-  test("resume flow refreshes model preset without explicit --model", () => {
-    const indexPath = fileURLToPath(new URL("../../index.ts", import.meta.url));
-    const source = readFileSync(indexPath, "utf-8");
-
-    expect(source).toContain("getModelPresetUpdateForAgent");
-    expect(source).toContain(
-      "const presetRefresh = getModelPresetUpdateForAgent(agent)",
-    );
-    expect(source).toContain("await updateAgentLLMConfig(");
-    expect(source).toContain("presetRefresh.modelHandle");
-    expect(source).toContain("presetRefresh.updateArgs");
-  });
 });

--- a/src/tests/headless/approval-recovery-wiring.test.ts
+++ b/src/tests/headless/approval-recovery-wiring.test.ts
@@ -66,14 +66,4 @@ describe("headless approval recovery wiring", () => {
     const importBlock = source.slice(0, source.indexOf("export "));
     expect(importBlock).toContain("extractConflictDetail");
   });
-
-  test("resume flow refreshes model preset without explicit --model", () => {
-    expect(source).toContain("getModelPresetUpdateForAgent");
-    expect(source).toContain(
-      "const presetRefresh = getModelPresetUpdateForAgent(agent)",
-    );
-    expect(source).toContain("await updateAgentLLMConfig(");
-    expect(source).toContain("presetRefresh.modelHandle");
-    expect(source).toContain("presetRefresh.updateArgs");
-  });
 });


### PR DESCRIPTION
## Summary
- Re-apply `models.json` preset `updateArgs` on agent resume/startup even when `--model` is not provided (interactive + headless)
- Make `updateAgentLLMConfig` selective: only keys explicitly present in `updateArgs` are updated, preserving unrelated per-agent `model_settings`
- Support preset-driven `parallel_tool_calls` and add `parallel_tool_calls: true` to model preset `updateArgs` entries
- Add wiring tests for resume refresh behavior and selective update support

## Test plan
- [x] `bun run fix`
- [x] `bun run lint`
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts`
- [ ] `bun run typecheck` *(currently fails in this environment due to widespread missing type dependencies unrelated to this change)*

👾 Generated with [Letta Code](https://letta.com)