### PR TITLE
fix(input): let autocomplete own arrow-key history navigation

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1174,9 +1174,8 @@ export function Input({
   // Handle up/down arrow keys for wrapped text navigation and command history
   useInput((_input, key) => {
     if (!interactionEnabled) return;
-    // Don't interfere with autocomplete navigation, BUT allow history navigation
-    // when we're already browsing history (historyIndex !== -1)
-    if (isAutocompleteActive && historyIndex === -1) {
+    // Don't interfere with autocomplete navigation.
+    if (isAutocompleteActive) {
       return;
     }
 
@@ -1474,6 +1473,21 @@ export function Input({
     setCursorPos(selectedCommand.length);
   }, []);
 
+  const handleAutocompleteActiveChange = useCallback((isActive: boolean) => {
+    setIsAutocompleteActive(isActive);
+
+    if (!isActive) return;
+
+    // Autocomplete owns arrow-key navigation while open. Clear any in-progress
+    // history-navigation state so Down/Up cannot simultaneously mutate the
+    // input draft and the autocomplete selection.
+    setHistoryIndex(-1);
+    setTemporaryInput("");
+    setAtStartBoundary(false);
+    setAtEndBoundary(false);
+    setPreferredColumn(null);
+  }, []);
+
   // Get display name and color for permission mode (ralph modes take precedence)
   // Memoized to prevent unnecessary footer re-renders
   const modeInfo = useMemo<{
@@ -1609,7 +1623,7 @@ export function Input({
                 onFileSelect={handleFileSelect}
                 onCommandSelect={handleCommandSelect}
                 onCommandAutocomplete={handleCommandAutocomplete}
-                onAutocompleteActiveChange={setIsAutocompleteActive}
+                onAutocompleteActiveChange={handleAutocompleteActiveChange}
                 agentId={agentId}
                 agentName={agentName}
                 currentModel={currentModel}
@@ -1670,6 +1684,7 @@ export function Input({
     handleFileSelect,
     handleCommandSelect,
     handleCommandAutocomplete,
+    handleAutocompleteActiveChange,
     agentId,
     agentName,
     serverUrl,

--- a/src/tests/cli/input-autocomplete-history-guard.test.ts
+++ b/src/tests/cli/input-autocomplete-history-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("input autocomplete history guard", () => {
+  test("history navigation fully yields to autocomplete while suggestions are active", () => {
+    const path = fileURLToPath(
+      new URL("../../cli/components/InputRich.tsx", import.meta.url),
+    );
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain("if (isAutocompleteActive) {");
+    expect(source).not.toContain(
+      "if (isAutocompleteActive && historyIndex === -1)",
+    );
+  });
+
+  test("activating autocomplete clears latent history-navigation state", () => {
+    const path = fileURLToPath(
+      new URL("../../cli/components/InputRich.tsx", import.meta.url),
+    );
+    const source = readFileSync(path, "utf-8");
+
+    expect(source).toContain(
+      "const handleAutocompleteActiveChange = useCallback((isActive: boolean) => {",
+    );
+    expect(source).toContain('setHistoryIndex(-1);');
+    expect(source).toContain('setTemporaryInput("");');
+    expect(source).toContain(
+      'onAutocompleteActiveChange={handleAutocompleteActiveChange}',
+    );
+  });
+});


### PR DESCRIPTION
When autocomplete suggestions are open, clear stale history-navigation state and give arrow keys exclusively to the autocomplete UI so prompt drafts cannot be mutated by both systems at once.

👾 Generated with [Letta Code](https://letta.com)