### PR TITLE
fix(permissions): require approval for ExitPlanMode in bypass mode

### DIFF
--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -256,7 +256,11 @@ class PermissionModeManager {
   ): "allow" | "deny" | null {
     switch (this.currentMode) {
       case "bypassPermissions":
-        // Auto-allow everything (except explicit deny rules checked earlier)
+        // ExitPlanMode always requires human approval, even in yolo mode
+        if (toolName === "ExitPlanMode" || toolName === "exit_plan_mode") {
+          return null;
+        }
+        // Auto-allow everything else (except explicit deny rules checked earlier)
         return "allow";
 
       case "acceptEdits":

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -66,6 +66,42 @@ test("bypassPermissions mode - allows all tools", () => {
   expect(writeResult.decision).toBe("allow");
 });
 
+test("bypassPermissions mode - ExitPlanMode always requires approval", () => {
+  permissionMode.setMode("bypassPermissions");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+  };
+
+  // ExitPlanMode should NOT be auto-approved in yolo mode
+  const exitResult = checkPermission(
+    "ExitPlanMode",
+    {},
+    permissions,
+    "/Users/test/project",
+  );
+  expect(exitResult.decision).toBe("ask");
+
+  const exitSnakeResult = checkPermission(
+    "exit_plan_mode",
+    {},
+    permissions,
+    "/Users/test/project",
+  );
+  expect(exitSnakeResult.decision).toBe("ask");
+
+  // EnterPlanMode should still be auto-approved
+  const enterResult = checkPermission(
+    "EnterPlanMode",
+    {},
+    permissions,
+    "/Users/test/project",
+  );
+  expect(enterResult.decision).toBe("allow");
+});
+
 test("bypassPermissions mode - does NOT override deny rules", () => {
   permissionMode.setMode("bypassPermissions");
 


### PR DESCRIPTION
## Summary
- prevent `bypassPermissions`/yolo mode from auto-allowing `ExitPlanMode` (and `exit_plan_mode`)
- preserve existing bypass behavior for all other tools, including `EnterPlanMode`
- add a permissions-mode unit test that verifies `ExitPlanMode` is still prompted in bypass mode

## Test plan
- [x] bun test src/tests/permissions-mode.test.ts
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)