### PR TITLE
feat(cli): add /fork command to fork current conversation

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8268,6 +8268,84 @@ export default function App({
           return { submitted: true };
         }
 
+        // Special handling for /fork command - fork the current conversation
+        if (msg.trim() === "/fork") {
+          if (conversationIdRef.current === "default") {
+            const cmd = commandRunner.start(
+              msg.trim(),
+              "Forking conversation...",
+            );
+            cmd.fail("Cannot fork the default conversation — use /new instead");
+            return { submitted: true };
+          }
+
+          const cmd = commandRunner.start(
+            msg.trim(),
+            "Forking conversation...",
+          );
+
+          resetPendingReasoningCycle();
+          setCommandRunning(true);
+
+          await runEndHooks();
+
+          try {
+            const client = await getClient();
+
+            const forked = await client.post<
+              import("@letta-ai/letta-client/resources/conversations/conversations").Conversation
+            >(`/v1/conversations/${conversationIdRef.current}/fork`);
+
+            await maybeCarryOverActiveConversationModel(forked.id);
+
+            setConversationId(forked.id);
+
+            pendingConversationSwitchRef.current = {
+              origin: "fork",
+              conversationId: forked.id,
+              isDefault: false,
+            };
+
+            settingsManager.setLocalLastSession(
+              { agentId, conversationId: forked.id },
+              process.cwd(),
+            );
+            settingsManager.setGlobalLastSession({
+              agentId,
+              conversationId: forked.id,
+            });
+
+            resetContextHistory(contextTrackerRef.current);
+            resetBootstrapReminderState();
+
+            sessionHooksRanRef.current = false;
+            runSessionStartHooks(
+              true,
+              agentId,
+              agentName ?? undefined,
+              forked.id,
+            )
+              .then((result) => {
+                if (result.feedback.length > 0) {
+                  sessionStartFeedbackRef.current = result.feedback;
+                }
+              })
+              .catch(() => {});
+            sessionHooksRanRef.current = true;
+
+            cmd.finish(
+              "Forked conversation (use /resume to switch back)",
+              true,
+            );
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+          return { submitted: true };
+        }
+
         // Special handling for /clear command - reset all agent messages (destructive)
         if (msg.trim() === "/clear") {
           const cmd = commandRunner.start(

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -176,6 +176,15 @@ export const commands: Record<string, Command> = {
       return "Starting new conversation...";
     },
   },
+  "/fork": {
+    desc: "Fork the current conversation",
+    order: 20.5,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx to fork current conversation
+      return "Forking conversation...";
+    },
+  },
   "/pin": {
     desc: "Pin current agent globally, or use -l for local only",
     order: 22,

--- a/src/cli/helpers/conversationSwitchAlert.ts
+++ b/src/cli/helpers/conversationSwitchAlert.ts
@@ -11,7 +11,8 @@ export interface ConversationSwitchContext {
     | "new"
     | "clear"
     | "search"
-    | "agent-switch";
+    | "agent-switch"
+    | "fork";
   conversationId: string;
   isDefault: boolean;
 
@@ -35,7 +36,12 @@ export function buildConversationSwitchAlert(
 ): string {
   const parts: string[] = [];
 
-  if (ctx.origin === "new" || ctx.origin === "clear") {
+  if (ctx.origin === "fork") {
+    parts.push(
+      "Forked conversation. This is a copy of the previous conversation with a freshly compiled system message.",
+    );
+    parts.push(`Conversation: ${ctx.conversationId}`);
+  } else if (ctx.origin === "new" || ctx.origin === "clear") {
     parts.push(
       "New conversation started. This is a fresh conversation thread with no prior messages.",
     );


### PR DESCRIPTION
## Summary
- Adds `/fork` slash command that calls `POST /v1/conversations/{conversation_id}/fork` and switches to the newly forked conversation
- Guards against forking the default conversation (shows "use /new instead")
- Uses `client.post<Conversation>()` since the SDK doesn't have a typed `.fork()` method yet
- Follows the same state management pattern as `/new` (session persistence, context reset, hook lifecycle)

## Test plan
- [ ] Run `/fork` on a named conversation — verify it creates a forked conversation and switches to it
- [ ] Run `/fork` on the default conversation — verify it fails with a clear message
- [ ] After forking, run `/resume` to verify the original conversation is still accessible
- [ ] Verify `/fork` appears in the command list

👾 Generated with [Letta Code](https://letta.com)