### PR TITLE
feat: enable LETTA_RESPONSES_WS=1 by default in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "fix": "bunx --bun @biomejs/biome@2.2.5 check --write src",
     "typecheck": "tsc --noEmit",
     "check": "bun run scripts/check.js",
-    "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts",
+    "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts",
     "build": "node scripts/postinstall-patches.js && bun run build.js",
     "test:update-chain:manual": "bun run src/tests/update-chain-smoke.ts --mode manual",
     "test:update-chain:startup": "bun run src/tests/update-chain-smoke.ts --mode startup",


### PR DESCRIPTION
## Summary
Add `LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1}` to the `bun run dev` script so the WebSocket Responses API header is enabled by default during local development.

Uses the same `${VAR:-default}` pattern as `LETTA_DEBUG`. Override with `LETTA_RESPONSES_WS=0 bun run dev` to disable.

## Test plan
- [ ] `bun run dev` → verify `LETTA_RESPONSES_WS=1` is in the env
- [ ] `LETTA_RESPONSES_WS=0 bun run dev` → verify it's overridden to 0