### PR TITLE
feat(protocol): add static transcript sync message types (LSS1)

### DIFF
--- a/src/tests/protocol/static-sync-types.test.ts
+++ b/src/tests/protocol/static-sync-types.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the static transcript sync protocol types (LSS1).
+ *
+ * Verifies structural correctness, discriminant exhaustiveness, and
+ * membership in WireMessage / WsProtocolEvent unions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  QueueSnapshotMessage,
+  SyncCompleteMessage,
+  TranscriptBackfillMessage,
+  TranscriptSupplementMessage,
+  WireMessage,
+} from "../../types/protocol";
+import type { WsProtocolEvent } from "../../websocket/listen-client";
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+const ENVELOPE = { session_id: "sess-1", uuid: "uuid-1" } as const;
+
+// ── TranscriptBackfillMessage ─────────────────────────────────────
+
+describe("TranscriptBackfillMessage", () => {
+  test("minimal empty backfill is structurally valid", () => {
+    const msg: TranscriptBackfillMessage = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: true,
+    };
+    expect(msg.type).toBe("transcript_backfill");
+    expect(msg.messages).toHaveLength(0);
+    expect(msg.is_final).toBe(true);
+  });
+
+  test("is_final: false marks a non-terminal chunk", () => {
+    const msg: TranscriptBackfillMessage = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: false,
+    };
+    expect(msg.is_final).toBe(false);
+  });
+
+  test("type discriminant is 'transcript_backfill'", () => {
+    const msg: TranscriptBackfillMessage = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: true,
+    };
+    // Narrowing works via the discriminant
+    if (msg.type === "transcript_backfill") {
+      expect(msg.is_final).toBeDefined();
+    }
+  });
+});
+
+// ── QueueSnapshotMessage ──────────────────────────────────────────
+
+describe("QueueSnapshotMessage", () => {
+  test("empty snapshot is valid", () => {
+    const msg: QueueSnapshotMessage = {
+      ...ENVELOPE,
+      type: "queue_snapshot",
+      items: [],
+    };
+    expect(msg.type).toBe("queue_snapshot");
+    expect(msg.items).toHaveLength(0);
+  });
+
+  test("snapshot with items preserves order and fields", () => {
+    const msg: QueueSnapshotMessage = {
+      ...ENVELOPE,
+      type: "queue_snapshot",
+      items: [
+        { item_id: "item-1", kind: "message", source: "user" },
+        {
+          item_id: "item-2",
+          kind: "task_notification",
+          source: "task_notification",
+        },
+      ],
+    };
+    expect(msg.items).toHaveLength(2);
+    const [first, second] = msg.items;
+    expect(first?.item_id).toBe("item-1");
+    expect(first?.kind).toBe("message");
+    expect(first?.source).toBe("user");
+    expect(second?.kind).toBe("task_notification");
+  });
+});
+
+// ── SyncCompleteMessage ───────────────────────────────────────────
+
+describe("SyncCompleteMessage", () => {
+  test("had_pending_turn: false for idle connect", () => {
+    const msg: SyncCompleteMessage = {
+      ...ENVELOPE,
+      type: "sync_complete",
+      had_pending_turn: false,
+    };
+    expect(msg.type).toBe("sync_complete");
+    expect(msg.had_pending_turn).toBe(false);
+  });
+
+  test("had_pending_turn: true for mid-turn connect", () => {
+    const msg: SyncCompleteMessage = {
+      ...ENVELOPE,
+      type: "sync_complete",
+      had_pending_turn: true,
+    };
+    expect(msg.had_pending_turn).toBe(true);
+  });
+});
+
+// ── TranscriptSupplementMessage ───────────────────────────────────
+
+describe("TranscriptSupplementMessage", () => {
+  test("empty supplement is valid", () => {
+    const msg: TranscriptSupplementMessage = {
+      ...ENVELOPE,
+      type: "transcript_supplement",
+      messages: [],
+    };
+    expect(msg.type).toBe("transcript_supplement");
+    expect(msg.messages).toHaveLength(0);
+  });
+
+  test("distinct type discriminant from transcript_backfill", () => {
+    const backfill: TranscriptBackfillMessage = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: true,
+    };
+    const supplement: TranscriptSupplementMessage = {
+      ...ENVELOPE,
+      type: "transcript_supplement",
+      messages: [],
+    };
+    expect(backfill.type).not.toBe(supplement.type);
+  });
+});
+
+// ── Union membership ──────────────────────────────────────────────
+
+describe("WireMessage union membership", () => {
+  test("TranscriptBackfillMessage is assignable to WireMessage", () => {
+    const msg: WireMessage = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: true,
+    };
+    expect(msg.type).toBe("transcript_backfill");
+  });
+
+  test("QueueSnapshotMessage is assignable to WireMessage", () => {
+    const msg: WireMessage = {
+      ...ENVELOPE,
+      type: "queue_snapshot",
+      items: [],
+    };
+    expect(msg.type).toBe("queue_snapshot");
+  });
+
+  test("SyncCompleteMessage is assignable to WireMessage", () => {
+    const msg: WireMessage = {
+      ...ENVELOPE,
+      type: "sync_complete",
+      had_pending_turn: false,
+    };
+    expect(msg.type).toBe("sync_complete");
+  });
+
+  test("TranscriptSupplementMessage is assignable to WireMessage", () => {
+    const msg: WireMessage = {
+      ...ENVELOPE,
+      type: "transcript_supplement",
+      messages: [],
+    };
+    expect(msg.type).toBe("transcript_supplement");
+  });
+});
+
+describe("WsProtocolEvent union membership", () => {
+  test("TranscriptBackfillMessage is assignable to WsProtocolEvent", () => {
+    const msg: WsProtocolEvent = {
+      ...ENVELOPE,
+      type: "transcript_backfill",
+      messages: [],
+      is_final: true,
+    };
+    expect(msg.type).toBe("transcript_backfill");
+  });
+
+  test("QueueSnapshotMessage is assignable to WsProtocolEvent", () => {
+    const msg: WsProtocolEvent = {
+      ...ENVELOPE,
+      type: "queue_snapshot",
+      items: [],
+    };
+    expect(msg.type).toBe("queue_snapshot");
+  });
+
+  test("SyncCompleteMessage is assignable to WsProtocolEvent", () => {
+    const msg: WsProtocolEvent = {
+      ...ENVELOPE,
+      type: "sync_complete",
+      had_pending_turn: false,
+    };
+    expect(msg.type).toBe("sync_complete");
+  });
+
+  test("TranscriptSupplementMessage is assignable to WsProtocolEvent", () => {
+    const msg: WsProtocolEvent = {
+      ...ENVELOPE,
+      type: "transcript_supplement",
+      messages: [],
+    };
+    expect(msg.type).toBe("transcript_supplement");
+  });
+});
+
+// ── Discriminant exhaustiveness ───────────────────────────────────
+
+describe("type discriminants are unique across all four types", () => {
+  test("all four sync-phase discriminants are distinct", () => {
+    const types = [
+      "transcript_backfill",
+      "queue_snapshot",
+      "sync_complete",
+      "transcript_supplement",
+    ];
+    const unique = new Set(types);
+    expect(unique.size).toBe(types.length);
+  });
+
+  test("none conflict with existing WireMessage discriminants", () => {
+    // Existing discriminants: system, message, stream_event, auto_approval,
+    // error, retry, recovery, result, control_response, control_request,
+    // queue_item_enqueued, queue_batch_dequeued, queue_blocked, queue_cleared,
+    // queue_item_dropped
+    const existing = new Set([
+      "system",
+      "message",
+      "stream_event",
+      "auto_approval",
+      "error",
+      "retry",
+      "recovery",
+      "result",
+      "control_response",
+      "control_request",
+      "queue_item_enqueued",
+      "queue_batch_dequeued",
+      "queue_blocked",
+      "queue_cleared",
+      "queue_item_dropped",
+    ]);
+    for (const t of [
+      "transcript_backfill",
+      "queue_snapshot",
+      "sync_complete",
+      "transcript_supplement",
+    ]) {
+      expect(existing.has(t)).toBe(false);
+    }
+  });
+});

