### PR TITLE
fix: normalize Cloudflare HTML errors in telemetry

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -210,6 +210,7 @@ import {
 import { setErrorContext } from "./helpers/errorContext";
 import {
   formatErrorDetails,
+  formatTelemetryErrorMessage,
   getRetryStatusMessage,
   isEncryptedContentError,
 } from "./helpers/errorFormatter";
@@ -362,6 +363,7 @@ function deriveReasoningEffort(
       )
         return re;
     }
+
     // Anthropic/Bedrock: effort field
     if (
       modelSettings.provider_type === "anthropic" ||
@@ -3896,7 +3898,9 @@ export default function App({
               // Log the conversation-busy error
               telemetry.trackError(
                 "retry_conversation_busy",
-                errorDetail || "Conversation is busy",
+                formatTelemetryErrorMessage(
+                  errorDetail || "Conversation is busy",
+                ),
                 "pre_stream_retry",
                 {
                   httpStatus:
@@ -3962,7 +3966,9 @@ export default function App({
               // Log the error that triggered the retry
               telemetry.trackError(
                 "retry_pre_stream_transient",
-                errorDetail || "Pre-stream transient error",
+                formatTelemetryErrorMessage(
+                  errorDetail || "Pre-stream transient error",
+                ),
                 "pre_stream_retry",
                 {
                   httpStatus:
@@ -5207,9 +5213,11 @@ export default function App({
             // Log the error that triggered the retry
             telemetry.trackError(
               "retry_post_stream_error",
-              detailFromRun ||
-                fallbackError ||
-                `Stream stopped: ${stopReasonToHandle}`,
+              formatTelemetryErrorMessage(
+                detailFromRun ||
+                  fallbackError ||
+                  `Stream stopped: ${stopReasonToHandle}`,
+              ),
               "post_stream_retry",
               {
                 modelId: currentModelId || undefined,
@@ -5339,9 +5347,10 @@ export default function App({
                 // — skip the generic "Something went wrong?" hint
                 appendError(errorDetails, {
                   ...errorTelemetryBase,
-                  errorMessage:
+                  errorMessage: formatTelemetryErrorMessage(
                     serverErrorDetail ||
-                    `Stream stopped with reason: ${stopReasonToHandle}`,
+                      `Stream stopped with reason: ${stopReasonToHandle}`,
+                  ),
                 });
 
                 if (!isEncryptedContentError(errorObject)) {

--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -83,6 +83,18 @@ export function checkCloudflareEdgeError(text: string): string | undefined {
   return `${codeLabel}${statusSegment}${hostSegment}${raySegment}. This is usually a temporary edge/origin outage. Please retry in a moment.`;
 }
 
+/**
+ * Normalize raw provider error payloads before sending to telemetry.
+ * Keeps telemetry concise by collapsing Cloudflare HTML pages into a
+ * single readable line while preserving non-Cloudflare messages as-is.
+ */
+export function formatTelemetryErrorMessage(
+  message: string | null | undefined,
+): string {
+  if (!message) return "Unknown error";
+  return checkCloudflareEdgeError(message) ?? message;
+}
+
 function getErrorReasons(e: APIError): string[] {
   const reasons = new Set<string>();
 


### PR DESCRIPTION
## Summary
- add `formatTelemetryErrorMessage` helper to collapse Cloudflare HTML error payloads into concise one-line messages
- apply telemetry normalization on stream retry and final stream error tracking paths in `App.tsx`
- preserve non-Cloudflare error telemetry messages unchanged

## Test plan
- [x] `bun run fix`
- [x] `bun test src/tests/cli/errorFormatter.test.ts src/tests/turn-recovery-policy.test.ts`
- [ ] Trigger Cloudflare HTML error and verify PostHog receives concise message instead of raw HTML

👾 Generated with [Letta Code](https://letta.com)