### PR TITLE
refactor: hoist resume model-refresh imports

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -23,7 +23,12 @@ import { setAgentContext, setConversationId } from "./agent/context";
 import { createAgent } from "./agent/create";
 import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import { getStreamToolContextId, sendMessageStream } from "./agent/message";
-import { getModelUpdateArgs } from "./agent/model";
+import {
+  getModelPresetUpdateForAgent,
+  getModelUpdateArgs,
+  resolveModel,
+} from "./agent/model";
+import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import type { SkillSource } from "./agent/skills";
 import { SessionStats } from "./agent/stats";
@@ -882,10 +887,7 @@ export async function handleHeadlessCommand(
   // preset-derived fields in sync, then apply optional command-line
   // overrides (model/system prompt).
   if (isResumingAgent) {
-    const { updateAgentLLMConfig } = await import("./agent/modify");
-
     if (model) {
-      const { resolveModel } = await import("./agent/model");
       const modelHandle = resolveModel(model);
       if (typeof modelHandle !== "string") {
         console.error(`Error: Invalid model "${model}"`);
@@ -899,7 +901,6 @@ export async function handleHeadlessCommand(
       // Refresh agent state after model update
       agent = await client.agents.retrieve(agent.id);
     } else {
-      const { getModelPresetUpdateForAgent } = await import("./agent/model");
       const presetRefresh = getModelPresetUpdateForAgent(agent);
       if (presetRefresh) {
         // Resume preset refresh is intentionally scoped for now.
@@ -931,7 +932,6 @@ export async function handleHeadlessCommand(
     }
 
     if (systemPromptPreset) {
-      const { updateAgentSystemPrompt } = await import("./agent/modify");
       const result = await updateAgentSystemPrompt(
         agent.id,
         systemPromptPreset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,12 @@ import {
 import type { AgentProvenance } from "./agent/create";
 import { getLettaCodeHeaders } from "./agent/http-headers";
 import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
+import {
+  getModelPresetUpdateForAgent,
+  getModelUpdateArgs,
+  resolveModel,
+} from "./agent/model";
+import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import { LETTA_CLOUD_API_URL } from "./auth/oauth";
 import { ConversationSelector } from "./cli/components/ConversationSelector";
@@ -1561,7 +1567,6 @@ async function main(): Promise<void> {
 
         setLoadingState("initializing");
         const { createAgent } = await import("./agent/create");
-        const { getModelUpdateArgs } = await import("./agent/model");
 
         let agent: AgentState | null = null;
 
@@ -1793,12 +1798,7 @@ async function main(): Promise<void> {
         // preset-derived fields in sync, then apply optional command-line
         // overrides (model/system prompt).
         if (resuming) {
-          const { updateAgentLLMConfig } = await import("./agent/modify");
-
           if (model) {
-            const { resolveModel, getModelUpdateArgs } = await import(
-              "./agent/model"
-            );
             const modelHandle = resolveModel(model);
             if (!modelHandle) {
               console.error(`Error: Invalid model "${model}"`);
@@ -1812,9 +1812,6 @@ async function main(): Promise<void> {
             // Refresh agent state after model update
             agent = await client.agents.retrieve(agent.id);
           } else {
-            const { getModelPresetUpdateForAgent } = await import(
-              "./agent/model"
-            );
             const presetRefresh = getModelPresetUpdateForAgent(agent);
             if (presetRefresh) {
               // Resume preset refresh is intentionally scoped for now.
@@ -1851,7 +1848,6 @@ async function main(): Promise<void> {
           }
 
           if (systemPromptPreset) {
-            const { updateAgentSystemPrompt } = await import("./agent/modify");
             const result = await updateAgentSystemPrompt(
               agent.id,
               systemPromptPreset,


### PR DESCRIPTION
## Summary
- move resume model-refresh imports (`agent/model`, `agent/modify`) to top-level imports in `src/index.ts` and `src/headless.ts`
- remove dynamic imports from the resume branch while preserving behavior
- keep existing scoped refresh semantics unchanged

## Test plan
- [x] bun run fix
- [x] bun test src/tests/agent/model-preset-refresh.wiring.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts

👾 Generated with [Letta Code](https://letta.com)