### PR TITLE
fix(memfs): refresh memory git origin before push operations

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -62,10 +62,82 @@ export function normalizeCredentialBaseUrl(serverUrl: string): string {
   }
 }
 
+function normalizeRemoteUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Returns true when a remote URL points to this agent's memfs git endpoint.
+ */
+export function isMemfsRemoteUrlForAgent(
+  remoteUrl: string,
+  agentId: string,
+): boolean {
+  const normalized = normalizeRemoteUrl(remoteUrl);
+  const escapedAgentId = escapeRegex(agentId);
+  return new RegExp(
+    `^https?://[^\\s]+/v1/git/${escapedAgentId}/state\\.git$`,
+    "i",
+  ).test(normalized);
+}
+
 /** Git remote URL for the agent's state repo */
-function getGitRemoteUrl(agentId: string): string {
-  const baseUrl = getServerUrl().trim().replace(/\/+$/, "");
-  return `${baseUrl}/v1/git/${agentId}/state.git`;
+export function getGitRemoteUrl(agentId: string, baseUrl?: string): string {
+  const resolvedBaseUrl = (baseUrl ?? getServerUrl())
+    .trim()
+    .replace(/\/+$/, "");
+  return `${resolvedBaseUrl}/v1/git/${agentId}/state.git`;
+}
+
+/**
+ * Keep the local repo's `origin` URL aligned with the current server base URL.
+ *
+ * Best-effort: if origin is missing or not a memfs endpoint for this agent,
+ * this function is a no-op.
+ */
+export async function maybeUpdateMemoryRemoteOrigin(
+  repoDir: string,
+  agentId: string,
+): Promise<void> {
+  let currentOrigin = "";
+  try {
+    const { stdout } = await runGit(repoDir, ["remote", "get-url", "origin"]);
+    currentOrigin = stdout.trim();
+  } catch {
+    // No origin remote configured — leave as-is.
+    return;
+  }
+
+  if (!currentOrigin) {
+    return;
+  }
+
+  if (!isMemfsRemoteUrlForAgent(currentOrigin, agentId)) {
+    return;
+  }
+
+  const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
+  const normalizedCurrent = normalizeRemoteUrl(currentOrigin);
+
+  if (normalizedCurrent === expectedOrigin) {
+    return;
+  }
+
+  await runGit(repoDir, ["remote", "set-url", "origin", expectedOrigin]);
+
+  debugLog(
+    "memfs-git",
+    `Updated origin remote for ${agentId}: ${normalizedCurrent} -> ${expectedOrigin}`,
+  );
+}
+
+/** Git remote URL for the agent's state repo */
+function getMemoryRemoteUrl(agentId: string): string {
+  return getGitRemoteUrl(agentId);
 }
 
 /**
@@ -384,7 +456,7 @@ export function isGitRepo(agentId: string): boolean {
  */
 export async function cloneMemoryRepo(agentId: string): Promise<void> {
   const token = await getAuthToken();
-  const url = getGitRemoteUrl(agentId);
+  const url = getMemoryRemoteUrl(agentId);
   const dir = getMemoryRepoDir(agentId);
 
   debugLog("memfs-git", `Cloning ${url} → ${dir}`);
@@ -440,6 +512,8 @@ export async function pullMemory(
   const token = await getAuthToken();
   const dir = getMemoryRepoDir(agentId);
 
+  await maybeUpdateMemoryRemoteOrigin(dir, agentId);
+
   // Self-healing: ensure credential helper and pre-commit hook are configured
   await configureLocalCredentialHelper(dir, token);
   installPreCommitHook(dir);
@@ -488,6 +562,8 @@ export async function pullMemory(
 export async function pushMemory(agentId: string): Promise<void> {
   const token = await getAuthToken();
   const dir = getMemoryRepoDir(agentId);
+
+  await maybeUpdateMemoryRemoteOrigin(dir, agentId);
 
   await configureLocalCredentialHelper(dir, token);
 

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -1,12 +1,50 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeCredentialBaseUrl } from "../../agent/memoryGit";
+import {
+  getGitRemoteUrl,
+  isMemfsRemoteUrlForAgent,
+  normalizeCredentialBaseUrl,
+} from "../../agent/memoryGit";
 
 describe("normalizeCredentialBaseUrl", () => {
   test("normalizes Letta Cloud URL to origin", () => {
     expect(normalizeCredentialBaseUrl("https://api.letta.com")).toBe(
       "https://api.letta.com",
     );
+  });
+
+  describe("getGitRemoteUrl", () => {
+    test("builds remote URL from provided base URL", () => {
+      expect(getGitRemoteUrl("agent-123", "http://localhost:51338/")).toBe(
+        "http://localhost:51338/v1/git/agent-123/state.git",
+      );
+    });
+  });
+
+  describe("isMemfsRemoteUrlForAgent", () => {
+    test("returns true for this agent's memfs HTTP URL", () => {
+      expect(
+        isMemfsRemoteUrlForAgent(
+          "http://localhost:51338/v1/git/agent-123/state.git/",
+          "agent-123",
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false for different agent ID", () => {
+      expect(
+        isMemfsRemoteUrlForAgent(
+          "http://localhost:51338/v1/git/agent-999/state.git",
+          "agent-123",
+        ),
+      ).toBe(false);
+    });
+
+    test("returns false for non-memfs remotes", () => {
+      expect(isMemfsRemoteUrlForAgent("/tmp/remote.git", "agent-123")).toBe(
+        false,
+      );
+    });
   });
 
   test("strips trailing slashes", () => {

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -23,6 +23,7 @@ mock.module("../../agent/client", () => ({
       },
     }),
   ),
+  getServerUrl: () => "http://localhost:8283",
 }));
 
 const { memory } = await import("../../tools/impl/Memory");

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -14,6 +14,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
+import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
 
 const execFile = promisify(execFileCb);
@@ -576,6 +577,8 @@ async function commitAndPush(
 
   const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
   const sha = head.stdout.trim();
+
+  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
 
   try {
     await runGit(memoryDir, ["push"]);

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -14,6 +14,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
+import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
 
 const execFile = promisify(execFileCb);
@@ -767,6 +768,8 @@ async function commitAndPush(
 
   const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
   const sha = head.stdout.trim();
+
+  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
 
   try {
     await runGit(memoryDir, ["push"]);


### PR DESCRIPTION
Heal stale memfs origin URLs when BASE_URL rotates so memory tool commits can still push successfully.

👾 Generated with [Letta Code](https://letta.com)