### PR TITLE
feat: show update notification in TUI and footer

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -234,6 +234,7 @@ const InputFooter = memo(function InputFooter({
   statusLineText,
   statusLineRight,
   statusLinePadding,
+  footerNotification,
 }: {
   ctrlCPressed: boolean;
   escapePressed: boolean;
@@ -252,6 +253,7 @@ const InputFooter = memo(function InputFooter({
   statusLineText?: string;
   statusLineRight?: string;
   statusLinePadding?: number;
+  footerNotification?: string | null;
 }) {
   const hideFooterContent = hideFooter;
   const maxAgentChars = Math.max(10, Math.floor(rightColumnWidth * 0.45));
@@ -327,6 +329,10 @@ const InputFooter = memo(function InputFooter({
               {" "}
               (shift+tab to {showExitHint ? "exit" : "cycle"})
             </Text>
+          </Text>
+        ) : footerNotification ? (
+          <Text color={colors.status.processingShimmer}>
+            {footerNotification}
           </Text>
         ) : (
           <Text dimColor>Press / for commands</Text>
@@ -621,6 +627,7 @@ export function Input({
   statusLinePadding = 0,
   statusLinePrompt,
   onCycleReasoningEffort,
+  footerNotification,
 }: {
   visible?: boolean;
   streaming: boolean;
@@ -662,6 +669,7 @@ export function Input({
   statusLinePadding?: number;
   statusLinePrompt?: string;
   onCycleReasoningEffort?: () => void;
+  footerNotification?: string | null;
 }) {
   const [value, setValue] = useState("");
   const [escapePressed, setEscapePressed] = useState(false);
@@ -1484,6 +1492,7 @@ export function Input({
                 statusLineText={statusLineText}
                 statusLineRight={statusLineRight}
                 statusLinePadding={statusLinePadding}
+                footerNotification={footerNotification}
               />
             )}
           </Box>
@@ -1530,6 +1539,7 @@ export function Input({
     statusLineText,
     statusLineRight,
     statusLinePadding,
+    footerNotification,
     promptChar,
     promptVisualWidth,
     suppressDividers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,7 @@ async function main(): Promise<void> {
 
   // Check for updates on startup (non-blocking)
   const { checkAndAutoUpdate } = await import("./updater/auto-update");
-  startStartupAutoUpdateCheck(checkAndAutoUpdate);
+  const autoUpdatePromise = startStartupAutoUpdateCheck(checkAndAutoUpdate);
 
   // Clean up old overflow files (non-blocking, 24h retention)
   const { cleanupOldOverflowFiles } = await import("./tools/impl/overflow");
@@ -1031,6 +1031,20 @@ async function main(): Promise<void> {
 
     // Release notes to display (checked once on mount)
     const [releaseNotes, setReleaseNotes] = useState<string | null>(null);
+
+    // Update notification: set when auto-update applied a significant new version
+    const [updateNotification, setUpdateNotification] = useState<string | null>(
+      null,
+    );
+    useEffect(() => {
+      autoUpdatePromise
+        .then((result) => {
+          if (result?.latestVersion) {
+            setUpdateNotification(result.latestVersion);
+          }
+        })
+        .catch(() => {});
+    }, []);
 
     // Auto-install Shift+Enter keybinding for VS Code/Cursor/Windsurf (silent, no prompt)
     useEffect(() => {
@@ -2067,6 +2081,7 @@ async function main(): Promise<void> {
       showCompactions: settings.showCompactions,
       agentProvenance,
       releaseNotes,
+      updateNotification,
       sessionContextReminderEnabled: !noSystemInfoReminderFlag,
     });
   }

--- a/src/startup-auto-update.ts
+++ b/src/startup-auto-update.ts
@@ -1,11 +1,22 @@
+export interface UpdateNotification {
+  latestVersion: string;
+}
+
 export function startStartupAutoUpdateCheck(
-  checkAndAutoUpdate: () => Promise<{ enotemptyFailed?: boolean } | undefined>,
+  checkAndAutoUpdate: () => Promise<
+    | {
+        enotemptyFailed?: boolean;
+        latestVersion?: string;
+        updateApplied?: boolean;
+      }
+    | undefined
+  >,
   logError: (
     message?: unknown,
     ...optionalParams: unknown[]
   ) => void = console.error,
-): void {
-  checkAndAutoUpdate()
+): Promise<UpdateNotification | undefined> {
+  return checkAndAutoUpdate()
     .then((result) => {
       // Surface ENOTEMPTY failures so users know how to fix
       if (result?.enotemptyFailed) {
@@ -14,8 +25,11 @@ export function startStartupAutoUpdateCheck(
           "Fix: rm -rf $(npm prefix -g)/lib/node_modules/@letta-ai/letta-code && npm i -g @letta-ai/letta-code\n",
         );
       }
+      // Return notification payload for the TUI to consume
+      if (result?.updateApplied && result.latestVersion) {
+        return { latestVersion: result.latestVersion };
+      }
+      return undefined;
     })
-    .catch(() => {
-      // Silently ignore other update failures (network timeouts, etc.)
-    });
+    .catch(() => undefined);
 }

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -331,6 +331,23 @@ async function performUpdate(): Promise<{
 export interface AutoUpdateResult {
   /** Whether an ENOTEMPTY error persisted after cleanup and retry */
   enotemptyFailed?: boolean;
+  /** Latest version available (set when a significant update was applied) */
+  latestVersion?: string;
+  /** True when the binary was updated and the user should restart */
+  updateApplied?: boolean;
+}
+
+/**
+ * Returns true when `latest` is at least one minor version ahead of `current`.
+ * Used to gate the in-app "restart to update" notification — patch-only bumps
+ * are applied silently without interrupting the user.
+ */
+function isSignificantUpdate(current: string, latest: string): boolean {
+  const [cMajor = 0, cMinor = 0] = current.split(".").map(Number);
+  const [lMajor = 0, lMinor = 0] = latest.split(".").map(Number);
+  if (lMajor > cMajor) return true;
+  if (lMajor === cMajor && lMinor > cMinor) return true;
+  return false;
 }
 
 export async function checkAndAutoUpdate(): Promise<
@@ -357,6 +374,13 @@ export async function checkAndAutoUpdate(): Promise<
     const updateResult = await performUpdate();
     if (updateResult.enotemptyFailed) {
       return { enotemptyFailed: true };
+    }
+    if (
+      updateResult.success &&
+      result.latestVersion &&
+      isSignificantUpdate(result.currentVersion, result.latestVersion)
+    ) {
+      return { updateApplied: true, latestVersion: result.latestVersion };
     }
   }
 }
@@ -401,8 +425,9 @@ export async function manualUpdate(): Promise<{
     };
   }
 
+  const installCmd = buildInstallCommand(detectPackageManager());
   return {
     success: false,
-    message: `Update failed: ${updateResult.error}`,
+    message: `Update failed: ${updateResult.error}\n\nTo update manually: ${installCmd}`,
   };
 }


### PR DESCRIPTION
## Summary

- When the startup auto-update applies a version that is at least one minor version ahead (e.g. 0.16.x → 0.17.x), two notifications appear:
  - **In-transcript**: a static status message `A new version of Letta Code is available (X.Y.Z). Restart to update!`
  - **Footer**: the `Press / for commands` placeholder is temporarily replaced with `New version available (X.Y.Z). Restart to update!` in `colors.status.processingShimmer` (light lavender) for 8 seconds, then reverts to normal
- Patch-only bumps are applied silently to avoid noise on frequent releases
- When `letta update` fails, the error message now includes the exact manual install command (e.g. `npm install -g @letta-ai/letta-code@latest`)

## Test plan

- [ ] Trigger notification by temporarily hardcoding `"0.99.0"` as the initial `updateNotification` state in `src/index.ts` and running `bun run dev`
- [ ] Verify the in-transcript status message appears on load
- [ ] Verify the footer shows the lavender notification text for ~8 seconds then reverts to `Press / for commands`
- [ ] Verify no footer notification appears when `updateNotification` is `null` (normal case)
- [ ] Verify `letta update` failure message includes the manual install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)