### PR TITLE
fix(plan-mode): make yolo approval policy configurable

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -12803,6 +12803,7 @@ ${SYSTEM_REMINDER_CLOSE}
   }, [
     pendingApprovals,
     approvalResults.length,
+    handlePlanApprove,
     handlePlanKeepPlanning,
     refreshDerived,
     queueApprovalResults,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -113,6 +113,10 @@ import { updateProjectSettings } from "../settings";
 import { settingsManager } from "../settings-manager";
 import { telemetry } from "../telemetry";
 import {
+  shouldAutoApproveEnterPlanMode,
+  shouldAutoApproveExitPlanMode,
+} from "../tools/interactivePolicy";
+import {
   analyzeToolApproval,
   checkToolPermission,
   executeTool,
@@ -12722,12 +12726,18 @@ ${SYSTEM_REMINDER_CLOSE}
       const hasUsablePlan = planFileExists(fallbackPlanPath);
 
       if (mode !== "plan") {
-        if (hasUsablePlan) {
-          // Keep approval flow alive and let user manually approve.
-          return;
-        }
-
         if (mode === "bypassPermissions") {
+          if (hasUsablePlan && shouldAutoApproveExitPlanMode()) {
+            lastAutoHandledExitPlanToolCallIdRef.current = approval.toolCallId;
+            handlePlanApprove();
+            return;
+          }
+
+          if (hasUsablePlan) {
+            // Keep approval flow alive and let user manually approve.
+            return;
+          }
+
           // YOLO mode but no plan file yet — tell agent to write it first.
           const planFilePath = activePlanPath ?? fallbackPlanPath;
           const plansDir = join(homedir(), ".letta", "plans");
@@ -12967,14 +12977,16 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
   }, [pendingApprovals, approvalResults, sendAllResults]);
 
   // Guard EnterPlanMode:
-  // When in bypassPermissions (YOLO) mode, auto-approve EnterPlanMode and stay
-  // in YOLO — the agent gets plan instructions but keeps full permissions.
-  // ExitPlanMode still requires explicit user approval.
+  // In bypassPermissions (YOLO) mode, optionally auto-approve EnterPlanMode
+  // based on the shared plan-mode approval policy.
   useEffect(() => {
     const currentIndex = approvalResults.length;
     const approval = pendingApprovals[currentIndex];
     if (approval?.toolName === "EnterPlanMode") {
-      if (permissionMode.getMode() === "bypassPermissions") {
+      if (
+        permissionMode.getMode() === "bypassPermissions" &&
+        shouldAutoApproveEnterPlanMode()
+      ) {
         if (
           lastAutoApprovedEnterPlanToolCallIdRef.current === approval.toolCallId
         ) {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1944,8 +1944,8 @@ ${SYSTEM_REMINDER_CLOSE}
           })),
           ...needsUserInput.map((ac) => {
             // One-shot headless mode has no control channel for interactive
-            // approvals. Auto-allow plan-mode entry/exit tools, while denying
-            // tools that need runtime user responses.
+            // approvals. Auto-allow plan-mode entry/exit only when the shared
+            // policy says to, while denying tools that need runtime user responses.
             if (isHeadlessAutoAllowTool(ac.approval.toolName)) {
               return {
                 type: "approve" as const,

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -266,7 +266,8 @@ class PermissionModeManager {
         : this.getPlanFilePath();
     switch (effectiveMode) {
       case "bypassPermissions":
-        // ExitPlanMode always requires human approval, even in yolo mode
+        // ExitPlanMode should still flow through the approval pipeline so the
+        // interactive/headless policy layer can decide whether to auto-approve it.
         if (toolName === "ExitPlanMode" || toolName === "exit_plan_mode") {
           return null;
         }

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -168,6 +168,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain(
       'permissionMode.getMode() === "bypassPermissions"',
     );
+    expect(segment).toContain("shouldAutoApproveEnterPlanMode()");
     expect(segment).toContain("handleEnterPlanModeApprove(true)");
   });
 
@@ -209,7 +210,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain('"bypassPermissions"');
   });
 
-  test("does not auto-approve ExitPlanMode in bypassPermissions mode", () => {
+  test("ExitPlanMode auto-approve in bypassPermissions mode is policy-driven", () => {
     const source = readAppSource();
 
     const guardStart = source.indexOf("Guard ExitPlanMode:");
@@ -229,8 +230,11 @@ describe("permission mode retry wiring", () => {
     expect(modeGuardEnd).toBeGreaterThan(modeGuardStart);
 
     const modeGuard = segment.slice(modeGuardStart, modeGuardEnd);
-    expect(modeGuard).toContain("if (hasUsablePlan) {");
+    expect(modeGuard).toContain('if (mode === "bypassPermissions")');
+    expect(modeGuard).toContain(
+      "hasUsablePlan && shouldAutoApproveExitPlanMode()",
+    );
+    expect(modeGuard).toContain("handlePlanApprove()");
     expect(modeGuard).toContain("let user manually approve");
-    expect(modeGuard).not.toContain("handlePlanApprove()");
   });
 });

--- a/src/tests/tools/interactivepolicy.test.ts
+++ b/src/tests/tools/interactivepolicy.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, test } from "bun:test";
 import {
+  getYoloPlanModeApprovalPolicy,
   isHeadlessAutoAllowTool,
   isInteractiveApprovalTool,
   requiresRuntimeUserInput,
+  shouldAutoApproveEnterPlanMode,
+  shouldAutoApproveExitPlanMode,
 } from "../../tools/interactivePolicy";
+
+const ENV_KEYS = [
+  "LETTA_YOLO_PLAN_MODE_APPROVAL",
+  "LETTA_AUTO_APPROVE_PLAN_MODE",
+  "LETTA_AUTO_APPROVE_ENTER_PLAN_MODE",
+  "LETTA_AUTO_APPROVE_EXIT_PLAN_MODE",
+] as const;
+
+function withCleanEnv(run: () => void): void {
+  const original = new Map<string, string | undefined>(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const key of ENV_KEYS) delete process.env[key];
+    run();
+  } finally {
+    for (const key of ENV_KEYS) {
+      const value = original.get(key);
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 describe("interactive tool policy", () => {
   test("marks interactive approval tools", () => {
@@ -19,9 +48,68 @@ describe("interactive tool policy", () => {
     expect(requiresRuntimeUserInput("EnterPlanMode")).toBe(false);
   });
 
-  test("marks headless auto-allow tools", () => {
-    expect(isHeadlessAutoAllowTool("EnterPlanMode")).toBe(true);
-    expect(isHeadlessAutoAllowTool("ExitPlanMode")).toBe(true);
-    expect(isHeadlessAutoAllowTool("AskUserQuestion")).toBe(false);
+  test("defaults YOLO plan-mode policy to manual", () => {
+    withCleanEnv(() => {
+      expect(getYoloPlanModeApprovalPolicy()).toBe("manual");
+      expect(shouldAutoApproveEnterPlanMode()).toBe(false);
+      expect(shouldAutoApproveExitPlanMode()).toBe(false);
+      expect(isHeadlessAutoAllowTool("EnterPlanMode")).toBe(false);
+      expect(isHeadlessAutoAllowTool("ExitPlanMode")).toBe(false);
+      expect(isHeadlessAutoAllowTool("AskUserQuestion")).toBe(false);
+    });
+  });
+
+  test("supports env policy values", () => {
+    withCleanEnv(() => {
+      process.env.LETTA_YOLO_PLAN_MODE_APPROVAL = "enter_only";
+      expect(getYoloPlanModeApprovalPolicy()).toBe("enter_only");
+      expect(shouldAutoApproveEnterPlanMode()).toBe(true);
+      expect(shouldAutoApproveExitPlanMode()).toBe(false);
+      expect(isHeadlessAutoAllowTool("EnterPlanMode")).toBe(true);
+      expect(isHeadlessAutoAllowTool("ExitPlanMode")).toBe(false);
+
+      process.env.LETTA_YOLO_PLAN_MODE_APPROVAL = "enter_and_exit";
+      expect(getYoloPlanModeApprovalPolicy()).toBe("enter_and_exit");
+      expect(shouldAutoApproveEnterPlanMode()).toBe(true);
+      expect(shouldAutoApproveExitPlanMode()).toBe(true);
+      expect(isHeadlessAutoAllowTool("EnterPlanMode")).toBe(true);
+      expect(isHeadlessAutoAllowTool("ExitPlanMode")).toBe(true);
+    });
+  });
+
+  test("ignores invalid env policy values", () => {
+    withCleanEnv(() => {
+      process.env.LETTA_YOLO_PLAN_MODE_APPROVAL = "wat";
+      expect(getYoloPlanModeApprovalPolicy()).toBe("manual");
+      expect(shouldAutoApproveEnterPlanMode()).toBe(false);
+      expect(shouldAutoApproveExitPlanMode()).toBe(false);
+    });
+  });
+
+  test("invalid env policy does not block legacy flags", () => {
+    withCleanEnv(() => {
+      process.env.LETTA_YOLO_PLAN_MODE_APPROVAL = "wat";
+      process.env.LETTA_AUTO_APPROVE_EXIT_PLAN_MODE = "1";
+      expect(getYoloPlanModeApprovalPolicy()).toBe("manual");
+      expect(shouldAutoApproveEnterPlanMode()).toBe(false);
+      expect(shouldAutoApproveExitPlanMode()).toBe(true);
+    });
+  });
+
+  test("preserves legacy auto-approve env flags", () => {
+    withCleanEnv(() => {
+      process.env.LETTA_AUTO_APPROVE_ENTER_PLAN_MODE = "1";
+      expect(shouldAutoApproveEnterPlanMode()).toBe(true);
+      expect(shouldAutoApproveExitPlanMode()).toBe(false);
+
+      delete process.env.LETTA_AUTO_APPROVE_ENTER_PLAN_MODE;
+      process.env.LETTA_AUTO_APPROVE_EXIT_PLAN_MODE = "1";
+      expect(shouldAutoApproveEnterPlanMode()).toBe(false);
+      expect(shouldAutoApproveExitPlanMode()).toBe(true);
+
+      process.env.LETTA_AUTO_APPROVE_PLAN_MODE = "1";
+      expect(shouldAutoApproveEnterPlanMode()).toBe(true);
+      expect(shouldAutoApproveExitPlanMode()).toBe(true);
+    });
   });
 });

--- a/src/tools/interactivePolicy.ts
+++ b/src/tools/interactivePolicy.ts
@@ -1,6 +1,11 @@
 // Interactive tool capability policy shared across UI/headless/SDK-compatible paths.
 // This avoids scattering name-based checks throughout approval handling.
 
+export type YoloPlanModeApprovalPolicy =
+  | "manual"
+  | "enter_only"
+  | "enter_and_exit";
+
 const INTERACTIVE_APPROVAL_TOOLS = new Set([
   "AskUserQuestion",
   "EnterPlanMode",
@@ -9,7 +14,44 @@ const INTERACTIVE_APPROVAL_TOOLS = new Set([
 
 const RUNTIME_USER_INPUT_TOOLS = new Set(["AskUserQuestion", "ExitPlanMode"]);
 
-const HEADLESS_AUTO_ALLOW_TOOLS = new Set(["EnterPlanMode", "ExitPlanMode"]);
+function envFlagEnabled(name: string): boolean {
+  const value = process.env[name];
+  if (!value) return false;
+  return value === "1" || value.toLowerCase() === "true";
+}
+
+function readYoloPlanModeApprovalPolicyFromEnv(): YoloPlanModeApprovalPolicy | null {
+  const value = process.env.LETTA_YOLO_PLAN_MODE_APPROVAL?.trim().toLowerCase();
+  if (!value) return null;
+  if (value === "manual") return "manual";
+  if (value === "enter_only") return "enter_only";
+  if (value === "enter_and_exit") return "enter_and_exit";
+  return null;
+}
+
+export function getYoloPlanModeApprovalPolicy(): YoloPlanModeApprovalPolicy {
+  return readYoloPlanModeApprovalPolicyFromEnv() ?? "manual";
+}
+
+export function shouldAutoApproveEnterPlanMode(): boolean {
+  const policy = readYoloPlanModeApprovalPolicyFromEnv();
+  if (policy) {
+    return policy === "enter_only" || policy === "enter_and_exit";
+  }
+  return (
+    envFlagEnabled("LETTA_AUTO_APPROVE_PLAN_MODE") ||
+    envFlagEnabled("LETTA_AUTO_APPROVE_ENTER_PLAN_MODE")
+  );
+}
+
+export function shouldAutoApproveExitPlanMode(): boolean {
+  const policy = readYoloPlanModeApprovalPolicyFromEnv();
+  if (policy) return policy === "enter_and_exit";
+  return (
+    envFlagEnabled("LETTA_AUTO_APPROVE_PLAN_MODE") ||
+    envFlagEnabled("LETTA_AUTO_APPROVE_EXIT_PLAN_MODE")
+  );
+}
 
 export function isInteractiveApprovalTool(toolName: string): boolean {
   return INTERACTIVE_APPROVAL_TOOLS.has(toolName);
@@ -20,5 +62,7 @@ export function requiresRuntimeUserInput(toolName: string): boolean {
 }
 
 export function isHeadlessAutoAllowTool(toolName: string): boolean {
-  return HEADLESS_AUTO_ALLOW_TOOLS.has(toolName);
+  if (toolName === "EnterPlanMode") return shouldAutoApproveEnterPlanMode();
+  if (toolName === "ExitPlanMode") return shouldAutoApproveExitPlanMode();
+  return false;
 }


### PR DESCRIPTION
## Summary
- add a single `LETTA_YOLO_PLAN_MODE_APPROVAL` policy knob for yolo plan-mode approvals with `manual`, `enter_only`, and `enter_and_exit` modes
- route TUI and headless EnterPlanMode/ExitPlanMode auto-approval through the shared policy helper while preserving legacy env flags as fallback
- keep upstream's conservative default as `manual` while making fork/autonomous behavior configurable without a hardcoded divergence

## Test plan
- [x] `bun test src/tests/tools/interactivepolicy.test.ts src/tests/cli/permission-mode-retry-wiring.test.ts src/tests/permissions-mode.test.ts src/tests/tools/exitplanmode.test.ts src/tests/plan-approval-mode.test.ts`
- [x] `bun run build`
- [x] `bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run src/index.ts --help`

👾 Generated with [Letta Code](https://letta.com)