### PR TITLE
fix(listener): relay abort signals for websocket stream retries

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -17,6 +17,7 @@ import {
   waitForToolsetReady,
 } from "../tools/manager";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
+import { createStreamAbortRelay } from "../utils/streamAbortRelay";
 import { isTimingsEnabled } from "../utils/timing";
 import {
   type ApprovalNormalizationOptions,
@@ -225,12 +226,14 @@ export async function sendMessageStream(
   );
 
   let stream: Stream<LettaStreamingResponse>;
+  const abortRelay = createStreamAbortRelay(requestOptions.signal);
   try {
     stream = await client.conversations.messages.create(
       resolvedConversationId,
       requestBody,
       {
         ...requestOptions,
+        ...(abortRelay ? { signal: abortRelay.signal } : {}),
         headers: {
           ...((requestOptions.headers as Record<string, string>) ?? {}),
           ...extraHeaders,
@@ -238,6 +241,7 @@ export async function sendMessageStream(
       },
     );
   } catch (error) {
+    abortRelay?.cleanup();
     debugWarn(
       "send-message-stream",
       "request_error conversation_id=%s otid=%s status=%s error=%s",
@@ -255,6 +259,8 @@ export async function sendMessageStream(
     resolvedConversationId,
     firstOtid ?? "none",
   );
+
+  abortRelay?.attach(stream as object);
 
   if (requestStartTime !== undefined) {
     streamRequestStartTimes.set(stream as object, requestStartTime);

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -17,6 +17,10 @@ import {
 } from "../../agent/message";
 import { telemetry } from "../../telemetry";
 import { debugLog, debugWarn } from "../../utils/debug";
+import {
+  cleanupStreamAbortRelay,
+  createStreamAbortRelay,
+} from "../../utils/streamAbortRelay";
 import { formatDuration, logTiming } from "../../utils/timing";
 
 import {
@@ -423,6 +427,8 @@ export async function drainStream(
       abortSignal.removeEventListener("abort", abortHandler);
     }
 
+    cleanupStreamAbortRelay(stream as object);
+
     // Clear SDK parse diagnostics on stream completion so they don't leak
     // into a future stream. On error paths the catch block already consumed
     // them; this handles the success path.
@@ -680,28 +686,45 @@ export async function drainStreamWithResume(
       // Create the resume stream: use OTID-based conversations endpoint only when
       // run_id is unavailable (server resolves the exact run, safe for multi-client).
       // When we already have run_id from stream chunks, use the run stream directly.
-      const resumeStream =
-        runIdSource === "otid" && streamOtid && streamRequestContext
-          ? await client.conversations.messages.stream(
-              streamRequestContext.resolvedConversationId,
-              {
-                agent_id:
-                  streamRequestContext.conversationId === "default"
-                    ? (streamRequestContext.agentId ?? undefined)
-                    : undefined,
-                otid: streamOtid,
-                starting_after: result.lastSeqId ?? 0,
-                batch_size: 1000,
-              } as unknown as Parameters<
-                typeof client.conversations.messages.stream
-              >[1],
-            )
-          : await client.runs.messages.stream(runIdToResume as string, {
-              // If lastSeqId is null the stream failed before any seq_id-bearing
-              // chunk arrived; use 0 to replay the run from the beginning.
-              starting_after: result.lastSeqId ?? 0,
-              batch_size: 1000,
-            });
+      const resumeAbortRelay = createStreamAbortRelay(abortSignal);
+      let resumeStream: Stream<LettaStreamingResponse>;
+      try {
+        resumeStream =
+          runIdSource === "otid" && streamOtid && streamRequestContext
+            ? await client.conversations.messages.stream(
+                streamRequestContext.resolvedConversationId,
+                {
+                  agent_id:
+                    streamRequestContext.conversationId === "default"
+                      ? (streamRequestContext.agentId ?? undefined)
+                      : undefined,
+                  otid: streamOtid,
+                  starting_after: result.lastSeqId ?? 0,
+                  batch_size: 1000,
+                } as unknown as Parameters<
+                  typeof client.conversations.messages.stream
+                >[1],
+                resumeAbortRelay
+                  ? { signal: resumeAbortRelay.signal }
+                  : undefined,
+              )
+            : await client.runs.messages.stream(
+                runIdToResume as string,
+                {
+                  // If lastSeqId is null the stream failed before any seq_id-bearing
+                  // chunk arrived; use 0 to replay the run from the beginning.
+                  starting_after: result.lastSeqId ?? 0,
+                  batch_size: 1000,
+                },
+                resumeAbortRelay
+                  ? { signal: resumeAbortRelay.signal }
+                  : undefined,
+              );
+      } catch (resumeError) {
+        resumeAbortRelay?.cleanup();
+        throw resumeError;
+      }
+      resumeAbortRelay?.attach(resumeStream as object);
 
       // Continue draining from where we left off
       // Note: Don't pass onFirstMessage again - already called in initial drain

--- a/src/tests/cli/stream-stop-reason-wiring.test.ts
+++ b/src/tests/cli/stream-stop-reason-wiring.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { getEventListeners } from "node:events";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStream } from "../../cli/helpers/stream";
+import { createStreamAbortRelay } from "../../utils/streamAbortRelay";
 
 function makeStreamWithToolCall(
   toolCallId = "tc-1",
@@ -100,5 +102,36 @@ describe("drainStream stop reason wiring", () => {
     expect(tl2.phase).not.toBe("finished");
     // interrupted flag should still be set
     expect(buffers.interrupted).toBe(true);
+  });
+
+  test("drainStream cleans up registered relayed abort listeners after completion", async () => {
+    const parent = new AbortController();
+    const relay = createStreamAbortRelay(parent.signal);
+    if (!relay) {
+      throw new Error("expected stream abort relay");
+    }
+
+    const fakeStream = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    relay.attach(fakeStream as object);
+    expect(getEventListeners(parent.signal, "abort")).toHaveLength(1);
+
+    const result = await drainStream(
+      fakeStream,
+      createBuffers("agent-test"),
+      () => {},
+      parent.signal,
+    );
+
+    expect(result.stopReason).toBe("end_turn");
+    expect(getEventListeners(parent.signal, "abort")).toHaveLength(0);
   });
 });

--- a/src/tests/utils/createRelayedAbortController.test.ts
+++ b/src/tests/utils/createRelayedAbortController.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { getEventListeners, once } from "node:events";
+import { createServer } from "node:http";
+import { createRelayedAbortController } from "../../utils/createRelayedAbortController";
+
+describe("createRelayedAbortController", () => {
+  test("does not accumulate parent abort listeners across repeated fetches", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("[]");
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected tcp server address");
+    }
+
+    const parent = new AbortController();
+
+    for (let i = 0; i < 12; i += 1) {
+      const requestAbort = createRelayedAbortController(parent.signal);
+      const response = await fetch(`http://127.0.0.1:${address.port}/`, {
+        signal: requestAbort.signal,
+      });
+      await response.text();
+      requestAbort.cleanup();
+
+      expect(getEventListeners(parent.signal, "abort")).toHaveLength(0);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+});

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -119,6 +119,9 @@ const conversationMessagesStreamMock = mock(
       starting_after?: number;
       batch_size?: number;
     },
+    _options?: {
+      signal?: AbortSignal;
+    },
   ): Promise<MockStream> => ({
     conversationId,
   }),
@@ -2030,10 +2033,12 @@ describe("listen-client multi-worker concurrency", () => {
       messageHistory: [],
     });
 
+    const parentAbortController = new AbortController();
+
     const result = await __listenClientTestUtils.resolveStaleApprovals(
       runtime,
       socket as unknown as WebSocket,
-      new AbortController().signal,
+      parentAbortController.signal,
       {
         getResumeData: getResumeDataMock,
       },
@@ -2049,5 +2054,9 @@ describe("listen-client multi-worker concurrency", () => {
       starting_after: 0,
       batch_size: 1000,
     });
+    expect(firstCall?.[2]).toMatchObject({
+      signal: expect.any(AbortSignal),
+    });
+    expect(firstCall?.[2]?.signal).not.toBe(parentAbortController.signal);
   });
 });

--- a/src/utils/createRelayedAbortController.ts
+++ b/src/utils/createRelayedAbortController.ts
@@ -1,0 +1,51 @@
+export interface RelayedAbortController {
+  controller: AbortController;
+  signal: AbortSignal;
+  cleanup: () => void;
+}
+
+/**
+ * Create a per-request AbortController that relays aborts from a longer-lived
+ * parent signal.
+ *
+ * Reusing the same long-lived signal across many streamed requests can cause
+ * abort listeners from the underlying fetch/stream implementation to pile up on
+ * the parent. Giving each request a fresh child signal keeps those listeners
+ * scoped to the request instead.
+ */
+export function createRelayedAbortController(
+  parentSignal?: AbortSignal,
+): RelayedAbortController {
+  const controller = new AbortController();
+
+  if (!parentSignal) {
+    return {
+      controller,
+      signal: controller.signal,
+      cleanup: () => {},
+    };
+  }
+
+  if (parentSignal.aborted) {
+    controller.abort(parentSignal.reason);
+    return {
+      controller,
+      signal: controller.signal,
+      cleanup: () => {},
+    };
+  }
+
+  const relayAbort = () => {
+    controller.abort(parentSignal.reason);
+  };
+
+  parentSignal.addEventListener("abort", relayAbort, { once: true });
+
+  return {
+    controller,
+    signal: controller.signal,
+    cleanup: () => {
+      parentSignal.removeEventListener("abort", relayAbort);
+    },
+  };
+}

--- a/src/utils/streamAbortRelay.ts
+++ b/src/utils/streamAbortRelay.ts
@@ -1,0 +1,62 @@
+import { createRelayedAbortController } from "./createRelayedAbortController";
+
+const streamAbortRelayCleanupByStream = new WeakMap<object, () => void>();
+
+function composeCleanups(first: () => void, second: () => void): () => void {
+  let cleaned = false;
+  return () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    first();
+    second();
+  };
+}
+
+export interface StreamAbortRelay {
+  signal: AbortSignal;
+  attach: (stream: object) => void;
+  cleanup: () => void;
+}
+
+export function createStreamAbortRelay(
+  parentSignal?: AbortSignal,
+): StreamAbortRelay | null {
+  if (!parentSignal) {
+    return null;
+  }
+
+  const requestAbort = createRelayedAbortController(parentSignal);
+  let cleaned = false;
+
+  const cleanup = () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    requestAbort.cleanup();
+  };
+
+  return {
+    signal: requestAbort.signal,
+    attach(stream: object) {
+      const existingCleanup = streamAbortRelayCleanupByStream.get(stream);
+      streamAbortRelayCleanupByStream.set(
+        stream,
+        existingCleanup ? composeCleanups(existingCleanup, cleanup) : cleanup,
+      );
+    },
+    cleanup,
+  };
+}
+
+export function cleanupStreamAbortRelay(stream: object): void {
+  const cleanup = streamAbortRelayCleanupByStream.get(stream);
+  if (!cleanup) {
+    return;
+  }
+
+  streamAbortRelayCleanupByStream.delete(stream);
+  cleanup();
+}

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -26,6 +26,7 @@ import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
 import type { ControlRequest } from "../../types/protocol_v2";
+import { createStreamAbortRelay } from "../../utils/streamAbortRelay";
 import {
   rememberPendingApprovalBatchIds,
   requestApprovalOverWS,
@@ -561,22 +562,36 @@ export async function sendMessageStreamWithRetry(
           const messageOtid = messages
             .map((item) => (item as Record<string, unknown>).otid)
             .find((value): value is string => typeof value === "string");
+          const resumeAbortRelay = createStreamAbortRelay(abortSignal);
 
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");
           }
 
-          return await client.conversations.messages.stream(conversationId, {
-            agent_id:
-              conversationId === "default"
-                ? (runtime.agentId ?? undefined)
+          try {
+            const resumeStream = await client.conversations.messages.stream(
+              conversationId,
+              {
+                agent_id:
+                  conversationId === "default"
+                    ? (runtime.agentId ?? undefined)
+                    : undefined,
+                otid: messageOtid ?? undefined,
+                starting_after: 0,
+                batch_size: 1000,
+              } as unknown as Parameters<
+                typeof client.conversations.messages.stream
+              >[1],
+              resumeAbortRelay
+                ? { signal: resumeAbortRelay.signal }
                 : undefined,
-            otid: messageOtid ?? undefined,
-            starting_after: 0,
-            batch_size: 1000,
-          } as unknown as Parameters<
-            typeof client.conversations.messages.stream
-          >[1]);
+            );
+            resumeAbortRelay?.attach(resumeStream as object);
+            return resumeStream;
+          } catch (resumeError) {
+            resumeAbortRelay?.cleanup();
+            throw resumeError;
+          }
         } catch (resumeError) {
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");
@@ -765,22 +780,36 @@ export async function sendApprovalContinuationWithRetry(
           const messageOtid = messages
             .map((item) => (item as Record<string, unknown>).otid)
             .find((value): value is string => typeof value === "string");
+          const resumeAbortRelay = createStreamAbortRelay(abortSignal);
 
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");
           }
 
-          return await client.conversations.messages.stream(conversationId, {
-            agent_id:
-              conversationId === "default"
-                ? (runtime.agentId ?? undefined)
+          try {
+            const resumeStream = await client.conversations.messages.stream(
+              conversationId,
+              {
+                agent_id:
+                  conversationId === "default"
+                    ? (runtime.agentId ?? undefined)
+                    : undefined,
+                otid: messageOtid ?? undefined,
+                starting_after: 0,
+                batch_size: 1000,
+              } as unknown as Parameters<
+                typeof client.conversations.messages.stream
+              >[1],
+              resumeAbortRelay
+                ? { signal: resumeAbortRelay.signal }
                 : undefined,
-            otid: messageOtid ?? undefined,
-            starting_after: 0,
-            batch_size: 1000,
-          } as unknown as Parameters<
-            typeof client.conversations.messages.stream
-          >[1]);
+            );
+            resumeAbortRelay?.attach(resumeStream as object);
+            return resumeStream;
+          } catch (resumeError) {
+            resumeAbortRelay?.cleanup();
+            throw resumeError;
+          }
         } catch (resumeError) {
           if (abortSignal?.aborted) {
             throw new Error("Cancelled by user");


### PR DESCRIPTION
## Summary
- relay turn-scoped abort signals through fresh child controllers for listener send requests and websocket resume streams so repeated recovery attempts stop stacking listeners on the shared turn signal
- register relay cleanup on returned streams and consume it in the stream drain path so abort propagation stays active for the full request lifetime and is removed deterministically on completion
- add regression coverage for repeated relay cleanup, drain-time cleanup, and the listener 409 resume path using a fresh child signal

👾 Generated with [Letta Code](https://letta.com)