### PR TITLE
refactor(channels): generalize core channel seams

### DIFF
--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -160,6 +160,44 @@ function parseYamlValue(raw: string): unknown {
 
 // ── Config read/write ─────────────────────────────────────────────
 
+interface ChannelConfigCodec<TConfig extends ChannelConfig> {
+  parse(parsed: Record<string, unknown>): TConfig;
+  serialize(config: TConfig): Record<string, unknown>;
+}
+
+const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
+  parse(parsed) {
+    return {
+      channel: "telegram",
+      enabled: parsed.enabled !== false,
+      token: String(parsed.token ?? ""),
+      dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
+      allowedUsers: (parsed.allowed_users as string[]) ?? [],
+    };
+  },
+  serialize(config) {
+    return {
+      channel: config.channel,
+      enabled: config.enabled,
+      token: config.token,
+      dm_policy: config.dmPolicy,
+      allowed_users: config.allowedUsers,
+    };
+  },
+};
+
+const CHANNEL_CONFIG_CODECS: Partial<
+  Record<string, ChannelConfigCodec<ChannelConfig>>
+> = {
+  telegram: telegramConfigCodec as ChannelConfigCodec<ChannelConfig>,
+};
+
+function getChannelConfigCodec(
+  channelId: string,
+): ChannelConfigCodec<ChannelConfig> | null {
+  return CHANNEL_CONFIG_CODECS[channelId] ?? null;
+}
+
 export function channelConfigExists(channelId: string): boolean {
   return existsSync(getChannelConfigPath(channelId));
 }
