### PR TITLE
fix: align listener task_notification queue semantics

### DIFF
--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -853,7 +853,68 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtime.queuedMessagesByItemId.size).toBe(0);
   });
 
-  test("consumeQueuedTurn only drains the next same-scope queued turn batch", () => {
+  test("task_notification-only queue items re-enter the listener loop as standalone turns", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-task",
+    );
+    const socket = new MockSocket();
+    const processed: IncomingMessage[] = [];
+
+    const taskInput = {
+      kind: "task_notification",
+      source: "task_notification",
+      text: "<task-notification>done</task-notification>",
+      clientMessageId: "cm-task-only",
+      agentId: "agent-1",
+      conversationId: "conv-task",
+    } satisfies Omit<TaskNotificationQueueItem, "id" | "enqueuedAt">;
+
+    const taskItem = runtime.queueRuntime.enqueue(taskInput);
+
+    expect(taskItem).not.toBeNull();
+    expect(runtime.queueRuntime.length).toBe(1);
+
+    __listenClientTestUtils.scheduleQueuePump(
+      runtime,
+      socket as unknown as WebSocket,
+      {
+        connectionId: "conn-1",
+        onStatusChange: undefined,
+      } as never,
+      async (queuedTurn: IncomingMessage) => {
+        processed.push(queuedTurn);
+      },
+    );
+
+    await waitFor(() => processed.length === 1);
+
+    expect(processed[0]).toEqual(
+      expect.objectContaining({
+        type: "message",
+        agentId: "agent-1",
+        conversationId: "conv-task",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "<task-notification>done</task-notification>",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(runtime.queueRuntime.length).toBe(0);
+    expect(runtime.queuedMessagesByItemId.size).toBe(0);
+  });
+
+  test("consumeQueuedTurn coalesces same-scope task notifications into the next queued turn batch", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const messageInput = {
       kind: "message",
@@ -912,17 +973,23 @@ describe("listen-client multi-worker concurrency", () => {
     expect(consumed).not.toBeNull();
     expect(
       consumed?.dequeuedBatch.items.map((item: { id: string }) => item.id),
-    ).toEqual([messageItem.id]);
+    ).toEqual([messageItem.id, taskItem.id]);
     expect(consumed?.queuedTurn.messages).toEqual([
       {
         role: "user",
-        content: [{ type: "text", text: "queued user" }],
+        content: [
+          { type: "text", text: "queued user" },
+          { type: "text", text: "\n" },
+          {
+            type: "text",
+            text: "<task-notification>done</task-notification>",
+          },
+        ],
       },
     ]);
-    expect(runtime.queueRuntime.length).toBe(2);
+    expect(runtime.queueRuntime.length).toBe(1);
     expect(runtime.queuedMessagesByItemId.has(otherMessageItem.id)).toBe(true);
     expect(runtime.queueRuntime.peek().map((item) => item.id)).toEqual([
-      taskItem.id,
       otherMessageItem.id,
     ]);
   });
@@ -1025,7 +1092,14 @@ describe("listen-client multi-worker concurrency", () => {
     );
     expect(continuationMessages?.[1]).toEqual({
       role: "user",
-      content: [{ type: "text", text: "queued user" }],
+      content: [
+        { type: "text", text: "queued user" },
+        { type: "text", text: "\n" },
+        {
+          type: "text",
+          text: "<task-notification>done</task-notification>",
+        },
+      ],
     });
     expect(continuationMessages?.[2]).toEqual({
       role: "user",
@@ -1038,8 +1112,7 @@ describe("listen-client multi-worker concurrency", () => {
       otid: expect.any(String),
     });
     expect(runtime.loopStatus as string).toBe("PROCESSING_API_RESPONSE");
-    expect(runtime.queueRuntime.length).toBe(1);
-    expect(runtime.queueRuntime.peek()[0]?.kind).toBe("task_notification");
+    expect(runtime.queueRuntime.length).toBe(0);
     expect(runtime.queuedMessagesByItemId.size).toBe(0);
     expect(
       socket.sentPayloads.some((payload) => payload.includes("queued user")),
@@ -1048,7 +1121,7 @@ describe("listen-client multi-worker concurrency", () => {
       socket.sentPayloads.some((payload) =>
         payload.includes("<task-notification>done</task-notification>"),
       ),
-    ).toBe(false);
+    ).toBe(true);
 
     drain.resolve({
       stopReason: "end_turn",

--- a/src/tests/websocket/listen-reflection-wiring.test.ts
+++ b/src/tests/websocket/listen-reflection-wiring.test.ts
@@ -17,7 +17,9 @@ describe("listen reflection wiring", () => {
     expect(turnSource).toContain("buildAutoReflectionPayload(");
     expect(turnSource).toContain("finalizeAutoReflectionPayload(");
     expect(turnSource).toContain("handleMemorySubagentCompletion(");
-    expect(turnSource).toContain("emitStatusDelta(socket, runtime, {");
+    expect(turnSource).toContain("emitCanonicalMessageDelta(");
+    expect(turnSource).toContain('message_type: "user_message"');
+    expect(turnSource).toContain("<task-notification><summary>${escapeTaskNotificationSummary(");
     expect(turnSource).toContain('subagentType: "reflection"');
     expect(turnSource).toContain("appendTranscriptDeltaJsonl(");
     expect(turnSource).toContain("syncReminderStateFromContextTracker(");
@@ -25,6 +27,7 @@ describe("listen reflection wiring", () => {
     expect(turnSource).toContain("maybeLaunchReflectionSubagent:");
     expect(turnSource).toContain("runtime.contextTracker,");
     expect(turnSource).not.toContain("emitCompletionNotification: true");
+    expect(turnSource).not.toContain("emitStatusDelta(socket, runtime, {");
 
     expect(listenContextSource).toContain(
       "reflectionSettings: ReflectionSettings",

--- a/src/tests/websocket/listen-reflection-wiring.test.ts
+++ b/src/tests/websocket/listen-reflection-wiring.test.ts
@@ -17,12 +17,14 @@ describe("listen reflection wiring", () => {
     expect(turnSource).toContain("buildAutoReflectionPayload(");
     expect(turnSource).toContain("finalizeAutoReflectionPayload(");
     expect(turnSource).toContain("handleMemorySubagentCompletion(");
+    expect(turnSource).toContain("emitStatusDelta(socket, runtime, {");
     expect(turnSource).toContain('subagentType: "reflection"');
     expect(turnSource).toContain("appendTranscriptDeltaJsonl(");
     expect(turnSource).toContain("syncReminderStateFromContextTracker(");
     expect(turnSource).toContain("getReflectionSettings(");
     expect(turnSource).toContain("maybeLaunchReflectionSubagent:");
     expect(turnSource).toContain("runtime.contextTracker,");
+    expect(turnSource).not.toContain("emitCompletionNotification: true");
 
     expect(listenContextSource).toContain(
       "reflectionSettings: ReflectionSettings",

--- a/src/tests/websocket/listen-reflection-wiring.test.ts
+++ b/src/tests/websocket/listen-reflection-wiring.test.ts
@@ -19,7 +19,9 @@ describe("listen reflection wiring", () => {
     expect(turnSource).toContain("handleMemorySubagentCompletion(");
     expect(turnSource).toContain("emitCanonicalMessageDelta(");
     expect(turnSource).toContain('message_type: "user_message"');
-    expect(turnSource).toContain("<task-notification><summary>${escapeTaskNotificationSummary(");
+    expect(turnSource).toContain(
+      "<task-notification><summary>${escapeTaskNotificationSummary(",
+    );
     expect(turnSource).toContain('subagentType: "reflection"');
     expect(turnSource).toContain("appendTranscriptDeltaJsonl(");
     expect(turnSource).toContain("syncReminderStateFromContextTracker(");

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -308,17 +308,6 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
       break;
     }
 
-    // Keep task notifications in their own dequeue batch so they don't get
-    // merged into adjacent user/cron payloads.
-    if (
-      (firstQueuedItem.kind === "task_notification" &&
-        item.kind !== "task_notification") ||
-      (firstQueuedItem.kind !== "task_notification" &&
-        item.kind === "task_notification")
-    ) {
-      break;
-    }
-
     queueLen += 1;
     if (item.kind === "message") {
       hasMessage = true;
@@ -409,16 +398,6 @@ async function drainQueuedMessages(
       const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
 
       emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
-
-      // Notification-only batches: emit to frontend for display, skip
-      // model execution. The agent doesn't need the notification text —
-      // the system prompt was already recompiled with updated memories.
-      const isNotificationOnlyBatch =
-        dequeuedBatch.items.length > 0 &&
-        dequeuedBatch.items.every((item) => item.kind === "task_notification");
-      if (isNotificationOnlyBatch) {
-        continue;
-      }
 
       const preTurnStatus =
         getListenerStatus(runtime.listener) === "processing"

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -75,7 +75,6 @@ import {
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
-  emitStatusDelta,
   setLoopStatus,
 } from "./protocol-outbound";
 import {
@@ -150,6 +149,13 @@ function hasActiveReflectionSubagent(
       agent.parentAgentId === agentId && parentConversationId === conversationId
     );
   });
+}
+
+function escapeTaskNotificationSummary(summary: string): string {
+  return summary
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function buildMaybeLaunchReflectionSubagent(params: {
@@ -236,12 +242,24 @@ function buildMaybeLaunchReflectionSubagent(params: {
               logRecompileFailure: (message) => debugWarn("memory", message),
             },
           );
-          emitStatusDelta(socket, runtime, {
-            message: completionMessage,
-            level: success ? "success" : "warning",
-            agentId,
-            conversationId,
-          });
+          const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
+            completionMessage,
+          )}</summary></task-notification>`;
+          emitCanonicalMessageDelta(
+            socket,
+            runtime,
+            {
+              type: "message",
+              id: `user-msg-${crypto.randomUUID()}`,
+              date: new Date().toISOString(),
+              message_type: "user_message",
+              content: notificationXml,
+            } as StreamDelta,
+            {
+              agent_id: agentId,
+              conversation_id: conversationId,
+            },
+          );
         },
       });
       telemetry.trackReflectionStart(triggerSource, {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -253,7 +253,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
               id: `user-msg-${crypto.randomUUID()}`,
               date: new Date().toISOString(),
               message_type: "user_message",
-              content: notificationXml,
+              content: [{ type: "text", text: notificationXml }],
             } as StreamDelta,
             {
               agent_id: agentId,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -75,6 +75,7 @@ import {
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
+  emitStatusDelta,
   setLoopStatus,
 } from "./protocol-outbound";
 import {
@@ -153,12 +154,14 @@ function hasActiveReflectionSubagent(
 
 function buildMaybeLaunchReflectionSubagent(params: {
   runtime: ConversationRuntime;
+  socket: WebSocket;
   agentId: string;
   conversationId: string;
   workingDirectory: string;
 }): (triggerSource: Exclude<ReflectionTrigger, "off">) => Promise<boolean> {
   return async (triggerSource) => {
-    const { runtime, agentId, conversationId, workingDirectory } = params;
+    const { runtime, socket, agentId, conversationId, workingDirectory } =
+      params;
 
     if (!agentId || !settingsManager.isMemfsEnabled(agentId)) {
       return false;
@@ -197,18 +200,11 @@ function buildMaybeLaunchReflectionSubagent(params: {
       const { spawnBackgroundSubagentTask } = await import(
         "../../tools/impl/Task"
       );
-      const reflectionSuccessSummary =
-        "Reflected on the memory palace, the halls remember more now";
       const { subagentId } = spawnBackgroundSubagentTask({
         subagentType: "reflection",
         prompt: reflectionPrompt,
         description: AUTO_REFLECTION_DESCRIPTION,
         silentCompletion: true,
-        emitCompletionNotification: true,
-        completionSummary: ({ success, error }) =>
-          success
-            ? reflectionSuccessSummary
-            : `Tried to reflect, but got lost in the palace: ${error || "Unknown error"}`,
         parentScope: { agentId, conversationId },
         onComplete: async ({ success, error }) => {
           telemetry.trackReflectionEnd(triggerSource, success, {
@@ -224,7 +220,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
             success,
           );
 
-          await handleMemorySubagentCompletion(
+          const completionMessage = await handleMemorySubagentCompletion(
             {
               agentId,
               conversationId,
@@ -240,6 +236,12 @@ function buildMaybeLaunchReflectionSubagent(params: {
               logRecompileFailure: (message) => debugWarn("memory", message),
             },
           );
+          emitStatusDelta(socket, runtime, {
+            message: completionMessage,
+            level: success ? "success" : "warning",
+            agentId,
+            conversationId,
+          });
         },
       });
       telemetry.trackReflectionStart(triggerSource, {
@@ -470,6 +472,7 @@ export async function handleIncomingMessage(
             maybeLaunchReflectionSubagent: agentId
               ? buildMaybeLaunchReflectionSubagent({
                   runtime,
+                  socket,
                   agentId,
                   conversationId,
                   workingDirectory: turnWorkingDirectory,


### PR DESCRIPTION
## Summary

This PR fixes a listener-only semantic drift around `task_notification` handling.

It does two things:

- restores listener queue behavior to match TUI/headless for real queued `task_notification` items
- moves reflection-specific silencing back to the source, while preserving the existing desktop-friendly task-notification UI

Concretely:

- notification-only `task_notification` batches now re-enter the listener loop as standalone turns
- same-scope `task_notification` items can coalesce with adjacent queued `message` / `cron_prompt` input again, using the shared queued-turn merge model
- listener auto-reflection no longer relies on the queue-level `task_notification` special-case to stay “silent”
- instead, reflection completion emits a synthetic `user_message` stream delta containing pure `<task-notification>...</task-notification>` XML, which preserves the existing desktop rendering without re-enqueuing agent input

## What Was Wrong With The Earlier Listener Fix

Christina's earlier listener fixes addressed a real problem: reflection/task completions were surfacing awkwardly, and reflection notifications needed to look nice in the desktop UI.

Those fixes did two tactical things in the listener queue layer:

1. `task_notification`-only batches were dequeued, emitted to the frontend, and then skipped instead of going through `processQueuedTurn()`
2. `task_notification` items were forced into their own dequeue batch so they would not merge into adjacent same-scope `message` / `cron_prompt` payloads

That solved the immediate reflection/display issue, but it also changed the meaning of **all** listener `task_notification` items:

- background task completions stopped behaving like real queued turn input in listener mode
- listener diverged from TUI/headless, which both treat `task_notification` as a real queued input kind
- a reflection-specific policy got applied globally at the queue layer

In other words: the fix worked locally for reflection UI, but at the cost of making listener queue semantics inconsistent with the rest of the app.

## How This Patches It Safely

This PR fixes the problem in two safer layers.

### 1. Restore shared queue semantics

In the listener queue, this PR removes the two special cases above.

That means:

- `task_notification`-only batches now behave like other coalescable queued input and restart the loop
- same-scope `task_notification` can merge with adjacent `message` / `cron_prompt` input again
- listener now matches the shared merge model already used elsewhere via `mergeQueuedTurnInput()` in `src/queue/turnQueueRuntime.ts`

This is the actual semantic fix.

### 2. Move reflection silencing to the source

Reflection was the main reason those listener queue exceptions existed.

Instead of encoding reflection policy in the generic queue consumer, this PR now handles it in `src/websocket/listener/turn.ts`:

- auto-reflection no longer emits a queued `task_notification`
- reflection still stays silent from the agent-loop perspective
- on completion, listener emits a synthetic `user_message` stream delta containing pure task-notification XML

That preserves the existing desktop/ADE rendering behavior, because the UI already renders pure `<task-notification>` content inside a `user_message` as a task-notification event row.

So we keep the good UX from the earlier fix, but we stop making the queue itself lie about what `task_notification` means.

## What Changes In The Cron Area

There was a second place where the old listener behavior showed up: cron-adjacent batching.

Listener had a special rule that prevented `task_notification` from being dequeued together with adjacent same-scope `cron_prompt` input.

This PR removes that listener-only split.

After this change:

- `cron_prompt` and `task_notification` both go through the same shared queued-turn merge logic
- same-scope cron/task/user input can coalesce into a single queued turn when appropriate
- listener stops treating cron-adjacent task notifications as a special exception

Why this is safe:

- `cron_prompt` is already part of the shared queued-turn merge contract in `src/queue/turnQueueRuntime.ts`
- TUI/headless already rely on the shared “queued inputs merge into next turn content” model
- the listener-only split was defensive local behavior, not a deeper protocol requirement

So the cron part of this PR is not a new feature; it is removal of a listener-only divergence so cron/task batching follows the same queue model as the rest of the app.

## Behavior Change

After this PR:

- `task_notification`-only batches trigger `processQueuedTurn()` in listener mode
- same-scope `message + task_notification` batches merge into one queued turn
- same-scope `cron_prompt + task_notification` batches can also merge through the shared queued-turn path
- stale approval recovery carries same-scope queued task notifications forward in the continuation turn instead of leaving them stranded
- silent reflection completion no longer depends on queue-level suppression; it emits a UI-visible task-notification transcript delta without re-enqueuing agent input

## Tests

Ran:

- `bun test src/tests/websocket/listen-reflection-wiring.test.ts`
- `bun test src/tests/websocket/listen-client-concurrency.test.ts --test-name-pattern "task_notification-only|same-scope|stale approval"`
- `bun test src/tests/websocket/listen-client-protocol.test.ts --test-name-pattern "status|reflection|stream_delta"`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)
