### PR TITLE
fix: pass --conv alias to headless mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -988,7 +988,7 @@ async function main(): Promise<void> {
 
     const { handleHeadlessCommand } = await import("./headless");
     await handleHeadlessCommand(
-      process.argv,
+      processedArgs,
       specifiedModel,
       skillsDirectory,
       resolvedSkillSources,


### PR DESCRIPTION
## Summary
- Headless mode received raw `process.argv`, so the `--conv` → `--conversation` alias preprocessing was skipped
- Pass `processedArgs` instead so `--conv` works in both interactive and headless mode