### PR TITLE
fix(cron): replace deprecated recursive rmdir

### DIFF
--- a/src/cron/cronFile.ts
+++ b/src/cron/cronFile.ts
@@ -14,7 +14,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
-  rmdirSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -179,7 +179,7 @@ function isLockStale(lockDir: string): boolean {
 
 function stealLock(lockDir: string): void {
   try {
-    rmdirSync(lockDir, { recursive: true } as Parameters<typeof rmdirSync>[1]);
+    rmSync(lockDir, { recursive: true, force: true });
   } catch {
     // Best effort
   }
@@ -214,9 +214,7 @@ export function acquireLock(): LockHandle {
             // Verify we still own it before releasing
             const current = readLockOwner(lockDir);
             if (current && current.token === token) {
-              rmdirSync(lockDir, { recursive: true } as Parameters<
-                typeof rmdirSync
-              >[1]);
+              rmSync(lockDir, { recursive: true, force: true });
             }
           } catch {
             // Best effort


### PR DESCRIPTION
## Summary

This PR removes the deprecated recursive `rmdirSync()` usage from cron lock cleanup.

## User-visible symptom

Desktop logs sometimes show:

```text
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

The direct source is cron lock cleanup in `src/cron/cronFile.ts`.

## What changed

Replaced the two recursive lock-dir removals with `rmSync(..., { recursive: true, force: true })`:

- stale lock stealing
- lock release on normal unlock

## Why this is the right fix

`rmdirSync(path, { recursive: true })` is deprecated in current Node and produces the exact warning seen in desktop logs.

For this code path we want recursive directory removal semantics, and `rmSync()` is the supported replacement.

## Validation

Passed locally:
- `bun test src/tests/cron/cronFile.test.ts src/tests/cron/scheduler.test.ts`
- `bun run typecheck`
- `git diff --check`

## Scope

This is intentionally narrow:
- no scheduler behavior changes
- no lease semantics changes
- no logging changes
- just the Node deprecation cleanup in cron lock handling
