### PR TITLE
feat: log chunks for feedback

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1466,12 +1466,10 @@ export default function App({
   const sessionHooksRanRef = useRef(false);
 
   // Initialize chunk log for this agent + session (clears buffer, GCs old files).
-  // Must wait until agentId resolves from "loading" to the real ID.
-  const chunkLogInitRef = useRef(false);
+  // Re-runs when agentId changes (e.g. agent switch via /agents).
   useEffect(() => {
-    if (agentId && agentId !== "loading" && !chunkLogInitRef.current) {
+    if (agentId && agentId !== "loading") {
       chunkLog.init(agentId, telemetry.getSessionId());
-      chunkLogInitRef.current = true;
     }
   }, [agentId]);
 

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -155,7 +155,11 @@ export async function drainStream(
         streamProcessor.processChunk(chunk);
 
       // Log chunk for feedback diagnostics
-      chunkLog.append(chunk);
+      try {
+        chunkLog.append(chunk);
+      } catch {
+        // Silently ignore -- diagnostics should not break streaming
+      }
 
       // Check abort signal before processing - don't add data after interrupt
       if (abortSignal?.aborted) {
@@ -232,7 +236,11 @@ export async function drainStream(
     queueMicrotask(refresh);
   } finally {
     // Persist chunk log to disk (one write per stream, not per chunk)
-    chunkLog.flush();
+    try {
+      chunkLog.flush();
+    } catch {
+      // Silently ignore -- diagnostics should not break streaming
+    }
 
     // Clean up abort listener
     if (abortSignal) {


### PR DESCRIPTION
## Summary
- Fix `version` field in feedback and telemetry to use `getVersion()` (reads from package.json) instead of `process.env.npm_package_version` which returns `"unknown"` for global installs
- Add rolling chunk log (`~/.letta/logs/chunk-logs/{agent_id}/{session_id}.jsonl`) that stores the last 100 streaming chunks with smart truncation (metadata preserved, content fields capped at 200 chars)
- Include chunk log as `recent_chunks` array in `/feedback` POST body for debugging user-reported issues
- Per-agent per-session log files, with automatic GC (keeps last 5 sessions per agent)
- Buffered I/O: chunks accumulate in memory during streaming, single disk write in `drainStream`'s `finally` block
- Fix null fields (`billingTier`, `agentName`, `agentDescription`, `currentModelId`) causing Zod validation errors -- coerce `null` to `undefined` so they're omitted from the payload

## Test plan
- [ ] Run `/feedback` and verify `version` field shows actual version (not "unknown")
- [ ] Verify `~/.letta/logs/chunk-logs/{agent_id}/` directory is created after agent responses
- [ ] Verify chunk log resets on new session
- [ ] Verify `recent_chunks` appears in feedback POST body as an array
- [ ] Verify feedback succeeds when `billingTier` etc. are null (no Zod error)

🐾 Generated with [Letta Code](https://letta.com)