### PR TITLE
feat: silence reflection subagent from primary agent context

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9361,8 +9361,8 @@ ${SYSTEM_REMINDER_CLOSE}
             silentCompletion: true,
             onComplete: ({ success, error }) => {
               const msg = success
-                ? "Memory updated from recent conversation."
-                : `Memory reflection failed: ${error}`;
+                ? "Reflected on /palace, the halls remember more now."
+                : `Tried to reflect, but got lost in the palace: ${error}`;
               appendTaskNotificationEvents([msg]);
             },
           });


### PR DESCRIPTION
## Summary
- Adds `silentCompletion: true` to the reflection subagent so its completion no longer injects into the primary agent's message queue/context
- Adds `onComplete` callback to still show a user-facing notification via `appendTaskNotificationEvents`

## Test plan
- [ ] Trigger a reflection subagent (via step-count or compaction-event)
- [ ] Verify the primary agent does NOT receive reflection completion in its context
- [ ] Verify the user sees the notification event line in the terminal
- [ ] Trigger a reflection failure and verify the error message is shown