### PR TITLE
fix(retry): increase Cloudflare transient backoff to 5/10/20

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -13,12 +13,14 @@ export type {
   PreStreamConflictKind,
   PreStreamErrorAction,
   PreStreamErrorOptions,
+  RetryDelayCategory,
 } from "./turn-recovery-policy";
 // ── Re-export pure policy helpers (single source of truth) ──────────
 export {
   classifyPreStreamConflict,
   extractConflictDetail,
   getPreStreamErrorAction,
+  getRetryDelayMs,
   getTransientRetryDelayMs,
   isApprovalPendingError,
   isConversationBusyError,

--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -67,6 +67,8 @@ const NON_RETRYABLE_4XX_PATTERN = /Error code:\s*4(0[0-8]|1\d|2\d|3\d|4\d|51)/i;
 const RETRYABLE_429_PATTERN = /Error code:\s*429|rate limit|too many requests/i;
 const DEFAULT_TRANSIENT_RETRY_BASE_DELAY_MS = 1000;
 const CLOUDFLARE_EDGE_52X_RETRY_BASE_DELAY_MS = 5000;
+const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000;
+const EMPTY_RESPONSE_RETRY_BASE_DELAY_MS = 500;
 
 function isCloudflareEdge52xDetail(detail: unknown): boolean {
   if (typeof detail !== "string") return false;
@@ -209,23 +211,54 @@ export function parseRetryAfterHeaderMs(
   return delayMs > 0 ? delayMs : 0;
 }
 
+export type RetryDelayCategory =
+  | "transient_provider"
+  | "conversation_busy"
+  | "empty_response";
+
 /**
- * Compute transient retry delay with optional Retry-After override.
- * Cloudflare edge 52x errors use a larger base delay.
+ * Compute retry delay for known retry classes.
+ * - `transient_provider`: exponential (Cloudflare-specific base) with Retry-After override
+ * - `conversation_busy`: exponential
+ * - `empty_response`: linear
+ */
+export function getRetryDelayMs(opts: {
+  category: RetryDelayCategory;
+  attempt: number;
+  detail?: unknown;
+  retryAfterMs?: number | null;
+}): number {
+  const { category, attempt, detail, retryAfterMs = null } = opts;
+
+  if (category === "transient_provider") {
+    if (retryAfterMs !== null) return retryAfterMs;
+    const baseDelayMs = isCloudflareEdge52xDetail(detail)
+      ? CLOUDFLARE_EDGE_52X_RETRY_BASE_DELAY_MS
+      : DEFAULT_TRANSIENT_RETRY_BASE_DELAY_MS;
+    return baseDelayMs * 2 ** (attempt - 1);
+  }
+
+  if (category === "conversation_busy") {
+    return CONVERSATION_BUSY_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+  }
+
+  return EMPTY_RESPONSE_RETRY_BASE_DELAY_MS * attempt;
+}
+
+/**
+ * Backward-compatible wrapper for transient provider retries.
  */
 export function getTransientRetryDelayMs(opts: {
   attempt: number;
   detail: unknown;
   retryAfterMs?: number | null;
 }): number {
-  const { attempt, detail, retryAfterMs = null } = opts;
-  if (retryAfterMs !== null) return retryAfterMs;
-
-  const baseDelayMs = isCloudflareEdge52xDetail(detail)
-    ? CLOUDFLARE_EDGE_52X_RETRY_BASE_DELAY_MS
-    : DEFAULT_TRANSIENT_RETRY_BASE_DELAY_MS;
-
-  return baseDelayMs * 2 ** (attempt - 1);
+  return getRetryDelayMs({
+    category: "transient_provider",
+    attempt: opts.attempt,
+    detail: opts.detail,
+    retryAfterMs: opts.retryAfterMs,
+  });
 }
 
 // ── Pre-stream conflict routing ─────────────────────────────────────

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -32,7 +32,7 @@ import {
   extractConflictDetail,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
-  getTransientRetryDelayMs,
+  getRetryDelayMs,
   isApprovalPendingError,
   isEmptyResponseRetryable,
   isInvalidToolCallIdsError,
@@ -332,7 +332,6 @@ const EMPTY_RESPONSE_MAX_RETRIES = 2;
 
 // Retry config for 409 "conversation busy" errors (exponential backoff)
 const CONVERSATION_BUSY_MAX_RETRIES = 3; // 10s -> 20s -> 40s
-const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000; // 10 seconds
 
 // Message shown when user interrupts the stream
 const INTERRUPT_MESSAGE =
@@ -4073,9 +4072,10 @@ export default function App({
             // Check for 409 "conversation busy" error - retry with exponential backoff
             if (preStreamAction === "retry_conversation_busy") {
               conversationBusyRetriesRef.current += 1;
-              const retryDelayMs =
-                CONVERSATION_BUSY_RETRY_BASE_DELAY_MS *
-                2 ** (conversationBusyRetriesRef.current - 1);
+              const retryDelayMs = getRetryDelayMs({
+                category: "conversation_busy",
+                attempt: conversationBusyRetriesRef.current,
+              });
 
               // Log the conversation-busy error
               telemetry.trackError(
@@ -4143,7 +4143,8 @@ export default function App({
                       preStreamError.headers?.get("retry-after"),
                     )
                   : null;
-              const delayMs = getTransientRetryDelayMs({
+              const delayMs = getRetryDelayMs({
+                category: "transient_provider",
                 attempt,
                 detail: errorDetail,
                 retryAfterMs,
@@ -5353,7 +5354,10 @@ export default function App({
           ) {
             emptyResponseRetriesRef.current += 1;
             const attempt = emptyResponseRetriesRef.current;
-            const delayMs = 500 * attempt;
+            const delayMs = getRetryDelayMs({
+              category: "empty_response",
+              attempt,
+            });
 
             // Only append a nudge on the last attempt
             if (attempt >= EMPTY_RESPONSE_MAX_RETRIES) {
@@ -5402,7 +5406,8 @@ export default function App({
           ) {
             llmApiErrorRetriesRef.current += 1;
             const attempt = llmApiErrorRetriesRef.current;
-            const delayMs = getTransientRetryDelayMs({
+            const delayMs = getRetryDelayMs({
+              category: "transient_provider",
               attempt,
               detail: detailFromRun ?? fallbackError,
             });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -12,7 +12,7 @@ import {
   extractConflictDetail,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
-  getTransientRetryDelayMs,
+  getRetryDelayMs,
   isApprovalPendingError,
   isEmptyResponseRetryable,
   isInvalidToolCallIdsError,
@@ -134,7 +134,6 @@ const EMPTY_RESPONSE_MAX_RETRIES = 2;
 
 // Retry config for 409 "conversation busy" errors (exponential backoff)
 const CONVERSATION_BUSY_MAX_RETRIES = 3; // 10s -> 20s -> 40s
-const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000; // 10 seconds
 
 export type BidirectionalQueuedInput = QueuedTurnInput<
   MessageCreate["content"]
@@ -1545,9 +1544,10 @@ ${SYSTEM_REMINDER_CLOSE}
         // Check for 409 "conversation busy" error - retry once with delay
         if (preStreamAction === "retry_conversation_busy") {
           conversationBusyRetries += 1;
-          const retryDelayMs =
-            CONVERSATION_BUSY_RETRY_BASE_DELAY_MS *
-            2 ** (conversationBusyRetries - 1);
+          const retryDelayMs = getRetryDelayMs({
+            category: "conversation_busy",
+            attempt: conversationBusyRetries,
+          });
 
           // Emit retry message for stream-json mode
           if (outputFormat === "stream-json") {
@@ -1580,7 +1580,8 @@ ${SYSTEM_REMINDER_CLOSE}
                   preStreamError.headers?.get("retry-after"),
                 )
               : null;
-          const delayMs = getTransientRetryDelayMs({
+          const delayMs = getRetryDelayMs({
+            category: "transient_provider",
             attempt,
             detail: errorDetail,
             retryAfterMs,
@@ -1915,7 +1916,8 @@ ${SYSTEM_REMINDER_CLOSE}
       if (stopReason === "llm_api_error") {
         if (llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           const attempt = llmApiErrorRetries + 1;
-          const delayMs = getTransientRetryDelayMs({
+          const delayMs = getRetryDelayMs({
+            category: "transient_provider",
             attempt,
             detail: detailFromRun,
           });
@@ -2045,7 +2047,10 @@ ${SYSTEM_REMINDER_CLOSE}
             )
           ) {
             const attempt = emptyResponseRetries + 1;
-            const delayMs = 500 * attempt;
+            const delayMs = getRetryDelayMs({
+              category: "empty_response",
+              attempt,
+            });
 
             emptyResponseRetries = attempt;
 
@@ -2082,7 +2087,8 @@ ${SYSTEM_REMINDER_CLOSE}
 
           if (shouldRetryRunMetadataError(errorType, detail)) {
             const attempt = llmApiErrorRetries + 1;
-            const delayMs = getTransientRetryDelayMs({
+            const delayMs = getRetryDelayMs({
+              category: "transient_provider",
               attempt,
               detail,
             });
@@ -3178,7 +3184,8 @@ async function runBidirectionalMode(
                       preStreamError.headers?.get("retry-after"),
                     )
                   : null;
-              const delayMs = getTransientRetryDelayMs({
+              const delayMs = getRetryDelayMs({
+                category: "transient_provider",
                 attempt,
                 detail: errorDetail,
                 retryAfterMs,

--- a/src/tests/turn-recovery-policy.test.ts
+++ b/src/tests/turn-recovery-policy.test.ts
@@ -3,6 +3,7 @@ import {
   classifyPreStreamConflict,
   extractConflictDetail,
   getPreStreamErrorAction,
+  getRetryDelayMs,
   getTransientRetryDelayMs,
   isApprovalPendingError,
   isConversationBusyError,
@@ -285,41 +286,87 @@ describe("parseRetryAfterHeaderMs", () => {
   });
 });
 
-describe("getTransientRetryDelayMs", () => {
-  test("uses default backoff for non-Cloudflare details", () => {
+describe("getRetryDelayMs", () => {
+  test("uses default transient backoff for non-Cloudflare details", () => {
     expect(
-      getTransientRetryDelayMs({
+      getRetryDelayMs({
+        category: "transient_provider",
         attempt: 1,
         detail: "Connection error during streaming",
       }),
     ).toBe(1000);
     expect(
-      getTransientRetryDelayMs({
+      getRetryDelayMs({
+        category: "transient_provider",
         attempt: 2,
         detail: "Connection error during streaming",
       }),
     ).toBe(2000);
   });
 
-  test("uses larger base backoff for Cloudflare edge 52x details", () => {
-    const detail =
-      "521 <!DOCTYPE html><html><head><title>api.letta.com | 521: Web server is down</title></head><body>Cloudflare Ray ID: 9d431b5f6f656c08</body></html>";
-
-    expect(getTransientRetryDelayMs({ attempt: 1, detail })).toBe(5000);
-    expect(getTransientRetryDelayMs({ attempt: 3, detail })).toBe(20000);
-  });
-
-  test("uses Retry-After delay when provided", () => {
+  test("uses larger transient base for Cloudflare edge 52x details", () => {
     const detail =
       "521 <!DOCTYPE html><html><head><title>api.letta.com | 521: Web server is down</title></head><body>Cloudflare Ray ID: 9d431b5f6f656c08</body></html>";
 
     expect(
-      getTransientRetryDelayMs({
+      getRetryDelayMs({
+        category: "transient_provider",
+        attempt: 1,
+        detail,
+      }),
+    ).toBe(5000);
+    expect(
+      getRetryDelayMs({
+        category: "transient_provider",
+        attempt: 3,
+        detail,
+      }),
+    ).toBe(20000);
+  });
+
+  test("uses Retry-After delay when provided for transient retries", () => {
+    const detail =
+      "521 <!DOCTYPE html><html><head><title>api.letta.com | 521: Web server is down</title></head><body>Cloudflare Ray ID: 9d431b5f6f656c08</body></html>";
+
+    expect(
+      getRetryDelayMs({
+        category: "transient_provider",
         attempt: 3,
         detail,
         retryAfterMs: 7000,
       }),
     ).toBe(7000);
+  });
+
+  test("uses exponential conversation_busy profile", () => {
+    expect(getRetryDelayMs({ category: "conversation_busy", attempt: 1 })).toBe(
+      10000,
+    );
+    expect(getRetryDelayMs({ category: "conversation_busy", attempt: 2 })).toBe(
+      20000,
+    );
+  });
+
+  test("uses linear empty_response profile", () => {
+    expect(getRetryDelayMs({ category: "empty_response", attempt: 1 })).toBe(
+      500,
+    );
+    expect(getRetryDelayMs({ category: "empty_response", attempt: 2 })).toBe(
+      1000,
+    );
+  });
+});
+
+describe("getTransientRetryDelayMs", () => {
+  test("matches transient_provider category behavior", () => {
+    const detail = "Connection error during streaming";
+    expect(getTransientRetryDelayMs({ attempt: 2, detail })).toBe(
+      getRetryDelayMs({
+        category: "transient_provider",
+        attempt: 2,
+        detail,
+      }),
+    );
   });
 });
 

--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -25,7 +25,7 @@ import { getStreamToolContextId, sendMessageStream } from "../agent/message";
 import {
   extractConflictDetail,
   getPreStreamErrorAction,
-  getTransientRetryDelayMs,
+  getRetryDelayMs,
   isApprovalPendingError,
   isInvalidToolCallIdsError,
   parseRetryAfterHeaderMs,
@@ -1527,7 +1527,7 @@ async function sendMessageStreamWithRetry(
   let transientRetries = 0;
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
-  const MAX_CONVERSATION_BUSY_RETRIES = 1;
+  const MAX_CONVERSATION_BUSY_RETRIES = 3;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -1600,7 +1600,8 @@ async function sendMessageStreamWithRetry(
                 preStreamError.headers?.get("retry-after"),
               )
             : null;
-        const delayMs = getTransientRetryDelayMs({
+        const delayMs = getRetryDelayMs({
+          category: "transient_provider",
           attempt,
           detail: errorDetail,
           retryAfterMs,
@@ -1626,7 +1627,10 @@ async function sendMessageStreamWithRetry(
 
       if (action === "retry_conversation_busy") {
         const attempt = conversationBusyRetries + 1;
-        const delayMs = 2500;
+        const delayMs = getRetryDelayMs({
+          category: "conversation_busy",
+          attempt,
+        });
         conversationBusyRetries = attempt;
 
         emitToWS(socket, {


### PR DESCRIPTION
## Summary
- centralize retry delay computation in `turn-recovery-policy` with `getRetryDelayMs(...)` categories:
  - `transient_provider` (Cloudflare-aware 5s/10s/20s, otherwise 1s/2s/4s)
  - `conversation_busy` (10s/20s/40s)
  - `empty_response` (500ms/1000ms linear)
- keep `Retry-After` precedence for transient provider retries
- wire the shared helper through TUI, headless, and listen-mode pre-stream retry paths
- align listen-mode conversation-busy behavior to the shared 10s/20s/40s profile

## Test plan
- [x] `bun test src/tests/turn-recovery-policy.test.ts`
- [x] `bun run --cwd /Users/jinjpeng/letta/letta-code fix`
- [ ] `bun run typecheck` *(currently reports existing unrelated compaction typing errors in `src/cli/App.tsx` on main)*

👾 Generated with [Letta Code](https://letta.com)