### PR TITLE
fix(skills): avoid resending unchanged client_skills

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -25,6 +25,7 @@ import { buildClientSkillsPayload } from "./clientSkills";
 
 const streamRequestStartTimes = new WeakMap<object, number>();
 const streamToolContextIds = new WeakMap<object, string>();
+const lastSentClientSkillsFingerprintByConversation = new Map<string, string>();
 
 export type StreamRequestContext = {
   conversationId: string;
@@ -59,6 +60,41 @@ export type SendMessageStreamOptions = {
   approvalNormalization?: ApprovalNormalizationOptions;
   workingDirectory?: string;
 };
+
+type ClientSkillsPayload = NonNullable<
+  ConversationMessageCreateParams["client_skills"]
+>;
+
+type SelectedClientSkillsForRequest = {
+  clientSkillsForRequest: ClientSkillsPayload;
+  stateKey: string;
+  fingerprintToPersist: string | null;
+};
+
+export function selectClientSkillsForRequest(
+  conversationId: string,
+  agentId: string | undefined,
+  clientSkills: ClientSkillsPayload,
+  previousFingerprints: Map<string, string> =
+    lastSentClientSkillsFingerprintByConversation,
+): SelectedClientSkillsForRequest {
+  const stateKey = `${agentId ?? ""}:${conversationId}`;
+  const fingerprint = JSON.stringify(clientSkills);
+
+  if (previousFingerprints.get(stateKey) === fingerprint) {
+    return {
+      clientSkillsForRequest: [],
+      stateKey,
+      fingerprintToPersist: null,
+    };
+  }
+
+  return {
+    clientSkillsForRequest: clientSkills,
+    stateKey,
+    fingerprintToPersist: fingerprint,
+  };
+}
 
 export function buildConversationMessagesCreateRequestBody(
   conversationId: string,
@@ -128,6 +164,11 @@ export async function sendMessageStream(
     await buildClientSkillsPayload({
       agentId: opts.agentId,
     });
+  const {
+    clientSkillsForRequest,
+    stateKey: clientSkillsStateKey,
+    fingerprintToPersist: clientSkillsFingerprintToPersist,
+  } = selectClientSkillsForRequest(conversationId, opts.agentId, clientSkills);
 
   const resolvedConversationId = conversationId;
   const requestBody = buildConversationMessagesCreateRequestBody(
@@ -135,7 +176,7 @@ export async function sendMessageStream(
     messages,
     opts,
     clientTools,
-    clientSkills,
+    clientSkillsForRequest,
   );
 
   if (process.env.DEBUG) {
@@ -143,11 +184,11 @@ export async function sendMessageStream(
       `[DEBUG] sendMessageStream: conversationId=${conversationId}, agentId=${opts.agentId ?? "(none)"}`,
     );
 
-    const formattedSkills = clientSkills.map(
+    const formattedSkills = clientSkillsForRequest.map(
       (skill) => `${skill.name} (${skill.location})`,
     );
     console.log(
-      `[DEBUG] sendMessageStream: client_skills (${clientSkills.length}) ${
+      `[DEBUG] sendMessageStream: client_skills discovered=${clientSkills.length} sent=${clientSkillsForRequest.length} ${
         formattedSkills.length > 0 ? formattedSkills.join(", ") : "(none)"
       }`,
     );
@@ -222,6 +263,13 @@ export async function sendMessageStream(
     "request_ok conversation_id=%s",
     resolvedConversationId,
   );
+
+  if (clientSkillsFingerprintToPersist !== null) {
+    lastSentClientSkillsFingerprintByConversation.set(
+      clientSkillsStateKey,
+      clientSkillsFingerprintToPersist,
+    );
+  }
 
   if (requestStartTime !== undefined) {
     streamRequestStartTimes.set(stream as object, requestStartTime);

--- a/src/tests/agent/message-client-skills.test.ts
+++ b/src/tests/agent/message-client-skills.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { buildConversationMessagesCreateRequestBody } from "../../agent/message";
+import {
+  buildConversationMessagesCreateRequestBody,
+  selectClientSkillsForRequest,
+} from "../../agent/message";
 
 describe("buildConversationMessagesCreateRequestBody client_skills", () => {
   test("includes client_skills alongside client_tools", () => {
@@ -31,5 +34,92 @@ describe("buildConversationMessagesCreateRequestBody client_skills", () => {
         location: "/tmp/.skills/debugging/SKILL.md",
       },
     ]);
+  });
+});
+
+describe("selectClientSkillsForRequest", () => {
+  test("suppresses unchanged client_skills for the same conversation", () => {
+    const previousFingerprints = new Map<string, string>();
+    const clientSkills = [
+      {
+        name: "debugging",
+        description: "Debugging checklist",
+        location: "/tmp/.skills/debugging/SKILL.md",
+      },
+    ];
+
+    const firstSelection = selectClientSkillsForRequest(
+      "default",
+      "agent-1",
+      clientSkills,
+      previousFingerprints,
+    );
+
+    expect(firstSelection.clientSkillsForRequest).toEqual(clientSkills);
+    expect(firstSelection.fingerprintToPersist).not.toBeNull();
+
+    if (firstSelection.fingerprintToPersist === null) {
+      throw new Error("expected first selection fingerprint");
+    }
+    previousFingerprints.set(
+      firstSelection.stateKey,
+      firstSelection.fingerprintToPersist,
+    );
+
+    const secondSelection = selectClientSkillsForRequest(
+      "default",
+      "agent-1",
+      clientSkills,
+      previousFingerprints,
+    );
+
+    expect(secondSelection.clientSkillsForRequest).toEqual([]);
+    expect(secondSelection.fingerprintToPersist).toBeNull();
+  });
+
+  test("re-sends client_skills when the payload changes", () => {
+    const previousFingerprints = new Map<string, string>();
+    const initialSkills = [
+      {
+        name: "debugging",
+        description: "Debugging checklist",
+        location: "/tmp/.skills/debugging/SKILL.md",
+      },
+    ];
+
+    const changedSkills = [
+      ...initialSkills,
+      {
+        name: "review-pr",
+        description: "Review pull requests",
+        location: "/tmp/.skills/review-pr/SKILL.md",
+      },
+    ];
+
+    const initialSelection = selectClientSkillsForRequest(
+      "default",
+      "agent-1",
+      initialSkills,
+      previousFingerprints,
+    );
+
+    expect(initialSelection.fingerprintToPersist).not.toBeNull();
+    if (initialSelection.fingerprintToPersist === null) {
+      throw new Error("expected initial selection fingerprint");
+    }
+    previousFingerprints.set(
+      initialSelection.stateKey,
+      initialSelection.fingerprintToPersist,
+    );
+
+    const changedSelection = selectClientSkillsForRequest(
+      "default",
+      "agent-1",
+      changedSkills,
+      previousFingerprints,
+    );
+
+    expect(changedSelection.clientSkillsForRequest).toEqual(changedSkills);
+    expect(changedSelection.fingerprintToPersist).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Mitigate prompt inflation by only sending `client_skills` when the payload changes for a given `(agentId, conversationId)` instead of sending it on every turn.
- Persist the skills fingerprint only after a successful request so failed sends do not suppress a needed retry.
- Add unit tests for unchanged payload suppression and changed payload re-send behavior.

## Test plan
- [x] `bun test src/tests/agent/message-client-skills.test.ts`
- [ ] Reproduce a multi-turn conversation and verify backend prompt no longer repeats identical `available_skills` blocks across turns.
- [ ] Confirm behavior when skills change during runtime (new skill installed) sends updated payload once.

👾 Generated with [Letta Code](https://letta.com)