### PR TITLE
fix(export): embed skills client-side instead of POSTing to server

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9882,46 +9882,21 @@ export default function App({
             const { packageSkills } = await import("../agent/export");
             const skills = await packageSkills(agentId);
 
-            // Export agent with skills
-            let fileContent: unknown;
+            // Export agent via SDK (GET endpoint), then embed skills client-side
+            const baseContent = await client.agents.exportFile(
+              agentId,
+              exportParams,
+            );
+
+            // Parse if returned as a string, otherwise use as-is
+            const fileContent: Record<string, unknown> =
+              typeof baseContent === "string"
+                ? JSON.parse(baseContent)
+                : (baseContent as Record<string, unknown>);
+
+            // Embed skills into the .af JSON (client-side, no server support needed)
             if (skills.length > 0) {
-              // Use raw fetch with auth from settings
-              const { settingsManager } = await import("../settings-manager");
-              const { getServerUrl } = await import("../agent/client");
-              const settings =
-                await settingsManager.getSettingsWithSecureTokens();
-              const apiKey =
-                process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
-              const baseUrl = getServerUrl();
-
-              const body: Record<string, unknown> = {
-                ...exportParams,
-                skills,
-              };
-
-              const response = await fetch(
-                `${baseUrl}/v1/agents/${agentId}/export`,
-                {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Bearer ${apiKey}`,
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify(body),
-                },
-              );
-
-              if (!response.ok) {
-                throw new Error(`Export failed: ${response.statusText}`);
-              }
-
-              fileContent = await response.json();
-            } else {
-              // No skills to include, use SDK
-              fileContent = await client.agents.exportFile(
-                agentId,
-                exportParams,
-              );
+              fileContent.skills = skills;
             }
 
             // Generate filename


### PR DESCRIPTION
## Summary

- `/export` was sending a `POST /v1/agents/{id}/export` with a `skills` field in the body when skills were present, but the server only supports `GET` for this endpoint — causing a **422 Unprocessable Entity** error every time the user had skills
- Fix: always use the SDK's `GET` endpoint (`client.agents.exportFile`) to fetch the base agent file, then embed the packaged skills into the parsed JSON **client-side** before writing the `.af` file to disk
- Removes ~25 lines of raw `fetch` boilerplate (auth header construction, URL building, error handling) that duplicated SDK logic unnecessarily

## Test plan

- [ ] Run `/export` with skills present (e.g. `.skills/` directory populated) — should succeed and produce an `.af` file with a `skills` array embedded
- [ ] Run `/export` with no skills — should still work as before
- [ ] Verify the exported `.af` can be re-imported with `--import` and skills are restored correctly

👾 Generated with [Letta Code](https://letta.com)