### PR TITLE
fix(tui): prevent reflow glitches (footer + resize)

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1733,15 +1733,123 @@ export default function App({
     null,
   );
   const prevColumnsRef = useRef(rawColumns);
+  const lastResizeColumnsRef = useRef(rawColumns);
+  const lastResizeRowsRef = useRef(terminalRows);
   const lastClearedColumnsRef = useRef(rawColumns);
   const pendingResizeRef = useRef(false);
   const pendingResizeColumnsRef = useRef<number | null>(null);
   const [staticRenderEpoch, setStaticRenderEpoch] = useState(0);
   const resizeClearTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClearAtRef = useRef(0);
+  const resizeGestureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const didImmediateShrinkClearRef = useRef(false);
   const isInitialResizeRef = useRef(true);
   const columns = stableColumns;
+  // Keep bottom chrome from ever exceeding the *actual* terminal width.
+  // When widening, we prefer the old behavior (wait until settle), so we use
+  // stableColumns. When shrinking, we must clamp to rawColumns to avoid Ink
+  // wrapping the footer/input chrome and "printing" divider rows into the
+  // transcript while dragging.
+  const chromeColumns = Math.min(rawColumns, stableColumns);
   const debugFlicker = process.env.LETTA_DEBUG_FLICKER === "1";
+
+  // Terminal resize + Ink:
+  // When the terminal shrinks, the *previous* frame reflows (wraps to more
+  // lines) instantly at the emulator level. Ink's incremental redraw then tries
+  // to clear based on the old line count and can leave stale rows behind.
+  //
+  // Fix: on shrink events, clear the screen *synchronously* in the resize event
+  // handler (before React/Ink flushes the next frame) and remount Static output.
+  useEffect(() => {
+    if (
+      typeof process === "undefined" ||
+      !process.stdout ||
+      !("on" in process.stdout) ||
+      !process.stdout.isTTY
+    ) {
+      return;
+    }
+
+    const stdout = process.stdout;
+    const onResize = () => {
+      const nextColumns = stdout.columns ?? lastResizeColumnsRef.current;
+      const nextRows = stdout.rows ?? lastResizeRowsRef.current;
+
+      const prevColumns = lastResizeColumnsRef.current;
+      const prevRows = lastResizeRowsRef.current;
+
+      lastResizeColumnsRef.current = nextColumns;
+      lastResizeRowsRef.current = nextRows;
+
+      // Skip initial mount.
+      if (isInitialResizeRef.current) {
+        return;
+      }
+
+      const shrunk = nextColumns < prevColumns || nextRows < prevRows;
+      if (!shrunk) {
+        // Reset shrink-clear guard once the gesture ends.
+        if (resizeGestureTimeoutRef.current) {
+          clearTimeout(resizeGestureTimeoutRef.current);
+        }
+        resizeGestureTimeoutRef.current = setTimeout(() => {
+          resizeGestureTimeoutRef.current = null;
+          didImmediateShrinkClearRef.current = false;
+        }, RESIZE_SETTLE_MS);
+        return;
+      }
+
+      // During a shrink gesture, do an immediate clear only once.
+      // Clearing on every resize event causes extreme flicker.
+      if (didImmediateShrinkClearRef.current) {
+        if (resizeGestureTimeoutRef.current) {
+          clearTimeout(resizeGestureTimeoutRef.current);
+        }
+        resizeGestureTimeoutRef.current = setTimeout(() => {
+          resizeGestureTimeoutRef.current = null;
+          didImmediateShrinkClearRef.current = false;
+        }, RESIZE_SETTLE_MS);
+        return;
+      }
+
+      if (debugFlicker) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[debug:flicker:resize-immediate-clear] next=${nextColumns}x${nextRows} prev=${prevColumns}x${prevRows} streaming=${streamingRef.current}`,
+        );
+      }
+
+      // Cancel any debounced clear; we're taking the immediate-clear path.
+      if (resizeClearTimeout.current) {
+        clearTimeout(resizeClearTimeout.current);
+        resizeClearTimeout.current = null;
+      }
+
+      stdout.write(CLEAR_SCREEN_AND_HOME);
+      setStaticRenderEpoch((epoch) => epoch + 1);
+      lastClearedColumnsRef.current = nextColumns;
+      lastClearAtRef.current = Date.now();
+      didImmediateShrinkClearRef.current = true;
+      if (resizeGestureTimeoutRef.current) {
+        clearTimeout(resizeGestureTimeoutRef.current);
+      }
+      resizeGestureTimeoutRef.current = setTimeout(() => {
+        resizeGestureTimeoutRef.current = null;
+        didImmediateShrinkClearRef.current = false;
+      }, RESIZE_SETTLE_MS);
+    };
+
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+      if (resizeGestureTimeoutRef.current) {
+        clearTimeout(resizeGestureTimeoutRef.current);
+        resizeGestureTimeoutRef.current = null;
+      }
+    };
+  }, [debugFlicker, streamingRef]);
 
   useEffect(() => {
     if (rawColumns === stableColumns) {
@@ -1901,6 +2009,20 @@ export default function App({
 
     prevColumnsRef.current = rawColumns;
   }, [rawColumns, streaming, scheduleResizeClear]);
+
+  // Reflow Static output for 1-col width changes too.
+  // rawColumns resize handling intentionally ignores 1-col "jitter" to reduce
+  // flicker, but that also means widening by small increments won't remount
+  // Static and existing output won't reflow.
+  //
+  // stableColumns only advances once the width has settled, so it's safe to use
+  // for a low-frequency remount trigger.
+  useEffect(() => {
+    if (isInitialResizeRef.current) return;
+    if (streaming) return;
+    if (stableColumns === lastClearedColumnsRef.current) return;
+    scheduleResizeClear(stableColumns);
+  }, [stableColumns, streaming, scheduleResizeClear]);
 
   useEffect(() => {
     if (streaming) {
@@ -2135,6 +2257,9 @@ export default function App({
   const statusLine = useConfigurableStatusLine({
     modelId: llmConfigRef.current?.model ?? null,
     modelDisplayName: currentModelDisplay,
+    reasoningEffort: currentReasoningEffort,
+    systemPromptId: currentSystemPromptId,
+    toolset: currentToolset,
     currentDirectory: process.cwd(),
     projectDirectory,
     sessionId: conversationId,
@@ -2147,7 +2272,7 @@ export default function App({
     usedContextTokens: contextTrackerRef.current.lastContextTokens,
     permissionMode: uiPermissionMode,
     networkPhase,
-    terminalWidth: columns,
+    terminalWidth: chromeColumns,
     triggerVersion: statusLineTriggerVersion,
   });
 
@@ -2160,7 +2285,7 @@ export default function App({
     previousStreamingForStatusLineRef.current = streaming;
   }, [streaming, triggerStatusLineRefresh]);
 
-  const statusLineRefreshIdentity = `${conversationId}|${currentModelDisplay ?? ""}|${currentModelProvider ?? ""}|${agentName ?? ""}|${columns}|${contextWindowSize ?? ""}`;
+  const statusLineRefreshIdentity = `${conversationId}|${currentModelDisplay ?? ""}|${currentModelProvider ?? ""}|${agentName ?? ""}|${columns}|${contextWindowSize ?? ""}|${currentReasoningEffort ?? ""}|${currentSystemPromptId ?? ""}|${currentToolset ?? ""}`;
 
   // Trigger status line when key session identity/display state changes.
   useEffect(() => {
@@ -6620,6 +6745,9 @@ export default function App({
                   buildStatusLinePayload({
                     modelId: llmConfigRef.current?.model ?? null,
                     modelDisplayName: currentModelDisplay,
+                    reasoningEffort: currentReasoningEffort,
+                    systemPromptId: currentSystemPromptId,
+                    toolset: currentToolset,
                     currentDirectory: wd,
                     projectDirectory,
                     sessionId: conversationIdRef.current,
@@ -6633,7 +6761,7 @@ export default function App({
                       contextTrackerRef.current.lastContextTokens,
                     permissionMode: uiPermissionMode,
                     networkPhase,
-                    terminalWidth: columns,
+                    terminalWidth: chromeColumns,
                   }),
                   { timeout: config.timeout, workingDirectory: wd },
                 );
@@ -12000,6 +12128,8 @@ Plan file path: ${planFilePath}`;
                 currentModel={currentModelDisplay}
                 currentModelProvider={currentModelProvider}
                 currentReasoningEffort={currentReasoningEffort}
+                currentSystemPromptId={currentSystemPromptId}
+                currentToolset={currentToolset}
                 messageQueue={messageQueue}
                 onEnterQueueEditMode={handleEnterQueueEditMode}
                 onEscapeCancel={
@@ -12014,7 +12144,7 @@ Plan file path: ${planFilePath}`;
                 restoredInput={restoredInput}
                 onRestoredInputConsumed={() => setRestoredInput(null)}
                 networkPhase={networkPhase}
-                terminalWidth={columns}
+                terminalWidth={chromeColumns}
                 shouldAnimate={shouldAnimate}
                 statusLineText={statusLine.text || undefined}
                 statusLineRight={statusLine.rightText || undefined}

--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -1,12 +1,29 @@
 import { Box } from "ink";
-import Link from "ink-link";
 import { memo, useMemo } from "react";
+import stringWidth from "string-width";
 import type { ModelReasoningEffort } from "../../agent/model";
 import { DEFAULT_AGENT_NAME } from "../../constants";
 import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { Text } from "./Text";
+
+function truncateText(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (stringWidth(text) <= maxWidth) return text;
+  if (maxWidth <= 3) return ".".repeat(maxWidth);
+
+  const suffix = "...";
+  const budget = Math.max(0, maxWidth - stringWidth(suffix));
+  let out = "";
+  for (const ch of text) {
+    const next = out + ch;
+    if (stringWidth(next) > budget) break;
+    out = next;
+  }
+  return out + suffix;
+}
 
 interface AgentInfoBarProps {
   agentId?: string;
@@ -40,7 +57,7 @@ export const AgentInfoBar = memo(function AgentInfoBar({
   serverUrl,
   conversationId,
 }: AgentInfoBarProps) {
-  const isTmux = Boolean(process.env.TMUX);
+  const columns = useTerminalWidth();
   // Check if current agent is pinned
   const isPinned = useMemo(() => {
     if (!agentId) return false;
@@ -50,9 +67,12 @@ export const AgentInfoBar = memo(function AgentInfoBar({
   }, [agentId]);
 
   const isCloudUser = serverUrl?.includes("api.letta.com");
-  const adeUrl =
-    agentId && agentId !== "loading"
-      ? `https://app.letta.com/agents/${agentId}${conversationId && conversationId !== "default" ? `?conversation=${conversationId}` : ""}`
+  const adeConversationUrl =
+    agentId &&
+    agentId !== "loading" &&
+    conversationId &&
+    conversationId !== "default"
+      ? `https://app.letta.com/agents/${agentId}?conversation=${conversationId}`
       : "";
   const showBottomBar = agentId && agentId !== "loading";
   const reasoningLabel = formatReasoningLabel(currentReasoningEffort);
@@ -66,6 +86,16 @@ export const AgentInfoBar = memo(function AgentInfoBar({
 
   // Alien ASCII art lines (4 lines tall, with 2-char indent + extra space before text)
   const alienLines = ["   ▗▖▗▖   ", "  ▙█▜▛█▟  ", "  ▝▜▛▜▛▘  ", "          "];
+  const leftWidth = Math.max(...alienLines.map((l) => stringWidth(l)));
+  const rightWidth = Math.max(0, columns - leftWidth);
+
+  const agentNameLabel = agentName || "Unnamed";
+  const agentHint = isPinned
+    ? " (pinned)"
+    : agentName === DEFAULT_AGENT_NAME || !agentName
+      ? " (type /pin to give your agent a real name!)"
+      : " (type /pin to pin agent)";
+  const agentNameLine = `${agentNameLabel}${agentHint}`;
 
   return (
     <Box flexDirection="column">
@@ -74,11 +104,8 @@ export const AgentInfoBar = memo(function AgentInfoBar({
 
       {/* Version and Discord/feedback info */}
       <Box>
-        <Text>
-          {"  "}Letta Code v{getVersion()} · Report bugs with /feedback or{" "}
-          <Link url="https://discord.gg/letta">
-            <Text>on Discord ↗</Text>
-          </Link>
+        <Text wrap="truncate-end">
+          {"  "}Letta Code v{getVersion()} · /feedback · discord.gg/letta
         </Text>
       </Box>
 
@@ -88,61 +115,83 @@ export const AgentInfoBar = memo(function AgentInfoBar({
       {/* Alien + Agent name */}
       <Box>
         <Text color={colors.footer.agentName}>{alienLines[0]}</Text>
-        <Text bold color={colors.footer.agentName}>
-          {agentName || "Unnamed"}
-        </Text>
-        {isPinned ? (
-          <Text color="green"> (pinned ✓)</Text>
-        ) : agentName === DEFAULT_AGENT_NAME || !agentName ? (
-          <Text color="gray"> (type /pin to give your agent a real name!)</Text>
-        ) : (
-          <Text color="gray"> (type /pin to pin agent)</Text>
-        )}
+        <Box width={rightWidth} flexShrink={1}>
+          <Text bold color={colors.footer.agentName} wrap="truncate-end">
+            {truncateText(agentNameLine, rightWidth)}
+          </Text>
+        </Box>
       </Box>
 
       {/* Alien + Links */}
       <Box>
         <Text color={colors.footer.agentName}>{alienLines[1]}</Text>
-        {isCloudUser && adeUrl && !isTmux && (
-          <>
-            <Link url={adeUrl}>
-              <Text>Open in ADE ↗</Text>
-            </Link>
-            <Text dimColor>· </Text>
-          </>
+        {!isCloudUser && (
+          <Box width={rightWidth} flexShrink={1}>
+            <Text dimColor wrap="truncate-end">
+              {truncateText(serverUrl ?? "", rightWidth)}
+            </Text>
+          </Box>
         )}
-        {isCloudUser && adeUrl && isTmux && (
-          <Text dimColor>Open in ADE: {adeUrl} · </Text>
-        )}
-        {isCloudUser && (
-          <Link url="https://app.letta.com/settings/organization/usage">
-            <Text>View usage ↗</Text>
-          </Link>
-        )}
-        {!isCloudUser && <Text dimColor>{serverUrl}</Text>}
       </Box>
+
+      {/* Keep usage on its own line to avoid breaking the alien art rows. */}
+      {isCloudUser && (
+        <Box>
+          <Text color={colors.footer.agentName}>{alienLines[3]}</Text>
+          <Box width={rightWidth} flexShrink={1}>
+            <Text dimColor wrap="truncate-end">
+              {truncateText(
+                "Usage: https://app.letta.com/settings/organization/usage",
+                rightWidth,
+              )}
+            </Text>
+          </Box>
+        </Box>
+      )}
 
       {/* Model summary */}
       <Box>
         <Text color={colors.footer.agentName}>{alienLines[2]}</Text>
-        <Text dimColor>{modelLine ?? "model unknown"}</Text>
+        <Box width={rightWidth} flexShrink={1}>
+          <Text dimColor wrap="truncate-end">
+            {truncateText(modelLine ?? "model unknown", rightWidth)}
+          </Text>
+        </Box>
       </Box>
 
       {/* Agent ID */}
       <Box>
         <Text>{alienLines[3]}</Text>
-        <Text dimColor>{agentId}</Text>
+        <Box width={rightWidth} flexShrink={1}>
+          <Text dimColor wrap="truncate-end">
+            {truncateText(agentId, rightWidth)}
+          </Text>
+        </Box>
       </Box>
 
       {/* Phantom alien row + Conversation ID */}
       <Box>
         <Text>{alienLines[3]}</Text>
         {conversationId && conversationId !== "default" ? (
-          <Text dimColor>{conversationId}</Text>
+          <Box width={rightWidth} flexShrink={1}>
+            <Text dimColor wrap="truncate-end">
+              {truncateText(conversationId, rightWidth)}
+            </Text>
+          </Box>
         ) : (
-          <Text dimColor>default conversation</Text>
+          <Box width={rightWidth} flexShrink={1}>
+            <Text dimColor>default conversation</Text>
+          </Box>
         )}
       </Box>
+
+      {/* Full ADE conversation URL (may wrap; kept last so it can't break the art rows) */}
+      {isCloudUser && adeConversationUrl && (
+        <Box>
+          <Text>{alienLines[3]}</Text>
+          <Text dimColor>{`ADE: ${adeConversationUrl}`}</Text>
+        </Box>
+      )}
     </Box>
   );
 });

--- a/src/cli/components/Autocomplete.tsx
+++ b/src/cli/components/Autocomplete.tsx
@@ -42,6 +42,8 @@ export function AutocompleteItem({
     <Text
       color={selected ? colors.command.selected : undefined}
       bold={selected}
+      // Keep each item one visual line tall so navigating doesn't reflow the footer.
+      wrap="truncate-end"
     >
       {"  "}
       {children}

--- a/src/cli/helpers/statusLinePayload.ts
+++ b/src/cli/helpers/statusLinePayload.ts
@@ -3,6 +3,9 @@ import { getVersion } from "../../version";
 export interface StatusLinePayloadBuildInput {
   modelId?: string | null;
   modelDisplayName?: string | null;
+  reasoningEffort?: string | null;
+  systemPromptId?: string | null;
+  toolset?: string | null;
   currentDirectory: string;
   projectDirectory: string;
   sessionId?: string;
@@ -32,6 +35,10 @@ export interface StatusLinePayload {
   session_id?: string;
   transcript_path: string | null;
   version: string;
+  // Back-compat fields used by custom statusline scripts.
+  reasoning_effort: string | null;
+  system_prompt_id: string | null;
+  toolset: string | null;
   model: {
     id: string | null;
     display_name: string | null;
@@ -122,6 +129,9 @@ export function buildStatusLinePayload(
     ...(input.sessionId ? { session_id: input.sessionId } : {}),
     transcript_path: null,
     version: getVersion(),
+    reasoning_effort: input.reasoningEffort ?? null,
+    system_prompt_id: input.systemPromptId ?? null,
+    toolset: input.toolset ?? null,
     model: {
       id: input.modelId ?? null,
       display_name: input.modelDisplayName ?? null,

--- a/src/cli/hooks/useConfigurableStatusLine.ts
+++ b/src/cli/hooks/useConfigurableStatusLine.ts
@@ -21,6 +21,9 @@ import { executeStatusLineCommand } from "../helpers/statusLineRuntime";
 export interface StatusLineInputs {
   modelId?: string | null;
   modelDisplayName?: string | null;
+  reasoningEffort?: string | null;
+  systemPromptId?: string | null;
+  toolset?: string | null;
   currentDirectory: string;
   projectDirectory: string;
   sessionId?: string;
@@ -54,6 +57,9 @@ function toPayloadInput(inputs: StatusLineInputs): StatusLinePayloadBuildInput {
   return {
     modelId: inputs.modelId,
     modelDisplayName: inputs.modelDisplayName,
+    reasoningEffort: inputs.reasoningEffort,
+    systemPromptId: inputs.systemPromptId,
+    toolset: inputs.toolset,
     currentDirectory: inputs.currentDirectory,
     projectDirectory: inputs.projectDirectory,
     sessionId: inputs.sessionId,


### PR DESCRIPTION
### Problem
- Long footer content (notably the ADE link/URL) can wrap and visually break the footer ASCII art.
- While navigating the `/` command menu with the up/down arrow keys, the transcript can scroll by blank lines due to footer reflow.
- While the app is streaming (animated status line/spinner), resizing the terminal can cause previous animation frames to be written into the scrollback.

### Fix
- Force autocomplete items to stay one visual line tall (`wrap="truncate-end"`).
- Truncate slash command rows based on terminal width to prevent wrap-driven footer height changes.
- Stabilize the footer info bar by avoiding `ink-link` OSC8 hyperlinks in the footer and truncating long fields based on terminal width.
- Freeze the streaming status animation briefly while the user is actively resizing the terminal.
- Reduce ANSI churn in the streaming status line by rendering shimmer/hints with Ink <Text> spans (instead of per-character chalk strings), improving wrap stability during resize.

### Testing
- `bun run check`
- `bun test src/tests/approval-recovery.test.ts src/tests/cli/backfill-follow-dedupe.test.ts`
