### PR TITLE
feat(server): add OAuth device flow for headless deployments

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -9,7 +9,6 @@ import { Box, render, Text } from "ink";
 import TextInput from "ink-text-input";
 import type React from "react";
 import { useState } from "react";
-import { getServerUrl } from "../../agent/client";
 import {
   LETTA_CLOUD_API_URL,
   pollForToken,
@@ -20,10 +19,20 @@ import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
 import { RemoteSessionLog } from "../../websocket/listen-log";
 import {
+  type RegisterOptions,
   registerWithCloud,
   registerWithCloudRetry,
 } from "../../websocket/listen-register";
 import { ListenerStatusUI } from "../components/ListenerStatusUI";
+
+const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+class MissingListenerApiKeyError extends Error {
+  constructor() {
+    super("LETTA_API_KEY not found");
+    this.name = "MissingListenerApiKeyError";
+  }
+}
 
 /**
  * Interactive prompt for environment name
@@ -66,8 +75,154 @@ async function flushListenerTelemetryEnd(exitReason: string): Promise<void> {
   }
 }
 
+function getListenerServerUrl(settings: {
+  env?: Record<string, string>;
+}): string {
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    LETTA_CLOUD_API_URL
+  );
+}
+
+async function refreshListenerAccessToken(
+  settings: Awaited<
+    ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+  >,
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  const now = Date.now();
+
+  console.log("Access token expired, refreshing...");
+
+  const tokens = await refreshAccessToken(
+    settings.refreshToken as string,
+    deviceId,
+    connectionName,
+  );
+
+  settingsManager.updateSettings({
+    env: {
+      ...settings.env,
+      LETTA_API_KEY: tokens.access_token,
+    },
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+  });
+  await settingsManager.flush();
+
+  console.log("Token refreshed successfully.");
+
+  return tokens.access_token;
+}
+
+async function runListenerOAuthLogin(
+  currentEnv: Record<string, string> | undefined,
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  console.log("No API key found. Starting OAuth login...\n");
+
+  const deviceData = await requestDeviceCode();
+
+  console.log(
+    `To authenticate, visit: ${deviceData.verification_uri_complete}`,
+  );
+  console.log(`Your code: ${deviceData.user_code}\n`);
+  console.log("Waiting for authorization...\n");
+
+  const tokens = await pollForToken(
+    deviceData.device_code,
+    deviceData.interval,
+    deviceData.expires_in,
+    deviceId,
+    connectionName,
+  );
+  const now = Date.now();
+
+  settingsManager.updateSettings({
+    env: {
+      ...currentEnv,
+      LETTA_API_KEY: tokens.access_token,
+    },
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+  });
+  await settingsManager.flush();
+
+  console.log("Authenticated successfully.\n");
+
+  return tokens.access_token;
+}
+
+async function resolveListenerRegistrationOptions(
+  deviceId: string,
+  connectionName: string,
+): Promise<RegisterOptions> {
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const serverUrl = getListenerServerUrl(settings);
+  const envApiKey = process.env.LETTA_API_KEY;
+
+  if (envApiKey) {
+    return {
+      serverUrl,
+      apiKey: envApiKey,
+      deviceId,
+      connectionName,
+    };
+  }
+
+  let apiKey = settings.env?.LETTA_API_KEY;
+
+  if (serverUrl === LETTA_CLOUD_API_URL) {
+    const expiresAt = settings.tokenExpiresAt;
+    if (settings.refreshToken && expiresAt) {
+      const now = Date.now();
+      if (!apiKey || now >= expiresAt - LISTENER_TOKEN_REFRESH_WINDOW_MS) {
+        try {
+          apiKey = await refreshListenerAccessToken(
+            settings,
+            deviceId,
+            connectionName,
+          );
+        } catch (refreshErr) {
+          console.warn(
+            "Token refresh failed:",
+            refreshErr instanceof Error
+              ? refreshErr.message
+              : String(refreshErr),
+          );
+          apiKey = undefined;
+        }
+      }
+    }
+
+    if (!apiKey) {
+      apiKey = await runListenerOAuthLogin(
+        settings.env,
+        deviceId,
+        connectionName,
+      );
+    }
+  }
+
+  if (!apiKey) {
+    throw new MissingListenerApiKeyError();
+  }
+
+  return {
+    serverUrl,
+    apiKey,
+    deviceId,
+    connectionName,
+  };
+}
+
 export const __listenSubcommandTestUtils = {
   flushListenerTelemetryEnd,
+  getListenerServerUrl,
+  resolveListenerRegistrationOptions,
 };
 
 export async function runListenSubcommand(argv: string[]): Promise<number> {
@@ -171,124 +326,45 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   try {
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
+    let registerOptions: RegisterOptions;
 
-    // Get API key — prefer keychain/settings over env var so a stale
-    // shell export doesn't shadow the real key from OAuth login.
-    const settings = await settingsManager.getSettingsWithSecureTokens();
-    let apiKey = settings.env?.LETTA_API_KEY || process.env.LETTA_API_KEY;
-
-    // If access token is saved but expired, try refreshing it
-    if (apiKey && settings.refreshToken && settings.tokenExpiresAt) {
-      const now = Date.now();
-      // Refresh if token expires within 5 minutes
-      if (now >= settings.tokenExpiresAt - 5 * 60 * 1000) {
-        try {
-          console.log("Access token expired, refreshing...");
-          const tokens = await refreshAccessToken(
-            settings.refreshToken,
-            deviceId,
-            connectionName,
-          );
-          apiKey = tokens.access_token;
-          settingsManager.updateSettings({
-            env: {
-              ...settingsManager.getSettings().env,
-              LETTA_API_KEY: tokens.access_token,
-            },
-            refreshToken: tokens.refresh_token ?? settings.refreshToken,
-            tokenExpiresAt: now + tokens.expires_in * 1000,
-          });
-          await settingsManager.flush();
-          console.log("Token refreshed successfully.");
-        } catch (refreshErr) {
-          // Refresh failed — clear stale tokens and fall through to re-auth
-          console.warn(
-            "Token refresh failed:",
-            refreshErr instanceof Error
-              ? refreshErr.message
-              : String(refreshErr),
-          );
-          apiKey = undefined;
-        }
-      }
-    }
-
-    // No API key found — attempt Device Code OAuth if pointing at Letta Cloud
-    if (!apiKey) {
-      const serverUrl = getServerUrl();
-      if (serverUrl !== LETTA_CLOUD_API_URL) {
-        // Self-hosted: can't use Letta Cloud OAuth
+    try {
+      registerOptions = await resolveListenerRegistrationOptions(
+        deviceId,
+        connectionName,
+      );
+    } catch (authErr) {
+      if (authErr instanceof MissingListenerApiKeyError) {
         console.error("Error: LETTA_API_KEY not found");
         console.error("Set your API key with: export LETTA_API_KEY=<your-key>");
         await flushListenerTelemetryEnd("listener_missing_api_key");
         return 1;
       }
 
-      console.log("No API key found. Starting OAuth login...\n");
-
-      try {
-        const deviceData = await requestDeviceCode();
-
-        console.log(
-          `To authenticate, visit: ${deviceData.verification_uri_complete}`,
-        );
-        console.log(`Your code: ${deviceData.user_code}\n`);
-        console.log("Waiting for authorization...\n");
-
-        const tokens = await pollForToken(
-          deviceData.device_code,
-          deviceData.interval,
-          deviceData.expires_in,
-          deviceId,
-          connectionName,
-        );
-
-        apiKey = tokens.access_token;
-        const now = Date.now();
-
-        settingsManager.updateSettings({
-          env: {
-            ...settingsManager.getSettings().env,
-            LETTA_API_KEY: tokens.access_token,
-          },
-          refreshToken: tokens.refresh_token,
-          tokenExpiresAt: now + tokens.expires_in * 1000,
-        });
-        await settingsManager.flush();
-
-        console.log("Authenticated successfully.\n");
-      } catch (authErr) {
-        console.error(
-          "OAuth login failed:",
-          authErr instanceof Error ? authErr.message : String(authErr),
-        );
-        await flushListenerTelemetryEnd("listener_oauth_failed");
-        return 1;
-      }
+      console.error(
+        "OAuth login failed:",
+        authErr instanceof Error ? authErr.message : String(authErr),
+      );
+      await flushListenerTelemetryEnd("listener_oauth_failed");
+      return 1;
     }
 
     sessionLog.log(`Session started (debug=${debugMode})`);
     sessionLog.log(`deviceId: ${deviceId}`);
     sessionLog.log(`connectionName: ${connectionName}`);
 
-    // Register with cloud
-    const serverUrl = getServerUrl();
-
     if (debugMode) {
       console.log(
-        `[${formatTimestamp()}] Registering with ${serverUrl}/v1/environments/register`,
+        `[${formatTimestamp()}] Registering with ${registerOptions.serverUrl}/v1/environments/register`,
       );
       console.log(`[${formatTimestamp()}]   deviceId: ${deviceId}`);
       console.log(`[${formatTimestamp()}]   connectionName: ${connectionName}`);
     }
-    sessionLog.log(`Registering with ${serverUrl}/v1/environments/register`);
+    sessionLog.log(
+      `Registering with ${registerOptions.serverUrl}/v1/environments/register`,
+    );
 
-    const { connectionId, wsUrl } = await registerWithCloud({
-      serverUrl,
-      apiKey,
-      deviceId,
-      connectionName,
-    });
+    const { connectionId, wsUrl } = await registerWithCloud(registerOptions);
 
     sessionLog.log(`Registered: connectionId=${connectionId}`);
     sessionLog.log(`wsUrl: ${wsUrl}`);
@@ -314,21 +390,22 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       wsUrl: string;
     }> => {
       sessionLog.log("Re-registering with retry...");
-      const result = await registerWithCloudRetry(
-        { serverUrl, apiKey, deviceId, connectionName },
-        {
-          onRetry: (attempt, delayMs, error) => {
-            sessionLog.log(
-              `Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
-            );
-            if (debugMode) {
-              console.log(
-                `[${formatTimestamp()}] Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
-              );
-            }
-          },
-        },
+      const nextRegisterOptions = await resolveListenerRegistrationOptions(
+        deviceId,
+        connectionName,
       );
+      const result = await registerWithCloudRetry(nextRegisterOptions, {
+        onRetry: (attempt, delayMs, error) => {
+          sessionLog.log(
+            `Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+          );
+          if (debugMode) {
+            console.log(
+              `[${formatTimestamp()}] Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+            );
+          }
+        },
+      });
       sessionLog.log(`Re-registered: connectionId=${result.connectionId}`);
       return result;
     };

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -10,6 +10,12 @@ import TextInput from "ink-text-input";
 import type React from "react";
 import { useState } from "react";
 import { getServerUrl } from "../../agent/client";
+import {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+} from "../../auth/oauth";
 import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
 import { RemoteSessionLog } from "../../websocket/listen-log";
@@ -166,15 +172,99 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
 
-    // Get API key (include secure token storage fallback)
+    // Get API key — prefer keychain/settings over env var so a stale
+    // shell export doesn't shadow the real key from OAuth login.
     const settings = await settingsManager.getSettingsWithSecureTokens();
-    const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
+    let apiKey = settings.env?.LETTA_API_KEY || process.env.LETTA_API_KEY;
 
+    // If access token is saved but expired, try refreshing it
+    if (apiKey && settings.refreshToken && settings.tokenExpiresAt) {
+      const now = Date.now();
+      // Refresh if token expires within 5 minutes
+      if (now >= settings.tokenExpiresAt - 5 * 60 * 1000) {
+        try {
+          console.log("Access token expired, refreshing...");
+          const tokens = await refreshAccessToken(
+            settings.refreshToken,
+            deviceId,
+            connectionName,
+          );
+          apiKey = tokens.access_token;
+          settingsManager.updateSettings({
+            env: {
+              ...settingsManager.getSettings().env,
+              LETTA_API_KEY: tokens.access_token,
+            },
+            refreshToken: tokens.refresh_token ?? settings.refreshToken,
+            tokenExpiresAt: now + tokens.expires_in * 1000,
+          });
+          await settingsManager.flush();
+          console.log("Token refreshed successfully.");
+        } catch (refreshErr) {
+          // Refresh failed — clear stale tokens and fall through to re-auth
+          console.warn(
+            "Token refresh failed:",
+            refreshErr instanceof Error
+              ? refreshErr.message
+              : String(refreshErr),
+          );
+          apiKey = undefined;
+        }
+      }
+    }
+
+    // No API key found — attempt Device Code OAuth if pointing at Letta Cloud
     if (!apiKey) {
-      console.error("Error: LETTA_API_KEY not found");
-      console.error("Set your API key with: export LETTA_API_KEY=<your-key>");
-      await flushListenerTelemetryEnd("listener_missing_api_key");
-      return 1;
+      const serverUrl = getServerUrl();
+      if (serverUrl !== LETTA_CLOUD_API_URL) {
+        // Self-hosted: can't use Letta Cloud OAuth
+        console.error("Error: LETTA_API_KEY not found");
+        console.error("Set your API key with: export LETTA_API_KEY=<your-key>");
+        await flushListenerTelemetryEnd("listener_missing_api_key");
+        return 1;
+      }
+
+      console.log("No API key found. Starting OAuth login...\n");
+
+      try {
+        const deviceData = await requestDeviceCode();
+
+        console.log(
+          `To authenticate, visit: ${deviceData.verification_uri_complete}`,
+        );
+        console.log(`Your code: ${deviceData.user_code}\n`);
+        console.log("Waiting for authorization...\n");
+
+        const tokens = await pollForToken(
+          deviceData.device_code,
+          deviceData.interval,
+          deviceData.expires_in,
+          deviceId,
+          connectionName,
+        );
+
+        apiKey = tokens.access_token;
+        const now = Date.now();
+
+        settingsManager.updateSettings({
+          env: {
+            ...settingsManager.getSettings().env,
+            LETTA_API_KEY: tokens.access_token,
+          },
+          refreshToken: tokens.refresh_token,
+          tokenExpiresAt: now + tokens.expires_in * 1000,
+        });
+        await settingsManager.flush();
+
+        console.log("Authenticated successfully.\n");
+      } catch (authErr) {
+        console.error(
+          "OAuth login failed:",
+          authErr instanceof Error ? authErr.message : String(authErr),
+        );
+        await flushListenerTelemetryEnd("listener_oauth_failed");
+        return 1;
+      }
     }
 
     sessionLog.log(`Session started (debug=${debugMode})`);

--- a/src/tests/cli/listen-subcommand-auth.test.ts
+++ b/src/tests/cli/listen-subcommand-auth.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { DeviceCodeResponse, TokenResponse } from "../../auth/oauth";
+import { settingsManager } from "../../settings-manager";
+
+const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
+  throw new Error("refreshAccessToken not mocked");
+});
+const requestDeviceCodeMock = mock(async (): Promise<DeviceCodeResponse> => {
+  throw new Error("requestDeviceCode not mocked");
+});
+const pollForTokenMock = mock(async (): Promise<TokenResponse> => {
+  throw new Error("pollForToken not mocked");
+});
+
+mock.module("../../auth/oauth", () => ({
+  LETTA_CLOUD_API_URL: "https://api.letta.com",
+  refreshAccessToken: refreshAccessTokenMock,
+  requestDeviceCode: requestDeviceCodeMock,
+  pollForToken: pollForTokenMock,
+}));
+
+const { __listenSubcommandTestUtils } = await import(
+  "../../cli/subcommands/listen"
+);
+
+describe("listen subcommand auth resolution", () => {
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalUpdateSettings = settingsManager.updateSettings;
+  const originalFlush = settingsManager.flush;
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+
+  beforeEach(() => {
+    refreshAccessTokenMock.mockReset();
+    requestDeviceCodeMock.mockReset();
+    pollForTokenMock.mockReset();
+
+    delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings = mock(
+      () => {},
+    ) as typeof settingsManager.updateSettings;
+    settingsManager.flush = mock(
+      async () => {},
+    ) as typeof settingsManager.flush;
+
+    console.log = mock(() => {}) as typeof console.log;
+    console.warn = mock(() => {}) as typeof console.warn;
+  });
+
+  afterEach(() => {
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.updateSettings = originalUpdateSettings;
+    settingsManager.flush = originalFlush;
+
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+
+    if (originalApiKey === undefined) {
+      delete process.env.LETTA_API_KEY;
+    } else {
+      process.env.LETTA_API_KEY = originalApiKey;
+    }
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  test("prefers explicit LETTA_API_KEY over saved OAuth credentials", async () => {
+    process.env.LETTA_API_KEY = "env-key";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {
+        LETTA_API_KEY: "stored-key",
+      },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() - 1000,
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result =
+      await __listenSubcommandTestUtils.resolveListenerRegistrationOptions(
+        "device-1",
+        "listener-env",
+      );
+
+    expect(result).toMatchObject({
+      serverUrl: "https://api.letta.com",
+      apiKey: "env-key",
+      deviceId: "device-1",
+      connectionName: "listener-env",
+    });
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshes saved Letta Cloud tokens when they are expired", async () => {
+    const updateSettingsMock = mock(() => {});
+    const flushMock = mock(async () => {});
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {
+        SOME_FLAG: "1",
+        LETTA_API_KEY: "stored-key",
+      },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() - 1000,
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings =
+      updateSettingsMock as typeof settingsManager.updateSettings;
+    settingsManager.flush = flushMock as typeof settingsManager.flush;
+
+    refreshAccessTokenMock.mockImplementation(async () => ({
+      access_token: "refreshed-key",
+      refresh_token: "new-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    }));
+
+    const result =
+      await __listenSubcommandTestUtils.resolveListenerRegistrationOptions(
+        "device-2",
+        "listener-refresh",
+      );
+
+    expect(result.apiKey).toBe("refreshed-key");
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+      "refresh-token",
+      "device-2",
+      "listener-refresh",
+    );
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          SOME_FLAG: "1",
+          LETTA_API_KEY: "refreshed-key",
+        },
+        refreshToken: "new-refresh-token",
+        tokenExpiresAt: expect.any(Number),
+      }),
+    );
+    expect(flushMock).toHaveBeenCalledTimes(1);
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+  });
+
+  test("falls back to device flow when refresh fails", async () => {
+    const updateSettingsMock = mock(() => {});
+    const flushMock = mock(async () => {});
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {
+        SOME_FLAG: "1",
+        LETTA_API_KEY: "stored-key",
+      },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() - 1000,
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings =
+      updateSettingsMock as typeof settingsManager.updateSettings;
+    settingsManager.flush = flushMock as typeof settingsManager.flush;
+
+    refreshAccessTokenMock.mockRejectedValue(new Error("refresh broke"));
+    requestDeviceCodeMock.mockImplementation(async () => ({
+      device_code: "device-code",
+      user_code: "ABC123",
+      verification_uri: "https://app.letta.com/device",
+      verification_uri_complete: "https://app.letta.com/device?code=ABC123",
+      expires_in: 900,
+      interval: 5,
+    }));
+    pollForTokenMock.mockImplementation(async () => ({
+      access_token: "oauth-key",
+      refresh_token: "oauth-refresh",
+      token_type: "Bearer",
+      expires_in: 3600,
+    }));
+
+    const result =
+      await __listenSubcommandTestUtils.resolveListenerRegistrationOptions(
+        "device-3",
+        "listener-oauth",
+      );
+
+    expect(result.apiKey).toBe("oauth-key");
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(requestDeviceCodeMock).toHaveBeenCalledTimes(1);
+    expect(pollForTokenMock).toHaveBeenCalledWith(
+      "device-code",
+      5,
+      900,
+      "device-3",
+      "listener-oauth",
+    );
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          SOME_FLAG: "1",
+          LETTA_API_KEY: "oauth-key",
+        },
+        refreshToken: "oauth-refresh",
+        tokenExpiresAt: expect.any(Number),
+      }),
+    );
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not start OAuth for self-hosted listeners without an API key", async () => {
+    process.env.LETTA_BASE_URL = "https://self-hosted.example.com";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    await expect(
+      __listenSubcommandTestUtils.resolveListenerRegistrationOptions(
+        "device-4",
+        "listener-self-hosted",
+      ),
+    ).rejects.toThrow("LETTA_API_KEY not found");
+
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/cli/listen-subcommand-telemetry.test.ts
+++ b/src/tests/cli/listen-subcommand-telemetry.test.ts
@@ -10,6 +10,7 @@ describe("listen subcommand telemetry", () => {
   const originalGetOrCreateDeviceId = settingsManager.getOrCreateDeviceId;
   const originalGetSettingsWithSecureTokens =
     settingsManager.getSettingsWithSecureTokens;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
 
   const originalTrackSessionEnd = telemetry.trackSessionEnd;
   const originalFlush = telemetry.flush;
@@ -17,6 +18,7 @@ describe("listen subcommand telemetry", () => {
   beforeEach(() => {
     telemetry.cleanup();
     delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
 
     settingsManager.loadLocalProjectSettings = mock(async () => ({
       lastAgent: null,
@@ -38,6 +40,13 @@ describe("listen subcommand telemetry", () => {
     settingsManager.getOrCreateDeviceId = originalGetOrCreateDeviceId;
     settingsManager.getSettingsWithSecureTokens =
       originalGetSettingsWithSecureTokens;
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+
     telemetry.trackSessionEnd = originalTrackSessionEnd;
     telemetry.flush = originalFlush;
   });
@@ -48,6 +57,7 @@ describe("listen subcommand telemetry", () => {
     telemetry.trackSessionEnd =
       trackSessionEndMock as typeof telemetry.trackSessionEnd;
     telemetry.flush = flushMock as typeof telemetry.flush;
+    process.env.LETTA_BASE_URL = "https://self-hosted.example.com";
 
     const exitCode = await runListenSubcommand(["--env-name", "ci-env"]);
 

--- a/src/types/letta-client-augmentations.d.ts
+++ b/src/types/letta-client-augmentations.d.ts
@@ -6,5 +6,3 @@ declare module "@letta-ai/letta-client/resources/agents/messages" {
     otid?: string | null;
   }
 }
-
-export {};


### PR DESCRIPTION
## Summary

- When `letta server` runs without a `LETTA_API_KEY` and is pointing at `api.letta.com`, it now starts an OAuth Device Code Flow instead of exiting with an error
- Prints an authorization URL and code to stdout (visible in cloud deploy logs)
- Polls until the user approves in their browser, then saves tokens and connects
- On restart, saved tokens are reused; expired access tokens are auto-refreshed using the stored refresh token
- Self-hosted servers (`LETTA_BASE_URL` != `api.letta.com`) still require `LETTA_API_KEY` and show the existing error

Tested end-to-end on Railway: container starts, prints OAuth URL, user approves in browser, container authenticates and connects to WebSocket.

Written by Cameron ◯ Letta Code