### PR TITLE
fix: always right-align status bar footer content [LET-7888]

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -412,12 +412,8 @@ const InputFooter = memo(function InputFooter({
         )}
       </Box>
       <Box
-        flexDirection={
-          statusLineRight && !hideFooterContent ? "column" : undefined
-        }
-        alignItems={
-          statusLineRight && !hideFooterContent ? "flex-end" : undefined
-        }
+        flexDirection="column"
+        alignItems="flex-end"
         width={
           statusLineRight && !hideFooterContent
             ? undefined


### PR DESCRIPTION
## Summary
- The right column in the footer (`InputFooter`) only applied `flexDirection="column"` and `alignItems="flex-end"` when a custom `statusLineRight` was set
- This caused the default status bar and background-agent views to be left-aligned within their fixed-width box
- Now unconditionally applies column layout with flex-end alignment so the right side content is always flush right

## Test plan
- [ ] Verify the status bar right column (model name, agent info) is right-aligned in the default view
- [ ] Verify right-alignment when background agents are active
- [ ] Verify right-alignment when a custom `statusLineRight` is configured
- [ ] Verify layout stability during streaming (no jitter)