### PR TITLE
feat: advertise supported remote commands in device status [LET-8218]

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -138,6 +138,8 @@ export interface DeviceStatus {
   background_processes: BackgroundProcessSummary[];
   pending_control_requests: PendingControlRequest[];
   memory_directory: string | null;
+  /** Remote slash command IDs this letta-code version can handle via `execute_command`. */
+  supported_commands: string[];
 }
 
 export type LoopStatus =

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -16,6 +16,15 @@ import type { ConversationRuntime, StartListenerOptions } from "./types";
 const ISOLATED_BLOCK_LABELS = ["human", "persona"];
 
 /**
+ * Command IDs that this letta-code version can handle via `execute_command`.
+ * Advertised in DeviceStatus.supported_commands so the web UI only shows
+ * commands the connected device actually supports.
+ *
+ * When adding a new case to `handleExecuteCommand`, add the ID here too.
+ */
+export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = ["clear"];
+
+/**
  * Handle an `execute_command` message from the web app.
  *
  * Dispatches to the appropriate command handler based on `command_id`.

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -24,6 +24,7 @@ import type {
   SubagentStateUpdateMessage,
   WsProtocolMessage,
 } from "../../types/protocol_v2";
+import { SUPPORTED_REMOTE_COMMANDS } from "./commands";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import { getConversationPermissionModeState } from "./permissionMode";
@@ -107,6 +108,7 @@ export function buildDeviceStatus(
       background_processes: [],
       pending_control_requests: [],
       memory_directory: null,
+      supported_commands: [...SUPPORTED_REMOTE_COMMANDS],
     };
   }
   const scope = getScopeForRuntime(runtime, params);
@@ -157,6 +159,7 @@ export function buildDeviceStatus(
     memory_directory: scopedAgentId
       ? getMemoryFilesystemRoot(scopedAgentId)
       : null,
+    supported_commands: [...SUPPORTED_REMOTE_COMMANDS],
   };
 }
 


### PR DESCRIPTION
Add `supported_commands` field to DeviceStatus so the web UI can filter slash commands based on what the connected letta-code version actually supports.

🤖 Generated with [Letta Code](https://letta.com)