### PR TITLE
test(cli): add tests for /fork command and default conversation guard

### DIFF
--- a/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
+++ b/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
@@ -31,6 +31,7 @@ describe("bootstrap reminder reset wiring", () => {
       'const inputCmd = "/new";', // new-agent creation flow
       "const newMatch = msg.trim().match(/^\\/new(?:\\s+(.+))?$/);",
       'if (msg.trim() === "/clear")',
+      'if (msg.trim() === "/fork")', // fork conversation flow
       'origin: "resume-direct"',
       'if (action.type === "switch_conversation")', // queued conversation switch flow
       'origin: "resume-selector"',

--- a/src/tests/cli/conversationSwitchAlert.test.ts
+++ b/src/tests/cli/conversationSwitchAlert.test.ts
@@ -19,4 +19,20 @@ describe("conversationSwitchAlert", () => {
     expect(alert).toContain("Conversation resumed via /resume selector.");
     expect(alert).toContain("Conversation: conv-123 (14 messages)");
   });
+
+  test("fork origin produces forked conversation message", () => {
+    const alert = buildConversationSwitchAlert({
+      origin: "fork",
+      conversationId: "conv-456",
+      isDefault: false,
+    });
+
+    expect(alert).toContain(SYSTEM_REMINDER_OPEN);
+    expect(alert).toContain(SYSTEM_REMINDER_CLOSE);
+    expect(alert).toContain("Forked conversation.");
+    expect(alert).toContain(
+      "This is a copy of the previous conversation with a freshly compiled system message.",
+    );
+    expect(alert).toContain("Conversation: conv-456");
+  });
 });

--- a/src/tests/cli/fork-command-wiring.test.ts
+++ b/src/tests/cli/fork-command-wiring.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("/fork command wiring", () => {
+  test("guards against forking the default conversation", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    // Find the /fork handler
+    const forkHandlerIndex = source.indexOf('if (msg.trim() === "/fork")');
+    expect(forkHandlerIndex).toBeGreaterThanOrEqual(0);
+
+    // Check the guard is right after the handler starts
+    const windowEnd = Math.min(source.length, forkHandlerIndex + 1500);
+    const scoped = source.slice(forkHandlerIndex, windowEnd);
+
+    // Must check for default conversation
+    expect(scoped).toContain('conversationIdRef.current === "default"');
+
+    // Must fail with appropriate message
+    expect(scoped).toContain(
+      "Cannot fork the default conversation — use /new instead",
+    );
+  });
+
+  test("calls client.post for fork endpoint", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    const forkHandlerIndex = source.indexOf('if (msg.trim() === "/fork")');
+    expect(forkHandlerIndex).toBeGreaterThanOrEqual(0);
+
+    const windowEnd = Math.min(source.length, forkHandlerIndex + 3000);
+    const scoped = source.slice(forkHandlerIndex, windowEnd);
+
+    // Must call POST to fork endpoint
+    expect(scoped).toContain("client.post<");
+    expect(scoped).toContain("/fork");
+  });
+
+  test("sets origin to fork for conversation switch context", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    const forkHandlerIndex = source.indexOf('if (msg.trim() === "/fork")');
+    expect(forkHandlerIndex).toBeGreaterThanOrEqual(0);
+
+    const windowEnd = Math.min(source.length, forkHandlerIndex + 3000);
+    const scoped = source.slice(forkHandlerIndex, windowEnd);
+
+    expect(scoped).toContain('origin: "fork"');
+  });
+
+  test("fork origin is defined in ConversationSwitchContext type", () => {
+    const alertPath = fileURLToPath(
+      new URL(
+        "../../cli/helpers/conversationSwitchAlert.ts",
+        import.meta.url,
+      ),
+    );
+    const source = readFileSync(alertPath, "utf-8");
+
+    // The origin union type should include "fork"
+    expect(source).toContain('"fork"');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `fork-command-wiring.test.ts`: verifies `/fork` handler guards against default conversation, calls correct API endpoint, and sets `origin: "fork"`
- Updates `conversationSwitchAlert.test.ts`: tests fork origin alert message ("Forked conversation. This is a copy...")
- Updates `bootstrap-reminders-reset-wiring.test.ts`: includes `/fork` in the anchor list for reset wiring verification

Follow-up to #1517.

## Test plan
- [x] All 9 tests pass locally

👾 Generated with [Letta Code](https://letta.com)