### PR TITLE
revert: restore free-tier lock emoji behavior in model selector

### DIFF
--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -159,6 +159,7 @@ export function ModelSelector({
     () => getModelCategories(billingTier, isSelfHosted),
     [billingTier, isSelfHosted],
   );
+  const isFreeTier = billingTier === "free";
   const defaultCategory = modelCategories[0] ?? "supported";
 
   const [category, setCategory] = useState<ModelCategory>(defaultCategory);

--- a/src/models.json
+++ b/src/models.json
@@ -5,14 +5,16 @@
       "handle": "letta/auto",
       "label": "Auto (Beta)",
       "description": "Automatically select the best model",
-      "isFeatured": true
+      "isFeatured": true,
+      "free": true
     },
     {
       "id": "auto-fast",
       "handle": "letta/auto-fast",
       "label": "Auto Fast (Beta)",
       "description": "Automatically select the best fast model",
-      "isFeatured": true
+      "isFeatured": true,
+      "free": true
     },
     {
       "id": "sonnet",


### PR DESCRIPTION
## Summary
- Reverts PR #1176 (`c5a8871be7689cb68cf4308b71500390d8de3020`)
- Restores free-tier lock emoji rendering in `ModelSelector` for non-free Letta API models
- Restores free-tier copy: \"Upgrade your account to access more models\" for supported/all Letta API tabs

## Test plan
- [x] Revert applied cleanly with `git revert`
- [x] `bunx @biomejs/biome check src/cli/components/ModelSelector.tsx`
- [ ] Manually verify model selector UI in free-tier account

👾 Generated with [Letta Code](https://letta.com)