### PR TITLE
chore: Remove agent-info shared reminder for subagents [LET-7974]

### DIFF
--- a/src/reminders/catalog.ts
+++ b/src/reminders/catalog.ts
@@ -32,12 +32,7 @@ export const SHARED_REMINDER_CATALOG: ReadonlyArray<SharedReminderDefinition> =
     {
       id: "agent-info",
       description: "Agent identity (ID, name, server, memory dir)",
-      modes: [
-        "interactive",
-        "headless-one-shot",
-        "headless-bidirectional",
-        "subagent",
-      ],
+      modes: ["interactive", "headless-one-shot", "headless-bidirectional"],
     },
     {
       id: "permission-mode",

--- a/src/tests/reminders/catalog.test.ts
+++ b/src/tests/reminders/catalog.test.ts
@@ -30,11 +30,11 @@ describe("shared reminder catalog", () => {
     }
   });
 
-  test("subagent mode only has agent-info reminder", () => {
+  test("subagent mode has no shared reminders", () => {
     const subagentReminders = SHARED_REMINDER_CATALOG.filter((entry) =>
       entry.modes.includes("subagent"),
     );
-    expect(subagentReminders.map((entry) => entry.id)).toEqual(["agent-info"]);
+    expect(subagentReminders.map((entry) => entry.id)).toEqual([]);
   });
 
   test("command and toolset reminders are interactive-only", () => {

--- a/src/tests/reminders/engine-parity.test.ts
+++ b/src/tests/reminders/engine-parity.test.ts
@@ -88,7 +88,7 @@ describe("shared reminder parity", () => {
     );
   });
 
-  test("subagent mode produces only agent-info reminder", async () => {
+  test("subagent mode produces no shared reminders", async () => {
     for (const reminderId of SHARED_REMINDER_IDS) {
       providerMap[reminderId] = async () => reminderId;
     }
@@ -114,7 +114,7 @@ describe("shared reminder parity", () => {
     });
 
     expect(subagent.appliedReminderIds).toEqual(reminderIdsForMode("subagent"));
-    expect(subagent.appliedReminderIds).toEqual(["agent-info"]);
-    expect(subagent.parts.map((part) => part.text)).toEqual(["agent-info"]);
+    expect(subagent.appliedReminderIds).toEqual([]);
+    expect(subagent.parts.map((part) => part.text)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- remove subagent from the agent-info shared reminder modes
- update reminder catalog tests to assert subagent mode has no shared reminders
- update shared reminder parity tests to assert empty reminder output for subagent mode

## Testing
- bun test src/tests/reminders/catalog.test.ts src/tests/reminders/engine-parity.test.ts