### PR TITLE
fix(cli): allow forking default conversation with agent_id param and move to using the SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@letta-ai/letta-client": "1.8.0",
+        "@letta-ai/letta-client": "1.10.0",
         "glob": "^13.0.0",
         "highlight.js": "^11.11.1",
         "ink-link": "^5.0.0",
@@ -96,7 +95,7 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.8.0", "", {}, "sha512-OdeMH0vfwFqMNuNyOypJ2wgWI9m6xFDhcODQVJk1geAoCJ3F1BkmEWz8+lWM+NyNkk/4JjcoqUTimIzVH+u0JQ=="],
+    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.10.0", "", {}, "sha512-DKBQNUyYdXjKVu6Lxg1+uKqvUQDoBA9/hHxGH0LJSzSeMM0RUX03GSlAOOLu1/L/Mp5H0s2UoW5K3BGObKH8gQ=="],
 
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@letta-ai/letta-client": "1.8.0",
+    "@letta-ai/letta-client": "1.10.0",
     "glob": "^13.0.0",
     "highlight.js": "^11.11.1",
     "ink-link": "^5.0.0",

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8379,16 +8379,12 @@ export default function App({
           try {
             const client = await getClient();
 
-            // For default conversation, pass agent_id as query param
+            // For default conversation, pass agent_id
             const isDefault = conversationIdRef.current === "default";
-            const forkUrl = isDefault
-              ? `/v1/conversations/default/fork?agent_id=${agentId}`
-              : `/v1/conversations/${conversationIdRef.current}/fork`;
-
-            const forked =
-              await client.post<
-                import("@letta-ai/letta-client/resources/conversations/conversations").Conversation
-              >(forkUrl);
+            const forked = await client.conversations.fork(
+              conversationIdRef.current,
+              isDefault ? { agent_id: agentId } : undefined,
+            );
 
             await maybeCarryOverActiveConversationModel(forked.id);
 


### PR DESCRIPTION
## Summary
- Removes the guard that prevented `/fork` from working on the default conversation
- When forking "default", passes `agent_id` as a query parameter to the API

## Test plan
- [x] Run `/fork` on the default conversation — verify it creates a forked conversation
- [x] Run `/fork` on a named conversation — verify it still works as before

👾 Generated with [Letta Code](https://letta.com)