### PR TITLE
fix: correct Docker pull image in outdated warning

### DIFF
--- a/src/startup-docker-check.ts
+++ b/src/startup-docker-check.ts
@@ -38,7 +38,7 @@ export async function startDockerVersionCheck(): Promise<void> {
     // Check if version is below minimum
     if (isVersionBelow(serverVersion, MINIMUM_DOCKER_VERSION)) {
       console.warn(
-        `\n⚠️  Warning: Your Docker image is outdated (v${serverVersion}). Minimum recommended: v${MINIMUM_DOCKER_VERSION}.\n   Please update with: docker pull letta/letta-server:latest\n`,
+        `\n⚠️  Warning: Your Docker image is outdated (v${serverVersion}). Minimum recommended: v${MINIMUM_DOCKER_VERSION}.\n   Please update with: docker pull letta/letta:latest\n`,
       );
     }
   } catch {


### PR DESCRIPTION
## Summary
- Fix the startup Docker version warning to use the correct published image name.
- Replace `docker pull letta/letta-server:latest` with `docker pull letta/letta:latest` in `src/startup-docker-check.ts`.
- Prevent user confusion when following the recommended update command.

## Test plan
- [x] Confirm warning string now prints `docker pull letta/letta:latest`.
- [x] Verify no behavior changes outside this warning text (single-line string edit).

👾 Generated with [Letta Code](https://letta.com)