### PR TITLE
fix: silence Cloudflare retry status message in terminal UI

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4006,14 +4006,18 @@ export default function App({
                 },
               );
 
-              const statusId = uid("status");
-              buffersRef.current.byId.set(statusId, {
-                kind: "status",
-                id: statusId,
-                lines: [getRetryStatusMessage(errorDetail)],
-              });
-              buffersRef.current.order.push(statusId);
-              refreshDerived();
+              const retryStatusMsg = getRetryStatusMessage(errorDetail);
+              const retryStatusId =
+                retryStatusMsg != null ? uid("status") : null;
+              if (retryStatusId && retryStatusMsg) {
+                buffersRef.current.byId.set(retryStatusId, {
+                  kind: "status",
+                  id: retryStatusId,
+                  lines: [retryStatusMsg],
+                });
+                buffersRef.current.order.push(retryStatusId);
+                refreshDerived();
+              }
 
               let cancelled = false;
               const startTime = Date.now();
@@ -4028,11 +4032,13 @@ export default function App({
                 await new Promise((resolve) => setTimeout(resolve, 100));
               }
 
-              buffersRef.current.byId.delete(statusId);
-              buffersRef.current.order = buffersRef.current.order.filter(
-                (id) => id !== statusId,
-              );
-              refreshDerived();
+              if (retryStatusId) {
+                buffersRef.current.byId.delete(retryStatusId);
+                buffersRef.current.order = buffersRef.current.order.filter(
+                  (id) => id !== retryStatusId,
+                );
+                refreshDerived();
+              }
 
               if (!cancelled) {
                 buffersRef.current.interrupted = false;
@@ -5252,16 +5258,18 @@ export default function App({
               },
             );
 
-            // Show subtle grey status message
-            const statusId = uid("status");
-            const statusLines = [getRetryStatusMessage(detailFromRun)];
-            buffersRef.current.byId.set(statusId, {
-              kind: "status",
-              id: statusId,
-              lines: statusLines,
-            });
-            buffersRef.current.order.push(statusId);
-            refreshDerived();
+            // Show subtle grey status message (skip for silently-retried errors)
+            const retryStatusMsg = getRetryStatusMessage(detailFromRun);
+            const retryStatusId = retryStatusMsg != null ? uid("status") : null;
+            if (retryStatusId && retryStatusMsg) {
+              buffersRef.current.byId.set(retryStatusId, {
+                kind: "status",
+                id: retryStatusId,
+                lines: [retryStatusMsg],
+              });
+              buffersRef.current.order.push(retryStatusId);
+              refreshDerived();
+            }
 
             // Wait before retry (check abort signal periodically for ESC cancellation)
             let cancelled = false;
@@ -5278,11 +5286,13 @@ export default function App({
             }
 
             // Remove status message
-            buffersRef.current.byId.delete(statusId);
-            buffersRef.current.order = buffersRef.current.order.filter(
-              (id) => id !== statusId,
-            );
-            refreshDerived();
+            if (retryStatusId) {
+              buffersRef.current.byId.delete(retryStatusId);
+              buffersRef.current.order = buffersRef.current.order.filter(
+                (id) => id !== retryStatusId,
+              );
+              refreshDerived();
+            }
 
             if (!cancelled) {
               // Reset interrupted flag so retry stream chunks are processed

--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -699,14 +699,11 @@ const DEFAULT_RETRY_MESSAGE =
  */
 export function getRetryStatusMessage(
   errorDetail: string | null | undefined,
-): string {
+): string | null {
   if (!errorDetail) return DEFAULT_RETRY_MESSAGE;
 
-  const cloudflareInfo = parseCloudflareEdgeError(errorDetail);
-  if (cloudflareInfo) {
-    const codeSegment = cloudflareInfo.code ? ` ${cloudflareInfo.code}` : "";
-    return `Cloudflare${codeSegment} upstream outage, retrying...`;
-  }
+  // Cloudflare edge errors are transient and retried silently — no status line
+  if (parseCloudflareEdgeError(errorDetail)) return null;
 
   if (checkZaiError(errorDetail)) return "Z.ai API error, retrying...";
 


### PR DESCRIPTION
## Summary
- Cloudflare 52x errors are transient and retried automatically — the "Cloudflare 521 upstream outage, retrying..." status message is noisy and unnecessary
- `getRetryStatusMessage` now returns `null` for Cloudflare errors, and both retry call sites in App.tsx skip the status line when null
- Retries still happen, telemetry still fires, only the UI status line is suppressed

## Test plan
- [x] `bun run check` passes (lint + typecheck)
- [x] All 75 tests pass across errorFormatter and turn-recovery-policy test files
- [ ] Manual: trigger a Cloudflare 52x error and verify no status message appears during retry

🐾 Generated with [Letta Code](https://letta.com)