--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -44,9 +44,13 @@ import type {
   MessageWire,
   ResultMessage as ProtocolResultMessage,
   QueueLifecycleEvent,
+  QueueSnapshotMessage,
   RecoveryMessage,
   RetryMessage,
   StopReasonType,
+  SyncCompleteMessage,
+  TranscriptBackfillMessage,
+  TranscriptSupplementMessage,
 } from "../types/protocol";
 
 interface StartListenerOptions {
@@ -373,7 +377,11 @@ export type WsProtocolEvent =
   | RetryMessage
   | RecoveryMessage
   | ProtocolResultMessage
-  | QueueLifecycleEvent;
+  | QueueLifecycleEvent
+  | TranscriptBackfillMessage
+  | QueueSnapshotMessage
+  | SyncCompleteMessage
+  | TranscriptSupplementMessage;
 
 /**
  * Single adapter for all outbound typed protocol events.


### PR DESCRIPTION
## Summary

Adds four new protocol types for the `/listen` static transcript sync phase — the initial burst of committed state a remote consumer receives on connect before live events begin:

- **`TranscriptBackfillMessage`** (`type: "transcript_backfill"`) — committed `LettaMessage[]` history for the current conversation; `is_final` flag reserved for future multi-page pagination
- **`QueueSnapshotMessage`** (`type: "queue_snapshot"`) — point-in-time snapshot of turn-queue contents at connect time; omitted when queue is empty
- **`SyncCompleteMessage`** (`type: "sync_complete"`) — end-of-sync marker; `had_pending_turn` signals a turn was in-flight at connect time
- **`TranscriptSupplementMessage`** (`type: "transcript_supplement"`) — post-sync supplemental backfill emitted at most once when agent/conversation context resolves late (first-message path)

Also imports `Message as LettaMessage` from letta-client and re-exports it. All four types added to `WireMessage` and `WsProtocolEvent` unions. 19 tests covering structure, discriminants, and union assignability.

Part of the `/listen` static transcript sync sequence (LSS1 of N). Isolated to `src/types/protocol.ts` + `src/websocket/listen-client.ts` imports — no emit logic yet (LSS2+).

👾 Generated with [Letta Code](https://letta.com)