### PR TITLE
fix: externalize grammY from bundled CLI

### DIFF
--- a/build.js
+++ b/build.js
@@ -44,12 +44,14 @@ await Bun.build({
     ".md": "text",
     ".mdx": "text",
     ".txt": "text",
-
   },
-  // Keep most native Node.js modules external to avoid bundling issues
+  // Keep most native Node.js modules external to avoid bundling issues.
+  // grammY must stay external too: bundling its node-fetch/abort-controller
+  // stack into letta.js breaks Telegram startup because node-fetch rejects the
+  // bundled AbortSignal class during bot.init().
   // But don't make `sharp` external, causes issues with global Bun-based installs
   // ref: #745, #1200
-  external: ["ws", "@vscode/ripgrep", "node-pty"],
+  external: ["ws", "@vscode/ripgrep", "node-pty", "grammy"],
   features: features,
 });
 


### PR DESCRIPTION
## Summary
- keep `grammy` external in the Bun build instead of bundling it into `letta.js`
- document why this needs to stay external in `build.js`

## Root cause
Bundling `grammy` pulls its `node-fetch` + `abort-controller` stack into `letta.js`.

In the bundled artifact, the abort-controller class gets renamed during bundling, and bundled `node-fetch` rejects the resulting signal during Telegram startup with:

```txt
TypeError: Expected signal to be an instanceof AbortSignal
```

That failure gets wrapped as a grammY `HttpError` during `bot.init()`, and grammY retries `getMe()` indefinitely. From the desktop app this looks like `channel_start` timing out forever, even though direct `fetch(getMe)` still works.

Keeping `grammy` external preserves the real package boundary and fixes Telegram startup in the packaged CLI / desktop path.

## Verification
- `bun run build`
- launched the freshly built local `letta.js` against the desktop local API
- sent the real status WS command:

```json
{"type":"channel_start","request_id":"verify_channel_start_after_build","channel_id":"telegram"}
```

- confirmed it now returns successfully instead of timing out:

```json
{"type":"channel_start_response","request_id":"verify_channel_start_after_build","success":true,...}
```
