### PR TITLE
feat: add telemetry tracking for retry-inducing errors

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -223,11 +223,11 @@ export async function drainStream(
       }
     }
 
-    // Only set fallbackError if we don't have a run_id - if we have a run_id,
-    // App.tsx will fetch detailed error info from the server which is better
-    if (!streamProcessor.lastRunId) {
-      fallbackError = errorMessage;
-    }
+    // Always capture the client-side error message. Even when we have a run_id
+    // (and App.tsx can fetch server-side detail), the client-side exception is
+    // valuable for telemetry — e.g. stream disconnections where the server run
+    // is still in-progress and has no error metadata yet.
+    fallbackError = errorMessage;
 
     // Preserve a stop reason already parsed from stream chunks (e.g. llm_api_error)
     // and only fall back to generic "error" when none is available.


### PR DESCRIPTION
## Summary
- Add PostHog telemetry for errors that trigger retries, capturing root causes (e.g., mid-stream disconnections) that previously went unlogged
- Track pre-stream transient errors (429/5xx/network) as `retry_pre_stream_transient` with HTTP status
- Track post-stream retriable errors as `retry_post_stream_error` with run error detail or client-side exception
- Always capture client-side exception in `fallbackError` from `drainStream` so telemetry has the raw error even when the server run is still in-progress and has no error metadata yet
- Guard the display `if (fallbackError)` block with `!lastRunId` to preserve existing behavior where richer server-side error details are shown when available

## Test plan
- [ ] Verify pre-existing `ws` type error is the only typecheck failure (`bun run check`)
- [ ] Trigger a retriable error (e.g., 429 rate limit) and confirm `retry_pre_stream_transient` event appears in PostHog with HTTP status
- [ ] Trigger a mid-stream disconnect and confirm `retry_post_stream_error` event appears with the client-side exception message
- [ ] Confirm that when retries exhaust and the error surfaces to the user, the existing richer server-side error display is unchanged (not replaced by raw `fallbackError`)

🐾 Generated with [Letta Code](https://letta.com)