### PR TITLE
fix(skills): include memfs skills in client_skills payload

### DIFF
--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -7,8 +7,70 @@ import {
   SKILLS_DIR,
   type Skill,
   type SkillDiscoveryError,
+  type SkillDiscoveryResult,
   type SkillSource,
 } from "./skills";
+
+function getMemorySkillsDirs(agentId?: string): string[] {
+  const dirs = new Set<string>();
+
+  const memoryDir = process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
+  if (memoryDir && memoryDir.trim().length > 0) {
+    dirs.add(join(memoryDir.trim(), "skills"));
+  }
+
+  if (agentId) {
+    dirs.add(
+      join(
+        process.env.HOME || process.env.USERPROFILE || "~",
+        ".letta/agents",
+        agentId,
+        "memory",
+        "skills",
+      ),
+    );
+  }
+
+  return Array.from(dirs);
+}
+
+async function discoverMemorySkills(
+  agentId?: string,
+): Promise<SkillDiscoveryResult> {
+  const skillsById = new Map<string, Skill>();
+  const errors: SkillDiscoveryError[] = [];
+
+  for (const dir of getMemorySkillsDirs(agentId)) {
+    try {
+      // Reuse the canonical skill parser by scanning this path as a project scope.
+      // We remap source to "agent" because memory skill precedence should be:
+      // project > agent > memory > global > bundled.
+      const discovery = await discoverSkills(dir, undefined, {
+        sources: ["project"],
+        skipBundled: true,
+      });
+      errors.push(...discovery.errors);
+      for (const skill of discovery.skills) {
+        if (!skillsById.has(skill.id)) {
+          skillsById.set(skill.id, { ...skill, source: "agent" });
+        }
+      }
+    } catch (error) {
+      errors.push({
+        path: dir,
+        message:
+          error instanceof Error
+            ? error.message
+            : `Unknown error: ${String(error)}`,
+      });
+    }
+  }
+
+  return {
+    skills: [...skillsById.values()].sort(compareSkills),
+    errors,
+  };
+}
 
 export type ClientSkill = NonNullable<
   ConversationMessageCreateParams["client_skills"]
