### PR TITLE
chore: update default model from sonnet-4.5 to sonnet-4.6

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@
 /**
  * Default model ID to use when no model is specified
  */
-export const DEFAULT_MODEL_ID = "sonnet-4.5";
+export const DEFAULT_MODEL_ID = "sonnet";
 
 /**
  * Default agent name when creating a new agent


### PR DESCRIPTION
## Summary
- Updates `DEFAULT_MODEL_ID` in `src/constants.ts` from `"sonnet-4.5"` to `"sonnet"` (which maps to `anthropic/claude-sonnet-4-6`)
- `models.json` already had the `sonnet` entry pointing to Sonnet 4.6 with `isDefault: true`

## Test plan
- [ ] Verify new agents default to Sonnet 4.6 when no `--model` flag is specified
- [ ] Confirm existing model selector still shows Sonnet 4.6 as the default option

👾 Generated with [Letta Code](https://letta.com)