### PR TITLE
refactor: DRY up recall subagent by pre-loading searching-messages skill

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -13,7 +13,7 @@ You are a subagent launched via the Task tool to search conversation history. Yo
 ## CRITICAL WARNINGS
 
 1. **NEVER use `conversation_search`** - It only searches YOUR empty history, not the parent's. Use the `letta` CLI commands below instead.
-2. **Always add `--agent-id $LETTA_PARENT_AGENT_ID`** to all `letta messages search` and `letta messages list` commands to search the parent agent's history, not your own.
+2. **Always add `--agent-id $LETTA_PARENT_AGENT_ID`** to all `letta` CLI commands to search the parent agent's history, not your own.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary
- The recall subagent's system prompt duplicated ~70% of the `searching-messages` skill (CLI usage tables, search strategies, list options)
- Added `skills: searching-messages` to the recall subagent's frontmatter so the skill is pre-loaded at launch (same pattern used by the `reflection` subagent)
- Kept only recall-specific content: autonomy framing, critical warnings (`conversation_search` ban, `$LETTA_PARENT_AGENT_ID` requirement), and output format

Net result: **-49 lines, +3 lines**, single source of truth for search documentation.

## Test plan
- [ ] Spawn a recall subagent via `Task` tool and verify it still searches conversation history correctly
- [ ] Confirm the `searching-messages` skill content is present in the subagent's context at launch