### PR TITLE
fix(listen): fix listen agent info reminder metadata

### DIFF
--- a/src/reminders/listenContext.ts
+++ b/src/reminders/listenContext.ts
@@ -5,6 +5,9 @@ import type { SessionContextReason, SharedReminderState } from "./state";
 interface BuildListenReminderContextParams {
   agentId: string;
   conversationId?: string;
+  agentName?: string | null;
+  agentDescription?: string | null;
+  agentLastRunAt?: string | null;
   state: SharedReminderState;
   reflectionSettings: ReflectionSettings;
   maybeLaunchReflectionSubagent?: SharedReminderContext["maybeLaunchReflectionSubagent"];
@@ -22,9 +25,9 @@ export function buildListenReminderContext(
     mode: "listen",
     agent: {
       id: params.agentId,
-      name: null,
-      description: null,
-      lastRunAt: null,
+      name: params.agentName ?? null,
+      description: params.agentDescription ?? null,
+      lastRunAt: params.agentLastRunAt ?? null,
       conversationId: params.conversationId,
     },
     state: params.state,

--- a/src/tests/reminders/listen-session-context.test.ts
+++ b/src/tests/reminders/listen-session-context.test.ts
@@ -60,6 +60,9 @@ function withStubbedProviders(fn: () => Promise<void>): () => Promise<void> {
 function listenContext(
   state: SharedReminderState,
   overrides?: {
+    agentName?: string | null;
+    agentDescription?: string | null;
+    agentLastRunAt?: string | null;
     workingDirectory?: string;
     sessionContextReason?: "initial_attach" | "cwd_changed";
   },
@@ -210,6 +213,22 @@ describe("listen-mode session context", () => {
     );
     expect(stepCount.modes).toContain("listen");
     expect(compaction.modes).toContain("listen");
+  });
+
+  test("listen reminder context preserves provided agent metadata", () => {
+    const state = createSharedReminderState();
+    const ctx = listenContext(state, {
+      agentName: "Letta Code",
+      agentDescription: "Helpful coding agent",
+      agentLastRunAt: "2026-04-01T19:00:00.000Z",
+    });
+
+    expect(ctx.agent).toMatchObject({
+      id: "agent-test",
+      name: "Letta Code",
+      description: "Helpful coding agent",
+      lastRunAt: "2026-04-01T19:00:00.000Z",
+    });
   });
 });
 

--- a/src/tests/websocket/listen-agent-info-wiring.test.ts
+++ b/src/tests/websocket/listen-agent-info-wiring.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("listen agent-info wiring", () => {
+  test("listener turns fetch and pass real agent metadata into the shared reminder context", () => {
+    const turnPath = fileURLToPath(
+      new URL("../../websocket/listener/turn.ts", import.meta.url),
+    );
+    const listenContextPath = fileURLToPath(
+      new URL("../../reminders/listenContext.ts", import.meta.url),
+    );
+    const turnSource = readFileSync(turnPath, "utf-8");
+    const listenContextSource = readFileSync(listenContextPath, "utf-8");
+
+    expect(turnSource).toContain(
+      "if (!runtime.reminderState.hasSentAgentInfo && agentId)",
+    );
+    expect(turnSource).toContain(
+      "const agent = await client.agents.retrieve(agentId);",
+    );
+    expect(turnSource).toContain("name: agent.name ?? null,");
+    expect(turnSource).toContain("description: agent.description ?? null,");
+    expect(turnSource).toContain("lastRunAt:");
+    expect(turnSource).toContain(
+      "agentName: listenAgentMetadata?.name ?? null",
+    );
+    expect(turnSource).toContain(
+      "agentDescription: listenAgentMetadata?.description ?? null",
+    );
+    expect(turnSource).toContain(
+      "agentLastRunAt: listenAgentMetadata?.lastRunAt ?? null",
+    );
+
+    expect(listenContextSource).toContain("agentName?: string | null;");
+    expect(listenContextSource).toContain("agentDescription?: string | null;");
+    expect(listenContextSource).toContain("agentLastRunAt?: string | null;");
+    expect(listenContextSource).toContain("name: params.agentName ?? null,");
+    expect(listenContextSource).toContain(
+      "description: params.agentDescription ?? null,",
+    );
+    expect(listenContextSource).toContain(
+      "lastRunAt: params.agentLastRunAt ?? null,",
+    );
+  });
+});

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -389,6 +389,27 @@ export async function handleIncomingMessage(
           runtime.reminderState,
           runtime.contextTracker,
         );
+        let listenAgentMetadata: {
+          name: string | null;
+          description: string | null;
+          lastRunAt: string | null;
+        } | null = null;
+        if (!runtime.reminderState.hasSentAgentInfo && agentId) {
+          try {
+            const client = await getClient();
+            const agent = await client.agents.retrieve(agentId);
+            listenAgentMetadata = {
+              name: agent.name ?? null,
+              description: agent.description ?? null,
+              lastRunAt:
+                (agent as { last_run_completion?: string | null })
+                  .last_run_completion ?? null,
+            };
+          } catch {
+            // Best-effort only. If the fetch fails, reminder building will
+            // fall back to the existing null/placeholder behavior.
+          }
+        }
         const reflectionSettings = getReflectionSettings(
           agentId || undefined,
           turnWorkingDirectory,
@@ -397,6 +418,9 @@ export async function handleIncomingMessage(
           buildListenReminderContext({
             agentId: agentId || "",
             conversationId,
+            agentName: listenAgentMetadata?.name ?? null,
+            agentDescription: listenAgentMetadata?.description ?? null,
+            agentLastRunAt: listenAgentMetadata?.lastRunAt ?? null,
             state: runtime.reminderState,
             reflectionSettings,
             maybeLaunchReflectionSubagent: agentId


### PR DESCRIPTION
## Summary
- fetch real agent metadata before building the first listen-mode shared reminders
- pass agent name, description, and last-run timestamp through the listen reminder context instead of hardcoding nulls
- add reminder and websocket wiring tests for the listen/Desktop path

## Problem
The websocket/Desktop system reminder was always rendering the agent as `(unnamed)` because listen-mode reminder context dropped agent metadata before calling the shared agent-info reminder builder.

## Testing
- bun test src/tests/reminders/listen-session-context.test.ts src/tests/websocket/listen-agent-info-wiring.test.ts src/tests/websocket/listen-client-concurrency.test.ts
- git diff --check