### PR TITLE
fix(listen): scope subagent state by agent + convo

### DIFF
--- a/src/cli/helpers/subagentState.ts
+++ b/src/cli/helpers/subagentState.ts
@@ -33,6 +33,8 @@ export interface SubagentState {
   toolCallId?: string; // Links this subagent to its parent Task tool call
   isBackground?: boolean; // True if running in background (fire-and-forget)
   silent?: boolean; // True if this subagent should be hidden from SubagentGroupDisplay
+  parentAgentId?: string; // Parent runtime scope agent id (for listener-mode WS scoping)
+  parentConversationId?: string; // Parent runtime scope conversation id
 }
 
 interface SubagentStore {
@@ -112,6 +114,10 @@ export function registerSubagent(
   toolCallId?: string,
   isBackground?: boolean,
   silent?: boolean,
+  parentScope?: {
+    agentId?: string | null;
+    conversationId?: string | null;
+  },
 ): void {
   // Capitalize type for display (explore -> Explore)
   const displayType = type.charAt(0).toUpperCase() + type.slice(1);
@@ -130,6 +136,11 @@ export function registerSubagent(
     toolCallId,
     isBackground,
     silent,
+    parentAgentId: parentScope?.agentId ?? undefined,
+    parentConversationId:
+      parentScope?.conversationId && parentScope.conversationId.length > 0
+        ? parentScope.conversationId
+        : undefined,
   };
 
   store.agents.set(id, agent);

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1299,6 +1299,10 @@ describe("listen-client v2 status builders", () => {
         undefined,
         true,
         true,
+        {
+          agentId: "agent-1",
+          conversationId: "default",
+        },
       );
 
       const listener = __listenClientTestUtils.createListenerRuntime();
@@ -1333,6 +1337,64 @@ describe("listen-client v2 status builders", () => {
             silent: true,
           }),
         ],
+      });
+    } finally {
+      clearAllSubagents();
+    }
+  });
+
+  test("sync scopes update_subagent_state to runtime agent and conversation", () => {
+    clearAllSubagents();
+    try {
+      registerSubagent(
+        "subagent-reflection-target",
+        "reflection",
+        "Target scope",
+        undefined,
+        true,
+        true,
+        {
+          agentId: "agent-1",
+          conversationId: "default",
+        },
+      );
+      registerSubagent(
+        "subagent-reflection-other",
+        "reflection",
+        "Other scope",
+        undefined,
+        true,
+        true,
+        {
+          agentId: "agent-2",
+          conversationId: "default",
+        },
+      );
+
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+        listener,
+        "agent-1",
+        "default",
+      );
+      const socket = new MockSocket(WebSocket.OPEN);
+
+      __listenClientTestUtils.emitStateSync(
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          agent_id: "agent-1",
+          conversation_id: "default",
+        },
+      );
+
+      const outbound = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(outbound[3].type).toBe("update_subagent_state");
+      expect(outbound[3].subagents).toHaveLength(1);
+      expect(outbound[3].subagents[0]).toMatchObject({
+        subagent_id: "subagent-reflection-target",
       });
     } finally {
       clearAllSubagents();

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -166,6 +166,27 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function resolveParentScope(parentScope?: {
+  agentId: string;
+  conversationId: string;
+}): { agentId: string; conversationId: string } | undefined {
+  if (parentScope?.agentId) {
+    return {
+      agentId: parentScope.agentId,
+      conversationId: parentScope.conversationId || "default",
+    };
+  }
+
+  try {
+    return {
+      agentId: getCurrentAgentId(),
+      conversationId: getConversationId() ?? "default",
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Wait briefly for a background subagent to publish its agent URL.
  * This keeps Task mostly non-blocking while allowing static transcript rows
@@ -225,6 +246,8 @@ export function spawnBackgroundSubagentTask(
     deps,
   } = args;
 
+  const resolvedParentScope = resolveParentScope(parentScope);
+
   const spawnSubagentFn = deps?.spawnSubagentImpl ?? spawnSubagent;
   const addToMessageQueueFn = deps?.addToMessageQueueImpl ?? addToMessageQueue;
   const formatTaskNotificationFn =
@@ -246,6 +269,7 @@ export function spawnBackgroundSubagentTask(
     toolCallId,
     true,
     silentCompletion,
+    resolvedParentScope,
   );
 
   const taskId = getNextTaskId();
@@ -346,8 +370,8 @@ export function spawnBackgroundSubagentTask(
         addToMessageQueueFn({
           kind: "task_notification",
           text: notificationXml,
-          agentId: parentScope?.agentId,
-          conversationId: parentScope?.conversationId,
+          agentId: resolvedParentScope?.agentId,
+          conversationId: resolvedParentScope?.conversationId,
         });
       }
 
@@ -415,8 +439,8 @@ export function spawnBackgroundSubagentTask(
         addToMessageQueueFn({
           kind: "task_notification",
           text: notificationXml,
-          agentId: parentScope?.agentId,
-          conversationId: parentScope?.conversationId,
+          agentId: resolvedParentScope?.agentId,
+          conversationId: resolvedParentScope?.conversationId,
         });
       }
 
@@ -537,6 +561,7 @@ export async function task(args: TaskArgs): Promise<string> {
   const prompt = inputPrompt;
 
   const isBackground = args.run_in_background ?? config.background;
+  const resolvedParentScope = resolveParentScope(args.parentScope);
 
   // Handle background execution
   if (isBackground) {
@@ -550,7 +575,7 @@ export async function task(args: TaskArgs): Promise<string> {
       existingConversationId: effectiveConversationId,
       maxTurns: args.max_turns,
       forkedContext: config.fork,
-      parentScope: args.parentScope,
+      parentScope: resolvedParentScope,
     });
 
     await waitForBackgroundSubagentLink(subagentId, null, signal);
@@ -567,7 +592,15 @@ export async function task(args: TaskArgs): Promise<string> {
 
   // Register subagent with state store for UI display (foreground path)
   const subagentId = generateSubagentId();
-  registerSubagent(subagentId, subagent_type, description, toolCallId, false);
+  registerSubagent(
+    subagentId,
+    subagent_type,
+    description,
+    toolCallId,
+    false,
+    false,
+    resolvedParentScope,
+  );
 
   // Foreground tasks now also write transcripts so users can inspect full output
   // even when inline content is truncated.

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -335,6 +335,8 @@ export interface SubagentSnapshot {
   is_background?: boolean;
   silent?: boolean;
   tool_call_id?: string;
+  parent_agent_id?: string;
+  parent_conversation_id?: string;
   start_time: number;
   tool_calls: SubagentSnapshotToolCall[];
   total_tokens: number;

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1895,7 +1895,17 @@ async function connectWithRetry(
     // Store the unsubscribe function on the runtime for cleanup on close.
     runtime._unsubscribeSubagentState?.();
     runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
-      emitSubagentStateIfOpen(runtime);
+      if (runtime.conversationRuntimes.size === 0) {
+        emitSubagentStateIfOpen(runtime);
+        return;
+      }
+
+      for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+        emitSubagentStateIfOpen(runtime, {
+          agent_id: conversationRuntime.agentId,
+          conversation_id: conversationRuntime.conversationId,
+        });
+      }
     });
 
     // Subscribe to subagent stream events and forward as tagged stream_delta.
@@ -1907,10 +1917,10 @@ async function connectWithRetry(
       (subagentId, event) => {
         if (socket.readyState !== WebSocket.OPEN) return;
 
-        const isSilentSubagent = getSubagents().some(
-          (subagent) => subagent.id === subagentId && subagent.silent === true,
+        const subagent = getSubagents().find(
+          (entry) => entry.id === subagentId,
         );
-        if (isSilentSubagent) {
+        if (subagent?.silent === true) {
           // Reflection/background "silent" subagents should not stream their
           // internal transcript into the parent conversation.
           return;
@@ -1922,7 +1932,12 @@ async function connectWithRetry(
           socket,
           runtime,
           event as unknown as import("../../types/protocol_v2").StreamDelta,
-          undefined, // scope: falls back to listener's default agent/conversation
+          subagent?.parentAgentId
+            ? {
+                agent_id: subagent.parentAgentId,
+                conversation_id: subagent.parentConversationId ?? "default",
+              }
+            : undefined,
           subagentId,
         );
       },

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -540,13 +540,47 @@ export function emitStateSync(
 // Subagent state
 // ─────────────────────────────────────────────
 
-export function buildSubagentSnapshot(): SubagentSnapshot[] {
+function resolveSubagentScopeForSnapshot(
+  runtime: RuntimeCarrier,
+  scope?: {
+    agent_id?: string | null;
+    conversation_id?: string | null;
+  },
+): RuntimeScope | null {
+  const listener = getListenerRuntime(runtime);
+  return resolveRuntimeScope(listener, getScopeForRuntime(runtime, scope));
+}
+
+export function buildSubagentSnapshot(
+  runtime: RuntimeCarrier,
+  scope?: {
+    agent_id?: string | null;
+    conversation_id?: string | null;
+  },
+): SubagentSnapshot[] {
+  const runtimeScope = resolveSubagentScopeForSnapshot(runtime, scope);
+
   return getSubagents()
     .filter((a) => {
       if (a.status !== "pending" && a.status !== "running") {
         return false;
       }
-      return !a.silent || a.isBackground === true;
+      if (a.silent && a.isBackground !== true) {
+        return false;
+      }
+
+      if (!runtimeScope) {
+        return true;
+      }
+
+      // Scope listener-mode snapshots to the parent runtime that launched
+      // the subagent so active reflection/task state does not bleed across
+      // other agent/conversation tabs.
+      if (!a.parentAgentId || a.parentAgentId !== runtimeScope.agent_id) {
+        return false;
+      }
+      const parentConversationId = a.parentConversationId ?? "default";
+      return parentConversationId === runtimeScope.conversation_id;
     })
     .map((a) => ({
       subagent_id: a.id,
@@ -558,6 +592,8 @@ export function buildSubagentSnapshot(): SubagentSnapshot[] {
       is_background: a.isBackground,
       silent: a.silent,
       tool_call_id: a.toolCallId,
+      parent_agent_id: a.parentAgentId,
+      parent_conversation_id: a.parentConversationId,
       start_time: a.startTime,
       tool_calls: a.toolCalls,
       total_tokens: a.totalTokens,
@@ -579,7 +615,7 @@ export function emitSubagentStateUpdate(
     "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
   > = {
     type: "update_subagent_state",
-    subagents: buildSubagentSnapshot(),
+    subagents: buildSubagentSnapshot(runtime, scope),
   };
   emitProtocolV2Message(socket, runtime, message, scope);
 }

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -99,12 +99,25 @@ import type { ConversationRuntime, IncomingMessage } from "./types";
 
 const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
 
-function hasActiveReflectionSubagent(): boolean {
-  return getSubagents().some(
-    (agent) =>
-      agent.type.toLowerCase() === "reflection" &&
-      (agent.status === "pending" || agent.status === "running"),
-  );
+function hasActiveReflectionSubagent(
+  agentId: string,
+  conversationId: string,
+): boolean {
+  return getSubagents().some((agent) => {
+    if (agent.type.toLowerCase() !== "reflection") {
+      return false;
+    }
+    if (agent.status !== "pending" && agent.status !== "running") {
+      return false;
+    }
+    if (!agent.parentAgentId) {
+      return false;
+    }
+    const parentConversationId = agent.parentConversationId ?? "default";
+    return (
+      agent.parentAgentId === agentId && parentConversationId === conversationId
+    );
+  });
 }
 
 function buildMaybeLaunchReflectionSubagent(params: {
@@ -120,7 +133,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
       return false;
     }
 
-    if (hasActiveReflectionSubagent()) {
+    if (hasActiveReflectionSubagent(agentId, conversationId)) {
       debugLog(
         "memory",
         `Skipping auto reflection launch (${triggerSource}) because one is already active`,


### PR DESCRIPTION
**context**

Before:
- Backend subagent snapshots were built from a global active set.
- So runtime A could receive mixed data like [a1, a2, b1], and runtime B could also receive [a1, a2, b1].
- Frontend (UMI) correctly stored state per runtimeKey (agentId + conversationId), but each runtime slice could still be polluted because the payload itself was mixed.
- **Result**: cross-conversation/agent bleed (especially visible in reflection UI). For explore/task subagents, rendering is tied to the current message’s tool_call_id (and approval/tool-return maps), so leaked subagents from another convo usually had no matching call id in this convo and didn’t render

After:
- Backend stamps each subagent with parent scope (parentAgentId + parentConversationId) at creation time.
- Backend filters emitted snapshots by runtime scope.
- So runtime A gets only [a1, a2], runtime B gets only [b1].
- Frontend still stores per runtimeKey, but now each slice is clean.
- **Result**: UI A shows only A’s subagents; UI B shows only B’s subagents.

**fix**

- Adds parent scope metadata to subagent state.
- Threads that scope from Task creation time.
- Scopes backend `update_subagent_state` snapshots to runtime `(agent, convo)`.
- Scopes forwarded subagent stream deltas by parent runtime.
- Makes reflection “already running” check runtime-scoped.
- Adds protocol fields (`parent_agent_id`, `parent_conversation_id`) + regression test for scoped snapshot behavior.