### PR TITLE
feat(memory): protect required files via pre-commit hook

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -163,6 +163,7 @@ export const PRE_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
 AGENT_EDITABLE_KEYS="description limit"
 PROTECTED_KEYS="read_only"
 ALL_KNOWN_KEYS="description limit read_only"
+REQUIRED_FILES="memory/system/persona.md"
 errors=""
 
 # Helper: extract a frontmatter value from content
@@ -281,7 +282,39 @@ for file in $(git diff --cached --name-only --diff-filter=ACM | grep '^memory/.*
       fi
     done
   fi
+
+  # Check required files are not emptied (body must be non-whitespace)
+  for req in $REQUIRED_FILES; do
+    if [ "$file" = "$req" ]; then
+      body=$(echo "$staged" | tail -n +$((closing_line + 2)))
+      trimmed=$(echo "$body" | tr -d '[:space:]')
+      if [ -z "$trimmed" ]; then
+        errors="$errors\\\\n  $file: is a required file and cannot have empty content"
+      fi
+      break
+    fi
+  done
 done
+
+# Check required files are not deleted or renamed away
+while IFS=$'\\t' read -r status old_path new_path; do
+  case "$status" in
+    D)
+      for req in $REQUIRED_FILES; do
+        if [ "$old_path" = "$req" ]; then
+          errors="$errors\\\\n  $old_path: is a required file and cannot be deleted"
+        fi
+      done
+      ;;
+    R*)
+      for req in $REQUIRED_FILES; do
+        if [ "$old_path" = "$req" ]; then
+          errors="$errors\\\\n  $old_path: is a required file and cannot be renamed"
+        fi
+      done
+      ;;
+  esac
+done < <(git diff --cached --name-status)
 
 if [ -n "$errors" ]; then
   echo "Frontmatter validation failed:"

--- a/src/tests/agent/memoryGit.precommit.test.ts
+++ b/src/tests/agent/memoryGit.precommit.test.ts
@@ -290,6 +290,60 @@ describe("pre-commit hook: read_only protection", () => {
   });
 });
 
+describe("pre-commit hook: required file protection", () => {
+  /** Seed system/persona.md so it exists for protection tests */
+  function seedPersona(): void {
+    const hookPath = join(tempDir, ".git", "hooks", "pre-commit");
+    rmSync(hookPath);
+    writeAndStage(
+      "memory/system/persona.md",
+      `${VALID_FM}I'm a coding assistant.\n`,
+    );
+    tryCommit();
+    writeFileSync(hookPath, PRE_COMMIT_HOOK_SCRIPT, { mode: 0o755 });
+  }
+
+  test("rejects deleting a required file", () => {
+    seedPersona();
+    git("rm memory/system/persona.md");
+    const result = tryCommit();
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("required file");
+    expect(result.output).toContain("cannot be deleted");
+  });
+
+  test("rejects renaming a required file", () => {
+    seedPersona();
+    git("mv memory/system/persona.md memory/system/old-persona.md");
+    const result = tryCommit();
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("required file");
+    expect(result.output).toContain("cannot be renamed");
+  });
+
+  test("rejects emptying a required file body", () => {
+    seedPersona();
+    writeAndStage(
+      "memory/system/persona.md",
+      "---\ndescription: Who I am\nlimit: 20000\n---\n\n   \n",
+    );
+    const result = tryCommit();
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("required file");
+    expect(result.output).toContain("cannot have empty content");
+  });
+
+  test("allows modifying a required file with non-empty body", () => {
+    seedPersona();
+    writeAndStage(
+      "memory/system/persona.md",
+      `${VALID_FM}Updated persona content.\n`,
+    );
+    const result = tryCommit();
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("pre-commit hook: non-memory files", () => {
   test("ignores non-memory files", () => {
     writeAndStage("README.md", "---\nbogus: true\n---\n\nThis is fine.\n");


### PR DESCRIPTION
## Summary
- Adds required file protection to the memory filesystem pre-commit hook
- `system/persona.md` is now protected: cannot be deleted, renamed away, or emptied
- Uses `git diff --cached --name-status` to detect deletions (`D`) and renames (`R*`) of required files
- Checks staged body content for required files to prevent hollowing out
- `REQUIRED_FILES` variable in the hook is easily extensible for future required files
- 4 new tests in `memoryGit.precommit.test.ts` (delete, rename, empty body, valid modify)

## Test plan
- [x] `bun test src/tests/agent/memoryGit.precommit.test.ts` — 23/23 pass (4 new + 19 existing)
- [x] `bun test src/tests/tools/memory-tool.test.ts` — 6/6 pass (unchanged)
- [x] `bun run check` — lint + typecheck pass

👾 Generated with [Letta Code](https://letta.com)