### PR TITLE
docs(skills): prefer repo-local memfs auth and warn on global helper conflicts

### DIFF
--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -717,4 +717,4 @@ git push
 | Subagent exits with code `null`, 0 tool uses | `letta.js` not built | Run `bun run build` |
 | Subagent hangs on "Tool requires approval" | Wrong subagent type | Use `subagent_type: "history-analyzer"` (workers) or `"memory"` (synthesis) |
 | Merge conflict during synthesis | Workers touched overlapping files | Resolve by checking `git log` for context |
-| Auth fails on push ("repository not found") | Credential helper broken | Use `http.extraHeader` (see syncing-memory-filesystem skill) |
+| Auth fails on push ("repository not found") | Credential helper broken or global helper conflict | Reconfigure **repo-local** helper and check/clear conflicting global `credential.<host>.helper` entries (see syncing-memory-filesystem skill) |


### PR DESCRIPTION
## Summary
Updates memfs-related skills to make authentication guidance safer and less confusing when global git credential helpers are present.

### Changes
- `syncing-memory-filesystem`
  - Clarify that **repo-local** credential helper is the preferred/default model
  - Add warning about conflicting global `credential.<host>.helper` entries
  - Use `git config --local ...` in examples
  - Add commands to inspect/clear global helper conflicts
  - Replace global-helper clone guidance with one-off `http.extraHeader` clone example
  - Expand troubleshooting with local + global helper diagnostics
- `initializing-memory`
  - Update troubleshooting row to mention global helper conflicts and point to repo-local reconfiguration

## Why
We saw cases where host-level global helper config (e.g. installed by other tooling) could override/conflict with memfs auth, causing misleading sync/auth failures. This makes the docs match harness behavior and reduce operator confusion.

## Validation
- Manual memfs sync validation performed in agent memory repo:
  - local memory file edit
  - commit + push to Letta git remote
  - `letta memfs pull` returned up-to-date
  - `letta memfs status` returned clean
