### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@letta-ai/letta-code",
-  "version": "0.19.10",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@letta-ai/letta-code",
-      "version": "0.19.10",
+      "version": "0.20.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/letta-code",
-  "version": "0.19.10",
+  "version": "0.20.0",
   "description": "Letta Code is a CLI tool for interacting with stateful Letta agents from the terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Syncs main's package.json with npm — both 0.19.11 and 0.20.0 were published but their version bump commits never landed on main (branch protection blocked direct push)
- After merging, running the release action with `minor` will produce 0.21.0

👾 Generated with [Letta Code](https://letta.com)