### PR TITLE
fix(tests): stabilize headless Task stream-json integration test

### DIFF
--- a/src/integration-tests/headless-input-format.test.ts
+++ b/src/integration-tests/headless-input-format.test.ts
@@ -626,6 +626,8 @@ describe("input-format stream-json", () => {
         await rm(fixture.rootDir, { recursive: true, force: true });
       }
     },
-    { timeout: 260000 },
+    // Must exceed the helper timeout + retry budget, otherwise Bun can kill the
+    // retry attempt before runBidirectionalWithRetry() finishes.
+    { timeout: 520000 },
   );
 });


### PR DESCRIPTION
## Summary
- run the flaky stream-json Task/explore integration test against a tiny temp fixture directory instead of the full repo
- pass USER_CWD through the bidirectional test helper so the subagent searches a deterministic workspace
- assert the Task auto-approval plus expected `.ts` paths, and exclude non-TS fixture files

👾 Generated with [Letta Code](https://letta.com)