### PR TITLE
fix: replace console.debug with debugLog in updateAgentSystemPrompt

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -9,6 +9,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
+import { debugLog } from "../utils/debug";
 import { getModelContextWindow } from "./available-models";
 import { getClient } from "./client";
 
@@ -386,7 +387,7 @@ export async function updateAgentSystemPrompt(
       memoryMode,
     );
 
-    console.debug("[modify] systemPromptContent:", systemPromptContent);
+    debugLog("modify", "systemPromptContent: %s", systemPromptContent);
 
     const updateResult = await updateAgentSystemPromptRaw(
       agentId,


### PR DESCRIPTION
## Summary
- `console.debug` in `updateAgentSystemPrompt` was printing the full compiled system prompt to stdout for **all users** after running `/system`
- Replaced with `debugLog` from `src/utils/debug`, which gates screen output behind `LETTA_DEBUG=1` but still writes to the session log file

## Test plan
- [ ] Run `/system` and switch prompts — system prompt content should no longer appear in the console
- [ ] Run with `LETTA_DEBUG=1` and verify the system prompt content is still visible for debugging
- [ ] Verify it appears in `~/.letta/logs/debug/{agentId}/{sessionId}.log`

👾 Generated with [Letta Code](https://letta.com)