### PR TITLE
fix(listener): preserve websocket loop error details

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -8,6 +8,13 @@
 
 import { getClient } from "./client";
 
+export interface RunErrorInfo {
+  error_type?: string;
+  message?: string;
+  detail?: string;
+  run_id?: string;
+}
+
 export type {
   PendingApprovalInfo,
   PreStreamConflictKind,
@@ -41,31 +48,53 @@ export {
 
 type RunErrorMetadata =
   | {
+      type?: string;
       error_type?: string;
       message?: string;
       detail?: string;
-      error?: { error_type?: string; message?: string; detail?: string };
+      run_id?: string;
+      error?: {
+        type?: string;
+        error_type?: string;
+        message?: string;
+        detail?: string;
+        run_id?: string;
+      };
     }
   | undefined
   | null;
 
-export async function fetchRunErrorDetail(
+export async function fetchRunErrorInfo(
   runId: string | null | undefined,
-): Promise<string | null> {
+): Promise<RunErrorInfo | null> {
   if (!runId) return null;
   try {
     const client = await getClient();
     const run = await client.runs.retrieve(runId);
     const metaError = run.metadata?.error as RunErrorMetadata;
+    const nestedError = metaError?.error;
+    const errorInfo: RunErrorInfo = {
+      error_type:
+        metaError?.error_type ??
+        metaError?.type ??
+        nestedError?.error_type ??
+        nestedError?.type,
+      message: metaError?.message ?? nestedError?.message,
+      detail: metaError?.detail ?? nestedError?.detail,
+      run_id: metaError?.run_id ?? nestedError?.run_id ?? runId,
+    };
 
-    return (
-      metaError?.detail ??
-      metaError?.message ??
-      metaError?.error?.detail ??
-      metaError?.error?.message ??
-      null
-    );
+    return errorInfo.error_type || errorInfo.message || errorInfo.detail
+      ? errorInfo
+      : null;
   } catch {
     return null;
   }
+}
+
+export async function fetchRunErrorDetail(
+  runId: string | null | undefined,
+): Promise<string | null> {
+  const errorInfo = await fetchRunErrorInfo(runId);
+  return errorInfo?.detail ?? errorInfo?.message ?? null;
 }

--- a/src/cli/helpers/streamProcessor.ts
+++ b/src/cli/helpers/streamProcessor.ts
@@ -94,6 +94,7 @@ export class StreamProcessor {
       const errorDetail = chunkWithError.error.detail || "";
       errorInfo = {
         message: errorDetail ? `${errorText}: ${errorDetail}` : errorText,
+        detail: errorDetail || undefined,
         run_id: this.lastRunId || undefined,
       };
     }

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { APIError } from "@letta-ai/letta-client/core/error";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import WebSocket from "ws";
 import { buildConversationMessagesCreateRequestBody } from "../../agent/message";
@@ -12,6 +13,7 @@ import {
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   getPersonalityOption,
 } from "../../agent/personality";
+import { formatErrorDetails } from "../../cli/helpers/errorFormatter";
 import {
   clearAllSubagents,
   registerSubagent,
@@ -39,8 +41,10 @@ import {
 import { isEditFileCommand } from "../../websocket/listener/protocol-inbound";
 import {
   DESKTOP_DEBUG_PANEL_INFO_PREFIX,
+  emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
+  getLoopErrorNoticeDecision,
   getRecoverableRetryNoticeVisibility,
   getRecoverableStatusNoticeVisibility,
 } from "../../websocket/listener/recoverable-notices";
@@ -2645,6 +2649,178 @@ describe("listen-client recoverable status notices", () => {
       max_attempts: 3,
       delay_ms: 2000,
     });
+  });
+});
+
+describe("listen-client loop error notices", () => {
+  test("suppresses terminated process noise from the transcript", () => {
+    expect(
+      getLoopErrorNoticeDecision({
+        message: "terminated",
+      }),
+    ).toEqual({
+      visibility: "debug_only",
+      message: "terminated",
+    });
+  });
+
+  test("normalizes Cloudflare HTML errors to match TUI formatting", () => {
+    const message = `520 <!DOCTYPE html><html><head><title>letta.com | 520: Web server is returning an unknown error</title></head><body>Error code 520 Visit <a href="https://www.cloudflare.com/5xx-error-landing?utm_campaign=api.letta.com">cloudflare</a> Cloudflare Ray ID: abc123</body></html>`;
+
+    expect(
+      getLoopErrorNoticeDecision({
+        message,
+      }),
+    ).toEqual({
+      visibility: "transcript",
+      message:
+        "Cloudflare 520: Web server is returning an unknown error for api.letta.com (Ray ID: abc123). This is usually a temporary edge/origin outage. Please retry in a moment.",
+    });
+  });
+
+  test("normalizes proxy transport errors into a friendly transcript message", () => {
+    const error = new APIError(
+      504,
+      {
+        detail:
+          "Error occurred while trying to proxy to: http://localhost:3000",
+      },
+      undefined,
+      new Headers(),
+    );
+
+    expect(
+      getLoopErrorNoticeDecision({
+        message:
+          "504 Error occurred while trying to proxy to: http://localhost:3000",
+        error,
+      }),
+    ).toEqual({
+      visibility: "transcript",
+      message: "Connection to Letta service failed. Please retry.",
+    });
+  });
+
+  test("reuses TUI formatter for structured run errors", () => {
+    const apiError = {
+      message_type: "error_message" as const,
+      error_type: "insufficient_credits_error",
+      message: "Insufficient credits",
+      detail: "Please add credits to continue.",
+      run_id: "run-123",
+    };
+    const expectedMessage = formatErrorDetails(
+      {
+        error: {
+          error: {
+            type: apiError.error_type,
+            message: apiError.message,
+            detail: apiError.detail,
+          },
+          run_id: apiError.run_id,
+        },
+      },
+      "agent-1",
+      "default",
+    );
+
+    expect(
+      getLoopErrorNoticeDecision({
+        message: apiError.detail,
+        runErrorInfo: {
+          error_type: apiError.error_type,
+          message: apiError.message,
+          detail: apiError.detail,
+          run_id: apiError.run_id,
+        },
+        agentId: "agent-1",
+        conversationId: "default",
+      }),
+    ).toEqual({
+      visibility: "transcript",
+      message: expectedMessage,
+      apiError,
+    });
+  });
+
+  test("emits structured api_error for loop errors when available", () => {
+    const runtime = __listenClientTestUtils.createRuntime();
+    runtime.activeAgentId = "agent-1";
+    runtime.activeConversationId = "default";
+    const socket = new MockSocket();
+    const apiError = {
+      message_type: "error_message" as const,
+      error_type: "internal_error",
+      message: "Internal error",
+      detail: "provider overloaded",
+      run_id: "run-123",
+    };
+
+    emitLoopErrorNotice(socket as unknown as WebSocket, runtime, {
+      message: apiError.detail,
+      stopReason: "llm_api_error",
+      isTerminal: true,
+      runId: apiError.run_id,
+      agentId: "agent-1",
+      conversationId: "default",
+      apiError,
+    });
+
+    expect(socket.sentPayloads).toHaveLength(1);
+    const [firstPayload] = socket.sentPayloads;
+    expect(firstPayload).toBeDefined();
+    const payload = JSON.parse(firstPayload as string) as {
+      type: string;
+      delta: Record<string, unknown>;
+    };
+
+    expect(payload.type).toBe("stream_delta");
+    expect(payload.delta).toMatchObject({
+      message_type: "loop_error",
+      stop_reason: "llm_api_error",
+      is_terminal: true,
+      api_error: apiError,
+    });
+  });
+
+  test("suppresses abort-like loop errors from transcript and mirrors them to desktop logs", () => {
+    const runtime = __listenClientTestUtils.createRuntime();
+    const socket = new MockSocket();
+    const originalFlag = process.env.LETTA_DESKTOP_DEBUG_PANEL;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const mirroredLines: string[] = [];
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      mirroredLines.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      emitLoopErrorNotice(socket as unknown as WebSocket, runtime, {
+        message: abortError.message,
+        stopReason: "error",
+        isTerminal: true,
+        error: abortError,
+      });
+    } finally {
+      process.stderr.write = originalWrite as typeof process.stderr.write;
+      if (originalFlag === undefined) {
+        delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
+      } else {
+        process.env.LETTA_DESKTOP_DEBUG_PANEL = originalFlag;
+      }
+    }
+
+    expect(socket.sentPayloads).toHaveLength(0);
+    expect(mirroredLines).toHaveLength(1);
+    expect(mirroredLines[0]).toContain(DESKTOP_DEBUG_PANEL_INFO_PREFIX);
+    expect(mirroredLines[0]).toContain("The operation was aborted");
   });
 });
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -159,7 +159,6 @@ import {
   buildQueueSnapshot,
   emitDeviceStatusUpdate,
   emitInterruptedStatusDelta,
-  emitLoopErrorDelta,
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
@@ -179,6 +178,7 @@ import {
   scheduleQueuePump,
   shouldQueueInboundMessage,
 } from "./queue";
+import { emitLoopErrorNotice } from "./recoverable-notices";
 import {
   getApprovalContinuationRecoveryDisposition,
   recoverApprovalStateForSync,
@@ -351,12 +351,13 @@ function handleModeChange(
       error,
       "listener_mode_change",
     );
-    emitLoopErrorDelta(socket, runtime, {
+    emitLoopErrorNotice(socket, runtime, {
       message: error instanceof Error ? error.message : "Mode change failed",
       stopReason: "error",
       isTerminal: false,
       agentId: scope?.agent_id,
       conversationId: scope?.conversation_id,
+      error,
     });
 
     if (isDebugEnabled()) {
@@ -1868,7 +1869,7 @@ async function handleCwdChange(
       conversation_id: conversationId,
     });
   } catch (error) {
-    emitLoopErrorDelta(socket, runtime, {
+    emitLoopErrorNotice(socket, runtime, {
       message:
         error instanceof Error
           ? error.message
@@ -1877,6 +1878,7 @@ async function handleCwdChange(
       isTerminal: false,
       agentId,
       conversationId,
+      error,
     });
   }
 }
@@ -2237,7 +2239,7 @@ async function connectWithRetry(
       }
 
       if (parsed.type === "__invalid_input") {
-        emitLoopErrorDelta(socket, runtime, {
+        emitLoopErrorNotice(socket, runtime, {
           message: parsed.reason,
           stopReason: "error",
           isTerminal: false,
@@ -2295,7 +2297,7 @@ async function connectWithRetry(
 
         const inputPayload = parsed.payload;
         if (inputPayload.kind !== "create_message") {
-          emitLoopErrorDelta(socket, runtime, {
+          emitLoopErrorNotice(socket, runtime, {
             message: `Unsupported input payload kind: ${String((inputPayload as { kind?: unknown }).kind)}`,
             stopReason: "error",
             isTerminal: false,
@@ -2316,7 +2318,7 @@ async function connectWithRetry(
             "type" in payload && payload.type === "approval",
         );
         if (hasApprovalPayload) {
-          emitLoopErrorDelta(socket, runtime, {
+          emitLoopErrorNotice(socket, runtime, {
             message:
               "Protocol violation: approval payloads are not allowed in input.kind=create_message. Use input.kind=approval_response.",
             stopReason: "error",
@@ -3240,7 +3242,7 @@ async function connectWithRetry(
         return;
       }
 
-      emitLoopErrorDelta(socket, runtime, {
+      emitLoopErrorNotice(socket, runtime, {
         message:
           error instanceof Error
             ? error.message
@@ -3249,6 +3251,7 @@ async function connectWithRetry(
         isTerminal: false,
         agentId: parsedScope.agent_id,
         conversationId: parsedScope.conversation_id,
+        error,
       });
     }
   });

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -1,4 +1,5 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import WebSocket from "ws";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { getGitContext } from "../../cli/helpers/gitContext";
@@ -700,6 +701,7 @@ export function emitLoopErrorDelta(
     runId?: string | null;
     agentId?: string | null;
     conversationId?: string | null;
+    apiError?: LettaStreamingResponse.LettaErrorMessage;
   },
 ): void {
   emitCanonicalMessageDelta(
@@ -710,6 +712,7 @@ export function emitLoopErrorDelta(
       message: params.message,
       stop_reason: params.stopReason,
       is_terminal: params.isTerminal,
+      ...(params.apiError ? { api_error: params.apiError } : {}),
     } as StreamDelta,
     {
       agent_id: params.agentId,

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -1,11 +1,37 @@
+import { APIError, APIUserAbortError } from "@letta-ai/letta-client/core/error";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
-import type { StatusMessage } from "../../types/protocol_v2";
+import type { RunErrorInfo } from "../../agent/approval-recovery";
+import { extractConflictDetail } from "../../agent/turn-recovery-policy";
+import {
+  checkCloudflareEdgeError,
+  formatErrorDetails,
+} from "../../cli/helpers/errorFormatter";
+import type { ErrorInfo } from "../../cli/helpers/streamProcessor";
+import type { StatusMessage, StopReasonType } from "../../types/protocol_v2";
 import { debugLog } from "../../utils/debug";
-import { emitRetryDelta, emitStatusDelta } from "./protocol-outbound";
+import {
+  emitLoopErrorDelta,
+  emitRetryDelta,
+  emitStatusDelta,
+} from "./protocol-outbound";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
 export type RecoverableStatusNoticeKind = "stale_approval_conflict_recovery";
 export type RecoverableRetryNoticeKind = "transient_provider_retry";
+
+type LifecycleNoticeVisibility = "debug_only" | "transcript";
+
+type StructuredLoopErrorInfo =
+  | ErrorInfo
+  | RunErrorInfo
+  | LettaStreamingResponse.LettaErrorMessage;
+
+export interface LoopErrorNoticeDecision {
+  visibility: LifecycleNoticeVisibility;
+  message: string;
+  apiError?: LettaStreamingResponse.LettaErrorMessage;
+}
 
 export const DESKTOP_DEBUG_PANEL_INFO_PREFIX =
   "[LETTA_DESKTOP_DEBUG_PANEL_INFO]";
@@ -47,6 +73,214 @@ function mirrorRecoverableNoticeToDesktopDebugPanel(message: string): void {
   } catch {
     // Best-effort only.
   }
+}
+
+function toStructuredApiError(
+  errorInfo?: StructuredLoopErrorInfo,
+): LettaStreamingResponse.LettaErrorMessage | undefined {
+  if (!errorInfo?.error_type || !errorInfo.run_id) {
+    return undefined;
+  }
+
+  return {
+    message_type: "error_message",
+    message: errorInfo.message || errorInfo.detail || "An error occurred",
+    error_type: errorInfo.error_type,
+    run_id: errorInfo.run_id,
+    ...(errorInfo.detail ? { detail: errorInfo.detail } : {}),
+  };
+}
+
+function getStructuredApiErrorFromError(
+  error: unknown,
+): LettaStreamingResponse.LettaErrorMessage | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+
+  const errorWithStructuredInfo = error as Error & {
+    apiError?: LettaStreamingResponse.LettaErrorMessage;
+    runErrorInfo?: RunErrorInfo;
+  };
+
+  return (
+    errorWithStructuredInfo.apiError ??
+    toStructuredApiError(errorWithStructuredInfo.runErrorInfo)
+  );
+}
+
+function buildStructuredFormatInput(
+  apiError: LettaStreamingResponse.LettaErrorMessage,
+): {
+  error: {
+    error: {
+      type: string;
+      message: string;
+      detail?: string;
+    };
+    run_id: string;
+  };
+} {
+  return {
+    error: {
+      error: {
+        type: apiError.error_type,
+        message: apiError.message,
+        ...(apiError.detail ? { detail: apiError.detail } : {}),
+      },
+      run_id: apiError.run_id,
+    },
+  };
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  if (error instanceof APIUserAbortError) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errorWithCode = error as Error & { code?: string };
+
+  return (
+    error.name === "AbortError" ||
+    error.message === "The operation was aborted" ||
+    errorWithCode.code === "ABORT_ERR"
+  );
+}
+
+function isTerminatedProcessNoise(message: string): boolean {
+  return message.trim().toLowerCase() === "terminated";
+}
+
+function isProxyTransportError(
+  detail: string,
+  error: unknown,
+  message: string,
+): boolean {
+  if (
+    error instanceof APIError &&
+    error.status >= 500 &&
+    detail.toLowerCase().includes("trying to proxy")
+  ) {
+    return true;
+  }
+
+  return (
+    detail.toLowerCase().includes("error occurred while trying to proxy") ||
+    message.toLowerCase().includes("error occurred while trying to proxy")
+  );
+}
+
+export function getLoopErrorNoticeDecision(params: {
+  message: string;
+  error?: unknown;
+  errorInfo?: ErrorInfo;
+  runErrorInfo?: RunErrorInfo;
+  apiError?: LettaStreamingResponse.LettaErrorMessage;
+  agentId?: string | null;
+  conversationId?: string | null;
+  cancelRequested?: boolean;
+  abortSignal?: AbortSignal;
+}): LoopErrorNoticeDecision {
+  const apiError =
+    params.apiError ??
+    toStructuredApiError(params.errorInfo) ??
+    toStructuredApiError(params.runErrorInfo) ??
+    getStructuredApiErrorFromError(params.error);
+  const detail =
+    apiError?.detail ??
+    params.errorInfo?.detail ??
+    params.runErrorInfo?.detail ??
+    extractConflictDetail(params.error) ??
+    "";
+
+  if (
+    params.cancelRequested ||
+    params.abortSignal?.aborted ||
+    isAbortLikeError(params.error) ||
+    isTerminatedProcessNoise(params.message)
+  ) {
+    return {
+      visibility: "debug_only",
+      message: params.message,
+    };
+  }
+
+  const cloudflareMessage =
+    checkCloudflareEdgeError(detail) ??
+    checkCloudflareEdgeError(params.message);
+  if (cloudflareMessage) {
+    return {
+      visibility: "transcript",
+      message: cloudflareMessage,
+      apiError,
+    };
+  }
+
+  if (isProxyTransportError(detail, params.error, params.message)) {
+    return {
+      visibility: "transcript",
+      message: "Connection to Letta service failed. Please retry.",
+      apiError,
+    };
+  }
+
+  const formattedMessage = formatErrorDetails(
+    apiError
+      ? buildStructuredFormatInput(apiError)
+      : (params.error ?? params.message),
+    params.agentId ?? undefined,
+    params.conversationId ?? undefined,
+  );
+
+  return {
+    visibility: "transcript",
+    message: formattedMessage,
+    apiError,
+  };
+}
+
+export function emitLoopErrorNotice(
+  socket: WebSocket,
+  runtime: ListenerRuntime | ConversationRuntime,
+  params: {
+    message: string;
+    stopReason: StopReasonType;
+    isTerminal: boolean;
+    runId?: string | null;
+    agentId?: string | null;
+    conversationId?: string | null;
+    error?: unknown;
+    errorInfo?: ErrorInfo;
+    runErrorInfo?: RunErrorInfo;
+    apiError?: LettaStreamingResponse.LettaErrorMessage;
+    cancelRequested?: boolean;
+    abortSignal?: AbortSignal;
+  },
+): void {
+  const decision = getLoopErrorNoticeDecision(params);
+
+  if (decision.visibility === "debug_only") {
+    debugLog(
+      "recovery",
+      `Debug-only loop error (${params.stopReason}): ${params.message}`,
+    );
+    mirrorRecoverableNoticeToDesktopDebugPanel(params.message);
+    return;
+  }
+
+  emitLoopErrorDelta(socket, runtime, {
+    message: decision.message,
+    stopReason: params.stopReason,
+    isTerminal: params.isTerminal,
+    runId: params.runId,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    apiError: decision.apiError,
+  });
 }
 
 export function emitRecoverableStatusNotice(

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -49,12 +49,12 @@ import {
   emitCanonicalMessageDelta,
   emitDequeuedUserMessage,
   emitInterruptedStatusDelta,
-  emitLoopErrorDelta,
   emitLoopStatusUpdate,
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
 import { consumeQueuedTurn } from "./queue";
+import { emitLoopErrorNotice } from "./recoverable-notices";
 import {
   clearActiveRunState,
   clearRecoveredApprovalState,
@@ -176,13 +176,15 @@ export async function drainRecoveryStreamWithEmission(
       }
 
       if (errorInfo) {
-        emitLoopErrorDelta(socket, runtime, {
+        emitLoopErrorNotice(socket, runtime, {
           message: errorInfo.message || "Stream error",
           stopReason: (errorInfo.error_type as StopReasonType) || "error",
           isTerminal: false,
           runId: runtime.activeRunId || errorInfo.run_id,
           agentId: params.agentId ?? undefined,
           conversationId: params.conversationId,
+          errorInfo,
+          abortSignal: params.abortSignal,
         });
       }
 
@@ -256,7 +258,7 @@ export function finalizeHandledRecoveryTurn(
   const runId = runtime.activeRunId;
   clearActiveRunState(runtime);
   emitRuntimeStateUpdates(runtime, scope);
-  emitLoopErrorDelta(socket, runtime, {
+  emitLoopErrorNotice(socket, runtime, {
     message: `Recovery continuation ended unexpectedly: ${terminalStopReason}`,
     stopReason: terminalStopReason,
     isTerminal: true,

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -10,7 +10,7 @@ import {
   type ApprovalDecision,
   executeApprovalBatch,
 } from "../../agent/approval-execution";
-import { fetchRunErrorDetail } from "../../agent/approval-recovery";
+import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
 import { sendMessageStream } from "../../agent/message";
@@ -498,10 +498,14 @@ export async function sendMessageStreamWithRetry(
           }
         }
 
-        const detail = await fetchRunErrorDetail(runtime.activeRunId);
-        throw new Error(
-          detail ||
-            `Pre-stream approval conflict after ${preStreamRecoveryAttempts} recovery attempts`,
+        const runErrorInfo = await fetchRunErrorInfo(runtime.activeRunId);
+        throw Object.assign(
+          new Error(
+            runErrorInfo?.detail ||
+              runErrorInfo?.message ||
+              `Pre-stream approval conflict after ${preStreamRecoveryAttempts} recovery attempts`,
+          ),
+          { runErrorInfo },
         );
       }
 
@@ -710,10 +714,14 @@ export async function sendApprovalContinuationWithRetry(
           continue;
         }
 
-        const detail = await fetchRunErrorDetail(runtime.activeRunId);
-        throw new Error(
-          detail ||
-            `Approval continuation conflict after ${preStreamRecoveryAttempts} recovery attempts`,
+        const runErrorInfo = await fetchRunErrorInfo(runtime.activeRunId);
+        throw Object.assign(
+          new Error(
+            runErrorInfo?.detail ||
+              runErrorInfo?.message ||
+              `Approval continuation conflict after ${preStreamRecoveryAttempts} recovery attempts`,
+          ),
+          { runErrorInfo },
         );
       }
 

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -38,11 +38,11 @@ import {
 } from "./interrupts";
 import {
   emitDequeuedUserMessage,
-  emitLoopErrorDelta,
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
 import { consumeQueuedTurn } from "./queue";
+import { emitLoopErrorNotice } from "./recoverable-notices";
 import { debugLogApprovalResumeState } from "./recovery";
 import {
   markAwaitingAcceptedApprovalContinuationRunId,
@@ -143,7 +143,7 @@ export async function handleApprovalStop(params: {
       conversation_id: conversationId,
     });
 
-    emitLoopErrorDelta(socket, runtime, {
+    emitLoopErrorNotice(socket, runtime, {
       message: "requires_approval stop returned no approvals",
       stopReason: "error",
       isTerminal: true,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -6,7 +6,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
 import type { ApprovalResult } from "../../agent/approval-execution";
-import { fetchRunErrorDetail } from "../../agent/approval-recovery";
+import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
 import { setConversationId, setCurrentAgentId } from "../../agent/context";
@@ -71,13 +71,13 @@ import {
   emitCanonicalMessageDelta,
   emitDeviceStatusIfOpen,
   emitInterruptedStatusDelta,
-  emitLoopErrorDelta,
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
 import {
+  emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
 } from "./recoverable-notices";
@@ -565,13 +565,16 @@ export async function handleIncomingMessage(
 
           if (errorInfo) {
             latestErrorText = errorInfo.message || latestErrorText;
-            emitLoopErrorDelta(socket, runtime, {
+            emitLoopErrorNotice(socket, runtime, {
               message: errorInfo.message || "Stream error",
               stopReason: (errorInfo.error_type as StopReasonType) || "error",
               isTerminal: false,
               runId: runId || errorInfo.run_id,
               agentId,
               conversationId,
+              errorInfo,
+              cancelRequested: runtime.cancelRequested,
+              abortSignal: turnAbortSignal,
             });
           }
 
@@ -659,9 +662,14 @@ export async function handleIncomingMessage(
 
       if (stopReason !== "requires_approval") {
         const lastRunId = runId || msgRunIds[msgRunIds.length - 1] || null;
+        const runErrorInfo = lastRunId
+          ? await fetchRunErrorInfo(lastRunId)
+          : null;
         const errorDetail =
           latestErrorText ||
-          (lastRunId ? await fetchRunErrorDetail(lastRunId) : null);
+          runErrorInfo?.detail ||
+          runErrorInfo?.message ||
+          null;
 
         if (
           shouldAttemptPostStopApprovalRecovery({
@@ -926,13 +934,16 @@ export async function handleIncomingMessage(
         const errorMessage =
           errorDetail || `Unexpected stop reason: ${stopReason}`;
 
-        emitLoopErrorDelta(socket, runtime, {
+        emitLoopErrorNotice(socket, runtime, {
           message: errorMessage,
           stopReason: effectiveStopReason,
           isTerminal: true,
           runId: runId,
           agentId,
           conversationId,
+          runErrorInfo: runErrorInfo ?? undefined,
+          cancelRequested: runtime.cancelRequested,
+          abortSignal: turnAbortSignal,
         });
         break;
       }
@@ -1031,12 +1042,15 @@ export async function handleIncomingMessage(
     });
 
     const errorMessage = error instanceof Error ? error.message : String(error);
-    emitLoopErrorDelta(socket, runtime, {
+    emitLoopErrorNotice(socket, runtime, {
       message: errorMessage,
       stopReason: "error",
       isTerminal: true,
       agentId: agentId || undefined,
       conversationId,
+      error,
+      cancelRequested: runtime.cancelRequested,
+      abortSignal: turnAbortSignal,
     });
     if (isDebugEnabled()) {
       console.error("[Listen] Error handling message:", error);


### PR DESCRIPTION
## Summary
- preserve structured websocket run and stream error metadata instead of flattening loop errors early
- route websocket loop-error emissions through the recoverable notice policy so terminated/abort noise stays out of the transcript
- attach protocol_v2 `api_error` metadata and add parity tests for formatted websocket loop errors

## Test plan
- [x] `bun --loader:.md=text --loader:.mdx=text --loader:.txt=text test "src/tests/websocket/listen-client-protocol.test.ts"`
- [ ] `bun run typecheck` *(currently fails on unrelated existing repo errors in `src/agent/check-approval.ts`, `src/cli/components/ConversationSelector.tsx`, and `src/tools/impl/Task.ts`)*

👾 Generated with [Letta Code](https://letta.com)