### PR TITLE
fix(cli): preserve conversation context window on reasoning updates

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -258,14 +258,25 @@ export async function updateConversationLLMConfig(
   conversationId: string,
   modelHandle: string,
   updateArgs?: Record<string, unknown>,
+  options?: UpdateAgentLLMConfigOptions,
 ): Promise<Conversation> {
   const client = await getClient();
 
   const modelSettings = buildModelSettings(modelHandle, updateArgs);
+  const explicitContextWindow = updateArgs?.context_window as
+    | number
+    | undefined;
+  const shouldPreserveContextWindow = options?.preserveContextWindow === true;
+  const contextWindow =
+    explicitContextWindow ??
+    (!shouldPreserveContextWindow
+      ? await getModelContextWindow(modelHandle)
+      : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
   const payload = {
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
+    ...(contextWindow && { context_window_limit: contextWindow }),
   } as unknown as Parameters<typeof client.conversations.update>[1];
 
   return client.conversations.update(conversationId, payload);

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3706,6 +3706,7 @@ export default function App({
           targetConversationId,
           modelHandle,
           Object.keys(updateArgs).length > 0 ? updateArgs : undefined,
+          { preserveContextWindow: true },
         );
       } catch (error) {
         debugWarn(
@@ -12516,6 +12517,7 @@ ${SYSTEM_REMINDER_CLOSE}
               conversationIdRef.current,
               modelHandle,
               model.updateArgs,
+              { preserveContextWindow: false },
             );
             conversationModelSettings = (
               updatedConversation as {
@@ -13497,6 +13499,7 @@ ${SYSTEM_REMINDER_CLOSE}
               {
                 reasoning_effort: desired.effort,
               },
+              { preserveContextWindow: true },
             );
             conversationModelSettings = (
               updatedConversation as {

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -75,6 +75,10 @@ describe("model preset refresh wiring", () => {
       "client.conversations.update(conversationId, payload)",
     );
     expect(updateSegment).toContain("model: modelHandle");
+    expect(updateSegment).toContain("options?: UpdateAgentLLMConfigOptions");
+    expect(updateSegment).toContain("shouldPreserveContextWindow");
+    expect(updateSegment).toContain("getModelContextWindow(modelHandle)");
+    expect(updateSegment).toContain("context_window_limit");
     expect(updateSegment).not.toContain("client.agents.update(");
   });
 
@@ -95,6 +99,7 @@ describe("model preset refresh wiring", () => {
     expect(segment).toContain("updateAgentLLMConfig(");
     expect(segment).toContain("conversationIdRef.current");
     expect(segment).toContain('conversationIdRef.current === "default"');
+    expect(segment).toContain("preserveContextWindow: false");
   });
 
   test("App defines helper to carry over active conversation model", () => {
@@ -116,6 +121,7 @@ describe("model preset refresh wiring", () => {
     expect(segment).toContain("buildModelHandleFromLlmConfig");
     expect(segment).toContain("getModelInfoForLlmConfig(");
     expect(segment).toContain("updateConversationLLMConfig(");
+    expect(segment).toContain("preserveContextWindow: true");
     expect(segment).toContain(
       "Failed to carry over active model to new conversation",
     );

--- a/src/tests/cli/reasoning-cycle-wiring.test.ts
+++ b/src/tests/cli/reasoning-cycle-wiring.test.ts
@@ -67,6 +67,7 @@ describe("reasoning tier cycle wiring", () => {
     expect(segment).toContain("updateAgentLLMConfig(");
     expect(segment).toContain("conversationIdRef.current");
     expect(segment).toContain('conversationIdRef.current === "default"');
+    expect(segment).toContain("preserveContextWindow: true");
   });
 
   test("tab-based reasoning cycling is opt-in only", () => {

--- a/src/tests/websocket/listen-model-update.test.ts
+++ b/src/tests/websocket/listen-model-update.test.ts
@@ -183,6 +183,7 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
 
     // Conversation-scoped update for non-default
     expect(source).toContain("updateConversationLLMConfig(");
+    expect(source).toContain("preserveContextWindow: false");
     expect(source).toContain('appliedTo = "conversation"');
   });
 });

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -549,6 +549,7 @@ async function applyModelUpdateForRuntime(params: {
       conversationId,
       model.handle,
       updateArgs,
+      { preserveContextWindow: false },
     );
     modelSettings =
       ((


### PR DESCRIPTION
## Summary
- extend `updateConversationLLMConfig` to set `context_window_limit` on conversation model updates
- add `preserveContextWindow` option so reasoning/carryover updates keep existing conversation limits while explicit model switches reset to selected preset context
- wire option through App + listener update paths and update wiring tests accordingly

## Test plan
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts src/tests/cli/reasoning-cycle-wiring.test.ts src/tests/websocket/listen-model-update.test.ts`
- [ ] run broader `bun run check` in CI

## Notes
- Pairs with letta-cloud PR that persists and applies conversation `context_window_limit` server-side.

👾 Generated with [Letta Code](https://letta.com)