### PR TITLE
fix(cli): default summarization model and reconcile attached agent tools

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -6,7 +6,7 @@ import type {
   AgentState,
   AgentType,
 } from "@letta-ai/letta-client/resources/agents/agents";
-import { DEFAULT_AGENT_NAME } from "../constants";
+import { DEFAULT_AGENT_NAME, DEFAULT_SUMMARIZATION_MODEL } from "../constants";
 import { settingsManager } from "../settings-manager";
 import { getModelContextWindow } from "./available-models";
 import { getClient, getServerUrl } from "./client";
@@ -221,44 +221,8 @@ export async function createAgent(
   // Only attach server-side tools to the agent.
   // Client-side tools (Read, Write, Bash, etc.) are passed via client_tools at runtime,
   // NOT attached to the agent. This is the new pattern - no more stub tool registration.
-  const { isOpenAIModel } = await import("../tools/manager");
-  const baseMemoryTool = isOpenAIModel(modelHandle)
-    ? "memory_apply_patch"
-    : "memory";
-  const defaultBaseTools = options.baseTools ?? [
-    baseMemoryTool,
-    "web_search",
-    "fetch_webpage",
-  ];
-
-  let toolNames = [...defaultBaseTools];
-
-  // Fallback: if server doesn't have memory_apply_patch, use legacy memory tool
-  if (toolNames.includes("memory_apply_patch")) {
-    try {
-      const resp = await client.tools.list({ name: "memory_apply_patch" });
-      const hasMemoryApplyPatch =
-        Array.isArray(resp.items) && resp.items.length > 0;
-      if (!hasMemoryApplyPatch) {
-        console.warn(
-          "memory_apply_patch tool not found on server; falling back to 'memory' tool",
-        );
-        toolNames = toolNames.map((n) =>
-          n === "memory_apply_patch" ? "memory" : n,
-        );
-      }
-    } catch (err) {
-      // If the capability check fails for any reason, conservatively fall back to 'memory'
-      console.warn(
-        `Unable to verify memory_apply_patch availability (falling back to 'memory'): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-      toolNames = toolNames.map((n) =>
-        n === "memory_apply_patch" ? "memory" : n,
-      );
-    }
-  }
+  const defaultBaseTools = options.baseTools ?? ["web_search", "fetch_webpage"];
+  const toolNames = [...defaultBaseTools];
 
   // Determine which memory blocks to use:
   // 1. If options.memoryBlocks is provided, use those (custom blocks and/or block references)
@@ -403,6 +367,9 @@ export async function createAgent(
     initial_message_sequence: [],
     parallel_tool_calls: parallelToolCallsVal,
     enable_sleeptime: enableSleeptimeVal,
+    compaction_settings: {
+      model: DEFAULT_SUMMARIZATION_MODEL,
+    },
   };
 
   const createWithTools = (tools: string[]) =>
@@ -416,8 +383,6 @@ export async function createAgent(
     toolNames,
     addBaseToolsToServer,
   );
-
-  // Note: Preflight check above falls back to 'memory' when 'memory_apply_patch' is unavailable.
 
   // Apply updateArgs if provided (e.g., context_window, reasoning_effort, verbosity, etc.).
   // Also apply tier defaults from models.json when the caller explicitly selected a model.

--- a/src/agent/reconcileExistingAgentState.ts
+++ b/src/agent/reconcileExistingAgentState.ts
@@ -1,0 +1,194 @@
+import type {
+  AgentState,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type { Tool } from "@letta-ai/letta-client/resources/tools";
+import { DEFAULT_SUMMARIZATION_MODEL } from "../constants";
+
+export const DEFAULT_ATTACHED_BASE_TOOLS = [
+  "web_search",
+  "fetch_webpage",
+] as const;
+
+type AgentStateReconcileClient = {
+  agents: {
+    update: (agentID: string, body: AgentUpdateParams) => Promise<AgentState>;
+  };
+  tools: {
+    list: (query?: { name?: string | null; limit?: number | null }) => Promise<{
+      items: Tool[];
+    }>;
+  };
+};
+
+export interface ReconcileAgentStateResult {
+  updated: boolean;
+  agent: AgentState;
+  appliedTweaks: string[];
+  skippedTweaks: string[];
+}
+
+function areToolSetsEqual(
+  currentToolIds: string[],
+  desiredToolIds: string[],
+): boolean {
+  if (currentToolIds.length !== desiredToolIds.length) {
+    return false;
+  }
+
+  const currentSet = new Set(currentToolIds);
+  for (const toolId of desiredToolIds) {
+    if (!currentSet.has(toolId)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getToolName(tool: Tool): string {
+  if (typeof tool.name !== "string") {
+    return "";
+  }
+  return tool.name.trim();
+}
+
+function getAttachedToolIdsByName(agent: AgentState): Map<string, string> {
+  const toolIdsByName = new Map<string, string>();
+  for (const tool of agent.tools ?? []) {
+    const name = getToolName(tool);
+    if (!name || !tool.id || toolIdsByName.has(name)) {
+      continue;
+    }
+    toolIdsByName.set(name, tool.id);
+  }
+  return toolIdsByName;
+}
+
+async function resolveToolIdByName(
+  client: AgentStateReconcileClient,
+  toolName: string,
+): Promise<string | null> {
+  const response = await client.tools.list({
+    name: toolName,
+    limit: 10,
+  });
+
+  if (!Array.isArray(response.items) || response.items.length === 0) {
+    return null;
+  }
+
+  const exactMatch = response.items.find(
+    (tool) => getToolName(tool) === toolName,
+  );
+  const match = exactMatch ?? response.items[0];
+  return match?.id ?? null;
+}
+
+async function resolveDesiredAttachedToolIds(
+  client: AgentStateReconcileClient,
+  agent: AgentState,
+  desiredToolNames: readonly string[],
+): Promise<{ toolIds: string[] | null; missingToolNames: string[] }> {
+  const attachedByName = getAttachedToolIdsByName(agent);
+  const resolvedByName = new Map<string, string>();
+  const missingToolNames: string[] = [];
+
+  await Promise.all(
+    desiredToolNames.map(async (toolName) => {
+      const existingId = attachedByName.get(toolName);
+      if (existingId) {
+        resolvedByName.set(toolName, existingId);
+        return;
+      }
+
+      try {
+        const resolvedId = await resolveToolIdByName(client, toolName);
+        if (resolvedId) {
+          resolvedByName.set(toolName, resolvedId);
+          return;
+        }
+      } catch {
+        // Treat as missing; caller decides whether to skip this tweak.
+      }
+
+      missingToolNames.push(toolName);
+    }),
+  );
+
+  if (missingToolNames.length > 0) {
+    return {
+      toolIds: null,
+      missingToolNames,
+    };
+  }
+
+  const toolIds = desiredToolNames
+    .map((toolName) => resolvedByName.get(toolName))
+    .filter((toolId): toolId is string => Boolean(toolId));
+
+  return {
+    toolIds,
+    missingToolNames: [],
+  };
+}
+
+export async function reconcileExistingAgentState(
+  client: AgentStateReconcileClient,
+  agent: AgentState,
+): Promise<ReconcileAgentStateResult> {
+  const patch: AgentUpdateParams = {};
+  const appliedTweaks: string[] = [];
+  const skippedTweaks: string[] = [];
+
+  const configuredCompactionModel =
+    typeof agent.compaction_settings?.model === "string"
+      ? agent.compaction_settings.model.trim()
+      : "";
+
+  if (!configuredCompactionModel) {
+    patch.compaction_settings = {
+      ...(agent.compaction_settings ?? {}),
+      model: DEFAULT_SUMMARIZATION_MODEL,
+    };
+    appliedTweaks.push("set_compaction_model");
+  }
+
+  const desiredToolNames = DEFAULT_ATTACHED_BASE_TOOLS;
+  const desiredTools = await resolveDesiredAttachedToolIds(
+    client,
+    agent,
+    desiredToolNames,
+  );
+
+  if (desiredTools.missingToolNames.length > 0 || !desiredTools.toolIds) {
+    skippedTweaks.push(
+      `sync_attached_tools_missing:${desiredTools.missingToolNames.join(",")}`,
+    );
+  } else {
+    const currentToolIds = (agent.tools ?? [])
+      .map((tool) => tool.id)
+      .filter((toolId): toolId is string => Boolean(toolId));
+
+    if (!areToolSetsEqual(currentToolIds, desiredTools.toolIds)) {
+      patch.tool_ids = desiredTools.toolIds;
+      appliedTweaks.push("sync_attached_tools");
+    }
+  }
+
+  if (appliedTweaks.length === 0) {
+    return {
+      updated: false,
+      agent,
+      appliedTweaks,
+      skippedTweaks,
+    };
+  }
+
+  const updatedAgent = await client.agents.update(agent.id, patch);
+  return {
+    updated: true,
+    agent: updatedAgent,
+    appliedTweaks,
+    skippedTweaks,
+  };
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -67,9 +67,11 @@ import {
   INTERRUPT_RECOVERY_ALERT,
   shouldRecommendDefaultPrompt,
 } from "../agent/promptAssets";
+import { reconcileExistingAgentState } from "../agent/reconcileExistingAgentState";
 import { recordSessionEnd } from "../agent/sessionHistory";
 import { SessionStats } from "../agent/stats";
 import {
+  DEFAULT_SUMMARIZATION_MODEL,
   INTERRUPTED_BY_USER,
   MEMFS_CONFLICT_CHECK_INTERVAL,
   SYSTEM_ALERT_CLOSE,
@@ -3137,11 +3139,14 @@ export default function App({
   // Fetch llmConfig when agent is ready
   useEffect(() => {
     if (loadingState === "ready" && agentId && agentId !== "loading") {
+      let cancelled = false;
+
       const fetchConfig = async () => {
         try {
           const { getClient } = await import("../agent/client");
           const client = await getClient();
           const agent = await client.agents.retrieve(agentId);
+
           setAgentState(agent);
           setLlmConfig(agent.llm_config);
           setAgentDescription(agent.description ?? null);
@@ -3203,8 +3208,11 @@ export default function App({
             setCurrentSystemPromptId("custom");
           }
           // Get last message timestamp from agent state if available
-          const lastRunCompletion = (agent as { last_run_completion?: string })
-            .last_run_completion;
+          const lastRunCompletion = (
+            agent as {
+              last_run_completion?: string;
+            }
+          ).last_run_completion;
           setAgentLastRunAt(lastRunCompletion ?? null);
 
           // Derive model ID from llm_config for ModelSelector
@@ -3250,11 +3258,38 @@ export default function App({
             await forceToolsetSwitch(persistedToolsetPreference, agentId);
             setCurrentToolset(persistedToolsetPreference);
           }
+
+          void reconcileExistingAgentState(client, agent)
+            .then((reconcileResult) => {
+              if (!reconcileResult.updated || cancelled) {
+                return;
+              }
+              if (agentIdRef.current !== agent.id) {
+                return;
+              }
+
+              setAgentState(reconcileResult.agent);
+              setAgentDescription(reconcileResult.agent.description ?? null);
+            })
+            .catch((reconcileError) => {
+              debugWarn(
+                "agent-config",
+                `Failed to reconcile existing agent settings for ${agentId}: ${
+                  reconcileError instanceof Error
+                    ? reconcileError.message
+                    : String(reconcileError)
+                }`,
+              );
+            });
         } catch (error) {
           debugLog("agent-config", "Error fetching agent config: %O", error);
         }
       };
       fetchConfig();
+
+      return () => {
+        cancelled = true;
+      };
     }
   }, [loadingState, agentId]);
 
@@ -8272,6 +8307,9 @@ export default function App({
               ? {
                   compaction_settings: {
                     mode: modeArg,
+                    model:
+                      agentStateRef.current?.compaction_settings?.model?.trim() ||
+                      DEFAULT_SUMMARIZATION_MODEL,
                   },
                 }
               : undefined;
@@ -11763,14 +11801,15 @@ ${SYSTEM_REMINDER_CLOSE}
         try {
           const client = await getClient();
           // Spread existing compaction_settings to preserve model/other fields,
-          // only override the mode. If no existing settings, use empty model
-          // string which tells the backend to use its default lightweight model.
+          // only override the mode. If no model is configured, default to
+          // letta/auto so compaction uses a consistent summarization model.
           const existing = agentState?.compaction_settings;
+          const existingModel = existing?.model?.trim();
 
           await client.agents.update(agentId, {
             compaction_settings: {
-              model: existing?.model ?? "",
               ...existing,
+              model: existingModel || DEFAULT_SUMMARIZATION_MODEL,
               mode: mode as
                 | "all"
                 | "sliding_window"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,11 @@
 export const DEFAULT_MODEL_ID = "sonnet";
 
 /**
+ * Default model handle to use for conversation compaction / summarization.
+ */
+export const DEFAULT_SUMMARIZATION_MODEL = "letta/auto";
+
+/**
  * Default agent name when creating a new agent
  */
 export const DEFAULT_AGENT_NAME = "Letta Code";

--- a/src/tests/agent/reconcile-existing-agent-state.test.ts
+++ b/src/tests/agent/reconcile-existing-agent-state.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  AgentState,
+  AgentUpdateParams,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type { Tool } from "@letta-ai/letta-client/resources/tools";
+import {
+  DEFAULT_ATTACHED_BASE_TOOLS,
+  reconcileExistingAgentState,
+} from "../../agent/reconcileExistingAgentState";
+
+function mkTool(id: string, name: string): Tool {
+  return { id, name } as Tool;
+}
+
+function mkAgentState(overrides: Partial<AgentState>): AgentState {
+  return {
+    id: "agent-test",
+    tools: [],
+    name: "test-agent",
+    system: "system",
+    agent_type: "letta_v1_agent",
+    blocks: [],
+    llm_config: {} as AgentState["llm_config"],
+    memory: { blocks: [] } as AgentState["memory"],
+    sources: [],
+    tags: [],
+    ...overrides,
+  } as AgentState;
+}
+
+describe("reconcileExistingAgentState", () => {
+  test("does not update when compaction model and attached tools are already correct", async () => {
+    const agent = mkAgentState({
+      tools: [
+        mkTool("tool-web", "web_search"),
+        mkTool("tool-fetch", "fetch_webpage"),
+      ],
+      compaction_settings: {
+        model: "letta/auto",
+      },
+    });
+
+    const update = mock(() => Promise.resolve(agent));
+    const list = mock(() => Promise.resolve({ items: [] as Tool[] }));
+
+    const result = await reconcileExistingAgentState(
+      {
+        agents: { update },
+        tools: { list },
+      },
+      agent,
+    );
+
+    expect(result.updated).toBe(false);
+    expect(result.appliedTweaks).toEqual([]);
+    expect(update).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  test("updates missing compaction model and enforces only default base tools", async () => {
+    const initialAgent = mkAgentState({
+      tools: [
+        mkTool("tool-web", "web_search"),
+        mkTool("tool-convo", "conversation_search"),
+      ],
+      compaction_settings: {
+        mode: "sliding_window",
+        model: "",
+      },
+    });
+
+    const updatedAgent = mkAgentState({
+      tools: [
+        mkTool("tool-web", "web_search"),
+        mkTool("tool-fetch", "fetch_webpage"),
+      ],
+      compaction_settings: {
+        mode: "sliding_window",
+        model: "letta/auto",
+      },
+    });
+
+    const update = mock((_agentID: string, _body: AgentUpdateParams) =>
+      Promise.resolve(updatedAgent),
+    );
+    const list = mock((query?: { name?: string | null }) => {
+      if (query?.name === "fetch_webpage") {
+        return Promise.resolve({
+          items: [mkTool("tool-fetch", "fetch_webpage")],
+        });
+      }
+      return Promise.resolve({ items: [] as Tool[] });
+    });
+
+    const result = await reconcileExistingAgentState(
+      {
+        agents: { update },
+        tools: { list },
+      },
+      initialAgent,
+    );
+
+    expect(result.updated).toBe(true);
+    expect(result.appliedTweaks).toEqual([
+      "set_compaction_model",
+      "sync_attached_tools",
+    ]);
+    expect(result.agent).toBe(updatedAgent);
+
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith({ name: "fetch_webpage", limit: 10 });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith("agent-test", {
+      compaction_settings: {
+        mode: "sliding_window",
+        model: "letta/auto",
+      },
+      tool_ids: ["tool-web", "tool-fetch"],
+    });
+
+    expect(DEFAULT_ATTACHED_BASE_TOOLS).toEqual([
+      "web_search",
+      "fetch_webpage",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- set `DEFAULT_SUMMARIZATION_MODEL` to `letta/auto` and apply it for new agent creation compaction settings
- add an async, non-blocking existing-agent reconciler that backfills missing compaction model and normalizes attached tools to only `web_search` + `fetch_webpage`
- wire reconciliation into startup fetch flow so UI loads immediately and applies reconciliation updates afterward
- remove memory tool defaults from server-attached base tools for new agents, and add targeted unit tests for the reconciler behavior

## Test plan
- [x] `bunx @biomejs/biome check src/agent/create.ts src/agent/reconcileExistingAgentState.ts src/cli/App.tsx src/constants.ts src/tests/agent/reconcile-existing-agent-state.test.ts`
- [x] `bun run typecheck`
- [x] `bun test src/tests/agent/reconcile-existing-agent-state.test.ts src/tests/agent/create-base-tools-recovery.test.ts`

👾 Generated with [Letta Code](https://letta.com)