### PR TITLE
fix(auth): clarify OAuth setup network errors

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -37,29 +37,128 @@ export interface OAuthError {
   error_description?: string;
 }
 
+function getOAuthAuthHost(): string {
+  try {
+    return new URL(OAUTH_CONFIG.authBaseUrl).host;
+  } catch {
+    return OAUTH_CONFIG.authBaseUrl;
+  }
+}
+
+function getErrorLikeMessage(value: unknown): string | null {
+  if (value instanceof Error) {
+    return value.message.trim() || null;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const message = (value as { message?: unknown }).message;
+  return typeof message === "string" && message.trim().length > 0
+    ? message.trim()
+    : null;
+}
+
+function getErrorLikeCode(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const code = (value as { code?: unknown }).code;
+  return typeof code === "string" && code.trim().length > 0
+    ? code.trim()
+    : null;
+}
+
+function isGenericFetchFailureMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  return normalized === "fetch failed" || normalized === "network request failed";
+}
+
+function isOAuthTransportError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (isGenericFetchFailureMessage(error.message)) {
+    return true;
+  }
+
+  return error.name === "TypeError" && error.cause !== undefined;
+}
+
+function extractOAuthTransportDetail(error: Error): string | null {
+  const directMessage = isGenericFetchFailureMessage(error.message)
+    ? null
+    : error.message.trim() || null;
+  const causeMessage = getErrorLikeMessage(error.cause);
+  const causeCode = getErrorLikeCode(error.cause);
+
+  let detail = causeMessage ?? directMessage;
+  if (!detail && causeCode) {
+    detail = causeCode;
+  }
+
+  if (detail && causeCode && !detail.includes(causeCode)) {
+    detail = `${detail} (${causeCode})`;
+  }
+
+  return detail;
+}
+
+function toOAuthActionError(
+  action: string,
+  error: unknown,
+  options?: { browserHint?: boolean },
+): Error {
+  if (isOAuthTransportError(error)) {
+    const host = getOAuthAuthHost();
+    const detail = extractOAuthTransportDetail(error);
+    const reachabilityHint = options?.browserHint
+      ? "Browser authorization may have succeeded, but the CLI could not reach Letta auth servers from this machine."
+      : "The CLI could not reach Letta auth servers from this machine.";
+
+    return new Error(
+      `Failed to ${action} from ${host}${detail ? `: ${detail}` : ""}. ${reachabilityHint} Check your network, DNS, proxy, VPN, or TLS settings.`,
+    );
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(`Failed to ${action}: ${String(error)}`);
+}
+
 /**
  * Device Code Flow - Step 1: Request device code
  */
 export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
-  const response = await fetch(
-    `${OAUTH_CONFIG.authBaseUrl}/api/oauth/device/code`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        client_id: OAUTH_CONFIG.clientId,
-      }),
-    },
-  );
-
-  if (!response.ok) {
-    const error = (await response.json()) as OAuthError;
-    throw new Error(
-      `Failed to request device code: ${error.error_description || error.error}`,
+  const authHost = getOAuthAuthHost();
+  try {
+    const response = await fetch(
+      `${OAUTH_CONFIG.authBaseUrl}/api/oauth/device/code`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: OAUTH_CONFIG.clientId,
+        }),
+      },
     );
-  }
 
