### PR TITLE
feat: add fork subagent type for conversation forking

### DIFF
--- a/src/agent/subagents/builtin/fork.md
+++ b/src/agent/subagents/builtin/fork.md
@@ -1,0 +1,13 @@
+---
+name: fork
+description: Fork of the parent agent with full context and tools. Recommended to run in background (run_in_background: true).
+tools: Bash, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+model: inherit
+memoryBlocks: all
+mode: stateful
+fork: true
+background: true
+---
+
+Fork subagent that inherits the parent agent's full conversation history via conversation forking.
+The system prompt body is not used at runtime — the forked conversation retains the parent's system prompt.

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -19,6 +19,7 @@ import { MEMORY_BLOCK_LABELS, type MemoryBlockLabel } from "../memory";
 
 // Built-in subagent definitions (embedded at build time)
 import exploreAgentMd from "./builtin/explore.md";
+import forkAgentMd from "./builtin/fork.md";
 import generalPurposeAgentMd from "./builtin/general-purpose.md";
 import historyAnalyzerAgentMd from "./builtin/history-analyzer.md";
 import initAgentMd from "./builtin/init.md";
@@ -29,6 +30,7 @@ import reflectionAgentMd from "./builtin/reflection.md";
 
 const BUILTIN_SOURCES = [
   exploreAgentMd,
+  forkAgentMd,
   generalPurposeAgentMd,
   historyAnalyzerAgentMd,
   initAgentMd,
@@ -66,6 +68,10 @@ export interface SubagentConfig {
   memoryBlocks: MemoryBlockLabel[] | "all" | "none";
   /** Stateless agents should not persist private working memory. */
   mode: SubagentMode;
+  /** Whether this subagent should fork the parent conversation before launch. */
+  fork: boolean;
+  /** Whether this subagent should run in the background by default. */
+  background: boolean;
   /** Permission mode for this subagent (default, acceptEdits, plan, bypassPermissions) */
   permissionMode?: string;
 }
@@ -239,6 +245,9 @@ function parseSubagentContent(content: string): SubagentConfig {
       getStringField(frontmatter, "memoryBlocks"),
     ),
     mode: parseSubagentMode(getStringField(frontmatter, "mode")),
+    fork: getStringField(frontmatter, "fork")?.toLowerCase() === "true",
+    background:
+      getStringField(frontmatter, "background")?.toLowerCase() === "true",
     permissionMode: getStringField(frontmatter, "permissionMode"),
   };
 }

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -268,7 +268,9 @@ function handleInitEvent(
 ): void {
   if (event.agent_id) {
     state.agentId = event.agent_id;
-    const agentURL = buildChatUrl(event.agent_id);
+    const agentURL = buildChatUrl(event.agent_id, {
+      conversationId: event.conversation_id,
+    });
     updateSubagent(subagentId, { agentURL });
   }
   if (event.conversation_id) {
@@ -893,6 +895,16 @@ ${SYSTEM_REMINDER_CLOSE}
 `;
 }
 
+function buildForkSystemReminder(): string {
+  return `${SYSTEM_REMINDER_OPEN}
+You have been forked from the primary conversational thread to run as an independent subagent.
+You CANNOT ask questions mid-execution - all instructions are provided upfront.
+Your final message will be returned to the caller.
+${SYSTEM_REMINDER_CLOSE}
+
+`;
+}
+
 /**
  * Spawn a subagent and execute it autonomously
  *
@@ -913,6 +925,7 @@ export async function spawnSubagent(
   existingAgentId?: string,
   existingConversationId?: string,
   maxTurns?: number,
+  forkedContext?: boolean,
 ): Promise<SubagentResult> {
   const allConfigs = await getAllSubagentConfigs();
   const config = allConfigs[type];
@@ -951,12 +964,17 @@ export async function spawnSubagent(
       const parentAgentId = getCurrentAgentId();
       const client = await getClient();
       const parentAgent = await client.agents.retrieve(parentAgentId);
-      const systemReminder = buildDeploySystemReminder(
-        parentAgent.name,
-        parentAgentId,
-        type,
-      );
-      finalPrompt = systemReminder + prompt;
+      if (forkedContext) {
+        const systemReminder = buildForkSystemReminder();
+        finalPrompt = systemReminder + prompt;
+      } else {
+        const systemReminder = buildDeploySystemReminder(
+          parentAgent.name,
+          parentAgentId,
+          type,
+        );
+        finalPrompt = systemReminder + prompt;
+      }
     } catch {
       // If we can't get parent agent info, proceed without the reminder
     }

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -45,6 +45,7 @@ type TaskInfo = {
   description: string;
   prompt: string;
   model?: string;
+  isBackground?: boolean;
 };
 
 type Question = {
@@ -177,6 +178,7 @@ function getTaskInfo(approval: ApprovalRequest): TaskInfo | null {
           : "(no description)",
       prompt: typeof args.prompt === "string" ? args.prompt : "(no prompt)",
       model: typeof args.model === "string" ? args.model : undefined,
+      isBackground: args.run_in_background === true,
     };
   } catch {
     return {

--- a/src/cli/components/InlineTaskApproval.tsx
+++ b/src/cli/components/InlineTaskApproval.tsx
@@ -12,6 +12,7 @@ type Props = {
     description: string;
     prompt: string;
     model?: string;
+    isBackground?: boolean;
   };
   onApprove: () => void;
   onApproveAlways: (scope: "project" | "session") => void;
@@ -131,7 +132,8 @@ export const InlineTaskApproval = memo(
 
     // Memoize the static task content so it doesn't re-render on keystroke
     const memoizedTaskContent = useMemo(() => {
-      const { subagentType, description, prompt, model } = taskInfo;
+      const { subagentType, description, prompt, model, isBackground } =
+        taskInfo;
 
       // Show full prompt - users need to see what the task will do
       const truncatedPrompt = prompt;
@@ -155,6 +157,7 @@ export const InlineTaskApproval = memo(
                   <Text bold color={colors.subagent.header}>
                     {subagentType}
                   </Text>
+                  {isBackground && <Text dimColor>{" [background]"}</Text>}
                   <Text dimColor>
                     {" — "}
                     {description}

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -130,6 +130,8 @@ describe("buildSubagentArgs", () => {
     skills: [],
     memoryBlocks: "none",
     mode: "stateful",
+    fork: false,
+    background: false,
   };
 
   test("adds --no-memfs for newly spawned subagents by default", () => {

--- a/src/tools/descriptions/Task.md
+++ b/src/tools/descriptions/Task.md
@@ -109,6 +109,30 @@ Task({
 })
 ```
 
+## Forking Parent Context
+
+Use `subagent_type: "fork"` to launch a subagent that inherits the parent's full conversation history. The subagent runs against a forked copy of the current conversation, so it has all accumulated context without the parent needing to serialize it into the prompt.
+
+This is useful when:
+- The subagent needs deep context that would be expensive to re-explain in the prompt
+- You want to leverage prompt caching across multiple parallel forked subagents
+- The task requires understanding decisions and discussion from earlier in the conversation
+
+```typescript
+// Fork with full parent context
+Task({
+  subagent_type: "fork",
+  description: "Implement auth module",
+  prompt: "Implement the auth module we discussed. Use the patterns from the existing code."
+})
+
+// Parallel forks share the same cached prefix
+Task({ subagent_type: "fork", description: "Implement component A", prompt: "..." })
+Task({ subagent_type: "fork", description: "Implement component B", prompt: "..." })
+```
+
+Note: `fork` cannot be combined with `agent_id` or `conversation_id`.
+
 ## Concurrency and Safety:
 
 - **Safe**: Multiple read-only agents (explore, plan) running in parallel

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -5,6 +5,8 @@
  * Supports both built-in subagent types and custom subagents defined in .letta/agents/.
  */
 
+import { getClient } from "../../agent/client";
+import { getConversationId, getCurrentAgentId } from "../../agent/context";
 import {
   clearSubagentConfigCache,
   discoverSubagents,
@@ -68,6 +70,7 @@ export interface SpawnBackgroundSubagentTaskArgs {
   existingAgentId?: string;
   existingConversationId?: string;
   maxTurns?: number;
+  forkedContext?: boolean;
   /** Parent conversation scope for routing notifications in listener mode. */
   parentScope?: { agentId: string; conversationId: string };
   /**
@@ -215,6 +218,7 @@ export function spawnBackgroundSubagentTask(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    forkedContext,
     parentScope,
     silentCompletion,
     onComplete,
@@ -273,6 +277,7 @@ export function spawnBackgroundSubagentTask(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    forkedContext,
   )
     .then(async (result) => {
       bgTask.status = result.success ? "completed" : "failed";
@@ -501,9 +506,37 @@ export async function task(args: TaskArgs): Promise<string> {
     return `Error: When deploying an existing agent, subagent_type must be "explore" (read-only) or "general-purpose" (read-write). Got: "${subagent_type}"`;
   }
 
+  // If subagent config requires forked context, fork the parent conversation
+  const config = allConfigs[subagent_type];
+  if (!config) {
+    return `Error: Invalid subagent type "${subagent_type}"`;
+  }
+  let effectiveAgentId = args.agent_id;
+  let effectiveConversationId = args.conversation_id;
+
+  if (config.fork) {
+    if (args.agent_id || args.conversation_id) {
+      return "Error: Subagent type with fork: true cannot be combined with agent_id or conversation_id";
+    }
+    try {
+      const client = await getClient();
+      const parentAgentId = getCurrentAgentId();
+      const parentConvId = getConversationId() ?? "default";
+      const forkedConv = await client.conversations.fork(parentConvId, {
+        agent_id: parentAgentId,
+      });
+      effectiveAgentId = parentAgentId;
+      effectiveConversationId = forkedConv.id;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return `Error: Failed to fork parent conversation: ${errorMessage}`;
+    }
+  }
+
   const prompt = inputPrompt;
 
-  const isBackground = args.run_in_background ?? false;
+  const isBackground = args.run_in_background ?? config.background;
 
   // Handle background execution
   if (isBackground) {
@@ -513,9 +546,10 @@ export async function task(args: TaskArgs): Promise<string> {
       description,
       model,
       toolCallId,
-      existingAgentId: args.agent_id,
-      existingConversationId: args.conversation_id,
+      existingAgentId: effectiveAgentId,
+      existingConversationId: effectiveConversationId,
       maxTurns: args.max_turns,
+      forkedContext: config.fork,
       parentScope: args.parentScope,
     });
 
@@ -548,9 +582,10 @@ export async function task(args: TaskArgs): Promise<string> {
       model,
       subagentId,
       signal,
-      args.agent_id,
-      args.conversation_id,
+      effectiveAgentId,
+      effectiveConversationId,
       args.max_turns,
+      config.fork,
     );
 
     // Mark subagent as completed in state store
@@ -617,8 +652,8 @@ export async function task(args: TaskArgs): Promise<string> {
       subagent_type,
       subagentId,
       {
-        agentId: args.agent_id ?? "",
-        conversationId: args.conversation_id,
+        agentId: effectiveAgentId ?? "",
+        conversationId: effectiveConversationId,
       },
       "error",
     );
@@ -630,8 +665,8 @@ export async function task(args: TaskArgs): Promise<string> {
       subagentId,
       false,
       errorMessage,
-      args.agent_id,
-      args.conversation_id,
+      effectiveAgentId,
+      effectiveConversationId,
     ).catch(() => {
       // Silently ignore hook errors
     });


### PR DESCRIPTION
## Summary
- Adds a new `fork` subagent type that forks the parent conversation via `client.conversations.fork()` before spawning, giving the subagent full conversation history without prompt serialization
- Adds `fork` and `background` boolean fields to `SubagentConfig` (parsed from frontmatter)
- Fork subagents default to background execution (`background: true`)
- Shows `[background]` indicator in subagent dispatch approval preview
- Includes `?conversation=` in subagent chat URLs (applies to all subagent types, not just fork)

## Test plan
- [ ] Verify `bun run check` passes (lint + typecheck)
- [ ] Test `Task({ subagent_type: "fork", ... })` creates a forked conversation and runs the subagent against it
- [ ] Test parallel fork subagents share prompt cache prefix
- [ ] Verify `[background]` shows in dispatch preview for background tasks
- [ ] Verify subagent chat URL includes `?conversation=conv-xxx`
- [ ] Verify `fork` cannot be combined with `agent_id` or `conversation_id`

👾 Generated with [Letta Code](https://letta.com)