### PR TITLE
feat: use conversations endpoint for default conversation

### DIFF
--- a/src/agent/bootstrapHandler.ts
+++ b/src/agent/bootstrapHandler.ts
@@ -28,10 +28,6 @@ export interface BootstrapMessagesPage {
   getPaginatedItems(): unknown[];
 }
 
-export interface BootstrapAgentsPage {
-  items: unknown[];
-}
-
 export interface BootstrapHandlerClient {
   conversations: {
     messages: {
@@ -44,20 +40,6 @@ export interface BootstrapHandlerClient {
           after?: string;
         },
       ): Promise<BootstrapMessagesPage>;
-    };
-  };
-  agents: {
-    messages: {
-      list(
-        agentId: string,
-        opts: {
-          limit: number;
-          order: "asc" | "desc";
-          before?: string;
-          after?: string;
-          conversation_id?: "default";
-        },
-      ): Promise<BootstrapAgentsPage>;
     };
   };
 }
@@ -115,22 +97,11 @@ export async function handleBootstrapSessionState(
     );
 
     const listStart = Date.now();
-    let items: unknown[];
-
-    if (route.kind === "conversations") {
-      const page = await client.conversations.messages.list(
-        route.conversationId,
-        { limit, order },
-      );
-      items = page.getPaginatedItems();
-    } else {
-      const page = await client.agents.messages.list(route.agentId, {
-        limit,
-        order,
-        conversation_id: "default",
-      });
-      items = page.items;
-    }
+    const page = await client.conversations.messages.list(
+      route.conversationId,
+      { limit, order },
+    );
+    const items = page.getPaginatedItems();
     const listEnd = Date.now();
 
     const hasMore = items.length >= limit;

--- a/src/agent/listMessagesHandler.ts
+++ b/src/agent/listMessagesHandler.ts
@@ -22,10 +22,6 @@ export interface ConversationsMessagesPage {
   getPaginatedItems(): unknown[];
 }
 
-export interface AgentsMessagesPage {
-  items: unknown[];
-}
-
 export interface ListMessagesHandlerClient {
   conversations: {
     messages: {
@@ -38,20 +34,6 @@ export interface ListMessagesHandlerClient {
           after?: string;
         },
       ): Promise<ConversationsMessagesPage>;
-    };
-  };
-  agents: {
-    messages: {
-      list(
-        agentId: string,
-        opts: {
-          limit: number;
-          order: "asc" | "desc";
-          before?: string;
-          after?: string;
-          conversation_id?: "default";
-        },
-      ): Promise<AgentsMessagesPage>;
     };
   };
 }
