### PR TITLE
fix(recovery): classify pending approvals from structured 409 payloads

### DIFF
--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -70,6 +70,67 @@ const CLOUDFLARE_EDGE_52X_RETRY_BASE_DELAY_MS = 5000;
 const CONVERSATION_BUSY_RETRY_BASE_DELAY_MS = 10000;
 const EMPTY_RESPONSE_RETRY_BASE_DELAY_MS = 500;
 
+const PENDING_APPROVAL_ERROR_CODE = "PENDING_APPROVAL";
+const PENDING_APPROVAL_CODE_PATTERN =
+  /"(?:code|error_code)"\s*:\s*"PENDING_APPROVAL"/i;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+}
+
+function extractCodeField(value: unknown): string | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  if (typeof record.code === "string") return record.code;
+  if (typeof record.error_code === "string") return record.error_code;
+
+  return null;
+}
+
+function extractConflictCode(value: unknown): string | null {
+  const directCode = extractCodeField(value);
+  if (directCode) return directCode;
+
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const detailCode = extractConflictCode(record.detail);
+  if (detailCode) return detailCode;
+
+  const nestedErrorCode = extractConflictCode(record.error);
+  if (nestedErrorCode) return nestedErrorCode;
+
+  return null;
+}
+
+function extractMessageFromConflictValue(value: unknown): string | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  if (typeof record.detail === "string") return record.detail;
+  if (typeof record.message === "string") return record.message;
+
+  if (record.detail && typeof record.detail === "object") {
+    const detailRecord = record.detail as Record<string, unknown>;
+    if (typeof detailRecord.message === "string") return detailRecord.message;
+    if (typeof detailRecord.detail === "string") return detailRecord.detail;
+  }
+
+  const nested = extractMessageFromConflictValue(record.error);
+  if (nested) return nested;
+
+  return null;
+}
+
+function isPendingApprovalCode(code: unknown): boolean {
+  return (
+    typeof code === "string" &&
+    code.toUpperCase() === PENDING_APPROVAL_ERROR_CODE
+  );
+}
+
 function isCloudflareEdge52xDetail(detail: unknown): boolean {
   if (typeof detail !== "string") return false;
   return isCloudflareEdge52xHtmlError(detail);
@@ -104,8 +165,13 @@ export function isInvalidToolCallIdsError(detail: unknown): boolean {
 
 /** Backend has a pending approval blocking new messages. */
 export function isApprovalPendingError(detail: unknown): boolean {
+  if (isPendingApprovalCode(extractConflictCode(detail))) return true;
+
   if (typeof detail !== "string") return false;
-  return detail.toLowerCase().includes(APPROVAL_PENDING_DETAIL_FRAGMENT);
+  return (
+    detail.toLowerCase().includes(APPROVAL_PENDING_DETAIL_FRAGMENT) ||
+    PENDING_APPROVAL_CODE_PATTERN.test(detail)
+  );
 }
 
 /** Conversation is busy (another request is being processed). */
@@ -288,23 +354,36 @@ export interface PreStreamErrorOptions {
   maxTransientRetries?: number;
 }
 
-/** Classify a pre-stream 409 conflict detail string. */
+/**
+ * Classify a pre-stream 409 conflict from either a raw detail string
+ * or an SDK error object with nested `{ detail: { code, message, ... } }`.
+ */
 export function classifyPreStreamConflict(
-  detail: unknown,
+  errorOrDetail: unknown,
 ): PreStreamConflictKind {
-  if (isApprovalPendingError(detail)) return "approval_pending";
+  if (isApprovalPendingError(errorOrDetail)) return "approval_pending";
+
+  const detail =
+    typeof errorOrDetail === "string"
+      ? errorOrDetail
+      : extractConflictDetail(errorOrDetail);
+
   if (isConversationBusyError(detail)) return "conversation_busy";
   return null;
 }
 
 /** Determine the recovery action for a pre-stream 409 error. */
 export function getPreStreamErrorAction(
-  detail: unknown,
+  errorOrDetail: unknown,
   conversationBusyRetries: number,
   maxConversationBusyRetries: number,
   opts?: PreStreamErrorOptions,
 ): PreStreamErrorAction {
-  const kind = classifyPreStreamConflict(detail);
+  const kind = classifyPreStreamConflict(errorOrDetail);
+  const detail =
+    typeof errorOrDetail === "string"
+      ? errorOrDetail
+      : extractConflictDetail(errorOrDetail);
 
   if (kind === "approval_pending") {
     return "resolve_approval_pending";
@@ -341,21 +420,9 @@ export function getPreStreamErrorAction(
  * Checks `detail` first (specific) then `message` (generic) at each level.
  */
 export function extractConflictDetail(error: unknown): string {
-  if (error && typeof error === "object" && "error" in error) {
-    const errObj = (error as Record<string, unknown>).error;
-    if (errObj && typeof errObj === "object") {
-      const outer = errObj as Record<string, unknown>;
-      // Nested: e.error.error.detail → e.error.error.message
-      if (outer.error && typeof outer.error === "object") {
-        const nested = outer.error as Record<string, unknown>;
-        if (typeof nested.detail === "string") return nested.detail;
-        if (typeof nested.message === "string") return nested.message;
-      }
-      // Direct: e.error.detail → e.error.message
-      if (typeof outer.detail === "string") return outer.detail;
-      if (typeof outer.message === "string") return outer.message;
-    }
-  }
+  const fromObject = extractMessageFromConflictValue(error);
+  if (fromObject) return fromObject;
+
   if (error instanceof Error) return error.message;
   return "";
 }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -352,6 +352,9 @@ const EAGER_CANCEL = true;
 // Maximum retries for transient LLM API errors (matches headless.ts)
 const LLM_API_ERROR_MAX_RETRIES = 3;
 
+// Maximum retries for approval-pending recovery (independent from LLM retries)
+const APPROVAL_RECOVERY_MAX_RETRIES = 3;
+
 // Retry config for empty response errors (Opus 4.6 SADs)
 // Retry 1: same input. Retry 2: with system reminder nudge.
 const EMPTY_RESPONSE_MAX_RETRIES = 2;
@@ -1857,6 +1860,7 @@ export default function App({
   // Retry counter for transient LLM API errors (ref for synchronous access in loop)
   const llmApiErrorRetriesRef = useRef(0);
   const quotaAutoSwapAttemptedRef = useRef(false);
+  const approvalRecoveryRetriesRef = useRef(0);
   const emptyResponseRetriesRef = useRef(0);
 
   // Retry counter for 409 "conversation busy" errors
@@ -4000,6 +4004,7 @@ export default function App({
       // Reset retry counters for new conversation turns (fresh budget per user message)
       if (!allowReentry) {
         llmApiErrorRetriesRef.current = 0;
+        approvalRecoveryRetriesRef.current = 0;
         emptyResponseRetriesRef.current = 0;
         conversationBusyRetriesRef.current = 0;
         quotaAutoSwapAttemptedRef.current = false;
@@ -4177,7 +4182,7 @@ export default function App({
 
             // Route through shared pre-stream conflict classifier (parity with headless.ts)
             const preStreamAction = getPreStreamErrorAction(
-              errorDetail,
+              preStreamError,
               conversationBusyRetriesRef.current,
               CONVERSATION_BUSY_MAX_RETRIES,
               {
@@ -4191,17 +4196,16 @@ export default function App({
             );
 
             // Resolve stale approval conflict: fetch real pending approvals, auto-deny, retry.
-            // Shares llmApiErrorRetriesRef budget with LLM transient-error retries (max 3 per turn).
-            // Resets on each processConversation entry and on success.
+            // Uses a dedicated approval-recovery retry budget (separate from transient LLM retries).
             if (
               shouldAttemptApprovalRecovery({
                 approvalPendingDetected:
                   preStreamAction === "resolve_approval_pending",
-                retries: llmApiErrorRetriesRef.current,
-                maxRetries: LLM_API_ERROR_MAX_RETRIES,
+                retries: approvalRecoveryRetriesRef.current,
+                maxRetries: APPROVAL_RECOVERY_MAX_RETRIES,
               })
             ) {
-              llmApiErrorRetriesRef.current += 1;
+              approvalRecoveryRetriesRef.current += 1;
               try {
                 const client = await getClient();
                 const agent = await client.agents.retrieve(agentIdRef.current);
@@ -4750,6 +4754,7 @@ export default function App({
             })();
             closeTrajectorySegment();
             llmApiErrorRetriesRef.current = 0; // Reset retry counter on success
+            approvalRecoveryRetriesRef.current = 0;
             emptyResponseRetriesRef.current = 0;
             conversationBusyRetriesRef.current = 0;
             lastDequeuedMessageRef.current = null; // Clear - message was processed successfully
@@ -5603,11 +5608,11 @@ export default function App({
           if (
             shouldAttemptApprovalRecovery({
               approvalPendingDetected,
-              retries: llmApiErrorRetriesRef.current,
-              maxRetries: LLM_API_ERROR_MAX_RETRIES,
+              retries: approvalRecoveryRetriesRef.current,
+              maxRetries: APPROVAL_RECOVERY_MAX_RETRIES,
             })
           ) {
-            llmApiErrorRetriesRef.current += 1;
+            approvalRecoveryRetriesRef.current += 1;
 
             try {
               // Fetch pending approvals and auto-deny them
@@ -5828,6 +5833,7 @@ export default function App({
 
           // Reset retry counters on non-retriable error (or max retries exceeded)
           llmApiErrorRetriesRef.current = 0;
+          approvalRecoveryRetriesRef.current = 0;
           emptyResponseRetriesRef.current = 0;
           conversationBusyRetriesRef.current = 0;
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1634,7 +1634,7 @@ ${SYSTEM_REMINDER_CLOSE}
         const errorDetail = extractConflictDetail(preStreamError);
 
         const preStreamAction = getPreStreamErrorAction(
-          errorDetail,
+          preStreamError,
           conversationBusyRetries,
           CONVERSATION_BUSY_MAX_RETRIES,
           {
@@ -3495,14 +3495,19 @@ async function runBidirectionalMode(
 
             // Route through shared pre-stream conflict classifier (parity with main loop + TUI)
             // Bidir mode has no conversation-busy retry budget, so pass 0/0 to disable busy-retry.
-            const preStreamAction = getPreStreamErrorAction(errorDetail, 0, 0, {
-              status:
-                preStreamError instanceof APIError
-                  ? preStreamError.status
-                  : undefined,
-              transientRetries: preStreamTransientRetries,
-              maxTransientRetries: LLM_API_ERROR_MAX_RETRIES,
-            });
+            const preStreamAction = getPreStreamErrorAction(
+              preStreamError,
+              0,
+              0,
+              {
+                status:
+                  preStreamError instanceof APIError
+                    ? preStreamError.status
+                    : undefined,
+                transientRetries: preStreamTransientRetries,
+                maxTransientRetries: LLM_API_ERROR_MAX_RETRIES,
+              },
+            );
 
             if (preStreamAction === "resolve_approval_pending") {
               const recoveryMsg: RecoveryMessage = {

--- a/src/tests/approval-recovery.test.ts
+++ b/src/tests/approval-recovery.test.ts
@@ -164,6 +164,20 @@ describe("classifyPreStreamConflict", () => {
   test("returns null for non-conflict errors", () => {
     expect(classifyPreStreamConflict("Rate limit exceeded")).toBeNull();
   });
+
+  test("classifies structured PENDING_APPROVAL payloads", () => {
+    expect(
+      classifyPreStreamConflict({
+        error: {
+          detail: {
+            code: "PENDING_APPROVAL",
+            message: "Approval required before continuing",
+            pending_request_id: "message-abc",
+          },
+        },
+      }),
+    ).toBe("approval_pending");
+  });
 });
 
 describe("getPreStreamErrorAction", () => {
@@ -174,6 +188,24 @@ describe("getPreStreamErrorAction", () => {
     expect(getPreStreamErrorAction(detail, 0, 1)).toBe(
       "resolve_approval_pending",
     );
+  });
+
+  test("returns resolve_approval_pending for structured conflict details", () => {
+    expect(
+      getPreStreamErrorAction(
+        {
+          error: {
+            detail: {
+              code: "PENDING_APPROVAL",
+              message: "Approval required before continuing",
+              pending_request_id: "message-1",
+            },
+          },
+        },
+        0,
+        1,
+      ),
+    ).toBe("resolve_approval_pending");
   });
 
   test("returns retry_conversation_busy when busy and retries remain", () => {
@@ -401,6 +433,23 @@ describe("extractConflictDetail", () => {
     };
     const detail = extractConflictDetail(error);
     expect(isConversationBusyError(detail)).toBe(true);
+  });
+
+  test("extracts message from structured detail object", () => {
+    const error = {
+      error: {
+        detail: {
+          code: "PENDING_APPROVAL",
+          message:
+            "CONFLICT: Cannot send a new message: approval is pending on a tool call.",
+          pending_request_id: "message-42",
+        },
+      },
+    };
+
+    expect(extractConflictDetail(error)).toBe(
+      "CONFLICT: Cannot send a new message: approval is pending on a tool call.",
+    );
   });
 
   test("extracts from flat shape (e.error.message) when detail is missing", () => {

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -22,6 +22,8 @@ describe("approval recovery wiring", () => {
     expect(segment).toContain("extractConflictDetail(preStreamError)");
     expect(segment).toContain("getPreStreamErrorAction(");
     expect(segment).toContain("shouldAttemptApprovalRecovery(");
+    expect(segment).toContain("approvalRecoveryRetriesRef.current");
+    expect(segment).toContain("APPROVAL_RECOVERY_MAX_RETRIES");
     expect(segment).toContain("rebuildInputWithFreshDenials(");
     expect(segment).toContain('preStreamAction === "retry_transient"');
   });
@@ -41,6 +43,8 @@ describe("approval recovery wiring", () => {
     const segment = source.slice(start, end);
 
     expect(segment).toContain("shouldAttemptApprovalRecovery(");
+    expect(segment).toContain("approvalRecoveryRetriesRef.current");
+    expect(segment).toContain("APPROVAL_RECOVERY_MAX_RETRIES");
     expect(segment).not.toContain("!hasApprovalInPayload &&");
   });
 

--- a/src/tests/turn-recovery-policy.test.ts
+++ b/src/tests/turn-recovery-policy.test.ts
@@ -34,6 +34,25 @@ describe("isApprovalPendingError", () => {
     expect(isApprovalPendingError("WAITING FOR APPROVAL")).toBe(true);
   });
 
+  test("detects structured PENDING_APPROVAL detail objects", () => {
+    expect(
+      isApprovalPendingError({
+        detail: {
+          code: "PENDING_APPROVAL",
+          message: "Approval required before continuing",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("detects serialized PENDING_APPROVAL codes", () => {
+    expect(
+      isApprovalPendingError(
+        '409 {"detail":{"code":"PENDING_APPROVAL","message":"approval needed"}}',
+      ),
+    ).toBe(true);
+  });
+
   test("does not match conversation-busy", () => {
     expect(
       isApprovalPendingError(
@@ -104,6 +123,19 @@ describe("classifyPreStreamConflict", () => {
   test("unknown", () => {
     expect(classifyPreStreamConflict("Connection refused")).toBeNull();
   });
+
+  test("structured pending-approval object", () => {
+    expect(
+      classifyPreStreamConflict({
+        error: {
+          detail: {
+            code: "PENDING_APPROVAL",
+            message: "Approval required before continuing",
+          },
+        },
+      }),
+    ).toBe("approval_pending");
+  });
 });
 
 describe("getPreStreamErrorAction", () => {
@@ -111,6 +143,29 @@ describe("getPreStreamErrorAction", () => {
     expect(getPreStreamErrorAction("waiting for approval", 0, 3)).toBe(
       "resolve_approval_pending",
     );
+  });
+
+  test("structured PENDING_APPROVAL → resolve", () => {
+    expect(
+      getPreStreamErrorAction(
+        {
+          error: {
+            detail: {
+              code: "PENDING_APPROVAL",
+              message: "Approval required before continuing",
+              pending_request_id: "message-123",
+            },
+          },
+        },
+        0,
+        3,
+        {
+          status: 409,
+          transientRetries: 0,
+          maxTransientRetries: 3,
+        },
+      ),
+    ).toBe("resolve_approval_pending");
   });
 
   test("conversation busy with budget → retry", () => {

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -402,7 +402,7 @@ export async function sendMessageStreamWithRetry(
 
       const errorDetail = extractConflictDetail(preStreamError);
       const action = getPreStreamErrorAction(
-        errorDetail,
+        preStreamError,
         conversationBusyRetries,
         MAX_CONVERSATION_BUSY_RETRIES,
         {
@@ -602,7 +602,7 @@ export async function sendApprovalContinuationWithRetry(
 
       const errorDetail = extractConflictDetail(preStreamError);
       const action = getPreStreamErrorAction(
-        errorDetail,
+        preStreamError,
         conversationBusyRetries,
         MAX_CONVERSATION_BUSY_RETRIES,
         {


### PR DESCRIPTION
## Summary
- make pre-stream approval conflict detection code-aware (`PENDING_APPROVAL`) instead of relying only on brittle string fragments
- pass raw pre-stream API errors into the shared recovery router across TUI, headless, and websocket listener flows
- separate approval-recovery retry budget from transient LLM retry budget in TUI and add regression tests for structured payloads + wiring

## Test plan
- [x] `bun test src/tests/turn-recovery-policy.test.ts src/tests/approval-recovery.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/agent/turn-recovery-policy.ts src/cli/App.tsx src/headless.ts src/websocket/listener/send.ts src/tests/turn-recovery-policy.test.ts src/tests/approval-recovery.test.ts src/tests/cli/approval-recovery-wiring.test.ts`
- [ ] `bun run check` *(fails in this branch due pre-existing unrelated type errors in untouched files: `src/agent/check-approval.ts`, `src/cli/components/ConversationSelector.tsx`)*

👾 Generated with [Letta Code](https://letta.com)