### PR TITLE
fix(headless): scope default list_messages to default conversation

### DIFF
--- a/src/agent/listMessagesHandler.ts
+++ b/src/agent/listMessagesHandler.ts
@@ -49,6 +49,7 @@ export interface ListMessagesHandlerClient {
           order: "asc" | "desc";
           before?: string;
           after?: string;
+          conversation_id?: "default";
         },
       ): Promise<AgentsMessagesPage>;
     };
@@ -114,6 +115,7 @@ export async function handleListMessages(
       const page = await client.agents.messages.list(route.agentId, {
         limit,
         order,
+        conversation_id: "default",
         ...cursorOpts,
       });
       items = page.items;

--- a/src/tests/headless/list-messages-handler.test.ts
+++ b/src/tests/headless/list-messages-handler.test.ts
@@ -197,9 +197,11 @@ describe("handleListMessages — API call arguments", () => {
     const opts = agentListSpy.mock.calls[0]?.[1] as {
       limit: number;
       order: string;
+      conversation_id?: string;
     };
     expect(opts.limit).toBe(50);
     expect(opts.order).toBe("desc");
+    expect(opts.conversation_id).toBe("default");
   });
 
   test("forwards before cursor to conversations path", async () => {
@@ -232,8 +234,12 @@ describe("handleListMessages — API call arguments", () => {
       client,
     });
 
-    const opts = agentListSpy.mock.calls[0]?.[1] as { before?: string };
+    const opts = agentListSpy.mock.calls[0]?.[1] as {
+      before?: string;
+      conversation_id?: string;
+    };
     expect(opts.before).toBe("msg-cursor-agents");
+    expect(opts.conversation_id).toBe("default");
   });
 
   test("does not include before/after when absent", async () => {


### PR DESCRIPTION
## Summary
- fix headless `list_messages` default-route behavior to pass `conversation_id: "default"` when calling `agents.messages.list`
- prevents default backfill from pulling messages outside the agent's default conversation
- add handler tests to assert the default conversation filter is present on agents-route calls

## Why
Desktop SDK transcript backfill for `default` could diverge from send routing because list-backfill used agents-route without the default filter.

## Validation
- `bun test src/tests/headless/list-messages-handler.test.ts src/tests/headless/list-messages-protocol.test.ts`
- `bun run check`
