### PR TITLE
feat(channels): add markdown formatting for outbound Telegram messages

### DIFF
--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -130,12 +130,20 @@ export function createTelegramAdapter(
     async sendMessage(
       msg: OutboundChannelMessage,
     ): Promise<{ messageId: string }> {
+      const opts: Record<string, unknown> = {};
+      if (msg.replyToMessageId) {
+        opts.reply_parameters = {
+          message_id: Number(msg.replyToMessageId),
+        };
+      }
+      if (msg.parseMode) {
+        opts.parse_mode = msg.parseMode;
+      }
+
       const result = await bot.api.sendMessage(
         msg.chatId,
         msg.text,
-        msg.replyToMessageId
-          ? { reply_parameters: { message_id: Number(msg.replyToMessageId) } }
-          : undefined,
+        opts,
       );
       return { messageId: String(result.message_id) };
     },

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -71,6 +71,8 @@ export interface OutboundChannelMessage {
   text: string;
   /** Optional: reply to a specific message. */
   replyToMessageId?: string;
+  /** Optional: parse mode hint for the adapter (e.g. "HTML", "MarkdownV2"). */
+  parseMode?: string;
 }
 
 // ── Routing ───────────────────────────────────────────────────────

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -288,6 +288,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     return 0;
   }
 
+  await settingsManager.initialize();
   telemetry.setSurface("websocket");
   telemetry.init();
 
@@ -366,8 +367,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   console.log(`Log file: ${sessionLog.path}`);
 
   try {
-    await settingsManager.initialize();
-
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
     let registerOptions: RegisterOptions;

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -9,6 +9,49 @@
 import { getChannelRegistry } from "../../channels/registry";
 import type { ChannelRoute } from "../../channels/types";
 
+/**
+ * Convert standard markdown to Telegram-safe HTML.
+ * Handles bold, italic, code, pre, links, and strikethrough.
+ * HTML is more forgiving than MarkdownV2 (no escaping headaches).
+ */
+function markdownToTelegramHtml(text: string): string {
+  let result = text;
+
+  // Escape HTML entities first (before adding our own tags)
+  result = result
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  // Code blocks (``` ... ```) — must come before inline code
+  result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_m, _lang, code) => {
+    return `<pre>${code.trimEnd()}</pre>`;
+  });
+
+  // Inline code (` ... `)
+  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
+
+  // Bold+italic (***text*** or ___text___)
+  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<b><i>$1</i></b>");
+
+  // Bold (**text**)
+  result = result.replace(/\*\*(.+?)\*\*/g, "<b>$1</b>");
+
+  // Italic (*text* — but not inside words like file*name)
+  result = result.replace(/(?<!\w)\*(.+?)\*(?!\w)/g, "<i>$1</i>");
+
+  // Strikethrough (~~text~~)
+  result = result.replace(/~~(.+?)~~/g, "<s>$1</s>");
+
+  // Links [text](url)
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2">$1</a>',
+  );
+
+  return result;
+}
+
 interface MessageChannelArgs {
   channel: string;
   chat_id: string;
@@ -56,11 +99,16 @@ export async function message_channel(
   }
 
   try {
+    // Convert standard markdown to Telegram HTML for rich formatting.
+    // Adapters that don't support parseMode will ignore it.
+    const formattedText = markdownToTelegramHtml(args.text);
+
     const result = await adapter.sendMessage({
       channel: args.channel,
       chatId: args.chat_id,
-      text: args.text,
+      text: formattedText,
       replyToMessageId: args.reply_to_message_id,
+      parseMode: "HTML",
     });
 
     return `Message sent to ${args.channel} (message_id: ${result.messageId})`;


### PR DESCRIPTION
## Summary

- Agent responses contain standard markdown (`**bold**`, `*italic*`, etc.) but the Telegram adapter was sending plain text, rendering literal asterisks
- Adds `markdownToTelegramHtml()` in the MessageChannel tool to convert standard markdown to Telegram-safe HTML (bold, italic, bold+italic, code blocks, inline code, strikethrough, links)
- Adds `parseMode` field to `OutboundChannelMessage` type
- Passes `parse_mode` through to grammY in the Telegram adapter
- Uses HTML rather than MarkdownV2 to avoid Telegram's escaping requirements
- Conversion lives in the tool layer so future channel adapters can have their own formatting

Stacked on #1752.

## Test plan

- [ ] Send a message with `**bold**` text through Telegram -- should render as bold
- [ ] Send a message with `*italic*`, `` `code` ``, code blocks, `[links](url)`, `~~strikethrough~~`
- [ ] Verify HTML entities (`<`, `>`, `&`) in agent text don't break Telegram parsing
- [ ] Verify adapters that don't use parseMode are unaffected (field is optional)

Written by Cameron ◯ Letta Code

"The medium is the message." -- Marshall McLuhan