### PR TITLE
chore: bump @letta-ai/letta-client to 1.7.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@letta-ai/letta-client": "^1.7.11",
+        "@letta-ai/letta-client": "^1.7.12",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "open": "^10.2.0",
@@ -93,7 +92,7 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.7.11", "", {}, "sha512-8tB+v/p7xb8/ato/MUhJx2MtTCIZToaTGGHOCFqPql20aN1aJmp2b67ro8cK8jbOygYvHtBYnsogHkY4hvMO1Q=="],
+    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.7.12", "", {}, "sha512-OV3YuT+f8iVfu56JugDEz/29tBm3SZXMgdNAG016Lu1zneDSSt+7tFpI6eetrKRhJ8RWLJzCwnrkmXNnph1Wuw=="],
 
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@letta-ai/letta-client": "^1.7.8",
+        "@letta-ai/letta-client": "^1.7.12",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "open": "^10.2.0",
@@ -36,6 +36,9 @@
         "picomatch": "^2.3.1",
         "react": "18.2.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "optionalDependencies": {
         "@vscode/ripgrep": "^1.17.0"
@@ -552,9 +555,9 @@
       }
     },
     "node_modules/@letta-ai/letta-client": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-client/-/letta-client-1.7.8.tgz",
-      "integrity": "sha512-l7BGsAZOI8b+H1RO2IMzMv3P0VXj6Of2wXLCg5LZejOk0dHLLBi2me4WspLg+6zWPGIRJwMRsxmfp4kV9Zzh6g==",
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-client/-/letta-client-1.7.12.tgz",
+      "integrity": "sha512-OV3YuT+f8iVfu56JugDEz/29tBm3SZXMgdNAG016Lu1zneDSSt+7tFpI6eetrKRhJ8RWLJzCwnrkmXNnph1Wuw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/bun": {
@@ -582,6 +585,7 @@
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -608,11 +612,11 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      },
-      "dev": true
+      }
     },
     "node_modules/@vscode/ripgrep": {
       "version": "1.17.0",
@@ -2002,6 +2006,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@letta-ai/letta-client": "^1.7.11",
+    "@letta-ai/letta-client": "^1.7.12",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",
     "open": "^10.2.0",


### PR DESCRIPTION
## Summary
- bump `@letta-ai/letta-client` to `1.7.12`
- refresh `bun.lock` and `package-lock.json` so Bun and npm installs stay in sync
- replace the package-lock-only update in #1304 with a Bun-aware dependency bump

## Testing
- `bun run check`
- `./letta.js --help`