### PR TITLE
feat(telemetry): track reflection start/end with message id range

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10578,12 +10578,17 @@ export default function App({
             const { spawnBackgroundSubagentTask } = await import(
               "../tools/impl/Task"
             );
-            spawnBackgroundSubagentTask({
+            const { subagentId } = spawnBackgroundSubagentTask({
               subagentType: "reflection",
               prompt: reflectionPrompt,
               description: "Reflecting on conversation",
               silentCompletion: true,
               onComplete: async ({ success, error }) => {
+                telemetry.trackReflectionEnd("manual", success, {
+                  subagentId,
+                  conversationId: reflectionConversationId,
+                  error,
+                });
                 await finalizeAutoReflectionPayload(
                   agentId,
                   reflectionConversationId,
@@ -10611,6 +10616,12 @@ export default function App({
                 );
                 appendTaskNotificationEvents([msg]);
               },
+            });
+            telemetry.trackReflectionStart("manual", {
+              subagentId,
+              conversationId: reflectionConversationId,
+              startMessageId: autoPayload.startMessageId,
+              endMessageId: autoPayload.endMessageId,
             });
 
             cmd.finish(
@@ -11040,12 +11051,17 @@ ${SYSTEM_REMINDER_CLOSE}
           const { spawnBackgroundSubagentTask } = await import(
             "../tools/impl/Task"
           );
-          spawnBackgroundSubagentTask({
+          const { subagentId } = spawnBackgroundSubagentTask({
             subagentType: "reflection",
             prompt: reflectionPrompt,
             description: AUTO_REFLECTION_DESCRIPTION,
             silentCompletion: true,
             onComplete: async ({ success, error }) => {
+              telemetry.trackReflectionEnd(triggerSource, success, {
+                subagentId,
+                conversationId: reflectionConversationId,
+                error,
+              });
               await finalizeAutoReflectionPayload(
                 agentId,
                 reflectionConversationId,
@@ -11073,6 +11089,12 @@ ${SYSTEM_REMINDER_CLOSE}
               );
               appendTaskNotificationEvents([msg]);
             },
+          });
+          telemetry.trackReflectionStart(triggerSource, {
+            subagentId,
+            conversationId: reflectionConversationId,
+            startMessageId: autoPayload.startMessageId,
+            endMessageId: autoPayload.endMessageId,
           });
           debugLog(
             "memory",

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -27,6 +27,7 @@ type TranscriptEntry =
       kind: "user" | "assistant" | "reasoning" | "error";
       text: string;
       captured_at: string;
+      source_line_id?: string;
     }
   | {
       kind: "tool_call";
@@ -35,6 +36,7 @@ type TranscriptEntry =
       resultText?: string;
       resultOk?: boolean;
       captured_at: string;
+      source_line_id?: string;
     };
 
 export interface ReflectionTranscriptPaths {
@@ -46,6 +48,8 @@ export interface ReflectionTranscriptPaths {
 
 export interface AutoReflectionPayload {
   payloadPath: string;
+  startMessageId?: string;
+  endMessageId?: string;
   endSnapshotLine: number;
 }
 
@@ -386,13 +390,33 @@ function lineToTranscriptEntry(
 ): TranscriptEntry | null {
   switch (line.kind) {
     case "user":
-      return { kind: "user", text: line.text, captured_at: capturedAt };
+      return {
+        kind: "user",
+        text: line.text,
+        captured_at: capturedAt,
+        source_line_id: line.id,
+      };
     case "assistant":
-      return { kind: "assistant", text: line.text, captured_at: capturedAt };
+      return {
+        kind: "assistant",
+        text: line.text,
+        captured_at: capturedAt,
+        source_line_id: line.id,
+      };
     case "reasoning":
-      return { kind: "reasoning", text: line.text, captured_at: capturedAt };
+      return {
+        kind: "reasoning",
+        text: line.text,
+        captured_at: capturedAt,
+        source_line_id: line.id,
+      };
     case "error":
-      return { kind: "error", text: line.text, captured_at: capturedAt };
+      return {
+        kind: "error",
+        text: line.text,
+        captured_at: capturedAt,
+        source_line_id: line.id,
+      };
     case "tool_call":
       return {
         kind: "tool_call",
@@ -401,6 +425,7 @@ function lineToTranscriptEntry(
         resultText: line.resultText,
         resultOk: line.resultOk,
         captured_at: capturedAt,
+        source_line_id: line.id,
       };
     default:
       return null;
@@ -537,6 +562,11 @@ export async function buildAutoReflectionPayload(
   const entries = snapshotLines
     .map((line) => parseJsonLine<TranscriptEntry>(line))
     .filter((entry): entry is TranscriptEntry => entry !== null);
+  const messageIds = entries
+    .map((entry) => entry.source_line_id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  const startMessageId = messageIds[0];
+  const endMessageId = messageIds[messageIds.length - 1];
   const transcript = formatTaggedTranscript(entries);
   if (!transcript) {
     return null;
@@ -550,6 +580,8 @@ export async function buildAutoReflectionPayload(
 
   return {
     payloadPath,
+    startMessageId,
+    endMessageId,
     endSnapshotLine: lines.length,
   };
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -7,7 +7,14 @@ import { getVersion } from "../version";
 export type TelemetrySurface = "tui" | "headless" | "websocket";
 
 export interface TelemetryEvent {
-  type: "session_start" | "session_end" | "tool_usage" | "error" | "user_input";
+  type:
+    | "session_start"
+    | "session_end"
+    | "tool_usage"
+    | "error"
+    | "user_input"
+    | "reflection_start"
+    | "reflection_end";
   timestamp: string;
   data: Record<string, unknown>;
 }
@@ -63,6 +70,22 @@ export interface UserInputData {
   command_name?: string;
   message_type: string;
   model_id: string;
+}
+
+export interface ReflectionStartData {
+  trigger_source: "manual" | "step-count" | "compaction-event";
+  subagent_id?: string;
+  conversation_id?: string;
+  start_message_id?: string;
+  end_message_id?: string;
+}
+
+export interface ReflectionEndData {
+  trigger_source: "manual" | "step-count" | "compaction-event";
+  success: boolean;
+  subagent_id?: string;
+  conversation_id?: string;
+  error?: string;
 }
 
 class TelemetryManager {
@@ -241,7 +264,9 @@ class TelemetryManager {
       | SessionEndData
       | ToolUsageData
       | ErrorData
-      | UserInputData,
+      | UserInputData
+      | ReflectionStartData
+      | ReflectionEndData,
   ) {
     if (!this.isTelemetryEnabled()) {
       return;
@@ -513,6 +538,50 @@ class TelemetryManager {
       model_id: modelId,
     };
     this.track("user_input", data);
+  }
+
+  /**
+   * Track reflection start events (manual and auto-triggered).
+   */
+  trackReflectionStart(
+    triggerSource: "manual" | "step-count" | "compaction-event",
+    options?: {
+      subagentId?: string;
+      conversationId?: string;
+      startMessageId?: string;
+      endMessageId?: string;
+    },
+  ) {
+    const data: ReflectionStartData = {
+      trigger_source: triggerSource,
+      subagent_id: options?.subagentId,
+      conversation_id: options?.conversationId,
+      start_message_id: options?.startMessageId,
+      end_message_id: options?.endMessageId,
+    };
+    this.track("reflection_start", data);
+  }
+
+  /**
+   * Track reflection completion events.
+   */
+  trackReflectionEnd(
+    triggerSource: "manual" | "step-count" | "compaction-event",
+    success: boolean,
+    options?: {
+      subagentId?: string;
+      conversationId?: string;
+      error?: string;
+    },
+  ) {
+    const data: ReflectionEndData = {
+      trigger_source: triggerSource,
+      success,
+      subagent_id: options?.subagentId,
+      conversation_id: options?.conversationId,
+      error: options?.error,
+    };
+    this.track("reflection_end", data);
   }
 
   /**

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -59,6 +59,8 @@ describe("reflectionTranscript helper", () => {
     const payload = await buildAutoReflectionPayload(agentId, conversationId);
     expect(payload).not.toBeNull();
     if (!payload) return;
+    expect(payload.startMessageId).toBe("u1");
+    expect(payload.endMessageId).toBe("a1");
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
     expect(payloadText).toContain("<user>hello</user>");
@@ -94,6 +96,8 @@ describe("reflectionTranscript helper", () => {
     const payload = await buildAutoReflectionPayload(agentId, conversationId);
     expect(payload).not.toBeNull();
     if (!payload) return;
+    expect(payload.startMessageId).toBe("u1");
+    expect(payload.endMessageId).toBe("u1");
 
     await finalizeAutoReflectionPayload(
       agentId,
@@ -144,6 +148,8 @@ describe("reflectionTranscript helper", () => {
     );
     expect(secondAttempt).not.toBeNull();
     if (!secondAttempt) return;
+    expect(secondAttempt.startMessageId).toBe("a2");
+    expect(secondAttempt.endMessageId).toBe("a2");
 
     const payloadText = await readFile(secondAttempt.payloadPath, "utf-8");
     expect(payloadText).toContain("<assistant>second</assistant>");

--- a/src/tests/telemetry/reflection-events-wiring.test.ts
+++ b/src/tests/telemetry/reflection-events-wiring.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("reflection telemetry wiring", () => {
+  test("telemetry manager exposes reflection start/end event types and trackers", () => {
+    const telemetryPath = fileURLToPath(
+      new URL("../../telemetry/index.ts", import.meta.url),
+    );
+    const telemetrySource = readFileSync(telemetryPath, "utf-8");
+
+    expect(telemetrySource).toContain('"reflection_start"');
+    expect(telemetrySource).toContain('"reflection_end"');
+    expect(telemetrySource).toContain("trackReflectionStart(");
+    expect(telemetrySource).toContain("trackReflectionEnd(");
+    expect(telemetrySource).toContain("start_message_id");
+    expect(telemetrySource).toContain("end_message_id");
+  });
+
+  test("interactive app tracks reflection start/end for manual and auto launches", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const appSource = readFileSync(appPath, "utf-8");
+
+    expect(appSource).toContain('telemetry.trackReflectionStart("manual"');
+    expect(appSource).toContain('telemetry.trackReflectionEnd("manual"');
+    expect(appSource).toContain("telemetry.trackReflectionStart(triggerSource");
+    expect(appSource).toContain("telemetry.trackReflectionEnd(triggerSource");
+    expect(appSource).toContain("startMessageId: autoPayload.startMessageId");
+    expect(appSource).toContain("endMessageId: autoPayload.endMessageId");
+  });
+
+  test("listener turn loop tracks reflection start/end for auto launches", () => {
+    const turnPath = fileURLToPath(
+      new URL("../../websocket/listener/turn.ts", import.meta.url),
+    );
+    const turnSource = readFileSync(turnPath, "utf-8");
+
+    expect(turnSource).toContain(
+      "telemetry.trackReflectionStart(triggerSource",
+    );
+    expect(turnSource).toContain("telemetry.trackReflectionEnd(triggerSource");
+    expect(turnSource).toContain("startMessageId: autoPayload.startMessageId");
+    expect(turnSource).toContain("endMessageId: autoPayload.endMessageId");
+  });
+});

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -199,7 +199,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
       );
       const reflectionSuccessSummary =
         "Reflected on the memory palace, the halls remember more now";
-      spawnBackgroundSubagentTask({
+      const { subagentId } = spawnBackgroundSubagentTask({
         subagentType: "reflection",
         prompt: reflectionPrompt,
         description: AUTO_REFLECTION_DESCRIPTION,
@@ -211,6 +211,11 @@ function buildMaybeLaunchReflectionSubagent(params: {
             : `Tried to reflect, but got lost in the palace: ${error || "Unknown error"}`,
         parentScope: { agentId, conversationId },
         onComplete: async ({ success, error }) => {
+          telemetry.trackReflectionEnd(triggerSource, success, {
+            subagentId,
+            conversationId,
+            error,
+          });
           await finalizeAutoReflectionPayload(
             agentId,
             conversationId,
@@ -236,6 +241,12 @@ function buildMaybeLaunchReflectionSubagent(params: {
             },
           );
         },
+      });
+      telemetry.trackReflectionStart(triggerSource, {
+        subagentId,
+        conversationId,
+        startMessageId: autoPayload.startMessageId,
+        endMessageId: autoPayload.endMessageId,
       });
 
       debugLog(


### PR DESCRIPTION
## Summary
- add `reflection_start` and `reflection_end` telemetry events to the Letta Code telemetry manager
- include reflection trigger metadata (`manual`, `step-count`, `compaction-event`) plus `subagent_id` and `conversation_id`
- include reflection source message range on start events (`start_message_id`, `end_message_id`) by propagating IDs from reflection transcript payload generation

## Test plan
- [x] `bun test src/tests/telemetry/reflection-events-wiring.test.ts src/tests/cli/reflection-transcript.test.ts src/tests/cli/reflection-auto-launch-wiring.test.ts src/tests/websocket/listen-reflection-wiring.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)