### PR TITLE
fix: better mojibake detection for lone multi-byte lead

### DIFF
--- a/src/cli/components/Text.tsx
+++ b/src/cli/components/Text.tsx
@@ -37,6 +37,13 @@ function looksLikeMojibake(value: string): boolean {
       }
     }
 
+    // A lone multi-byte lead with even one valid continuation is mojibake
+    if (byte >= 0xc2 && byte <= 0xf4) {
+      if (i + 1 < value.length && isContinuationByte(value.charCodeAt(i + 1))) {
+        sawUtf8Sequence = true;
+      }
+    }
+
     if (byte >= 0xf0 && byte <= 0xf4) {
       if (
         i + 3 < value.length &&


### PR DESCRIPTION
Before on left, after on right

<img width="2502" height="654" alt="image" src="https://github.com/user-attachments/assets/391e6ce8-2f45-4aab-a54c-e65dd98309da" />
