### PR TITLE
fix(input): make Backspace respect line boundaries

### DIFF
--- a/src/cli/components/PasteAwareTextInput.tsx
+++ b/src/cli/components/PasteAwareTextInput.tsx
@@ -57,24 +57,32 @@ function sanitizeForDisplay(text: string): string {
   return text.replace(/\r\n|\r|\n/g, "↵");
 }
 
-/** Find the boundary of the previous word for option+left navigation */
+/** Find the boundary of the previous word for option+left navigation.
+ * Stops at newlines so Option+Backspace deletes only to the start of the current line. */
 function findPreviousWordBoundary(text: string, cursorPos: number): number {
   if (cursorPos === 0) return 0;
 
-  // Move back one position if we're at the end of a word
   let pos = cursorPos - 1;
 
-  // Skip whitespace backwards
-  while (pos > 0 && /\s/.test(text.charAt(pos))) {
+  // Skip whitespace backwards (but stop at newline)
+  while (pos > 0 && /\s/.test(text.charAt(pos)) && text.charAt(pos) !== "\n") {
     pos--;
   }
 
-  // Skip word characters backwards
+  // If we hit a newline, position after it (start of current line)
+  if (pos >= 0 && text.charAt(pos) === "\n") {
+    return pos + 1;
+  }
+
+  // Skip word characters backwards (stop at newline)
   while (pos > 0 && /\S/.test(text.charAt(pos))) {
     pos--;
+    if (text.charAt(pos) === "\n") {
+      return pos + 1;
+    }
   }
 
-  // If we stopped at whitespace, move forward one
+  // If we stopped at whitespace (including newline), move forward one
   if (pos > 0 && /\s/.test(text.charAt(pos))) {
     pos++;
   }

--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -42,6 +42,13 @@ function isControlSequence(input, key) {
     return false;
 }
 
+function findLineStart(text, cursorPos) {
+    for (let i = cursorPos - 1; i >= 0; i--) {
+        if (text.charAt(i) === '\n') return i + 1;
+    }
+    return 0;
+}
+
 function TextInput({ value: originalValue, placeholder = '', focus = true, mask, highlightPastedText = false, showCursor = true, onChange, onSubmit, externalCursorOffset, onCursorOffsetChange }) {
     const [state, setState] = useState({ cursorOffset: (originalValue || '').length, cursorWidth: 0, killBuffer: '' });
     const { cursorOffset, cursorWidth, killBuffer } = state;
@@ -145,11 +152,14 @@ function TextInput({ value: originalValue, placeholder = '', focus = true, mask,
             }
         }
         else if (key.ctrl && input === 'u') {
-            // CTRL-U: kill from beginning to cursor
+            // CTRL-U: kill from start of current line to cursor (line-aware; Cmd+Backspace on macOS)
             if (cursorOffset > 0) {
-                nextKillBuffer = originalValue.slice(0, cursorOffset);
-                nextValue = originalValue.slice(cursorOffset);
-                nextCursorOffset = 0;
+                const lineStart = findLineStart(originalValue, cursorOffset);
+                if (lineStart < cursorOffset) {
+                    nextKillBuffer = originalValue.slice(lineStart, cursorOffset);
+                    nextValue = originalValue.slice(0, lineStart) + originalValue.slice(cursorOffset);
+                    nextCursorOffset = lineStart;
+                }
             }
         }
         else if (key.ctrl && input === 'y') {


### PR DESCRIPTION
## Problem

When pressing Cmd+Backspace (or Option+Backspace) in the multi-line input, Backspace deletes from the cursor to position 0, clearing all content including previous lines.

## Solution

Modified `findPreviousWordBoundary` in PasteAwareTextInput.tsx to stop at newlines, so Backspace deletes only to the start of the current line instead of the entire text.

## Test plan

1. Create a multi-line input (use Shift+Enter to add newlines)
2. Position cursor in the middle of a line
3. Press Cmd+Backspace or Option+Backspace
4. Verify it deletes to the start of the current line, not the entire text

Made with [Cursor](https://cursor.com)