### PR TITLE
fix(telemetry): reduce stream error spam and telemetry overhead

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -40,6 +40,19 @@ export type ApprovalRequest = {
   toolArgs: string;
 };
 
+type MidStreamResumeSource = "stream_chunk" | "discovery" | "otid" | null;
+
+type FinalStreamTelemetryParams = {
+  stopReason: StopReasonType;
+  fallbackError?: string | null;
+  lastRunId?: string | null;
+  resumeAttempted: boolean;
+  resumeSource: MidStreamResumeSource;
+  resumeErrorMessage?: string | null;
+  lookupErrorMessage?: string | null;
+  skipReasons?: string[];
+};
+
 export type DrainStreamHookContext = {
   chunk: LettaStreamingResponse;
   shouldOutput: boolean;
@@ -90,6 +103,105 @@ type RunsListClient = {
 };
 
 const FALLBACK_RUN_DISCOVERY_TIMEOUT_MS = 5000;
+
+function shouldAttemptMidStreamResume(params: {
+  stopReason: StopReasonType;
+  fallbackError?: string | null;
+  runIdToResume?: string | null;
+  runIdSource: MidStreamResumeSource;
+  abortSignal?: AbortSignal;
+}): boolean {
+  const { stopReason, fallbackError, runIdToResume, runIdSource, abortSignal } =
+    params;
+
+  const isApprovalPendingConflict =
+    fallbackError?.includes("waiting for approval on a tool call") ?? false;
+
+  return (
+    stopReason === "error" &&
+    !isApprovalPendingConflict &&
+    (Boolean(runIdToResume) || runIdSource === "otid") &&
+    !abortSignal?.aborted
+  );
+}
+
+function getMidStreamResumeSkipReasons(params: {
+  stopReason: StopReasonType;
+  runIdToResume?: string | null;
+  runIdSource: MidStreamResumeSource;
+  abortSignal?: AbortSignal;
+  lookupErrorMessage?: string | null;
+  fallbackError?: string | null;
+}): string[] {
+  const reasons: string[] = [];
+  const {
+    stopReason,
+    runIdToResume,
+    runIdSource,
+    abortSignal,
+    lookupErrorMessage,
+    fallbackError,
+  } = params;
+
+  if (stopReason !== "error") {
+    return reasons;
+  }
+
+  const isApprovalPendingConflict =
+    fallbackError?.includes("waiting for approval on a tool call") ?? false;
+  if (isApprovalPendingConflict) {
+    reasons.push("approval_pending_conflict");
+  }
+  if (!runIdToResume && runIdSource !== "otid") {
+    reasons.push("no_run_id");
+  }
+  if (abortSignal?.aborted) {
+    reasons.push("user_aborted");
+  }
+  if (lookupErrorMessage) {
+    reasons.push(`lookup_failed: ${lookupErrorMessage}`);
+  }
+
+  return reasons;
+}
+
+function buildFinalStreamTelemetry(params: FinalStreamTelemetryParams): {
+  errorType: string;
+  errorMessage: string;
+  context: string;
+  runId?: string;
+} | null {
+  if (params.stopReason !== "error") {
+    return null;
+  }
+
+  const messageParts = [
+    params.fallbackError || "Stream error (no client-side detail)",
+  ];
+
+  if (params.resumeAttempted) {
+    if (params.resumeErrorMessage) {
+      messageParts.push(`[resume failed: ${params.resumeErrorMessage}]`);
+    } else if (params.resumeSource) {
+      messageParts.push(`[resume attempted via ${params.resumeSource}]`);
+    }
+  } else if ((params.skipReasons?.length ?? 0) > 0) {
+    messageParts.push(`[resume skipped: ${params.skipReasons?.join(", ")}]`);
+  }
+
+  return {
+    errorType: "stream_drain_error",
+    errorMessage: messageParts.join(" "),
+    context: "stream_drain",
+    ...(params.lastRunId ? { runId: params.lastRunId } : {}),
+  };
+}
+
+export const __streamTelemetryTestUtils = {
+  buildFinalStreamTelemetry,
+  getMidStreamResumeSkipReasons,
+  shouldAttemptMidStreamResume,
+};
 
 function hasPaginatedItems(
   response: RunsListResponse,
@@ -387,15 +499,6 @@ export async function drainStream(
     // is still in-progress and has no error metadata yet.
     fallbackError = errorMessageWithDiagnostic;
 
-    telemetry.trackError(
-      "stream_drain_error",
-      errorMessageWithDiagnostic,
-      "stream_drain",
-      {
-        runId: streamProcessor.lastRunId || undefined,
-      },
-    );
-
     // Preserve a stop reason already parsed from stream chunks (e.g. llm_api_error)
     // and only fall back to generic "error" when none is available.
     stopReason = streamProcessor.stopReason || "error";
@@ -562,8 +665,12 @@ export async function drainStreamWithResume(
   );
 
   let runIdToResume = result.lastRunId ?? null;
-  let runIdSource: "stream_chunk" | "discovery" | "otid" | null =
-    result.lastRunId ? "stream_chunk" : null;
+  let runIdSource: MidStreamResumeSource = result.lastRunId
+    ? "stream_chunk"
+    : null;
+  let resumeAttempted = false;
+  let resumeErrorMessage: string | null = null;
+  let lookupErrorMessage: string | null = null;
 
   // If the stream failed before exposing run_id, attempt to find the right run.
   // Prefer OTID-based lookup via the conversations stream endpoint: it lets the
@@ -613,11 +720,7 @@ export async function drainStreamWithResume(
           lookupError instanceof Error
             ? lookupError.message
             : String(lookupError);
-        telemetry.trackError(
-          "stream_resume_lookup_failed",
-          lookupErrorMsg,
-          "stream_resume",
-        );
+        lookupErrorMessage = lookupErrorMsg;
         debugWarn(
           "drainStreamWithResume",
           "Fallback run_id lookup failed:",
@@ -634,15 +737,13 @@ export async function drainStreamWithResume(
   // recovery path handle them instead.
   // "waiting for approval on a tool call" = server in requires_approval state, not resumable
   // (distinct from "is currently being processed" = conversation-busy 409, which IS resumable)
-  const isApprovalPendingConflict =
-    result.fallbackError?.includes("waiting for approval on a tool call") ??
-    false;
-  const canResume =
-    result.stopReason === "error" &&
-    !isApprovalPendingConflict &&
-    (runIdToResume || runIdSource === "otid") &&
-    abortSignal &&
-    !abortSignal.aborted;
+  const canResume = shouldAttemptMidStreamResume({
+    stopReason: result.stopReason,
+    fallbackError: result.fallbackError,
+    runIdToResume,
+    runIdSource,
+    abortSignal,
+  });
 
   if (canResume) {
     // Resume path: markCurrentLineAsFinished was skipped in the catch block.
@@ -654,14 +755,7 @@ export async function drainStreamWithResume(
     const originalApproval = result.approval;
 
     // Log that we're attempting a stream resume
-    telemetry.trackError(
-      "stream_resume_attempt",
-      originalFallbackError || "Stream error (no client-side detail)",
-      "stream_resume",
-      {
-        runId: result.lastRunId ?? undefined,
-      },
-    );
+    resumeAttempted = true;
 
     debugWarn(
       "stream",
@@ -803,51 +897,38 @@ export async function drainStreamWithResume(
         resumeError instanceof Error
           ? resumeError.message
           : String(resumeError);
+      resumeErrorMessage = resumeErrorMsg;
       debugWarn(
         "stream",
         "[MID-STREAM RESUME] ❌ Failed (runId=%s): %s",
         runIdToResume,
         resumeErrorMsg,
       );
-      telemetry.trackError(
-        "stream_resume_failed",
-        resumeErrorMsg,
-        "stream_resume",
-        {
-          runId: result.lastRunId ?? undefined,
-        },
-      );
     }
   }
 
-  // Log when stream errored but resume was NOT attempted, with reasons why
-  if (result.stopReason === "error") {
-    const skipReasons: string[] = [];
-    if (!result.lastRunId && runIdSource !== "otid")
-      skipReasons.push("no_run_id");
-    if (!abortSignal) skipReasons.push("no_abort_signal");
-    if (abortSignal?.aborted) skipReasons.push("user_aborted");
+  // Log when stream errored but resume was NOT attempted, with reasons why.
+  // This remains a local debug diagnostic only; telemetry is emitted once below
+  // after the final outcome is known.
+  const skipReasons = getMidStreamResumeSkipReasons({
+    stopReason: result.stopReason,
+    runIdToResume: result.lastRunId,
+    runIdSource,
+    abortSignal,
+    lookupErrorMessage,
+    fallbackError: result.fallbackError,
+  });
 
-    // Only log if we actually skipped for a reason (i.e., we didn't enter the resume branch above)
-    if (skipReasons.length > 0) {
-      // No resume — cancel tools and finalize the streaming line now
-      // (both were skipped in the initial drain's catch block above)
-      markIncompleteToolsAsCancelled(buffers, false, "stream_error", true);
-      markCurrentLineAsFinished(buffers);
-      debugLog(
-        "stream",
-        "Mid-stream resume skipped: %s",
-        skipReasons.join(", "),
-      );
-      telemetry.trackError(
-        "stream_resume_skipped",
-        `${result.fallbackError || "Stream error (no client-side detail)"} [skip: ${skipReasons.join(", ")}]`,
-        "stream_resume",
-        {
-          runId: result.lastRunId ?? undefined,
-        },
-      );
-    }
+  if (
+    result.stopReason === "error" &&
+    !resumeAttempted &&
+    skipReasons.length > 0
+  ) {
+    // No resume — cancel tools and finalize the streaming line now
+    // (both were skipped in the initial drain's catch block above)
+    markIncompleteToolsAsCancelled(buffers, false, "stream_error", true);
+    markCurrentLineAsFinished(buffers);
+    debugLog("stream", "Mid-stream resume skipped: %s", skipReasons.join(", "));
   }
 
   // If the initial drain's catch block set buffers.interrupted=true (skipCancelToolsOnError)
@@ -864,6 +945,28 @@ export async function drainStreamWithResume(
 
   // Update duration to reflect total time (including resume attempt)
   result.apiDurationMs = performance.now() - overallStartTime;
+
+  const finalStreamTelemetry = buildFinalStreamTelemetry({
+    stopReason: result.stopReason,
+    fallbackError: result.fallbackError,
+    lastRunId: result.lastRunId,
+    resumeAttempted,
+    resumeSource: runIdSource,
+    resumeErrorMessage,
+    lookupErrorMessage,
+    skipReasons,
+  });
+
+  if (finalStreamTelemetry) {
+    telemetry.trackError(
+      finalStreamTelemetry.errorType,
+      finalStreamTelemetry.errorMessage,
+      finalStreamTelemetry.context,
+      {
+        runId: finalStreamTelemetry.runId,
+      },
+    );
+  }
 
   return result;
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -77,6 +77,7 @@ class TelemetryManager {
   private sessionEndTracked = false;
   private initialized = false;
   private flushInterval: NodeJS.Timeout | null = null;
+  private flushInFlight: Promise<void> | null = null;
   private serverVersion: string | null = null;
 
   private async resolveTelemetryApiKey(): Promise<string | undefined> {
@@ -499,48 +500,69 @@ class TelemetryManager {
    * Flush events to the server
    */
   async flush(): Promise<void> {
-    if (this.events.length === 0 || !this.isTelemetryEnabled()) {
+    if (!this.isTelemetryEnabled()) {
       return;
     }
 
-    const eventsToSend = [...this.events];
-    this.events = [];
+    if (this.flushInFlight) {
+      await this.flushInFlight;
+      if (this.events.length === 0) {
+        return;
+      }
+    }
 
-    const apiKey = await this.resolveTelemetryApiKey();
+    this.flushInFlight = (async () => {
+      while (this.events.length > 0 && this.isTelemetryEnabled()) {
+        const eventsToSend = [...this.events];
+        this.events = [];
+
+        const apiKey = await this.resolveTelemetryApiKey();
+
+        try {
+          // Add 5 second timeout to prevent telemetry from blocking shutdown
+          const timeoutPromise = new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error("Telemetry request timeout")),
+              5000,
+            ),
+          );
+
+          const fetchPromise = fetch(
+            "https://api.letta.com/v1/metadata/telemetry",
+            {
+              method: "POST",
+              headers: {
+                ...getLettaCodeHeaders(apiKey),
+                "X-Letta-Code-Device-ID": this.deviceId || "",
+              },
+              body: JSON.stringify({
+                service: "letta-code",
+                server_version: this.serverVersion || undefined,
+                events: eventsToSend,
+              }),
+            },
+          );
+
+          const response = (await Promise.race([
+            fetchPromise,
+            timeoutPromise,
+          ])) as Response;
+
+          if (!response.ok) {
+            throw new Error(`Telemetry flush failed: ${response.status}`);
+          }
+        } catch {
+          // If flush fails, put events back in queue, but don't throw error
+          this.events.unshift(...eventsToSend);
+          break;
+        }
+      }
+    })();
 
     try {
-      // Add 5 second timeout to prevent telemetry from blocking shutdown
-      const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error("Telemetry request timeout")), 5000),
-      );
-
-      const fetchPromise = fetch(
-        "https://api.letta.com/v1/metadata/telemetry",
-        {
-          method: "POST",
-          headers: {
-            ...getLettaCodeHeaders(apiKey),
-            "X-Letta-Code-Device-ID": this.deviceId || "",
-          },
-          body: JSON.stringify({
-            service: "letta-code",
-            server_version: this.serverVersion || undefined,
-            events: eventsToSend,
-          }),
-        },
-      );
-
-      const response = (await Promise.race([
-        fetchPromise,
-        timeoutPromise,
-      ])) as Response;
-
-      if (!response.ok) {
-        throw new Error(`Telemetry flush failed: ${response.status}`);
-      }
-    } catch {
-      // If flush fails, put events back in queue, but don't throw error
-      this.events.unshift(...eventsToSend);
+      await this.flushInFlight;
+    } finally {
+      this.flushInFlight = null;
     }
   }
 

--- a/src/tests/cli/stream-telemetry.test.ts
+++ b/src/tests/cli/stream-telemetry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { __streamTelemetryTestUtils } from "../../cli/helpers/stream";
+
+describe("stream telemetry helpers", () => {
+  test("allows mid-stream resume without an abort signal", () => {
+    expect(
+      __streamTelemetryTestUtils.shouldAttemptMidStreamResume({
+        stopReason: "error",
+        fallbackError: "socket closed",
+        runIdToResume: "run-123",
+        runIdSource: "stream_chunk",
+        abortSignal: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  test("blocks mid-stream resume only when abort signal is already aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(
+      __streamTelemetryTestUtils.shouldAttemptMidStreamResume({
+        stopReason: "error",
+        fallbackError: "socket closed",
+        runIdToResume: "run-123",
+        runIdSource: "stream_chunk",
+        abortSignal: controller.signal,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not emit terminal telemetry when resume succeeds", () => {
+    expect(
+      __streamTelemetryTestUtils.buildFinalStreamTelemetry({
+        stopReason: "end_turn",
+        fallbackError: "socket closed",
+        lastRunId: "run-123",
+        resumeAttempted: true,
+        resumeSource: "stream_chunk",
+      }),
+    ).toBeNull();
+  });
+
+  test("builds one terminal telemetry event when resume ultimately fails", () => {
+    expect(
+      __streamTelemetryTestUtils.buildFinalStreamTelemetry({
+        stopReason: "error",
+        fallbackError: "socket closed",
+        lastRunId: "run-123",
+        resumeAttempted: true,
+        resumeSource: "stream_chunk",
+        resumeErrorMessage: "resume endpoint closed",
+      }),
+    ).toEqual({
+      errorType: "stream_drain_error",
+      errorMessage: "socket closed [resume failed: resume endpoint closed]",
+      context: "stream_drain",
+      runId: "run-123",
+    });
+  });
+
+  test("captures skip reasons for terminal failures without duplicate resume telemetry", () => {
+    expect(
+      __streamTelemetryTestUtils.buildFinalStreamTelemetry({
+        stopReason: "error",
+        fallbackError: "socket closed",
+        lastRunId: null,
+        resumeAttempted: false,
+        resumeSource: null,
+        skipReasons: ["no_run_id", "lookup_failed: timeout"],
+      }),
+    ).toEqual({
+      errorType: "stream_drain_error",
+      errorMessage:
+        "socket closed [resume skipped: no_run_id, lookup_failed: timeout]",
+      context: "stream_drain",
+    });
+  });
+});

--- a/src/tests/telemetry/flush-auth.test.ts
+++ b/src/tests/telemetry/flush-auth.test.ts
@@ -4,6 +4,7 @@ import { telemetry } from "../../telemetry";
 
 type TelemetryTestState = {
   events: unknown[];
+  flushInFlight: Promise<void> | null;
   messageCount: number;
   currentAgentId: string | null;
   surface: "tui" | "headless" | "websocket";
@@ -20,6 +21,7 @@ describe("telemetry flush auth", () => {
   beforeEach(() => {
     telemetry.cleanup();
     telemetryState.events = [];
+    telemetryState.flushInFlight = null;
     telemetryState.messageCount = 0;
     telemetryState.currentAgentId = null;
     telemetryState.surface = "tui";
@@ -78,6 +80,39 @@ describe("telemetry flush auth", () => {
 
     telemetry.trackUserInput("hello", "user", "model-1");
     await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent flush calls share one in-flight request", async () => {
+    let resolveFetch!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    const fetchMock = mock(async () => {
+      await fetchStarted;
+      return new Response(null, { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {
+        LETTA_API_KEY: "settings-key",
+      },
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    telemetry.trackUserInput("hello", "user", "model-1");
+
+    const flushA = telemetry.flush();
+    const flushB = telemetry.flush();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch();
+    await Promise.all([flushA, flushB]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/src/tests/tools/tool-telemetry.test.ts
+++ b/src/tests/tools/tool-telemetry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { __toolTelemetryTestUtils } from "../../tools/manager";
+
+describe("tool telemetry size estimation", () => {
+  test("uses string length for text responses", () => {
+    expect(__toolTelemetryTestUtils.estimateToolResponseSize("hello")).toBe(5);
+  });
+
+  test("sums multimodal block sizes without JSON serialization", () => {
+    expect(
+      __toolTelemetryTestUtils.estimateToolResponseSize([
+        { type: "text", text: "hello" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "abcd",
+            detail: "high",
+          },
+        },
+      ]),
+    ).toBe(5 + 4 + "image/png".length + "high".length);
+  });
+});

--- a/src/tests/utils/debug.test.ts
+++ b/src/tests/utils/debug.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { debugLogFile } from "../../utils/debug";
+
+describe("debugLogFile tail buffering", () => {
+  test("returns the in-memory tail for the current session", () => {
+    debugLogFile.init("agent-debug-test", `session-${Date.now()}-a`);
+    debugLogFile.appendLine("first line\n");
+    debugLogFile.appendLine("second line\n");
+
+    expect(debugLogFile.getTail(1)).toBe("second line");
+    expect(debugLogFile.getTail(2)).toBe("first line\nsecond line");
+  });
+
+  test("init resets the buffered tail for a new session", () => {
+    debugLogFile.init("agent-debug-test", `session-${Date.now()}-b`);
+
+    expect(debugLogFile.getTail()).toBeUndefined();
+  });
+});

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1310,6 +1310,45 @@ function flattenToolResponse(result: unknown): ToolReturnContent {
   return JSON.stringify(result);
 }
 
+function estimateToolResponseSize(response: ToolReturnContent): number {
+  if (typeof response === "string") {
+    return response.length;
+  }
+
+  let total = 0;
+  for (const block of response) {
+    if (block.type === "text") {
+      total += block.text.length;
+      continue;
+    }
+
+    if (block.type === "image") {
+      const { source } = block;
+      if ("url" in source && typeof source.url === "string") {
+        total += source.url.length;
+      }
+      if ("data" in source && typeof source.data === "string") {
+        total += source.data.length;
+      }
+      if ("file_id" in source && typeof source.file_id === "string") {
+        total += source.file_id.length;
+      }
+      if ("media_type" in source && typeof source.media_type === "string") {
+        total += source.media_type.length;
+      }
+      if ("detail" in source && typeof source.detail === "string") {
+        total += source.detail.length;
+      }
+    }
+  }
+
+  return total;
+}
+
+export const __toolTelemetryTestUtils = {
+  estimateToolResponseSize,
+};
+
 /**
  * Executes a tool by name with the provided arguments.
  *
@@ -1491,10 +1530,7 @@ export async function executeTool(
     }
 
     // Track tool usage (calculate size for multimodal content)
-    const responseSize =
-      typeof flattenedResponse === "string"
-        ? flattenedResponse.length
-        : JSON.stringify(flattenedResponse).length;
+    const responseSize = estimateToolResponseSize(flattenedResponse);
     telemetry.trackToolUsage(
       internalName,
       toolStatus === "success",

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -12,7 +12,6 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
-  readFileSync,
   unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -68,11 +67,13 @@ function printDebugLine(line: string, level: "log" | "warn" = "log"): void {
 const DEBUG_LOG_DIR = join(homedir(), ".letta", "logs", "debug");
 const MAX_SESSION_FILES = 5;
 const DEFAULT_TAIL_LINES = 50;
+const MAX_BUFFERED_TAIL_LINES = 200;
 
 class DebugLogFile {
   private logPath: string | null = null;
   private agentDir: string | null = null;
   private dirCreated = false;
+  private recentLines: string[] = [];
 
   /**
    * Initialize for an agent + session. Call once at session start.
@@ -86,11 +87,21 @@ class DebugLogFile {
     this.agentDir = join(DEBUG_LOG_DIR, agentId);
     this.logPath = join(this.agentDir, `${sessionId}.log`);
     this.dirCreated = false;
+    this.recentLines = [];
     this.pruneOldSessions();
   }
 
   /** Append a single line to the log file (best-effort, sync). */
   appendLine(line: string): void {
+    const normalizedLine = line.endsWith("\n") ? line.slice(0, -1) : line;
+    this.recentLines.push(normalizedLine);
+    if (this.recentLines.length > MAX_BUFFERED_TAIL_LINES) {
+      this.recentLines.splice(
+        0,
+        this.recentLines.length - MAX_BUFFERED_TAIL_LINES,
+      );
+    }
+
     if (!this.logPath) return;
     this.ensureDir();
     try {
@@ -100,17 +111,12 @@ class DebugLogFile {
     }
   }
 
-  /** Read the last N lines from the current log file. */
+  /** Read the last N lines from the in-memory current-session tail. */
   getTail(maxLines = DEFAULT_TAIL_LINES): string | undefined {
-    if (!this.logPath) return undefined;
-    try {
-      if (!existsSync(this.logPath)) return undefined;
-      const content = readFileSync(this.logPath, "utf8");
-      const lines = content.trimEnd().split("\n");
-      return lines.slice(-maxLines).join("\n");
-    } catch {
+    if (this.recentLines.length === 0) {
       return undefined;
     }
+    return this.recentLines.slice(-maxLines).join("\n");
   }
 
   private ensureDir(): void {


### PR DESCRIPTION
## Summary
- emit a single terminal stream telemetry error only after mid-stream recovery settles, and allow resume even when no abort signal is present so headless flows don't spam `stream_resume_skipped`
- coalesce concurrent telemetry flushes and keep the current session's debug tail in memory so error tracking avoids overlapping POSTs and synchronous log-file reads
- estimate tool response sizes directly for telemetry instead of JSON-stringifying full multimodal tool returns, with focused regression coverage for the new telemetry behavior

👾 Generated with [Letta Code](https://letta.com)