### PR TITLE
feat: colorize debug log screen output

### DIFF
--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -49,7 +49,7 @@ function printDebugLine(line: string, level: "log" | "warn" = "log"): void {
   }
   const colored =
     level === "warn"
-      ? `\x1b[38;5;173m${line.trimEnd()}\x1b[0m` // muted red-orange
+      ? `\x1b[38;5;167m${line.trimEnd()}\x1b[0m` // muted red
       : `\x1b[38;5;179m${line.trimEnd()}\x1b[0m`; // muted golden yellow
   console.log(colored);
 }


### PR DESCRIPTION
## Summary
- `debugLog` prints in golden yellow (256-color 220) when `LETTA_DEBUG=1`
- `debugWarn` prints in red-orange (256-color 202) when `LETTA_DEBUG=1`
- File output (`~/.letta/logs/debug/` and `LETTA_DEBUG_FILE`) remains plain text

## Test plan
- [ ] Run with `LETTA_DEBUG=1 bun run dev` and verify `debugLog` lines appear in golden yellow
- [ ] Trigger a warning path and verify `debugWarn` lines appear in red-orange
- [ ] Verify file logs at `~/.letta/logs/debug/` contain no ANSI escape codes