### PR TITLE
fix: omit reasoning tag when set to none

### DIFF
--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -20,7 +20,7 @@ interface AgentInfoBarProps {
 function formatReasoningLabel(
   effort: ModelReasoningEffort | null | undefined,
 ): string | null {
-  if (effort === "none") return "no";
+  if (effort === "none") return null;
   if (effort === "xhigh") return "max";
   if (effort === "minimal") return "minimal";
   if (effort === "low") return "low";

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -54,7 +54,7 @@ function truncateEnd(value: string, maxChars: number): string {
 function getReasoningEffortTag(
   effort: ModelReasoningEffort | null | undefined,
 ): string | null {
-  if (effort === "none") return "no";
+  if (effort === "none") return null;
   if (effort === "xhigh") return "max";
   if (effort === "minimal") return "minimal";
   if (effort === "low") return "low";


### PR DESCRIPTION
## Summary
- When reasoning is set to "none", the status line showed "Opus 4.6 (no)" which is confusing
- Now it just shows "Opus 4.6" with no parenthetical, same as when no reasoning effort is configured
- Fixed in both `getReasoningEffortTag` (InputRich) and `formatReasoningLabel` (AgentInfoBar)

👾 Generated with [Letta Code](https://letta.com)