### PR TITLE
feat(cli): add optional summary argument to /fork command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8365,10 +8365,14 @@ export default function App({
         }
 
         // Special handling for /fork command - fork the current conversation
-        if (msg.trim() === "/fork") {
+        const forkMatch = msg.trim().match(/^\/fork(?:\s+(.+))?$/);
+        if (forkMatch) {
+          const conversationSummary = forkMatch[1]?.trim();
           const cmd = commandRunner.start(
             msg.trim(),
-            "Forking conversation...",
+            conversationSummary
+              ? `Forking conversation: ${conversationSummary}...`
+              : "Forking conversation...",
           );
 
           resetPendingReasoningCycle();
@@ -8385,6 +8389,14 @@ export default function App({
               conversationIdRef.current,
               isDefault ? { agent_id: agentId } : undefined,
             );
+
+            // If we forked with an explicit summary, update it
+            if (conversationSummary) {
+              await client.conversations.update(forked.id, {
+                summary: conversationSummary,
+              });
+              hasSetConversationSummaryRef.current = true;
+            }
 
             await maybeCarryOverActiveConversationModel(forked.id);
 


### PR DESCRIPTION
## Summary
- Mirrors `/new` command behavior - allows passing a summary when forking: `/fork my new feature`
- Sets the summary on the forked conversation via `client.conversations.update()`
- Prevents auto-summary from overwriting by setting `hasSetConversationSummaryRef.current = true`

## Test plan
- [ ] `/fork` still works without arguments
- [ ] `/fork my summary` sets the summary on the forked conversation
- [ ] Auto-summary doesn't overwrite manually set summary