### PR TITLE
fix: guard against undefined input in vendored Ink handleData on Bun/Linux

### DIFF
--- a/vendor/ink/build/hooks/use-input.js
+++ b/vendor/ink/build/hooks/use-input.js
@@ -218,7 +218,7 @@ const useInput = (inputHandler, options = {}) => {
                 console.error(`[debug:ink-keypress] raw=${rawHex} name="${keypress.name}" seq="${keypress.sequence}" key={escape:${key.escape},tab:${key.tab},shift:${key.shift},ctrl:${key.ctrl},meta:${key.meta}}`);
             }
 
-            let input = keypress.ctrl ? keypress.name : keypress.sequence;
+            let input = (keypress.ctrl ? keypress.name : keypress.sequence) ?? '';
             const seq = typeof keypress.sequence === 'string' ? keypress.sequence : '';
             // Filter xterm focus in/out sequences (ESC[I / ESC[O)
             if (seq === '\u001B[I' || seq === '\u001B[O' || input === '[I' || input === '[O' || /^(?:\[I|\[O)+$/.test(input || '')) {


### PR DESCRIPTION
## Summary

- On Bun/Linux, `parseKeypress` can return `undefined` for both `name` and `sequence` fields, causing `TypeError: undefined is not an object (evaluating 'input.length')` in `handleData`.
- Added nullish coalescing (`?? ''`) when assigning `input` so it always defaults to an empty string.
- One-line fix in `vendor/ink/build/hooks/use-input.js`.

Closes #1350

👾 Generated with [Letta Code](https://letta.com)