### PR TITLE
feat(tools): remove memory tool from default toolsets

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -103,7 +103,6 @@ export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
   "TaskStop",
   // "MultiEdit",
   // "LS",
-  "memory",
   "Read",
   "Skill",
   "Task",
@@ -116,7 +115,6 @@ export const OPENAI_DEFAULT_TOOLS: ToolName[] = [
   // TODO(codex-parity): add once request_user_input tool exists in raw codex path.
   // "request_user_input",
   "apply_patch",
-  "memory",
   "update_plan",
   "view_image",
 ];
@@ -127,7 +125,6 @@ export const GEMINI_DEFAULT_TOOLS: ToolName[] = [
   "list_directory",
   "glob_gemini",
   "search_file_content",
-  "memory",
   "replace",
   "write_file_gemini",
   "write_todos",
@@ -142,7 +139,6 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "EnterPlanMode",
   "ExitPlanMode",
-  "memory",
   "Task",
   "TaskOutput",
   "TaskStop",
@@ -159,7 +155,6 @@ export const GEMINI_PASCAL_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "EnterPlanMode",
   "ExitPlanMode",
-  "memory",
   "Skill",
   "Task",
   // Standard Gemini tools


### PR DESCRIPTION
## Summary
- Remove the client-side `memory` tool from all 5 default toolset arrays (`ANTHROPIC_DEFAULT_TOOLS`, `OPENAI_DEFAULT_TOOLS`, `GEMINI_DEFAULT_TOOLS`, `OPENAI_PASCAL_TOOLS`, `GEMINI_PASCAL_TOOLS`)
- The memory tool implementation files and `GLOBAL_LOCK_TOOLS` entry are kept intact — this only removes it from being loaded by default

## Test plan
- [x] `bun run check` passes (lint + typecheck)
- [ ] Verify memory tool is still available when explicitly added
- [ ] Verify agents start correctly without memory tool in default toolset

👾 Generated with [Letta Code](https://letta.com)