### PR TITLE
fix(channels): send telegram reminders as content parts

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,7 @@
  * 4. Buffered messages flush through the registered onMessage handler
  */
 
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { readChannelConfig } from "./config";
 import {
   consumePairingCode,
@@ -53,7 +54,7 @@ export function getActiveChannelIds(): string[] {
 
 export type ChannelMessageHandler = (
   route: ChannelRoute,
-  xmlContent: string,
+  content: MessageCreate["content"],
 ) => void;
 
 export type ChannelRegistryEvent = {
@@ -70,7 +71,7 @@ export class ChannelRegistry {
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private readonly buffer: Array<{
     route: ChannelRoute;
-    xmlContent: string;
+    content: MessageCreate["content"];
   }> = [];
 
   constructor() {
@@ -281,13 +282,13 @@ export class ChannelRegistry {
     }
 
     // 3. Format as XML
-    const xmlContent = formatChannelNotification(msg);
+    const content = formatChannelNotification(msg);
 
     // 4. Deliver or buffer
     if (this.isReady()) {
-      this.messageHandler?.(route, xmlContent);
+      this.messageHandler?.(route, content);
     } else {
-      this.buffer.push({ route, xmlContent });
+      this.buffer.push({ route, content });
     }
   }
 
@@ -297,7 +298,7 @@ export class ChannelRegistry {
     while (this.buffer.length > 0) {
       const item = this.buffer.shift();
       if (item) {
-        this.messageHandler(item.route, item.xmlContent);
+        this.messageHandler(item.route, item.content);
       }
     }
   }

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -5,6 +5,7 @@
  * Follows the same escaping patterns used in taskNotifications.ts.
  */
 
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { getLocalTime } from "../cli/helpers/sessionContext";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
 import type { InboundChannelMessage } from "./types";
@@ -23,6 +24,25 @@ function escapeXml(text: string): string {
 }
 
 /**
+ * Format the reminder text that explains channel reply semantics to the agent.
+ */
+export function buildChannelReminderText(msg: InboundChannelMessage): string {
+  const localTime = escapeXml(getLocalTime());
+  const escapedChannel = escapeXml(msg.channel);
+  const escapedChatId = escapeXml(msg.chatId);
+
+  return [
+    SYSTEM_REMINDER_OPEN,
+    `This message originated from an external ${escapedChannel} channel.`,
+    `If you want the ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
+    `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
+    "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
+    `Current local time on this device: ${localTime}`,
+    SYSTEM_REMINDER_CLOSE,
+  ].join("\n");
+}
+
+/**
  * Format an inbound channel message as XML for the agent.
  *
  * Example output:
@@ -32,8 +52,9 @@ function escapeXml(text: string): string {
  * </channel-notification>
  * ```
  */
-export function formatChannelNotification(msg: InboundChannelMessage): string {
-  const localTime = escapeXml(getLocalTime());
+export function buildChannelNotificationXml(
+  msg: InboundChannelMessage,
+): string {
   const attrs: string[] = [
     `source="${escapeXml(msg.channel)}"`,
     `chat_id="${escapeXml(msg.chatId)}"`,
@@ -50,18 +71,22 @@ export function formatChannelNotification(msg: InboundChannelMessage): string {
 
   const attrString = attrs.join(" ");
   const escapedText = escapeXml(msg.text);
-  const escapedChannel = escapeXml(msg.channel);
-  const escapedChatId = escapeXml(msg.chatId);
 
-  const reminder = [
-    SYSTEM_REMINDER_OPEN,
-    `This message originated from an external ${escapedChannel} channel.`,
-    `If you want the ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
-    `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
-    "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
-    `Current local time on this device: ${localTime}`,
-    SYSTEM_REMINDER_CLOSE,
-  ].join("\n");
+  return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+}
 
-  return `${reminder}\n<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+/**
+ * Format an inbound channel message as structured content parts.
+ *
+ * The reminder and the notification XML are emitted as separate text parts so
+ * UIs that already know how to hide pure system-reminder parts can do so
+ * without needing to parse concatenated XML blobs.
+ */
+export function formatChannelNotification(
+  msg: InboundChannelMessage,
+): MessageCreate["content"] {
+  return [
+    { type: "text", text: buildChannelReminderText(msg) },
+    { type: "text", text: buildChannelNotificationXml(msg) },
+  ] as MessageCreate["content"];
 }

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { InboundChannelMessage } from "../../channels/types";
-import { formatChannelNotification } from "../../channels/xml";
+import {
+  buildChannelNotificationXml,
+  buildChannelReminderText,
+  formatChannelNotification,
+} from "../../channels/xml";
+
+function expectTextParts(
+  content: MessageCreate["content"],
+): Array<{ type: "text"; text: string }> {
+  expect(Array.isArray(content)).toBe(true);
+  return content as Array<{ type: "text"; text: string }>;
+}
 
 describe("formatChannelNotification", () => {
-  test("formats a basic message with all fields", () => {
+  test("formats structured content parts with reminder first and xml second", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "12345",
@@ -14,19 +26,22 @@ describe("formatChannelNotification", () => {
       messageId: "msg-42",
     };
 
-    const xml = formatChannelNotification(msg);
+    const content = formatChannelNotification(msg);
+    const parts = expectTextParts(content);
 
-    expect(xml).toContain("<channel-notification");
-    expect(xml).toContain('source="telegram"');
-    expect(xml).toContain('chat_id="12345"');
-    expect(xml).toContain('sender_id="67890"');
-    expect(xml).toContain('sender_name="John"');
-    expect(xml).toContain('message_id="msg-42"');
-    expect(xml).toContain("Hello from Telegram!");
-    expect(xml).toContain("</channel-notification>");
+    expect(parts).toHaveLength(2);
+    expect(parts[0].text).toContain("<system-reminder>");
+    expect(parts[1].text).toContain("<channel-notification");
+    expect(parts[1].text).toContain('source="telegram"');
+    expect(parts[1].text).toContain('chat_id="12345"');
+    expect(parts[1].text).toContain('sender_id="67890"');
+    expect(parts[1].text).toContain('sender_name="John"');
+    expect(parts[1].text).toContain('message_id="msg-42"');
+    expect(parts[1].text).toContain("Hello from Telegram!");
+    expect(parts[1].text).toContain("</channel-notification>");
   });
 
-  test("prepends a system reminder describing reply semantics", () => {
+  test("builds a reminder part describing reply semantics", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "12345",
@@ -35,18 +50,15 @@ describe("formatChannelNotification", () => {
       timestamp: Date.now(),
     };
 
-    const xml = formatChannelNotification(msg);
+    const reminder = buildChannelReminderText(msg);
 
-    expect(xml).toContain("<system-reminder>");
-    expect(xml).toContain("must call the MessageChannel tool");
-    expect(xml).toContain('channel="telegram" and chat_id="12345"');
-    expect(xml).toContain("Current local time on this device:");
-    expect(xml.indexOf("<system-reminder>")).toBeLessThan(
-      xml.indexOf("<channel-notification"),
-    );
+    expect(reminder).toContain("<system-reminder>");
+    expect(reminder).toContain("must call the MessageChannel tool");
+    expect(reminder).toContain('channel="telegram" and chat_id="12345"');
+    expect(reminder).toContain("Current local time on this device:");
   });
 
-  test("escapes XML special characters in text", () => {
+  test("escapes XML special characters in notification text", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "123",
@@ -55,7 +67,7 @@ describe("formatChannelNotification", () => {
       timestamp: Date.now(),
     };
 
-    const xml = formatChannelNotification(msg);
+    const xml = buildChannelNotificationXml(msg);
 
     expect(xml).toContain("&lt;world&gt;");
     expect(xml).toContain("&amp;");
@@ -63,7 +75,7 @@ describe("formatChannelNotification", () => {
     expect(xml).toContain("&apos;here&apos;");
   });
 
-  test("escapes XML special characters in attributes", () => {
+  test("escapes XML special characters in notification attributes", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "123",
@@ -73,12 +85,12 @@ describe("formatChannelNotification", () => {
       timestamp: Date.now(),
     };
 
-    const xml = formatChannelNotification(msg);
+    const xml = buildChannelNotificationXml(msg);
 
     expect(xml).toContain("John &quot;The &lt;Bot&gt;&quot;");
   });
 
-  test("omits optional fields when not present", () => {
+  test("omits optional notification attributes when not present", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "123",
@@ -87,7 +99,7 @@ describe("formatChannelNotification", () => {
       timestamp: Date.now(),
     };
 
-    const xml = formatChannelNotification(msg);
+    const xml = buildChannelNotificationXml(msg);
 
     expect(xml).not.toContain("sender_name=");
     expect(xml).not.toContain("message_id=");

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -805,8 +805,16 @@ describe("listen-client multi-worker concurrency", () => {
     );
     const socket = new MockSocket();
     const processed: IncomingMessage[] = [];
-    const xml =
-      '<channel-notification source="telegram" chat_id="7952253975">hello from telegram</channel-notification>';
+    const channelContent = [
+      {
+        type: "text" as const,
+        text: "<system-reminder>Call MessageChannel to reply.</system-reminder>",
+      },
+      {
+        type: "text" as const,
+        text: '<channel-notification source="telegram" chat_id="7952253975">hello from telegram</channel-notification>',
+      },
+    ];
 
     const enqueuedItem = __listenClientTestUtils.enqueueChannelTurn(
       runtime,
@@ -814,7 +822,7 @@ describe("listen-client multi-worker concurrency", () => {
         agentId: "agent-1",
         conversationId: "conv-channel",
       },
-      xml,
+      channelContent,
     );
 
     expect(enqueuedItem).not.toBeNull();
@@ -843,7 +851,7 @@ describe("listen-client multi-worker concurrency", () => {
         messages: [
           expect.objectContaining({
             role: "user",
-            content: [{ type: "text", text: xml }],
+            content: channelContent,
             client_message_id: expect.stringMatching(/^cm-channel-/),
           }),
         ],

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1889,7 +1889,7 @@ function wireChannelIngress(
   const registry = getChannelRegistry();
   if (!registry) return;
 
-  registry.setMessageHandler((route, xmlContent) => {
+  registry.setMessageHandler((route, messageContent) => {
     // Follow the same pattern as cron/scheduler.ts:131-157
     const rawRuntime = getOrCreateConversationRuntime(
       listener,
@@ -1903,7 +1903,7 @@ function wireChannelIngress(
       rawRuntime,
     );
 
-    enqueueChannelTurn(conversationRuntime, route, xmlContent);
+    enqueueChannelTurn(conversationRuntime, route, messageContent);
 
     scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
   });
@@ -1924,13 +1924,13 @@ function enqueueChannelTurn(
     agentId: string;
     conversationId: string;
   },
-  xmlContent: MessageCreate["content"],
+  messageContent: MessageCreate["content"],
 ): { id: string } | null {
   const clientMessageId = `cm-channel-${crypto.randomUUID()}`;
   const enqueuedItem = runtime.queueRuntime.enqueue({
     kind: "message",
     source: "channel" as import("../../types/protocol").QueueItemSource,
-    content: xmlContent,
+    content: messageContent,
     clientMessageId,
     agentId: route.agentId,
     conversationId: route.conversationId,
@@ -1950,7 +1950,7 @@ function enqueueChannelTurn(
     messages: [
       {
         role: "user",
-        content: xmlContent,
+        content: messageContent,
         client_message_id: clientMessageId,
       } satisfies MessageCreate & { client_message_id?: string },
     ],


### PR DESCRIPTION
## Summary
- send inbound channel reminders and notification XML as separate user-message content parts instead of one concatenated text blob
- thread `MessageCreate["content"]` through channel registry buffering and listener ingress instead of treating channel payloads as string-only XML
- update channel and listener tests to assert the reminder and `<channel-notification>` arrive as distinct text parts

## Why
UMI already knows how to strip pure `<system-reminder>...</system-reminder>` text parts, but concatenated channel payloads forced the reminder and the notification into a single blob.

Splitting them into separate content parts keeps the agent-facing semantics the same while letting downstream UIs hide the reminder without needing to parse mixed XML text.

## Validation
- `bun test src/tests/channels/xml.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/channels/xml.ts src/channels/registry.ts src/websocket/listener/client.ts src/tests/channels/xml.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- `bun run lint`
