### PR TITLE
fix: clarify plan-mode path guidance for apply_patch

### DIFF
--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -328,6 +328,33 @@ test("plan mode - allows ApplyPatch with relative path to plan file", () => {
   expect(result.matchedRule).toBe("plan mode");
 });
 
+test("plan mode deny reason includes apply_patch relative path hint", () => {
+  permissionMode.setMode("plan");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+  };
+
+  const workingDirectory = join(homedir(), "dev", "repo");
+  const planPath = join(homedir(), ".letta", "plans", "zesty-witty-cloud.md");
+  permissionMode.setPlanFilePath(planPath);
+
+  const result = checkPermission(
+    "Bash",
+    { command: "npm install" },
+    permissions,
+    workingDirectory,
+  );
+
+  expect(result.decision).toBe("deny");
+  expect(result.reason).toContain(`Write your plan to: ${planPath}.`);
+  expect(result.reason).toContain(
+    `use: ${relative(workingDirectory, planPath)}.`,
+  );
+});
+
 test("plan mode - denies ApplyPatch when any target is outside plans dir", () => {
   permissionMode.setMode("plan");
 


### PR DESCRIPTION
## Summary
- improve plan-mode denial guidance to include both the absolute plan file path and an apply_patch-compatible relative path hint
- update the in-context plan-mode reminder with explicit path rules per tool type (Write/Edit absolute path vs ApplyPatch/apply_patch relative file directives)
- add a regression test to lock in the relative-path hint in plan-mode deny messaging

## Why
Codex and GPT plan-mode runs can get stuck after trying to write the suggested absolute plan file path with apply_patch, which only accepts relative file directives.

## Validation
- bun test src/tests/permissions-mode.test.ts

Closes #1045