### PR TITLE
feat: include recent chunks in error telemetry

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2910,6 +2910,7 @@ export default function App({
       if (!skipTelemetry) {
         telemetry.trackError("ui_error", text, "error_display", {
           modelId: currentModelId || undefined,
+          recentChunks: chunkLog.getEntries(),
         });
       }
     },
@@ -4737,6 +4738,7 @@ export default function App({
             {
               modelId: currentModelId || undefined,
               runId: lastRunId ?? undefined,
+              recentChunks: chunkLog.getEntries(),
             },
           );
 
@@ -4907,6 +4909,7 @@ export default function App({
           httpStatus,
           modelId: currentModelId || undefined,
           runId: currentRunId,
+          recentChunks: chunkLog.getEntries(),
         });
 
         // Use comprehensive error formatting

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -49,6 +49,7 @@ export interface ErrorData {
   http_status?: number;
   model_id?: string;
   run_id?: string;
+  recent_chunks?: Record<string, unknown>[];
 }
 
 export interface UserInputData {
@@ -356,6 +357,7 @@ class TelemetryManager {
       httpStatus?: number;
       modelId?: string;
       runId?: string;
+      recentChunks?: Record<string, unknown>[];
     },
   ) {
     const data: ErrorData = {
@@ -365,6 +367,7 @@ class TelemetryManager {
       http_status: options?.httpStatus,
       model_id: options?.modelId,
       run_id: options?.runId,
+      recent_chunks: options?.recentChunks,
     };
     this.track("error", data);
   }


### PR DESCRIPTION
## Summary
- Adds `recent_chunks` to the `ErrorData` interface and `trackError()` options in the telemetry module
- Passes `chunkLog.getEntries()` at all 3 `trackError` call sites in `App.tsx` (ui_error, stream stop reason, stream exception)
- Error telemetry events now carry the same rolling chunk log (last 100 truncated streaming chunks) that feedback submissions already include

## Context
Companion PR for letta-cloud schema changes: the server-side `ErrorDataSchema` and `LettaCodeErrorProperty` need to accept the new `recent_chunks` field.

## Test plan
- [ ] Trigger a stream error (e.g. invalid API key) and verify the telemetry payload includes `recent_chunks`
- [ ] Verify feedback submission still includes `recent_chunks` as before
- [ ] Confirm no type errors with `bun run build`