### PR TITLE
feat: inject primary agent memory into memory defrag subagent and standardize naming

### DIFF
--- a/src/agent/subagents/builtin/memory.md
+++ b/src/agent/subagents/builtin/memory.md
@@ -194,11 +194,31 @@ Check `git status` — if there are no changes to commit,
 skip straight to Step 5d (cleanup). Report "no updates
 needed" in your output.
 
-If there are changes, commit:
+If there are changes, resolve the actual ID values first:
 
 ```bash
-git commit -m "chore(defrag): <summary>"
+echo "AGENT_ID=$LETTA_AGENT_ID"
+echo "PARENT_AGENT_ID=$LETTA_PARENT_AGENT_ID"
 ```
+
+Use the printed values (e.g., `agent-abc123...`) in the trailers. If a variable is empty or unset, omit that trailer. Never write a literal variable name like `$LETTA_AGENT_ID` or `$AGENT_ID` in the commit message.
+
+```bash
+git commit --author="Memory Defrag Subagent <<ACTUAL_AGENT_ID>@letta.com>" -m "<type>(memory-defrag): <summary>
+
+Updates:
+- <what changed and why>
+
+Generated-By: Letta Code
+Agent-ID: <ACTUAL_AGENT_ID>
+Parent-Agent-ID: <ACTUAL_PARENT_AGENT_ID>"
+```
+
+**Commit type** — pick the one that fits:
+- `refactor` — reorganizing/splitting/merging files (most common for defrag)
+- `fix` — correcting stale or incorrect memory content
+- `feat` — adding wholly new memory content
+- `chore` — routine cleanup, removing redundancy
 
 **Step 5b: Pull + merge to main**
 

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -28,6 +28,8 @@ The primary agent's context is *who* the agent is. Your refinement is fundamenta
 - **Build relationships** where trust compounds over time
 - **Carry forward context** that makes every interaction richer than the last
 
+Focus on improvement to the agent's prompting (the system prompt). Additional information can also be represented in the additional reference files (external memory).
+
 Context refinement is also a mechanism for *learning*. Learning should serve the purpose of improvement over time. Dimensions of learning include:
 
 **Deepening understanding of the user and their work:**
@@ -45,18 +47,19 @@ Context refinement is also a mechanism for *learning*. Learning should serve the
 - Guard against undesired behaviors from underlying models
 - Steer future behavior to match the user's preferences
 
+
 ## Memory Filesystem
 
 The primary agent's context (its prompts, skills, and external memory files) is stored in a "memory filesystem" that you can modify. Changes to these files are reflected in the primary agent's context.
 
 The filesystem contains:
-- **Prompts** (`system/`): Part of the system prompt — the most important memories that should always be in-context
+- **Prompts** (`system/`): Part of the system prompt — the most important memories and instructions that should always be in-context
 - **Skills** (`skills/`): Procedural memory for specialized workflows
 - **External memory** (everything else): Reference material retrieved on-demand by name/description
 
 You can create, delete, or modify files — including their contents, names, and descriptions. You can also move files between folders (e.g., moving files from `system/` to a lower-priority location).
 
-**Visibility**: The primary agent always sees prompts, the filesystem tree, and skill/external file descriptions. Skill and external file *contents* must be retrieved by the primary agent based on name/description.
+**Visibility**: The primary agent always sees prompts, the filesystem tree, and skill/external file descriptions. Skill and external file *contents* must be retrieved by the primary agent based on name/description. Making changes ONLY to external memory files are unlikely to change the agent's future behavior, unless the information is explicitly retrieved by the agent based on the file's description. Make sure to maintain informative descriptions, reference external files from promptor other context visible to the agent, or focus on making improvements to the files in `system/` which are always visible. 
 
 ## Operating Procedure
 

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -69,7 +69,7 @@ export function buildReflectionSubagentPrompt(
     `Review the conversation transcript and update memory files. The current conversation transcript has been saved to: ${input.transcriptPath}`,
     "",
     `The primary agent's memory filesystem is located at: ${input.memoryDir}`,
-    "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the parent agent's system prompt.",
+    "In-context memory (in the primary agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the primary agent's system prompt.",
     "Additional memory files (such as skills and external memory) may also be read and modified.",
     "",
   );
@@ -224,7 +224,7 @@ export async function buildParentMemorySnapshot(
   );
 
   const lines = [
-    "<parent_memory>",
+    "<primary_agent_memory>",
     "<memory_filesystem>",
     tree,
     "</memory_filesystem>",
@@ -243,7 +243,7 @@ export async function buildParentMemorySnapshot(
     }
   }
 
