### PR TITLE
rename: `letta remote` -> `letta server` with `remote` as alias

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7209,8 +7209,13 @@ export default function App({
           return { submitted: true };
         }
 
-        // Special handling for /listen command - start listener mode
-        if (trimmed === "/remote" || trimmed.startsWith("/remote ")) {
+        // Special handling for /server command (alias: /remote)
+        if (
+          trimmed === "/server" ||
+          trimmed.startsWith("/server ") ||
+          trimmed === "/remote" ||
+          trimmed.startsWith("/remote ")
+        ) {
           // Tokenize with quote support: --name "my laptop"
           const parts = Array.from(
             trimmed.matchAll(

--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -1,6 +1,6 @@
 /**
- * Listen mode - Register letta-code as a listener to receive messages from Letta Cloud
- * Usage: letta listen --name "george"
+ * Server mode - Register letta-code as a listener to receive messages from Letta Cloud
+ * Usage: letta server --name "george"
  */
 
 import { hostname } from "node:os";
@@ -135,17 +135,18 @@ export async function handleListen(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      "Usage: /remote [--env-name <name>]\n" +
-        "       /remote off\n\n" +
-        "Register this letta-code instance to receive messages from Letta Cloud.\n\n" +
+      "Usage: /server [--env-name <name>]\n" +
+        "       /server off\n\n" +
+        "Register this letta-code instance to receive messages from Letta Cloud.\n" +
+        "Alias: /remote\n\n" +
         "Options:\n" +
         "  --env-name <name>  Friendly name for this environment (uses hostname if not provided)\n" +
         "  off                Stop the active listener connection\n" +
         "  -h, --help         Show this help message\n\n" +
         "Examples:\n" +
-        "  /remote                         # Start listener with hostname\n" +
-        '  /remote --env-name "work-laptop" # Start with custom name\n' +
-        "  /remote off                     # Stop listening\n\n" +
+        "  /server                         # Start listener with hostname\n" +
+        '  /server --env-name "work-laptop" # Start with custom name\n' +
+        "  /server off                     # Stop listening\n\n" +
         "Once connected, this instance will listen for incoming messages from cloud agents.\n" +
         "Messages will be executed locally using your letta-code environment.",
       true,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -1,5 +1,5 @@
 /**
- * CLI subcommand: letta listen --name \"george\"
+ * CLI subcommand: letta server --name \"george\"
  * Register letta-code as a listener to receive messages from Letta Cloud
  */
 
@@ -63,7 +63,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
 
   // Show help
   if (values.help) {
-    console.log("Usage: letta remote [--env-name <name>] [--debug]\n");
+    console.log("Usage: letta server [--env-name <name>] [--debug]\n");
     console.log(
       "Register this letta-code instance to receive messages from Letta Cloud.\n",
     );
@@ -77,10 +77,10 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     console.log("  -h, --help         Show this help message\n");
     console.log("Examples:");
     console.log(
-      "  letta remote                      # Uses hostname as default",
+      "  letta server                      # Uses hostname as default",
     );
-    console.log('  letta remote --env-name "work-laptop"');
-    console.log("  letta remote --debug              # Log all WS events\n");
+    console.log('  letta server --env-name "work-laptop"');
+    console.log("  letta server --debug              # Log all WS events\n");
     console.log(
       "Once connected, this instance will listen for incoming messages from cloud agents.",
     );

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -21,7 +21,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runMessagesSubcommand(rest);
     case "blocks":
       return runBlocksSubcommand(rest);
-    case "remote":
+    case "server":
+    case "remote": // alias
       return runListenSubcommand(rest);
     case "connect":
       return runConnectSubcommand(rest);

--- a/src/websocket/listen-log.ts
+++ b/src/websocket/listen-log.ts
@@ -1,5 +1,5 @@
 /**
- * Always-on file logger for letta remote sessions.
+ * Always-on file logger for letta server sessions.
  * Writes to ~/.letta/logs/remote/{timestamp}.log regardless of --debug mode.
  * Debug mode additionally prints to console; this file always captures the log.
  */

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -1,5 +1,5 @@
 /**
- * Shared registration helper for letta remote / /remote command.
+ * Shared registration helper for letta server / /server command.
  * Owns the HTTP request contract and error handling; callers own UX strings and logging.
  */
 import { getVersion } from "../version.ts";


### PR DESCRIPTION
The primary CLI subcommand and slash command are now `letta server` and `/server`. `letta remote` and `/remote` continue to work as aliases for backwards compatibility.

👾 Generated with [Letta Code](https://letta.com)