### PR TITLE
feat: add live websocket channel management

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -40,6 +40,10 @@ export function getChannelRegistry(): ChannelRegistry | null {
   return instance;
 }
 
+export function ensureChannelRegistry(): ChannelRegistry {
+  return instance ?? new ChannelRegistry();
+}
+
 export function getActiveChannelIds(): string[] {
   if (!instance) return [];
   return instance.getActiveChannelIds();
@@ -52,12 +56,18 @@ export type ChannelMessageHandler = (
   xmlContent: string,
 ) => void;
 
+export type ChannelRegistryEvent = {
+  type: "pairings_updated";
+  channelId: string;
+};
+
 // ── Registry ──────────────────────────────────────────────────────
 
 export class ChannelRegistry {
   private readonly adapters = new Map<string, ChannelAdapter>();
   private ready = false;
   private messageHandler: ChannelMessageHandler | null = null;
+  private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private readonly buffer: Array<{
     route: ChannelRoute;
     xmlContent: string;
@@ -103,6 +113,12 @@ export class ChannelRegistry {
     this.messageHandler = handler;
   }
 
+  setEventHandler(
+    handler: ((event: ChannelRegistryEvent) => void) | null,
+  ): void {
+    this.eventHandler = handler;
+  }
+
   /**
    * Mark the registry as ready, flushing any buffered messages.
    */
@@ -124,6 +140,45 @@ export class ChannelRegistry {
     return getRouteFromStore(channel, chatId);
   }
 
+  async startChannel(channelId: string): Promise<boolean> {
+    const config = readChannelConfig(channelId);
+    if (!config) {
+      return false;
+    }
+
+    loadRoutes(channelId);
+    loadPairingStore(channelId);
+
+    const existing = this.adapters.get(channelId);
+    if (existing?.isRunning()) {
+      await existing.stop();
+    }
+    this.adapters.delete(channelId);
+
+    if (channelId === "telegram") {
+      const { createTelegramAdapter } = await import("./telegram/adapter");
+      const adapter = createTelegramAdapter(config);
+      this.registerAdapter(adapter);
+      await adapter.start();
+      return true;
+    }
+
+    console.error(`Unknown channel "${channelId}". Supported: telegram`);
+    return false;
+  }
+
+  async stopChannel(channelId: string): Promise<boolean> {
+    const adapter = this.adapters.get(channelId);
+    if (!adapter) {
+      return false;
+    }
+    if (adapter.isRunning()) {
+      await adapter.stop();
+    }
+    this.adapters.delete(channelId);
+    return true;
+  }
+
   // ── Lifecycle ─────────────────────────────────────────────────
 
   async startAll(): Promise<void> {
@@ -142,6 +197,7 @@ export class ChannelRegistry {
   pause(): void {
     this.ready = false;
     this.messageHandler = null;
+    this.eventHandler = null;
   }
 
   /**
@@ -156,6 +212,7 @@ export class ChannelRegistry {
     }
     this.ready = false;
     this.messageHandler = null;
+    this.eventHandler = null;
     instance = null;
   }
 
@@ -192,6 +249,10 @@ export class ChannelRegistry {
           msg.chatId,
           msg.senderName,
         );
+        this.eventHandler?.({
+          type: "pairings_updated",
+          channelId: msg.channel,
+        });
         await adapter.sendDirectReply(
           msg.chatId,
           `To connect this chat to a Letta Code agent, run:\n\n` +
@@ -258,7 +319,7 @@ export class ChannelRegistry {
 export async function initializeChannels(
   channelNames: string[],
 ): Promise<ChannelRegistry> {
-  const registry = new ChannelRegistry();
+  const registry = ensureChannelRegistry();
 
   for (const channelId of channelNames) {
     const config = readChannelConfig(channelId);
@@ -274,22 +335,8 @@ export async function initializeChannels(
       continue;
     }
 
-    // Load persistent state
-    loadRoutes(channelId);
-    loadPairingStore(channelId);
-
-    // Create and register adapter
-    if (channelId === "telegram") {
-      const { createTelegramAdapter } = await import("./telegram/adapter");
-      const adapter = createTelegramAdapter(config);
-      registry.registerAdapter(adapter);
-    } else {
-      console.error(`Unknown channel: "${channelId}". Supported: telegram`);
-    }
+    await registry.startChannel(channelId);
   }
-
-  // Start all adapters (begin receiving, buffer until ready)
-  await registry.startAll();
 
   return registry;
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1,0 +1,333 @@
+import { readChannelConfig, writeChannelConfig } from "./config";
+import {
+  getApprovedUsers,
+  getPendingPairings,
+  loadPairingStore,
+} from "./pairing";
+import {
+  completePairing,
+  ensureChannelRegistry,
+  getChannelRegistry,
+  initializeChannels,
+} from "./registry";
+import {
+  getRoute,
+  getRoutesForChannel,
+  loadRoutes,
+  removeRoute,
+} from "./routing";
+import type {
+  ChannelConfig,
+  ChannelRoute,
+  DmPolicy,
+  SupportedChannelId,
+  TelegramChannelConfig,
+} from "./types";
+
+export const CHANNEL_DISPLAY_NAMES: Record<SupportedChannelId, string> = {
+  telegram: "Telegram",
+};
+
+export interface ChannelSummary {
+  channelId: SupportedChannelId;
+  displayName: string;
+  configured: boolean;
+  enabled: boolean;
+  running: boolean;
+  dmPolicy: DmPolicy | null;
+  pendingPairingsCount: number;
+  approvedUsersCount: number;
+  routesCount: number;
+}
+
+export interface ChannelConfigSnapshot {
+  channelId: SupportedChannelId;
+  enabled: boolean;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+  hasToken: boolean;
+}
+
+export interface PendingPairingSnapshot {
+  code: string;
+  senderId: string;
+  senderName?: string;
+  chatId: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface ChannelRouteSnapshot {
+  channelId: SupportedChannelId;
+  chatId: string;
+  agentId: string;
+  conversationId: string;
+  enabled: boolean;
+  createdAt: string;
+}
+
+export interface ChannelConfigPatch {
+  token?: string;
+  dmPolicy?: DmPolicy;
+  allowedUsers?: string[];
+}
+
+function assertSupportedChannelId(
+  channelId: string,
+): asserts channelId is SupportedChannelId {
+  if (channelId !== "telegram") {
+    throw new Error(`Unsupported channel: ${channelId}`);
+  }
+}
+
+function toConfigSnapshot(
+  channelId: SupportedChannelId,
+  config: ChannelConfig,
+): ChannelConfigSnapshot {
+  return {
+    channelId,
+    enabled: config.enabled,
+    dmPolicy: config.dmPolicy,
+    allowedUsers: [...config.allowedUsers],
+    hasToken: config.token.trim().length > 0,
+  };
+}
+
+function toPendingPairingSnapshot(pending: {
+  code: string;
+  telegramUserId: string;
+  telegramUsername?: string;
+  chatId: string;
+  createdAt: string;
+  expiresAt: string;
+}): PendingPairingSnapshot {
+  return {
+    code: pending.code,
+    senderId: pending.telegramUserId,
+    senderName: pending.telegramUsername,
+    chatId: pending.chatId,
+    createdAt: pending.createdAt,
+    expiresAt: pending.expiresAt,
+  };
+}
+
+function toRouteSnapshot(
+  channelId: SupportedChannelId,
+  route: ChannelRoute,
+): ChannelRouteSnapshot {
+  return {
+    channelId,
+    chatId: route.chatId,
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+    enabled: route.enabled,
+    createdAt: route.createdAt,
+  };
+}
+
+export function listChannelSummaries(): ChannelSummary[] {
+  const registry = getChannelRegistry();
+  const channelId = "telegram" as const;
+  const config = readChannelConfig(channelId);
+
+  if (!config) {
+    return [
+      {
+        channelId,
+        displayName: CHANNEL_DISPLAY_NAMES[channelId],
+        configured: false,
+        enabled: false,
+        running: false,
+        dmPolicy: null,
+        pendingPairingsCount: 0,
+        approvedUsersCount: 0,
+        routesCount: 0,
+      },
+    ];
+  }
+
+  loadRoutes(channelId);
+  loadPairingStore(channelId);
+
+  return [
+    {
+      channelId,
+      displayName: CHANNEL_DISPLAY_NAMES[channelId],
+      configured: true,
+      enabled: config.enabled,
+      running: registry?.getAdapter(channelId)?.isRunning() ?? false,
+      dmPolicy: config.dmPolicy,
+      pendingPairingsCount: getPendingPairings(channelId).length,
+      approvedUsersCount: getApprovedUsers(channelId).length,
+      routesCount: getRoutesForChannel(channelId).length,
+    },
+  ];
+}
+
+export function getChannelConfigSnapshot(
+  channelId: string,
+): ChannelConfigSnapshot | null {
+  assertSupportedChannelId(channelId);
+  const config = readChannelConfig(channelId);
+  if (!config) {
+    return null;
+  }
+  return toConfigSnapshot(channelId, config);
+}
+
+export async function setChannelConfigLive(
+  channelId: string,
+  patch: ChannelConfigPatch,
+): Promise<ChannelConfigSnapshot> {
+  assertSupportedChannelId(channelId);
+
+  const existing = readChannelConfig(channelId);
+  const merged: TelegramChannelConfig = {
+    channel: "telegram",
+    enabled: existing?.enabled ?? false,
+    token: patch.token ?? existing?.token ?? "",
+    dmPolicy: patch.dmPolicy ?? existing?.dmPolicy ?? "pairing",
+    allowedUsers: patch.allowedUsers ?? existing?.allowedUsers ?? [],
+  };
+
+  writeChannelConfig(channelId, merged);
+
+  if (merged.enabled) {
+    const registry = ensureChannelRegistry();
+    await registry.startChannel(channelId);
+  }
+
+  return toConfigSnapshot(channelId, merged);
+}
+
+export async function startChannelLive(
+  channelId: string,
+): Promise<ChannelSummary> {
+  assertSupportedChannelId(channelId);
+
+  const existing = readChannelConfig(channelId);
+  if (!existing) {
+    throw new Error(
+      `Channel "${channelId}" is not configured. Configure it first.`,
+    );
+  }
+  if (!existing.token.trim()) {
+    throw new Error(
+      `Channel "${channelId}" is missing a token. Configure it first.`,
+    );
+  }
+
+  if (!existing.enabled) {
+    writeChannelConfig(channelId, {
+      ...existing,
+      enabled: true,
+    });
+  }
+
+  if (!getChannelRegistry()) {
+    await initializeChannels([channelId]);
+  } else {
+    await ensureChannelRegistry().startChannel(channelId);
+  }
+
+  const summary = listChannelSummaries().find(
+    (entry) => entry.channelId === channelId,
+  );
+  if (!summary) {
+    throw new Error(`Channel "${channelId}" summary not found after start`);
+  }
+  return summary;
+}
+
+export async function stopChannelLive(
+  channelId: string,
+): Promise<ChannelSummary> {
+  assertSupportedChannelId(channelId);
+
+  const existing = readChannelConfig(channelId);
+  if (!existing) {
+    throw new Error(
+      `Channel "${channelId}" is not configured. Configure it first.`,
+    );
+  }
+
+  writeChannelConfig(channelId, {
+    ...existing,
+    enabled: false,
+  });
+
+  await getChannelRegistry()?.stopChannel(channelId);
+
+  const summary = listChannelSummaries().find(
+    (entry) => entry.channelId === channelId,
+  );
+  if (!summary) {
+    throw new Error(`Channel "${channelId}" summary not found after stop`);
+  }
+  return summary;
+}
+
+export function listPendingPairingSnapshots(
+  channelId: string,
+): PendingPairingSnapshot[] {
+  assertSupportedChannelId(channelId);
+  loadPairingStore(channelId);
+  return getPendingPairings(channelId).map(toPendingPairingSnapshot);
+}
+
+export function bindChannelPairing(
+  channelId: string,
+  code: string,
+  agentId: string,
+  conversationId: string,
+): { chatId: string; route: ChannelRouteSnapshot } {
+  assertSupportedChannelId(channelId);
+  loadRoutes(channelId);
+  loadPairingStore(channelId);
+
+  const result = completePairing(channelId, code, agentId, conversationId);
+  if (!result.success || !result.chatId) {
+    throw new Error(result.error ?? "Failed to bind pairing");
+  }
+
+  const route = getRoute(channelId, result.chatId);
+  if (!route) {
+    throw new Error("Pairing succeeded but route was not found");
+  }
+
+  return {
+    chatId: result.chatId,
+    route: toRouteSnapshot(channelId, route),
+  };
+}
+
+export function listChannelRouteSnapshots(params?: {
+  channelId?: string;
+  agentId?: string;
+  conversationId?: string;
+}): ChannelRouteSnapshot[] {
+  const channelId = (params?.channelId ?? "telegram") as string;
+  assertSupportedChannelId(channelId);
+
+  loadRoutes(channelId);
+
+  return getRoutesForChannel(channelId)
+    .filter((route) =>
+      params?.agentId ? route.agentId === params.agentId : true,
+    )
+    .filter((route) =>
+      params?.conversationId
+        ? route.conversationId === params.conversationId
+        : true,
+    )
+    .map((route) => toRouteSnapshot(channelId, route));
+}
+
+export function removeChannelRouteLive(
+  channelId: string,
+  chatId: string,
+): boolean {
+  assertSupportedChannelId(channelId);
+  loadRoutes(channelId);
+  return removeRoute(channelId, chatId);
+}

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -87,17 +87,33 @@ export function createTelegramAdapter(
         `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
       );
 
-      // Start long-polling in background (non-blocking)
-      void bot
-        .start({
-          onStart: () => {
-            running = true;
-          },
-        })
-        .catch((error) => {
-          running = false;
-          console.error("[Telegram] Long-polling stopped unexpectedly:", error);
-        });
+      // Wait until grammY confirms polling has started so live status queries
+      // can report a real running state immediately after channel_start.
+      await new Promise<void>((resolve, reject) => {
+        let started = false;
+
+        void bot
+          .start({
+            onStart: () => {
+              running = true;
+              started = true;
+              resolve();
+            },
+          })
+          .catch((error) => {
+            running = false;
+
+            if (!started) {
+              reject(error);
+              return;
+            }
+
+            console.error(
+              "[Telegram] Long-polling stopped unexpectedly:",
+              error,
+            );
+          });
+      });
     },
 
     async stop(): Promise<void> {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,6 +7,9 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
+export const SUPPORTED_CHANNEL_IDS = ["telegram"] as const;
+export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
+
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -9,7 +9,17 @@ type FakeBotStartOptions = {
 
 class FakeBot {
   static instances: FakeBot[] = [];
-  static nextStartImpl: () => Promise<void> = async () => {};
+  static nextStartImpl: (
+    options?: FakeBotStartOptions,
+    botInfo?: { username?: string; id: number },
+  ) => Promise<void> = async (options, botInfo) => {
+    await options?.onStart?.(
+      botInfo ?? {
+        username: "test_bot",
+        id: 12345,
+      },
+    );
+  };
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
@@ -39,8 +49,7 @@ class FakeBot {
   async init(): Promise<void> {}
 
   start(options?: FakeBotStartOptions): Promise<void> {
-    void options?.onStart?.(this.botInfo);
-    return FakeBot.nextStartImpl();
+    return FakeBot.nextStartImpl(options, this.botInfo);
   }
 
   async stop(): Promise<void> {}
@@ -68,7 +77,14 @@ const originalConsoleError = console.error;
 
 beforeEach(() => {
   FakeBot.instances.length = 0;
-  FakeBot.nextStartImpl = async () => {};
+  FakeBot.nextStartImpl = async (options, botInfo) => {
+    await options?.onStart?.(
+      botInfo ?? {
+        username: "test_bot",
+        id: 12345,
+      },
+    );
+  };
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
 });
@@ -104,8 +120,54 @@ test("telegram adapter logs unhandled grammY errors with update context", async 
   );
 });
 
+test("telegram adapter start waits until polling is live before resolving", async () => {
+  let releaseStart: (() => Promise<void>) | undefined;
+
+  FakeBot.nextStartImpl = async (options, botInfo) => {
+    await new Promise<void>((resolve) => {
+      releaseStart = async () => {
+        await options?.onStart?.(
+          botInfo ?? {
+            username: "test_bot",
+            id: 12345,
+          },
+        );
+        resolve();
+      };
+    });
+  };
+
+  const adapter = createTelegramAdapter({
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const startPromise = adapter.start();
+  expect(adapter.isRunning()).toBe(false);
+
+  await Promise.resolve();
+  expect(releaseStart).toBeDefined();
+  const triggerStart = releaseStart;
+  if (!triggerStart) {
+    throw new Error("Expected start callback to be registered");
+  }
+  await triggerStart();
+  await startPromise;
+
+  expect(adapter.isRunning()).toBe(true);
+});
+
 test("telegram adapter logs and clears running state when polling exits unexpectedly", async () => {
-  FakeBot.nextStartImpl = async () => {
+  FakeBot.nextStartImpl = async (options, botInfo) => {
+    await options?.onStart?.(
+      botInfo ?? {
+        username: "test_bot",
+        id: 12345,
+      },
+    );
     throw new Error("polling failed");
   };
 

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -76,6 +76,12 @@ class MockSocket {
     return this;
   }
 }
+
+const actualChannelsService = await import("../../channels/service");
+
+afterEach(() => {
+  mock.module("../../channels/service", () => actualChannelsService);
+});
 
 function makeControlRequest(requestId: string): ControlRequest {
   return {
@@ -384,6 +390,109 @@ describe("listen-client parseServerMessage", () => {
     expect(cronGet?.type).toBe("cron_get");
     expect(cronDelete?.type).toBe("cron_delete");
     expect(cronDeleteAll?.type).toBe("cron_delete_all");
+  });
+
+  test("parses channels management commands", () => {
+    const channelsList = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channels_list",
+          request_id: "channels-list-1",
+        }),
+      ),
+    );
+    const channelGetConfig = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_get_config",
+          request_id: "channel-get-config-1",
+          channel_id: "telegram",
+        }),
+      ),
+    );
+    const channelSetConfig = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_set_config",
+          request_id: "channel-set-config-1",
+          channel_id: "telegram",
+          config: {
+            token: "123:abc",
+            dm_policy: "pairing",
+            allowed_users: ["user-1"],
+          },
+        }),
+      ),
+    );
+    const channelStart = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_start",
+          request_id: "channel-start-1",
+          channel_id: "telegram",
+        }),
+      ),
+    );
+    const channelStop = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_stop",
+          request_id: "channel-stop-1",
+          channel_id: "telegram",
+        }),
+      ),
+    );
+    const channelPairingsList = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_pairings_list",
+          request_id: "channel-pairings-list-1",
+          channel_id: "telegram",
+        }),
+      ),
+    );
+    const channelPairingBind = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_pairing_bind",
+          request_id: "channel-pairing-bind-1",
+          channel_id: "telegram",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          code: "A7X9K2",
+        }),
+      ),
+    );
+    const channelRoutesList = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_routes_list",
+          request_id: "channel-routes-list-1",
+          channel_id: "telegram",
+          agent_id: "agent-1",
+          conversation_id: "default",
+        }),
+      ),
+    );
+    const channelRouteRemove = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_route_remove",
+          request_id: "channel-route-remove-1",
+          channel_id: "telegram",
+          chat_id: "chat-1",
+        }),
+      ),
+    );
+
+    expect(channelsList?.type).toBe("channels_list");
+    expect(channelGetConfig?.type).toBe("channel_get_config");
+    expect(channelSetConfig?.type).toBe("channel_set_config");
+    expect(channelStart?.type).toBe("channel_start");
+    expect(channelStop?.type).toBe("channel_stop");
+    expect(channelPairingsList?.type).toBe("channel_pairings_list");
+    expect(channelPairingBind?.type).toBe("channel_pairing_bind");
+    expect(channelRoutesList?.type).toBe("channel_routes_list");
+    expect(channelRouteRemove?.type).toBe("channel_route_remove");
   });
 
   test("parses list_models command", () => {
@@ -806,6 +915,146 @@ describe("listen-client cron command handling", () => {
         delete process.env.LETTA_HOME;
       }
       await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("listen-client channels command handling", () => {
+  test("returns typed channel summaries over WS", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    mock.module("../../channels/service", () => ({
+      ...actualChannelsService,
+      listChannelSummaries: () => [
+        {
+          channelId: "telegram" as const,
+          displayName: "Telegram",
+          configured: true,
+          enabled: true,
+          running: true,
+          dmPolicy: "pairing" as const,
+          pendingPairingsCount: 2,
+          approvedUsersCount: 3,
+          routesCount: 4,
+        },
+      ],
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channels_list",
+          request_id: "channels-list-1",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      expect(socket.sentPayloads).toHaveLength(1);
+      expect(JSON.parse(socket.sentPayloads[0] as string)).toMatchObject({
+        type: "channels_list_response",
+        request_id: "channels-list-1",
+        success: true,
+        channels: [
+          {
+            channel_id: "telegram",
+            display_name: "Telegram",
+            configured: true,
+            enabled: true,
+            running: true,
+            dm_policy: "pairing",
+            pending_pairings_count: 2,
+            approved_users_count: 3,
+            routes_count: 4,
+          },
+        ],
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("bind emits pairing, route, and channel update events", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    mock.module("../../channels/service", () => ({
+      ...actualChannelsService,
+      bindChannelPairing: () => ({
+        chatId: "chat-42",
+        route: {
+          channelId: "telegram" as const,
+          chatId: "chat-42",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enabled: true,
+          createdAt: "2026-04-09T00:00:00.000Z",
+        },
+      }),
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_pairing_bind",
+          request_id: "channel-bind-1",
+          channel_id: "telegram",
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+          },
+          code: "A7X9K2",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_pairing_bind_response",
+        request_id: "channel-bind-1",
+        success: true,
+        channel_id: "telegram",
+        chat_id: "chat-42",
+        route: {
+          channel_id: "telegram",
+          chat_id: "chat-42",
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+          enabled: true,
+          created_at: "2026-04-09T00:00:00.000Z",
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_pairings_updated",
+        channel_id: "telegram",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channel_routes_updated",
+        channel_id: "telegram",
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+      });
+      expect(messages[3]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "telegram",
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
     }
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -9,6 +9,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import type { DmPolicy } from "../channels/types";
 import type { CronTask } from "../cron";
 
 /**
@@ -134,6 +135,46 @@ export interface ReflectionSettingsSnapshot {
   agent_id: string;
   trigger: ReflectionTriggerMode;
   step_count: number;
+}
+
+export type ChannelId = "telegram";
+
+export interface ChannelSummary {
+  channel_id: ChannelId;
+  display_name: string;
+  configured: boolean;
+  enabled: boolean;
+  running: boolean;
+  dm_policy: DmPolicy | null;
+  pending_pairings_count: number;
+  approved_users_count: number;
+  routes_count: number;
+}
+
+export interface ChannelConfigSnapshot {
+  channel_id: ChannelId;
+  enabled: boolean;
+  dm_policy: DmPolicy;
+  allowed_users: string[];
+  has_token: boolean;
+}
+
+export interface ChannelPendingPairing {
+  code: string;
+  sender_id: string;
+  sender_name?: string;
+  chat_id: string;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface ChannelRouteSnapshot {
+  channel_id: ChannelId;
+  chat_id: string;
+  agent_id: string;
+  conversation_id: string;
+  enabled: boolean;
+  created_at: string;
 }
 
 /**
@@ -739,6 +780,69 @@ export interface SetReflectionSettingsCommand {
   scope?: ReflectionSettingsScope;
 }
 
+export interface ChannelsListCommand {
+  type: "channels_list";
+  request_id: string;
+}
+
+export interface ChannelGetConfigCommand {
+  type: "channel_get_config";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export interface ChannelSetConfigCommand {
+  type: "channel_set_config";
+  request_id: string;
+  channel_id: ChannelId;
+  config: {
+    token?: string;
+    dm_policy?: DmPolicy;
+    allowed_users?: string[];
+  };
+}
+
+export interface ChannelStartCommand {
+  type: "channel_start";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export interface ChannelStopCommand {
+  type: "channel_stop";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export interface ChannelPairingsListCommand {
+  type: "channel_pairings_list";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export interface ChannelPairingBindCommand {
+  type: "channel_pairing_bind";
+  request_id: string;
+  channel_id: ChannelId;
+  runtime: RuntimeScope;
+  code: string;
+}
+
+export interface ChannelRoutesListCommand {
+  type: "channel_routes_list";
+  request_id: string;
+  channel_id?: ChannelId;
+  agent_id?: string;
+  conversation_id?: string;
+}
+
+export interface ChannelRouteRemoveCommand {
+  type: "channel_route_remove";
+  request_id: string;
+  channel_id: ChannelId;
+  chat_id: string;
+}
+
 export interface CronListResponseMessage {
   type: "cron_list_response";
   request_id: string;
@@ -814,6 +918,104 @@ export interface SetReflectionSettingsResponseMessage {
   reflection_settings: ReflectionSettingsSnapshot | null;
   scope: ReflectionSettingsScope;
   error?: string;
+}
+
+export interface ChannelsListResponseMessage {
+  type: "channels_list_response";
+  request_id: string;
+  success: boolean;
+  channels: ChannelSummary[];
+  error?: string;
+}
+
+export interface ChannelGetConfigResponseMessage {
+  type: "channel_get_config_response";
+  request_id: string;
+  success: boolean;
+  config: ChannelConfigSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelSetConfigResponseMessage {
+  type: "channel_set_config_response";
+  request_id: string;
+  success: boolean;
+  config: ChannelConfigSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelStartResponseMessage {
+  type: "channel_start_response";
+  request_id: string;
+  success: boolean;
+  channel: ChannelSummary | null;
+  error?: string;
+}
+
+export interface ChannelStopResponseMessage {
+  type: "channel_stop_response";
+  request_id: string;
+  success: boolean;
+  channel: ChannelSummary | null;
+  error?: string;
+}
+
+export interface ChannelPairingsListResponseMessage {
+  type: "channel_pairings_list_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  pending: ChannelPendingPairing[];
+  error?: string;
+}
+
+export interface ChannelPairingBindResponseMessage {
+  type: "channel_pairing_bind_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  chat_id?: string;
+  route?: ChannelRouteSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelRoutesListResponseMessage {
+  type: "channel_routes_list_response";
+  request_id: string;
+  success: boolean;
+  channel_id?: ChannelId;
+  routes: ChannelRouteSnapshot[];
+  error?: string;
+}
+
+export interface ChannelRouteRemoveResponseMessage {
+  type: "channel_route_remove_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  chat_id: string;
+  found: boolean;
+  error?: string;
+}
+
+export interface ChannelsUpdatedMessage {
+  type: "channels_updated";
+  timestamp: number;
+  channel_id?: ChannelId;
+}
+
+export interface ChannelPairingsUpdatedMessage {
+  type: "channel_pairings_updated";
+  timestamp: number;
+  channel_id: ChannelId;
+}
+
+export interface ChannelRoutesUpdatedMessage {
+  type: "channel_routes_updated";
+  timestamp: number;
+  channel_id: ChannelId;
+  agent_id?: string;
+  conversation_id?: string | null;
 }
 
 /**
@@ -916,6 +1118,15 @@ export type WsProtocolCommand =
   | CreateAgentCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
+  | ChannelsListCommand
+  | ChannelGetConfigCommand
+  | ChannelSetConfigCommand
+  | ChannelStartCommand
+  | ChannelStopCommand
+  | ChannelPairingsListCommand
+  | ChannelPairingBindCommand
+  | ChannelRoutesListCommand
+  | ChannelRouteRemoveCommand
   | ExecuteCommandCommand
   | SearchBranchesCommand
   | CheckoutBranchCommand;
@@ -927,6 +1138,18 @@ export type WsProtocolMessage =
   | StreamDeltaMessage
   | SubagentStateUpdateMessage
   | ListModelsResponseMessage
-  | UpdateModelResponseMessage;
+  | UpdateModelResponseMessage
+  | ChannelsListResponseMessage
+  | ChannelGetConfigResponseMessage
+  | ChannelSetConfigResponseMessage
+  | ChannelStartResponseMessage
+  | ChannelStopResponseMessage
+  | ChannelPairingsListResponseMessage
+  | ChannelPairingBindResponseMessage
+  | ChannelRoutesListResponseMessage
+  | ChannelRouteRemoveResponseMessage
+  | ChannelsUpdatedMessage
+  | ChannelPairingsUpdatedMessage
+  | ChannelRoutesUpdatedMessage;
 
 export type { StopReasonType };

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -72,6 +72,15 @@ import type {
   AbortMessageCommand,
   ApprovalResponseBody,
   ChangeDeviceStateCommand,
+  ChannelGetConfigCommand,
+  ChannelPairingBindCommand,
+  ChannelPairingsListCommand,
+  ChannelRouteRemoveCommand,
+  ChannelRoutesListCommand,
+  ChannelSetConfigCommand,
+  ChannelStartCommand,
+  ChannelStopCommand,
+  ChannelsListCommand,
   CreateAgentCommand,
   CronAddCommand,
   CronDeleteAllCommand,
@@ -130,6 +139,15 @@ import {
   persistPermissionModeMapForRuntime,
 } from "./permissionMode";
 import {
+  isChannelGetConfigCommand,
+  isChannelPairingBindCommand,
+  isChannelPairingsListCommand,
+  isChannelRouteRemoveCommand,
+  isChannelRoutesListCommand,
+  isChannelSetConfigCommand,
+  isChannelStartCommand,
+  isChannelStopCommand,
+  isChannelsListCommand,
   isCheckoutBranchCommand,
   isCreateAgentCommand,
   isCronAddCommand,
@@ -726,6 +744,17 @@ type ReflectionSettingsCommand =
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand;
 
+type ChannelsCommand =
+  | ChannelsListCommand
+  | ChannelGetConfigCommand
+  | ChannelSetConfigCommand
+  | ChannelStartCommand
+  | ChannelStopCommand
+  | ChannelPairingsListCommand
+  | ChannelPairingBindCommand
+  | ChannelRoutesListCommand
+  | ChannelRouteRemoveCommand;
+
 function emitCronsUpdated(
   socket: WebSocket,
   scope?: { agent_id?: string; conversation_id?: string | null },
@@ -742,6 +771,59 @@ function emitCronsUpdated(
     },
     "listener_cron_send_failed",
     "listener_cron_command",
+  );
+}
+
+function emitChannelsUpdated(socket: WebSocket, channelId?: "telegram"): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "channels_updated",
+      timestamp: Date.now(),
+      ...(channelId ? { channel_id: channelId } : {}),
+    },
+    "listener_channels_send_failed",
+    "listener_channels_command",
+  );
+}
+
+function emitChannelPairingsUpdated(
+  socket: WebSocket,
+  channelId: "telegram",
+): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "channel_pairings_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    },
+    "listener_channels_send_failed",
+    "listener_channels_command",
+  );
+}
+
+function emitChannelRoutesUpdated(
+  socket: WebSocket,
+  params: {
+    channelId: "telegram";
+    agentId?: string;
+    conversationId?: string | null;
+  },
+): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "channel_routes_updated",
+      timestamp: Date.now(),
+      channel_id: params.channelId,
+      ...(params.agentId ? { agent_id: params.agentId } : {}),
+      ...(params.conversationId !== undefined
+        ? { conversation_id: params.conversationId }
+        : {}),
+    },
+    "listener_channels_send_failed",
+    "listener_channels_command",
   );
 }
 
@@ -939,6 +1021,436 @@ async function handleCronCommand(
       "listener_cron_command",
     );
   }
+  return true;
+}
+
+async function handleChannelsProtocolCommand(
+  parsed: ChannelsCommand,
+  socket: WebSocket,
+  runtime: ListenerRuntime,
+  opts: Pick<StartListenerOptions, "onStatusChange" | "connectionId">,
+  processQueuedTurn: ProcessQueuedTurn,
+): Promise<boolean> {
+  const {
+    bindChannelPairing,
+    getChannelConfigSnapshot,
+    listChannelRouteSnapshots,
+    listChannelSummaries,
+    listPendingPairingSnapshots,
+    removeChannelRouteLive,
+    setChannelConfigLive,
+    startChannelLive,
+    stopChannelLive,
+  } = await import("../../channels/service");
+
+  if (parsed.type === "channels_list") {
+    try {
+      safeSocketSend(
+        socket,
+        {
+          type: "channels_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          channels: listChannelSummaries().map((summary) => ({
+            channel_id: summary.channelId,
+            display_name: summary.displayName,
+            configured: summary.configured,
+            enabled: summary.enabled,
+            running: summary.running,
+            dm_policy: summary.dmPolicy,
+            pending_pairings_count: summary.pendingPairingsCount,
+            approved_users_count: summary.approvedUsersCount,
+            routes_count: summary.routesCount,
+          })),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channels_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          channels: [],
+          error: err instanceof Error ? err.message : "Failed to list channels",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_get_config") {
+    try {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_get_config_response",
+          request_id: parsed.request_id,
+          success: true,
+          config: (() => {
+            const snapshot = getChannelConfigSnapshot(parsed.channel_id);
+            return snapshot
+              ? {
+                  channel_id: snapshot.channelId,
+                  enabled: snapshot.enabled,
+                  dm_policy: snapshot.dmPolicy,
+                  allowed_users: snapshot.allowedUsers,
+                  has_token: snapshot.hasToken,
+                }
+              : null;
+          })(),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_get_config_response",
+          request_id: parsed.request_id,
+          success: false,
+          config: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to read channel config",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_set_config") {
+    try {
+      const snapshot = await setChannelConfigLive(parsed.channel_id, {
+        token: parsed.config.token,
+        dmPolicy: parsed.config.dm_policy,
+        allowedUsers: parsed.config.allowed_users,
+      });
+
+      if (snapshot.enabled) {
+        wireChannelIngress(
+          runtime,
+          socket,
+          opts as StartListenerOptions,
+          processQueuedTurn,
+        );
+      }
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_set_config_response",
+          request_id: parsed.request_id,
+          success: true,
+          config: {
+            channel_id: snapshot.channelId,
+            enabled: snapshot.enabled,
+            dm_policy: snapshot.dmPolicy,
+            allowed_users: snapshot.allowedUsers,
+            has_token: snapshot.hasToken,
+          },
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_set_config_response",
+          request_id: parsed.request_id,
+          success: false,
+          config: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to update channel config",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_start") {
+    try {
+      const summary = await startChannelLive(parsed.channel_id);
+      wireChannelIngress(
+        runtime,
+        socket,
+        opts as StartListenerOptions,
+        processQueuedTurn,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_start_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel: {
+            channel_id: summary.channelId,
+            display_name: summary.displayName,
+            configured: summary.configured,
+            enabled: summary.enabled,
+            running: summary.running,
+            dm_policy: summary.dmPolicy,
+            pending_pairings_count: summary.pendingPairingsCount,
+            approved_users_count: summary.approvedUsersCount,
+            routes_count: summary.routesCount,
+          },
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_start_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel: null,
+          error: err instanceof Error ? err.message : "Failed to start channel",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_stop") {
+    try {
+      const summary = await stopChannelLive(parsed.channel_id);
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_stop_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel: {
+            channel_id: summary.channelId,
+            display_name: summary.displayName,
+            configured: summary.configured,
+            enabled: summary.enabled,
+            running: summary.running,
+            dm_policy: summary.dmPolicy,
+            pending_pairings_count: summary.pendingPairingsCount,
+            approved_users_count: summary.approvedUsersCount,
+            routes_count: summary.routesCount,
+          },
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_stop_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel: null,
+          error: err instanceof Error ? err.message : "Failed to stop channel",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_pairings_list") {
+    try {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_pairings_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          pending: listPendingPairingSnapshots(parsed.channel_id).map(
+            (pending) => ({
+              code: pending.code,
+              sender_id: pending.senderId,
+              sender_name: pending.senderName,
+              chat_id: pending.chatId,
+              created_at: pending.createdAt,
+              expires_at: pending.expiresAt,
+            }),
+          ),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_pairings_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          pending: [],
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to list pending pairings",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_pairing_bind") {
+    try {
+      const result = bindChannelPairing(
+        parsed.channel_id,
+        parsed.code,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_pairing_bind_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          chat_id: result.chatId,
+          route: {
+            channel_id: result.route.channelId,
+            chat_id: result.route.chatId,
+            agent_id: result.route.agentId,
+            conversation_id: result.route.conversationId,
+            enabled: result.route.enabled,
+            created_at: result.route.createdAt,
+          },
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelPairingsUpdated(socket, parsed.channel_id);
+      emitChannelRoutesUpdated(socket, {
+        channelId: parsed.channel_id,
+        agentId: parsed.runtime.agent_id,
+        conversationId: parsed.runtime.conversation_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_pairing_bind_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          route: null,
+          error: err instanceof Error ? err.message : "Failed to bind pairing",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_routes_list") {
+    try {
+      const channelId = parsed.channel_id ?? "telegram";
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_routes_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: channelId,
+          routes: listChannelRouteSnapshots({
+            channelId,
+            agentId: parsed.agent_id,
+            conversationId: parsed.conversation_id,
+          }).map((route) => ({
+            channel_id: route.channelId,
+            chat_id: route.chatId,
+            agent_id: route.agentId,
+            conversation_id: route.conversationId,
+            enabled: route.enabled,
+            created_at: route.createdAt,
+          })),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_routes_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          routes: [],
+          error: err instanceof Error ? err.message : "Failed to list routes",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  try {
+    const found = removeChannelRouteLive(parsed.channel_id, parsed.chat_id);
+    safeSocketSend(
+      socket,
+      {
+        type: "channel_route_remove_response",
+        request_id: parsed.request_id,
+        success: true,
+        channel_id: parsed.channel_id,
+        chat_id: parsed.chat_id,
+        found,
+      },
+      "listener_channels_send_failed",
+      "listener_channels_command",
+    );
+    if (found) {
+      emitChannelRoutesUpdated(socket, {
+        channelId: parsed.channel_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    }
+  } catch (err) {
+    safeSocketSend(
+      socket,
+      {
+        type: "channel_route_remove_response",
+        request_id: parsed.request_id,
+        success: false,
+        channel_id: parsed.channel_id,
+        chat_id: parsed.chat_id,
+        found: false,
+        error: err instanceof Error ? err.message : "Failed to remove route",
+      },
+      "listener_channels_send_failed",
+      "listener_channels_command",
+    );
+  }
+
   return true;
 }
 
@@ -1394,6 +1906,13 @@ function wireChannelIngress(
     enqueueChannelTurn(conversationRuntime, route, xmlContent);
 
     scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
+  });
+
+  registry.setEventHandler((event) => {
+    if (event.type === "pairings_updated") {
+      emitChannelPairingsUpdated(socket, event.channelId as "telegram");
+      emitChannelsUpdated(socket, event.channelId as "telegram");
+    }
   });
 
   registry.setReady();
@@ -3546,6 +4065,30 @@ async function connectWithRetry(
         return;
       }
 
+      // ── Channels management commands (device/live management) ─────────
+      if (
+        isChannelsListCommand(parsed) ||
+        isChannelGetConfigCommand(parsed) ||
+        isChannelSetConfigCommand(parsed) ||
+        isChannelStartCommand(parsed) ||
+        isChannelStopCommand(parsed) ||
+        isChannelPairingsListCommand(parsed) ||
+        isChannelPairingBindCommand(parsed) ||
+        isChannelRoutesListCommand(parsed) ||
+        isChannelRouteRemoveCommand(parsed)
+      ) {
+        runDetachedListenerTask("channels_command", async () => {
+          await handleChannelsProtocolCommand(
+            parsed,
+            socket,
+            runtime,
+            opts,
+            processQueuedTurn,
+          );
+        });
+        return;
+      }
+
       // ── Skill enable/disable commands (no runtime scope required) ─────
       if (isSkillEnableCommand(parsed) || isSkillDisableCommand(parsed)) {
         runDetachedListenerTask("skill_command", async () => {
@@ -4215,6 +4758,7 @@ export const __listenClientTestUtils = {
   handleAbortMessageInput,
   handleChangeDeviceStateInput,
   handleCronCommand,
+  handleChannelsProtocolCommand,
   handleSkillCommand,
   handleCreateAgentCommand,
   handleReflectionSettingsCommand,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -2,6 +2,15 @@ import type WebSocket from "ws";
 import type {
   AbortMessageCommand,
   ChangeDeviceStateCommand,
+  ChannelGetConfigCommand,
+  ChannelPairingBindCommand,
+  ChannelPairingsListCommand,
+  ChannelRouteRemoveCommand,
+  ChannelRoutesListCommand,
+  ChannelSetConfigCommand,
+  ChannelStartCommand,
+  ChannelStopCommand,
+  ChannelsListCommand,
   CheckoutBranchCommand,
   CreateAgentCommand,
   CronAddCommand,
@@ -683,6 +692,178 @@ export function isSetReflectionSettingsCommand(
   );
 }
 
+function isChannelId(value: unknown): value is "telegram" {
+  return value === "telegram";
+}
+
+export function isChannelsListCommand(
+  value: unknown,
+): value is ChannelsListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as { type?: unknown; request_id?: unknown };
+  return c.type === "channels_list" && typeof c.request_id === "string";
+}
+
+export function isChannelGetConfigCommand(
+  value: unknown,
+): value is ChannelGetConfigCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_get_config" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelSetConfigCommand(
+  value: unknown,
+): value is ChannelSetConfigCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    config?: unknown;
+  };
+  if (
+    c.type !== "channel_set_config" ||
+    typeof c.request_id !== "string" ||
+    !isChannelId(c.channel_id) ||
+    !c.config ||
+    typeof c.config !== "object"
+  ) {
+    return false;
+  }
+  const config = c.config as {
+    token?: unknown;
+    dm_policy?: unknown;
+    allowed_users?: unknown;
+  };
+  return (
+    (config.token === undefined || typeof config.token === "string") &&
+    (config.dm_policy === undefined ||
+      config.dm_policy === "pairing" ||
+      config.dm_policy === "allowlist" ||
+      config.dm_policy === "open") &&
+    (config.allowed_users === undefined ||
+      (Array.isArray(config.allowed_users) &&
+        config.allowed_users.every((entry) => typeof entry === "string")))
+  );
+}
+
+export function isChannelStartCommand(
+  value: unknown,
+): value is ChannelStartCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_start" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelStopCommand(
+  value: unknown,
+): value is ChannelStopCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_stop" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelPairingsListCommand(
+  value: unknown,
+): value is ChannelPairingsListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_pairings_list" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelPairingBindCommand(
+  value: unknown,
+): value is ChannelPairingBindCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    runtime?: unknown;
+    code?: unknown;
+  };
+  return (
+    c.type === "channel_pairing_bind" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    isRuntimeScope(c.runtime) &&
+    typeof c.code === "string" &&
+    c.code.length > 0
+  );
+}
+
+export function isChannelRoutesListCommand(
+  value: unknown,
+): value is ChannelRoutesListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    agent_id?: unknown;
+    conversation_id?: unknown;
+  };
+  return (
+    c.type === "channel_routes_list" &&
+    typeof c.request_id === "string" &&
+    (c.channel_id === undefined || isChannelId(c.channel_id)) &&
+    (c.agent_id === undefined || typeof c.agent_id === "string") &&
+    (c.conversation_id === undefined || typeof c.conversation_id === "string")
+  );
+}
+
+export function isChannelRouteRemoveCommand(
+  value: unknown,
+): value is ChannelRouteRemoveCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    chat_id?: unknown;
+  };
+  return (
+    c.type === "channel_route_remove" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.chat_id === "string" &&
+    c.chat_id.length > 0
+  );
+}
+
 export function isSearchBranchesCommand(
   value: unknown,
 ): value is SearchBranchesCommand {
@@ -774,6 +955,15 @@ export function parseServerMessage(
       isCreateAgentCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||
       isSetReflectionSettingsCommand(parsed) ||
+      isChannelsListCommand(parsed) ||
+      isChannelGetConfigCommand(parsed) ||
+      isChannelSetConfigCommand(parsed) ||
+      isChannelStartCommand(parsed) ||
+      isChannelStopCommand(parsed) ||
+      isChannelPairingsListCommand(parsed) ||
+      isChannelPairingBindCommand(parsed) ||
+      isChannelRoutesListCommand(parsed) ||
+      isChannelRouteRemoveCommand(parsed) ||
       isExecuteCommandCommand(parsed) ||
       isSearchBranchesCommand(parsed) ||
       isCheckoutBranchCommand(parsed)


### PR DESCRIPTION
## Summary
- add typed websocket protocol commands/responses/events for live channel management
- support device-scoped channel config/start-stop/list operations plus conversation-scoped pairing bind
- keep Telegram adapter/channel registry live-updatable without restarting the listener
- add backend coverage for channel protocol handling and Telegram adapter startup behavior

## Added WS commands
- `channels_list`
- `channel_get_config`
- `channel_set_config`
- `channel_start`
- `channel_stop`
- `channel_pairings_list`
- `channel_pairing_bind`
- `channel_routes_list`
- `channel_route_remove`

## Added WS events
- `channels_updated`
- `channel_pairings_updated`
- `channel_routes_updated`

## Notes
- normal channel operations now update live in-memory listener state and persist to disk
- Telegram adapter startup waits until polling is actually live before reporting success

## Testing
- `bunx tsc --noEmit`
- `bun test src/tests/channels/telegram-adapter.test.ts src/tests/websocket/listen-client-protocol.test.ts`
