### PR TITLE
fix(tui): clip legacy bash fallback output path

### DIFF
--- a/src/cli/components/BashCommandMessage.tsx
+++ b/src/cli/components/BashCommandMessage.tsx
@@ -1,6 +1,7 @@
 import { Box } from "ink";
 import { memo } from "react";
 import { INTERRUPTED_BY_USER } from "../../constants";
+import { clipToolReturn } from "../../tools/manager";
 import type { StreamingState } from "../helpers/accumulator";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { BlinkDot } from "./BlinkDot.js";
@@ -90,7 +91,9 @@ export const BashCommandMessage = memo(
               <Text>{"  ⎿  "}</Text>
             </Box>
             <Box flexGrow={1} width={Math.max(0, columns - 5)}>
-              <MarkdownDisplay text={line.output.replace(/\n+$/, "")} />
+              <MarkdownDisplay
+                text={clipToolReturn(line.output).replace(/\n+$/, "")}
+              />
             </Box>
           </Box>
         )}

--- a/src/tests/tools/clip-tool-return.test.ts
+++ b/src/tests/tools/clip-tool-return.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { clipToolReturn } from "../../tools/manager";
+
+describe("clipToolReturn", () => {
+  test("clips long single-line output and appends ellipsis", () => {
+    const long = "A".repeat(1200);
+    const clipped = clipToolReturn(long);
+
+    expect(clipped.length).toBeLessThan(400);
+    expect(clipped.endsWith("…")).toBe(true);
+  });
+
+  test("clips by line count for multiline output", () => {
+    const text = "line1\nline2\nline3\nline4\nline5";
+    const clipped = clipToolReturn(text, 3, 10_000);
+
+    expect(clipped).toContain("line1");
+    expect(clipped).toContain("line2");
+    expect(clipped).toContain("line3");
+    expect(clipped).not.toContain("line4");
+    expect(clipped.endsWith("…")).toBe(true);
+  });
+
+  test("does not clip user-denial reasons", () => {
+    const denial = `Error: request to call tool denied. User reason: ${"B".repeat(800)}`;
+    const clipped = clipToolReturn(denial);
+
+    expect(clipped).toBe(denial);
+  });
+});


### PR DESCRIPTION
Apply the same clipToolReturn cap to BashCommandMessage's legacy no-phase output renderer so very long single-line blobs no longer flood multiple terminal screens. Add regression tests for clipToolReturn behavior used by this path.

👾 Generated with [Letta Code](https://letta.com)