### PR TITLE
feat(listen): sync memfs repo on first message for remote agents

### DIFF
--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -801,6 +801,7 @@ function createRuntime(): ListenerRuntime {
     connectionName: null,
     conversationRuntimes: new Map(),
     approvalRuntimeKeyByRequestId: new Map(),
+    memfsSyncedAgents: new Map(),
     lastEmittedStatus: null,
   };
 }
@@ -1691,6 +1692,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   hasSuccessfulConnection: boolean;
   conversationRuntimes: ListenerRuntime["conversationRuntimes"];
   approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
+  memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
   lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
 } {
   const listener = createRuntime();
@@ -1719,6 +1721,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     hasSuccessfulConnection: boolean;
     conversationRuntimes: ListenerRuntime["conversationRuntimes"];
     approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
+    memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
     lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
   };
   for (const [prop, getSet] of Object.entries({
@@ -1835,6 +1838,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.approvalRuntimeKeyByRequestId,
       set: (value: ListenerRuntime["approvalRuntimeKeyByRequestId"]) => {
         listener.approvalRuntimeKeyByRequestId = value;
+      },
+    },
+    memfsSyncedAgents: {
+      get: () => listener.memfsSyncedAgents,
+      set: (value: ListenerRuntime["memfsSyncedAgents"]) => {
+        listener.memfsSyncedAgents = value;
       },
     },
     lastEmittedStatus: {

--- a/src/websocket/listener/memfs-sync.ts
+++ b/src/websocket/listener/memfs-sync.ts
@@ -1,0 +1,76 @@
+/**
+ * Lazy memfs sync for listen mode.
+ *
+ * When the listener receives the first message for an agent, this module
+ * checks whether the agent has the `git-memory-enabled` tag and, if so,
+ * clones or pulls the memory repo so the Memory tool and $MEMORY_DIR work
+ * correctly — mirroring what the local headless path does during bootstrap.
+ */
+
+import { debugLog, debugWarn } from "../../utils/debug";
+import type { ListenerRuntime } from "./types";
+
+/**
+ * Core sync logic — fetches agent, checks tag, clones/pulls repo.
+ */
+async function syncMemfsForAgent(agentId: string): Promise<void> {
+  const { getClient } = await import("../../agent/client");
+  const client = await getClient();
+  const agent = await client.agents.retrieve(agentId);
+
+  const { GIT_MEMORY_ENABLED_TAG } = await import("../../agent/memoryGit");
+  if (!agent.tags?.includes(GIT_MEMORY_ENABLED_TAG)) {
+    debugLog(
+      "memfs-sync",
+      `Agent ${agentId} does not have memfs tag, skipping`,
+    );
+    return;
+  }
+
+  debugLog("memfs-sync", `Syncing memfs for agent ${agentId}`);
+
+  const { applyMemfsFlags } = await import("../../agent/memoryFilesystem");
+  await applyMemfsFlags(agentId, undefined, undefined, {
+    pullOnExistingRepo: true,
+    agentTags: agent.tags,
+    skipPromptUpdate: true,
+  });
+
+  debugLog("memfs-sync", `Memfs sync complete for agent ${agentId}`);
+}
+
+/**
+ * Ensure the memfs git repo is cloned/pulled for the given agent.
+ *
+ * No-ops if:
+ * - The agent was already synced this session
+ * - The agent doesn't have the `git-memory-enabled` tag
+ *
+ * Concurrent callers for the same agent coalesce onto a single in-flight
+ * promise so turn ordering stays deterministic.
+ *
+ * Non-fatal: logs a warning on failure but doesn't throw.
+ */
+export async function ensureMemfsSyncedForAgent(
+  listener: ListenerRuntime,
+  agentId: string,
+): Promise<void> {
+  const existing = listener.memfsSyncedAgents.get(agentId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const promise = syncMemfsForAgent(agentId).catch((err) => {
+    // Non-fatal — agent can still process messages, just without local memory.
+    debugWarn(
+      "memfs-sync",
+      `Failed to sync memfs for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // Remove so next turn retries.
+    listener.memfsSyncedAgents.delete(agentId);
+  });
+
+  listener.memfsSyncedAgents.set(agentId, promise);
+  await promise;
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -190,6 +190,10 @@ export async function handleIncomingMessage(
       return;
     }
 
+    // Ensure memfs repo is cloned/pulled for this agent (lazy, once per session).
+    const { ensureMemfsSyncedForAgent } = await import("./memfs-sync");
+    await ensureMemfsSyncedForAgent(runtime.listener, agentId);
+
     // Set agent context for tools that need it (e.g., Skill tool)
     setCurrentAgentId(agentId);
     setConversationId(conversationId);

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -160,6 +160,8 @@ export type ListenerRuntime = {
   connectionName: string | null;
   conversationRuntimes: Map<string, ConversationRuntime>;
   approvalRuntimeKeyByRequestId: Map<string, string>;
+  /** Agent IDs whose memfs repo has been cloned/pulled this session. Concurrent callers coalesce on the same promise. */
+  memfsSyncedAgents: Map<string, Promise<void>>;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;
   /** Unsubscribe from subagent state store (set on socket open, cleared on close). */
   _unsubscribeSubagentState?: (() => void) | undefined;


### PR DESCRIPTION
When the listener receives the first message for an agent with the git-memory-enabled tag, clone or pull the memfs git repo so $MEMORY_DIR and the Memory tool work correctly — matching the local headless bootstrap.

🐾 Generated with [Letta Code](https://letta.com)