### PR TITLE
fix: restore conversation from local session when using --agent/--name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1271,6 +1271,22 @@ async function main(): Promise<void> {
 
         // Short-circuit: flags handled by init() skip resolution entirely
         if (forceNew || agentIdArg || fromAfFile) {
+          // For --agent/--name: restore conversation from local session if the
+          // agent matches, so we don't clobber a real conv ID with "default".
+          if (agentIdArg && !forceNew && !fromAfFile && !forceNewConversation) {
+            // loadLocalProjectSettings is cached if already loaded (e.g. --name)
+            await settingsManager.loadLocalProjectSettings(process.cwd());
+            const localSession = settingsManager.getLocalLastSession(
+              process.cwd(),
+            );
+            if (
+              localSession?.agentId === agentIdArg &&
+              localSession.conversationId &&
+              localSession.conversationId !== "default"
+            ) {
+              setSelectedConversationId(localSession.conversationId);
+            }
+          }
           setLoadingState("assembling");
           return;
         }


### PR DESCRIPTION
## Summary
- The `--agent` and `--name` flags short-circuit past `resolveStartupTarget`, so `selectedConversationId` was never set from local settings
- This caused every `-n` startup to fall through to the `"default"` conversation, clobbering the real conversation ID stored in `.letta/settings.local.json`
- Now the short-circuit path checks local session settings and restores the conversation if the agent matches

## Test plan
- [ ] Run `letta`, use `/new` to create a named conversation, exit
- [ ] Run `letta -n <agent>` — should resume the conversation from the previous session, not "default"
- [ ] Run `letta -n <different agent>` — should start with "default" (no conversation to restore)
- [ ] Run `letta --new-agent` — should not attempt conversation restoration
- [ ] Verify `bun run typecheck` passes

🐾 Generated with [Letta Code](https://letta.com)