### PR TITLE
fix(tools): re-enable memory tool in default toolsets

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -107,6 +107,7 @@ export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
   "TaskStop",
   // "MultiEdit",
   // "LS",
+  "memory",
   "Read",
   "Skill",
   "Task",
@@ -119,6 +120,7 @@ export const OPENAI_DEFAULT_TOOLS: ToolName[] = [
   // TODO(codex-parity): add once request_user_input tool exists in raw codex path.
   // "request_user_input",
   "apply_patch",
+  "memory",
   "update_plan",
   "view_image",
 ];
@@ -129,6 +131,7 @@ export const GEMINI_DEFAULT_TOOLS: ToolName[] = [
   "list_directory",
   "glob_gemini",
   "search_file_content",
+  "memory",
   "replace",
   "write_file_gemini",
   "write_todos",
@@ -143,6 +146,7 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "EnterPlanMode",
   "ExitPlanMode",
+  "memory",
   "Task",
   "TaskOutput",
   "TaskStop",
@@ -159,6 +163,7 @@ export const GEMINI_PASCAL_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "EnterPlanMode",
   "ExitPlanMode",
+  "memory",
   "Skill",
   "Task",
   // Standard Gemini tools


### PR DESCRIPTION
## Summary
- re-add the `memory` tool to `ANTHROPIC_DEFAULT_TOOLS`
- re-add the `memory` tool to `OPENAI_DEFAULT_TOOLS` and `GEMINI_DEFAULT_TOOLS`
- re-add the `memory` tool to `OPENAI_PASCAL_TOOLS` and `GEMINI_PASCAL_TOOLS`

## Test plan
- [x] `bun test src/tests/agent/create-base-tools-recovery.test.ts`
- [x] `bun test src/tests/tools/model-provider-detection.test.ts`

👾 Generated with [Letta Code](https://letta.com)