### PR TITLE
feat(subagents): enable recursive delegation — Phase 1

### DIFF
--- a/docs/bootstrap-prompt.md
+++ b/docs/bootstrap-prompt.md
@@ -1,0 +1,120 @@
+# Bootstrap Prompt — Session 0: Orientation
+
+Paste this into Letta Code after running `/init` on the letta-code repo.
+
+---
+
+## The Prompt
+
+```
+Read the design doc at docs/recursive-session-experiment.md carefully. This is a plan to build recursive session decomposition on top of Letta Code itself — enabling agents to recursively break down coding tasks into sub-sessions, each with their own context, and learn which decomposition strategies work over time through persistent memory.
+
+We're going to build this system together using the approach it describes. I'll act as the "pilot" — manually decomposing the implementation into phases and subtasks, delegating work to you, and capturing what we learn along the way. By the time we're done building it, your memory will already contain the decomposition strategies, codebase knowledge, and implementation skills — because we'll generate them as we go.
+
+Before we start building, I need you to:
+
+1. Read through the full design doc and summarize your understanding of what we're building and why.
+
+2. Assess the Letta Code codebase for feasibility. Specifically:
+   - Where is the Task tool's delegation depth limit enforced? What file, what line?
+   - How does the Task tool currently spawn sub-agents? What's the call chain?
+   - How is budget/token tracking handled for delegated tasks?
+   - What's the current depth limit, and what mechanism enforces it?
+   - Are there any other constraints that would block recursive delegation?
+
+3. Identify the key files we'll need to modify for Phase 1 (enabling recursive delegation). Give me a concrete file list with what needs to change in each.
+
+4. Flag anything in the design doc that seems wrong or impractical given what you've now learned about the codebase. Push back on anything that won't work.
+
+After this, I'll use /remember to capture your findings in memory, and we'll start Phase 1 by decomposing it into subtasks together.
+```
+
+---
+
+## After the agent responds, run:
+
+```
+/remember The agent analyzed the letta-code codebase for recursive delegation feasibility. Key files identified: [paste the files it found]. Depth limit is enforced in [location]. The approach [is/isn't] feasible because [reasons]. Concerns raised: [any pushback].
+```
+
+Then move to Session 1 by decomposing Phase 1 based on what it found. The design doc has the subtask breakdown, but adapt it based on the agent's actual findings about the codebase — the agent knows its own internals better than our plan does.
+
+---
+
+## Session 1 Prompt Template
+
+After Session 0's /remember, start a new conversation (/clear) and:
+
+```
+We're building recursive session decomposition on top of Letta Code. Check your memory for the codebase analysis from our last session — you identified the key files and the delegation depth limit location.
+
+Phase 1 is enabling recursive delegation. I'm going to decompose this into subtasks and delegate them to you one at a time. After each subtask, I'll capture what we learned.
+
+Subtask 1A: [adapted based on Session 0 findings]
+
+Go.
+```
+
+After each subtask completes:
+```
+/remember [what worked, what was harder than expected, key decisions made]
+```
+
+After all Phase 1 subtasks:
+```
+/skill Learn from this session how to patch Letta Code's delegation internals. Capture: which files we touched, what the constraints were, what patterns to follow when modifying the tool dispatch chain.
+```
+
+---
+
+## Session 2 Prompt Template
+
+```
+We completed Phase 1 — recursive delegation is enabled. Check your memory for what we learned. Now we're building Phase 2: the decomposition skill and pilot prompt.
+
+I'm decomposing this phase into subtasks:
+
+Subtask 2A: Create the recursive-session skill. Read the SKILL.md template in the design doc (docs/recursive-session-experiment.md, "The Recursive Decomposition Skill" section). Write it to .skills/recursive-session/SKILL.md. Adapt the decomposition patterns based on what you've learned about this codebase specifically.
+
+Go.
+```
+
+---
+
+## Session 3 Prompt Template
+
+```
+Phase 1 (recursive delegation) and Phase 2 (decomposition skill + pilot prompt) are done. Check your memory for accumulated learnings.
+
+Phase 3: Memory-based learning. We need to build the sleep-time consolidation mechanism — a way for you to review your session history and update your memory/system/*.md files with generalizable strategies.
+
+I'm decomposing this:
+
+Subtask 3A: Write a consolidation prompt that, when given to you between sessions, causes you to review recent work and update your memory. The prompt should focus on: what decomposition strategies worked, what codebase knowledge to persist, what patterns to generalize. Save it to docs/consolidation-prompt.md.
+
+Go.
+```
+
+---
+
+## Session 4: The Handoff
+
+```
+We've built the recursive decomposition system together across 4 sessions. Your memory now contains codebase knowledge, decomposition strategies, and implementation skills accumulated through the process.
+
+It's time for you to be the pilot.
+
+Review your memory/system/decomposition.md. For the task I'm about to give you, decide:
+- Should you do it directly?
+- Should you delegate flat (single level)?
+- Should you recursively decompose into sub-sessions?
+
+Explain your reasoning, then execute your plan.
+
+The task: [give it a real multi-file coding task on this repo or another project]
+```
+
+After observing:
+```
+/remember How the handoff went. Did the agent decompose well? What knowledge was missing? What would make the next handoff smoother?
+```

--- a/docs/recursive-session-autopilot-log.md
+++ b/docs/recursive-session-autopilot-log.md
@@ -1,0 +1,82 @@
+# Recursive Session Experiment — Autopilot Log
+
+This document records autonomous decisions, progress, and audit notes from the autopilot execution of the remaining experiment phases.
+
+---
+
+## Phase 1: Enable Recursive Delegation
+
+**Status:** Complete
+
+### Goals
+- Enable intentional recursive delegation in Letta Code
+- Add explicit depth tracking with a configurable safety limit
+- Add advisory budget propagation
+- Add regression tests for recursion and guardrails
+
+### Implementation Summary
+
+1. **Recursion policy (1B):** Added `Task` tool to `general-purpose` and `fork` built-in subagent configs. Kept `explore` non-recursive. Left other built-ins unchanged.
+
+2. **Depth tracking + safety limit (1C):** Added three env-based metadata variables propagated through the child process spawn path:
+   - `LETTA_TASK_DEPTH` — current recursion depth (incremented on each spawn)
+   - `LETTA_TASK_MAX_DEPTH` — configurable cap (defaults to 5)
+   - Enforcement in `Task.ts` rejects delegation when depth >= max depth
+
+3. **Budget propagation (1D):** Added advisory budget model:
+   - `LETTA_TASK_BUDGET_TOKENS` propagated through child env
+   - Explicit `budget_tokens` parameter on Task schema to override inherited budget
+   - Budget and depth metadata surfaced in transcript headers and result headers
+   - No hard budget enforcement in Phase 1
+
+4. **Tests (1E):** Added targeted tests in three files:
+   - `src/tests/agent/subagent-builtins.test.ts` — recursive delegation tool policy
+   - `src/tests/agent/subagent-model-resolution.test.ts` — child env propagation, depth, budget
+   - `src/tests/tools/task-recursion.test.ts` — recursion metadata derivation and limit enforcement
+
+### Autonomous Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Env-based metadata over CLI args | Subagents are spawned as child processes; env is already the mechanism for runtime context propagation |
+| Default max depth of 5 | Matches the design doc template; conservative enough to prevent runaway recursion while allowing meaningful decomposition |
+| Advisory-only budget for Phase 1 | Full tree accounting and hard enforcement are out of scope; advisory budget gives the model information to make decisions without adding complex cross-process state |
+| `buildSubagentChildEnv` extraction | The original inline env construction in `executeSubagent` was growing; extracting it into a testable pure function improved both clarity and testability |
+| Keep `build.js` changes separate | The `build.js` diff (target: bun, shebang change) is unrelated to this experiment and should not be included in the Phase 1 commit |
+
+### Validation
+- All targeted tests pass (39 tests across 3 files)
+- `bun run typecheck` passes
+
+### Files Changed
+- `src/agent/subagents/builtin/general-purpose.md` — added Task to tools
+- `src/agent/subagents/builtin/fork.md` — added Task to tools
+- `src/agent/subagents/manager.ts` — depth/budget env helpers, `buildSubagentChildEnv`, `budgetTokens` param threading
+- `src/tools/impl/Task.ts` — recursion check, metadata helpers, depth/budget in headers/transcripts
+- `src/tools/schemas/Task.json` — `budget_tokens` property
+- `src/tools/descriptions/Task.md` — recursion + budget docs
+- `src/tests/agent/subagent-builtins.test.ts` — recursion policy test
+- `src/tests/agent/subagent-model-resolution.test.ts` — child env tests
+- `src/tests/tools/task-recursion.test.ts` — new recursion metadata tests
+
+---
+
+## Phase 2: Decomposition Skill + Pilot Prompt
+
+**Status:** Pending
+
+### Goals
+- Create the recursive-session SKILL.md
+- Write pilot identity and decomposition memory seeds
+- Test decomposition decision framework
+
+---
+
+## Phase 3: Memory-Based Learning
+
+**Status:** Pending
+
+### Goals
+- Build sleep-time consolidation prompt
+- Wire as post-session hook or command
+- Test that memory evolves across sessions

