### PR TITLE
fix: normalize animated logo frame width

### DIFF
--- a/src/cli/components/AnimatedLogo.tsx
+++ b/src/cli/components/AnimatedLogo.tsx
@@ -2,6 +2,8 @@ import { useSyncExternalStore } from "react";
 import { colors } from "./colors";
 import { Text } from "./Text";
 
+const LOGO_WIDTH = 10;
+
 // Define animation frames - 3D rotation effect with gradient (█ → ▓ → ▒ → ░)
 // Each frame is ~10 chars wide, 5 lines tall - matches login dialog asciiLogo size
 const logoFrames = [
@@ -91,6 +93,17 @@ const logoFrames = [
   █████▓  `,
 ];
 
+function padFrameToFixedWidth(frame: string, width: number): string {
+  return frame
+    .split("\n")
+    .map((line) => line.padEnd(width, " "))
+    .join("\n");
+}
+
+const normalizedLogoFrames = logoFrames.map((frame) =>
+  padFrameToFixedWidth(frame, LOGO_WIDTH),
+);
+
 // Shared module-level ticker for animation sync across all AnimatedLogo instances
 // Single timer, guaranteed sync, no time-jump artifacts
 let tick = 0;
@@ -133,9 +146,9 @@ export function AnimatedLogo({
   animate = true,
 }: AnimatedLogoProps) {
   const tick = useSyncExternalStore(subscribe, getSnapshot);
-  const frame = animate ? tick % logoFrames.length : 0;
+  const frame = animate ? tick % normalizedLogoFrames.length : 0;
 
-  const logoLines = logoFrames[frame]?.split("\n") ?? [];
+  const logoLines = normalizedLogoFrames[frame]?.split("\n") ?? [];
 
   return (
     <>


### PR DESCRIPTION
## Summary
- normalize `AnimatedLogo` rendering by padding each frame row to a fixed width of 10 characters
- switch rendering to use normalized frames so startup/OAuth logo animation does not shift text selection/highlight region horizontally
- preserve existing animation timing and frame content while stabilizing layout

## Test plan
- [x] Run `bun run fix`
- [ ] Manually verify startup OAuth screen no longer shifts while logo spins

👾 Generated with [Letta Code](https://letta.com)