### PR TITLE
feat(channels): add Slack adapter and target binding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "ws": "^8.19.0",
       },
       "devDependencies": {
+        "@slack/bolt": "^4.7.0",
         "@types/bun": "^1.3.7",
         "@types/diff": "^8.0.0",
         "@types/picomatch": "^4.0.2",
@@ -100,17 +101,53 @@
 
     "@letta-ai/letta-client": ["@letta-ai/letta-client@1.10.1", "", {}, "sha512-cBVk+XbiECMNSxh54jVsDAYyTvzOMsbwOl82mEjI+Wzi741mE5EUiu8YpsVXa4KnhZ47hPJ1gIv5Wyhwh+MPGw=="],
 
+    "@slack/bolt": ["@slack/bolt@4.7.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/oauth": "^3.0.5", "@slack/socket-mode": "^2.0.6", "@slack/types": "^2.20.1", "@slack/web-api": "^7.15.0", "axios": "^1.12.0", "express": "^5.0.0", "path-to-regexp": "^8.1.0", "raw-body": "^3", "tsscmp": "^1.0.6" }, "peerDependencies": { "@types/express": "^5.0.0" } }, "sha512-Xpf+gKegNvkHpft1z4YiuqZdciJ3tUp1bIRQxylW30Ovf+hzjb0M1zTHVtJsRw9jsjPxHTPoyanEXVvG6qVE1g=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/oauth": ["@slack/oauth@3.0.5", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A=="],
+
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.6", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ=="],
+
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
+
+    "@slack/web-api": ["@slack/web-api@7.15.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
 
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
+    "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
     "@types/react": ["@types/react@19.2.9", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -120,6 +157,8 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
@@ -128,15 +167,29 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -152,9 +205,19 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -166,6 +229,10 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -174,37 +241,89 @@
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "es-toolkit": ["es-toolkit@1.41.0", "", {}, "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
 
     "has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
 
@@ -214,7 +333,11 @@
 
     "ink-text-input": ["ink-text-input@5.0.1", "", { "dependencies": { "chalk": "^5.2.0", "type-fest": "^3.6.1" }, "peerDependencies": { "ink": "^4.0.0", "react": "^18.0.0" } }, "sha512-crnsYJalG4EhneOFnr/q+Kzw1RgmXI2KsBaLFE6mpiIKxAtJLUnvygOF2IUKO8z4nwkSkveGRBMd81RoYdRSag=="],
 
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
@@ -224,13 +347,37 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "lint-staged": ["lint-staged@16.2.4", "", { "dependencies": { "commander": "^14.0.1", "listr2": "^9.0.4", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-Pkyr/wd90oAyXk98i/2KwfkIhoYQUMtss769FIT9hFM5ogYZwrk+GRE46yKXSg2ZGhcJ1p38Gf5gmI5Ohjg2yg=="],
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
@@ -240,7 +387,17 @@
 
     "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -254,19 +411,39 @@
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -274,7 +451,15 @@
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
 
@@ -282,21 +467,45 @@
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
@@ -312,15 +521,25 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -329,6 +548,8 @@
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
@@ -340,7 +561,11 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
+    "axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
@@ -352,7 +577,11 @@
 
     "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "listr2/cli-truncate/string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@vscode/ripgrep": "^1.17.0"
   },
   "devDependencies": {
+    "@slack/bolt": "^4.7.0",
     "@types/bun": "^1.3.7",
     "@types/diff": "^8.0.0",
     "@types/picomatch": "^4.0.2",

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -8,7 +8,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ChannelConfig, DmPolicy, TelegramChannelConfig } from "./types";
+import type {
+  ChannelConfig,
+  DmPolicy,
+  SlackChannelConfig,
+  TelegramChannelConfig,
+} from "./types";
 
 // ── Paths ─────────────────────────────────────────────────────────
 
@@ -32,6 +37,10 @@ export function getChannelRoutingPath(channelId: string): string {
 
 export function getChannelPairingPath(channelId: string): string {
   return join(getChannelDir(channelId), "pairing.yaml");
+}
+
+export function getChannelTargetsPath(channelId: string): string {
+  return join(getChannelDir(channelId), "targets.json");
 }
 
 // ── YAML helpers ──────────────────────────────────────────────────
@@ -186,10 +195,36 @@ const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
   },
 };
 
+const slackConfigCodec: ChannelConfigCodec<SlackChannelConfig> = {
+  parse(parsed) {
+    return {
+      channel: "slack",
+      enabled: parsed.enabled !== false,
+      mode: "socket",
+      botToken: String(parsed.bot_token ?? ""),
+      appToken: String(parsed.app_token ?? ""),
+      dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
+      allowedUsers: (parsed.allowed_users as string[]) ?? [],
+    };
+  },
+  serialize(config) {
+    return {
+      channel: config.channel,
+      enabled: config.enabled,
+      mode: config.mode,
+      bot_token: config.botToken,
+      app_token: config.appToken,
+      dm_policy: config.dmPolicy,
+      allowed_users: config.allowedUsers,
+    };
+  },
+};
+
 const CHANNEL_CONFIG_CODECS: Partial<
   Record<string, ChannelConfigCodec<ChannelConfig>>
 > = {
   telegram: telegramConfigCodec as ChannelConfigCodec<ChannelConfig>,
+  slack: slackConfigCodec as ChannelConfigCodec<ChannelConfig>,
 };
 
 function getChannelConfigCodec(

--- a/src/channels/pluginRegistry.ts
+++ b/src/channels/pluginRegistry.ts
@@ -23,6 +23,18 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
       return telegramChannelPlugin;
     },
   },
+  slack: {
+    metadata: {
+      id: "slack",
+      displayName: "Slack",
+      runtimePackages: ["@slack/bolt@4.7.0"],
+      runtimeModules: ["@slack/bolt"],
+    },
+    load: async () => {
+      const { slackChannelPlugin } = await import("./slack/plugin");
+      return slackChannelPlugin;
+    },
+  },
 };
 
 export function isSupportedChannelId(

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -27,6 +27,7 @@ import {
   removeRouteInMemory,
   setRouteInMemory,
 } from "./routing";
+import { loadTargetStore, upsertChannelTarget } from "./targets";
 import type {
   ChannelAdapter,
   ChannelRoute,
@@ -50,6 +51,14 @@ function buildUnboundRouteInstructions(
     `This chat isn't bound to an agent. ` +
     `Run \`/channels ${channelId} enable --chat-id ${chatId}\` ` +
     `on your Letta Code agent to connect.`
+  );
+}
+
+function buildSlackTargetInstructions(): string {
+  return (
+    "This Slack channel isn't connected to an agent yet.\n\n" +
+    "Open Channels > Slack > Connections in Letta Code to bind this channel, " +
+    "then mention the bot again."
   );
 }
 
@@ -77,10 +86,15 @@ export type ChannelMessageHandler = (
   content: MessageCreate["content"],
 ) => void;
 
-export type ChannelRegistryEvent = {
-  type: "pairings_updated";
-  channelId: string;
-};
+export type ChannelRegistryEvent =
+  | {
+      type: "pairings_updated";
+      channelId: string;
+    }
+  | {
+      type: "targets_updated";
+      channelId: string;
+    };
 
 // ── Registry ──────────────────────────────────────────────────────
 
@@ -169,6 +183,7 @@ export class ChannelRegistry {
 
     loadRoutes(channelId);
     loadPairingStore(channelId);
+    loadTargetStore(channelId);
 
     const existing = this.adapters.get(channelId);
     if (existing?.isRunning()) {
@@ -243,6 +258,11 @@ export class ChannelRegistry {
     const config = readChannelConfig(msg.channel);
     if (!config) return;
 
+    if (msg.channel === "slack" && msg.chatType === "channel") {
+      await this.handleSlackChannelMessage(adapter, msg);
+      return;
+    }
+
     // 1. Check pairing/allowlist policy
     if (config.dmPolicy === "allowlist") {
       if (!config.allowedUsers.includes(msg.senderId)) {
@@ -296,11 +316,56 @@ export class ChannelRegistry {
     const content = formatChannelNotification(msg);
 
     // 4. Deliver or buffer
+    this.deliverOrBuffer(route, content);
+  }
+
+  private async handleSlackChannelMessage(
+    adapter: ChannelAdapter,
+    msg: InboundChannelMessage,
+  ): Promise<void> {
+    let route = getRouteFromStore(msg.channel, msg.chatId);
+    if (!route) {
+      loadRoutes(msg.channel);
+      route = getRouteFromStore(msg.channel, msg.chatId);
+    }
+
+    if (!route) {
+      const now = new Date().toISOString();
+      loadTargetStore(msg.channel);
+      upsertChannelTarget(msg.channel, {
+        targetId: msg.chatId,
+        targetType: "channel",
+        chatId: msg.chatId,
+        label: msg.chatLabel ?? `Slack channel ${msg.chatId}`,
+        discoveredAt: now,
+        lastSeenAt: now,
+        lastMessageId: msg.messageId,
+      });
+      this.eventHandler?.({
+        type: "targets_updated",
+        channelId: msg.channel,
+      });
+      await adapter.sendDirectReply(
+        msg.chatId,
+        buildSlackTargetInstructions(),
+        msg.messageId ? { replyToMessageId: msg.messageId } : undefined,
+      );
+      return;
+    }
+
+    this.deliverOrBuffer(route, formatChannelNotification(msg));
+  }
+
+  private deliverOrBuffer(
+    route: ChannelRoute,
+    content: MessageCreate["content"],
+  ): void {
     if (this.isReady()) {
       this.messageHandler?.(route, content);
-    } else {
-      this.buffer.push({ route, content });
+      return;
     }
+
+    this.buffer.push({ route, content });
   }
 
   private flushBuffer(): void {

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -21,12 +21,14 @@ import {
   getRoutesForChannel,
   loadRoutes,
   removeRoute,
+  removeRouteInMemory,
 } from "./routing";
 import {
   getChannelTarget,
   listChannelTargets,
   loadTargetStore,
   removeChannelTarget,
+  upsertChannelTarget,
 } from "./targets";
 import type {
   ChannelBindableTarget,
@@ -114,6 +116,10 @@ function assertSupportedChannelId(
   if (!isSupportedChannelId(channelId)) {
     throw new Error(`Unsupported channel: ${channelId}`);
   }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }
 
 function toConfigSnapshot(config: ChannelConfig): ChannelConfigSnapshot {
@@ -427,11 +433,51 @@ export function bindChannelTarget(
   };
 
   try {
-    addRoute(channelId, route);
     removeChannelTarget(channelId, targetId);
   } catch (error) {
+    try {
+      upsertChannelTarget(channelId, target);
+    } catch (rollbackError) {
+      throw new Error(
+        `Failed to bind channel target: ${getErrorMessage(
+          error,
+          "Failed to remove pending target",
+        )}. Failed to restore pending target: ${getErrorMessage(
+          rollbackError,
+          "Target rollback failed",
+        )}`,
+      );
+    }
     throw new Error(
-      error instanceof Error ? error.message : "Failed to bind channel target",
+      `Failed to bind channel target: ${getErrorMessage(
+        error,
+        "Failed to remove pending target",
+      )}`,
+    );
+  }
+
+  try {
+    addRoute(channelId, route);
+  } catch (error) {
+    removeRouteInMemory(channelId, route.chatId);
+    try {
+      upsertChannelTarget(channelId, target);
+    } catch (rollbackError) {
+      throw new Error(
+        `Failed to bind channel target: ${getErrorMessage(
+          error,
+          "Failed to create route",
+        )}. Failed to restore pending target: ${getErrorMessage(
+          rollbackError,
+          "Target rollback failed",
+        )}`,
+      );
+    }
+    throw new Error(
+      `Failed to bind channel target: ${getErrorMessage(
+        error,
+        "Failed to create route",
+      )}. Changes were rolled back.`,
     );
   }
 

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -16,16 +16,26 @@ import {
   initializeChannels,
 } from "./registry";
 import {
+  addRoute,
   getRoute,
   getRoutesForChannel,
   loadRoutes,
   removeRoute,
 } from "./routing";
+import {
+  getChannelTarget,
+  listChannelTargets,
+  loadTargetStore,
+  removeChannelTarget,
+} from "./targets";
 import type {
+  ChannelBindableTarget,
   ChannelConfig,
   ChannelRoute,
   DmPolicy,
   PendingPairing,
+  SlackChannelConfig,
+  SlackChannelMode,
   SupportedChannelId,
   TelegramChannelConfig,
 } from "./types";
@@ -42,13 +52,23 @@ export interface ChannelSummary {
   routesCount: number;
 }
 
-export interface ChannelConfigSnapshot {
-  channelId: SupportedChannelId;
-  enabled: boolean;
-  dmPolicy: DmPolicy;
-  allowedUsers: string[];
-  hasToken: boolean;
-}
+export type ChannelConfigSnapshot =
+  | {
+      channelId: "telegram";
+      enabled: boolean;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasToken: boolean;
+    }
+  | {
+      channelId: "slack";
+      enabled: boolean;
+      mode: SlackChannelMode;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasBotToken: boolean;
+      hasAppToken: boolean;
+    };
 
 export interface PendingPairingSnapshot {
   code: string;
@@ -68,8 +88,22 @@ export interface ChannelRouteSnapshot {
   createdAt: string;
 }
 
+export interface ChannelTargetSnapshot {
+  channelId: SupportedChannelId;
+  targetId: string;
+  targetType: "channel";
+  chatId: string;
+  label: string;
+  discoveredAt: string;
+  lastSeenAt: string;
+  lastMessageId?: string;
+}
+
 export interface ChannelConfigPatch {
   token?: string;
+  botToken?: string;
+  appToken?: string;
+  mode?: SlackChannelMode;
   dmPolicy?: DmPolicy;
   allowedUsers?: string[];
 }
@@ -82,16 +116,25 @@ function assertSupportedChannelId(
   }
 }
 
-function toConfigSnapshot(
-  channelId: SupportedChannelId,
-  config: ChannelConfig,
-): ChannelConfigSnapshot {
+function toConfigSnapshot(config: ChannelConfig): ChannelConfigSnapshot {
+  if (config.channel === "telegram") {
+    return {
+      channelId: "telegram",
+      enabled: config.enabled,
+      dmPolicy: config.dmPolicy,
+      allowedUsers: [...config.allowedUsers],
+      hasToken: config.token.trim().length > 0,
+    };
+  }
+
   return {
-    channelId,
+    channelId: "slack",
     enabled: config.enabled,
+    mode: config.mode,
     dmPolicy: config.dmPolicy,
     allowedUsers: [...config.allowedUsers],
-    hasToken: config.token.trim().length > 0,
+    hasBotToken: config.botToken.trim().length > 0,
+    hasAppToken: config.appToken.trim().length > 0,
   };
 }
 
@@ -125,11 +168,70 @@ function toRouteSnapshot(
   };
 }
 
+function toTargetSnapshot(
+  channelId: SupportedChannelId,
+  target: ChannelBindableTarget,
+): ChannelTargetSnapshot {
+  return {
+    channelId,
+    targetId: target.targetId,
+    targetType: target.targetType,
+    chatId: target.chatId,
+    label: target.label,
+    discoveredAt: target.discoveredAt,
+    lastSeenAt: target.lastSeenAt,
+    lastMessageId: target.lastMessageId,
+  };
+}
+
+function isConfigReadyToStart(config: ChannelConfig): boolean {
+  if (config.channel === "telegram") {
+    return config.token.trim().length > 0;
+  }
+  return config.botToken.trim().length > 0 && config.appToken.trim().length > 0;
+}
+
+function getMissingCredentialError(config: ChannelConfig): string {
+  if (config.channel === "telegram") {
+    return 'Channel "telegram" is missing a token. Configure it first.';
+  }
+  return 'Channel "slack" is missing a bot token or app token. Configure it first.';
+}
+
+function mergeChannelConfig(
+  channelId: SupportedChannelId,
+  existing: ChannelConfig | null,
+  patch: ChannelConfigPatch,
+): ChannelConfig {
+  if (channelId === "telegram") {
+    const telegramExisting = existing?.channel === "telegram" ? existing : null;
+    const merged: TelegramChannelConfig = {
+      channel: "telegram",
+      enabled: telegramExisting?.enabled ?? false,
+      token: patch.token ?? telegramExisting?.token ?? "",
+      dmPolicy: patch.dmPolicy ?? telegramExisting?.dmPolicy ?? "pairing",
+      allowedUsers: patch.allowedUsers ?? telegramExisting?.allowedUsers ?? [],
+    };
+    return merged;
+  }
+
+  const slackExisting = existing?.channel === "slack" ? existing : null;
+  const merged: SlackChannelConfig = {
+    channel: "slack",
+    enabled: slackExisting?.enabled ?? false,
+    mode: patch.mode ?? slackExisting?.mode ?? "socket",
+    botToken: patch.botToken ?? slackExisting?.botToken ?? "",
+    appToken: patch.appToken ?? slackExisting?.appToken ?? "",
+    dmPolicy: patch.dmPolicy ?? slackExisting?.dmPolicy ?? "pairing",
+    allowedUsers: patch.allowedUsers ?? slackExisting?.allowedUsers ?? [],
+  };
+  return merged;
+}
+
 export function listChannelSummaries(): ChannelSummary[] {
   const registry = getChannelRegistry();
   return getSupportedChannelIds().map((channelId) => {
     const config = readChannelConfig(channelId);
-
     if (!config) {
       return {
         channelId,
@@ -169,7 +271,7 @@ export function getChannelConfigSnapshot(
   if (!config) {
     return null;
   }
-  return toConfigSnapshot(channelId, config);
+  return toConfigSnapshot(config);
 }
 
 export async function setChannelConfigLive(
@@ -178,23 +280,18 @@ export async function setChannelConfigLive(
 ): Promise<ChannelConfigSnapshot> {
   assertSupportedChannelId(channelId);
 
-  const existing = readChannelConfig(channelId);
-  const merged: TelegramChannelConfig = {
-    channel: channelId,
-    enabled: existing?.enabled ?? false,
-    token: patch.token ?? existing?.token ?? "",
-    dmPolicy: patch.dmPolicy ?? existing?.dmPolicy ?? "pairing",
-    allowedUsers: patch.allowedUsers ?? existing?.allowedUsers ?? [],
-  };
-
+  const merged = mergeChannelConfig(
+    channelId,
+    readChannelConfig(channelId),
+    patch,
+  );
   writeChannelConfig(channelId, merged);
 
   if (merged.enabled) {
-    const registry = ensureChannelRegistry();
-    await registry.startChannel(channelId);
+    await ensureChannelRegistry().startChannel(channelId);
   }
 
-  return toConfigSnapshot(channelId, merged);
+  return toConfigSnapshot(merged);
 }
 
 export async function startChannelLive(
@@ -208,10 +305,8 @@ export async function startChannelLive(
       `Channel "${channelId}" is not configured. Configure it first.`,
     );
   }
-  if (!existing.token.trim()) {
-    throw new Error(
-      `Channel "${channelId}" is missing a token. Configure it first.`,
-    );
+  if (!isConfigReadyToStart(existing)) {
+    throw new Error(getMissingCredentialError(existing));
   }
 
   if (!existing.enabled) {
@@ -294,6 +389,54 @@ export function bindChannelPairing(
 
   return {
     chatId: result.chatId,
+    route: toRouteSnapshot(channelId, route),
+  };
+}
+
+export function listChannelTargetSnapshots(
+  channelId: string,
+): ChannelTargetSnapshot[] {
+  assertSupportedChannelId(channelId);
+  loadTargetStore(channelId);
+  return listChannelTargets(channelId).map((target) =>
+    toTargetSnapshot(channelId, target),
+  );
+}
+
+export function bindChannelTarget(
+  channelId: string,
+  targetId: string,
+  agentId: string,
+  conversationId: string,
+): { chatId: string; route: ChannelRouteSnapshot } {
+  assertSupportedChannelId(channelId);
+  loadRoutes(channelId);
+  loadTargetStore(channelId);
+
+  const target = getChannelTarget(channelId, targetId);
+  if (!target) {
+    throw new Error(`Unknown channel target: ${targetId}`);
+  }
+
+  const route: ChannelRoute = {
+    chatId: target.chatId,
+    agentId,
+    conversationId,
+    enabled: true,
+    createdAt: new Date().toISOString(),
+  };
+
+  try {
+    addRoute(channelId, route);
+    removeChannelTarget(channelId, targetId);
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? error.message : "Failed to bind channel target",
+    );
+  }
+
+  return {
+    chatId: route.chatId,
     route: toRouteSnapshot(channelId, route),
   };
 }

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1,0 +1,206 @@
+import type SlackApp from "@slack/bolt";
+import type {
+  ChannelAdapter,
+  InboundChannelMessage,
+  OutboundChannelMessage,
+  SlackChannelConfig,
+} from "../types";
+import { loadSlackBoltModule } from "./runtime";
+
+type SlackBoltModule = typeof import("@slack/bolt");
+type SlackAppConstructor = SlackBoltModule["default"];
+
+function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
+  const App = mod.default;
+  if (!App) {
+    throw new Error('Installed Slack runtime did not export default "App".');
+  }
+  return App;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeSlackText(text: string): string {
+  return text.replace(/<@[A-Z0-9]+>/g, "").trim();
+}
+
+function slackTimestampToMillis(timestamp: string): number {
+  return Math.round(Number.parseFloat(timestamp) * 1000);
+}
+
+export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
+  let app: SlackApp | null = null;
+  let running = false;
+
+  async function ensureApp(): Promise<SlackApp> {
+    if (app) {
+      return app;
+    }
+
+    const bolt = await loadSlackBoltModule();
+    const App = resolveSlackAppConstructor(bolt);
+    const instance = new App({
+      token: config.botToken,
+      appToken: config.appToken,
+      socketMode: true,
+    });
+
+    instance.error(async (error) => {
+      console.error("[Slack] Unhandled app error:", error);
+    });
+
+    instance.message(async ({ message }) => {
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      const rawMessage = asRecord(message);
+      if (!rawMessage) {
+        return;
+      }
+
+      const channelId = rawMessage.channel;
+      if (!isNonEmptyString(channelId) || !channelId.startsWith("D")) {
+        return;
+      }
+
+      if (
+        isNonEmptyString(rawMessage.subtype) ||
+        isNonEmptyString(rawMessage.bot_id) ||
+        !isNonEmptyString(rawMessage.user) ||
+        !isNonEmptyString(rawMessage.ts)
+      ) {
+        return;
+      }
+
+      const text = isNonEmptyString(rawMessage.text) ? rawMessage.text : "";
+      const inbound: InboundChannelMessage = {
+        channel: "slack",
+        chatId: channelId,
+        senderId: rawMessage.user,
+        senderName: rawMessage.user,
+        text,
+        timestamp: slackTimestampToMillis(rawMessage.ts),
+        messageId: rawMessage.ts,
+        chatType: "direct",
+        raw: message,
+      };
+
+      try {
+        await adapter.onMessage(inbound);
+      } catch (error) {
+        console.error("[Slack] Error handling DM message:", error);
+      }
+    });
+
+    instance.event("app_mention", async ({ event }) => {
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      if (
+        !isNonEmptyString(event.channel) ||
+        !isNonEmptyString(event.user) ||
+        !isNonEmptyString(event.ts)
+      ) {
+        return;
+      }
+
+      const inbound: InboundChannelMessage = {
+        channel: "slack",
+        chatId: event.channel,
+        senderId: event.user,
+        senderName: event.user,
+        text: normalizeSlackText(event.text ?? ""),
+        timestamp: slackTimestampToMillis(event.ts),
+        messageId: event.thread_ts ?? event.ts,
+        chatType: "channel",
+        raw: event,
+      };
+
+      try {
+        await adapter.onMessage(inbound);
+      } catch (error) {
+        console.error("[Slack] Error handling channel mention:", error);
+      }
+    });
+
+    app = instance;
+    return instance;
+  }
+
+  const adapter: ChannelAdapter = {
+    id: "slack",
+    name: "Slack",
+
+    async start(): Promise<void> {
+      if (running) {
+        return;
+      }
+
+      const slackApp = await ensureApp();
+      await slackApp.init();
+      const auth = await slackApp.client.auth.test();
+      await slackApp.start();
+      running = true;
+
+      console.log(
+        `[Slack] App started for workspace ${auth.team ?? "unknown"} (dm_policy: ${config.dmPolicy})`,
+      );
+    },
+
+    async stop(): Promise<void> {
+      if (!app || !running) {
+        return;
+      }
+      await app.stop();
+      running = false;
+      app = null;
+      console.log("[Slack] App stopped");
+    },
+
+    isRunning(): boolean {
+      return running;
+    },
+
+    async sendMessage(
+      msg: OutboundChannelMessage,
+    ): Promise<{ messageId: string }> {
+      const slackApp = await ensureApp();
+      const response = await slackApp.client.chat.postMessage({
+        channel: msg.chatId,
+        text: msg.text,
+        ...(msg.replyToMessageId ? { thread_ts: msg.replyToMessageId } : {}),
+      });
+
+      return { messageId: response.ts ?? "" };
+    },
+
+    async sendDirectReply(
+      chatId: string,
+      text: string,
+      options?: { replyToMessageId?: string },
+    ): Promise<void> {
+      const slackApp = await ensureApp();
+      await slackApp.client.chat.postMessage({
+        channel: chatId,
+        text,
+        ...(options?.replyToMessageId
+          ? { thread_ts: options.replyToMessageId }
+          : {}),
+      });
+    },
+
+    onMessage: undefined,
+  };
+
+  return adapter;
+}

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -29,7 +29,7 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function normalizeSlackText(text: string): string {
-  return text.replace(/<@[A-Z0-9]+>/g, "").trim();
+  return text.replace(/^(?:\s*<@[A-Z0-9]+>\s*)+/, "").trim();
 }
 
 function slackTimestampToMillis(timestamp: string): number {

--- a/src/channels/slack/plugin.ts
+++ b/src/channels/slack/plugin.ts
@@ -1,0 +1,19 @@
+import type { ChannelPlugin } from "../pluginTypes";
+import type { ChannelConfig, SlackChannelConfig } from "../types";
+import { createSlackAdapter } from "./adapter";
+import { runSlackSetup } from "./setup";
+
+export const slackChannelPlugin: ChannelPlugin = {
+  metadata: {
+    id: "slack",
+    displayName: "Slack",
+    runtimePackages: ["@slack/bolt@4.7.0"],
+    runtimeModules: ["@slack/bolt"],
+  },
+  createAdapter(config: ChannelConfig) {
+    return createSlackAdapter(config as SlackChannelConfig);
+  },
+  runSetup() {
+    return runSlackSetup();
+  },
+};

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -1,0 +1,27 @@
+import {
+  ensureChannelRuntimeInstalled,
+  installChannelRuntime,
+  isChannelRuntimeInstalled,
+  loadChannelRuntimeModule,
+} from "../runtimeDeps";
+
+export async function loadSlackBoltModule(): Promise<
+  typeof import("@slack/bolt")
+> {
+  return loadChannelRuntimeModule<typeof import("@slack/bolt")>(
+    "slack",
+    "@slack/bolt",
+  );
+}
+
+export function isSlackRuntimeInstalled(): boolean {
+  return isChannelRuntimeInstalled("slack");
+}
+
+export async function installSlackRuntime(): Promise<void> {
+  await installChannelRuntime("slack");
+}
+
+export async function ensureSlackRuntimeInstalled(): Promise<boolean> {
+  return ensureChannelRuntimeInstalled("slack");
+}

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -1,0 +1,97 @@
+import { createInterface } from "node:readline/promises";
+import { writeChannelConfig } from "../config";
+import type { DmPolicy, SlackChannelConfig } from "../types";
+import { ensureSlackRuntimeInstalled } from "./runtime";
+
+function isValidBotToken(token: string): boolean {
+  return token.startsWith("xoxb-") && token.length >= 20;
+}
+
+function isValidAppToken(token: string): boolean {
+  return token.startsWith("xapp-") && token.length >= 20;
+}
+
+export async function runSlackSetup(): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log("\n💬 Slack App Setup\n");
+    console.log("You'll need a Slack app configured for Socket Mode.");
+    console.log("Recommended setup:");
+    console.log("  1. Create a Slack app for your workspace");
+    console.log("  2. Enable Socket Mode and generate an app token (xapp-...)");
+    console.log(
+      "  3. Install the app to the workspace to get a bot token (xoxb-...)",
+    );
+    console.log(
+      "  4. Enable App Home messages and subscribe to app_mention + message.im\n",
+    );
+
+    await ensureSlackRuntimeInstalled();
+
+    const botToken = (
+      await rl.question("Enter your Slack bot token (xoxb-...): ")
+    ).trim();
+    if (!isValidBotToken(botToken)) {
+      console.error("Invalid Slack bot token. Expected an xoxb- token.");
+      return false;
+    }
+
+    const appToken = (
+      await rl.question("Enter your Slack app token (xapp-...): ")
+    ).trim();
+    if (!isValidAppToken(appToken)) {
+      console.error("Invalid Slack app token. Expected an xapp- token.");
+      return false;
+    }
+
+    console.log("\nDM Policy — who can message this app directly?\n");
+    console.log("  pairing   — Users must pair with a code (recommended)");
+    console.log("  allowlist — Only pre-approved Slack user IDs");
+    console.log("  open      — Anyone in DMs can message\n");
+
+    const policyInput = await rl.question("DM policy [pairing]: ");
+    const policy = (policyInput.trim() || "pairing") as DmPolicy;
+    if (!["pairing", "allowlist", "open"].includes(policy)) {
+      console.error(`Invalid policy "${policy}". Setup cancelled.`);
+      return false;
+    }
+
+    let allowedUsers: string[] = [];
+    if (policy === "allowlist") {
+      const usersInput = await rl.question(
+        "Enter allowed Slack user IDs (comma-separated): ",
+      );
+      allowedUsers = usersInput
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+
+    const config: SlackChannelConfig = {
+      channel: "slack",
+      enabled: true,
+      mode: "socket",
+      botToken,
+      appToken,
+      dmPolicy: policy,
+      allowedUsers,
+    };
+
+    writeChannelConfig("slack", config);
+    console.log("\n✓ Slack app configured!");
+    console.log("Config written to: ~/.letta/channels/slack/config.yaml\n");
+    console.log("Next steps:");
+    console.log("  1. Start the listener: letta server --channels slack");
+    console.log("  2. DM the app once to generate a pairing code");
+    console.log("  3. Mention the app in a Slack channel once to discover it");
+    console.log("  4. Bind the DM or channel from Letta Code\n");
+
+    return true;
+  } finally {
+    rl.close();
+  }
+}

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { getChannelDir, getChannelTargetsPath } from "./config";
+import type { ChannelBindableTarget } from "./types";
+
+interface ChannelTargetStore {
+  targets: ChannelBindableTarget[];
+}
+
+const stores = new Map<string, ChannelTargetStore>();
+
+function getStore(channelId: string): ChannelTargetStore {
+  let store = stores.get(channelId);
+  if (!store) {
+    store = { targets: [] };
+    stores.set(channelId, store);
+  }
+  return store;
+}
+
+export function loadTargetStore(channelId: string): void {
+  const path = getChannelTargetsPath(channelId);
+  if (!existsSync(path)) {
+    return;
+  }
+
+  try {
+    const text = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(text) as Partial<ChannelTargetStore>;
+    stores.set(channelId, {
+      targets: parsed.targets ?? [],
+    });
+  } catch {
+    // Corrupted target caches should not block startup.
+  }
+}
+
+function saveTargetStore(channelId: string): void {
+  const dir = getChannelDir(channelId);
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    getChannelTargetsPath(channelId),
+    `${JSON.stringify(getStore(channelId), null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+export function listChannelTargets(channelId: string): ChannelBindableTarget[] {
+  return [...getStore(channelId).targets];
+}
+
+export function getChannelTarget(
+  channelId: string,
+  targetId: string,
+): ChannelBindableTarget | null {
+  return (
+    getStore(channelId).targets.find(
+      (target) => target.targetId === targetId,
+    ) ?? null
+  );
+}
+
+export function upsertChannelTarget(
+  channelId: string,
+  target: ChannelBindableTarget,
+): ChannelBindableTarget {
+  const store = getStore(channelId);
+  const existingIndex = store.targets.findIndex(
+    (candidate) => candidate.targetId === target.targetId,
+  );
+
+  if (existingIndex >= 0) {
+    const existing = store.targets[existingIndex];
+    if (!existing) {
+      throw new Error(
+        `Target index ${existingIndex} missing for ${target.targetId}`,
+      );
+    }
+    const merged: ChannelBindableTarget = {
+      ...existing,
+      ...target,
+      discoveredAt: existing.discoveredAt,
+      lastSeenAt: target.lastSeenAt,
+    };
+    store.targets[existingIndex] = merged;
+    saveTargetStore(channelId);
+    return merged;
+  }
+
+  store.targets.push(target);
+  saveTargetStore(channelId);
+  return target;
+}
+
+export function removeChannelTarget(
+  channelId: string,
+  targetId: string,
+): boolean {
+  const store = getStore(channelId);
+  const nextTargets = store.targets.filter(
+    (target) => target.targetId !== targetId,
+  );
+  if (nextTargets.length === store.targets.length) {
+    return false;
+  }
+  store.targets = nextTargets;
+  saveTargetStore(channelId);
+  return true;
+}
+
+export function clearTargetStores(): void {
+  stores.clear();
+}

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -7,6 +7,10 @@ interface ChannelTargetStore {
 }
 
 const stores = new Map<string, ChannelTargetStore>();
+let loadTargetStoreOverride: ((channelId: string) => void) | null = null;
+let saveTargetStoreOverride:
+  | ((channelId: string, store: ChannelTargetStore) => void)
+  | null = null;
 
 function getStore(channelId: string): ChannelTargetStore {
   let store = stores.get(channelId);
@@ -18,6 +22,11 @@ function getStore(channelId: string): ChannelTargetStore {
 }
 
 export function loadTargetStore(channelId: string): void {
+  if (loadTargetStoreOverride) {
+    loadTargetStoreOverride(channelId);
+    return;
+  }
+
   const path = getChannelTargetsPath(channelId);
   if (!existsSync(path)) {
     return;
@@ -35,6 +44,11 @@ export function loadTargetStore(channelId: string): void {
 }
 
 function saveTargetStore(channelId: string): void {
+  if (saveTargetStoreOverride) {
+    saveTargetStoreOverride(channelId, getStore(channelId));
+    return;
+  }
+
   const dir = getChannelDir(channelId);
   mkdirSync(dir, { recursive: true });
 
@@ -110,4 +124,18 @@ export function removeChannelTarget(
 
 export function clearTargetStores(): void {
   stores.clear();
+}
+
+/** @internal Test-only: override loadTargetStore behavior. Pass null to restore. */
+export function __testOverrideLoadTargetStore(
+  fn: ((channelId: string) => void) | null,
+): void {
+  loadTargetStoreOverride = fn;
+}
+
+/** @internal Test-only: override saveTargetStore behavior. Pass null to restore. */
+export function __testOverrideSaveTargetStore(
+  fn: ((channelId: string, store: ChannelTargetStore) => void) | null,
+): void {
+  saveTargetStoreOverride = fn;
 }

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -72,6 +72,7 @@ export function createTelegramAdapter(
         text: msg.text,
         timestamp: msg.date * 1000,
         messageId: String(msg.message_id),
+        chatType: "direct",
         raw: msg,
       };
 
@@ -179,9 +180,22 @@ export function createTelegramAdapter(
       return { messageId: String(result.message_id) };
     },
 
-    async sendDirectReply(chatId: string, text: string): Promise<void> {
+    async sendDirectReply(
+      chatId: string,
+      text: string,
+      options?: { replyToMessageId?: string },
+    ): Promise<void> {
       const telegramBot = await ensureBot();
-      await telegramBot.api.sendMessage(chatId, text);
+      const reply_parameters = options?.replyToMessageId
+        ? {
+            message_id: Number(options.replyToMessageId),
+          }
+        : undefined;
+      await telegramBot.api.sendMessage(
+        chatId,
+        text,
+        reply_parameters ? { reply_parameters } : {},
+      );
     },
 
     onMessage: undefined,

--- a/src/channels/telegram/plugin.ts
+++ b/src/channels/telegram/plugin.ts
@@ -1,5 +1,5 @@
 import type { ChannelPlugin } from "../pluginTypes";
-import type { ChannelConfig } from "../types";
+import type { ChannelConfig, TelegramChannelConfig } from "../types";
 import { createTelegramAdapter } from "./adapter";
 import { runTelegramSetup } from "./setup";
 
@@ -11,7 +11,7 @@ export const telegramChannelPlugin: ChannelPlugin = {
     runtimeModules: ["grammy"],
   },
   createAdapter(config: ChannelConfig) {
-    return createTelegramAdapter(config);
+    return createTelegramAdapter(config as TelegramChannelConfig);
   },
   runSetup() {
     return runTelegramSetup();

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,8 +7,9 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
-export const SUPPORTED_CHANNEL_IDS = ["telegram"] as const;
+export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack"] as const;
 export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
+export type ChannelChatType = "direct" | "channel";
 
 // ── Adapter interface ─────────────────────────────────────────────
 
@@ -32,7 +33,11 @@ export interface ChannelAdapter {
    * Send a direct reply on the platform (for pairing codes, no-route
    * messages, etc.) without going through the agent.
    */
-  sendDirectReply(chatId: string, text: string): Promise<void>;
+  sendDirectReply(
+    chatId: string,
+    text: string,
+    options?: { replyToMessageId?: string },
+  ): Promise<void>;
 
   /**
    * Called by the registry when the adapter receives an inbound message.
@@ -52,6 +57,8 @@ export interface InboundChannelMessage {
   senderId: string;
   /** Sender display name, if available. */
   senderName?: string;
+  /** Chat/channel label, if available (for discovery UIs). */
+  chatLabel?: string;
   /** Message text content. */
   text: string;
   /** Unix timestamp (ms) of the message. */
@@ -60,6 +67,8 @@ export interface InboundChannelMessage {
   messageId?: string;
   /** Raw platform-specific event data for future use. */
   raw?: unknown;
+  /** Broad chat surface type used for routing/pairing decisions. */
+  chatType?: ChannelChatType;
 }
 
 export interface OutboundChannelMessage {
@@ -93,6 +102,7 @@ export interface ChannelRoute {
 // ── Config ────────────────────────────────────────────────────────
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
+export type SlackChannelMode = "socket";
 
 export interface TelegramChannelConfig {
   channel: "telegram";
@@ -102,7 +112,17 @@ export interface TelegramChannelConfig {
   allowedUsers: string[];
 }
 
-export type ChannelConfig = TelegramChannelConfig;
+export interface SlackChannelConfig {
+  channel: "slack";
+  enabled: boolean;
+  mode: SlackChannelMode;
+  botToken: string;
+  appToken: string;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+}
+
+export type ChannelConfig = TelegramChannelConfig | SlackChannelConfig;
 
 // ── Pairing ───────────────────────────────────────────────────────
 
@@ -124,4 +144,16 @@ export interface ApprovedUser {
 export interface PairingStore {
   pending: PendingPairing[];
   approved: ApprovedUser[];
+}
+
+// ── Discovered bind targets ───────────────────────────────────────
+
+export interface ChannelBindableTarget {
+  targetId: string;
+  targetType: "channel";
+  chatId: string;
+  label: string;
+  discoveredAt: string;
+  lastSeenAt: string;
+  lastMessageId?: string;
 }

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -30,16 +30,28 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const localTime = escapeXml(getLocalTime());
   const escapedChannel = escapeXml(msg.channel);
   const escapedChatId = escapeXml(msg.chatId);
+  const threadLine =
+    msg.channel === "slack" &&
+    msg.chatType === "channel" &&
+    msg.messageId?.trim()
+      ? `Use reply_to_message_id="${escapeXml(msg.messageId)}" if you want your reply to stay in the same Slack thread.`
+      : null;
 
-  return [
+  const lines = [
     SYSTEM_REMINDER_OPEN,
     `This message originated from an external ${escapedChannel} channel.`,
-    `If you want the ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
+    `If you want to ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
     `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
     "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
     `Current local time on this device: ${localTime}`,
     SYSTEM_REMINDER_CLOSE,
-  ].join("\n");
+  ];
+
+  if (threadLine) {
+    lines.splice(lines.length - 2, 0, threadLine);
+  }
+
+  return lines.join("\n");
 }
 
 /**

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -135,7 +135,6 @@ async function handleInstall(channel: string): Promise<number> {
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
-
   if (isChannelRuntimeInstalled(channelId)) {
     console.log(
       JSON.stringify(
@@ -408,7 +407,9 @@ export async function runChannelsSubcommand(argv: string[]): Promise<number> {
     case "configure": {
       const channel = rest[0];
       if (!channel) {
-        console.error("Error: specify a channel to configure (e.g., telegram)");
+        console.error(
+          "Error: specify a channel to configure (e.g., telegram or slack)",
+        );
         return 1;
       }
       return handleConfigure(channel);

--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import {
   formatOutboundChannelMessage,
+  markdownToSlackMrkdwn,
   markdownToTelegramHtml,
 } from "../../tools/impl/MessageChannel";
 
@@ -17,10 +18,16 @@ test("formats Telegram markdown as HTML", () => {
   });
 });
 
-test("leaves non-Telegram channel messages unchanged", () => {
+test("formats Slack markdown as mrkdwn", () => {
   expect(formatOutboundChannelMessage("slack", "**bold**")).toEqual({
-    text: "**bold**",
+    text: "*bold*",
   });
+});
+
+test("converts markdown links for Slack mrkdwn", () => {
+  expect(markdownToSlackMrkdwn("[docs](https://example.com)")).toBe(
+    "<https://example.com|docs>",
+  );
 });
 
 test("preserves markdown markers inside inline code", () => {

--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -30,6 +30,38 @@ test("converts markdown links for Slack mrkdwn", () => {
   );
 });
 
+test("preserves markdown markers inside inline code for Slack", () => {
+  expect(markdownToSlackMrkdwn("`**bold**`")).toBe("`**bold**`");
+});
+
+test("preserves markdown markers inside fenced code blocks for Slack", () => {
+  expect(markdownToSlackMrkdwn('```js\nconst x = "**bold**";\n```')).toBe(
+    '```\nconst x = "**bold**";\n```',
+  );
+});
+
+test("escapes unsafe characters for Slack mrkdwn", () => {
+  expect(markdownToSlackMrkdwn("a & b < c > d")).toBe(
+    "a &amp; b &lt; c &gt; d",
+  );
+});
+
+test("preserves existing Slack angle-bracket tokens", () => {
+  expect(
+    markdownToSlackMrkdwn(
+      "hi <@U123> see <https://example.com|docs> and <!here>",
+    ),
+  ).toBe("hi <@U123> see <https://example.com|docs> and <!here>");
+});
+
+test("renders bullet lists for Slack", () => {
+  expect(markdownToSlackMrkdwn("- one\n- two")).toBe("• one\n• two");
+});
+
+test("renders headings as bold text for Slack", () => {
+  expect(markdownToSlackMrkdwn("# Title")).toBe("*Title*");
+});
+
 test("preserves markdown markers inside inline code", () => {
   expect(markdownToTelegramHtml("`**bold**`")).toBe("<code>**bold**</code>");
 });

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { fileURLToPath, pathToFileURL } from "node:url";
 import { clearPairingStores } from "../../channels/pairing";
 import {
   __testOverrideSaveRoutes,
@@ -8,18 +7,15 @@ import {
   getRoute,
 } from "../../channels/routing";
 import {
+  bindChannelTarget,
+  listChannelTargetSnapshots,
+} from "../../channels/service";
+import {
   __testOverrideLoadTargetStore,
   __testOverrideSaveTargetStore,
   clearTargetStores,
   upsertChannelTarget,
 } from "../../channels/targets";
-
-const serviceModuleUrl = pathToFileURL(
-  fileURLToPath(new URL("../../channels/service.ts", import.meta.url)),
-).href;
-const { bindChannelTarget, listChannelTargetSnapshots } = await import(
-  serviceModuleUrl
-);
 
 describe("channel service", () => {
   function resetState(): void {

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -9,7 +9,12 @@ import {
   bindChannelTarget,
   listChannelTargetSnapshots,
 } from "../../channels/service";
-import { clearTargetStores, upsertChannelTarget } from "../../channels/targets";
+import {
+  __testOverrideLoadTargetStore,
+  __testOverrideSaveTargetStore,
+  clearTargetStores,
+  upsertChannelTarget,
+} from "../../channels/targets";
 
 describe("channel service", () => {
   afterEach(() => {
@@ -17,9 +22,14 @@ describe("channel service", () => {
     clearPairingStores();
     clearTargetStores();
     __testOverrideSaveRoutes(null);
+    __testOverrideLoadTargetStore(null);
+    __testOverrideSaveTargetStore(null);
   });
 
   test("bindChannelTarget rolls back the route and restores the target when route save fails", () => {
+    __testOverrideLoadTargetStore(() => {});
+    __testOverrideSaveTargetStore(() => {});
+
     upsertChannelTarget("slack", {
       targetId: "test-target-bind-rollback",
       targetType: "channel",

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { clearPairingStores } from "../../channels/pairing";
 import {
   __testOverrideSaveRoutes,
@@ -7,15 +8,18 @@ import {
   getRoute,
 } from "../../channels/routing";
 import {
-  bindChannelTarget,
-  listChannelTargetSnapshots,
-} from "../../channels/service";
-import {
   __testOverrideLoadTargetStore,
   __testOverrideSaveTargetStore,
   clearTargetStores,
   upsertChannelTarget,
 } from "../../channels/targets";
+
+const serviceModuleUrl = pathToFileURL(
+  fileURLToPath(new URL("../../channels/service.ts", import.meta.url)),
+).href;
+const { bindChannelTarget, listChannelTargetSnapshots } = await import(
+  serviceModuleUrl
+);
 
 describe("channel service", () => {
   function resetState(): void {

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearPairingStores } from "../../channels/pairing";
+import {
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRoute,
+} from "../../channels/routing";
+import {
+  bindChannelTarget,
+  listChannelTargetSnapshots,
+} from "../../channels/service";
+import { clearTargetStores, upsertChannelTarget } from "../../channels/targets";
+
+describe("channel service", () => {
+  afterEach(() => {
+    clearAllRoutes();
+    clearPairingStores();
+    clearTargetStores();
+    __testOverrideSaveRoutes(null);
+  });
+
+  test("bindChannelTarget rolls back the route and restores the target when route save fails", () => {
+    upsertChannelTarget("slack", {
+      targetId: "test-target-bind-rollback",
+      targetType: "channel",
+      chatId: "test-chat-bind-rollback",
+      label: "#test-bind-rollback",
+      discoveredAt: "2026-04-11T00:00:00.000Z",
+      lastSeenAt: "2026-04-11T00:00:00.000Z",
+      lastMessageId: "1712790000.000100",
+    });
+
+    __testOverrideSaveRoutes(() => {
+      throw new Error("ENOSPC: no space left");
+    });
+
+    expect(() =>
+      bindChannelTarget(
+        "slack",
+        "test-target-bind-rollback",
+        "agent-test",
+        "conv-test",
+      ),
+    ).toThrow(/rolled back/i);
+
+    expect(getRoute("slack", "test-chat-bind-rollback")).toBeNull();
+    expect(listChannelTargetSnapshots("slack")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channelId: "slack",
+          targetId: "test-target-bind-rollback",
+          chatId: "test-chat-bind-rollback",
+          label: "#test-bind-rollback",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import { clearPairingStores } from "../../channels/pairing";
 import {
   __testOverrideSaveRoutes,
@@ -17,24 +18,48 @@ import {
 } from "../../channels/targets";
 
 describe("channel service", () => {
-  afterEach(() => {
+  function resetState(): void {
     clearAllRoutes();
     clearPairingStores();
     clearTargetStores();
     __testOverrideSaveRoutes(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+  }
+
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    resetState();
   });
 
   test("bindChannelTarget rolls back the route and restores the target when route save fails", () => {
+    const suffix = randomUUID();
+    const targetId = `test-target-bind-rollback-${suffix}`;
+    const chatId = `test-chat-bind-rollback-${suffix}`;
+    const label = `#test-bind-rollback-${suffix}`;
+    const savedTargetSnapshots: Array<
+      Array<{ targetId: string; chatId: string; label: string }>
+    > = [];
+
     __testOverrideLoadTargetStore(() => {});
-    __testOverrideSaveTargetStore(() => {});
+    __testOverrideSaveTargetStore((_channelId, store) => {
+      savedTargetSnapshots.push(
+        store.targets.map((target) => ({
+          targetId: target.targetId,
+          chatId: target.chatId,
+          label: target.label,
+        })),
+      );
+    });
 
     upsertChannelTarget("slack", {
-      targetId: "test-target-bind-rollback",
+      targetId,
       targetType: "channel",
-      chatId: "test-chat-bind-rollback",
-      label: "#test-bind-rollback",
+      chatId,
+      label,
       discoveredAt: "2026-04-11T00:00:00.000Z",
       lastSeenAt: "2026-04-11T00:00:00.000Z",
       lastMessageId: "1712790000.000100",
@@ -45,22 +70,26 @@ describe("channel service", () => {
     });
 
     expect(() =>
-      bindChannelTarget(
-        "slack",
-        "test-target-bind-rollback",
-        "agent-test",
-        "conv-test",
-      ),
+      bindChannelTarget("slack", targetId, "agent-test", "conv-test"),
     ).toThrow(/rolled back/i);
 
-    expect(getRoute("slack", "test-chat-bind-rollback")).toBeNull();
+    expect(getRoute("slack", chatId)).toBeNull();
     expect(listChannelTargetSnapshots("slack")).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           channelId: "slack",
-          targetId: "test-target-bind-rollback",
-          chatId: "test-chat-bind-rollback",
-          label: "#test-bind-rollback",
+          targetId,
+          chatId,
+          label,
+        }),
+      ]),
+    );
+    expect(savedTargetSnapshots.at(-1)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetId,
+          chatId,
+          label,
         }),
       ]),
     );

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+type SlackMessageHandler = (args: {
+  message: {
+    channel?: string;
+    user?: string;
+    text?: string;
+    ts?: string;
+    thread_ts?: string;
+    subtype?: string;
+    bot_id?: string;
+  };
+}) => Promise<void>;
+
+type SlackEventHandler = (args: {
+  event: {
+    channel?: string;
+    user?: string;
+    text?: string;
+    ts?: string;
+    thread_ts?: string;
+  };
+}) => Promise<void>;
+
+class FakeSlackApp {
+  static instances: FakeSlackApp[] = [];
+
+  readonly client = {
+    auth: {
+      test: mock(async () => ({ team: "Test Workspace" })),
+    },
+    chat: {
+      postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+    },
+  };
+
+  messageHandler: SlackMessageHandler | null = null;
+  eventHandlers = new Map<string, SlackEventHandler>();
+  errorHandler: ((error: Error) => Promise<void>) | null = null;
+
+  constructor(_options: Record<string, unknown>) {
+    FakeSlackApp.instances.push(this);
+  }
+
+  message(handler: SlackMessageHandler): void {
+    this.messageHandler = handler;
+  }
+
+  event(name: string, handler: SlackEventHandler): void {
+    this.eventHandlers.set(name, handler);
+  }
+
+  error(handler: (error: Error) => Promise<void>): void {
+    this.errorHandler = handler;
+  }
+
+  async init(): Promise<void> {}
+
+  async start(): Promise<void> {}
+
+  async stop(): Promise<void> {}
+}
+
+mock.module("../../channels/slack/runtime", () => ({
+  loadSlackBoltModule: async () => ({
+    default: FakeSlackApp,
+  }),
+}));
+
+const { createSlackAdapter } = await import("../../channels/slack/adapter");
+
+beforeEach(() => {
+  FakeSlackApp.instances.length = 0;
+});
+
+afterEach(() => {
+  for (const instance of FakeSlackApp.instances) {
+    instance.client.auth.test.mockClear();
+    instance.client.chat.postMessage.mockClear();
+  }
+});
+
+test("slack adapter maps reply_to_message_id to thread_ts", async () => {
+  const adapter = createSlackAdapter({
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "slack",
+    chatId: "C123",
+    text: "hello",
+    replyToMessageId: "1712800000.000200",
+  });
+
+  const app = FakeSlackApp.instances[0];
+  expect(app).toBeDefined();
+  expect(app?.client.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "hello",
+    thread_ts: "1712800000.000200",
+  });
+});
+
+test("slack adapter forwards DM messages as direct channel input", async () => {
+  const adapter = createSlackAdapter({
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "D123",
+      user: "U123",
+      text: "hello from slack",
+      ts: "1712800000.000100",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "D123",
+      senderId: "U123",
+      text: "hello from slack",
+      messageId: "1712800000.000100",
+      chatType: "direct",
+    }),
+  );
+});
+
+test("slack adapter forwards app mentions as channel input", async () => {
+  const adapter = createSlackAdapter({
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.eventHandlers.get("app_mention");
+  if (!handler) {
+    throw new Error("Expected app_mention handler");
+  }
+
+  await handler({
+    event: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U999> please help",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "please help",
+      messageId: "1712790000.000050",
+      chatType: "channel",
+    }),
+  );
+});

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -192,3 +192,40 @@ test("slack adapter forwards app mentions as channel input", async () => {
     }),
   );
 });
+
+test("slack adapter preserves non-leading user mentions in app mention text", async () => {
+  const adapter = createSlackAdapter({
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.eventHandlers.get("app_mention");
+  if (!handler) {
+    throw new Error("Expected app_mention handler");
+  }
+
+  await handler({
+    event: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U999> ask <@U555> for help",
+      ts: "1712800000.000100",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      text: "ask <@U555> for help",
+    }),
+  );
+});

--- a/src/tests/channels/targets.test.ts
+++ b/src/tests/channels/targets.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearTargetStores,
+  getChannelTarget,
+  listChannelTargets,
+  upsertChannelTarget,
+} from "../../channels/targets";
+
+describe("channel targets", () => {
+  afterEach(() => {
+    clearTargetStores();
+  });
+
+  test("upserts a discovered channel target", () => {
+    upsertChannelTarget("slack", {
+      targetId: "C123",
+      targetType: "channel",
+      chatId: "C123",
+      label: "#eng",
+      discoveredAt: "2026-04-10T00:00:00.000Z",
+      lastSeenAt: "2026-04-10T00:00:00.000Z",
+      lastMessageId: "1712700000.000100",
+    });
+
+    expect(listChannelTargets("slack")).toHaveLength(1);
+    expect(getChannelTarget("slack", "C123")?.label).toBe("#eng");
+  });
+
+  test("preserves discoveredAt when a target is rediscovered", () => {
+    upsertChannelTarget("slack", {
+      targetId: "C123",
+      targetType: "channel",
+      chatId: "C123",
+      label: "#eng",
+      discoveredAt: "2026-04-10T00:00:00.000Z",
+      lastSeenAt: "2026-04-10T00:00:00.000Z",
+    });
+
+    const updated = upsertChannelTarget("slack", {
+      targetId: "C123",
+      targetType: "channel",
+      chatId: "C123",
+      label: "#eng-updated",
+      discoveredAt: "2026-04-10T01:00:00.000Z",
+      lastSeenAt: "2026-04-10T01:00:00.000Z",
+      lastMessageId: "1712703600.000200",
+    });
+
+    expect(updated.discoveredAt).toBe("2026-04-10T00:00:00.000Z");
+    expect(updated.lastSeenAt).toBe("2026-04-10T01:00:00.000Z");
+    expect(updated.lastMessageId).toBe("1712703600.000200");
+  });
+});

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -65,6 +65,23 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain("Current local time on this device:");
   });
 
+  test("adds Slack thread guidance for channel notifications", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "ping",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      chatType: "channel",
+    };
+
+    const reminder = buildChannelReminderText(msg);
+
+    expect(reminder).toContain('reply_to_message_id="1712800000.000100"');
+    expect(reminder).toContain("stay in the same Slack thread");
+  });
+
   test("escapes XML special characters in notification text", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -415,9 +415,11 @@ describe("listen-client parseServerMessage", () => {
         JSON.stringify({
           type: "channel_set_config",
           request_id: "channel-set-config-1",
-          channel_id: "telegram",
+          channel_id: "slack",
           config: {
-            token: "123:abc",
+            bot_token: "xoxb-test",
+            app_token: "xapp-test",
+            mode: "socket",
             dm_policy: "pairing",
             allowed_users: ["user-1"],
           },
@@ -483,6 +485,26 @@ describe("listen-client parseServerMessage", () => {
         }),
       ),
     );
+    const channelTargetsList = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_targets_list",
+          request_id: "channel-targets-list-1",
+          channel_id: "slack",
+        }),
+      ),
+    );
+    const channelTargetBind = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_target_bind",
+          request_id: "channel-target-bind-1",
+          channel_id: "slack",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          target_id: "C123",
+        }),
+      ),
+    );
 
     expect(channelsList?.type).toBe("channels_list");
     expect(channelGetConfig?.type).toBe("channel_get_config");
@@ -493,6 +515,8 @@ describe("listen-client parseServerMessage", () => {
     expect(channelPairingBind?.type).toBe("channel_pairing_bind");
     expect(channelRoutesList?.type).toBe("channel_routes_list");
     expect(channelRouteRemove?.type).toBe("channel_route_remove");
+    expect(channelTargetsList?.type).toBe("channel_targets_list");
+    expect(channelTargetBind?.type).toBe("channel_target_bind");
   });
 
   test("parses list_models command", () => {
@@ -1052,6 +1076,86 @@ describe("listen-client channels command handling", () => {
       expect(messages[3]).toMatchObject({
         type: "channels_updated",
         channel_id: "telegram",
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("target bind emits target, route, and channel update events", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    mock.module("../../channels/service", () => ({
+      ...actualChannelsService,
+      bindChannelTarget: () => ({
+        chatId: "C123",
+        route: {
+          channelId: "slack" as const,
+          chatId: "C123",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enabled: true,
+          createdAt: "2026-04-10T00:00:00.000Z",
+        },
+      }),
+      listChannelTargetSnapshots: () => [],
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_target_bind",
+          request_id: "channel-target-bind-1",
+          channel_id: "slack",
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+          },
+          target_id: "C123",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_target_bind_response",
+        request_id: "channel-target-bind-1",
+        success: true,
+        channel_id: "slack",
+        target_id: "C123",
+        chat_id: "C123",
+        route: {
+          channel_id: "slack",
+          chat_id: "C123",
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+          enabled: true,
+          created_at: "2026-04-10T00:00:00.000Z",
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_targets_updated",
+        channel_id: "slack",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channel_routes_updated",
+        channel_id: "slack",
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+      });
+      expect(messages[3]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "slack",
       });
     } finally {
       __listenClientTestUtils.stopRuntime(runtime, true);

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -80,7 +80,7 @@ class MockSocket {
 const actualChannelsService = await import("../../channels/service");
 
 afterEach(() => {
-  mock.module("../../channels/service", () => actualChannelsService);
+  __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
 });
 
 function makeControlRequest(requestId: string): ControlRequest {
@@ -948,7 +948,7 @@ describe("listen-client channels command handling", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();
 
-    mock.module("../../channels/service", () => ({
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
       ...actualChannelsService,
       listChannelSummaries: () => [
         {
@@ -1008,7 +1008,7 @@ describe("listen-client channels command handling", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();
 
-    mock.module("../../channels/service", () => ({
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
       ...actualChannelsService,
       bindChannelPairing: () => ({
         chatId: "chat-42",
@@ -1086,7 +1086,7 @@ describe("listen-client channels command handling", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();
 
-    mock.module("../../channels/service", () => ({
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
       ...actualChannelsService,
       bindChannelTarget: () => ({
         chatId: "C123",

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -213,6 +213,16 @@ export function markdownToTelegramHtml(text: string): string {
   return formatTelegramText(text);
 }
 
+export function markdownToSlackMrkdwn(text: string): string {
+  return text
+    .replace(/```[a-zA-Z0-9_-]+\n/g, "```\n")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "<$2|$1>")
+    .replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, "_$1_")
+    .replace(/\*\*([^*]+?)\*\*/g, "*$1*")
+    .replace(/__([^_]+?)__/g, "*$1*")
+    .replace(/~~([^~]+?)~~/g, "~$1~");
+}
+
 const CHANNEL_OUTBOUND_FORMATTERS: Partial<
   Record<string, OutboundChannelFormatter>
 > = {
@@ -220,6 +230,11 @@ const CHANNEL_OUTBOUND_FORMATTERS: Partial<
     return {
       text: markdownToTelegramHtml(text),
       parseMode: "HTML",
+    };
+  },
+  slack(text) {
+    return {
+      text: markdownToSlackMrkdwn(text),
     };
   },
 };

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -16,6 +16,10 @@ const TELEGRAM_CHANNEL_ID = "telegram";
 const TELEGRAM_PLACEHOLDER_PREFIX = "LCTELEGRAMHTMLPLACEHOLDER";
 const TELEGRAM_PLACEHOLDER_SUFFIX = "X";
 const TELEGRAM_PLACEHOLDER_PATTERN = /LCTELEGRAMHTMLPLACEHOLDER(\d+)X/g;
+const SLACK_PLACEHOLDER_PREFIX = "LCSLACKMRKDWNPLACEHOLDER";
+const SLACK_PLACEHOLDER_SUFFIX = "X";
+const SLACK_PLACEHOLDER_PATTERN = /LCSLACKMRKDWNPLACEHOLDER(\d+)X/g;
+const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
 type OutboundChannelFormatter = (
   text: string,
@@ -48,6 +52,21 @@ function restoreTelegramPlaceholders(
   placeholders: string[],
 ): string {
   return text.replace(TELEGRAM_PLACEHOLDER_PATTERN, (_match, index) => {
+    return placeholders[Number(index)] ?? "";
+  });
+}
+
+function createSlackPlaceholder(placeholders: string[], value: string): string {
+  const placeholder = `${SLACK_PLACEHOLDER_PREFIX}${placeholders.length}${SLACK_PLACEHOLDER_SUFFIX}`;
+  placeholders.push(value);
+  return placeholder;
+}
+
+function restoreSlackPlaceholders(
+  text: string,
+  placeholders: string[],
+): string {
+  return text.replace(SLACK_PLACEHOLDER_PATTERN, (_match, index) => {
     return placeholders[Number(index)] ?? "";
   });
 }
@@ -213,14 +232,186 @@ export function markdownToTelegramHtml(text: string): string {
   return formatTelegramText(text);
 }
 
-export function markdownToSlackMrkdwn(text: string): string {
+function escapeSlackMrkdwnSegment(text: string): string {
   return text
-    .replace(/```[a-zA-Z0-9_-]+\n/g, "```\n")
-    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "<$2|$1>")
-    .replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, "_$1_")
-    .replace(/\*\*([^*]+?)\*\*/g, "*$1*")
-    .replace(/__([^_]+?)__/g, "*$1*")
-    .replace(/~~([^~]+?)~~/g, "~$1~");
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function isAllowedSlackAngleToken(token: string): boolean {
+  if (!token.startsWith("<") || !token.endsWith(">")) {
+    return false;
+  }
+  const inner = token.slice(1, -1);
+  return (
+    inner.startsWith("@") ||
+    inner.startsWith("#") ||
+    inner.startsWith("!") ||
+    inner.startsWith("mailto:") ||
+    inner.startsWith("tel:") ||
+    inner.startsWith("http://") ||
+    inner.startsWith("https://") ||
+    inner.startsWith("slack://")
+  );
+}
+
+function escapeSlackMrkdwnContent(text: string): string {
+  if (!text) {
+    return "";
+  }
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+    return text;
+  }
+
+  SLACK_ANGLE_TOKEN_RE.lastIndex = 0;
+  const out: string[] = [];
+  let lastIndex = 0;
+
+  for (
+    let match = SLACK_ANGLE_TOKEN_RE.exec(text);
+    match;
+    match = SLACK_ANGLE_TOKEN_RE.exec(text)
+  ) {
+    const matchIndex = match.index ?? 0;
+    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
+    const token = match[0] ?? "";
+    out.push(
+      isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token),
+    );
+    lastIndex = matchIndex + token.length;
+  }
+
+  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  return out.join("");
+}
+
+function escapeSlackMrkdwnText(text: string): string {
+  if (!text) {
+    return "";
+  }
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+    return text;
+  }
+
+  return text
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("> ")) {
+        return `> ${escapeSlackMrkdwnContent(line.slice(2))}`;
+      }
+      return escapeSlackMrkdwnContent(line);
+    })
+    .join("\n");
+}
+
+function replaceSlackFencedCodeBlocks(
+  text: string,
+  placeholders: string[],
+): string {
+  return text.replace(
+    /```([^\n`]*)\n?([\s\S]*?)```/g,
+    (_match, _lang, code) => {
+      const normalized = String(code).trimEnd();
+      return createSlackPlaceholder(
+        placeholders,
+        normalized.length > 0 ? `\`\`\`\n${normalized}\n\`\`\`` : "```\n```",
+      );
+    },
+  );
+}
+
+function replaceSlackInlineCode(text: string, placeholders: string[]): string {
+  return text.replace(/`([^`\n]+)`/g, (_match, code) => {
+    return createSlackPlaceholder(placeholders, `\`${String(code)}\``);
+  });
+}
+
+function applySlackInlineFormatting(text: string): string {
+  return text
+    .replace(/~~([^\s~](?:[\s\S]*?[^\s~])?)~~/g, "~$1~")
+    .replace(/(^|[^\w*])\*([^\s*](?:[\s\S]*?[^\s*])?)\*(?!\w)/g, "$1_$2_")
+    .replace(/\*\*\*([^\s*](?:[\s\S]*?[^\s*])?)\*\*\*/g, "_*$1*_")
+    .replace(/___([^\s_](?:[\s\S]*?[^\s_])?)___/g, "_*$1*_")
+    .replace(/\*\*([^\s*](?:[\s\S]*?[^\s*])?)\*\*/g, "*$1*")
+    .replace(/__([^\s_](?:[\s\S]*?[^\s_])?)__/g, "*$1*");
+}
+
+function formatSlackLinkLabel(text: string): string {
+  return applySlackInlineFormatting(escapeSlackMrkdwnText(text));
+}
+
+function replaceSlackMarkdownLinks(
+  text: string,
+  placeholders: string[],
+): string {
+  let result = "";
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "[") {
+      result += text[index];
+      index++;
+      continue;
+    }
+
+    const link = parseMarkdownLink(text, index);
+    if (!link) {
+      result += text[index];
+      index++;
+      continue;
+    }
+
+    result += createSlackPlaceholder(
+      placeholders,
+      `<${escapeSlackMrkdwnSegment(link.url)}|${formatSlackLinkLabel(link.label)}>`,
+    );
+    index = link.endIndex;
+  }
+
+  return result;
+}
+
+function normalizeSlackBlockFormatting(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      const headingMatch = line.match(/^\s{0,3}#{1,6}\s+(.+)$/);
+      if (headingMatch) {
+        return `*${headingMatch[1]?.trim() ?? ""}*`;
+      }
+
+      const bulletMatch = line.match(/^(\s*)[-+*]\s+(.+)$/);
+      if (bulletMatch) {
+        return `${bulletMatch[1] ?? ""}• ${bulletMatch[2] ?? ""}`;
+      }
+
+      return line;
+    })
+    .join("\n");
+}
+
+function formatSlackText(
+  text: string,
+  options?: { enableLinks?: boolean },
+): string {
+  const placeholders: string[] = [];
+  let result = replaceSlackFencedCodeBlocks(text, placeholders);
+  result = replaceSlackInlineCode(result, placeholders);
+
+  if (options?.enableLinks !== false) {
+    result = replaceSlackMarkdownLinks(result, placeholders);
+  }
+
+  result = escapeSlackMrkdwnText(result);
+  result = applySlackInlineFormatting(result);
+  result = normalizeSlackBlockFormatting(result);
+
+  return restoreSlackPlaceholders(result, placeholders);
+}
+
+export function markdownToSlackMrkdwn(text: string): string {
+  return formatSlackText(text);
 }
 
 const CHANNEL_OUTBOUND_FORMATTERS: Partial<

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -9,7 +9,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import type { DmPolicy } from "../channels/types";
+import type { DmPolicy, SlackChannelMode } from "../channels/types";
 import type { CronTask } from "../cron";
 
 /**
@@ -137,7 +137,7 @@ export interface ReflectionSettingsSnapshot {
   step_count: number;
 }
 
-export type ChannelId = "telegram";
+export type ChannelId = "telegram" | "slack";
 
 export interface ChannelSummary {
   channel_id: ChannelId;
@@ -151,13 +151,23 @@ export interface ChannelSummary {
   routes_count: number;
 }
 
-export interface ChannelConfigSnapshot {
-  channel_id: ChannelId;
-  enabled: boolean;
-  dm_policy: DmPolicy;
-  allowed_users: string[];
-  has_token: boolean;
-}
+export type ChannelConfigSnapshot =
+  | {
+      channel_id: "telegram";
+      enabled: boolean;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_token: boolean;
+    }
+  | {
+      channel_id: "slack";
+      enabled: boolean;
+      mode: SlackChannelMode;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_bot_token: boolean;
+      has_app_token: boolean;
+    };
 
 export interface ChannelPendingPairing {
   code: string;
@@ -175,6 +185,17 @@ export interface ChannelRouteSnapshot {
   conversation_id: string;
   enabled: boolean;
   created_at: string;
+}
+
+export interface ChannelTargetSnapshot {
+  channel_id: ChannelId;
+  target_id: string;
+  target_type: "channel";
+  chat_id: string;
+  label: string;
+  discovered_at: string;
+  last_seen_at: string;
+  last_message_id?: string;
 }
 
 /**
@@ -795,11 +816,19 @@ export interface ChannelSetConfigCommand {
   type: "channel_set_config";
   request_id: string;
   channel_id: ChannelId;
-  config: {
-    token?: string;
-    dm_policy?: DmPolicy;
-    allowed_users?: string[];
-  };
+  config:
+    | {
+        token?: string;
+        dm_policy?: DmPolicy;
+        allowed_users?: string[];
+      }
+    | {
+        bot_token?: string;
+        app_token?: string;
+        mode?: SlackChannelMode;
+        dm_policy?: DmPolicy;
+        allowed_users?: string[];
+      };
 }
 
 export interface ChannelStartCommand {
@@ -834,6 +863,20 @@ export interface ChannelRoutesListCommand {
   channel_id?: ChannelId;
   agent_id?: string;
   conversation_id?: string;
+}
+
+export interface ChannelTargetsListCommand {
+  type: "channel_targets_list";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export interface ChannelTargetBindCommand {
+  type: "channel_target_bind";
+  request_id: string;
+  channel_id: ChannelId;
+  runtime: RuntimeScope;
+  target_id: string;
 }
 
 export interface ChannelRouteRemoveCommand {
@@ -998,6 +1041,26 @@ export interface ChannelRouteRemoveResponseMessage {
   error?: string;
 }
 
+export interface ChannelTargetsListResponseMessage {
+  type: "channel_targets_list_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  targets: ChannelTargetSnapshot[];
+  error?: string;
+}
+
+export interface ChannelTargetBindResponseMessage {
+  type: "channel_target_bind_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  target_id: string;
+  chat_id?: string;
+  route?: ChannelRouteSnapshot | null;
+  error?: string;
+}
+
 export interface ChannelsUpdatedMessage {
   type: "channels_updated";
   timestamp: number;
@@ -1016,6 +1079,12 @@ export interface ChannelRoutesUpdatedMessage {
   channel_id: ChannelId;
   agent_id?: string;
   conversation_id?: string | null;
+}
+
+export interface ChannelTargetsUpdatedMessage {
+  type: "channel_targets_updated";
+  timestamp: number;
+  channel_id: ChannelId;
 }
 
 /**
@@ -1126,6 +1195,8 @@ export type WsProtocolCommand =
   | ChannelPairingsListCommand
   | ChannelPairingBindCommand
   | ChannelRoutesListCommand
+  | ChannelTargetsListCommand
+  | ChannelTargetBindCommand
   | ChannelRouteRemoveCommand
   | ExecuteCommandCommand
   | SearchBranchesCommand
@@ -1147,9 +1218,12 @@ export type WsProtocolMessage =
   | ChannelPairingsListResponseMessage
   | ChannelPairingBindResponseMessage
   | ChannelRoutesListResponseMessage
+  | ChannelTargetsListResponseMessage
+  | ChannelTargetBindResponseMessage
   | ChannelRouteRemoveResponseMessage
   | ChannelsUpdatedMessage
   | ChannelPairingsUpdatedMessage
-  | ChannelRoutesUpdatedMessage;
+  | ChannelRoutesUpdatedMessage
+  | ChannelTargetsUpdatedMessage;
 
 export type { StopReasonType };

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -81,6 +81,8 @@ import type {
   ChannelStartCommand,
   ChannelStopCommand,
   ChannelsListCommand,
+  ChannelTargetBindCommand,
+  ChannelTargetsListCommand,
   CreateAgentCommand,
   CronAddCommand,
   CronDeleteAllCommand,
@@ -148,6 +150,8 @@ import {
   isChannelStartCommand,
   isChannelStopCommand,
   isChannelsListCommand,
+  isChannelTargetBindCommand,
+  isChannelTargetsListCommand,
   isCheckoutBranchCommand,
   isCreateAgentCommand,
   isCronAddCommand,
@@ -753,6 +757,8 @@ type ChannelsCommand =
   | ChannelPairingsListCommand
   | ChannelPairingBindCommand
   | ChannelRoutesListCommand
+  | ChannelTargetsListCommand
+  | ChannelTargetBindCommand
   | ChannelRouteRemoveCommand;
 
 function emitCronsUpdated(
@@ -774,7 +780,10 @@ function emitCronsUpdated(
   );
 }
 
-function emitChannelsUpdated(socket: WebSocket, channelId?: "telegram"): void {
+function emitChannelsUpdated(
+  socket: WebSocket,
+  channelId?: "telegram" | "slack",
+): void {
   safeSocketSend(
     socket,
     {
@@ -789,7 +798,7 @@ function emitChannelsUpdated(socket: WebSocket, channelId?: "telegram"): void {
 
 function emitChannelPairingsUpdated(
   socket: WebSocket,
-  channelId: "telegram",
+  channelId: "telegram" | "slack",
 ): void {
   safeSocketSend(
     socket,
@@ -806,7 +815,7 @@ function emitChannelPairingsUpdated(
 function emitChannelRoutesUpdated(
   socket: WebSocket,
   params: {
-    channelId: "telegram";
+    channelId: "telegram" | "slack";
     agentId?: string;
     conversationId?: string | null;
   },
@@ -821,6 +830,22 @@ function emitChannelRoutesUpdated(
       ...(params.conversationId !== undefined
         ? { conversation_id: params.conversationId }
         : {}),
+    },
+    "listener_channels_send_failed",
+    "listener_channels_command",
+  );
+}
+
+function emitChannelTargetsUpdated(
+  socket: WebSocket,
+  channelId: "telegram" | "slack",
+): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "channel_targets_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
     },
     "listener_channels_send_failed",
     "listener_channels_command",
@@ -1033,15 +1058,81 @@ async function handleChannelsProtocolCommand(
 ): Promise<boolean> {
   const {
     bindChannelPairing,
+    bindChannelTarget,
     getChannelConfigSnapshot,
     listChannelRouteSnapshots,
     listChannelSummaries,
     listPendingPairingSnapshots,
+    listChannelTargetSnapshots,
     removeChannelRouteLive,
     setChannelConfigLive,
     startChannelLive,
     stopChannelLive,
   } = await import("../../channels/service");
+
+  const mapChannelSummary = (
+    summary: ReturnType<typeof listChannelSummaries>[number],
+  ) => ({
+    channel_id: summary.channelId,
+    display_name: summary.displayName,
+    configured: summary.configured,
+    enabled: summary.enabled,
+    running: summary.running,
+    dm_policy: summary.dmPolicy,
+    pending_pairings_count: summary.pendingPairingsCount,
+    approved_users_count: summary.approvedUsersCount,
+    routes_count: summary.routesCount,
+  });
+
+  const mapChannelConfig = (
+    snapshot: ReturnType<typeof getChannelConfigSnapshot>,
+  ) => {
+    if (!snapshot) {
+      return null;
+    }
+    if (snapshot.channelId === "telegram") {
+      return {
+        channel_id: snapshot.channelId,
+        enabled: snapshot.enabled,
+        dm_policy: snapshot.dmPolicy,
+        allowed_users: snapshot.allowedUsers,
+        has_token: snapshot.hasToken,
+      };
+    }
+    return {
+      channel_id: snapshot.channelId,
+      enabled: snapshot.enabled,
+      mode: snapshot.mode,
+      dm_policy: snapshot.dmPolicy,
+      allowed_users: snapshot.allowedUsers,
+      has_bot_token: snapshot.hasBotToken,
+      has_app_token: snapshot.hasAppToken,
+    };
+  };
+
+  const mapRouteSnapshot = (
+    route: ReturnType<typeof listChannelRouteSnapshots>[number],
+  ) => ({
+    channel_id: route.channelId,
+    chat_id: route.chatId,
+    agent_id: route.agentId,
+    conversation_id: route.conversationId,
+    enabled: route.enabled,
+    created_at: route.createdAt,
+  });
+
+  const mapTargetSnapshot = (
+    target: ReturnType<typeof listChannelTargetSnapshots>[number],
+  ) => ({
+    channel_id: target.channelId,
+    target_id: target.targetId,
+    target_type: target.targetType,
+    chat_id: target.chatId,
+    label: target.label,
+    discovered_at: target.discoveredAt,
+    last_seen_at: target.lastSeenAt,
+    ...(target.lastMessageId ? { last_message_id: target.lastMessageId } : {}),
+  });
 
   if (parsed.type === "channels_list") {
     try {
@@ -1051,17 +1142,7 @@ async function handleChannelsProtocolCommand(
           type: "channels_list_response",
           request_id: parsed.request_id,
           success: true,
-          channels: listChannelSummaries().map((summary) => ({
-            channel_id: summary.channelId,
-            display_name: summary.displayName,
-            configured: summary.configured,
-            enabled: summary.enabled,
-            running: summary.running,
-            dm_policy: summary.dmPolicy,
-            pending_pairings_count: summary.pendingPairingsCount,
-            approved_users_count: summary.approvedUsersCount,
-            routes_count: summary.routesCount,
-          })),
+          channels: listChannelSummaries().map(mapChannelSummary),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1091,18 +1172,7 @@ async function handleChannelsProtocolCommand(
           type: "channel_get_config_response",
           request_id: parsed.request_id,
           success: true,
-          config: (() => {
-            const snapshot = getChannelConfigSnapshot(parsed.channel_id);
-            return snapshot
-              ? {
-                  channel_id: snapshot.channelId,
-                  enabled: snapshot.enabled,
-                  dm_policy: snapshot.dmPolicy,
-                  allowed_users: snapshot.allowedUsers,
-                  has_token: snapshot.hasToken,
-                }
-              : null;
-          })(),
+          config: mapChannelConfig(getChannelConfigSnapshot(parsed.channel_id)),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1130,7 +1200,12 @@ async function handleChannelsProtocolCommand(
   if (parsed.type === "channel_set_config") {
     try {
       const snapshot = await setChannelConfigLive(parsed.channel_id, {
-        token: parsed.config.token,
+        token: "token" in parsed.config ? parsed.config.token : undefined,
+        botToken:
+          "bot_token" in parsed.config ? parsed.config.bot_token : undefined,
+        appToken:
+          "app_token" in parsed.config ? parsed.config.app_token : undefined,
+        mode: "mode" in parsed.config ? parsed.config.mode : undefined,
         dmPolicy: parsed.config.dm_policy,
         allowedUsers: parsed.config.allowed_users,
       });
@@ -1150,13 +1225,7 @@ async function handleChannelsProtocolCommand(
           type: "channel_set_config_response",
           request_id: parsed.request_id,
           success: true,
-          config: {
-            channel_id: snapshot.channelId,
-            enabled: snapshot.enabled,
-            dm_policy: snapshot.dmPolicy,
-            allowed_users: snapshot.allowedUsers,
-            has_token: snapshot.hasToken,
-          },
+          config: mapChannelConfig(snapshot),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1197,17 +1266,7 @@ async function handleChannelsProtocolCommand(
           type: "channel_start_response",
           request_id: parsed.request_id,
           success: true,
-          channel: {
-            channel_id: summary.channelId,
-            display_name: summary.displayName,
-            configured: summary.configured,
-            enabled: summary.enabled,
-            running: summary.running,
-            dm_policy: summary.dmPolicy,
-            pending_pairings_count: summary.pendingPairingsCount,
-            approved_users_count: summary.approvedUsersCount,
-            routes_count: summary.routesCount,
-          },
+          channel: mapChannelSummary(summary),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1239,17 +1298,7 @@ async function handleChannelsProtocolCommand(
           type: "channel_stop_response",
           request_id: parsed.request_id,
           success: true,
-          channel: {
-            channel_id: summary.channelId,
-            display_name: summary.displayName,
-            configured: summary.configured,
-            enabled: summary.enabled,
-            running: summary.running,
-            dm_policy: summary.dmPolicy,
-            pending_pairings_count: summary.pendingPairingsCount,
-            approved_users_count: summary.approvedUsersCount,
-            routes_count: summary.routesCount,
-          },
+          channel: mapChannelSummary(summary),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1332,14 +1381,7 @@ async function handleChannelsProtocolCommand(
           success: true,
           channel_id: parsed.channel_id,
           chat_id: result.chatId,
-          route: {
-            channel_id: result.route.channelId,
-            chat_id: result.route.chatId,
-            agent_id: result.route.agentId,
-            conversation_id: result.route.conversationId,
-            enabled: result.route.enabled,
-            created_at: result.route.createdAt,
-          },
+          route: mapRouteSnapshot(result.route),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1383,14 +1425,7 @@ async function handleChannelsProtocolCommand(
             channelId,
             agentId: parsed.agent_id,
             conversationId: parsed.conversation_id,
-          }).map((route) => ({
-            channel_id: route.channelId,
-            chat_id: route.chatId,
-            agent_id: route.agentId,
-            conversation_id: route.conversationId,
-            enabled: route.enabled,
-            created_at: route.createdAt,
-          })),
+          }).map(mapRouteSnapshot),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1405,6 +1440,94 @@ async function handleChannelsProtocolCommand(
           channel_id: parsed.channel_id,
           routes: [],
           error: err instanceof Error ? err.message : "Failed to list routes",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_targets_list") {
+    try {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_targets_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          targets: listChannelTargetSnapshots(parsed.channel_id).map(
+            mapTargetSnapshot,
+          ),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_targets_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          targets: [],
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to list channel targets",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_target_bind") {
+    try {
+      const result = bindChannelTarget(
+        parsed.channel_id,
+        parsed.target_id,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_target_bind_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          target_id: parsed.target_id,
+          chat_id: result.chatId,
+          route: mapRouteSnapshot(result.route),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelTargetsUpdated(socket, parsed.channel_id);
+      emitChannelRoutesUpdated(socket, {
+        channelId: parsed.channel_id,
+        agentId: parsed.runtime.agent_id,
+        conversationId: parsed.runtime.conversation_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_target_bind_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          target_id: parsed.target_id,
+          route: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to bind channel target",
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1910,9 +2033,15 @@ function wireChannelIngress(
 
   registry.setEventHandler((event) => {
     if (event.type === "pairings_updated") {
-      emitChannelPairingsUpdated(socket, event.channelId as "telegram");
-      emitChannelsUpdated(socket, event.channelId as "telegram");
+      emitChannelPairingsUpdated(
+        socket,
+        event.channelId as "telegram" | "slack",
+      );
+      emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+      return;
     }
+    emitChannelTargetsUpdated(socket, event.channelId as "telegram" | "slack");
+    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
   });
 
   registry.setReady();
@@ -4075,6 +4204,8 @@ async function connectWithRetry(
         isChannelPairingsListCommand(parsed) ||
         isChannelPairingBindCommand(parsed) ||
         isChannelRoutesListCommand(parsed) ||
+        isChannelTargetsListCommand(parsed) ||
+        isChannelTargetBindCommand(parsed) ||
         isChannelRouteRemoveCommand(parsed)
       ) {
         runDetachedListenerTask("channels_command", async () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -247,6 +247,19 @@ import type {
   StartListenerOptions,
 } from "./types";
 
+type ChannelsServiceModule = typeof import("../../channels/service");
+
+let channelsServiceLoaderOverride:
+  | null
+  | (() => Promise<ChannelsServiceModule>) = null;
+
+async function loadChannelsService(): Promise<ChannelsServiceModule> {
+  if (channelsServiceLoaderOverride) {
+    return channelsServiceLoaderOverride();
+  }
+  return import("../../channels/service");
+}
+
 const WIKI_LINK_REGEX = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 
 function trackListenerError(
@@ -1068,7 +1081,7 @@ async function handleChannelsProtocolCommand(
     setChannelConfigLive,
     startChannelLive,
     stopChannelLive,
-  } = await import("../../channels/service");
+  } = await loadChannelsService();
 
   const mapChannelSummary = (
     summary: ReturnType<typeof listChannelSummaries>[number],
@@ -4838,6 +4851,11 @@ export { parseServerMessage } from "./protocol-inbound";
 export { emitInterruptedStatusDelta } from "./protocol-outbound";
 
 export const __listenClientTestUtils = {
+  setChannelsServiceLoaderForTests: (
+    loader: null | (() => Promise<ChannelsServiceModule>),
+  ) => {
+    channelsServiceLoaderOverride = loader;
+  },
   createRuntime: createLegacyTestRuntime,
   createListenerRuntime: createRuntime,
   handleModeChange,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -11,6 +11,8 @@ import type {
   ChannelStartCommand,
   ChannelStopCommand,
   ChannelsListCommand,
+  ChannelTargetBindCommand,
+  ChannelTargetsListCommand,
   CheckoutBranchCommand,
   CreateAgentCommand,
   CronAddCommand,
@@ -692,8 +694,8 @@ export function isSetReflectionSettingsCommand(
   );
 }
 
-function isChannelId(value: unknown): value is "telegram" {
-  return value === "telegram";
+function isChannelId(value: unknown): value is "telegram" | "slack" {
+  return value === "telegram" || value === "slack";
 }
 
 export function isChannelsListCommand(
@@ -739,20 +741,29 @@ export function isChannelSetConfigCommand(
   ) {
     return false;
   }
-  const config = c.config as {
-    token?: unknown;
-    dm_policy?: unknown;
-    allowed_users?: unknown;
-  };
+  const config = c.config as Record<string, unknown>;
+  const hasValidDmPolicy =
+    config.dm_policy === undefined ||
+    config.dm_policy === "pairing" ||
+    config.dm_policy === "allowlist" ||
+    config.dm_policy === "open";
+  const hasValidAllowedUsers =
+    config.allowed_users === undefined ||
+    (Array.isArray(config.allowed_users) &&
+      config.allowed_users.every((entry) => typeof entry === "string"));
+
+  if (!hasValidDmPolicy || !hasValidAllowedUsers) {
+    return false;
+  }
+
+  if (c.channel_id === "telegram") {
+    return config.token === undefined || typeof config.token === "string";
+  }
+
   return (
-    (config.token === undefined || typeof config.token === "string") &&
-    (config.dm_policy === undefined ||
-      config.dm_policy === "pairing" ||
-      config.dm_policy === "allowlist" ||
-      config.dm_policy === "open") &&
-    (config.allowed_users === undefined ||
-      (Array.isArray(config.allowed_users) &&
-        config.allowed_users.every((entry) => typeof entry === "string")))
+    (config.bot_token === undefined || typeof config.bot_token === "string") &&
+    (config.app_token === undefined || typeof config.app_token === "string") &&
+    (config.mode === undefined || config.mode === "socket")
   );
 }
 
@@ -864,6 +875,43 @@ export function isChannelRouteRemoveCommand(
   );
 }
 
+export function isChannelTargetsListCommand(
+  value: unknown,
+): value is ChannelTargetsListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_targets_list" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelTargetBindCommand(
+  value: unknown,
+): value is ChannelTargetBindCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    runtime?: unknown;
+    target_id?: unknown;
+  };
+  return (
+    c.type === "channel_target_bind" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    isRuntimeScope(c.runtime) &&
+    typeof c.target_id === "string" &&
+    c.target_id.length > 0
+  );
+}
+
 export function isSearchBranchesCommand(
   value: unknown,
 ): value is SearchBranchesCommand {
@@ -963,6 +1011,8 @@ export function parseServerMessage(
       isChannelPairingsListCommand(parsed) ||
       isChannelPairingBindCommand(parsed) ||
       isChannelRoutesListCommand(parsed) ||
+      isChannelTargetsListCommand(parsed) ||
+      isChannelTargetBindCommand(parsed) ||
       isChannelRouteRemoveCommand(parsed) ||
       isExecuteCommandCommand(parsed) ||
       isSearchBranchesCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add a Slack channel adapter using Slack Bolt socket mode, plus CLI setup for bot/app tokens
- add discovered Slack target storage/binding so channel mentions can be routed to agent conversations over WS
- extend the typed channels protocol with Slack config snapshots plus target list/bind commands and tests

## Notes
- This PR is stacked on top of #1762
- The current Slack flow supports DMs and app mentions in channels; unbound channel mentions are surfaced as bindable targets in the Channels control plane

## Testing
- bun test src/tests/channels/message-channel-formatting.test.ts src/tests/channels/xml.test.ts src/tests/channels/targets.test.ts src/tests/channels/slack-adapter.test.ts src/tests/websocket/listen-client-protocol.test.ts
- bun run lint
