### PR TITLE
fix: restore /ade and add /chat

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -224,7 +224,7 @@ import {
   type ClassifiedApproval,
   classifyApprovals,
 } from "./helpers/approvalClassification";
-import { buildChatUrl } from "./helpers/appUrls";
+import { buildAdeUrl, buildChatUrl } from "./helpers/appUrls";
 import { backfillBuffers } from "./helpers/backfill";
 import { chunkLog } from "./helpers/chunkLog";
 import {
@@ -615,6 +615,7 @@ const INTERACTIVE_SLASH_COMMANDS = new Set([
 // These don't modify agent state, so they should bypass queueing
 const NON_STATE_COMMANDS = new Set([
   "/ade",
+  "/chat",
   "/bg",
   "/usage",
   "/help",
@@ -7888,9 +7889,9 @@ export default function App({
           return { submitted: true };
         }
 
-        // Special handling for /ade command - open agent in browser
+        // Special handling for /ade command - open ADE in browser
         if (trimmed === "/ade") {
-          const adeUrl = buildChatUrl(agentId, {
+          const adeUrl = buildAdeUrl(agentId, {
             conversationId: conversationIdRef.current,
           });
 
@@ -7905,6 +7906,26 @@ export default function App({
 
           // Always show the URL in case browser doesn't open
           cmd.finish(`Opening ADE...\n→ ${adeUrl}`, true);
+          return { submitted: true };
+        }
+
+        // Special handling for /chat command - open chat UI in browser
+        if (trimmed === "/chat") {
+          const chatUrl = buildChatUrl(agentId, {
+            conversationId: conversationIdRef.current,
+          });
+
+          const cmd = commandRunner.start("/chat", "Opening chat...");
+
+          // Fire-and-forget browser open
+          import("open")
+            .then(({ default: open }) => open(chatUrl, { wait: false }))
+            .catch(() => {
+              // Silently ignore - user can use the URL from the output
+            });
+
+          // Always show the URL in case browser doesn't open
+          cmd.finish(`Opening chat...\n→ ${chatUrl}`, true);
           return { submitted: true };
         }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -252,6 +252,15 @@ export const commands: Record<string, Command> = {
       return "Opening ADE...";
     },
   },
+  "/chat": {
+    desc: "Open agent in chat UI (browser)",
+    order: 28.1,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx to access agent ID and open browser
+      return "Opening chat...";
+    },
+  },
 
   // === Page 3: Advanced features (order 30-39) ===
   "/system": {

--- a/src/cli/helpers/appUrls.ts
+++ b/src/cli/helpers/appUrls.ts
@@ -1,17 +1,12 @@
 const APP_BASE = "https://app.letta.com";
 
-/**
- * Build a chat URL for an agent, with optional conversation and extra query params.
- */
-export function buildChatUrl(
-  agentId: string,
-  options?: {
-    conversationId?: string;
-    view?: string;
-    deviceId?: string;
-  },
-): string {
-  const base = `${APP_BASE}/chat/${agentId}`;
+type AgentUrlOptions = {
+  conversationId?: string;
+  view?: string;
+  deviceId?: string;
+};
+
+function buildAgentUrl(base: string, options?: AgentUrlOptions): string {
   const params = new URLSearchParams();
 
   if (options?.view) {
@@ -26,6 +21,26 @@ export function buildChatUrl(
 
   const qs = params.toString();
   return qs ? `${base}?${qs}` : base;
+}
+
+/**
+ * Build the ADE URL for an agent, with optional conversation and extra query params.
+ */
+export function buildAdeUrl(
+  agentId: string,
+  options?: AgentUrlOptions,
+): string {
+  return buildAgentUrl(`${APP_BASE}/agents/${agentId}`, options);
+}
+
+/**
+ * Build a chat URL for an agent, with optional conversation and extra query params.
+ */
+export function buildChatUrl(
+  agentId: string,
+  options?: AgentUrlOptions,
+): string {
+  return buildAgentUrl(`${APP_BASE}/chat/${agentId}`, options);
 }
 
 /**

--- a/src/tests/cli/appUrls.test.ts
+++ b/src/tests/cli/appUrls.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { buildAdeUrl, buildChatUrl } from "../../cli/helpers/appUrls";
+
+describe("appUrls", () => {
+  test("buildAdeUrl points to the ADE agent route", () => {
+    expect(buildAdeUrl("agent-123")).toBe(
+      "https://app.letta.com/agents/agent-123",
+    );
+  });
+
+  test("buildAdeUrl includes a non-default conversation", () => {
+    expect(
+      buildAdeUrl("agent-123", {
+        conversationId: "conv-456",
+      }),
+    ).toBe("https://app.letta.com/agents/agent-123?conversation=conv-456");
+  });
+
+  test("buildChatUrl keeps the chat route and omits default conversation", () => {
+    expect(
+      buildChatUrl("agent-123", {
+        conversationId: "default",
+      }),
+    ).toBe("https://app.letta.com/chat/agent-123");
+  });
+
+  test("buildChatUrl preserves extra chat query params", () => {
+    expect(
+      buildChatUrl("agent-123", {
+        conversationId: "conv-456",
+        view: "tools",
+        deviceId: "device-789",
+      }),
+    ).toBe(
+      "https://app.letta.com/chat/agent-123?view=tools&deviceId=device-789&conversation=conv-456",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- restore `/ade` to open the ADE `/agents/:id` route again
- add a new `/chat` slash command that opens the current agent's chat UI route
- cover ADE/chat URL building with targeted helper tests

## Test plan
- [x] `bun test src/tests/cli/appUrls.test.ts`
- [x] `bun run typecheck`