### PR TITLE
fix: prevent last-char clipping on deferred-wrap terminals

### DIFF
--- a/vendor/ink/build/log-update.js
+++ b/vendor/ink/build/log-update.js
@@ -1,5 +1,6 @@
 import ansiEscapes from 'ansi-escapes';
 import cliCursor from 'cli-cursor';
+import stringWidth from 'string-width';
 
 const create = (stream, { showCursor = false } = {}) => {
     let previousLineCount = 0;
@@ -7,8 +8,17 @@ const create = (stream, { showCursor = false } = {}) => {
     let hasHiddenCursor = false;
 
     const renderWithClearedLineEnds = (output) => {
+        // On some terminals, writing to the last column leaves the cursor in a
+        // deferred-wrap state where CSI K (Erase in Line) erases the character
+        // at the final column instead of being a no-op.  Skip the erase for
+        // lines that already fill the terminal width — there is nothing beyond
+        // them to clean up.
+        const cols = stream.columns || 80;
         const lines = output.split('\n');
-        return lines.map((line) => line + ansiEscapes.eraseEndLine).join('\n');
+        return lines.map((line) => {
+            if (stringWidth(line) >= cols) return line;
+            return line + ansiEscapes.eraseEndLine;
+        }).join('\n');
     };
 
     const render = (str) => {
@@ -60,4 +70,3 @@ const create = (stream, { showCursor = false } = {}) => {
 
 const logUpdate = { create };
 export default logUpdate;
-


### PR DESCRIPTION
## Summary
- The status line right column always extends to the terminal's last column (yoga layout positions it flush-right via `alignItems=flex-end` + `flexGrow=1` on the left sibling)
- Ink's vendored `log-update.js` appends `\x1b[K` (CSI Erase in Line) after every rendered line to clean up stale characters
- On terminals where deferred-wrap keeps the cursor **at** the last column (rather than past it), `\x1b[K` erases the character at that position — clipping the last character of the right column
- Fix: skip `eraseEndLine` for lines whose `stringWidth` already fills `stream.columns` — there is nothing beyond them to erase

## Technical details
The deferred-wrap behavior diverges across terminals:
- **Safe terminals** (xterm, most modern): cursor is logically past the last column, `\x1b[K` is a no-op
- **Affected terminals**: cursor stays at last column with a pending wrap flag, `\x1b[K` erases from cursor (inclusive) to end of line

This also fixes the same theoretical issue for horizontal divider lines and the default footer label, which also fill the full terminal width.

## Test plan
- [ ] Verify status line right column renders fully on affected terminals (e.g., Terminal.app, older tmux)
- [ ] Verify short lines still get `eraseEndLine` (no stale characters from previous renders)
- [ ] Verify horizontal dividers still render cleanly at full width
- [ ] Verify no visual regressions during streaming (footer, status bar, shimmer text)

🐾 Generated with [Letta Code](https://letta.com)