### PR TITLE
fix(cli): recover restored approvals through live pipeline

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -13116,6 +13116,12 @@ ${SYSTEM_REMINDER_CLOSE}
                 resetContextHistory(contextTrackerRef.current);
                 resetBootstrapReminderState();
 
+                if (resumeData.pendingApprovals.length > 0) {
+                  await recoverRestoredPendingApprovals(
+                    resumeData.pendingApprovals,
+                  );
+                }
+
                 cmd.finish(
                   `Switched to conversation (${resumeData.messageHistory.length} messages)`,
                   true,
@@ -13159,6 +13165,7 @@ ${SYSTEM_REMINDER_CLOSE}
     setCommandRunning,
     commandRunner.getHandle,
     commandRunner.start,
+    recoverRestoredPendingApprovals,
     resetBootstrapReminderState,
   ]);
 

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -81,5 +81,22 @@ describe("approval recovery wiring", () => {
     expect(source).not.toContain(
       "setPendingApprovals(resumeData.pendingApprovals);",
     );
+
+    const queuedSwitchStart = source.indexOf(
+      'if (action.type === "switch_conversation")',
+    );
+    const queuedSwitchEnd = source.indexOf(
+      '} else if (action.type === "switch_toolset")',
+    );
+    expect(queuedSwitchStart).toBeGreaterThan(-1);
+    expect(queuedSwitchEnd).toBeGreaterThan(queuedSwitchStart);
+
+    const queuedSwitchSegment = source.slice(
+      queuedSwitchStart,
+      queuedSwitchEnd,
+    );
+    expect(queuedSwitchSegment).toContain(
+      "await recoverRestoredPendingApprovals(",
+    );
   });
 });

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -72,6 +72,24 @@ const drainStreamWithResumeMock = mock(
   },
 );
 const retrieveAgentMock = mock(async (agentId: string) => ({ id: agentId }));
