### PR TITLE
feat(listen): Add websocket approval suggestion support

### DIFF
--- a/src/tests/websocket/listen-approval-suggestions.test.ts
+++ b/src/tests/websocket/listen-approval-suggestions.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ApprovalContext } from "../../permissions/analyzer";
+import { loadPermissions } from "../../permissions/loader";
+import {
+  applySuggestedPermissionsForApproval,
+  buildApprovalSuggestionPayload,
+} from "../../websocket/listener/approval-suggestions";
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "letta-listen-approval-suggestions-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+test("buildApprovalSuggestionPayload exposes TUI-equivalent suggestion text", () => {
+  const context: ApprovalContext = {
+    recommendedRule: "Bash(rm:*)",
+    ruleDescription: "rm commands",
+    approveAlwaysText:
+      "Yes, and don't ask again for 'rm' commands in this project",
+    defaultScope: "project",
+    allowPersistence: true,
+    safetyLevel: "moderate",
+  };
+
+  expect(buildApprovalSuggestionPayload(context)).toEqual({
+    permission_suggestions: [
+      {
+        id: "save-default",
+        text: "Yes, and don't ask again for 'rm' commands in this project",
+      },
+    ],
+  });
+});
+
+test("buildApprovalSuggestionPayload omits suggestions when approval cannot be persisted", () => {
+  const context: ApprovalContext = {
+    recommendedRule: "",
+    ruleDescription: "",
+    approveAlwaysText: "",
+    defaultScope: "session",
+    allowPersistence: false,
+    safetyLevel: "dangerous",
+  };
+
+  expect(buildApprovalSuggestionPayload(context)).toEqual({
+    permission_suggestions: [],
+  });
+});
+
+test("applySuggestedPermissionsForApproval saves the selected backend suggestion", async () => {
+  const context: ApprovalContext = {
+    recommendedRule: "Bash(rm:*)",
+    ruleDescription: "rm commands",
+    approveAlwaysText:
+      "Yes, and don't ask again for 'rm' commands in this project",
+    defaultScope: "project",
+    allowPersistence: true,
+    safetyLevel: "moderate",
+  };
+
+  const applied = await applySuggestedPermissionsForApproval({
+    decision: {
+      behavior: "allow",
+      selected_permission_suggestion_ids: ["save-default"],
+    },
+    context,
+    workingDirectory: testDir,
+  });
+
+  const permissions = await loadPermissions(testDir);
+  expect(applied).toBe(true);
+  expect(permissions.allow).toContain("Bash(rm:*)");
+});
+
+test("applySuggestedPermissionsForApproval ignores unselected suggestions", async () => {
+  const context: ApprovalContext = {
+    recommendedRule: "Bash(rm:*)",
+    ruleDescription: "rm commands",
+    approveAlwaysText:
+      "Yes, and don't ask again for 'rm' commands in this project",
+    defaultScope: "project",
+    allowPersistence: true,
+    safetyLevel: "moderate",
+  };
+
+  const applied = await applySuggestedPermissionsForApproval({
+    decision: {
+      behavior: "allow",
+      selected_permission_suggestion_ids: [],
+    },
+    context,
+    workingDirectory: testDir,
+  });
+
+  const permissions = await loadPermissions(testDir);
+  expect(applied).toBe(false);
+  expect(permissions.allow).not.toContain("Bash(rm:*)");
+});

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -662,6 +662,7 @@ describe("listen-client multi-worker concurrency", () => {
               toolName: "Bash",
               toolArgs: "{}",
             },
+            approvalContext: null,
             controlRequest: {
               type: "control_request",
               request_id: "perm-a",
@@ -1100,6 +1101,7 @@ describe("listen-client multi-worker concurrency", () => {
               toolName: "Write",
               toolArgs: '{"file_path":"foo.ts"}',
             },
+            approvalContext: null,
             controlRequest: {
               type: "control_request",
               request_id: "perm-recovered-1",
@@ -1234,6 +1236,15 @@ describe("listen-client multi-worker concurrency", () => {
           approval: manualApproval,
           parsedArgs: { command: "rm -rf tmp" },
           permission: { decision: "ask", reason: "needs approval" },
+          context: {
+            recommendedRule: "Bash(rm:*)",
+            ruleDescription: "rm commands",
+            approveAlwaysText:
+              "Yes, and don't ask again for 'rm' commands in this project",
+            defaultScope: "project",
+            allowPersistence: true,
+            safetyLevel: "moderate",
+          },
         },
       ],
     } as never);
@@ -1274,6 +1285,12 @@ describe("listen-client multi-worker concurrency", () => {
           subtype: "can_use_tool",
           tool_name: "Bash",
           tool_call_id: "tool-manual",
+          permission_suggestions: [
+            {
+              id: "save-default",
+              text: "Yes, and don't ask again for 'rm' commands in this project",
+            },
+          ],
         }),
       },
     ]);
