### PR TITLE
fix(listener): refresh loop status when plan file path changes

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -2262,6 +2262,63 @@ describe("listen-client capability-gated approval flow", () => {
     }
   });
 
+  test("mode changes emit fresh loop status plan_file_path on enter exit and re-enter", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const socket = new MockSocket(WebSocket.OPEN);
+    listener.socket = socket as unknown as WebSocket;
+
+    const scope = {
+      agent_id: "agent-1",
+      conversation_id: "default",
+    } as const;
+
+    __listenClientTestUtils.handleModeChange(
+      { mode: "plan" },
+      socket as unknown as WebSocket,
+      listener,
+      scope,
+    );
+
+    const firstPlanPath = (socket.sentPayloads
+      .map((payload) => JSON.parse(payload as string))
+      .findLast((payload) => payload.type === "update_loop_status")?.loop_status
+      ?.plan_file_path ?? null) as string | null;
+
+    expect(firstPlanPath).toBeTruthy();
+
+    __listenClientTestUtils.handleModeChange(
+      { mode: "default" },
+      socket as unknown as WebSocket,
+      listener,
+      scope,
+    );
+
+    const afterExitLoopStatus = socket.sentPayloads
+      .map((payload) => JSON.parse(payload as string))
+      .findLast(
+        (payload) =>
+          payload.type === "update_loop_status" &&
+          payload.loop_status?.status === "WAITING_ON_INPUT",
+      );
+
+    expect(afterExitLoopStatus?.loop_status?.plan_file_path).toBeNull();
+
+    __listenClientTestUtils.handleModeChange(
+      { mode: "plan" },
+      socket as unknown as WebSocket,
+      listener,
+      scope,
+    );
+
+    const secondPlanPath = (socket.sentPayloads
+      .map((payload) => JSON.parse(payload as string))
+      .findLast((payload) => payload.type === "update_loop_status")?.loop_status
+      ?.plan_file_path ?? null) as string | null;
+
+    expect(secondPlanPath).toBeTruthy();
+    expect(secondPlanPath).not.toBe(firstPlanPath);
+  });
+
   test("requestApprovalOverWS exposes the control request through device status instead of stream_delta", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -340,7 +340,7 @@ function handleModeChange(
 
     persistPermissionModeMapForRuntime(runtime);
 
-    emitDeviceStatusUpdate(socket, runtime, scope);
+    emitRuntimeStateUpdates(runtime, scope);
 
     if (isDebugEnabled()) {
       console.log(`[Listen] Mode changed to: ${msg.mode}`);
@@ -3645,6 +3645,7 @@ export { emitInterruptedStatusDelta } from "./protocol-outbound";
 export const __listenClientTestUtils = {
   createRuntime: createLegacyTestRuntime,
   createListenerRuntime: createRuntime,
+  handleModeChange,
   getOrCreateScopedRuntime,
   buildListModelsEntries,
   buildListModelsResponse,


### PR DESCRIPTION
## Summary
- emit loop-status updates when websocket permission mode changes so `loop_status.plan_file_path` stays in sync with the active plan file
- add a regression test covering enter, exit, and re-enter plan mode to ensure stale plan paths are cleared and regenerated correctly

👾 Generated with [Letta Code](https://letta.com)