-  lines.push("</parent_memory>");
+  lines.push("</primary_agent_memory>");
   return lines.join("\n");
 }
 

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -155,7 +155,7 @@ describe("reflectionTranscript helper", () => {
 
     const snapshot = await buildParentMemorySnapshot(memoryDir);
 
-    expect(snapshot).toContain("<parent_memory>");
+    expect(snapshot).toContain("<primary_agent_memory>");
     expect(snapshot).toContain("<memory_filesystem>");
     expect(snapshot).toContain("/memory/");
     expect(snapshot).toContain("system/");
@@ -176,7 +176,7 @@ describe("reflectionTranscript helper", () => {
     expect(snapshot).not.toContain(
       "This body should not be inlined into parent memory.",
     );
-    expect(snapshot).toContain("</parent_memory>");
+    expect(snapshot).toContain("</primary_agent_memory>");
   });
 
   test("buildReflectionSubagentPrompt uses expanded reflection instructions", () => {
@@ -184,7 +184,7 @@ describe("reflectionTranscript helper", () => {
       transcriptPath: "/tmp/transcript.txt",
       memoryDir: "/tmp/memory",
       cwd: "/tmp/work",
-      parentMemory: "<parent_memory>snapshot</parent_memory>",
+      parentMemory: "<primary_agent_memory>snapshot</primary_agent_memory>",
     });
 
     expect(prompt).toContain("Review the conversation transcript");
@@ -193,11 +193,13 @@ describe("reflectionTranscript helper", () => {
       "The current conversation transcript has been saved",
     );
     expect(prompt).toContain(
-      "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below.",
+      "In-context memory (in the primary agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below.",
     );
     expect(prompt).toContain(
       "Additional memory files (such as skills and external memory) may also be read and modified.",
     );
-    expect(prompt).toContain("<parent_memory>snapshot</parent_memory>");
+    expect(prompt).toContain(
+      "<primary_agent_memory>snapshot</primary_agent_memory>",
+    );
   });
 });

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -475,7 +475,35 @@ export async function task(args: TaskArgs): Promise<string> {
     return `Error: When deploying an existing agent, subagent_type must be "explore" (read-only) or "general-purpose" (read-write). Got: "${subagent_type}"`;
   }
 
-  const prompt = inputPrompt;
+  // Inject primary agent memory for memory-type subagents (mirrors reflection prompt pattern)
+  let prompt = inputPrompt;
+  if (subagent_type === "memory") {
+    try {
+      const { getMemoryFilesystemRoot } = await import(
+        "../../agent/memoryFilesystem"
+      );
+      const { buildParentMemorySnapshot } = await import(
+        "../../cli/helpers/reflectionTranscript"
+      );
+      const { getCurrentAgentId } = await import("../../agent/context");
+      const { settingsManager } = await import("../../settings-manager");
+      const agentId = getCurrentAgentId();
+      if (settingsManager.isMemfsEnabled(agentId)) {
+        const memoryDir = getMemoryFilesystemRoot(agentId);
+        const parentMemory = await buildParentMemorySnapshot(memoryDir);
+        const memoryPreamble = [
+          `The primary agent's memory filesystem is located at: ${memoryDir}`,
+          "In-context memory (in the primary agent's system prompt) is stored in the `system/` folder.",
+          "",
+          parentMemory,
+          "",
+        ].join("\n");
+        prompt = `${memoryPreamble}\n${inputPrompt}`;
+      }
+    } catch {
+      // If memory snapshot fails, proceed with original prompt
+    }
+  }
 
   const isBackground = args.run_in_background ?? false;
 


### PR DESCRIPTION
## Summary
- **Memory defrag subagent now receives parent memory**: When `subagent_type === "memory"`, the Task tool automatically injects `buildParentMemorySnapshot()` into the prompt (same pattern as reflection subagent)
- **Consistent "primary" terminology**: Renamed `<parent_memory>` tag to `<primary_agent_memory>`, updated all prose from "parent agent" to "primary agent" in both code and tests
- **Proper commit signing for memory defrag**: Added `--author`, agent ID trailers, and commit type guidance to `memory.md` matching the reflection subagent's pattern
- Minor `reflection.md` improvements: added visibility guidance for external memory files, emphasis on system prompt focus

## Test plan
- [x] `bun test src/tests/cli/reflection-transcript.test.ts` — 5 pass
- [x] `bun test src/tests/tools/task-background-helper.test.ts` — 7 pass
- [x] `bun test src/tests/tools/task-foreground-transcript.test.ts` — 1 pass
- [x] `bun run check` — lint + type check pass
- [ ] Manual: invoke memory defrag subagent and verify parent memory appears in prompt

👾 Generated with [Letta Code](https://letta.com)