### PR TITLE
fix(zai): route coding-plan providers through the dedicated endpoint

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -13,6 +13,14 @@ import { debugLog } from "../utils/debug";
 import { getModelContextWindow } from "./available-models";
 import { getClient } from "./client";
 
+function isZaiFamilyModel(modelHandle: string): boolean {
+  return (
+    modelHandle.startsWith("zai/") ||
+    modelHandle.startsWith("lc-zai/") ||
+    modelHandle.startsWith("lc-zai-coding/")
+  );
+}
+
 type ModelSettings =
   | OpenAIModelSettings
   | AnthropicModelSettings
@@ -36,7 +44,7 @@ function buildModelSettings(
     modelHandle.startsWith("anthropic/") ||
     modelHandle.startsWith("claude-pro-max/") ||
     modelHandle.startsWith("minimax/");
-  const isZai = modelHandle.startsWith("zai/");
+  const isZai = isZaiFamilyModel(modelHandle);
   const isGoogleAI = modelHandle.startsWith("google_ai/");
   const isGoogleVertex = modelHandle.startsWith("google_vertex/");
   const isOpenRouter = modelHandle.startsWith("openrouter/");

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -120,6 +120,7 @@ const BYOK_PROVIDER_TO_BASE: Record<string, string> = {
   "lc-anthropic": "anthropic",
   "lc-openai": "openai",
   "lc-zai": "zai",
+  "lc-zai-coding": "zai",
   "lc-gemini": "google_ai",
   "lc-openrouter": "openrouter",
   "lc-minimax": "minimax",

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -4,6 +4,7 @@
 import {
   checkProviderApiKey,
   createOrUpdateProvider,
+  getByokProviderBaseUrl,
   getProviderByName,
   removeProviderByName,
 } from "../../providers/byok-providers";
@@ -309,7 +310,14 @@ async function handleConnectApiKeyProvider(
   ctx.setCommandRunning(true);
 
   try {
-    await checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+    await checkProviderApiKey(
+      provider.byokProvider.providerType,
+      apiKey,
+      undefined,
+      undefined,
+      undefined,
+      getByokProviderBaseUrl(provider.byokId),
+    );
 
     updateCommandResult(
       ctx.buffersRef,
@@ -325,6 +333,10 @@ async function handleConnectApiKeyProvider(
       provider.byokProvider.providerType,
       provider.byokProvider.providerName,
       apiKey,
+      undefined,
+      undefined,
+      undefined,
+      getByokProviderBaseUrl(provider.byokId),
     );
 
     updateCommandResult(
@@ -425,6 +437,7 @@ async function handleConnectBedrock(
       method === "iam" ? parsed.accessKey : undefined,
       parsed.region,
       method === "profile" ? parsed.profile : undefined,
+      getByokProviderBaseUrl(provider.byokId),
     );
 
     updateCommandResult(
@@ -444,6 +457,7 @@ async function handleConnectBedrock(
       method === "iam" ? parsed.accessKey : undefined,
       parsed.region,
       method === "profile" ? parsed.profile : undefined,
+      getByokProviderBaseUrl(provider.byokId),
     );
 
     updateCommandResult(

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -6,6 +6,7 @@ import {
   type ByokProvider,
   checkProviderApiKey,
   createOrUpdateProvider,
+  getByokProviderBaseUrl,
   getConnectedProviders,
   type ProviderField,
   type ProviderResponse,
@@ -226,6 +227,10 @@ export function ProviderSelector({
           provider.providerType,
           provider.providerName,
           apiKeyInput.trim(),
+          undefined,
+          undefined,
+          undefined,
+          getByokProviderBaseUrl(provider.id),
         );
         // Refresh connected providers
         const providers = await getConnectedProviders();
@@ -251,7 +256,14 @@ export function ProviderSelector({
     setValidationError(null);
 
     try {
-      await checkProviderApiKey(provider.providerType, apiKeyInput.trim());
+      await checkProviderApiKey(
+        provider.providerType,
+        apiKeyInput.trim(),
+        undefined,
+        undefined,
+        undefined,
+        getByokProviderBaseUrl(provider.id),
+      );
       if (mountedRef.current) {
         setValidationState("valid");
       }
@@ -296,6 +308,7 @@ export function ProviderSelector({
           accessKey,
           region,
           profile,
+          getByokProviderBaseUrl(provider.id),
         );
         // Refresh connected providers
         const providers = await getConnectedProviders();
@@ -327,6 +340,7 @@ export function ProviderSelector({
         accessKey,
         region,
         profile,
+        getByokProviderBaseUrl(provider.id),
       );
       if (mountedRef.current) {
         setValidationState("valid");

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 import {
   checkProviderApiKey,
   createOrUpdateProvider,
+  getByokProviderBaseUrl,
 } from "../../providers/byok-providers";
 import { settingsManager } from "../../settings-manager";
 import { getErrorMessage } from "../../utils/error";
@@ -44,6 +45,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    baseUrl?: string,
   ) => Promise<void>;
   createOrUpdateProvider: (
     providerType: string,
@@ -52,6 +54,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    baseUrl?: string,
   ) => Promise<unknown>;
   isChatGPTOAuthConnected: () => Promise<boolean>;
   runChatGPTOAuthConnectFlow: (
@@ -242,6 +245,7 @@ export async function runConnectSubcommand(
         method === "iam" ? accessKey : undefined,
         region,
         method === "profile" ? profile : undefined,
+        getByokProviderBaseUrl(provider.byokId),
       );
 
       io.stdout("Saving provider...");
@@ -252,6 +256,7 @@ export async function runConnectSubcommand(
         method === "iam" ? accessKey : undefined,
         region,
         method === "profile" ? profile : undefined,
+        getByokProviderBaseUrl(provider.byokId),
       );
 
       io.stdout(
@@ -294,13 +299,24 @@ export async function runConnectSubcommand(
 
     try {
       io.stdout(`Validating ${provider.byokProvider.displayName} API key...`);
-      await io.checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+      await io.checkProviderApiKey(
+        provider.byokProvider.providerType,
+        apiKey,
+        undefined,
+        undefined,
+        undefined,
+        getByokProviderBaseUrl(provider.byokId),
+      );
 
       io.stdout("Saving provider...");
       await io.createOrUpdateProvider(
         provider.byokProvider.providerType,
         provider.byokProvider.providerName,
         apiKey,
+        undefined,
+        undefined,
+        undefined,
+        getByokProviderBaseUrl(provider.byokId),
       );
 
       io.stdout(

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -116,6 +116,8 @@ export const BYOK_PROVIDERS = [
   },
 ] as const;
 
+export const ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
+
 export type ByokProviderId = (typeof BYOK_PROVIDERS)[number]["id"];
 export type ByokProvider = (typeof BYOK_PROVIDERS)[number];
 
@@ -208,6 +210,17 @@ export interface ProviderResponse {
   base_url?: string;
   access_key?: string;
   region?: string;
+}
+
+export function getByokProviderBaseUrl(
+  providerId: ByokProviderId,
+): string | undefined {
+  switch (providerId) {
+    case "zai-coding":
+      return ZAI_CODING_BASE_URL;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -312,6 +325,7 @@ export async function checkProviderApiKey(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<void> {
   await providersRequest<{ message: string }>("POST", "/v1/providers/check", {
     provider_type: providerType,
@@ -319,6 +333,7 @@ export async function checkProviderApiKey(
     ...(accessKey && { access_key: accessKey }),
     ...(region && { region }),
     ...(profile && { profile }),
+    ...(baseUrl && { base_url: baseUrl }),
   });
 }
 
@@ -332,6 +347,7 @@ export async function createProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   return providersRequest<ProviderResponse>("POST", "/v1/providers", {
     name: providerName,
@@ -340,6 +356,7 @@ export async function createProvider(
     ...(accessKey && { access_key: accessKey }),
     ...(region && { region }),
     ...(profile && { profile }),
+    ...(baseUrl && { base_url: baseUrl }),
   });
 }
 
@@ -352,6 +369,7 @@ export async function updateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   return providersRequest<ProviderResponse>(
     "PATCH",
@@ -361,6 +379,7 @@ export async function updateProvider(
       ...(accessKey && { access_key: accessKey }),
       ...(region && { region }),
       ...(profile && { profile }),
+      ...(baseUrl && { base_url: baseUrl }),
     },
   );
 }
@@ -383,11 +402,19 @@ export async function createOrUpdateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   const existing = await getProviderByName(providerName);
 
   if (existing) {
-    return updateProvider(existing.id, apiKey, accessKey, region, profile);
+    return updateProvider(
+      existing.id,
+      apiKey,
+      accessKey,
+      region,
+      profile,
+      baseUrl,
+    );
   }
 
   return createProvider(
@@ -397,6 +424,7 @@ export async function createOrUpdateProvider(
     accessKey,
     region,
     profile,
+    baseUrl,
   );
 }
 

--- a/src/providers/zai-provider.ts
+++ b/src/providers/zai-provider.ts
@@ -2,114 +2,22 @@
  * Direct API calls to Letta for managing Zai provider
  */
 
-import { getLettaCodeHeaders } from "../agent/http-headers";
-import { LETTA_CLOUD_API_URL } from "../auth/oauth";
-import { settingsManager } from "../settings-manager";
+import {
+  createOrUpdateProvider,
+  getByokProviderBaseUrl,
+  getProviderByName,
+  type ProviderResponse,
+  removeProviderByName,
+} from "./byok-providers";
 
-// Provider name constant for Zai coding plan
+// Legacy wrapper around the shared BYOK provider flow for Z.ai coding plan.
 export const ZAI_PROVIDER_NAME = "zai-coding-plan";
-
-interface ProviderResponse {
-  id: string;
-  name: string;
-  provider_type: string;
-  api_key?: string;
-  base_url?: string;
-}
-
-/**
- * Get the Letta API base URL and auth token
- */
-async function getLettaConfig(): Promise<{ baseUrl: string; apiKey: string }> {
-  const settings = await settingsManager.getSettingsWithSecureTokens();
-  const baseUrl =
-    process.env.LETTA_BASE_URL ||
-    settings.env?.LETTA_BASE_URL ||
-    LETTA_CLOUD_API_URL;
-  const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY || "";
-  return { baseUrl, apiKey };
-}
-
-/**
- * Make a request to the Letta providers API
- */
-async function providersRequest<T>(
-  method: "GET" | "POST" | "PATCH" | "DELETE",
-  path: string,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  const { baseUrl, apiKey } = await getLettaConfig();
-  const url = `${baseUrl}${path}`;
-
-  const response = await fetch(url, {
-    method,
-    headers: getLettaCodeHeaders(apiKey),
-    ...(body && { body: JSON.stringify(body) }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Provider API error (${response.status}): ${errorText}`);
-  }
-
-  // Handle empty responses (e.g., DELETE)
-  const text = await response.text();
-  if (!text) {
-    return {} as T;
-  }
-  return JSON.parse(text) as T;
-}
-
-/**
- * List all providers
- */
-async function listProviders(): Promise<ProviderResponse[]> {
-  try {
-    const response = await providersRequest<ProviderResponse[]>(
-      "GET",
-      "/v1/providers",
-    );
-    return response;
-  } catch {
-    return [];
-  }
-}
 
 /**
  * Get the zai-coding-plan provider if it exists
  */
 export async function getZaiProvider(): Promise<ProviderResponse | null> {
-  const providers = await listProviders();
-  return providers.find((p) => p.name === ZAI_PROVIDER_NAME) || null;
-}
-
-/**
- * Create the Zai coding plan provider with the given API key
- */
-export async function createZaiProvider(
-  apiKey: string,
-): Promise<ProviderResponse> {
-  return providersRequest<ProviderResponse>("POST", "/v1/providers", {
-    name: ZAI_PROVIDER_NAME,
-    provider_type: "zai",
-    api_key: apiKey,
-  });
-}
-
-/**
- * Update an existing Zai provider with a new API key
- */
-export async function updateZaiProvider(
-  providerId: string,
-  apiKey: string,
-): Promise<ProviderResponse> {
-  return providersRequest<ProviderResponse>(
-    "PATCH",
-    `/v1/providers/${providerId}`,
-    {
-      api_key: apiKey,
-    },
-  );
+  return getProviderByName(ZAI_PROVIDER_NAME);
 }
 
 /**
@@ -120,28 +28,20 @@ export async function updateZaiProvider(
 export async function createOrUpdateZaiProvider(
   apiKey: string,
 ): Promise<ProviderResponse> {
-  const existing = await getZaiProvider();
-
-  if (existing) {
-    return updateZaiProvider(existing.id, apiKey);
-  }
-
-  return createZaiProvider(apiKey);
-}
-
-/**
- * Delete the Zai provider by ID
- */
-async function deleteZaiProvider(providerId: string): Promise<void> {
-  await providersRequest<void>("DELETE", `/v1/providers/${providerId}`);
+  return createOrUpdateProvider(
+    "zai_coding",
+    ZAI_PROVIDER_NAME,
+    apiKey,
+    undefined,
+    undefined,
+    undefined,
+    getByokProviderBaseUrl("zai-coding"),
+  );
 }
 
 /**
  * Remove the Zai provider (called on /disconnect zai)
  */
 export async function removeZaiProvider(): Promise<void> {
-  const existing = await getZaiProvider();
-  if (existing) {
-    await deleteZaiProvider(existing.id);
-  }
+  await removeProviderByName(ZAI_PROVIDER_NAME);
 }

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -201,6 +201,7 @@ describe("resolveSubagentModel", () => {
       { parentProvider: "lc-anthropic", baseProvider: "anthropic" },
       { parentProvider: "lc-openai", baseProvider: "openai" },
       { parentProvider: "lc-zai", baseProvider: "zai" },
+      { parentProvider: "lc-zai-coding", baseProvider: "zai" },
       { parentProvider: "lc-gemini", baseProvider: "google_ai" },
       { parentProvider: "lc-openrouter", baseProvider: "openrouter" },
       { parentProvider: "lc-minimax", baseProvider: "minimax" },

--- a/src/tests/cli/connect-subcommand.test.ts
+++ b/src/tests/cli/connect-subcommand.test.ts
@@ -50,11 +50,44 @@ describe("connect subcommand", () => {
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "anthropic",
       "sk-ant-123",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "anthropic",
       "lc-anthropic",
       "sk-ant-123",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  test("connects zAI coding plan with dedicated base URL", async () => {
+    const { deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(["zai-coding", "zk-123"], deps);
+
+    expect(exitCode).toBe(0);
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "zai_coding",
+      "zk-123",
+      undefined,
+      undefined,
+      undefined,
+      "https://api.z.ai/api/coding/paas/v4",
+    );
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "zai_coding",
+      "lc-zai-coding",
+      "zk-123",
+      undefined,
+      undefined,
+      undefined,
+      "https://api.z.ai/api/coding/paas/v4",
     );
   });
 
@@ -79,6 +112,10 @@ describe("connect subcommand", () => {
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "google_ai",
       "prompted-key",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
     );
   });
 

--- a/src/tests/providers/byok-provider-aliases.test.ts
+++ b/src/tests/providers/byok-provider-aliases.test.ts
@@ -21,6 +21,7 @@ describe("buildByokProviderAliases", () => {
     expect(aliases["lc-anthropic"]).toBe("anthropic");
     expect(aliases["lc-openai"]).toBe("openai");
     expect(aliases["lc-zai"]).toBe("zai");
+    expect(aliases["lc-zai-coding"]).toBe("zai");
     expect(aliases["lc-gemini"]).toBe("google_ai");
     expect(aliases["lc-minimax"]).toBe("minimax");
     expect(aliases["lc-openrouter"]).toBe("openrouter");
@@ -73,6 +74,9 @@ describe("isByokHandleForSelector", () => {
   test("matches lc-* prefix", () => {
     expect(
       isByokHandleForSelector("lc-anthropic/claude-sonnet-4", defaultAliases),
+    ).toBe(true);
+    expect(
+      isByokHandleForSelector("lc-zai-coding/glm-5.1", defaultAliases),
     ).toBe(true);
   });
 

--- a/src/tests/providers/zai-provider-base-url.test.ts
+++ b/src/tests/providers/zai-provider-base-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getByokProviderBaseUrl,
+  ZAI_CODING_BASE_URL,
+} from "../../providers/byok-providers";
+
+describe("getByokProviderBaseUrl", () => {
+  test("returns dedicated coding endpoint for zai-coding", () => {
+    expect(getByokProviderBaseUrl("zai-coding")).toBe(ZAI_CODING_BASE_URL);
+  });
+
+  test("returns undefined for providers without a custom base URL", () => {
+    expect(getByokProviderBaseUrl("zai")).toBeUndefined();
+    expect(getByokProviderBaseUrl("anthropic")).toBeUndefined();
+  });
+});

--- a/src/tests/tools/model-provider-detection.test.ts
+++ b/src/tests/tools/model-provider-detection.test.ts
@@ -25,6 +25,11 @@ describe("isOpenAIModel", () => {
     expect(isOpenAIModel("anthropic/claude-sonnet-4-6")).toBe(false);
   });
 
+  test("does not detect zAI coding-plan handles as openai models", () => {
+    expect(isOpenAIModel("lc-zai-coding/glm-5.1")).toBe(false);
+    expect(isOpenAIModel("zai/glm-5.1")).toBe(false);
+  });
+
   test("does not detect auto model ids/handles", () => {
     expect(isOpenAIModel("auto")).toBe(false);
     expect(isOpenAIModel("letta/auto")).toBe(false);


### PR DESCRIPTION
## Summary
- wire zAI Coding Plan provider validation and persistence through the dedicated `https://api.z.ai/api/coding/paas/v4` endpoint
- treat `lc-zai-coding/*` handles as Z.ai-family models so model updates and subagent inheritance do not fall back to generic OpenAI-compatible plumbing
- add targeted regression tests for connect flows, BYOK aliases, provider base URL mapping, and subagent model resolution

## Test plan
- [x] `bun test src/tests/cli/connect-subcommand.test.ts src/tests/providers/byok-provider-aliases.test.ts src/tests/providers/zai-provider-base-url.test.ts src/tests/agent/subagent-model-resolution.test.ts src/tests/tools/model-provider-detection.test.ts --timeout 20000`
- [x] `bun run build`
- [ ] manually connect `zai-coding` in the built CLI and select `lc-zai-coding/glm-5.1`

👾 Generated with [Letta Code](https://letta.com)