### PR TITLE
fix: preserve self-hosted model endpoints on model changes

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -11,7 +11,7 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import { debugLog } from "../utils/debug";
 import { getModelContextWindow } from "./available-models";
-import { getClient } from "./client";
+import { getClient, getServerUrl } from "./client";
 
 type ModelSettings =
   | OpenAIModelSettings
@@ -208,6 +208,70 @@ export interface UpdateAgentLLMConfigOptions {
   preserveContextWindow?: boolean;
 }
 
+function parseModelHandle(modelHandle: string): {
+  provider: string | null;
+  modelName: string;
+} {
+  const slash = modelHandle.indexOf("/");
+  if (slash === -1) {
+    return { provider: null, modelName: modelHandle };
+  }
+
+  return {
+    provider: modelHandle.slice(0, slash),
+    modelName: modelHandle.slice(slash + 1),
+  };
+}
+
+function isSelfHostedServer(): boolean {
+  return !getServerUrl().includes("api.letta.com");
+}
+
+function shouldPreserveSelfHostedLlmConfig(
+  agent: AgentState,
+  nextHandle: string,
+): boolean {
+  if (!isSelfHostedServer()) {
+    return false;
+  }
+
+  const current = agent.llm_config;
+  if (!current?.model_endpoint) {
+    return false;
+  }
+
+  const { provider } = parseModelHandle(nextHandle);
+  if (!provider) {
+    return false;
+  }
+
+  const currentProvider =
+    current.provider_name ??
+    (current.handle?.includes("/") ? current.handle.split("/", 1)[0] : null);
+
+  return currentProvider === provider;
+}
+
+function buildPreservedLlmConfig(
+  current: NonNullable<AgentState["llm_config"]>,
+  nextHandle: string,
+): NonNullable<AgentState["llm_config"]> {
+  const { provider, modelName } = parseModelHandle(nextHandle);
+
+  return {
+    ...current,
+    handle: nextHandle,
+    model: modelName,
+    provider_name: provider ?? current.provider_name,
+  };
+}
+
+function shouldPreserveSelfHostedEmbeddingConfig(agent: AgentState): boolean {
+  return (
+    isSelfHostedServer() && !!agent.embedding_config?.embedding_endpoint
+  );
+}
+
 export async function updateAgentLLMConfig(
   agentId: string,
   modelHandle: string,
@@ -215,6 +279,7 @@ export async function updateAgentLLMConfig(
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<AgentState> {
   const client = await getClient();
+  const currentAgent = await client.agents.retrieve(agentId);
 
   const modelSettings = buildModelSettings(modelHandle, updateArgs);
   const explicitContextWindow = updateArgs?.context_window as
@@ -229,7 +294,7 @@ export async function updateAgentLLMConfig(
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
 
-  await client.agents.update(agentId, {
+  const updatePayload: Parameters<typeof client.agents.update>[1] = {
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
     ...(contextWindow && { context_window_limit: contextWindow }),
@@ -237,7 +302,26 @@ export async function updateAgentLLMConfig(
       updateArgs?.max_output_tokens === null) && {
       max_tokens: updateArgs.max_output_tokens,
     }),
-  });
+  };
+
+  if (
+    shouldPreserveSelfHostedLlmConfig(currentAgent, modelHandle) &&
+    currentAgent.llm_config
+  ) {
+    updatePayload.llm_config = buildPreservedLlmConfig(
+      currentAgent.llm_config,
+      modelHandle,
+    );
+  }
+
+  if (
+    shouldPreserveSelfHostedEmbeddingConfig(currentAgent) &&
+    currentAgent.embedding_config
+  ) {
+    updatePayload.embedding_config = { ...currentAgent.embedding_config };
+  }
+
+  await client.agents.update(agentId, updatePayload);
 
   const finalAgent = await client.agents.retrieve(agentId);
   return finalAgent;

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -196,7 +196,10 @@ function buildModelSettings(
 /**
  * Updates an agent's model and model settings.
  *
- * Uses the new model_settings field instead of deprecated llm_config.
+ * Uses the new model_settings field for model configuration. On self-hosted
+ * servers, this may also preserve existing llm_config/embedding_config
+ * endpoint values when they are required to keep custom providers such as
+ * Ollama working across model changes.
  *
  * @param agentId - The agent ID
  * @param modelHandle - The model handle (e.g., "anthropic/claude-sonnet-4-5-20250929")
@@ -279,7 +282,10 @@ export async function updateAgentLLMConfig(
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<AgentState> {
   const client = await getClient();
-  const currentAgent = await client.agents.retrieve(agentId);
+  const shouldPreserveSelfHostedConfig = isSelfHostedServer();
+  const currentAgent = shouldPreserveSelfHostedConfig
+    ? await client.agents.retrieve(agentId)
+    : null;
 
   const modelSettings = buildModelSettings(modelHandle, updateArgs);
   const explicitContextWindow = updateArgs?.context_window as
@@ -305,6 +311,7 @@ export async function updateAgentLLMConfig(
   };
 
   if (
+    currentAgent &&
     shouldPreserveSelfHostedLlmConfig(currentAgent, modelHandle) &&
     currentAgent.llm_config
   ) {
@@ -315,6 +322,7 @@ export async function updateAgentLLMConfig(
   }
 
   if (
+    currentAgent &&
     shouldPreserveSelfHostedEmbeddingConfig(currentAgent) &&
     currentAgent.embedding_config
   ) {

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -40,8 +40,14 @@ describe("model preset refresh wiring", () => {
     expect(updateSegment).not.toContain(
       "(updateArgs?.context_window as number | undefined) ??\n    (await getModelContextWindow(modelHandle));",
     );
-    expect(updateSegment).not.toContain(
-      "const currentAgent = await client.agents.retrieve(",
+    expect(updateSegment).toContain(
+      "const currentAgent = await client.agents.retrieve(agentId);",
+    );
+    expect(updateSegment).toContain(
+      "shouldPreserveSelfHostedLlmConfig(currentAgent, modelHandle)",
+    );
+    expect(updateSegment).toContain(
+      "shouldPreserveSelfHostedEmbeddingConfig(currentAgent)",
     );
     expect(source).not.toContain(
       'hasUpdateArg(updateArgs, "parallel_tool_calls")',

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -40,9 +40,9 @@ describe("model preset refresh wiring", () => {
     expect(updateSegment).not.toContain(
       "(updateArgs?.context_window as number | undefined) ??\n    (await getModelContextWindow(modelHandle));",
     );
-    expect(updateSegment).toContain(
-      "const currentAgent = await client.agents.retrieve(agentId);",
-    );
+    expect(updateSegment).toContain("const shouldPreserveSelfHostedConfig");
+    expect(updateSegment).toContain("isSelfHostedServer()");
+    expect(updateSegment).toContain("? await client.agents.retrieve(agentId)");
     expect(updateSegment).toContain(
       "shouldPreserveSelfHostedLlmConfig(currentAgent, modelHandle)",
     );

--- a/src/tests/agent/modify.test.ts
+++ b/src/tests/agent/modify.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockAgentsRetrieve = mock();
+const mockAgentsUpdate = mock();
+const mockGetModelContextWindow = mock();
+const mockGetServerUrl = mock();
+
+mock.module("../../agent/client", () => ({
+  getClient: async () => ({
+    agents: {
+      retrieve: mockAgentsRetrieve,
+      update: mockAgentsUpdate,
+    },
+  }),
+  getServerUrl: mockGetServerUrl,
+}));
+
+mock.module("../../agent/available-models", () => ({
+  getModelContextWindow: mockGetModelContextWindow,
+}));
+
+mock.module("../../providers/openai-codex-provider", () => ({
+  OPENAI_CODEX_PROVIDER_NAME: "chatgpt-plus-pro",
+}));
+
+describe("updateAgentLLMConfig", () => {
+  beforeEach(() => {
+    mockAgentsRetrieve.mockReset();
+    mockAgentsUpdate.mockReset();
+    mockGetModelContextWindow.mockReset();
+    mockGetServerUrl.mockReset();
+  });
+
+  test("preserves self-hosted Ollama endpoints when switching Ollama models", async () => {
+    mockGetServerUrl.mockReturnValue("http://localhost:8283");
+    mockGetModelContextWindow.mockResolvedValue(32000);
+
+    const currentAgent = {
+      llm_config: {
+        context_window: 128000,
+        model: "kimi-k2.5:cloud",
+        model_endpoint_type: "openai",
+        model_endpoint: "http://host.docker.internal:11434/v1",
+        provider_name: "ollama",
+        provider_category: "base",
+        model_wrapper: null,
+        handle: "ollama/kimi-k2.5:cloud",
+        temperature: 0.7,
+        max_tokens: 16384,
+        enable_reasoner: true,
+        reasoning_effort: "high",
+        max_reasoning_tokens: 0,
+        effort: null,
+        frequency_penalty: null,
+        compatibility_type: null,
+        verbosity: null,
+        tier: null,
+        parallel_tool_calls: true,
+        response_format: null,
+        put_inner_thoughts_in_kwargs: false,
+      },
+      embedding_config: {
+        embedding_dim: 4096,
+        embedding_endpoint_type: "openai",
+        embedding_model: "qwen3-embedding:8b-q8_0",
+        embedding_chunk_size: 300,
+        embedding_endpoint: "http://host.docker.internal:11434/v1",
+        handle: "ollama/qwen3-embedding:8b-q8_0",
+        batch_size: 32,
+        azure_endpoint: null,
+        azure_version: null,
+        azure_deployment: null,
+      },
+    };
+
+    const finalAgent = {
+      id: "agent-1",
+      ...currentAgent,
+    };
+
+    mockAgentsRetrieve
+      .mockResolvedValueOnce(currentAgent)
+      .mockResolvedValueOnce(finalAgent);
+    mockAgentsUpdate.mockResolvedValue(finalAgent);
+
+    const { updateAgentLLMConfig } = await import("../../agent/modify");
+    const result = await updateAgentLLMConfig(
+      "agent-1",
+      "ollama/glm-5:cloud",
+    );
+
+    expect(result).toBe(finalAgent);
+    expect(mockAgentsUpdate).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        model: "ollama/glm-5:cloud",
+        llm_config: expect.objectContaining({
+          model: "glm-5:cloud",
+          handle: "ollama/glm-5:cloud",
+          model_endpoint: "http://host.docker.internal:11434/v1",
+        }),
+        embedding_config: expect.objectContaining({
+          embedding_endpoint: "http://host.docker.internal:11434/v1",
+        }),
+      }),
+    );
+  });
+
+  test("keeps cloud updates minimal", async () => {
+    mockGetServerUrl.mockReturnValue("https://api.letta.com");
+    mockGetModelContextWindow.mockResolvedValue(128000);
+
+    const currentAgent = {
+      llm_config: {
+        context_window: 128000,
+        model: "kimi-k2.5:cloud",
+        model_endpoint_type: "openai",
+        model_endpoint: "http://host.docker.internal:11434/v1",
+        provider_name: "ollama",
+        handle: "ollama/kimi-k2.5:cloud",
+      },
+      embedding_config: {
+        embedding_dim: 4096,
+        embedding_endpoint_type: "openai",
+        embedding_model: "qwen3-embedding:8b-q8_0",
+        embedding_endpoint: "http://host.docker.internal:11434/v1",
+      },
+    };
+
+    mockAgentsRetrieve
+      .mockResolvedValueOnce(currentAgent)
+      .mockResolvedValueOnce({ id: "agent-1", ...currentAgent });
+    mockAgentsUpdate.mockResolvedValue({});
+
+    const { updateAgentLLMConfig } = await import("../../agent/modify");
+    await updateAgentLLMConfig(
+      "agent-1",
+      "anthropic/claude-sonnet-4-5-20250929",
+    );
+
+    expect(mockAgentsUpdate).toHaveBeenCalledWith(
+      "agent-1",
+      expect.not.objectContaining({
+        llm_config: expect.anything(),
+        embedding_config: expect.anything(),
+      }),
+    );
+    expect(mockAgentsUpdate).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        model: "anthropic/claude-sonnet-4-5-20250929",
+      }),
+    );
+  });
+});

--- a/src/tests/agent/modify.test.ts
+++ b/src/tests/agent/modify.test.ts
@@ -110,7 +110,8 @@ describe("updateAgentLLMConfig", () => {
     mockGetServerUrl.mockReturnValue("https://api.letta.com");
     mockGetModelContextWindow.mockResolvedValue(128000);
 
-    const currentAgent = {
+    const finalAgent = {
+      id: "agent-1",
       llm_config: {
         context_window: 128000,
         model: "kimi-k2.5:cloud",
@@ -127,9 +128,7 @@ describe("updateAgentLLMConfig", () => {
       },
     };
 
-    mockAgentsRetrieve
-      .mockResolvedValueOnce(currentAgent)
-      .mockResolvedValueOnce({ id: "agent-1", ...currentAgent });
+    mockAgentsRetrieve.mockResolvedValueOnce(finalAgent);
     mockAgentsUpdate.mockResolvedValue({});
 
     const { updateAgentLLMConfig } = await import("../../agent/modify");
@@ -151,5 +150,6 @@ describe("updateAgentLLMConfig", () => {
         model: "anthropic/claude-sonnet-4-5-20250929",
       }),
     );
+    expect(mockAgentsRetrieve).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- preserve self-hosted LLM endpoints when switching models
- preserve self-hosted embedding endpoints during model changes
- add regression coverage for self-hosted Ollama and cloud-only updates

## Context
Self-hosted Letta deployments can store custom model and embedding endpoints such as Ollama. Updating the model was mutating the agent without preserving those saved endpoints, which could break local Docker plus Ollama setups when /model or related flows changed the model.

## Testing
- bun test src/tests/agent/modify.test.ts src/tests/agent/model-preset-refresh.wiring.test.ts