### PR TITLE
fix(memfs): recover from missing cwd during memory git clone/pull

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -33,6 +33,9 @@ const RETRYABLE_GIT_HTTP_ERROR_RE =
 const RETRYABLE_GIT_NETWORK_ERROR_RE =
   /(remote end hung up unexpectedly|connection reset by peer|operation timed out|timed out)/i;
 
+const MISSING_CWD_GIT_ERROR_RE =
+  /(Unable to read current working directory: No such file or directory|\buv_cwd\b|\bcwd\b.*\bENOENT\b)/i;
+
 /** Get the agent root directory (~/.letta/agents/{id}/) */
 export function getAgentRootDir(agentId: string): string {
   return join(homedir(), ".letta", "agents", agentId);
@@ -217,6 +220,11 @@ export function isRetryableGitTransientError(error: unknown): boolean {
   return false;
 }
 
+export function isMissingCwdGitError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return MISSING_CWD_GIT_ERROR_RE.test(message);
+}
+
 async function runGitWithRetry(
   cwd: string,
   args: string[],
@@ -229,8 +237,20 @@ async function runGitWithRetry(
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
+      // Self-heal against transient cwd removal races.
+      if (!existsSync(cwd)) {
+        mkdirSync(cwd, { recursive: true });
+      }
       return await runGit(cwd, args, token);
     } catch (error) {
+      if (isMissingCwdGitError(error)) {
+        // Recreate cwd and retry once through the normal loop.
+        mkdirSync(cwd, { recursive: true });
+        if (attempt < attempts) {
+          continue;
+        }
+      }
+
       if (!isRetryableGitTransientError(error) || attempt >= attempts) {
         throw error;
       }

--- a/src/tests/agent/memoryGit.retry.test.ts
+++ b/src/tests/agent/memoryGit.retry.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { isRetryableGitTransientError } from "../../agent/memoryGit";
+import {
+  isMissingCwdGitError,
+  isRetryableGitTransientError,
+} from "../../agent/memoryGit";
 
 describe("isRetryableGitTransientError", () => {
   test("returns true for Cloudflare 52x HTTP errors", () => {
@@ -17,6 +20,26 @@ describe("isRetryableGitTransientError", () => {
         new Error("error: RPC failed; HTTP 520 curl 22"),
       ),
     ).toBe(true);
+  });
+
+  describe("isMissingCwdGitError", () => {
+    test("returns true for missing cwd git error", () => {
+      expect(
+        isMissingCwdGitError(
+          new Error(
+            "fatal: Unable to read current working directory: No such file or directory",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false for non-cwd errors", () => {
+      expect(
+        isMissingCwdGitError(
+          new Error("fatal: the remote end hung up unexpectedly"),
+        ),
+      ).toBe(false);
+    });
   });
 
   test("returns true for RPC failed + remote hung up", () => {


### PR DESCRIPTION
## Summary

Repair erros like: 
```
letta --agent agent-4140c4b5-f32e-475c-9573-bcfd9446ca7b --new
Command failed: git -c http.extraHeader=Authorization: Basic ... = clone https://api.letta.com/v1/git/agent-4140c4b5-f32e-475c-9573-bcfd9446ca7b/state.git .
Cloning into '.'...
fatal: Unable to read current working directory: No such file or directory
fatal: the remote end hung up unexpectedl
```
- reproduce and harden around the `fatal: Unable to read current working directory: No such file or directory` git failure during memfs sync
- ensure `runGitWithRetry` recreates the target cwd if missing before running git, and retries once when git reports a missing-cwd ENOENT/uv_cwd error
- add unit coverage for missing-cwd error detection in `memoryGit.retry.test.ts`

## Test plan
- [x] `bun test src/tests/agent/memoryGit.retry.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)