### PR TITLE
fix: disable animated logo on setup/login page

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -162,7 +162,7 @@ export function SetupUI({ onComplete }: SetupUIProps) {
   // Main menu
   return (
     <Box flexDirection="column" padding={1}>
-      <AnimatedLogo color={colors.welcome.accent} animate={false} />
+      <AnimatedLogo color={colors.welcome.accent} />
       <Text> </Text>
       <Text bold>Welcome to Letta Code!</Text>
       <Text> </Text>


### PR DESCRIPTION
## Summary
- Passes `animate={false}` to `AnimatedLogo` on the device-code screens in the setup UI
- The logo now displays as a static icon instead of spinning during authentication