### PR TITLE
chore: resync version to 0.17.1 to match npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@letta-ai/letta-code",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@letta-ai/letta-code",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/letta-code",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Letta Code is a CLI tool for interacting with stateful Letta agents from the terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
The March 5 release published 0.17.1 to npm but the version bump commit never landed on main, leaving package.json at 0.17.0. This caused subsequent release runs to fail with "cannot publish over previously published versions". Resyncing so the next release bumps to 0.17.2.

🐾 Generated with [Letta Code](https://letta.com)