### PR TITLE
feat(memory): allow str_replace to update frontmatter

### DIFF
--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -144,15 +144,17 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     const relPath = toRepoRelative(memoryDir, filePath);
     const file = await loadEditableMemoryFile(filePath, pathArg);
 
-    const idx = file.body.indexOf(oldString);
+    const currentText = renderMemoryFile(file.frontmatter, file.body);
+    const idx = currentText.indexOf(oldString);
     if (idx === -1) {
       throw new Error(
         "memory str_replace: old_string was not found in the target memory block",
       );
     }
 
-    const nextBody = `${file.body.slice(0, idx)}${newString}${file.body.slice(idx + oldString.length)}`;
-    const rendered = renderMemoryFile(file.frontmatter, nextBody);
+    const nextText = `${currentText.slice(0, idx)}${newString}${currentText.slice(idx + oldString.length)}`;
+    const nextFile = parseMemoryFile(nextText);
+    const rendered = renderMemoryFile(nextFile.frontmatter, nextFile.body);
     await writeFile(filePath, rendered, "utf8");
     affectedPaths = [relPath];
   } else if (command === "insert") {


### PR DESCRIPTION
## Summary
- Allow `str_replace` to search and replace text in the frontmatter section of memory blocks
- Previously only body content could be modified; now description, limit, and read_only fields can be updated via str_replace

## Example usage
```json
{
  "command": "str_replace",
  "path": "system/preferences.md",
  "old_string": "description: Old description",
  "new_string": "description: New description",
  "reason": "Update memory block description"
}
```

## Testing
- Existing tests pass