### PR TITLE
fix(tui): preserve reasoning label for chatgpt_oauth during streaming and sync

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -363,9 +363,10 @@ function deriveReasoningEffort(
   llmConfig: LlmConfig | null | undefined,
 ): ModelReasoningEffort | null {
   if (modelSettings && "provider_type" in modelSettings) {
-    // OpenAI/OpenRouter: reasoning.reasoning_effort
+    // OpenAI/OpenRouter/ChatGPT OAuth: reasoning.reasoning_effort
     if (
-      modelSettings.provider_type === "openai" &&
+      (modelSettings.provider_type === "openai" ||
+        modelSettings.provider_type === "chatgpt_oauth") &&
       "reasoning" in modelSettings &&
       modelSettings.reasoning
     ) {
@@ -3200,19 +3201,30 @@ export default function App({
             .last_run_completion;
           setAgentLastRunAt(lastRunCompletion ?? null);
 
-          // Derive model ID from llm_config for ModelSelector
+          // Derive model ID from llm_config for ModelSelector.
+          // Use deriveReasoningEffort so chatgpt_oauth (and similar) models
+          // resolve the correct tier even when llm_config omits the legacy field.
           const agentModelHandle =
             agent.llm_config.model_endpoint_type && agent.llm_config.model
               ? `${agent.llm_config.model_endpoint_type}/${agent.llm_config.model}`
               : agent.llm_config.model;
           const { getModelInfoForLlmConfig } = await import("../agent/model");
-          const modelInfo = getModelInfoForLlmConfig(
-            agentModelHandle || "",
-            agent.llm_config as unknown as {
-              reasoning_effort?: string | null;
-              enable_reasoner?: boolean | null;
-            },
+          const effectiveReasoningEffort = deriveReasoningEffort(
+            agent.model_settings,
+            agent.llm_config,
           );
+          const modelInfo = getModelInfoForLlmConfig(agentModelHandle || "", {
+            reasoning_effort:
+              effectiveReasoningEffort ??
+              agent.llm_config.reasoning_effort ??
+              null,
+            enable_reasoner:
+              (
+                agent.llm_config as {
+                  enable_reasoner?: boolean | null;
+                }
+              ).enable_reasoner ?? null,
+          });
           if (modelInfo) {
             setCurrentModelId(modelInfo.id);
           } else {
@@ -4306,9 +4318,15 @@ export default function App({
               // Keep model UI in sync with the agent configuration.
               // Note: many tiers share the same handle (e.g. gpt-5.2-none/high), so we
               // must also treat reasoning settings as model-affecting.
+              // Use deriveReasoningEffort for robust comparison -- covers chatgpt_oauth
+              // and other providers where llm_config.reasoning_effort may be absent but
+              // the canonical value lives in model_settings.
               const currentModel = llmConfigRef.current?.model;
               const currentEndpoint = llmConfigRef.current?.model_endpoint_type;
-              const currentEffort = llmConfigRef.current?.reasoning_effort;
+              const currentEffort = deriveReasoningEffort(
+                agentStateRef.current?.model_settings,
+                llmConfigRef.current,
+              );
               const currentEnableReasoner = (
                 llmConfigRef.current as unknown as {
                   enable_reasoner?: boolean | null;
@@ -4317,7 +4335,10 @@ export default function App({
 
               const agentModel = agent.llm_config.model;
               const agentEndpoint = agent.llm_config.model_endpoint_type;
-              const agentEffort = agent.llm_config.reasoning_effort;
+              const agentEffort = deriveReasoningEffort(
+                agent.model_settings,
+                agent.llm_config,
+              );
               const agentEnableReasoner = (
                 agent.llm_config as unknown as {
                   enable_reasoner?: boolean | null;
@@ -4339,11 +4360,16 @@ export default function App({
                     agent.llm_config,
                   );
 
+                  // Prefer effective reasoning from model_settings so
+                  // ChatGPT OAuth (and similar) resolve the correct tier.
                   const modelInfo = getModelInfoForLlmConfig(
                     agentModelHandle || "",
-                    agent.llm_config as unknown as {
-                      reasoning_effort?: string | null;
-                      enable_reasoner?: boolean | null;
+                    {
+                      reasoning_effort:
+                        agentEffort ??
+                        agent.llm_config.reasoning_effort ??
+                        null,
+                      enable_reasoner: agentEnableReasoner ?? null,
                     },
                   );
                   if (modelInfo) {

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -414,16 +414,10 @@ const InputFooter = memo(function InputFooter({
       <Box
         flexDirection="column"
         alignItems="flex-end"
-        width={
-          statusLineRight && !hideFooterContent
-            ? undefined
-            : effectiveRightWidth
-        }
+        width={statusLineRight ? undefined : effectiveRightWidth}
         flexShrink={0}
       >
-        {hideFooterContent ? (
-          <Text>{" ".repeat(rightColumnWidth)}</Text>
-        ) : statusLineRight ? (
+        {statusLineRight ? (
           statusLineRight.split("\n").map((line, i) => (
             <Text key={`${i}-${line}`} wrap="truncate-end">
               {parseOsc8Line(line, `r${i}`)}

--- a/src/tests/cli/footer-reasoning-regression.test.ts
+++ b/src/tests/cli/footer-reasoning-regression.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("footer reasoning regression", () => {
+  test("right-side model/reasoning label is not blanked when footer is hidden", () => {
+    const path = fileURLToPath(
+      new URL("../../cli/components/InputRich.tsx", import.meta.url),
+    );
+    const source = readFileSync(path, "utf-8");
+
+    // The InputFooter right-side column must NOT use hideFooterContent to
+    // replace the label with spaces. The left side may still be hidden.
+    // Previously the right-side had:
+    //   {hideFooterContent ? (<Text>{" ".repeat(...)}</Text>) : ...}
+    // which blanked the model/reasoning tag during streaming.
+    const rightColumnStart = source.indexOf(
+      "flexShrink={0}\n      >\n",
+      source.indexOf("const InputFooter = memo("),
+    );
+    expect(rightColumnStart).toBeGreaterThanOrEqual(0);
+
+    // The first rendering branch after the right-column Box must NOT be
+    // a hideFooterContent ternary that emits blank spaces.
+    const rightColumnWindow = source.slice(
+      rightColumnStart,
+      rightColumnStart + 200,
+    );
+    expect(rightColumnWindow).not.toMatch(
+      /hideFooterContent\s*\?\s*\(\s*<Text>\{" "\.repeat/,
+    );
+
+    // Confirm the left side still respects hideFooterContent.
+    const leftSideContent = source.slice(
+      source.indexOf("<Box flexGrow={1} paddingRight={1}>"),
+      source.indexOf(
+        "</Box>",
+        source.indexOf("<Box flexGrow={1} paddingRight={1}>"),
+      ),
+    );
+    expect(leftSideContent).toContain("hideFooterContent");
+  });
+
+  test("hideFooterContent only suppresses left-side footer content", () => {
+    const path = fileURLToPath(
+      new URL("../../cli/components/InputRich.tsx", import.meta.url),
+    );
+    const source = readFileSync(path, "utf-8");
+
+    // hideFooterContent must only appear in the left-side column, never in
+    // the right-side column (which renders the model/reasoning label).
+    const footerFn = source.slice(source.indexOf("const InputFooter = memo("));
+    const leftColumn = footerFn.slice(
+      footerFn.indexOf("<Box flexGrow={1}"),
+      footerFn.indexOf("</Box>", footerFn.indexOf("<Box flexGrow={1}")),
+    );
+    expect(leftColumn).toContain("hideFooterContent");
+
+    // Right column should NOT reference hideFooterContent at all.
+    const rightColumnStart = footerFn.indexOf("flexShrink={0}");
+    const rightColumnEnd = footerFn.indexOf(
+      "</Box>",
+      footerFn.indexOf("</Box>", rightColumnStart) + 1,
+    );
+    const rightColumn = footerFn.slice(rightColumnStart, rightColumnEnd);
+    expect(rightColumn).not.toContain("hideFooterContent");
+  });
+
+  test("deriveReasoningEffort handles chatgpt_oauth provider", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    const fnStart = source.indexOf("function deriveReasoningEffort(");
+    const fnEnd = source.indexOf("\n}\n", fnStart);
+    expect(fnStart).toBeGreaterThanOrEqual(0);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const fnBody = source.slice(fnStart, fnEnd);
+
+    // Must explicitly handle chatgpt_oauth alongside openai.
+    expect(fnBody).toContain('modelSettings.provider_type === "chatgpt_oauth"');
+    // Both should use reasoning.reasoning_effort shape.
+    expect(fnBody).toContain('modelSettings.provider_type === "openai"');
+  });
+
+  test("syncAgentState uses deriveReasoningEffort for comparison", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    const syncStart = source.indexOf("const syncAgentState = async ()");
+    const syncEnd = source.indexOf("void syncAgentState();", syncStart);
+    expect(syncStart).toBeGreaterThanOrEqual(0);
+    expect(syncEnd).toBeGreaterThan(syncStart);
+    const syncBody = source.slice(syncStart, syncEnd);
+
+    // Reasoning comparison must use deriveReasoningEffort, not raw
+    // llm_config.reasoning_effort, to correctly handle chatgpt_oauth and
+    // other providers where model_settings is the source of truth.
+    const deriveCallCount = (syncBody.match(/deriveReasoningEffort\(/g) ?? [])
+      .length;
+    expect(deriveCallCount).toBeGreaterThanOrEqual(2);
+
+    // Must NOT directly compare llm_config.reasoning_effort for the
+    // current vs agent staleness check.
+    expect(syncBody).not.toContain(
+      "const currentEffort = llmConfigRef.current?.reasoning_effort",
+    );
+    expect(syncBody).not.toContain(
+      "const agentEffort = agent.llm_config.reasoning_effort",
+    );
+  });
+
+  test("initial config fetch uses deriveReasoningEffort for model info", () => {
+    const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+    const source = readFileSync(path, "utf-8");
+
+    // Find the fetchConfig block that runs on loadingState === "ready"
+    const fetchConfigStart = source.indexOf("const fetchConfig = async ()");
+    const fetchConfigEnd = source.indexOf("fetchConfig();", fetchConfigStart);
+    expect(fetchConfigStart).toBeGreaterThanOrEqual(0);
+    expect(fetchConfigEnd).toBeGreaterThan(fetchConfigStart);
+    const fetchConfigBody = source.slice(fetchConfigStart, fetchConfigEnd);
+
+    // Should derive effective reasoning from model_settings, not just
+    // pass raw llm_config to getModelInfoForLlmConfig.
+    expect(fetchConfigBody).toContain("deriveReasoningEffort(");
+    expect(fetchConfigBody).toContain("effectiveReasoningEffort");
+  });
+});


### PR DESCRIPTION
## Summary

- **Footer label visibility**: Removed `hideFooterContent` blanking from the right-side footer column so the agent/model/reasoning label stays visible during streaming (left-side still hides correctly)
- **ChatGPT OAuth reasoning derivation**: Extended `deriveReasoningEffort()` to recognize `chatgpt_oauth` provider alongside `openai` — both use the same `reasoning.reasoning_effort` shape in `model_settings`
- **Sync path correctness**: Updated `syncAgentState` and initial `fetchConfig` to use `deriveReasoningEffort()` instead of the legacy `llm_config.reasoning_effort` field, which is absent for chatgpt_oauth models

Adds 5 source-level regression tests covering all three fixes.

## Test plan

- [ ] Verify `(high)` tag appears in footer for chatgpt_oauth models
- [ ] Verify footer right-side label remains visible while a run is streaming
- [ ] Verify model tier resolves correctly after resume/sync with chatgpt_oauth
- [ ] `bun test src/tests/cli/footer-reasoning-regression.test.ts` — 5 pass
- [ ] `bun test src/tests/cli/reasoning-cycle-wiring.test.ts` — existing tests pass (1 pre-existing failure unrelated)
- [ ] `npx tsc --noEmit` — clean (pre-existing `client_skills` SDK errors are unrelated)

🐾 Generated with [Letta Code](https://letta.com)