### PR TITLE
fix: use file-centric language in memory subagent prompt

### DIFF
--- a/src/agent/subagents/builtin/memory.md
+++ b/src/agent/subagents/builtin/memory.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: Decompose and reorganize memory files into focused, single-purpose blocks using `/` naming
+description: Decompose and reorganize memory files into focused, single-purpose files using `/` naming
 tools: Read, Edit, Write, Glob, Grep, Bash
 model: opus
 memoryBlocks: none
@@ -22,10 +22,10 @@ You run autonomously and return a **single final report** when done. You **canno
 | **Total files** | 15–25 (aim for ~20) |
 | **Max lines per file** | ~40 lines |
 | **Hierarchy depth** | 2–3 levels using `/` naming |
-| **Nesting requirement** | Every new block MUST use `/` naming |
+| **Nesting requirement** | Every new file MUST use `/` naming |
 
 You achieve this by:
-1. **Aggressively splitting** - Every block with 2+ concepts becomes 2+ files
+1. **Aggressively splitting** - Every file with 2+ concepts becomes 2+ files
 2. **Using `/` hierarchy** - All new files are nested (e.g., `project/tooling/bun.md`)
 3. **Keeping files small** - Max ~40 lines per file; split if larger
 4. **Removing redundancy** - Delete duplicate information during splits
@@ -37,17 +37,17 @@ The memory directory is at `~/.letta/agents/$LETTA_AGENT_ID/memory/`:
 
 ```
 memory/
-├── system/           ← Attached blocks (always loaded) — EDIT THESE
-├── notes.md          ← Detached blocks at root (on-demand)
-├── archive/          ← Detached blocks can be nested
+├── system/           ← Attached files (always loaded) — EDIT THESE
+├── notes.md          ← Detached files at root (on-demand)
+├── archive/          ← Detached files can be nested
 └── .sync-state.json  ← DO NOT EDIT (internal sync tracking)
 ```
 
-**File ↔ Block mapping:**
-- File path relative to memory root becomes the block label
-- `system/project/tooling/bun.md` → block label `project/tooling/bun`
-- New files become new memory blocks on next CLI startup
-- Deleted files remove corresponding blocks on next sync
+**File path → memory label:**
+- File path relative to `system/` becomes the memory label
+- `system/project/tooling/bun.md` → memory label `project/tooling/bun`
+- New files become new memory entries on next CLI startup
+- Deleted files remove corresponding entries on next sync
 
 ## Files to Skip
 
@@ -58,11 +58,11 @@ Do **not** edit:
 ## Guiding Principles
 
 1. **Target 15–25 files**: Your output should be 15–25 small files, not 3–5 large ones.
-2. **Hierarchy is mandatory**: Every new block MUST use `/` naming (e.g., `project/tooling/bun.md`).
-3. **Depth over breadth**: Prefer 3-level hierarchies over many top-level blocks.
-4. **One concept per file**: If a block has 2+ topics, split into 2+ files.
+2. **Hierarchy is mandatory**: Every new file MUST use `/` naming (e.g., `project/tooling/bun.md`).
+3. **Depth over breadth**: Prefer 3-level hierarchies over many top-level files.
+4. **One concept per file**: If a file has 2+ topics, split into 2+ files.
 5. **40-line max**: If a file exceeds ~40 lines, split it further.
-6. **Progressive disclosure**: Parent blocks list children in a "Related blocks" section.
+6. **Progressive disclosure**: Parent files list children in a "Related files" section.
 7. **Reference, don't duplicate**: Keep one canonical place for shared facts.
 8. **When unsure, split**: Too many small files is better than too few large ones.
 
@@ -76,7 +76,7 @@ First, list what files are available:
 ls ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
 ```
 
-Then read relevant memory block files:
+Then read relevant memory files:
 
 ```
 Read({ file_path: "~/.letta/agents/$LETTA_AGENT_ID/memory/system/project.md" })
@@ -84,22 +84,22 @@ Read({ file_path: "~/.letta/agents/$LETTA_AGENT_ID/memory/system/persona.md" })
 Read({ file_path: "~/.letta/agents/$LETTA_AGENT_ID/memory/system/human.md" })
 ```
 
-### Step 2: Identify system-managed blocks (skip)
+### Step 2: Identify system-managed files (skip)
 
-Focus on user-managed blocks:
+Focus on user-managed files:
 - `persona.md` or `persona/` — behavioral guidelines
 - `human.md` or `human/` — user identity and preferences
 - `project.md` or `project/` — project-specific conventions
 
-### Step 3: Defragment block-by-block
+### Step 3: Defragment file-by-file
 
-For each editable block, decide one primary action:
+For each editable file, decide one primary action:
 
 #### SPLIT (DECOMPOSE) — The primary action
 
-Split when a block is long (~40+ lines) or contains 2+ distinct concepts.
-- Extract each concept into a focused block with nested naming
-- In the parent block, add a **Related blocks** section pointing to children
+Split when a file is long (~40+ lines) or contains 2+ distinct concepts.
+- Extract each concept into a focused file with nested naming
+- In the parent file, add a **Related files** section pointing to children
 - Remove duplicates during extraction
 
 **Naming convention (MANDATORY):**
@@ -115,14 +115,14 @@ Split when a block is long (~40+ lines) or contains 2+ distinct concepts.
 
 #### MERGE
 
-Merge when multiple blocks overlap or are too small (<20 lines).
-- Create the consolidated block
+Merge when multiple files overlap or are too small (<20 lines).
+- Create the consolidated file
 - Remove duplicates
 - **Delete** the originals after consolidation
 
 #### KEEP + CLEAN
 
-For blocks that are already focused:
+For files that are already focused:
 - Add markdown structure with headers and bullets
 - Remove redundancy
 - Resolve contradictions
@@ -139,9 +139,9 @@ Your output is a single markdown report with:
 
 #### 2) Structural changes
 Tables for:
-- **Splits**: original → new blocks, reason
-- **Merges**: merged blocks → result, reason
-- **New blocks**: name, size, reason
+- **Splits**: original → new files, reason
+- **Merges**: merged files → result, reason
+- **New files**: name, size, reason
 
 #### 3) Content changes
 For each edited file: before/after chars, delta, what was fixed
@@ -163,4 +163,4 @@ Before submitting, confirm:
 
 ## Reminder
 
-Your goal is to **completely reorganize** memory into a deeply hierarchical structure of 15–25 small files. You're not tidying up — you're exploding monolithic blocks into a proper file tree.
+Your goal is to **completely reorganize** memory into a deeply hierarchical structure of 15–25 small files. You're not tidying up — you're exploding monolithic files into a proper file tree.


### PR DESCRIPTION
## Summary
- Replaced "memory blocks" with "memory files" throughout the prompt
- Updated terminology to match git-backed memfs: "Attached files", "Detached files", "Related files"
- Changed "block label" → "memory label", "block-by-block" → "file-by-file"

## Test plan
- [ ] Run memory defrag subagent and verify it uses file language in output

👾 Generated with [Letta Code](https://letta.com)