### PR TITLE
fix: use shadowed frame for static logo

### DIFF
--- a/src/cli/components/AnimatedLogo.tsx
+++ b/src/cli/components/AnimatedLogo.tsx
@@ -137,7 +137,7 @@ function getSnapshot(): number {
 
 interface AnimatedLogoProps {
   color?: string;
-  /** When false, show static frame 0 (flat logo). Defaults to true. */
+  /** When false, show static frame 1 (logo with shadow). Defaults to true. */
   animate?: boolean;
 }
 
@@ -146,7 +146,7 @@ export function AnimatedLogo({
   animate = true,
 }: AnimatedLogoProps) {
   const tick = useSyncExternalStore(subscribe, getSnapshot);
-  const frame = animate ? tick % normalizedLogoFrames.length : 0;
+  const frame = animate ? tick % normalizedLogoFrames.length : 1;
 
   const logoLines = normalizedLogoFrames[frame]?.split("\n") ?? [];
 


### PR DESCRIPTION
## Summary
- Changes the static (non-animated) `AnimatedLogo` to use frame 1 instead of frame 0
- Frame 1 has a subtle shadow/depth effect (`▓`) giving the logo more dimension when static

Follows up on #1330.

## Test plan
- [ ] Run `letta` without valid credentials to trigger the setup flow
- [ ] Verify the static logo on the device-code page shows with shadow depth