### PR TITLE
fix(listener): include plan file path in loop state

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1333,9 +1333,38 @@ describe("listen-client v2 status builders", () => {
     const loopStatus = __listenClientTestUtils.buildLoopStatus(runtime);
     expect(loopStatus.status).toBe("WAITING_ON_INPUT");
     expect(loopStatus.active_run_ids).toEqual([]);
+    expect(loopStatus.plan_file_path).toBeNull();
     // queue is now separate from loopStatus — verify via buildQueueSnapshot
     const queueSnapshot = __listenClientTestUtils.buildQueueSnapshot(runtime);
     expect(queueSnapshot).toEqual([]);
+  });
+
+  test("buildLoopStatus includes plan file path for scoped plan mode", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    listener.permissionModeByConversation.set(
+      "agent:agent-1::conversation:default",
+      {
+        mode: "plan",
+        planFilePath: "/tmp/listener-plan.md",
+        modeBeforePlan: "default",
+      },
+    );
+
+    expect(
+      __listenClientTestUtils.buildLoopStatus(listener, {
+        agent_id: "agent-1",
+        conversation_id: "default",
+      }),
+    ).toEqual({
+      status: "WAITING_ON_INPUT",
+      active_run_ids: [],
+      plan_file_path: "/tmp/listener-plan.md",
+    });
   });
 
   test("buildDeviceStatus includes the effective working directory", () => {
@@ -1694,6 +1723,7 @@ describe("listen-client v2 status builders", () => {
     expect(outbound[1].loop_status).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
+      plan_file_path: null,
     });
   });
 
@@ -1831,6 +1861,7 @@ describe("listen-client v2 status builders", () => {
     ).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
+      plan_file_path: null,
     });
   });
 

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -212,6 +212,7 @@ export interface QueueMessage {
 export interface LoopState {
   status: LoopStatus;
   active_run_ids: string[];
+  plan_file_path: string | null;
 }
 
 export interface DeviceStatusUpdateMessage extends RuntimeEnvelope {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -240,11 +240,20 @@ export function buildLoopStatus(
 ): LoopState {
   const listener = getListenerRuntime(runtime);
   if (!listener) {
-    return { status: "WAITING_ON_INPUT", active_run_ids: [] };
+    return {
+      status: "WAITING_ON_INPUT",
+      active_run_ids: [],
+      plan_file_path: null,
+    };
   }
   const scope = getScopeForRuntime(runtime, params);
   const scopedAgentId = resolveScopedAgentId(listener, scope);
   const scopedConversationId = resolveScopedConversationId(listener, scope);
+  const conversationPermissionModeState = getConversationPermissionModeState(
+    listener,
+    scopedAgentId,
+    scopedConversationId,
+  );
   const conversationRuntime = getConversationRuntime(
     listener,
     scopedAgentId,
@@ -271,6 +280,10 @@ export function buildLoopStatus(
         : conversationRuntime?.activeRunId
           ? [conversationRuntime.activeRunId]
           : [],
+    plan_file_path:
+      conversationPermissionModeState.mode === "plan"
+        ? conversationPermissionModeState.planFilePath
+        : null,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `plan_file_path` to listener `LoopState` so websocket consumers can discover the active plan file during plan mode
- project the existing per-conversation listener plan path into `update_loop_status`, returning `null` outside plan mode
- extend websocket protocol tests to cover the new field and scoped plan-mode behavior

👾 Generated with [Letta Code](https://letta.com)