### PR TITLE
fix(ci): add pull-requests permission and remove [skip ci] from versi…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     environment: npm-publish
     permissions:
       contents: write
+      pull-requests: write
       id-token: write  # Required for npm OIDC trusted publishing
     steps:
       - name: Checkout
@@ -152,7 +153,7 @@ jobs:
       - name: Commit and tag version bump (local only)
         run: |
           git add package.json package-lock.json
-          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git tag "${{ steps.version.outputs.tag }}"
 
       - name: Install dependencies


### PR DESCRIPTION
…on bump

The version bump PR step needs pull-requests: write permission, and [skip ci] is no longer needed since the bump goes through a PR now.

👾 Generated with [Letta Code](https://letta.com)