### PR TITLE
fix: handle default conversation sentinel in headless startup

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -735,8 +735,10 @@ export async function handleHeadlessCommand(
     }
   }
 
-  // Priority 0: --conversation derives agent from conversation ID
-  if (specifiedConversationId) {
+  // Priority 0: --conversation derives agent from conversation ID.
+  // "default" is a virtual agent-scoped conversation (not a retrievable conv-*).
+  // It requires --agent and should not hit conversations.retrieve().
+  if (specifiedConversationId && specifiedConversationId !== "default") {
     try {
       const conversation = await client.conversations.retrieve(
         specifiedConversationId,

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -230,6 +230,57 @@ describe("Startup Flow - Integration", () => {
   );
 
   test(
+    "--agent + --conversation default succeeds and stays on default route",
+    async () => {
+      let agentIdForTest = testAgentId;
+      if (!agentIdForTest) {
+        const bootstrapResult = await runCli(
+          [
+            "--new-agent",
+            "-m",
+            "haiku",
+            "-p",
+            "Say OK",
+            "--output-format",
+            "json",
+          ],
+          { timeoutMs: 120000 },
+        );
+        expect(bootstrapResult.exitCode).toBe(0);
+        const bootstrapJsonStart = bootstrapResult.stdout.indexOf("{");
+        const bootstrapOutput = JSON.parse(
+          bootstrapResult.stdout.slice(bootstrapJsonStart),
+        );
+        agentIdForTest = bootstrapOutput.agent_id as string;
+        testAgentId = agentIdForTest;
+      }
+
+      const result = await runCli(
+        [
+          "--agent",
+          agentIdForTest,
+          "--conversation",
+          "default",
+          "-m",
+          "haiku",
+          "-p",
+          "Say OK",
+          "--output-format",
+          "json",
+        ],
+        { timeoutMs: 120000 },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const jsonStart = result.stdout.indexOf("{");
+      const output = JSON.parse(result.stdout.slice(jsonStart));
+      expect(output.agent_id).toBe(agentIdForTest);
+      expect(output.conversation_id).toBe("default");
+    },
+    { timeout: 130000 },
+  );
+
+  test(
     "--new-agent with --init-blocks none creates minimal agent",
     async () => {
       const result = await runCli(


### PR DESCRIPTION
## Summary
- avoid resolving `conversation=default` via `conversations.retrieve` during startup
- preserve default-route semantics so SDK sessions boot against the default conversation correctly
- add integration regression coverage for `--agent + --conversation default`

## Validation
- bun run check
- LETTA_API_KEY=*** bun test src/integration-tests/startup-flow.integration.test.ts -t "default route"