### PR TITLE
fix(memfs): recompile system message after memfs addon is toggled

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -298,6 +298,11 @@ export async function applyMemfsFlags(
       if (!promptUpdate.success) {
         throw new Error(promptUpdate.message);
       }
+      // Force recompile of the system message so the updated template
+      // (with/without memfs addon) is reflected in the compiled prompt.
+      const { getClient } = await import("./client");
+      const client = await getClient();
+      await client.agents.recompile(agentId, { update_timestamp: false });
     }
     settingsManager.setMemfsEnabled(agentId, targetEnabled);
   }


### PR DESCRIPTION
## Summary

- When `letta --memfs` enables memfs on an agent, `updateAgentSystemPromptMemfs` updates `agent.system` (the template) via `client.agents.update()`, but the server's `update_agent` does **not** automatically recompile the system message (message-0)
- This means the compiled prompt the model actually sees never gets the memfs instructions (`# Memory`, syncing, `$MEMORY_DIR`, etc.) — they exist in the template but not in the system message sent to the LLM
- Adds `client.agents.recompile(agentId, { update_timestamp: false })` after the template update so the server rebuilds message-0 from the updated template

## Context

Discovered while investigating why agents created via the Letta SDK and then started with `letta --memfs` had the memfs addon in `agent.system` but not in the compiled system message — the model was seeing `<memory_blocks>` but had no instructions on how to use the memory filesystem.

## Test plan

- [ ] Create an agent via the SDK with a custom `system` prompt (no `{CORE_MEMORY}` placeholder)
- [ ] Run `letta --memfs` on the agent
- [ ] Export the agent (`.af`) and verify message-0 contains the memfs instructions (`# Memory`, `$MEMORY_DIR`, syncing section)
- [ ] Verify `/memfs enable` and `/memfs disable` also result in correct recompilation

👾 Generated with [Letta Code](https://letta.com)