### PR TITLE
fix: resume stream from seq 0 when no seq_id was received

### DIFF
--- a/src/cli/helpers/streamProcessor.ts
+++ b/src/cli/helpers/streamProcessor.ts
@@ -52,7 +52,7 @@ export class StreamProcessor {
     }
 
     // Track seq_id (drainStream line 122-124)
-    if ("seq_id" in chunk && chunk.seq_id) {
+    if ("seq_id" in chunk && chunk.seq_id != null) {
       this.lastSeqId = chunk.seq_id;
     }
 


### PR DESCRIPTION
## Summary

Two related issues caused `stream_resume_skipped [skip: no_seq_id]`:

- **Truthy check bug**: `streamProcessor` tracked `seq_id` with `if (chunk.seq_id)`, which drops `seq_id === 0`. `lastSeqId` stayed `null` even when a valid zero seq_id was received.
- **Guard too strict**: `drainStreamWithResume` required `lastSeqId !== null` before attempting resume. A stream that failed before any seq_id-bearing chunk arrived (e.g. very early disconnect) was never retried even though a valid `runId` existed.

**Fixes:**
- Change truthy check to `chunk.seq_id != null` to correctly handle zero
- Remove `lastSeqId !== null` from the resume guard — `lastRunId` is sufficient
- Pass `lastSeqId ?? 0` as `starting_after` so a null seq_id replays the run from the beginning (equivalent to "give me everything")

## Test plan
- [ ] Trigger a stream disconnect before any seq_id-bearing chunk arrives — confirm resume is attempted rather than skipped
- [ ] Confirm normal mid-stream disconnects (with a captured seq_id) still resume correctly from the right position
- [ ] Confirm `no_seq_id` no longer appears in `stream_resume_skipped` telemetry