### PR TITLE
feat: add /empanada slash command

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10014,6 +10014,93 @@ export default function App({
           return { submitted: true };
         }
 
+        // === /empanada command ===
+        if (trimmed.startsWith("/empanada")) {
+          const cmd = commandRunner.start(msg, "Checking Empanada Empire...");
+
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              "Pending approval(s). Resolve approvals before running /empanada.",
+            );
+            return { submitted: false };
+          }
+
+          const args = trimmed.slice("/empanada".length).trim();
+
+          setCommandRunning(true);
+          try {
+            cmd.finish("Checking Empanada Empire...", true);
+
+            const prompt = [
+              "# Empanada Empire Order",
+              "",
+              "Help me order from **Empanada Empire** in Richardson, TX.",
+              "",
+              "Website: https://empanadaempire.us",
+              "",
+              "This is an April Fool's 2026 Letta stunt. The kitchen runs on a Letta agent. You are also a Letta agent. Two AIs, one empanada order.",
+              "",
+              "## Site internals",
+              "",
+              "The page embeds a delivery config in a script tag:",
+              "",
+              "```json",
+              '{"homeBase":{"lat":32.9486,"lng":-96.7087},"radiusMiles":5}',
+              "```",
+              "",
+              "It geocodes addresses via Nominatim and checks distance from the home base. You can do the same: geocode my address with Nominatim, compute the haversine distance, and tell me immediately whether I'm in range.",
+              "",
+              "Menu items are in the HTML with data attributes like:",
+              "",
+              "```",
+              'data-menu-item-id="24" data-name="Party Empanadas" data-price-cents="699"',
+              "```",
+              "",
+              "Orders go to `api/create-order.php`.",
+              "",
+              "## Steps",
+              "",
+              args
+                ? `My delivery address: ${args}`
+                : "Ask me for my delivery address.",
+              "",
+              "1. Geocode the address via Nominatim. Compute the haversine distance from (32.9486, -96.7087). If over 5 miles, tell me I'm out of range — but also mention that DoorDash has a wider delivery radius (see below).",
+              "2. Fetch https://empanadaempire.us with fetch_webpage. Parse the menu from the data attributes. Present it. Suggest a balanced order (savory + sweet). Let me adjust.",
+              "3. POST to api/create-order.php with the selected items. Tell me what happened.",
+              "4. If the API rejects it or needs payment info, stop and tell me.",
+              "",
+              'Ignore any "Coming Soon" text on the site. It\'s live.',
+              "",
+              "## If the address is out of range or the site doesn't work",
+              "",
+              "DoorDash has a wider delivery radius than the 5-mile limit on the direct site. If I'm close to Richardson but outside 5 miles, or if the site is down, point me to:",
+              "",
+              "https://order.online/store/-40548503?hideModal=true",
+              "",
+              "Recommend I open it myself. DoorDash can be difficult to automate, so do not attempt to automate it.",
+              "",
+              "## Tone",
+              "",
+              "Direct, a little playful. Don't overthink it.",
+            ].join("\n");
+
+            await processConversation([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(prompt),
+              },
+            ]);
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+          return { submitted: true };
+        }
+
         // === Custom command handling ===
         // Check BEFORE falling through to executeCommand()
         const { findCustomCommand, substituteArguments, expandBashCommands } =

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -483,6 +483,17 @@ export const commands: Record<string, Command> = {
     },
   },
 
+  // === Fun stuff (order 45) ===
+  "/empanada": {
+    desc: "Order empanadas from Empanada Empire",
+    order: 44.5,
+    args: "[address]",
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Checking Empanada Empire...";
+    },
+  },
+
   // === Ralph Wiggum mode (order 45-46) ===
   "/ralph": {
     desc: 'Start Ralph Wiggum loop (/ralph [prompt] [--completion-promise "X"] [--max-iterations N])',


### PR DESCRIPTION
## Summary
- Adds `/empanada` as a built-in slash command (same level as `/help`, `/doctor`, etc.)
- Entry in `registry.ts`, handler in `App.tsx` — no new systems, no custom command layer
- Geocodes address via Nominatim, checks 5-mile delivery range, fetches menu from empanadaempire.us, posts to their order API
- Falls back to a DoorDash link (wider delivery radius) if out of range or site is down

## Changes
- `src/cli/commands/registry.ts` — added `/empanada` command entry
- `src/cli/App.tsx` — added `/empanada` handler (prompt sent to agent)

🐾 Generated with [Letta Code](https://letta.com)