### PR TITLE
fix: use default conversation for freshly created subagents (LET-7643)

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1018,6 +1018,10 @@ export async function handleHeadlessCommand(
       isolated_block_labels: isolatedBlockLabels,
     });
     conversationId = conversation.id;
+  } else if (isSubagent) {
+    // Freshly created subagents have no concurrency risk — use the default
+    // conversation so it's easy to inspect in the ADE.
+    conversationId = "default";
   } else {
     // Default for headless: always create a new conversation to avoid
     // 409 "conversation busy" races (e.g., parent agent calling letta -p).


### PR DESCRIPTION
## Summary
- Headless mode recently changed to always create a new conversation to avoid 409 "conversation busy" races
- But freshly created subagents (Task tool with `--new-agent`) have no concurrency risk — the agent was just created, nobody else is talking to it
- This change makes new subagents use the default conversation instead, so their activity is visible on the agent's primary conversation in the ADE
- Deployed existing agents are unaffected — they pass `--new` or `--conv` which hit earlier branches in the conversation resolution logic

Closes LET-7643

👾 Generated with [Letta Code](https://letta.com)