### PR TITLE
feat: channels system with Telegram MVP (WS-only, listener mode)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
         "@letta-ai/letta-client": "1.10.1",
         "glob": "^13.0.0",
+        "grammy": "^1.42.0",
         "highlight.js": "^11.11.1",
         "ink-link": "^5.0.0",
         "lowlight": "^3.3.0",
@@ -41,6 +41,8 @@
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -116,6 +118,8 @@
 
     "@vscode/ripgrep": ["@vscode/ripgrep@1.17.0", "", { "dependencies": { "https-proxy-agent": "^7.0.2", "proxy-from-env": "^1.1.0", "yauzl": "^2.9.2" } }, "sha512-mBRKm+ASPkUcw4o9aAgfbusIu6H4Sdhw09bjeP1YOBFTJEZAnrnk6WZwzv8NEjgC82f7ILvhmb1WIElSugea6g=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
@@ -178,6 +182,8 @@
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
@@ -187,6 +193,8 @@
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
+
+    "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
 
     "has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
 
@@ -248,6 +256,8 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
@@ -302,6 +312,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -309,6 +321,10 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 

--- a/docs/channels-telegram.md
+++ b/docs/channels-telegram.md
@@ -1,0 +1,21 @@
+# Telegram Channels MVP
+
+Current setup flow:
+
+1. Run `letta channels configure telegram`.
+2. Start the listener with `letta server --channels telegram`.
+3. Message the bot from Telegram once to receive a pairing code.
+4. In the target ADE/Desktop conversation, run `/channels telegram pair <code>`.
+5. Continue chatting with the agent from Telegram.
+
+Persisted state lives under `~/.letta/channels/telegram/`:
+
+- `config.yaml`: bot token, enabled flag, DM policy
+- `pairing.yaml`: pending pairing codes and approved users
+- `routing.yaml`: Telegram `chat_id` to Letta `agent_id` + `conversation_id` bindings
+
+Notes:
+
+- Channel config is machine-scoped, not agent-scoped.
+- The recommended live management path is the `/channels ...` command from the target ADE/Desktop conversation.
+- Standalone `letta channels route ...` and `letta channels pair ...` commands modify files on disk, but a running listener may not pick them up immediately.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@letta-ai/letta-client": "1.10.1",
     "glob": "^13.0.0",
+    "grammy": "^1.42.0",
     "highlight.js": "^11.11.1",
     "ink-link": "^5.0.0",
     "lowlight": "^3.3.0",

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -1,0 +1,210 @@
+/**
+ * Channel config read/write helpers.
+ *
+ * Channel configs live at ~/.letta/channels/<channel_name>/config.yaml.
+ * This module handles reading, writing, and validating channel configs.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ChannelConfig, DmPolicy, TelegramChannelConfig } from "./types";
+
+// ── Paths ─────────────────────────────────────────────────────────
+
+const CHANNELS_ROOT = join(homedir(), ".letta", "channels");
+
+export function getChannelsRoot(): string {
+  return CHANNELS_ROOT;
+}
+
+export function getChannelDir(channelId: string): string {
+  return join(CHANNELS_ROOT, channelId);
+}
+
+export function getChannelConfigPath(channelId: string): string {
+  return join(getChannelDir(channelId), "config.yaml");
+}
+
+export function getChannelRoutingPath(channelId: string): string {
+  return join(getChannelDir(channelId), "routing.yaml");
+}
+
+export function getChannelPairingPath(channelId: string): string {
+  return join(getChannelDir(channelId), "pairing.yaml");
+}
+
+// ── YAML helpers ──────────────────────────────────────────────────
+
+/**
+ * Minimal YAML serializer for flat/shallow objects.
+ * Avoids pulling in a full YAML library for simple config files.
+ */
+function toSimpleYaml(obj: Record<string, unknown>, indent = 0): string {
+  const prefix = " ".repeat(indent);
+  const lines: string[] = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        lines.push(`${prefix}${key}: []`);
+      } else if (
+        typeof value[0] === "object" &&
+        value[0] !== null &&
+        !Array.isArray(value[0])
+      ) {
+        lines.push(`${prefix}${key}:`);
+        for (const item of value) {
+          const itemLines = toSimpleYaml(
+            item as Record<string, unknown>,
+            indent + 4,
+          ).split("\n");
+          if (itemLines.length > 0 && itemLines[0]) {
+            lines.push(`${prefix}  - ${itemLines[0].trimStart()}`);
+            for (let i = 1; i < itemLines.length; i++) {
+              if (itemLines[i]) {
+                lines.push(`${prefix}    ${itemLines[i]?.trimStart()}`);
+              }
+            }
+          }
+        }
+      } else {
+        lines.push(`${prefix}${key}:`);
+        for (const item of value) {
+          lines.push(`${prefix}  - ${JSON.stringify(item)}`);
+        }
+      }
+    } else if (typeof value === "object" && value !== null) {
+      lines.push(`${prefix}${key}:`);
+      lines.push(toSimpleYaml(value as Record<string, unknown>, indent + 2));
+    } else if (typeof value === "string") {
+      lines.push(`${prefix}${key}: ${JSON.stringify(value)}`);
+    } else {
+      lines.push(`${prefix}${key}: ${String(value)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Minimal YAML parser for simple key-value configs.
+ * Handles: strings, booleans, numbers, simple arrays.
+ */
+function parseSimpleYaml(text: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = text.split("\n");
+  let currentKey: string | null = null;
+  let currentArray: unknown[] | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line || line.startsWith("#")) continue;
+
+    // Array item
+    const arrayMatch = line.match(/^\s+-\s+(.*)/);
+    if (arrayMatch && currentKey && currentArray) {
+      const val = parseYamlValue(arrayMatch[1]?.trim() ?? "");
+      currentArray.push(val);
+      continue;
+    }
+
+    // Key-value pair
+    const kvMatch = line.match(/^(\w[\w_]*)\s*:\s*(.*)/);
+    if (kvMatch) {
+      // Save previous array if any
+      if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+        currentArray = null;
+      }
+
+      const key = kvMatch[1] as string;
+      const rawValue = (kvMatch[2] ?? "").trim();
+
+      if (rawValue === "" || rawValue === "[]") {
+        currentKey = key;
+        currentArray = rawValue === "[]" ? [] : [];
+        result[key] = currentArray;
+      } else {
+        currentKey = null;
+        currentArray = null;
+        result[key] = parseYamlValue(rawValue);
+      }
+    }
+  }
+
+  // Save trailing array
+  if (currentKey && currentArray) {
+    result[currentKey] = currentArray;
+  }
+
+  return result;
+}
+
+function parseYamlValue(raw: string): unknown {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null") return null;
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+  // Strip quotes
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+// ── Config read/write ─────────────────────────────────────────────
+
+export function channelConfigExists(channelId: string): boolean {
+  return existsSync(getChannelConfigPath(channelId));
+}
+
+export function readChannelConfig(channelId: string): ChannelConfig | null {
+  const configPath = getChannelConfigPath(channelId);
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const text = readFileSync(configPath, "utf-8");
+    const parsed = parseSimpleYaml(text);
+
+    if (channelId === "telegram") {
+      return {
+        channel: "telegram",
+        enabled: parsed.enabled !== false,
+        token: String(parsed.token ?? ""),
+        dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
+        allowedUsers: (parsed.allowed_users as string[]) ?? [],
+      } satisfies TelegramChannelConfig;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeChannelConfig(
+  channelId: string,
+  config: ChannelConfig,
+): void {
+  const dir = getChannelDir(channelId);
+  mkdirSync(dir, { recursive: true });
+
+  const yamlObj: Record<string, unknown> = {};
+
+  if (config.channel === "telegram") {
+    yamlObj.channel = config.channel;
+    yamlObj.enabled = config.enabled;
+    yamlObj.token = config.token;
+    yamlObj.dm_policy = config.dmPolicy;
+    yamlObj.allowed_users = config.allowedUsers;
+  }
+
+  const text = toSimpleYaml(yamlObj);
+  writeFileSync(getChannelConfigPath(channelId), `${text}\n`, "utf-8");
+}

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -1,0 +1,220 @@
+/**
+ * Channel pairing store.
+ *
+ * Handles the pairing flow for channels with dm_policy: "pairing".
+ * When an unknown user messages the bot, they get a pairing code.
+ * The user runs `/channels telegram pair <code>` to approve the connection.
+ *
+ * Persisted in ~/.letta/channels/<channel>/pairing.yaml.
+ *
+ * Reference: lettabot src/pairing/store.ts
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { getChannelDir, getChannelPairingPath } from "./config";
+import type { ApprovedUser, PairingStore, PendingPairing } from "./types";
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/** Pairing codes expire after 15 minutes. */
+const PAIRING_CODE_TTL_MS = 15 * 60 * 1000;
+
+/** Maximum pending pairing codes to keep. */
+const MAX_PENDING_CODES = 50;
+
+/** Code character set (uppercase alphanumeric, no ambiguous chars). */
+const CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // No I, O, 0, 1
+
+// ── In-memory store ───────────────────────────────────────────────
+
+const stores = new Map<string, PairingStore>();
+
+function getStore(channelId: string): PairingStore {
+  let store = stores.get(channelId);
+  if (!store) {
+    store = { pending: [], approved: [] };
+    stores.set(channelId, store);
+  }
+  return store;
+}
+
+// ── Load/save ─────────────────────────────────────────────────────
+
+export function loadPairingStore(channelId: string): void {
+  const path = getChannelPairingPath(channelId);
+  if (!existsSync(path)) return;
+
+  try {
+    const text = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(text) as Partial<PairingStore>;
+    stores.set(channelId, {
+      pending: parsed.pending ?? [],
+      approved: parsed.approved ?? [],
+    });
+  } catch {
+    // Corrupted — start fresh.
+  }
+}
+
+function savePairingStore(channelId: string): void {
+  const dir = getChannelDir(channelId);
+  mkdirSync(dir, { recursive: true });
+
+  const store = getStore(channelId);
+  writeFileSync(
+    getChannelPairingPath(channelId),
+    `${JSON.stringify(store, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+// ── Code generation ───────────────────────────────────────────────
+
+function generateCode(length = 6): string {
+  let code = "";
+  for (let i = 0; i < length; i++) {
+    code += CODE_CHARS[Math.floor(Math.random() * CODE_CHARS.length)];
+  }
+  return code;
+}
+
+// ── Pairing operations ────────────────────────────────────────────
+
+/**
+ * Check if a user is approved (has completed pairing).
+ */
+export function isUserApproved(channelId: string, userId: string): boolean {
+  const store = getStore(channelId);
+  return store.approved.some((u) => u.telegramUserId === userId);
+}
+
+/**
+ * Create a pending pairing code for an unknown user.
+ * Returns the generated code.
+ */
+export function createPairingCode(
+  channelId: string,
+  userId: string,
+  chatId: string,
+  username?: string,
+): string {
+  const store = getStore(channelId);
+
+  // Remove any existing pending code for this user
+  store.pending = store.pending.filter((p) => p.telegramUserId !== userId);
+
+  // Prune expired codes
+  const now = Date.now();
+  store.pending = store.pending.filter(
+    (p) => new Date(p.expiresAt).getTime() > now,
+  );
+
+  // Enforce max pending limit
+  while (store.pending.length >= MAX_PENDING_CODES) {
+    store.pending.shift();
+  }
+
+  const code = generateCode();
+  const pending: PendingPairing = {
+    code,
+    telegramUserId: userId,
+    telegramUsername: username,
+    chatId,
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(now + PAIRING_CODE_TTL_MS).toISOString(),
+  };
+
+  store.pending.push(pending);
+  savePairingStore(channelId);
+
+  return code;
+}
+
+/**
+ * Validate and consume a pairing code.
+ * Returns the pending pairing info if valid, null if invalid/expired.
+ */
+export function consumePairingCode(
+  channelId: string,
+  code: string,
+): PendingPairing | null {
+  const store = getStore(channelId);
+  const upperCode = code.toUpperCase();
+
+  const index = store.pending.findIndex((p) => p.code === upperCode);
+  if (index === -1) return null;
+
+  const pending = store.pending[index] as PendingPairing;
+
+  // Check expiry
+  if (new Date(pending.expiresAt).getTime() < Date.now()) {
+    // Remove expired code
+    store.pending.splice(index, 1);
+    savePairingStore(channelId);
+    return null;
+  }
+
+  // Remove from pending
+  store.pending.splice(index, 1);
+
+  // Add to approved (if not already)
+  if (
+    !store.approved.some((u) => u.telegramUserId === pending.telegramUserId)
+  ) {
+    const approved: ApprovedUser = {
+      telegramUserId: pending.telegramUserId,
+      telegramUsername: pending.telegramUsername,
+      approvedAt: new Date().toISOString(),
+    };
+    store.approved.push(approved);
+  }
+
+  savePairingStore(channelId);
+  return pending;
+}
+
+/**
+ * Get all pending pairing codes for a channel.
+ * Filters out expired codes.
+ */
+export function getPendingPairings(channelId: string): PendingPairing[] {
+  const store = getStore(channelId);
+  const now = Date.now();
+  return store.pending.filter((p) => new Date(p.expiresAt).getTime() > now);
+}
+
+/**
+ * Get all approved users for a channel.
+ */
+export function getApprovedUsers(channelId: string): ApprovedUser[] {
+  return getStore(channelId).approved;
+}
+
+/**
+ * Roll back a pairing approval.
+ * Re-adds the pending code and removes the approved user entry.
+ * Used when route creation fails after pairing was consumed.
+ */
+export function rollbackPairingApproval(
+  channelId: string,
+  pending: PendingPairing,
+): void {
+  const store = getStore(channelId);
+
+  // Remove from approved
+  store.approved = store.approved.filter(
+    (u) => u.telegramUserId !== pending.telegramUserId,
+  );
+
+  // Re-add to pending
+  store.pending.push(pending);
+
+  savePairingStore(channelId);
+}
+
+/**
+ * Clear all pairing state (for testing).
+ */
+export function clearPairingStores(): void {
+  stores.clear();
+}

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -180,6 +180,10 @@ export class ChannelRegistry {
         return;
       }
     } else if (config.dmPolicy === "pairing") {
+      // Reload pairing store from disk on miss (allows standalone CLI pairing)
+      if (!isUserApproved(msg.channel, msg.senderId)) {
+        loadPairingStore(msg.channel);
+      }
       if (!isUserApproved(msg.channel, msg.senderId)) {
         // Generate pairing code
         const code = createPairingCode(

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -199,8 +199,12 @@ export class ChannelRegistry {
     }
     // dm_policy === "open" → skip check
 
-    // 2. Route lookup
-    const route = getRouteFromStore(msg.channel, msg.chatId);
+    // 2. Route lookup (reload from disk on miss — allows standalone CLI pairing)
+    let route = getRouteFromStore(msg.channel, msg.chatId);
+    if (!route) {
+      loadRoutes(msg.channel);
+      route = getRouteFromStore(msg.channel, msg.chatId);
+    }
     if (!route) {
       await adapter.sendDirectReply(
         msg.chatId,

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,0 +1,335 @@
+/**
+ * Channel Registry — singleton that manages channel adapters, routing,
+ * pairing, and the ingress pipeline.
+ *
+ * Lifecycle:
+ * 1. initializeChannels() creates adapters from configs
+ * 2. Adapters start long-polling (buffer inbound until ready)
+ * 3. setReady() is called from inside startListenerClient() once closure state exists
+ * 4. Buffered messages flush through the registered onMessage handler
+ */
+
+import { readChannelConfig } from "./config";
+import {
+  consumePairingCode,
+  createPairingCode,
+  isUserApproved,
+  loadPairingStore,
+  rollbackPairingApproval,
+} from "./pairing";
+import {
+  addRoute,
+  getRoute as getRouteFromStore,
+  getRouteRaw,
+  loadRoutes,
+  removeRouteInMemory,
+  setRouteInMemory,
+} from "./routing";
+import type {
+  ChannelAdapter,
+  ChannelRoute,
+  InboundChannelMessage,
+} from "./types";
+import { formatChannelNotification } from "./xml";
+
+// ── Singleton ─────────────────────────────────────────────────────
+
+let instance: ChannelRegistry | null = null;
+
+export function getChannelRegistry(): ChannelRegistry | null {
+  return instance;
+}
+
+export function getActiveChannelIds(): string[] {
+  if (!instance) return [];
+  return instance.getActiveChannelIds();
+}
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export type ChannelMessageHandler = (
+  route: ChannelRoute,
+  xmlContent: string,
+) => void;
+
+// ── Registry ──────────────────────────────────────────────────────
+
+export class ChannelRegistry {
+  private readonly adapters = new Map<string, ChannelAdapter>();
+  private ready = false;
+  private messageHandler: ChannelMessageHandler | null = null;
+  private readonly buffer: Array<{
+    route: ChannelRoute;
+    xmlContent: string;
+  }> = [];
+
+  constructor() {
+    if (instance) {
+      throw new Error(
+        "ChannelRegistry is a singleton — use getChannelRegistry()",
+      );
+    }
+    instance = this;
+  }
+
+  // ── Adapter management ────────────────────────────────────────
+
+  registerAdapter(adapter: ChannelAdapter): void {
+    this.adapters.set(adapter.id, adapter);
+
+    // Wire the adapter's onMessage to our ingress pipeline
+    adapter.onMessage = async (msg: InboundChannelMessage) => {
+      await this.handleInboundMessage(msg);
+    };
+  }
+
+  getAdapter(channelId: string): ChannelAdapter | null {
+    return this.adapters.get(channelId) ?? null;
+  }
+
+  getActiveChannelIds(): string[] {
+    return Array.from(this.adapters.entries())
+      .filter(([_, adapter]) => adapter.isRunning())
+      .map(([id]) => id);
+  }
+
+  // ── Readiness / ingress handler ───────────────────────────────
+
+  /**
+   * Set the message handler and mark the registry as ready.
+   * Called from inside startListenerClient() with closure-scoped state.
+   */
+  setMessageHandler(handler: ChannelMessageHandler): void {
+    this.messageHandler = handler;
+  }
+
+  /**
+   * Mark the registry as ready, flushing any buffered messages.
+   */
+  setReady(): void {
+    this.ready = true;
+    this.flushBuffer();
+  }
+
+  /**
+   * Check if the registry is ready to deliver messages.
+   */
+  isReady(): boolean {
+    return this.ready && this.messageHandler !== null;
+  }
+
+  // ── Routing ───────────────────────────────────────────────────
+
+  getRoute(channel: string, chatId: string): ChannelRoute | null {
+    return getRouteFromStore(channel, chatId);
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────
+
+  async startAll(): Promise<void> {
+    for (const adapter of Array.from(this.adapters.values())) {
+      if (!adapter.isRunning()) {
+        await adapter.start();
+      }
+    }
+  }
+
+  /**
+   * Pause delivery without stopping adapters.
+   * Called on WS disconnect — adapters keep polling, messages buffer.
+   * On reconnect, wireChannelIngress re-registers the handler and calls setReady().
+   */
+  pause(): void {
+    this.ready = false;
+    this.messageHandler = null;
+  }
+
+  /**
+   * Fully stop all adapters and destroy the singleton.
+   * Only called on actual process shutdown, NOT on WS disconnect.
+   */
+  async stopAll(): Promise<void> {
+    for (const adapter of Array.from(this.adapters.values())) {
+      if (adapter.isRunning()) {
+        await adapter.stop();
+      }
+    }
+    this.ready = false;
+    this.messageHandler = null;
+    instance = null;
+  }
+
+  // ── Inbound message pipeline ──────────────────────────────────
+
+  private async handleInboundMessage(
+    msg: InboundChannelMessage,
+  ): Promise<void> {
+    const adapter = this.getAdapter(msg.channel);
+    if (!adapter) return;
+
+    const config = readChannelConfig(msg.channel);
+    if (!config) return;
+
+    // 1. Check pairing/allowlist policy
+    if (config.dmPolicy === "allowlist") {
+      if (!config.allowedUsers.includes(msg.senderId)) {
+        await adapter.sendDirectReply(
+          msg.chatId,
+          "You are not on the allowed users list for this bot.",
+        );
+        return;
+      }
+    } else if (config.dmPolicy === "pairing") {
+      if (!isUserApproved(msg.channel, msg.senderId)) {
+        // Generate pairing code
+        const code = createPairingCode(
+          msg.channel,
+          msg.senderId,
+          msg.chatId,
+          msg.senderName,
+        );
+        await adapter.sendDirectReply(
+          msg.chatId,
+          `To connect this chat to a Letta Code agent, run:\n\n` +
+            `/channels telegram pair ${code}\n\n` +
+            `This code expires in 15 minutes.`,
+        );
+        return;
+      }
+    }
+    // dm_policy === "open" → skip check
+
+    // 2. Route lookup
+    const route = getRouteFromStore(msg.channel, msg.chatId);
+    if (!route) {
+      await adapter.sendDirectReply(
+        msg.chatId,
+        `This chat isn't bound to an agent. ` +
+          `Run \`/channels telegram enable --chat-id ${msg.chatId}\` ` +
+          `on your Letta Code agent to connect.`,
+      );
+      return;
+    }
+
+    // 3. Format as XML
+    const xmlContent = formatChannelNotification(msg);
+
+    // 4. Deliver or buffer
+    if (this.isReady()) {
+      this.messageHandler?.(route, xmlContent);
+    } else {
+      this.buffer.push({ route, xmlContent });
+    }
+  }
+
+  private flushBuffer(): void {
+    if (!this.messageHandler) return;
+
+    while (this.buffer.length > 0) {
+      const item = this.buffer.shift();
+      if (item) {
+        this.messageHandler(item.route, item.xmlContent);
+      }
+    }
+  }
+}
+
+// ── Initialization ────────────────────────────────────────────────
+
+/**
+ * Initialize the channel system.
+ *
+ * 1. Creates the ChannelRegistry singleton
+ * 2. Loads configs, routing tables, and pairing stores
+ * 3. Creates adapters for each requested channel
+ * 4. Starts adapters (begin long-polling, buffer until ready)
+ *
+ * Does NOT set the message handler or mark ready — that happens
+ * inside startListenerClient() when closure state is available.
+ */
+export async function initializeChannels(
+  channelNames: string[],
+): Promise<ChannelRegistry> {
+  const registry = new ChannelRegistry();
+
+  for (const channelId of channelNames) {
+    const config = readChannelConfig(channelId);
+    if (!config) {
+      console.error(
+        `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`,
+      );
+      continue;
+    }
+
+    if (!config.enabled) {
+      console.log(`Channel "${channelId}" is disabled in config, skipping.`);
+      continue;
+    }
+
+    // Load persistent state
+    loadRoutes(channelId);
+    loadPairingStore(channelId);
+
+    // Create and register adapter
+    if (channelId === "telegram") {
+      const { createTelegramAdapter } = await import("./telegram/adapter");
+      const adapter = createTelegramAdapter(config);
+      registry.registerAdapter(adapter);
+    } else {
+      console.error(`Unknown channel: "${channelId}". Supported: telegram`);
+    }
+  }
+
+  // Start all adapters (begin receiving, buffer until ready)
+  await registry.startAll();
+
+  return registry;
+}
+
+/**
+ * Complete a pairing and create a route (atomic operation).
+ *
+ * Validates the pairing code, approves the user, and binds their
+ * chat to the specified agent+conversation.
+ */
+export function completePairing(
+  channelId: string,
+  code: string,
+  agentId: string,
+  conversationId: string,
+): { success: boolean; error?: string; chatId?: string } {
+  const pending = consumePairingCode(channelId, code);
+  if (!pending) {
+    return { success: false, error: "Invalid or expired pairing code." };
+  }
+
+  // Snapshot existing route so we can restore it on failure
+  const previousRoute = getRouteRaw(channelId, pending.chatId);
+
+  // Create route — roll back pairing approval AND in-memory route if this fails
+  try {
+    addRoute(channelId, {
+      chatId: pending.chatId,
+      agentId,
+      conversationId,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    // Restore in-memory route to prior state (no disk write — disk is what failed)
+    if (previousRoute) {
+      setRouteInMemory(channelId, previousRoute);
+    } else {
+      removeRouteInMemory(channelId, pending.chatId);
+    }
+    // Roll back: re-add the pending code and remove the approved user
+    rollbackPairingApproval(channelId, pending);
+    const msg = err instanceof Error ? err.message : "unknown error";
+    return {
+      success: false,
+      error: `Pairing approved but route creation failed (rolled back): ${msg}`,
+    };
+  }
+
+  return { success: true, chatId: pending.chatId };
+}

--- a/src/channels/routing.ts
+++ b/src/channels/routing.ts
@@ -1,0 +1,199 @@
+/**
+ * Channel routing table.
+ *
+ * Maps platform chat IDs to Letta agent+conversation pairs.
+ * Persisted in ~/.letta/channels/<channel>/routing.yaml.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { getChannelDir, getChannelRoutingPath } from "./config";
+import type { ChannelRoute } from "./types";
+
+// ── In-memory store ───────────────────────────────────────────────
+
+/** Key: "channel:chatId" */
+const routesByKey = new Map<string, ChannelRoute>();
+
+function routeKey(channel: string, chatId: string): string {
+  return `${channel}:${chatId}`;
+}
+
+// ── Load/save ─────────────────────────────────────────────────────
+
+/**
+ * Load routing table from disk for a given channel.
+ */
+export function loadRoutes(channelId: string): void {
+  const path = getChannelRoutingPath(channelId);
+  if (!existsSync(path)) return;
+
+  try {
+    const text = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(text) as { routes?: ChannelRoute[] };
+    const routes = parsed.routes ?? [];
+
+    for (const route of routes) {
+      if (route.chatId && route.agentId && route.conversationId) {
+        routesByKey.set(routeKey(channelId, route.chatId), {
+          chatId: route.chatId,
+          agentId: route.agentId,
+          conversationId: route.conversationId,
+          enabled: route.enabled !== false,
+          createdAt: route.createdAt ?? new Date().toISOString(),
+        });
+      }
+    }
+  } catch {
+    // Corrupted file — start fresh.
+  }
+}
+
+// Test hook: when set, saveRoutes calls this instead of writing to disk.
+let saveRoutesOverride: ((channelId: string) => void) | null = null;
+
+/** @internal Test-only: override saveRoutes behavior. Pass null to restore. */
+export function __testOverrideSaveRoutes(
+  fn: ((channelId: string) => void) | null,
+): void {
+  saveRoutesOverride = fn;
+}
+
+/**
+ * Save all routes for a given channel to disk.
+ */
+export function saveRoutes(channelId: string): void {
+  if (saveRoutesOverride) {
+    saveRoutesOverride(channelId);
+    return;
+  }
+
+  const dir = getChannelDir(channelId);
+  mkdirSync(dir, { recursive: true });
+
+  const routes = getRoutesForChannel(channelId);
+  const data = { routes };
+  writeFileSync(
+    getChannelRoutingPath(channelId),
+    `${JSON.stringify(data, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+// ── Lookup ────────────────────────────────────────────────────────
+
+/**
+ * Get the route for a specific channel + chatId.
+ * Returns null if no route exists or the route is disabled.
+ */
+export function getRoute(channel: string, chatId: string): ChannelRoute | null {
+  const route = routesByKey.get(routeKey(channel, chatId));
+  if (!route || !route.enabled) return null;
+  return route;
+}
+
+/**
+ * Get the raw route entry (including disabled), or undefined.
+ * Used for snapshotting before an overwrite.
+ */
+export function getRouteRaw(
+  channel: string,
+  chatId: string,
+): ChannelRoute | undefined {
+  return routesByKey.get(routeKey(channel, chatId));
+}
+
+/**
+ * Get all routes for a channel.
+ */
+export function getRoutesForChannel(channelId: string): ChannelRoute[] {
+  const prefix = `${channelId}:`;
+  const routes: ChannelRoute[] = [];
+  for (const [key, route] of routesByKey) {
+    if (key.startsWith(prefix)) {
+      routes.push(route);
+    }
+  }
+  return routes;
+}
+
+/**
+ * Get all routes across all channels.
+ */
+export function getAllRoutes(): ChannelRoute[] {
+  return Array.from(routesByKey.values());
+}
+
+// ── Mutations ─────────────────────────────────────────────────────
+
+/**
+ * Add or update a route. Automatically saves to disk.
+ */
+export function addRoute(channelId: string, route: ChannelRoute): void {
+  routesByKey.set(routeKey(channelId, route.chatId), route);
+  saveRoutes(channelId);
+}
+
+/**
+ * Remove a route. Automatically saves to disk.
+ */
+export function removeRoute(channelId: string, chatId: string): boolean {
+  const key = routeKey(channelId, chatId);
+  const existed = routesByKey.delete(key);
+  if (existed) {
+    saveRoutes(channelId);
+  }
+  return existed;
+}
+
+/**
+ * Remove a route from the in-memory map only (no disk write).
+ * Used by rollback paths where the original disk write already failed.
+ */
+export function removeRouteInMemory(
+  channelId: string,
+  chatId: string,
+): boolean {
+  return routesByKey.delete(routeKey(channelId, chatId));
+}
+
+/**
+ * Set a route in the in-memory map only (no disk write).
+ * Used to restore a snapshot on rollback.
+ */
+export function setRouteInMemory(channelId: string, route: ChannelRoute): void {
+  routesByKey.set(routeKey(channelId, route.chatId), route);
+}
+
+/**
+ * Remove all routes for a specific agent+conversation.
+ * Used when disabling channels for an agent.
+ */
+export function removeRoutesForScope(
+  channelId: string,
+  agentId: string,
+  conversationId: string,
+): number {
+  let removed = 0;
+  const prefix = `${channelId}:`;
+  for (const [key, route] of routesByKey) {
+    if (
+      key.startsWith(prefix) &&
+      route.agentId === agentId &&
+      route.conversationId === conversationId
+    ) {
+      routesByKey.delete(key);
+      removed++;
+    }
+  }
+  if (removed > 0) {
+    saveRoutes(channelId);
+  }
+  return removed;
+}
+
+/**
+ * Clear all in-memory routes (for testing).
+ */
+export function clearAllRoutes(): void {
+  routesByKey.clear();
+}

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -1,0 +1,137 @@
+/**
+ * Telegram channel adapter using grammY.
+ *
+ * Uses long-polling (no webhook setup needed).
+ * Reference: lettabot src/channels/telegram.ts
+ */
+
+import { Bot } from "grammy";
+import type {
+  ChannelAdapter,
+  InboundChannelMessage,
+  OutboundChannelMessage,
+  TelegramChannelConfig,
+} from "../types";
+
+export function createTelegramAdapter(
+  config: TelegramChannelConfig,
+): ChannelAdapter {
+  const bot = new Bot(config.token);
+  let running = false;
+
+  // Wire message handlers
+  bot.on("message:text", async (ctx) => {
+    const msg = ctx.message;
+    if (!msg.text) return;
+
+    const inbound: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: String(msg.chat.id),
+      senderId: String(msg.from.id),
+      senderName:
+        msg.from.username ??
+        [msg.from.first_name, msg.from.last_name].filter(Boolean).join(" "),
+      text: msg.text,
+      timestamp: msg.date * 1000,
+      messageId: String(msg.message_id),
+      raw: msg,
+    };
+
+    if (adapter.onMessage) {
+      try {
+        await adapter.onMessage(inbound);
+      } catch (err) {
+        console.error("[Telegram] Error handling inbound message:", err);
+      }
+    }
+  });
+
+  // Basic bot commands
+  bot.command("start", async (ctx) => {
+    await ctx.reply(
+      "Welcome! This bot is connected to Letta Code.\n\n" +
+        "If this is your first time, send any message and you'll " +
+        "receive a pairing code to connect to an agent.",
+    );
+  });
+
+  bot.command("status", async (ctx) => {
+    const botInfo = bot.botInfo;
+    await ctx.reply(
+      `Bot: @${botInfo.username ?? "unknown"}\n` +
+        `Status: Running\n` +
+        `DM Policy: ${config.dmPolicy}`,
+    );
+  });
+
+  const adapter: ChannelAdapter = {
+    id: "telegram",
+    name: "Telegram",
+
+    async start(): Promise<void> {
+      if (running) return;
+
+      // Fetch bot info first (validates the token)
+      await bot.init();
+      const info = bot.botInfo;
+      console.log(
+        `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
+      );
+
+      // Start long-polling in background (non-blocking)
+      bot.start({
+        onStart: () => {
+          running = true;
+        },
+      });
+    },
+
+    async stop(): Promise<void> {
+      if (!running) return;
+      bot.stop();
+      running = false;
+      console.log("[Telegram] Bot stopped");
+    },
+
+    isRunning(): boolean {
+      return running;
+    },
+
+    async sendMessage(
+      msg: OutboundChannelMessage,
+    ): Promise<{ messageId: string }> {
+      const result = await bot.api.sendMessage(
+        msg.chatId,
+        msg.text,
+        msg.replyToMessageId
+          ? { reply_parameters: { message_id: Number(msg.replyToMessageId) } }
+          : undefined,
+      );
+      return { messageId: String(result.message_id) };
+    },
+
+    async sendDirectReply(chatId: string, text: string): Promise<void> {
+      await bot.api.sendMessage(chatId, text);
+    },
+
+    onMessage: undefined,
+  };
+
+  return adapter;
+}
+
+/**
+ * Validate a Telegram bot token by calling getMe().
+ * Returns the bot username on success, throws on failure.
+ */
+export async function validateTelegramToken(
+  token: string,
+): Promise<{ username: string; id: number }> {
+  const bot = new Bot(token);
+  await bot.init();
+  const info = bot.botInfo;
+  return {
+    username: info.username ?? "",
+    id: info.id,
+  };
+}

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -19,6 +19,15 @@ export function createTelegramAdapter(
   const bot = new Bot(config.token);
   let running = false;
 
+  bot.catch((error) => {
+    const updateId = error.ctx?.update?.update_id;
+    const prefix =
+      updateId === undefined
+        ? "[Telegram] Unhandled bot error:"
+        : `[Telegram] Unhandled bot error for update ${updateId}:`;
+    console.error(prefix, error.error);
+  });
+
   // Wire message handlers
   bot.on("message:text", async (ctx) => {
     const msg = ctx.message;
@@ -79,16 +88,21 @@ export function createTelegramAdapter(
       );
 
       // Start long-polling in background (non-blocking)
-      bot.start({
-        onStart: () => {
-          running = true;
-        },
-      });
+      void bot
+        .start({
+          onStart: () => {
+            running = true;
+          },
+        })
+        .catch((error) => {
+          running = false;
+          console.error("[Telegram] Long-polling stopped unexpectedly:", error);
+        });
     },
 
     async stop(): Promise<void> {
       if (!running) return;
-      bot.stop();
+      await bot.stop();
       running = false;
       console.log("[Telegram] Bot stopped");
     },

--- a/src/channels/telegram/setup.ts
+++ b/src/channels/telegram/setup.ts
@@ -6,6 +6,9 @@
  * 2. Validate via getMe()
  * 3. Choose DM policy
  * 4. Write config to ~/.letta/channels/telegram/config.yaml
+ * 5. Start `letta server --channels telegram`
+ * 6. Message the bot from Telegram to get a pairing code
+ * 7. Run `/channels telegram pair <code>` in the target ADE/Desktop conversation
  */
 
 import { createInterface } from "node:readline/promises";
@@ -80,7 +83,13 @@ export async function runTelegramSetup(): Promise<boolean> {
 
     writeChannelConfig("telegram", config);
     console.log("\n✓ Telegram bot configured!");
-    console.log("Start with: letta server --channels telegram\n");
+    console.log("Config written to: ~/.letta/channels/telegram/config.yaml\n");
+    console.log("Next steps:");
+    console.log("  1. Start the listener: letta server --channels telegram");
+    console.log("  2. Message the bot from Telegram to get a pairing code");
+    console.log(
+      "  3. In the target ADE/Desktop conversation, run: /channels telegram pair <code>\n",
+    );
 
     return true;
   } finally {

--- a/src/channels/telegram/setup.ts
+++ b/src/channels/telegram/setup.ts
@@ -1,0 +1,89 @@
+/**
+ * Telegram bot setup wizard for `letta channels configure telegram`.
+ *
+ * Interactive CLI flow:
+ * 1. Prompt for bot token from @BotFather
+ * 2. Validate via getMe()
+ * 3. Choose DM policy
+ * 4. Write config to ~/.letta/channels/telegram/config.yaml
+ */
+
+import { createInterface } from "node:readline/promises";
+import { writeChannelConfig } from "../config";
+import type { DmPolicy, TelegramChannelConfig } from "../types";
+import { validateTelegramToken } from "./adapter";
+
+export async function runTelegramSetup(): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log("\n🤖 Telegram Bot Setup\n");
+    console.log("You'll need a bot token from @BotFather on Telegram.");
+    console.log("Create one by messaging @BotFather and using /newbot.\n");
+
+    // Step 1: Get token
+    const token = await rl.question("Enter your Telegram bot token: ");
+    if (!token.trim()) {
+      console.error("No token provided. Setup cancelled.");
+      return false;
+    }
+
+    // Step 2: Validate token
+    console.log("\nValidating token...");
+    try {
+      const info = await validateTelegramToken(token.trim());
+      console.log(`✓ Connected to @${info.username} (ID: ${info.id})\n`);
+    } catch (err) {
+      console.error(
+        `✗ Invalid token: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+      return false;
+    }
+
+    // Step 3: Choose DM policy
+    console.log("DM Policy — who can message this bot?\n");
+    console.log("  pairing   — Users must pair with a code (recommended)");
+    console.log("  allowlist — Only pre-approved user IDs");
+    console.log("  open      — Anyone can message\n");
+
+    const policyInput = await rl.question("DM policy [pairing]: ");
+    const policy = (policyInput.trim() || "pairing") as DmPolicy;
+
+    if (!["pairing", "allowlist", "open"].includes(policy)) {
+      console.error(`Invalid policy "${policy}". Setup cancelled.`);
+      return false;
+    }
+
+    // Step 4: Allowlist if needed
+    let allowedUsers: string[] = [];
+    if (policy === "allowlist") {
+      const usersInput = await rl.question(
+        "Enter allowed Telegram user IDs (comma-separated): ",
+      );
+      allowedUsers = usersInput
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+
+    // Step 5: Write config
+    const config: TelegramChannelConfig = {
+      channel: "telegram",
+      enabled: true,
+      token: token.trim(),
+      dmPolicy: policy,
+      allowedUsers,
+    };
+
+    writeChannelConfig("telegram", config);
+    console.log("\n✓ Telegram bot configured!");
+    console.log("Start with: letta server --channels telegram\n");
+
+    return true;
+  } finally {
+    rl.close();
+  }
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Channel system types.
+ *
+ * A "channel" connects Letta Code agents to external messaging platforms
+ * (Telegram, Slack, etc.). Each channel has an adapter that handles
+ * platform-specific communication, and a routing table that maps
+ * platform chat IDs to agent+conversation pairs.
+ */
+
+// ── Adapter interface ─────────────────────────────────────────────
+
+export interface ChannelAdapter {
+  /** Platform identifier, e.g. "telegram", "slack". */
+  readonly id: string;
+  /** Human-readable display name, e.g. "Telegram". */
+  readonly name: string;
+
+  /** Start receiving messages (e.g. begin long-polling). */
+  start(): Promise<void>;
+  /** Stop receiving messages gracefully. */
+  stop(): Promise<void>;
+  /** Whether the adapter is currently running. */
+  isRunning(): boolean;
+
+  /** Send a message through this channel. */
+  sendMessage(msg: OutboundChannelMessage): Promise<{ messageId: string }>;
+
+  /**
+   * Send a direct reply on the platform (for pairing codes, no-route
+   * messages, etc.) without going through the agent.
+   */
+  sendDirectReply(chatId: string, text: string): Promise<void>;
+
+  /**
+   * Called by the registry when the adapter receives an inbound message.
+   * Set by ChannelRegistry during initialization.
+   */
+  onMessage?: (msg: InboundChannelMessage) => Promise<void>;
+}
+
+// ── Message types ─────────────────────────────────────────────────
+
+export interface InboundChannelMessage {
+  /** Platform identifier, e.g. "telegram". */
+  channel: string;
+  /** Platform-specific chat/conversation ID. */
+  chatId: string;
+  /** Platform-specific sender user ID. */
+  senderId: string;
+  /** Sender display name, if available. */
+  senderName?: string;
+  /** Message text content. */
+  text: string;
+  /** Unix timestamp (ms) of the message. */
+  timestamp: number;
+  /** Platform message ID for threading/replies. */
+  messageId?: string;
+  /** Raw platform-specific event data for future use. */
+  raw?: unknown;
+}
+
+export interface OutboundChannelMessage {
+  /** Platform identifier. */
+  channel: string;
+  /** Target chat/conversation ID. */
+  chatId: string;
+  /** Message text to send. */
+  text: string;
+  /** Optional: reply to a specific message. */
+  replyToMessageId?: string;
+}
+
+// ── Routing ───────────────────────────────────────────────────────
+
+export interface ChannelRoute {
+  /** Platform-specific chat ID. */
+  chatId: string;
+  /** Letta agent ID this chat is bound to. */
+  agentId: string;
+  /** Letta conversation ID this chat is bound to. */
+  conversationId: string;
+  /** Whether this route is active. */
+  enabled: boolean;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+}
+
+// ── Config ────────────────────────────────────────────────────────
+
+export type DmPolicy = "pairing" | "allowlist" | "open";
+
+export interface TelegramChannelConfig {
+  channel: "telegram";
+  enabled: boolean;
+  token: string;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+}
+
+export type ChannelConfig = TelegramChannelConfig;
+
+// ── Pairing ───────────────────────────────────────────────────────
+
+export interface PendingPairing {
+  code: string;
+  telegramUserId: string;
+  telegramUsername?: string;
+  chatId: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface ApprovedUser {
+  telegramUserId: string;
+  telegramUsername?: string;
+  approvedAt: string;
+}
+
+export interface PairingStore {
+  pending: PendingPairing[];
+  approved: ApprovedUser[];
+}

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -1,0 +1,52 @@
+/**
+ * XML formatting for channel notifications.
+ *
+ * Produces structured XML that the agent receives as message content.
+ * Follows the same escaping patterns used in taskNotifications.ts.
+ */
+
+import type { InboundChannelMessage } from "./types";
+
+/**
+ * Escape special XML characters in text content.
+ * Reference: src/cli/helpers/taskNotifications.ts uses similar escaping.
+ */
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Format an inbound channel message as XML for the agent.
+ *
+ * Example output:
+ * ```xml
+ * <channel-notification source="telegram" chat_id="12345" sender_id="67890" sender_name="John">
+ * Hello from Telegram!
+ * </channel-notification>
+ * ```
+ */
+export function formatChannelNotification(msg: InboundChannelMessage): string {
+  const attrs: string[] = [
+    `source="${escapeXml(msg.channel)}"`,
+    `chat_id="${escapeXml(msg.chatId)}"`,
+    `sender_id="${escapeXml(msg.senderId)}"`,
+  ];
+
+  if (msg.senderName) {
+    attrs.push(`sender_name="${escapeXml(msg.senderName)}"`);
+  }
+
+  if (msg.messageId) {
+    attrs.push(`message_id="${escapeXml(msg.messageId)}"`);
+  }
+
+  const attrString = attrs.join(" ");
+  const escapedText = escapeXml(msg.text);
+
+  return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+}

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -56,6 +56,18 @@ Note: "configure" and "status" are standalone-safe. "route add/remove" and
 "pair" modify files but do NOT update a running listener — use the /channels
 WS command from ADE/desktop for live changes, or restart the server.
 
+Recommended Telegram flow:
+  1. letta channels configure telegram
+  2. letta server --channels telegram
+  3. Message the bot from Telegram once to get a pairing code
+  4. In the target ADE/desktop conversation, run:
+     /channels telegram pair <code>
+
+State files:
+  ~/.letta/channels/telegram/config.yaml
+  ~/.letta/channels/telegram/pairing.yaml
+  ~/.letta/channels/telegram/routing.yaml
+
 Output is JSON.
 `.trim(),
   );

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -1,0 +1,314 @@
+/**
+ * `letta channels` CLI subcommand.
+ *
+ * Usage:
+ *   letta channels configure telegram
+ *   letta channels status
+ *   letta channels route list
+ *   letta channels route add --channel telegram --chat-id <id> --agent <id> --conversation <id>
+ *   letta channels route remove --channel telegram --chat-id <id>
+ *   letta channels pair --channel telegram --code <code> --agent <id> --conversation <id>
+ */
+
+import { parseArgs } from "node:util";
+import { readChannelConfig } from "../../channels/config";
+import {
+  getApprovedUsers,
+  getPendingPairings,
+  loadPairingStore,
+} from "../../channels/pairing";
+import { completePairing } from "../../channels/registry";
+import {
+  addRoute,
+  getAllRoutes,
+  getRoutesForChannel,
+  loadRoutes,
+  removeRoute,
+} from "../../channels/routing";
+import type { ChannelRoute } from "../../channels/types";
+
+// ── Usage ───────────────────────────────────────────────────────────
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta channels configure <channel>          Set up a channel (interactive wizard)
+  letta channels status                       Show channel config, routing, pairing state
+  letta channels route list [--channel <ch>]  Show routing table
+  letta channels route add [options]          Add a route
+  letta channels route remove [options]       Remove a route
+  letta channels pair [options]               Approve pairing + bind to agent
+
+Route add options:
+  --channel <name>       Channel name (e.g. "telegram")
+  --chat-id <id>         Chat/conversation ID on the platform
+  --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
+  --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID)
+
+Pair options:
+  --channel <name>       Channel name (e.g. "telegram")
+  --code <code>          Pairing code from the bot
+  --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
+  --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID)
+
+Note: "configure" and "status" are standalone-safe. "route add/remove" and
+"pair" modify files but do NOT update a running listener — use the /channels
+WS command from ADE/desktop for live changes, or restart the server.
+
+Output is JSON.
+`.trim(),
+  );
+}
+
+// ── Args ────────────────────────────────────────────────────────────
+
+const CHANNELS_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  channel: { type: "string" },
+  "chat-id": { type: "string" },
+  agent: { type: "string" },
+  conversation: { type: "string" },
+  code: { type: "string" },
+} as const;
+
+function parseChannelsArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: CHANNELS_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function getAgentId(fromArgs?: string): string {
+  return fromArgs || process.env.LETTA_AGENT_ID || "";
+}
+
+function getConversationId(fromArgs?: string): string {
+  return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
+}
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+async function handleConfigure(channel: string): Promise<number> {
+  if (channel === "telegram") {
+    const { runTelegramSetup } = await import("../../channels/telegram/setup");
+    const success = await runTelegramSetup();
+    return success ? 0 : 1;
+  }
+
+  console.error(`Unknown channel: "${channel}". Supported: telegram`);
+  return 1;
+}
+
+function handleStatus(): number {
+  const channels = ["telegram"];
+  const result: Record<string, unknown> = {};
+
+  for (const channelId of channels) {
+    const config = readChannelConfig(channelId);
+    if (!config) {
+      result[channelId] = { configured: false };
+      continue;
+    }
+
+    loadRoutes(channelId);
+    loadPairingStore(channelId);
+    const routes = getRoutesForChannel(channelId);
+    const pending = getPendingPairings(channelId);
+    const approved = getApprovedUsers(channelId);
+
+    result[channelId] = {
+      configured: true,
+      enabled: config.enabled,
+      dmPolicy: config.dmPolicy,
+      routes: routes.length,
+      pendingPairings: pending.length,
+      approvedUsers: approved.length,
+    };
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+  return 0;
+}
+
+function handleRouteList(
+  values: ReturnType<typeof parseChannelsArgs>["values"],
+): number {
+  const channelId = values.channel;
+
+  if (channelId) {
+    loadRoutes(channelId);
+    const routes = getRoutesForChannel(channelId);
+    console.log(JSON.stringify(routes, null, 2));
+  } else {
+    // Load all known channels
+    for (const ch of ["telegram"]) {
+      loadRoutes(ch);
+    }
+    const routes = getAllRoutes();
+    console.log(JSON.stringify(routes, null, 2));
+  }
+
+  return 0;
+}
+
+function handleRouteAdd(
+  values: ReturnType<typeof parseChannelsArgs>["values"],
+): number {
+  const channelId = values.channel;
+  const chatId = values["chat-id"];
+  const agentId = getAgentId(values.agent);
+  const conversationId = getConversationId(values.conversation);
+
+  if (!channelId) {
+    console.error("Error: --channel is required.");
+    return 1;
+  }
+  if (!chatId) {
+    console.error("Error: --chat-id is required.");
+    return 1;
+  }
+  if (!agentId) {
+    console.error(
+      "Error: --agent is required (or set LETTA_AGENT_ID env var).",
+    );
+    return 1;
+  }
+
+  const route: ChannelRoute = {
+    chatId,
+    agentId,
+    conversationId,
+    enabled: true,
+    createdAt: new Date().toISOString(),
+  };
+
+  loadRoutes(channelId);
+  addRoute(channelId, route);
+  console.log(JSON.stringify({ success: true, route }, null, 2));
+  console.warn(
+    "Note: If a listener is running, restart it or use /channels telegram enable via WS.",
+  );
+  return 0;
+}
+
+function handleRouteRemove(
+  values: ReturnType<typeof parseChannelsArgs>["values"],
+): number {
+  const channelId = values.channel;
+  const chatId = values["chat-id"];
+
+  if (!channelId) {
+    console.error("Error: --channel is required.");
+    return 1;
+  }
+  if (!chatId) {
+    console.error("Error: --chat-id is required.");
+    return 1;
+  }
+
+  loadRoutes(channelId);
+  const removed = removeRoute(channelId, chatId);
+  console.log(JSON.stringify({ success: removed }, null, 2));
+  if (removed) {
+    console.warn(
+      "Note: A running listener won't see this change until restarted.",
+    );
+  }
+  return removed ? 0 : 1;
+}
+
+async function handlePair(
+  values: ReturnType<typeof parseChannelsArgs>["values"],
+): Promise<number> {
+  const channelId = values.channel;
+  const code = values.code;
+  const agentId = getAgentId(values.agent);
+  const conversationId = getConversationId(values.conversation);
+
+  if (!channelId) {
+    console.error("Error: --channel is required.");
+    return 1;
+  }
+  if (!code) {
+    console.error("Error: --code is required.");
+    return 1;
+  }
+  if (!agentId) {
+    console.error(
+      "Error: --agent is required (or set LETTA_AGENT_ID env var).",
+    );
+    return 1;
+  }
+
+  // Load existing state
+  loadRoutes(channelId);
+  const { loadPairingStore: loadPairing } = await import(
+    "../../channels/pairing"
+  );
+  loadPairing(channelId);
+
+  const result = completePairing(channelId, code, agentId, conversationId);
+  console.log(JSON.stringify(result, null, 2));
+  if (result.success) {
+    console.warn(
+      "Note: If a listener is running, restart it or use /channels telegram pair via WS.",
+    );
+  }
+  return result.success ? 0 : 1;
+}
+
+// ── Router ──────────────────────────────────────────────────────────
+
+export async function runChannelsSubcommand(argv: string[]): Promise<number> {
+  const { values, positionals } = parseChannelsArgs(argv);
+
+  if (values.help) {
+    printUsage();
+    return 0;
+  }
+
+  const [action, ...rest] = positionals;
+
+  switch (action) {
+    case "configure": {
+      const channel = rest[0];
+      if (!channel) {
+        console.error("Error: specify a channel to configure (e.g., telegram)");
+        return 1;
+      }
+      return handleConfigure(channel);
+    }
+    case "status":
+      return handleStatus();
+    case "route": {
+      const routeAction = rest[0];
+      switch (routeAction) {
+        case "list":
+          return handleRouteList(values);
+        case "add":
+          return handleRouteAdd(values);
+        case "remove":
+          return handleRouteRemove(values);
+        default:
+          console.error(
+            `Unknown route action: "${routeAction}". Use: list, add, remove`,
+          );
+          return 1;
+      }
+    }
+    case "pair":
+      return await handlePair(values);
+    default:
+      if (!action) {
+        printUsage();
+        return 0;
+      }
+      console.error(
+        `Unknown channels action: "${action}". Use: configure, status, route, pair`,
+      );
+      return 1;
+  }
+}

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -100,6 +100,9 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     console.log("  -h, --help         Show this help message\n");
     console.log("Examples:");
     console.log(
+      "  letta channels configure telegram          # Configure Telegram first",
+    );
+    console.log(
       "  letta server                              # Uses hostname as default",
     );
     console.log('  letta server --env-name "work-laptop"');
@@ -114,6 +117,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     );
     console.log(
       "Messages will be executed locally using your letta-code environment.",
+    );
+    console.log(
+      "Telegram flow: configure the bot, start the listener with --channels telegram,",
+    );
+    console.log(
+      "then message the bot from Telegram and run /channels telegram pair <code> in the target conversation.",
     );
     return 0;
   }

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -70,6 +70,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     args: argv,
     options: {
       "env-name": { type: "string" },
+      channels: { type: "string" },
       help: { type: "boolean", short: "h" },
       debug: { type: "boolean" },
     },
@@ -80,7 +81,9 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
 
   // Show help
   if (values.help) {
-    console.log("Usage: letta server [--env-name <name>] [--debug]\n");
+    console.log(
+      "Usage: letta server [--env-name <name>] [--channels <list>] [--debug]\n",
+    );
     console.log(
       "Register this letta-code instance to receive messages from Letta Cloud.\n",
     );
@@ -89,15 +92,23 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       "  --env-name <name>  Friendly name for this environment (uses hostname if not provided)",
     );
     console.log(
+      "  --channels <list>  Comma-separated channel names to enable (e.g. telegram)",
+    );
+    console.log(
       "  --debug            Plain-text mode: log all WebSocket events instead of interactive UI",
     );
     console.log("  -h, --help         Show this help message\n");
     console.log("Examples:");
     console.log(
-      "  letta server                      # Uses hostname as default",
+      "  letta server                              # Uses hostname as default",
     );
     console.log('  letta server --env-name "work-laptop"');
-    console.log("  letta server --debug              # Log all WS events\n");
+    console.log(
+      "  letta server --channels telegram           # Enable Telegram channel",
+    );
+    console.log(
+      "  letta server --debug                       # Log all WS events\n",
+    );
     console.log(
       "Once connected, this instance will listen for incoming messages from cloud agents.",
     );
@@ -114,12 +125,34 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     code: number,
     exitReason: string,
   ): Promise<never> => {
+    // Stop channel adapters on actual process exit
+    try {
+      const { getChannelRegistry } = await import("../../channels/registry");
+      const registry = getChannelRegistry();
+      if (registry) {
+        await registry.stopAll();
+      }
+    } catch {
+      // Best effort — don't block exit on channel cleanup failure
+    }
     await flushListenerTelemetryEnd(exitReason);
     process.exit(code);
   };
 
   // Load local project settings to access saved environment name
   await settingsManager.loadLocalProjectSettings();
+
+  // Initialize channels if --channels flag provided
+  if (values.channels) {
+    const channelNames = values.channels
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (channelNames.length > 0) {
+      const { initializeChannels } = await import("../../channels/registry");
+      await initializeChannels(channelNames);
+    }
+  }
 
   // Determine connection name
   let connectionName: string;

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -1,5 +1,6 @@
 import { runAgentsSubcommand } from "./agents";
 import { runBlocksSubcommand } from "./blocks";
+import { runChannelsSubcommand } from "./channels";
 import { runConnectSubcommand } from "./connect";
 import { runCronSubcommand } from "./cron";
 import { runListenSubcommand } from "./listen.tsx";
@@ -29,6 +30,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runConnectSubcommand(rest);
     case "cron":
       return runCronSubcommand(rest);
+    case "channels":
+      return runChannelsSubcommand(rest);
     default:
       return null;
   }

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -764,6 +764,8 @@ function getDefaultDecision(
     // own path/read_only guardrails, so allow by default.
     "memory",
     "memory_apply_patch",
+    // Channel sends are scoped by routing + parentScope checks in the tool.
+    "MessageChannel",
   ];
 
   if (autoAllowTools.includes(toolName)) {

--- a/src/tests/channels/pairing.test.ts
+++ b/src/tests/channels/pairing.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearPairingStores,
+  consumePairingCode,
+  createPairingCode,
+  getApprovedUsers,
+  getPendingPairings,
+  isUserApproved,
+  rollbackPairingApproval,
+} from "../../channels/pairing";
+
+describe("pairing", () => {
+  afterEach(() => {
+    clearPairingStores();
+  });
+
+  test("creates a pairing code for a user", () => {
+    const code = createPairingCode("telegram", "user-1", "chat-1", "john");
+    expect(code).toHaveLength(6);
+    expect(/^[A-Z0-9]+$/.test(code)).toBe(true);
+
+    const pending = getPendingPairings("telegram");
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.code).toBe(code);
+    expect(pending[0]?.telegramUserId).toBe("user-1");
+    expect(pending[0]?.chatId).toBe("chat-1");
+  });
+
+  test("consumes a valid pairing code", () => {
+    const code = createPairingCode("telegram", "user-1", "chat-1", "john");
+
+    const result = consumePairingCode("telegram", code);
+    expect(result).not.toBeNull();
+    expect(result?.telegramUserId).toBe("user-1");
+    expect(result?.chatId).toBe("chat-1");
+
+    // User should now be approved
+    expect(isUserApproved("telegram", "user-1")).toBe(true);
+    const approved = getApprovedUsers("telegram");
+    expect(approved).toHaveLength(1);
+
+    // Code should be consumed (pending cleared)
+    const pending = getPendingPairings("telegram");
+    expect(pending).toHaveLength(0);
+  });
+
+  test("rejects an invalid code", () => {
+    createPairingCode("telegram", "user-1", "chat-1");
+
+    const result = consumePairingCode("telegram", "INVALID");
+    expect(result).toBeNull();
+  });
+
+  test("case-insensitive code matching", () => {
+    const code = createPairingCode("telegram", "user-1", "chat-1");
+
+    const result = consumePairingCode("telegram", code.toLowerCase());
+    expect(result).not.toBeNull();
+  });
+
+  test("replaces existing pending code for same user", () => {
+    const code1 = createPairingCode("telegram", "user-1", "chat-1");
+    const code2 = createPairingCode("telegram", "user-1", "chat-1");
+
+    expect(code1).not.toBe(code2);
+
+    // Only the new code should work
+    expect(consumePairingCode("telegram", code1)).toBeNull();
+    expect(consumePairingCode("telegram", code2)).not.toBeNull();
+  });
+
+  test("isUserApproved returns false for unknown users", () => {
+    expect(isUserApproved("telegram", "unknown")).toBe(false);
+  });
+
+  test("rollbackPairingApproval restores pending and removes approved", () => {
+    const code = createPairingCode("telegram", "user-1", "chat-1", "john");
+    const pending = consumePairingCode("telegram", code);
+    expect(pending).not.toBeNull();
+
+    // User is now approved, no pending codes
+    expect(isUserApproved("telegram", "user-1")).toBe(true);
+    expect(getPendingPairings("telegram")).toHaveLength(0);
+
+    // Roll back
+    rollbackPairingApproval("telegram", pending!);
+
+    // User should no longer be approved, pending code restored
+    expect(isUserApproved("telegram", "user-1")).toBe(false);
+    expect(getPendingPairings("telegram")).toHaveLength(1);
+    expect(getPendingPairings("telegram")[0]?.code).toBe(code);
+  });
+});

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearPairingStores,
+  createPairingCode,
+  getPendingPairings,
+  isUserApproved,
+} from "../../channels/pairing";
+import {
+  ChannelRegistry,
+  completePairing,
+  getChannelRegistry,
+} from "../../channels/registry";
+import {
+  __testOverrideSaveRoutes,
+  addRoute,
+  clearAllRoutes,
+  getRoute,
+} from "../../channels/routing";
+
+describe("ChannelRegistry", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+    clearPairingStores();
+    __testOverrideSaveRoutes(null);
+  });
+
+  test("pause() stops delivery but keeps singleton alive", () => {
+    const registry = new ChannelRegistry();
+    registry.setMessageHandler(() => {});
+    registry.setReady();
+
+    expect(registry.isReady()).toBe(true);
+    expect(getChannelRegistry()).toBe(registry);
+
+    registry.pause();
+    expect(registry.isReady()).toBe(false);
+    // Singleton survives pause (unlike stopAll)
+    expect(getChannelRegistry()).toBe(registry);
+
+    // Re-register and setReady (simulates WS reconnect)
+    registry.setMessageHandler(() => {});
+    registry.setReady();
+    expect(registry.isReady()).toBe(true);
+  });
+
+  test("stopAll() destroys the singleton", async () => {
+    const registry = new ChannelRegistry();
+    expect(getChannelRegistry()).toBe(registry);
+
+    await registry.stopAll();
+    expect(getChannelRegistry()).toBeNull();
+  });
+});
+
+describe("completePairing", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+    clearPairingStores();
+    __testOverrideSaveRoutes(null);
+  });
+
+  test("successful pairing creates route", () => {
+    new ChannelRegistry();
+
+    const code = createPairingCode("telegram", "user-1", "chat-1", "john");
+    const result = completePairing("telegram", code, "agent-a", "conv-1");
+
+    expect(result.success).toBe(true);
+    expect(result.chatId).toBe("chat-1");
+
+    const route = getRoute("telegram", "chat-1");
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("agent-a");
+    expect(route?.conversationId).toBe("conv-1");
+  });
+
+  test("invalid code returns error", () => {
+    new ChannelRegistry();
+
+    const result = completePairing("telegram", "BADCODE", "agent-a", "conv-1");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid or expired");
+  });
+
+  test("rolls back both in-memory route and pairing when disk write fails", () => {
+    new ChannelRegistry();
+
+    const code = createPairingCode("telegram", "user-1", "chat-99", "john");
+
+    // Make saveRoutes throw to simulate disk write failure.
+    // addRoute() calls routesByKey.set() (succeeds) then saveRoutes() (throws).
+    // The completePairing catch path must:
+    //   1. Remove the in-memory route via removeRouteInMemory (no disk write)
+    //   2. Restore the pending pairing code via rollbackPairingApproval
+    __testOverrideSaveRoutes(() => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    const result = completePairing("telegram", code, "agent-a", "conv-1");
+
+    // Should report failure with rollback
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("rolled back");
+    expect(result.error).toContain("EACCES");
+
+    // In-memory route must NOT exist
+    expect(getRoute("telegram", "chat-99")).toBeNull();
+
+    // Pairing must be rolled back: user not approved, pending code restored
+    expect(isUserApproved("telegram", "user-1")).toBe(false);
+    expect(getPendingPairings("telegram")).toHaveLength(1);
+    expect(getPendingPairings("telegram")[0]?.code).toBe(code);
+  });
+
+  test("restores pre-existing route when rebind fails", () => {
+    new ChannelRegistry();
+
+    // Set up an existing route for chat-50
+    addRoute("telegram", {
+      chatId: "chat-50",
+      agentId: "agent-old",
+      conversationId: "conv-old",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+
+    // Verify it exists
+    const before = getRoute("telegram", "chat-50");
+    expect(before).not.toBeNull();
+    expect(before?.agentId).toBe("agent-old");
+
+    // Create a pairing for the same chat
+    const code = createPairingCode("telegram", "user-2", "chat-50", "jane");
+
+    // Make saveRoutes throw on the rebind attempt
+    __testOverrideSaveRoutes(() => {
+      throw new Error("ENOSPC: no space left");
+    });
+
+    const result = completePairing("telegram", code, "agent-new", "conv-new");
+    expect(result.success).toBe(false);
+
+    // The OLD route must still be in memory (restored from snapshot)
+    const after = getRoute("telegram", "chat-50");
+    expect(after).not.toBeNull();
+    expect(after?.agentId).toBe("agent-old");
+    expect(after?.conversationId).toBe("conv-old");
+  });
+});

--- a/src/tests/channels/routing.test.ts
+++ b/src/tests/channels/routing.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  addRoute,
+  clearAllRoutes,
+  getAllRoutes,
+  getRoute,
+  getRoutesForChannel,
+  removeRoute,
+  removeRoutesForScope,
+} from "../../channels/routing";
+
+describe("routing", () => {
+  afterEach(() => {
+    clearAllRoutes();
+  });
+
+  test("adds and retrieves a route", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    const route = getRoute("telegram", "chat-1");
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("agent-a");
+    expect(route?.conversationId).toBe("conv-1");
+  });
+
+  test("returns null for non-existent route", () => {
+    expect(getRoute("telegram", "nonexistent")).toBeNull();
+  });
+
+  test("returns null for disabled route", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: false,
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(getRoute("telegram", "chat-1")).toBeNull();
+  });
+
+  test("removes a route", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(removeRoute("telegram", "chat-1")).toBe(true);
+    expect(getRoute("telegram", "chat-1")).toBeNull();
+  });
+
+  test("removeRoutesForScope removes matching routes", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+    addRoute("telegram", {
+      chatId: "chat-2",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+    addRoute("telegram", {
+      chatId: "chat-3",
+      agentId: "agent-b",
+      conversationId: "conv-2",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    const removed = removeRoutesForScope("telegram", "agent-a", "conv-1");
+    expect(removed).toBe(2);
+
+    expect(getRoute("telegram", "chat-1")).toBeNull();
+    expect(getRoute("telegram", "chat-2")).toBeNull();
+    expect(getRoute("telegram", "chat-3")).not.toBeNull();
+  });
+
+  test("getRoutesForChannel returns channel-specific routes", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    const routes = getRoutesForChannel("telegram");
+    expect(routes).toHaveLength(1);
+
+    const slackRoutes = getRoutesForChannel("slack");
+    expect(slackRoutes).toHaveLength(0);
+  });
+
+  test("getAllRoutes returns all routes", () => {
+    addRoute("telegram", {
+      chatId: "chat-1",
+      agentId: "agent-a",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(getAllRoutes()).toHaveLength(1);
+  });
+});

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+type FakeBotStartOptions = {
+  onStart?: (botInfo: {
+    username?: string;
+    id: number;
+  }) => void | Promise<void>;
+};
+
+class FakeBot {
+  static instances: FakeBot[] = [];
+  static nextStartImpl: () => Promise<void> = async () => {};
+
+  readonly token: string;
+  botInfo = { username: "test_bot", id: 12345 };
+  readonly api = {
+    sendMessage: mock(async () => ({ message_id: 999 })),
+  };
+  catchHandler:
+    | ((error: {
+        ctx?: { update?: { update_id?: number } };
+        error: unknown;
+      }) => unknown)
+    | null = null;
+
+  constructor(token: string) {
+    this.token = token;
+    FakeBot.instances.push(this);
+  }
+
+  on(): this {
+    return this;
+  }
+
+  command(): this {
+    return this;
+  }
+
+  async init(): Promise<void> {}
+
+  start(options?: FakeBotStartOptions): Promise<void> {
+    void options?.onStart?.(this.botInfo);
+    return FakeBot.nextStartImpl();
+  }
+
+  async stop(): Promise<void> {}
+
+  catch(
+    handler: (error: {
+      ctx?: { update?: { update_id?: number } };
+      error: unknown;
+    }) => unknown,
+  ): void {
+    this.catchHandler = handler;
+  }
+}
+
+mock.module("grammy", () => ({
+  Bot: FakeBot,
+}));
+
+const { createTelegramAdapter } = await import(
+  "../../channels/telegram/adapter"
+);
+
+const consoleErrorSpy = mock(() => {});
+const originalConsoleError = console.error;
+
+beforeEach(() => {
+  FakeBot.instances.length = 0;
+  FakeBot.nextStartImpl = async () => {};
+  consoleErrorSpy.mockClear();
+  console.error = consoleErrorSpy as typeof console.error;
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+test("telegram adapter logs unhandled grammY errors with update context", async () => {
+  const adapter = createTelegramAdapter({
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  expect(bot).toBeDefined();
+  expect(bot?.catchHandler).not.toBeNull();
+
+  const error = new Error("middleware boom");
+  bot?.catchHandler?.({
+    ctx: { update: { update_id: 42 } },
+    error,
+  });
+
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    "[Telegram] Unhandled bot error for update 42:",
+    error,
+  );
+});
+
+test("telegram adapter logs and clears running state when polling exits unexpectedly", async () => {
+  FakeBot.nextStartImpl = async () => {
+    throw new Error("polling failed");
+  };
+
+  const adapter = createTelegramAdapter({
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(adapter.isRunning()).toBe(false);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    "[Telegram] Long-polling stopped unexpectedly:",
+    expect.objectContaining({ message: "polling failed" }),
+  );
+});

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { InboundChannelMessage } from "../../channels/types";
+import { formatChannelNotification } from "../../channels/xml";
+
+describe("formatChannelNotification", () => {
+  test("formats a basic message with all fields", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      senderName: "John",
+      text: "Hello from Telegram!",
+      timestamp: Date.now(),
+      messageId: "msg-42",
+    };
+
+    const xml = formatChannelNotification(msg);
+
+    expect(xml).toContain("<channel-notification");
+    expect(xml).toContain('source="telegram"');
+    expect(xml).toContain('chat_id="12345"');
+    expect(xml).toContain('sender_id="67890"');
+    expect(xml).toContain('sender_name="John"');
+    expect(xml).toContain('message_id="msg-42"');
+    expect(xml).toContain("Hello from Telegram!");
+    expect(xml).toContain("</channel-notification>");
+  });
+
+  test("escapes XML special characters in text", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "Hello <world> & \"friends\" 'here'",
+      timestamp: Date.now(),
+    };
+
+    const xml = formatChannelNotification(msg);
+
+    expect(xml).toContain("&lt;world&gt;");
+    expect(xml).toContain("&amp;");
+    expect(xml).toContain("&quot;friends&quot;");
+    expect(xml).toContain("&apos;here&apos;");
+  });
+
+  test("escapes XML special characters in attributes", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      senderName: 'John "The <Bot>"',
+      text: "test",
+      timestamp: Date.now(),
+    };
+
+    const xml = formatChannelNotification(msg);
+
+    expect(xml).toContain("John &quot;The &lt;Bot&gt;&quot;");
+  });
+
+  test("omits optional fields when not present", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "simple message",
+      timestamp: Date.now(),
+    };
+
+    const xml = formatChannelNotification(msg);
+
+    expect(xml).not.toContain("sender_name=");
+    expect(xml).not.toContain("message_id=");
+  });
+});

--- a/src/tests/permissions-checker.test.ts
+++ b/src/tests/permissions-checker.test.ts
@@ -484,6 +484,18 @@ test("TodoWrite defaults to allow", () => {
   expect(result.decision).toBe("allow");
 });
 
+test("MessageChannel defaults to allow", () => {
+  const result = checkPermission(
+    "MessageChannel",
+    { channel: "telegram", message: "hello there" },
+    { allow: [], deny: [], ask: [] },
+    "/Users/test/project",
+  );
+
+  expect(result.decision).toBe("allow");
+  expect(result.reason).toBe("Default behavior for tool");
+});
+
 // ============================================================================
 // Precedence Order Tests
 // ============================================================================

--- a/src/tests/protocol/queue-lifecycle-types.test.ts
+++ b/src/tests/protocol/queue-lifecycle-types.test.ts
@@ -49,8 +49,9 @@ describe("QueueItemEnqueuedEvent wire shape", () => {
       cron: true,
       subagent: true,
       system: true,
+      channel: true,
     } satisfies Record<QueueItemSource, true>;
-    expect(Object.keys(sources)).toHaveLength(5);
+    expect(Object.keys(sources)).toHaveLength(6);
   });
 
   test("kind covers all content types", () => {

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -795,6 +795,64 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtimeB.queuedMessagesByItemId.size).toBe(0);
   });
 
+  test("channel queue items re-enter the listener loop as normal queued turns", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-channel",
+    );
+    const socket = new MockSocket();
+    const processed: IncomingMessage[] = [];
+    const xml =
+      '<channel-notification source="telegram" chat_id="7952253975">hello from telegram</channel-notification>';
+
+    const enqueuedItem = __listenClientTestUtils.enqueueChannelTurn(
+      runtime,
+      {
+        agentId: "agent-1",
+        conversationId: "conv-channel",
+      },
+      xml,
+    );
+
+    expect(enqueuedItem).not.toBeNull();
+    expect(runtime.queueRuntime.length).toBe(1);
+    expect(runtime.queuedMessagesByItemId.size).toBe(1);
+
+    __listenClientTestUtils.scheduleQueuePump(
+      runtime,
+      socket as unknown as WebSocket,
+      {
+        connectionId: "conn-1",
+        onStatusChange: undefined,
+      } as never,
+      async (queuedTurn: IncomingMessage) => {
+        processed.push(queuedTurn);
+      },
+    );
+
+    await waitFor(() => processed.length === 1);
+
+    expect(processed[0]).toEqual(
+      expect.objectContaining({
+        type: "message",
+        agentId: "agent-1",
+        conversationId: "conv-channel",
+        messages: [
+          expect.objectContaining({
+            role: "user",
+            content: [{ type: "text", text: xml }],
+            client_message_id: expect.stringMatching(/^cm-channel-/),
+          }),
+        ],
+      }),
+    );
+    expect(runtime.queueRuntime.length).toBe(0);
+    expect(runtime.queuedMessagesByItemId.size).toBe(0);
+  });
+
   test("consumeQueuedTurn only drains the next same-scope queued turn batch", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const messageInput = {

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -1,0 +1,11 @@
+# MessageChannel
+
+Send a message to an external channel (Telegram, Slack, etc.) in response to a channel notification.
+
+When you receive a `<channel-notification>`, use this tool to reply. Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
+
+Parameters:
+- `channel`: The platform to send to (matches the `source` attribute)
+- `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
+- `text`: The message text to send
+- `reply_to_message_id`: (Optional) Reply to a specific message by its `message_id`

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -1,0 +1,71 @@
+/**
+ * MessageChannel tool — sends messages to external channels.
+ *
+ * Uses parentScope (injected per-execution by manager.ts executeTool())
+ * for agent+conversation authorization. Does NOT use global context
+ * singleton, which is unsafe in the listener's multi-runtime model.
+ */
+
+import { getChannelRegistry } from "../../channels/registry";
+import type { ChannelRoute } from "../../channels/types";
+
+interface MessageChannelArgs {
+  channel: string;
+  chat_id: string;
+  text: string;
+  reply_to_message_id?: string;
+  /** Injected by executeTool() — NOT read from global context. */
+  parentScope?: { agentId: string; conversationId: string };
+}
+
+export async function message_channel(
+  args: MessageChannelArgs,
+): Promise<string> {
+  const registry = getChannelRegistry();
+  if (!registry) {
+    return "Error: Channel system is not initialized. Start with --channels flag.";
+  }
+
+  const adapter = registry.getAdapter(args.channel);
+  if (!adapter) {
+    return `Error: Channel "${args.channel}" is not configured or not running.`;
+  }
+
+  if (!adapter.isRunning()) {
+    return `Error: Channel "${args.channel}" is not currently running.`;
+  }
+
+  // Per-agent+conversation authorization via injected scope.
+  // parentScope comes from executeTool() options in manager.ts,
+  // NOT the global context singleton (agent/context.ts).
+  const scope = args.parentScope;
+  if (!scope) {
+    return "Error: MessageChannel requires execution scope (agentId + conversationId).";
+  }
+
+  const route: ChannelRoute | null = registry.getRoute(
+    args.channel,
+    args.chat_id,
+  );
+  if (
+    !route ||
+    route.agentId !== scope.agentId ||
+    route.conversationId !== scope.conversationId
+  ) {
+    return `Error: No route for chat_id "${args.chat_id}" on "${args.channel}" for this agent/conversation.`;
+  }
+
+  try {
+    const result = await adapter.sendMessage({
+      channel: args.channel,
+      chatId: args.chat_id,
+      text: args.text,
+      replyToMessageId: args.reply_to_message_id,
+    });
+
+    return `Message sent to ${args.channel} (message_id: ${result.messageId})`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    return `Error sending message to ${args.channel}: ${msg}`;
+  }
+}

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -207,7 +207,7 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   LS: { requiresApproval: false },
   memory: { requiresApproval: false },
   memory_apply_patch: { requiresApproval: false },
-  MessageChannel: { requiresApproval: true },
+  MessageChannel: { requiresApproval: false },
   MultiEdit: { requiresApproval: true },
   Read: { requiresApproval: false },
   view_image: { requiresApproval: false },

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1,6 +1,7 @@
 import { getDisplayableToolReturn } from "../agent/approval-execution";
 import { getModelInfo } from "../agent/model";
 import { getAllSubagentConfigs } from "../agent/subagents";
+import { getActiveChannelIds } from "../channels/registry";
 import { refreshFileIndex } from "../cli/helpers/fileIndex";
 import { INTERRUPTED_BY_USER } from "../constants";
 import {
@@ -22,6 +23,41 @@ import {
 import { TOOL_DEFINITIONS, type ToolName } from "./toolDefinitions";
 
 export const TOOL_NAMES = Object.keys(TOOL_DEFINITIONS) as ToolName[];
+
+/**
+ * Append MessageChannel tool if any channels are active.
+ * Used by both resolveBaseToolNamesForModel() and getToolNamesForToolset().
+ */
+function maybeAppendChannelTools(toolNames: ToolName[]): ToolName[] {
+  if (
+    getActiveChannelIds().length > 0 &&
+    !toolNames.includes("MessageChannel" as ToolName)
+  ) {
+    return [...toolNames, "MessageChannel" as ToolName];
+  }
+  return toolNames;
+}
+
+/**
+ * Inject channel enum into MessageChannel schema if channels are active.
+ * Used by both buildRegistryForModel() and buildSpecificToolRegistry().
+ */
+function maybeInjectChannelEnum(
+  name: string,
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  if (name !== "MessageChannel") return schema;
+  const activeChannels = getActiveChannelIds();
+  if (activeChannels.length === 0) return schema;
+  const injected = structuredClone(schema);
+  const props = injected.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (props?.channel) {
+    props.channel.enum = activeChannels;
+  }
+  return injected;
+}
 const STREAMING_SHELL_TOOLS = new Set([
   "Bash",
   "BashOutput",
@@ -171,6 +207,7 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   LS: { requiresApproval: false },
   memory: { requiresApproval: false },
   memory_apply_patch: { requiresApproval: false },
+  MessageChannel: { requiresApproval: true },
   MultiEdit: { requiresApproval: true },
   Read: { requiresApproval: false },
   view_image: { requiresApproval: false },
@@ -928,7 +965,7 @@ async function buildSpecificToolRegistry(
     const toolSchema: ToolSchema = {
       name: internalName,
       description: definition.description,
-      input_schema: definition.schema,
+      input_schema: maybeInjectChannelEnum(internalName, definition.schema),
     };
 
     newRegistry.set(internalName, {
@@ -969,6 +1006,9 @@ async function resolveBaseToolNamesForModel(
     const excludeSet = new Set(options.exclude);
     baseToolNames = baseToolNames.filter((name) => !excludeSet.has(name));
   }
+
+  // Append channel tool if channels are active
+  baseToolNames = maybeAppendChannelTools(baseToolNames);
 
   return baseToolNames;
 }
@@ -1018,7 +1058,7 @@ async function buildRegistryForModel(
       const toolSchema: ToolSchema = {
         name,
         description,
-        input_schema: definition.schema,
+        input_schema: maybeInjectChannelEnum(name, definition.schema),
       };
 
       newRegistry.set(name, {
@@ -1420,6 +1460,11 @@ export async function executeTool(
     // Inject toolCallId for Skill tool (used for skill content registry)
     if (internalName === "Skill" && options?.toolCallId) {
       enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
+    }
+
+    // Inject parent scope for MessageChannel tool (per-execution, not global singleton)
+    if (internalName === "MessageChannel" && options?.parentScope) {
+      enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
     }
 
     // Inject the execution context id for plan-mode tools so they can update

--- a/src/tools/schemas/MessageChannel.json
+++ b/src/tools/schemas/MessageChannel.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "channel": {
+      "type": "string",
+      "description": "The channel to send the message to (e.g., 'telegram')"
+    },
+    "chat_id": {
+      "type": "string",
+      "description": "The chat/conversation ID to send to (from the channel-notification attributes)"
+    },
+    "text": {
+      "type": "string",
+      "description": "The message text to send"
+    },
+    "reply_to_message_id": {
+      "type": "string",
+      "description": "Optional message ID to reply to"
+    }
+  },
+  "required": ["channel", "chat_id", "text"],
+  "additionalProperties": false
+}

--- a/src/tools/toolDefinitions.ts
+++ b/src/tools/toolDefinitions.ts
@@ -16,6 +16,7 @@ import ListDirectoryGeminiDescription from "./descriptions/ListDirectoryGemini.m
 import LSDescription from "./descriptions/LS.md";
 import MemoryDescription from "./descriptions/Memory.md";
 import MemoryApplyPatchDescription from "./descriptions/MemoryApplyPatch.md";
+import MessageChannelDescription from "./descriptions/MessageChannel.md";
 import MultiEditDescription from "./descriptions/MultiEdit.md";
 import ReadDescription from "./descriptions/Read.md";
 import ReadFileCodexDescription from "./descriptions/ReadFileCodex.md";
@@ -55,6 +56,7 @@ import { list_directory } from "./impl/ListDirectoryGemini";
 import { ls } from "./impl/LS";
 import { memory } from "./impl/Memory";
 import { memory_apply_patch } from "./impl/MemoryApplyPatch";
+import { message_channel } from "./impl/MessageChannel";
 import { multi_edit } from "./impl/MultiEdit";
 import { read } from "./impl/Read";
 import { read_file } from "./impl/ReadFileCodex";
@@ -94,6 +96,7 @@ import ListDirectoryGeminiSchema from "./schemas/ListDirectoryGemini.json";
 import LSSchema from "./schemas/LS.json";
 import MemorySchema from "./schemas/Memory.json";
 import MemoryApplyPatchSchema from "./schemas/MemoryApplyPatch.json";
+import MessageChannelSchema from "./schemas/MessageChannel.json";
 import MultiEditSchema from "./schemas/MultiEdit.json";
 import ReadSchema from "./schemas/Read.json";
 import ReadFileCodexSchema from "./schemas/ReadFileCodex.json";
@@ -194,6 +197,11 @@ const toolDefinitions = {
     schema: MemoryApplyPatchSchema,
     description: MemoryApplyPatchDescription.trim(),
     impl: memory_apply_patch as unknown as ToolImplementation,
+  },
+  MessageChannel: {
+    schema: MessageChannelSchema,
+    description: MessageChannelDescription.trim(),
+    impl: message_channel as unknown as ToolImplementation,
   },
   MultiEdit: {
     schema: MultiEditSchema,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -1,6 +1,7 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getClient } from "../agent/client";
 import { resolveModel } from "../agent/model";
+import { getActiveChannelIds } from "../channels/registry";
 import { settingsManager } from "../settings-manager";
 import { toolFilter } from "./filter";
 import {
@@ -93,20 +94,36 @@ function getPreferredAgentModelHandle(
 }
 
 function getToolNamesForToolset(toolsetName: ToolsetName): ToolName[] {
+  let tools: ToolName[];
   switch (toolsetName) {
     case "codex":
-      return [...OPENAI_PASCAL_TOOLS];
+      tools = [...OPENAI_PASCAL_TOOLS];
+      break;
     case "codex_snake":
-      return [...OPENAI_DEFAULT_TOOLS];
+      tools = [...OPENAI_DEFAULT_TOOLS];
+      break;
     case "gemini":
-      return [...GEMINI_PASCAL_TOOLS];
+      tools = [...GEMINI_PASCAL_TOOLS];
+      break;
     case "gemini_snake":
-      return [...GEMINI_DEFAULT_TOOLS];
+      tools = [...GEMINI_DEFAULT_TOOLS];
+      break;
     case "none":
       return [];
     default:
-      return [...ANTHROPIC_DEFAULT_TOOLS];
+      tools = [...ANTHROPIC_DEFAULT_TOOLS];
+      break;
   }
+
+  // Append channel tool if channels are active (covers ALL pinned toolsets)
+  if (
+    getActiveChannelIds().length > 0 &&
+    !tools.includes("MessageChannel" as ToolName)
+  ) {
+    tools.push("MessageChannel" as ToolName);
+  }
+
+  return tools;
 }
 
 export async function prepareToolExecutionContextForResolvedTarget(params: {

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -350,6 +350,7 @@ export type QueueItemSource =
   | "user"
   | "task_notification"
   | "cron"
+  | "channel"
   | "subagent"
   | "system";
 

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -193,7 +193,8 @@ export type QueueMessageSource =
   | "task_notification"
   | "cron"
   | "subagent"
-  | "system";
+  | "system"
+  | "channel";
 
 export interface QueueMessage {
   id: string;

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -17,6 +17,7 @@ import {
   updateAgentLLMConfig,
   updateConversationLLMConfig,
 } from "../../agent/modify";
+import { getChannelRegistry } from "../../channels/registry";
 import { resetContextHistory } from "../../cli/helpers/contextTracker";
 import {
   ensureFileIndex,
@@ -1357,6 +1358,56 @@ async function handleReflectionSettingsCommand(
   return true;
 }
 
+/**
+ * Wire channel ingress into the listener.
+ *
+ * Registers the ChannelRegistry's message handler and marks it as ready,
+ * allowing buffered and future inbound channel messages to flow through
+ * the queue pump.
+ *
+ * Called from the socket "open" handler — same pattern as startCronScheduler.
+ * Uses closure-scoped socket/opts/processQueuedTurn.
+ */
+function wireChannelIngress(
+  listener: ListenerRuntime,
+  socket: WebSocket,
+  opts: StartListenerOptions,
+  processQueuedTurn: ProcessQueuedTurn,
+): void {
+  const registry = getChannelRegistry();
+  if (!registry) return;
+
+  registry.setMessageHandler((route, xmlContent) => {
+    // Follow the same pattern as cron/scheduler.ts:131-157
+    const rawRuntime = getOrCreateConversationRuntime(
+      listener,
+      route.agentId,
+      route.conversationId,
+    );
+    if (!rawRuntime) return;
+
+    const conversationRuntime = ensureConversationQueueRuntime(
+      listener,
+      rawRuntime,
+    );
+
+    conversationRuntime.queueRuntime.enqueue({
+      kind: "message",
+      source: "channel" as import("../../types/protocol").QueueItemSource,
+      content: xmlContent,
+      agentId: route.agentId,
+      conversationId: route.conversationId,
+    } as Omit<
+      import("../../queue/queueRuntime").MessageQueueItem,
+      "id" | "enqueuedAt"
+    >);
+
+    scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
+  });
+
+  registry.setReady();
+}
+
 export function ensureConversationQueueRuntime(
   listener: ListenerRuntime,
   runtime: ConversationRuntime,
@@ -2276,6 +2327,9 @@ async function connectWithRetry(
 
     // Start cron scheduler if tasks exist
     startCronScheduler(socket, opts, processQueuedTurn);
+
+    // Wire channel ingress (if channels are active)
+    wireChannelIngress(runtime, socket, opts, processQueuedTurn);
   });
 
   socket.on("message", async (data: WebSocket.RawData) => {
@@ -3704,6 +3758,13 @@ async function connectWithRetry(
 
     // Stop cron scheduler on disconnect
     stopCronScheduler();
+
+    // Pause channel delivery on disconnect (adapters keep polling, messages buffer).
+    // On reconnect, wireChannelIngress() re-registers the handler and calls setReady().
+    const channelRegistry = getChannelRegistry();
+    if (channelRegistry) {
+      channelRegistry.pause();
+    }
 
     // Clear the bridge before queue clearing to prevent a race where a task
     // completion enqueues into a shutting-down runtime.

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1375,9 +1375,16 @@ function wireChannelIngress(
   processQueuedTurn: ProcessQueuedTurn,
 ): void {
   const registry = getChannelRegistry();
-  if (!registry) return;
+  if (!registry) {
+    console.log("[wireChannelIngress] No channel registry found, skipping");
+    return;
+  }
 
+  console.log("[wireChannelIngress] Setting message handler and marking ready");
   registry.setMessageHandler((route, xmlContent) => {
+    console.log(
+      `[wireChannelIngress] Delivering message to ${route.agentId}/${route.conversationId}`,
+    );
     // Follow the same pattern as cron/scheduler.ts:131-157
     const rawRuntime = getOrCreateConversationRuntime(
       listener,
@@ -1391,21 +1398,53 @@ function wireChannelIngress(
       rawRuntime,
     );
 
-    conversationRuntime.queueRuntime.enqueue({
-      kind: "message",
-      source: "channel" as import("../../types/protocol").QueueItemSource,
-      content: xmlContent,
-      agentId: route.agentId,
-      conversationId: route.conversationId,
-    } as Omit<
-      import("../../queue/queueRuntime").MessageQueueItem,
-      "id" | "enqueuedAt"
-    >);
+    enqueueChannelTurn(conversationRuntime, route, xmlContent);
 
     scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
   });
 
   registry.setReady();
+}
+
+function enqueueChannelTurn(
+  runtime: ConversationRuntime,
+  route: {
+    agentId: string;
+    conversationId: string;
+  },
+  xmlContent: MessageCreate["content"],
+): { id: string } | null {
+  const clientMessageId = `cm-channel-${crypto.randomUUID()}`;
+  const enqueuedItem = runtime.queueRuntime.enqueue({
+    kind: "message",
+    source: "channel" as import("../../types/protocol").QueueItemSource,
+    content: xmlContent,
+    clientMessageId,
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+  } as Omit<
+    import("../../queue/queueRuntime").MessageQueueItem,
+    "id" | "enqueuedAt"
+  >);
+
+  if (!enqueuedItem) {
+    return null;
+  }
+
+  runtime.queuedMessagesByItemId.set(enqueuedItem.id, {
+    type: "message",
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+    messages: [
+      {
+        role: "user",
+        content: xmlContent,
+        client_message_id: clientMessageId,
+      } satisfies MessageCreate & { client_message_id?: string },
+    ],
+  });
+
+  return enqueuedItem;
 }
 
 export function ensureConversationQueueRuntime(
@@ -4186,6 +4225,7 @@ export const __listenClientTestUtils = {
   handleSkillCommand,
   handleCreateAgentCommand,
   handleReflectionSettingsCommand,
+  enqueueChannelTurn,
   scheduleQueuePump,
   replaySyncStateForRuntime,
   recoverApprovalStateForSync,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1375,16 +1375,9 @@ function wireChannelIngress(
   processQueuedTurn: ProcessQueuedTurn,
 ): void {
   const registry = getChannelRegistry();
-  if (!registry) {
-    console.log("[wireChannelIngress] No channel registry found, skipping");
-    return;
-  }
+  if (!registry) return;
 
-  console.log("[wireChannelIngress] Setting message handler and marking ready");
   registry.setMessageHandler((route, xmlContent) => {
-    console.log(
-      `[wireChannelIngress] Delivering message to ${route.agentId}/${route.conversationId}`,
-    );
     // Follow the same pattern as cron/scheduler.ts:131-157
     const rawRuntime = getOrCreateConversationRuntime(
       listener,

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -37,6 +37,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "doctor",
   "init",
   "remember",
+  "channels",
 ];
 
 /**
@@ -96,6 +97,15 @@ export async function handleExecuteCommand(
 
       case "remember":
         output = await handleRememberCommand(
+          socket,
+          conversationRuntime,
+          trimmedArgs,
+          opts,
+        );
+        break;
+
+      case "channels":
+        output = await handleChannelsCommand(
           socket,
           conversationRuntime,
           trimmedArgs,
@@ -367,4 +377,125 @@ async function handleRememberCommand(
   );
 
   return "Memory request submitted";
+}
+
+/**
+ * /channels — Manage external channel integrations.
+ *
+ * Subcommands (via WS):
+ *   /channels telegram pair <code>    — Approve pairing + bind chat to this agent/conversation
+ *   /channels telegram enable --chat-id <id> — Bind a known chat to this agent/conversation
+ *   /channels telegram disable        — Unbind this agent/conversation
+ *   /channels status                  — Show channel status
+ */
+async function handleChannelsCommand(
+  _socket: WebSocket,
+  conversationRuntime: ConversationRuntime,
+  args: string | undefined,
+  _opts: {
+    onStatusChange?: StartListenerOptions["onStatusChange"];
+    connectionId?: string;
+  },
+): Promise<string> {
+  const parts = (args ?? "").trim().split(/\s+/);
+  const [subCmd, action, ...rest] = parts;
+
+  const agentId = conversationRuntime.agentId;
+  const conversationId = conversationRuntime.conversationId;
+
+  if (!agentId) {
+    return "Error: No agent ID in current context.";
+  }
+
+  if (subCmd === "status") {
+    const { readChannelConfig } = await import("../../channels/config");
+    const { getRoutesForChannel, loadRoutes } = await import(
+      "../../channels/routing"
+    );
+    const { getPendingPairings, getApprovedUsers, loadPairingStore } =
+      await import("../../channels/pairing");
+
+    const channels = ["telegram"];
+    const lines: string[] = [];
+
+    for (const ch of channels) {
+      const config = readChannelConfig(ch);
+      if (!config) {
+        lines.push(`${ch}: not configured`);
+        continue;
+      }
+      loadRoutes(ch);
+      loadPairingStore(ch);
+      const routes = getRoutesForChannel(ch);
+      const pending = getPendingPairings(ch);
+      const approved = getApprovedUsers(ch);
+      lines.push(
+        `${ch}: enabled=${config.enabled}, policy=${config.dmPolicy}, ` +
+          `routes=${routes.length}, pending=${pending.length}, approved=${approved.length}`,
+      );
+    }
+
+    return lines.join("\n") || "No channels configured.";
+  }
+
+  if (subCmd === "telegram") {
+    if (action === "pair") {
+      const code = rest[0];
+      if (!code) {
+        return "Usage: /channels telegram pair <code>";
+      }
+
+      const { completePairing } = await import("../../channels/registry");
+      const { loadRoutes } = await import("../../channels/routing");
+      const { loadPairingStore } = await import("../../channels/pairing");
+
+      loadRoutes("telegram");
+      loadPairingStore("telegram");
+
+      const result = completePairing("telegram", code, agentId, conversationId);
+
+      if (result.success) {
+        return `Pairing approved! Chat ${result.chatId} is now bound to this agent/conversation.`;
+      }
+      return `Pairing failed: ${result.error}`;
+    }
+
+    if (action === "enable") {
+      const chatIdFlag = rest.indexOf("--chat-id");
+      const chatId = chatIdFlag >= 0 ? rest[chatIdFlag + 1] : undefined;
+
+      if (!chatId) {
+        return "Usage: /channels telegram enable --chat-id <id>";
+      }
+
+      const { addRoute, loadRoutes } = await import("../../channels/routing");
+
+      loadRoutes("telegram");
+      addRoute("telegram", {
+        chatId,
+        agentId,
+        conversationId,
+        enabled: true,
+        createdAt: new Date().toISOString(),
+      });
+
+      return `Route created: telegram:${chatId} → ${agentId}/${conversationId}`;
+    }
+
+    if (action === "disable") {
+      const { removeRoutesForScope, loadRoutes } = await import(
+        "../../channels/routing"
+      );
+
+      loadRoutes("telegram");
+      const removed = removeRoutesForScope("telegram", agentId, conversationId);
+      return removed > 0
+        ? `Removed ${removed} route(s) for this agent/conversation.`
+        : "No routes found for this agent/conversation.";
+    }
+
+    return "Usage: /channels telegram <pair|enable|disable>";
+  }
+
+  return "Usage: /channels <telegram|status>";
 }


### PR DESCRIPTION
## Summary

- Adds a **channels system** enabling agents to receive and respond to messages from external platforms, starting with Telegram
- Messages flow into the agent queue as XML-wrapped `kind: "message"` items with `source: "channel"`
- Agents reply via a new **MessageChannel** client-side tool
- Telegram adapter uses **grammY** with long-polling (no webhook/public URL needed)
- Includes CLI (`letta channels configure|status|route|pair`), `--channels` flag on `letta server`, and `/channels` WS command for live management from ADE
- Channels survive WS reconnects (pause/resume lifecycle — adapters keep polling, messages buffer)
- Atomic pairing with snapshot-based rollback on disk failure
- Includes tests for XML formatting, pairing, routing, registry lifecycle, Telegram adapter error handling, and protocol types

## Setup Instructions

Current recommended Telegram flow:

1. Configure Telegram:
   - `letta channels configure telegram`
2. Start the WS listener with Telegram enabled:
   - `letta server --channels telegram`
3. Message the bot from **Telegram** once to receive a pairing code.
4. In the target ADE/Desktop conversation, bind that Telegram chat to the current agent/conversation:
   - `/channels telegram pair <code>`
5. Continue chatting with the agent from Telegram.

Notes:
- `letta channels pair ...` and `letta channels route ...` also exist as standalone CLI commands, but they are file-oriented management commands. The recommended live path is the `/channels ...` WS command from the target conversation.
- Current listener startup is explicit: Telegram only starts when the listener is launched with `--channels telegram`.

## Data Storage

Persisted state lives under `~/.letta/channels/telegram/`:

- `config.yaml`
  - bot token
  - `enabled`
  - `dmPolicy`
  - `allowedUsers`
- `pairing.yaml`
  - pending pairing codes
  - approved Telegram users
- `routing.yaml`
  - Telegram `chat_id` -> Letta `agent_id` + `conversation_id` bindings

These files are currently **machine-scoped**, not agent-scoped.

## Client-Side Tool

### Tool Name

`MessageChannel`

### Description

> Send a message to an external channel (Telegram, Slack, etc.) in response to a channel notification.
>
> When you receive a `<channel-notification>`, use this tool to reply. Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
>
> Parameters:
> - `channel`: The platform to send to (matches the `source` attribute)
> - `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
> - `text`: The message text to send
> - `reply_to_message_id`: (Optional) Reply to a specific message by its `message_id`

### Schema

```json
{
  "type": "object",
  "properties": {
    "channel": {
      "type": "string",
      "description": "The channel to send the message to (e.g., 'telegram')"
    },
    "chat_id": {
      "type": "string",
      "description": "The chat/conversation ID to send to (from the channel-notification attributes)"
    },
    "text": {
      "type": "string",
      "description": "The message text to send"
    },
    "reply_to_message_id": {
      "type": "string",
      "description": "Optional message ID to reply to"
    }
  },
  "required": ["channel", "chat_id", "text"],
  "additionalProperties": false
}
```

Runtime note:
- when channels are active, the `channel` field gets a runtime-injected enum limited to the currently active channel ids

### Exposure / Attachment Behavior

Important clarification for reviewers: in this MVP, `MessageChannel` is **not** attached only to agent/conversation pairs that already have a Telegram route.

Current behavior:
- if any channels are active in the listener process, `MessageChannel` is added to the prepared client toolset
- this is a **process-global exposure** decision, not per-route/per-conversation tool attachment
- the actual safety boundary is execution-time validation in the tool implementation:
  - the tool receives injected `parentScope` (`agentId` + `conversationId`)
  - it looks up the route for `channel + chat_id`
  - it only sends if that route belongs to the executing agent/conversation

So the MVP tradeoff is:
- broad tool availability when channels are enabled
- strict send authorization at execution time

👾 Generated with [Letta Code](https://letta.com)
