### PR TITLE
fix(channels): show CLI pairing command in Telegram pairing message

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -38,7 +38,10 @@ import { formatChannelNotification } from "./xml";
 function buildPairingInstructions(channelId: string, code: string): string {
   return (
     `To connect this chat to a Letta Code agent, run:\n\n` +
+    `From ADE/desktop:\n` +
     `/channels ${channelId} pair ${code}\n\n` +
+    `From CLI:\n` +
+    `letta channels pair --channel ${channelId} --code ${code} --agent <AGENT_ID>\n\n` +
     `This code expires in 15 minutes.`
   );
 }


### PR DESCRIPTION
## Summary

- The pairing code message sent to Telegram only showed the `/channels telegram pair <code>` WS command (for ADE/desktop users)
- CLI-only users had no way to know the command without checking docs
- Now shows both options:
  - `From ADE/desktop: /channels telegram pair <code>`
  - `From CLI: letta channels pair --channel telegram --code <code> --agent <AGENT_ID>`

## Test plan

- [ ] Message a Telegram bot with pairing policy, verify the reply shows both ADE and CLI commands
- [ ] Verify the CLI command format is copy-pasteable (just need to replace `<AGENT_ID>`)

Written by Cameron ◯ Letta Code

"Give them the third best to go on with; the second best comes too late, the best never comes." -- Robert Watson-Watt