### PR TITLE
fix(plan): add return-to-previous mode plan exit

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -79,6 +79,7 @@ import {
 } from "../hooks";
 import type { ApprovalContext } from "../permissions/analyzer";
 import { type PermissionMode, permissionMode } from "../permissions/mode";
+import { resolvePlanExitMode, type PlanExitDecision } from "./helpers/planExitApproval";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import {
   type MessageQueueItem,
@@ -9239,6 +9240,15 @@ export default function App({
           // Generate plan file path and enter plan mode
           const planPath = generatePlanFilePath();
           permissionMode.setPlanFilePath(planPath);
+
+          // Ensure plan mode remembers the permission mode the UI was showing.
+          const modeBeforePlan = uiPermissionModeRef.current;
+          if (
+            modeBeforePlan !== "plan" &&
+            permissionMode.getMode() !== modeBeforePlan
+          ) {
+            permissionMode.setMode(modeBeforePlan);
+          }
           permissionMode.setMode("plan");
           setUiPermissionMode("plan");
 
@@ -12260,7 +12270,7 @@ ${SYSTEM_REMINDER_CLOSE}
   }, [agentId, flushPendingReasoningEffort]);
 
   const handlePlanApprove = useCallback(
-    async (acceptEdits: boolean = false) => {
+    async (decision: PlanExitDecision = "restore") => {
       const currentIndex = approvalResults.length;
       const approval = pendingApprovals[currentIndex];
       if (!approval) return;
@@ -12272,9 +12282,10 @@ ${SYSTEM_REMINDER_CLOSE}
       lastPlanFilePathRef.current = planFilePath;
 
       // Exit plan mode
-      const restoreMode = acceptEdits
-        ? "acceptEdits"
-        : (permissionMode.getModeBeforePlan() ?? "default");
+      const restoreMode = resolvePlanExitMode(
+        decision,
+        permissionMode.getModeBeforePlan(),
+      );
       permissionMode.setMode(restoreMode);
       setUiPermissionMode(restoreMode);
 
@@ -12506,6 +12517,11 @@ ${SYSTEM_REMINDER_CLOSE}
     ).replace(/\\/g, "/");
 
     // Toggle plan mode on and store plan file path
+    // Ensure plan mode remembers the permission mode the UI was showing.
+    const modeBeforePlan = uiPermissionModeRef.current;
+    if (modeBeforePlan !== "plan" && permissionMode.getMode() !== modeBeforePlan) {
+      permissionMode.setMode(modeBeforePlan);
+    }
     permissionMode.setMode("plan");
     permissionMode.setPlanFilePath(planFilePath);
     setUiPermissionMode("plan");

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -79,7 +79,6 @@ import {
 } from "../hooks";
 import type { ApprovalContext } from "../permissions/analyzer";
 import { type PermissionMode, permissionMode } from "../permissions/mode";
-import { resolvePlanExitMode, type PlanExitDecision } from "./helpers/planExitApproval";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import {
   type MessageQueueItem,
@@ -241,6 +240,10 @@ import {
   clearPlaceholdersInText,
   resolvePlaceholders,
 } from "./helpers/pasteRegistry";
+import {
+  type PlanExitDecision,
+  resolvePlanExitMode,
+} from "./helpers/planExitApproval";
 import { generatePlanFilePath } from "./helpers/planName";
 import {
   buildContentFromQueueBatch,
@@ -12519,7 +12522,10 @@ ${SYSTEM_REMINDER_CLOSE}
     // Toggle plan mode on and store plan file path
     // Ensure plan mode remembers the permission mode the UI was showing.
     const modeBeforePlan = uiPermissionModeRef.current;
-    if (modeBeforePlan !== "plan" && permissionMode.getMode() !== modeBeforePlan) {
+    if (
+      modeBeforePlan !== "plan" &&
+      permissionMode.getMode() !== modeBeforePlan
+    ) {
       permissionMode.setMode(modeBeforePlan);
     }
     permissionMode.setMode("plan");

--- a/src/cli/commands/runner.ts
+++ b/src/cli/commands/runner.ts
@@ -77,61 +77,53 @@ export function createCommandRunner({
     const handle: CommandHandle = {
       id,
       input,
-      update: null!,
-      finish: null!,
-      fail: null!,
+      update: (updateData: CommandUpdate) => {
+        const previous = buffersRef.current.byId.get(id);
+        const wasFinished =
+          previous?.kind === "command" && previous.phase === "finished";
+
+        upsertCommandLine(buffersRef.current, id, input, updateData);
+        if (!buffersRef.current.order.includes(id)) {
+          buffersRef.current.order.push(id);
+        }
+
+        const next = buffersRef.current.byId.get(id);
+        const becameFinished =
+          !wasFinished && next?.kind === "command" && next.phase === "finished";
+        if (becameFinished) {
+          onCommandFinished?.({
+            id,
+            input: next.input,
+            output: next.output,
+            success: next.success !== false,
+            dimOutput: next.dimOutput,
+            preformatted: next.preformatted,
+            agentHint: handle.agentHint,
+          });
+        }
+
+        refreshDerived();
+      },
+      finish: (
+        finalOutput: string,
+        success = true,
+        dimOutput?: boolean,
+        preformatted?: boolean,
+      ) =>
+        handle.update({
+          output: finalOutput,
+          phase: "finished",
+          success,
+          dimOutput,
+          preformatted,
+        }),
+      fail: (finalOutput: string) =>
+        handle.update({
+          output: finalOutput,
+          phase: "finished",
+          success: false,
+        }),
     };
-
-    const update = (updateData: CommandUpdate) => {
-      const previous = buffersRef.current.byId.get(id);
-      const wasFinished =
-        previous?.kind === "command" && previous.phase === "finished";
-
-      upsertCommandLine(buffersRef.current, id, input, updateData);
-      if (!buffersRef.current.order.includes(id)) {
-        buffersRef.current.order.push(id);
-      }
-
-      const next = buffersRef.current.byId.get(id);
-      const becameFinished =
-        !wasFinished && next?.kind === "command" && next.phase === "finished";
-      if (becameFinished) {
-        onCommandFinished?.({
-          id,
-          input: next.input,
-          output: next.output,
-          success: next.success !== false,
-          dimOutput: next.dimOutput,
-          preformatted: next.preformatted,
-          agentHint: handle.agentHint,
-        });
-      }
-
-      refreshDerived();
-    };
-
-    handle.update = update;
-
-    handle.finish = (
-      finalOutput: string,
-      success = true,
-      dimOutput?: boolean,
-      preformatted?: boolean,
-    ) =>
-      update({
-        output: finalOutput,
-        phase: "finished",
-        success,
-        dimOutput,
-        preformatted,
-      });
-
-    handle.fail = (finalOutput: string) =>
-      update({
-        output: finalOutput,
-        phase: "finished",
-        success: false,
-      });
 
     return handle;
   }

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -15,6 +15,7 @@ import { InlineGenericApproval } from "./InlineGenericApproval";
 import { InlineQuestionApproval } from "./InlineQuestionApproval";
 import { InlineTaskApproval } from "./InlineTaskApproval";
 import { StaticPlanApproval } from "./StaticPlanApproval";
+import type { PlanExitDecision } from "../helpers/planExitApproval";
 
 // Types for parsed tool data
 type BashInfo = {
@@ -71,7 +72,7 @@ type Props = {
   defaultScope?: "project" | "session";
 
   // Special handlers for ExitPlanMode
-  onPlanApprove?: (acceptEdits: boolean) => void;
+  onPlanApprove?: (decision: PlanExitDecision) => void;
   onPlanKeepPlanning?: (reason: string) => void;
 
   // Special handlers for AskUserQuestion
@@ -232,8 +233,9 @@ export const ApprovalSwitch = memo(
     if (toolName === "ExitPlanMode" && onPlanApprove && onPlanKeepPlanning) {
       return (
         <StaticPlanApproval
-          onApprove={() => onPlanApprove(false)}
-          onApproveAndAcceptEdits={() => onPlanApprove(true)}
+          onApproveRestore={() => onPlanApprove("restore")}
+          onApproveManual={() => onPlanApprove("manual")}
+          onApproveAndAcceptEdits={() => onPlanApprove("autoAccept")}
           onKeepPlanning={onPlanKeepPlanning}
           onCancel={onCancel ?? (() => {})}
           isFocused={isFocused}

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import type { AdvancedDiffSuccess } from "../helpers/diff";
+import type { PlanExitDecision } from "../helpers/planExitApproval";
 import type { ApprovalRequest } from "../helpers/stream";
 import {
   isFileEditTool,
@@ -15,7 +16,6 @@ import { InlineGenericApproval } from "./InlineGenericApproval";
 import { InlineQuestionApproval } from "./InlineQuestionApproval";
 import { InlineTaskApproval } from "./InlineTaskApproval";
 import { StaticPlanApproval } from "./StaticPlanApproval";
-import type { PlanExitDecision } from "../helpers/planExitApproval";
 
 // Types for parsed tool data
 type BashInfo = {

--- a/src/cli/components/InlinePlanApproval.tsx
+++ b/src/cli/components/InlinePlanApproval.tsx
@@ -1,5 +1,10 @@
 import { Box, useInput } from "ink";
 import { memo, useMemo, useState } from "react";
+import { permissionMode } from "../../permissions/mode";
+import {
+  getPlanExitChoices,
+  type PlanExitChoice,
+} from "../helpers/planExitApproval";
 import { useProgressIndicator } from "../hooks/useProgressIndicator";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { useTextInputCursor } from "../hooks/useTextInputCursor";
@@ -9,7 +14,8 @@ import { Text } from "./Text";
 
 type Props = {
   plan: string;
-  onApprove: () => void;
+  onApproveRestore: () => void;
+  onApproveManual: () => void;
   onApproveAndAcceptEdits: () => void;
   onKeepPlanning: (reason: string) => void;
   isFocused?: boolean;
@@ -30,7 +36,8 @@ const DOTTED_LINE = "╌";
 export const InlinePlanApproval = memo(
   ({
     plan,
-    onApprove,
+    onApproveRestore,
+    onApproveManual,
     onApproveAndAcceptEdits,
     onKeepPlanning,
     isFocused = true,
@@ -45,8 +52,10 @@ export const InlinePlanApproval = memo(
     const columns = useTerminalWidth();
     useProgressIndicator();
 
-    const customOptionIndex = 2;
-    const maxOptionIndex = customOptionIndex;
+    const modeBeforePlan = permissionMode.getModeBeforePlan() ?? "default";
+    const options: PlanExitChoice[] = getPlanExitChoices(modeBeforePlan);
+    const customOptionIndex = options.findIndex((o) => o.decision === "custom");
+    const maxOptionIndex = Math.max(0, options.length - 1);
     const isOnCustomOption = selectedOption === customOptionIndex;
     const customOptionPlaceholder =
       "Type here to tell Letta Code what to change";
@@ -93,15 +102,29 @@ export const InlinePlanApproval = memo(
 
         // When on regular options
         if (key.return) {
-          if (selectedOption === 0) {
-            onApproveAndAcceptEdits();
-          } else if (selectedOption === 1) {
-            onApprove();
-          }
+          const choice = options[selectedOption];
+          if (!choice) return;
+          if (choice.decision === "restore") onApproveRestore();
+          if (choice.decision === "manual") onApproveManual();
+          if (choice.decision === "autoAccept") onApproveAndAcceptEdits();
           return;
         }
         if (key.escape) {
           onKeepPlanning("User cancelled");
+          return;
+        }
+
+        if (/^[1-9]$/.test(input)) {
+          const idx = Number(input) - 1;
+          const choice = options[idx];
+          if (!choice) return;
+          if (choice.decision === "custom") {
+            setSelectedOption(idx);
+            return;
+          }
+          if (choice.decision === "restore") onApproveRestore();
+          if (choice.decision === "manual") onApproveManual();
+          if (choice.decision === "autoAccept") onApproveAndAcceptEdits();
         }
       },
       { isActive: isFocused },
@@ -159,76 +182,41 @@ export const InlinePlanApproval = memo(
 
         {/* Options */}
         <Box marginTop={1} flexDirection="column">
-          {/* Option 1: Yes, and auto-accept edits */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={
-                  selectedOption === 0 ? colors.approval.header : undefined
-                }
-              >
-                {selectedOption === 0 ? "❯" : " "} 1.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              <Text
-                wrap="wrap"
-                color={
-                  selectedOption === 0 ? colors.approval.header : undefined
-                }
-              >
-                Yes, and auto-accept edits
-              </Text>
-            </Box>
-          </Box>
+          {options.map((opt, idx) => {
+            const isSelected = selectedOption === idx;
+            const color = isSelected ? colors.approval.header : undefined;
+            const isCustom = opt.decision === "custom";
 
-          {/* Option 2: Yes, and manually approve edits */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={
-                  selectedOption === 1 ? colors.approval.header : undefined
-                }
-              >
-                {selectedOption === 1 ? "❯" : " "} 2.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              <Text
-                wrap="wrap"
-                color={
-                  selectedOption === 1 ? colors.approval.header : undefined
-                }
-              >
-                Yes, and manually approve edits
-              </Text>
-            </Box>
-          </Box>
-
-          {/* Option 3: Custom input */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={isOnCustomOption ? colors.approval.header : undefined}
-              >
-                {isOnCustomOption ? "❯" : " "} 3.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              {customReason ? (
-                <Text wrap="wrap">
-                  {customReason.slice(0, cursorPos)}
-                  {isOnCustomOption && "█"}
-                  {customReason.slice(cursorPos)}
-                </Text>
-              ) : (
-                <Text wrap="wrap" dimColor>
-                  {customOptionPlaceholder}
-                  {isOnCustomOption && "█"}
-                </Text>
-              )}
-            </Box>
-          </Box>
+            return (
+              <Box key={`${opt.decision}-${idx}`} flexDirection="row">
+                <Box width={5} flexShrink={0}>
+                  <Text color={color}>
+                    {isSelected ? "❯" : " "} {idx + 1}.
+                  </Text>
+                </Box>
+                <Box flexGrow={1} width={Math.max(0, columns - 5)}>
+                  {isCustom ? (
+                    customReason ? (
+                      <Text wrap="wrap">
+                        {customReason.slice(0, cursorPos)}
+                        {isSelected && "█"}
+                        {customReason.slice(cursorPos)}
+                      </Text>
+                    ) : (
+                      <Text wrap="wrap" dimColor>
+                        {customOptionPlaceholder}
+                        {isSelected && "█"}
+                      </Text>
+                    )
+                  ) : (
+                    <Text wrap="wrap" color={color}>
+                      {opt.label}
+                    </Text>
+                  )}
+                </Box>
+              </Box>
+            );
+          })}
         </Box>
 
         {/* Hint */}

--- a/src/cli/components/PlanModeDialog.tsx
+++ b/src/cli/components/PlanModeDialog.tsx
@@ -1,6 +1,11 @@
 import { Box, useInput } from "ink";
 import { memo, useState } from "react";
+import { permissionMode } from "../../permissions/mode";
 import { resolvePlaceholders } from "../helpers/pasteRegistry";
+import {
+  getPlanExitChoices,
+  type PlanExitChoice,
+} from "../helpers/planExitApproval";
 import { useProgressIndicator } from "../hooks/useProgressIndicator";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
@@ -9,7 +14,8 @@ import { Text } from "./Text";
 
 type Props = {
   plan: string;
-  onApprove: () => void;
+  onApproveRestore: () => void;
+  onApproveManual: () => void;
   onApproveAndAcceptEdits: () => void;
   onKeepPlanning: (reason: string) => void;
 };
@@ -19,7 +25,7 @@ const OptionsRenderer = memo(
     options,
     selectedOption,
   }: {
-    options: Array<{ label: string }>;
+    options: PlanExitChoice[];
     selectedOption: number;
   }) => {
     return (
@@ -43,17 +49,20 @@ const OptionsRenderer = memo(
 OptionsRenderer.displayName = "OptionsRenderer";
 
 export const PlanModeDialog = memo(
-  ({ plan, onApprove, onApproveAndAcceptEdits, onKeepPlanning }: Props) => {
+  ({
+    plan,
+    onApproveRestore,
+    onApproveManual,
+    onApproveAndAcceptEdits,
+    onKeepPlanning,
+  }: Props) => {
     const [selectedOption, setSelectedOption] = useState(0);
     const [isEnteringReason, setIsEnteringReason] = useState(false);
     const [denyReason, setDenyReason] = useState("");
     useProgressIndicator();
 
-    const options = [
-      { label: "Yes, and auto-accept edits", action: onApproveAndAcceptEdits },
-      { label: "Yes, and manually approve edits", action: onApprove },
-      { label: "No, keep planning", action: () => {} }, // Handled via setIsEnteringReason
-    ];
+    const modeBeforePlan = permissionMode.getModeBeforePlan() ?? "default";
+    const options = getPlanExitChoices(modeBeforePlan);
 
     useInput((_input, key) => {
       // CTRL-C: immediately exit plan approval (closest to cancel)
@@ -82,11 +91,15 @@ export const PlanModeDialog = memo(
       } else if (key.downArrow) {
         setSelectedOption((prev) => Math.min(options.length - 1, prev + 1));
       } else if (key.return) {
-        // Check if this is the "keep planning" option (last option)
-        if (selectedOption === options.length - 1) {
+        const choice = options[selectedOption];
+        if (!choice) return;
+
+        if (choice.decision === "custom") {
           setIsEnteringReason(true);
         } else {
-          options[selectedOption]?.action();
+          if (choice.decision === "restore") onApproveRestore();
+          if (choice.decision === "manual") onApproveManual();
+          if (choice.decision === "autoAccept") onApproveAndAcceptEdits();
         }
       } else if (key.escape) {
         setIsEnteringReason(true); // ESC also goes to denial input

--- a/src/cli/components/StaticPlanApproval.tsx
+++ b/src/cli/components/StaticPlanApproval.tsx
@@ -1,6 +1,11 @@
 import { Box, useInput } from "ink";
 import { memo, useCallback, useState } from "react";
+import { permissionMode } from "../../permissions/mode";
 import { generateAndOpenPlanViewer } from "../../web/generate-plan-viewer";
+import {
+  getPlanExitChoices,
+  type PlanExitChoice,
+} from "../helpers/planExitApproval";
 import { useProgressIndicator } from "../hooks/useProgressIndicator";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { useTextInputCursor } from "../hooks/useTextInputCursor";
@@ -8,7 +13,8 @@ import { colors } from "./colors";
 import { Text } from "./Text";
 
 type Props = {
-  onApprove: () => void;
+  onApproveRestore: () => void;
+  onApproveManual: () => void;
   onApproveAndAcceptEdits: () => void;
   onKeepPlanning: (reason: string) => void;
   onCancel: () => void; // For CTRL-C to queue denial (like other approval screens)
@@ -31,7 +37,8 @@ type Props = {
  */
 export const StaticPlanApproval = memo(
   ({
-    onApprove,
+    onApproveRestore,
+    onApproveManual,
     onApproveAndAcceptEdits,
     onKeepPlanning,
     onCancel,
@@ -51,6 +58,12 @@ export const StaticPlanApproval = memo(
     const columns = useTerminalWidth();
     useProgressIndicator();
 
+    const modeBeforePlan = permissionMode.getModeBeforePlan() ?? "default";
+    const options: PlanExitChoice[] = getPlanExitChoices(modeBeforePlan);
+    const customOptionIndex = options.findIndex((o) => o.decision === "custom");
+    const maxOptionIndex = Math.max(0, options.length - 1);
+    const isOnCustomOption = selectedOption === customOptionIndex;
+
     const openInBrowser = useCallback(() => {
       if (!planContent || !planFilePath) return;
       setBrowserStatus("Opening in browser...");
@@ -69,9 +82,6 @@ export const StaticPlanApproval = memo(
         });
     }, [planContent, planFilePath, agentName]);
 
-    const customOptionIndex = 2;
-    const maxOptionIndex = customOptionIndex;
-    const isOnCustomOption = selectedOption === customOptionIndex;
     const customOptionPlaceholder =
       "Type here to tell Letta Code what to change";
 
@@ -127,11 +137,11 @@ export const StaticPlanApproval = memo(
 
         // When on regular options
         if (key.return) {
-          if (selectedOption === 0) {
-            onApproveAndAcceptEdits();
-          } else if (selectedOption === 1) {
-            onApprove();
-          }
+          const choice = options[selectedOption];
+          if (!choice) return;
+          if (choice.decision === "restore") onApproveRestore();
+          if (choice.decision === "manual") onApproveManual();
+          if (choice.decision === "autoAccept") onApproveAndAcceptEdits();
           return;
         }
         if (key.escape) {
@@ -140,12 +150,17 @@ export const StaticPlanApproval = memo(
         }
 
         // Number keys for quick selection (only for fixed options, not custom text input)
-        if (input === "1") {
-          onApproveAndAcceptEdits();
-          return;
-        }
-        if (input === "2") {
-          onApprove();
+        if (/^[1-9]$/.test(input)) {
+          const idx = Number(input) - 1;
+          const choice = options[idx];
+          if (!choice) return;
+          if (choice.decision === "custom") {
+            setSelectedOption(idx);
+            return;
+          }
+          if (choice.decision === "restore") onApproveRestore();
+          if (choice.decision === "manual") onApproveManual();
+          if (choice.decision === "autoAccept") onApproveAndAcceptEdits();
           return;
         }
       },
@@ -169,76 +184,40 @@ export const StaticPlanApproval = memo(
 
         {/* Options */}
         <Box marginTop={1} flexDirection="column">
-          {/* Option 1: Yes, and auto-accept edits */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={
-                  selectedOption === 0 ? colors.approval.header : undefined
-                }
-              >
-                {selectedOption === 0 ? "❯" : " "} 1.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              <Text
-                wrap="wrap"
-                color={
-                  selectedOption === 0 ? colors.approval.header : undefined
-                }
-              >
-                Yes, and auto-accept edits
-              </Text>
-            </Box>
-          </Box>
-
-          {/* Option 2: Yes, and manually approve edits */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={
-                  selectedOption === 1 ? colors.approval.header : undefined
-                }
-              >
-                {selectedOption === 1 ? "❯" : " "} 2.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              <Text
-                wrap="wrap"
-                color={
-                  selectedOption === 1 ? colors.approval.header : undefined
-                }
-              >
-                Yes, and manually approve edits
-              </Text>
-            </Box>
-          </Box>
-
-          {/* Option 3: Custom input */}
-          <Box flexDirection="row">
-            <Box width={5} flexShrink={0}>
-              <Text
-                color={isOnCustomOption ? colors.approval.header : undefined}
-              >
-                {isOnCustomOption ? "❯" : " "} 3.
-              </Text>
-            </Box>
-            <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              {customReason ? (
-                <Text wrap="wrap">
-                  {customReason.slice(0, cursorPos)}
-                  {isOnCustomOption && "█"}
-                  {customReason.slice(cursorPos)}
-                </Text>
-              ) : (
-                <Text wrap="wrap" dimColor>
-                  {customOptionPlaceholder}
-                  {isOnCustomOption && "█"}
-                </Text>
-              )}
-            </Box>
-          </Box>
+          {options.map((opt, idx) => {
+            const isSelected = selectedOption === idx;
+            const color = isSelected ? colors.approval.header : undefined;
+            const isCustom = opt.decision === "custom";
+            return (
+              <Box key={`${opt.decision}-${idx}`} flexDirection="row">
+                <Box width={5} flexShrink={0}>
+                  <Text color={color}>
+                    {isSelected ? "❯" : " "} {idx + 1}.
+                  </Text>
+                </Box>
+                <Box flexGrow={1} width={Math.max(0, columns - 5)}>
+                  {isCustom ? (
+                    customReason ? (
+                      <Text wrap="wrap">
+                        {customReason.slice(0, cursorPos)}
+                        {isSelected && "█"}
+                        {customReason.slice(cursorPos)}
+                      </Text>
+                    ) : (
+                      <Text wrap="wrap" dimColor>
+                        {customOptionPlaceholder}
+                        {isSelected && "█"}
+                      </Text>
+                    )
+                  ) : (
+                    <Text wrap="wrap" color={color}>
+                      {opt.label}
+                    </Text>
+                  )}
+                </Box>
+              </Box>
+            );
+          })}
         </Box>
 
         {/* Hint */}

--- a/src/cli/helpers/planExitApproval.ts
+++ b/src/cli/helpers/planExitApproval.ts
@@ -28,6 +28,22 @@ export function formatPermissionModeForPlanReturnLabel(
   }
 }
 
+export function getPlanExitRestoreLabel(
+  modeBeforePlan: PermissionMode | null | undefined,
+): string {
+  const prev = normalizeModeBeforePlan(modeBeforePlan);
+
+  switch (prev) {
+    case "bypassPermissions":
+      return "Yes, and return to yolo mode";
+    case "acceptEdits":
+      return "Yes, and return to auto-accept edits";
+    case "default":
+    case "plan":
+      return "Yes, and return to manual approvals";
+  }
+}
+
 /**
  * Build the list of choices shown when approving ExitPlanMode.
  *
@@ -39,12 +55,11 @@ export function getPlanExitChoices(
   modeBeforePlan: PermissionMode | null | undefined,
 ): PlanExitChoice[] {
   const prev = normalizeModeBeforePlan(modeBeforePlan);
-  const prevLabel = formatPermissionModeForPlanReturnLabel(prev);
 
   const choices: PlanExitChoice[] = [
     {
       decision: "restore",
-      label: `Yes, and return to previous mode (${prevLabel})`,
+      label: getPlanExitRestoreLabel(prev),
     },
   ];
 

--- a/src/cli/helpers/planExitApproval.ts
+++ b/src/cli/helpers/planExitApproval.ts
@@ -1,0 +1,75 @@
+import type { PermissionMode } from "../../permissions/mode";
+
+export type PlanExitDecision = "restore" | "manual" | "autoAccept";
+export type PlanExitChoice = {
+  decision: PlanExitDecision | "custom";
+  label: string;
+};
+
+function normalizeModeBeforePlan(
+  modeBeforePlan: PermissionMode | null | undefined,
+): PermissionMode {
+  if (!modeBeforePlan || modeBeforePlan === "plan") return "default";
+  return modeBeforePlan;
+}
+
+export function formatPermissionModeForPlanReturnLabel(mode: PermissionMode): string {
+  switch (mode) {
+    case "bypassPermissions":
+      return "yolo";
+    case "acceptEdits":
+      return "auto-accept edits";
+    case "default":
+      return "manual approvals";
+    case "plan":
+      return "manual approvals";
+  }
+}
+
+/**
+ * Build the list of choices shown when approving ExitPlanMode.
+ *
+ * Always includes the "return to previous mode" option as the default.
+ * Omits duplicate options when the previous mode already corresponds to
+ * manual approvals (default) or auto-accept edits (acceptEdits).
+ */
+export function getPlanExitChoices(
+  modeBeforePlan: PermissionMode | null | undefined,
+): PlanExitChoice[] {
+  const prev = normalizeModeBeforePlan(modeBeforePlan);
+  const prevLabel = formatPermissionModeForPlanReturnLabel(prev);
+
+  const choices: PlanExitChoice[] = [
+    {
+      decision: "restore",
+      label: `Yes, and return to previous mode (${prevLabel})`,
+    },
+  ];
+
+  // Avoid duplicates.
+  if (prev !== "default") {
+    choices.push({
+      decision: "manual",
+      label: "Yes, and manually approve edits",
+    });
+  }
+  if (prev !== "acceptEdits") {
+    choices.push({
+      decision: "autoAccept",
+      label: "Yes, and auto-accept edits",
+    });
+  }
+
+  choices.push({ decision: "custom", label: "custom" });
+  return choices;
+}
+
+export function resolvePlanExitMode(
+  decision: PlanExitDecision,
+  modeBeforePlan: PermissionMode | null | undefined,
+): PermissionMode {
+  const prev = normalizeModeBeforePlan(modeBeforePlan);
+  if (decision === "restore") return prev;
+  if (decision === "manual") return "default";
+  return "acceptEdits";
+}

--- a/src/cli/helpers/planExitApproval.ts
+++ b/src/cli/helpers/planExitApproval.ts
@@ -13,7 +13,9 @@ function normalizeModeBeforePlan(
   return modeBeforePlan;
 }
 
-export function formatPermissionModeForPlanReturnLabel(mode: PermissionMode): string {
+export function formatPermissionModeForPlanReturnLabel(
+  mode: PermissionMode,
+): string {
   switch (mode) {
     case "bypassPermissions":
       return "yolo";

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -26,6 +26,22 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain('permissionMode.setMode("plan")');
   });
 
+  test("slash plan syncs singleton before switching to plan", () => {
+    const source = readAppSource();
+
+    const start = source.indexOf('if (trimmed === "/plan") {');
+    const end = source.indexOf("return { submitted: true };", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain(
+      "const modeBeforePlan = uiPermissionModeRef.current",
+    );
+    expect(segment).toContain("permissionMode.setMode(modeBeforePlan);");
+    expect(segment).toContain('permissionMode.setMode("plan")');
+  });
+
   test("setUiPermissionMode syncs singleton mode immediately", () => {
     const source = readAppSource();
 

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -19,7 +19,9 @@ describe("permission mode retry wiring", () => {
     expect(end).toBeGreaterThan(start);
 
     const segment = source.slice(start, end);
-    expect(segment).toContain("const modeBeforePlan = uiPermissionModeRef.current");
+    expect(segment).toContain(
+      "const modeBeforePlan = uiPermissionModeRef.current",
+    );
     expect(segment).toContain("permissionMode.setMode(modeBeforePlan);");
     expect(segment).toContain('permissionMode.setMode("plan")');
   });

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -8,6 +8,22 @@ function readAppSource(): string {
 }
 
 describe("permission mode retry wiring", () => {
+  test("enter plan mode approval syncs singleton before switching to plan", () => {
+    const source = readAppSource();
+
+    const start = source.indexOf(
+      "const handleEnterPlanModeApprove = useCallback(async () => {",
+    );
+    const end = source.indexOf("const handleEnterPlanModeReject = useCallback");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("const modeBeforePlan = uiPermissionModeRef.current");
+    expect(segment).toContain("permissionMode.setMode(modeBeforePlan);");
+    expect(segment).toContain('permissionMode.setMode("plan")');
+  });
+
   test("setUiPermissionMode syncs singleton mode immediately", () => {
     const source = readAppSource();
 

--- a/src/tests/cli/plan-exit-approval.test.ts
+++ b/src/tests/cli/plan-exit-approval.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getPlanExitChoices,
+  getPlanExitRestoreLabel,
   resolvePlanExitMode,
 } from "../../cli/helpers/planExitApproval";
 
@@ -19,6 +20,21 @@ describe("plan exit approval", () => {
       (c) => c.decision,
     );
     expect(yoloChoices).toEqual(["restore", "manual", "autoAccept", "custom"]);
+  });
+
+  test("restore labels are explicit about the mode being restored", () => {
+    expect(getPlanExitRestoreLabel("bypassPermissions")).toBe(
+      "Yes, and return to yolo mode",
+    );
+    expect(getPlanExitRestoreLabel("acceptEdits")).toBe(
+      "Yes, and return to auto-accept edits",
+    );
+    expect(getPlanExitRestoreLabel("default")).toBe(
+      "Yes, and return to manual approvals",
+    );
+    expect(getPlanExitChoices("bypassPermissions")[0]?.label).toBe(
+      "Yes, and return to yolo mode",
+    );
   });
 
   test("exit mode resolution", () => {

--- a/src/tests/cli/plan-exit-approval.test.ts
+++ b/src/tests/cli/plan-exit-approval.test.ts
@@ -10,10 +10,14 @@ describe("plan exit approval", () => {
     const defaultChoices = getPlanExitChoices("default").map((c) => c.decision);
     expect(defaultChoices).toEqual(["restore", "autoAccept", "custom"]);
 
-    const acceptChoices = getPlanExitChoices("acceptEdits").map((c) => c.decision);
+    const acceptChoices = getPlanExitChoices("acceptEdits").map(
+      (c) => c.decision,
+    );
     expect(acceptChoices).toEqual(["restore", "manual", "custom"]);
 
-    const yoloChoices = getPlanExitChoices("bypassPermissions").map((c) => c.decision);
+    const yoloChoices = getPlanExitChoices("bypassPermissions").map(
+      (c) => c.decision,
+    );
     expect(yoloChoices).toEqual(["restore", "manual", "autoAccept", "custom"]);
   });
 

--- a/src/tests/cli/plan-exit-approval.test.ts
+++ b/src/tests/cli/plan-exit-approval.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getPlanExitChoices,
+  resolvePlanExitMode,
+} from "../../cli/helpers/planExitApproval";
+
+describe("plan exit approval", () => {
+  test("choices omit duplicates for default/acceptEdits", () => {
+    const defaultChoices = getPlanExitChoices("default").map((c) => c.decision);
+    expect(defaultChoices).toEqual(["restore", "autoAccept", "custom"]);
+
+    const acceptChoices = getPlanExitChoices("acceptEdits").map((c) => c.decision);
+    expect(acceptChoices).toEqual(["restore", "manual", "custom"]);
+
+    const yoloChoices = getPlanExitChoices("bypassPermissions").map((c) => c.decision);
+    expect(yoloChoices).toEqual(["restore", "manual", "autoAccept", "custom"]);
+  });
+
+  test("exit mode resolution", () => {
+    expect(resolvePlanExitMode("restore", "bypassPermissions")).toBe(
+      "bypassPermissions",
+    );
+    expect(resolvePlanExitMode("restore", null)).toBe("default");
+
+    expect(resolvePlanExitMode("manual", "bypassPermissions")).toBe("default");
+    expect(resolvePlanExitMode("manual", "acceptEdits")).toBe("default");
+
+    expect(resolvePlanExitMode("autoAccept", "default")).toBe("acceptEdits");
+    expect(resolvePlanExitMode("autoAccept", "bypassPermissions")).toBe(
+      "acceptEdits",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ExitPlanMode approval now defaults to returning to the permission mode that was active before plan mode (and shows that mode in the option label).
- Avoids duplicate options when the previous mode already corresponds to manual approvals or auto-accept edits.
- Syncs the permissionMode singleton with the UI mode right before switching to plan mode (EnterPlanMode approval + /plan).

## Test plan
- [x] bun test src/tests/cli/plan-exit-approval.test.ts
- [x] bun test src/tests/cli/permission-mode-retry-wiring.test.ts

👾 Generated with [Letta Code](https://letta.com)