### PR TITLE
feat: add SetWorkingDirectory tool for agent-initiated cwd changes

### DIFF
--- a/src/tools/descriptions/SetWorkingDirectory.md
+++ b/src/tools/descriptions/SetWorkingDirectory.md
@@ -1,0 +1,20 @@
+# SetWorkingDirectory
+
+Changes the working directory for the current conversation. All subsequent tool calls (Bash, Glob, Grep, Read, Write, etc.) will use this as their default directory.
+
+## When to Use
+
+- After creating a git worktree (`git worktree add`), switch into the new worktree so tools operate there
+- When you need to work in a different project directory mid-session
+- After cloning a repository, switch into the cloned directory
+
+## Parameters
+
+- **path** (required): Absolute or relative path to the new directory. Relative paths resolve against the current working directory.
+
+## Notes
+
+- The path must exist and be a directory
+- The change persists across turns for this conversation
+- Other conversations are not affected
+- The file search index will automatically re-root if the new directory is outside the current index scope

--- a/src/tools/impl/SetWorkingDirectory.ts
+++ b/src/tools/impl/SetWorkingDirectory.ts
@@ -1,0 +1,74 @@
+import { realpath, stat } from "node:fs/promises";
+import * as path from "node:path";
+import { getIndexRoot, setIndexRoot } from "../../cli/helpers/fileIndex";
+import { getExecutionContextCwdChanger } from "../manager";
+import { validateRequiredParams } from "./validation";
+
+interface SetWorkingDirectoryArgs {
+  path: string;
+  /** Injected by executeTool — do not pass manually */
+  _executionContextId?: string;
+}
+
+interface SetWorkingDirectoryResult {
+  status: string;
+  message: string;
+  previous_cwd: string;
+  new_cwd: string;
+}
+
+export async function set_working_directory(
+  args: SetWorkingDirectoryArgs,
+): Promise<SetWorkingDirectoryResult> {
+  validateRequiredParams(args, ["path"], "SetWorkingDirectory");
+
+  const requestedPath = args.path?.trim();
+  if (!requestedPath) {
+    throw new Error("Working directory path cannot be empty");
+  }
+
+  const currentCwd = process.env.USER_CWD || process.cwd();
+
+  // Resolve relative paths against current working directory
+  const resolvedPath = path.isAbsolute(requestedPath)
+    ? requestedPath
+    : path.resolve(currentCwd, requestedPath);
+
+  // Validate the path exists and is a directory
+  let normalizedPath: string;
+  try {
+    normalizedPath = await realpath(resolvedPath);
+  } catch {
+    throw new Error(`Path does not exist: ${resolvedPath}`);
+  }
+
+  const stats = await stat(normalizedPath);
+  if (!stats.isDirectory()) {
+    throw new Error(`Not a directory: ${normalizedPath}`);
+  }
+
+  // Update the execution context so subsequent tools in this turn use the new cwd
+  const cwdChanger = args._executionContextId
+    ? getExecutionContextCwdChanger(args._executionContextId)
+    : undefined;
+
+  if (cwdChanger) {
+    cwdChanger(normalizedPath);
+  }
+
+  // Also update process.env.USER_CWD as immediate fallback
+  process.env.USER_CWD = normalizedPath;
+
+  // Re-root the file index if the new cwd is outside the current root
+  const currentRoot = getIndexRoot();
+  if (!normalizedPath.startsWith(currentRoot)) {
+    setIndexRoot(normalizedPath);
+  }
+
+  return {
+    status: "OK",
+    message: `Working directory changed to ${normalizedPath}`,
+    previous_cwd: currentCwd,
+    new_cwd: normalizedPath,
+  };
+}

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -86,6 +86,7 @@ export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
   // "LS",
   "memory",
   "Read",
+  "SetWorkingDirectory",
   "Skill",
   "Task",
   "TodoWrite",
@@ -124,6 +125,7 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "EnterPlanMode",
   "ExitPlanMode",
   "memory_apply_patch",
+  "SetWorkingDirectory",
   "Task",
   "TaskOutput",
   "TaskStop",
