### PR TITLE
fix: redact credential helper value from memfs-git debug log

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -92,7 +92,15 @@ async function runGit(
     : [];
   const allArgs = [...authArgs, ...args];
 
-  debugLog("memfs-git", `git ${args.join(" ")} (in ${cwd})`);
+  // Redact credential helper values to avoid leaking tokens in debug logs.
+  const loggableArgs =
+    args[0] === "config" &&
+    typeof args[1] === "string" &&
+    args[1].includes("credential") &&
+    args[1].includes(".helper")
+      ? [args[0], args[1], "<redacted>"]
+      : args;
+  debugLog("memfs-git", `git ${loggableArgs.join(" ")} (in ${cwd})`);
 
   const result = await execFile("git", allArgs, {
     cwd,


### PR DESCRIPTION
## Summary
- `runGit()` was logging all git args verbatim via `debugLog`, including when called from `configureLocalCredentialHelper`
- This caused the plaintext API token to appear in `[memfs-git]` debug output: `git config credential.https://api.letta.com.helper !f() { echo "password=at-let-..."; }; f`
- Added a targeted redaction: when the config key matches `credential.<url>.helper`, the value arg is replaced with `<redacted>` in the log line only — the actual `execFile` call is unaffected

## Test plan
- [ ] Start with `DEBUG=memfs-git` — confirm the log shows `git config credential.https://api.letta.com.helper <redacted>` instead of the token
- [ ] Confirm memfs git operations (pull, push) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)