### PR TITLE
fix: use empty string fallback for toolArgs to prevent corrupted approval args on merge

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -458,7 +458,7 @@ export async function drainStream(
   const approvals: ApprovalRequest[] = allPending.map((a) => ({
     toolCallId: a.toolCallId,
     toolName: a.toolName || "",
-    toolArgs: a.toolArgs || "{}",
+    toolArgs: a.toolArgs || "",
   }));
   const approval: ApprovalRequest | null = approvals[0] || null;
   streamProcessor.pendingApprovals.clear();


### PR DESCRIPTION
## Summary
- `toolArgs: a.toolArgs || "{}"` in `drainStream` causes approval arg corruption when a mid-stream drop splits an `approval_request_message` across the drop boundary
- When the original drain receives the tool call ID but args haven't started streaming yet, `toolArgs` defaults to `"{}"` instead of `""`
- The merge in `drainStreamWithResume` then produces `'{}' + suffix` → garbage JSON (e.g. `'{}"ls -la"}'`)
- All consumption points in App.tsx already apply their own `|| "{}"` fallback, so the default here was redundant and harmful

## Fix
Change the intermediate fallback from `"{}"` to `""` so merging works correctly. The `"{}"` default is preserved at all call sites that actually send the args to the server.

👾 Generated with [Letta Code](https://letta.com)