### PR TITLE
feat: add max reasoning tier for Sonnet 4.6

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -69,6 +69,19 @@
     }
   },
   {
+    "id": "sonnet-4.6-xhigh",
+    "handle": "anthropic/claude-sonnet-4-6",
+    "label": "Sonnet 4.6",
+    "description": "Sonnet 4.6 (max reasoning)",
+    "updateArgs": {
+      "context_window": 200000,
+      "max_output_tokens": 128000,
+      "reasoning_effort": "xhigh",
+      "enable_reasoner": true,
+      "parallel_tool_calls": true
+    }
+  },
+  {
     "id": "sonnet-4.5",
     "handle": "anthropic/claude-sonnet-4-5-20250929",
     "label": "Sonnet 4.5",

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -95,12 +95,14 @@ describe("getReasoningTierOptionsForHandle", () => {
       "low",
       "medium",
       "high",
+      "xhigh",
     ]);
     expect(options.map((option) => option.modelId)).toEqual([
       "sonnet-4.6-no-reasoning",
       "sonnet-4.6-low",
       "sonnet-4.6-medium",
       "sonnet",
+      "sonnet-4.6-xhigh",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Adds `xhigh` reasoning effort tier for Sonnet 4.6, matching the existing Opus 4.6 `xhigh` entry from #1248 
- Updates model tier selection tests to cover the new tier

## Note
`xhigh` is OpenAI terminology — once `max` is added to the Anthropic TypeScript SDK types, we should rename `xhigh` to `max` for Anthropic models.

## Test plan
- [x] `bun test src/tests/model-tier-selection.test.ts` passes (9/9)
- [ ] CI passes on all platforms