### PR TITLE
fix(listener): preserve inbound otids on websocket sends

### DIFF
--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -1907,6 +1907,44 @@ describe("listen-client multi-worker concurrency", () => {
     await turnPromise;
   });
 
+  test("initial send preserves inbound message otid", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-preserve-otid",
+      "conv-preserve-otid",
+    );
+    const socket = new MockSocket();
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      {
+        type: "message",
+        agentId: "agent-preserve-otid",
+        conversationId: "conv-preserve-otid",
+        messages: [
+          {
+            role: "user",
+            content: "hello",
+            otid: "otid-preserved",
+          } as unknown as IncomingMessage["messages"][number],
+        ],
+      },
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    expect(sendMessageStreamMock.mock.calls.length).toBeGreaterThan(0);
+    const sentMessages = sendMessageStreamMock.mock.calls[0]?.[1] as
+      | Array<Record<string, unknown>>
+      | undefined;
+
+    expect(sentMessages?.[0]).toMatchObject({
+      role: "user",
+      content: "hello",
+      otid: "otid-preserved",
+    });
+  });
+
   test("pre-stream 409 resume on default conversation includes agent_id", async () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -399,7 +399,9 @@ export type ApprovalResponseBody =
  */
 export interface InputCreateMessagePayload {
   kind: "create_message";
-  messages: Array<MessageCreate & { client_message_id?: string }>;
+  messages: Array<
+    MessageCreate & { client_message_id?: string; otid?: string | null }
+  >;
 }
 
 export type InputApprovalResponsePayload = {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -2337,8 +2337,10 @@ async function connectWithRetry(
           const firstUserPayload = incoming.messages.find(
             (
               payload,
-            ): payload is MessageCreate & { client_message_id?: string } =>
-              "content" in payload,
+            ): payload is MessageCreate & {
+              client_message_id?: string;
+              otid?: string | null;
+            } => "content" in payload,
           );
           if (firstUserPayload) {
             const enqueuedItem = scopedRuntime.queueRuntime.enqueue({

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -478,8 +478,12 @@ export function emitDequeuedUserMessage(
   batch: DequeuedBatch,
 ): void {
   const firstUserPayload = incoming.messages.find(
-    (payload): payload is MessageCreate & { client_message_id?: string } =>
-      "content" in payload,
+    (
+      payload,
+    ): payload is MessageCreate & {
+      client_message_id?: string;
+      otid?: string | null;
+    } => "content" in payload,
   );
   if (!firstUserPayload) return;
 

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -259,8 +259,12 @@ function buildQueuedTurnMessage(
   }
 
   const firstMessageIndex = template.messages.findIndex(
-    (payload): payload is MessageCreate & { client_message_id?: string } =>
-      "content" in payload,
+    (
+      payload,
+    ): payload is MessageCreate & {
+      client_message_id?: string;
+      otid?: string | null;
+    } => "content" in payload,
   );
   if (firstMessageIndex === -1) {
     return null;
@@ -268,6 +272,7 @@ function buildQueuedTurnMessage(
 
   const firstMessage = template.messages[firstMessageIndex] as MessageCreate & {
     client_message_id?: string;
+    otid?: string | null;
   };
   const mergedFirstMessage = {
     ...firstMessage,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -375,7 +375,12 @@ export async function handleIncomingMessage(
 
     messagesToSend.push(
       ...normalizedMessages.map((m) =>
-        "content" in m && !m.otid ? { ...m, otid: crypto.randomUUID() } : m,
+        "content" in m
+          ? {
+              ...m,
+              otid: m.otid ?? crypto.randomUUID(),
+            }
+          : m,
       ),
     );
 

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -55,7 +55,8 @@ export interface IncomingMessage {
   agentId?: string;
   conversationId?: string;
   messages: Array<
-    (MessageCreate & { client_message_id?: string }) | ApprovalCreate
+    | (MessageCreate & { client_message_id?: string; otid?: string | null })
+    | ApprovalCreate
   >;
 }
 
@@ -70,7 +71,7 @@ export interface ChangeCwdMessage {
 }
 
 export type InboundMessagePayload =
-  | (MessageCreate & { client_message_id?: string })
+  | (MessageCreate & { client_message_id?: string; otid?: string | null })
   | ApprovalCreate;
 
 export type ServerMessage = WsProtocolCommand;


### PR DESCRIPTION
## Summary
- preserve inbound otids through the websocket listener send path instead of minting replacements
- widen listener protocol types so inbound payloads can carry nullable otids cleanly
- add a websocket listener regression test that asserts a provided otid is forwarded unchanged