### PR TITLE
fix(tui): trim leading space on word-wrapped continuation lines

### DIFF
--- a/scripts/postinstall-patches.js
+++ b/scripts/postinstall-patches.js
@@ -101,6 +101,7 @@ await copyToResolved(
 );
 await copyToResolved("vendor/ink/build/devtools.js", "ink/build/devtools.js");
 await copyToResolved("vendor/ink/build/log-update.js", "ink/build/log-update.js");
+await copyToResolved("vendor/ink/build/wrap-text.js", "ink/build/wrap-text.js");
 
 // ink-text-input (optional vendor with externalCursorOffset support)
 await copyToResolved(

--- a/vendor/ink/build/wrap-text.js
+++ b/vendor/ink/build/wrap-text.js
@@ -1,0 +1,31 @@
+import wrapAnsi from 'wrap-ansi';
+import cliTruncate from 'cli-truncate';
+const cache = {};
+const wrapText = (text, maxWidth, wrapType) => {
+    const cacheKey = text + String(maxWidth) + String(wrapType);
+    const cachedText = cache[cacheKey];
+    if (cachedText) {
+        return cachedText;
+    }
+    let wrappedText = text;
+    if (wrapType === 'wrap') {
+        wrappedText = wrapAnsi(text, maxWidth, {
+            trim: true,
+            hard: true,
+        });
+    }
+    if (wrapType.startsWith('truncate')) {
+        let position = 'end';
+        if (wrapType === 'truncate-middle') {
+            position = 'middle';
+        }
+        if (wrapType === 'truncate-start') {
+            position = 'start';
+        }
+        wrappedText = cliTruncate(text, maxWidth, { position });
+    }
+    cache[cacheKey] = wrappedText;
+    return wrappedText;
+};
+export default wrapText;
+//# sourceMappingURL=wrap-text.js.map


### PR DESCRIPTION
## Summary

- Ink's `wrap-text.js` calls `wrap-ansi` with `trim: false`, which preserves the trailing space from the previous line as a leading space on wrapped continuation lines
- Vendor-patches `wrap-text.js` to use `trim: true` (wrap-ansi's default), eliminating the extra space
- Also adds the new vendor file to `postinstall-patches.js` so it gets applied on install

**Before:** `...It seems I may need\n to create a patch...` (extra leading space)
**After:** `...It seems I may need\nto create a patch...` (clean wrap)

Fixes LET-7907

👾 Generated with [Letta Code](https://letta.com)