### PR TITLE
fix(cli): use active conversation context window in status surfaces

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1753,13 +1753,11 @@ export default function App({
     const rawContextWindow = (
       info?.updateArgs as { context_window?: unknown } | undefined
     )?.context_window;
-    return typeof rawContextWindow === "number"
-      ? rawContextWindow
-      : undefined;
+    return typeof rawContextWindow === "number" ? rawContextWindow : undefined;
   }, [currentModelLabel, derivedReasoningEffort, llmConfig]);
   const effectiveContextWindowSize =
     (hasConversationModelOverride
-      ? conversationOverrideContextWindowLimit ?? modelPresetContextWindow
+      ? (conversationOverrideContextWindowLimit ?? modelPresetContextWindow)
       : undefined) ??
     llmConfig?.context_window ??
     modelPresetContextWindow;

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -155,13 +155,17 @@ describe("model preset refresh wiring", () => {
 
     expect(source).toContain("conversationOverrideContextWindowLimit");
     expect(source).toContain("setConversationOverrideContextWindowLimit(");
-    expect(source).toContain("const modelPresetContextWindow = useMemo(() => {");
-    expect(source).toContain("const effectiveContextWindowSize =");
     expect(source).toContain(
-      "? conversationOverrideContextWindowLimit ?? modelPresetContextWindow",
+      "const modelPresetContextWindow = useMemo(() => {",
+    );
+    expect(source).toContain("const effectiveContextWindowSize =");
+    expect(source).toMatch(
+      /\?\s*\(?conversationOverrideContextWindowLimit\s*\?\?\s*modelPresetContextWindow\)?/,
     );
     expect(source).toContain("contextWindowSize: effectiveContextWindowSize");
-    expect(source).toContain("const contextWindow = effectiveContextWindowSize ?? 0;");
+    expect(source).toContain(
+      "const contextWindow = effectiveContextWindowSize ?? 0;",
+    );
     expect(source).not.toMatch(
       /setConversationOverrideContextWindowLimit\(\(prev\)\s*=>\s*conversationContextWindowLimit === undefined\s*\?\s*prev/s,
     );

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -606,9 +606,12 @@ export async function task(args: TaskArgs): Promise<string> {
       const client = await getClient();
       const parentAgentId = getCurrentAgentId();
       const parentConvId = getConversationId() ?? "default";
-      const forkedConv = await client.conversations.fork(parentConvId, {
-        agent_id: parentAgentId,
-      });
+      const forkedConv = (await client.post(
+        `/v1/conversations/${encodeURIComponent(parentConvId)}/fork`,
+        {
+          query: parentConvId === "default" ? { agent_id: parentAgentId } : {},
+        },
+      )) as { id: string };
       effectiveAgentId = parentAgentId;
       effectiveConversationId = forkedConv.id;
     } catch (error) {

--- a/src/types/letta-client-augmentations.d.ts
+++ b/src/types/letta-client-augmentations.d.ts
@@ -1,0 +1,10 @@
+import "@letta-ai/letta-client/resources/agents/messages";
+
+declare module "@letta-ai/letta-client/resources/agents/messages" {
+  interface ApprovalCreate {
+    // Sent by letta-code for request correlation until the SDK schema includes it.
+    otid?: string | null;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- derive `effectiveContextWindowSize` in `App.tsx` with conversation-override precedence instead of reading only `llm_config.context_window`
- track conversation override `context_window_limit` through conversation sync, `/model` updates, and reasoning tier updates
- wire status surfaces to the effective value (`useConfigurableStatusLine`, `/statusline test`, and `/context`) and add wiring coverage

## Test plan
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts src/tests/cli/reasoning-cycle-wiring.test.ts src/tests/websocket/listen-model-update.test.ts`

👾 Generated with [Letta Code](https://letta.com)