### PR TITLE
fix(memory): unstage paths after commit hook failure

### DIFF
--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -569,15 +569,23 @@ async function commitAndPush(
   const authorName = agentName.trim() || agentId;
   const authorEmail = `${agentId}@letta.com`;
 
-  await runGit(memoryDir, [
-    "-c",
-    `user.name=${authorName}`,
-    "-c",
-    `user.email=${authorEmail}`,
-    "commit",
-    "-m",
-    reason,
-  ]);
+  try {
+    await runGit(memoryDir, [
+      "-c",
+      `user.name=${authorName}`,
+      "-c",
+      `user.email=${authorEmail}`,
+      "commit",
+      "-m",
+      reason,
+    ]);
+  } catch (error) {
+    // If commit fails (e.g. pre-commit hook rejects staged changes),
+    // unstage just the paths this memory operation added so future memory
+    // commands do not inherit stale staged entries.
+    await unstagePaths(memoryDir, pathspecs);
+    throw error;
+  }
 
   const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
   const sha = head.stdout.trim();
@@ -597,6 +605,21 @@ async function commitAndPush(
     committed: true,
     sha,
   };
+}
+
+async function unstagePaths(
+  memoryDir: string,
+  pathspecs: string[],
+): Promise<void> {
+  if (pathspecs.length === 0) {
+    return;
+  }
+
+  try {
+    await runGit(memoryDir, ["reset", "HEAD", "--", ...pathspecs]);
+  } catch {
+    // Best-effort cleanup only — keep original error from commit path.
+  }
 }
 
 function requireString(


### PR DESCRIPTION
## Summary
- reset staged paths for the current memory operation when `git commit` fails in the memory tool
- prevent stale staged files from poisoning subsequent memory operations after a pre-commit/frontmatter validation failure
- keep cleanup best-effort and preserve the original commit failure error

## Test plan
- [x] `bun run check`
- [x] Reproduced original failure mode conceptually: first invalid staged file blocks second valid create
- [x] Verified code path now calls `git reset HEAD -- <pathspecs>` on commit failure

👾 Generated with [Letta Code](https://letta.com)