### PR TITLE
fix(statusline): align turn_count with reflection cadence source

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2518,7 +2518,7 @@ export default function App({
     contextWindowSize,
     usedContextTokens: contextTrackerRef.current.lastContextTokens,
     stepCount: sessionStatsSnapshot.usage.stepCount,
-    turnCount: contextTrackerRef.current.currentTurnId,
+    turnCount: sharedReminderStateRef.current.turnCount,
     reflectionMode: reflectionSettings.trigger,
     reflectionStepCount: reflectionSettings.stepCount,
     memfsEnabled,
@@ -7638,7 +7638,7 @@ export default function App({
                     usedContextTokens:
                       contextTrackerRef.current.lastContextTokens,
                     stepCount: stats.usage.stepCount,
-                    turnCount: contextTrackerRef.current.currentTurnId,
+                    turnCount: sharedReminderStateRef.current.turnCount,
                     reflectionMode: getReflectionSettings().trigger,
                     reflectionStepCount: getReflectionSettings().stepCount,
                     memfsEnabled:


### PR DESCRIPTION
## Summary
- Use `sharedReminderStateRef.current.turnCount` as the statusline payload `turn_count` source in both live statusline updates and `/statusline test`
- This aligns statusline countdown math with the same turn counter used by reflection step-count scheduling
- Eliminates drift caused by previously using `contextTrackerRef.current.currentTurnId`, which is a different counter

## Test plan
- [x] `bun run --cwd /Users/jinjpeng/letta/letta-code fix`
- [x] `bun test /Users/jinjpeng/letta/letta-code/src/tests/cli/statusline-payload.test.ts /Users/jinjpeng/letta/letta-code/src/tests/cli/statusline-schema.test.ts`
- [ ] Manual: set `/sleeptime` to every 10 turns and verify statusline countdown matches actual reflection trigger cadence

👾 Generated with [Letta Code](https://letta.com)