### PR TITLE
fix: don't extern sharp

### DIFF
--- a/build.js
+++ b/build.js
@@ -46,7 +46,9 @@ await Bun.build({
     ".txt": "text",
 
   },
-  // Keep native Node.js modules external to avoid bundling issues
+  // Keep most native Node.js modules external to avoid bundling issues
+  // But don't make `sharp` external, causes issues with global Bun-based installs
+  // ref: #745, #1200
   external: ["ws", "@vscode/ripgrep"],
   features: features,
 });


### PR DESCRIPTION
d35a13f3d6567d16978d333e6e63a7f5301eb634 caused a regression that was originally fixed in #745 , causing AUR/Bun installs to fail. See: https://aur.archlinux.org/packages/letta-code#comment-1061320

@4shub 