### PR TITLE
fix: Windows-compatible git credential helper for memory sync

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -65,6 +65,16 @@ export function normalizeCredentialBaseUrl(serverUrl: string): string {
   }
 }
 
+/**
+ * Format an executable helper path for git config values.
+ *
+ * Git splits helper commands on whitespace, so we must escape any
+ * spaces/tabs in absolute paths (common on Windows profile paths).
+ */
+export function formatGitCredentialHelperPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\s/g, "\\$&");
+}
+
 function normalizeRemoteUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
 }
@@ -294,8 +304,8 @@ echo username=letta
 echo password=${token}
 `;
     writeFileSync(helperScriptPath, batchScript, "utf-8");
-    // Git expects the helper path with forward slashes even on Windows
-    helper = helperScriptPath.replace(/\\/g, "/");
+    // Use a normalized path and escape whitespace for profiles like "Jane Doe".
+    helper = formatGitCredentialHelperPath(helperScriptPath);
     debugLog("memfs-git", `Wrote Windows credential helper script`);
   } else {
     // Unix/macOS: use inline bash helper

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  formatGitCredentialHelperPath,
   getGitRemoteUrl,
   isMemfsRemoteUrlForAgent,
   normalizeCredentialBaseUrl,
@@ -70,6 +71,18 @@ describe("normalizeCredentialBaseUrl", () => {
   test("falls back to trimmed value when URL parsing fails", () => {
     expect(normalizeCredentialBaseUrl("not-a-valid-url///")).toBe(
       "not-a-valid-url",
+    );
+  });
+});
+
+describe("formatGitCredentialHelperPath", () => {
+  test("normalizes slashes and escapes whitespace for helper command parsing", () => {
+    expect(
+      formatGitCredentialHelperPath(
+        String.raw`C:\Users\Jane Doe\.letta\agents\agent-1\memory\.git\letta-credential-helper.cmd`,
+      ),
+    ).toBe(
+      "C:/Users/Jane\\ Doe/.letta/agents/agent-1/memory/.git/letta-credential-helper.cmd",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Fixes memory push failures on Windows where read access works but write access fails with "Authentication failed"
- The inline bash credential helper (`!f() { echo ...; }; f`) doesn't work on Windows PowerShell/cmd
- On Windows, we now write a batch script to `.git/letta-credential-helper.cmd` and reference it in the git config
- Unix/macOS continues using the existing inline bash helper

## Root Cause

1. Agent could successfully read from the git repo (HTTP 200 on `git-upload-pack`)
2. But push failed with `fatal: Authentication failed`
3. The credential helper was configured correctly in git config with bash syntax
4. But bash syntax (`!f() { ... }; f`) doesn't execute properly on Windows PowerShell

## Test plan

- [x] Linter passes
- [ ] Manual test on Windows (need Windows user to verify)
- [ ] Verify Unix/macOS still works (no regression)

👾 Generated with [Letta Code](https://letta.com)