### PR TITLE
fix(ci): open PR for version bump instead of pushing directly to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,10 +180,21 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --tag ${{ steps.version.outputs.npm_tag }}
 
-      - name: Push commit and tag after publish
+      - name: Push tag after publish
+        run: git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin main
-          git push origin "${{ steps.version.outputs.tag }}"
+          BRANCH="chore/bump-v${{ steps.version.outputs.new_version }}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump version to ${{ steps.version.outputs.new_version }}" \
+            --body "Automated version bump after npm publish of v${{ steps.version.outputs.new_version }}." \
+            --base main \
+            --head "$BRANCH"
 
       - name: Create GitHub Release
         if: steps.version.outputs.is_prerelease == 'false'


### PR DESCRIPTION
## Summary

- Branch protection on `main` requires changes go through PRs, which broke the release workflow's `git push origin main` step
- Now pushes only the tag (not protected) and opens a PR for the `package.json` version bump commit
- npm publish still happens before this step, so the release is already out — the PR just syncs the version in the repo

👾 Generated with [Letta Code](https://letta.com)