### PR TITLE
feat(message): add OpenAI websocket responses mode header

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -128,7 +128,7 @@ export async function sendMessageStream(
   }
 
   const extraHeaders: Record<string, string> = {};
-  if (process.env.LETTA_EXPERIMENTAL_OPENAI_RESPONSES_WS === "1") {
+  if (process.env.LETTA_RESPONSES_WS === "1") {
     extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
   }
 


### PR DESCRIPTION
## Summary
- Sends `X-Experimental-OpenAI-Responses-Websocket: true` header on `conversations.messages.create()` calls via SDK per-request headers, gated behind `LETTA_RESPONSES_WS=1`
- Adds `headers?` to the existing `requestOptions` type (keeping the narrow type to avoid exposing dangerous SDK knobs like `method`, `path`, `body`)
- Header is injected at the single call site in `sendMessageStream`, so all 6 callers (headless × 4, listen-client × 2) get it automatically

## Usage
```bash
LETTA_RESPONSES_WS=1 letta-code
```
Without the env var, no extra header is sent.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors, 4 warnings (pre-existing)
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts` — 11/11 pass

👾 Generated with [Letta Code](https://letta.com)