### PR TITLE
fix(ci): patch failing ci

### DIFF
--- a/src/tests/telemetry/flush-auth.test.ts
+++ b/src/tests/telemetry/flush-auth.test.ts
@@ -17,6 +17,18 @@ describe("telemetry flush auth", () => {
   const originalGetSettingsWithSecureTokens =
     settingsManager.getSettingsWithSecureTokens;
   const originalGetSettings = settingsManager.getSettings;
+  const originalLettaApiKey = process.env.LETTA_API_KEY;
+  const originalTelemetryDisabled = process.env.LETTA_TELEMETRY_DISABLED;
+  const originalLettaBaseUrl = process.env.LETTA_BASE_URL;
+
+  function restoreEnvVar(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+      return;
+    }
+
+    process.env[name] = value;
+  }
 
   beforeEach(() => {
     telemetry.cleanup();
@@ -38,6 +50,9 @@ describe("telemetry flush auth", () => {
     settingsManager.getSettingsWithSecureTokens =
       originalGetSettingsWithSecureTokens;
     settingsManager.getSettings = originalGetSettings;
+    restoreEnvVar("LETTA_API_KEY", originalLettaApiKey);
+    restoreEnvVar("LETTA_TELEMETRY_DISABLED", originalTelemetryDisabled);
+    restoreEnvVar("LETTA_BASE_URL", originalLettaBaseUrl);
   });
 
   test("flush falls back to secure settings token when env var is absent", async () => {


### PR DESCRIPTION
## Summary
- restore `LETTA_API_KEY`, `LETTA_TELEMETRY_DISABLED`, and `LETTA_BASE_URL` after `flush-auth.test.ts`
- keep the telemetry auth tests isolated from later suites that inspect process env
- eliminate the order-dependent Linux x64 hook E2E flake introduced when the suite started setting a fake `LETTA_API_KEY`

## Verification
- `env -u LETTA_API_KEY -u LETTA_TELEMETRY_DISABLED -u LETTA_BASE_URL bun test --max-concurrency 1 src/tests/telemetry/flush-auth.test.ts src/tests/hooks/e2e.test.ts`
- `for seed in 1 2 3 4 5 6 7 8 9 10; do env -u LETTA_API_KEY -u LETTA_TELEMETRY_DISABLED -u LETTA_BASE_URL bun test --randomize --seed=$seed --max-concurrency 1 src/tests/telemetry/flush-auth.test.ts src/tests/hooks/e2e.test.ts | rg "src/tests/(hooks|telemetry)/|pass|skip|fail|Ran|--seed"; done`

## Root cause
`src/tests/telemetry/flush-auth.test.ts` set `process.env.LETTA_API_KEY = "env-key"` in one test, but never restored it in `afterEach`. When Bun later ran `src/tests/hooks/e2e.test.ts` in the same worker, those tests saw the leaked fake key, stopped skipping, and failed against the real CLI flow with an empty hook marker.