### PR TITLE
fix(cli): resolve self-hosted model fallback for new agents

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -48,6 +48,7 @@ import { getResumeData } from "../agent/check-approval";
 import { getClient, getServerUrl } from "../agent/client";
 import { getCurrentAgentId, setCurrentAgentId } from "../agent/context";
 import { type AgentProvenance, createAgent } from "../agent/create";
+import { selectDefaultAgentModel } from "../agent/defaults";
 import { getLettaCodeHeaders } from "../agent/http-headers";
 import { ISOLATED_BLOCK_LABELS } from "../agent/memory";
 import {
@@ -6766,9 +6767,31 @@ export default function App({
         );
         const willAutoEnableMemfs = await isLettaCloud();
 
+        let effectiveModel = currentModelId || currentModelHandle || undefined;
+        const isSelfHosted = !getServerUrl().includes("api.letta.com");
+        if (isSelfHosted) {
+          try {
+            const client = await getClient();
+            const availableHandles = (await client.models.list())
+              .map((model) => model.handle)
+              .filter((handle): handle is string => typeof handle === "string");
+            effectiveModel = selectDefaultAgentModel({
+              preferredModel: effectiveModel,
+              isSelfHosted: true,
+              availableHandles,
+            });
+          } catch {
+            effectiveModel = selectDefaultAgentModel({
+              preferredModel: effectiveModel,
+              isSelfHosted: true,
+            });
+          }
+        }
+
         // Create the new agent
         const { agent } = await createAgent({
           name,
+          model: effectiveModel,
           memoryPromptMode: willAutoEnableMemfs ? "memfs" : undefined,
         });
 
@@ -6869,6 +6892,8 @@ export default function App({
     [
       agentId,
       commandRunner,
+      currentModelHandle,
+      currentModelId,
       setCommandRunning,
       resetDeferredToolCallCommits,
       resetTrajectoryBases,

--- a/src/tests/agent/defaults.test.ts
+++ b/src/tests/agent/defaults.test.ts
@@ -28,6 +28,25 @@ describe("selectDefaultAgentModel", () => {
     expect(result).toBe("anthropic/claude-haiku-4-5");
   });
 
+  test("falls back when the preferred self-hosted model is unavailable", () => {
+    const result = selectDefaultAgentModel({
+      preferredModel: "gpt-5",
+      isSelfHosted: true,
+      availableHandles: ["letta/auto", "anthropic/claude-haiku-4-5"],
+    });
+
+    expect(result).toBe("anthropic/claude-haiku-4-5");
+  });
+
+  test("keeps the preferred self-hosted handle when model availability cannot be fetched", () => {
+    const result = selectDefaultAgentModel({
+      preferredModel: "anthropic/claude-haiku-4-5",
+      isSelfHosted: true,
+    });
+
+    expect(result).toBe("anthropic/claude-haiku-4-5");
+  });
+
   test("passes through the preferred model on cloud", () => {
     const result = selectDefaultAgentModel({
       preferredModel: "haiku",


### PR DESCRIPTION
## Summary
- reuse the existing self-hosted model fallback when `/new` creates an agent from the TUI
- prefer the current selected model when it is available, otherwise fall back to a server-available non-`letta/auto` handle on self-hosted servers
- add focused coverage for unavailable preferred models and `models.list()` failure fallback behavior

Closes #1597

## Test plan
- [x] `bun test src/tests/agent/defaults.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)