### PR TITLE
fix(plan): merge scoped path relaxation with quote-aware shell parsing

### DIFF
--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -203,6 +203,7 @@ class PermissionModeManager {
           "Grep",
           "NotebookRead",
           "TodoWrite",
+          "TaskOutput",
           // Plan mode tools (must allow exit!)
           "ExitPlanMode",
           "exit_plan_mode",
@@ -326,7 +327,10 @@ class PermissionModeManager {
         ];
         if (shellTools.includes(toolName)) {
           const command = toolArgs?.command as string | string[] | undefined;
-          if (command && isReadOnlyShellCommand(command)) {
+          if (
+            command &&
+            isReadOnlyShellCommand(command, { allowExternalPaths: true })
+          ) {
             return "allow";
           }
         }

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -454,6 +454,24 @@ test("plan mode - allows read-only Bash commands", () => {
   );
   expect(chainedResult.decision).toBe("allow");
 
+  // absolute path reads should be allowed in plan mode
+  const absolutePathResult = checkPermission(
+    "Bash",
+    { command: "ls -la /Users/test/.letta/plans" },
+    permissions,
+    "/Users/test/project",
+  );
+  expect(absolutePathResult.decision).toBe("allow");
+
+  // traversal reads should be allowed in plan mode
+  const traversalResult = checkPermission(
+    "Bash",
+    { command: "cat ../../README.md" },
+    permissions,
+    "/Users/test/project",
+  );
+  expect(traversalResult.decision).toBe("allow");
+
   // cd && dangerous command should still be denied
   const cdDangerousResult = checkPermission(
     "Bash",
@@ -462,6 +480,35 @@ test("plan mode - allows read-only Bash commands", () => {
     "/Users/test/project",
   );
   expect(cdDangerousResult.decision).toBe("deny");
+
+  // quoted pipes in regex patterns should be allowed
+  const quotedPipeResult = checkPermission(
+    "Bash",
+    { command: 'rg -n "foo|bar|baz" src/permissions' },
+    permissions,
+    "/Users/test/project",
+  );
+  expect(quotedPipeResult.decision).toBe("allow");
+});
+
+test("plan mode - allows TaskOutput", () => {
+  permissionMode.setMode("plan");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+  };
+
+  const result = checkPermission(
+    "TaskOutput",
+    { task_id: "task_123", block: false },
+    permissions,
+    "/Users/test/project",
+  );
+
+  expect(result.decision).toBe("allow");
+  expect(result.matchedRule).toBe("plan mode");
 });
 
 test("plan mode - denies WebFetch", () => {


### PR DESCRIPTION
## Summary
- preserve strict default read-only shell path checks while allowing external-path reads only in plan mode via `allowExternalPaths`
- add quote-aware shell segment parsing so quoted pipe patterns like `rg -n "foo|bar|baz" ...` are treated as literals, not command separators
- keep dangerous command substitution blocked (`$()` and backticks), including inside double quotes where shell still evaluates substitution
- allow `TaskOutput` in plan mode so planning flows can inspect background/read-only task results
- add regression coverage for quoted operators, plan-mode shell behavior, and `TaskOutput` permission handling

## Validation
- `bun test src/tests/permissions/readOnlyShell.test.ts src/tests/permissions-mode.test.ts src/tests/permissions_security.test.ts` (93 pass)
- `bun run check` still reports pre-existing unrelated `src/cli/App.tsx` type errors (`compaction_settings.model`)
