### PR TITLE
fix: clear isExecutingTool on interrupt to unblock slash commands

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5136,6 +5136,7 @@ export default function App({
       setStreaming(false);
       resetTrajectoryBases();
       toolResultsInFlightRef.current = false;
+      setIsExecutingTool(false);
       if (!toolsCancelled) {
         appendError(INTERRUPT_MESSAGE, true);
       }
@@ -5215,13 +5216,18 @@ export default function App({
 
         if (abortControllerRef.current) {
           abortControllerRef.current.abort();
+          abortControllerRef.current = null;
         }
+        setIsExecutingTool(false);
+        toolResultsInFlightRef.current = false;
         pendingInterruptRecoveryConversationIdRef.current =
           conversationIdRef.current;
       } catch (e) {
         const errorDetails = formatErrorDetails(e, agentId);
         appendError(`Failed to interrupt stream: ${errorDetails}`);
         setInterruptRequested(false);
+        setIsExecutingTool(false);
+        toolResultsInFlightRef.current = false;
       }
     }
   }, [


### PR DESCRIPTION
## Summary
- When interrupting (Esc) during tool execution, if the tool-interrupt guard conditions aren't all met (e.g. `toolResultsInFlightRef.current` is true), execution falls through to the EAGER_CANCEL path which never called `setIsExecutingTool(false)`. This left `isAgentBusy()` permanently true, blocking all slash commands with "disabled while the agent is running"
- Added `setIsExecutingTool(false)` to the EAGER_CANCEL interrupt path
- Also hardened the non-EAGER_CANCEL fallback: added `abortControllerRef.current = null`, `setIsExecutingTool(false)`, and `toolResultsInFlightRef.current = false` in both success and error branches

Closes LET-7620

👾 Generated with [Letta Code](https://letta.com)