### PR TITLE
fix: ExitPlanMode restores to default instead of memory mode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -14042,7 +14042,9 @@ ${SYSTEM_REMINDER_CLOSE}
             ? "bypassPermissions"
             : acceptEdits
               ? "acceptEdits"
-              : (previousMode ?? "default");
+              : previousMode === "memory"
+                ? "default"
+                : (previousMode ?? "default");
         permissionMode.setMode(restoreMode);
         setUiPermissionMode(restoreMode);
       } else {

--- a/src/tests/tools/exitplanmode.test.ts
+++ b/src/tests/tools/exitplanmode.test.ts
@@ -26,6 +26,18 @@ describe("ExitPlanMode tool", () => {
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 
+  test("restores to default (not memory) when entering plan from memory mode", async () => {
+    permissionMode.reset();
+    permissionMode.setMode("memory");
+    permissionMode.setMode("plan");
+    permissionMode.setPlanFilePath("/tmp/test-plan.md");
+
+    await exit_plan_mode();
+
+    expect(permissionMode.getMode()).toBe("default");
+    expect(permissionMode.getPlanFilePath()).toBeNull();
+  });
+
   test("returns approval message", async () => {
     permissionMode.reset();
     const result = await exit_plan_mode();

--- a/src/tools/impl/ExitPlanMode.ts
+++ b/src/tools/impl/ExitPlanMode.ts
@@ -26,12 +26,16 @@ export async function exit_plan_mode(
   // restore here as a fallback to avoid getting stuck in plan mode.
   if (scopedState) {
     if (scopedState.mode === "plan") {
-      scopedState.mode = scopedState.modeBeforePlan ?? "default";
+      const prev = scopedState.modeBeforePlan;
+      // Restore the previous mode, but never restore "memory" — fall back to
+      // "default" so the user isn't stuck in a restricted mode after plan approval.
+      scopedState.mode = prev === "memory" ? "default" : (prev ?? "default");
       scopedState.modeBeforePlan = null;
       scopedState.planFilePath = null;
     }
   } else if (permissionMode.getMode() === "plan") {
-    const restoredMode = permissionMode.getModeBeforePlan() ?? "default";
+    const prev = permissionMode.getModeBeforePlan();
+    const restoredMode = prev === "memory" ? "default" : (prev ?? "default");
     permissionMode.setMode(restoredMode);
   }
 


### PR DESCRIPTION
When plan mode was entered from memory mode, approving the plan incorrectly restored to memory mode. Now always restores to default (manual approve) unless the user was in bypassPermissions/yolo.

🐾 Generated with [Letta Code](https://letta.com)