### PR TITLE
fix: align headless 409 busy retry with TUI exponential backoff

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -328,8 +328,8 @@ const LLM_API_ERROR_MAX_RETRIES = 3;
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 
 // Retry config for 409 "conversation busy" errors (exponential backoff)
-const CONVERSATION_BUSY_MAX_RETRIES = 3; // 2.5s -> 5s -> 10s
-const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 2500; // 2.5 seconds
+const CONVERSATION_BUSY_MAX_RETRIES = 3; // 10s -> 20s -> 40s
+const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000; // 10 seconds
 
 // Message shown when user interrupts the stream
 const INTERRUPT_MESSAGE =

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -131,9 +131,9 @@ const LLM_API_ERROR_MAX_RETRIES = 3;
 // Retry 1: same input. Retry 2: with system reminder nudge.
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
 
-// Retry config for 409 "conversation busy" errors
-const CONVERSATION_BUSY_MAX_RETRIES = 1; // Only retry once, fail on 2nd 409
-const CONVERSATION_BUSY_RETRY_DELAY_MS = 2500; // 2.5 seconds
+// Retry config for 409 "conversation busy" errors (exponential backoff)
+const CONVERSATION_BUSY_MAX_RETRIES = 3; // 10s -> 20s -> 40s
+const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000; // 10 seconds
 
 export type BidirectionalQueuedInput = QueuedTurnInput<
   MessageCreate["content"]
@@ -1553,6 +1553,9 @@ ${SYSTEM_REMINDER_CLOSE}
         // Check for 409 "conversation busy" error - retry once with delay
         if (preStreamAction === "retry_conversation_busy") {
           conversationBusyRetries += 1;
+          const retryDelayMs =
+            CONVERSATION_BUSY_RETRY_BASE_DELAY_MS *
+            2 ** (conversationBusyRetries - 1);
 
           // Emit retry message for stream-json mode
           if (outputFormat === "stream-json") {
@@ -1561,21 +1564,19 @@ ${SYSTEM_REMINDER_CLOSE}
               reason: "error", // 409 conversation busy is a pre-stream error
               attempt: conversationBusyRetries,
               max_attempts: CONVERSATION_BUSY_MAX_RETRIES,
-              delay_ms: CONVERSATION_BUSY_RETRY_DELAY_MS,
+              delay_ms: retryDelayMs,
               session_id: sessionId,
               uuid: `retry-conversation-busy-${randomUUID()}`,
             };
             console.log(JSON.stringify(retryMsg));
           } else {
             console.error(
-              `Conversation is busy, waiting ${CONVERSATION_BUSY_RETRY_DELAY_MS / 1000}s and retrying...`,
+              `Conversation is busy, waiting ${Math.round(retryDelayMs / 1000)}s and retrying...`,
             );
           }
 
           // Wait before retry
-          await new Promise((resolve) =>
-            setTimeout(resolve, CONVERSATION_BUSY_RETRY_DELAY_MS),
-          );
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Headless mode was missed when #780 upgraded the TUI's 409 "conversation busy" retry from a single flat delay to exponential backoff — it was still doing 1 retry at a flat 2.5s
- Aligns headless with TUI: 3 retries with exponential backoff
- Bumps base delay from 2.5s → 10s for both TUI and headless, giving the schedule **10s → 20s → 40s** (total 70s budget vs previous 17.5s)

## Test plan
- [ ] Trigger a 409 in headless mode — verify 3 retries with 10s/20s/40s delays in `stream-json` output
- [ ] Trigger a 409 in TUI — verify the same backoff schedule
- [ ] Confirm retry messages display the correct delay (`waiting 10s`, `waiting 20s`, etc.)

🐾 Generated with [Letta Code](https://letta.com)