### PR TITLE
fix: skip auto-open memory palace in tmux on macOS

### DIFF
--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -113,7 +113,13 @@ export function MemfsTreeViewer({
     if ((input === "o" || input === "O") && hasGitRepo) {
       showStatus("Opening in browser...", 10000);
       generateAndOpenMemoryViewer(agentId, { agentName })
-        .then(() => showStatus("Opened in browser", 3000))
+        .then((result) => {
+          if (result.opened) {
+            showStatus("Opened in browser", 3000);
+          } else {
+            showStatus(`Run: open ${result.filePath}`, 15000);
+          }
+        })
         .catch((err: unknown) =>
           showStatus(
             err instanceof Error ? err.message : "Failed to open viewer",


### PR DESCRIPTION
macOS `open` inside tmux spawns a new browser instance that doesn't render properly instead of reusing the running one. Detect TMUX env var and skip the open call, showing the file path in the status bar so the user can open it manually.

🐾 Generated with [Letta Code](https://letta.com)