### PR TITLE
fix: restore interactive slash bypass while agent is busy

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7082,20 +7082,20 @@ export default function App({
       }
 
       const isSlashCommand = userTextForInput.startsWith("/");
-      if (isAgentBusy() && isSlashCommand) {
+      // Interactive/non-state slash commands bypass queueing so menus stay responsive
+      // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
+      const shouldBypassQueue =
+        isSlashCommand &&
+        (isInteractiveCommand(userTextForInput) ||
+          isNonStateCommand(userTextForInput));
+
+      if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
         const disabledMessage = `'${attemptedCommand}' is disabled while the agent is running.`;
         const cmd = commandRunner.start(userTextForInput, disabledMessage);
         cmd.fail(disabledMessage);
         return { submitted: true }; // Clears input
       }
-
-      // Interactive slash commands (like /memory, /model, /agents) bypass queueing
-      // so users can browse/view while the agent is working.
-      // Changes made in these overlays will be queued until end_turn.
-      const shouldBypassQueue =
-        isInteractiveCommand(userTextForInput) ||
-        isNonStateCommand(userTextForInput);
 
       if (isAgentBusy() && !shouldBypassQueue) {
         // Enqueue via QueueRuntime — onEnqueued callback updates queueDisplay.


### PR DESCRIPTION
## Summary
- reorder slash-command busy-state checks in `src/cli/App.tsx` so bypass eligibility is computed before blanket slash blocking
- allow interactive/non-state slash commands (like `/memory`, `/model`, `/agents`) to execute overlay actions while a turn is running
- keep non-interactive slash commands blocked during busy state, preserving queue safety for mutating operations

## Test plan
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/App.tsx`
- [ ] manual verify while agent is busy:
  - [ ] `/memory` opens immediately
  - [ ] `/model` overlay is accessible and writes are deferred until `end_turn`
  - [ ] non-interactive slash commands remain blocked with the disabled message