### PR TITLE
chore: restore null! placeholders for forward-reference pattern

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3686,7 +3686,7 @@ export default function App({
   // removed. Git-backed memory uses standard git merge conflict resolution via the agent.
 
   // Core streaming function - iterative loop that processes conversation turns
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refs read .current dynamically, complex callback with intentional deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: blanket suppression — this callback has ~16 omitted deps (refs, stable functions, etc.). Refs are safe (read .current dynamically), but the blanket ignore also hides any genuinely missing reactive deps. If stale-closure bugs appear in processConversation, audit the dep array here first.
   const processConversation = useCallback(
     async (
       initialInput: Array<MessageCreate | ApprovalCreate>,
@@ -6733,7 +6733,7 @@ export default function App({
     queueApprovalResults,
   ]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refs read .current dynamically, complex callback with intentional deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: blanket suppression — same caveat as processConversation above. Omitted deps are mostly refs and stable callbacks, but this hides any genuinely missing reactive deps too.
   const onSubmit = useCallback(
     async (message?: string): Promise<{ submitted: boolean }> => {
       const msg = message?.trim() ?? "";

--- a/src/cli/commands/runner.ts
+++ b/src/cli/commands/runner.ts
@@ -73,18 +73,13 @@ export function createCommandRunner({
   onCommandFinished,
 }: RunnerDeps) {
   function getHandle(id: string, input: string): CommandHandle {
+    // biome-ignore lint/style/noNonNullAssertion: forward-reference pattern — overwritten synchronously below. null! preferred over no-ops to crash loudly if invariant breaks.
     const handle: CommandHandle = {
       id,
       input,
-      // Placeholders are overwritten below before the handle is returned.
-      update: (_update: CommandUpdate) => {},
-      finish: (
-        _output: string,
-        _success?: boolean,
-        _dimOutput?: boolean,
-        _preformatted?: boolean,
-      ) => {},
-      fail: (_output: string) => {},
+      update: null!,
+      finish: null!,
+      fail: null!,
     };
 
     const update = (updateData: CommandUpdate) => {


### PR DESCRIPTION
## Summary
- Reverts the `null!` → no-op function change from #1238 in `src/cli/commands/runner.ts`
- `null!` is the correct default for a synchronous forward-reference pattern: if the overwrite invariant ever breaks, a `TypeError: null is not a function` crash is easier to debug than a silent no-op swallowing the call
- Adds a targeted `biome-ignore lint/style/noNonNullAssertion` with an explanation so lint stays clean

## Test plan
- [x] `bun run lint` — 0 errors, 4 warnings (all pre-existing)

👾 Generated with [Letta Code](https://letta.com)