### PR TITLE
feat: add reasoning effort tiers for Opus 4.5 and xhigh for Opus 4.6

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -148,14 +148,70 @@
     }
   },
   {
+    "id": "opus-4.6-xhigh",
+    "handle": "anthropic/claude-opus-4-6",
+    "label": "Opus 4.6",
+    "description": "Opus 4.6 (max reasoning)",
+    "updateArgs": {
+      "context_window": 200000,
+      "max_output_tokens": 128000,
+      "reasoning_effort": "xhigh",
+      "enable_reasoner": true,
+      "parallel_tool_calls": true
+    }
+  },
+  {
     "id": "opus-4.5",
     "handle": "anthropic/claude-opus-4-5-20251101",
     "label": "Opus 4.5",
-    "description": "Anthropic's (legacy) best model",
+    "description": "Anthropic's (legacy) best model (high reasoning)",
     "updateArgs": {
       "context_window": 180000,
       "max_output_tokens": 64000,
+      "reasoning_effort": "high",
+      "enable_reasoner": true,
       "max_reasoning_tokens": 31999,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "opus-4.5-no-reasoning",
+    "handle": "anthropic/claude-opus-4-5-20251101",
+    "label": "Opus 4.5",
+    "description": "Opus 4.5 with no reasoning (faster)",
+    "updateArgs": {
+      "context_window": 180000,
+      "max_output_tokens": 64000,
+      "reasoning_effort": "none",
+      "enable_reasoner": false,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "opus-4.5-low",
+    "handle": "anthropic/claude-opus-4-5-20251101",
+    "label": "Opus 4.5",
+    "description": "Opus 4.5 (low reasoning)",
+    "updateArgs": {
+      "context_window": 180000,
+      "max_output_tokens": 64000,
+      "reasoning_effort": "low",
+      "enable_reasoner": true,
+      "max_reasoning_tokens": 4000,
+      "parallel_tool_calls": true
+    }
+  },
+  {
+    "id": "opus-4.5-medium",
+    "handle": "anthropic/claude-opus-4-5-20251101",
+    "label": "Opus 4.5",
+    "description": "Opus 4.5 (med reasoning)",
+    "updateArgs": {
+      "context_window": 180000,
+      "max_output_tokens": 64000,
+      "reasoning_effort": "medium",
+      "enable_reasoner": true,
+      "max_reasoning_tokens": 12000,
       "parallel_tool_calls": true
     }
   },

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -113,12 +113,32 @@ describe("getReasoningTierOptionsForHandle", () => {
       "low",
       "medium",
       "high",
+      "xhigh",
     ]);
     expect(options.map((option) => option.modelId)).toEqual([
       "opus-4.6-no-reasoning",
       "opus-4.6-low",
       "opus-4.6-medium",
       "opus",
+      "opus-4.6-xhigh",
+    ]);
+  });
+
+  test("returns reasoning options for anthropic opus 4.5", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "anthropic/claude-opus-4-5-20251101",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "opus-4.5-no-reasoning",
+      "opus-4.5-low",
+      "opus-4.5-medium",
+      "opus-4.5",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- **Opus 4.5**: Add reasoning effort tier entries (none/low/medium/high) to `models.json`. Previously had a single entry with no `reasoning_effort` field, so the cycling system (`/reasoning` command, Tab cycling) completely skipped it.
- **Opus 4.6**: Add xhigh tier entry. The backend already supports `effort: "max"` for Opus 4.6 via the `max-effort-2026-01-24` beta header, and `modify.ts` already maps `xhigh → max` — this just adds the models.json entry to expose it in the UI.
- **Note**: xhigh is intentionally NOT added for Opus 4.5 — Anthropic's API only supports low/medium/high for that model ([docs](https://platform.claude.com/docs/en/build-with-claude/effort): "Only available on Opus 4.6; requests using `max` on other models return an error").

## Test plan
- [x] `model-tier-selection.test.ts` updated with Opus 4.5 tier test and Opus 4.6 xhigh tier test
- [x] All 9 model tier tests pass
- [x] Lint passes (`bun run fix`)
- [ ] Manual: Switch to Opus 4.5, cycle through reasoning tiers with `/reasoning`
- [ ] Manual: Switch to Opus 4.6, verify xhigh tier appears and works

🐾 Generated with [Letta Code](https://letta.com)