### PR TITLE
feat: warn at startup when context repositories are not enabled

### DIFF
--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -145,8 +145,8 @@ export function WelcomeScreen({
             ? tildePath
             : getLoadingMessage(loadingState, !!continueSession)}
         </Text>
-        {/* Row 4: memfs warning if not enabled */}
-        {loadingState === "ready" && !memfsEnabled && (
+        {/* Row 4: memfs warning if not enabled (skip for self-hosted servers) */}
+        {loadingState === "ready" && !memfsEnabled && authMethod !== "url" && (
           <Text color="yellow">
             Warning: Context repositories are not enabled for this agent. Run
             /memfs enable to enable.


### PR DESCRIPTION
## Summary
- Adds a yellow warning to the welcome banner when memfs (context repositories) is not enabled for the current agent
- Warning text: `Warning: Context repositories are not enabled for this agent. Run /memfs enable to enable.`
- Only shown once the agent is fully loaded (`loadingState === "ready"`)
- Skipped for self-hosted servers (`LETTA_BASE_URL` set) since memfs is a Letta Cloud feature

## Test plan
- [ ] Start letta-code with an agent that has memfs disabled — verify yellow warning appears in the welcome banner
- [ ] Start letta-code with an agent that has memfs enabled — verify no warning appears
- [ ] Start letta-code with `LETTA_BASE_URL` set (self-hosted) and memfs disabled — verify no warning appears
- [ ] Run `/memfs enable` on a disabled agent, restart — verify warning goes away

👾 Generated with [Letta Code](https://letta.com)