-  return (await response.json()) as DeviceCodeResponse;
+    if (!response.ok) {
+      const error = (await response.json()) as OAuthError;
+      throw new Error(
+        `Failed to request device code from ${authHost}: ${error.error_description || error.error}`,
+      );
+    }
+
+    return (await response.json()) as DeviceCodeResponse;
+  } catch (error) {
+    throw toOAuthActionError("request device code", error);
+  }
 }
 
 /**
@@ -130,7 +229,9 @@ export async function pollForToken(
         context: "auth_oauth_token_poll",
       });
       if (error instanceof Error) {
-        throw error;
+        throw toOAuthActionError("poll for OAuth token", error, {
+          browserHint: true,
+        });
       }
       throw new Error(`Failed to poll for token: ${String(error)}`);
     }
@@ -147,27 +248,32 @@ export async function refreshAccessToken(
   deviceId: string,
   deviceName?: string,
 ): Promise<TokenResponse> {
-  const response = await fetch(`${OAUTH_CONFIG.authBaseUrl}/api/oauth/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      grant_type: "refresh_token",
-      client_id: OAUTH_CONFIG.clientId,
-      refresh_token: refreshToken,
-      refresh_token_mode: "new",
-      device_id: deviceId,
-      ...(deviceName && { device_name: deviceName }),
-    }),
-  });
+  const authHost = getOAuthAuthHost();
+  try {
+    const response = await fetch(`${OAUTH_CONFIG.authBaseUrl}/api/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: OAUTH_CONFIG.clientId,
+        refresh_token: refreshToken,
+        refresh_token_mode: "new",
+        device_id: deviceId,
+        ...(deviceName && { device_name: deviceName }),
+      }),
+    });
 
-  if (!response.ok) {
-    const error = (await response.json()) as OAuthError;
-    throw new Error(
-      `Failed to refresh access token: ${error.error_description || error.error}`,
-    );
+    if (!response.ok) {
+      const error = (await response.json()) as OAuthError;
+      throw new Error(
+        `Failed to refresh access token from ${authHost}: ${error.error_description || error.error}`,
+      );
+    }
+
+    return (await response.json()) as TokenResponse;
+  } catch (error) {
+    throw toOAuthActionError("refresh access token", error);
   }
-
-  return (await response.json()) as TokenResponse;
 }
 
 /**

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -73,7 +73,9 @@ function getErrorLikeCode(value: unknown): string | null {
 
 function isGenericFetchFailureMessage(message: string): boolean {
   const normalized = message.trim().toLowerCase();
-  return normalized === "fetch failed" || normalized === "network request failed";
+  return (
+    normalized === "fetch failed" || normalized === "network request failed"
+  );
 }
 
 function isOAuthTransportError(error: unknown): error is Error {
@@ -250,18 +252,21 @@ export async function refreshAccessToken(
 ): Promise<TokenResponse> {
   const authHost = getOAuthAuthHost();
   try {
-    const response = await fetch(`${OAUTH_CONFIG.authBaseUrl}/api/oauth/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        client_id: OAUTH_CONFIG.clientId,
-        refresh_token: refreshToken,
-        refresh_token_mode: "new",
-        device_id: deviceId,
-        ...(deviceName && { device_name: deviceName }),
-      }),
-    });
+    const response = await fetch(
+      `${OAUTH_CONFIG.authBaseUrl}/api/oauth/token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          client_id: OAUTH_CONFIG.clientId,
+          refresh_token: refreshToken,
+          refresh_token_mode: "new",
+          device_id: deviceId,
+          ...(deviceName && { device_name: deviceName }),
+        }),
+      },
+    );
 
     if (!response.ok) {
       const error = (await response.json()) as OAuthError;

--- a/src/tests/auth/oauth-network-errors.test.ts
+++ b/src/tests/auth/oauth-network-errors.test.ts
@@ -20,10 +20,7 @@ describe("OAuth network errors", () => {
   test("requestDeviceCode includes auth host and network detail", async () => {
     globalThis.fetch = mock(() =>
       Promise.reject(
-        makeFetchFailure(
-          "getaddrinfo ENOTFOUND app.letta.com",
-          "ENOTFOUND",
-        ),
+        makeFetchFailure("getaddrinfo ENOTFOUND app.letta.com", "ENOTFOUND"),
       ),
     ) as unknown as typeof fetch;
 
@@ -44,10 +41,7 @@ describe("OAuth network errors", () => {
   test("pollForToken explains that browser auth may have succeeded", async () => {
     globalThis.fetch = mock(() =>
       Promise.reject(
-        makeFetchFailure(
-          "connect ECONNRESET 104.18.34.223:443",
-          "ECONNRESET",
-        ),
+        makeFetchFailure("connect ECONNRESET 104.18.34.223:443", "ECONNRESET"),
       ),
     ) as unknown as typeof fetch;
 
@@ -68,10 +62,7 @@ describe("OAuth network errors", () => {
   test("refreshAccessToken includes auth host and low-level cause", async () => {
     globalThis.fetch = mock(() =>
       Promise.reject(
-        makeFetchFailure(
-          "certificate has expired",
-          "CERT_HAS_EXPIRED",
-        ),
+        makeFetchFailure("certificate has expired", "CERT_HAS_EXPIRED"),
       ),
     ) as unknown as typeof fetch;
 
@@ -92,8 +83,8 @@ describe("OAuth network errors", () => {
       ),
     ) as unknown as typeof fetch;
 
-    await expect(pollForToken("device-code", 0, 60, "device-id")).rejects.toThrow(
-      "User denied authorization",
-    );
+    await expect(
+      pollForToken("device-code", 0, 60, "device-id"),
+    ).rejects.toThrow("User denied authorization");
   });
 });

--- a/src/tests/auth/oauth-network-errors.test.ts
+++ b/src/tests/auth/oauth-network-errors.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+} from "../../auth/oauth";
+
+const originalFetch = globalThis.fetch;
+
+function makeFetchFailure(message: string, code?: string): Error {
+  const cause = Object.assign(new Error(message), code ? { code } : {});
+  return new TypeError("fetch failed", { cause });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("OAuth network errors", () => {
+  test("requestDeviceCode includes auth host and network detail", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(
+        makeFetchFailure(
+          "getaddrinfo ENOTFOUND app.letta.com",
+          "ENOTFOUND",
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await requestDeviceCode();
+      throw new Error("Expected requestDeviceCode to fail");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain(
+        "Failed to request device code from app.letta.com: getaddrinfo ENOTFOUND app.letta.com.",
+      );
+      expect(message).toContain(
+        "Check your network, DNS, proxy, VPN, or TLS settings.",
+      );
+    }
+  });
+
+  test("pollForToken explains that browser auth may have succeeded", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(
+        makeFetchFailure(
+          "connect ECONNRESET 104.18.34.223:443",
+          "ECONNRESET",
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await pollForToken("device-code", 0, 60, "device-id");
+      throw new Error("Expected pollForToken to fail");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain(
+        "Failed to poll for OAuth token from app.letta.com: connect ECONNRESET 104.18.34.223:443.",
+      );
+      expect(message).toContain(
+        "Browser authorization may have succeeded, but the CLI could not reach Letta auth servers from this machine.",
+      );
+    }
+  });
+
+  test("refreshAccessToken includes auth host and low-level cause", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(
+        makeFetchFailure(
+          "certificate has expired",
+          "CERT_HAS_EXPIRED",
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      refreshAccessToken("refresh-token", "device-id", "device-name"),
+    ).rejects.toThrow(
+      "Failed to refresh access token from app.letta.com: certificate has expired (CERT_HAS_EXPIRED).",
+    );
+  });
+
+  test("pollForToken preserves non-network OAuth errors", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "access_denied" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(pollForToken("device-code", 0, 60, "device-id")).rejects.toThrow(
+      "User denied authorization",
+    );
+  });
+});

--- a/src/types/letta-client-augmentations.d.ts
+++ b/src/types/letta-client-augmentations.d.ts
@@ -6,5 +6,3 @@ declare module "@letta-ai/letta-client/resources/agents/messages" {
     otid?: string | null;
   }
 }
-
-export {};


### PR DESCRIPTION
## Summary
- make OAuth device-code and token-poll failures mention the Letta auth host and low-level network cause when `fetch` fails before an HTTP response
- explain when browser authorization may have succeeded but the CLI still could not reach Letta auth servers
- preserve existing user-facing OAuth errors for non-network cases like `access_denied`

## Verification
- bun test src/tests/auth/oauth-network-errors.test.ts
- bun test src/tests/cli/connect-oauth-core.test.ts
- bun run typecheck