### PR TITLE
fix: temporarily disable xhigh reasoning for Anthropic models

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -69,20 +69,6 @@
     }
   },
   {
-    "id": "sonnet-4.6-xhigh",
-    "handle": "anthropic/claude-sonnet-4-6",
-    "label": "Sonnet 4.6",
-    "description": "Sonnet 4.6 (max reasoning)",
-    "updateArgs": {
-      "context_window": 200000,
-      "max_output_tokens": 128000,
-      "reasoning_effort": "xhigh",
-      "enable_reasoner": true,
-      "max_reasoning_tokens": 31999,
-      "parallel_tool_calls": true
-    }
-  },
-  {
     "id": "sonnet-4.5",
     "handle": "anthropic/claude-sonnet-4-5-20250929",
     "label": "Sonnet 4.5",
@@ -158,20 +144,6 @@
       "reasoning_effort": "medium",
       "enable_reasoner": true,
       "max_reasoning_tokens": 12000,
-      "parallel_tool_calls": true
-    }
-  },
-  {
-    "id": "opus-4.6-xhigh",
-    "handle": "anthropic/claude-opus-4-6",
-    "label": "Opus 4.6",
-    "description": "Opus 4.6 (max reasoning)",
-    "updateArgs": {
-      "context_window": 200000,
-      "max_output_tokens": 128000,
-      "reasoning_effort": "xhigh",
-      "enable_reasoner": true,
-      "max_reasoning_tokens": 31999,
       "parallel_tool_calls": true
     }
   },

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -77,14 +77,12 @@ describe("getReasoningTierOptionsForHandle", () => {
       "low",
       "medium",
       "high",
-      "xhigh",
     ]);
     expect(options.map((option) => option.modelId)).toEqual([
       "sonnet-4.6-no-reasoning",
       "sonnet-4.6-low",
       "sonnet-4.6-medium",
       "sonnet",
-      "sonnet-4.6-xhigh",
     ]);
   });
 
@@ -97,14 +95,12 @@ describe("getReasoningTierOptionsForHandle", () => {
       "low",
       "medium",
       "high",
-      "xhigh",
     ]);
     expect(options.map((option) => option.modelId)).toEqual([
       "opus-4.6-no-reasoning",
       "opus-4.6-low",
       "opus-4.6-medium",
       "opus",
-      "opus-4.6-xhigh",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Removes `sonnet-4.6-xhigh` and `opus-4.6-xhigh` entries from `models.json`
- The backend doesn't support `xhigh` for Anthropic yet, so cycling to it via `/reasoning` or tab causes: `Input should be 'low', 'medium' or 'high'`
- Revert this once backend adds `xhigh` support for Anthropic

👾 Generated with [Letta Code](https://letta.com)