### PR TITLE
fix(cli): pass agent_id as query param in /fork for default conversation

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8538,7 +8538,7 @@ export default function App({
             const forked = (await client.post(
               `/v1/conversations/${encodeURIComponent(conversationIdRef.current)}/fork`,
               {
-                body: isDefault ? { agent_id: agentId } : {},
+                query: isDefault ? { agent_id: agentId } : {},
               },
             )) as { id: string };
 


### PR DESCRIPTION
## Summary
- `/fork` on the default conversation failed with `Conversation not found with id='['default']'` because `agent_id` was sent in the request body instead of as a query parameter.
- The server's `fork_conversation` endpoint declares `agent_id` as a `Query(...)` param, so it was always `None`, causing the fallback path to look up `"default"` as a literal conversation ID.
- Fix: change `body:` → `query:` to match the server contract (consistent with the SDK's `cancel` method pattern).

## Test plan
- [ ] Run `/fork` on a default conversation and verify it creates a new forked conversation successfully
- [ ] Run `/fork` on a named (non-default) conversation and verify it still works as before

🐾 Generated with [Letta Code](https://letta.com)