### PR TITLE
chore(subagents): switch memory workers to sonnet

### DIFF
--- a/src/agent/subagents/builtin/history-analyzer.md
+++ b/src/agent/subagents/builtin/history-analyzer.md
@@ -3,7 +3,7 @@ name: history-analyzer
 description: Analyze Claude Code or Codex conversation history and directly update agent memory files with insights
 tools: Read, Write, Bash, Glob, Grep
 skills: migrating-from-codex-and-claude-code
-model: glm-5
+model: sonnet
 memoryBlocks: none
 mode: stateless
 permissionMode: bypassPermissions

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -2,7 +2,7 @@
 name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
 tools: Read, Edit, Write, Glob, Grep, Bash, TaskOutput
-model: glm-5
+model: sonnet
 memoryBlocks: none
 skills: searching-messages
 mode: stateless


### PR DESCRIPTION
## Summary
- switch `reflection` subagent model from `glm-5` to `sonnet`
- switch `history-analyzer` subagent model from `glm-5` to `sonnet`

## Validation
- `bun test src/tests/agent/subagent-builtins.test.ts src/tests/agent/subagent-model-resolution.test.ts`
