### PR TITLE
chore: remove system-append flag

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -143,8 +143,6 @@ export interface CreateAgentOptions {
   systemPromptPreset?: string;
   /** Raw system prompt string (mutually exclusive with systemPromptPreset) */
   systemPromptCustom?: string;
-  /** Additional text to append to the resolved system prompt */
-  systemPromptAppend?: string;
   /** Which managed memory prompt mode to apply */
   memoryPromptMode?: MemoryPromptMode;
   /** Block labels to initialize (from default blocks) */
@@ -357,7 +355,6 @@ export async function createAgent(
   // 1. If systemPromptCustom is provided, use it as-is
   // 2. Otherwise, resolve systemPromptPreset to content
   // 3. Reconcile to the selected managed memory mode
-  // 4. If systemPromptAppend is provided, append it to the result
   let systemPromptContent: string;
   if (options.systemPromptCustom) {
     systemPromptContent = options.systemPromptCustom;
@@ -369,11 +366,6 @@ export async function createAgent(
     systemPromptContent,
     options.memoryPromptMode ?? "standard",
   );
-
-  // Append additional instructions if provided
-  if (options.systemPromptAppend) {
-    systemPromptContent = `${systemPromptContent}\n\n${options.systemPromptAppend}`;
-  }
 
   // Create agent with inline memory blocks (LET-7101: single API call instead of N+1)
   // - memory_blocks: new blocks to create inline

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -111,7 +111,6 @@ export const CLI_FLAG_CATALOG = {
     },
   },
   "system-custom": { parser: { type: "string" }, mode: "both" },
-  "system-append": { parser: { type: "string" }, mode: "headless" },
   "memory-blocks": { parser: { type: "string" }, mode: "both" },
   "block-value": {
     parser: { type: "string", multiple: true },

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -387,7 +387,6 @@ export async function handleHeadlessCommand(
   const forceNew = values["new-agent"];
   const systemPromptPreset = values.system;
   const systemCustom = values["system-custom"];
-  const systemAppend = values["system-append"];
   const embeddingModel = values.embedding;
   const memoryBlocksJson = values["memory-blocks"];
   const blockValueArgs = values["block-value"];
@@ -804,7 +803,6 @@ export async function handleHeadlessCommand(
       parallelToolCalls: true,
       systemPromptPreset,
       systemPromptCustom: systemCustom,
-      systemPromptAppend: systemAppend,
       memoryPromptMode: requestedMemoryPromptMode,
       initBlocks,
       baseTools,

--- a/src/index.ts
+++ b/src/index.ts
@@ -492,7 +492,6 @@ async function main(): Promise<void> {
   const specifiedModel = values.model ?? undefined;
   const systemPromptPreset = values.system ?? undefined;
   const systemCustom = values["system-custom"] ?? undefined;
-  // Note: systemAppend is also parsed but only used in headless mode (headless.ts handles it)
   const memoryBlocksJson = values["memory-blocks"] ?? undefined;
   const specifiedToolset = values.toolset ?? undefined;
   const skillsDirectory = values.skills ?? undefined;

--- a/src/tests/cli/args.test.ts
+++ b/src/tests/cli/args.test.ts
@@ -105,6 +105,22 @@ describe("shared CLI arg schema", () => {
     expect(parsed.values["block-value"]).toEqual(["persona=hello"]);
   });
 
+  test("rejects removed system-append flag in strict mode", () => {
+    expect(() =>
+      parseCliArgs(
+        preprocessCliArgs([
+          "node",
+          "script",
+          "-p",
+          "hello",
+          "--system-append",
+          "extra instructions",
+        ]),
+        true,
+      ),
+    ).toThrow();
+  });
+
   test("treats --import argument as a flag value, not prompt text", () => {
     const parsed = parseCliArgs(
       preprocessCliArgs([


### PR DESCRIPTION
## Summary
- remove the system-append CLI flag from the shared arg catalog
- stop threading appended system prompt text through headless agent creation
- add a strict parsing regression test for the removed flag

## Testing
- bun test src/tests/cli/args.test.ts
- bun run typecheck