### PR TITLE
fix: Default conversation system prompt recompilation routing [LET-7976]

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -276,21 +276,41 @@ export async function updateConversationLLMConfig(
  *
  * @param conversationId - The conversation whose prompt should be recompiled
  * @param agentId - Agent id for the parent conversation
+ * @param dryRun - Optional dry-run control
+ * @param clientOverride - Optional injected client for tests
  * @returns The compiled system prompt returned by the API
  */
 export async function recompileAgentSystemPrompt(
   conversationId: string,
   agentId: string,
+  dryRun?: boolean,
+  clientOverride?: {
+    conversations: {
+      recompile: (
+        conversationId: string,
+        params: {
+          dry_run?: boolean;
+          agent_id?: string;
+        },
+      ) => Promise<string>;
+    };
+  },
 ): Promise<string> {
-  const client = await getClient();
+  const client = (clientOverride ?? (await getClient())) as Exclude<
+    typeof clientOverride,
+    undefined
+  >;
 
   if (!agentId) {
     throw new Error("recompileAgentSystemPrompt requires agentId");
   }
 
-  return client.conversations.recompile(conversationId, {
+  const params = {
+    dry_run: dryRun,
     agent_id: agentId,
-  });
+  };
+
+  return client.conversations.recompile(conversationId, params);
 }
 
 export interface SystemPromptUpdateResult {

--- a/src/cli/helpers/memorySubagentCompletion.ts
+++ b/src/cli/helpers/memorySubagentCompletion.ts
@@ -5,6 +5,7 @@ export type MemorySubagentType = "init" | "reflection";
 type RecompileAgentSystemPromptFn = (
   conversationId: string,
   agentId: string,
+  dryRun?: boolean,
 ) => Promise<string>;
 
 export interface MemorySubagentCompletionArgs {

--- a/src/tests/agent/recompile-system-prompt.test.ts
+++ b/src/tests/agent/recompile-system-prompt.test.ts
@@ -1,60 +1,89 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-const conversationsRecompileMock = mock(
-  (_conversationId: string, _params?: Record<string, unknown>) =>
-    Promise.resolve("compiled-system-prompt"),
-);
-
-mock.module("../../agent/client", () => ({
-  getClient: () => ({
-    conversations: {
-      recompile: conversationsRecompileMock,
-    },
-  }),
-}));
-
-const { recompileAgentSystemPrompt } = await import("../../agent/modify");
+import { describe, expect, mock, test } from "bun:test";
+import { recompileAgentSystemPrompt } from "../../agent/modify";
 
 describe("recompileAgentSystemPrompt", () => {
-  beforeEach(() => {
-    conversationsRecompileMock.mockReset();
-    conversationsRecompileMock.mockImplementation(() =>
-      Promise.resolve("compiled-system-prompt"),
-    );
-  });
-
   test("calls the conversation recompile endpoint with mapped params", async () => {
+    const conversationsRecompileMock = mock(
+      (_conversationId: string, _params?: Record<string, unknown>) =>
+        Promise.resolve("compiled-system-prompt"),
+    );
+    const client = {
+      conversations: {
+        recompile: conversationsRecompileMock,
+      },
+    };
+
     const compiledPrompt = await recompileAgentSystemPrompt(
       "conv-123",
       "agent-123",
+      true,
+      client,
     );
 
     expect(compiledPrompt).toBe("compiled-system-prompt");
     expect(conversationsRecompileMock).toHaveBeenCalledWith("conv-123", {
+      dry_run: true,
       agent_id: "agent-123",
     });
   });
 
   test("passes agent_id for default conversation recompiles", async () => {
-    await recompileAgentSystemPrompt("default", "agent-123");
+    const conversationsRecompileMock = mock(
+      (_conversationId: string, _params?: Record<string, unknown>) =>
+        Promise.resolve("compiled-system-prompt"),
+    );
+    const client = {
+      conversations: {
+        recompile: conversationsRecompileMock,
+      },
+    };
+
+    await recompileAgentSystemPrompt("default", "agent-123", undefined, client);
 
     expect(conversationsRecompileMock).toHaveBeenCalledWith("default", {
+      dry_run: undefined,
       agent_id: "agent-123",
     });
   });
 
   test("passes non-default conversation ids through unchanged", async () => {
-    await recompileAgentSystemPrompt("['default']", "agent-123");
+    const conversationsRecompileMock = mock(
+      (_conversationId: string, _params?: Record<string, unknown>) =>
+        Promise.resolve("compiled-system-prompt"),
+    );
+    const client = {
+      conversations: {
+        recompile: conversationsRecompileMock,
+      },
+    };
+
+    await recompileAgentSystemPrompt(
+      "['default']",
+      "agent-123",
+      undefined,
+      client,
+    );
 
     expect(conversationsRecompileMock).toHaveBeenCalledWith("['default']", {
+      dry_run: undefined,
       agent_id: "agent-123",
     });
   });
 
   test("throws when conversation recompile has empty agent id", async () => {
-    await expect(recompileAgentSystemPrompt("default", "")).rejects.toThrow(
-      "recompileAgentSystemPrompt requires agentId",
+    const conversationsRecompileMock = mock(
+      (_conversationId: string, _params?: Record<string, unknown>) =>
+        Promise.resolve("compiled-system-prompt"),
     );
+    const client = {
+      conversations: {
+        recompile: conversationsRecompileMock,
+      },
+    };
+
+    await expect(
+      recompileAgentSystemPrompt("default", "", undefined, client),
+    ).rejects.toThrow("recompileAgentSystemPrompt requires agentId");
     expect(conversationsRecompileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/cli/memory-subagent-recompile-wiring.test.ts
+++ b/src/tests/cli/memory-subagent-recompile-wiring.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { handleMemorySubagentCompletion } from "../../cli/helpers/memorySubagentCompletion";
 
 const recompileAgentSystemPromptMock = mock(
-  (_conversationId: string, _agentId: string) =>
+  (_conversationId: string, _agentId: string, _dryRun?: boolean) =>
     Promise.resolve("compiled-system-prompt"),
 );
 
@@ -18,7 +18,7 @@ describe("memory subagent recompile handling", () => {
   beforeEach(() => {
     recompileAgentSystemPromptMock.mockReset();
     recompileAgentSystemPromptMock.mockImplementation(
-      (_conversationId: string, _agentId: string) =>
+      (_conversationId: string, _agentId: string, _dryRun?: boolean) =>
         Promise.resolve("compiled-system-prompt"),
     );
   });


### PR DESCRIPTION
## Summary
- Simplify system prompt recompilation to always use `conversations.recompile` with `agent_id`
- Flatten `RecompileAgentSystemPromptOptions` into positional args (`conversationId`, `agentId`, `dryRun?`)

## Testing
- `bun test src/tests/agent/recompile-system-prompt.test.ts src/tests/cli/memory-subagent-recompile-wiring.test.ts`
- `bun run typecheck`