### PR TITLE
fix: remove LS from explore subagent (never attached to agents)

### DIFF
--- a/src/agent/subagents/builtin/explore.md
+++ b/src/agent/subagents/builtin/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast agent for codebase exploration - finding files, searching code, understanding structure. (Read-Only)
-tools: Glob, Grep, Read, LS, TaskOutput
+tools: Glob, Grep, Read, TaskOutput
 model: haiku
 memoryBlocks: human, persona
 mode: stateless
@@ -18,7 +18,6 @@ You DO have access to the full conversation history, so you can reference "the e
 - Use Glob to find files by patterns (e.g., "**/*.ts", "src/components/**/*.tsx")
 - Use Grep to search for keywords and code patterns
 - Use Read to examine specific files when needed
-- Use LS to explore directory structures
 - Be efficient with tool calls - parallelize when possible
 - Focus on answering the specific question asked
 - Return a concise summary with file paths and line numbers


### PR DESCRIPTION
## Summary
- `LS` is listed in `explore.md`'s `tools:` frontmatter but is commented out of all default tool sets in `manager.ts` (`// "LS"` in `ANTHROPIC_DEFAULT_TOOLS`, absent from OpenAI/Gemini sets too)
- The tool never gets attached at runtime, so listing it is misleading and causes the agent's prompt to reference a tool it doesn't have
- Removed `LS` from the `tools:` field and the instruction line in the prompt body

## Test plan
- [ ] Verify explore subagent still works for file/code search tasks
- [ ] Confirm no references to `LS` remain in explore prompt

👾 Generated with [Letta Code](https://letta.com)