### PR TITLE
feat(telegram): support inbound image attachments

### DIFF
--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -5,6 +5,10 @@
  * Reference: lettabot src/channels/telegram.ts
  */
 
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import type {
   ChannelAdapter,
@@ -14,6 +18,32 @@ import type {
   TelegramChannelConfig,
 } from "../types";
 import { loadGrammyModule } from "./runtime";
+
+const SAFE_CHARS_RE = /[^A-Za-z0-9._-]/g;
+
+/**
+ * Save an image buffer to a temp directory and return the absolute path.
+ * Structure: <tmpdir>/letta-attachments/telegram/<chatId>/<timestamp>-<uuid>-<name>
+ */
+function saveImageToTemp(
+  buffer: Buffer,
+  chatId: string,
+  fileName: string,
+): string {
+  const dir = join(
+    tmpdir(),
+    "letta-attachments",
+    "telegram",
+    chatId.replace(SAFE_CHARS_RE, "_"),
+  );
+  mkdirSync(dir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const token = randomUUID().slice(0, 8);
+  const safeName = fileName.replace(SAFE_CHARS_RE, "_") || "image";
+  const filePath = join(dir, `${stamp}-${token}-${safeName}`);
+  writeFileSync(filePath, buffer);
+  return filePath;
+}
 
 type TelegramBot = GrammYBot<GrammYContext>;
 type GrammYModule = typeof import("grammy") & {
@@ -148,10 +178,25 @@ export function createTelegramAdapter(
               throw fetchErr;
             }
             if (response.ok) {
-              const buffer = await response.arrayBuffer();
+              const buffer = Buffer.from(await response.arrayBuffer());
               if (buffer.byteLength <= MAX_IMAGE_BYTES) {
-                const base64 = Buffer.from(buffer).toString("base64");
-                images.push({ data: base64, mediaType });
+                const base64 = buffer.toString("base64");
+                // Derive a reasonable filename for the temp file
+                const ext = mediaType.split("/")[1] ?? "jpg";
+                const baseName = isPhoto
+                  ? `photo.${ext}`
+                  : (doc?.file_name ?? `image.${ext}`);
+                let localPath: string | undefined;
+                try {
+                  localPath = saveImageToTemp(
+                    buffer,
+                    String(msg.chat.id),
+                    baseName,
+                  );
+                } catch {
+                  // Non-fatal: agent still gets the base64 image
+                }
+                images.push({ data: base64, mediaType, localPath });
               } else {
                 console.warn(
                   `[Telegram] Downloaded image too large (${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB), discarding.`,

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -9,6 +9,7 @@ import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import type {
   ChannelAdapter,
   InboundChannelMessage,
+  InboundImageAttachment,
   OutboundChannelMessage,
   TelegramChannelConfig,
 } from "../types";
@@ -81,6 +82,111 @@ export function createTelegramAdapter(
           await adapter.onMessage(inbound);
         } catch (err) {
           console.error("[Telegram] Error handling inbound message:", err);
+        }
+      }
+    });
+
+    // Handle photo messages (and image documents)
+    // Match the desktop app's 5MB limit (see imageResize.ts).
+    const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+    const FETCH_TIMEOUT_MS = 15_000;
+
+    instance.on(["message:photo", "message:document"], async (ctx) => {
+      const msg = ctx.message;
+      if (!msg.from) return;
+
+      // Determine if this is a photo or an image document
+      const photos = msg.photo ?? [];
+      const isPhoto = photos.length > 0;
+      const doc = msg.document;
+      const isImageDoc = !!doc?.mime_type?.startsWith("image/");
+      if (!isPhoto && !isImageDoc) return;
+
+      const displayName =
+        msg.from.username ??
+        [msg.from.first_name, msg.from.last_name].filter(Boolean).join(" ");
+
+      // Download the image
+      const images: InboundImageAttachment[] = [];
+      try {
+        let fileId: string;
+        let mediaType: string;
+        let reportedSize: number | undefined;
+
+        if (isPhoto) {
+          // Use the largest photo size (last in array).
+          // isPhoto guarantees photos.length > 0, so the index is safe.
+          const photo = photos[photos.length - 1] as (typeof photos)[number];
+          fileId = photo.file_id;
+          mediaType = "image/jpeg"; // Telegram photos are always JPEG
+          reportedSize = photo.file_size;
+        } else {
+          fileId = doc!.file_id;
+          mediaType = doc!.mime_type ?? "image/jpeg";
+          reportedSize = doc!.file_size;
+        }
+
+        // Skip oversized files before downloading
+        if (reportedSize && reportedSize > MAX_IMAGE_BYTES) {
+          console.warn(
+            `[Telegram] Image too large (${(reportedSize / 1024 / 1024).toFixed(1)}MB), skipping download.`,
+          );
+        } else {
+          const file = await instance.api.getFile(fileId);
+          if (file.file_path) {
+            // Note: Telegram Bot API requires the token in the download URL.
+            // We avoid logging the URL to prevent token leakage.
+            const fileUrl = `https://api.telegram.org/file/bot${config.token}/${file.file_path}`;
+            let response: Response;
+            try {
+              response = await fetch(fileUrl, {
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+              });
+            } catch (fetchErr) {
+              // Log without the URL to avoid leaking the bot token
+              console.error("[Telegram] Failed to fetch image file.");
+              throw fetchErr;
+            }
+            if (response.ok) {
+              const buffer = await response.arrayBuffer();
+              if (buffer.byteLength <= MAX_IMAGE_BYTES) {
+                const base64 = Buffer.from(buffer).toString("base64");
+                images.push({ data: base64, mediaType });
+              } else {
+                console.warn(
+                  `[Telegram] Downloaded image too large (${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB), discarding.`,
+                );
+              }
+            }
+          }
+        }
+      } catch (err) {
+        // Intentionally terse to avoid leaking the bot token from URLs in error messages
+        const errMsg = err instanceof Error ? err.message : "unknown error";
+        console.error(`[Telegram] Failed to download image: ${errMsg}`);
+      }
+
+      // If we couldn't download the image, still forward the caption if present
+      if (images.length === 0 && !msg.caption) return;
+
+      const inbound: InboundChannelMessage = {
+        channel: "telegram",
+        chatId: String(msg.chat.id),
+        senderId: String(msg.from.id),
+        senderName: displayName || undefined,
+        text: msg.caption ?? "",
+        timestamp: msg.date * 1000,
+        messageId: String(msg.message_id),
+        chatType: "direct",
+        raw: msg,
+        images: images.length > 0 ? images : undefined,
+      };
+
+      if (adapter.onMessage) {
+        try {
+          await adapter.onMessage(inbound);
+        } catch (err) {
+          console.error("[Telegram] Error handling inbound photo:", err);
         }
       }
     });

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -53,6 +53,8 @@ export interface InboundImageAttachment {
   data: string;
   /** MIME type, e.g. "image/jpeg". */
   mediaType: string;
+  /** Absolute path where the image was saved to disk (temp dir). */
+  localPath?: string;
 }
 
 // ── Message types ─────────────────────────────────────────────────

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -46,6 +46,15 @@ export interface ChannelAdapter {
   onMessage?: (msg: InboundChannelMessage) => Promise<void>;
 }
 
+// ── Attachments ───────────────────────────────────────────────────
+
+export interface InboundImageAttachment {
+  /** Base64-encoded image data. */
+  data: string;
+  /** MIME type, e.g. "image/jpeg". */
+  mediaType: string;
+}
+
 // ── Message types ─────────────────────────────────────────────────
 
 export interface InboundChannelMessage {
@@ -69,6 +78,8 @@ export interface InboundChannelMessage {
   raw?: unknown;
   /** Broad chat surface type used for routing/pairing decisions. */
   chatType?: ChannelChatType;
+  /** Inbound image attachments (photos, image documents). */
+  images?: InboundImageAttachment[];
 }
 
 export interface OutboundChannelMessage {

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -93,12 +93,36 @@ export function buildChannelNotificationXml(
  * The reminder and the notification XML are emitted as separate text parts so
  * UIs that already know how to hide pure system-reminder parts can do so
  * without needing to parse concatenated XML blobs.
+ *
+ * When the inbound message includes images, they are appended as ImageContent
+ * parts so the agent can see them inline.
  */
 export function formatChannelNotification(
   msg: InboundChannelMessage,
 ): MessageCreate["content"] {
-  return [
+  const parts: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: { type: "base64"; media_type: string; data: string };
+      }
+  > = [
     { type: "text", text: buildChannelReminderText(msg) },
     { type: "text", text: buildChannelNotificationXml(msg) },
-  ] as MessageCreate["content"];
+  ];
+
+  if (msg.images?.length) {
+    for (const img of msg.images) {
+      parts.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: img.mediaType,
+          data: img.data,
+        },
+      });
+    }
+  }
+
+  return parts as MessageCreate["content"];
 }

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -37,6 +37,14 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
       ? `Use reply_to_message_id="${escapeXml(msg.messageId)}" if you want your reply to stay in the same Slack thread.`
       : null;
 
+  // Build attachment path lines for images saved to disk
+  const attachmentLines = (msg.images ?? [])
+    .filter((img) => img.localPath)
+    .map(
+      (img) =>
+        `Attached image (${escapeXml(img.mediaType)}) saved to ${escapeXml(img.localPath!)}`,
+    );
+
   const lines = [
     SYSTEM_REMINDER_OPEN,
     `This message originated from an external ${escapedChannel} channel.`,
@@ -49,6 +57,11 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
 
   if (threadLine) {
     lines.splice(lines.length - 2, 0, threadLine);
+  }
+
+  if (attachmentLines.length > 0) {
+    // Insert before the closing tag
+    lines.splice(lines.length - 1, 0, ...attachmentLines);
   }
 
   return lines.join("\n");

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -11,15 +11,19 @@ function expectTextParts(
   content: MessageCreate["content"],
 ): [{ type: "text"; text: string }, { type: "text"; text: string }] {
   expect(Array.isArray(content)).toBe(true);
-  const parts = content as Array<{ type: "text"; text: string }>;
-  expect(parts).toHaveLength(2);
+  const parts = content as Array<{ type: string; text?: string }>;
+  // At least 2 text parts (reminder + notification); may have more (images)
+  expect(parts.length).toBeGreaterThanOrEqual(2);
 
   const [reminderPart, notificationPart] = parts;
   if (!reminderPart || !notificationPart) {
     throw new Error("Expected reminder and notification text parts");
   }
 
-  return [reminderPart, notificationPart];
+  return [
+    reminderPart as { type: "text"; text: string },
+    notificationPart as { type: "text"; text: string },
+  ];
 }
 
 describe("formatChannelNotification", () => {
@@ -112,6 +116,57 @@ describe("formatChannelNotification", () => {
     const xml = buildChannelNotificationXml(msg);
 
     expect(xml).toContain("John &quot;The &lt;Bot&gt;&quot;");
+  });
+
+  test("includes ImageContent parts when message has images", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      senderName: "John",
+      text: "Check this photo",
+      timestamp: Date.now(),
+      messageId: "msg-99",
+      images: [{ data: "aGVsbG8=", mediaType: "image/jpeg" }],
+    };
+
+    const content = formatChannelNotification(msg);
+    const parts = content as Array<{
+      type: string;
+      text?: string;
+      source?: { type: string; media_type: string; data: string };
+    }>;
+
+    expect(parts).toHaveLength(3);
+    expect(parts[0]!.type).toBe("text");
+    expect(parts[1]!.type).toBe("text");
+    expect(parts[2]!.type).toBe("image");
+    expect(parts[2]!.source).toEqual({
+      type: "base64",
+      media_type: "image/jpeg",
+      data: "aGVsbG8=",
+    });
+  });
+
+  test("handles multiple images", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      text: "",
+      timestamp: Date.now(),
+      images: [
+        { data: "img1data", mediaType: "image/jpeg" },
+        { data: "img2data", mediaType: "image/png" },
+      ],
+    };
+
+    const content = formatChannelNotification(msg);
+    const parts = content as Array<{ type: string }>;
+
+    expect(parts).toHaveLength(4); // 2 text + 2 images
+    expect(parts[2]!.type).toBe("image");
+    expect(parts[3]!.type).toBe("image");
   });
 
   test("omits optional notification attributes when not present", () => {

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -164,9 +164,57 @@ describe("formatChannelNotification", () => {
     const content = formatChannelNotification(msg);
     const parts = content as Array<{ type: string }>;
 
-    expect(parts).toHaveLength(4); // 2 text + 2 images
+    expect(parts).toHaveLength(4); // 2 text + 2 images (no localPath = no path text part)
     expect(parts[2]!.type).toBe("image");
     expect(parts[3]!.type).toBe("image");
+  });
+
+  test("includes image path in system reminder when images have localPath", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      text: "Here's a photo",
+      timestamp: Date.now(),
+      images: [
+        {
+          data: "aGVsbG8=",
+          mediaType: "image/jpeg",
+          localPath: "/tmp/letta-attachments/telegram/12345/photo.jpg",
+        },
+      ],
+    };
+
+    const content = formatChannelNotification(msg);
+    const parts = content as Array<{ type: string; text?: string }>;
+
+    // 2 text (reminder + notification) + 1 image = 3 parts
+    expect(parts).toHaveLength(3);
+    // Path info is inside the system reminder (part 0)
+    expect(parts[0]!.text).toContain(
+      "saved to /tmp/letta-attachments/telegram/12345/photo.jpg",
+    );
+    expect(parts[0]!.text).toContain("image/jpeg");
+    expect(parts[2]!.type).toBe("image");
+  });
+
+  test("omits image path in system reminder when images lack localPath", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "12345",
+      senderId: "67890",
+      text: "No path",
+      timestamp: Date.now(),
+      images: [{ data: "aGVsbG8=", mediaType: "image/jpeg" }],
+    };
+
+    const content = formatChannelNotification(msg);
+    const parts = content as Array<{ type: string; text?: string }>;
+
+    // 2 text (reminder + notification) + 1 image = 3 parts
+    expect(parts).toHaveLength(3);
+    expect(parts[0]!.text).not.toContain("saved to");
+    expect(parts[2]!.type).toBe("image");
   });
 
   test("omits optional notification attributes when not present", () => {


### PR DESCRIPTION
## Summary

- Adds image receiving support for the Telegram channel adapter. Photos and image documents sent via Telegram are downloaded, validated against a 5MB size limit, and forwarded to the agent as base64 `ImageContent` parts.
- Images are also saved to a temp directory (`<tmpdir>/letta-attachments/telegram/<chatId>/`) and the file path is included in the system reminder, so agents can `Read` the file even if the model doesn't process inline image parts.

## Changes

| File | What |
|------|------|
| `src/channels/types.ts` | `InboundImageAttachment` type with `data`, `mediaType`, `localPath`; added `images` to `InboundChannelMessage` |
| `src/channels/telegram/adapter.ts` | `message:photo` + `message:document` handler: downloads image, saves to temp, builds base64 attachment |
| `src/channels/xml.ts` | `buildChannelReminderText` includes attachment paths in system reminder; `formatChannelNotification` appends `ImageContent` parts |
| `src/tests/channels/xml.test.ts` | Tests for image parts, localPath in reminder, and omission when no localPath |

Written by Cameron ◯ Letta Code