### PR TITLE
fix(models): recommend GPT-5.3 Codex over GPT-5.2

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -226,7 +226,7 @@
     "id": "gpt-5.3-codex-plus-pro-high",
     "handle": "chatgpt-plus-pro/gpt-5.3-codex",
     "label": "GPT-5.3 Codex",
-    "description": "GPT-5.3 Codex (high reasoning) via ChatGPT Plus/Pro",
+    "description": "OpenAI's best coding model (high reasoning)",
     "isFeatured": true,
     "updateArgs": {
       "reasoning_effort": "high",
@@ -410,7 +410,6 @@
     "handle": "openai/gpt-5.2",
     "label": "GPT-5.2",
     "description": "Latest general-purpose GPT (med reasoning)",
-    "isFeatured": true,
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
@@ -440,6 +439,72 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-none",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (no reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "none",
+      "verbosity": "low",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-low",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (low reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "low",
+      "verbosity": "low",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-medium",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (med reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "medium",
+      "verbosity": "low",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-high",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "OpenAI's best coding model (high reasoning)",
+    "isFeatured": true,
+    "updateArgs": {
+      "reasoning_effort": "high",
+      "verbosity": "low",
+      "context_window": 272000,
+      "max_output_tokens": 128000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "gpt-5.3-codex-xhigh",
+    "handle": "openai/gpt-5.3-codex",
+    "label": "GPT-5.3-Codex",
+    "description": "GPT-5.3 variant (max reasoning) optimized for coding",
+    "updateArgs": {
+      "reasoning_effort": "xhigh",
+      "verbosity": "low",
       "context_window": 272000,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -48,6 +48,24 @@ describe("getReasoningTierOptionsForHandle", () => {
     ]);
   });
 
+  test("returns ordered reasoning options for gpt-5.3-codex", () => {
+    const options = getReasoningTierOptionsForHandle("openai/gpt-5.3-codex");
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "gpt-5.3-codex-none",
+      "gpt-5.3-codex-low",
+      "gpt-5.3-codex-medium",
+      "gpt-5.3-codex-high",
+      "gpt-5.3-codex-xhigh",
+    ]);
+  });
+
   test("returns byok reasoning options for chatgpt-plus-pro gpt-5.3-codex", () => {
     const options = getReasoningTierOptionsForHandle(
       "chatgpt-plus-pro/gpt-5.3-codex",


### PR DESCRIPTION
## Summary
- add Letta API `openai/gpt-5.3-codex` reasoning tiers (`none/low/medium/high/xhigh`)
- mark `gpt-5.3-codex-high` as featured
- remove featured flag from `gpt-5.2-medium`
- update GPT-5.3 Codex high-tier description to: "OpenAI's best coding model (high reasoning)"
- add tier-selection test coverage for `openai/gpt-5.3-codex`

## Validation
- `bun test src/tests/model-tier-selection.test.ts`
- pre-commit checks passed (Biome + TypeScript)
