### PR TITLE
feat: add telemetry tracking for conversation-busy retries

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3440,6 +3440,20 @@ export default function App({
                 CONVERSATION_BUSY_RETRY_BASE_DELAY_MS *
                 2 ** (conversationBusyRetriesRef.current - 1);
 
+              // Log the conversation-busy error
+              telemetry.trackError(
+                "retry_conversation_busy",
+                errorDetail || "Conversation is busy",
+                "pre_stream_retry",
+                {
+                  httpStatus:
+                    preStreamError instanceof APIError
+                      ? preStreamError.status
+                      : undefined,
+                  modelId: currentModelId || undefined,
+                },
+              );
+
               // Show status message
               const statusId = uid("status");
               buffersRef.current.byId.set(statusId, {


### PR DESCRIPTION
## Summary
- Follow-up to #1131 (merged)
- Add `telemetry.trackError("retry_conversation_busy", ...)` to the 409 conversation-busy retry branch in the pre-stream catch block
- Logs the error detail and HTTP status on each conversation-busy retry attempt for PostHog visibility

This completes telemetry coverage across all three retry paths:
- `retry_pre_stream_transient` (429/5xx/network) - added in #1131
- `retry_post_stream_error` (stream broke mid-flight) - added in #1131
- `retry_conversation_busy` (409 conversation busy) - **this PR**

## Test plan
- [ ] Trigger a conversation-busy 409 (e.g., send a message while another is processing) and confirm `retry_conversation_busy` event appears in PostHog with HTTP status 409

🐾 Generated with [Letta Code](https://letta.com)