### PR TITLE
fix(skills): respect --no-skills flag in sendMessageStream

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -25,7 +25,7 @@ import {
 } from "./approval-result-normalization";
 import { getClient } from "./client";
 import { buildClientSkillsPayload } from "./clientSkills";
-import { ALL_SKILL_SOURCES } from "./skillSources";
+import { getSkillSources } from "./context";
 
 const streamRequestStartTimes = new WeakMap<object, number>();
 const streamToolContextIds = new WeakMap<object, string>();
@@ -149,7 +149,7 @@ export async function sendMessageStream(
   const { clientSkills, errors: clientSkillDiscoveryErrors } =
     await buildClientSkillsPayload({
       agentId: opts.agentId,
-      skillSources: ALL_SKILL_SOURCES,
+      skillSources: getSkillSources(),
     });
 
   const resolvedConversationId = conversationId;


### PR DESCRIPTION
## Summary

- `sendMessageStream` in `message.ts` was hardcoding `ALL_SKILL_SOURCES` when building the client skills payload, causing `--no-skills` (and `--skill-sources`) to be ignored on every message send
- Fixed by replacing `ALL_SKILL_SOURCES` with `getSkillSources()`, which reads the runtime context set at startup

## Test plan

- [ ] Start agent with `--no-skills` and confirm no skills appear in the system prompt
- [ ] Start agent with `--skill-sources project` and confirm only project-scoped skills are sent
- [ ] Start agent without any skill flags and confirm all skills still load normally

👾 Generated with [Letta Code](https://letta.com)