### PR TITLE
chore: default to auto model instead of sonnet

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -3,7 +3,7 @@ name: recall
 description: Search conversation history to recall past discussions, decisions, and context
 tools: Bash, Read, TaskOutput
 skills: searching-messages
-model: haiku
+model: auto-fast
 memoryBlocks: none
 mode: stateless
 ---

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@
 /**
  * Default model ID to use when no model is specified
  */
-export const DEFAULT_MODEL_ID = "sonnet";
+export const DEFAULT_MODEL_ID = "auto";
 
 /**
  * Default model handle to use for conversation compaction / summarization.

--- a/src/models.json
+++ b/src/models.json
@@ -2,6 +2,7 @@
   "models": [
     {
       "id": "auto",
+      "isDefault": true,
       "handle": "letta/auto",
       "label": "Auto",
       "description": "Automatically select the best model",
@@ -21,7 +22,6 @@
       "handle": "anthropic/claude-sonnet-4-6",
       "label": "Sonnet 4.6",
       "description": "Anthropic's new Sonnet model (high reasoning)",
-      "isDefault": true,
       "isFeatured": true,
       "updateArgs": {
         "context_window": 200000,


### PR DESCRIPTION
## Summary
- Change default model from sonnet to auto
- Update recall subagent to use auto-fast instead of haiku

## Changes
- Set `isDefault: true` on auto model in models.json
- Remove `isDefault` from sonnet model
- Update `DEFAULT_MODEL_ID` to "auto" in constants.ts
- Change recall subagent model from haiku to auto-fast

## Test plan
- [ ] Verify default model selection shows Auto
- [ ] Verify recall subagent uses auto-fast

👾 Generated with [Letta Code](https://letta.com)