### PR TITLE
fix: pretty-print ChatGPT usage_limit_reached errors with reset time

### DIFF
--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -60,6 +60,7 @@ const NON_RETRYABLE_429_REASONS = [
 const NON_RETRYABLE_QUOTA_DETAIL_PATTERNS = [
   "hosted model usage limit",
   "out of credits",
+  "usage_limit_reached",
 ];
 const NON_RETRYABLE_4XX_PATTERN = /Error code:\s*4(0[0-8]|1\d|2\d|3\d|4\d|51)/i;
 const RETRYABLE_429_PATTERN = /Error code:\s*429|rate limit|too many requests/i;

--- a/src/tests/turn-recovery-policy.test.ts
+++ b/src/tests/turn-recovery-policy.test.ts
@@ -211,6 +211,16 @@ describe("provider detail retry helpers", () => {
     ).toBe(false);
   });
 
+  test("ChatGPT usage_limit_reached is non-retryable", () => {
+    const detail =
+      'RATE_LIMIT_EXCEEDED: ChatGPT rate limit exceeded: {"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"team","resets_at":1772074086,"resets_in_seconds":3032}}';
+
+    expect(shouldRetryRunMetadataError("llm_error", detail)).toBe(false);
+    expect(shouldRetryPreStreamTransientError({ status: 429, detail })).toBe(
+      false,
+    );
+  });
+
   test("pre-stream transient classifier handles status and detail", () => {
     expect(
       shouldRetryPreStreamTransientError({


### PR DESCRIPTION
## Summary
- Pretty-prints ChatGPT `usage_limit_reached` errors with plan type and human-readable reset time instead of raw `[usage_limit_reached] The usage limit has been reached`
- Marks `usage_limit_reached` as non-retryable in turn-recovery-policy so retry attempts aren't wasted on a hard account limit
- Adds informative retry status message (`"ChatGPT usage limit reached, waiting..."`) for the edge case where it's seen during retries

**Before:**
```
[usage_limit_reached] The usage limit has been reached
```

**After:**
```
ChatGPT usage limit reached (team plan). Resets at 4:01 PM (51m).
Switch models with /model, or connect your own provider keys with /connect.
```

## Test plan
- [x] 6 new tests in `errorFormatter.test.ts` (reset time, `resets_at` fallback, no reset info, malformed JSON, non-matching, run-metadata object shape)
- [x] 1 new test in `turn-recovery-policy.test.ts` (non-retryable for both `shouldRetryRunMetadataError` and `shouldRetryPreStreamTransientError`)
- [x] `bun run check` passes (lint + typecheck)
- [x] All 70 tests pass across both test files
- [ ] Manual test: trigger ChatGPT usage limit to verify pretty-printed output

🐾 Generated with [Letta Code](https://letta.com)