### PR TITLE
fix(models): set GPT-5.x context_window to 90% of current values

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -274,7 +274,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "low",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -287,7 +287,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "low",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -300,7 +300,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "low",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -313,7 +313,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "low",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -326,7 +326,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "low",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -339,7 +339,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -352,7 +352,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -365,7 +365,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -378,7 +378,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -391,7 +391,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -404,7 +404,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -417,7 +417,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -430,7 +430,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -443,7 +443,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -456,7 +456,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -469,7 +469,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -482,7 +482,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -495,7 +495,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -508,7 +508,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -521,7 +521,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -534,7 +534,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -547,7 +547,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -560,7 +560,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -573,7 +573,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -586,7 +586,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -599,7 +599,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -612,7 +612,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -625,7 +625,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -639,7 +639,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -652,7 +652,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -665,7 +665,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -678,7 +678,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -691,7 +691,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -705,7 +705,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -718,7 +718,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": null,
       "parallel_tool_calls": true
     }
@@ -731,7 +731,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -744,7 +744,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -757,7 +757,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -770,7 +770,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -783,7 +783,7 @@
     "updateArgs": {
       "reasoning_effort": "none",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -796,7 +796,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -809,7 +809,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -822,7 +822,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -835,7 +835,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -848,7 +848,7 @@
     "updateArgs": {
       "reasoning_effort": "xhigh",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -861,7 +861,7 @@
     "updateArgs": {
       "reasoning_effort": "minimal",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -874,7 +874,7 @@
     "updateArgs": {
       "reasoning_effort": "low",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -887,7 +887,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -900,7 +900,7 @@
     "updateArgs": {
       "reasoning_effort": "high",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -913,7 +913,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }
@@ -926,7 +926,7 @@
     "updateArgs": {
       "reasoning_effort": "medium",
       "verbosity": "medium",
-      "context_window": 272000,
+      "context_window": 244800,
       "max_output_tokens": 128000,
       "parallel_tool_calls": true
     }


### PR DESCRIPTION
## Summary
- Set `context_window` to `244800` (90% of `272000`) for all GPT-5.x model presets in `src/models.json`
- Leave `max_output_tokens` unchanged from `main` for each GPT-5.x model (no max-output-token changes in this PR)

## Test plan
- [ ] Run `/model` and switch between GPT-5.x variants (5.1/5.2/5.3-codex/5.4)
- [ ] Confirm model switch succeeds
- [ ] Verify selected GPT-5.x model uses `context_window=244800`
- [ ] Verify `max_output_tokens` remains unchanged per model definition

👾 Generated with [Letta Code](https://letta.com)