### PR TITLE
fix(telemetry): add trackError to approval and interrupt error paths

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3069,7 +3069,7 @@ export default function App({
 
       // Track error in telemetry (unless explicitly skipped)
       const skip =
-        typeof options === "boolean" ? options : options?.skip ?? false;
+        typeof options === "boolean" ? options : (options?.skip ?? false);
       if (!skip) {
         const opts = typeof options === "object" ? options : undefined;
         telemetry.trackError(

--- a/src/cli/components/ListenerStatusUI.tsx
+++ b/src/cli/components/ListenerStatusUI.tsx
@@ -13,7 +13,7 @@ interface ListenerStatusUIProps {
 }
 
 export function ListenerStatusUI(props: ListenerStatusUIProps) {
-  const { connectionId, envName, onReady } = props;
+  const { envName, onReady } = props;
   const [status, setStatus] = useState<"idle" | "receiving" | "processing">(
     "idle",
   );


### PR DESCRIPTION
## Summary

- Extend `appendError` to accept an options object (`errorType`, `context`, `httpStatus`, `runId`) that enriches its internal `trackError` call, eliminating the need for separate `trackError` + `appendError(..., true)` pairs
- Add rich telemetry to 5 error paths that previously only got generic `"ui_error"` / `"error_display"` tracking:
  - `handleApproveCurrent` catch → `"approval_send"`
  - `handleDenyCurrent` catch → `"approval_send"`
  - plan-mode approval catch → `"approval_send"`
  - tool execution error in `sendAllResults` → `"tool_execution"`
  - stream interrupt failure → `"stream_interrupt"`
- Consolidate the outer `processConversation` catch which previously used the separate `trackError` + `appendError(..., true)` pattern

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] Trigger an approval-send error (e.g., network failure during tool approval) and verify telemetry event fires with context `"approval_send"` and proper error type
- [ ] Trigger a stream interrupt failure and verify telemetry event fires with context `"stream_interrupt"`
- [ ] Verify no duplicate telemetry events — `appendError` with options tracks once; `appendError(msg, true)` still skips