### PR TITLE
fix: don't pass null max_output_tokens in model_settings

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -159,13 +159,12 @@ function buildModelSettings(
     settings = {};
   }
 
-  // Apply max_output_tokens only when provider_type is present.
-  // Without provider_type the discriminated union rejects the payload (e.g. MiniMax).
-  // Pass null through so the server can explicitly unset max_output_tokens
-  // (prevents stale values lingering from a previous model).
+  // Apply max_output_tokens only when provider_type is present and the value
+  // is a concrete number.  Null means "unset" and should only be forwarded via
+  // the top-level max_tokens field — some providers (e.g. OpenAI) reject null
+  // inside their typed model_settings.
   if (
-    (typeof updateArgs?.max_output_tokens === "number" ||
-      updateArgs?.max_output_tokens === null) &&
+    typeof updateArgs?.max_output_tokens === "number" &&
     "provider_type" in settings
   ) {
     (settings as Record<string, unknown>).max_output_tokens =


### PR DESCRIPTION
## Summary

- Models with `max_output_tokens: null` in their preset (e.g. `openai/gpt-5.3-codex`) caused a Pydantic validation error on the Letta server: `OpenAIModelSettings.max_output_tokens` requires an integer, not `None`.
- `buildModelSettings` now only includes `max_output_tokens` when the value is a concrete number. The `null` case is still handled by the top-level `max_tokens` field in the `agents.update` call, which the server accepts for unsetting stale values.

## Test plan

- [ ] Create an agent with `openai/gpt-5.3-codex` model — should no longer fail with `int_type` validation error
- [ ] Switch an existing agent from a model with `max_output_tokens: 128000` to one with `max_output_tokens: null` — stale value should be cleared via top-level `max_tokens`