--- a/docs/recursive-session-experiment.md
+++ b/docs/recursive-session-experiment.md
@@ -1,0 +1,552 @@
+# Recursive Session Decomposition: Design Doc
+
+**Date:** 2026-04-10
+**Status:** Proposal
+**Context:** Belayer v6 runtime experiment, validated against landscape research
+
+---
+
+## The Thesis
+
+The Mismanaged Geniuses Hypothesis (MGH) posits that frontier language models are severely underutilized due to sub-optimal decomposition of tasks. The next leap in capabilities comes not from scaling models, but from enabling models to **manage themselves** — natively decomposing tasks and acting on those decompositions.
+
+The space of decompositions available to the orchestrator determines what problems the system can solve, with exponential impact relative to recursion depth. Current coding agents cap delegation at depth 1-2, preventing recursive decomposition.
+
+**This experiment tests:** Can a persistent, memory-equipped coding agent learn to recursively decompose coding tasks into sub-sessions, and does this produce better results than flat delegation? Does the agent improve its decomposition strategies over time through memory?
+
+---
+
+## Landscape Context
+
+### What Exists Today
+
+We surveyed the full multi-agent coding runtime landscape (April 2026). Key findings:
+
+**Nobody covers all six runtime interfaces.** Belayer's philosophy defines six infrastructure interfaces (Session, Orchestration, Sandbox, Communication, Memory, Tools). The closest framework is Scion (Google, 4/6 partial), but it's one month old with no memory story.
+
+**The industry splits into three tiers:**
+- Orchestration frameworks (CrewAI, AutoGen, LangGraph) — strong orchestration/tools, weak sandbox/communication
+- Coding agent tools (SWE-agent, Aider, OpenHands) — strong tools, single-agent
+- Infrastructure primitives (E2B, Daytona) — exceptional sandboxing, zero agent logic
+
+**Every framework caps delegation at depth 1-2:**
+- Claude Code Agent tool: depth 1 (subagents cannot spawn subagents)
+- Hermes Agent delegate_task: depth 2 hard cap
+- OpenClaw sessions_spawn: depth 2 (depth-2+ agents don't get spawn capability)
+- Anthropic Managed Agents: 1 level ("agents cannot call agents of their own")
+- Letta Code Task tool: depth-limited
+
+**The only exception:** Scion uses emergent CLI-based spawning (agents learn to invoke `scion start`), enabling unbounded recursion. This validates the approach.
+
+### Key Architectural Patterns Discovered
+
+**OpenClaw ecosystem (354K stars):** Personal AI gateway spawning orchestration derivatives. ClawTeam-OpenClaw (tmux/worktrees, leader-worker), HiClaw (Matrix rooms, credential isolation), Clawith (persistent agent identity via `soul.md`).
+
+**Oh-My-OpenAgent (50K stars):** Multi-model orchestration plugin on OpenClaw. Category-based model routing (semantic intent, not model name). Prometheus interview-based planning. Atlas conductor with wisdom accumulation. Reply listeners bridge tmux to Discord/Telegram for "building in public" observability.
+
+**Hermes Agent (52K stars, Nous Research):** Research-grade agent with 48 tools, 6 sandbox backends (Docker, SSH, Daytona, Modal, Singularity), 18+ LLM providers, RL training pipeline (Atropos). Memory is bolted together: MEMORY.md (2,200 chars) + 8 external provider plugins.
+
+**Letta Code (2.2K stars):** Memory-first coding agent. Three-tier memory (core/progressive/recall), git-backed, agent-managed via standard file tools. Agent identity = git repo. Skill learning writes procedures into memory. This is the architecture closest to what we need.
+
+### The Tool Protocol Landscape
+
+MCP is NOT the universal default despite 97M downloads. Evidence shows:
+- MCP tool schemas consume 3.25x-236.5x more tokens (MCPGAUGE academic study)
+- Perplexity CTO reported 72% context consumed by 3 MCP servers
+- CLI is 10-32x cheaper and 100% reliable vs 72% for MCP (Scalekit benchmark)
+- Vercel proved 8KB AGENTS.md (100% eval score) outperforms dynamic skill loading (79%)
+
+The industry is converging on a **five-layer model:**
+1. Always-in-context markdown (AGENTS.md / CLAUDE.md) — ~8KB, always loaded
+2. On-demand skills (SKILL.md, agentskills.io standard) — ~100 tokens metadata, loaded when needed
+3. CLI tools via bash — zero additional context cost, LLMs already know Unix
+4. MCP for dynamic discovery / enterprise / compliance — justified overhead
+5. Skill-embedded MCPs — scoped to task, spun up on demand, evicted when done
+
+### Ten Points of Industry Consensus
+
+1. Session is the primitive, not the conversation
+2. Sandboxing is non-negotiable for autonomous operation
+3. Three-tier memory (episodic/semantic/procedural) is the consensus model
+4. The pilot must be an LLM, not a state machine
+5. Git worktrees are the isolation primitive for parallel coding
+6. Verification is the bottleneck, not generation
+7. Context engineering > prompt engineering
+8. Peer messaging beats hub-and-spoke for coordination
+9. Skills/learnings as `.md` files in git is the persistence pattern
+10. Sleep-time compute is the frontier
+
+---
+
+## Why Letta Code
+
+### The Right Brain, Add Hands Later
+
+| Dimension | Why Letta Code Wins |
+|-----------|-------------------|
+| **Memory model** | Native three-tier (core/progressive/recall), git-backed, agent-managed via file tools. Exactly matches Belayer's spec. |
+| **Agent identity** | Agent = git repo of memory files. `git clone` = clone the agent. Matches Belayer's "agent identity is portable." |
+| **Skill learning** | Skills are memory files the agent writes. No separate mechanism. Unified model. |
+| **Memory management** | Agent uses Read/Write/Edit on memory — same tools as code. No special API, no character limits. |
+| **Git-backed versioning** | Rollback, conflict resolution, audit trail — all free via git. |
+| **System prompt** | "Your ability to edit and curate your own long-term memory is what makes you more than a stateless tool." The right framing. |
+
+### What's Missing (And How To Address It)
+
+| Gap | Severity | Solution |
+|-----|----------|----------|
+| Subagent depth limit | **Critical** (blocks the experiment) | Patch Task tool to remove depth cap, or build `session.create` tool |
+| No sandboxing | Medium (not needed for initial experiment) | Add Docker wrapper around Bash tool later |
+| No structured event log | Medium | Append events to a session log file in memory |
+| No sleep-time compute | Medium (build it) | Post-session hook or cron that triggers memory consolidation |
+| Basic tool set | Low | Standard coding tools are sufficient; add MCP/CLI tools as needed |
+| CLI only (no Discord/Telegram) | Low | Add later; terminal observability sufficient for experiment |
+
+---
+
+## The Experiment Design
+
+### What We're Testing
+
+**H1:** Recursive decomposition produces better results than flat delegation for multi-file/multi-package coding tasks.
+
+**H2:** A persistent agent that writes decomposition strategies to its own memory improves its decomposition quality over N sessions.
+
+**H3:** The six decomposition primitives (session.create, session.events, message.send, memory.read/write, sandbox.exec, tool.invoke) are sufficient to express any multi-agent coding workflow.
+
+### Architecture
+
+```
+Letta Code Agent (Pilot)
+├── Identity: ~/.letta/agents/{pilot-id}/memory/
+│   ├── system/
+│   │   ├── identity.md          ← "I am a recursive decomposition pilot"
+│   │   ├── decomposition.md     ← learned decomposition strategies
+│   │   └── codebase.md          ← project knowledge
+│   ├── skills/
+│   │   └── recursive-session/
+│   │       └── SKILL.md         ← the recursive decomposition procedure
+│   └── sessions/
+│       └── {session-log}.md     ← event history for learning
+│
+├── Tools:
+│   ├── Standard: Read, Write, Edit, Bash, Grep, Glob
+│   ├── Task (patched): spawn sub-agents, NO depth limit
+│   ├── Skill: load learned procedures
+│   └── NEW — session.create: spawn a new Letta agent with inherited memory
+│
+└── Decomposition Flow:
+    1. Receive task
+    2. Check memory/system/decomposition.md for known strategies
+    3. Analyze task shape (single-file? cross-package? needs review?)
+    4. Decide: do directly, flat delegate, or recursive decompose
+    5. If recursive: create sub-sessions via Task tool
+    6. Collect results, verify, integrate
+    7. Write learnings to memory
+```
+
+### The Template Concept
+
+A template defines the **decomposition space** — what the pilot has access to — not the agents themselves:
+
+```yaml
+template: recursive-implement
+pilot:
+  model: opus
+  memory: inherited from parent + session-specific additions
+  primitives:
+    - task.create        # spawn sub-agents (recursion primitive)
+    - memory.write       # persist learnings
+    - skill.invoke       # load learned procedures
+  constraints:
+    max_depth: 5         # safety valve
+    max_concurrent: 3    # resource limit
+    budget: configurable # token budget per session
+```
+
+The pilot decides everything else: team composition, task decomposition, recursion depth, which sub-tasks need their own sub-pilots.
+
+### The Recursive Decomposition Skill
+
+The initial skill that teaches the pilot how to decompose:
+
+```markdown
+# SKILL.md — recursive-session
+
+## When to Use
+When a task spans multiple files, packages, or concerns that can be
+worked on independently. When flat delegation would lose context
+that a sub-pilot could maintain.
+
+## Decision Framework
+1. Can this task be completed in < 50 tool calls? → Do it directly
+2. Can it be split into 2-5 independent subtasks? → Flat delegate via Task
+3. Does any subtask itself need decomposition? → Recursive: create sub-session
+   with its own pilot that can further decompose
+
+## Decomposition Patterns
+### By Package/Module
+Split cross-package work into one sub-session per package.
+Each sub-session gets the package context + the interface contract.
+
+### By Concern (Implement/Review/Test)
+One sub-session implements, another reviews with fresh eyes,
+a third writes tests. Review sub-session gets NO implementation context.
+
+### By Complexity
+Simple subtasks → direct Task delegation (sonnet, low budget)
+Complex subtasks → recursive sub-session with own pilot (opus, higher budget)
+
+## Result Integration
+After sub-sessions complete:
+1. Read all results
+2. Check for consistency across sub-sessions
+3. If conflicts: create a reconciliation sub-session
+4. Write integration learnings to memory/system/decomposition.md
+
+## What To Remember
+After each session, update memory with:
+- Which decomposition pattern worked for this task shape
+- What went wrong and how it was fixed
+- Any new patterns discovered
+```
+
+### Sleep-Time Compute
+
+Between sessions, a consolidation pass reviews the agent's session history and updates memory:
+
+```
+Trigger: post-session hook or manual /remember command
+
+The consolidation prompt:
+"Review your recent session events. Update your memory:
+ - system/decomposition.md: What decomposition strategies worked? What failed?
+ - system/codebase.md: What did you learn about the codebase?
+ - system/patterns.md: What patterns should you remember?
+ 
+ Consolidate raw observations into generalizable strategies.
+ Remove stale facts. Strengthen what's proven useful."
+```
+
+This runs as the same Letta agent with a special system prompt focused on memory curation rather than coding. The agent reviews its own history and updates its own files.
+
+### Evaluation
+
+**Benchmark task set:** 5-10 coding tasks of increasing complexity:
+1. Single-file bug fix (baseline — should NOT decompose)
+2. Multi-file refactor within one package
+3. Feature spanning 3 packages with shared interfaces
+4. Full-stack feature (API + frontend + database + tests)
+5. Cross-repo dependency update
+
+**Comparison conditions:**
+- A: Single agent, no delegation (baseline)
+- B: Single agent with flat delegation (depth 1, current Letta Code)
+- C: Single agent with recursive decomposition (this experiment)
+- D: Same as C, but with 5 prior sessions of memory accumulation
+
+**Metrics:**
+- Task completion rate
+- Code quality (lint, type errors, test pass rate)
+- Token usage
+- Time to completion
+- Number of human interventions required
+- Decomposition depth used per task
+
+---
+
+## Implementation Plan
+
+### Phase 0: Bootstrap — Build The System Using The Approach (Day 0)
+
+**The meta-insight:** Use manual recursive decomposition to build the automated recursive decomposition system. You (the human) act as the pilot. Letta Code is the worker. The process itself validates the approach and seeds the agent's memory with real decomposition knowledge.
+
+**Why this matters:**
+- By the time the system is built, the agent's memory already contains decomposition strategies, codebase knowledge, and implementation skills — generated during the build process itself
+- You experience the pilot role firsthand, informing the automated pilot's prompt design
+- The agent learns its own codebase via `/init`, then learns how it was built via accumulated session memory
+- Every `/remember` and `/skill` call during the build becomes training data for the agent's future behavior
+
+**The bootstrap protocol:**
+
+```
+SESSION 0: Orientation
+  1. Start Letta Code in the letta-code repo
+  2. Run /init — let the agent deeply explore its own codebase
+  3. Feed it the design doc: "Read docs/recursive-session-experiment.md"
+  4. Ask it to assess feasibility and identify the key files to modify
+  5. /remember — capture what it learned about its own architecture
+
+SESSION 1: Phase 1 — Enable Recursive Delegation
+  YOU (acting as pilot) decompose Phase 1:
+    Subtask 1A: "Correct the runtime model: verify the current Task pipeline.
+                 Confirm whether there is a real depth cap vs a tool-availability cap,
+                 and trace the spawn path through Task.ts and subagents/manager.ts."
+    Subtask 1B: "Enable recursive delegation intentionally.
+                 Update the built-in subagent configs that should be able to recurse
+                 so they can access Task, instead of assuming a hidden depth guard exists."
+    Subtask 1C: "Add explicit recursion metadata.
+                 Pass delegation depth through the spawn path (env and/or args),
+                 surface it to child sessions, and enforce a configurable safety limit."
+    Subtask 1D: "Add budget propagation.
+                 Define a real delegated-budget mechanism, since the current code only
+                 reports per-subagent token usage and does not enforce a tree budget."
+    Subtask 1E: "Write end-to-end tests.
+                 Prove that a pilot can spawn a sub-agent that spawns a sub-agent,
+                 and that depth/budget guardrails fail safely when limits are exceeded."
+  
+  Delegate each subtask (via Task tool or sequential prompting).
+  After each: /remember what worked, what was harder than expected.
+  After all: /skill to capture "how to patch Letta Code internals"
+
+SESSION 2: Phase 2 — Decomposition Skill + Pilot Prompt
+  YOU decompose Phase 2:
+    Subtask 2A: "Create .skills/recursive-session/SKILL.md with the
+                 decomposition decision framework from the design doc."
+    Subtask 2B: "Write initial memory/system/identity.md for the pilot persona."
+    Subtask 2C: "Write initial memory/system/decomposition.md with seed strategies."
+    Subtask 2D: "Test: give the pilot a multi-package task. Does it decompose correctly?"
+  
+  /remember decomposition learnings after each subtask.
+  /skill to capture "how to write effective decomposition skills"
+
+SESSION 3: Phase 3 — Memory-Based Learning
+  YOU decompose Phase 3:
+    Subtask 3A: "Build sleep-time consolidation prompt (see design doc)."
+    Subtask 3B: "Wire it as a post-session hook or /consolidate command."
+    Subtask 3C: "Run 3 test sessions. Verify memory/system/decomposition.md evolves."
+  
+  /remember what the consolidation process needs to capture.
+  /skill to capture "how to design sleep-time prompts"
+
+SESSION 4: Handoff — The Agent Becomes Its Own Pilot
+  Feed the agent: "You now have enough memory and skills to act as the pilot
+  yourself. Review your memory/system/decomposition.md. For the next task I
+  give you, decide whether to do it directly, delegate flat, or recursively
+  decompose. Explain your reasoning, then execute."
+  
+  Give it a real multi-file task. Observe whether it decomposes well.
+  /remember how the handoff went — what knowledge was missing?
+```
+
+**What the agent's memory looks like after bootstrap:**
+
+```
+~/.letta/agents/{pilot-id}/memory/
+├── system/
+│   ├── identity.md          ← "I am a recursive decomposition pilot..."
+│   ├── decomposition.md     ← strategies learned during bootstrap sessions
+│   ├── codebase.md          ← deep knowledge of letta-code internals
+│   └── patterns.md          ← "Task tool depth is in src/tools/...",
+│                               "budget propagation formula is...", etc.
+├── skills/
+│   ├── recursive-session/
+│   │   └── SKILL.md         ← the decomposition procedure
+│   ├── patching-letta-internals/
+│   │   └── SKILL.md         ← learned during Session 1
+│   ├── writing-skills/
+│   │   └── SKILL.md         ← learned during Session 2
+│   └── sleep-time-design/
+│       └── SKILL.md         ← learned during Session 3
+└── sessions/
+    └── bootstrap-log.md     ← what happened across all bootstrap sessions
+```
+
+The agent built itself, and its memory is the proof.
+
+---
+
+### Phase 1: Enable Recursive Delegation (Days 1-2)
+
+1. Correct the assumption in the design: there is no explicit Task depth cap today; the practical blocker is that built-in subagents do not have the `Task` tool in their `tools:` lists.
+2. Decide which built-in subagent types should be allowed to recurse, and update their configs accordingly.
+3. Add explicit depth tracking so each sub-agent knows its delegation depth.
+4. Enforce a configurable recursion safety limit in the Task/subagent spawn path.
+5. Add real budget propagation and clarify whether it is advisory reporting, enforced budgeting, or both.
+6. Test: can a pilot spawn a sub-agent that spawns a sub-agent, and do guardrails behave correctly?
+
+#### Session 1 execution notes
+
+The pilot should own the trunk plan. It should not immediately dump raw subtasks onto child agents and ask them to plan everything themselves. The point of the pilot is to preserve the shape of the problem, choose boundaries, define contracts, and integrate results.
+
+That said, the pilot also should not pretend it already understands the whole task when it does not. Before decomposing, it should run a short orientation pass:
+
+1. What is the task shape?
+2. Do I understand the relevant code paths and boundaries?
+3. Do I know what success looks like?
+4. If not, what kind of additional session would reduce uncertainty fastest?
+
+The orchestration interface should stay capability-based and evolvable, not hardcoded around fixed roles like `helper`, `worker`, or `sub-pilot`. Those are useful design labels, but they should describe how the model is using a session, not freeze the runtime API.
+
+For now, the pilot should think in terms of flexible session capabilities:
+
+- `session.inspect` — lightweight orientation before committing to a plan
+- `session.map` — build a dependency/workstream map for the whole task
+- `session.create` — create another session with a chosen context envelope, tool access, and mission
+- `session.message` / `session.result` — pass contracts, findings, and completion payloads between sessions
+- `session.verify` — run validation or request an independent verification pass
+- `memory.read` / `memory.write` — incorporate and store decomposition learnings
+
+Those capabilities can be emulated initially with prompts and the existing Task tool. The important point is that the model should reason about what kind of session it needs, rather than selecting from a rigid role taxonomy.
+
+#### Session 1 decomposition using the approach itself
+
+| Subtask | Session shape | Why |
+|---|---|---|
+| 1A Correct runtime model | Direct + reconnaissance session | Core architectural understanding stays with the pilot; a read-oriented child session can gather references |
+| 1B Enable recursion intentionally | Direct | This is a safety/product boundary decision about which built-ins may recurse |
+| 1C Depth tracking + safety limit | Execution session | Once the contract is defined, this becomes bounded implementation work |
+| 1D Budget propagation | Recursive planning session | This needs local design choices, not just plumbing |
+| 1E End-to-end tests | Execution session | Clear implementation and acceptance criteria after earlier design work settles |
+
+#### Session 1 per-subtask implementation notes
+
+**1A — Correct the runtime model and trace the current pipeline**
+
+- Goal:
+  - confirm there is no explicit numeric depth cap today
+  - confirm the real recursion gate is tool availability in built-in subagent configs
+  - trace the exact spawn and token-reporting path
+- Files to inspect:
+  - `src/tools/impl/Task.ts`
+  - `src/agent/subagents/manager.ts`
+  - `src/agent/subagents/builtin/*.md`
+  - `src/tools/impl/process_manager.ts`
+- Deliverable:
+  - corrected architectural brief for Phase 1
+
+**1B — Enable recursive delegation intentionally via tool access**
+
+- Goal:
+  - move from accidental/custom recursion to deliberate recursion policy
+- Likely scope:
+  - audit `src/agent/subagents/builtin/*.md`
+  - decide which built-in types should get `Task`
+  - confirm permission implications through the existing `--tools` and `--allowedTools` flow
+- Initial recommendation:
+  - allow recursion for `general-purpose`
+  - consider `fork` if forked-context recursion is desired
+  - keep `explore` non-recursive
+- Deliverable:
+  - explicit recursion policy encoded in built-in subagent configs
+
+**1C — Add explicit depth tracking and configurable safety limit**
+
+- Goal:
+  - make recursion observable and bounded
+- Likely files:
+  - `src/tools/impl/Task.ts`
+  - `src/agent/subagents/manager.ts`
+  - relevant tests
+- Proposed mechanism:
+  - parent session carries current depth via env or equivalent metadata
+  - spawn path increments depth for children
+  - Task rejects further delegation beyond a configurable limit
+  - failure message is explicit and testable
+- Deliverable:
+  - explicit depth semantics plus configurable safety valve
+
+**1D — Add budget propagation**
+
+- Goal:
+  - move from passive per-subagent token reporting to explicit recursive budget semantics
+- Why this is its own planning subtree:
+  - this requires policy choices, not just implementation detail
+  - advisory vs enforced budget is still open
+  - allocation and overrun behavior are still open
+- Recommended Phase 1 budget model:
+  - start with advisory token budgets
+  - propagate child budget metadata explicitly
+  - report actual usage against budget
+  - add hard enforcement only if it is clean enough for Phase 1
+- Likely files:
+  - `src/tools/impl/Task.ts`
+  - `src/agent/subagents/manager.ts`
+  - state / notification / test files that surface usage
+- Deliverable:
+  - minimal recursive budget model for Phase 1
+
+**1E — End-to-end recursion and guardrail tests**
+
+- Goal:
+  - prove nested delegation works and that failures are controlled
+- Test targets:
+  - child can spawn grandchild
+  - depth metadata increments correctly
+  - configured depth limit fails predictably
+  - budget metadata propagates according to chosen semantics
+  - non-recursive built-ins remain non-recursive if left unchanged
+- Deliverable:
+  - regression coverage for recursive delegation
+
+#### Session 1 recommended order
+
+1. 1A — lock the true runtime model
+2. 1B — decide which sessions may recurse
+3. 1C — implement depth tracking and the safety limit
+4. 1D — design and implement budget semantics
+5. 1E — test the full flow and the guardrails
+
+### Phase 2: Decomposition Skill + Pilot Prompt (Days 2-3)
+
+1. Write the recursive-session SKILL.md (see above)
+2. Write the pilot's system/identity.md and system/decomposition.md
+3. Run `/init` on a target codebase to build initial codebase knowledge
+4. Test: does the pilot correctly choose when to decompose vs direct?
+
+### Phase 3: Memory-Based Learning (Days 3-5)
+
+1. Build the sleep-time consolidation prompt
+2. Wire it as a post-session hook or manual command
+3. Run the pilot through 3-5 sessions on the same codebase
+4. Verify: does system/decomposition.md accumulate useful strategies?
+5. Verify: does session N+1 start smarter than session N?
+
+### Phase 4: Evaluation (Days 5-7)
+
+1. Run the benchmark task set under conditions A, B, C, D
+2. Measure all metrics
+3. Write up results
+4. If positive: plan migration path to Belayer runtime (Go)
+
+### Phase 5: Belayer Integration (Future)
+
+If the experiment validates recursive decomposition:
+1. Port the decomposition primitives to Belayer's Go runtime
+2. Implement session.create as a first-class tool in the pilot's registry
+3. Build the structured event log (append-only, queryable)
+4. Add Docker sandbox isolation
+5. Add the Communication interface (message broker between sessions)
+6. Wire sleep-time compute as a runtime-triggered background process
+
+---
+
+## Appendix: Key References
+
+### Papers & Research
+- **Mismanaged Geniuses Hypothesis** — Zhang, Li, Khattab (2026). Models are underutilized; the bottleneck is decomposition scaffolding, not model capability. Training models to decompose is more efficient than continued scaling.
+- **Recursive Language Models (RLMs)** — Expanding decomposition space via code execution with recursive sub-calls. 4B parameter RLM solves benchmarks that frontier models fail at.
+- **MCPGAUGE** (arxiv, Aug 2025) — MCP reduces accuracy by 9.5%, increases tokens 3.25x-236.5x.
+
+### Frameworks Evaluated
+- **Scion** (Google, Go) — Closest architectural peer to Belayer. Emergent CLI-based recursion, container isolation, multi-harness. 1K stars, experimental.
+- **Hermes Agent** (Nous Research, Python) — Best "hands" (48 tools, 6 backends, RL pipeline). Wrong memory model for this experiment.
+- **Letta Code** (Letta AI, TypeScript) — Best "brain" (three-tier memory, git-backed identity, agent-managed). Chosen as experiment base.
+- **Oh-My-OpenAgent** (50K stars, TypeScript) — Category-based model routing, Prometheus planning, wisdom accumulation, Discord observability.
+- **OpenClaw** (354K stars, TypeScript) — Gateway runtime. Ecosystem proves demand for multi-agent orchestration.
+
+### Blog Posts & Analysis
+- **Cognition vs Anthropic debate** — Single-agent (Devin) vs multi-agent (Anthropic). Resolution: dynamic architecture selection.
+- **Addy Osmani "Code Agent Orchestra"** — Three-tier tool landscape, verification bottleneck, peer messaging, ralph loop, quality gates.
+- **Anthropic 2026 Agentic Coding Trends** — Agents become team players, learn when to ask for help, spread beyond engineering.
+- **Vercel AGENTS.md evals** — 8KB static markdown (100%) outperforms dynamic skill loading (79%) for domain knowledge.
+- **Perplexity CTO** — Shifted away from MCP; 3 servers consumed 72% of context.
+
+### Belayer Philosophy Alignment
+This experiment validates Belayer's six-interface model:
+- **Session** → Letta agent with persistent identity (recursive via patched Task tool)
+- **Orchestration** → Pilot agent with decomposition skill (LLM-driven, not state machine)
+- **Memory** → Letta's three-tier model with git-backed persistence
+- **Tools** → Standard coding tools + recursive task creation
+- **Sandbox** → Future: Docker wrapper (not needed for initial experiment)
+- **Communication** → Future: event log + message passing between sub-sessions

--- a/src/agent/subagents/builtin/fork.md
+++ b/src/agent/subagents/builtin/fork.md
@@ -1,7 +1,7 @@
 ---
 name: fork
 description: Fork of the parent agent with full context and tools. Recommended to run in background (run_in_background: true).
-tools: Bash, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+tools: Bash, Task, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: inherit
 memoryBlocks: all
 mode: stateful

--- a/src/agent/subagents/builtin/general-purpose.md
+++ b/src/agent/subagents/builtin/general-purpose.md
@@ -1,7 +1,7 @@
 ---
 name: general-purpose
 description: Full-capability agent for research, planning, and implementation
-tools: Bash, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+tools: Bash, Task, TaskOutput, Edit, Glob, Grep, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: auto
 memoryBlocks: all
 mode: stateful

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -50,6 +50,11 @@ export interface SubagentResult {
   totalTokens?: number;
 }
 
+const DEFAULT_TASK_MAX_DEPTH = 5;
+const TASK_DEPTH_ENV_VAR = "LETTA_TASK_DEPTH";
+const TASK_MAX_DEPTH_ENV_VAR = "LETTA_TASK_MAX_DEPTH";
+const TASK_BUDGET_ENV_VAR = "LETTA_TASK_BUDGET_TOKENS";
+
 /**
  * State tracked during subagent execution
  */
@@ -80,6 +85,95 @@ function getModelHandleFromAgent(agent: {
     return `${endpoint}/${model}`;
   }
   return model || null;
+}
+
+function parseNonNegativeInteger(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+export function getTaskDepthFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return parseNonNegativeInteger(env[TASK_DEPTH_ENV_VAR]) ?? 0;
+}
+
+export function getTaskMaxDepthFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return (
+    parseNonNegativeInteger(env[TASK_MAX_DEPTH_ENV_VAR]) ??
+    DEFAULT_TASK_MAX_DEPTH
+  );
+}
+
+export function getTaskBudgetFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const parsed = parseNonNegativeInteger(env[TASK_BUDGET_ENV_VAR]);
+  return parsed === null ? undefined : parsed;
+}
+
+export function buildSubagentChildEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  options: {
+    config: SubagentConfig;
+    parentAgentId?: string;
+    budgetTokens?: number;
+    inheritedApiKey?: string;
+    inheritedBaseUrl?: string;
+    inheritedMemoryRoots?: ReturnType<typeof resolveAllowedMemoryRoots>;
+  },
+): NodeJS.ProcessEnv {
+  const {
+    config,
+    parentAgentId,
+    budgetTokens,
+    inheritedApiKey,
+    inheritedBaseUrl,
+    inheritedMemoryRoots,
+  } = options;
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
+    ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
+    LETTA_CODE_AGENT_ROLE: "subagent",
+    ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
+    [TASK_DEPTH_ENV_VAR]: String(getTaskDepthFromEnv(baseEnv) + 1),
+    [TASK_MAX_DEPTH_ENV_VAR]: String(getTaskMaxDepthFromEnv(baseEnv)),
+  };
+
+  if (budgetTokens !== undefined) {
+    childEnv[TASK_BUDGET_ENV_VAR] = String(budgetTokens);
+  } else if (baseEnv[TASK_BUDGET_ENV_VAR] !== undefined) {
+    childEnv[TASK_BUDGET_ENV_VAR] = baseEnv[TASK_BUDGET_ENV_VAR];
+  } else {
+    delete childEnv[TASK_BUDGET_ENV_VAR];
+  }
+
+  if (config.permissionMode === "memory") {
+    if (inheritedMemoryRoots?.primaryRoot) {
+      childEnv.MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
+      childEnv.LETTA_MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
+    } else {
+      delete childEnv.MEMORY_DIR;
+      delete childEnv.LETTA_MEMORY_DIR;
+    }
+
+    const parentMemoryDir = baseEnv.MEMORY_DIR || baseEnv.LETTA_MEMORY_DIR;
+    if (parentMemoryDir && parentMemoryDir.trim().length > 0) {
+      childEnv.PARENT_MEMORY_DIR = parentMemoryDir;
+    } else {
+      delete childEnv.PARENT_MEMORY_DIR;
+    }
+  }
+
+  return childEnv;
 }
 
 async function getPrimaryAgentModelHandle(): Promise<string | null> {
@@ -653,6 +747,7 @@ async function executeSubagent(
   existingAgentId?: string,
   existingConversationId?: string,
   maxTurns?: number,
+  budgetTokens?: number,
 ): Promise<SubagentResult> {
   // Check if already aborted before starting
   if (signal?.aborted) {
@@ -698,31 +793,14 @@ async function executeSubagent(
       process.env.LETTA_BASE_URL || settings.env?.LETTA_BASE_URL;
     const subagentWorkingDirectory = resolveSubagentWorkingDirectory();
     const inheritedMemoryRoots = resolveAllowedMemoryRoots();
-    const childEnv: NodeJS.ProcessEnv = {
-      ...process.env,
-      ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
-      ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
-      LETTA_CODE_AGENT_ROLE: "subagent",
-      ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
-    };
-
-    if (config.permissionMode === "memory") {
-      if (inheritedMemoryRoots.primaryRoot) {
-        childEnv.MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
-        childEnv.LETTA_MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
-      } else {
-        delete childEnv.MEMORY_DIR;
-        delete childEnv.LETTA_MEMORY_DIR;
-      }
-
-      const parentMemoryDir =
-        process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-      if (parentMemoryDir && parentMemoryDir.trim().length > 0) {
-        childEnv.PARENT_MEMORY_DIR = parentMemoryDir;
-      } else {
-        delete childEnv.PARENT_MEMORY_DIR;
-      }
-    }
+    const childEnv = buildSubagentChildEnv(process.env, {
+      config,
+      parentAgentId,
+      budgetTokens,
+      inheritedApiKey,
+      inheritedBaseUrl,
+      inheritedMemoryRoots,
+    });
 
     const proc = spawn(launcher.command, launcher.args, {
       cwd: subagentWorkingDirectory,
@@ -828,6 +906,7 @@ async function executeSubagent(
             undefined, // existingAgentId
             undefined, // existingConversationId
             maxTurns,
+            budgetTokens,
           );
         }
       }
@@ -953,6 +1032,7 @@ export async function spawnSubagent(
   existingConversationId?: string,
   maxTurns?: number,
   forkedContext?: boolean,
+  budgetTokens?: number,
 ): Promise<SubagentResult> {
   const allConfigs = await getAllSubagentConfigs();
   const config = allConfigs[type];
@@ -1020,6 +1100,7 @@ export async function spawnSubagent(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    budgetTokens,
   );
 
   return result;

--- a/src/tests/agent/subagent-builtins.test.ts
+++ b/src/tests/agent/subagent-builtins.test.ts
@@ -59,6 +59,14 @@ describe("built-in subagents", () => {
     expect(configs.memory?.mode).toBe("stateful");
   });
 
+  test("recursive delegation is enabled only for selected built-ins", async () => {
+    const configs = await getAllSubagentConfigs();
+
+    expect(configs["general-purpose"]?.allowedTools).toContain("Task");
+    expect(configs.fork?.allowedTools).toContain("Task");
+    expect(configs.explore?.allowedTools).not.toContain("Task");
+  });
+
   test("custom CRLF reflection override replaces built-in reflection", async () => {
     tempDir = createTempProjectDir();
     writeCustomSubagent(

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { SubagentConfig } from "../../agent/subagents";
 import {
   buildSubagentArgs,
+  buildSubagentChildEnv,
+  getTaskBudgetFromEnv,
+  getTaskDepthFromEnv,
+  getTaskMaxDepthFromEnv,
   resolveSubagentLauncher,
   resolveSubagentModel,
   resolveSubagentWorkingDirectory,
@@ -192,6 +196,48 @@ describe("buildSubagentArgs", () => {
 
     expect(args).toContain("--permission-mode");
     expect(args).toContain("memory");
+  });
+
+  test("buildSubagentChildEnv increments depth and inherits depth limit", () => {
+    const childEnv = buildSubagentChildEnv(
+      {
+        LETTA_TASK_DEPTH: "2",
+        LETTA_TASK_MAX_DEPTH: "7",
+      } as NodeJS.ProcessEnv,
+      {
+        config: baseConfig,
+      },
+    );
+
+    expect(getTaskDepthFromEnv(childEnv)).toBe(3);
+    expect(getTaskMaxDepthFromEnv(childEnv)).toBe(7);
+  });
+
+  test("buildSubagentChildEnv inherits advisory budget by default", () => {
+    const childEnv = buildSubagentChildEnv(
+      {
+        LETTA_TASK_BUDGET_TOKENS: "1200",
+      } as NodeJS.ProcessEnv,
+      {
+        config: baseConfig,
+      },
+    );
+
+    expect(getTaskBudgetFromEnv(childEnv)).toBe(1200);
+  });
+
+  test("buildSubagentChildEnv allows explicit advisory budget override", () => {
+    const childEnv = buildSubagentChildEnv(
+      {
+        LETTA_TASK_BUDGET_TOKENS: "1200",
+      } as NodeJS.ProcessEnv,
+      {
+        config: baseConfig,
+        budgetTokens: 300,
+      },
+    );
+
+    expect(getTaskBudgetFromEnv(childEnv)).toBe(300);
   });
 });
 

--- a/src/tests/tools/task-recursion.test.ts
+++ b/src/tests/tools/task-recursion.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getTaskExecutionMetadata,
+  getTaskRecursionLimitError,
+} from "../../tools/impl/Task";
+
+describe("Task recursion metadata", () => {
+  test("derives child depth and inherited advisory budget", () => {
+    const metadata = getTaskExecutionMetadata(undefined, {
+      LETTA_TASK_DEPTH: "1",
+      LETTA_TASK_MAX_DEPTH: "4",
+      LETTA_TASK_BUDGET_TOKENS: "800",
+    } as NodeJS.ProcessEnv);
+
+    expect(metadata).toEqual({
+      currentDepth: 1,
+      childDepth: 2,
+      maxDepth: 4,
+      budgetTokens: 800,
+    });
+  });
+
+  test("explicit budget overrides inherited advisory budget", () => {
+    const metadata = getTaskExecutionMetadata(250, {
+      LETTA_TASK_DEPTH: "0",
+      LETTA_TASK_MAX_DEPTH: "5",
+      LETTA_TASK_BUDGET_TOKENS: "800",
+    } as NodeJS.ProcessEnv);
+
+    expect(metadata.budgetTokens).toBe(250);
+  });
+
+  test("blocks recursion when current depth reaches configured max", () => {
+    expect(
+      getTaskRecursionLimitError({
+        LETTA_TASK_DEPTH: "5",
+        LETTA_TASK_MAX_DEPTH: "5",
+      } as NodeJS.ProcessEnv),
+    ).toBe(
+      "Error: Task recursion limit reached at depth 5 (max 5). Further delegation is blocked.",
+    );
+  });
+
+  test("allows recursion when current depth is below configured max", () => {
+    expect(
+      getTaskRecursionLimitError({
+        LETTA_TASK_DEPTH: "4",
+        LETTA_TASK_MAX_DEPTH: "5",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+});

--- a/src/tools/descriptions/Task.md
+++ b/src/tools/descriptions/Task.md
@@ -19,6 +19,8 @@ When using the Task tool, you must specify a subagent_type parameter to select w
 - Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
 - When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
 - You can optionally run agents in the background using the run_in_background parameter. When an agent runs in the background, the tool result will include an output_file path. To check on the agent's progress or retrieve its results, use the Read tool to read the output file, or use Bash with `tail` to see recent output. You can continue working while background agents run.
+- Recursive Task delegation is allowed only for subagent types whose tool lists include `Task`, and the runtime enforces a recursion depth limit via environment metadata.
+- You can optionally pass `budget_tokens` as an advisory subtree budget. This budget is propagated to child Task calls for reporting and planning, but is not a hard enforcement boundary in Phase 1.
 - Agents can be resumed using the `conversation_id` parameter by passing the conversation ID from a previous invocation. When resumed, the agent continues with its full previous context preserved.
 - When the agent is done, it will return a single message back to you along with its conversation ID. You can use this ID to resume the agent later if needed for follow-up work.
 - Provide clear, detailed prompts so the agent can work autonomously and return exactly the information you need.

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -12,7 +12,12 @@ import {
   discoverSubagents,
   getAllSubagentConfigs,
 } from "../../agent/subagents";
-import { spawnSubagent } from "../../agent/subagents/manager";
+import {
+  getTaskBudgetFromEnv,
+  getTaskDepthFromEnv,
+  getTaskMaxDepthFromEnv,
+  spawnSubagent,
+} from "../../agent/subagents/manager";
 import { addToMessageQueue } from "../../cli/helpers/messageQueueBridge.js";
 import {
   completeSubagent,
@@ -46,6 +51,7 @@ interface TaskArgs {
   conversation_id?: string; // Resume from an existing conversation
   run_in_background?: boolean; // Run the task in background
   max_turns?: number; // Maximum number of agentic turns
+  budget_tokens?: number; // Advisory token budget for the spawned subtree
   toolCallId?: string; // Injected by executeTool for linking subagent to parent tool call
   signal?: AbortSignal; // Injected by executeTool for interruption handling
   parentScope?: { agentId: string; conversationId: string }; // Injected by executeTool for notification routing
@@ -73,6 +79,7 @@ export interface SpawnBackgroundSubagentTaskArgs {
   existingAgentId?: string;
   existingConversationId?: string;
   maxTurns?: number;
+  budgetTokens?: number;
   forkedContext?: boolean;
   /** Parent conversation scope for routing notifications in listener mode. */
   parentScope?: { agentId: string; conversationId: string };
@@ -151,11 +158,55 @@ async function resolveCompletionSummary(
   return trimmed.length > 0 ? trimmed : defaultSummary;
 }
 
+interface TaskExecutionMetadata {
+  currentDepth: number;
+  childDepth: number;
+  maxDepth: number;
+  budgetTokens?: number;
+}
+
+export function getTaskExecutionMetadata(
+  argsBudgetTokens?: number,
+  env: NodeJS.ProcessEnv = process.env,
+): TaskExecutionMetadata {
+  const currentDepth = getTaskDepthFromEnv(env);
+  return {
+    currentDepth,
+    childDepth: currentDepth + 1,
+    maxDepth: getTaskMaxDepthFromEnv(env),
+    budgetTokens: argsBudgetTokens ?? getTaskBudgetFromEnv(env),
+  };
+}
+
+export function getTaskRecursionLimitError(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const currentDepth = getTaskDepthFromEnv(env);
+  const maxDepth = getTaskMaxDepthFromEnv(env);
+
+  if (currentDepth < maxDepth) {
+    return null;
+  }
+
+  return `Error: Task recursion limit reached at depth ${currentDepth} (max ${maxDepth}). Further delegation is blocked.`;
+}
+
+function formatTaskMetadataHeader(metadata: TaskExecutionMetadata): string[] {
+  return [
+    `task_depth=${metadata.childDepth}`,
+    `task_max_depth=${metadata.maxDepth}`,
+    metadata.budgetTokens !== undefined
+      ? `task_budget_tokens=${metadata.budgetTokens}`
+      : undefined,
+  ].filter(Boolean) as string[];
+}
+
 function buildTaskResultHeader(
   subagentType: string,
   subagentId: string,
   result?: Pick<TaskRunResult, "agentId" | "conversationId">,
   status?: "success" | "error",
+  metadata?: TaskExecutionMetadata,
 ): string {
   return [
     `subagent_type=${subagentType}`,
@@ -165,6 +216,9 @@ function buildTaskResultHeader(
     result?.conversationId
       ? `conversation_id=${result.conversationId}`
       : undefined,
+    ...formatTaskMetadataHeader(
+      metadata ?? getTaskExecutionMetadata(undefined, process.env),
+    ),
   ]
     .filter(Boolean)
     .join(" ");
@@ -174,10 +228,11 @@ function writeTaskTranscriptStart(
   outputFile: string,
   description: string,
   subagentType: string,
+  metadata: TaskExecutionMetadata,
 ): void {
   appendToOutputFile(
     outputFile,
-    `[Task started: ${description}]\n[subagent_type: ${subagentType}]\n\n`,
+    `[Task started: ${description}]\n[subagent_type: ${subagentType}]\n[task_depth: ${metadata.childDepth}]\n[task_max_depth: ${metadata.maxDepth}]${metadata.budgetTokens !== undefined ? `\n[task_budget_tokens: ${metadata.budgetTokens}]` : ""}\n\n`,
   );
 }
 
@@ -279,6 +334,7 @@ export function spawnBackgroundSubagentTask(
     existingAgentId,
     existingConversationId,
     maxTurns,
+    budgetTokens,
     forkedContext,
     parentScope,
     silentCompletion,
@@ -331,7 +387,8 @@ export function spawnBackgroundSubagentTask(
     abortController,
   };
   backgroundTasks.set(taskId, bgTask);
-  writeTaskTranscriptStart(outputFile, description, subagentType);
+  const metadata = getTaskExecutionMetadata(budgetTokens);
+  writeTaskTranscriptStart(outputFile, description, subagentType, metadata);
 
   // Intentionally fire-and-forget: background tasks own their lifecycle and
   // capture failures in task state/transcripts instead of surfacing a promise
@@ -346,6 +403,7 @@ export function spawnBackgroundSubagentTask(
     existingConversationId,
     maxTurns,
     forkedContext,
+    budgetTokens,
   )
     .then(async (result) => {
       bgTask.status = result.success ? "completed" : "failed";
@@ -358,6 +416,7 @@ export function spawnBackgroundSubagentTask(
         subagentId,
         result,
         result.success ? "success" : "error",
+        metadata,
       );
       writeTaskTranscriptResult(outputFile, result, header);
       if (result.success) {
@@ -553,6 +612,10 @@ export async function task(args: TaskArgs): Promise<string> {
 
   // Determine if deploying an existing agent
   const isDeployingExisting = Boolean(args.agent_id || args.conversation_id);
+  const recursionLimitError = getTaskRecursionLimitError(process.env);
+  if (recursionLimitError) {
+    return recursionLimitError;
+  }
 
   // Validate required parameters based on mode
   if (isDeployingExisting) {
@@ -622,6 +685,7 @@ export async function task(args: TaskArgs): Promise<string> {
   }
 
   const prompt = inputPrompt;
+  const taskMetadata = getTaskExecutionMetadata(args.budget_tokens);
 
   const isBackground = args.run_in_background ?? config.background;
   const resolvedParentScope = resolveParentScope(args.parentScope);
@@ -637,6 +701,7 @@ export async function task(args: TaskArgs): Promise<string> {
       existingAgentId: effectiveAgentId,
       existingConversationId: effectiveConversationId,
       maxTurns: args.max_turns,
+      budgetTokens: taskMetadata.budgetTokens,
       forkedContext: config.fork,
       parentScope: resolvedParentScope,
     });
@@ -669,7 +734,12 @@ export async function task(args: TaskArgs): Promise<string> {
   // even when inline content is truncated.
   const foregroundTaskId = getNextTaskId();
   const outputFile = createBackgroundOutputFile(foregroundTaskId);
-  writeTaskTranscriptStart(outputFile, description, subagent_type);
+  writeTaskTranscriptStart(
+    outputFile,
+    description,
+    subagent_type,
+    taskMetadata,
+  );
 
   try {
     const result = await spawnSubagent(
@@ -682,6 +752,7 @@ export async function task(args: TaskArgs): Promise<string> {
       effectiveConversationId,
       args.max_turns,
       config.fork,
+      taskMetadata.budgetTokens,
     );
 
     // Mark subagent as completed in state store
@@ -714,6 +785,7 @@ export async function task(args: TaskArgs): Promise<string> {
         subagentId,
         failedResult,
         "error",
+        taskMetadata,
       );
       writeTaskTranscriptResult(outputFile, failedResult, header);
       return `${header}\n\nError: ${errorMessage}\nOutput file: ${outputFile}`;
@@ -726,6 +798,7 @@ export async function task(args: TaskArgs): Promise<string> {
       subagentId,
       result,
       "success",
+      taskMetadata,
     );
 
     const fullOutput = `${header}\n\n${result.report}`;
@@ -752,6 +825,7 @@ export async function task(args: TaskArgs): Promise<string> {
         conversationId: effectiveConversationId,
       },
       "error",
+      taskMetadata,
     );
     completeSubagent(subagentId, { success: false, error: errorMessage });
 

--- a/src/tools/schemas/Task.json
+++ b/src/tools/schemas/Task.json
@@ -21,6 +21,10 @@
       "type": "boolean",
       "description": "Set to true to run this agent in the background. The tool result will include an output_file path - use Read tool or Bash tail to check on output."
     },
+    "budget_tokens": {
+      "type": "integer",
+      "description": "Optional advisory token budget for the spawned subtree. Propagated to child Task calls for reporting and budgeting decisions."
+    },
     "agent_id": {
       "type": "string",
       "description": "Deploy an existing agent instead of creating a new one. Starts a new conversation with that agent."


### PR DESCRIPTION
## Summary
- Enable intentional recursive Task delegation by surfacing `Task` to `general-purpose` and `fork` built-in subagents
- Add explicit recursion depth tracking via `LETTA_TASK_DEPTH` / `LETTA_TASK_MAX_DEPTH` env propagation
- Add advisory token budget propagation via `LETTA_TASK_BUDGET_TOKENS` and `budget_tokens` Task parameter
- Enforce configurable depth limit (default 5) before spawning children
- Surface depth/budget metadata in task transcript and result headers
- Add targeted regression tests for recursion policy, env propagation, and depth limit enforcement
- Include experiment design doc, bootstrap prompt templates, and autopilot audit log

## Test plan
- [x] `bun test src/tests/agent/subagent-builtins.test.ts` — recursion policy for built-ins
- [x] `bun test src/tests/agent/subagent-model-resolution.test.ts` — child env depth/budget propagation
- [x] `bun test src/tests/tools/task-recursion.test.ts` — recursion metadata and limit enforcement
- [x] `bun run typecheck` passes
- [x] Pre-commit lint-staged + tsc passes

## Design context
See `docs/recursive-session-experiment.md` and `docs/recursive-session-autopilot-log.md` for the full experiment design and autonomous decision audit trail.

👾 Generated with [Letta Code](https://letta.com)