### PR TITLE
fix(listener): make approval request projection atomic

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -2193,6 +2193,7 @@ describe("listen-client capability-gated approval flow", () => {
     expect(deviceStatus).toBeDefined();
     expect(loopStatus.type).toBe("update_loop_status");
     expect(loopStatus.loop_status.status).toBe("WAITING_ON_APPROVAL");
+    expect(runtime.lastStopReason).toBe("requires_approval");
     expect(deviceStatus.type).toBe("update_device_status");
     expect(deviceStatus.device_status.pending_control_requests).toEqual([
       {
@@ -2202,6 +2203,45 @@ describe("listen-client capability-gated approval flow", () => {
     ]);
 
     // Cleanup
+    rejectPendingApprovalResolvers(runtime, "test cleanup");
+  });
+
+  test("interrupted cache does not project WAITING_ON_APPROVAL when pending requests are suppressed", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    runtime.isProcessing = true;
+    runtime.activeRunId = "run-1";
+    void requestApprovalOverWS(
+      runtime,
+      socket as unknown as WebSocket,
+      "perm-interrupted",
+      makeControlRequest("perm-interrupted"),
+    ).catch(() => {});
+    runtime.pendingInterruptedContext = {
+      agentId: "agent-1",
+      conversationId: "default",
+      continuationEpoch: runtime.continuationEpoch,
+    };
+
+    const deviceStatus = __listenClientTestUtils.buildDeviceStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "default",
+    });
+    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "default",
+    });
+
+    expect(deviceStatus.pending_control_requests).toEqual([]);
+    expect(loopStatus.status).toBe("WAITING_ON_INPUT");
+    expect(loopStatus.active_run_ids).toEqual(["run-1"]);
+
     rejectPendingApprovalResolvers(runtime, "test cleanup");
   });
 

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -255,6 +255,7 @@ export function requestApprovalOverWS(
       controlRequest,
     });
     runtime.listener.approvalRuntimeKeyByRequestId.set(requestId, runtime.key);
+    runtime.lastStopReason = "requires_approval";
     setLoopStatus(runtime, "WAITING_ON_APPROVAL");
     emitLoopStatusIfOpen(runtime.listener, {
       agent_id: runtime.agentId,

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -254,7 +254,9 @@ export function buildLoopStatus(
   const status = interruptedCacheActive
     ? !conversationRuntime?.isProcessing
       ? "WAITING_ON_INPUT"
-      : (conversationRuntime?.loopStatus ?? "WAITING_ON_INPUT")
+      : conversationRuntime?.loopStatus === "WAITING_ON_APPROVAL"
+        ? "WAITING_ON_INPUT"
+        : (conversationRuntime?.loopStatus ?? "WAITING_ON_INPUT")
     : recovered &&
         recovered.pendingRequestIds.size > 0 &&
         conversationRuntime?.loopStatus === "WAITING_ON_INPUT"

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -198,10 +198,6 @@ export async function resolveStaleApprovals(
 
     let pendingNeedsUserInput = [...needsUserInput];
     if (pendingNeedsUserInput.length > 0) {
-      runtime.lastStopReason = "requires_approval";
-      setLoopStatus(runtime, "WAITING_ON_APPROVAL", scope);
-      emitRuntimeStateUpdates(runtime, scope);
-
       while (pendingNeedsUserInput.length > 0) {
         const ac = pendingNeedsUserInput.shift();
         if (!ac) {

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -233,12 +233,6 @@ export async function handleApprovalStop(params: {
       return interruptTermination();
     }
 
-    runtime.lastStopReason = "requires_approval";
-    setLoopStatus(runtime, "WAITING_ON_APPROVAL", {
-      agent_id: agentId,
-      conversation_id: conversationId,
-    });
-
     while (pendingNeedsUserInput.length > 0) {
       const ac = pendingNeedsUserInput.shift();
       if (!ac) {


### PR DESCRIPTION
## Summary
- move the listener's `requires_approval` / `WAITING_ON_APPROVAL` transition into `requestApprovalOverWS()` so approval state is only projected after the control request is registered
- stop stale approval recovery and turn approval handling from emitting an early approval-wait state before any pending request exists
- keep interrupt-cache suppression from projecting `WAITING_ON_APPROVAL` while `pending_control_requests` is intentionally hidden, and add regression coverage for both paths

## Test plan
- [x] `bun test --cwd "/Users/caren/Dev/letta-code" "src/tests/websocket/listen-client-protocol.test.ts"`
- [x] `bun test --cwd "/Users/caren/Dev/letta-code" "src/tests/websocket/listen-client-concurrency.test.ts"`
- [ ] `npm --prefix "/Users/caren/Dev/letta-code" run typecheck` *(currently fails on unrelated pre-existing repo issues in `check-approval.ts`, `ConversationSelector.tsx`, and `Task.ts`)*

👾 Generated with [Letta Code](https://letta.com)