@@ -97,29 +79,17 @@ export async function handleListMessages(
   };
 
   try {
-    let items: unknown[];
-
     const route = resolveListMessagesRoute(
       listReq,
       sessionConversationId,
       sessionAgentId,
     );
 
-    if (route.kind === "conversations") {
-      const page = await client.conversations.messages.list(
-        route.conversationId,
-        { limit, order, ...cursorOpts },
-      );
-      items = page.getPaginatedItems();
-    } else {
-      const page = await client.agents.messages.list(route.agentId, {
-        limit,
-        order,
-        conversation_id: "default",
-        ...cursorOpts,
-      });
-      items = page.items;
-    }
+    const page = await client.conversations.messages.list(
+      route.conversationId,
+      { limit, order, ...cursorOpts },
+    );
+    const items = page.getPaginatedItems();
 
     const hasMore = items.length >= limit;
     const oldestId =

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5690,10 +5690,11 @@ export default function App({
       // causing CONFLICT on the next user message.
       getClient()
         .then((client) => {
-          if (conversationIdRef.current === "default") {
-            return client.agents.messages.cancel(agentIdRef.current);
-          }
-          return client.conversations.cancel(conversationIdRef.current);
+          const cancelId =
+            conversationIdRef.current === "default"
+              ? agentIdRef.current
+              : conversationIdRef.current;
+          return client.conversations.cancel(cancelId);
         })
         .catch(() => {
           // Silently ignore - cancellation already happened client-side
@@ -5808,11 +5809,11 @@ export default function App({
       // Don't wait for it or show errors since user already got feedback
       getClient()
         .then((client) => {
-          // Use agents API for "default" conversation (primary message history)
-          if (conversationIdRef.current === "default") {
-            return client.agents.messages.cancel(agentIdRef.current);
-          }
-          return client.conversations.cancel(conversationIdRef.current);
+          const cancelId =
+            conversationIdRef.current === "default"
+              ? agentIdRef.current
+              : conversationIdRef.current;
+          return client.conversations.cancel(cancelId);
         })
         .catch(() => {
           // Silently ignore - cancellation already happened client-side
@@ -5832,12 +5833,11 @@ export default function App({
       setInterruptRequested(true);
       try {
         const client = await getClient();
-        // Use agents API for "default" conversation (primary message history)
-        if (conversationIdRef.current === "default") {
-          await client.agents.messages.cancel(agentIdRef.current);
-        } else {
-          await client.conversations.cancel(conversationIdRef.current);
-        }
+        const cancelId =
+          conversationIdRef.current === "default"
+            ? agentIdRef.current
+            : conversationIdRef.current;
+        await client.conversations.cancel(cancelId);
 
         if (abortControllerRef.current) {
           abortControllerRef.current.abort();
@@ -7886,15 +7886,14 @@ export default function App({
                 }
               : undefined;
 
-            // Use agent-level compact API for "default" conversation,
-            // otherwise use conversation-level API
-            const result =
+            const compactId =
               conversationIdRef.current === "default"
-                ? await client.agents.messages.compact(agentId, compactParams)
-                : await client.conversations.messages.compact(
-                    conversationIdRef.current,
-                    compactParams,
-                  );
+                ? agentId
+                : conversationIdRef.current;
+            const result = await client.conversations.messages.compact(
+              compactId,
+              compactParams,
+            );
 
             // Format success message with before/after counts and summary
             const outputLines = [

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -242,12 +242,14 @@ export function ConversationSelector({
         let defaultConversation: EnrichedConversation | null = null;
         if (!afterCursor) {
           try {
-            const defaultMessages = await client.agents.messages.list(agentId, {
-              limit: 20,
-              order: "desc",
-              conversation_id: "default", // Filter to default conversation only
-            });
-            const defaultMsgItems = defaultMessages.items;
+            const defaultMessages = await client.conversations.messages.list(
+              agentId,
+              {
+                limit: 20,
+                order: "desc",
+              },
+            );
+            const defaultMsgItems = defaultMessages.getPaginatedItems();
             if (defaultMsgItems.length > 0) {
               const defaultStats = getMessageStats(
                 [...defaultMsgItems].reverse(),

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -159,14 +159,14 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         return 1;
       }
 
-      const response = await client.agents.messages.list(agentId, {
+      const response = await client.conversations.messages.list(agentId, {
         limit: parseLimit(parsed.values.limit, 20),
         after: parsed.values.after,
         before: parsed.values.before,
         order,
       });
 
-      const messages = response.items ?? [];
+      const messages = response.getPaginatedItems() ?? [];
       const startDate = parsed.values["start-date"];
       const endDate = parsed.values["end-date"];
 

--- a/src/tests/agent/getResumeData.test.ts
+++ b/src/tests/agent/getResumeData.test.ts
@@ -104,10 +104,10 @@ describe("getResumeData", () => {
       in_context_message_ids: ["msg-last"],
     }));
     const conversationsList = mock(async () => ({
-      getPaginatedItems: () => [],
-    }));
-    const agentsList = mock(async () => ({
-      items: [makeUserMessage("msg-a"), makeUserMessage("msg-b")],
+      getPaginatedItems: () => [
+        makeUserMessage("msg-a"),
+        makeUserMessage("msg-b"),
+      ],
     }));
     const messagesRetrieve = mock(async () => [makeUserMessage()]);
 
@@ -116,14 +116,13 @@ describe("getResumeData", () => {
         retrieve: conversationsRetrieve,
         messages: { list: conversationsList },
       },
-      agents: { messages: { list: agentsList } },
       messages: { retrieve: messagesRetrieve },
     } as unknown as Letta;
 
     const resume = await getResumeData(client, makeAgent(), "default");
 
     expect(messagesRetrieve).toHaveBeenCalledTimes(1);
-    expect(agentsList).toHaveBeenCalledTimes(1);
+    expect(conversationsList).toHaveBeenCalledTimes(1);
     expect(resume.pendingApprovals).toHaveLength(0);
     expect(resume.messageHistory.length).toBeGreaterThan(0);
   });

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -59,7 +59,6 @@ describe("approval recovery wiring", () => {
     const segment = source.slice(start, end);
 
     expect(segment).toContain("getClient()");
-    expect(segment).toContain("client.agents.messages.cancel");
     expect(segment).toContain("client.conversations.cancel");
   });
 });


### PR DESCRIPTION
## Summary
- Removes all `client.agents.messages.*` usage (create, list, cancel, compact) in favor of `client.conversations.*`
- For default conversations, passes the agent ID as the conversation_id — the server now accepts `agent-*` IDs for agent-direct messaging (letta-cloud#9706)
- Simplifies `sendMessageStream` from if/else branching to a single code path
- Removes `ListMessagesRoute` union type (`agents` | `conversations` kind) — now always `conversations`
- Only remaining `agents.messages` call is `reset` in `/clear` (agent-level operation, no conversations equivalent)

Depends on: letta-cloud#9706 (server-side agent-direct support in conversations endpoint)

## Test plan
- [x] Typecheck clean (pre-existing error on main unrelated)
- [x] 1652 tests pass (20 pre-existing failures on main — integration tests requiring server)
- [ ] Manual: verify send, cancel, list, compact work on default conversation

🐾 Generated with [Letta Code](https://letta.com)