### PR TITLE
fix(listener): use conversation stream OTID resume for pre-stream 409 retries

### DIFF
--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { APIError } from "@letta-ai/letta-client/error";
 import WebSocket from "ws";
 import type { ResumeData } from "../../agent/check-approval";
 import { permissionMode } from "../../permissions/mode";
@@ -32,15 +33,23 @@ const defaultDrainResult: DrainResult = {
   apiDurationMs: 0,
 };
 
+const sendMessageStreamCalls: Array<{
+  conversationId: string;
+  messages: unknown[];
+  opts?: { agentId?: string };
+}> = [];
 const sendMessageStreamMock = mock(
   async (
     conversationId: string,
-    _messages: unknown[],
+    messages: unknown[],
     opts?: { agentId?: string },
-  ): Promise<MockStream> => ({
-    conversationId,
-    agentId: opts?.agentId,
-  }),
+  ): Promise<MockStream> => {
+    sendMessageStreamCalls.push({ conversationId, messages, opts });
+    return {
+      conversationId,
+      agentId: opts?.agentId,
+    };
+  },
 );
 const getStreamToolContextIdMock = mock(() => null);
 const drainHandlers = new Map<
@@ -63,12 +72,28 @@ const drainStreamWithResumeMock = mock(
 );
 const retrieveAgentMock = mock(async (agentId: string) => ({ id: agentId }));
 const cancelConversationMock = mock(async (_conversationId: string) => {});