@@ -1334,6 +1351,7 @@ describe("listen-client multi-worker concurrency", () => {
           "perm-tool-manual",
           {
             approval: manualApproval,
+            approvalContext: null,
             controlRequest: {
               type: "control_request",
               request_id: "perm-tool-manual",
@@ -1446,6 +1464,7 @@ describe("listen-client multi-worker concurrency", () => {
               toolName: "Bash",
               toolArgs: '{"command":"sleep 300"}',
             },
+            approvalContext: null,
             controlRequest: {
               type: "control_request",
               request_id: "perm-sync",
@@ -1529,6 +1548,7 @@ describe("listen-client multi-worker concurrency", () => {
               toolName: "Bash",
               toolArgs: '{"command":"sleep 300"}',
             },
+            approvalContext: null,
             controlRequest: {
               type: "control_request",
               request_id: "perm-stale",

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -106,6 +106,28 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("input");
   });
 
+  test("parses approval_response with selected permission suggestion ids", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "approval_response",
+            request_id: "perm-1",
+            decision: {
+              behavior: "allow",
+              selected_permission_suggestion_ids: ["save-default"],
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("input");
+  });
+
   describe("listen-client create_agent command handling", () => {
     test("creates the memo, linus, and kawaii presets through the shared helper", async () => {
       expect(DEFAULT_CREATE_AGENT_PERSONALITIES).toEqual([
@@ -1588,6 +1610,7 @@ describe("listen-client v2 status builders", () => {
           requestId,
           {
             approval: {} as never,
+            approvalContext: null,
             controlRequest: makeControlRequest(requestId),
           },
         ],
@@ -1627,8 +1650,9 @@ describe("listen-client v2 status builders", () => {
     const source = readFileSync(recoveryPath, "utf-8");
 
     expect(source).toContain(
-      "const { needsUserInput, autoAllowed, autoDenied } = await classifyApprovals(",
+      "const { needsUserInput, autoAllowed, autoDenied } =",
     );
+    expect(source).toContain("classifyApprovalsWithSuggestions(");
     expect(source).toContain(
       "const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);",
     );
@@ -1651,6 +1675,7 @@ describe("listen-client v2 status builders", () => {
           "perm-stale",
           {
             approval: {} as never,
+            approvalContext: null,
             controlRequest: makeControlRequest("perm-stale"),
           },
         ],
@@ -1682,6 +1707,7 @@ describe("listen-client v2 status builders", () => {
           "perm-stale",
           {
             approval: {} as never,
+            approvalContext: null,
             controlRequest: makeControlRequest("perm-stale"),
           },
         ],
@@ -1951,6 +1977,7 @@ describe("listen-client interrupt queue projection", () => {
               toolName: "Bash",
               toolArgs: '{"command":"ls"}',
             },
+            approvalContext: null,
             controlRequest: makeControlRequest("perm-tool-1"),
           },
         ],
@@ -1962,6 +1989,7 @@ describe("listen-client interrupt queue projection", () => {
               toolName: "Bash",
               toolArgs: '{"command":"pwd"}',
             },
+            approvalContext: null,
             controlRequest: makeControlRequest("perm-tool-2"),
           },
         ],

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -95,12 +95,17 @@ export type DiffPreview =
   | { mode: "fallback"; fileName: string; reason: string }
   | { mode: "unpreviewable"; fileName: string; reason: string };
 
+export interface PermissionSuggestion {
+  id: string;
+  text: string;
+}
+
 export interface CanUseToolControlRequestBody {
   subtype: "can_use_tool";
   tool_name: string;
   input: Record<string, unknown>;
   tool_call_id: string;
-  permission_suggestions: string[];
+  permission_suggestions: PermissionSuggestion[];
   blocked_path: string | null;
   diffs?: DiffPreview[];
 }
@@ -365,7 +370,7 @@ export interface ApprovalResponseAllowDecision {
   behavior: "allow";
   message?: string;
   updated_input?: Record<string, unknown> | null;
-  updated_permissions?: string[];
+  selected_permission_suggestion_ids?: string[];
 }
 
 export interface ApprovalResponseDenyDecision {

--- a/src/websocket/listener/approval-suggestions.ts
+++ b/src/websocket/listener/approval-suggestions.ts
@@ -1,0 +1,114 @@
+import {
+  type ApprovalClassification,
+  type ClassifyApprovalsOptions,
+  classifyApprovals,
+} from "../../cli/helpers/approvalClassification";
+import type { ApprovalRequest } from "../../cli/helpers/stream";
+import type { ApprovalContext } from "../../permissions/analyzer";
+import { analyzeToolApproval, savePermissionRule } from "../../tools/manager";
+import type {
+  ApprovalResponseAllowDecision,
+  PermissionSuggestion,
+} from "../../types/protocol_v2";
+
+type SuggestedApprovalClassification = ApprovalClassification<ApprovalContext>;
+
+type PermissionSuggestionDefinition = {
+  suggestion: PermissionSuggestion;
+  rule: string;
+  scope: ApprovalContext["defaultScope"];
+};
+
+function getSuggestedPermissionRule(
+  context: ApprovalContext | null,
+): string | null {
+  if (
+    !context?.allowPersistence ||
+    context.recommendedRule.trim().length === 0
+  ) {
+    return null;
+  }
+  return context.recommendedRule;
+}
+
+function getApprovalPermissionSuggestions(
+  context: ApprovalContext | null,
+): PermissionSuggestionDefinition[] {
+  const suggestedRule = getSuggestedPermissionRule(context);
+  if (suggestedRule === null || !context) {
+    return [];
+  }
+
+  const text = context.approveAlwaysText.trim();
+  if (text.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      suggestion: {
+        id: "save-default",
+        text,
+      },
+      rule: suggestedRule,
+      scope: context.defaultScope,
+    },
+  ];
+}
+
+export function buildApprovalSuggestionPayload(
+  context: ApprovalContext | null,
+): {
+  permission_suggestions: PermissionSuggestion[];
+} {
+  return {
+    permission_suggestions: getApprovalPermissionSuggestions(context).map(
+      ({ suggestion }) => suggestion,
+    ),
+  };
+}
+
+export async function classifyApprovalsWithSuggestions(
+  approvals: ApprovalRequest[],
+  opts: Omit<ClassifyApprovalsOptions<ApprovalContext>, "getContext"> = {},
+): Promise<SuggestedApprovalClassification> {
+  return classifyApprovals(approvals, {
+    ...opts,
+    getContext: async (toolName, parsedArgs, workingDirectory) =>
+      analyzeToolApproval(toolName, parsedArgs, workingDirectory),
+  });
+}
+
+export async function applySuggestedPermissionsForApproval(params: {
+  decision: ApprovalResponseAllowDecision;
+  context: ApprovalContext | null;
+  workingDirectory: string;
+}): Promise<boolean> {
+  const { decision, context, workingDirectory } = params;
+  if (!context?.allowPersistence || context.defaultScope === undefined) {
+    return false;
+  }
+
+  const selectedIds = decision.selected_permission_suggestion_ids ?? [];
+  if (selectedIds.length === 0) {
+    return false;
+  }
+
+  const matchedSuggestions = getApprovalPermissionSuggestions(context).filter(
+    ({ suggestion }) => selectedIds.includes(suggestion.id),
+  );
+  if (matchedSuggestions.length === 0) {
+    return false;
+  }
+
+  for (const matchedSuggestion of matchedSuggestions) {
+    await savePermissionRule(
+      matchedSuggestion.rule,
+      "allow",
+      matchedSuggestion.scope,
+      workingDirectory,
+    );
+  }
+
+  return true;
+}

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -91,7 +91,7 @@ export function isValidApprovalResponseBody(
     behavior?: unknown;
     message?: unknown;
     updated_input?: unknown;
-    updated_permissions?: unknown;
+    selected_permission_suggestion_ids?: unknown;
   };
   if (decision.behavior === "allow") {
     const hasMessage =
@@ -100,13 +100,13 @@ export function isValidApprovalResponseBody(
       decision.updated_input === undefined ||
       decision.updated_input === null ||
       typeof decision.updated_input === "object";
-    const hasUpdatedPermissions =
-      decision.updated_permissions === undefined ||
-      (Array.isArray(decision.updated_permissions) &&
-        decision.updated_permissions.every(
+    const hasSelectedPermissionSuggestionIds =
+      decision.selected_permission_suggestion_ids === undefined ||
+      (Array.isArray(decision.selected_permission_suggestion_ids) &&
+        decision.selected_permission_suggestion_ids.every(
           (entry) => typeof entry === "string",
         ));
-    return hasMessage && hasUpdatedInput && hasUpdatedPermissions;
+    return hasMessage && hasUpdatedInput && hasSelectedPermissionSuggestionIds;
   }
   if (decision.behavior === "deny") {
     return typeof decision.message === "string";

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -19,7 +19,6 @@ import {
   shouldRetryRunMetadataError,
 } from "../../agent/turn-recovery-policy";
 import { createBuffers } from "../../cli/helpers/accumulator";
-import { classifyApprovals } from "../../cli/helpers/approvalClassification";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
@@ -29,6 +28,11 @@ import type {
   StopReasonType,
   StreamDelta,
 } from "../../types/protocol_v2";
+import {
+  applySuggestedPermissionsForApproval,
+  buildApprovalSuggestionPayload,
+  classifyApprovalsWithSuggestions,
+} from "./approval-suggestions";
 import {
   MAX_POST_STOP_APPROVAL_RECOVERY,
   NO_AWAITING_APPROVAL_DETAIL_FRAGMENT,
@@ -332,8 +336,12 @@ export async function debugLogApprovalResumeState(
 }
 
 function buildRecoveredAutoDecisions(
-  autoAllowed: Awaited<ReturnType<typeof classifyApprovals>>["autoAllowed"],
-  autoDenied: Awaited<ReturnType<typeof classifyApprovals>>["autoDenied"],
+  autoAllowed: Awaited<
+    ReturnType<typeof classifyApprovalsWithSuggestions>
+  >["autoAllowed"],
+  autoDenied: Awaited<
+    ReturnType<typeof classifyApprovalsWithSuggestions>
+  >["autoDenied"],
 ): ApprovalDecision[] {
   return [
     ...autoAllowed.map((ac) => ({
@@ -416,20 +424,19 @@ export async function recoverApprovalStateForSync(
     scope.agent_id,
     scope.conversation_id,
   );
-  const { needsUserInput, autoAllowed, autoDenied } = await classifyApprovals(
-    pendingApprovals,
-    {
+  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+    runtime.listener,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  const { needsUserInput, autoAllowed, autoDenied } =
+    await classifyApprovalsWithSuggestions(pendingApprovals, {
       alwaysRequiresUserInput: isInteractiveApprovalTool,
       requireArgsForAutoApprove: true,
       missingNameReason: "Tool call incomplete - missing name",
       workingDirectory,
-      permissionModeState: getOrCreateConversationPermissionModeStateRef(
-        runtime.listener,
-        scope.agent_id,
-        scope.conversation_id,
-      ),
-    },
-  );
+      permissionModeState,
+    });
   const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);
 
   if (needsUserInput.length === 0) {
@@ -451,6 +458,7 @@ export async function recoverApprovalStateForSync(
 
       approvalsByRequestId.set(requestId, {
         approval,
+        approvalContext: approvalEntry.context,
         controlRequest: {
           type: "control_request",
           request_id: requestId,
@@ -459,7 +467,7 @@ export async function recoverApprovalStateForSync(
             tool_name: approval.toolName,
             input,
             tool_call_id: approval.toolCallId,
-            permission_suggestions: [],
+            ...buildApprovalSuggestionPayload(approvalEntry.context),
             blocked_path: null,
             ...(diffs.length > 0 ? { diffs } : {}),
           },
@@ -516,6 +524,73 @@ export async function resolveRecoveredApprovalResponse(
 
   recovered.responsesByRequestId.set(requestId, response);
   recovered.pendingRequestIds.delete(requestId);
+  const workingDirectory = getConversationWorkingDirectory(
+    runtime.listener,
+    recovered.agentId,
+    recovered.conversationId,
+  );
+  const respondedEntry = recovered.approvalsByRequestId.get(requestId);
+  if (
+    respondedEntry &&
+    "decision" in response &&
+    response.decision.behavior === "allow"
+  ) {
+    const savedSuggestions = await applySuggestedPermissionsForApproval({
+      decision: response.decision,
+      context: respondedEntry.approvalContext,
+      workingDirectory,
+    });
+
+    if (savedSuggestions && recovered.pendingRequestIds.size > 0) {
+      const remainingRecoveredEntries = [...recovered.pendingRequestIds]
+        .map((id) => recovered.approvalsByRequestId.get(id))
+        .filter((entry): entry is RecoveredPendingApproval => !!entry);
+      const reclassified = await classifyApprovalsWithSuggestions(
+        remainingRecoveredEntries.map((entry) => entry.approval),
+        {
+          alwaysRequiresUserInput: isInteractiveApprovalTool,
+          requireArgsForAutoApprove: true,
+          missingNameReason: "Tool call incomplete - missing name",
+          workingDirectory,
+          permissionModeState: getOrCreateConversationPermissionModeStateRef(
+            runtime.listener,
+            recovered.agentId,
+            recovered.conversationId,
+          ),
+        },
+      );
+
+      if (
+        reclassified.autoAllowed.length > 0 ||
+        reclassified.autoDenied.length > 0
+      ) {
+        recovered.autoDecisions = [
+          ...(recovered.autoDecisions ?? []),
+          ...buildRecoveredAutoDecisions(
+            reclassified.autoAllowed,
+            reclassified.autoDenied,
+          ),
+        ];
+
+        const reclassifiedToolCallIds = new Set(
+          [...reclassified.autoAllowed, ...reclassified.autoDenied].map(
+            (entry) => entry.approval.toolCallId,
+          ),
+        );
+        for (const pendingId of [...recovered.pendingRequestIds]) {
+          const pendingEntry = recovered.approvalsByRequestId.get(pendingId);
+          if (
+            pendingEntry &&
+            reclassifiedToolCallIds.has(pendingEntry.approval.toolCallId)
+          ) {
+            recovered.pendingRequestIds.delete(pendingId);
+            recovered.approvalsByRequestId.delete(pendingId);
+            recovered.responsesByRequestId.delete(pendingId);
+          }
+        }
+      }
+    }
+  }
 
   if (recovered.pendingRequestIds.size > 0) {
     emitRuntimeStateUpdates(runtime, {
@@ -581,11 +656,7 @@ export async function resolveRecoveredApprovalResponse(
   emitRuntimeStateUpdates(runtime, scope);
 
   runtime.isProcessing = true;
-  runtime.activeWorkingDirectory = getConversationWorkingDirectory(
-    runtime.listener,
-    recovered.agentId,
-    recovered.conversationId,
-  );
+  runtime.activeWorkingDirectory = workingDirectory;
   runtime.activeExecutingToolCallIds = [...approvedToolCallIds];
   setLoopStatus(runtime, "EXECUTING_CLIENT_SIDE_TOOL", scope);
   emitRuntimeStateUpdates(runtime, scope);
@@ -615,11 +686,7 @@ export async function resolveRecoveredApprovalResponse(
     const approvalResults = await executeApprovalBatch(decisions, undefined, {
       abortSignal: recoveryAbortController.signal,
       toolContextId: preparedToolContext.preparedToolContext.contextId,
-      workingDirectory: getConversationWorkingDirectory(
-        runtime.listener,
-        recovered.agentId,
-        recovered.conversationId,
-      ),
+      workingDirectory,
       parentScope:
         recovered.agentId && recovered.conversationId
           ? {

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -20,7 +20,6 @@ import {
   getRetryDelayMs,
   parseRetryAfterHeaderMs,
 } from "../../agent/turn-recovery-policy";
-import { classifyApprovals } from "../../cli/helpers/approvalClassification";
 import { getRetryStatusMessage } from "../../cli/helpers/errorFormatter";
 
 import { computeDiffPreviews } from "../../helpers/diffPreview";
@@ -32,6 +31,11 @@ import {
   requestApprovalOverWS,
   resolveRecoveryBatchId,
 } from "./approval";
+import {
+  applySuggestedPermissionsForApproval,
+  buildApprovalSuggestionPayload,
+  classifyApprovalsWithSuggestions,
+} from "./approval-suggestions";
 import {
   LLM_API_ERROR_MAX_RETRIES,
   MAX_PRE_STREAM_RECOVERY,
@@ -166,20 +170,19 @@ export async function resolveStaleApprovals(
     }
     rememberPendingApprovalBatchIds(runtime, pendingApprovals, recoveryBatchId);
 
-    const { autoAllowed, autoDenied, needsUserInput } = await classifyApprovals(
-      pendingApprovals,
-      {
+    const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+      runtime.listener,
+      runtime.agentId,
+      runtime.conversationId,
+    );
+    const { autoAllowed, autoDenied, needsUserInput } =
+      await classifyApprovalsWithSuggestions(pendingApprovals, {
         alwaysRequiresUserInput: isInteractiveApprovalTool,
         requireArgsForAutoApprove: true,
         missingNameReason: "Tool call incomplete - missing name",
         workingDirectory: recoveryWorkingDirectory,
-        permissionModeState: getOrCreateConversationPermissionModeStateRef(
-          runtime.listener,
-          runtime.agentId,
-          runtime.conversationId,
-        ),
-      },
-    );
+        permissionModeState,
+      });
 
     const decisions: ApprovalDecision[] = [
       ...autoAllowed.map((ac) => ({
@@ -193,12 +196,18 @@ export async function resolveStaleApprovals(
       })),
     ];
 
-    if (needsUserInput.length > 0) {
+    let pendingNeedsUserInput = [...needsUserInput];
+    if (pendingNeedsUserInput.length > 0) {
       runtime.lastStopReason = "requires_approval";
       setLoopStatus(runtime, "WAITING_ON_APPROVAL", scope);
       emitRuntimeStateUpdates(runtime, scope);
 
-      for (const ac of needsUserInput) {
+      while (pendingNeedsUserInput.length > 0) {
+        const ac = pendingNeedsUserInput.shift();
+        if (!ac) {
+          break;
+        }
+
         if (abortSignal.aborted) throw new Error("Cancelled");
 
         const requestId = `perm-${ac.approval.toolCallId}`;
@@ -215,7 +224,7 @@ export async function resolveStaleApprovals(
             tool_name: ac.approval.toolName,
             input: ac.parsedArgs,
             tool_call_id: ac.approval.toolCallId,
-            permission_suggestions: [],
+            ...buildApprovalSuggestionPayload(ac.context),
             blocked_path: null,
             ...(diffs.length > 0 ? { diffs } : {}),
           },
@@ -233,6 +242,13 @@ export async function resolveStaleApprovals(
         if ("decision" in responseBody) {
           const response = responseBody.decision;
           if (response.behavior === "allow") {
+            const savedSuggestions = await applySuggestedPermissionsForApproval(
+              {
+                decision: response,
+                context: ac.context,
+                workingDirectory: recoveryWorkingDirectory,
+              },
+            );
             decisions.push({
               type: "approve",
               approval: response.updated_input
@@ -243,6 +259,35 @@ export async function resolveStaleApprovals(
                 : ac.approval,
               reason: response.message,
             });
+
+            if (savedSuggestions && pendingNeedsUserInput.length > 0) {
+              const reclassified = await classifyApprovalsWithSuggestions(
+                pendingNeedsUserInput.map((entry) => entry.approval),
+                {
+                  alwaysRequiresUserInput: isInteractiveApprovalTool,
+                  requireArgsForAutoApprove: true,
+                  missingNameReason: "Tool call incomplete - missing name",
+                  workingDirectory: recoveryWorkingDirectory,
+                  permissionModeState,
+                },
+              );
+
+              decisions.push(
+                ...reclassified.autoAllowed.map((entry) => ({
+                  type: "approve" as const,
+                  approval: entry.approval,
+                })),
+                ...reclassified.autoDenied.map((entry) => ({
+                  type: "deny" as const,
+                  approval: entry.approval,
+                  reason:
+                    entry.denyReason ||
+                    entry.permission.reason ||
+                    "Permission denied",
+                })),
+              );
+              pendingNeedsUserInput = [...reclassified.needsUserInput];
+            }
           } else {
             decisions.push({
               type: "deny",

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -9,7 +9,6 @@ import {
   type ApprovalResult,
   executeApprovalBatch,
 } from "../../agent/approval-execution";
-import { classifyApprovals } from "../../cli/helpers/approvalClassification";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import type {
@@ -25,6 +24,11 @@ import {
   requestApprovalOverWS,
   validateApprovalResultIds,
 } from "./approval";
+import {
+  applySuggestedPermissionsForApproval,
+  buildApprovalSuggestionPayload,
+  classifyApprovalsWithSuggestions,
+} from "./approval-suggestions";
 import {
   emitInterruptToolReturnMessage,
   emitToolExecutionFinishedEvents,
@@ -163,19 +167,18 @@ export async function handleApprovalStop(params: {
   clearPendingApprovalBatchIds(runtime, approvals);
   rememberPendingApprovalBatchIds(runtime, approvals, dequeuedBatchId);
 
-  const { autoAllowed, autoDenied, needsUserInput } = await classifyApprovals(
-    approvals,
-    {
+  const { autoAllowed, autoDenied, needsUserInput } =
+    await classifyApprovalsWithSuggestions(approvals, {
       alwaysRequiresUserInput: isInteractiveApprovalTool,
       treatAskAsDeny: false,
       requireArgsForAutoApprove: true,
       missingNameReason: "Tool call incomplete - missing name",
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
-    },
-  );
+    });
 
-  const lastNeedsUserInputToolCallIds = needsUserInput.map(
+  let pendingNeedsUserInput = [...needsUserInput];
+  let lastNeedsUserInputToolCallIds = pendingNeedsUserInput.map(
     (ac) => ac.approval.toolCallId,
   );
   let lastExecutionResults: ApprovalResult[] | null = null;
@@ -225,7 +228,7 @@ export async function handleApprovalStop(params: {
     return interruptTermination();
   }
 
-  if (needsUserInput.length > 0) {
+  if (pendingNeedsUserInput.length > 0) {
     if (shouldInterrupt()) {
       return interruptTermination();
     }
@@ -236,7 +239,12 @@ export async function handleApprovalStop(params: {
       conversation_id: conversationId,
     });
 
-    for (const ac of needsUserInput) {
+    while (pendingNeedsUserInput.length > 0) {
+      const ac = pendingNeedsUserInput.shift();
+      if (!ac) {
+        break;
+      }
+
       if (shouldInterrupt()) {
         return interruptTermination();
       }
@@ -258,7 +266,7 @@ export async function handleApprovalStop(params: {
           tool_name: ac.approval.toolName,
           input: ac.parsedArgs,
           tool_call_id: ac.approval.toolCallId,
-          permission_suggestions: [],
+          ...buildApprovalSuggestionPayload(ac.context),
           blocked_path: null,
           ...(diffs.length > 0 ? { diffs } : {}),
         },
@@ -288,6 +296,11 @@ export async function handleApprovalStop(params: {
       if ("decision" in responseBody) {
         const response = responseBody.decision as ApprovalResponseDecision;
         if (response.behavior === "allow") {
+          const savedSuggestions = await applySuggestedPermissionsForApproval({
+            decision: response,
+            context: ac.context,
+            workingDirectory: turnWorkingDirectory,
+          });
           const finalApproval = response.updated_input
             ? {
                 ...ac.approval,
@@ -299,6 +312,39 @@ export async function handleApprovalStop(params: {
             approval: finalApproval,
             reason: response.message,
           });
+
+          if (savedSuggestions && pendingNeedsUserInput.length > 0) {
+            const reclassified = await classifyApprovalsWithSuggestions(
+              pendingNeedsUserInput.map((entry) => entry.approval),
+              {
+                alwaysRequiresUserInput: isInteractiveApprovalTool,
+                treatAskAsDeny: false,
+                requireArgsForAutoApprove: true,
+                missingNameReason: "Tool call incomplete - missing name",
+                workingDirectory: turnWorkingDirectory,
+                permissionModeState: turnPermissionModeState,
+              },
+            );
+
+            decisions.push(
+              ...reclassified.autoAllowed.map((entry) => ({
+                type: "approve" as const,
+                approval: entry.approval,
+              })),
+              ...reclassified.autoDenied.map((entry) => ({
+                type: "deny" as const,
+                approval: entry.approval,
+                reason:
+                  entry.denyReason ||
+                  entry.permission.reason ||
+                  "Permission denied",
+              })),
+            );
+            pendingNeedsUserInput = [...reclassified.needsUserInput];
+            lastNeedsUserInputToolCallIds = pendingNeedsUserInput.map(
+              (entry) => entry.approval.toolCallId,
+            );
+          }
         } else {
           decisions.push({
             type: "deny",

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../agent/approval-execution";
 import type { ContextTracker } from "../../cli/helpers/contextTracker";
 import type { ApprovalRequest } from "../../cli/helpers/stream";
+import type { ApprovalContext } from "../../permissions/analyzer";
 import type {
   DequeuedBatch,
   QueueBlockedReason,
@@ -91,6 +92,7 @@ export type PendingApprovalResolver = {
 export type RecoveredPendingApproval = {
   approval: ApprovalRequest;
   controlRequest: ControlRequest;
+  approvalContext: ApprovalContext | null;
 };
 
 export type RecoveredApprovalState = {


### PR DESCRIPTION
## Summary
- add typed websocket approval suggestions for can_use_tool prompts
- let approval responses select suggestion ids and apply the save server-side
- re-check remaining websocket approval batches after saving so LCD matches TUI behavior

## Testing
- bun test src/tests/websocket/listen-approval-suggestions.test.ts
- bun test src/tests/websocket/listen-client-protocol.test.ts
- bun test src/tests/websocket/listen-client-concurrency.test.ts
- bunx tsc --noEmit