### PR TITLE
feat(telemetry): add surface tagging for runtime mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -365,9 +365,6 @@ async function main(): Promise<void> {
     }
   }
 
-  // Initialize telemetry (enabled by default, opt-out via LETTA_CODE_TELEM=0)
-  telemetry.init();
-
   // Check for updates on startup (non-blocking)
   const { checkAndAutoUpdate } = await import("./updater/auto-update");
   const autoUpdatePromise = startStartupAutoUpdateCheck(checkAndAutoUpdate);
@@ -530,6 +527,11 @@ async function main(): Promise<void> {
     fromAfFlagValue: values["from-af"],
   });
   const isHeadless = values.prompt || values.run || !process.stdin.isTTY;
+
+  // Initialize telemetry (enabled by default, opt-out via LETTA_CODE_TELEM=0)
+  // Surface is set here so session_start captures the correct mode.
+  telemetry.setSurface(isHeadless ? "headless" : "tui");
+  telemetry.init();
 
   // Fail if an unknown command/argument is passed (and we're not in headless mode where it might be a prompt)
   if (command && !isHeadless) {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -4,6 +4,8 @@ import { settingsManager } from "../settings-manager";
 import { debugLogFile } from "../utils/debug";
 import { getVersion } from "../version";
 
+export type TelemetrySurface = "tui" | "headless" | "websocket";
+
 export interface TelemetryEvent {
   type: "session_start" | "session_end" | "tool_usage" | "error" | "user_input";
   timestamp: string;
@@ -68,6 +70,7 @@ class TelemetryManager {
   private sessionId: string;
   private deviceId: string | null = null;
   private currentAgentId: string | null = null;
+  private surface: TelemetrySurface = "tui";
   private sessionStartTime: number;
   private messageCount = 0;
   private toolCallCount = 0;
@@ -191,6 +194,7 @@ class TelemetryManager {
         ...data,
         session_id: this.sessionId,
         agent_id: this.currentAgentId || undefined,
+        surface: this.surface,
       },
     };
 
@@ -212,6 +216,10 @@ class TelemetryManager {
    */
   setCurrentAgentId(agentId: string | null) {
     this.currentAgentId = agentId;
+  }
+
+  setSurface(surface: TelemetrySurface) {
+    this.surface = surface;
   }
 
   /**

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -28,6 +28,7 @@ import {
   resetSharedReminderState,
 } from "../../reminders/state";
 import { settingsManager } from "../../settings-manager";
+import { telemetry } from "../../telemetry";
 import { loadTools } from "../../tools/manager";
 import type {
   AbortMessageCommand,
@@ -865,6 +866,7 @@ export async function startListenerClient(
   runtime.connectionId = opts.connectionId;
   runtime.connectionName = opts.connectionName;
   setActiveRuntime(runtime);
+  telemetry.setSurface("websocket");
 
   await connectWithRetry(runtime, opts);
 }
@@ -1675,6 +1677,7 @@ export function stopListenerClient(): void {
     return;
   }
   setActiveRuntime(null);
+  telemetry.setSurface(process.stdin.isTTY ? "tui" : "headless");
   stopRuntime(runtime, true);
 }
 


### PR DESCRIPTION
## Summary
- add a `TelemetrySurface` type and telemetry manager setter so runtime mode can be tracked as `tui`, `headless`, or `websocket`
- include `surface` on all telemetry events from the centralized telemetry `track()` payload path
- initialize surface before `session_start` is emitted and switch to/from `websocket` when listener mode starts/stops

## Test plan
- [x] `bun run check` *(fails on existing unrelated typecheck issue: `src/cli/App.tsx(8395,55) Property 'fork' does not exist on type 'Conversations'`)*
- [x] Verify diff only touches telemetry surface wiring in `src/telemetry/index.ts`, `src/index.ts`, and `src/websocket/listener/client.ts`

👾 Generated with [Letta Code](https://letta.com)