@@ -171,18 +209,9 @@ export function readChannelConfig(channelId: string): ChannelConfig | null {
   try {
     const text = readFileSync(configPath, "utf-8");
     const parsed = parseSimpleYaml(text);
-
-    if (channelId === "telegram") {
-      return {
-        channel: "telegram",
-        enabled: parsed.enabled !== false,
-        token: String(parsed.token ?? ""),
-        dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
-        allowedUsers: (parsed.allowed_users as string[]) ?? [],
-      } satisfies TelegramChannelConfig;
-    }
-
-    return null;
+    const codec = getChannelConfigCodec(channelId);
+    if (!codec) return null;
+    return codec.parse(parsed);
   } catch {
     return null;
   }
@@ -194,17 +223,11 @@ export function writeChannelConfig(
 ): void {
   const dir = getChannelDir(channelId);
   mkdirSync(dir, { recursive: true });
-
-  const yamlObj: Record<string, unknown> = {};
-
-  if (config.channel === "telegram") {
-    yamlObj.channel = config.channel;
-    yamlObj.enabled = config.enabled;
-    yamlObj.token = config.token;
-    yamlObj.dm_policy = config.dmPolicy;
-    yamlObj.allowed_users = config.allowedUsers;
+  const codec = getChannelConfigCodec(channelId);
+  if (!codec) {
+    throw new Error(`Unsupported channel config: ${channelId}`);
   }
 
-  const text = toSimpleYaml(yamlObj);
+  const text = toSimpleYaml(codec.serialize(config));
   writeFileSync(getChannelConfigPath(channelId), `${text}\n`, "utf-8");
 }

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -3,7 +3,7 @@
  *
  * Handles the pairing flow for channels with dm_policy: "pairing".
  * When an unknown user messages the bot, they get a pairing code.
- * The user runs `/channels telegram pair <code>` to approve the connection.
+ * The user runs `/channels <channel> pair <code>` to approve the connection.
  *
  * Persisted in ~/.letta/channels/<channel>/pairing.yaml.
  *
@@ -85,7 +85,7 @@ function generateCode(length = 6): string {
  */
 export function isUserApproved(channelId: string, userId: string): boolean {
   const store = getStore(channelId);
-  return store.approved.some((u) => u.telegramUserId === userId);
+  return store.approved.some((u) => u.senderId === userId);
 }
 
 /**
@@ -101,7 +101,7 @@ export function createPairingCode(
   const store = getStore(channelId);
 
   // Remove any existing pending code for this user
-  store.pending = store.pending.filter((p) => p.telegramUserId !== userId);
+  store.pending = store.pending.filter((p) => p.senderId !== userId);
 
   // Prune expired codes
   const now = Date.now();
@@ -117,8 +117,8 @@ export function createPairingCode(
   const code = generateCode();
   const pending: PendingPairing = {
     code,
-    telegramUserId: userId,
-    telegramUsername: username,
+    senderId: userId,
+    senderName: username,
     chatId,
     createdAt: new Date().toISOString(),
     expiresAt: new Date(now + PAIRING_CODE_TTL_MS).toISOString(),
@@ -158,12 +158,10 @@ export function consumePairingCode(
   store.pending.splice(index, 1);
 
   // Add to approved (if not already)
-  if (
-    !store.approved.some((u) => u.telegramUserId === pending.telegramUserId)
-  ) {
+  if (!store.approved.some((u) => u.senderId === pending.senderId)) {
     const approved: ApprovedUser = {
-      telegramUserId: pending.telegramUserId,
-      telegramUsername: pending.telegramUsername,
+      senderId: pending.senderId,
+      senderName: pending.senderName,
       approvedAt: new Date().toISOString(),
     };
     store.approved.push(approved);
@@ -203,7 +201,7 @@ export function rollbackPairingApproval(
 
   // Remove from approved
   store.approved = store.approved.filter(
-    (u) => u.telegramUserId !== pending.telegramUserId,
+    (u) => u.senderId !== pending.senderId,
   );
 
   // Re-add to pending

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -30,8 +30,37 @@ import type {
   ChannelAdapter,
   ChannelRoute,
   InboundChannelMessage,
+  TelegramChannelConfig,
 } from "./types";
 import { formatChannelNotification } from "./xml";
+
+type ChannelAdapterFactory = (config: unknown) => Promise<ChannelAdapter>;
+
+const CHANNEL_ADAPTER_FACTORIES: Record<string, ChannelAdapterFactory> = {
+  async telegram(config) {
+    const { createTelegramAdapter } = await import("./telegram/adapter");
+    return createTelegramAdapter(config as TelegramChannelConfig);
+  },
+};
+
+function buildPairingInstructions(channelId: string, code: string): string {
+  return (
+    `To connect this chat to a Letta Code agent, run:\n\n` +
+    `/channels ${channelId} pair ${code}\n\n` +
+    `This code expires in 15 minutes.`
+  );
+}
+
+function buildUnboundRouteInstructions(
+  channelId: string,
+  chatId: string,
+): string {
+  return (
+    `This chat isn't bound to an agent. ` +
+    `Run \`/channels ${channelId} enable --chat-id ${chatId}\` ` +
+    `on your Letta Code agent to connect.`
+  );
+}
 
 // ── Singleton ─────────────────────────────────────────────────────
 
@@ -156,16 +185,17 @@ export class ChannelRegistry {
     }
     this.adapters.delete(channelId);
 
-    if (channelId === "telegram") {
-      const { createTelegramAdapter } = await import("./telegram/adapter");
-      const adapter = createTelegramAdapter(config);
-      this.registerAdapter(adapter);
-      await adapter.start();
-      return true;
+    const createAdapter = CHANNEL_ADAPTER_FACTORIES[channelId];
+    if (!createAdapter) {
+      const supported = Object.keys(CHANNEL_ADAPTER_FACTORIES).join(", ");
+      console.error(`Unknown channel "${channelId}". Supported: ${supported}`);
+      return false;
     }
 
-    console.error(`Unknown channel "${channelId}". Supported: telegram`);
-    return false;
+    const adapter = await createAdapter(config);
+    this.registerAdapter(adapter);
+    await adapter.start();
+    return true;
   }
 
   async stopChannel(channelId: string): Promise<boolean> {
@@ -256,9 +286,7 @@ export class ChannelRegistry {
         });
         await adapter.sendDirectReply(
           msg.chatId,
-          `To connect this chat to a Letta Code agent, run:\n\n` +
-            `/channels telegram pair ${code}\n\n` +
-            `This code expires in 15 minutes.`,
+          buildPairingInstructions(msg.channel, code),
         );
         return;
       }
@@ -274,9 +302,7 @@ export class ChannelRegistry {
     if (!route) {
       await adapter.sendDirectReply(
         msg.chatId,
-        `This chat isn't bound to an agent. ` +
-          `Run \`/channels telegram enable --chat-id ${msg.chatId}\` ` +
-          `on your Letta Code agent to connect.`,
+        buildUnboundRouteInstructions(msg.channel, msg.chatId),
       );
       return;
     }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -20,9 +20,11 @@ import type {
   ChannelConfig,
   ChannelRoute,
   DmPolicy,
+  PendingPairing,
   SupportedChannelId,
   TelegramChannelConfig,
 } from "./types";
+import { SUPPORTED_CHANNEL_IDS } from "./types";
 
 export const CHANNEL_DISPLAY_NAMES: Record<SupportedChannelId, string> = {
   telegram: "Telegram",
@@ -75,7 +77,7 @@ export interface ChannelConfigPatch {
 function assertSupportedChannelId(
   channelId: string,
 ): asserts channelId is SupportedChannelId {
-  if (channelId !== "telegram") {
+  if (!SUPPORTED_CHANNEL_IDS.includes(channelId as SupportedChannelId)) {
     throw new Error(`Unsupported channel: ${channelId}`);
   }
 }
@@ -93,18 +95,16 @@ function toConfigSnapshot(
   };
 }
 
-function toPendingPairingSnapshot(pending: {
-  code: string;
-  telegramUserId: string;
-  telegramUsername?: string;
-  chatId: string;
-  createdAt: string;
-  expiresAt: string;
-}): PendingPairingSnapshot {
+function toPendingPairingSnapshot(
+  pending: Pick<
+    PendingPairing,
+    "code" | "senderId" | "senderName" | "chatId" | "createdAt" | "expiresAt"
+  >,
+): PendingPairingSnapshot {
   return {
     code: pending.code,
-    senderId: pending.telegramUserId,
-    senderName: pending.telegramUsername,
+    senderId: pending.senderId,
+    senderName: pending.senderName,
     chatId: pending.chatId,
     createdAt: pending.createdAt,
     expiresAt: pending.expiresAt,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -108,16 +108,16 @@ export type ChannelConfig = TelegramChannelConfig;
 
 export interface PendingPairing {
   code: string;
-  telegramUserId: string;
-  telegramUsername?: string;
+  senderId: string;
+  senderName?: string;
   chatId: string;
   createdAt: string;
   expiresAt: string;
 }
 
 export interface ApprovedUser {
-  telegramUserId: string;
-  telegramUsername?: string;
+  senderId: string;
+  senderName?: string;
   approvedAt: string;
 }
 

--- a/src/tests/channels/pairing.test.ts
+++ b/src/tests/channels/pairing.test.ts
@@ -22,7 +22,7 @@ describe("pairing", () => {
     const pending = getPendingPairings("telegram");
     expect(pending).toHaveLength(1);
     expect(pending[0]?.code).toBe(code);
-    expect(pending[0]?.telegramUserId).toBe("user-1");
+    expect(pending[0]?.senderId).toBe("user-1");
     expect(pending[0]?.chatId).toBe("chat-1");
   });
 
@@ -31,7 +31,7 @@ describe("pairing", () => {
 
     const result = consumePairingCode("telegram", code);
     expect(result).not.toBeNull();
-    expect(result?.telegramUserId).toBe("user-1");
+    expect(result?.senderId).toBe("user-1");
     expect(result?.chatId).toBe("chat-1");
 
     // User should now be approved
@@ -83,7 +83,10 @@ describe("pairing", () => {
     expect(getPendingPairings("telegram")).toHaveLength(0);
 
     // Roll back
-    rollbackPairingApproval("telegram", pending!);
+    if (!pending) {
+      throw new Error("Expected pending pairing to exist");
+    }
+    rollbackPairingApproval("telegram", pending);
 
     // User should no longer be approved, pending code restored
     expect(isUserApproved("telegram", "user-1")).toBe(false);

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -17,6 +17,10 @@ const TELEGRAM_PLACEHOLDER_PREFIX = "LCTELEGRAMHTMLPLACEHOLDER";
 const TELEGRAM_PLACEHOLDER_SUFFIX = "X";
 const TELEGRAM_PLACEHOLDER_PATTERN = /LCTELEGRAMHTMLPLACEHOLDER(\d+)X/g;
 
+type OutboundChannelFormatter = (
+  text: string,
+) => Pick<OutboundChannelMessage, "text" | "parseMode">;
+
 function escapeTelegramHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -209,18 +213,26 @@ export function markdownToTelegramHtml(text: string): string {
   return formatTelegramText(text);
 }
 
+const CHANNEL_OUTBOUND_FORMATTERS: Partial<
+  Record<string, OutboundChannelFormatter>
+> = {
+  [TELEGRAM_CHANNEL_ID](text) {
+    return {
+      text: markdownToTelegramHtml(text),
+      parseMode: "HTML",
+    };
+  },
+};
+
 export function formatOutboundChannelMessage(
   channel: string,
   text: string,
 ): Pick<OutboundChannelMessage, "text" | "parseMode"> {
-  if (channel !== TELEGRAM_CHANNEL_ID) {
+  const formatter = CHANNEL_OUTBOUND_FORMATTERS[channel];
+  if (!formatter) {
     return { text };
   }
-
-  return {
-    text: markdownToTelegramHtml(text),
-    parseMode: "HTML",
-  };
+  return formatter(text);
 }
 
 interface MessageChannelArgs {


### PR DESCRIPTION
## Summary
- generalize channel config, pairing, registry, and outbound formatting seams so channel implementations are no longer Telegram-only
- switch channel service/registry code to work from channel factories/codecs instead of hard-coded Telegram branches
- add regression coverage for the generalized pairing/config/message-channel paths

## Testing
- bun test src/tests/channels/pairing.test.ts src/tests/channels/registry.test.ts src/tests/channels/message-channel-formatting.test.ts src/tests/websocket/listen-client-protocol.test.ts
- bun run lint
