### PR TITLE
fix(model): prevent conversation model override snap-back after /model

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -240,8 +240,30 @@ export async function updateConversationLLMConfig(
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
   } as unknown as Parameters<typeof client.conversations.update>[1];
+  const updatedConversation = await client.conversations.update(
+    conversationId,
+    payload,
+  );
+  const updatedConversationModel = (
+    updatedConversation as { model?: string | null }
+  ).model;
 
-  return client.conversations.update(conversationId, payload);
+  if (!updatedConversationModel) {
+    try {
+      const fallbackConversation =
+        await client.conversations.retrieve(conversationId);
+      const fallbackConversationModel = (
+        fallbackConversation as { model?: string | null }
+      ).model;
+      if (fallbackConversationModel) {
+        return fallbackConversation;
+      }
+    } catch {
+      // Best-effort fallback only; return the update response if retrieve fails.
+    }
+  }
+
+  return updatedConversation;
 }
 
 export interface SystemPromptUpdateResult {

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1464,6 +1464,36 @@ export default function App({
   useEffect(() => {
     hasConversationModelOverrideRef.current = hasConversationModelOverride;
   }, [hasConversationModelOverride]);
+  const recentConversationModelOverrideRef = useRef<{
+    conversationId: string;
+    updatedAtMs: number;
+  } | null>(null);
+  const markRecentConversationModelOverride = useCallback(
+    (targetConversationId: string) => {
+      if (targetConversationId === "default") {
+        return;
+      }
+      recentConversationModelOverrideRef.current = {
+        conversationId: targetConversationId,
+        updatedAtMs: Date.now(),
+      };
+    },
+    [],
+  );
+  const hasFreshConversationModelOverride = useCallback(
+    (targetConversationId: string): boolean => {
+      if (targetConversationId === "default") {
+        return false;
+      }
+      const recent = recentConversationModelOverrideRef.current;
+      if (!recent || recent.conversationId !== targetConversationId) {
+        return false;
+      }
+      return Date.now() - recent.updatedAtMs < 10_000;
+    },
+    [],
+  );
+  const modelSyncGenerationRef = useRef(0);
   const agentStateRef = useRef(agentState);
   useEffect(() => {
     agentStateRef.current = agentState;
@@ -3234,8 +3264,18 @@ export default function App({
     }
 
     let cancelled = false;
+    const syncGeneration = ++modelSyncGenerationRef.current;
+    const isStaleSync = () =>
+      cancelled || syncGeneration !== modelSyncGenerationRef.current;
 
     const applyAgentModelLocally = () => {
+      if (hasFreshConversationModelOverride(conversationId)) {
+        debugLog(
+          "conversation-model",
+          "Skipping local agent model apply due to fresh conversation override",
+        );
+        return;
+      }
       const agentModelHandle =
         agentState.model ??
         buildModelHandleFromLlmConfig(agentState.llm_config);
@@ -3257,6 +3297,7 @@ export default function App({
       // "default" is a virtual sentinel for the agent's primary message history,
       // not a real conversation object — skip the API call.
       if (conversationId === "default") {
+        recentConversationModelOverrideRef.current = null;
         applyAgentModelLocally();
         return;
       }
@@ -3265,7 +3306,7 @@ export default function App({
         const client = await getClient();
         const conversation =
           await client.conversations.retrieve(conversationId);
-        if (cancelled) return;
+        if (isStaleSync()) return;
 
         const conversationModel = (conversation as { model?: string | null })
           .model;
@@ -3279,6 +3320,10 @@ export default function App({
             ? true
             : conversationModelSettings !== undefined &&
               conversationModelSettings !== null;
+
+        if (hasOverride) {
+          recentConversationModelOverrideRef.current = null;
+        }
 
         if (!hasOverride) {
           applyAgentModelLocally();
@@ -3319,7 +3364,7 @@ export default function App({
             : {}),
         });
       } catch (error) {
-        if (cancelled) return;
+        if (isStaleSync()) return;
         debugLog(
           "conversation-model",
           "Failed to sync conversation model override: %O",
@@ -3334,7 +3379,13 @@ export default function App({
     return () => {
       cancelled = true;
     };
-  }, [agentId, agentState, conversationId, loadingState]);
+  }, [
+    agentId,
+    agentState,
+    conversationId,
+    loadingState,
+    hasFreshConversationModelOverride,
+  ]);
 
   // Helper to append an error to the transcript
   // Also tracks the error in telemetry so we know an error was shown.
@@ -10924,12 +10975,13 @@ ${SYSTEM_REMINDER_CLOSE}
             | AgentState["model_settings"]
             | null
             | undefined;
-          if (conversationIdRef.current !== "default") {
+          const targetConversationId = conversationIdRef.current;
+          if (targetConversationId !== "default") {
             const { updateConversationLLMConfig } = await import(
               "../agent/modify"
             );
             const updatedConversation = await updateConversationLLMConfig(
-              conversationIdRef.current,
+              targetConversationId,
               modelHandle,
               model.updateArgs,
             );
@@ -10938,6 +10990,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 model_settings?: AgentState["model_settings"] | null;
               }
             ).model_settings;
+            markRecentConversationModelOverride(targetConversationId);
           }
 
           // The API may not echo reasoning_effort back, so populate it from
@@ -11048,6 +11101,7 @@ ${SYSTEM_REMINDER_CLOSE}
       consumeOverlayCommand,
       currentToolset,
       isAgentBusy,
+      markRecentConversationModelOverride,
       maybeRecordToolsetChangeReminder,
       resetPendingReasoningCycle,
       withCommandLock,
@@ -11632,12 +11686,13 @@ ${SYSTEM_REMINDER_CLOSE}
             | AgentState["model_settings"]
             | null
             | undefined;
-          if (conversationIdRef.current !== "default") {
+          const targetConversationId = conversationIdRef.current;
+          if (targetConversationId !== "default") {
             const { updateConversationLLMConfig } = await import(
               "../agent/modify"
             );
             const updatedConversation = await updateConversationLLMConfig(
-              conversationIdRef.current,
+              targetConversationId,
               desired.modelHandle,
               {
                 reasoning_effort: desired.effort,
@@ -11648,6 +11703,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 model_settings?: AgentState["model_settings"] | null;
               }
             ).model_settings;
+            markRecentConversationModelOverride(targetConversationId);
           }
           const resolvedReasoningEffort =
             deriveReasoningEffort(
@@ -11715,7 +11771,13 @@ ${SYSTEM_REMINDER_CLOSE}
     } finally {
       reasoningCycleInFlightRef.current = false;
     }
-  }, [agentId, commandRunner, isAgentBusy, withCommandLock]);
+  }, [
+    agentId,
+    commandRunner,
+    isAgentBusy,
+    markRecentConversationModelOverride,
+    withCommandLock,
+  ]);
 
   const handleCycleReasoningEffort = useCallback(() => {
     void (async () => {

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -64,9 +64,11 @@ describe("model preset refresh wiring", () => {
     expect(updateSegment).toContain(
       "Parameters<typeof client.conversations.update>[1]",
     );
-    expect(updateSegment).toContain(
-      "client.conversations.update(conversationId, payload)",
-    );
+    expect(updateSegment).toContain("client.conversations.update(");
+    expect(updateSegment).toContain("conversationId,");
+    expect(updateSegment).toContain("payload,");
+    expect(updateSegment).toContain("if (!updatedConversationModel)");
+    expect(updateSegment).toContain("client.conversations.retrieve(");
     expect(updateSegment).toContain("model: modelHandle");
     expect(updateSegment).not.toContain("client.agents.update(");
   });

--- a/src/tests/cli/conversation-model-sync-guard.wiring.test.ts
+++ b/src/tests/cli/conversation-model-sync-guard.wiring.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("conversation model sync guard wiring", () => {
+  test("App.tsx tracks recent conversation overrides and guards local fallback", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain("recentConversationModelOverrideRef");
+    expect(source).toContain("markRecentConversationModelOverride");
+    expect(source).toContain("hasFreshConversationModelOverride");
+    expect(source).toContain(
+      "Skipping local agent model apply due to fresh conversation override",
+    );
+  });
+
+  test("sync effect uses generation guard to prevent stale commits", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain("const modelSyncGenerationRef = useRef(0);");
+    expect(source).toContain(
+      "const syncGeneration = ++modelSyncGenerationRef.current;",
+    );
+    expect(source).toContain(
+      "const isStaleSync = () =>\n      cancelled || syncGeneration !== modelSyncGenerationRef.current;",
+    );
+    expect(source).toContain("if (isStaleSync()) return;");
+  });
+
+  test("sync effect does not apply agent defaults when a recent local override exists", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    const effectStart = source.indexOf(
+      "// Keep effective model state in sync with the active conversation override.",
+    );
+    const effectEnd = source.indexOf(
+      "// Helper to append an error to the transcript",
+      effectStart,
+    );
+    expect(effectStart).toBeGreaterThanOrEqual(0);
+    expect(effectEnd).toBeGreaterThan(effectStart);
+    const segment = source.slice(effectStart, effectEnd);
+
+    expect(segment).toContain(
+      "if (hasFreshConversationModelOverride(conversationId))",
+    );
+    expect(segment).toContain(
+      "Skipping local agent model apply due to fresh conversation override",
+    );
+  });
+
+  test("/model and reasoning flush mark recent conversation overrides", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    const modelHandlerStart = source.indexOf(
+      "const handleModelSelect = useCallback(",
+    );
+    const modelHandlerEnd = source.indexOf(
+      "const handleSystemPromptSelect = useCallback(",
+      modelHandlerStart,
+    );
+    expect(modelHandlerStart).toBeGreaterThanOrEqual(0);
+    expect(modelHandlerEnd).toBeGreaterThan(modelHandlerStart);
+    const modelHandlerSegment = source.slice(
+      modelHandlerStart,
+      modelHandlerEnd,
+    );
+    expect(modelHandlerSegment).toContain(
+      "markRecentConversationModelOverride(targetConversationId)",
+    );
+
+    const reasoningStart = source.indexOf(
+      "const flushPendingReasoningEffort = useCallback(async () => {",
+    );
+    const reasoningEnd = source.indexOf(
+      "const handleCycleReasoningEffort = useCallback(() => {",
+      reasoningStart,
+    );
+    expect(reasoningStart).toBeGreaterThanOrEqual(0);
+    expect(reasoningEnd).toBeGreaterThan(reasoningStart);
+    const reasoningSegment = source.slice(reasoningStart, reasoningEnd);
+    expect(reasoningSegment).toContain(
+      "markRecentConversationModelOverride(targetConversationId)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a conversation-scoped model regression where selecting a model with `/model` could revert back to the agent default after subsequent async state syncs.

### What changed
- Add a sync-generation guard in `src/cli/App.tsx` so stale async model-sync runs can't overwrite newer state.
- Track recent per-conversation model override writes and skip local fallback-to-agent-default during a short freshness window.
- Mark override freshness on both `/model` selection and reasoning-tier flush paths.
- Add best-effort fallback in `src/agent/modify.ts` to `conversations.retrieve` after `conversations.update` if the update response omits `model`.
- Add a wiring regression test for the new guard behavior and update existing model wiring assertions.

## Why
`handleModelSelect` correctly persists conversation overrides, but later sync passes (triggered by agent refresh / conversation sync) could run with stale timing and call `applyAgentModelLocally`, resetting UI state back to the agent model.

## Testing
- `bun test src/tests/agent/model-preset-refresh.wiring.test.ts`
- `bun test src/tests/cli/reasoning-cycle-wiring.test.ts`
- `bun test src/tests/cli/conversation-model-sync-guard.wiring.test.ts`

## Notes
There is an existing unrelated typecheck issue in `App.tsx` around compact params (`compaction_settings.model`), pre-existing in this branch base and not introduced by this PR.
