### PR TITLE
fix: scope search_files results to conversation cwd

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -394,6 +394,9 @@ export interface SearchFilesCommand {
   request_id: string;
   /** Maximum number of results to return. Defaults to 5. */
   max_results?: number;
+  /** Working directory to scope the search to. When provided, only files
+   *  within this directory (relative to the index root) are returned. */
+  cwd?: string;
 }
 
 export interface ListInDirectoryCommand {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1003,8 +1003,21 @@ async function connectWithRetry(
     if (isSearchFilesCommand(parsed)) {
       void (async () => {
         await ensureFileIndex();
+
+        // Scope search to the conversation's cwd when provided.
+        // The file index stores paths relative to process.cwd(), so we
+        // compute the relative path from the index root to the requested cwd.
+        let searchDir = ".";
+        if (parsed.cwd) {
+          const rel = path.relative(process.cwd(), parsed.cwd);
+          // Only scope if cwd is within the index root (not "../" etc.)
+          if (rel && !rel.startsWith("..")) {
+            searchDir = rel;
+          }
+        }
+
         const files = searchFileIndex({
-          searchDir: ".",
+          searchDir,
           pattern: parsed.query,
           deep: true,
           maxResults: parsed.max_results ?? 5,


### PR DESCRIPTION
The search_files handler was hardcoding searchDir to "." which searched the entire index root, ignoring the cwd sent by the web app's FilePicker. Now computes the relative path from the index root to the provided cwd and uses it as searchDir to scope results correctly.

🐾 Generated with [Letta Code](https://letta.com)