### PR TITLE
fix(channels): harden Telegram markdown formatting

### DIFF
--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -140,11 +140,7 @@ export function createTelegramAdapter(
         opts.parse_mode = msg.parseMode;
       }
 
-      const result = await bot.api.sendMessage(
-        msg.chatId,
-        msg.text,
-        opts,
-      );
+      const result = await bot.api.sendMessage(msg.chatId, msg.text, opts);
       return { messageId: String(result.message_id) };
     },
 

--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+
+import {
+  formatOutboundChannelMessage,
+  markdownToTelegramHtml,
+} from "../../tools/impl/MessageChannel";
+
+test("formats Telegram markdown as HTML", () => {
+  const formatted = formatOutboundChannelMessage(
+    "telegram",
+    "**bold** and *italic* and ~~gone~~",
+  );
+
+  expect(formatted).toEqual({
+    text: "<b>bold</b> and <i>italic</i> and <s>gone</s>",
+    parseMode: "HTML",
+  });
+});
+
+test("leaves non-Telegram channel messages unchanged", () => {
+  expect(formatOutboundChannelMessage("slack", "**bold**")).toEqual({
+    text: "**bold**",
+  });
+});
+
+test("preserves markdown markers inside inline code", () => {
+  expect(markdownToTelegramHtml("`**bold**`")).toBe("<code>**bold**</code>");
+});
+
+test("preserves markdown markers inside fenced code blocks", () => {
+  expect(markdownToTelegramHtml('```js\nconst x = "**bold**";\n```')).toBe(
+    '<pre>const x = "**bold**";</pre>',
+  );
+});
+
+test("renders markdown links with balanced parentheses and escaped attributes", () => {
+  expect(
+    markdownToTelegramHtml('[**docs**](https://example.com/?q="x"&ref=(test))'),
+  ).toBe(
+    '<a href="https://example.com/?q=&quot;x&quot;&amp;ref=(test)"><b>docs</b></a>',
+  );
+});
+
+test("does not treat spaced arithmetic operators as italic markup", () => {
+  expect(markdownToTelegramHtml("2 * 3 * 4")).toBe("2 * 3 * 4");
+});

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -188,3 +188,29 @@ test("telegram adapter logs and clears running state when polling exits unexpect
     expect.objectContaining({ message: "polling failed" }),
   );
 });
