### PR TITLE
fix(listener): skip scopeless device_status on fresh connect [LET-8223]

### DIFF
--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1861,7 +1861,11 @@ async function connectWithRetry(
     opts.onConnected(opts.connectionId);
 
     if (runtime.conversationRuntimes.size === 0) {
-      emitDeviceStatusUpdate(socket, runtime);
+      // Don't emit device_status before the lookup store exists.
+      // Without a conversation runtime, the scope resolves to
+      // agent:__unknown__ which misses persisted CWD and permission
+      // mode entries. The web's sync command will create a scoped
+      // runtime and emit a properly-scoped device_status at that point.
       emitLoopStatusUpdate(socket, runtime);
     } else {
       for (const reminderState of runtime.reminderStateByConversation.values()) {


### PR DESCRIPTION
On crash restart, the onopen handler emitted device_status with no agentId scope (conversationRuntimes is empty on a fresh process). This caused the lookup key to resolve to agent:__unknown__ which missed persisted CWD and permission mode entries, sending defaults to the web and overwriting the user's settings.

Now we skip emitDeviceStatusUpdate when there are no conversation runtimes. The web's sync command creates a scoped runtime and emits a properly-scoped device_status with the correct persisted values.

🐾 Generated with [Letta Code](https://letta.com)