### PR TITLE
feat: apply real-time sync for filesystem

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -199,6 +199,7 @@ async function executeSingleDecision(
     ) => void;
     toolContextId?: string;
     parentScope?: { agentId: string; conversationId: string };
+    onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<ApprovalResult> {
   // If aborted, record an interrupted result
@@ -266,6 +267,7 @@ async function executeSingleDecision(
                   stream === "stderr",
                 )
             : undefined,
+          onFileWrite: options?.onFileWrite,
         },
       );
 
@@ -375,6 +377,7 @@ export async function executeApprovalBatch(
     toolContextId?: string;
     workingDirectory?: string;
     parentScope?: { agentId: string; conversationId: string };
+    onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<ApprovalResult[]> {
   const toolContextId =
@@ -485,6 +488,7 @@ export async function executeAutoAllowedTools(
     ) => void;
     toolContextId?: string;
     workingDirectory?: string;
+    onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<AutoAllowedResult[]> {
   const decisions: ApprovalDecision[] = autoAllowed.map((ac) => ({

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1,3 +1,5 @@
+import * as nodeFs from "node:fs/promises";
+import * as nodePath from "node:path";
 import { getDisplayableToolReturn } from "../agent/approval-execution";
 import { getModelInfo } from "../agent/model";
 import { getAllSubagentConfigs } from "../agent/subagents";
@@ -33,6 +35,9 @@ const STREAMING_SHELL_TOOLS = new Set([
   "run_shell_command",
   "RunShellCommand",
 ]);
+
+// Tools that write files — used to trigger onFileWrite broadcast after execution.
+const FILE_MUTATING_TOOLS = new Set(["Edit", "Write", "MultiEdit", "replace"]);
 
 // Maps internal tool names to server/model-facing tool names
 // This allows us to have multiple implementations (e.g., write_file_gemini, Write from Anthropic)
@@ -1453,29 +1458,16 @@ export async function executeTool(
 
     // Broadcast file content after file-mutating tools so web clients update
     // in real time without waiting for fs.watch → file_changed → re-read.
-    const FILE_MUTATING_TOOLS = new Set([
-      "Edit",
-      "Write",
-      "MultiEdit",
-      "replace",
-    ]);
     if (options?.onFileWrite && FILE_MUTATING_TOOLS.has(internalName)) {
-      const rawArgs = enhancedArgs as Record<string, unknown>;
-      const filePath =
-        (rawArgs.file_path as string | undefined) ??
-        // MultiEdit uses edits[].file_path — broadcast the first one.
-        (rawArgs.edits as Array<{ file_path?: string }> | undefined)?.[0]
-          ?.file_path ??
-        undefined;
+      const filePath = (enhancedArgs as Record<string, unknown>).file_path as
+        | string
+        | undefined;
       if (filePath) {
         try {
-          const nodePath = await import("node:path");
-          const { readFile } = await import("node:fs/promises");
-          const userCwd = process.env.USER_CWD || process.cwd();
           const resolvedPath = nodePath.isAbsolute(filePath)
             ? filePath
-            : nodePath.resolve(userCwd, filePath);
-          const content = await readFile(resolvedPath, "utf-8");
+            : nodePath.resolve(process.env.USER_CWD || process.cwd(), filePath);
+          const content = await nodeFs.readFile(resolvedPath, "utf-8");
           options.onFileWrite(resolvedPath, content);
         } catch {
           // Best-effort — don't fail the tool call if the read fails.

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1327,6 +1327,9 @@ export async function executeTool(
     onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
     toolContextId?: string;
     parentScope?: { agentId: string; conversationId: string };
+    /** Called after a file-mutating tool (Edit, Write, MultiEdit) writes to disk.
+     *  The listener layer uses this to broadcast the new content via WebSocket. */
+    onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<ToolExecutionResult> {
   const context = options?.toolContextId
@@ -1447,6 +1450,38 @@ export async function executeTool(
     // The incremental rebuild is cheap (metadata-based skip for unchanged
     // subtrees), so running on every tool adds negligible overhead.
     void refreshFileIndex();
+
+    // Broadcast file content after file-mutating tools so web clients update
+    // in real time without waiting for fs.watch → file_changed → re-read.
+    const FILE_MUTATING_TOOLS = new Set([
+      "Edit",
+      "Write",
+      "MultiEdit",
+      "replace",
+    ]);
+    if (options?.onFileWrite && FILE_MUTATING_TOOLS.has(internalName)) {
+      const rawArgs = enhancedArgs as Record<string, unknown>;
+      const filePath =
+        (rawArgs.file_path as string | undefined) ??
+        // MultiEdit uses edits[].file_path — broadcast the first one.
+        (rawArgs.edits as Array<{ file_path?: string }> | undefined)?.[0]
+          ?.file_path ??
+        undefined;
+      if (filePath) {
+        try {
+          const nodePath = await import("node:path");
+          const { readFile } = await import("node:fs/promises");
+          const userCwd = process.env.USER_CWD || process.cwd();
+          const resolvedPath = nodePath.isAbsolute(filePath)
+            ? filePath
+            : nodePath.resolve(userCwd, filePath);
+          const content = await readFile(resolvedPath, "utf-8");
+          options.onFileWrite(resolvedPath, content);
+        } catch {
+          // Best-effort — don't fail the tool call if the read fails.
+        }
+      }
+    }
 
     // Extract stdout/stderr if present (for bash tools)
     const recordResult = isRecord(result) ? result : undefined;

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -529,6 +529,30 @@ export interface UnwatchFileCommand {
   request_id: string;
 }
 
+/** Bidirectional: Egwalker CRDT ops for collaborative editing. */
+export interface FileOpsCommand {
+  type: "file_ops";
+  /** Absolute path to the file being edited. */
+  path: string;
+  /** Serialized causal-graph entries. */
+  cg_entries: {
+    agent: string;
+    seq: number;
+    len: number;
+    parents: [string, number][];
+  }[];
+  /** The operations (insert / delete). */
+  ops: {
+    type: "ins" | "del";
+    pos: number;
+    content?: string;
+  }[];
+  /** Who generated these ops (e.g. 'window-abc', 'agent-xyz'). */
+  source: string;
+  /** Full document content after these ops were applied. */
+  document_content?: string;
+}
+
 export interface EditFileCommand {
   type: "edit_file";
   /** Absolute path to the file to edit. */
@@ -899,6 +923,7 @@ export type WsProtocolCommand =
   | WatchFileCommand
   | UnwatchFileCommand
   | EditFileCommand
+  | FileOpsCommand
   | ListMemoryCommand
   | MemoryHistoryCommand
   | MemoryFileAtRefCommand

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -139,6 +139,7 @@ import {
   isEditFileCommand,
   isEnableMemfsCommand,
   isExecuteCommandCommand,
+  isFileOpsCommand,
   isGetReflectionSettingsCommand,
   isListInDirectoryCommand,
   isListMemoryCommand,
@@ -2875,7 +2876,17 @@ async function connectWithRetry(
         );
         runDetachedListenerTask("edit_file", async () => {
           try {
+            const { readFile } = await import("node:fs/promises");
             const { edit } = await import("../../tools/impl/Edit");
+
+            // Read file BEFORE the edit so we can diff for CRDT ops.
+            let contentBefore: string | null = null;
+            try {
+              contentBefore = await readFile(parsed.file_path, "utf-8");
+            } catch {
+              // If we can't read, we'll skip CRDT op generation.
+            }
+
             console.log(
               `[Listen] Executing edit: old_string="${parsed.old_string.slice(0, 50)}${parsed.old_string.length > 50 ? "..." : ""}"`,
             );
@@ -2889,6 +2900,29 @@ async function connectWithRetry(
             console.log(
               `[Listen] edit_file success: ${result.replacements} replacement(s) at line ${result.startLine}`,
             );
+
+            // Notify web clients of the new content so they can update live.
+            if (result.replacements > 0) {
+              try {
+                const contentAfter = await readFile(parsed.file_path, "utf-8");
+                safeSocketSend(
+                  socket,
+                  {
+                    type: "file_ops",
+                    path: parsed.file_path,
+                    cg_entries: [],
+                    ops: [],
+                    source: "agent",
+                    document_content: contentAfter,
+                  },
+                  "listener_edit_file_ops_send_failed",
+                  "listener_edit_file",
+                );
+              } catch {
+                // Non-fatal: content broadcast is best-effort.
+              }
+            }
+
             safeSocketSend(
               socket,
               {
@@ -2929,6 +2963,28 @@ async function connectWithRetry(
             );
           }
         });
+        return;
+      }
+
+      // ── Egwalker CRDT ops (no runtime scope required) ─────────────────
+      if (isFileOpsCommand(parsed)) {
+        // Use document_content if provided (reliable, no race conditions).
+        // Falls back to applying ops character-by-character.
+        if (parsed.document_content !== undefined) {
+          runDetachedListenerTask("file_ops", async () => {
+            try {
+              const { writeFile } = await import("node:fs/promises");
+              await writeFile(parsed.path, parsed.document_content!, "utf-8");
+              console.log(
+                `[Listen] file_ops: wrote ${parsed.document_content!.length} bytes to ${parsed.path}`,
+              );
+            } catch (err) {
+              console.error(
+                `[Listen] file_ops error: ${err instanceof Error ? err.message : "Unknown error"}`,
+              );
+            }
+          });
+        }
         return;
       }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -2966,9 +2966,10 @@ async function connectWithRetry(
           runDetachedListenerTask("file_ops", async () => {
             try {
               const { writeFile } = await import("node:fs/promises");
-              await writeFile(parsed.path, parsed.document_content!, "utf-8");
+              const content = parsed.document_content as string;
+              await writeFile(parsed.path, content, "utf-8");
               console.log(
-                `[Listen] file_ops: wrote ${parsed.document_content!.length} bytes to ${parsed.path}`,
+                `[Listen] file_ops: wrote ${content.length} bytes to ${parsed.path}`,
               );
             } catch (err) {
               console.error(

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -2879,14 +2879,6 @@ async function connectWithRetry(
             const { readFile } = await import("node:fs/promises");
             const { edit } = await import("../../tools/impl/Edit");
 
-            // Read file BEFORE the edit so we can diff for CRDT ops.
-            let contentBefore: string | null = null;
-            try {
-              contentBefore = await readFile(parsed.file_path, "utf-8");
-            } catch {
-              // If we can't read, we'll skip CRDT op generation.
-            }
-
             console.log(
               `[Listen] Executing edit: old_string="${parsed.old_string.slice(0, 50)}${parsed.old_string.length > 50 ? "..." : ""}"`,
             );

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -12,6 +12,7 @@ import type {
   EditFileCommand,
   EnableMemfsCommand,
   ExecuteCommandCommand,
+  FileOpsCommand,
   GetReflectionSettingsCommand,
   InputCommand,
   ListInDirectoryCommand,
@@ -356,6 +357,24 @@ export function isEditFileCommand(value: unknown): value is EditFileCommand {
       (typeof c.expected_replacements === "number" &&
         Number.isInteger(c.expected_replacements) &&
         c.expected_replacements > 0))
+  );
+}
+
+export function isFileOpsCommand(value: unknown): value is FileOpsCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    path?: unknown;
+    cg_entries?: unknown;
+    ops?: unknown;
+    source?: unknown;
+  };
+  return (
+    c.type === "file_ops" &&
+    typeof c.path === "string" &&
+    Array.isArray(c.cg_entries) &&
+    Array.isArray(c.ops) &&
+    typeof c.source === "string"
   );
 }
 
@@ -758,6 +777,7 @@ export function parseServerMessage(
       isWatchFileCommand(parsed) ||
       isUnwatchFileCommand(parsed) ||
       isEditFileCommand(parsed) ||
+      isFileOpsCommand(parsed) ||
       isListMemoryCommand(parsed) ||
       isMemoryHistoryCommand(parsed) ||
       isMemoryFileAtRefCommand(parsed) ||

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -4,7 +4,7 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import type WebSocket from "ws";
+import WebSocket from "ws";
 import {
   type ApprovalResult,
   executeApprovalBatch,
@@ -388,12 +388,30 @@ export async function handleApprovalStop(params: {
     return interruptTermination();
   }
 
+  // Broadcast new file content to web clients when a file-mutating tool
+  // (Edit, Write, MultiEdit) writes to disk, so all windows update immediately.
+  const onFileWrite = (filePath: string, content: string) => {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(
+        JSON.stringify({
+          type: "file_ops",
+          path: filePath,
+          cg_entries: [],
+          ops: [],
+          source: "agent",
+          document_content: content,
+        }),
+      );
+    }
+  };
+
   const executionResults = await executeApprovalBatch(decisions, undefined, {
     toolContextId: turnToolContextId ?? undefined,
     abortSignal: abortController.signal,
     workingDirectory: turnWorkingDirectory,
     parentScope:
       agentId && conversationId ? { agentId, conversationId } : undefined,
+    onFileWrite,
   });
   const persistedExecutionResults = normalizeExecutionResultsForInterruptParity(
     runtime,


### PR DESCRIPTION
Adds support for the file_ops WebSocket message that enables real-time file sync between the coding agent and connected web clients (browser windows). When the agent edits a file (via Edit, Write, or MultiEdit tool), the new content is immediately broadcast to all subscribers so editors update without waiting for filesystem watchers.