### PR TITLE
feat: resume server-side run on pre-stream 409 conversation busy

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -53,8 +53,8 @@ import {
   getMemoryFilesystemRoot,
 } from "../agent/memoryFilesystem";
 import {
-  type StreamRequestContext,
   getStreamToolContextId,
+  type StreamRequestContext,
   sendMessageStream,
 } from "../agent/message";
 import {
@@ -3999,16 +3999,18 @@ export default function App({
           // Wrap in try-catch to handle pre-stream desync errors (when sendMessageStream
           // throws before streaming begins, e.g., retry after LLM error when backend
           // already cleared the approval)
-          let stream: Awaited<ReturnType<typeof sendMessageStream>>;
+          let stream: Awaited<ReturnType<typeof sendMessageStream>> | null =
+            null;
           let turnToolContextId: string | null = null;
           let preStreamResumeResult: DrainResult | null = null;
           try {
-            stream = await sendMessageStream(
+            const nextStream = await sendMessageStream(
               conversationIdRef.current,
               currentInput,
               { agentId: agentIdRef.current },
             );
-            turnToolContextId = getStreamToolContextId(stream);
+            stream = nextStream;
+            turnToolContextId = getStreamToolContextId(nextStream);
           } catch (preStreamError) {
             debugLog(
               "stream",
@@ -4112,8 +4114,10 @@ export default function App({
                   resumeCtx.agentId,
                 );
                 const client = await getClient();
-                const discoveredRunId =
-                  await discoverFallbackRunIdWithTimeout(client, resumeCtx);
+                const discoveredRunId = await discoverFallbackRunIdWithTimeout(
+                  client,
+                  resumeCtx,
+                );
                 debugLog(
                   "stream",
                   "Run discovery result: %s",
@@ -4121,6 +4125,15 @@ export default function App({
                 );
 
                 if (discoveredRunId) {
+                  if (signal?.aborted || userCancelledRef.current) {
+                    const isStaleAtAbort =
+                      myGeneration !== conversationGenerationRef.current;
+                    if (!isStaleAtAbort) {
+                      setStreaming(false);
+                    }
+                    return;
+                  }
+
                   // Found a running run — resume its stream
                   buffersRef.current.interrupted = false;
                   buffersRef.current.commitGeneration =
@@ -4138,7 +4151,7 @@ export default function App({
                     resumeStream,
                     buffersRef.current,
                     refreshDerivedThrottled,
-                    abortControllerRef.current?.signal,
+                    signal,
                     undefined, // no handleFirstMessage on resume
                     undefined,
                     contextTrackerRef.current,
@@ -4156,6 +4169,15 @@ export default function App({
                   // Fall through — preStreamResumeResult will short-circuit drainStreamWithResume
                 }
               } catch (resumeError) {
+                if (signal?.aborted || userCancelledRef.current) {
+                  const isStaleAtAbort =
+                    myGeneration !== conversationGenerationRef.current;
+                  if (!isStaleAtAbort) {
+                    setStreaming(false);
+                  }
+                  return;
+                }
+
                 debugLog(
                   "stream",
                   "Pre-stream resume failed, falling back to wait/retry: %s",
@@ -4493,6 +4515,25 @@ export default function App({
             contextTrackerRef.current.currentTurnId++;
           }
 
+          const drainResult = preStreamResumeResult
+            ? preStreamResumeResult
+            : (() => {
+                if (!stream) {
+                  throw new Error(
+                    "Expected stream when pre-stream resume did not succeed",
+                  );
+                }
+                return drainStreamWithResume(
+                  stream,
+                  buffersRef.current,
+                  refreshDerivedThrottled,
+                  signal, // Use captured signal, not ref (which may be nulled by handleInterrupt)
+                  handleFirstMessage,
+                  undefined,
+                  contextTrackerRef.current,
+                );
+              })();
+
           const {
             stopReason,
             approval,
@@ -4500,16 +4541,7 @@ export default function App({
             apiDurationMs,
             lastRunId,
             fallbackError,
-          } = preStreamResumeResult ??
-            (await drainStreamWithResume(
-              stream!,
-              buffersRef.current,
-              refreshDerivedThrottled,
-              signal, // Use captured signal, not ref (which may be nulled by handleInterrupt)
-              handleFirstMessage,
-              undefined,
-              contextTrackerRef.current,
-            ));
+          } = await drainResult;
 
           // Update currentRunId for error reporting in catch block
           currentRunId = lastRunId ?? undefined;

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -512,6 +512,9 @@ export async function drainStreamWithResume(
   );
 
   let runIdToResume = result.lastRunId ?? null;
+  let runIdSource: "stream_chunk" | "discovery" | null = result.lastRunId
+    ? "stream_chunk"
+    : null;
 
   // If the stream failed before exposing run_id, try to discover the latest
   // running/created run for this conversation that was created after send start.
@@ -541,6 +544,7 @@ export async function drainStreamWithResume(
       );
       if (runIdToResume) {
         result.lastRunId = runIdToResume;
+        runIdSource = "discovery";
       }
     } catch (lookupError) {
       const lookupErrorMsg =
@@ -583,6 +587,14 @@ export async function drainStreamWithResume(
       {
         runId: result.lastRunId ?? undefined,
       },
+    );
+
+    debugLog(
+      "stream",
+      "Mid-stream resume: fetching run stream (source=%s, runId=%s, lastSeqId=%s)",
+      runIdSource ?? "unknown",
+      runIdToResume,
+      result.lastSeqId ?? 0,
     );
 
     debugLog(

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1610,6 +1610,11 @@ ${SYSTEM_REMINDER_CLOSE}
         }
 
         // Check for 409 "conversation busy" error - retry once with delay
+        // TODO: Add pre-stream resume logic for parity with App.tsx.
+        // Before waiting, attempt to discover the in-flight run via
+        // discoverFallbackRunIdWithTimeout() and resume its stream with
+        // client.runs.messages.stream() + drainStream(). See App.tsx
+        // retry_conversation_busy handler for reference implementation.
         if (preStreamAction === "retry_conversation_busy") {
           conversationBusyRetries += 1;
           const retryDelayMs = getRetryDelayMs({

--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -2174,6 +2174,13 @@ async function sendMessageStreamWithRetry(
       }
 
       if (action === "retry_conversation_busy") {
+        // TODO: Add pre-stream resume logic for parity with App.tsx.
+        // Before waiting, attempt to discover the in-flight run via
+        // discoverFallbackRunIdWithTimeout() and resume its stream with
+        // client.runs.messages.stream() + drainStream(). This avoids
+        // blind wait/retry cycles when the server already created a run
+        // from the original request. See App.tsx retry_conversation_busy
+        // handler for reference implementation.
         const attempt = conversationBusyRetries + 1;
         const delayMs = getRetryDelayMs({
           category: "conversation_busy",


### PR DESCRIPTION
## Summary

- When `sendMessageStream()` reaches the server but the client connection drops before receiving the response, the server creates a run and starts processing. On retry, the server returns 409 "conversation busy". Previously the CLI waited ~10s and retried (likely hitting 409 again, cycling until max retries). Now we discover the in-flight run and resume its stream directly, recovering the original response.
- Exports `discoverFallbackRunIdWithTimeout` and `DrainResult` from `stream.ts` so `App.tsx` can use them for pre-stream resume.
- Captures `requestStartedAtMs` before the retry loop (not per-iteration) so the temporal filter correctly covers runs created by any attempt.

## How it works

1. On 409 "conversation busy", before the wait/retry loop, construct a `StreamRequestContext` and call `discoverFallbackRunIdWithTimeout` to find the running run
2. If found, resume via `client.runs.messages.stream(runId, { starting_after: 0 })` + `drainStream()`
3. The result short-circuits `drainStreamWithResume` so all normal post-stream processing (stats, stop reason handling, `setStreaming(false)`) runs as usual
4. If discovery fails or no run found, falls through to existing wait/retry behavior

## Test plan

- [ ] Simulate client disconnect (connection drops after POST reaches server but before response)
- [ ] With `LETTA_DEBUG=1`, verify debug logs show discovery attempt, discovered run ID, and successful resume
- [ ] Verify the agent response completes normally instead of cycling through 409 retries
- [ ] Verify normal (non-409) flows are unaffected
- [ ] Verify ESC cancellation during conversation busy still works