### PR TITLE
feat: add silent flag to SubagentState for display filtering

### DIFF
--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -340,8 +340,12 @@ export const SubagentGroupDisplay = memo(() => {
     }
   });
 
+  // Hide silent subagents (e.g. init) — they handle user notifications
+  // via their own mechanisms (e.g. EventMessage).
+  const visible = agents.filter((a) => !a.silent);
+
   // Don't render if no agents
-  if (agents.length === 0) {
+  if (visible.length === 0) {
     return null;
   }
 
@@ -349,24 +353,24 @@ export const SubagentGroupDisplay = memo(() => {
   // This ensures consistent behavior - when we disable animation, we also simplify the view
   const condensed = !shouldAnimate;
 
-  const allCompleted = agents.every(
+  const allCompleted = visible.every(
     (a) => a.status === "completed" || a.status === "error",
   );
-  const hasErrors = agents.some((a) => a.status === "error");
+  const hasErrors = visible.some((a) => a.status === "error");
 
   return (
     <Box flexDirection="column" marginTop={1}>
       <GroupHeader
-        count={agents.length}
+        count={visible.length}
         allCompleted={allCompleted}
         hasErrors={hasErrors}
         expanded={expanded}
       />
-      {agents.map((agent, index) => (
+      {visible.map((agent, index) => (
         <AgentRow
           key={agent.id}
           agent={agent}
-          isLast={index === agents.length - 1}
+          isLast={index === visible.length - 1}
           expanded={expanded}
           condensed={condensed}
         />

--- a/src/cli/helpers/subagentState.ts
+++ b/src/cli/helpers/subagentState.ts
@@ -30,6 +30,7 @@ export interface SubagentState {
   startTime: number;
   toolCallId?: string; // Links this subagent to its parent Task tool call
   isBackground?: boolean; // True if running in background (fire-and-forget)
+  silent?: boolean; // True if this subagent should be hidden from SubagentGroupDisplay
 }
 
 interface SubagentStore {
@@ -108,6 +109,7 @@ export function registerSubagent(
   description: string,
   toolCallId?: string,
   isBackground?: boolean,
+  silent?: boolean,
 ): void {
   // Capitalize type for display (explore -> Explore)
   const displayType = type.charAt(0).toUpperCase() + type.slice(1);
@@ -124,6 +126,7 @@ export function registerSubagent(
     startTime: Date.now(),
     toolCallId,
     isBackground,
+    silent,
   };
 
   store.agents.set(id, agent);

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -67,6 +67,11 @@ export interface SpawnBackgroundSubagentTaskArgs {
   existingConversationId?: string;
   maxTurns?: number;
   /**
+   * When true, skip injecting the completion notification into the primary
+   * agent's message queue and hide from SubagentGroupDisplay.
+   */
+  silentCompletion?: boolean;
+  /**
    * Optional dependency overrides for tests.
    * Production callers should not provide this.
    */
@@ -191,6 +196,7 @@ export function spawnBackgroundSubagentTask(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    silentCompletion,
     deps,
   } = args;
 
@@ -208,7 +214,14 @@ export function spawnBackgroundSubagentTask(
     deps?.getSubagentSnapshotImpl ?? getSubagentSnapshot;
 
   const subagentId = generateSubagentIdFn();
-  registerSubagentFn(subagentId, subagentType, description, toolCallId, true);
+  registerSubagentFn(
+    subagentId,
+    subagentType,
+    description,
+    toolCallId,
+    true,
+    silentCompletion,
+  );
 
   const taskId = getNextTaskId();
   const outputFile = createBackgroundOutputFile(taskId);


### PR DESCRIPTION
## Summary

- **Problem**: Currently there is no way to hide specific background subagents from `SubagentGroupDisplay`. Hiding *all* background subagents would be too aggressive — only certain ones (e.g. init subagents that handle their own user notifications via `EventMessage`) should be hidden.
- **Solution**: Add a `silent?: boolean` flag to `SubagentState` that propagates from `spawnBackgroundSubagentTask`'s `silentCompletion` parameter through `registerSubagent`, then filter silent subagents out of `SubagentGroupDisplay`.
- Works together with #1217 (`silentCompletion`) — when a background subagent is spawned with `silentCompletion: true`, it will now also be hidden from the live subagent group UI.

### Changes
- **`src/cli/helpers/subagentState.ts`**: Add `silent?: boolean` to `SubagentState` interface; add `silent` parameter to `registerSubagent` function
- **`src/tools/impl/Task.ts`**: Add `silentCompletion?: boolean` to `SpawnBackgroundSubagentTaskArgs`; destructure and pass it through to `registerSubagent` as the `silent` flag
- **`src/cli/components/SubagentGroupDisplay.tsx`**: Filter out silent subagents into a `visible` array and use that for all rendering logic (count, completion status, error status, mapping rows)

## Test plan

- [x] `bun run check` passes (lint + typecheck)
- [x] `bun test src/tests/tools/task-background-helper.test.ts` — all 4 existing tests pass
- [ ] Manual: spawn a background subagent with `silentCompletion: true` and verify it does not appear in SubagentGroupDisplay
- [ ] Manual: spawn a background subagent without `silentCompletion` and verify it still appears normally
- [ ] Manual: verify the "Running N agents" count only reflects visible (non-silent) agents