### PR TITLE
fix: persist conversation ID on session exit

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -694,13 +694,28 @@ async function isRetriableError(
   return false;
 }
 
-// Save current agent as lastAgent before exiting
-// This ensures subagent overwrites during the session don't persist
-function saveLastAgentBeforeExit() {
+// Save current agent + conversation as last session before exiting.
+// This ensures subagent overwrites during the session don't persist,
+// and the conversation ID is always up-to-date on exit.
+function saveLastSessionBeforeExit(conversationId?: string | null) {
   try {
     const currentAgentId = getCurrentAgentId();
+    // Legacy field — kept for backwards compat
     settingsManager.updateLocalProjectSettings({ lastAgent: currentAgentId });
     settingsManager.updateSettings({ lastAgent: currentAgentId });
+
+    // Save the full session (agent + conversation) so the next startup
+    // resumes the correct conversation, not just the agent.
+    if (conversationId && conversationId !== "default") {
+      settingsManager.setLocalLastSession(
+        { agentId: currentAgentId, conversationId },
+        process.cwd(),
+      );
+      settingsManager.setGlobalLastSession({
+        agentId: currentAgentId,
+        conversationId,
+      });
+    }
   } catch {
     // Ignore if no agent context set
   }
@@ -5968,7 +5983,7 @@ export default function App({
   );
 
   const handleExit = useCallback(async () => {
-    saveLastAgentBeforeExit();
+    saveLastSessionBeforeExit(conversationIdRef.current);
 
     // Run SessionEnd hooks
     await runEndHooks();
@@ -7973,7 +7988,7 @@ export default function App({
               true,
             );
 
-            saveLastAgentBeforeExit();
+            saveLastSessionBeforeExit(conversationIdRef.current);
 
             // Track session end explicitly (before exit) with stats
             const stats = sessionStatsRef.current.getSnapshot();


### PR DESCRIPTION
## Summary
- `saveLastAgentBeforeExit` only saved the agent ID (legacy `lastAgent` field) on exit — the conversation ID was never persisted at exit time
- Renamed to `saveLastSessionBeforeExit` and now also calls `setLocalLastSession`/`setGlobalLastSession` with the current conversation ID
- Skips writing `"default"` since it's the implicit fallback and would clobber real conversation IDs

## Test plan
- [ ] Run `letta`, use `/new` to create a conversation, exit with Ctrl+C — check `.letta/settings.local.json` has the real conv ID
- [ ] Run `letta`, use `/resume` to switch conversations mid-session, exit — verify the switched-to conversation is persisted
- [ ] Run `letta` with a fresh agent (no previous conversation) — verify `"default"` is not written to settings
- [ ] Verify `bun run typecheck` passes

🐾 Generated with [Letta Code](https://letta.com)