### PR TITLE
feat: add openai/gpt-5.3-codex model tiers

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -511,6 +511,71 @@
     }
   },
   {
+    "id": "gpt-5.3-codex-none",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (no reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "none",
+      "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-low",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (low reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "low",
+      "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-medium",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (med reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "medium",
+      "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-high",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (high reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "high",
+      "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-xhigh",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (max reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "xhigh",
+      "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
     "id": "gpt-5.1-none",
     "handle": "openai/gpt-5.1",
     "label": "GPT-5.1",


### PR DESCRIPTION
Add none/low/medium/high/xhigh reasoning tiers for openai/gpt-5.3-codex to models.json, mirroring the existing gpt-5.2-codex pattern.

🐾 Generated with [Letta Code](https://letta.com)