### PR TITLE
fix(headless): avoid max-turn exits during approval continuations

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1640,8 +1640,17 @@ ${SYSTEM_REMINDER_CLOSE}
 
   try {
     while (true) {
-      // Check max turns limit before starting a new turn (uses server-side step count)
-      checkMaxTurns();
+      const hasApprovalContinuation = currentInput.some(
+        (item) => item.type === "approval",
+      );
+
+      // Check max turns limit before starting a new user turn.
+      // Do NOT enforce before approval continuations: otherwise we can exit
+      // with max_steps while the backend is still waiting for the approval
+      // response, leaving the run stuck in requires_approval.
+      if (!hasApprovalContinuation) {
+        checkMaxTurns();
+      }
 
       // Inject queued skill content as user message parts (LET-7353)
       {
@@ -2013,8 +2022,13 @@ ${SYSTEM_REMINDER_CLOSE}
       // Track API duration for this stream
       sessionStats.endTurn(apiDurationMs);
 
-      // Check max turns after each turn (server may have taken multiple steps)
-      checkMaxTurns();
+      // Check max turns after each turn (server may have taken multiple steps),
+      // but defer the limit when we're still resolving pending approvals.
+      // Otherwise we can exit while the backend is waiting for approval input,
+      // leaving the run stuck in requires_approval.
+      if (stopReason !== "requires_approval" && !approvalPendingRecovery) {
+        checkMaxTurns();
+      }
 
       if (approvalPendingRecovery) {
         await resolveAllPendingApprovals();


### PR DESCRIPTION
## Summary
- defer one-shot headless max-turn enforcement while sending approval continuations (`type: "approval"`) so the client does not exit before responding to pending approvals
- defer post-drain max-turn enforcement when the stop reason is `requires_approval` or when approval-pending recovery is active
- prevents client/server desync where runs are left in `requires_approval` without a follow-up approval payload

## Why this change was needed
We were seeing intermittent headless `--yolo` failures with `rc=1` where the client exited while the backend run remained in `requires_approval`. In those failures:

- server logs showed `approval_request_message` followed by terminal `stop_reason=requires_approval`
- no subsequent approval response was sent from the client
- stream finalizer warnings appeared because the stream closed without a clean approval continuation
- repeated runs could get stuck in an approval loop because each new attempt hit the same pending-approval state

### Root cause
In one-shot headless mode, `checkMaxTurns()` ran in two places:
1. at the start of every loop iteration, and
2. again right after draining a stream turn.

If a turn ended in `requires_approval`, the client still performed max-turn checks before sending the approval continuation payload. If the step budget was reached at that point, the client exited with `max_steps` immediately.

That creates a protocol mismatch:
- backend state: waiting for approval continuation
- client state: process exited

### Why deferring max-turn checks is correct
Approval continuations are not a new user turn; they are required completion of an in-flight turn. Enforcing turn limits before that continuation is sent can only leave the run half-complete.

This change preserves the max-turn guard for normal turns, but defers it for approval continuation paths so the client can finish the required approval round-trip first.

## Test plan
- [x] `bun test src/tests/headless/approval-recovery-wiring.test.ts src/tests/headless/bootstrap-pending-approval-wiring.test.ts`
- [x] `bun run check` *(fails on pre-existing unrelated type errors in `src/agent/check-approval.ts` and `src/cli/components/ConversationSelector.tsx`, plus pre-existing Biome findings in `src/tests/cli/fileIndex.test.ts`)*

👾 Generated with [Letta Code](https://letta.com)