### PR TITLE
fix: skip auto-open viewers in SSH sessions

### DIFF
--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -445,10 +445,13 @@ export async function generateAndOpenMemoryViewer(
   writeFileSync(filePath, html);
   chmodSync(filePath, 0o600);
 
-  // 4. Open in browser (skip inside tmux — `open` launches a broken new
-  //    browser instance instead of reusing the running one)
-  const isTmux = Boolean(process.env.TMUX);
-  if (!isTmux) {
+  // 4. Open in browser (skip inside tmux or SSH — `open` either launches a
+  //    broken browser instance or fails entirely on remote machines)
+  const skipOpen =
+    Boolean(process.env.TMUX) ||
+    Boolean(process.env.SSH_CONNECTION) ||
+    Boolean(process.env.SSH_TTY);
+  if (!skipOpen) {
     try {
       const { default: openUrl } = await import("open");
       await openUrl(filePath, { wait: false });
@@ -457,5 +460,5 @@ export async function generateAndOpenMemoryViewer(
     }
   }
 
-  return { filePath, opened: !isTmux };
+  return { filePath, opened: !skipOpen };
 }

--- a/src/web/generate-plan-viewer.ts
+++ b/src/web/generate-plan-viewer.ts
@@ -50,9 +50,12 @@ export async function generateAndOpenPlanViewer(
   writeFileSync(filePath, html);
   chmodSync(filePath, 0o600);
 
-  // Open in browser (skip inside tmux)
-  const isTmux = Boolean(process.env.TMUX);
-  if (!isTmux) {
+  // Open in browser (skip inside tmux or SSH)
+  const skipOpen =
+    Boolean(process.env.TMUX) ||
+    Boolean(process.env.SSH_CONNECTION) ||
+    Boolean(process.env.SSH_TTY);
+  if (!skipOpen) {
     try {
       const { default: openUrl } = await import("open");
       await openUrl(filePath, { wait: false });
@@ -61,5 +64,5 @@ export async function generateAndOpenPlanViewer(
     }
   }
 
-  return { filePath, opened: !isTmux };
+  return { filePath, opened: !skipOpen };
 }


### PR DESCRIPTION
## Summary
- Detect SSH sessions via `SSH_CONNECTION` / `SSH_TTY` env vars and skip the automatic `open` call in both the memory palace and plan viewers
- Same approach as the tmux fix in #1069 — shows `Run: open <path>` so the user can handle it manually
- Fixes viewers failing silently on remote/SSH machines where no local browser is available

## Test plan
- [ ] SSH into a machine, run Letta Code, press `o` on the memory palace — should show the file path instead of attempting to open
- [ ] Same for the plan viewer
- [ ] Verify non-SSH, non-tmux sessions still auto-open as before

🐾 Generated with [Letta Code](https://letta.com)