### PR TITLE
fix: skip YAML continuation lines in pre-commit frontmatter validator

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -405,6 +405,10 @@ for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memor
   # Validate each line
   while IFS= read -r line; do
     [ -z "$line" ] && continue
+    # Skip YAML multiline continuation lines (indented lines that continue a previous value)
+    case "$line" in
+      " "*|$'\t'*) continue ;;
+    esac
 
     key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
     value=$(echo "$line" | cut -d: -f2- | sed 's/^ *//;s/ *$//')


### PR DESCRIPTION
Closes #1678

## Problem

The pre-commit hook installed by `installPreCommitHook()` in `src/agent/memoryGit.ts` validates frontmatter line-by-line using:

```bash
key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
```

This does not account for YAML multiline scalar continuation lines — indented lines that are a continuation of the previous key's value. For example:

```yaml
---
description: What I've learned about the person I'm working with. Understanding them
  helps me be genuinely helpful rather than generically helpful.
---
```

The continuation line `  helps me be genuinely helpful...` gets parsed as a new key (`helpsmebegenuinelyhelpfulratherthangenericallyhelpful.`), which is not in `ALL_KNOWN_KEYS`, causing the commit to fail with a misleading error:

```
Frontmatter validation failed:
  system/human.md: unknown frontmatter key 'helpsmebegenuinelyhelpfulratherthangenericallyhelpful.' (allowed: description read_only limit)
```

## Fix

Add a `case` statement in the `while IFS= read -r line` loop to skip lines that begin with whitespace (spaces or tabs). These are valid YAML multiline scalar continuation lines and should not be treated as new keys:

```bash
# Skip YAML multiline continuation lines (indented lines that continue a previous value)
case "$line" in
  " "*|$'\t'*) continue ;;
esac
```

This is the minimal, correct fix: continuation lines in block scalars and folded/literal multiline values always start with at least one space of indentation beyond the key level.