### PR TITLE
fix: skip conversation model sync for default conversation

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3218,6 +3218,13 @@ export default function App({
     };
 
     const syncConversationModel = async () => {
+      // "default" is a virtual sentinel for the agent's primary message history,
+      // not a real conversation object — skip the API call.
+      if (conversationId === "default") {
+        applyAgentModelLocally();
+        return;
+      }
+
       try {
         const client = await getClient();
         const conversation =


### PR DESCRIPTION
## Summary
- `syncConversationModel` was calling `conversations.retrieve("default")` on every startup, producing two `[conversation-model] Failed to sync` 404 errors in the dev logs
- `"default"` is a virtual sentinel (set in `index.ts` when no explicit conversation is selected) meaning the agent's primary message history — there is no real conversation object to fetch
- Added an early return that calls `applyAgentModelLocally()` instead, consistent with how all other `conversationId === "default"` guards work throughout `App.tsx`

## Test plan
- [ ] Start `npm run dev` with no explicit `--conversation` flag — confirm the two `[conversation-model]` 404 errors are gone
- [ ] Start with an explicit conversation ID — confirm model override sync still works
- [ ] Verify the model shown in the footer matches the agent's configured model on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)