### PR TITLE
fix(resume): preserve recency when injecting assistant anchor

### DIFF
--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -162,11 +162,13 @@ export function prepareMessageHistory(
         .map((m) => m.message_type)
         .lastIndexOf("assistant_message");
       if (lastAssistantIndex >= 0) {
-        const start = Math.max(
-          0,
-          lastAssistantIndex - (BACKFILL_PRIMARY_MESSAGE_LIMIT - 1),
-        );
-        trimmed = convo.slice(start, start + BACKFILL_PRIMARY_MESSAGE_LIMIT);
+        const lastAssistant = convo[lastAssistantIndex];
+        if (lastAssistant) {
+          // Preserve recency: keep the newest tail and prepend the last assistant.
+          const tailLimit = Math.max(BACKFILL_PRIMARY_MESSAGE_LIMIT - 1, 0);
+          const newestTail = tailLimit > 0 ? convo.slice(-tailLimit) : [];
+          trimmed = [lastAssistant, ...newestTail];
+        }
       }
     }
     if (trimmed.length > 0) return trimmed;

--- a/src/tests/cli/prepareMessageHistory.test.ts
+++ b/src/tests/cli/prepareMessageHistory.test.ts
@@ -62,6 +62,21 @@ describe("prepareMessageHistory", () => {
         ].includes(m.message_type as string),
       ),
     ).toBe(true);
+    // Preserve recency: keep latest tail and prepend last assistant anchor.
+    expect(out.map((m) => m.id)).toEqual([
+      "a1",
+      "u19",
+      "u20",
+      "u21",
+      "u22",
+      "u23",
+      "u24",
+      "u25",
+      "u26",
+      "u27",
+      "u28",
+      "u29",
+    ]);
   });
 
   test("primaryOnly falls back to reasoning when no primary messages exist", () => {


### PR DESCRIPTION
## Summary
- fix prepareMessageHistory(..., { primaryOnly: true }) so assistant injection does not shift the backfill window to stale messages
- preserve newest backfill tail and prepend the latest assistant anchor when the tail has no assistant
- strengthen the regression test to assert exact recency-preserving output ids

## Context
Fast follow for #1082.

## Validation
- bun test ./src/tests/cli/prepareMessageHistory.test.ts
- bun test ./src/tests/approval-recovery.test.ts
