### PR TITLE
fix(plan): restore pre-plan permission mode reliably

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1050,6 +1050,21 @@ export default function App({
   const setUiPermissionMode = useCallback((mode: PermissionMode) => {
     uiPermissionModeRef.current = mode;
     _setUiPermissionMode(mode);
+
+    // Keep the permissionMode singleton in sync *immediately*.
+    //
+    // We also have a useEffect sync (below) as a safety net, but relying on it
+    // introduces a render/effect window where the UI can show YOLO while the
+    // singleton still reports an older mode. That window is enough to break
+    // plan-mode restoration (plan remembers the singleton's mode-at-entry).
+    if (permissionMode.getMode() !== mode) {
+      // If entering plan mode via UI state, ensure a plan file path is set.
+      if (mode === "plan" && !permissionMode.getPlanFilePath()) {
+        const planPath = generatePlanFilePath();
+        permissionMode.setPlanFilePath(planPath);
+      }
+      permissionMode.setMode(mode);
+    }
   }, []);
 
   const statusLineTriggerVersionRef = useRef(0);


### PR DESCRIPTION
### Problem
When entering plan mode from the TUI, we remember the current permission mode so that exiting plan mode can restore it (e.g. bypassPermissions/YOLO).

In practice, the UI permission state (uiPermissionMode) could update before the permissionMode singleton was synced (via a later useEffect). If EnterPlanMode ran in that render/effect window, plan mode would capture a stale "modeBeforePlan" and ExitPlanMode would restore the wrong mode (often acceptEdits).

### Fix
Synchronize the permissionMode singleton immediately inside setUiPermissionMode, and ensure a plan file path exists when switching into plan mode via UI state.

### Testing
- bun run check
- bun test src/tests/permissions-mode.test.ts src/tests/tools/exitplanmode.test.ts src/tests/plan-approval-mode.test.ts
