### PR TITLE
feat(cli): add /recompile slash command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7806,6 +7806,49 @@ export default function App({
           return { submitted: true };
         }
 
+        // Special handling for /recompile command - recompile agent + current conversation
+        if (trimmed === "/recompile") {
+          const cmd = commandRunner.start(
+            trimmed,
+            "Recompiling agent and conversation...",
+          );
+
+          setCommandRunning(true);
+
+          try {
+            const client = await getClient();
+            const currentConversationId = conversationIdRef.current;
+
+            await client.agents.recompile(agentId, {
+              update_timestamp: true,
+            });
+
+            const conversationParams =
+              currentConversationId === "default"
+                ? { agent_id: agentId }
+                : undefined;
+            await client.conversations.recompile(
+              currentConversationId,
+              conversationParams,
+            );
+
+            cmd.finish(
+              [
+                "Recompiled current agent and conversation.",
+                "(warning: this will evict the cache and increase costs)",
+              ].join("\n"),
+              true,
+            );
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+
         // Special handling for /exit command - exit without stats
         if (trimmed === "/exit") {
           const cmd = commandRunner.start(trimmed, "See ya!");

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -270,6 +270,15 @@ export const commands: Record<string, Command> = {
       return "Fetching context usage...";
     },
   },
+  "/recompile": {
+    desc: "Recompile current agent + conversation (warning: this will evict the cache and increase costs)",
+    order: 33.6,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Recompiling agent and conversation...";
+    },
+  },
   "/feedback": {
     desc: "Send feedback to the Letta team",
     order: 34,


### PR DESCRIPTION
## Summary
- add a new `/recompile` slash command to the CLI command registry with a clear cost warning in the autocomplete description
- implement `/recompile` handling in `App.tsx` to call both `client.agents.recompile()` and `client.conversations.recompile()` for the active session
- ensure default-conversation recompiles pass `agent_id` when calling the conversation endpoint and show success/failure via the existing command runner UX

## Test plan
- [x] `bunx @biomejs/biome check src/cli/App.tsx src/cli/commands/registry.ts`
- [x] `bun run typecheck`
- [x] run `/recompile` in the CLI and verify it reports success plus the cache/cost warning

👾 Generated with [Letta Code](https://letta.com)