### PR TITLE
fix: use SYSTEM_PROMPT for default preset instead of letta-claude

### DIFF
--- a/src/agent/promptAssets.ts
+++ b/src/agent/promptAssets.ts
@@ -68,8 +68,8 @@ export const SYSTEM_PROMPTS: SystemPromptOption[] = [
   {
     id: "default",
     label: "Default",
-    description: "Alias for letta-claude",
-    content: lettaAnthropicPrompt,
+    description: "Letta-tuned system prompt",
+    content: systemPrompt,
     isDefault: true,
     isFeatured: true,
   },

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -42,7 +42,7 @@ export type {
  * Use this to select a built-in system prompt with optional appended text.
  *
  * Available presets (validated at runtime by CLI):
- * - 'default' - Alias for letta-claude
+ * - 'default' - Letta-tuned system prompt
  * - 'letta-claude' - Full Letta Code prompt (Claude-optimized)
  * - 'letta-codex' - Full Letta Code prompt (Codex-optimized)
  * - 'letta-gemini' - Full Letta Code prompt (Gemini-optimized)


### PR DESCRIPTION
## Summary

The `"default"` preset in `SYSTEM_PROMPTS` was an alias for `letta-claude` (used `lettaAnthropicPrompt`), but `resolveSystemPrompt(undefined)` returned `SYSTEM_PROMPT` (the Letta-tuned prompt from `system_prompt.txt`). This meant the two paths for "give me the default prompt" returned different content.

Now `"default"` uses `systemPrompt` (i.e. `SYSTEM_PROMPT`), making both paths consistent.

## Changes

- `src/agent/promptAssets.ts` — Changed `SYSTEM_PROMPTS[0].content` from `lettaAnthropicPrompt` to `systemPrompt`, updated description to "Letta-tuned system prompt"
- `src/types/protocol.ts` — Updated docs from "Alias for letta-claude" to "Letta-tuned system prompt"

## Test plan

- [ ] `letta --new-agent --system default` produces the same prompt as `letta --new-agent` (no `--system` flag)
- [ ] `letta --new-agent --system letta-claude` still uses the Claude-optimized prompt
- [ ] `/system` UI shows "Letta-tuned system prompt" for the Default option