+const conversationMessagesStreamMock = mock(
+  async (
+    conversationId: string,
+    _params?: {
+      agent_id?: string;
+      otid?: string;
+      starting_after?: number;
+      batch_size?: number;
+    },
+  ): Promise<MockStream> => ({
+    conversationId,
+  }),
+);
 const getClientMock = mock(async () => ({
   agents: {
     retrieve: retrieveAgentMock,
   },
   conversations: {
     cancel: cancelConversationMock,
+    messages: {
+      stream: conversationMessagesStreamMock,
+    },
   },
 }));
 const getResumeDataMock = mock(
@@ -204,6 +229,7 @@ describe("listen-client multi-worker concurrency", () => {
     injectQueuedSkillContent([]);
     permissionMode.reset();
     sendMessageStreamMock.mockClear();
+    sendMessageStreamCalls.length = 0;
     getStreamToolContextIdMock.mockClear();
     drainStreamWithResumeMock.mockClear();
     getClientMock.mockClear();
@@ -212,6 +238,7 @@ describe("listen-client multi-worker concurrency", () => {
     classifyApprovalsMock.mockClear();
     executeApprovalBatchMock.mockClear();
     cancelConversationMock.mockClear();
+    conversationMessagesStreamMock.mockClear();
     fetchRunErrorDetailMock.mockClear();
     drainHandlers.clear();
     __listenClientTestUtils.setActiveRuntime(null);
@@ -716,7 +743,7 @@ describe("listen-client multi-worker concurrency", () => {
       pendingApprovals: [approval],
       messageHistory: [],
     });
-    classifyApprovalsMock.mockResolvedValueOnce({
+    (classifyApprovalsMock as any).mockResolvedValueOnce({
       autoAllowed: [
         {
           approval,
@@ -1241,5 +1268,201 @@ describe("listen-client multi-worker concurrency", () => {
         "agent:agent-1::conversation:default",
       ),
     ).toBe(true);
+  });
+
+  test("pre-stream 409 resumes via conversations stream with message otid", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-409-otid",
+      "conv-409-otid",
+    );
+    const socket = new MockSocket();
+
+    sendMessageStreamMock.mockRejectedValueOnce(
+      new APIError(
+        409,
+        {
+          error: {
+            detail:
+              "Cannot send a new message: Another request is currently being processed for this conversation.",
+          },
+        },
+        undefined,
+        new Headers(),
+      ),
+    );
+
+    const turnPromise = __listenClientTestUtils.handleIncomingMessage(
+      {
+        type: "message",
+        agentId: "agent-409-otid",
+        conversationId: "conv-409-otid",
+        messages: [
+          {
+            role: "user",
+            content: "hello",
+            otid: "otid-123",
+          } as unknown as IncomingMessage["messages"][number],
+        ],
+      },
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    await waitFor(() => conversationMessagesStreamMock.mock.calls.length === 1);
+
+    const [, resumeParams] = conversationMessagesStreamMock.mock.calls[0] ?? [];
+    expect(resumeParams).toMatchObject({
+      agent_id: undefined,
+      otid: "otid-123",
+      starting_after: 0,
+      batch_size: 1000,
+    });
+
+    await turnPromise;
+  });
+
+  test("pre-stream 409 resume on default conversation includes agent_id", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-409-default",
+      "default",
+    );
+    const socket = new MockSocket();
+
+    sendMessageStreamMock.mockRejectedValueOnce(
+      new APIError(
+        409,
+        {
+          error: {
+            detail:
+              "Cannot send a new message: Another request is currently being processed for this conversation.",
+          },
+        },
+        undefined,
+        new Headers(),
+      ),
+    );
+
+    const turnPromise = __listenClientTestUtils.handleIncomingMessage(
+      {
+        type: "message",
+        agentId: "agent-409-default",
+        conversationId: "default",
+        messages: [
+          {
+            role: "user",
+            content: "hello default",
+            otid: "otid-default",
+          } as unknown as IncomingMessage["messages"][number],
+        ],
+      },
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    await waitFor(() => conversationMessagesStreamMock.mock.calls.length === 1);
+
+    const [resumeConversationId, resumeParams] =
+      conversationMessagesStreamMock.mock.calls[0] ?? [];
+    expect(resumeConversationId).toBe("default");
+    expect(resumeParams).toMatchObject({
+      agent_id: "agent-409-default",
+      otid: "otid-default",
+      starting_after: 0,
+      batch_size: 1000,
+    });
+
+    await turnPromise;
+  });
+
+  test("approval continuation 409 resumes via conversations stream with approval otid", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-409-approval",
+      "conv-409-approval",
+    );
+    const socket = new MockSocket();
+
+    (classifyApprovalsMock as any).mockResolvedValueOnce({
+      autoAllowed: [
+        {
+          approval: {
+            toolCallId: "tool-1",
+            toolName: "Read",
+            toolArgs: "{}",
+          },
+          parsedArgs: {},
+          permission: { allowed: true, reason: "auto" },
+          denyReason: null,
+        },
+      ],
+      autoDenied: [],
+      needsUserInput: [],
+    });
+
+    executeApprovalBatchMock.mockResolvedValueOnce([
+      {
+        type: "tool",
+        toolCallId: "tool-1",
+        toolName: "Read",
+        toolArgs: "{}",
+        result: "ok",
+        approved: true,
+      },
+    ] as never);
+
+    sendMessageStreamMock.mockRejectedValueOnce(
+      new APIError(
+        409,
+        {
+          error: {
+            detail:
+              "Cannot send a new message: Another request is currently being processed for this conversation.",
+          },
+        },
+        undefined,
+        new Headers(),
+      ),
+    );
+
+    getResumeDataMock.mockResolvedValueOnce({
+      pendingApproval: {
+        toolCallId: "tool-1",
+        toolName: "Read",
+        toolArgs: "{}",
+      },
+      pendingApprovals: [
+        {
+          toolCallId: "tool-1",
+          toolName: "Read",
+          toolArgs: "{}",
+        },
+      ],
+      messageHistory: [],
+    });
+
+    const result = await __listenClientTestUtils.resolveStaleApprovals(
+      runtime,
+      socket as unknown as WebSocket,
+      new AbortController().signal,
+      {
+        getResumeData: getResumeDataMock,
+      },
+    );
+
+    expect(result?.stopReason).toBe("end_turn");
+    await waitFor(() => conversationMessagesStreamMock.mock.calls.length >= 1);
+
+    const firstCall = conversationMessagesStreamMock.mock.calls[0];
+    expect(firstCall?.[0]).toBe("conv-409-approval");
+    expect(firstCall?.[1]).toMatchObject({
+      otid: expect.any(String),
+      starting_after: 0,
+      batch_size: 1000,
+    });
   });
 });

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -22,7 +22,7 @@ import {
 } from "../../agent/turn-recovery-policy";
 import { classifyApprovals } from "../../cli/helpers/approvalClassification";
 import { getRetryStatusMessage } from "../../cli/helpers/errorFormatter";
-import { discoverFallbackRunIdWithTimeout } from "../../cli/helpers/stream";
+
 import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import type { ControlRequest } from "../../types/protocol_v2";
@@ -367,7 +367,6 @@ export async function sendMessageStreamWithRetry(
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
-  const requestStartedAtMs = Date.now();
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -490,25 +489,25 @@ export async function sendMessageStreamWithRetry(
         });
         try {
           const client = await getClient();
-          const discoveredRunId = await discoverFallbackRunIdWithTimeout(
-            client,
-            {
-              conversationId,
-              resolvedConversationId: conversationId,
-              agentId: runtime.agentId ?? null,
-              requestStartedAtMs,
-            },
-          );
+          const messageOtid = messages
+            .map((item) => (item as Record<string, unknown>).otid)
+            .find((value): value is string => typeof value === "string");
 
-          if (discoveredRunId) {
-            if (abortSignal?.aborted) {
-              throw new Error("Cancelled by user");
-            }
-            return await client.runs.messages.stream(discoveredRunId, {
-              starting_after: 0,
-              batch_size: 1000,
-            });
+          if (abortSignal?.aborted) {
+            throw new Error("Cancelled by user");
           }
+
+          return await client.conversations.messages.stream(conversationId, {
+            agent_id:
+              conversationId === "default"
+                ? (runtime.agentId ?? undefined)
+                : undefined,
+            otid: messageOtid ?? undefined,
+            starting_after: 0,
+            batch_size: 1000,
+          } as unknown as Parameters<
+            typeof client.conversations.messages.stream
+          >[1]);
         } catch (resumeError) {
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");
@@ -568,7 +567,6 @@ export async function sendApprovalContinuationWithRetry(
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
-  const requestStartedAtMs = Date.now();
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -691,25 +689,25 @@ export async function sendApprovalContinuationWithRetry(
 
         try {
           const client = await getClient();
-          const discoveredRunId = await discoverFallbackRunIdWithTimeout(
-            client,
-            {
-              conversationId,
-              resolvedConversationId: conversationId,
-              agentId: runtime.agentId ?? null,
-              requestStartedAtMs,
-            },
-          );
+          const messageOtid = messages
+            .map((item) => (item as Record<string, unknown>).otid)
+            .find((value): value is string => typeof value === "string");
 
-          if (discoveredRunId) {
-            if (abortSignal?.aborted) {
-              throw new Error("Cancelled by user");
-            }
-            return await client.runs.messages.stream(discoveredRunId, {
-              starting_after: 0,
-              batch_size: 1000,
-            });
+          if (abortSignal?.aborted) {
+            throw new Error("Cancelled by user");
           }
+
+          return await client.conversations.messages.stream(conversationId, {
+            agent_id:
+              conversationId === "default"
+                ? (runtime.agentId ?? undefined)
+                : undefined,
+            otid: messageOtid ?? undefined,
+            starting_after: 0,
+            batch_size: 1000,
+          } as unknown as Parameters<
+            typeof client.conversations.messages.stream
+          >[1]);
         } catch (resumeError) {
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");


### PR DESCRIPTION
## Summary
- This PR ports the **same pre-stream 409 resume direction already implemented in App/headless** to websocket listener mode.
- Specifically, listener `retry_conversation_busy` now resumes via `conversations.messages.stream(...)` (OTID-aware) instead of fallback run discovery + `runs.messages.stream(...)`.
- Applied in both listener retry entry points:
  - `sendMessageStreamWithRetry`
  - `sendApprovalContinuationWithRetry`

## Why this change
Recent related work established the intended flow:
- **#1497** added OTID wiring for request deduplication across client paths.
- **#1500** (App/headless) moved pre-stream 409 recovery to conversation-stream resume with OTID-aware lookup.

Listener mode still used the older run-discovery path, so this PR brings WS into parity with that newer approach.

## What was changed
- `src/websocket/listener/send.ts`
  - Replaced `discoverFallbackRunIdWithTimeout(...)` + `client.runs.messages.stream(...)` on `retry_conversation_busy`
  - With `client.conversations.messages.stream(...)` using:
    - `otid` from outgoing payload when present
    - `agent_id` only for `default` conversation
    - `starting_after: 0`, `batch_size: 1000`
  - Preserved existing abort checks and exponential backoff fallback on resume failure.

## Test coverage
- `src/tests/websocket/listen-client-concurrency.test.ts`
  - Added assertions that 409 pre-stream retries resume through conversation stream:
    - named conversation uses OTID
    - default conversation includes `agent_id`
    - approval-continuation path also resumes via conversation stream

👾 Generated with [Letta Code](https://letta.com)