+const retrieveConversationMock = mock(async (conversationId: string) => ({
+  id: conversationId,
+  in_context_message_ids: ["msg-recovered-approval"],
+}));
+const retrieveMessageMock = mock(async () => [
+  {
+    id: "msg-recovered-approval",
+    message_type: "approval_request_message",
+    tool_calls: [] as Array<{
+      tool_call_id: string;
+      name: string;
+      arguments: string;
+    }>,
+  },
+]);
+const listAgentMessagesMock = mock(async () => ({
+  getPaginatedItems: () => [],
+}));
 const cancelConversationMock = mock(async (_conversationId: string) => {});
 const conversationMessagesStreamMock = mock(
   async (
@@ -89,12 +107,19 @@ const conversationMessagesStreamMock = mock(
 const getClientMock = mock(async () => ({
   agents: {
     retrieve: retrieveAgentMock,
+    messages: {
+      list: listAgentMessagesMock,
+    },
   },
   conversations: {
+    retrieve: retrieveConversationMock,
     cancel: cancelConversationMock,
     messages: {
       stream: conversationMessagesStreamMock,
     },
+  },
+  messages: {
+    retrieve: retrieveMessageMock,
   },
 }));
 const getResumeDataMock = mock(
@@ -246,6 +271,9 @@ describe("listen-client multi-worker concurrency", () => {
     drainStreamWithResumeMock.mockClear();
     getClientMock.mockClear();
     retrieveAgentMock.mockClear();
+    retrieveConversationMock.mockClear();
+    retrieveMessageMock.mockClear();
+    listAgentMessagesMock.mockClear();
     getResumeDataMock.mockClear();
     classifyApprovalsMock.mockClear();
     executeApprovalBatchMock.mockClear();
@@ -1022,6 +1050,257 @@ describe("listen-client multi-worker concurrency", () => {
       ],
       otid: expect.any(String),
     });
+  });
+
+  test("sync replay preserves hidden auto decisions while only surfacing manual recovered approvals", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-mixed-sync",
+    );
+
+    const autoAllowedApproval = {
+      toolCallId: "tool-auto-allow",
+      toolName: "Read",
+      toolArgs: '{"file_path":"foo.ts"}',
+    };
+    const manualApproval = {
+      toolCallId: "tool-manual",
+      toolName: "Bash",
+      toolArgs: '{"command":"rm -rf tmp"}',
+    };
+    const autoDeniedApproval = {
+      toolCallId: "tool-auto-deny",
+      toolName: "Write",
+      toolArgs: '{"file_path":"denied.ts","content":"nope"}',
+    };
+
+    retrieveConversationMock.mockResolvedValueOnce({
+      id: "conv-mixed-sync",
+      in_context_message_ids: ["msg-recovered-approval"],
+    });
+    retrieveMessageMock.mockResolvedValueOnce([
+      {
+        id: "msg-recovered-approval",
+        message_type: "approval_request_message",
+        tool_calls: [
+          {
+            tool_call_id: autoAllowedApproval.toolCallId,
+            name: autoAllowedApproval.toolName,
+            arguments: autoAllowedApproval.toolArgs,
+          },
+          {
+            tool_call_id: manualApproval.toolCallId,
+            name: manualApproval.toolName,
+            arguments: manualApproval.toolArgs,
+          },
+          {
+            tool_call_id: autoDeniedApproval.toolCallId,
+            name: autoDeniedApproval.toolName,
+            arguments: autoDeniedApproval.toolArgs,
+          },
+        ],
+      },
+    ]);
+    // biome-ignore lint/suspicious/noExplicitAny: mock method access
+    (classifyApprovalsMock as any).mockResolvedValueOnce({
+      autoAllowed: [
+        {
+          approval: autoAllowedApproval,
+          parsedArgs: { file_path: "foo.ts" },
+          permission: { decision: "allow", reason: "auto" },
+        },
+      ],
+      autoDenied: [
+        {
+          approval: autoDeniedApproval,
+          parsedArgs: { file_path: "denied.ts", content: "nope" },
+          permission: { decision: "deny", reason: "blocked" },
+          denyReason: "blocked by policy",
+        },
+      ],
+      needsUserInput: [
+        {
+          approval: manualApproval,
+          parsedArgs: { command: "rm -rf tmp" },
+          permission: { decision: "ask", reason: "needs approval" },
+        },
+      ],
+    } as never);
+
+    await __listenClientTestUtils.recoverApprovalStateForSync(runtime, {
+      agent_id: "agent-1",
+      conversation_id: "conv-mixed-sync",
+    });
+
+    expect(runtime.recoveredApprovalState?.pendingRequestIds).toEqual(
+      new Set(["perm-tool-manual"]),
+    );
+    expect(runtime.recoveredApprovalState?.autoDecisions).toEqual([
+      {
+        type: "approve",
+        approval: autoAllowedApproval,
+      },
+      {
+        type: "deny",
+        approval: autoDeniedApproval,
+        reason: "blocked by policy",
+      },
+    ]);
+    expect(runtime.recoveredApprovalState?.allApprovals).toEqual([
+      autoAllowedApproval,
+      manualApproval,
+      autoDeniedApproval,
+    ]);
+
+    const deviceStatus = __listenClientTestUtils.buildDeviceStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-mixed-sync",
+    });
+    expect(deviceStatus.pending_control_requests).toEqual([
+      {
+        request_id: "perm-tool-manual",
+        request: expect.objectContaining({
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          tool_call_id: "tool-manual",
+        }),
+      },
+    ]);
+  });
+
+  test("recovered approval continuation executes hidden auto decisions together with manual responses", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-mixed-recovered",
+    );
+    const socket = new MockSocket();
+
+    const autoAllowedApproval = {
+      toolCallId: "tool-auto-allow",
+      toolName: "Read",
+      toolArgs: '{"file_path":"foo.ts"}',
+    };
+    const manualApproval = {
+      toolCallId: "tool-manual",
+      toolName: "Bash",
+      toolArgs: '{"command":"rm -rf tmp"}',
+    };
+    const autoDeniedApproval = {
+      toolCallId: "tool-auto-deny",
+      toolName: "Write",
+      toolArgs: '{"file_path":"denied.ts","content":"nope"}',
+    };
+    const approvalResults = [
+      {
+        type: "tool",
+        tool_call_id: "tool-auto-allow",
+        tool_return: "auto ok",
+        status: "success",
+      },
+      {
+        type: "approval",
+        tool_call_id: "tool-auto-deny",
+        approve: false,
+        reason: "blocked by policy",
+      },
+      {
+        type: "tool",
+        tool_call_id: "tool-manual",
+        tool_return: "manual ok",
+        status: "success",
+      },
+    ];
+    executeApprovalBatchMock.mockResolvedValueOnce(approvalResults as never);
+
+    runtime.recoveredApprovalState = {
+      agentId: "agent-1",
+      conversationId: "conv-mixed-recovered",
+      approvalsByRequestId: new Map([
+        [
+          "perm-tool-manual",
+          {
+            approval: manualApproval,
+            controlRequest: {
+              type: "control_request",
+              request_id: "perm-tool-manual",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                input: { command: "rm -rf tmp" },
+                tool_call_id: "tool-manual",
+                permission_suggestions: [],
+                blocked_path: null,
+              },
+              agent_id: "agent-1",
+              conversation_id: "conv-mixed-recovered",
+            },
+          },
+        ],
+      ]),
+      pendingRequestIds: new Set(["perm-tool-manual"]),
+      responsesByRequestId: new Map(),
+      autoDecisions: [
+        {
+          type: "approve",
+          approval: autoAllowedApproval,
+        },
+        {
+          type: "deny",
+          approval: autoDeniedApproval,
+          reason: "blocked by policy",
+        },
+      ],
+      allApprovals: [autoAllowedApproval, manualApproval, autoDeniedApproval],
+    };
+
+    const handled = await resolveRecoveredApprovalResponse(
+      runtime,
+      socket as unknown as WebSocket,
+      {
+        request_id: "perm-tool-manual",
+        decision: { behavior: "allow", message: "approved manually" },
+      },
+      __listenClientTestUtils.handleIncomingMessage,
+      {},
+    );
+
+    expect(handled).toBe(true);
+    expect(executeApprovalBatchMock).toHaveBeenCalledWith(
+      [
+        {
+          type: "approve",
+          approval: autoAllowedApproval,
+        },
+        {
+          type: "deny",
+          approval: autoDeniedApproval,
+          reason: "blocked by policy",
+        },
+        {
+          type: "approve",
+          approval: manualApproval,
+          reason: "approved manually",
+        },
+      ],
+      undefined,
+      expect.any(Object),
+    );
+
+    const continuationMessages = sendMessageStreamMock.mock.calls[0]?.[1] as
+      | Array<Record<string, unknown>>
+      | undefined;
+    expect(continuationMessages?.[0]).toEqual(
+      expect.objectContaining({
+        type: "approval",
+        approvals: approvalResults,
+      }),
+    );
   });
 
   test("sync replay suppresses recovered approvals when interrupted cache is active", async () => {

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1627,7 +1627,10 @@ describe("listen-client v2 status builders", () => {
     const source = readFileSync(recoveryPath, "utf-8");
 
     expect(source).toContain(
-      "const { needsUserInput } = await classifyApprovals(",
+      "const { needsUserInput, autoAllowed, autoDenied } = await classifyApprovals(",
+    );
+    expect(source).toContain(
+      "const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);",
     );
     expect(source).toContain("if (needsUserInput.length === 0) {");
     expect(source).toContain("needsUserInput.map(async (approvalEntry) => {");

--- a/src/websocket/listener/interrupts.ts
+++ b/src/websocket/listener/interrupts.ts
@@ -531,9 +531,9 @@ export function stashRecoveredApprovalInterrupts(
   runtime: ConversationRuntime,
   recovered: RecoveredApprovalState,
 ): boolean {
-  const approvals = [...recovered.approvalsByRequestId.values()].map(
-    (entry) => entry.approval,
-  );
+  const approvals =
+    recovered.allApprovals ??
+    [...recovered.approvalsByRequestId.values()].map((entry) => entry.approval);
   if (approvals.length === 0) {
     clearRecoveredApprovalState(runtime);
     return false;

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -330,6 +330,23 @@ export async function debugLogApprovalResumeState(
   }
 }
 
+function buildRecoveredAutoDecisions(
+  autoAllowed: Awaited<ReturnType<typeof classifyApprovals>>["autoAllowed"],
+  autoDenied: Awaited<ReturnType<typeof classifyApprovals>>["autoDenied"],
+): ApprovalDecision[] {
+  return [
+    ...autoAllowed.map((ac) => ({
+      type: "approve" as const,
+      approval: ac.approval,
+    })),
+    ...autoDenied.map((ac) => ({
+      type: "deny" as const,
+      approval: ac.approval,
+      reason: ac.denyReason || ac.permission.reason || "Permission denied",
+    })),
+  ];
+}
+
 export async function recoverApprovalStateForSync(
   runtime: ConversationRuntime,
   scope: { agent_id: string; conversation_id: string },
@@ -398,17 +415,21 @@ export async function recoverApprovalStateForSync(
     scope.agent_id,
     scope.conversation_id,
   );
-  const { needsUserInput } = await classifyApprovals(pendingApprovals, {
-    alwaysRequiresUserInput: isInteractiveApprovalTool,
-    requireArgsForAutoApprove: true,
-    missingNameReason: "Tool call incomplete - missing name",
-    workingDirectory,
-    permissionModeState: getOrCreateConversationPermissionModeStateRef(
-      runtime.listener,
-      scope.agent_id,
-      scope.conversation_id,
-    ),
-  });
+  const { needsUserInput, autoAllowed, autoDenied } = await classifyApprovals(
+    pendingApprovals,
+    {
+      alwaysRequiresUserInput: isInteractiveApprovalTool,
+      requireArgsForAutoApprove: true,
+      missingNameReason: "Tool call incomplete - missing name",
+      workingDirectory,
+      permissionModeState: getOrCreateConversationPermissionModeStateRef(
+        runtime.listener,
+        scope.agent_id,
+        scope.conversation_id,
+      ),
+    },
+  );
+  const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);
 
   if (needsUserInput.length === 0) {
     clearRecoveredApprovalState(runtime);
@@ -454,6 +475,8 @@ export async function recoverApprovalStateForSync(
     approvalsByRequestId,
     pendingRequestIds: new Set(approvalsByRequestId.keys()),
     responsesByRequestId: new Map(),
+    autoDecisions,
+    allApprovals: pendingApprovals,
   };
 }
 
@@ -501,7 +524,7 @@ export async function resolveRecoveredApprovalResponse(
     return true;
   }
 
-  const decisions: ApprovalDecision[] = [];
+  const decisions: ApprovalDecision[] = [...(recovered.autoDecisions ?? [])];
   for (const [id, entry] of recovered.approvalsByRequestId) {
     const approvalResponse = recovered.responsesByRequestId.get(id);
     if (!approvalResponse) {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -1,7 +1,10 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
-import type { ApprovalResult } from "../../agent/approval-execution";
+import type {
+  ApprovalDecision,
+  ApprovalResult,
+} from "../../agent/approval-execution";
 import type { ContextTracker } from "../../cli/helpers/contextTracker";
 import type { ApprovalRequest } from "../../cli/helpers/stream";
 import type {
@@ -95,6 +98,8 @@ export type RecoveredApprovalState = {
   approvalsByRequestId: Map<string, RecoveredPendingApproval>;
   pendingRequestIds: Set<string>;
   responsesByRequestId: Map<string, ApprovalResponseBody>;
+  autoDecisions?: ApprovalDecision[];
+  allApprovals?: ApprovalRequest[];
 };
 
 export type ConversationRuntime = {


### PR DESCRIPTION
## Summary
- route restored pending approvals back through the same classify → auto-execute → continuation path used by live turns so reconnects do not strand auto-approvable tools in manual approval UI
- reuse that shared recovery helper across startup restore and the TUI resume/conversation-switch paths, while preserving manual approval UI restoration when user input is still required
- limit websocket sync recovery to approvals that still need user input and add wiring tests covering both the TUI recovery path and sync filtering behavior

👾 Generated with [Letta Code](https://letta.com)