### PR TITLE
feat(hooks): fire PreToolUse hooks before approval UI for ExitPlanMode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -84,6 +84,7 @@ import {
   runPreCompactHooks,
   runSessionEndHooks,
   runSessionStartHooks,
+  runPreToolUseHooks,
   runStopHooks,
   runUserPromptSubmitHooks,
 } from "../hooks";
@@ -12690,13 +12691,51 @@ ${SYSTEM_REMINDER_CLOSE}
   );
 
   // Guard ExitPlanMode:
+  // - Run PreToolUse hooks first — if hooks block (exit 2), auto-deny; if hooks pass (exit 0), auto-approve
+  // - If no hooks matched, fall through to normal UI approval flow
   // - If not in plan mode, allow graceful continuation when we still have a known plan file path
   // - Otherwise reject with an expiry message
   // - If in plan mode but no plan file exists, keep planning
+  const preApprovalHookCheckedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     const currentIndex = approvalResults.length;
     const approval = pendingApprovals[currentIndex];
     if (approval?.toolName === "ExitPlanMode") {
+      // Run PreToolUse hooks before showing the approval dialog.
+      // If hooks handle the decision (block or approve), skip the UI entirely.
+      if (!preApprovalHookCheckedRef.current.has(approval.toolCallId)) {
+        preApprovalHookCheckedRef.current.add(approval.toolCallId);
+        (async () => {
+          try {
+            const toolInput = JSON.parse(approval.toolArgs || "{}");
+            const hookResult = await runPreToolUseHooks(
+              "ExitPlanMode",
+              toolInput,
+              approval.toolCallId,
+              process.env.USER_CWD || process.cwd(),
+              agentId,
+            );
+            if (hookResult.blocked) {
+              const feedback =
+                hookResult.feedback.join("\n") || "Blocked by PreToolUse hook";
+              handlePlanKeepPlanning(feedback);
+              return;
+            }
+            if (hookResult.results.length > 0) {
+              // Hooks existed and all passed — auto-approve, skip the dialog
+              handlePlanApprove();
+              return;
+            }
+            // No hooks matched — fall through handled by next render cycle
+          } catch {
+            // Hook execution failed — fall through to normal approval UI
+          }
+        })();
+        // Return immediately — let the async hook decide before showing UI.
+        // If hooks don't handle it, the effect will re-fire on next state change.
+        return;
+      }
+
       const mode = permissionMode.getMode();
       const activePlanPath = permissionMode.getPlanFilePath();
       const fallbackPlanPath = lastPlanFilePathRef.current;
@@ -12780,6 +12819,7 @@ ${SYSTEM_REMINDER_CLOSE}
     handlePlanKeepPlanning,
     refreshDerived,
     queueApprovalResults,
+    agentId,
   ]);
 
   const handleQuestionSubmit = useCallback(


### PR DESCRIPTION
**Status: Proof of Concept. Not necessarily merge-ready.**

## Summary

- Runs `PreToolUse` hooks when an `ExitPlanMode` approval request arrives, **before** the plan approval dialog renders
- Hook exit 2 (block): rejects the plan back to the agent with feedback, user never sees the dialog
- Hook exit 0 (allow): auto-approves the plan, skips the dialog entirely
- No matching hooks: falls through to the existing approval UI unchanged

Refs: #1419

## What works
- Blocking hooks (exit 2) successfully reject plans before the user sees any dialog
- Allowing hooks (exit 0) successfully auto-approve plans without user interaction
- No hooks configured: behavior is identical to before
- Tested with both command hooks and confirmed via hook logs

## What to consider before merging
- **Async in useEffect**: The hook runs async inside the guard `useEffect`. The guard returns early to prevent the dialog from rendering while the hook is in flight. This works in practice but relies on React not rendering the approval UI during the await window.
- **Scoped to ExitPlanMode only**: This doesn't address `EnterPlanMode` or `AskUserQuestion`. A more general solution would apply pre-approval hooks to all interactive approval tools.
- **The dialog may flash briefly** in edge cases before the hook resolves, though this wasn't observed in testing.

## Test plan

- [ ] Configure a `PreToolUse` hook with matcher `ExitPlanMode` that exits 2. Verify plan is rejected without showing dialog
- [ ] Configure a `PreToolUse` hook with matcher `ExitPlanMode` that exits 0. Verify plan is auto-approved without dialog
- [ ] Remove all ExitPlanMode hooks. Verify normal approval dialog works unchanged
- [ ] Test in YOLO mode. Verify existing auto-approve behavior still works
- [ ] Test plan mode expiry (CLI restart). Verify existing denial behavior still works