### PR TITLE
fix(hooks): don't log full error stack when project settings not loaded

### DIFF
--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -308,12 +308,11 @@ export function areHooksDisabled(
       if (projectDisabled === true) {
         return true;
       }
-    } catch (error) {
+    } catch {
       // Project settings not loaded, skip
       debugLog(
         "hooks",
         "areHooksDisabled: Project settings not loaded, skipping",
-        error,
       );
     }
 
@@ -325,21 +324,19 @@ export function areHooksDisabled(
       if (localDisabled === true) {
         return true;
       }
-    } catch (error) {
+    } catch {
       // Local project settings not loaded, skip
       debugLog(
         "hooks",
         "areHooksDisabled: Local project settings not loaded, skipping",
-        error,
       );
     }
 
     return false;
-  } catch (error) {
+  } catch {
     debugLog(
       "hooks",
       "areHooksDisabled: Failed to check hooks disabled status",
-      error,
     );
     return false;
   }


### PR DESCRIPTION
## Summary
- Removes the error object from `debugLog()` calls in `areHooksDisabled()` 
- The message "Project settings not loaded, skipping" is already descriptive enough
- The error was being handled gracefully, but the full stack trace was noisy

Fixes #1113

## Problem

When running in headless/subprocess mode, project settings aren't loaded. The `areHooksDisabled()` function catches this and continues correctly, but was logging the full error stack trace which looked scary to users.

## Solution

Just don't pass the error object to `debugLog()`. The message is sufficient.

## Test Plan
- Verified the code path is correct - the catch blocks continue execution after logging
- The hooks system correctly skips project settings checks when not loaded
- No functional change, just cleaner logs

👾 Generated with [Letta Code](https://letta.com)