### PR TITLE
fix: graceful retry on 521/transient errors in remote mode

### DIFF
--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -7,7 +7,10 @@ import { hostname } from "node:os";
 import { getServerUrl } from "../../agent/client";
 import { settingsManager } from "../../settings-manager";
 import { getErrorMessage } from "../../utils/error";
-import { registerWithCloud } from "../../websocket/listen-register";
+import {
+  registerWithCloud,
+  registerWithCloudRetry,
+} from "../../websocket/listen-register";
 import type { Buffers, Line } from "../helpers/accumulator";
 import { buildChatUrl } from "../helpers/appUrls";
 
@@ -324,12 +327,23 @@ export async function handleListen(
           );
 
           try {
-            const reregisterResult = await registerWithCloud({
-              serverUrl,
-              apiKey,
-              deviceId,
-              connectionName,
-            });
+            const reregisterResult = await registerWithCloudRetry(
+              { serverUrl, apiKey, deviceId, connectionName },
+              {
+                onRetry: (attempt, delayMs, error) => {
+                  updateCommandResult(
+                    ctx.buffersRef,
+                    ctx.refreshDerived,
+                    cmdId,
+                    msg,
+                    `Re-registering "${connectionName}"...\n` +
+                      `Retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+                    true,
+                    "running",
+                  );
+                },
+              },
+            );
 
             // Restart client with new connectionId
             await startClient(

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -12,7 +12,10 @@ import { useState } from "react";
 import { getServerUrl } from "../../agent/client";
 import { settingsManager } from "../../settings-manager";
 import { RemoteSessionLog } from "../../websocket/listen-log";
-import { registerWithCloud } from "../../websocket/listen-register";
+import {
+  registerWithCloud,
+  registerWithCloudRetry,
+} from "../../websocket/listen-register";
 import { ListenerStatusUI } from "../components/ListenerStatusUI";
 
 /**
@@ -187,18 +190,29 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       "../../websocket/listen-client"
     );
 
-    // Re-register helper for when the server closes with 1008 (environment not found)
+    // Re-register helper with retry for transient errors (e.g. 521).
+    // Uses exponential backoff so a temporary server outage doesn't
+    // permanently kill the connection.
     const reregister = async (): Promise<{
       connectionId: string;
       wsUrl: string;
     }> => {
-      sessionLog.log("Environment expired, re-registering...");
-      const result = await registerWithCloud({
-        serverUrl,
-        apiKey,
-        deviceId,
-        connectionName,
-      });
+      sessionLog.log("Re-registering with retry...");
+      const result = await registerWithCloudRetry(
+        { serverUrl, apiKey, deviceId, connectionName },
+        {
+          onRetry: (attempt, delayMs, error) => {
+            sessionLog.log(
+              `Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+            );
+            if (debugMode) {
+              console.log(
+                `[${formatTimestamp()}] Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+              );
+            }
+          },
+        },
+      );
       sessionLog.log(`Re-registered: connectionId=${result.connectionId}`);
       return result;
     };

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -17,6 +17,30 @@ export interface RegisterOptions {
 }
 
 /**
+ * Error thrown by registration that carries the HTTP status code (if any).
+ * Network errors (fetch failure) have `statusCode = 0`.
+ */
+export class RegistrationError extends Error {
+  readonly statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "RegistrationError";
+    this.statusCode = statusCode;
+  }
+}
+
+/** Returns true for errors that are likely transient and worth retrying. */
+function isTransientRegistrationError(error: unknown): boolean {
+  if (error instanceof RegistrationError) {
+    // 5xx = server errors (including Cloudflare 521/522/523/524)
+    // 0 = network-level failure (DNS, TCP, TLS)
+    return error.statusCode === 0 || error.statusCode >= 500;
+  }
+  // Non-RegistrationError from fetch (e.g. TypeError for DNS failure)
+  return true;
+}
+
+/**
  * Register this device with the Letta Cloud environments endpoint.
  * Throws on any failure with an error message suitable for wrapping in caller-specific context.
  */
@@ -41,6 +65,11 @@ export async function registerWithCloud(
         nodeVersion: process.version,
       },
     }),
+  }).catch((fetchError: unknown) => {
+    // Network-level failures (DNS, TCP, TLS, etc.)
+    const msg =
+      fetchError instanceof Error ? fetchError.message : String(fetchError);
+    throw new RegistrationError(`Network error: ${msg}`, 0);
   });
 
   if (!response.ok) {
@@ -58,15 +87,16 @@ export async function registerWithCloud(
         detail += `: ${text.slice(0, 200)}`;
       }
     }
-    throw new Error(detail);
+    throw new RegistrationError(detail, response.status);
   }
 
   let body: unknown;
   try {
     body = await response.json();
   } catch {
-    throw new Error(
+    throw new RegistrationError(
       "Server returned non-JSON response — is the server running?",
+      response.status,
     );
   }
 
@@ -75,8 +105,9 @@ export async function registerWithCloud(
     typeof result.connectionId !== "string" ||
     typeof result.wsUrl !== "string"
   ) {
-    throw new Error(
+    throw new RegistrationError(
       "Server returned unexpected response shape (missing connectionId or wsUrl)",
+      response.status,
     );
   }
 
@@ -84,4 +115,52 @@ export async function registerWithCloud(
     connectionId: result.connectionId,
     wsUrl: result.wsUrl,
   };
+}
+
+const REGISTER_INITIAL_DELAY_MS = 1_000;
+const REGISTER_MAX_DELAY_MS = 30_000;
+const REGISTER_MAX_DURATION_MS = 2 * 60 * 1_000; // 2 minutes
+
+export interface RegisterRetryCallbacks {
+  /** Called before each retry attempt. */
+  onRetry?: (attempt: number, delayMs: number, error: Error) => void;
+}
+
+/**
+ * Register with Cloud, retrying on transient errors (5xx, network failures)
+ * with exponential backoff. Fails immediately on client errors (4xx).
+ */
+export async function registerWithCloudRetry(
+  opts: RegisterOptions,
+  callbacks?: RegisterRetryCallbacks,
+): Promise<RegisterResult> {
+  const startTime = Date.now();
+  let attempt = 0;
+
+  for (;;) {
+    try {
+      return await registerWithCloud(opts);
+    } catch (error) {
+      const elapsed = Date.now() - startTime;
+
+      if (
+        !isTransientRegistrationError(error) ||
+        elapsed >= REGISTER_MAX_DURATION_MS
+      ) {
+        throw error;
+      }
+
+      attempt++;
+      const delay = Math.min(
+        REGISTER_INITIAL_DELAY_MS * 2 ** (attempt - 1),
+        REGISTER_MAX_DELAY_MS,
+      );
+
+      if (error instanceof Error) {
+        callbacks?.onRetry?.(attempt, delay, error);
+      }
+
+      await new Promise<void>((resolve) => setTimeout(resolve, delay));
+    }
+  }
 }

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -791,6 +791,7 @@ function createRuntime(): ListenerRuntime {
     reconnectTimeout: null,
     intentionallyClosed: false,
     hasSuccessfulConnection: false,
+    everConnected: false,
     sessionId: `listen-${crypto.randomUUID()}`,
     eventSeqCounter: 0,
     lastStopReason: null,
@@ -889,6 +890,13 @@ async function connectWithRetry(
 
   if (attempt > 0) {
     if (elapsedTime >= MAX_RETRY_DURATION_MS) {
+      // If we ever had a successful connection, try to re-register instead
+      // of giving up. This keeps established sessions alive through transient
+      // outages (e.g. Cloudflare 521, server deploys).
+      if (runtime.everConnected && opts.onNeedsReregister) {
+        opts.onNeedsReregister();
+        return;
+      }
       opts.onError(new Error("Failed to connect after 5 minutes of retrying"));
       return;
     }
@@ -963,6 +971,7 @@ async function connectWithRetry(
 
     safeEmitWsEvent("recv", "lifecycle", { type: "_ws_open" });
     runtime.hasSuccessfulConnection = true;
+    runtime.everConnected = true;
     opts.onConnected(opts.connectionId);
 
     if (runtime.conversationRuntimes.size === 0) {
@@ -1771,6 +1780,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   heartbeatInterval: NodeJS.Timeout | null;
   intentionallyClosed: boolean;
   hasSuccessfulConnection: boolean;
+  everConnected: boolean;
   conversationRuntimes: ListenerRuntime["conversationRuntimes"];
   approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
   lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
@@ -1799,6 +1809,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     heartbeatInterval: NodeJS.Timeout | null;
     intentionallyClosed: boolean;
     hasSuccessfulConnection: boolean;
+    everConnected: boolean;
     conversationRuntimes: ListenerRuntime["conversationRuntimes"];
     approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
     lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
@@ -1905,6 +1916,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.hasSuccessfulConnection,
       set: (value: boolean) => {
         listener.hasSuccessfulConnection = value;
+      },
+    },
+    everConnected: {
+      get: () => listener.everConnected,
+      set: (value: boolean) => {
+        listener.everConnected = value;
       },
     },
     conversationRuntimes: {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -139,6 +139,8 @@ export type ListenerRuntime = {
   reconnectTimeout: NodeJS.Timeout | null;
   intentionallyClosed: boolean;
   hasSuccessfulConnection: boolean;
+  /** True once the WS has connected at least once. Never reset to false. */
+  everConnected: boolean;
   sessionId: string;
   eventSeqCounter: number;
   lastStopReason: string | null;


### PR DESCRIPTION
Previously, a transient server outage (e.g. Cloudflare 521) would crash established remote sessions after 5 minutes of WS retries. Now:

- registerWithCloudRetry: retries registration with exponential backoff (1s→30s, up to 2min) for 5xx/network errors, fails fast on 4xx
- connectWithRetry: when retry window exhausts on a previously-connected session, triggers re-registration instead of calling onError
- Both CLI paths (letta server + /remote) use retrying registration

An established remote session will now cycle indefinitely between WS retry and re-registration through transient outages.

🐾 Generated with [Letta Code](https://letta.com)