### PR TITLE
fix(client-skills): make .agents/skills primary with .skills legacy fallback

### DIFF
--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -39,18 +39,18 @@ function toClientSkill(skill: Skill): ClientSkill {
 function resolveSkillDiscoveryContext(
   options: BuildClientSkillsPayloadOptions,
 ): {
-  skillsDirectory: string;
+  legacySkillsDirectory: string;
   skillSources: SkillSource[];
 } {
-  const skillsDirectory =
+  const legacySkillsDirectory =
     options.skillsDirectory ??
     getSkillsDirectory() ??
     join(process.cwd(), SKILLS_DIR);
   const skillSources = options.skillSources ?? getSkillSources();
-  return { skillsDirectory, skillSources };
+  return { legacySkillsDirectory, skillSources };
 }
 
-function getAdditionalProjectSkillsDirectory(): string {
+function getPrimaryProjectSkillsDirectory(): string {
   return join(process.cwd(), ".agents", "skills");
 }
 
@@ -64,26 +64,47 @@ function getAdditionalProjectSkillsDirectory(): string {
 export async function buildClientSkillsPayload(
   options: BuildClientSkillsPayloadOptions = {},
 ): Promise<BuildClientSkillsPayloadResult> {
-  const { skillsDirectory, skillSources } =
+  const { legacySkillsDirectory, skillSources } =
     resolveSkillDiscoveryContext(options);
   const discoverSkillsFn = options.discoverSkillsFn ?? discoverSkills;
   const skillsById = new Map<string, Skill>();
   const errors: SkillDiscoveryError[] = [];
 
+  const primaryProjectSkillsDirectory = getPrimaryProjectSkillsDirectory();
+  const nonProjectSources = skillSources.filter(
+    (source): source is SkillSource => source !== "project",
+  );
+
   const discoveryRuns: Array<{ path: string; sources: SkillSource[] }> = [];
+
+  // For bundled/global/agent sources, use the primary project root.
+  if (nonProjectSources.length > 0) {
+    discoveryRuns.push({
+      path: primaryProjectSkillsDirectory,
+      sources: nonProjectSources,
+    });
+  }
+
   const includeProjectSource = skillSources.includes("project");
-  const additionalProjectSkillsDirectory =
-    getAdditionalProjectSkillsDirectory();
+
+  // Legacy project location (.skills): discovered first so primary path can override.
   if (
     includeProjectSource &&
-    additionalProjectSkillsDirectory !== skillsDirectory
+    legacySkillsDirectory !== primaryProjectSkillsDirectory
   ) {
     discoveryRuns.push({
-      path: additionalProjectSkillsDirectory,
+      path: legacySkillsDirectory,
       sources: ["project"],
     });
   }
-  discoveryRuns.push({ path: skillsDirectory, sources: skillSources });
+
+  // Primary location for project-scoped client skills.
+  if (includeProjectSource) {
+    discoveryRuns.push({
+      path: primaryProjectSkillsDirectory,
+      sources: ["project"],
+    });
+  }
 
   for (const run of discoveryRuns) {
     try {

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -65,7 +65,7 @@ describe("buildClientSkillsPayload", () => {
     expect(result.errors).toEqual([]);
   });
 
-  test("includes .agents/skills as additional project source and lets .skills override", async () => {
+  test("treats .agents/skills as primary and .skills as legacy fallback", async () => {
     const { buildClientSkillsPayload } = await import(
       "../../agent/clientSkills"
     );
@@ -133,9 +133,9 @@ describe("buildClientSkillsPayload", () => {
     });
 
     expect(calls).toHaveLength(2);
-    expect(calls[0]?.path.endsWith("/.agents/skills")).toBe(true);
-    expect(calls[0]?.sources).toEqual(["project"]);
-    expect(calls[1]).toEqual({ path: "/tmp/.skills", sources: ["project"] });
+    expect(calls[0]).toEqual({ path: "/tmp/.skills", sources: ["project"] });
+    expect(calls[1]?.path.endsWith("/.agents/skills")).toBe(true);
+    expect(calls[1]?.sources).toEqual(["project"]);
     expect(result.clientSkills).toEqual([
       {
         name: "agents-only",
@@ -149,8 +149,8 @@ describe("buildClientSkillsPayload", () => {
       },
       {
         name: "shared",
-        description: "from .skills",
-        location: "/tmp/.skills/shared/SKILL.md",
+        description: "from .agents",
+        location: "/tmp/.agents/skills/shared/SKILL.md",
       },
     ]);
     expect(result.errors).toEqual([]);


### PR DESCRIPTION
## Summary
- make `.agents/skills` the primary project path for `client_skills` discovery
- treat `.skills` as a legacy project location and discover it first so `.agents/skills` wins on collisions
- keep deterministic merge behavior and error aggregation across discovery runs
- add/adjust tests to verify primary-vs-legacy precedence and partial-failure behavior

## Test plan
- [x] `bun test src/tests/agent/clientSkills.test.ts`
- [x] `bun run check` *(lint passes; typecheck fails due to pre-existing missing `node-pty` in `src/websocket/terminalHandler.ts` in this worktree)*

👾 Generated with [Letta Code](https://letta.com)