### PR TITLE
fix(ci): pin harbor==0.1.45 to fix regression workflow

### DIFF
--- a/.github/workflows/terminal-bench-regression.yml
+++ b/.github/workflows/terminal-bench-regression.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           uv venv .venv
           source .venv/bin/activate
-          uv pip install "harbor>=0.1.45" "litellm>=1.0.0" "modal>=1.3.5"
+          uv pip install "harbor==0.1.45" "litellm>=1.0.0" "modal>=1.3.5"
 
       - name: Configure Modal
         env:


### PR DESCRIPTION
## Summary
- Pin `harbor==0.1.45` in the Terminal-Bench regression workflow (was `>=0.1.45`)
- `harbor==0.2.0` removed `ExecInput` from `harbor.agents.installed.base`, breaking the `letta_code_agent` import and failing all 89 tasks with `ValueError: Failed to import module`

## Test plan
- [ ] Re-run the [regression workflow](https://github.com/letta-ai/letta-code/actions/workflows/terminal-bench-regression.yml) and confirm it passes

🤖 Generated with [Letta Code](https://letta.com)