### PR TITLE
fix(models): set max_output_tokens for GPT-5 reasoning variants

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -629,7 +629,8 @@
     "updateArgs": {
       "reasoning_effort": "minimal",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {
@@ -640,7 +641,8 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {
@@ -651,7 +653,8 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {
@@ -662,7 +665,8 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {
@@ -673,7 +677,8 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {
@@ -684,7 +689,8 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000
+      "context_window": 272000,
+      "max_output_tokens": 128000
     }
   },
   {


### PR DESCRIPTION
## Summary
- Add `max_output_tokens: 128000` to GPT-5 reasoning variants in `src/models.json` that previously omitted it.
- Keep OpenAI GPT-5 family entries consistent with documented limits (`gpt-5`, `gpt-5-mini-2025-08-07`, `gpt-5-nano-2025-08-07`).
- Prevent model/reasoning switches from omitting `max_tokens` and falling back to backend defaults.

## Test plan
- [x] Verify targeted entries now include `max_output_tokens`.
- [x] Re-run a check to confirm no GPT-5 reasoning variants are missing `max_output_tokens`.
- [x] In CLI, switch between GPT-5 reasoning tiers and confirm max output tokens no longer reset.

👾 Generated with [Letta Code](https://letta.com)