### PR TITLE
feat(headless): exclude AskUserQuestion from headless mode toolset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -910,7 +910,8 @@ async function main(): Promise<void> {
       specifiedModel,
       specifiedToolset as "auto" | "codex" | "default" | "gemini" | undefined,
     );
-    await loadTools(modelForTools);
+    // Exclude interactive-only tools that can't function without a live user session
+    await loadTools(modelForTools, { exclude: ["AskUserQuestion"] });
     markMilestone("TOOLS_LOADED");
 
     // Keep headless startup in sync with interactive name resolution.

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -787,9 +787,15 @@ export async function loadSpecificTools(toolNames: string[]): Promise<void> {
  * Acquires the toolset switch lock during loading to prevent message sends from
  * reading stale tools. Callers should use waitForToolsetReady() before sending messages.
  *
+ * @param modelIdentifier - Optional model identifier to select the appropriate toolset
+ * @param options - Optional configuration
+ * @param options.exclude - Tool names to exclude from the loaded toolset
  * @returns Promise that resolves when all tools are loaded
  */
-export async function loadTools(modelIdentifier?: string): Promise<void> {
+export async function loadTools(
+  modelIdentifier?: string,
+  options?: { exclude?: ToolName[] },
+): Promise<void> {
   // Acquire lock to signal that a switch is in progress
   acquireSwitchLock();
 
@@ -821,6 +827,12 @@ export async function loadTools(modelIdentifier?: string): Promise<void> {
     } else {
       // When user explicitly sets --tools, respect that and allow any tool name
       baseToolNames = TOOL_NAMES;
+    }
+
+    // Apply exclusions (e.g. remove interactive-only tools in headless mode)
+    if (options?.exclude && options.exclude.length > 0) {
+      const excludeSet = new Set(options.exclude);
+      baseToolNames = baseToolNames.filter((name) => !excludeSet.has(name));
     }
 
     // Build new registry in a temporary map (all async work happens above)


### PR DESCRIPTION
## Summary
- Adds an `options?: { exclude?: ToolName[] }` parameter to `loadTools` in `src/tools/manager.ts`
- In headless mode (`src/index.ts`), passes `{ exclude: ["AskUserQuestion"] }` so the tool is never registered with the agent
- Previously, `AskUserQuestion` was included in the toolset but denied at call time — now the model never sees it at all

## Test plan
- [ ] Verify headless mode (`-p "..."`) no longer includes `AskUserQuestion` in the agent's toolset
- [ ] Verify interactive (TUI) mode still has `AskUserQuestion` available as normal

👾 Generated with [Letta Code](https://letta.com)