### PR TITLE
fix: skip conversation API call for default conversation in /model and /reasoning

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10886,19 +10886,27 @@ ${SYSTEM_REMINDER_CLOSE}
             phase: "running",
           });
 
-          const { updateConversationLLMConfig } = await import(
-            "../agent/modify"
-          );
-          const updatedConversation = await updateConversationLLMConfig(
-            conversationIdRef.current,
-            modelHandle,
-            model.updateArgs,
-          );
-          const conversationModelSettings = (
-            updatedConversation as {
-              model_settings?: AgentState["model_settings"] | null;
-            }
-          ).model_settings;
+          // "default" is a virtual sentinel, not a real conversation object —
+          // skip the API call and fall through with undefined model_settings.
+          let conversationModelSettings:
+            | AgentState["model_settings"]
+            | null
+            | undefined;
+          if (conversationIdRef.current !== "default") {
+            const { updateConversationLLMConfig } = await import(
+              "../agent/modify"
+            );
+            const updatedConversation = await updateConversationLLMConfig(
+              conversationIdRef.current,
+              modelHandle,
+              model.updateArgs,
+            );
+            conversationModelSettings = (
+              updatedConversation as {
+                model_settings?: AgentState["model_settings"] | null;
+              }
+            ).model_settings;
+          }
 
           // The API may not echo reasoning_effort back, so populate it from
           // model.updateArgs as a reliable fallback.
@@ -11584,21 +11592,29 @@ ${SYSTEM_REMINDER_CLOSE}
         const cmd = commandRunner.start("/reasoning", "Setting reasoning...");
 
         try {
-          const { updateConversationLLMConfig } = await import(
-            "../agent/modify"
-          );
-          const updatedConversation = await updateConversationLLMConfig(
-            conversationIdRef.current,
-            desired.modelHandle,
-            {
-              reasoning_effort: desired.effort,
-            },
-          );
-          const conversationModelSettings = (
-            updatedConversation as {
-              model_settings?: AgentState["model_settings"] | null;
-            }
-          ).model_settings;
+          // "default" is a virtual sentinel, not a real conversation object —
+          // skip the API call and fall through with undefined model_settings.
+          let conversationModelSettings:
+            | AgentState["model_settings"]
+            | null
+            | undefined;
+          if (conversationIdRef.current !== "default") {
+            const { updateConversationLLMConfig } = await import(
+              "../agent/modify"
+            );
+            const updatedConversation = await updateConversationLLMConfig(
+              conversationIdRef.current,
+              desired.modelHandle,
+              {
+                reasoning_effort: desired.effort,
+              },
+            );
+            conversationModelSettings = (
+              updatedConversation as {
+                model_settings?: AgentState["model_settings"] | null;
+              }
+            ).model_settings;
+          }
           const resolvedReasoningEffort =
             deriveReasoningEffort(
               conversationModelSettings,


### PR DESCRIPTION
## Summary

Same root cause as #1202: `"default"` is a virtual sentinel for the agent's primary message history, not a real conversation object. Calling `conversations.update("default", ...)` produces a 404 error:

```
Failed to switch model to Sonnet 4.6: Conversation not found with id='['default']'
```

- `/model` — skips `updateConversationLLMConfig` when `conversationId === "default"`, proceeds with `conversationModelSettings = undefined` (reasoning effort still resolves correctly from `model.updateArgs`)
- `/reasoning` — same guard applied to the reasoning cycle handler

Both fall through to the existing local state updates (`setLlmConfig`, `setCurrentModelId`, etc.) so the switch still works for default-conversation users.

## Test plan

- [ ] Open letta with default conversation, run `/model` and switch models — should succeed without 404
- [ ] Run `/reasoning` to cycle reasoning effort — should succeed without 404
- [ ] With a real (non-default) conversation, verify `/model` and `/reasoning` still call the API as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)