### PR TITLE
fix(cli): keep auto models on default toolset

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -504,6 +504,16 @@ function buildModelHandleFromLlmConfig(
   return llmConfig.model ?? null;
 }
 
+function getPreferredAgentModelHandle(
+  agent: Pick<AgentState, "model" | "llm_config"> | null | undefined,
+): string | null {
+  if (!agent) return null;
+  if (typeof agent.model === "string" && agent.model.length > 0) {
+    return agent.model;
+  }
+  return buildModelHandleFromLlmConfig(agent.llm_config);
+}
+
 function mapHandleToLlmConfigPatch(modelHandle: string): Partial<LlmConfig> {
   const [provider, ...modelParts] = modelHandle.split("/");
   const modelName = modelParts.join("/");
@@ -3353,11 +3363,8 @@ export default function App({
           ).last_run_completion;
           setAgentLastRunAt(lastRunCompletion ?? null);
 
-          // Derive model ID from llm_config for ModelSelector
-          const agentModelHandle =
-            agent.llm_config.model_endpoint_type && agent.llm_config.model
-              ? `${agent.llm_config.model_endpoint_type}/${agent.llm_config.model}`
-              : agent.llm_config.model;
+          // Derive model ID from the configured model handle for ModelSelector.
+          const agentModelHandle = getPreferredAgentModelHandle(agent);
           const { getModelInfoForLlmConfig } = await import("../agent/model");
           const modelInfo = getModelInfoForLlmConfig(
             agentModelHandle || "",
@@ -3446,9 +3453,7 @@ export default function App({
     let cancelled = false;
 
     const applyAgentModelLocally = () => {
-      const agentModelHandle =
-        agentState.model ??
-        buildModelHandleFromLlmConfig(agentState.llm_config);
+      const agentModelHandle = getPreferredAgentModelHandle(agentState);
       setHasConversationModelOverride(false);
       setConversationOverrideModelSettings(null);
       setLlmConfig(agentState.llm_config);
@@ -3504,9 +3509,7 @@ export default function App({
           return;
         }
 
-        const agentModelHandle =
-          agentState.model ??
-          buildModelHandleFromLlmConfig(agentState.llm_config);
+        const agentModelHandle = getPreferredAgentModelHandle(agentState);
         const effectiveModelHandle = conversationModel ?? agentModelHandle;
         if (!effectiveModelHandle) {
           applyAgentModelLocally();
@@ -4670,10 +4673,8 @@ export default function App({
                   // Model has changed at the agent level - update local state.
                   setLlmConfig(agent.llm_config);
 
-                  // Derive model ID from llm_config for ModelSelector.
-                  const agentModelHandle = buildModelHandleFromLlmConfig(
-                    agent.llm_config,
-                  );
+                  // Derive model ID from the configured model handle for ModelSelector.
+                  const agentModelHandle = getPreferredAgentModelHandle(agent);
 
                   const modelInfo = getModelInfoForLlmConfig(
                     agentModelHandle || "",
@@ -6669,12 +6670,7 @@ export default function App({
         setAgentId(targetAgentId);
         setAgentState(agent);
         setLlmConfig(agent.llm_config);
-        const agentModelHandle =
-          agent.llm_config.model_endpoint_type && agent.llm_config.model
-            ? agent.llm_config.model_endpoint_type +
-              "/" +
-              agent.llm_config.model
-            : (agent.llm_config.model ?? null);
+        const agentModelHandle = getPreferredAgentModelHandle(agent);
         setCurrentModelHandle(agentModelHandle);
         setConversationId(targetConversationId);
 
@@ -6828,12 +6824,7 @@ export default function App({
         setAgentId(agent.id);
         setAgentState(agent);
         setLlmConfig(agent.llm_config);
-        const agentModelHandle =
-          agent.llm_config.model_endpoint_type && agent.llm_config.model
-            ? agent.llm_config.model_endpoint_type +
-              "/" +
-              agent.llm_config.model
-            : (agent.llm_config.model ?? null);
+        const agentModelHandle = getPreferredAgentModelHandle(agent);
         setCurrentModelHandle(agentModelHandle);
         setConversationId(targetConversationId);
 

--- a/src/tests/tools/model-provider-detection.test.ts
+++ b/src/tests/tools/model-provider-detection.test.ts
@@ -24,11 +24,25 @@ describe("isOpenAIModel", () => {
   test("does not detect anthropic handles", () => {
     expect(isOpenAIModel("anthropic/claude-sonnet-4-6")).toBe(false);
   });
+
+  test("does not detect auto model ids/handles", () => {
+    expect(isOpenAIModel("auto")).toBe(false);
+    expect(isOpenAIModel("letta/auto")).toBe(false);
+    expect(isOpenAIModel("auto-fast")).toBe(false);
+    expect(isOpenAIModel("letta/auto-fast")).toBe(false);
+  });
 });
 
 describe("deriveToolsetFromModel", () => {
   test("maps chatgpt_oauth handles to codex toolset", () => {
     expect(deriveToolsetFromModel("chatgpt_oauth/gpt-5.3-codex")).toBe("codex");
+  });
+
+  test("maps auto models to default (anthropic) toolset", () => {
+    expect(deriveToolsetFromModel("auto")).toBe("default");
+    expect(deriveToolsetFromModel("letta/auto")).toBe("default");
+    expect(deriveToolsetFromModel("auto-fast")).toBe("default");
+    expect(deriveToolsetFromModel("letta/auto-fast")).toBe("default");
   });
 });
 


### PR DESCRIPTION
## Summary
- Prefer `agent.model` over provider-expanded `agent.llm_config` when deriving the active model handle in the CLI.
- This keeps `auto` / `auto-fast` mapped to the default toolset behavior instead of incorrectly selecting Codex tools.
- Add regression tests for OpenAI model detection and `deriveToolsetFromModel` behavior for auto models.

## Testing
- `bun test src/tests/tools/model-provider-detection.test.ts`
- `bun test src/tests/agent/model-preset-refresh.wiring.test.ts`
- `bun run check` *(fails due to pre-existing unrelated TS errors about `include_return_message_types` in `src/agent/check-approval.ts` and `src/cli/components/ConversationSelector.tsx`)*

👾 Generated with [Letta Code](https://letta.com)