### PR TITLE
fix(cli): update insufficient credits error copy

### DIFF
--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -599,7 +599,7 @@ export function formatErrorDetails(
 
     // Check for credit exhaustion error - provide a friendly message
     if (isCreditExhaustedError(e, reasons)) {
-      return `Your account is out of credits for hosted inference. Add credits, enable auto-recharge, or upgrade at ${LETTA_USAGE_URL}. You can also connect your own provider keys with /connect.`;
+      return `Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.`;
     }
 
     const tierUsageLimitMsg = getTierUsageLimitMessage(reasons);

--- a/src/tests/cli/errorFormatter.test.ts
+++ b/src/tests/cli/errorFormatter.test.ts
@@ -108,8 +108,9 @@ describe("formatErrorDetails", () => {
 
     const message = formatErrorDetails(error);
 
-    expect(message).toContain("out of credits");
-    expect(message).toContain("/connect");
+    expect(message).toBe(
+      "Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.",
+    );
     expect(message).not.toContain("not available on Free plan");
     expect(message).not.toContain("Selected hosted model");
   });
@@ -127,7 +128,9 @@ describe("formatErrorDetails", () => {
     );
 
     const message = formatErrorDetails(error);
-    expect(message).toContain("out of credits");
+    expect(message).toBe(
+      "Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.",
+    );
   });
 
   test("shows explicit model availability guidance for model-unknown", () => {


### PR DESCRIPTION
## Summary
- replace the shared insufficient-credits formatter copy with the requested model-specific message
- keep TUI and desktop aligned since websocket loop errors reuse the same formatter
- update the formatter tests to assert the exact final copy for `not-enough-credits`

## Test plan
- [x] bun run check
- [x] bun test src/tests/cli/errorFormatter.test.ts src/tests/websocket/listen-client-protocol.test.ts

👾 Generated with [Letta Code](https://letta.com)