+
+test("telegram adapter forwards parse mode and reply parameters", async () => {
+  const adapter = createTelegramAdapter({
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "123",
+    text: "<b>hello</b>",
+    replyToMessageId: "456",
+    parseMode: "HTML",
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot).toBeDefined();
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith("123", "<b>hello</b>", {
+    parse_mode: "HTML",
+    reply_parameters: { message_id: 456 },
+  });
+});

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -7,49 +7,220 @@
  */
 
 import { getChannelRegistry } from "../../channels/registry";
-import type { ChannelRoute } from "../../channels/types";
+import type {
+  ChannelRoute,
+  OutboundChannelMessage,
+} from "../../channels/types";
 
-/**
- * Convert standard markdown to Telegram-safe HTML.
- * Handles bold, italic, code, pre, links, and strikethrough.
- * HTML is more forgiving than MarkdownV2 (no escaping headaches).
- */
-function markdownToTelegramHtml(text: string): string {
-  let result = text;
+const TELEGRAM_CHANNEL_ID = "telegram";
+const TELEGRAM_PLACEHOLDER_PREFIX = "LCTELEGRAMHTMLPLACEHOLDER";
+const TELEGRAM_PLACEHOLDER_SUFFIX = "X";
+const TELEGRAM_PLACEHOLDER_PATTERN = /LCTELEGRAMHTMLPLACEHOLDER(\d+)X/g;
 
-  // Escape HTML entities first (before adding our own tags)
-  result = result
+function escapeTelegramHtml(text: string): string {
+  return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
 
-  // Code blocks (``` ... ```) — must come before inline code
-  result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_m, _lang, code) => {
-    return `<pre>${code.trimEnd()}</pre>`;
+function escapeTelegramHtmlAttribute(text: string): string {
+  return escapeTelegramHtml(text)
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function createTelegramPlaceholder(
+  placeholders: string[],
+  value: string,
+): string {
+  const placeholder = `${TELEGRAM_PLACEHOLDER_PREFIX}${placeholders.length}${TELEGRAM_PLACEHOLDER_SUFFIX}`;
+  placeholders.push(value);
+  return placeholder;
+}
+
+function restoreTelegramPlaceholders(
+  text: string,
+  placeholders: string[],
+): string {
+  return text.replace(TELEGRAM_PLACEHOLDER_PATTERN, (_match, index) => {
+    return placeholders[Number(index)] ?? "";
   });
+}
 
-  // Inline code (` ... `)
-  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
-
-  // Bold+italic (***text*** or ___text___)
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<b><i>$1</i></b>");
-
-  // Bold (**text**)
-  result = result.replace(/\*\*(.+?)\*\*/g, "<b>$1</b>");
-
-  // Italic (*text* — but not inside words like file*name)
-  result = result.replace(/(?<!\w)\*(.+?)\*(?!\w)/g, "<i>$1</i>");
-
-  // Strikethrough (~~text~~)
-  result = result.replace(/~~(.+?)~~/g, "<s>$1</s>");
-
-  // Links [text](url)
-  result = result.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a href="$2">$1</a>',
+function replaceFencedCodeBlocks(text: string, placeholders: string[]): string {
+  return text.replace(
+    /```([^\n`]*)\n?([\s\S]*?)```/g,
+    (_match, _lang, code) => {
+      return createTelegramPlaceholder(
+        placeholders,
+        `<pre>${escapeTelegramHtml(String(code).trimEnd())}</pre>`,
+      );
+    },
   );
+}
+
+function replaceInlineCode(text: string, placeholders: string[]): string {
+  return text.replace(/`([^`\n]+)`/g, (_match, code) => {
+    return createTelegramPlaceholder(
+      placeholders,
+      `<code>${escapeTelegramHtml(String(code))}</code>`,
+    );
+  });
+}
+
+type ParsedMarkdownLink = {
+  label: string;
+  url: string;
+  endIndex: number;
+};
+
+function parseMarkdownLink(
+  text: string,
+  startIndex: number,
+): ParsedMarkdownLink | null {
+  if (text[startIndex] !== "[") {
+    return null;
+  }
+
+  let labelEnd = startIndex + 1;
+  let bracketDepth = 1;
+  while (labelEnd < text.length) {
+    const char = text[labelEnd];
+    if (char === "\\") {
+      labelEnd += 2;
+      continue;
+    }
+    if (char === "[") {
+      bracketDepth++;
+    } else if (char === "]") {
+      bracketDepth--;
+      if (bracketDepth === 0) {
+        break;
+      }
+    }
+    labelEnd++;
+  }
+
+  if (bracketDepth !== 0 || text[labelEnd + 1] !== "(") {
+    return null;
+  }
+
+  let urlEnd = labelEnd + 2;
+  let parenDepth = 1;
+  while (urlEnd < text.length) {
+    const char = text[urlEnd];
+    if (char === "\\") {
+      urlEnd += 2;
+      continue;
+    }
+    if (char === "(") {
+      parenDepth++;
+    } else if (char === ")") {
+      parenDepth--;
+      if (parenDepth === 0) {
+        break;
+      }
+    }
+    urlEnd++;
+  }
+
+  if (parenDepth !== 0) {
+    return null;
+  }
+
+  const label = text.slice(startIndex + 1, labelEnd);
+  const url = text.slice(labelEnd + 2, urlEnd).trim();
+  if (!url) {
+    return null;
+  }
+
+  return {
+    label,
+    url,
+    endIndex: urlEnd + 1,
+  };
+}
+
+function replaceMarkdownLinks(
+  text: string,
+  placeholders: string[],
+  renderLabel: (label: string) => string,
+): string {
+  let result = "";
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "[") {
+      result += text[index];
+      index++;
+      continue;
+    }
+
+    const link = parseMarkdownLink(text, index);
+    if (!link) {
+      result += text[index];
+      index++;
+      continue;
+    }
+
+    result += createTelegramPlaceholder(
+      placeholders,
+      `<a href="${escapeTelegramHtmlAttribute(link.url)}">${renderLabel(link.label)}</a>`,
+    );
+    index = link.endIndex;
+  }
 
   return result;
+}
+
+function applyTelegramInlineFormatting(text: string): string {
+  return text
+    .replace(/\*\*\*([^\s*](?:[\s\S]*?[^\s*])?)\*\*\*/g, "<b><i>$1</i></b>")
+    .replace(/___([^\s_](?:[\s\S]*?[^\s_])?)___/g, "<b><i>$1</i></b>")
+    .replace(/\*\*([^\s*](?:[\s\S]*?[^\s*])?)\*\*/g, "<b>$1</b>")
+    .replace(/__([^\s_](?:[\s\S]*?[^\s_])?)__/g, "<b>$1</b>")
+    .replace(/~~([^\s~](?:[\s\S]*?[^\s~])?)~~/g, "<s>$1</s>")
+    .replace(/(^|[^\w*])\*([^\s*](?:[\s\S]*?[^\s*])?)\*(?!\w)/g, "$1<i>$2</i>")
+    .replace(/(^|[^\w_])_([^\s_](?:[\s\S]*?[^\s_])?)_(?!\w)/g, "$1<i>$2</i>");
+}
+
+function formatTelegramText(
+  text: string,
+  options?: { enableLinks?: boolean },
+): string {
+  const placeholders: string[] = [];
+  let result = replaceFencedCodeBlocks(text, placeholders);
+  result = replaceInlineCode(result, placeholders);
+
+  if (options?.enableLinks !== false) {
+    result = replaceMarkdownLinks(result, placeholders, (label) =>
+      formatTelegramText(label, { enableLinks: false }),
+    );
+  }
+
+  result = escapeTelegramHtml(result);
+  result = applyTelegramInlineFormatting(result);
+
+  return restoreTelegramPlaceholders(result, placeholders);
+}
+
+export function markdownToTelegramHtml(text: string): string {
+  return formatTelegramText(text);
+}
+
+export function formatOutboundChannelMessage(
+  channel: string,
+  text: string,
+): Pick<OutboundChannelMessage, "text" | "parseMode"> {
+  if (channel !== TELEGRAM_CHANNEL_ID) {
+    return { text };
+  }
+
+  return {
+    text: markdownToTelegramHtml(text),
+    parseMode: "HTML",
+  };
 }
 
 interface MessageChannelArgs {
@@ -99,16 +270,17 @@ export async function message_channel(
   }
 
   try {
-    // Convert standard markdown to Telegram HTML for rich formatting.
-    // Adapters that don't support parseMode will ignore it.
-    const formattedText = markdownToTelegramHtml(args.text);
+    const formattedMessage = formatOutboundChannelMessage(
+      args.channel,
+      args.text,
+    );
 
     const result = await adapter.sendMessage({
       channel: args.channel,
       chatId: args.chat_id,
-      text: formattedText,
+      text: formattedMessage.text,
       replyToMessageId: args.reply_to_message_id,
-      parseMode: "HTML",
+      parseMode: formattedMessage.parseMode,
     });
 
     return `Message sent to ${args.channel} (message_id: ${result.messageId})`;


### PR DESCRIPTION
## Summary

- keep Telegram formatting conversion scoped to Telegram outbound messages only
- preserve fenced code blocks and inline code as literal content instead of reformatting markdown inside them
- harden markdown link conversion so balanced parentheses and quoted URL attributes render as valid Telegram HTML
- add regression coverage for formatter behavior and parse_mode passthrough

## Test plan

- bun test src/tests/channels/message-channel-formatting.test.ts src/tests/channels/telegram-adapter.test.ts
- bun run lint
- bun run check