### PR TITLE
fix(auth): update setup login copy and static auth logo

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -13,6 +13,9 @@ import { pollForToken, requestDeviceCode } from "./oauth";
 
 type SetupMode = "menu" | "device-code" | "auth-code" | "self-host" | "done";
 
+const AUTH_LOGIN_LABEL = "Login to Letta Code";
+const AUTH_LOGO_ANIMATE = false;
+
 interface SetupUIProps {
   onComplete: () => void;
 }
@@ -140,9 +143,12 @@ export function SetupUI({ onComplete }: SetupUIProps) {
   if (mode === "device-code") {
     return (
       <Box flexDirection="column" padding={1}>
-        <AnimatedLogo color={colors.welcome.accent} animate={false} />
+        <AnimatedLogo
+          color={colors.welcome.accent}
+          animate={AUTH_LOGO_ANIMATE}
+        />
         <Text> </Text>
-        <Text bold>Login to Letta Platform</Text>
+        <Text bold>{AUTH_LOGIN_LABEL}</Text>
         <Text> </Text>
         <Text dimColor>Opening browser for authorization...</Text>
         <Text> </Text>
@@ -162,7 +168,7 @@ export function SetupUI({ onComplete }: SetupUIProps) {
   // Main menu
   return (
     <Box flexDirection="column" padding={1}>
-      <AnimatedLogo color={colors.welcome.accent} />
+      <AnimatedLogo color={colors.welcome.accent} animate={AUTH_LOGO_ANIMATE} />
       <Text> </Text>
       <Text bold>Welcome to Letta Code!</Text>
       <Text> </Text>
@@ -174,7 +180,8 @@ export function SetupUI({ onComplete }: SetupUIProps) {
             selectedOption === 0 ? colors.selector.itemHighlighted : undefined
           }
         >
-          {selectedOption === 0 ? "> " : "  "}Login to Letta Platform
+          {selectedOption === 0 ? "> " : "  "}
+          {AUTH_LOGIN_LABEL}
         </Text>
       </Box>
       <Box>


### PR DESCRIPTION
## Summary
- Update auth setup copy from `Login to Letta Platform` to `Login to Letta Code` in the device-code title and menu option.
- Add top-level toggles in `src/auth/setup-ui.tsx` (`AUTH_LOGIN_LABEL`, `AUTH_LOGO_ANIMATE`) so behavior is easy to revert.
- Keep auth/setup logo static by default (`AUTH_LOGO_ANIMATE = false`) to avoid terminal animation issues during OAuth code/link copy.

## Test plan
- [x] Run `bun run check` (Biome + TypeScript)
- [ ] Open auth setup UI and verify title shows `Login to Letta Code`
- [ ] Verify menu option shows `Login to Letta Code`
- [ ] Verify auth/setup logo is static in both menu and device-code screens
- [ ] Verify loading/processing spinner behavior outside auth/setup remains unchanged

👾 Generated with [Letta Code](https://letta.com)