### PR TITLE
feat(channels): add inbound Telegram media support

### DIFF
--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -34,6 +34,10 @@ export function getChannelPairingPath(channelId: string): string {
   return join(getChannelDir(channelId), "pairing.yaml");
 }
 
+export function getChannelInboundMediaDir(channelId: string): string {
+  return join(getChannelDir(channelId), "inbound");
+}
+
 // ── YAML helpers ──────────────────────────────────────────────────
 
 /**

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -282,7 +282,7 @@ export class ChannelRegistry {
     }
 
     // 3. Format as XML
-    const content = formatChannelNotification(msg);
+    const content = await formatChannelNotification(msg);
 
     // 4. Deliver or buffer
     if (this.isReady()) {

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -5,19 +5,298 @@
  * Reference: lettabot src/channels/telegram.ts
  */
 
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { basename, join } from "node:path";
 import { Bot } from "grammy";
+import { getChannelInboundMediaDir } from "../config";
 import type {
   ChannelAdapter,
+  InboundChannelAttachment,
+  InboundChannelAttachmentKind,
   InboundChannelMessage,
   OutboundChannelMessage,
   TelegramChannelConfig,
 } from "../types";
 
+const DEFAULT_MEDIA_GROUP_FLUSH_MS = 150;
+const DEFAULT_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024;
+
+const IMAGE_FILE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+]);
+
+type TelegramAdapterDeps = {
+  fetchImpl?: typeof fetch;
+  mediaGroupFlushMs?: number;
+  resolveInboundMediaDir?: (chatId: string) => string;
+  now?: () => Date;
+  randomToken?: () => string;
+  setTimeoutImpl?: typeof setTimeout;
+  clearTimeoutImpl?: typeof clearTimeout;
+};
+
+type TelegramLikeMessage = {
+  media_group_id?: string;
+  message_id: number;
+  date: number;
+  text?: string;
+  caption?: string;
+  chat: { id: number | string };
+  from: {
+    id: number | string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+  photo?: Array<{
+    file_id: string;
+    file_unique_id?: string;
+    file_size?: number;
+  }>;
+  document?: {
+    file_id: string;
+    file_name?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  video?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  audio?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  voice?: {
+    file_id: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  animation?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  sticker?: {
+    file_id: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+    is_animated?: boolean;
+    is_video?: boolean;
+  };
+};
+
+type TelegramAttachmentCandidate = {
+  fileId: string;
+  kind: InboundChannelAttachmentKind;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+};
+
+type BufferedMediaGroup = {
+  messages: TelegramLikeMessage[];
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function normalizeMimeType(mimeType?: string): string | undefined {
+  const normalized = mimeType?.split(";")[0]?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function sanitizePathSegment(input: string): string {
+  const cleaned = input
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "attachment";
+}
+
+function coerceSizeBytes(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function inferAttachmentKind(params: {
+  mimeType?: string;
+  fileName?: string;
+  fallback: InboundChannelAttachmentKind;
+}): InboundChannelAttachmentKind {
+  const normalizedMimeType = normalizeMimeType(params.mimeType);
+  if (normalizedMimeType?.startsWith("image/")) {
+    return "image";
+  }
+  if (normalizedMimeType?.startsWith("audio/")) {
+    return "audio";
+  }
+  if (normalizedMimeType?.startsWith("video/")) {
+    return "video";
+  }
+
+  const lowerName = params.fileName?.toLowerCase();
+  if (lowerName) {
+    for (const ext of IMAGE_FILE_EXTENSIONS) {
+      if (lowerName.endsWith(ext)) {
+        return "image";
+      }
+    }
+  }
+
+  return params.fallback;
+}
+
+function extractMessageText(message: TelegramLikeMessage): string {
+  if (typeof message.text === "string") {
+    return message.text;
+  }
+  if (typeof message.caption === "string") {
+    return message.caption;
+  }
+  return "";
+}
+
+function getSenderName(message: TelegramLikeMessage): string | undefined {
+  return (
+    message.from.username ??
+    ([message.from.first_name, message.from.last_name]
+      .filter(Boolean)
+      .join(" ") ||
+      undefined)
+  );
+}
+
+function collectAttachmentCandidates(
+  message: TelegramLikeMessage,
+): TelegramAttachmentCandidate[] {
+  const attachments: TelegramAttachmentCandidate[] = [];
+
+  if (Array.isArray(message.photo) && message.photo.length > 0) {
+    const photo = message.photo[message.photo.length - 1];
+    if (photo?.file_id) {
+      attachments.push({
+        fileId: photo.file_id,
+        kind: "image",
+        name: `photo-${photo.file_unique_id ?? photo.file_id}.jpg`,
+        mimeType: "image/jpeg",
+        sizeBytes: coerceSizeBytes(photo.file_size),
+      });
+    }
+  }
+
+  if (message.document?.file_id) {
+    attachments.push({
+      fileId: message.document.file_id,
+      kind: inferAttachmentKind({
+        mimeType: message.document.mime_type,
+        fileName: message.document.file_name,
+        fallback: "file",
+      }),
+      name: message.document.file_name,
+      mimeType: message.document.mime_type,
+      sizeBytes: coerceSizeBytes(message.document.file_size),
+    });
+  }
+
+  if (message.video?.file_id) {
+    attachments.push({
+      fileId: message.video.file_id,
+      kind: "video",
+      name:
+        message.video.file_name ??
+        `video-${message.video.file_unique_id ?? message.video.file_id}.mp4`,
+      mimeType: message.video.mime_type,
+      sizeBytes: coerceSizeBytes(message.video.file_size),
+    });
+  }
+
+  if (message.audio?.file_id) {
+    attachments.push({
+      fileId: message.audio.file_id,
+      kind: "audio",
+      name:
+        message.audio.file_name ??
+        `audio-${message.audio.file_unique_id ?? message.audio.file_id}.mp3`,
+      mimeType: message.audio.mime_type,
+      sizeBytes: coerceSizeBytes(message.audio.file_size),
+    });
+  }
+
+  if (message.voice?.file_id) {
+    attachments.push({
+      fileId: message.voice.file_id,
+      kind: "audio",
+      name: `voice-${message.voice.file_unique_id ?? message.voice.file_id}.ogg`,
+      mimeType: message.voice.mime_type,
+      sizeBytes: coerceSizeBytes(message.voice.file_size),
+    });
+  }
+
+  if (message.animation?.file_id) {
+    attachments.push({
+      fileId: message.animation.file_id,
+      kind: inferAttachmentKind({
+        mimeType: message.animation.mime_type,
+        fileName: message.animation.file_name,
+        fallback: "video",
+      }),
+      name:
+        message.animation.file_name ??
+        `animation-${message.animation.file_unique_id ?? message.animation.file_id}.mp4`,
+      mimeType: message.animation.mime_type,
+      sizeBytes: coerceSizeBytes(message.animation.file_size),
+    });
+  }
+
+  if (
+    message.sticker?.file_id &&
+    !message.sticker.is_animated &&
+    !message.sticker.is_video
+  ) {
+    attachments.push({
+      fileId: message.sticker.file_id,
+      kind: "image",
+      name: `sticker-${message.sticker.file_unique_id ?? message.sticker.file_id}.webp`,
+      mimeType: message.sticker.mime_type ?? "image/webp",
+      sizeBytes: coerceSizeBytes(message.sticker.file_size),
+    });
+  }
+
+  return attachments;
+}
+
 export function createTelegramAdapter(
   config: TelegramChannelConfig,
+  deps: TelegramAdapterDeps = {},
 ): ChannelAdapter {
   const bot = new Bot(config.token);
   let running = false;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const mediaGroupFlushMs =
+    deps.mediaGroupFlushMs ?? DEFAULT_MEDIA_GROUP_FLUSH_MS;
+  const resolveInboundMediaDir =
+    deps.resolveInboundMediaDir ??
+    (() => getChannelInboundMediaDir("telegram"));
+  const now = deps.now ?? (() => new Date());
+  const randomToken = deps.randomToken ?? (() => randomUUID().slice(0, 8));
+  const setTimeoutImpl = deps.setTimeoutImpl ?? setTimeout;
+  const clearTimeoutImpl = deps.clearTimeoutImpl ?? clearTimeout;
+  const bufferedMediaGroups = new Map<string, BufferedMediaGroup>();
 
   bot.catch((error) => {
     const updateId = error.ctx?.update?.update_id;
@@ -28,31 +307,177 @@ export function createTelegramAdapter(
     console.error(prefix, error.error);
   });
 
-  // Wire message handlers
-  bot.on("message:text", async (ctx) => {
-    const msg = ctx.message;
-    if (!msg.text) return;
-
-    const inbound: InboundChannelMessage = {
-      channel: "telegram",
-      chatId: String(msg.chat.id),
-      senderId: String(msg.from.id),
-      senderName:
-        msg.from.username ??
-        [msg.from.first_name, msg.from.last_name].filter(Boolean).join(" "),
-      text: msg.text,
-      timestamp: msg.date * 1000,
-      messageId: String(msg.message_id),
-      raw: msg,
+  async function downloadAttachment(
+    candidate: TelegramAttachmentCandidate,
+    chatId: string,
+  ): Promise<InboundChannelAttachment> {
+    const attachment: InboundChannelAttachment = {
+      kind: candidate.kind,
+      name: candidate.name,
+      mimeType: normalizeMimeType(candidate.mimeType),
+      sizeBytes: candidate.sizeBytes,
     };
 
-    if (adapter.onMessage) {
-      try {
-        await adapter.onMessage(inbound);
-      } catch (err) {
-        console.error("[Telegram] Error handling inbound message:", err);
-      }
+    if (
+      typeof candidate.sizeBytes === "number" &&
+      candidate.sizeBytes > DEFAULT_ATTACHMENT_MAX_BYTES
+    ) {
+      console.warn(
+        `[Telegram] Skipping download for ${candidate.name ?? candidate.fileId}: attachment exceeds ${DEFAULT_ATTACHMENT_MAX_BYTES} bytes`,
+      );
+      return attachment;
     }
+
+    try {
+      const file = await bot.api.getFile(candidate.fileId);
+      const remotePath = file.file_path;
+      if (!remotePath) {
+        return attachment;
+      }
+
+      const url = `https://api.telegram.org/file/bot${config.token}/${remotePath}`;
+      const response = await fetchImpl(url);
+      if (!response.ok) {
+        throw new Error(`download failed (${response.status})`);
+      }
+
+      const contentLengthHeader = response.headers.get("content-length");
+      if (contentLengthHeader) {
+        const contentLength = Number(contentLengthHeader);
+        if (
+          Number.isFinite(contentLength) &&
+          contentLength > DEFAULT_ATTACHMENT_MAX_BYTES
+        ) {
+          throw new Error(
+            `download exceeds max size (${contentLength} > ${DEFAULT_ATTACHMENT_MAX_BYTES})`,
+          );
+        }
+      }
+
+      const fileBuffer = Buffer.from(await response.arrayBuffer());
+      if (fileBuffer.byteLength > DEFAULT_ATTACHMENT_MAX_BYTES) {
+        throw new Error(
+          `download exceeds max size (${fileBuffer.byteLength} > ${DEFAULT_ATTACHMENT_MAX_BYTES})`,
+        );
+      }
+
+      const inboundRoot = resolveInboundMediaDir(chatId);
+      const targetDir = join(inboundRoot, sanitizePathSegment(chatId));
+      await fs.mkdir(targetDir, { recursive: true });
+
+      const timestamp = now().toISOString().replace(/[:.]/g, "-");
+      const safeName = sanitizePathSegment(
+        candidate.name ?? basename(remotePath) ?? candidate.fileId,
+      );
+      const targetPath = join(
+        targetDir,
+        `${timestamp}-${randomToken()}-${safeName}`,
+      );
+
+      await fs.writeFile(targetPath, fileBuffer);
+      attachment.localPath = targetPath;
+      return attachment;
+    } catch (error) {
+      console.error(
+        `[Telegram] Failed to download inbound attachment ${candidate.name ?? candidate.fileId}:`,
+        error,
+      );
+      return attachment;
+    }
+  }
+
+  async function buildInboundMessage(
+    messages: TelegramLikeMessage[],
+  ): Promise<InboundChannelMessage | null> {
+    const primaryMessage =
+      messages.find((message) => extractMessageText(message).length > 0) ??
+      messages[0];
+    if (!primaryMessage) {
+      return null;
+    }
+
+    const candidates = messages.flatMap((message) =>
+      collectAttachmentCandidates(message),
+    );
+    const attachments = await Promise.all(
+      candidates.map((candidate) =>
+        downloadAttachment(candidate, String(primaryMessage.chat.id)),
+      ),
+    );
+    const text = extractMessageText(primaryMessage);
+
+    if (text.length === 0 && attachments.length === 0) {
+      return null;
+    }
+
+    return {
+      channel: "telegram",
+      chatId: String(primaryMessage.chat.id),
+      senderId: String(primaryMessage.from.id),
+      senderName: getSenderName(primaryMessage),
+      text,
+      timestamp: primaryMessage.date * 1000,
+      messageId: String(primaryMessage.message_id),
+      attachments: attachments.length > 0 ? attachments : undefined,
+      raw: messages.length === 1 ? primaryMessage : messages,
+    };
+  }
+
+  async function emitInboundMessages(
+    messages: TelegramLikeMessage[],
+  ): Promise<void> {
+    const inbound = await buildInboundMessage(messages);
+    if (!inbound || !adapter.onMessage) {
+      return;
+    }
+
+    try {
+      await adapter.onMessage(inbound);
+    } catch (error) {
+      console.error("[Telegram] Error handling inbound message:", error);
+    }
+  }
+
+  function scheduleBufferedMediaGroupFlush(mediaGroupId: string): void {
+    const entry = bufferedMediaGroups.get(mediaGroupId);
+    if (!entry) {
+      return;
+    }
+
+    clearTimeoutImpl(entry.timer);
+    entry.timer = setTimeoutImpl(async () => {
+      bufferedMediaGroups.delete(mediaGroupId);
+      await emitInboundMessages(entry.messages);
+    }, mediaGroupFlushMs);
+  }
+
+  // Wire message handlers
+  bot.on("message", async (ctx) => {
+    const message = ctx.message as TelegramLikeMessage | undefined;
+    if (!message) {
+      return;
+    }
+
+    const mediaGroupId =
+      typeof message.media_group_id === "string"
+        ? message.media_group_id
+        : null;
+    if (mediaGroupId) {
+      const existing = bufferedMediaGroups.get(mediaGroupId);
+      if (existing) {
+        existing.messages.push(message);
+        scheduleBufferedMediaGroupFlush(mediaGroupId);
+      } else {
+        bufferedMediaGroups.set(mediaGroupId, {
+          messages: [message],
+          timer: setTimeoutImpl(() => undefined, mediaGroupFlushMs),
+        });
+        scheduleBufferedMediaGroupFlush(mediaGroupId);
+      }
+      return;
+    }
+
+    await emitInboundMessages([message]);
   });
 
   // Basic bot commands
@@ -118,6 +543,10 @@ export function createTelegramAdapter(
 
     async stop(): Promise<void> {
       if (!running) return;
+      for (const entry of bufferedMediaGroups.values()) {
+        clearTimeoutImpl(entry.timer);
+      }
+      bufferedMediaGroups.clear();
       await bot.stop();
       running = false;
       console.log("[Telegram] Bot stopped");

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -43,6 +43,21 @@ export interface ChannelAdapter {
 
 // ── Message types ─────────────────────────────────────────────────
 
+export type InboundChannelAttachmentKind = "image" | "file" | "audio" | "video";
+
+export interface InboundChannelAttachment {
+  /** Normalized attachment kind used by channel formatters/adapters. */
+  kind: InboundChannelAttachmentKind;
+  /** Best-effort original filename, if provided by the platform. */
+  name?: string;
+  /** MIME type reported by the platform or inferred from filename. */
+  mimeType?: string;
+  /** Attachment size in bytes, if reported by the platform. */
+  sizeBytes?: number;
+  /** Local filesystem path where the inbound attachment was saved. */
+  localPath?: string;
+}
+
 export interface InboundChannelMessage {
   /** Platform identifier, e.g. "telegram". */
   channel: string;
@@ -58,6 +73,8 @@ export interface InboundChannelMessage {
   timestamp: number;
   /** Platform message ID for threading/replies. */
   messageId?: string;
+  /** Structured metadata for inbound attachments. */
+  attachments?: InboundChannelAttachment[];
   /** Raw platform-specific event data for future use. */
   raw?: unknown;
 }

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -5,10 +5,13 @@
  * Follows the same escaping patterns used in taskNotifications.ts.
  */
 
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import { resizeImageIfNeeded } from "../cli/helpers/imageResize";
 import { getLocalTime } from "../cli/helpers/sessionContext";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
-import type { InboundChannelMessage } from "./types";
+import type { InboundChannelAttachment, InboundChannelMessage } from "./types";
 
 /**
  * Escape special XML characters in text content.
@@ -70,9 +73,25 @@ export function buildChannelNotificationXml(
   }
 
   const attrString = attrs.join(" ");
-  const escapedText = escapeXml(msg.text);
+  if (!msg.attachments || msg.attachments.length === 0) {
+    const escapedText = escapeXml(msg.text);
+    return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+  }
 
-  return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+  const lines = [`<channel-notification ${attrString}>`];
+
+  if (msg.text.length > 0) {
+    lines.push(`  <text>${escapeXml(msg.text)}</text>`);
+  }
+
+  lines.push("  <attachments>");
+  for (const attachment of msg.attachments) {
+    lines.push(`    ${buildAttachmentXml(attachment)}`);
+  }
+  lines.push("  </attachments>");
+  lines.push("</channel-notification>");
+
+  return lines.join("\n");
 }
 
 /**
@@ -82,11 +101,133 @@ export function buildChannelNotificationXml(
  * UIs that already know how to hide pure system-reminder parts can do so
  * without needing to parse concatenated XML blobs.
  */
-export function formatChannelNotification(
+export async function formatChannelNotification(
   msg: InboundChannelMessage,
-): MessageCreate["content"] {
+): Promise<MessageCreate["content"]> {
+  const imageParts = await buildInlineImageParts(msg.attachments);
+
   return [
     { type: "text", text: buildChannelReminderText(msg) },
     { type: "text", text: buildChannelNotificationXml(msg) },
+    ...imageParts,
   ] as MessageCreate["content"];
+}
+
+const INLINE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+const INLINE_IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+]);
+
+function buildAttachmentXml(attachment: InboundChannelAttachment): string {
+  const attrs = [`kind="${escapeXml(attachment.kind)}"`];
+
+  if (attachment.name) {
+    attrs.push(`name="${escapeXml(attachment.name)}"`);
+  }
+  if (attachment.mimeType) {
+    attrs.push(`mime_type="${escapeXml(attachment.mimeType)}"`);
+  }
+  if (typeof attachment.sizeBytes === "number") {
+    attrs.push(`size_bytes="${attachment.sizeBytes}"`);
+  }
+  if (attachment.localPath) {
+    attrs.push(`local_path="${escapeXml(attachment.localPath)}"`);
+  }
+
+  return `<attachment ${attrs.join(" ")} />`;
+}
+
+function normalizeImageMimeType(mimeType?: string): string | null {
+  if (!mimeType) {
+    return null;
+  }
+  const normalized = mimeType.split(";")[0]?.trim().toLowerCase();
+  return normalized && INLINE_IMAGE_MIME_TYPES.has(normalized)
+    ? normalized
+    : null;
+}
+
+function inferImageMimeTypeFromPath(filePath: string): string | null {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!INLINE_IMAGE_EXTENSIONS.has(ext)) {
+    return null;
+  }
+
+  if (ext === ".png") {
+    return "image/png";
+  }
+  if (ext === ".gif") {
+    return "image/gif";
+  }
+  if (ext === ".webp") {
+    return "image/webp";
+  }
+
+  return "image/jpeg";
+}
+
+function canInlineImageAttachment(
+  attachment: InboundChannelAttachment,
+): attachment is InboundChannelAttachment & { localPath: string } {
+  if (attachment.kind !== "image" || !attachment.localPath) {
+    return false;
+  }
+
+  return Boolean(
+    normalizeImageMimeType(attachment.mimeType) ??
+      inferImageMimeTypeFromPath(attachment.localPath),
+  );
+}
+
+async function buildInlineImagePart(
+  attachment: InboundChannelAttachment & { localPath: string },
+): Promise<Exclude<MessageCreate["content"], string>[number] | null> {
+  const mediaType =
+    normalizeImageMimeType(attachment.mimeType) ??
+    inferImageMimeTypeFromPath(attachment.localPath);
+  if (!mediaType) {
+    return null;
+  }
+
+  try {
+    const buffer = await fs.readFile(attachment.localPath);
+    const resized = await resizeImageIfNeeded(buffer, mediaType);
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: resized.mediaType,
+        data: resized.data,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildInlineImageParts(
+  attachments: InboundChannelAttachment[] | undefined,
+): Promise<Array<Exclude<MessageCreate["content"], string>[number]>> {
+  const inlineCandidates = (attachments ?? []).filter(canInlineImageAttachment);
+  if (inlineCandidates.length === 0) {
+    return [];
+  }
+
+  const parts = await Promise.all(
+    inlineCandidates.map((attachment) => buildInlineImagePart(attachment)),
+  );
+  return parts.filter(
+    (part): part is Exclude<MessageCreate["content"], string>[number] =>
+      part !== null,
+  );
 }

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { InboundChannelMessage } from "../../channels/types";
 
 type FakeBotStartOptions = {
   onStart?: (botInfo: {
@@ -6,6 +11,8 @@ type FakeBotStartOptions = {
     id: number;
   }) => void | Promise<void>;
 };
+
+type FakeHandler = (ctx: unknown) => unknown | Promise<unknown>;
 
 class FakeBot {
   static instances: FakeBot[] = [];
@@ -20,11 +27,17 @@ class FakeBot {
       },
     );
   };
+  static nextGetFileImpl: (fileId: string) => Promise<{ file_path?: string }> =
+    async (fileId) => ({
+      file_path: `photos/${fileId}.jpg`,
+    });
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
+  readonly handlers = new Map<string, FakeHandler[]>();
   readonly api = {
     sendMessage: mock(async () => ({ message_id: 999 })),
+    getFile: mock(async (fileId: string) => FakeBot.nextGetFileImpl(fileId)),
   };
   catchHandler:
     | ((error: {
@@ -38,7 +51,10 @@ class FakeBot {
     FakeBot.instances.push(this);
   }
 
-  on(): this {
+  on(event: string, handler: FakeHandler): this {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler);
+    this.handlers.set(event, existing);
     return this;
   }
 
@@ -61,6 +77,13 @@ class FakeBot {
     }) => unknown,
   ): void {
     this.catchHandler = handler;
+  }
+
+  async emit(event: string, ctx: unknown): Promise<void> {
+    const handlers = this.handlers.get(event) ?? [];
+    for (const handler of handlers) {
+      await handler(ctx);
+    }
   }
 }
 
@@ -85,6 +108,9 @@ beforeEach(() => {
       },
     );
   };
+  FakeBot.nextGetFileImpl = async (fileId) => ({
+    file_path: `photos/${fileId}.jpg`,
+  });
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
 });
@@ -213,4 +239,132 @@ test("telegram adapter forwards parse mode and reply parameters", async () => {
     parse_mode: "HTML",
     reply_parameters: { message_id: 456 },
   });
+});
+
+test("telegram adapter forwards text messages through onMessage", async () => {
+  const adapter = createTelegramAdapter({
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  const bot = FakeBot.instances[0];
+  await bot?.emit("message", {
+    message: {
+      chat: { id: 123 },
+      from: { id: 456, username: "alice", first_name: "Alice" },
+      text: "Hello from Telegram",
+      date: 1_736_380_800,
+      message_id: 77,
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith({
+    channel: "telegram",
+    chatId: "123",
+    senderId: "456",
+    senderName: "alice",
+    text: "Hello from Telegram",
+    timestamp: 1_736_380_800_000,
+    messageId: "77",
+    attachments: undefined,
+    raw: expect.objectContaining({ message_id: 77 }),
+  });
+});
+
+test("telegram adapter batches media groups and downloads inbound images", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "letta-telegram-media-"));
+  const adapter = createTelegramAdapter(
+    {
+      channel: "telegram",
+      enabled: true,
+      token: "test-token",
+      dmPolicy: "pairing",
+      allowedUsers: [],
+    },
+    {
+      mediaGroupFlushMs: 1,
+      resolveInboundMediaDir: () => tempDir,
+      fetchImpl: mock(async (url: string) => {
+        const fileName = url.endsWith("photo2.jpg") ? "second" : "first";
+        const content = Buffer.from(`image-${fileName}`);
+        return new Response(content, {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        });
+      }) as unknown as typeof fetch,
+    },
+  );
+
+  FakeBot.nextGetFileImpl = async (fileId) => ({
+    file_path: fileId === "photo2" ? "photos/photo2.jpg" : "photos/photo1.jpg",
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  const bot = FakeBot.instances[0];
+  try {
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        caption: "Vacation photos",
+        date: 1_736_380_800,
+        message_id: 10,
+        media_group_id: "album-1",
+        photo: [
+          { file_id: "photo1", file_unique_id: "unique-1", file_size: 12 },
+        ],
+      },
+    });
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        date: 1_736_380_801,
+        message_id: 11,
+        media_group_id: "album-1",
+        photo: [
+          { file_id: "photo2", file_unique_id: "unique-2", file_size: 13 },
+        ],
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const firstCall = onMessage.mock.calls[0] as unknown as
+      | [InboundChannelMessage]
+      | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("Expected inbound Telegram album to emit a message");
+    }
+
+    const [inbound] = firstCall;
+
+    expect(inbound.text).toBe("Vacation photos");
+    expect(inbound.attachments).toHaveLength(2);
+    expect(
+      inbound.attachments?.every((attachment) => attachment.kind === "image"),
+    ).toBe(true);
+
+    const localPaths = inbound.attachments
+      ?.map((attachment) => attachment.localPath)
+      .filter((value): value is string => typeof value === "string");
+    expect(localPaths).toHaveLength(2);
+
+    for (const localPath of localPaths ?? []) {
+      expect(existsSync(localPath)).toBe(true);
+      expect(readFileSync(localPath, "utf-8").startsWith("image-")).toBe(true);
+    }
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { InboundChannelMessage } from "../../channels/types";
 import {
@@ -11,8 +14,10 @@ function expectTextParts(
   content: MessageCreate["content"],
 ): [{ type: "text"; text: string }, { type: "text"; text: string }] {
   expect(Array.isArray(content)).toBe(true);
-  const parts = content as Array<{ type: "text"; text: string }>;
-  expect(parts).toHaveLength(2);
+  const parts = (content as Array<{ type: "text"; text: string }>).filter(
+    (part) => part.type === "text",
+  );
+  expect(parts.length).toBeGreaterThanOrEqual(2);
 
   const [reminderPart, notificationPart] = parts;
   if (!reminderPart || !notificationPart) {
@@ -23,7 +28,7 @@ function expectTextParts(
 }
 
 describe("formatChannelNotification", () => {
-  test("formats structured content parts with reminder first and xml second", () => {
+  test("formats structured content parts with reminder first and xml second", async () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "12345",
@@ -34,7 +39,7 @@ describe("formatChannelNotification", () => {
       messageId: "msg-42",
     };
 
-    const content = formatChannelNotification(msg);
+    const content = await formatChannelNotification(msg);
     const [reminderPart, notificationPart] = expectTextParts(content);
 
     expect(reminderPart.text).toContain("<system-reminder>");
@@ -110,5 +115,81 @@ describe("formatChannelNotification", () => {
 
     expect(xml).not.toContain("sender_name=");
     expect(xml).not.toContain("message_id=");
+  });
+
+  test("serializes attachment metadata in xml when attachments are present", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "",
+      timestamp: Date.now(),
+      attachments: [
+        {
+          kind: "file",
+          name: "report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 2048,
+          localPath: "/tmp/report.pdf",
+        },
+      ],
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain("<attachments>");
+    expect(xml).toContain('kind="file"');
+    expect(xml).toContain('name="report.pdf"');
+    expect(xml).toContain('mime_type="application/pdf"');
+    expect(xml).toContain('size_bytes="2048"');
+    expect(xml).toContain('local_path="/tmp/report.pdf"');
+  });
+
+  test("appends inline image parts for downloaded image attachments", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "letta-channel-image-"));
+    const imagePath = join(dir, "tiny.png");
+    writeFileSync(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XM7sAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+
+    try {
+      const msg: InboundChannelMessage = {
+        channel: "telegram",
+        chatId: "123",
+        senderId: "456",
+        text: "see attached",
+        timestamp: Date.now(),
+        attachments: [
+          {
+            kind: "image",
+            name: "tiny.png",
+            mimeType: "image/png",
+            localPath: imagePath,
+          },
+        ],
+      };
+
+      const content = await formatChannelNotification(msg);
+      expect(Array.isArray(content)).toBe(true);
+      if (!Array.isArray(content)) {
+        return;
+      }
+
+      expect(content).toHaveLength(3);
+      expect(content[2]).toEqual({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: expect.any(String),
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add structured inbound attachment metadata to channel messages and let channel notifications append inline image parts for downloaded images
- teach the Telegram adapter to capture inbound media, batch album messages, and download supported attachments into Letta-managed channel storage
- add coverage for attachment XML formatting and Telegram media-group ingestion/download behavior

## Testing
- bun test src/tests/channels/xml.test.ts src/tests/channels/telegram-adapter.test.ts
- bun test src/tests/channels
- bun run typecheck
- bun run lint