### PR TITLE
fix(recovery): retry formatted Cloudflare 521 errors

### DIFF
--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -9,7 +9,7 @@
 import { randomUUID } from "node:crypto";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
-import { isCloudflareEdge52xHtmlError } from "../cli/helpers/errorFormatter";
+import { isCloudflareEdge52xErrorText } from "../cli/helpers/errorFormatter";
 import { isZaiNonRetryableError } from "../cli/helpers/zaiErrors";
 
 // ── Error fragment constants ────────────────────────────────────────
@@ -72,7 +72,7 @@ const EMPTY_RESPONSE_RETRY_BASE_DELAY_MS = 500;
 
 function isCloudflareEdge52xDetail(detail: unknown): boolean {
   if (typeof detail !== "string") return false;
-  return isCloudflareEdge52xHtmlError(detail);
+  return isCloudflareEdge52xErrorText(detail);
 }
 
 /**

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -795,6 +795,7 @@ function sendDesktopNotification(
 async function isRetriableError(
   stopReason: StopReasonType,
   lastRunId: string | null | undefined,
+  fallbackDetail?: string | null,
 ): Promise<boolean> {
   // Primary check: backend sets stop_reason=llm_api_error for LLMError exceptions
   if (stopReason === "llm_api_error") return true;
@@ -838,10 +839,10 @@ async function isRetriableError(
 
       return false;
     } catch {
-      return false;
+      return shouldRetryRunMetadataError(undefined, fallbackDetail);
     }
   }
-  return false;
+  return shouldRetryRunMetadataError(undefined, fallbackDetail);
 }
 
 // Save current agent + conversation as last session before exiting.
@@ -5902,6 +5903,7 @@ export default function App({
           const retriable = await isRetriableError(
             stopReasonToHandle,
             lastRunId,
+            detailFromRun ?? latestErrorText ?? fallbackError,
           );
 
           if (

--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -24,6 +24,7 @@ interface CloudflareEdgeErrorInfo {
 const CLOUDFLARE_EDGE_5XX_MARKER_PATTERN =
   /(^|\s)(502|52[0-6])\s*<!doctype html|error code\s*(502|52[0-6])/i;
 const CLOUDFLARE_EDGE_5XX_TITLE_PATTERN = /\|\s*(502|52[0-6])\s*:/i;
+const CLOUDFLARE_EDGE_5XX_FORMATTED_PATTERN = /\bCloudflare\s+(502|52[0-6])\b/i;
 
 export function isCloudflareEdge52xHtmlError(text: string): boolean {
   const normalized = text.toLowerCase();
@@ -37,6 +38,13 @@ export function isCloudflareEdge52xHtmlError(text: string): boolean {
     CLOUDFLARE_EDGE_5XX_TITLE_PATTERN.test(text);
 
   return hasCloudflare && hasHtml && has52xCode;
+}
+
+export function isCloudflareEdge52xErrorText(text: string): boolean {
+  return (
+    CLOUDFLARE_EDGE_5XX_FORMATTED_PATTERN.test(text) ||
+    isCloudflareEdge52xHtmlError(text)
+  );
 }
 
 function parseCloudflareEdgeError(
@@ -703,7 +711,7 @@ export function getRetryStatusMessage(
   if (!errorDetail) return DEFAULT_RETRY_MESSAGE;
 
   // Cloudflare edge errors are transient and retried silently — no status line
-  if (parseCloudflareEdgeError(errorDetail)) return null;
+  if (isCloudflareEdge52xErrorText(errorDetail)) return null;
 
   if (checkZaiError(errorDetail)) return "Z.ai API error, retrying...";
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2360,24 +2360,27 @@ ${SYSTEM_REMINDER_CLOSE}
       ];
       if (nonRetriableReasons.includes(stopReason)) {
         // Fall through to error display
-      } else if (lastRunId && llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
+      } else if (llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
         try {
-          const run = await client.runs.retrieve(lastRunId);
-          const metaError = run.metadata?.error as
-            | {
-                error_type?: string;
-                message?: string;
-                detail?: string;
-                // Handle nested error structure (error.error) that can occur in some edge cases
-                error?: { error_type?: string; detail?: string };
-              }
-            | undefined;
+          let errorType: string | undefined;
+          let detail = detailFromRun ?? latestErrorText ?? "";
 
-          // Check for llm_error at top level or nested (handles error.error nesting)
-          const errorType =
-            metaError?.error_type ?? metaError?.error?.error_type;
+          if (lastRunId) {
+            const run = await client.runs.retrieve(lastRunId);
+            const metaError = run.metadata?.error as
+              | {
+                  error_type?: string;
+                  message?: string;
+                  detail?: string;
+                  // Handle nested error structure (error.error) that can occur in some edge cases
+                  error?: { error_type?: string; detail?: string };
+                }
+              | undefined;
 
-          const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
+            // Check for llm_error at top level or nested (handles error.error nesting)
+            errorType = metaError?.error_type ?? metaError?.error?.error_type;
+            detail = metaError?.detail ?? metaError?.error?.detail ?? detail;
+          }
 
           // Special handling for empty response errors (Opus 4.6 SADs)
           // Empty LLM response retry (e.g. Opus 4.6 occasionally returns no content).
@@ -2467,6 +2470,47 @@ ${SYSTEM_REMINDER_CLOSE}
             continue;
           }
         } catch (_e) {
+          if (
+            shouldRetryRunMetadataError(
+              undefined,
+              detailFromRun ?? latestErrorText,
+            )
+          ) {
+            const attempt = llmApiErrorRetries + 1;
+            const detail = detailFromRun ?? latestErrorText;
+            const delayMs = getRetryDelayMs({
+              category: "transient_provider",
+              attempt,
+              detail,
+            });
+
+            llmApiErrorRetries = attempt;
+
+            if (outputFormat === "stream-json") {
+              const retryMsg: RetryMessage = {
+                type: "retry",
+                reason: "llm_api_error",
+                attempt,
+                max_attempts: LLM_API_ERROR_MAX_RETRIES,
+                delay_ms: delayMs,
+                run_id: lastRunId ?? undefined,
+                session_id: sessionId,
+                uuid: `retry-${lastRunId || randomUUID()}`,
+              };
+              console.log(JSON.stringify(retryMsg));
+            } else {
+              const delaySeconds = Math.round(delayMs / 1000);
+              console.error(
+                `LLM API error encountered (attempt ${attempt} of ${LLM_API_ERROR_MAX_RETRIES}), retrying in ${delaySeconds}s...`,
+              );
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            // Post-stream retry creates a new run/request.
+            refreshCurrentInputOtids();
+            continue;
+          }
+
           // If we can't fetch run metadata, fall through to normal error handling
         }
       }

--- a/src/tests/cli/errorFormatter.test.ts
+++ b/src/tests/cli/errorFormatter.test.ts
@@ -8,6 +8,8 @@ import {
   checkChatGptUsageLimitError,
   checkCloudflareEdgeError,
   formatErrorDetails,
+  getRetryStatusMessage,
+  isCloudflareEdge52xErrorText,
 } from "../../cli/helpers/errorFormatter";
 
 describe("formatErrorDetails", () => {
@@ -414,6 +416,14 @@ Cloudflare Ray ID: <strong>9d43b2d6dab269e2</strong>
       expect(result).toContain("Bad gateway");
       expect(result).toContain("api.letta.com");
       expect(result).toContain("Ray ID: 9d43b2d6dab269e2");
+    });
+
+    test("detects already-formatted Cloudflare 521 error text", () => {
+      const formatted =
+        "Cloudflare 521: Web server is down for api.letta.com (Ray ID: 9e829917ee973824). This is usually a temporary edge/origin outage. Please retry in a moment.";
+
+      expect(isCloudflareEdge52xErrorText(formatted)).toBe(true);
+      expect(getRetryStatusMessage(formatted)).toBeNull();
     });
   });
 });

--- a/src/tests/turn-recovery-policy.test.ts
+++ b/src/tests/turn-recovery-policy.test.ts
@@ -241,6 +241,16 @@ describe("provider detail retry helpers", () => {
     ).toBe(true);
   });
 
+  test("formatted Cloudflare 521 detail is retryable", () => {
+    const detail =
+      "Cloudflare 521: Web server is down for api.letta.com (Ray ID: 9e829917ee973824). This is usually a temporary edge/origin outage. Please retry in a moment.";
+
+    expect(shouldRetryRunMetadataError(undefined, detail)).toBe(true);
+    expect(
+      shouldRetryPreStreamTransientError({ status: undefined, detail }),
+    ).toBe(true);
+  });
+
   test("pre-stream transient classifier handles status and detail", () => {
     expect(
       shouldRetryPreStreamTransientError({
@@ -330,6 +340,19 @@ describe("getRetryDelayMs", () => {
         detail,
       }),
     ).toBe(20000);
+  });
+
+  test("uses larger transient base for formatted Cloudflare 52x details", () => {
+    const detail =
+      "Cloudflare 521: Web server is down for api.letta.com (Ray ID: 9e829917ee973824). This is usually a temporary edge/origin outage. Please retry in a moment.";
+
+    expect(
+      getRetryDelayMs({
+        category: "transient_provider",
+        attempt: 1,
+        detail,
+      }),
+    ).toBe(5000);
   });
 
   test("uses Retry-After delay when provided for transient retries", () => {

--- a/src/tests/websocket/recovery.test.ts
+++ b/src/tests/websocket/recovery.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { isRetriablePostStopError } from "../../websocket/listener/recovery";
+
+describe("websocket post-stop retry fallback", () => {
+  test("retries formatted Cloudflare 521 detail without a run id", async () => {
+    const detail =
+      "Cloudflare 521: Web server is down for api.letta.com (Ray ID: 9e829917ee973824). This is usually a temporary edge/origin outage. Please retry in a moment.";
+
+    await expect(isRetriablePostStopError("error", null, detail)).resolves.toBe(
+      true,
+    );
+  });
+});

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -100,6 +100,7 @@ export function shouldAttemptPostStopApprovalRecovery(params: {
 export async function isRetriablePostStopError(
   stopReason: StopReasonType,
   lastRunId: string | null | undefined,
+  fallbackDetail?: string | null,
 ): Promise<boolean> {
   if (stopReason === "llm_api_error") {
     return true;
@@ -120,7 +121,7 @@ export async function isRetriablePostStopError(
   }
 
   if (!lastRunId) {
-    return false;
+    return shouldRetryRunMetadataError(undefined, fallbackDetail);
   }
 
   try {
@@ -138,7 +139,7 @@ export async function isRetriablePostStopError(
     const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
     return shouldRetryRunMetadataError(errorType, detail);
   } catch {
-    return false;
+    return shouldRetryRunMetadataError(undefined, fallbackDetail);
   }
 }
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -836,6 +836,7 @@ export async function handleIncomingMessage(
         const retriable = await isRetriablePostStopError(
           (stopReason as StopReasonType) || "error",
           lastRunId,
+          errorDetail,
         );
         if (retriable && llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           llmApiErrorRetries += 1;


### PR DESCRIPTION
## Summary
- treat already-formatted `Cloudflare 52x: ...` last-mile error text as retryable in the shared retry classifier, not just raw Cloudflare HTML pages
- fall back to the local error detail when post-stop retry paths do not have a run ID, so TUI, websocket, and headless all retry transient 521 outages consistently
- add regression coverage for formatted Cloudflare 521 retry classification, Cloudflare backoff selection, and websocket post-stop retry without a run ID

## Test plan
- [x] bun run check
- [x] bun test src/tests/turn-recovery-policy.test.ts src/tests/cli/errorFormatter.test.ts src/tests/websocket/recovery.test.ts

👾 Generated with [Letta Code](https://letta.com)