### PR TITLE
feat(search): default to current agent scope

### DIFF
--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -116,7 +116,7 @@ export function MessageSearch({
   const [searchInput, setSearchInput] = useState(initialQuery ?? "");
   const [activeQuery, setActiveQuery] = useState(initialQuery ?? "");
   const [searchMode, setSearchMode] = useState<SearchMode>("hybrid");
-  const [searchRange, setSearchRange] = useState<SearchRange>("all");
+  const [searchRange, setSearchRange] = useState<SearchRange>("agent");
   const [results, setResults] = useState<MessageSearchResponse>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Change `/search` default scope from "all agents" to "current agent"
- Users can still cycle to other scopes (all agents, current conversation) via the scope picker

## Test plan
- Run `/search` and verify default scope shows "current agent"