### PR TITLE
fix(telemetry): close runtime error-reporting gaps

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -4,6 +4,7 @@
  */
 
 import Letta from "@letta-ai/letta-client";
+import { trackBoundaryError } from "../telemetry/errorReporting";
 
 export const LETTA_CLOUD_API_URL = "https://api.letta.com";
 
@@ -123,6 +124,11 @@ export async function pollForToken(
 
       throw new Error(`OAuth error: ${error.error_description || error.error}`);
     } catch (error) {
+      trackBoundaryError({
+        errorType: "oauth_token_poll_failed",
+        error,
+        context: "auth_oauth_token_poll",
+      });
       if (error instanceof Error) {
         throw error;
       }
@@ -185,12 +191,22 @@ export async function revokeToken(refreshToken: string): Promise<void> {
     // OAuth 2.0 revoke endpoint should return 200 even if token is already invalid
     if (!response.ok) {
       const error = (await response.json()) as OAuthError;
+      trackBoundaryError({
+        errorType: "oauth_revoke_failed",
+        error: error.error_description || error.error,
+        context: "auth_oauth_revoke",
+      });
       console.error(
         `Warning: Failed to revoke token: ${error.error_description || error.error}`,
       );
       // Don't throw - we still want to clear local credentials
     }
   } catch (error) {
+    trackBoundaryError({
+      errorType: "oauth_revoke_exception",
+      error,
+      context: "auth_oauth_revoke",
+    });
     console.error("Warning: Failed to revoke token:", error);
     // Don't throw - we still want to clear local credentials
   }

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -383,6 +383,15 @@ export async function drainStream(
     // is still in-progress and has no error metadata yet.
     fallbackError = errorMessageWithDiagnostic;
 
+    telemetry.trackError(
+      "stream_drain_error",
+      errorMessageWithDiagnostic,
+      "stream_drain",
+      {
+        runId: streamProcessor.lastRunId || undefined,
+      },
+    );
+
     // Preserve a stop reason already parsed from stream chunks (e.g. llm_api_error)
     // and only fall back to generic "error" when none is available.
     stopReason = streamProcessor.stopReason || "error";

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -92,6 +92,8 @@ import {
   syncReminderStateFromContextTracker,
 } from "./reminders/state";
 import { settingsManager } from "./settings-manager";
+import { telemetry } from "./telemetry";
+import { trackBoundaryError } from "./telemetry/errorReporting";
 import {
   isHeadlessAutoAllowTool,
   isInteractiveApprovalTool,
@@ -139,6 +141,30 @@ const EMPTY_RESPONSE_MAX_RETRIES = 2;
 
 // Retry config for 409 "conversation busy" errors (exponential backoff)
 const CONVERSATION_BUSY_MAX_RETRIES = 3; // 10s -> 20s -> 40s
+
+function trackHeadlessBoundaryError(
+  errorType: string,
+  error: unknown,
+  context: string,
+): void {
+  trackBoundaryError({
+    errorType,
+    error,
+    context,
+  });
+}
+
+function reportAndExitHeadless(
+  errorType: string,
+  error: unknown,
+  context: string,
+): never {
+  trackHeadlessBoundaryError(errorType, error, context);
+  console.error(
+    error instanceof Error ? `Error: ${error.message}` : String(error),
+  );
+  process.exit(1);
+}
 
 export type BidirectionalQueuedInput = QueuedTurnInput<
   MessageCreate["content"]
@@ -273,6 +299,7 @@ export async function handleHeadlessCommand(
   systemInfoReminderEnabledOverride?: boolean,
 ) {
   const { values, positionals } = parsedArgs;
+  telemetry.setSurface("headless");
 
   // Set tool filter if provided (controls which tools are loaded)
   if (values.tools !== undefined) {
@@ -355,6 +382,11 @@ export async function handleHeadlessCommand(
   }
 
   if (!prompt && !isBidirectionalMode) {
+    trackHeadlessBoundaryError(
+      "headless_missing_prompt",
+      "No prompt provided",
+      "headless_startup_input_validation",
+    );
     console.error("Error: No prompt provided");
     process.exit(1);
   }
@@ -364,6 +396,11 @@ export async function handleHeadlessCommand(
 
   // Check for --resume flag (interactive only)
   if (values.resume) {
+    trackHeadlessBoundaryError(
+      "headless_invalid_resume_flag",
+      "--resume is for interactive mode only in headless mode",
+      "headless_startup_flag_validation",
+    );
     console.error(
       "Error: --resume is for interactive mode only (opens conversation selector).\n" +
         "In headless mode, use:\n" +
@@ -421,10 +458,11 @@ export async function handleHeadlessCommand(
     try {
       return parseReflectionOverrides(values);
     } catch (error) {
-      console.error(
-        error instanceof Error ? `Error: ${error.message}` : String(error),
+      return reportAndExitHeadless(
+        "headless_reflection_overrides_failed",
+        error,
+        "headless_startup_reflection_overrides",
       );
-      process.exit(1);
     }
   })();
   const maxTurnsRaw = values["max-turns"];
@@ -440,10 +478,11 @@ export async function handleHeadlessCommand(
         noBundledSkills: noBundledSkillsFlag,
       });
     } catch (error) {
-      console.error(
-        error instanceof Error ? `Error: ${error.message}` : String(error),
+      return reportAndExitHeadless(
+        "headless_skill_sources_failed",
+        error,
+        "headless_startup_skill_sources",
       );
-      process.exit(1);
     }
   })();
 
@@ -457,6 +496,11 @@ export async function handleHeadlessCommand(
       flagName: "max-turns",
     });
   } catch (error) {
+    trackHeadlessBoundaryError(
+      "headless_max_turns_parse_failed",
+      error,
+      "headless_startup_max_turns",
+    );
     console.error(
       `Error: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -478,10 +522,11 @@ export async function handleHeadlessCommand(
     specifiedConversationId = normalized.specifiedConversationId ?? undefined;
     specifiedAgentId = normalized.specifiedAgentId ?? undefined;
   } catch (error) {
-    console.error(
-      error instanceof Error ? `Error: ${error.message}` : String(error),
+    return reportAndExitHeadless(
+      "headless_conversation_shorthand_failed",
+      error,
+      "headless_startup_conversation_shorthand",
     );
-    process.exit(1);
   }
 
   // Validate --conv default requires --agent (unless --new-agent will create one)
@@ -492,6 +537,11 @@ export async function handleHeadlessCommand(
       forceNew,
     });
   } catch (error) {
+    trackHeadlessBoundaryError(
+      "headless_conversation_flag_validation_failed",
+      error,
+      "headless_startup_conversation_flag_validation",
+    );
     console.error(
       error instanceof Error ? `Error: ${error.message}` : String(error),
     );
@@ -550,10 +600,11 @@ export async function handleHeadlessCommand(
       ],
     });
   } catch (error) {
-    console.error(
-      error instanceof Error ? `Error: ${error.message}` : String(error),
+    return reportAndExitHeadless(
+      "headless_flag_conflict_validation_failed",
+      error,
+      "headless_startup_flag_conflicts",
     );
-    process.exit(1);
   }
 
   // Validate --import flag (also accepts legacy --from-af)
@@ -579,10 +630,11 @@ export async function handleHeadlessCommand(
         ],
       });
     } catch (error) {
-      console.error(
-        error instanceof Error ? `Error: ${error.message}` : String(error),
+      return reportAndExitHeadless(
+        "headless_import_flag_validation_failed",
+        error,
+        "headless_startup_import_flag_validation",
       );
-      process.exit(1);
     }
 
     // Check if this looks like a registry handle (@author/name)
@@ -677,6 +729,11 @@ export async function handleHeadlessCommand(
         }
       }
     } catch (error) {
+      trackHeadlessBoundaryError(
+        "headless_memory_blocks_parse_failed",
+        error,
+        "headless_startup_memory_blocks",
+      );
       console.error(
         `Error: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -721,7 +778,12 @@ export async function handleHeadlessCommand(
         specifiedConversationId,
       );
       agent = await client.agents.retrieve(conversation.agent_id);
-    } catch (_error) {
+    } catch (error) {
+      trackHeadlessBoundaryError(
+        "headless_conversation_lookup_failed",
+        error,
+        "headless_startup_conversation_lookup",
+      );
       console.error(`Conversation ${specifiedConversationId} not found`);
       process.exit(1);
     }
@@ -920,6 +982,11 @@ export async function handleHeadlessCommand(
         skipPromptUpdate: forceNew,
       });
     } catch (error) {
+      trackHeadlessBoundaryError(
+        "headless_memfs_flags_failed",
+        error,
+        "headless_startup_memfs_flags",
+      );
       console.error(
         `Memory flags failed: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -933,6 +1000,11 @@ export async function handleHeadlessCommand(
       agentTags: agent.tags,
       skipPromptUpdate: forceNew,
     }).catch((error) => {
+      trackHeadlessBoundaryError(
+        "headless_memfs_background_pull_failed",
+        error,
+        "headless_runtime_memfs_background_pull",
+      );
       // Log to stderr only — the session is already live.
       console.error(
         `[memfs background pull] ${error instanceof Error ? error.message : String(error)}`,
@@ -953,12 +1025,22 @@ export async function handleHeadlessCommand(
         },
       );
       if (memfsResult.pullSummary?.includes("CONFLICT")) {
+        trackHeadlessBoundaryError(
+          "headless_memfs_conflict",
+          "Memory has merge conflicts. Run in interactive mode to resolve.",
+          "headless_startup_memfs_sync",
+        );
         console.error(
           "Memory has merge conflicts. Run in interactive mode to resolve.",
         );
         process.exit(1);
       }
     } catch (error) {
+      trackHeadlessBoundaryError(
+        "headless_memfs_sync_failed",
+        error,
+        "headless_startup_memfs_sync",
+      );
       console.error(
         `Memory git sync failed: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -975,6 +1057,11 @@ export async function handleHeadlessCommand(
   if (isResumingAgent && systemPromptPreset) {
     const result = await updateAgentSystemPrompt(agent.id, systemPromptPreset);
     if (!result.success || !result.agent) {
+      trackHeadlessBoundaryError(
+        "headless_system_prompt_update_failed",
+        result.message,
+        "headless_startup_system_prompt",
+      );
       console.error(`Failed to update system prompt: ${result.message}`);
       process.exit(1);
     }
@@ -2228,6 +2315,11 @@ ${SYSTEM_REMINDER_CLOSE}
         }
       }
 
+      trackHeadlessBoundaryError(
+        "headless_turn_failed",
+        errorMessage,
+        "headless_turn_execution",
+      );
       if (outputFormat === "stream-json") {
         // Emit error event
         const errorMsg: ErrorMessage = {
@@ -2250,6 +2342,11 @@ ${SYSTEM_REMINDER_CLOSE}
 
     // Use comprehensive error formatting (same as TUI mode)
     const errorDetails = formatErrorDetails(error, agent.id);
+    trackHeadlessBoundaryError(
+      "headless_runtime_exception",
+      error,
+      "headless_turn_execution",
+    );
 
     if (outputFormat === "stream-json") {
       const errorMsg: ErrorMessage = {
@@ -3751,6 +3848,11 @@ async function runBidirectionalMode(
       } catch (error) {
         // Use formatErrorDetails for comprehensive error formatting (same as one-shot mode)
         const errorDetails = formatErrorDetails(error, agent.id);
+        trackHeadlessBoundaryError(
+          "headless_bidirectional_runtime_exception",
+          error,
+          "headless_bidirectional_turn",
+        );
         const errorMsg: ErrorMessage = {
           type: "error",
           message: errorDetails,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { permissionMode } from "./permissions/mode";
 import { settingsManager } from "./settings-manager";
 import { startStartupAutoUpdateCheck } from "./startup-auto-update";
 import { telemetry } from "./telemetry";
+import { trackBoundaryError } from "./telemetry/errorReporting";
 import { loadTools } from "./tools/manager";
 import { clearPersistedClientToolRules } from "./tools/toolset";
 import { debugLog, debugWarn, isDebugEnabled } from "./utils/debug";
@@ -57,6 +58,19 @@ import { markMilestone } from "./utils/timing";
 // anti-pattern of creating new [] on every render which triggers useEffect re-runs
 const EMPTY_APPROVAL_ARRAY: ApprovalRequest[] = [];
 const EMPTY_MESSAGE_ARRAY: Message[] = [];
+
+function trackCliBoundaryError(
+  errorType: string,
+  error: unknown,
+  context: string,
+): void {
+  trackBoundaryError({
+    errorType,
+    error,
+    context,
+  });
+}
+
 void ensureFileIndex();
 
 function printHelp() {
@@ -361,6 +375,7 @@ async function main(): Promise<void> {
       const { lspManager } = await import("./lsp/manager.js");
       await lspManager.initialize(process.cwd());
     } catch (error) {
+      trackCliBoundaryError("lsp_init_failed", error, "tui_startup_lsp_init");
       console.error("[LSP] Failed to initialize:", error);
     }
   }
@@ -394,6 +409,11 @@ async function main(): Promise<void> {
     values = parsed.values;
     positionals = parsed.positionals;
   } catch (error) {
+    trackCliBoundaryError(
+      "cli_args_parse_failed",
+      error,
+      "tui_startup_parse_args",
+    );
     const errorMsg = error instanceof Error ? error.message : String(error);
     // Improve error message for common mistakes
     if (errorMsg.includes("Unknown option")) {
@@ -467,6 +487,11 @@ async function main(): Promise<void> {
     specifiedConversationId = normalized.specifiedConversationId ?? null;
     specifiedAgentId = normalized.specifiedAgentId ?? null;
   } catch (error) {
+    trackCliBoundaryError(
+      "conversation_shorthand_normalization_failed",
+      error,
+      "tui_startup_conversation_shorthand",
+    );
     console.error(
       error instanceof Error ? `Error: ${error.message}` : String(error),
     );
@@ -481,6 +506,11 @@ async function main(): Promise<void> {
       forceNew,
     });
   } catch (error) {
+    trackCliBoundaryError(
+      "conversation_flag_validation_failed",
+      error,
+      "tui_startup_conversation_flag_validation",
+    );
     console.error(
       error instanceof Error ? `Error: ${error.message}` : String(error),
     );
@@ -593,6 +623,11 @@ async function main(): Promise<void> {
         allowSubagentNames,
       });
     } catch (err) {
+      trackCliBoundaryError(
+        "system_prompt_preset_validation_failed",
+        err,
+        "tui_startup_system_prompt_preset",
+      );
       console.error(
         `Error: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -766,6 +801,7 @@ async function main(): Promise<void> {
     // After setup, restart main flow
     return main().catch((err: unknown) => {
       // Handle top-level errors gracefully without raw stack traces
+      trackCliBoundaryError("setup_restart_failed", err, "tui_setup_restart");
       const message =
         err instanceof Error ? err.message : "An unexpected error occurred";
       console.error(`\nError: ${message}`);
@@ -1935,6 +1971,11 @@ async function main(): Promise<void> {
 
       init().catch((err) => {
         // Handle errors gracefully without showing raw stack traces
+        trackCliBoundaryError(
+          "tui_initialization_failed",
+          err,
+          "tui_app_initialization",
+        );
         const message = formatErrorDetails(err);
         console.error(`\nError during initialization: ${message}`);
         if (isDebugEnabled()) {

--- a/src/startup-auto-update.ts
+++ b/src/startup-auto-update.ts
@@ -1,3 +1,5 @@
+import { trackBoundaryError } from "./telemetry/errorReporting";
+
 export interface UpdateNotification {
   latestVersion: string;
 }
@@ -31,5 +33,12 @@ export function startStartupAutoUpdateCheck(
       }
       return undefined;
     })
-    .catch(() => undefined);
+    .catch((error) => {
+      trackBoundaryError({
+        errorType: "startup_auto_update_failed",
+        error,
+        context: "startup_auto_update",
+      });
+      return undefined;
+    });
 }

--- a/src/telemetry/errorReporting.ts
+++ b/src/telemetry/errorReporting.ts
@@ -1,0 +1,39 @@
+import { telemetry } from "./index";
+
+export type BoundaryErrorOptions = {
+  context: string;
+  errorType: string;
+  error: unknown;
+  httpStatus?: number;
+  modelId?: string;
+  runId?: string;
+  recentChunks?: Record<string, unknown>[];
+};
+
+export function formatTelemetryErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function trackBoundaryError(options: BoundaryErrorOptions): void {
+  telemetry.trackError(
+    options.errorType,
+    formatTelemetryErrorMessage(options.error),
+    options.context,
+    {
+      httpStatus: options.httpStatus,
+      modelId: options.modelId,
+      runId: options.runId,
+      recentChunks: options.recentChunks,
+    },
+  );
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -75,6 +75,7 @@ class TelemetryManager {
   private messageCount = 0;
   private toolCallCount = 0;
   private sessionEndTracked = false;
+  private initialized = false;
   private flushInterval: NodeJS.Timeout | null = null;
   private serverVersion: string | null = null;
   private readonly FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -121,9 +122,10 @@ class TelemetryManager {
    * Initialize telemetry and start periodic flushing
    */
   init() {
-    if (!this.isTelemetryEnabled()) {
+    if (!this.isTelemetryEnabled() || this.initialized) {
       return;
     }
+    this.initialized = true;
 
     // Initialize device ID (persistent across sessions)
     this.deviceId = settingsManager.getOrCreateDeviceId();
@@ -160,6 +162,36 @@ class TelemetryManager {
       }
       // Exit immediately - don't wait for flush
       process.exit(0);
+    });
+
+    process.on("uncaughtException", (error) => {
+      try {
+        this.trackError(
+          "uncaught_exception",
+          error instanceof Error ? error.message : String(error),
+          "process_uncaught_exception",
+        );
+        this.flush().catch(() => {
+          // Silently ignore
+        });
+      } catch {
+        // Silently ignore - don't prevent process from exiting
+      }
+    });
+
+    process.on("unhandledRejection", (reason) => {
+      try {
+        this.trackError(
+          "unhandled_rejection",
+          reason instanceof Error ? reason.message : String(reason),
+          "process_unhandled_rejection",
+        );
+        this.flush().catch(() => {
+          // Silently ignore
+        });
+      } catch {
+        // Silently ignore - don't prevent process from exiting
+      }
     });
 
     // TODO: Add telemetry for crashes and abnormal exits
@@ -507,6 +539,7 @@ class TelemetryManager {
       clearInterval(this.flushInterval);
       this.flushInterval = null;
     }
+    this.initialized = false;
   }
 }
 

--- a/src/tests/telemetry/error-reporting.test.ts
+++ b/src/tests/telemetry/error-reporting.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from "bun:test";
+import { telemetry } from "../../telemetry";
+import {
+  formatTelemetryErrorMessage,
+  trackBoundaryError,
+} from "../../telemetry/errorReporting";
+
+describe("telemetry error reporting helper", () => {
+  test("formats error values safely", () => {
+    expect(formatTelemetryErrorMessage(new Error("boom"))).toBe("boom");
+    expect(formatTelemetryErrorMessage("oops")).toBe("oops");
+    expect(formatTelemetryErrorMessage({ foo: "bar" })).toBe(
+      JSON.stringify({ foo: "bar" }),
+    );
+
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    expect(formatTelemetryErrorMessage(circular)).toContain("[object Object]");
+  });
+
+  test("forwards boundary fields into telemetry.trackError", () => {
+    const originalTrackError = telemetry.trackError;
+    const trackErrorMock = mock(() => {});
+
+    telemetry.trackError = trackErrorMock as typeof telemetry.trackError;
+
+    try {
+      trackBoundaryError({
+        errorType: "listener_queue_pump_failed",
+        error: new Error("queue exploded"),
+        context: "listener_queue_pump",
+        runId: "run-123",
+        httpStatus: 503,
+      });
+
+      expect(trackErrorMock).toHaveBeenCalledWith(
+        "listener_queue_pump_failed",
+        "queue exploded",
+        "listener_queue_pump",
+        {
+          httpStatus: 503,
+          modelId: undefined,
+          runId: "run-123",
+          recentChunks: undefined,
+        },
+      );
+    } finally {
+      telemetry.trackError = originalTrackError;
+    }
+  });
+});

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { trackBoundaryError } from "../telemetry/errorReporting";
 import { getVersion } from "../version";
 
 const execFileAsync = promisify(execFile);
@@ -220,6 +221,11 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
     }
     debugLog("Already on latest version");
   } catch (error) {
+    trackBoundaryError({
+      errorType: "auto_update_check_failed",
+      error,
+      context: "updater_check",
+    });
     debugLog("Failed to check for updates:", error);
     return {
       updateAvailable: false,
@@ -296,6 +302,11 @@ async function performUpdate(): Promise<{
     debugLog("Update completed successfully");
     return { success: true };
   } catch (error) {
+    trackBoundaryError({
+      errorType: "auto_update_install_failed",
+      error,
+      context: "updater_install",
+    });
     const errorMsg = error instanceof Error ? error.message : String(error);
 
     // ENOTEMPTY retry is npm-specific
@@ -308,6 +319,11 @@ async function performUpdate(): Promise<{
         debugLog("Update succeeded after cleanup retry");
         return { success: true };
       } catch (retryError) {
+        trackBoundaryError({
+          errorType: "auto_update_install_retry_failed",
+          error: retryError,
+          context: "updater_install_retry",
+        });
         const retryMsg =
           retryError instanceof Error ? retryError.message : String(retryError);
         debugLog("Update failed after retry:", retryMsg);
@@ -342,6 +358,11 @@ async function performUpdate(): Promise<{
         debugLog("Update succeeded after race condition retry");
         return { success: true };
       } catch (retryError) {
+        trackBoundaryError({
+          errorType: "auto_update_race_retry_failed",
+          error: retryError,
+          context: "updater_install_race_retry",
+        });
         const retryMsg =
           retryError instanceof Error ? retryError.message : String(retryError);
         debugLog("Update failed after race condition retry:", retryMsg);

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -29,6 +29,7 @@ import {
 } from "../../reminders/state";
 import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
+import { trackBoundaryError } from "../../telemetry/errorReporting";
 import { loadTools } from "../../tools/manager";
 import type {
   AbortMessageCommand,
@@ -153,6 +154,18 @@ import type {
   StartListenerOptions,
 } from "./types";
 
+function trackListenerError(
+  errorType: string,
+  error: unknown,
+  context: string,
+): void {
+  trackBoundaryError({
+    errorType,
+    error,
+    context,
+  });
+}
+
 /**
  * Handle mode change request from cloud.
  * Stores the new mode in ListenerRuntime.permissionModeByConversation so
@@ -202,6 +215,11 @@ function handleModeChange(
       console.log(`[Listen] Mode changed to: ${msg.mode}`);
     }
   } catch (error) {
+    trackListenerError(
+      "listener_mode_change_failed",
+      error,
+      "listener_mode_change",
+    );
     emitLoopErrorDelta(socket, runtime, {
       message: error instanceof Error ? error.message : "Mode change failed",
       stopReason: "error",
@@ -1215,6 +1233,11 @@ async function connectWithRetry(
           scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
         })
         .catch((error: unknown) => {
+          trackListenerError(
+            "listener_queued_input_failed",
+            error,
+            "listener_message_queue",
+          );
           if (process.env.DEBUG) {
             console.error("[Listen] Error handling queued input:", error);
           }
@@ -1336,6 +1359,11 @@ async function connectWithRetry(
           }
           socket.send(JSON.stringify(response));
         } catch (err) {
+          trackListenerError(
+            "listener_list_directory_failed",
+            err,
+            "listener_file_browser",
+          );
           socket.send(
             JSON.stringify({
               type: "list_in_directory_response",
@@ -1374,6 +1402,11 @@ async function connectWithRetry(
             }),
           );
         } catch (err) {
+          trackListenerError(
+            "listener_read_file_failed",
+            err,
+            "listener_file_read",
+          );
           console.error(
             `[Listen] read_file error: ${err instanceof Error ? err.message : "Unknown error"}`,
           );
@@ -1425,6 +1458,11 @@ async function connectWithRetry(
             }),
           );
         } catch (err) {
+          trackListenerError(
+            "listener_edit_file_failed",
+            err,
+            "listener_file_edit",
+          );
           console.error(
             `[Listen] edit_file error: ${err instanceof Error ? err.message : "Unknown error"}`,
           );
@@ -1534,6 +1572,11 @@ async function connectWithRetry(
             );
           }
         } catch (err) {
+          trackListenerError(
+            "listener_list_memory_failed",
+            err,
+            "listener_memory_browser",
+          );
           socket.send(
             JSON.stringify({
               type: "list_memory_response",
@@ -1576,6 +1619,11 @@ async function connectWithRetry(
             }),
           );
         } catch (err) {
+          trackListenerError(
+            "listener_enable_memfs_failed",
+            err,
+            "listener_memfs_enable",
+          );
           socket.send(
             JSON.stringify({
               type: "enable_memfs_response",
@@ -1711,6 +1759,7 @@ async function connectWithRetry(
   });
 
   socket.on("error", (error: Error) => {
+    trackListenerError("listener_websocket_error", error, "listener_socket");
     safeEmitWsEvent("recv", "lifecycle", {
       type: "_ws_error",
       message: error.message,

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,5 +1,6 @@
 import type WebSocket from "ws";
 import { getClient } from "../../agent/client";
+import { trackBoundaryError } from "../../telemetry/errorReporting";
 import type {
   ExecuteCommandCommand,
   SlashCommandEndMessage,
@@ -76,6 +77,11 @@ export async function handleExecuteCommand(
       success: true,
     });
   } catch (error) {
+    trackBoundaryError({
+      errorType: "listener_execute_command_failed",
+      error,
+      context: "listener_command_execution",
+    });
     const errorMessage = error instanceof Error ? error.message : String(error);
     emitSlashCommandEnd(socket, conversationRuntime, scope, {
       command_id: command.command_id,
@@ -118,7 +124,7 @@ function emitSlashCommandEnd(
  * Returns a human-readable success message.
  */
 async function handleClearCommand(
-  socket: WebSocket,
+  _socket: WebSocket,
   conversationRuntime: ConversationRuntime,
   opts: {
     onStatusChange?: StartListenerOptions["onStatusChange"];

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../queue/queueRuntime";
 import { isCoalescable } from "../../queue/queueRuntime";
 import { mergeQueuedTurnInput } from "../../queue/turnQueueRuntime";
+import { trackBoundaryError } from "../../telemetry/errorReporting";
 import { getListenerBlockedReason } from "../helpers/listenerQueueAdapter";
 import { emitDequeuedUserMessage } from "./protocol-outbound";
 import {
@@ -430,6 +431,11 @@ export function scheduleQueuePump(
     })
     .catch((error: unknown) => {
       runtime.queuePumpScheduled = false;
+      trackBoundaryError({
+        errorType: "listener_queue_pump_failed",
+        error,
+        context: "listener_queue_pump",
+      });
       console.error("[Listen] Error in queue pump:", error);
       emitListenerStatus(
         runtime.listener,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -28,6 +28,7 @@ import {
 } from "../../reminders/engine";
 import { buildListenReminderContext } from "../../reminders/listenContext";
 import { getPlanModeReminder } from "../../reminders/planModeReminder";
+import { trackBoundaryError } from "../../telemetry/errorReporting";
 import type { StopReasonType, StreamDelta } from "../../types/protocol_v2";
 import { isDebugEnabled } from "../../utils/debug";
 import {
@@ -258,6 +259,11 @@ export async function handleIncomingMessage(
       } catch (err) {
         // Reminder injection is best-effort — failures must not prevent
         // the user message from being sent to the agent.
+        trackBoundaryError({
+          errorType: "listener_reminder_build_failed",
+          error: err,
+          context: "listener_turn_reminders",
+        });
         if (isDebugEnabled()) {
           console.error("[Listen] Failed to build reminder parts:", err);
         }
@@ -740,6 +746,12 @@ export async function handleIncomingMessage(
       );
     }
   } catch (error) {
+    trackBoundaryError({
+      errorType: "listener_turn_processing_failed",
+      error,
+      context: "listener_turn_processing",
+      runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
+    });
     if (runtime.cancelRequested) {
       if (!lastApprovalContinuationAccepted) {
         populateInterruptQueue(runtime, {


### PR DESCRIPTION
## Summary
- add a shared telemetry boundary-error helper (`src/telemetry/errorReporting.ts`) and process-level safety reporting for uncaught exceptions and unhandled rejections
- instrument missing high-impact runtime error boundaries across TUI startup, headless startup/turn execution, listener mode (socket/queue/turn/commands), auth oauth flows, and updater flows
- add focused unit coverage for the new helper in `src/tests/telemetry/error-reporting.test.ts`

## Test plan
- [x] `bun test src/tests/telemetry/error-reporting.test.ts`
- [x] `bun run typecheck` *(fails on pre-existing unrelated error: `src/cli/App.tsx(8395,55) Property 'fork' does not exist on type 'Conversations'`)*
- [x] `bun run check` *(lint passes; typecheck fails on same pre-existing `App.tsx` error)*

👾 Generated with [Letta Code](https://letta.com)