### PR TITLE
fix: resolve env vars in reflection/history-analyzer commit trailers

### DIFF
--- a/src/agent/subagents/builtin/history-analyzer.md
+++ b/src/agent/subagents/builtin/history-analyzer.md
@@ -94,8 +94,8 @@ Key updates:
 ...
 
 Generated-By: Letta Code
-Agent-ID: $LETTA_AGENT_ID
-Parent-Agent-ID: $LETTA_PARENT_AGENT_ID"
+Agent-ID: <ACTUAL_AGENT_ID>
+Parent-Agent-ID: <ACTUAL_PARENT_AGENT_ID>"
 ```
 
 **Commit type** — pick the one that fits:
@@ -107,9 +107,16 @@ Parent-Agent-ID: $LETTA_PARENT_AGENT_ID"
 - `chore(history-analyzer): ingest Claude Code history 2025-09 ⏳`
 - `refactor(history-analyzer): reorganize memory by project domain ⏳`
 
-**Trailers:** Omit `Agent-ID` or `Parent-Agent-ID` if the
-corresponding environment variable is unset (don't write
-the literal variable name).
+**Trailers:** Before writing the commit, resolve the actual
+ID values by running:
+```bash
+echo "AGENT_ID=$LETTA_AGENT_ID"
+echo "PARENT_AGENT_ID=$LETTA_PARENT_AGENT_ID"
+```
+Use the printed values (e.g. `agent-abc123...`) in the
+trailers. If a variable is empty or unset, omit that
+trailer entirely. Never write a literal variable name like
+`$LETTA_AGENT_ID` in the commit message.
 
 ## Important
 

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -224,8 +224,8 @@ Updates:
 - <what conversation context prompted each update>
 
 Generated-By: Letta Code
-Agent-ID: <value of $LETTA_AGENT_ID>
-Parent-Agent-ID: <value of $LETTA_PARENT_AGENT_ID>"
+Agent-ID: <ACTUAL_AGENT_ID>
+Parent-Agent-ID: <ACTUAL_PARENT_AGENT_ID>"
 ```
 
 **Commit type** — pick the one that fits:
@@ -240,9 +240,16 @@ Parent-Agent-ID: <value of $LETTA_PARENT_AGENT_ID>"
 - `fix(reflection): correct stale user preference note 🔮`
 - `feat(reflection): add new project context block 🔮`
 
-**Trailers:** Omit `Agent-ID` or `Parent-Agent-ID` if the
-corresponding environment variable is unset (don't write
-the literal variable name).
+**Trailers:** Before writing the commit, resolve the actual
+ID values by running:
+```bash
+echo "AGENT_ID=$LETTA_AGENT_ID"
+echo "PARENT_AGENT_ID=$LETTA_PARENT_AGENT_ID"
+```
+Use the printed values (e.g. `agent-abc123...`) in the
+trailers. If a variable is empty or unset, omit that
+trailer entirely. Never write a literal variable name like
+`$LETTA_AGENT_ID` in the commit message.
 
 **Step 5b: Pull + merge to main**
 


### PR DESCRIPTION
## Summary
- Reflection and history-analyzer subagents were writing literal `${LETTA_AGENT_ID}` in commit message trailers instead of the actual resolved values
- Root cause: the spec templates used shell variable syntax, but agents use single-quoted HEREDOCs (`<<'EOF'`) for commits which prevents shell expansion
- Updated both specs to instruct the agent to resolve env vars via `echo` first, then use the printed values in the commit message

Closes LET-7619

👾 Generated with [Letta Code](https://letta.com)