### PR TITLE
fix: update agentState.model on model switch for immediate status bar refresh

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10530,11 +10530,13 @@ ${SYSTEM_REMINDER_CLOSE}
               ? { reasoning_effort: rawEffort as ModelReasoningEffort }
               : {}),
           });
-          // Refresh agentState so model_settings (canonical reasoning effort source) is current
+          // Refresh agentState so model_settings (canonical reasoning effort source) is current.
+          // Include `model` so currentModelLabel (and the status bar) updates immediately.
           setAgentState((prev) =>
             prev
               ? {
                   ...prev,
+                  model: updatedAgent.model,
                   llm_config: updatedAgent.llm_config,
                   model_settings: updatedAgent.model_settings,
                 }
@@ -11216,11 +11218,13 @@ ${SYSTEM_REMINDER_CLOSE}
             ...updatedAgent.llm_config,
             reasoning_effort: desired.effort as ModelReasoningEffort,
           });
-          // Refresh agentState so model_settings (canonical reasoning effort source) is current
+          // Refresh agentState so model_settings (canonical reasoning effort source) is current.
+          // Include `model` so currentModelLabel (and the status bar) updates immediately.
           setAgentState((prev) =>
             prev
               ? {
                   ...prev,
+                  model: updatedAgent.model,
                   llm_config: updatedAgent.llm_config,
                   model_settings: updatedAgent.model_settings,
                 }


### PR DESCRIPTION
## Summary
- Fix stale model name in status bar after switching models via `/model` or `/reasoning`
- Both the `/model` handler and `/reasoning` cycle were updating `agentState` with `llm_config` and `model_settings` but omitting the `model` field
- Since `currentModelLabel` reads `agentState.model` as the primary source for the display name, the status bar stayed stale until the next message round-trip refreshed the full agent state
- Add `model: updatedAgent.model` to both `setAgentState` calls so the display updates immediately

## Test plan
- [ ] Switch model via `/model` — status bar should update immediately without sending a message
- [ ] Switch reasoning via `/reasoning` — status bar should update immediately

🐾 Generated with [Letta Code](https://letta.com)