### PR TITLE
fix(headless): auto-deny interactive approvals during recovery

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2941,28 +2941,17 @@ async function runBidirectionalMode(
         })),
       ];
 
+      // In headless recovery mode, auto-deny approvals that would require user
+      // input. Calling requestPermission() here would block waiting for a
+      // response that will never come, causing a timeout.
       for (const ac of needsUserInput) {
-        const permResponse = await requestPermission(
-          ac.approval.toolCallId,
-          ac.approval.toolName,
-          ac.parsedArgs,
-        );
-
-        if (permResponse.decision === "allow") {
-          const finalApproval = permResponse.updatedInput
-            ? {
-                ...ac.approval,
-                toolArgs: JSON.stringify(permResponse.updatedInput),
-              }
-            : ac.approval;
-          decisions.push({ type: "approve", approval: finalApproval });
-        } else {
-          decisions.push({
-            type: "deny",
-            approval: ac.approval,
-            reason: permResponse.reason || "Denied by SDK callback",
-          });
-        }
+        decisions.push({
+          type: "deny",
+          approval: ac.approval,
+          reason:
+            ac.denyReason ||
+            "Auto-denied during recovery - tool requires interactive approval",
+        });
       }
 
       if (decisions.length === 0) {


### PR DESCRIPTION
## Summary

Fixes timeout in headless approval recovery when pending approvals require user input.

In `recoverPendingApprovalsFromControlRequest`, approvals classified as `needsUserInput` would call `requestPermission()` which blocks waiting for a response. In headless recovery context (e.g., lettabot), there's no one to respond, causing the recovery to timeout.

**Before:** Recovery times out with "Timed out waiting for control_response"
**After:** Interactive approvals are auto-denied with a clear reason

## Test plan

- [x] Build passes
- [ ] Deploy lettabot and verify stuck approval recovery works

Written by Cameron ◯ Letta Code

"The first rule of any technology used in a business is that automation applied to an efficient operation will magnify the efficiency." - Bill Gates