### PR TITLE
feat: show provider status page links on downstream LLM errors

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -373,10 +373,7 @@ const PROVIDER_STATUS_PAGES: Record<string, { name: string; url: string }> = {
     name: "Anthropic",
     url: "https://status.claude.com/",
   },
-  bedrock: {
-    name: "Anthropic",
-    url: "https://status.claude.com/",
-  },
+
   openai: {
     name: "OpenAI",
     url: "https://status.openai.com",


### PR DESCRIPTION
## Summary

- When an `llm_api_error` stop reason fires, the error hint now includes the provider's status page URL (e.g. `status.claude.com` for Anthropic, `status.openai.com` for OpenAI) with a caveat that the page may not be up-to-date
- Covers Anthropic (direct API, BYOK, Bedrock), OpenAI (direct API, BYOK, ChatGPT OAuth), and a generic fallback for unknown providers
- Opus on direct Anthropic still suggests Bedrock as a specific alternative when available

🐛 Generated with [Letta Code](https://letta.com)