### PR TITLE
fix(auth): suppress repeated keychain read warnings on Linux

### DIFF
--- a/src/tests/agent/client-soft-fail.test.ts
+++ b/src/tests/agent/client-soft-fail.test.ts
@@ -220,4 +220,117 @@ describe("getClient soft failures", () => {
     expect(result.stderr).toContain("Failed to refresh access token:");
     expect(result.stderr).not.toContain("process.exit");
   });
+
+  test("refresh token in keychain remains usable after one failed read", async () => {
+    const result = await runIsolatedClientScript(
+      `
+        import { getClient } from "./src/agent/client";
+        import { settingsManager } from "./src/settings-manager";
+        import {
+          __resetSecretWarningStateForTests,
+          __setSecretGetOverrideForTests,
+        } from "./src/utils/secrets";
+
+        await settingsManager.initialize();
+        settingsManager.updateSettings({
+          env: {},
+          tokenExpiresAt: Date.now() - 1000,
+        });
+        await settingsManager.flush();
+
+        settingsManager.updateSettings = () => {};
+
+        let refreshReadCount = 0;
+        let fetchCalls = 0;
+
+        settingsManager.isKeychainAvailable = async () => true;
+        __resetSecretWarningStateForTests();
+        __setSecretGetOverrideForTests(async ({ name }) => {
+          if (name === "letta-refresh-token") {
+            refreshReadCount += 1;
+            if (refreshReadCount === 1) {
+              throw new Error("transient refresh read failure");
+            }
+            return "rt-keychain-only";
+          }
+          if (name === "letta-api-key") {
+            return null;
+          }
+          return null;
+        });
+
+        globalThis.fetch = async (_url, init) => {
+          fetchCalls += 1;
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          return {
+            ok: true,
+            async json() {
+              return {
+                access_token: "sk-refreshed-access-token",
+                refresh_token: body.refresh_token,
+                token_type: "Bearer",
+                expires_in: 3600,
+              };
+            },
+          };
+        };
+
+        let firstMessage = null;
+        try {
+          await getClient();
+        } catch (error) {
+          firstMessage = error instanceof Error ? error.message : String(error);
+        }
+
+        try {
+          const client = await getClient();
+          console.log(
+            "${RESULT_PREFIX}" +
+              JSON.stringify({
+                resolved: true,
+                firstMessage,
+                refreshReadCount,
+                fetchCalls,
+                hasClient: !!client,
+              }),
+          );
+        } catch (error) {
+          console.log(
+            "${RESULT_PREFIX}" +
+              JSON.stringify({
+                resolved: false,
+                message: error instanceof Error ? error.message : String(error),
+                firstMessage,
+                refreshReadCount,
+                fetchCalls,
+              }),
+          );
+        }
+      `,
+      testHomeDir,
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const payload = parseIsolatedResult<{
+      resolved: boolean;
+      message?: string;
+      firstMessage: string | null;
+      refreshReadCount: number;
+      fetchCalls: number;
+      hasClient?: boolean;
+    }>(result.stdout);
+
+    if (!payload.resolved) {
+      throw new Error(
+        `Expected keychain recovery scenario to succeed. stdout=${result.stdout} stderr=${result.stderr}`,
+      );
+    }
+
+    expect(payload.resolved).toBe(true);
+    expect(payload.refreshReadCount).toBeGreaterThanOrEqual(2);
+    expect(payload.firstMessage).toContain("Missing LETTA_API_KEY");
+    expect(payload.fetchCalls).toBe(1);
+    expect(payload.hasClient).toBe(true);
+  });
 });

--- a/src/tests/secrets.test.ts
+++ b/src/tests/secrets.test.ts
@@ -248,4 +248,34 @@ describe("Secrets utilities", () => {
       "Failed to retrieve refresh token from secrets",
     );
   });
