### PR TITLE
fix(listen): route background Task notifications to correct conversation runtime

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -198,6 +198,7 @@ async function executeSingleDecision(
       isStderr?: boolean,
     ) => void;
     toolContextId?: string;
+    parentScope?: { agentId: string; conversationId: string };
   },
 ): Promise<ApprovalResult> {
   // If aborted, record an interrupted result
@@ -256,6 +257,7 @@ async function executeSingleDecision(
           signal: options?.abortSignal,
           toolCallId: decision.approval.toolCallId,
           toolContextId: options?.toolContextId,
+          parentScope: options?.parentScope,
           onOutput: options?.onStreamingOutput
             ? (chunk, stream) =>
                 options.onStreamingOutput?.(
@@ -372,6 +374,7 @@ export async function executeApprovalBatch(
     ) => void;
     toolContextId?: string;
     workingDirectory?: string;
+    parentScope?: { agentId: string; conversationId: string };
   },
 ): Promise<ApprovalResult[]> {
   const toolContextId =

--- a/src/cli/helpers/messageQueueBridge.ts
+++ b/src/cli/helpers/messageQueueBridge.ts
@@ -2,7 +2,7 @@
  * Message Queue Bridge
  *
  * Allows non-React code (like Task.ts) to add messages to the messageQueue.
- * The queue adder function is set by App.tsx on mount.
+ * The queue adder function is set by the active consumer on mount.
  *
  * This enables background tasks to queue their notification XML directly
  * into messageQueue, where the existing dequeue logic handles auto-firing.
@@ -11,12 +11,16 @@
 export type QueuedMessage = {
   kind: "user" | "task_notification";
   text: string;
+  /** Optional parent agent scope for routing in listener mode. */
+  agentId?: string;
+  /** Optional parent conversation scope for routing in listener mode. */
+  conversationId?: string;
 };
 
 type QueueAdder = (message: QueuedMessage) => void;
 
-// Global bridge is intentionally single-consumer. Each process runs either
-// one TUI App instance or one headless bidirectional loop.
+// Global bridge is intentionally single-consumer. Each process runs exactly
+// one of: TUI App (App.tsx), headless bidirectional loop, or WebSocket listener.
 let queueAdder: QueueAdder | null = null;
 const pendingMessages: QueuedMessage[] = [];
 const MAX_PENDING_MESSAGES = 10;

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -43,6 +43,7 @@ interface TaskArgs {
   max_turns?: number; // Maximum number of agentic turns
   toolCallId?: string; // Injected by executeTool for linking subagent to parent tool call
   signal?: AbortSignal; // Injected by executeTool for interruption handling
+  parentScope?: { agentId: string; conversationId: string }; // Injected by executeTool for notification routing
 }
 
 // Valid subagent_types when deploying an existing agent
@@ -67,6 +68,8 @@ export interface SpawnBackgroundSubagentTaskArgs {
   existingAgentId?: string;
   existingConversationId?: string;
   maxTurns?: number;
+  /** Parent conversation scope for routing notifications in listener mode. */
+  parentScope?: { agentId: string; conversationId: string };
   /**
    * When true, skip injecting the completion notification into the primary
    * agent's message queue and hide from SubagentGroupDisplay.
@@ -212,6 +215,7 @@ export function spawnBackgroundSubagentTask(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    parentScope,
     silentCompletion,
     onComplete,
     deps,
@@ -337,6 +341,8 @@ export function spawnBackgroundSubagentTask(
         addToMessageQueueFn({
           kind: "task_notification",
           text: notificationXml,
+          agentId: parentScope?.agentId,
+          conversationId: parentScope?.conversationId,
         });
       }
 
@@ -404,6 +410,8 @@ export function spawnBackgroundSubagentTask(
         addToMessageQueueFn({
           kind: "task_notification",
           text: notificationXml,
+          agentId: parentScope?.agentId,
+          conversationId: parentScope?.conversationId,
         });
       }
 
@@ -508,6 +516,7 @@ export async function task(args: TaskArgs): Promise<string> {
       existingAgentId: args.agent_id,
       existingConversationId: args.conversation_id,
       maxTurns: args.max_turns,
+      parentScope: args.parentScope,
     });
 
     await waitForBackgroundSubagentLink(subagentId, null, signal);

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1263,6 +1263,7 @@ export async function executeTool(
     toolCallId?: string;
     onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
     toolContextId?: string;
+    parentScope?: { agentId: string; conversationId: string };
   },
 ): Promise<ToolExecutionResult> {
   const context = options?.toolContextId
@@ -1340,13 +1341,16 @@ export async function executeTool(
       enhancedArgs = substituteSecretsInArgs(enhancedArgs);
     }
 
-    // Inject toolCallId and abort signal for Task tool
+    // Inject toolCallId, abort signal, and parent scope for Task tool
     if (internalName === "Task") {
       if (options?.toolCallId) {
         enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
       }
       if (options?.signal) {
         enhancedArgs = { ...enhancedArgs, signal: options.signal };
+      }
+      if (options?.parentScope) {
+        enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
       }
     }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -10,6 +10,7 @@ import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/mes
 import WebSocket from "ws";
 import { getClient } from "../../agent/client";
 import { ensureFileIndex, searchFileIndex } from "../../cli/helpers/fileIndex";
+import { setMessageQueueAdder } from "../../cli/helpers/messageQueueBridge";
 import { generatePlanFilePath } from "../../cli/helpers/planName";
 import {
   subscribe as subscribeToSubagentState,
@@ -247,6 +248,22 @@ function getOrCreateScopedRuntime(
     listener,
     getOrCreateConversationRuntime(listener, agentId, conversationId),
   );
+}
+
+/**
+ * Fallback for unscoped task notifications (e.g., reflection/init spawned
+ * outside turn processing). Picks the first ConversationRuntime that has a
+ * QueueRuntime, or null if none exist.
+ */
+function findFallbackRuntime(
+  listener: ListenerRuntime,
+): ConversationRuntime | null {
+  for (const cr of listener.conversationRuntimes.values()) {
+    if (cr.queueRuntime) {
+      return cr;
+    }
+  }
+  return null;
 }
 
 function resolveRuntimeForApprovalRequest(
@@ -553,6 +570,7 @@ function stopRuntime(
   runtime: ListenerRuntime,
   suppressCallbacks: boolean,
 ): void {
+  setMessageQueueAdder(null); // Clear bridge for ALL stop paths
   runtime.intentionallyClosed = true;
   clearRuntimeTimers(runtime);
   for (const conversationRuntime of runtime.conversationRuntimes.values()) {
@@ -744,6 +762,39 @@ async function connectWithRetry(
       },
     );
 
+    // Register the message queue bridge to route task notifications into the
+    // correct per-conversation QueueRuntime. This enables background Task
+    // completions to reach the agent in listen mode.
+    setMessageQueueAdder((queuedMessage) => {
+      const targetRuntime =
+        queuedMessage.agentId && queuedMessage.conversationId
+          ? getOrCreateScopedRuntime(
+              runtime,
+              queuedMessage.agentId,
+              queuedMessage.conversationId,
+            )
+          : findFallbackRuntime(runtime);
+
+      if (!targetRuntime?.queueRuntime) {
+        return; // No target — notification dropped
+      }
+
+      targetRuntime.queueRuntime.enqueue({
+        kind: "task_notification",
+        source: "task_notification",
+        text: queuedMessage.text,
+        agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
+        conversationId:
+          queuedMessage.conversationId ?? targetRuntime.conversationId,
+      } as Omit<
+        import("../../queue/queueRuntime").TaskNotificationQueueItem,
+        "id" | "enqueuedAt"
+      >);
+
+      // Kick the queue pump so the notification can trigger a standalone turn
+      // (see consumeQueuedTurn notification-aware path in queue.ts).
+      scheduleQueuePump(targetRuntime, socket, opts, processQueuedTurn);
+    });
     runtime.heartbeatInterval = setInterval(() => {
       if (socket.readyState === WebSocket.OPEN) {
         socket.send(JSON.stringify({ type: "ping" }));
@@ -1347,6 +1398,10 @@ async function connectWithRetry(
       code,
       reason: reason.toString(),
     });
+
+    // Clear the bridge before queue clearing to prevent a race where a task
+    // completion enqueues into a shutting-down runtime.
+    setMessageQueueAdder(null);
 
     // Single authoritative queue clear for all close paths
     // (intentional and unintentional). Must fire before early returns.

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -207,10 +207,30 @@ function buildQueuedTurnMessage(
 ): IncomingMessage | null {
   const primaryItem = getPrimaryQueueMessageItem(batch.items);
   if (!primaryItem) {
+    // No user message in the batch — this is a notification-only batch.
+    // Build a synthetic IncomingMessage to restart the agent loop.
     for (const item of batch.items) {
       runtime.queuedMessagesByItemId.delete(item.id);
     }
-    return null;
+
+    const mergedContent = mergeDequeuedBatchContent(batch.items);
+    if (mergedContent === null) {
+      return null;
+    }
+
+    // Determine scope from the batch items (they all share the same scope)
+    const scopeItem = batch.items[0];
+    return {
+      type: "message",
+      agentId: scopeItem?.agentId ?? runtime.agentId ?? undefined,
+      conversationId: scopeItem?.conversationId ?? runtime.conversationId,
+      messages: [
+        {
+          role: "user",
+          content: mergedContent,
+        } satisfies MessageCreate,
+      ],
+    };
   }
 
   const template = runtime.queuedMessagesByItemId.get(primaryItem.id);
@@ -266,6 +286,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
 
   let queueLen = 0;
   let hasMessage = false;
+  let hasTaskNotification = false;
   for (const item of queuedItems) {
     if (
       !isCoalescable(item.kind) ||
@@ -277,9 +298,12 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     if (item.kind === "message") {
       hasMessage = true;
     }
+    if (item.kind === "task_notification") {
+      hasTaskNotification = true;
+    }
   }
 
-  if (!hasMessage || queueLen === 0) {
+  if ((!hasMessage && !hasTaskNotification) || queueLen === 0) {
     return null;
   }
 

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -546,6 +546,13 @@ export async function resolveRecoveredApprovalResponse(
         recovered.agentId,
         recovered.conversationId,
       ),
+      parentScope:
+        recovered.agentId && recovered.conversationId
+          ? {
+              agentId: recovered.agentId,
+              conversationId: recovered.conversationId,
+            }
+          : undefined,
     });
 
     emitToolExecutionFinishedEvents(socket, runtime, {

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -272,6 +272,13 @@ export async function resolveStaleApprovals(
       const approvalResults = await executeApprovalBatch(decisions, undefined, {
         abortSignal,
         workingDirectory: recoveryWorkingDirectory,
+        parentScope:
+          runtime.agentId && runtime.conversationId
+            ? {
+                agentId: runtime.agentId,
+                conversationId: runtime.conversationId,
+              }
+            : undefined,
       });
       emitToolExecutionFinishedEvents(socket, runtime, {
         approvals: approvalResults,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -286,6 +286,8 @@ export async function handleApprovalStop(params: {
     toolContextId: turnToolContextId ?? undefined,
     abortSignal: abortController.signal,
     workingDirectory: turnWorkingDirectory,
+    parentScope:
+      agentId && conversationId ? { agentId, conversationId } : undefined,
   });
   const persistedExecutionResults = normalizeExecutionResultsForInterruptParity(
     runtime,


### PR DESCRIPTION
## Summary

- Background Task completion notifications were silently dropped in WebSocket listen mode (`letta server`) because the message queue bridge wasn't connected to per-conversation runtimes
- Wires up parent scope threading (`agentId` + `conversationId`) through the full tool execution chain (`executeTool` → `executeApprovalBatch` → `Task.ts` → `addToMessageQueueFn`) so notifications carry their originating conversation scope
- Registers the message queue bridge in the socket open handler, routing incoming `QueuedMessage` items to the correct `ConversationRuntime` via `getOrCreateScopedRuntime` (with fallback for unscoped notifications)
- Extends `consumeQueuedTurn` to allow standalone `task_notification` items to trigger agent turns when idle (previously required a user message), building a synthetic `IncomingMessage` for notification-only batches
- Adds bridge cleanup in both `stopRuntime()` and socket close handler (fires before queue clearing to prevent race conditions)

👾 Generated with [Letta Code](https://letta.com)