### PR TITLE
fix: skip agents.messages.reset in /clear for named conversations

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7736,12 +7736,16 @@ export default function App({
           try {
             const client = await getClient();
 
-            // Reset all messages on the agent (destructive operation)
-            await client.agents.messages.reset(agentId, {
-              add_default_initial_messages: false,
-            });
+            // Reset all messages on the agent only when in the default conversation.
+            // For named conversations, clearing just means starting a new conversation —
+            // there is no reason to wipe the agent's entire message history.
+            if (conversationIdRef.current === "default") {
+              await client.agents.messages.reset(agentId, {
+                add_default_initial_messages: false,
+              });
+            }
 
-            // Also create a new conversation since messages were cleared
+            // Create a new conversation
             const conversation = await client.conversations.create({
               agent_id: agentId,
               isolated_block_labels: [...ISOLATED_BLOCK_LABELS],


### PR DESCRIPTION
## Summary

`agents.messages.reset` wipes the agent's entire message history — that's only appropriate when clearing the **default** conversation. For named conversations, creating a new conversation is sufficient to give the user a clean slate without destroying the agent's core context.

## Test plan

- [ ] In a named conversation, run `/clear` — should create a new conversation without resetting the agent's message history
- [ ] In the default conversation, run `/clear` — should still call `messages.reset` and create a new conversation as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)