+
+  test("warns again after a successful recovery read", async () => {
+    console.warn = mock(() => {});
+
+    const warn = console.warn as ReturnType<typeof mock>;
+    let calls = 0;
+
+    __setSecretGetOverrideForTests(async (options) => {
+      if (options.name !== "letta-api-key") {
+        return null;
+      }
+
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("api key failure 1");
+      }
+      if (calls === 2) {
+        return "sk-recovered";
+      }
+      throw new Error("api key failure 2");
+    });
+
+    expect(await getApiKey()).toBe(null);
+    expect(await getApiKey()).toBe("sk-recovered");
+    expect(await getApiKey()).toBe(null);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("api key failure 1");
+    expect(String(warn.mock.calls[1]?.[0])).toContain("api key failure 2");
+  });
 });

--- a/src/tests/secrets.test.ts
+++ b/src/tests/secrets.test.ts
@@ -1,8 +1,10 @@
 // src/tests/keychain.test.ts
 // Tests for secrets utility functions
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  __resetSecretWarningStateForTests,
+  __setSecretGetOverrideForTests,
   deleteApiKey,
   deleteRefreshToken,
   deleteSecureTokens,
@@ -18,13 +20,21 @@ import {
 } from "../utils/secrets";
 
 describe("Secrets utilities", () => {
+  const originalConsoleWarn = console.warn;
+
   beforeEach(async () => {
+    __resetSecretWarningStateForTests();
+    __setSecretGetOverrideForTests(null);
+    console.warn = originalConsoleWarn;
     if (keychainAvailablePrecompute) {
       await deleteSecureTokens();
     }
   });
 
   afterEach(async () => {
+    __resetSecretWarningStateForTests();
+    __setSecretGetOverrideForTests(null);
+    console.warn = originalConsoleWarn;
     if (keychainAvailablePrecompute) {
       await deleteSecureTokens();
     }
@@ -187,5 +197,55 @@ describe("Secrets utilities", () => {
       await expect(deleteApiKey()).resolves.toBeUndefined();
       await expect(deleteRefreshToken()).resolves.toBeUndefined();
     }
+  });
+
+  test("dedupes API key retrieval warnings after the first failure", async () => {
+    console.warn = mock(() => {});
+
+    const warn = console.warn as ReturnType<typeof mock>;
+    let calls = 0;
+
+    __setSecretGetOverrideForTests(async (options) => {
+      if (options.name === "letta-api-key") {
+        calls += 1;
+        throw new Error(`api key failure ${calls}`);
+      }
+      return null;
+    });
+
+    expect(await getApiKey()).toBe(null);
+    expect(await getApiKey()).toBe(null);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "Failed to retrieve API key from secrets",
+    );
+  });
+
+  test("warns once per token type when both reads fail", async () => {
+    console.warn = mock(() => {});
+
+    const warn = console.warn as ReturnType<typeof mock>;
+
+    __setSecretGetOverrideForTests(async (options) => {
+      if (
+        options.name === "letta-api-key" ||
+        options.name === "letta-refresh-token"
+      ) {
+        throw new Error(`failure for ${options.name}`);
+      }
+      return null;
+    });
+
+    expect(await getApiKey()).toBe(null);
+    expect(await getRefreshToken()).toBe(null);
+    expect(await getApiKey()).toBe(null);
+    expect(await getRefreshToken()).toBe(null);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "Failed to retrieve API key from secrets",
+    );
+    expect(String(warn.mock.calls[1]?.[0])).toContain(
+      "Failed to retrieve refresh token from secrets",
+    );
   });
 });

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -2,6 +2,8 @@
 // src/utils/secrets.ts
 // Secure storage utilities for tokens using Bun's secrets API with Node.js fallback
 
+import { debugWarn } from "./debug.js";
+
 let secrets: typeof Bun.secrets;
 let secretsAvailable = false;
 
@@ -18,6 +20,11 @@ let SERVICE_NAME = "letta-code";
 const API_KEY_NAME = "letta-api-key";
 const REFRESH_TOKEN_NAME = "letta-refresh-token";
 