@@ -121,6 +183,25 @@ export async function buildClientSkillsPayload(
           ? error.message
           : `Unknown error: ${String(error)}`;
       errors.push({ path: run.path, message });
+    }
+  }
+
+  // MemFS skills are discovered by the Skill tool, so include them in
+  // client_skills as well. This keeps the model's available-skills list in
+  // sync with actual Skill(...) resolution in desktop/listen mode.
+  if (skillSources.length > 0) {
+    const memoryDiscovery = await discoverMemorySkills(options.agentId);
+    errors.push(...memoryDiscovery.errors);
+    for (const skill of memoryDiscovery.skills) {
+      const existing = skillsById.get(skill.id);
+
+      // Preserve higher-priority skills: project and agent-scoped.
+      // MemFS should override only global/bundled or fill missing ids.
+      if (existing?.source === "project" || existing?.source === "agent") {
+        continue;
+      }
+
+      skillsById.set(skill.id, skill);
     }
   }
 

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import type {
   Skill,
   SkillDiscoveryResult,
@@ -214,5 +217,165 @@ describe("buildClientSkillsPayload", () => {
         m.includes("Failed to build some client_skills entries"),
       ),
     ).toBe(true);
+  });
+
+  test("includes memfs skills in client_skills and lets memfs override global/bundled", async () => {
+    const { buildClientSkillsPayload } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const originalMemoryDir = process.env.MEMORY_DIR;
+    const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-client-skills-"));
+
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      const memorySkillDir = join(memoryDir, "skills", "shared-skill");
+      await mkdir(memorySkillDir, { recursive: true });
+      await writeFile(
+        join(memorySkillDir, "SKILL.md"),
+        [
+          "---",
+          "id: shared-skill",
+          "name: shared-skill",
+          "description: from memfs",
+          "---",
+          "",
+          "Memfs body",
+        ].join("\n"),
+      );
+
+      process.env.MEMORY_DIR = memoryDir;
+      delete process.env.LETTA_MEMORY_DIR;
+
+      const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+        skills: [
+          {
+            ...baseSkill,
+            id: "shared-skill",
+            description: "from global",
+            path: "/tmp/global/shared-skill/SKILL.md",
+            source: "global",
+          },
+        ],
+        errors: [],
+      });
+
+      const result = await buildClientSkillsPayload({
+        agentId: "agent-1",
+        skillsDirectory: "/tmp/.skills",
+        skillSources: ["global"],
+        discoverSkillsFn,
+      });
+
+      expect(result.clientSkills).toEqual([
+        {
+          name: "shared-skill",
+          description: "from memfs",
+          location: join(memorySkillDir, "SKILL.md"),
+        },
+      ]);
+      expect(result.skillPathById).toEqual({
+        "shared-skill": join(memorySkillDir, "SKILL.md"),
+      });
+    } finally {
+      if (originalMemoryDir === undefined) {
+        delete process.env.MEMORY_DIR;
+      } else {
+        process.env.MEMORY_DIR = originalMemoryDir;
+      }
+      if (originalLettaMemoryDir === undefined) {
+        delete process.env.LETTA_MEMORY_DIR;
+      } else {
+        process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not let memfs skills override agent or project sources", async () => {
+    const { buildClientSkillsPayload } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const originalMemoryDir = process.env.MEMORY_DIR;
+    const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-client-skills-"));
+
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      const memorySkillDir = join(memoryDir, "skills", "shared-skill");
+      await mkdir(memorySkillDir, { recursive: true });
+      await writeFile(
+        join(memorySkillDir, "SKILL.md"),
+        [
+          "---",
+          "id: shared-skill",
+          "name: shared-skill",
+          "description: from memfs",
+          "---",
+          "",
+          "Memfs body",
+        ].join("\n"),
+      );
+
+      process.env.MEMORY_DIR = memoryDir;
+      delete process.env.LETTA_MEMORY_DIR;
+
+      const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+        skills: [
+          {
+            ...baseSkill,
+            id: "shared-skill",
+            description: "from agent",
+            path: "/tmp/agent/shared-skill/SKILL.md",
+            source: "agent",
+          },
+          {
+            ...baseSkill,
+            id: "project-wins",
+            description: "from project",
+            path: "/tmp/project/project-wins/SKILL.md",
+            source: "project",
+          },
+        ],
+        errors: [],
+      });
+
+      const result = await buildClientSkillsPayload({
+        agentId: "agent-1",
+        skillsDirectory: "/tmp/.skills",
+        skillSources: ["agent", "project"],
+        discoverSkillsFn,
+      });
+
+      expect(result.clientSkills).toContainEqual({
+        name: "shared-skill",
+        description: "from agent",
+        location: "/tmp/agent/shared-skill/SKILL.md",
+      });
+      expect(result.clientSkills).toContainEqual({
+        name: "project-wins",
+        description: "from project",
+        location: "/tmp/project/project-wins/SKILL.md",
+      });
+      expect(result.clientSkills).not.toContainEqual({
+        name: "shared-skill",
+        description: "from memfs",
+        location: join(memorySkillDir, "SKILL.md"),
+      });
+    } finally {
+      if (originalMemoryDir === undefined) {
+        delete process.env.MEMORY_DIR;
+      } else {
+        process.env.MEMORY_DIR = originalMemoryDir;
+      }
+      if (originalLettaMemoryDir === undefined) {
+        delete process.env.LETTA_MEMORY_DIR;
+      } else {
+        process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- include memfs `memory/skills` entries when building `client_skills` so desktop/listen mode exposes the same memfs-scoped skills that `Skill(...)` can resolve
- preserve source precedence: keep `project` and `agent` skills authoritative, while allowing memfs skills to override `global`/`bundled` duplicates
- add regression tests covering memfs inclusion and precedence behavior

👾 Generated with [Letta Code](https://letta.com)