### PR TITLE
feat: add per-personality default model, set kawaii to auto-chat

### DIFF
--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -24,6 +24,8 @@ export interface PersonalityOption {
   id: "kawaii" | "codex" | "claude" | "linus" | "memo";
   label: string;
   description: string;
+  /** Model ID from models.json to use when no explicit model is provided. */
+  defaultModel?: string;
 }
 
 export const PERSONALITY_OPTIONS: PersonalityOption[] = [
@@ -41,6 +43,7 @@ export const PERSONALITY_OPTIONS: PersonalityOption[] = [
     id: "kawaii",
     label: "Letta-Chan",
     description: "sugoi~ (◕‿◕)✨",
+    defaultModel: "auto-chat",
   },
   {
     id: "claude",
@@ -362,7 +365,7 @@ export async function buildCreateAgentOptionsForPersonality(params: {
   return {
     name: name ?? personality.label,
     description: description ?? personality.description,
-    model,
+    model: model ?? personality.defaultModel,
     tags,
     memoryPromptMode: "memfs",
     memoryBlocks: defaultMemoryBlocks.map((block) => {


### PR DESCRIPTION
## Summary
- Adds optional `defaultModel` field to `PersonalityOption` so each personality can specify its own default model from `models.json`
- Sets kawaii (Letta-Chan) to default to `auto-chat` instead of `auto`
- Priority chain: explicit model (`--model` flag / desktop picker) > personality default > global default (`letta/auto`)

## Test plan
- Create a kawaii agent via desktop or `letta agents create --personality kawaii` — should use `letta/auto-chat`
- Create a kawaii agent with `--model sonnet` — explicit model should win over personality default
- Create a memo/linus agent — should still use `letta/auto` (no personality default set)

👾 Generated with [Letta Code](https://letta.com)