### PR TITLE
fix(permissions): allow read-only shell inspection scripts

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -285,6 +285,12 @@ function splitShellSegments(input: string): string[] | null {
       continue;
     }
 
+    if (ch === "\\" && i + 1 < input.length) {
+      current += input.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+
     if (input.startsWith(">>", i) || ch === ">") {
       const skipLen = tryConsumeSafeRedirect(input, i);
       if (skipLen > 0) {
@@ -342,8 +348,294 @@ function splitShellSegments(input: string): string[] | null {
   return segments.map((segment) => segment.trim()).filter(Boolean);
 }
 
-function hasUnsafeFindOptions(tokens: string[]): boolean {
-  return tokens.slice(1).some((token) => UNSAFE_FIND_OPTIONS.has(token));
+const SAFE_FILE_TEST_FLAGS = new Set(["-e", "-f", "-d", "-s", "-L"]);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function substituteLoopVariable(
+  segment: string,
+  variableName: string,
+  value: string,
+): string {
+  const escapedName = escapeRegExp(variableName);
+  return segment
+    .replace(new RegExp(`\\$\\{${escapedName}\\}`, "g"), value)
+    .replace(new RegExp(`\\$${escapedName}(?![A-Za-z0-9_])`, "g"), value);
+}
+
+function isSafeConditionalTest(
+  condition: string,
+  options: ReadOnlyShellOptions,
+): boolean {
+  let tokens = tokenize(condition);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  if (tokens[0] === "!") {
+    tokens = tokens.slice(1);
+  }
+
+  if (tokens[0] === "[") {
+    if (tokens[tokens.length - 1] !== "]") {
+      return false;
+    }
+    tokens = tokens.slice(1, -1);
+  } else if (tokens[0] === "test") {
+    tokens = tokens.slice(1);
+  }
+
+  if (tokens.length !== 2) {
+    return false;
+  }
+
+  const [flag, pathToken] = tokens;
+  if (!flag || !pathToken || !SAFE_FILE_TEST_FLAGS.has(flag)) {
+    return false;
+  }
+
+  if (!options.allowExternalPaths && hasDisallowedPathArg(pathToken, options)) {
+    return false;
+  }
+
+  return true;
+}
+
+function parseIfSegments(
+  segments: string[],
+  startIndex: number,
+  options: ReadOnlyShellOptions,
+): { nextIndex: number; safe: boolean } {
+  const firstSegment = segments[startIndex]?.trim() ?? "";
+  if (!firstSegment.startsWith("if ")) {
+    return { nextIndex: startIndex, safe: false };
+  }
+
+  if (!isSafeConditionalTest(firstSegment.slice(3).trim(), options)) {
+    return { nextIndex: startIndex + 1, safe: false };
+  }
+
+  const bodySegments: string[] = [];
+  let sawThen = false;
+
+  for (let index = startIndex + 1; index < segments.length; index += 1) {
+    const segment = segments[index]?.trim() ?? "";
+    if (!segment) {
+      continue;
+    }
+
+    if (segment === "fi") {
+      return {
+        nextIndex: index + 1,
+        safe:
+          sawThen &&
+          bodySegments.length > 0 &&
+          areReadOnlySegments(bodySegments, options),
+      };
+    }
+
+    if (!sawThen) {
+      if (segment === "then") {
+        sawThen = true;
+        continue;
+      }
+      if (segment.startsWith("then ")) {
+        sawThen = true;
+        const inlineBody = segment.slice(5).trim();
+        if (inlineBody) {
+          bodySegments.push(inlineBody);
+        }
+        continue;
+      }
+      return { nextIndex: index, safe: false };
+    }
+
+    if (segment === "else" || segment.startsWith("else ")) {
+      return { nextIndex: index, safe: false };
+    }
+
+    bodySegments.push(segment);
+  }
+
+  return { nextIndex: segments.length, safe: false };
+}
+
+function parseForSegments(
+  segments: string[],
+  startIndex: number,
+  options: ReadOnlyShellOptions,
+): { nextIndex: number; safe: boolean } {
+  const firstSegment = segments[startIndex]?.trim() ?? "";
+  const tokens = tokenize(firstSegment);
+  const variableName = tokens[1];
+
+  if (
+    tokens[0] !== "for" ||
+    !variableName ||
+    !/^[A-Za-z_][A-Za-z0-9_]*$/.test(variableName) ||
+    tokens[2] !== "in"
+  ) {
+    return { nextIndex: startIndex, safe: false };
+  }
+
+  const items = tokens.slice(3);
+  if (items.length === 0) {
+    return { nextIndex: startIndex + 1, safe: false };
+  }
+
+  const bodySegments: string[] = [];
+  let sawDo = false;
+
+  for (let index = startIndex + 1; index < segments.length; index += 1) {
+    const segment = segments[index]?.trim() ?? "";
+    if (!segment) {
+      continue;
+    }
+
+    if (segment === "done") {
+      if (!sawDo || bodySegments.length === 0) {
+        return { nextIndex: index + 1, safe: false };
+      }
+
+      for (const item of items) {
+        const substitutedBody = bodySegments.map((bodySegment) =>
+          substituteLoopVariable(bodySegment, variableName, item),
+        );
+        if (!areReadOnlySegments(substitutedBody, options)) {
+          return { nextIndex: index + 1, safe: false };
+        }
+      }
+
+      return { nextIndex: index + 1, safe: true };
+    }
+
+    if (!sawDo) {
+      if (segment === "do") {
+        sawDo = true;
+        continue;
+      }
+      if (segment.startsWith("do ")) {
+        sawDo = true;
+        const inlineBody = segment.slice(3).trim();
+        if (inlineBody) {
+          bodySegments.push(inlineBody);
+        }
+        continue;
+      }
+      return { nextIndex: index, safe: false };
+    }
+
+    bodySegments.push(segment);
+  }
+
+  return { nextIndex: segments.length, safe: false };
+}
+
+function areReadOnlySegments(
+  segments: string[],
+  options: ReadOnlyShellOptions,
+): boolean {
+  for (let index = 0; index < segments.length; ) {
+    const segment = segments[index]?.trim() ?? "";
+    if (!segment) {
+      index += 1;
+      continue;
+    }
+
+    if (segment.startsWith("if ")) {
+      const parsed = parseIfSegments(segments, index, options);
+      if (!parsed.safe) {
+        return false;
+      }
+      index = parsed.nextIndex;
+      continue;
+    }
+
+    if (segment.startsWith("for ")) {
+      const parsed = parseForSegments(segments, index, options);
+      if (!parsed.safe) {
+        return false;
+      }
+      index = parsed.nextIndex;
+      continue;
+    }
+
+    if (
+      segment === "fi" ||
+      segment === "done" ||
+      segment === "then" ||
+      segment === "do" ||
+      segment.startsWith("then ") ||
+      segment.startsWith("do ") ||
+      segment === "else" ||
+      segment.startsWith("else ")
+    ) {
+      return false;
+    }
+
+    if (!isSafeSegment(segment, options)) {
+      return false;
+    }
+
+    index += 1;
+  }
+
+  return true;
+}
+
+function isSafeFindExecCommand(tokens: string[]): boolean {
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  if (tokens[0] !== "stat") {
+    return false;
+  }
+
+  return tokens.some((token) => token === "{}");
+}
+
+function isSafeFindInvocation(tokens: string[]): boolean {
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token) {
+      continue;
+    }
+
+    if (UNSAFE_FIND_OPTIONS.has(token) && token !== "-exec") {
+      return false;
+    }
+
+    if (token !== "-exec") {
+      continue;
+    }
+
+    const execTokens: string[] = [];
+    let terminator: string | null = null;
+    for (index += 1; index < tokens.length; index += 1) {
+      const execToken = tokens[index];
+      if (!execToken) {
+        continue;
+      }
+      if (execToken === ";" || execToken === "\\;" || execToken === "+") {
+        terminator = execToken;
+        break;
+      }
+      execTokens.push(execToken);
+    }
+
+    if (terminator !== "\\;" && terminator !== ";") {
+      return false;
+    }
+
+    if (!isSafeFindExecCommand(execTokens)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function hasUnsafeRipgrepOptions(tokens: string[]): boolean {
@@ -580,13 +872,7 @@ export function isReadOnlyShellCommand(
     return false;
   }
 
-  for (const segment of segments) {
-    if (!isSafeSegment(segment, options)) {
-      return false;
-    }
-  }
-
-  return true;
+  return areReadOnlySegments(segments, options);
 }
 
 function isSafeSegment(
@@ -723,7 +1009,7 @@ function isSafeSegment(
   }
 
   if (command === "find") {
-    return !hasUnsafeFindOptions(tokens);
+    return isSafeFindInvocation(tokens);
   }
   if (command === "sort") {
     return !/\s-o\b/.test(segment);
@@ -1286,7 +1572,7 @@ function isAllowedMemorySegment(
     return { nextCwd: cwd, safe: false };
   }
 
-  if (command === "find" && hasUnsafeFindOptions(tokens)) {
+  if (command === "find" && !isSafeFindInvocation(tokens)) {
     return { nextCwd: cwd, safe: false };
   }
 

--- a/src/tests/permissions-cli.test.ts
+++ b/src/tests/permissions-cli.test.ts
@@ -415,3 +415,30 @@ test("CLI allowedTools normalizes file alias family", () => {
   const tools = cliPermissions.getAllowedTools();
   expect(tools).toEqual(["Write(**)"]);
 });
+
+test("ShellCommand auto-allows captured read-only inspection scripts", () => {
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+  };
+
+  const capturedInspectionScripts = [
+    "printf '== apps/client-ui/vite.config.ts ==\\n'; sed -n '1,240p' apps/client-ui/vite.config.ts; printf '\\n== apps/client-ui/package.json ==\\n'; if [ -f apps/client-ui/package.json ]; then sed -n '1,240p' apps/client-ui/package.json; fi",
+    "printf '== workstation ui config files ==\\n'; rg --files apps/workstation/ui | rg '(vite\\.config|package\\.json|project\\.json|index\\.html|main\\.tsx|main\\.ts|tsconfig|sentry|source|map)' ; printf '\\n== apps/workstation/ui/project.json ==\\n'; sed -n '1,240p' apps/workstation/ui/project.json 2>/dev/null; printf '\\n== apps/workstation/ui/vite.config.* ==\\n'; for f in apps/workstation/ui/vite.config.*; do echo \"--- $f ---\"; sed -n '1,260p' \"$f\"; done",
+    "printf '== workstation packaging files ==\\n'; rg --files apps/workstation apps/workstation/electron | rg '(project\\.json|builder|forge|tsup|esbuild|vite\\.config|package\\.json|entitlements|plist|yaml|yml|desktop.*config|notarize|afterSign)' ; printf '\\n== relevant project/build files contents ==\\n'; for f in apps/workstation/project.json apps/workstation/electron/project.json apps/workstation/project.config.json apps/workstation/electron-builder.yml apps/workstation/electron/builder.yml; do if [ -f \"$f\" ]; then echo \"--- $f ---\"; sed -n '1,260p' \"$f\"; fi; done",
+    "printf '== stale asset summary ==\\n'; printf 'JS bundles: '; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.js' | wc -l; printf 'CSS bundles: '; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.css' | wc -l; printf 'All asset files: '; find apps/workstation/dist/assets -maxdepth 1 -type f | wc -l; printf '\\nRecent asset mtimes:\\n'; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.*' -exec stat -f '%Sm %N' -t '%Y-%m-%d %H:%M' {} \\; | sort | tail -n 20",
+  ] as const;
+
+  for (const command of capturedInspectionScripts) {
+    const result = checkPermission(
+      "ShellCommand",
+      { command },
+      permissions,
+      "/Users/test/project",
+    );
+
+    expect(result.decision).toBe("allow");
+    expect(result.reason).toBe("Read-only shell command");
+  }
+});

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -613,6 +613,35 @@ describe("isReadOnlyShellCommand", () => {
         }),
       ).toBe(true);
     });
+
+    test("allows captured read-only inspection scripts with conditionals, loops, and safe find execs", () => {
+      const capturedInspectionScripts = [
+        [
+          "printf '== apps/client-ui/vite.config.ts ==\\n'; sed -n '1,240p' apps/client-ui/vite.config.ts; printf '\\n== apps/client-ui/package.json ==\\n'; if [ -f apps/client-ui/package.json ]; then sed -n '1,240p' apps/client-ui/package.json; fi",
+          true,
+        ],
+        [
+          "printf '== workstation ui config files ==\\n'; rg --files apps/workstation/ui | rg '(vite\\.config|package\\.json|project\\.json|index\\.html|main\\.tsx|main\\.ts|tsconfig|sentry|source|map)' ; printf '\\n== apps/workstation/ui/project.json ==\\n'; sed -n '1,240p' apps/workstation/ui/project.json 2>/dev/null; printf '\\n== apps/workstation/ui/vite.config.* ==\\n'; for f in apps/workstation/ui/vite.config.*; do echo \"--- $f ---\"; sed -n '1,260p' \"$f\"; done",
+          true,
+        ],
+        [
+          "printf '== workstation packaging files ==\\n'; rg --files apps/workstation apps/workstation/electron | rg '(project\\.json|builder|forge|tsup|esbuild|vite\\.config|package\\.json|entitlements|plist|yaml|yml|desktop.*config|notarize|afterSign)' ; printf '\\n== relevant project/build files contents ==\\n'; for f in apps/workstation/project.json apps/workstation/electron/project.json apps/workstation/project.config.json apps/workstation/electron-builder.yml apps/workstation/electron/builder.yml; do if [ -f \"$f\" ]; then echo \"--- $f ---\"; sed -n '1,260p' \"$f\"; fi; done",
+          true,
+        ],
+        [
+          "printf '== stale asset summary ==\\n'; printf 'JS bundles: '; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.js' | wc -l; printf 'CSS bundles: '; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.css' | wc -l; printf 'All asset files: '; find apps/workstation/dist/assets -maxdepth 1 -type f | wc -l; printf '\\nRecent asset mtimes:\\n'; find apps/workstation/dist/assets -maxdepth 1 -type f -name 'index-*.*' -exec stat -f '%Sm %N' -t '%Y-%m-%d %H:%M' {} \\; | sort | tail -n 20",
+          true,
+        ],
+        [
+          "printf '== referenced renderer asset sizes ==\\n'; node - <<'NODE'\\nconst fs = require('fs');\\nconst html = fs.readFileSync('apps/workstation/dist/index.html', 'utf8');\\nconst js = html.match(/src=\"\\.\\/([^\"]+)\"/)?.[1];\\nconst css = html.match(/href=\"\\.\\/([^\"]+)\"/)?.[1];\\nfor (const f of [js, css]) {\\n  if (!f) continue;\\n  const st = fs.statSync('apps/workstation/dist/' + f);\\n  console.log(f, st.size);\\n}\\nNODE",
+          false,
+        ],
+      ] as const;
+
+      for (const [command, expected] of capturedInspectionScripts) {
+        expect(isReadOnlyShellCommand(command)).toBe(expected);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- allow read-only ShellCommand probes that use simple `if ...; then ...; fi` guards and `for ...; do ...; done` loops instead of treating them as unsupported shell syntax
- preserve escaped shell delimiters so captured inspection scripts with `find ... -exec stat {} \;` stay on the read-only auto-approval path
- add regression tests with anonymized captured commands at both the `isReadOnlyShellCommand` layer and the top-level permission checker

👾 Generated with [Letta Code](https://letta.com)