### PR TITLE
fix: strengthen inbound channel reply prompting

### DIFF
--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -55,8 +55,8 @@ export function formatChannelNotification(msg: InboundChannelMessage): string {
 
   const reminder = [
     SYSTEM_REMINDER_OPEN,
-    `This message came from an external ${escapedChannel} channel.`,
-    `If you want the user on ${escapedChannel} to see your reply, you must call the MessageChannel tool. A normal assistant response in Letta Code is not delivered back to the external user.`,
+    `This message originated from an external ${escapedChannel} channel.`,
+    `If you want the ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
     `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
     "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
     `Current local time on this device: ${localTime}`,

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -5,6 +5,8 @@
  * Follows the same escaping patterns used in taskNotifications.ts.
  */
 
+import { getLocalTime } from "../cli/helpers/sessionContext";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
 import type { InboundChannelMessage } from "./types";
 
 /**
@@ -31,6 +33,7 @@ function escapeXml(text: string): string {
  * ```
  */
 export function formatChannelNotification(msg: InboundChannelMessage): string {
+  const localTime = escapeXml(getLocalTime());
   const attrs: string[] = [
     `source="${escapeXml(msg.channel)}"`,
     `chat_id="${escapeXml(msg.chatId)}"`,
@@ -47,6 +50,18 @@ export function formatChannelNotification(msg: InboundChannelMessage): string {
 
   const attrString = attrs.join(" ");
   const escapedText = escapeXml(msg.text);
+  const escapedChannel = escapeXml(msg.channel);
+  const escapedChatId = escapeXml(msg.chatId);
 
-  return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+  const reminder = [
+    SYSTEM_REMINDER_OPEN,
+    `This message came from an external ${escapedChannel} channel.`,
+    `If you want the user on ${escapedChannel} to see your reply, you must call the MessageChannel tool. A normal assistant response in Letta Code is not delivered back to the external user.`,
+    `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
+    "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
+    `Current local time on this device: ${localTime}`,
+    SYSTEM_REMINDER_CLOSE,
+  ].join("\n");
+
+  return `${reminder}\n<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
 }

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -26,6 +26,26 @@ describe("formatChannelNotification", () => {
     expect(xml).toContain("</channel-notification>");
   });
 
+  test("prepends a system reminder describing reply semantics", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      text: "ping",
+      timestamp: Date.now(),
+    };
+
+    const xml = formatChannelNotification(msg);
+
+    expect(xml).toContain("<system-reminder>");
+    expect(xml).toContain("must call the MessageChannel tool");
+    expect(xml).toContain('channel="telegram" and chat_id="12345"');
+    expect(xml).toContain("Current local time on this device:");
+    expect(xml.indexOf("<system-reminder>")).toBeLessThan(
+      xml.indexOf("<channel-notification"),
+    );
+  });
+
   test("escapes XML special characters in text", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -2,10 +2,10 @@
 
 Send a message to an external channel (Telegram, Slack, etc.) in response to a channel notification.
 
-When you receive a `<channel-notification>`, use this tool to reply. Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
+When you receive a `<channel-notification>`, use this tool if you want the external user to see your reply. A normal assistant response in Letta Code is not delivered back to Telegram/Slack/etc. Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
 
 Parameters:
 - `channel`: The platform to send to (matches the `source` attribute)
 - `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
 - `text`: The message text to send
-- `reply_to_message_id`: (Optional) Reply to a specific message by its `message_id`
+- `reply_to_message_id`: (Optional) Reply to a specific message by its `message_id`. Omit this unless you intentionally want the platform's quote/reply UI.

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -2,7 +2,7 @@
 
 Send a message to an external channel (Telegram, Slack, etc.) in response to a channel notification.
 
-When you receive a `<channel-notification>`, use this tool if you want the external user to see your reply. A normal assistant response in Letta Code is not delivered back to Telegram/Slack/etc. Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
+When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel (a normal assistant response is not delivered back to Telegram/Slack/etc). Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
 
 Parameters:
 - `channel`: The platform to send to (matches the `source` attribute)


### PR DESCRIPTION
## Summary
- prepend a channel-specific `<system-reminder>` to inbound channel messages
- explicitly tell the agent that external users only see replies sent via `MessageChannel`
- include current local time and nudge against `reply_to_message_id` unless quote-thread UI is intentional

## Why
Channel turns currently arrive as raw `<channel-notification>` XML plus the generic listen-mode reminders. The only explicit instruction to use `MessageChannel` lives in the tool description, which is easy for the model to underweight. This makes Telegram replies feel inconsistent and loses some of the per-turn contextual framing that normal desktop input has.

## Verification
- `bun test src/tests/channels/xml.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/channels/xml.ts src/tests/channels/xml.test.ts src/tools/descriptions/MessageChannel.md`

## Notes
- `bunx tsc --noEmit` is currently noisy on latest `main` for unrelated repo-wide baseline issues, so I kept verification focused on the touched area.
