### PR TITLE
fix(skills): scope Skill lookup to the executing listener turn

### DIFF
--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -3,6 +3,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { consumeQueuedSkillContent } from "../../tools/impl/skillContentRegistry";
+import {
+  clearTools,
+  executeTool,
+  loadSpecificTools,
+} from "../../tools/manager";
 
 const TEST_AGENT_ID = "agent-skill-memfs-test";
 let currentSkillsDirectory: string | null = null;
@@ -19,6 +24,7 @@ describe("Skill tool memory filesystem lookup", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
   const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
   const originalHome = process.env.HOME;
+  const originalUserCwd = process.env.USER_CWD;
 
   beforeEach(() => {
     tempRoot = mkdtempSync(join(tmpdir(), "letta-skill-tool-"));
@@ -29,6 +35,7 @@ describe("Skill tool memory filesystem lookup", () => {
   afterEach(() => {
     consumeQueuedSkillContent();
     currentSkillsDirectory = null;
+    clearTools();
 
     if (originalMemoryDir === undefined) {
       delete process.env.MEMORY_DIR;
@@ -46,6 +53,12 @@ describe("Skill tool memory filesystem lookup", () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+
+    if (originalUserCwd === undefined) {
+      delete process.env.USER_CWD;
+    } else {
+      process.env.USER_CWD = originalUserCwd;
     }
 
     rmSync(tempRoot, { recursive: true, force: true });
@@ -109,5 +122,121 @@ describe("Skill tool memory filesystem lookup", () => {
     const queued = consumeQueuedSkillContent();
     expect(queued).toHaveLength(1);
     expect(queued[0]?.content).toContain("Loaded from agent memory fallback.");
+  });
+
+  test("prefers injected parentScope.agentId over global agent context for memfs fallback", async () => {
+    const skillName = "scoped-agent-skill";
+    const injectedAgentId = "agent-scoped-parent";
+    const skillDir = join(
+      tempRoot,
+      ".letta",
+      "agents",
+      injectedAgentId,
+      "memory",
+      "skills",
+      skillName,
+    );
+
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: scoped-agent-skill\ndescription: test\n---\n\nLoaded from injected agent scope.",
+      "utf8",
+    );
+
+    delete process.env.MEMORY_DIR;
+    delete process.env.LETTA_MEMORY_DIR;
+    process.env.HOME = tempRoot;
+
+    const result = await skill({
+      skill: skillName,
+      toolCallId: "tc-scoped-agent",
+      parentScope: {
+        agentId: injectedAgentId,
+        conversationId: "conversation-scoped-parent",
+      },
+    });
+    expect(result.message).toBe(`Launching skill: ${skillName}`);
+
+    const queued = consumeQueuedSkillContent();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toContain("Loaded from injected agent scope.");
+  });
+
+  test("uses USER_CWD fallback for project skill lookup when no explicit skills directory is set", async () => {
+    const skillName = "cwd-project-skill";
+    const projectRoot = join(tempRoot, "project-root");
+    const skillDir = join(projectRoot, ".skills", skillName);
+
+    currentSkillsDirectory = null;
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: cwd-project-skill\ndescription: test\n---\n\nLoaded from USER_CWD project skills.",
+      "utf8",
+    );
+
+    process.env.USER_CWD = projectRoot;
+
+    const result = await skill({
+      skill: skillName,
+      toolCallId: "tc-user-cwd",
+    });
+    expect(result.message).toBe(`Launching skill: ${skillName}`);
+
+    const queued = consumeQueuedSkillContent();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toContain(
+      "Loaded from USER_CWD project skills.",
+    );
+  });
+
+  test("executeTool forwards parentScope to Skill for listener-scoped memfs lookup", async () => {
+    const skillName = "execute-tool-scoped-skill";
+    const injectedAgentId = "agent-execute-tool-parent";
+    const skillDir = join(
+      tempRoot,
+      ".letta",
+      "agents",
+      injectedAgentId,
+      "memory",
+      "skills",
+      skillName,
+    );
+
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: execute-tool-scoped-skill\ndescription: test\n---\n\nLoaded through executeTool parent scope.",
+      "utf8",
+    );
+
+    delete process.env.MEMORY_DIR;
+    delete process.env.LETTA_MEMORY_DIR;
+    process.env.HOME = tempRoot;
+
+    clearTools();
+    await loadSpecificTools(["Skill"]);
+
+    const result = await executeTool(
+      "Skill",
+      { skill: skillName },
+      {
+        toolCallId: "tc-execute-tool-scoped",
+        parentScope: {
+          agentId: injectedAgentId,
+          conversationId: "conversation-execute-tool",
+        },
+      },
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.toolReturn).toBe(`Launching skill: ${skillName}`);
+
+    const queued = consumeQueuedSkillContent();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toContain(
+      "Loaded through executeTool parent scope.",
+    );
   });
 });

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -16,6 +16,8 @@ interface SkillArgs {
   args?: string;
   /** Injected by executeTool - the tool_call_id for this invocation */
   toolCallId?: string;
+  /** Injected by executeTool in listener mode for scoped agent resolution. */
+  parentScope?: { agentId: string; conversationId: string };
 }
 
 interface SkillResult {
@@ -153,8 +155,22 @@ async function getResolvedSkillsDir(): Promise<string> {
     return skillsDir;
   }
 
-  // Fall back to default .skills directory in cwd
-  return join(process.cwd(), SKILLS_DIR);
+  // Fall back to the execution working directory when available.
+  // executeTool() temporarily sets USER_CWD for the duration of the tool call,
+  // which keeps listener/desktop project skill lookup scoped correctly.
+  return join(process.env.USER_CWD || process.cwd(), SKILLS_DIR);
+}
+
+function getResolvedAgentId(args: SkillArgs): string | undefined {
+  if (args.parentScope?.agentId) {
+    return args.parentScope.agentId;
+  }
+
+  try {
+    return getCurrentAgentId();
+  } catch {
+    return undefined;
+  }
 }
 
 export async function skill(args: SkillArgs): Promise<SkillResult> {
@@ -168,7 +184,7 @@ export async function skill(args: SkillArgs): Promise<SkillResult> {
   }
 
   try {
-    const agentId = getCurrentAgentId();
+    const agentId = getResolvedAgentId(args);
     const skillsDir = await getResolvedSkillsDir();
 
     // Read the SKILL.md content

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1457,9 +1457,14 @@ export async function executeTool(
       }
     }
 
-    // Inject toolCallId for Skill tool (used for skill content registry)
+    // Inject scoped metadata for Skill tool.
+    // In listener/desktop mode, relying on global agent context is unsafe
+    // because multiple agent/conversation scopes can overlap in one process.
     if (internalName === "Skill" && options?.toolCallId) {
       enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
+    }
+    if (internalName === "Skill" && options?.parentScope) {
+      enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
     }
 
     // Inject parent scope for MessageChannel tool (per-execution, not global singleton)


### PR DESCRIPTION
## Summary
- resolve `Skill` tool files from the execution-scoped agent instead of the process-global agent context so desktop/listener turns stop looking in the wrong memfs repo
- use the execution working directory for project skill fallback so listener turns resolve `.skills/` from the scoped cwd rather than the desktop process cwd
- add regression tests for direct `skill(...)` calls and the `executeTool(...)` listener path

👾 Generated with [Letta Code](https://letta.com)