### PR TITLE
feat: tighten resume message fetching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@letta-ai/letta-client": "1.10.0",
+        "@letta-ai/letta-client": "1.10.1",
         "glob": "^13.0.0",
         "highlight.js": "^11.11.1",
         "ink-link": "^5.0.0",
@@ -95,7 +96,7 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.10.0", "", {}, "sha512-DKBQNUyYdXjKVu6Lxg1+uKqvUQDoBA9/hHxGH0LJSzSeMM0RUX03GSlAOOLu1/L/Mp5H0s2UoW5K3BGObKH8gQ=="],
+    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.10.1", "", {}, "sha512-cBVk+XbiECMNSxh54jVsDAYyTvzOMsbwOl82mEjI+Wzi741mE5EUiu8YpsVXa4KnhZ47hPJ1gIv5Wyhwh+MPGw=="],
 
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@letta-ai/letta-client": "1.10.0",
+    "@letta-ai/letta-client": "1.10.1",
     "glob": "^13.0.0",
     "highlight.js": "^11.11.1",
     "ink-link": "^5.0.0",

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -4,7 +4,10 @@
 import type Letta from "@letta-ai/letta-client";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
-import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Message,
+  MessageType,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
 
@@ -28,6 +31,20 @@ const BACKFILL_ANCHOR_MESSAGE_LIMIT = 6;
 const BACKFILL_PAGE_LIMIT = 200;
 const BACKFILL_MAX_PAGES = 25; // 5k messages max
 const BACKFILL_MIN_ASSISTANT = 1;
+
+const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
+  "user_message",
+  "assistant_message",
+  "reasoning_message",
+  "event_message",
+  "summary_message",
+];
+
+const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
+  ...RESUME_BACKFILL_MESSAGE_TYPES,
+  "approval_request_message",
+  "approval_response_message",
+];
 
 function isPrimaryMessageType(messageType: string | undefined): boolean {
   return (
@@ -271,6 +288,7 @@ async function fetchConversationBackfillMessages(
     const page = await client.conversations.messages.list(conversationId, {
       limit: BACKFILL_PAGE_LIMIT,
       order: "desc",
+      include_return_message_types: RESUME_BACKFILL_MESSAGE_TYPES,
       ...(cursorBefore ? { before: cursorBefore } : {}),
     });
     const items = page.getPaginatedItems();
@@ -466,6 +484,7 @@ export async function getResumeData(
             conversation_id: "default",
             limit: listLimit,
             order: "desc",
+            include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
           });
           defaultConversationMessages = sortChronological(
             messagesPage.getPaginatedItems(),

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -1,5 +1,8 @@
 import type { Letta } from "@letta-ai/letta-client";
-import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Message,
+  MessageType,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -46,6 +49,11 @@ interface EnrichedConversation {
 const DISPLAY_PAGE_SIZE = 3;
 const FETCH_PAGE_SIZE = 20;
 const ENRICH_MESSAGE_LIMIT = 20; // Same as original fetch limit
+
+const RESUME_PREVIEW_MESSAGE_TYPES: MessageType[] = [
+  "user_message",
+  "assistant_message",
+];
 
 /**
  * Format a relative time string from a date
@@ -232,6 +240,7 @@ export function ConversationSelector({
         const messages = await client.conversations.messages.list(convId, {
           limit: ENRICH_MESSAGE_LIMIT,
           order: "desc",
+          include_return_message_types: RESUME_PREVIEW_MESSAGE_TYPES,
         });
         const chronological = [...messages.getPaginatedItems()].reverse();
         const stats = getMessageStats(chronological);
@@ -296,6 +305,7 @@ export function ConversationSelector({
                   conversation_id: "default",
                   limit: ENRICH_MESSAGE_LIMIT,
                   order: "desc",
+                  include_return_message_types: RESUME_PREVIEW_MESSAGE_TYPES,
                 })
                 .then((msgs) => {
                   const items = msgs.getPaginatedItems();

--- a/src/tests/agent/getResumeData.test.ts
+++ b/src/tests/agent/getResumeData.test.ts
@@ -1,12 +1,29 @@
 import { describe, expect, mock, test } from "bun:test";
 import type Letta from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
-import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Message,
+  MessageType,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import { getResumeData } from "../../agent/check-approval";
 
 type ResumeAgentState = AgentState & {
   in_context_message_ids?: string[] | null;
 };
+
+const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
+  "user_message",
+  "assistant_message",
+  "reasoning_message",
+  "event_message",
+  "summary_message",
+];
+
+const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
+  ...RESUME_BACKFILL_MESSAGE_TYPES,
+  "approval_request_message",
+  "approval_response_message",
+];
 
 function makeAgent(overrides: Partial<ResumeAgentState> = {}): AgentState {
   return {
@@ -190,6 +207,12 @@ describe("getResumeData", () => {
 
     expect(messagesRetrieve).toHaveBeenCalledTimes(1);
     expect(agentsList).toHaveBeenCalledTimes(1);
+    expect(agentsList).toHaveBeenCalledWith("agent-test", {
+      conversation_id: "default",
+      limit: 200,
+      order: "desc",
+      include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
+    });
     expect(resume.pendingApprovals).toHaveLength(0);
     expect(resume.messageHistory.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary
- bump `@letta-ai/letta-client` to `1.10.1` so letta-code can use `include_return_message_types`
- filter `/resume` backfill and default-conversation resume fetches down to conversational + approval message types instead of dragging along tool chatter
- filter conversation selector preview fetches to user/assistant messages and cover the default resume backfill query in tests

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/tests/agent/getResumeData.test.ts`

Tested with `LETTA_DEBUG_TIMINGS=1` and it seems to be... ~25-50% faster on average