### PR TITLE
feat(resume): sort conversations by most recent activity

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -272,6 +272,8 @@ export function ConversationSelector({
           agent_id: agentId,
           limit: FETCH_PAGE_SIZE,
           ...(afterCursor && { after: afterCursor }),
+          order: "desc",
+          order_by: "last_run_completion",
         });
 
         // Enrich conversations with message data in parallel


### PR DESCRIPTION
## Summary
- Sort `/resume` conversation candidates by `last_run_completion` descending
- Most recently active conversations now appear first in the selector

## Test plan
- Run `/resume` and verify conversations are ordered by recent activity

## Example
Left side is with this update
<img width="1560" height="570" alt="image" src="https://github.com/user-attachments/assets/c6be7ccb-cf73-4e30-b08e-15149ac3027c" />
