### PR TITLE
fix: add missing otid to approval sends

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10612,6 +10612,7 @@ ${SYSTEM_REMINDER_CLOSE}
           initialInput.push({
             type: "approval",
             approvals: queuedApprovalResults,
+            otid: randomUUID(),
           });
         } else {
           debugWarn(
@@ -10969,7 +10970,11 @@ ${SYSTEM_REMINDER_CLOSE}
           const hadNotifications =
             appendTaskNotificationEvents(queuedNotifications);
           const input: Array<MessageCreate | ApprovalCreate> = [
-            { type: "approval", approvals: allResults as ApprovalResult[] },
+            {
+              type: "approval",
+              approvals: allResults as ApprovalResult[],
+              otid: randomUUID(),
+            },
           ];
           if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
             const queuedUserText = buildQueuedUserText(queuedItemsToAppend);


### PR DESCRIPTION
## Summary

- Two `ApprovalCreate` objects in `App.tsx` were constructed without `otid`, causing `streamRequestContext.otid` to be `undefined` for those streams
- `otid` on `messages[0]` feeds into `streamRequestContext.otid` which is used for OTID-based stream resume when no `run_id` is available from stream chunks
- Found via exhaustive audit of all `type: "approval"` top-level send callsites

**Affected paths:**
- `queuedApprovalResults` container pushed onto `initialInput` when a user message arrives with queued approval results (line ~10612)
- Auto-approval result send in the tool-execution-complete path (line ~10972)

## Test plan

- [ ] Verify `messages=approval:1 otid=<uuid>` (not `otid=none`) appears in logs for approval sends
- [ ] Confirm OTID-based stream resume fires correctly when run_id unavailable

👾 Generated with [Letta Code](https://letta.com)