### PR TITLE
fix(skills): add pre-commit hook guidance to working-in-parallel

### DIFF
--- a/src/skills/builtin/working-in-parallel/SKILL.md
+++ b/src/skills/builtin/working-in-parallel/SKILL.md
@@ -59,6 +59,10 @@ git worktree remove <path>                 # Remove worktree
 - Long-running task in one session, quick fix needed in another
 - User wants to continue development while an agent works on a separate feature
 
+## Pre-commit Hooks in Worktrees
+
+Worktrees share `.git`, but pre-commit hooks may need initialization depending on project setup. After creating a worktree and installing dependencies, verify hooks are active before committing. Check project docs or run the project's hook setup command if needed.
+
 ## Tips
 
 - **Check project setup docs before installing** - README, claude.md, project memory block


### PR DESCRIPTION
## Summary
- Adds guidance about pre-commit hooks in worktrees to the bundled `working-in-parallel` skill
- Generic advice that works with pre-commit framework, Husky, or native git hooks
- Prevents accidental commits without linting when working in parallel

## Test plan
- [ ] Verified skill file renders correctly
- [ ] Confirmed advice is generic and doesn't assume specific tooling