### PR TITLE
feat(search): warm tpuf cache on overlay open

### DIFF
--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -128,6 +128,22 @@ export function MessageSearch({
   // Cache results per query+mode+range combination to avoid re-fetching
   const resultsCache = useRef<Map<string, MessageSearchResponse>>(new Map());
 
+  // Warm tpuf cache on mount (fire-and-forget)
+  useEffect(() => {
+    const warmCache = async () => {
+      try {
+        const client = await getClient();
+        await client.post("/v1/messages/search", {
+          body: {},
+          query: { warm_only: true },
+        });
+      } catch {
+        // Silently ignore - cache warm is best-effort
+      }
+    };
+    void warmCache();
+  }, []);
+
   // Get cache key for a specific query+mode+range combination
   const getCacheKey = useCallback(
     (query: string, mode: SearchMode, range: SearchRange) => {


### PR DESCRIPTION
## Summary
- Fire tpuf cache warm hint when MessageSearch overlay opens
- Uses new warm-only mode on `POST /v1/messages/search` (empty body)
- Ensures hot cache by the time user types a query

## Test Plan
- [ ] Open `/search` overlay, verify warm call in network logs
- [ ] Type query, verify search is fast (cache should be warm)