### PR TITLE
fix(tui): don't clear conversation model override on transient retrieve errors

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3376,7 +3376,13 @@ export default function App({
           "Failed to sync conversation model override: %O",
           error,
         );
-        applyAgentModelLocally();
+        // Preserve current local state on transient errors — the override flag
+        // was set by a successful /model write and should not be cleared by a
+        // failed read. The next sync cycle will retry and self-correct.
+        debugLog(
+          "conversation-model",
+          "Keeping current model state after sync error (override in DB is authoritative)",
+        );
       }
     };
 


### PR DESCRIPTION
## Summary
- The model sync effect's `catch` block was calling `applyAgentModelLocally()` on any `conversations.retrieve` failure, which cleared `hasConversationModelOverride` and reset the model display to agent defaults — even though the override was still persisted in the DB.
- This caused intermittent model snap-back that didn't require a recent `/model` to trigger: any transient network error during the sync cycle would discard local override state, and without another `agentState` change to re-trigger the effect, the reset persisted.
- Fix: preserve current local state on error. The next sync cycle retries the retrieve and self-corrects.

## Context
This addresses the error-path fallback identified during review of #1229 and #1238. Those PRs target the narrow race between `handleModelSelect` and the first-chunk `syncAgentState`, but the observed snap-back (without recent `/model`) is more likely caused by this error-path resetting the override flag on transient failures.

## Test plan
- [x] `bun run typecheck` — pre-existing errors only, no new issues
- [x] `bun run lint` — clean (warnings only, pre-existing)
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts` — 9/9 pass

👾 Generated with [Letta Code](https://letta.com)