### PR TITLE
feat: add /palace alias for Memory Palace

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -74,6 +74,15 @@ export const commands: Record<string, Command> = {
       return "Opening memory viewer...";
     },
   },
+  "/palace": {
+    desc: "Open the Memory Palace in your browser",
+    order: 16,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx - opens browser directly
+      return "Opening Memory Palace...";
+    },
+  },
   "/sleeptime": {
     desc: "Configure reflection reminder trigger settings",
     order: 15.5,
@@ -94,7 +103,7 @@ export const commands: Record<string, Command> = {
   },
   "/search": {
     desc: "Search messages across all agents (/search [query])",
-    order: 16,
+    order: 15.1,
     handler: () => {
       // Handled specially in App.tsx to show message search
       return "Opening message search...";


### PR DESCRIPTION
## Summary
- Adds `/palace` as a shortcut command that opens the Memory Palace viewer directly
- Same behavior as `/memory` — both open the memory overlay (TUI tree viewer with 'o' to open in browser)

Part of LET-7645

👾 Generated with [Letta Code](https://letta.com)