### PR TITLE
fix: clean up buffers.interrupted when requires_approval data complete after stream drop

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -771,6 +771,18 @@ export async function drainStreamWithResume(
     }
   }
 
+  // If the initial drain's catch block set buffers.interrupted=true (skipCancelToolsOnError)
+  // but the stream ended with complete requires_approval data (stop_reason chunk arrived
+  // before the drop), no resume is needed — clean up so the approval prompt renders correctly.
+  if (
+    result.stopReason === "requires_approval" &&
+    (result.approvals?.length ?? 0) > 0 &&
+    buffers.interrupted
+  ) {
+    buffers.interrupted = false;
+    markCurrentLineAsFinished(buffers);
+  }
+
   // Update duration to reflect total time (including resume attempt)
   result.apiDurationMs = performance.now() - overallStartTime;
 


### PR DESCRIPTION
## Summary

- When a stream drops but `stop_reason: requires_approval` had already arrived in the processed chunks, `drainStream`'s catch block sets `buffers.interrupted = true` (via `skipCancelToolsOnError`)
- `canResume` is `false` (only gates on `stopReason === "error"`), so the normal cleanup path never runs
- This left `buffers.interrupted` dirty and the approval prompt unable to render — appearing as an unexpected turn termination to the user
- Fix: after `canResume`/skip blocks, if `stopReason === "requires_approval"` and `approvals` is populated, reset `buffers.interrupted` and call `markCurrentLineAsFinished`

**Diagnosed via** `[DRAIN-RESUME]` debug log showing `stopReason=requires_approval approvals=1 canResume=false`.

## Test plan

- [ ] With `LETTA_CHAOS_DROP_RATE=0.1`, trigger multi-tool turns; verify approval prompts always appear after drops
- [ ] Confirm `[DRAIN-RESUME] stopReason=requires_approval approvals=1 canResume=false` no longer causes stuck UI

👾 Generated with [Letta Code](https://letta.com)