### PR TITLE
feat: add /delete command for conversation management

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -556,6 +556,7 @@ const INTERACTIVE_SLASH_COMMANDS = new Set([
   "/help",
   "/agents",
   "/resume",
+  "/delete",
   "/pinned",
   "/profiles",
   "/search",
@@ -1417,6 +1418,8 @@ export default function App({
     | "skills"
     | null;
   const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>(null);
+  /** Tracks whether the conversation selector was opened for "resume" or "delete" */
+  const conversationOverlayModeRef = useRef<"resume" | "delete">("resume");
   const pendingOverlayCommandRef = useRef<{
     overlay: ActiveOverlay;
     command: CommandHandle;
@@ -1455,6 +1458,7 @@ export default function App({
     setSearchQuery("");
     setModelSelectorOptions({});
     setModelReasoningPrompt(null);
+    conversationOverlayModeRef.current = "resume";
   }, [activeOverlay]);
 
   // Queued overlay action - executed after end_turn when user makes a selection
@@ -9025,9 +9029,96 @@ export default function App({
           }
 
           // No conversation ID provided - show selector
+          conversationOverlayModeRef.current = "resume";
           startOverlayCommand(
             "conversations",
             "/resume",
+            "Opening conversation selector...",
+            "Conversation selector dismissed",
+          );
+          setActiveOverlay("conversations");
+          return { submitted: true };
+        }
+
+        // Special handling for /delete command - delete a conversation
+        if (msg.trim().startsWith("/delete")) {
+          const parts = msg.trim().split(/\s+/);
+          const targetConvId = parts[1]; // Optional conversation ID
+
+          if (targetConvId === "help") {
+            const cmd = commandRunner.start(
+              msg.trim(),
+              "Showing delete help...",
+            );
+            const output = [
+              "/delete help",
+              "",
+              "Delete a conversation (soft delete).",
+              "",
+              "USAGE",
+              "  /delete                       — open conversation selector to pick one to delete",
+              "  /delete <conversation_id>     — delete a specific conversation",
+              "  /delete help                  — show this help",
+              "",
+              "After deletion, you will be switched to the default conversation.",
+              "The 'default' and current conversation cannot be deleted.",
+            ].join("\n");
+            cmd.finish(output, true);
+            return { submitted: true };
+          }
+
+          if (targetConvId) {
+            const cmd = commandRunner.start(
+              msg.trim(),
+              "Deleting conversation...",
+            );
+
+            if (targetConvId === "default") {
+              cmd.fail("Cannot delete the default conversation");
+              return { submitted: true };
+            }
+
+            if (targetConvId === conversationId) {
+              cmd.fail(
+                "Cannot delete the current conversation. Switch to another conversation first using /resume, then delete this one.",
+              );
+              return { submitted: true };
+            }
+
+            setCommandRunning(true);
+
+            try {
+              const client = await getClient();
+
+              // Delete the conversation via API (soft delete)
+              await client.conversations.delete(targetConvId);
+
+              cmd.finish(`Deleted conversation ${targetConvId}`, true);
+            } catch (error) {
+              let errorMsg = "Unknown error";
+              if (error instanceof APIError) {
+                if (error.status === 404) {
+                  errorMsg = "Conversation not found";
+                } else if (error.status === 422) {
+                  errorMsg = "Invalid conversation ID";
+                } else {
+                  errorMsg = error.message;
+                }
+              } else if (error instanceof Error) {
+                errorMsg = error.message;
+              }
+              cmd.fail(`Failed to delete conversation: ${errorMsg}`);
+            } finally {
+              setCommandRunning(false);
+            }
+            return { submitted: true };
+          }
+
+          // No conversation ID provided - show conversation selector
+          conversationOverlayModeRef.current = "delete";
+          startOverlayCommand(
+            "conversations",
+            "/delete",
             "Opening conversation selector...",
             "Conversation selector dismissed",
           );
@@ -14162,15 +14253,70 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
               />
             )}
 
-            {/* Conversation Selector - for resuming conversations */}
+            {/* Conversation Selector - for resuming or deleting conversations */}
             {activeOverlay === "conversations" && (
               <ConversationSelector
                 agentId={agentId}
                 agentName={agentName ?? undefined}
                 currentConversationId={conversationId}
+                mode={conversationOverlayModeRef.current}
                 onSelect={async (convId, selectorContext) => {
+                  const overlayMode = conversationOverlayModeRef.current;
                   const overlayCommand = consumeOverlayCommand("conversations");
                   closeOverlay();
+
+                  // ── Delete mode ──
+                  if (overlayMode === "delete") {
+                    const cmd =
+                      overlayCommand ??
+                      commandRunner.start(
+                        "/delete",
+                        "Deleting conversation...",
+                      );
+
+                    if (convId === "default") {
+                      cmd.fail("Cannot delete the default conversation");
+                      return;
+                    }
+
+                    if (convId === conversationId) {
+                      cmd.fail(
+                        "Cannot delete the current conversation. Switch to another conversation first using /resume, then delete this one.",
+                      );
+                      return;
+                    }
+
+                    setCommandRunning(true);
+                    cmd.update({
+                      output: "Deleting conversation...",
+                      phase: "running",
+                    });
+
+                    try {
+                      const client = await getClient();
+                      await client.conversations.delete(convId);
+                      cmd.finish(`Deleted conversation ${convId}`, true);
+                    } catch (error) {
+                      let errorMsg = "Unknown error";
+                      if (error instanceof APIError) {
+                        if (error.status === 404) {
+                          errorMsg = "Conversation not found";
+                        } else if (error.status === 422) {
+                          errorMsg = "Invalid conversation ID";
+                        } else {
+                          errorMsg = error.message;
+                        }
+                      } else if (error instanceof Error) {
+                        errorMsg = error.message;
+                      }
+                      cmd.fail(`Failed to delete conversation: ${errorMsg}`);
+                    } finally {
+                      setCommandRunning(false);
+                    }
+                    return;
+                  }
+
+                  // ── Resume mode (default) ──
 
                   // Skip if already on this conversation
                   if (convId === conversationId) {
@@ -14375,6 +14521,9 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                   }
                 }}
                 onNewConversation={async () => {
+                  // New conversation is not available in delete mode
+                  if (conversationOverlayModeRef.current === "delete") return;
+
                   const overlayCommand = consumeOverlayCommand("conversations");
                   closeOverlay();
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -537,6 +537,15 @@ export const commands: Record<string, Command> = {
       return "Opening conversation selector...";
     },
   },
+  "/delete": {
+    desc: "Delete a conversation",
+    args: "[conversation_id]",
+    order: 20,
+    handler: () => {
+      // Handled specially in App.tsx to show conversation selector or delete directly
+      return "Opening conversation selector...";
+    },
+  },
   "/pinned": {
     desc: "Browse pinned agents",
     hidden: true, // Alias for /agents (opens to Pinned tab)

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -17,6 +17,8 @@ interface ConversationSelectorProps {
   agentId: string;
   agentName?: string;
   currentConversationId: string;
+  /** Controls the visual mode of the selector. "resume" (default) shows resume UI, "delete" shows delete UI. */
+  mode?: "resume" | "delete";
   onSelect: (
     conversationId: string,
     context?: {
@@ -204,6 +206,7 @@ export function ConversationSelector({
   agentId,
   agentName,
   currentConversationId,
+  mode = "resume",
   onSelect,
   onNewConversation,
   onCancel,
@@ -466,8 +469,8 @@ export function ConversationSelector({
       }
     } else if (key.escape) {
       onCancel();
-    } else if (input === "n" || input === "N") {
-      // New conversation
+    } else if ((input === "n" || input === "N") && mode !== "delete") {
+      // New conversation (disabled in delete mode)
       onNewConversation();
     } else if (key.leftArrow) {
       // Previous page
@@ -619,7 +622,7 @@ export function ConversationSelector({
   return (
     <Box flexDirection="column">
       {/* Command header */}
-      <Text dimColor>{"> /resume"}</Text>
+      <Text dimColor>{mode === "delete" ? "> /delete" : "> /resume"}</Text>
       <Text dimColor>{solidLine}</Text>
 
       <Box height={1} />
@@ -627,7 +630,9 @@ export function ConversationSelector({
       {/* Title */}
       <Box marginBottom={1}>
         <Text bold color={colors.selector.title}>
-          Resume a previous conversation
+          {mode === "delete"
+            ? "Delete a conversation"
+            : "Resume a previous conversation"}
         </Text>
       </Box>
 
@@ -682,7 +687,9 @@ export function ConversationSelector({
           const footerWidth = Math.max(0, terminalWidth - 2);
           const pageText = `Page ${page + 1}${hasMore ? "+" : `/${totalPages || 1}`}${loadingMore ? " (loading...)" : ""}`;
           const hintsText =
-            "Enter select · ↑↓ navigate · ←→ page · N new · Esc cancel";
+            mode === "delete"
+              ? "Enter delete · ↑↓ navigate · ←→ page · Esc cancel"
+              : "Enter select · ↑↓ navigate · ←→ page · N new · Esc cancel";
 
           return (
             <Box flexDirection="column">


### PR DESCRIPTION
Closes issue: https://github.com/letta-ai/letta-code/issues/1393
1. Add /delete slash command for soft-deleting conversations
2. We already have a delete API on the server and client side.
3. Three modes: /delete <id>, /delete (interactive selector), /delete help (just like /resume)
4. Reuse ConversationSelector with new mode prop ("resume" | "delete")
5. Adapt overlay UI: header, title, footer hints change per mode
6. Disable "N" (new conversation) shortcut in delete mode
7. Block deletion of default and currently active conversations
8. Track overlay mode via conversationOverlayModeRef in App.tsx
9. Branch onSelect callback to delete instead of resume


<img width="477" height="312" alt="Screenshot 2026-03-29 at 1 42 58 AM" src="https://github.com/user-attachments/assets/1b01cafd-04bb-4dd2-a490-632fbf5ec468" />

<img width="435" height="65" alt="Screenshot 2026-03-29 at 1 42 06 AM" src="https://github.com/user-attachments/assets/783042b5-502b-460c-ac26-2eb3b0de7106" />
