### PR TITLE
fix(sleeptime): trigger compaction reflection for legacy summary format

### DIFF
--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -106,6 +106,30 @@ describe("accumulator usage statistics", () => {
     expect(tracker.pendingReflectionTrigger).toBe(true);
   });
 
+  test("sets reflection trigger for legacy compaction summary user_message", () => {
+    const buffers = createBuffers("agent-1");
+    const tracker = createContextTracker();
+    const legacySummary = JSON.stringify({
+      type: "system_alert",
+      message:
+        "The following prior messages have been hidden due to the conversation context window being reached.\nThe following is a summary of the previous messages: compact summary",
+    });
+
+    onChunk(
+      buffers,
+      {
+        message_type: "user_message",
+        id: "legacy-compaction-1",
+        content: legacySummary,
+      } as unknown as LettaStreamingResponse,
+      tracker,
+    );
+
+    expect(tracker.pendingCompaction).toBe(true);
+    expect(tracker.pendingSkillsReinject).toBe(true);
+    expect(tracker.pendingReflectionTrigger).toBe(true);
+  });
+
   test("accumulates assistant messages when otid is missing but id is present", () => {
     const buffers = createBuffers();
 


### PR DESCRIPTION
## Summary
- centralize compaction-complete trigger flagging in accumulator
- apply the same trigger path for both compaction completion formats:
  - summary_message (new format)
  - legacy user_message system-alert compaction summary
- keep event_message as non-trigger (still treated as compaction-start/running)

## Why
Compaction transcript rendering could work for legacy compaction summaries while sleeptime auto-launch never armed, because pendingReflectionTrigger was only set on summary_message.

## Validation
- bun test ./src/tests/cli/accumulator-usage.test.ts
- bun test ./src/tests/cli/reflection-auto-launch-wiring.test.ts
