### PR TITLE
fix(listener): emit corrected device status after permission mode syn…

### DIFF
--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -48,6 +48,7 @@ import {
 } from "./permissionMode";
 import {
   emitCanonicalMessageDelta,
+  emitDeviceStatusIfOpen,
   emitInterruptedStatusDelta,
   emitLoopErrorDelta,
   emitLoopStatusUpdate,
@@ -768,6 +769,18 @@ export async function handleIncomingMessage(
       conversationId,
       turnPermissionModeState,
     );
+
+    // Emit a corrected device status now that the permission mode is synced.
+    // The emitRuntimeStateUpdates() calls earlier in the turn read from the map
+    // before setConversationPermissionModeState() ran, so they emitted a stale
+    // current_permission_mode. This final emission sends the correct value,
+    // ensuring the web UI (and desktop) always reflect mode changes from
+    // EnterPlanMode/ExitPlanMode and that mid-turn web permission changes
+    // are not reverted by a stale emission at turn end.
+    emitDeviceStatusIfOpen(runtime, {
+      agent_id: agentId || null,
+      conversation_id: conversationId,
+    });
 
     runtime.activeAbortController = null;
     runtime.cancelRequested = false;


### PR DESCRIPTION
…c [LET-8096]

emitRuntimeStateUpdates() was called before setConversationPermissionModeState() in the finally block, so the emitted update_device_status always carried the stale current_permission_mode from the map (the value from before the turn).

This caused two bugs:
- Bug 1 (web→code): User changes mode mid-session → turn ends → stale mode emitted → ChatView.tsx syncs it back, reverting the user's change
- Bug 2 (code→web): ExitPlanMode/EnterPlanMode updates turnPermissionModeState but the emission read the old map value → web UI never saw the mode change

Fix: add emitDeviceStatusIfOpen() in the finally block AFTER setConversationPermissionModeState() so the final emission always carries the correct, fully-synced permission mode.

👾 Generated with [Letta Code](https://letta.com)