### PR TITLE
fix: allow SDK request timeout override via LETTA_REQUEST_TIMEOUT_MS

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -203,7 +203,7 @@ export async function getClient() {
     apiKey,
     baseURL,
     logger: sdkLogger,
-    timeout: 10 * 60 * 1000, // 10 min — letta-code manages cancellation via AbortController; SDK default (60s) is too short
+    timeout: Number(process.env.LETTA_REQUEST_TIMEOUT_MS) || 10 * 60 * 1000, // default 10 min; override via env for slow local inference
     defaultHeaders: {
       "X-Letta-Source": "letta-code",
       "User-Agent": `letta-code/${packageJson.version}`,


### PR DESCRIPTION
## Summary

- Add `LETTA_REQUEST_TIMEOUT_MS` env var override for the SDK HTTP client timeout
- Default remains 10 minutes (already overridden from SDK's 60s default)
- Escape hatch for self-hosted users with extremely slow local inference (cold prefill >10min)

One-line change in `src/agent/client.ts`.

## Test plan

- [ ] Verify default behavior unchanged (no env var set = 10 min timeout)
- [ ] Verify `LETTA_REQUEST_TIMEOUT_MS=1800000` extends to 30 min
- [ ] Verify invalid values (NaN, 0) fall through to default

Closes #1691

🐾 Generated with [Letta Code](https://letta.com)