### PR TITLE
fix: resume project-specific conversation on bare `letta` startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ Letta Code is a general purpose CLI for interacting with Letta agents
 
 USAGE
   # interactive TUI
-  letta                 Resume default conversation (OG single-threaded experience)
+  letta                 Resume last conversation for this project
   letta --new           Create a new conversation (for concurrent sessions)
   letta --continue      Resume last session (agent + conversation) directly
   letta --resume        Open agent selector UI to pick agent/conversation
@@ -1374,9 +1374,10 @@ async function main(): Promise<void> {
         const { resolveStartupTarget } = await import(
           "./agent/resolve-startup-agent"
         );
+        const localSession = settingsManager.getLocalLastSession(process.cwd());
         const target = resolveStartupTarget({
           localAgentId,
-          localConversationId: null, // DEFAULT PATH always uses default conv
+          localConversationId: localSession?.conversationId ?? null,
           localAgentExists,
           globalAgentId,
           globalAgentExists,
@@ -1391,8 +1392,9 @@ async function main(): Promise<void> {
             if (cachedAgent && cachedAgent.id === target.agentId) {
               setValidatedAgent(cachedAgent);
             }
-            // Don't set selectedConversationId — DEFAULT PATH uses default conv.
-            // Conversation restoration is handled by --continue path instead.
+            if (target.conversationId && !forceNewConversation) {
+              setSelectedConversationId(target.conversationId);
+            }
             setLoadingState("assembling");
             return;
           case "select":
@@ -1918,7 +1920,7 @@ async function main(): Promise<void> {
             process.exit(1);
           }
         } else if (selectedConversationId) {
-          // User selected a specific conversation from the --resume selector
+          // Conversation selected from --resume selector or auto-restored from local project settings
           try {
             setLoadingState("checking");
             const data = await getResumeData(
@@ -1934,10 +1936,18 @@ async function main(): Promise<void> {
               error instanceof APIError &&
               (error.status === 404 || error.status === 422)
             ) {
-              console.error(`Conversation ${selectedConversationId} not found`);
-              process.exit(1);
+              // Conversation no longer exists — fall back to default conversation
+              console.warn(
+                `Previous conversation ${selectedConversationId} not found, falling back to default`,
+              );
+              conversationIdToUse = "default";
+              setLoadingState("checking");
+              const data = await getResumeData(client, agent, "default");
+              setResumeData(data);
+              setResumedExistingConversation(data.messageHistory.length > 0);
+            } else {
+              throw error;
             }
-            throw error;
           }
         } else if (forceNewConversation) {
           // --new flag: create a new conversation (for concurrent sessions)


### PR DESCRIPTION
## Summary
- When a local project has a stored conversation ID from a previous session, bare `letta` now resumes that conversation instead of always falling back to the default conversation
- Fixes the workflow where a single agent is used across multiple projects with separate conversations — previously `letta` would always resume the default conversation regardless of project
- Gracefully falls back to default conversation if the stored conversation was deleted server-side
- `--new` flag still creates a new conversation (guarded against auto-restore)
- Global agent fallback (no local agent found) still uses default conversation, unchanged

## Test plan
- [ ] Run `letta` in a project with an existing local session (`.letta/settings.local.json` has a `sessionsByServer` entry with a `conversationId`) — should resume that conversation
- [ ] Run `letta` in a project with no stored conversation — should use default conversation as before
- [ ] Run `letta` in a project with no local agent (global fallback) — should use default conversation as before
- [ ] Run `letta --new` in a project with a stored conversation — should still create a new conversation (not resume stored one)
- [ ] Delete a conversation on the server, then `letta` in the project that had it — should gracefully fall back to default conversation

🐾 Generated with [Letta Code](https://letta.com)