### PR TITLE
feat: tag new subagents with their type on creation [LET-7807]

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -515,6 +515,7 @@ function buildSubagentArgs(
   } else {
     // Create new agent (original behavior)
     args.push("--new-agent", "--system", type);
+    args.push("--tags", `type:${type}`);
     if (model) {
       args.push("--model", model);
     }


### PR DESCRIPTION
## Summary
- Adds a `type:<subagent_type>` tag (e.g. `type:explore`, `type:general-purpose`) to newly created subagents
- Makes it easy to filter/identify subagents by type in the ADE
- Only applies to new agents — existing agents deployed as subagents are unchanged

## Test plan
- [ ] Spawn a subagent via the Task tool and verify the created agent has `type:<subagent_type>` in its tags alongside `origin:letta-code` and `role:subagent`

👾 Generated with [Letta Code](https://letta.com)