### PR TITLE
fix(headless): set telemetry agent ID so errors include agent context

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -911,6 +911,7 @@ export async function handleHeadlessCommand(
     process.exit(1);
   }
   markMilestone("HEADLESS_AGENT_RESOLVED");
+  telemetry.setCurrentAgentId(agent.id);
 
   // Check if we're resuming an existing agent (not creating a new one)
   const isResumingAgent = !!(specifiedAgentId || (!forceNew && !fromAfFile));


### PR DESCRIPTION
## Summary
- Headless mode never called `telemetry.setCurrentAgentId()`, so all error telemetry (including unhandled rejections) was reported with empty `agent_id`, `run_id`, and `model` fields — making it impossible to trace errors back to specific agents.
- Adds `telemetry.setCurrentAgentId(agent.id)` right after agent resolution.

## Test plan
- [ ] Run headless and trigger an error — verify telemetry event includes `agent_id`
- [ ] Check that bidir mode also picks up the agent ID (called after the new line)

🤖 Generated with [Letta Code](https://letta.com)