### PR TITLE
fix(listen): recover queue pump on non-user errors

### DIFF
--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -623,6 +623,7 @@ function createRuntime(): ListenerRuntime {
       },
       onDropped: (item, reason, queueLen) => {
         runtime.pendingTurns = queueLen;
+        runtime.queuedMessagesByItemId.delete(item.id);
         if (runtime.socket?.readyState === WebSocket.OPEN) {
           emitToWS(runtime.socket, {
             type: "queue_item_dropped",
@@ -2816,6 +2817,7 @@ async function connectWithRetry(
             console.error("[Listen] Error handling queued message:", error);
           }
           opts.onStatusChange?.("idle", opts.connectionId);
+          scheduleQueuePump(runtime, socket, opts);
         });
     }
   });


### PR DESCRIPTION
## Summary
- Add scheduleQueuePump in the non-user queued-message catch path in listen-client.ts.
- Delete dropped queue item IDs from queuedMessagesByItemId in the queueRuntime onDropped callback.

## Why
Post-merge review identified two fast-follow issues:
1. If non-user queued message handling throws, status resets to idle but the queue pump was not re-triggered, which could delay queued user work until another trigger.
2. Dropped queue items could leave stale entries in queuedMessagesByItemId until shutdown.

## Scope
- Minimal patch only.
- No protocol schema changes.

## Validation
- bun test src/tests/websocket/listen-queue-events.test.ts
- bun run check