### PR TITLE
fix: Disable all shared reminders for subagents

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1343,7 +1343,7 @@ ${SYSTEM_REMINDER_CLOSE}
   const lastRunAt = (agent as { last_run_completion?: string })
     .last_run_completion;
   const { parts: sharedReminderParts } = await buildSharedReminderParts({
-    mode: "headless-one-shot",
+    mode: isSubagent ? "subagent" : "headless-one-shot",
     agent: {
       id: agent.id,
       name: agent.name,
@@ -2256,6 +2256,7 @@ async function runBidirectionalMode(
   let currentAbortController: AbortController | null = null;
   const reminderContextTracker = createContextTracker();
   const sharedReminderState = createSharedReminderState();
+  const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
 
   // Resolve pending approvals for this conversation before retrying user input.
   const resolveAllPendingApprovals = async () => {
@@ -2793,7 +2794,7 @@ async function runBidirectionalMode(
         const lastRunAt = (agent as { last_run_completion?: string })
           .last_run_completion;
         const { parts: sharedReminderParts } = await buildSharedReminderParts({
-          mode: "headless-bidirectional",
+          mode: isSubagent ? "subagent" : "headless-bidirectional",
           agent: {
             id: agent.id,
             name: agent.name,

--- a/src/reminders/catalog.ts
+++ b/src/reminders/catalog.ts
@@ -1,7 +1,8 @@
 export type SharedReminderMode =
   | "interactive"
   | "headless-one-shot"
-  | "headless-bidirectional";
+  | "headless-bidirectional"
+  | "subagent";
 
 export type SharedReminderId =
   | "session-context"

--- a/src/tests/headless/reminder-wiring.test.ts
+++ b/src/tests/headless/reminder-wiring.test.ts
@@ -9,7 +9,7 @@ describe("headless shared reminder wiring", () => {
     );
     const source = readFileSync(headlessPath, "utf-8");
 
-    expect(source).toContain('mode: "headless-one-shot"');
+    expect(source).toContain('isSubagent ? "subagent" : "headless-one-shot"');
     expect(source).toContain(
       "sessionContextReminderEnabled: systemInfoReminderEnabled",
     );
@@ -21,7 +21,9 @@ describe("headless shared reminder wiring", () => {
     );
     const source = readFileSync(headlessPath, "utf-8");
 
-    expect(source).toContain('mode: "headless-bidirectional"');
+    expect(source).toContain(
+      'isSubagent ? "subagent" : "headless-bidirectional"',
+    );
     expect(source).toContain("resolvePlanModeReminder: async () => {");
     expect(source).toContain("const { PLAN_MODE_REMINDER } = await import");
   });
@@ -34,6 +36,21 @@ describe("headless shared reminder wiring", () => {
 
     expect(source).toContain("syncReminderStateFromContextTracker(");
     expect(source).toContain("reminderContextTracker");
+  });
+
+  test("subagent mode is wired via LETTA_CODE_AGENT_ROLE check", () => {
+    const headlessPath = fileURLToPath(
+      new URL("../../headless.ts", import.meta.url),
+    );
+    const source = readFileSync(headlessPath, "utf-8");
+
+    expect(source).toContain(
+      'process.env.LETTA_CODE_AGENT_ROLE === "subagent"',
+    );
+    expect(source).toContain('isSubagent ? "subagent" : "headless-one-shot"');
+    expect(source).toContain(
+      'isSubagent ? "subagent" : "headless-bidirectional"',
+    );
   });
 
   test("one-shot approval drain uses shared stream processor", () => {

--- a/src/tests/reminders/catalog.test.ts
+++ b/src/tests/reminders/catalog.test.ts
@@ -30,6 +30,13 @@ describe("shared reminder catalog", () => {
     }
   });
 
+  test("subagent mode has no reminders", () => {
+    const subagentReminders = SHARED_REMINDER_CATALOG.filter((entry) =>
+      entry.modes.includes("subagent"),
+    );
+    expect(subagentReminders).toEqual([]);
+  });
+
   test("command and toolset reminders are interactive-only", () => {
     const commandReminder = SHARED_REMINDER_CATALOG.find(
       (entry) => entry.id === "command-io",

--- a/src/tests/reminders/engine-parity.test.ts
+++ b/src/tests/reminders/engine-parity.test.ts
@@ -88,4 +88,34 @@ describe("shared reminder parity", () => {
       reminderIdsForMode("headless-bidirectional"),
     );
   });
+
+  test("subagent mode produces no reminders", async () => {
+    for (const reminderId of SHARED_REMINDER_IDS) {
+      providerMap[reminderId] = async () => reminderId;
+    }
+
+    const reflectionSettings: ReflectionSettings = {
+      trigger: "off",
+      behavior: "reminder",
+      stepCount: 25,
+    };
+
+    const subagent = await buildSharedReminderParts({
+      agent: {
+        id: "agent-1",
+        name: "Agent 1",
+        description: "test",
+        lastRunAt: null,
+      },
+      sessionContextReminderEnabled: true,
+      reflectionSettings,
+      skillSources: [] as SkillSource[],
+      resolvePlanModeReminder: () => "plan",
+      mode: "subagent",
+      state: createSharedReminderState(),
+    });
+
+    expect(subagent.appliedReminderIds).toEqual([]);
+    expect(subagent.parts).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a `"subagent"` mode to `SharedReminderMode` with **no catalog entries**, so subagents receive zero shared reminders
- Wires `isSubagent` (via `LETTA_CODE_AGENT_ROLE === "subagent"`) into both one-shot and bidirectional reminder paths in `headless.ts`
- Previously, subagents received all 6 headless-mode reminders (session-context, skills, permission-mode, plan-mode, reflection-step-count, reflection-compaction) — none of which are appropriate for ephemeral, scoped subagent tasks

### Why remove all reminders?
| Reminder | Why not for subagents |
|---|---|
| `session-context` | Device/git info already available to the parent; wastes tokens |
| `skills` | Subagents have restricted toolsets and typically can't invoke the Skill tool |
| `permission-mode` | Already enforced mechanically via approval system and `--permission-mode` CLI flag |
| `plan-mode` | Plan mode is an interactive-only operation |
| `reflection-step-count` | Subagents are ephemeral — shouldn't trigger reflection/memory updates |
| `reflection-compaction` | Same as above |

### Note on pre-refactor behavior
Before the shared reminder refactor (#1001), subagents only received **skills + plan-mode** reminders. The refactor inadvertently added 4 new reminders (session-context, permission-mode, reflection-step-count, reflection-compaction) to subagents. This PR removes all of them — we can selectively re-enable specific reminders later if needed.

## Test plan
- [x] `src/tests/reminders/engine-parity.test.ts` — verifies subagent mode produces 0 parts
- [x] `src/tests/reminders/catalog.test.ts` — verifies no catalog entries list `"subagent"` in their modes
- [x] `src/tests/headless/reminder-wiring.test.ts` — verifies headless.ts contains the subagent wiring pattern
- [ ] Manual: spawn a subagent via Task tool and verify no `<system-reminder>` blocks are prepended to the user message

🤖 Generated with [Letta Code](https://letta.com)