### PR TITLE
fix(tui): clean up token counting in subagent display

### DIFF
--- a/src/cli/helpers/subagentDisplay.ts
+++ b/src/cli/helpers/subagentDisplay.ts
@@ -5,6 +5,7 @@
  */
 import { getModelShortName, resolveModel } from "../../agent/model";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../../providers/openai-codex-provider";
+import { formatCompact } from "./format";
 
 /**
  * Format tool count and token statistics for display
@@ -26,11 +27,7 @@ export function formatStats(
     return toolStr;
   }
 
-  const tokenStr =
-    totalTokens >= 1000
-      ? `${(totalTokens / 1000).toFixed(1)}k`
-      : String(totalTokens);
-  return `${toolStr} · ${tokenStr} tokens`;
+  return `${toolStr} · ${formatCompact(totalTokens)} tokens`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replaces inline token formatting in `formatStats()` with the existing `formatCompact()` utility from `format.ts`
- Before: `1326.1k tokens` — after: `1326k tokens` (and for millions: `1.3M` instead of `1326.1k`)
- `formatCompact` was already used elsewhere (context chart) but `formatStats` had its own less clean implementation

Fixes LET-7905

👾 Generated with [Letta Code](https://letta.com)