### PR TITLE
fix: use shared ISOLATED_BLOCK_LABELS in remote /clear command

### DIFF
--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,5 +1,6 @@
 import type WebSocket from "ws";
 import { getClient } from "../../agent/client";
+import { ISOLATED_BLOCK_LABELS } from "../../agent/memory";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import {
   buildDoctorMessage,
@@ -20,8 +21,6 @@ import {
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
 import { handleIncomingMessage } from "./turn";
 import type { ConversationRuntime, StartListenerOptions } from "./types";
-
-const ISOLATED_BLOCK_LABELS = ["human", "persona"];
 
 /**
  * Command IDs that this letta-code version can handle via `execute_command`.


### PR DESCRIPTION
## Summary
- The listener `commands.ts` had a hardcoded `["human", "persona"]` for `isolated_block_labels` when creating conversations via remote `/clear`, while the CLI path uses the shared constant from `agent/memory.ts` (currently `[]`)
- This caused `/clear` from the desktop ADE UI to fail with `Block with label 'human' not found` on memfs-enabled agents that don't have traditional flat-label blocks
- Fix: import the shared `ISOLATED_BLOCK_LABELS` constant instead of redefining it

## Test plan
- [ ] Run `/clear` from desktop ADE UI on a memfs-enabled agent — should no longer 400
- [ ] Run `/clear` from CLI terminal — should continue to work as before
- [ ] Run `/clear` on a non-memfs agent with human/persona blocks — should still work (empty isolated labels means no isolation attempt)

👾 Generated with [Letta Code](https://letta.com)