### PR TITLE
fix(ci): stop self-upgrading npm in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,12 @@ jobs:
         with:
           bun-version: 1.3.0
 
-      - name: Setup Node (for npm OIDC publishing)
+      - name: Setup Node (bundled npm 11 for OIDC publishing)
         if: steps.detect.outputs.should_publish == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24.13.0"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm for OIDC support
-        if: steps.detect.outputs.should_publish == 'true'
-        run: npm install -g npm@latest
 
       - name: Derive release metadata
         if: steps.detect.outputs.should_publish == 'true'


### PR DESCRIPTION
## Summary

This removes the `npm install -g npm@latest` step from the release workflow and instead uses a Node version that already ships with a sufficiently new npm for trusted publishing.

Concretely:
- switch the publish job from Node `22` to Node `24.13.0`
- remove the `Upgrade npm for OIDC support` step entirely
- keep the rest of the publish flow unchanged

## Bug this fixes

Recent `letta-code` release runs have been failing in the publish job before `npm publish`, at the workflow step that tries to upgrade npm in place:

- Run: https://github.com/letta-ai/letta-code/actions/runs/23973517391
- Failing step: `Upgrade npm for OIDC support`

Failure signature from the run log:

```text
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

The important detail is that this crash is coming from the runner-provided global npm installation under `/opt/hostedtoolcache/node/.../lib/node_modules/npm`, while npm is trying to replace itself with `npm install -g npm@latest`.

This is consistent with a flaky runner/toolcache/npm-self-upgrade problem, not a deterministic issue in our package or publish logic.

That also matches the observed behavior: retrying the same workflow often succeeds.

## Why this fix

We do not actually need to self-upgrade npm during the release job.

The reason that step exists is trusted publishing / OIDC support, but that requirement can be satisfied by the Node version we run the publish job on.

So the safest fix is:
- use a Node version that already bundles a modern npm
- stop mutating the runner's global npm installation during the job

That gives us a more reproducible release environment and removes the exact flaky step that is currently failing.

## Why Node 24.13.0

This PR pins the publish job to Node `24.13.0` instead of `22`.

Rationale:
- current Node 24 releases bundle npm 11, which satisfies npm trusted publishing requirements
- pinning an explicit patch version keeps the release environment stable instead of floating under us
- this is a narrow workflow change: no release semantics, package metadata, or publish command changes

## Why not keep `npm@latest`

`npm@latest` makes the release workflow drift over time and asks npm to upgrade itself in place on the hosted runner.
That is exactly the operation that is failing here.

Even if it usually works, it is unnecessary churn in the most sensitive job we have.

## Scope

This PR intentionally does **not** change:
- how the version is derived
- the tagging/release flow
- the publish command
- the Bun-based install/build/test steps

It only removes the flaky npm self-upgrade path.

## Validation

Local validation:
- pre-commit hook ran `tsc --noEmit` successfully during commit
- workflow YAML diff checked clean with `git diff --check`

## Reviewer notes

This is meant to be a narrow reliability fix for the release workflow, not a broader CI refactor.
If there is appetite later, we can separately revisit whether the workflow should pin more of its toolchain, but this PR is only addressing the concrete flaky failure above.
