### PR TITLE
perf(cli): use internal search cache warm endpoint

### DIFF
--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -34,6 +34,31 @@ const SEARCH_MODES: SearchMode[] = ["fts", "vector", "hybrid"]; // Display order
 type SearchRange = "all" | "agent" | "conv";
 const SEARCH_RANGES: SearchRange[] = ["all", "agent", "conv"];
 
+type SearchCacheWarmRequest = {
+  collection: "messages";
+  scope: Record<string, never>;
+};
+
+type SearchCacheWarmResponse = {
+  collection: "messages";
+  status: string;
+  warmed: boolean;
+};
+
+export async function warmMessageSearchCache(client: Letta) {
+  const body: SearchCacheWarmRequest = {
+    collection: "messages",
+    scope: {},
+  };
+
+  return client.post<SearchCacheWarmResponse>(
+    "/v1/_internal_search/cache-warm",
+    {
+      body,
+    },
+  );
+}
+
 /**
  * Format a timestamp in local timezone
  */
@@ -175,10 +200,7 @@ export function MessageSearch({
     const warmCache = async () => {
       try {
         const client = await getClient();
-        await client.post("/v1/messages/search", {
-          body: {},
-          query: { warm_only: true },
-        });
+        await warmMessageSearchCache(client);
       } catch {
         // Silently ignore - cache warm is best-effort
       }

--- a/src/tests/cli/message-search-cache-warm.test.ts
+++ b/src/tests/cli/message-search-cache-warm.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Letta } from "@letta-ai/letta-client";
+import { warmMessageSearchCache } from "../../cli/components/MessageSearch";
+
+describe("warmMessageSearchCache", () => {
+  test("posts the new internal search cache-warm request shape", async () => {
+    const post = mock((_path: string, _opts: { body: unknown }) =>
+      Promise.resolve({
+        collection: "messages",
+        status: "ACCEPTED",
+        warmed: true,
+      }),
+    );
+    const client = { post } as unknown as Letta;
+
+    const response = await warmMessageSearchCache(client);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const [path, opts] = post.mock.calls[0] ?? [];
+    expect(path).toBe("/v1/_internal_search/cache-warm");
+    expect(opts).toEqual({
+      body: {
+        collection: "messages",
+        scope: {},
+      },
+    });
+    expect(opts && "query" in opts).toBe(false);
+    expect(response).toEqual({
+      collection: "messages",
+      status: "ACCEPTED",
+      warmed: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- switch message search cache warming in `letta-code` from `POST /v1/messages/search?warm_only=true` to `POST /v1/_internal_search/cache-warm`
- send the new request body shape (`{ collection: \"messages\", scope: {} }`) via the existing raw client `post()` path so this does not need to wait on a published SDK update
- add a focused Bun test that locks the new path/body contract in place

## Context
- paired backend change: https://github.com/letta-ai/letta-cloud/pull/10148

## Test plan
- [x] `bun test src/tests/cli/message-search-cache-warm.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/MessageSearch.tsx src/tests/cli/message-search-cache-warm.test.ts`
- [x] `bun run typecheck`