### PR TITLE
fix(listener): stop sync recovery failures from spamming transcript

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1563,6 +1563,49 @@ describe("listen-client v2 status builders", () => {
     ]);
   });
 
+  test("sync replay soft-fails approval recovery errors without emitting loop_error rows", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    await __listenClientTestUtils.replaySyncStateForRuntime(
+      listener,
+      socket as unknown as WebSocket,
+      {
+        agent_id: "agent-1",
+        conversation_id: "default",
+      },
+      {
+        recoverApprovalStateForSync: async () => {
+          throw new Error(
+            "Unterminated string in JSON at position 183040 (line 1 column 183041)",
+          );
+        },
+      },
+    );
+
+    const outbound = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload as string),
+    );
+    expect(outbound.map((message) => message.type)).toEqual([
+      "update_device_status",
+      "update_loop_status",
+      "update_queue",
+      "update_subagent_state",
+    ]);
+    expect(
+      outbound.some(
+        (message) =>
+          message.type === "stream_delta" &&
+          message.delta?.message_type === "loop_error",
+      ),
+    ).toBe(false);
+  });
+
   test("sync includes silent background reflection subagents in update_subagent_state", () => {
     clearAllSubagents();
     try {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -272,6 +272,41 @@ function runDetachedListenerTask(
   });
 }
 
+async function replaySyncStateForRuntime(
+  listenerRuntime: ListenerRuntime,
+  socket: WebSocket,
+  scope: { agent_id: string; conversation_id: string },
+  opts?: {
+    recoverApprovalStateForSync?: (
+      runtime: ConversationRuntime,
+      scope: { agent_id: string; conversation_id: string },
+    ) => Promise<void>;
+  },
+): Promise<void> {
+  const syncScopedRuntime = getOrCreateScopedRuntime(
+    listenerRuntime,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  const recoverFn =
+    opts?.recoverApprovalStateForSync ?? recoverApprovalStateForSync;
+
+  try {
+    await recoverFn(syncScopedRuntime, scope);
+  } catch (error) {
+    trackListenerError(
+      "listener_sync_recovery_failed",
+      error,
+      "listener_sync_recovery",
+    );
+    if (isDebugEnabled()) {
+      console.warn("[Listen] Sync approval recovery failed:", error);
+    }
+  }
+
+  emitStateSync(socket, listenerRuntime, scope);
+}
+
 function getParsedRuntimeScope(
   parsed: unknown,
 ): { agent_id: string; conversation_id: string } | null {
@@ -2264,14 +2299,7 @@ async function connectWithRetry(
           console.log(`[Listen V2] Dropping sync: runtime mismatch or closed`);
           return;
         }
-        const syncScopedRuntime = getOrCreateScopedRuntime(
-          runtime,
-          parsed.runtime.agent_id,
-          parsed.runtime.conversation_id,
-        );
-        await recoverApprovalStateForSync(syncScopedRuntime, parsed.runtime);
-
-        emitStateSync(socket, runtime, parsed.runtime);
+        await replaySyncStateForRuntime(runtime, socket, parsed.runtime);
         return;
       }
 
@@ -3698,6 +3726,7 @@ export const __listenClientTestUtils = {
   handleCreateAgentCommand,
   handleReflectionSettingsCommand,
   scheduleQueuePump,
+  replaySyncStateForRuntime,
   recoverApprovalStateForSync,
   clearRecoveredApprovalStateForScope: (
     runtime: ListenerRuntime | ConversationRuntime,


### PR DESCRIPTION
After laptop sleep/wake or transient local proxy instability, the desktop controller keeps sending `sync` every ~5s. Failures inside `recoverApprovalStateForSync(...)` were bubbling into the generic listener message-handler catch, which emitted transcript-visible `loop_error` rows like "Connection to Letta service failed. Please retry." and raw parse text such as "Unterminated string in JSON..." repeatedly. This patch makes sync recovery soft-fail locally (telemetry/debug log only) and still emits `emitStateSync(...)`, so sync refresh continues but these periodic sync-path failures no longer pollute the transcript.

## Changes
- add `replaySyncStateForRuntime(...)` helper in `client.ts`
- catch and track sync approval-recovery errors (`listener_sync_recovery_failed`) without rethrowing
- keep state replay (`emitStateSync`) even when recovery fails
- add regression test asserting sync replay with a thrown JSON-parse-style error still emits normal state snapshots and emits no `loop_error` stream delta

## Validation
- `bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/client.ts src/tests/websocket/listen-client-protocol.test.ts`
- `bun test src/tests/websocket/listen-client-protocol.test.ts --timeout 20000` *(fails in this environment before test execution due missing package `picomatch` import from `src/tools/impl/LS.ts`)*