+const warnedSecretReadFailures = new Set<string>();
+let secretGetOverrideForTests:
+  | ((options: { service: string; name: string }) => Promise<string | null>)
+  | null = null;
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -28,6 +35,34 @@ function isDuplicateKeychainItemError(error: unknown): boolean {
     message.includes("already exists in the keychain") ||
     message.includes("code: -25299")
   );
+}
+
+async function getSecretValue(
+  name: string,
+  label: string,
+): Promise<string | null> {
+  if (!secretsAvailable && !secretGetOverrideForTests) {
+    return null;
+  }
+
+  try {
+    const options = {
+      service: SERVICE_NAME,
+      name,
+    };
+    return secretGetOverrideForTests
+      ? await secretGetOverrideForTests(options)
+      : await secrets.get(options);
+  } catch (error) {
+    const message = `Failed to retrieve ${label} from secrets: ${error}`;
+    if (!warnedSecretReadFailures.has(name)) {
+      warnedSecretReadFailures.add(name);
+      console.warn(message);
+    } else {
+      debugWarn("secrets", message);
+    }
+    return null;
+  }
 }
 
 async function setSecretValue(name: string, value: string): Promise<void> {
@@ -97,19 +132,7 @@ export async function setApiKey(apiKey: string): Promise<void> {
  * Retrieve API key from system secrets
  */
 export async function getApiKey(): Promise<string | null> {
-  if (secretsAvailable) {
-    try {
-      return await secrets.get({
-        service: SERVICE_NAME,
-        name: API_KEY_NAME,
-      });
-    } catch (error) {
-      console.warn(`Failed to retrieve API key from secrets: ${error}`);
-    }
-  }
-
-  // When secrets unavailable, return null (settings manager will use fallback)
-  return null;
+  return getSecretValue(API_KEY_NAME, "API key");
 }
 
 /**
@@ -128,19 +151,7 @@ export async function setRefreshToken(refreshToken: string): Promise<void> {
  * Retrieve refresh token from system secrets
  */
 export async function getRefreshToken(): Promise<string | null> {
-  if (secretsAvailable) {
-    try {
-      return await secrets.get({
-        service: SERVICE_NAME,
-        name: REFRESH_TOKEN_NAME,
-      });
-    } catch (error) {
-      console.warn(`Failed to retrieve refresh token from secrets: ${error}`);
-    }
-  }
-
-  // When secrets unavailable, return null (settings manager will use fallback)
-  return null;
+  return getSecretValue(REFRESH_TOKEN_NAME, "refresh token");
 }
 
 /**
@@ -258,3 +269,15 @@ export async function isKeychainAvailable(): Promise<boolean> {
  * Precomputed for tests
  */
 export const keychainAvailablePrecompute = await isKeychainAvailable();
+
+export function __resetSecretWarningStateForTests(): void {
+  warnedSecretReadFailures.clear();
+}
+
+export function __setSecretGetOverrideForTests(
+  override:
+    | ((options: { service: string; name: string }) => Promise<string | null>)
+    | null,
+): void {
+  secretGetOverrideForTests = override;
+}

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -50,9 +50,11 @@ async function getSecretValue(
       service: SERVICE_NAME,
       name,
     };
-    return secretGetOverrideForTests
+    const value = secretGetOverrideForTests
       ? await secretGetOverrideForTests(options)
       : await secrets.get(options);
+    warnedSecretReadFailures.delete(name);
+    return value;
   } catch (error) {
     const message = `Failed to retrieve ${label} from secrets: ${error}`;
     if (!warnedSecretReadFailures.has(name)) {


### PR DESCRIPTION
## Summary
- dedupe `Bun.secrets` read warnings per token type so transient Linux keychain failures don't flood stderr
- preserve existing auth fallback/recovery behavior and add a regression covering a keychain-only refresh token surviving an initial read failure
- add focused tests for warning suppression and keychain recovery behavior

👾 Generated with [Letta Code](https://letta.com)