### PR TITLE
fix: never auto-approve interactive tools in listen mode

### DIFF
--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -25,6 +25,7 @@ import { generatePlanFilePath } from "../cli/helpers/planName";
 import { drainStreamWithResume } from "../cli/helpers/stream";
 import { permissionMode } from "../permissions/mode";
 import { settingsManager } from "../settings-manager";
+import { isInteractiveApprovalTool } from "../tools/interactivePolicy";
 import { loadTools } from "../tools/manager";
 
 interface StartListenerOptions {
@@ -652,8 +653,10 @@ async function handleIncomingMessage(
 
       // Classify approvals (auto-allow, auto-deny, needs user input)
       // Don't treat "ask" as deny - cloud UI can handle approvals
+      // Interactive tools (AskUserQuestion, EnterPlanMode, ExitPlanMode) always need user input
       const { autoAllowed, autoDenied, needsUserInput } =
         await classifyApprovals(approvals, {
+          alwaysRequiresUserInput: isInteractiveApprovalTool,
           treatAskAsDeny: false, // Let cloud UI handle approvals
           requireArgsForAutoApprove: true,
         });


### PR DESCRIPTION
Interactive tools (AskUserQuestion, EnterPlanMode, ExitPlanMode) should always pause execution and wait for user input, even in bypassPermissions mode.

**Changes:**
- Imported isInteractiveApprovalTool from tools/interactivePolicy
- Added alwaysRequiresUserInput: isInteractiveApprovalTool to classifyApprovals call
- Added comment explaining interactive tools behavior

**How it works:**
- classifyApprovals checks each approval with isInteractiveApprovalTool(toolName)
- If true, forces classification to "needsUserInput" (overrides permission mode)
- letta-code breaks approval loop and sends result{stopReason: "requires_approval"}
- Cloud UI shows approval dialog
- User responds → cloud sends approval back → letta-code continues

**Interactive tools:**
- AskUserQuestion: Needs user to answer questions
- EnterPlanMode: Needs user to approve planning
- ExitPlanMode: Needs user to approve plan before implementation

**Why:**
- These tools are inherently interactive by design
- Auto-approving them in bypass mode would skip critical user interaction
- Matches headless.ts behavior (also uses isInteractiveApprovalTool)

🐾 Generated with [Letta Code](https://letta.com)