### PR TITLE
fix(server): initialize settings before telemetry in listen subcommand

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -288,6 +288,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     return 0;
   }
 
+  await settingsManager.initialize();
   telemetry.setSurface("websocket");
   telemetry.init();
 
@@ -366,8 +367,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   console.log(`Log file: ${sessionLog.path}`);
 
   try {
-    await settingsManager.initialize();
-
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
     let registerOptions: RegisterOptions;


### PR DESCRIPTION
## Summary
- `settingsManager.initialize()` was called after `telemetry.init()` in the listen subcommand, but telemetry needs `getOrCreateDeviceId()` which requires settings to be ready
- Crashes on `letta server` / `bun dev remote` with "Settings not initialized"
- Moved `initialize()` before telemetry and removed the now-duplicate call further down

Note: pre-commit hook has pre-existing TS errors in `src/channels/telegram/adapter.ts` (missing `grammy` types) unrelated to this change.

Written by Cameron ◯ Letta Code