@@ -141,6 +143,7 @@ export const GEMINI_PASCAL_TOOLS: ToolName[] = [
   "EnterPlanMode",
   "ExitPlanMode",
   "memory",
+  "SetWorkingDirectory",
   "Skill",
   "Task",
   // Standard Gemini tools
@@ -173,6 +176,7 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   memory_apply_patch: { requiresApproval: true },
   MultiEdit: { requiresApproval: true },
   Read: { requiresApproval: false },
+  SetWorkingDirectory: { requiresApproval: true },
   view_image: { requiresApproval: false },
   ViewImage: { requiresApproval: false },
   ReadLSP: { requiresApproval: false },
@@ -309,6 +313,8 @@ type ToolExecutionContextSnapshot = {
   externalExecutor?: ExternalToolExecutor;
   workingDirectory: string;
   permissionModeState: PermissionModeState;
+  /** Called by SetWorkingDirectory to persist cwd changes across turns. */
+  onCwdChange?: (newCwd: string) => void;
 };
 
 export type CapturedToolExecutionContext = {
@@ -360,6 +366,24 @@ export function getExecutionContextPermissionModeState(
   contextId: string,
 ): PermissionModeState | undefined {
   return getExecutionContextById(contextId)?.permissionModeState;
+}
+
+/**
+ * Returns a callback that updates the working directory for an execution context.
+ * SetWorkingDirectory uses this to persist cwd changes across turns and update
+ * the snapshot so subsequent tools in the same turn use the new cwd.
+ */
+export function getExecutionContextCwdChanger(
+  contextId: string,
+): ((newCwd: string) => void) | undefined {
+  const context = getExecutionContextById(contextId);
+  if (!context) return undefined;
+  return (newCwd: string) => {
+    // Update the snapshot so subsequent tools in this turn see the new cwd
+    context.workingDirectory = newCwd;
+    // Invoke the listener-level callback to persist across turns
+    context.onCwdChange?.(newCwd);
+  };
 }
 
 export function clearCapturedToolExecutionContexts(): void {
@@ -670,6 +694,7 @@ function capturePreparedToolExecutionContext(
   options?: {
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    onCwdChange?: (newCwd: string) => void;
   },
 ): PreparedToolExecutionContext {
   const executionSnapshot: ToolExecutionContextSnapshot = {
@@ -681,6 +706,7 @@ function capturePreparedToolExecutionContext(
     permissionModeState: getEffectivePermissionModeState(
       options?.permissionModeState,
     ),
+    onCwdChange: options?.onCwdChange,
   };
   const contextId = saveExecutionContext(executionSnapshot);
 
@@ -721,6 +747,7 @@ export async function prepareToolExecutionContextForSpecificTools(
   options?: {
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    onCwdChange?: (newCwd: string) => void;
   },
 ): Promise<PreparedToolExecutionContext> {
   const toolRegistrySnapshot = await buildSpecificToolRegistry(toolNames);
@@ -740,6 +767,7 @@ export async function prepareToolExecutionContextForModel(
     exclude?: ToolName[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    onCwdChange?: (newCwd: string) => void;
   },
 ): Promise<PreparedToolExecutionContext> {
   const toolRegistrySnapshot = await buildRegistryForModel(
@@ -1422,15 +1450,17 @@ export async function executeTool(
       enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
     }
 
-    // Inject the execution context id for plan-mode tools so they can update
-    // the per-conversation PermissionModeState without touching the global singleton.
-    const PLAN_MODE_TOOL_NAMES = new Set([
+    // Inject the execution context id for tools that need to update
+    // per-conversation state without touching global singletons.
+    const CONTEXT_AWARE_TOOL_NAMES = new Set([
       "EnterPlanMode",
       "enter_plan_mode",
       "ExitPlanMode",
       "exit_plan_mode",
+      "SetWorkingDirectory",
+      "set_working_directory",
     ]);
-    if (PLAN_MODE_TOOL_NAMES.has(internalName) && options?.toolContextId) {
+    if (CONTEXT_AWARE_TOOL_NAMES.has(internalName) && options?.toolContextId) {
       enhancedArgs = {
         ...enhancedArgs,
         _executionContextId: options.toolContextId,

--- a/src/tools/schemas/SetWorkingDirectory.json
+++ b/src/tools/schemas/SetWorkingDirectory.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "The absolute or relative path to the new working directory. Relative paths are resolved against the current working directory."
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/src/tools/toolDefinitions.ts
+++ b/src/tools/toolDefinitions.ts
@@ -25,6 +25,7 @@ import ReadManyFilesGeminiDescription from "./descriptions/ReadManyFilesGemini.m
 import ReplaceGeminiDescription from "./descriptions/ReplaceGemini.md";
 import RunShellCommandGeminiDescription from "./descriptions/RunShellCommandGemini.md";
 import SearchFileContentGeminiDescription from "./descriptions/SearchFileContentGemini.md";
+import SetWorkingDirectoryDescription from "./descriptions/SetWorkingDirectory.md";
 import ShellDescription from "./descriptions/Shell.md";
 import ShellCommandDescription from "./descriptions/ShellCommand.md";
 import SkillDescription from "./descriptions/Skill.md";
@@ -64,6 +65,7 @@ import { read_many_files } from "./impl/ReadManyFilesGemini";
 import { replace } from "./impl/ReplaceGemini";
 import { run_shell_command } from "./impl/RunShellCommandGemini";
 import { search_file_content } from "./impl/SearchFileContentGemini";
+import { set_working_directory } from "./impl/SetWorkingDirectory";
 import { shell } from "./impl/Shell";
 import { shell_command } from "./impl/ShellCommand";
 import { skill } from "./impl/Skill";
@@ -103,6 +105,7 @@ import ReadManyFilesGeminiSchema from "./schemas/ReadManyFilesGemini.json";
 import ReplaceGeminiSchema from "./schemas/ReplaceGemini.json";
 import RunShellCommandGeminiSchema from "./schemas/RunShellCommandGemini.json";
 import SearchFileContentGeminiSchema from "./schemas/SearchFileContentGemini.json";
+import SetWorkingDirectorySchema from "./schemas/SetWorkingDirectory.json";
 import ShellSchema from "./schemas/Shell.json";
 import ShellCommandSchema from "./schemas/ShellCommand.json";
 import SkillSchema from "./schemas/Skill.json";
@@ -204,6 +207,11 @@ const toolDefinitions = {
     schema: ReadSchema,
     description: ReadDescription.trim(),
     impl: read as unknown as ToolImplementation,
+  },
+  SetWorkingDirectory: {
+    schema: SetWorkingDirectorySchema,
+    description: SetWorkingDirectoryDescription.trim(),
+    impl: set_working_directory as unknown as ToolImplementation,
   },
   view_image: {
     schema: ViewImageSchema,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -115,6 +115,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   exclude?: ToolName[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  onCwdChange?: (newCwd: string) => void;
 }): Promise<PreparedScopeToolContext> {
   const {
     modelIdentifier,
@@ -122,6 +123,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    onCwdChange,
   } = params;
   const effectiveModel =
     modelIdentifier && modelIdentifier.length > 0
@@ -135,6 +137,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
         exclude,
         workingDirectory,
         permissionModeState,
+        onCwdChange,
       },
     );
 
@@ -155,6 +158,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     {
       workingDirectory,
       permissionModeState,
+      onCwdChange,
     },
   );
 
@@ -173,6 +177,7 @@ export async function prepareToolExecutionContextForScope(params: {
   exclude?: ToolName[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  onCwdChange?: (newCwd: string) => void;
 }): Promise<PreparedScopeToolContext> {
   const {
     agentId,
@@ -181,6 +186,7 @@ export async function prepareToolExecutionContextForScope(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    onCwdChange,
   } = params;
 
   const client = await getClient();
@@ -216,6 +222,7 @@ export async function prepareToolExecutionContextForScope(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    onCwdChange,
   });
 }
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -53,7 +53,10 @@ import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
 } from "./constants";
-import { getConversationWorkingDirectory } from "./cwd";
+import {
+  getConversationWorkingDirectory,
+  setConversationWorkingDirectory,
+} from "./cwd";
 import {
   consumeInterruptQueue,
   emitInterruptToolReturnMessage,
@@ -278,11 +281,27 @@ export async function handleIncomingMessage(
   const requestedConversationId = msg.conversationId || undefined;
   const conversationId = requestedConversationId ?? "default";
   const normalizedAgentId = normalizeCwdAgentId(agentId);
-  const turnWorkingDirectory = getConversationWorkingDirectory(
+  let turnWorkingDirectory = getConversationWorkingDirectory(
     runtime.listener,
     normalizedAgentId,
     conversationId,
   );
+
+  // Callback for the SetWorkingDirectory tool to persist cwd changes.
+  // Updates the per-conversation map, invalidates session context so the agent
+  // gets fresh git/cwd info, and updates turnWorkingDirectory for this turn.
+  const onCwdChange = (newCwd: string): void => {
+    setConversationWorkingDirectory(
+      runtime.listener,
+      normalizedAgentId ?? null,
+      conversationId,
+      newCwd,
+    );
+    runtime.reminderState.hasSentSessionContext = false;
+    runtime.reminderState.pendingSessionContextReason = "cwd_changed";
+    turnWorkingDirectory = newCwd;
+    runtime.activeWorkingDirectory = newCwd;
+  };
 
   // Get the canonical mutable permission mode state ref for this turn.
   // Websocket mode changes and tool implementations (EnterPlanMode/ExitPlanMode)
@@ -473,6 +492,7 @@ export async function handleIncomingMessage(
       conversationId,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
+      onCwdChange,
     });
     runtime.currentToolset = preparedToolContext.toolset;
     runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;


### PR DESCRIPTION
Allows agents to programmatically change their working directory mid-session (e.g., after creating a git worktree). The change persists across turns for the conversation and re-roots the file search index when needed.

🐾 Generated with [Letta Code](https://letta.com)