### PR TITLE
feat(channels): add account-scoped channel management

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -1,0 +1,237 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  getChannelAccountsPath,
+  getChannelDir,
+  readChannelConfig,
+} from "./config";
+import type {
+  ChannelAccount,
+  SlackChannelAccount,
+  SupportedChannelId,
+  TelegramChannelAccount,
+} from "./types";
+
+interface ChannelAccountStore {
+  accounts: ChannelAccount[];
+}
+
+export const LEGACY_CHANNEL_ACCOUNT_ID = "__legacy_migrated__";
+
+const stores = new Map<string, ChannelAccountStore>();
+
+let loadAccountsOverride:
+  | ((channelId: string) => ChannelAccount[] | null)
+  | null = null;
+let saveAccountsOverride:
+  | ((channelId: string, accounts: ChannelAccount[]) => void)
+  | null = null;
+
+function cloneAccount<T extends ChannelAccount>(account: T): T {
+  const cloned = {
+    ...account,
+    allowedUsers: [...account.allowedUsers],
+  } as T;
+
+  if (account.channel === "telegram") {
+    (cloned as TelegramChannelAccount).binding = { ...account.binding };
+  }
+
+  return cloned;
+}
+
+function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
+  const next = cloneAccount(account);
+  if (
+    (next.channel === "telegram" &&
+      (next.displayName === "Telegram bot" ||
+        next.displayName === "Migrated Telegram bot")) ||
+    (next.channel === "slack" &&
+      (next.displayName === "Slack app" ||
+        next.displayName === "Migrated Slack app"))
+  ) {
+    next.displayName = undefined;
+  }
+  return next;
+}
+
+function makeDefaultLegacyAccount(
+  channelId: SupportedChannelId,
+): TelegramChannelAccount | SlackChannelAccount {
+  const config = readChannelConfig(channelId);
+  const now = new Date().toISOString();
+
+  if (!config) {
+    throw new Error(`Missing legacy config for ${channelId}`);
+  }
+
+  if (config.channel === "telegram") {
+    return {
+      channel: "telegram",
+      accountId: LEGACY_CHANNEL_ACCOUNT_ID,
+      enabled: config.enabled,
+      token: config.token,
+      dmPolicy: config.dmPolicy,
+      allowedUsers: [...config.allowedUsers],
+      binding: {
+        agentId: null,
+        conversationId: null,
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  return {
+    channel: "slack",
+    accountId: LEGACY_CHANNEL_ACCOUNT_ID,
+    enabled: config.enabled,
+    mode: config.mode,
+    botToken: config.botToken,
+    appToken: config.appToken,
+    dmPolicy: config.dmPolicy,
+    allowedUsers: [...config.allowedUsers],
+    agentId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function getStore(channelId: string): ChannelAccountStore {
+  let store = stores.get(channelId);
+  if (!store) {
+    loadChannelAccounts(channelId);
+    store = stores.get(channelId);
+  }
+
+  if (!store) {
+    store = { accounts: [] };
+    stores.set(channelId, store);
+  }
+
+  return store;
+}
+
+export function loadChannelAccounts(channelId: string): void {
+  if (loadAccountsOverride) {
+    stores.set(channelId, {
+      accounts: (loadAccountsOverride(channelId) ?? []).map((account) =>
+        normalizeLoadedAccount(account),
+      ),
+    });
+    return;
+  }
+
+  const path = getChannelAccountsPath(channelId);
+  if (existsSync(path)) {
+    try {
+      const text = readFileSync(path, "utf-8");
+      const parsed = JSON.parse(text) as Partial<ChannelAccountStore>;
+      stores.set(channelId, {
+        accounts: (parsed.accounts ?? []).map((account) =>
+          normalizeLoadedAccount(account),
+        ),
+      });
+      return;
+    } catch {
+      stores.set(channelId, { accounts: [] });
+      return;
+    }
+  }
+
+  if (channelId === "telegram" || channelId === "slack") {
+    const legacyConfig = readChannelConfig(channelId);
+    if (legacyConfig) {
+      const migratedAccounts = [makeDefaultLegacyAccount(channelId)];
+      stores.set(channelId, {
+        accounts: migratedAccounts,
+      });
+      saveChannelAccounts(channelId);
+      return;
+    }
+  }
+
+  stores.set(channelId, { accounts: [] });
+}
+
+function saveChannelAccounts(channelId: string): void {
+  const store = getStore(channelId);
+  if (saveAccountsOverride) {
+    saveAccountsOverride(
+      channelId,
+      store.accounts.map((account) => cloneAccount(account)),
+    );
+    return;
+  }
+
+  const dir = getChannelDir(channelId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getChannelAccountsPath(channelId),
+    `${JSON.stringify({ accounts: store.accounts }, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+export function listChannelAccounts(channelId: string): ChannelAccount[] {
+  return getStore(channelId).accounts.map((account) => cloneAccount(account));
+}
+
+export function getChannelAccount(
+  channelId: string,
+  accountId: string,
+): ChannelAccount | null {
+  const account = getStore(channelId).accounts.find(
+    (entry) => entry.accountId === accountId,
+  );
+  return account ? cloneAccount(account) : null;
+}
+
+export function upsertChannelAccount(
+  channelId: string,
+  account: ChannelAccount,
+): ChannelAccount {
+  const store = getStore(channelId);
+  const next = cloneAccount(account);
+  const index = store.accounts.findIndex(
+    (entry) => entry.accountId === account.accountId,
+  );
+  if (index >= 0) {
+    store.accounts[index] = next;
+  } else {
+    store.accounts.push(next);
+  }
+  saveChannelAccounts(channelId);
+  return cloneAccount(next);
+}
+
+export function removeChannelAccount(
+  channelId: string,
+  accountId: string,
+): boolean {
+  const store = getStore(channelId);
+  const nextAccounts = store.accounts.filter(
+    (entry) => entry.accountId !== accountId,
+  );
+  if (nextAccounts.length === store.accounts.length) {
+    return false;
+  }
+  store.accounts = nextAccounts;
+  saveChannelAccounts(channelId);
+  return true;
+}
+
+export function clearChannelAccountStores(): void {
+  stores.clear();
+}
+
+export function __testOverrideLoadChannelAccounts(
+  fn: ((channelId: string) => ChannelAccount[] | null) | null,
+): void {
+  loadAccountsOverride = fn;
+}
+
+export function __testOverrideSaveChannelAccounts(
+  fn: ((channelId: string, accounts: ChannelAccount[]) => void) | null,
+): void {
+  saveAccountsOverride = fn;
+}

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -5,7 +5,7 @@
  * This module handles reading, writing, and validating channel configs.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -31,6 +31,10 @@ export function getChannelConfigPath(channelId: string): string {
   return join(getChannelDir(channelId), "config.yaml");
 }
 
+export function getChannelAccountsPath(channelId: string): string {
+  return join(getChannelDir(channelId), "accounts.json");
+}
+
 export function getChannelRoutingPath(channelId: string): string {
   return join(getChannelDir(channelId), "routing.yaml");
 }
@@ -44,59 +48,6 @@ export function getChannelTargetsPath(channelId: string): string {
 }
 
 // ── YAML helpers ──────────────────────────────────────────────────
-
-/**
- * Minimal YAML serializer for flat/shallow objects.
- * Avoids pulling in a full YAML library for simple config files.
- */
-function toSimpleYaml(obj: Record<string, unknown>, indent = 0): string {
-  const prefix = " ".repeat(indent);
-  const lines: string[] = [];
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === undefined || value === null) continue;
-
-    if (Array.isArray(value)) {
-      if (value.length === 0) {
-        lines.push(`${prefix}${key}: []`);
-      } else if (
-        typeof value[0] === "object" &&
-        value[0] !== null &&
-        !Array.isArray(value[0])
-      ) {
-        lines.push(`${prefix}${key}:`);
-        for (const item of value) {
-          const itemLines = toSimpleYaml(
-            item as Record<string, unknown>,
-            indent + 4,
-          ).split("\n");
-          if (itemLines.length > 0 && itemLines[0]) {
-            lines.push(`${prefix}  - ${itemLines[0].trimStart()}`);
-            for (let i = 1; i < itemLines.length; i++) {
-              if (itemLines[i]) {
-                lines.push(`${prefix}    ${itemLines[i]?.trimStart()}`);
-              }
-            }
-          }
-        }
-      } else {
-        lines.push(`${prefix}${key}:`);
-        for (const item of value) {
-          lines.push(`${prefix}  - ${JSON.stringify(item)}`);
-        }
-      }
-    } else if (typeof value === "object" && value !== null) {
-      lines.push(`${prefix}${key}:`);
-      lines.push(toSimpleYaml(value as Record<string, unknown>, indent + 2));
-    } else if (typeof value === "string") {
-      lines.push(`${prefix}${key}: ${JSON.stringify(value)}`);
-    } else {
-      lines.push(`${prefix}${key}: ${String(value)}`);
-    }
-  }
-
-  return lines.join("\n");
-}
 
 /**
  * Minimal YAML parser for simple key-value configs.
@@ -171,7 +122,6 @@ function parseYamlValue(raw: string): unknown {
 
 interface ChannelConfigCodec<TConfig extends ChannelConfig> {
   parse(parsed: Record<string, unknown>): TConfig;
-  serialize(config: TConfig): Record<string, unknown>;
 }
 
 const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
@@ -182,15 +132,6 @@ const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
       token: String(parsed.token ?? ""),
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
-    };
-  },
-  serialize(config) {
-    return {
-      channel: config.channel,
-      enabled: config.enabled,
-      token: config.token,
-      dm_policy: config.dmPolicy,
-      allowed_users: config.allowedUsers,
     };
   },
 };
@@ -205,17 +146,6 @@ const slackConfigCodec: ChannelConfigCodec<SlackChannelConfig> = {
       appToken: String(parsed.app_token ?? ""),
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
-    };
-  },
-  serialize(config) {
-    return {
-      channel: config.channel,
-      enabled: config.enabled,
-      mode: config.mode,
-      bot_token: config.botToken,
-      app_token: config.appToken,
-      dm_policy: config.dmPolicy,
-      allowed_users: config.allowedUsers,
     };
   },
 };
@@ -233,10 +163,6 @@ function getChannelConfigCodec(
   return CHANNEL_CONFIG_CODECS[channelId] ?? null;
 }
 
-export function channelConfigExists(channelId: string): boolean {
-  return existsSync(getChannelConfigPath(channelId));
-}
-
 export function readChannelConfig(channelId: string): ChannelConfig | null {
   const configPath = getChannelConfigPath(channelId);
   if (!existsSync(configPath)) return null;
@@ -250,19 +176,4 @@ export function readChannelConfig(channelId: string): ChannelConfig | null {
   } catch {
     return null;
   }
-}
-
-export function writeChannelConfig(
-  channelId: string,
-  config: ChannelConfig,
-): void {
-  const dir = getChannelDir(channelId);
-  mkdirSync(dir, { recursive: true });
-  const codec = getChannelConfigCodec(channelId);
-  if (!codec) {
-    throw new Error(`Unsupported channel config: ${channelId}`);
-  }
-
-  const text = toSimpleYaml(codec.serialize(config));
-  writeFileSync(getChannelConfigPath(channelId), `${text}\n`, "utf-8");
 }

--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -1,0 +1,87 @@
+import { loadChannelPlugin } from "./pluginRegistry";
+import type {
+  ChannelMessageToolDiscovery,
+  ChannelMessageToolSchemaContribution,
+} from "./pluginTypes";
+import { getActiveChannelIds } from "./registry";
+import type { SupportedChannelId } from "./types";
+
+/**
+ * Build the public schema for the shared MessageChannel tool by merging
+ * plugin-owned action discovery from each active channel.
+ *
+ * The top-level tool surface stays singular; individual channel plugins own
+ * their actions and schema fragments underneath it.
+ */
+function asSchemaContributionArray(
+  schema:
+    | ChannelMessageToolSchemaContribution
+    | ChannelMessageToolSchemaContribution[]
+    | null
+    | undefined,
+): ChannelMessageToolSchemaContribution[] {
+  if (!schema) {
+    return [];
+  }
+  return Array.isArray(schema) ? schema : [schema];
+}
+
+function mergeSchemaContributions(
+  schema: Record<string, unknown>,
+  contributions: ChannelMessageToolSchemaContribution[],
+): Record<string, unknown> {
+  const properties = schema.properties as Record<string, unknown> | undefined;
+  if (!properties) {
+    return schema;
+  }
+
+  for (const contribution of contributions) {
+    Object.assign(properties, structuredClone(contribution.properties));
+  }
+
+  return schema;
+}
+
+function collectDiscoveryActions(
+  discovery: ChannelMessageToolDiscovery | null | undefined,
+): string[] {
+  return discovery?.actions ? Array.from(discovery.actions) : [];
+}
+
+export async function buildDynamicMessageChannelSchema(
+  baseSchema: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const schema = structuredClone(baseSchema);
+  const properties = schema.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!properties) {
+    return schema;
+  }
+
+  const activeChannels = getActiveChannelIds();
+  if (properties.channel && activeChannels.length > 0) {
+    properties.channel.enum = activeChannels;
+  }
+
+  const actionEnum = new Set<string>(["send"]);
+  const contributions: ChannelMessageToolSchemaContribution[] = [];
+
+  for (const channelId of activeChannels) {
+    const plugin = await loadChannelPlugin(channelId as SupportedChannelId);
+    const discovery = plugin.messageActions?.describeMessageTool({
+      accountId: null,
+    });
+
+    for (const action of collectDiscoveryActions(discovery)) {
+      actionEnum.add(action);
+    }
+    contributions.push(...asSchemaContributionArray(discovery?.schema));
+  }
+
+  if (properties.action) {
+    properties.action.enum = Array.from(actionEnum);
+  }
+
+  return mergeSchemaContributions(schema, contributions);
+}

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getChannelDir, getChannelPairingPath } from "./config";
 import type { ApprovedUser, PairingStore, PendingPairing } from "./types";
 
@@ -29,6 +30,17 @@ const CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // No I, O, 0, 1
 
 const stores = new Map<string, PairingStore>();
 
+let loadPairingStoreOverride:
+  | ((channelId: string) => PairingStore | null)
+  | null = null;
+let savePairingStoreOverride:
+  | ((channelId: string, store: PairingStore) => void)
+  | null = null;
+
+function normalizeAccountId(accountId?: string): string {
+  return accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+}
+
 function getStore(channelId: string): PairingStore {
   let store = stores.get(channelId);
   if (!store) {
@@ -41,6 +53,18 @@ function getStore(channelId: string): PairingStore {
 // ── Load/save ─────────────────────────────────────────────────────
 
 export function loadPairingStore(channelId: string): void {
+  if (loadPairingStoreOverride) {
+    const overridden = loadPairingStoreOverride(channelId);
+    if (overridden === null) {
+      return;
+    }
+    stores.set(channelId, {
+      pending: [...overridden.pending],
+      approved: [...overridden.approved],
+    });
+    return;
+  }
+
   const path = getChannelPairingPath(channelId);
   if (!existsSync(path)) return;
 
@@ -57,10 +81,18 @@ export function loadPairingStore(channelId: string): void {
 }
 
 function savePairingStore(channelId: string): void {
+  const store = getStore(channelId);
+  if (savePairingStoreOverride) {
+    savePairingStoreOverride(channelId, {
+      pending: [...store.pending],
+      approved: [...store.approved],
+    });
+    return;
+  }
+
   const dir = getChannelDir(channelId);
   mkdirSync(dir, { recursive: true });
 
-  const store = getStore(channelId);
   writeFileSync(
     getChannelPairingPath(channelId),
     `${JSON.stringify(store, null, 2)}\n`,
@@ -83,9 +115,18 @@ function generateCode(length = 6): string {
 /**
  * Check if a user is approved (has completed pairing).
  */
-export function isUserApproved(channelId: string, userId: string): boolean {
+export function isUserApproved(
+  channelId: string,
+  userId: string,
+  accountId?: string,
+): boolean {
   const store = getStore(channelId);
-  return store.approved.some((u) => u.senderId === userId);
+  const normalizedAccountId = normalizeAccountId(accountId);
+  return store.approved.some(
+    (u) =>
+      u.senderId === userId &&
+      normalizeAccountId(u.accountId) === normalizedAccountId,
+  );
 }
 
 /**
@@ -97,11 +138,19 @@ export function createPairingCode(
   userId: string,
   chatId: string,
   username?: string,
+  accountId?: string,
 ): string {
   const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(accountId);
 
   // Remove any existing pending code for this user
-  store.pending = store.pending.filter((p) => p.senderId !== userId);
+  store.pending = store.pending.filter(
+    (p) =>
+      !(
+        p.senderId === userId &&
+        normalizeAccountId(p.accountId) === normalizedAccountId
+      ),
+  );
 
   // Prune expired codes
   const now = Date.now();
@@ -116,6 +165,7 @@ export function createPairingCode(
 
   const code = generateCode();
   const pending: PendingPairing = {
+    accountId: normalizedAccountId,
     code,
     senderId: userId,
     senderName: username,
@@ -137,14 +187,31 @@ export function createPairingCode(
 export function consumePairingCode(
   channelId: string,
   code: string,
+  accountId?: string,
 ): PendingPairing | null {
   const store = getStore(channelId);
   const upperCode = code.toUpperCase();
+  const normalizedAccountId =
+    accountId === undefined ? undefined : normalizeAccountId(accountId);
 
-  const index = store.pending.findIndex((p) => p.code === upperCode);
+  const matches = store.pending
+    .map((pending, index) => ({ pending, index }))
+    .filter(
+      ({ pending }) =>
+        pending.code === upperCode &&
+        (normalizedAccountId === undefined ||
+          normalizeAccountId(pending.accountId) === normalizedAccountId),
+    );
+
+  if (matches.length > 1) {
+    return null;
+  }
+
+  const index = matches[0]?.index ?? -1;
   if (index === -1) return null;
 
   const pending = store.pending[index] as PendingPairing;
+  const pendingAccountId = normalizeAccountId(pending.accountId);
 
   // Check expiry
   if (new Date(pending.expiresAt).getTime() < Date.now()) {
@@ -158,8 +225,15 @@ export function consumePairingCode(
   store.pending.splice(index, 1);
 
   // Add to approved (if not already)
-  if (!store.approved.some((u) => u.senderId === pending.senderId)) {
+  if (
+    !store.approved.some(
+      (u) =>
+        u.senderId === pending.senderId &&
+        normalizeAccountId(u.accountId) === pendingAccountId,
+    )
+  ) {
     const approved: ApprovedUser = {
+      accountId: pendingAccountId,
       senderId: pending.senderId,
       senderName: pending.senderName,
       approvedAt: new Date().toISOString(),
@@ -175,17 +249,36 @@ export function consumePairingCode(
  * Get all pending pairing codes for a channel.
  * Filters out expired codes.
  */
-export function getPendingPairings(channelId: string): PendingPairing[] {
+export function getPendingPairings(
+  channelId: string,
+  accountId?: string,
+): PendingPairing[] {
   const store = getStore(channelId);
   const now = Date.now();
-  return store.pending.filter((p) => new Date(p.expiresAt).getTime() > now);
+  const normalizedAccountId =
+    accountId === undefined ? undefined : normalizeAccountId(accountId);
+  return store.pending.filter(
+    (p) =>
+      new Date(p.expiresAt).getTime() > now &&
+      (normalizedAccountId === undefined ||
+        normalizeAccountId(p.accountId) === normalizedAccountId),
+  );
 }
 
 /**
  * Get all approved users for a channel.
  */
-export function getApprovedUsers(channelId: string): ApprovedUser[] {
-  return getStore(channelId).approved;
+export function getApprovedUsers(
+  channelId: string,
+  accountId?: string,
+): ApprovedUser[] {
+  const normalizedAccountId =
+    accountId === undefined ? undefined : normalizeAccountId(accountId);
+  return getStore(channelId).approved.filter(
+    (user) =>
+      normalizedAccountId === undefined ||
+      normalizeAccountId(user.accountId) === normalizedAccountId,
+  );
 }
 
 /**
@@ -198,10 +291,15 @@ export function rollbackPairingApproval(
   pending: PendingPairing,
 ): void {
   const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(pending.accountId);
 
   // Remove from approved
   store.approved = store.approved.filter(
-    (u) => u.senderId !== pending.senderId,
+    (u) =>
+      !(
+        u.senderId === pending.senderId &&
+        normalizeAccountId(u.accountId) === normalizedAccountId
+      ),
   );
 
   // Re-add to pending
@@ -210,9 +308,48 @@ export function rollbackPairingApproval(
   savePairingStore(channelId);
 }
 
+export function removePairingStateForAccount(
+  channelId: string,
+  accountId: string,
+): { pendingRemoved: number; approvedRemoved: number } {
+  const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const nextPending = store.pending.filter(
+    (pending) => normalizeAccountId(pending.accountId) !== normalizedAccountId,
+  );
+  const nextApproved = store.approved.filter(
+    (approved) =>
+      normalizeAccountId(approved.accountId) !== normalizedAccountId,
+  );
+
+  const pendingRemoved = store.pending.length - nextPending.length;
+  const approvedRemoved = store.approved.length - nextApproved.length;
+
+  if (pendingRemoved === 0 && approvedRemoved === 0) {
+    return { pendingRemoved, approvedRemoved };
+  }
+
+  store.pending = nextPending;
+  store.approved = nextApproved;
+  savePairingStore(channelId);
+  return { pendingRemoved, approvedRemoved };
+}
+
 /**
  * Clear all pairing state (for testing).
  */
 export function clearPairingStores(): void {
   stores.clear();
+}
+
+export function __testOverrideLoadPairingStore(
+  fn: ((channelId: string) => PairingStore | null) | null,
+): void {
+  loadPairingStoreOverride = fn;
+}
+
+export function __testOverrideSavePairingStore(
+  fn: ((channelId: string, store: PairingStore) => void) | null,
+): void {
+  savePairingStoreOverride = fn;
 }

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -1,6 +1,8 @@
 import type {
+  ChannelAccount,
   ChannelAdapter,
-  ChannelConfig,
+  ChannelRoute,
+  OutboundChannelMessage,
   SupportedChannelId,
 } from "./types";
 
@@ -11,10 +13,68 @@ export interface ChannelPluginMetadata {
   runtimeModules: string[];
 }
 
+export type ChannelMessageActionName = "send" | "react" | "upload-file";
+
+export interface ChannelMessageToolSchemaContribution {
+  properties: Record<string, unknown>;
+  visibility?: "all-configured";
+}
+
+/**
+ * Plugin-owned discovery for the shared MessageChannel tool.
+ * Channel plugins advertise their supported actions and any extra schema
+ * fragments here so the public tool surface stays singular while the
+ * capabilities remain channel-specific.
+ */
+export interface ChannelMessageToolDiscovery {
+  actions?: readonly ChannelMessageActionName[] | null;
+  schema?:
+    | ChannelMessageToolSchemaContribution
+    | ChannelMessageToolSchemaContribution[]
+    | null;
+}
+
+export interface ChannelMessageActionRequest {
+  action: ChannelMessageActionName;
+  channel: SupportedChannelId;
+  chatId: string;
+  message?: string;
+  replyToMessageId?: string;
+  threadId?: string | null;
+  messageId?: string;
+  emoji?: string;
+  remove?: boolean;
+  mediaPath?: string;
+  filename?: string;
+  title?: string;
+}
+
+export interface ChannelMessageActionContext {
+  request: ChannelMessageActionRequest;
+  route: ChannelRoute;
+  adapter: ChannelAdapter;
+  formatText: (
+    text: string,
+  ) => Pick<OutboundChannelMessage, "text" | "parseMode">;
+}
+
+/**
+ * Channel-owned action surface for the shared MessageChannel tool.
+ * This mirrors the OpenClaw pattern: one top-level tool, with each channel
+ * plugin owning action discovery and execution underneath it.
+ */
+export interface ChannelMessageActionAdapter {
+  describeMessageTool(params: {
+    accountId?: string | null;
+  }): ChannelMessageToolDiscovery;
+  handleAction(ctx: ChannelMessageActionContext): Promise<string>;
+}
+
 export interface ChannelPlugin {
   metadata: ChannelPluginMetadata;
   createAdapter(
-    config: ChannelConfig,
+    account: ChannelAccount,
   ): Promise<ChannelAdapter> | ChannelAdapter;
   runSetup?(): Promise<boolean>;
+  messageActions?: ChannelMessageActionAdapter;
 }

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -3,14 +3,21 @@
  * pairing, and the ingress pipeline.
  *
  * Lifecycle:
- * 1. initializeChannels() creates adapters from configs
+ * 1. initializeChannels() creates adapters from channel accounts
  * 2. Adapters start long-polling (buffer inbound until ready)
  * 3. setReady() is called from inside startListenerClient() once closure state exists
  * 4. Buffered messages flush through the registered onMessage handler
  */
 
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import { readChannelConfig } from "./config";
+import { getClient } from "../agent/client";
+import { ISOLATED_BLOCK_LABELS } from "../agent/memory";
+import {
+  getChannelAccount,
+  LEGACY_CHANNEL_ACCOUNT_ID,
+  listChannelAccounts,
+  loadChannelAccounts,
+} from "./accounts";
 import {
   consumePairingCode,
   createPairingCode,
@@ -23,6 +30,7 @@ import {
   addRoute,
   getRoute as getRouteFromStore,
   getRouteRaw,
+  getRoutesForChannel,
   loadRoutes,
   removeRouteInMemory,
   setRouteInMemory,
@@ -32,13 +40,15 @@ import type {
   ChannelAdapter,
   ChannelRoute,
   InboundChannelMessage,
+  SlackChannelAccount,
 } from "./types";
 import { formatChannelNotification } from "./xml";
 
 function buildPairingInstructions(channelId: string, code: string): string {
+  const displayName = channelId === "slack" ? "Slack" : "Telegram";
   return (
-    `To connect this chat to a Letta Code agent, run:\n\n` +
-    `/channels ${channelId} pair ${code}\n\n` +
+    `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
+    `Pairing code: ${code}\n\n` +
     `This code expires in 15 minutes.`
   );
 }
@@ -47,19 +57,54 @@ function buildUnboundRouteInstructions(
   channelId: string,
   chatId: string,
 ): string {
+  const displayName = channelId === "slack" ? "Slack" : "Telegram";
   return (
-    `This chat isn't bound to an agent. ` +
-    `Run \`/channels ${channelId} enable --chat-id ${chatId}\` ` +
-    `on your Letta Code agent to connect.`
+    `This chat isn't bound to a Letta Code agent yet.\n\n` +
+    `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +
+    `Chat ID: ${chatId}`
   );
 }
 
-function buildSlackTargetInstructions(): string {
+function buildSlackAppSetupInstructions(): string {
   return (
-    "This Slack channel isn't connected to an agent yet.\n\n" +
-    "Open Channels > Slack > Connections in Letta Code to bind this channel, " +
-    "then mention the bot again."
+    "This Slack app isn't connected to a Letta agent yet.\n\n" +
+    "Open Channels > Slack in Letta Code, choose which agent this app should represent, and try again."
   );
+}
+
+function truncateChannelSummaryPreview(
+  text: string,
+  maxLength = 72,
+): string | null {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function buildSlackConversationSummary(
+  msg: Pick<
+    InboundChannelMessage,
+    "chatId" | "chatLabel" | "chatType" | "senderId" | "senderName" | "text"
+  >,
+): string {
+  if (msg.chatType === "direct") {
+    return `[Slack] DM with ${msg.senderName?.trim() || msg.senderId}`;
+  }
+
+  const preview = truncateChannelSummaryPreview(msg.text);
+  const channelLabel =
+    msg.chatLabel && msg.chatLabel !== msg.chatId ? ` in ${msg.chatLabel}` : "";
+
+  if (preview) {
+    return `[Slack] Thread${channelLabel}: ${preview}`;
+  }
+
+  return `[Slack] Thread${channelLabel || ` ${msg.chatId}`}`;
 }
 
 // ── Singleton ─────────────────────────────────────────────────────
@@ -119,8 +164,18 @@ export class ChannelRegistry {
 
   // ── Adapter management ────────────────────────────────────────
 
+  private getAdapterKey(
+    channelId: string,
+    accountId = LEGACY_CHANNEL_ACCOUNT_ID,
+  ): string {
+    return `${channelId}:${accountId}`;
+  }
+
   registerAdapter(adapter: ChannelAdapter): void {
-    this.adapters.set(adapter.id, adapter);
+    this.adapters.set(
+      this.getAdapterKey(adapter.channelId ?? adapter.id, adapter.accountId),
+      adapter,
+    );
 
     // Wire the adapter's onMessage to our ingress pipeline
     adapter.onMessage = async (msg: InboundChannelMessage) => {
@@ -128,14 +183,17 @@ export class ChannelRegistry {
     };
   }
 
-  getAdapter(channelId: string): ChannelAdapter | null {
-    return this.adapters.get(channelId) ?? null;
+  getAdapter(
+    channelId: string,
+    accountId = LEGACY_CHANNEL_ACCOUNT_ID,
+  ): ChannelAdapter | null {
+    return this.adapters.get(this.getAdapterKey(channelId, accountId)) ?? null;
   }
 
   getActiveChannelIds(): string[] {
-    return Array.from(this.adapters.entries())
-      .filter(([_, adapter]) => adapter.isRunning())
-      .map(([id]) => id);
+    return Array.from(this.adapters.values())
+      .filter((adapter) => adapter.isRunning())
+      .map((adapter) => adapter.channelId ?? adapter.id);
   }
 
   // ── Readiness / ingress handler ───────────────────────────────
@@ -171,13 +229,75 @@ export class ChannelRegistry {
 
   // ── Routing ───────────────────────────────────────────────────
 
-  getRoute(channel: string, chatId: string): ChannelRoute | null {
-    return getRouteFromStore(channel, chatId);
+  getRoute(
+    channel: string,
+    chatId: string,
+    accountId?: string,
+    threadId?: string | null,
+  ): ChannelRoute | null {
+    if (accountId) {
+      return getRouteFromStore(channel, chatId, accountId, threadId);
+    }
+
+    const matches = getRoutesForChannel(channel).filter(
+      (route) =>
+        route.chatId === chatId &&
+        (threadId === undefined
+          ? true
+          : (route.threadId ?? null) === (threadId ?? null)),
+    );
+    if (matches.length !== 1) {
+      return null;
+    }
+    return matches[0] ?? null;
+  }
+
+  getRouteForScope(
+    channel: string,
+    chatId: string,
+    agentId: string,
+    conversationId: string,
+  ): ChannelRoute | null {
+    const matches = getRoutesForChannel(channel).filter(
+      (route) =>
+        route.chatId === chatId &&
+        route.agentId === agentId &&
+        route.conversationId === conversationId &&
+        route.enabled,
+    );
+
+    if (matches.length !== 1) {
+      return null;
+    }
+
+    return matches[0] ?? null;
   }
 
   async startChannel(channelId: string): Promise<boolean> {
-    const config = readChannelConfig(channelId);
-    if (!config) {
+    loadChannelAccounts(channelId);
+    const accounts = listChannelAccounts(channelId).filter(
+      (account) => account.enabled,
+    );
+    if (accounts.length === 0) {
+      return false;
+    }
+
+    let started = false;
+    for (const account of accounts) {
+      started =
+        (await this.startChannelAccount(channelId, account.accountId)) ||
+        started;
+    }
+    return started;
+  }
+
+  async startChannelAccount(
+    channelId: string,
+    accountId: string,
+  ): Promise<boolean> {
+    loadChannelAccounts(channelId);
+    const account = getChannelAccount(channelId, accountId);
+    if (!account) {
       return false;
     }
 
@@ -185,28 +305,54 @@ export class ChannelRegistry {
     loadPairingStore(channelId);
     loadTargetStore(channelId);
 
-    const existing = this.adapters.get(channelId);
+    const existing = this.getAdapter(channelId, accountId);
     if (existing?.isRunning()) {
       await existing.stop();
     }
-    this.adapters.delete(channelId);
+    this.adapters.delete(this.getAdapterKey(channelId, accountId));
 
-    const plugin = await loadChannelPlugin(config.channel);
-    const adapter = await plugin.createAdapter(config);
+    const plugin = await loadChannelPlugin(account.channel);
+    const adapter = await plugin.createAdapter(account);
     this.registerAdapter(adapter);
     await adapter.start();
     return true;
   }
 
   async stopChannel(channelId: string): Promise<boolean> {
-    const adapter = this.adapters.get(channelId);
+    const adapters = Array.from(this.adapters.values()).filter(
+      (adapter) => adapter.channelId === channelId,
+    );
+    if (adapters.length === 0) {
+      return false;
+    }
+
+    for (const adapter of adapters) {
+      if (adapter.isRunning()) {
+        await adapter.stop();
+      }
+      this.adapters.delete(
+        this.getAdapterKey(
+          adapter.channelId ?? adapter.id,
+          adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+        ),
+      );
+    }
+
+    return true;
+  }
+
+  async stopChannelAccount(
+    channelId: string,
+    accountId: string,
+  ): Promise<boolean> {
+    const adapter = this.getAdapter(channelId, accountId);
     if (!adapter) {
       return false;
     }
     if (adapter.isRunning()) {
       await adapter.stop();
     }
-    this.adapters.delete(channelId);
+    this.adapters.delete(this.getAdapterKey(channelId, accountId));
     return true;
   }
 
@@ -252,14 +398,18 @@ export class ChannelRegistry {
   private async handleInboundMessage(
     msg: InboundChannelMessage,
   ): Promise<void> {
-    const adapter = this.getAdapter(msg.channel);
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const adapter = this.getAdapter(msg.channel, accountId);
     if (!adapter) return;
-
-    const config = readChannelConfig(msg.channel);
+    const config = getChannelAccount(msg.channel, accountId);
     if (!config) return;
 
-    if (msg.channel === "slack" && msg.chatType === "channel") {
-      await this.handleSlackChannelMessage(adapter, msg);
+    if (msg.channel === "slack" && config.channel === "slack") {
+      const slackRoute = await this.ensureSlackRoute(adapter, msg, config);
+      if (!slackRoute) {
+        return;
+      }
+      this.deliverOrBuffer(slackRoute, formatChannelNotification(msg));
       return;
     }
 
@@ -274,16 +424,17 @@ export class ChannelRegistry {
       }
     } else if (config.dmPolicy === "pairing") {
       // Reload pairing store from disk on miss (allows standalone CLI pairing)
-      if (!isUserApproved(msg.channel, msg.senderId)) {
+      if (!isUserApproved(msg.channel, msg.senderId, accountId)) {
         loadPairingStore(msg.channel);
       }
-      if (!isUserApproved(msg.channel, msg.senderId)) {
+      if (!isUserApproved(msg.channel, msg.senderId, accountId)) {
         // Generate pairing code
         const code = createPairingCode(
           msg.channel,
           msg.senderId,
           msg.chatId,
           msg.senderName,
+          accountId,
         );
         this.eventHandler?.({
           type: "pairings_updated",
@@ -299,10 +450,20 @@ export class ChannelRegistry {
     // dm_policy === "open" → skip check
 
     // 2. Route lookup (reload from disk on miss — allows standalone CLI pairing)
-    let route = getRouteFromStore(msg.channel, msg.chatId);
+    let route = getRouteFromStore(
+      msg.channel,
+      msg.chatId,
+      accountId,
+      msg.threadId,
+    );
     if (!route) {
       loadRoutes(msg.channel);
-      route = getRouteFromStore(msg.channel, msg.chatId);
+      route = getRouteFromStore(
+        msg.channel,
+        msg.chatId,
+        accountId,
+        msg.threadId,
+      );
     }
     if (!route) {
       await adapter.sendDirectReply(
@@ -319,41 +480,127 @@ export class ChannelRegistry {
     this.deliverOrBuffer(route, content);
   }
 
-  private async handleSlackChannelMessage(
+  private async createConversationForAgent(
+    agentId: string,
+    summary?: string,
+  ): Promise<string> {
+    const client = await getClient();
+    const conversation = await client.conversations.create({
+      agent_id: agentId,
+      isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
+      ...(summary ? { summary } : {}),
+    });
+    return conversation.id;
+  }
+
+  private async createSlackRoute(
+    config: SlackChannelAccount,
+    msg: InboundChannelMessage,
+  ): Promise<ChannelRoute> {
+    if (!config.agentId) {
+      throw new Error("Slack app is missing an agent binding.");
+    }
+
+    const conversationId = await this.createConversationForAgent(
+      config.agentId,
+      buildSlackConversationSummary(msg),
+    );
+    const now = new Date().toISOString();
+    const route: ChannelRoute = {
+      accountId: config.accountId,
+      chatId: msg.chatId,
+      chatType: msg.chatType,
+      threadId:
+        msg.chatType === "channel"
+          ? (msg.threadId ?? msg.messageId ?? null)
+          : null,
+      agentId: config.agentId,
+      conversationId,
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    addRoute(msg.channel, route);
+    return route;
+  }
+
+  private async ensureSlackRoute(
     adapter: ChannelAdapter,
     msg: InboundChannelMessage,
-  ): Promise<void> {
-    let route = getRouteFromStore(msg.channel, msg.chatId);
-    if (!route) {
-      loadRoutes(msg.channel);
-      route = getRouteFromStore(msg.channel, msg.chatId);
-    }
-
-    if (!route) {
-      const now = new Date().toISOString();
-      loadTargetStore(msg.channel);
-      upsertChannelTarget(msg.channel, {
-        targetId: msg.chatId,
-        targetType: "channel",
-        chatId: msg.chatId,
-        label: msg.chatLabel ?? `Slack channel ${msg.chatId}`,
-        discoveredAt: now,
-        lastSeenAt: now,
-        lastMessageId: msg.messageId,
-      });
-      this.eventHandler?.({
-        type: "targets_updated",
-        channelId: msg.channel,
-      });
+    config: SlackChannelAccount,
+  ): Promise<ChannelRoute | null> {
+    if (!config.agentId) {
       await adapter.sendDirectReply(
         msg.chatId,
-        buildSlackTargetInstructions(),
-        msg.messageId ? { replyToMessageId: msg.messageId } : undefined,
+        buildSlackAppSetupInstructions(),
+        msg.chatType === "channel" && msg.threadId
+          ? { replyToMessageId: msg.threadId }
+          : msg.messageId
+            ? { replyToMessageId: msg.messageId }
+            : undefined,
       );
-      return;
+      return null;
     }
 
-    this.deliverOrBuffer(route, formatChannelNotification(msg));
+    if (msg.chatType === "direct") {
+      if (
+        config.dmPolicy === "allowlist" &&
+        !config.allowedUsers.includes(msg.senderId)
+      ) {
+        await adapter.sendDirectReply(
+          msg.chatId,
+          "You are not on the allowed users list for this Slack app.",
+        );
+        return null;
+      }
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const routeThreadId =
+      msg.chatType === "channel" ? (msg.threadId ?? null) : null;
+    let route = getRouteFromStore(
+      msg.channel,
+      msg.chatId,
+      accountId,
+      routeThreadId,
+    );
+    if (!route) {
+      loadRoutes(msg.channel);
+      route = getRouteFromStore(
+        msg.channel,
+        msg.chatId,
+        accountId,
+        routeThreadId,
+      );
+    }
+
+    if (route) {
+      return route;
+    }
+
+    if (msg.chatType === "channel" && !msg.isMention) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    loadTargetStore(msg.channel);
+    upsertChannelTarget(msg.channel, {
+      accountId,
+      targetId: msg.chatId,
+      targetType: "channel",
+      chatId: msg.chatId,
+      label: msg.chatLabel ?? `Slack channel ${msg.chatId}`,
+      discoveredAt: now,
+      lastSeenAt: now,
+      lastMessageId: msg.messageId,
+    });
+    this.eventHandler?.({
+      type: "targets_updated",
+      channelId: msg.channel,
+    });
+
+    return this.createSlackRoute(config, msg);
   }
 
   private deliverOrBuffer(
@@ -399,26 +646,28 @@ export async function initializeChannels(
   const registry = ensureChannelRegistry();
 
   for (const channelId of channelNames) {
-    const config = readChannelConfig(channelId);
-    if (!config) {
+    loadChannelAccounts(channelId);
+    const accounts = listChannelAccounts(channelId);
+    if (accounts.length === 0) {
       console.error(
         `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`,
       );
       continue;
     }
 
-    if (!config.enabled) {
-      console.log(`Channel "${channelId}" is disabled in config, skipping.`);
-      continue;
-    }
+    for (const account of accounts) {
+      if (!account.enabled) {
+        continue;
+      }
 
-    try {
-      await registry.startChannel(channelId);
-    } catch (error) {
-      console.error(
-        `[Channels] Failed to start ${channelId}:`,
-        error instanceof Error ? error.message : error,
-      );
+      try {
+        await registry.startChannelAccount(channelId, account.accountId);
+      } catch (error) {
+        console.error(
+          `[Channels] Failed to start ${channelId}/${account.accountId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
     }
   }
 
@@ -436,30 +685,42 @@ export function completePairing(
   code: string,
   agentId: string,
   conversationId: string,
-): { success: boolean; error?: string; chatId?: string } {
-  const pending = consumePairingCode(channelId, code);
+  accountId?: string,
+): { success: boolean; error?: string; chatId?: string; accountId?: string } {
+  const pending = consumePairingCode(channelId, code, accountId);
   if (!pending) {
     return { success: false, error: "Invalid or expired pairing code." };
   }
 
+  const resolvedAccountId = pending.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+
   // Snapshot existing route so we can restore it on failure
-  const previousRoute = getRouteRaw(channelId, pending.chatId);
+  const previousRoute = getRouteRaw(
+    channelId,
+    pending.chatId,
+    resolvedAccountId,
+  );
 
   // Create route — roll back pairing approval AND in-memory route if this fails
   try {
+    const now = new Date().toISOString();
     addRoute(channelId, {
+      accountId: resolvedAccountId,
       chatId: pending.chatId,
+      chatType: "direct",
+      threadId: null,
       agentId,
       conversationId,
       enabled: true,
-      createdAt: new Date().toISOString(),
+      createdAt: now,
+      updatedAt: now,
     });
   } catch (err) {
     // Restore in-memory route to prior state (no disk write — disk is what failed)
     if (previousRoute) {
       setRouteInMemory(channelId, previousRoute);
     } else {
-      removeRouteInMemory(channelId, pending.chatId);
+      removeRouteInMemory(channelId, pending.chatId, resolvedAccountId, null);
     }
     // Roll back: re-add the pending code and remove the approved user
     rollbackPairingApproval(channelId, pending);
@@ -470,5 +731,9 @@ export function completePairing(
     };
   }
 
-  return { success: true, chatId: pending.chatId };
+  return {
+    success: true,
+    chatId: pending.chatId,
+    accountId: resolvedAccountId,
+  };
 }

--- a/src/channels/routing.ts
+++ b/src/channels/routing.ts
@@ -6,6 +6,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getChannelDir, getChannelRoutingPath } from "./config";
 import type { ChannelRoute } from "./types";
 
@@ -14,8 +15,25 @@ import type { ChannelRoute } from "./types";
 /** Key: "channel:chatId" */
 const routesByKey = new Map<string, ChannelRoute>();
 
-function routeKey(channel: string, chatId: string): string {
-  return `${channel}:${chatId}`;
+let loadRoutesOverride: ((channelId: string) => ChannelRoute[] | null) | null =
+  null;
+
+function normalizeAccountId(accountId?: string): string {
+  return accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+}
+
+function normalizeThreadId(threadId?: string | null): string {
+  const trimmed = threadId?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : "__root__";
+}
+
+function routeKey(
+  channel: string,
+  chatId: string,
+  accountId?: string,
+  threadId?: string | null,
+): string {
+  return `${channel}:${normalizeAccountId(accountId)}:${chatId}:${normalizeThreadId(threadId)}`;
 }
 
 // ── Load/save ─────────────────────────────────────────────────────
@@ -24,6 +42,41 @@ function routeKey(channel: string, chatId: string): string {
  * Load routing table from disk for a given channel.
  */
 export function loadRoutes(channelId: string): void {
+  if (loadRoutesOverride) {
+    const overriddenRoutes = loadRoutesOverride(channelId);
+    if (overriddenRoutes === null) {
+      return;
+    }
+
+    const prefix = `${channelId}:`;
+    for (const key of Array.from(routesByKey.keys())) {
+      if (key.startsWith(prefix)) {
+        routesByKey.delete(key);
+      }
+    }
+
+    for (const route of overriddenRoutes) {
+      if (route.chatId && route.agentId && route.conversationId) {
+        routesByKey.set(
+          routeKey(channelId, route.chatId, route.accountId, route.threadId),
+          {
+            accountId: normalizeAccountId(route.accountId),
+            chatId: route.chatId,
+            chatType: route.chatType,
+            threadId: route.threadId ?? null,
+            agentId: route.agentId,
+            conversationId: route.conversationId,
+            enabled: route.enabled !== false,
+            createdAt: route.createdAt ?? new Date().toISOString(),
+            updatedAt:
+              route.updatedAt ?? route.createdAt ?? new Date().toISOString(),
+          },
+        );
+      }
+    }
+    return;
+  }
+
   const path = getChannelRoutingPath(channelId);
   if (!existsSync(path)) return;
 
@@ -34,13 +87,21 @@ export function loadRoutes(channelId: string): void {
 
     for (const route of routes) {
       if (route.chatId && route.agentId && route.conversationId) {
-        routesByKey.set(routeKey(channelId, route.chatId), {
-          chatId: route.chatId,
-          agentId: route.agentId,
-          conversationId: route.conversationId,
-          enabled: route.enabled !== false,
-          createdAt: route.createdAt ?? new Date().toISOString(),
-        });
+        routesByKey.set(
+          routeKey(channelId, route.chatId, route.accountId, route.threadId),
+          {
+            accountId: normalizeAccountId(route.accountId),
+            chatId: route.chatId,
+            chatType: route.chatType,
+            threadId: route.threadId ?? null,
+            agentId: route.agentId,
+            conversationId: route.conversationId,
+            enabled: route.enabled !== false,
+            createdAt: route.createdAt ?? new Date().toISOString(),
+            updatedAt:
+              route.updatedAt ?? route.createdAt ?? new Date().toISOString(),
+          },
+        );
       }
     }
   } catch {
@@ -56,6 +117,13 @@ export function __testOverrideSaveRoutes(
   fn: ((channelId: string) => void) | null,
 ): void {
   saveRoutesOverride = fn;
+}
+
+/** @internal Test-only: override loadRoutes behavior. Pass null to restore. */
+export function __testOverrideLoadRoutes(
+  fn: ((channelId: string) => ChannelRoute[] | null) | null,
+): void {
+  loadRoutesOverride = fn;
 }
 
 /**
@@ -85,8 +153,13 @@ export function saveRoutes(channelId: string): void {
  * Get the route for a specific channel + chatId.
  * Returns null if no route exists or the route is disabled.
  */
-export function getRoute(channel: string, chatId: string): ChannelRoute | null {
-  const route = routesByKey.get(routeKey(channel, chatId));
+export function getRoute(
+  channel: string,
+  chatId: string,
+  accountId?: string,
+  threadId?: string | null,
+): ChannelRoute | null {
+  const route = routesByKey.get(routeKey(channel, chatId, accountId, threadId));
   if (!route || !route.enabled) return null;
   return route;
 }
@@ -98,15 +171,23 @@ export function getRoute(channel: string, chatId: string): ChannelRoute | null {
 export function getRouteRaw(
   channel: string,
   chatId: string,
+  accountId?: string,
+  threadId?: string | null,
 ): ChannelRoute | undefined {
-  return routesByKey.get(routeKey(channel, chatId));
+  return routesByKey.get(routeKey(channel, chatId, accountId, threadId));
 }
 
 /**
  * Get all routes for a channel.
  */
-export function getRoutesForChannel(channelId: string): ChannelRoute[] {
-  const prefix = `${channelId}:`;
+export function getRoutesForChannel(
+  channelId: string,
+  accountId?: string,
+): ChannelRoute[] {
+  const prefix =
+    accountId === undefined
+      ? `${channelId}:`
+      : `${channelId}:${normalizeAccountId(accountId)}:`;
   const routes: ChannelRoute[] = [];
   for (const [key, route] of routesByKey) {
     if (key.startsWith(prefix)) {
@@ -129,15 +210,27 @@ export function getAllRoutes(): ChannelRoute[] {
  * Add or update a route. Automatically saves to disk.
  */
 export function addRoute(channelId: string, route: ChannelRoute): void {
-  routesByKey.set(routeKey(channelId, route.chatId), route);
+  routesByKey.set(
+    routeKey(channelId, route.chatId, route.accountId, route.threadId),
+    {
+      ...route,
+      accountId: normalizeAccountId(route.accountId),
+      threadId: route.threadId ?? null,
+    },
+  );
   saveRoutes(channelId);
 }
 
 /**
  * Remove a route. Automatically saves to disk.
  */
-export function removeRoute(channelId: string, chatId: string): boolean {
-  const key = routeKey(channelId, chatId);
+export function removeRoute(
+  channelId: string,
+  chatId: string,
+  accountId?: string,
+  threadId?: string | null,
+): boolean {
+  const key = routeKey(channelId, chatId, accountId, threadId);
   const existed = routesByKey.delete(key);
   if (existed) {
     saveRoutes(channelId);
@@ -152,8 +245,10 @@ export function removeRoute(channelId: string, chatId: string): boolean {
 export function removeRouteInMemory(
   channelId: string,
   chatId: string,
+  accountId?: string,
+  threadId?: string | null,
 ): boolean {
-  return routesByKey.delete(routeKey(channelId, chatId));
+  return routesByKey.delete(routeKey(channelId, chatId, accountId, threadId));
 }
 
 /**
@@ -161,7 +256,14 @@ export function removeRouteInMemory(
  * Used to restore a snapshot on rollback.
  */
 export function setRouteInMemory(channelId: string, route: ChannelRoute): void {
-  routesByKey.set(routeKey(channelId, route.chatId), route);
+  routesByKey.set(
+    routeKey(channelId, route.chatId, route.accountId, route.threadId),
+    {
+      ...route,
+      accountId: normalizeAccountId(route.accountId),
+      threadId: route.threadId ?? null,
+    },
+  );
 }
 
 /**
@@ -172,15 +274,37 @@ export function removeRoutesForScope(
   channelId: string,
   agentId: string,
   conversationId: string,
+  accountId?: string,
 ): number {
   let removed = 0;
-  const prefix = `${channelId}:`;
+  const prefix =
+    accountId === undefined
+      ? `${channelId}:`
+      : `${channelId}:${normalizeAccountId(accountId)}:`;
   for (const [key, route] of routesByKey) {
     if (
       key.startsWith(prefix) &&
       route.agentId === agentId &&
       route.conversationId === conversationId
     ) {
+      routesByKey.delete(key);
+      removed++;
+    }
+  }
+  if (removed > 0) {
+    saveRoutes(channelId);
+  }
+  return removed;
+}
+
+export function removeRoutesForAccount(
+  channelId: string,
+  accountId: string,
+): number {
+  let removed = 0;
+  const prefix = `${channelId}:${normalizeAccountId(accountId)}:`;
+  for (const [key] of routesByKey) {
+    if (key.startsWith(prefix)) {
       routesByKey.delete(key);
       removed++;
     }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1,8 +1,16 @@
-import { readChannelConfig, writeChannelConfig } from "./config";
+import { randomUUID } from "node:crypto";
+import {
+  getChannelAccount,
+  LEGACY_CHANNEL_ACCOUNT_ID,
+  listChannelAccounts,
+  removeChannelAccount,
+  upsertChannelAccount,
+} from "./accounts";
 import {
   getApprovedUsers,
   getPendingPairings,
   loadPairingStore,
+  removePairingStateForAccount,
 } from "./pairing";
 import {
   getChannelDisplayName,
@@ -13,7 +21,6 @@ import {
   completePairing,
   ensureChannelRegistry,
   getChannelRegistry,
-  initializeChannels,
 } from "./registry";
 import {
   addRoute,
@@ -22,24 +29,26 @@ import {
   loadRoutes,
   removeRoute,
   removeRouteInMemory,
+  removeRoutesForAccount,
+  setRouteInMemory,
 } from "./routing";
+import { resolveSlackAccountDisplayName } from "./slack/adapter";
 import {
-  getChannelTarget,
   listChannelTargets,
   loadTargetStore,
   removeChannelTarget,
+  removeChannelTargetsForAccount,
   upsertChannelTarget,
 } from "./targets";
+import { validateTelegramToken } from "./telegram/adapter";
 import type {
+  ChannelAccount,
   ChannelBindableTarget,
-  ChannelConfig,
   ChannelRoute,
   DmPolicy,
   PendingPairing,
-  SlackChannelConfig,
   SlackChannelMode,
   SupportedChannelId,
-  TelegramChannelConfig,
 } from "./types";
 
 export interface ChannelSummary {
@@ -57,6 +66,8 @@ export interface ChannelSummary {
 export type ChannelConfigSnapshot =
   | {
       channelId: "telegram";
+      accountId: string;
+      displayName?: string;
       enabled: boolean;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
@@ -64,6 +75,8 @@ export type ChannelConfigSnapshot =
     }
   | {
       channelId: "slack";
+      accountId: string;
+      displayName?: string;
       enabled: boolean;
       mode: SlackChannelMode;
       dmPolicy: DmPolicy;
@@ -73,6 +86,7 @@ export type ChannelConfigSnapshot =
     };
 
 export interface PendingPairingSnapshot {
+  accountId: string;
   code: string;
   senderId: string;
   senderName?: string;
@@ -83,15 +97,20 @@ export interface PendingPairingSnapshot {
 
 export interface ChannelRouteSnapshot {
   channelId: SupportedChannelId;
+  accountId: string;
   chatId: string;
+  chatType?: "direct" | "channel";
+  threadId?: string | null;
   agentId: string;
   conversationId: string;
   enabled: boolean;
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface ChannelTargetSnapshot {
   channelId: SupportedChannelId;
+  accountId: string;
   targetId: string;
   targetType: "channel";
   chatId: string;
@@ -101,6 +120,41 @@ export interface ChannelTargetSnapshot {
   lastMessageId?: string;
 }
 
+export type ChannelAccountSnapshot =
+  | {
+      channelId: "telegram";
+      accountId: string;
+      displayName?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasToken: boolean;
+      binding: {
+        agentId: string | null;
+        conversationId: string | null;
+      };
+      createdAt: string;
+      updatedAt: string;
+    }
+  | {
+      channelId: "slack";
+      accountId: string;
+      displayName?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      mode: SlackChannelMode;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasBotToken: boolean;
+      hasAppToken: boolean;
+      agentId: string | null;
+      createdAt: string;
+      updatedAt: string;
+    };
+
 export interface ChannelConfigPatch {
   token?: string;
   botToken?: string;
@@ -109,6 +163,24 @@ export interface ChannelConfigPatch {
   dmPolicy?: DmPolicy;
   allowedUsers?: string[];
 }
+
+export interface ChannelAccountPatch {
+  displayName?: string;
+  enabled?: boolean;
+  token?: string;
+  botToken?: string;
+  appToken?: string;
+  mode?: SlackChannelMode;
+  agentId?: string | null;
+  dmPolicy?: DmPolicy;
+  allowedUsers?: string[];
+}
+
+let resolveChannelAccountDisplayNameOverride:
+  | ((
+      account: ChannelAccount,
+    ) => Promise<string | undefined> | string | undefined)
+  | null = null;
 
 function assertSupportedChannelId(
   channelId: string,
@@ -122,35 +194,119 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-function toConfigSnapshot(config: ChannelConfig): ChannelConfigSnapshot {
-  if (config.channel === "telegram") {
-    return {
-      channelId: "telegram",
-      enabled: config.enabled,
-      dmPolicy: config.dmPolicy,
-      allowedUsers: [...config.allowedUsers],
-      hasToken: config.token.trim().length > 0,
-    };
+function normalizeDisplayName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+async function resolveChannelAccountDisplayName(
+  account: ChannelAccount,
+): Promise<string | undefined> {
+  if (resolveChannelAccountDisplayNameOverride) {
+    return normalizeDisplayName(
+      await resolveChannelAccountDisplayNameOverride(account),
+    );
   }
 
-  return {
-    channelId: "slack",
-    enabled: config.enabled,
-    mode: config.mode,
-    dmPolicy: config.dmPolicy,
-    allowedUsers: [...config.allowedUsers],
-    hasBotToken: config.botToken.trim().length > 0,
-    hasAppToken: config.appToken.trim().length > 0,
-  };
+  try {
+    if (account.channel === "telegram") {
+      if (!account.token.trim()) {
+        return undefined;
+      }
+      const info = await validateTelegramToken(account.token);
+      return normalizeDisplayName(
+        info.username ? `@${info.username}` : undefined,
+      );
+    }
+
+    if (!account.botToken.trim() || !account.appToken.trim()) {
+      return undefined;
+    }
+
+    return normalizeDisplayName(
+      await resolveSlackAccountDisplayName(account.botToken, account.appToken),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function getSelectedChannelAccount(
+  channelId: SupportedChannelId,
+  accountId?: string,
+): ChannelAccount | null {
+  const normalizedAccountId = accountId?.trim();
+  if (normalizedAccountId) {
+    return getChannelAccount(channelId, normalizedAccountId);
+  }
+
+  const accounts = listChannelAccounts(channelId);
+  if (accounts.length === 0) {
+    return null;
+  }
+  if (accounts.length === 1) {
+    return accounts[0] ?? null;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple accounts. Specify account_id.`,
+  );
+}
+
+function getSelectedRouteByChatId(
+  channelId: SupportedChannelId,
+  chatId: string,
+  accountId?: string,
+): ChannelRoute | null {
+  const matches = getRoutesForChannel(channelId, accountId).filter(
+    (route) => route.chatId === chatId,
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0] ?? null;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple routes for chat "${chatId}". Specify account_id.`,
+  );
+}
+
+function getSelectedTargetById(
+  channelId: SupportedChannelId,
+  targetId: string,
+  accountId?: string,
+): ChannelBindableTarget | null {
+  const matches = listChannelTargets(channelId, accountId).filter(
+    (target) => target.targetId === targetId,
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0] ?? null;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple targets named "${targetId}". Specify account_id.`,
+  );
 }
 
 function toPendingPairingSnapshot(
   pending: Pick<
     PendingPairing,
-    "code" | "senderId" | "senderName" | "chatId" | "createdAt" | "expiresAt"
+    | "accountId"
+    | "code"
+    | "senderId"
+    | "senderName"
+    | "chatId"
+    | "createdAt"
+    | "expiresAt"
   >,
 ): PendingPairingSnapshot {
   return {
+    accountId: pending.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
     code: pending.code,
     senderId: pending.senderId,
     senderName: pending.senderName,
@@ -166,11 +322,15 @@ function toRouteSnapshot(
 ): ChannelRouteSnapshot {
   return {
     channelId,
+    accountId: route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
     chatId: route.chatId,
+    chatType: route.chatType,
+    threadId: route.threadId ?? null,
     agentId: route.agentId,
     conversationId: route.conversationId,
     enabled: route.enabled,
     createdAt: route.createdAt,
+    updatedAt: route.updatedAt ?? route.createdAt,
   };
 }
 
@@ -180,6 +340,7 @@ function toTargetSnapshot(
 ): ChannelTargetSnapshot {
   return {
     channelId,
+    accountId: target.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
     targetId: target.targetId,
     targetType: target.targetType,
     chatId: target.chatId,
@@ -190,55 +351,140 @@ function toTargetSnapshot(
   };
 }
 
-function isConfigReadyToStart(config: ChannelConfig): boolean {
-  if (config.channel === "telegram") {
-    return config.token.trim().length > 0;
+function isAccountConfigured(account: ChannelAccount): boolean {
+  if (account.channel === "telegram") {
+    return account.token.trim().length > 0;
   }
-  return config.botToken.trim().length > 0 && config.appToken.trim().length > 0;
+
+  return (
+    account.botToken.trim().length > 0 && account.appToken.trim().length > 0
+  );
 }
 
-function getMissingCredentialError(config: ChannelConfig): string {
-  if (config.channel === "telegram") {
-    return 'Channel "telegram" is missing a token. Configure it first.';
-  }
-  return 'Channel "slack" is missing a bot token or app token. Configure it first.';
-}
+function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
+  const running =
+    getChannelRegistry()
+      ?.getAdapter(account.channel, account.accountId)
+      ?.isRunning() ?? false;
 
-function mergeChannelConfig(
-  channelId: SupportedChannelId,
-  existing: ChannelConfig | null,
-  patch: ChannelConfigPatch,
-): ChannelConfig {
-  if (channelId === "telegram") {
-    const telegramExisting = existing?.channel === "telegram" ? existing : null;
-    const merged: TelegramChannelConfig = {
-      channel: "telegram",
-      enabled: telegramExisting?.enabled ?? false,
-      token: patch.token ?? telegramExisting?.token ?? "",
-      dmPolicy: patch.dmPolicy ?? telegramExisting?.dmPolicy ?? "pairing",
-      allowedUsers: patch.allowedUsers ?? telegramExisting?.allowedUsers ?? [],
+  if (account.channel === "telegram") {
+    return {
+      channelId: "telegram",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      configured: isAccountConfigured(account),
+      running,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      hasToken: account.token.trim().length > 0,
+      binding: { ...account.binding },
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
     };
-    return merged;
   }
 
-  const slackExisting = existing?.channel === "slack" ? existing : null;
-  const merged: SlackChannelConfig = {
-    channel: "slack",
-    enabled: slackExisting?.enabled ?? false,
-    mode: patch.mode ?? slackExisting?.mode ?? "socket",
-    botToken: patch.botToken ?? slackExisting?.botToken ?? "",
-    appToken: patch.appToken ?? slackExisting?.appToken ?? "",
-    dmPolicy: patch.dmPolicy ?? slackExisting?.dmPolicy ?? "pairing",
-    allowedUsers: patch.allowedUsers ?? slackExisting?.allowedUsers ?? [],
+  return {
+    channelId: "slack",
+    accountId: account.accountId,
+    displayName: account.displayName,
+    enabled: account.enabled,
+    configured: isAccountConfigured(account),
+    running,
+    mode: account.mode,
+    dmPolicy: account.dmPolicy,
+    allowedUsers: [...account.allowedUsers],
+    hasBotToken: account.botToken.trim().length > 0,
+    hasAppToken: account.appToken.trim().length > 0,
+    agentId: account.agentId,
+    createdAt: account.createdAt,
+    updatedAt: account.updatedAt,
   };
-  return merged;
+}
+
+function createAccountFromPatch(
+  channelId: SupportedChannelId,
+  accountId: string,
+  patch: ChannelAccountPatch,
+): ChannelAccount {
+  const now = new Date().toISOString();
+  if (channelId === "telegram") {
+    return {
+      channel: "telegram",
+      accountId,
+      displayName: normalizeDisplayName(patch.displayName),
+      enabled: patch.enabled ?? false,
+      token: patch.token ?? "",
+      dmPolicy: patch.dmPolicy ?? "pairing",
+      allowedUsers: patch.allowedUsers ?? [],
+      binding: {
+        agentId: null,
+        conversationId: null,
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  return {
+    channel: "slack",
+    accountId,
+    displayName: normalizeDisplayName(patch.displayName),
+    enabled: patch.enabled ?? false,
+    mode: patch.mode ?? "socket",
+    botToken: patch.botToken ?? "",
+    appToken: patch.appToken ?? "",
+    agentId: patch.agentId ?? null,
+    dmPolicy: patch.dmPolicy ?? "open",
+    allowedUsers: patch.allowedUsers ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function mergeAccountPatch(
+  existing: ChannelAccount,
+  patch: ChannelAccountPatch,
+): ChannelAccount {
+  const nextUpdatedAt = new Date().toISOString();
+  if (existing.channel === "telegram") {
+    return {
+      ...existing,
+      displayName:
+        patch.displayName !== undefined
+          ? normalizeDisplayName(patch.displayName)
+          : existing.displayName,
+      enabled: patch.enabled ?? existing.enabled,
+      token: patch.token ?? existing.token,
+      dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+      updatedAt: nextUpdatedAt,
+    };
+  }
+
+  return {
+    ...existing,
+    displayName:
+      patch.displayName !== undefined
+        ? normalizeDisplayName(patch.displayName)
+        : existing.displayName,
+    enabled: patch.enabled ?? existing.enabled,
+    mode: patch.mode ?? existing.mode,
+    botToken: patch.botToken ?? existing.botToken,
+    appToken: patch.appToken ?? existing.appToken,
+    agentId: patch.agentId ?? existing.agentId,
+    dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
+    allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+    updatedAt: nextUpdatedAt,
+  };
 }
 
 export function listChannelSummaries(): ChannelSummary[] {
   const registry = getChannelRegistry();
+  const activeChannelIds = new Set(registry?.getActiveChannelIds() ?? []);
   return getSupportedChannelIds().map((channelId) => {
-    const config = readChannelConfig(channelId);
-    if (!config) {
+    const accounts = listChannelAccounts(channelId);
+    if (accounts.length === 0) {
       return {
         channelId,
         displayName: getChannelDisplayName(channelId),
@@ -258,10 +504,10 @@ export function listChannelSummaries(): ChannelSummary[] {
     return {
       channelId,
       displayName: getChannelDisplayName(channelId),
-      configured: true,
-      enabled: config.enabled,
-      running: registry?.getAdapter(channelId)?.isRunning() ?? false,
-      dmPolicy: config.dmPolicy,
+      configured: accounts.length > 0,
+      enabled: accounts.some((account) => account.enabled),
+      running: activeChannelIds.has(channelId),
+      dmPolicy: accounts[0]?.dmPolicy ?? null,
       pendingPairingsCount: getPendingPairings(channelId).length,
       approvedUsersCount: getApprovedUsers(channelId).length,
       routesCount: getRoutesForChannel(channelId).length,
@@ -271,62 +517,148 @@ export function listChannelSummaries(): ChannelSummary[] {
 
 export function getChannelConfigSnapshot(
   channelId: string,
+  accountId?: string,
 ): ChannelConfigSnapshot | null {
   assertSupportedChannelId(channelId);
-  const config = readChannelConfig(channelId);
-  if (!config) {
+  const account = getSelectedChannelAccount(channelId, accountId);
+  if (!account) {
     return null;
   }
-  return toConfigSnapshot(config);
+  if (account.channel === "telegram") {
+    return {
+      channelId: "telegram",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      hasToken: account.token.trim().length > 0,
+    };
+  }
+
+  return {
+    channelId: "slack",
+    accountId: account.accountId,
+    displayName: account.displayName,
+    enabled: account.enabled,
+    mode: account.mode,
+    dmPolicy: account.dmPolicy,
+    allowedUsers: [...account.allowedUsers],
+    hasBotToken: account.botToken.trim().length > 0,
+    hasAppToken: account.appToken.trim().length > 0,
+  };
 }
 
 export async function setChannelConfigLive(
   channelId: string,
   patch: ChannelConfigPatch,
+  accountId?: string,
 ): Promise<ChannelConfigSnapshot> {
   assertSupportedChannelId(channelId);
-
-  const merged = mergeChannelConfig(
-    channelId,
-    readChannelConfig(channelId),
-    patch,
-  );
-  writeChannelConfig(channelId, merged);
-
-  if (merged.enabled) {
-    await ensureChannelRegistry().startChannel(channelId);
+  const existing = getSelectedChannelAccount(channelId, accountId);
+  let targetAccountId = existing?.accountId;
+  let shouldRefreshDisplayName = false;
+  if (existing) {
+    updateChannelAccountLive(channelId, existing.accountId, {
+      enabled: existing.enabled,
+      token: patch.token,
+      botToken: patch.botToken,
+      appToken: patch.appToken,
+      mode: patch.mode,
+      dmPolicy: patch.dmPolicy,
+      allowedUsers: patch.allowedUsers,
+      displayName: existing.displayName,
+    });
+    shouldRefreshDisplayName =
+      channelId === "telegram"
+        ? patch.token !== undefined
+        : patch.botToken !== undefined || patch.appToken !== undefined;
+  } else {
+    const created = createChannelAccountLive(
+      channelId,
+      {
+        enabled: false,
+        token: patch.token,
+        botToken: patch.botToken,
+        appToken: patch.appToken,
+        mode: patch.mode,
+        dmPolicy: patch.dmPolicy,
+        allowedUsers: patch.allowedUsers,
+      },
+      accountId ? { accountId } : undefined,
+    );
+    targetAccountId = created.accountId;
+    shouldRefreshDisplayName = true;
   }
 
-  return toConfigSnapshot(merged);
+  if (existing) {
+    targetAccountId = existing.accountId;
+  }
+
+  if (!targetAccountId) {
+    throw new Error(`Failed to resolve ${channelId} account after update.`);
+  }
+
+  if (shouldRefreshDisplayName) {
+    await refreshChannelAccountDisplayNameLive(channelId, targetAccountId, {
+      force: true,
+    });
+  }
+
+  if (
+    (getChannelAccount(channelId, targetAccountId)?.enabled ?? false) === true
+  ) {
+    await ensureChannelRegistry().startChannelAccount(
+      channelId,
+      targetAccountId,
+    );
+  }
+
+  const snapshot = getChannelConfigSnapshot(channelId, targetAccountId);
+  if (!snapshot) {
+    throw new Error(`Failed to write ${channelId} channel config`);
+  }
+  return snapshot;
 }
 
 export async function startChannelLive(
   channelId: string,
+  accountId?: string,
 ): Promise<ChannelSummary> {
   assertSupportedChannelId(channelId);
 
-  const existing = readChannelConfig(channelId);
+  const existing = getSelectedChannelAccount(channelId, accountId);
   if (!existing) {
     throw new Error(
       `Channel "${channelId}" is not configured. Configure it first.`,
     );
   }
-  if (!isConfigReadyToStart(existing)) {
-    throw new Error(getMissingCredentialError(existing));
+  if (!isAccountConfigured(existing)) {
+    if (existing.channel === "telegram") {
+      throw new Error(
+        'Channel "telegram" is missing a token. Configure it first.',
+      );
+    }
+    throw new Error(
+      'Channel "slack" is missing a bot token or app token. Configure it first.',
+    );
   }
 
   if (!existing.enabled) {
-    writeChannelConfig(channelId, {
+    upsertChannelAccount(channelId, {
       ...existing,
       enabled: true,
+      updatedAt: new Date().toISOString(),
     });
   }
 
-  if (!getChannelRegistry()) {
-    await initializeChannels([channelId]);
-  } else {
-    await ensureChannelRegistry().startChannel(channelId);
-  }
+  await ensureChannelRegistry().startChannelAccount(
+    channelId,
+    existing.accountId,
+  );
+  await refreshChannelAccountDisplayNameLive(channelId, existing.accountId, {
+    force: channelId === "slack",
+  });
 
   const summary = listChannelSummaries().find(
     (entry) => entry.channelId === channelId,
@@ -339,22 +671,24 @@ export async function startChannelLive(
 
 export async function stopChannelLive(
   channelId: string,
+  accountId?: string,
 ): Promise<ChannelSummary> {
   assertSupportedChannelId(channelId);
 
-  const existing = readChannelConfig(channelId);
+  const existing = getSelectedChannelAccount(channelId, accountId);
   if (!existing) {
     throw new Error(
       `Channel "${channelId}" is not configured. Configure it first.`,
     );
   }
 
-  writeChannelConfig(channelId, {
+  upsertChannelAccount(channelId, {
     ...existing,
     enabled: false,
+    updatedAt: new Date().toISOString(),
   });
 
-  await getChannelRegistry()?.stopChannel(channelId);
+  await getChannelRegistry()?.stopChannelAccount(channelId, existing.accountId);
 
   const summary = listChannelSummaries().find(
     (entry) => entry.channelId === channelId,
@@ -365,12 +699,251 @@ export async function stopChannelLive(
   return summary;
 }
 
+export function listChannelAccountSnapshots(
+  channelId: string,
+): ChannelAccountSnapshot[] {
+  assertSupportedChannelId(channelId);
+  return listChannelAccounts(channelId).map(toAccountSnapshot);
+}
+
+export function getChannelAccountSnapshot(
+  channelId: string,
+  accountId: string,
+): ChannelAccountSnapshot | null {
+  assertSupportedChannelId(channelId);
+  const account = getChannelAccount(channelId, accountId);
+  return account ? toAccountSnapshot(account) : null;
+}
+
+export function createChannelAccountLive(
+  channelId: string,
+  patch: ChannelAccountPatch,
+  options?: { accountId?: string },
+): ChannelAccountSnapshot {
+  assertSupportedChannelId(channelId);
+  const accountId = options?.accountId?.trim() || randomUUID();
+  const existing = getChannelAccount(channelId, accountId);
+  if (existing) {
+    throw new Error(
+      `Channel account "${accountId}" already exists for ${channelId}.`,
+    );
+  }
+
+  const created = upsertChannelAccount(
+    channelId,
+    createAccountFromPatch(channelId, accountId, patch),
+  );
+  return toAccountSnapshot(created);
+}
+
+export function updateChannelAccountLive(
+  channelId: string,
+  accountId: string,
+  patch: ChannelAccountPatch,
+): ChannelAccountSnapshot {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+
+  const updated = upsertChannelAccount(
+    channelId,
+    mergeAccountPatch(existing, patch),
+  );
+  return toAccountSnapshot(updated);
+}
+
+export async function refreshChannelAccountDisplayNameLive(
+  channelId: string,
+  accountId: string,
+  options?: { force?: boolean },
+): Promise<ChannelAccountSnapshot> {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+  if (!isAccountConfigured(existing)) {
+    return toAccountSnapshot(existing);
+  }
+  if (!options?.force && existing.displayName) {
+    return toAccountSnapshot(existing);
+  }
+
+  const resolvedDisplayName = await resolveChannelAccountDisplayName(existing);
+  const nextDisplayName =
+    options?.force && resolvedDisplayName === undefined
+      ? undefined
+      : (resolvedDisplayName ?? existing.displayName);
+
+  if (nextDisplayName === existing.displayName) {
+    return toAccountSnapshot(existing);
+  }
+
+  const updated = upsertChannelAccount(channelId, {
+    ...existing,
+    displayName: nextDisplayName,
+    updatedAt: new Date().toISOString(),
+  });
+  return toAccountSnapshot(updated);
+}
+
+export function bindChannelAccountLive(
+  channelId: string,
+  accountId: string,
+  agentId: string,
+  conversationId: string,
+): ChannelAccountSnapshot {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+
+  const updated =
+    existing.channel === "telegram"
+      ? upsertChannelAccount(channelId, {
+          ...existing,
+          binding: {
+            agentId,
+            conversationId,
+          },
+          updatedAt: new Date().toISOString(),
+        })
+      : upsertChannelAccount(channelId, {
+          ...existing,
+          agentId,
+          updatedAt: new Date().toISOString(),
+        });
+
+  return toAccountSnapshot(updated);
+}
+
+export function unbindChannelAccountLive(
+  channelId: string,
+  accountId: string,
+): ChannelAccountSnapshot {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+
+  const updated =
+    existing.channel === "telegram"
+      ? upsertChannelAccount(channelId, {
+          ...existing,
+          binding: {
+            agentId: null,
+            conversationId: null,
+          },
+          updatedAt: new Date().toISOString(),
+        })
+      : upsertChannelAccount(channelId, {
+          ...existing,
+          agentId: null,
+          updatedAt: new Date().toISOString(),
+        });
+
+  return toAccountSnapshot(updated);
+}
+
+export async function startChannelAccountLive(
+  channelId: string,
+  accountId: string,
+): Promise<ChannelAccountSnapshot> {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+  if (!isAccountConfigured(existing)) {
+    if (existing.channel === "telegram") {
+      throw new Error(
+        'Channel "telegram" account is missing a token. Configure it first.',
+      );
+    }
+    throw new Error(
+      'Channel "slack" account is missing a bot token or app token. Configure it first.',
+    );
+  }
+
+  if (!existing.enabled) {
+    upsertChannelAccount(channelId, {
+      ...existing,
+      enabled: true,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  await ensureChannelRegistry().startChannelAccount(channelId, accountId);
+  return refreshChannelAccountDisplayNameLive(channelId, accountId, {
+    force: channelId === "slack",
+  });
+}
+
+export async function stopChannelAccountLive(
+  channelId: string,
+  accountId: string,
+): Promise<ChannelAccountSnapshot> {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+
+  const next = existing.enabled
+    ? upsertChannelAccount(channelId, {
+        ...existing,
+        enabled: false,
+        updatedAt: new Date().toISOString(),
+      })
+    : existing;
+
+  await getChannelRegistry()?.stopChannelAccount(channelId, accountId);
+  return toAccountSnapshot(next);
+}
+
+export async function removeChannelAccountLive(
+  channelId: string,
+  accountId: string,
+): Promise<boolean> {
+  assertSupportedChannelId(channelId);
+  const existing = getChannelAccount(channelId, accountId);
+  if (!existing) {
+    return false;
+  }
+
+  await getChannelRegistry()?.stopChannelAccount(channelId, accountId);
+  loadRoutes(channelId);
+  loadTargetStore(channelId);
+  loadPairingStore(channelId);
+  removeRoutesForAccount(channelId, accountId);
+  removeChannelTargetsForAccount(channelId, accountId);
+  removePairingStateForAccount(channelId, accountId);
+  return removeChannelAccount(channelId, accountId);
+}
+
 export function listPendingPairingSnapshots(
   channelId: string,
+  accountId?: string,
 ): PendingPairingSnapshot[] {
   assertSupportedChannelId(channelId);
   loadPairingStore(channelId);
-  return getPendingPairings(channelId).map(toPendingPairingSnapshot);
+  return getPendingPairings(channelId, accountId).map(toPendingPairingSnapshot);
 }
 
 export function bindChannelPairing(
@@ -378,17 +951,24 @@ export function bindChannelPairing(
   code: string,
   agentId: string,
   conversationId: string,
+  accountId?: string,
 ): { chatId: string; route: ChannelRouteSnapshot } {
   assertSupportedChannelId(channelId);
   loadRoutes(channelId);
   loadPairingStore(channelId);
 
-  const result = completePairing(channelId, code, agentId, conversationId);
+  const result = completePairing(
+    channelId,
+    code,
+    agentId,
+    conversationId,
+    accountId,
+  );
   if (!result.success || !result.chatId) {
     throw new Error(result.error ?? "Failed to bind pairing");
   }
 
-  const route = getRoute(channelId, result.chatId);
+  const route = getRoute(channelId, result.chatId, result.accountId);
   if (!route) {
     throw new Error("Pairing succeeded but route was not found");
   }
@@ -401,10 +981,11 @@ export function bindChannelPairing(
 
 export function listChannelTargetSnapshots(
   channelId: string,
+  accountId?: string,
 ): ChannelTargetSnapshot[] {
   assertSupportedChannelId(channelId);
   loadTargetStore(channelId);
-  return listChannelTargets(channelId).map((target) =>
+  return listChannelTargets(channelId, accountId).map((target) =>
     toTargetSnapshot(channelId, target),
   );
 }
@@ -414,26 +995,31 @@ export function bindChannelTarget(
   targetId: string,
   agentId: string,
   conversationId: string,
+  accountId?: string,
 ): { chatId: string; route: ChannelRouteSnapshot } {
   assertSupportedChannelId(channelId);
   loadRoutes(channelId);
   loadTargetStore(channelId);
 
-  const target = getChannelTarget(channelId, targetId);
+  const target = getSelectedTargetById(channelId, targetId, accountId);
   if (!target) {
     throw new Error(`Unknown channel target: ${targetId}`);
   }
 
   const route: ChannelRoute = {
+    accountId: target.accountId,
     chatId: target.chatId,
+    chatType: "channel",
+    threadId: null,
     agentId,
     conversationId,
     enabled: true,
     createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
   };
 
   try {
-    removeChannelTarget(channelId, targetId);
+    removeChannelTarget(channelId, targetId, target.accountId);
   } catch (error) {
     try {
       upsertChannelTarget(channelId, target);
@@ -459,7 +1045,12 @@ export function bindChannelTarget(
   try {
     addRoute(channelId, route);
   } catch (error) {
-    removeRouteInMemory(channelId, route.chatId);
+    removeRouteInMemory(
+      channelId,
+      route.chatId,
+      route.accountId,
+      route.threadId,
+    );
     try {
       upsertChannelTarget(channelId, target);
     } catch (rollbackError) {
@@ -487,8 +1078,85 @@ export function bindChannelTarget(
   };
 }
 
+export function updateChannelRouteLive(
+  channelId: string,
+  chatId: string,
+  agentId: string,
+  conversationId: string,
+  accountId?: string,
+): ChannelRouteSnapshot {
+  assertSupportedChannelId(channelId);
+  loadRoutes(channelId);
+
+  const existingRoute = getSelectedRouteByChatId(channelId, chatId, accountId);
+  if (!existingRoute) {
+    throw new Error(`Route "${channelId}:${chatId}" was not found.`);
+  }
+
+  const resolvedAccountId = existingRoute.accountId ?? accountId;
+  const existingAccount = resolvedAccountId
+    ? getChannelAccount(channelId, resolvedAccountId)
+    : null;
+
+  if (existingAccount?.channel === "telegram") {
+    upsertChannelAccount(channelId, {
+      ...existingAccount,
+      binding: {
+        agentId,
+        conversationId,
+      },
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  const updatedRoute: ChannelRoute = {
+    ...existingRoute,
+    agentId,
+    conversationId,
+    updatedAt: new Date().toISOString(),
+  };
+
+  try {
+    addRoute(channelId, updatedRoute);
+  } catch (error) {
+    removeRouteInMemory(
+      channelId,
+      chatId,
+      resolvedAccountId,
+      existingRoute.threadId,
+    );
+    setRouteInMemory(channelId, existingRoute);
+
+    if (existingAccount?.channel === "telegram") {
+      try {
+        upsertChannelAccount(channelId, existingAccount);
+      } catch (rollbackError) {
+        throw new Error(
+          `Failed to update channel route: ${getErrorMessage(
+            error,
+            "Failed to save route",
+          )}. Failed to restore account binding: ${getErrorMessage(
+            rollbackError,
+            "Account rollback failed",
+          )}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `Failed to update channel route: ${getErrorMessage(
+        error,
+        "Failed to save route",
+      )}. Changes were rolled back.`,
+    );
+  }
+
+  return toRouteSnapshot(channelId, updatedRoute);
+}
+
 export function listChannelRouteSnapshots(params?: {
   channelId?: string;
+  accountId?: string;
   agentId?: string;
   conversationId?: string;
 }): ChannelRouteSnapshot[] {
@@ -497,7 +1165,7 @@ export function listChannelRouteSnapshots(params?: {
 
   loadRoutes(channelId);
 
-  return getRoutesForChannel(channelId)
+  return getRoutesForChannel(channelId, params?.accountId)
     .filter((route) =>
       params?.agentId ? route.agentId === params.agentId : true,
     )
@@ -512,8 +1180,23 @@ export function listChannelRouteSnapshots(params?: {
 export function removeChannelRouteLive(
   channelId: string,
   chatId: string,
+  accountId?: string,
 ): boolean {
   assertSupportedChannelId(channelId);
   loadRoutes(channelId);
-  return removeRoute(channelId, chatId);
+  const route = getSelectedRouteByChatId(channelId, chatId, accountId);
+  if (!route) {
+    return false;
+  }
+  return removeRoute(channelId, chatId, route.accountId);
+}
+
+export function __testOverrideResolveChannelAccountDisplayName(
+  fn:
+    | ((
+        account: ChannelAccount,
+      ) => Promise<string | undefined> | string | undefined)
+    | null,
+): void {
+  resolveChannelAccountDisplayNameOverride = fn;
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -368,6 +368,21 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       ?.isRunning() ?? false;
 
   if (account.channel === "telegram") {
+    loadRoutes(account.channel);
+    const fallbackRoute = getRoutesForChannel(
+      account.channel,
+      account.accountId,
+    ).find((route) => route.enabled !== false);
+    const binding =
+      account.binding.agentId && account.binding.conversationId
+        ? { ...account.binding }
+        : fallbackRoute
+          ? {
+              agentId: fallbackRoute.agentId,
+              conversationId: fallbackRoute.conversationId,
+            }
+          : { ...account.binding };
+
     return {
       channelId: "telegram",
       accountId: account.accountId,
@@ -378,7 +393,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
       hasToken: account.token.trim().length > 0,
-      binding: { ...account.binding },
+      binding,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1,14 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
 import type SlackApp from "@slack/bolt";
 import type {
   ChannelAdapter,
   InboundChannelMessage,
   OutboundChannelMessage,
-  SlackChannelConfig,
+  SlackChannelAccount,
 } from "../types";
+import { resolveSlackInboundAttachments } from "./media";
 import { loadSlackBoltModule } from "./runtime";
 
 type SlackBoltModule = typeof import("@slack/bolt");
 type SlackAppConstructor = SlackBoltModule["default"];
+type SlackReactionEvent = {
+  item?: {
+    type?: string;
+    channel?: string;
+    ts?: string;
+  };
+  user?: string;
+  item_user?: string;
+  reaction?: string;
+  event_ts?: string;
+};
 
 function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
   const App = mod.default;
@@ -20,6 +34,10 @@ function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(isNonEmptyString);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -36,9 +54,170 @@ function slackTimestampToMillis(timestamp: string): number {
   return Math.round(Number.parseFloat(timestamp) * 1000);
 }
 
-export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
+function resolveSlackChatType(chatId: string): "direct" | "channel" {
+  return chatId.startsWith("D") ? "direct" : "channel";
+}
+
+function normalizeSlackReactionName(value: string): string {
+  return value.trim().replace(/^:+|:+$/g, "");
+}
+
+function resolveUploadMimeType(filePath: string): string | undefined {
+  switch (extname(filePath).toLowerCase()) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".pdf":
+      return "application/pdf";
+    case ".txt":
+      return "text/plain";
+    case ".md":
+      return "text/markdown";
+    default:
+      return undefined;
+  }
+}
+
+async function uploadSlackFile(
+  slackApp: SlackApp,
+  msg: OutboundChannelMessage,
+): Promise<{ messageId: string }> {
+  if (!msg.mediaPath) {
+    throw new Error("mediaPath is required for Slack file uploads.");
+  }
+
+  const buffer = await readFile(msg.mediaPath);
+  const uploadFileName = msg.fileName ?? basename(msg.mediaPath);
+  const uploadTitle = msg.title ?? uploadFileName;
+  const uploadMimeType = resolveUploadMimeType(uploadFileName);
+  const uploadUrlResp = await slackApp.client.files.getUploadURLExternal({
+    filename: uploadFileName,
+    length: buffer.length,
+  });
+
+  if (
+    !uploadUrlResp.ok ||
+    !uploadUrlResp.upload_url ||
+    !uploadUrlResp.file_id
+  ) {
+    throw new Error(
+      `Failed to get Slack upload URL: ${uploadUrlResp.error ?? "unknown error"}`,
+    );
+  }
+
+  const uploadResp = await fetch(uploadUrlResp.upload_url, {
+    method: "POST",
+    ...(uploadMimeType ? { headers: { "Content-Type": uploadMimeType } } : {}),
+    body: buffer,
+  });
+  if (!uploadResp.ok) {
+    throw new Error(`Failed to upload Slack file: HTTP ${uploadResp.status}`);
+  }
+
+  const completeResp = await slackApp.client.files.completeUploadExternal({
+    files: [{ id: uploadUrlResp.file_id, title: uploadTitle }],
+    channel_id: msg.chatId,
+    ...(msg.text.trim() ? { initial_comment: msg.text } : {}),
+    ...((msg.threadId ?? msg.replyToMessageId)
+      ? { thread_ts: msg.threadId ?? msg.replyToMessageId }
+      : {}),
+  });
+
+  if (!completeResp.ok) {
+    throw new Error(
+      `Failed to complete Slack upload: ${completeResp.error ?? "unknown error"}`,
+    );
+  }
+
+  return { messageId: uploadUrlResp.file_id };
+}
+
+function resolveSlackUserDisplayName(userInfo: unknown): string | undefined {
+  const user = asRecord(asRecord(userInfo)?.user);
+  const profile = asRecord(user?.profile);
+  return firstNonEmptyString(
+    profile?.display_name,
+    profile?.real_name,
+    user?.name,
+  );
+}
+
+export async function resolveSlackAccountDisplayName(
+  botToken: string,
+  appToken: string,
+): Promise<string | undefined> {
+  const bolt = await loadSlackBoltModule();
+  const App = resolveSlackAppConstructor(bolt);
+  const app = new App({
+    token: botToken,
+    appToken,
+    socketMode: true,
+  });
+  const auth = await app.client.auth.test({ token: botToken });
+  if (isNonEmptyString(auth.user_id)) {
+    try {
+      const userInfo = await app.client.users.info({
+        token: botToken,
+        user: auth.user_id,
+      });
+      const displayName = resolveSlackUserDisplayName(userInfo);
+      if (displayName) {
+        return displayName;
+      }
+    } catch {}
+  }
+  return isNonEmptyString(auth.user) ? auth.user : undefined;
+}
+
+export function createSlackAdapter(
+  config: SlackChannelAccount,
+): ChannelAdapter {
   let app: SlackApp | null = null;
   let running = false;
+  const knownThreadIdsByMessageId = new Map<string, string | null>();
+  const knownUserDisplayNames = new Map<string, string>();
+
+  function rememberMessageThread(
+    messageId: string | undefined,
+    threadId: string | null,
+  ): void {
+    if (!isNonEmptyString(messageId)) {
+      return;
+    }
+    knownThreadIdsByMessageId.set(messageId, threadId);
+  }
+
+  async function resolveUserName(
+    slackApp: SlackApp,
+    userId: string | undefined,
+  ): Promise<string | undefined> {
+    if (!isNonEmptyString(userId)) {
+      return undefined;
+    }
+
+    const cached = knownUserDisplayNames.get(userId);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const userInfo = await slackApp.client.users.info({ user: userId });
+      const displayName = resolveSlackUserDisplayName(userInfo);
+      if (displayName) {
+        knownUserDisplayNames.set(userId, displayName);
+        return displayName;
+      }
+    } catch {}
+
+    knownUserDisplayNames.set(userId, userId);
+    return userId;
+  }
 
   async function ensureApp(): Promise<SlackApp> {
     if (app) {
@@ -68,12 +247,13 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       }
 
       const channelId = rawMessage.channel;
-      if (!isNonEmptyString(channelId) || !channelId.startsWith("D")) {
+      if (!isNonEmptyString(channelId)) {
         return;
       }
 
       if (
-        isNonEmptyString(rawMessage.subtype) ||
+        (isNonEmptyString(rawMessage.subtype) &&
+          rawMessage.subtype !== "file_share") ||
         isNonEmptyString(rawMessage.bot_id) ||
         !isNonEmptyString(rawMessage.user) ||
         !isNonEmptyString(rawMessage.ts)
@@ -82,22 +262,72 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       }
 
       const text = isNonEmptyString(rawMessage.text) ? rawMessage.text : "";
+      const attachments = await resolveSlackInboundAttachments({
+        accountId: config.accountId,
+        token: config.botToken,
+        rawEvent: message,
+      });
+      const chatType = resolveSlackChatType(channelId);
+      const threadId =
+        chatType === "channel"
+          ? (firstNonEmptyString(rawMessage.thread_ts, rawMessage.ts) ?? null)
+          : null;
+      rememberMessageThread(rawMessage.ts, threadId);
+      const senderName = await resolveUserName(instance, rawMessage.user);
+
+      if (chatType === "direct") {
+        const inbound: InboundChannelMessage = {
+          channel: "slack",
+          accountId: config.accountId,
+          chatId: channelId,
+          senderId: rawMessage.user,
+          senderName,
+          text,
+          timestamp: slackTimestampToMillis(rawMessage.ts),
+          messageId: rawMessage.ts,
+          threadId: null,
+          chatType: "direct",
+          isMention: false,
+          attachments,
+          raw: message,
+        };
+
+        try {
+          await adapter.onMessage(inbound);
+        } catch (error) {
+          console.error("[Slack] Error handling DM message:", error);
+        }
+        return;
+      }
+
+      if (!isNonEmptyString(rawMessage.thread_ts)) {
+        return;
+      }
+
       const inbound: InboundChannelMessage = {
         channel: "slack",
+        accountId: config.accountId,
         chatId: channelId,
         senderId: rawMessage.user,
-        senderName: rawMessage.user,
+        senderName,
+        chatLabel: channelId,
         text,
         timestamp: slackTimestampToMillis(rawMessage.ts),
         messageId: rawMessage.ts,
-        chatType: "direct",
+        threadId,
+        chatType: "channel",
+        isMention: false,
+        attachments,
         raw: message,
       };
 
       try {
         await adapter.onMessage(inbound);
       } catch (error) {
-        console.error("[Slack] Error handling DM message:", error);
+        console.error(
+          "[Slack] Error handling threaded channel message:",
+          error,
+        );
       }
     });
 
@@ -114,15 +344,26 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
         return;
       }
 
+      rememberMessageThread(event.ts, event.thread_ts ?? event.ts);
+
       const inbound: InboundChannelMessage = {
         channel: "slack",
+        accountId: config.accountId,
         chatId: event.channel,
         senderId: event.user,
-        senderName: event.user,
+        senderName: await resolveUserName(instance, event.user),
+        chatLabel: event.channel,
         text: normalizeSlackText(event.text ?? ""),
         timestamp: slackTimestampToMillis(event.ts),
-        messageId: event.thread_ts ?? event.ts,
+        messageId: event.ts,
+        threadId: event.thread_ts ?? event.ts,
         chatType: "channel",
+        isMention: true,
+        attachments: await resolveSlackInboundAttachments({
+          accountId: config.accountId,
+          token: config.botToken,
+          rawEvent: event,
+        }),
         raw: event,
       };
 
@@ -133,12 +374,83 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       }
     });
 
+    const handleReactionEvent = async (
+      event: SlackReactionEvent,
+      action: "added" | "removed",
+    ) => {
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      const item = asRecord(event.item);
+      const chatId = item?.channel;
+      const targetMessageId = item?.ts;
+      if (
+        item?.type !== "message" ||
+        !isNonEmptyString(chatId) ||
+        !isNonEmptyString(targetMessageId) ||
+        !isNonEmptyString(event.user) ||
+        !isNonEmptyString(event.reaction)
+      ) {
+        return;
+      }
+
+      const chatType = resolveSlackChatType(chatId);
+      const threadId =
+        chatType === "channel"
+          ? (knownThreadIdsByMessageId.get(targetMessageId) ?? targetMessageId)
+          : null;
+
+      const inbound: InboundChannelMessage = {
+        channel: "slack",
+        accountId: config.accountId,
+        chatId,
+        senderId: event.user,
+        senderName: await resolveUserName(instance, event.user),
+        chatLabel: chatId,
+        text: `Slack reaction ${action}: :${event.reaction}:`,
+        timestamp: slackTimestampToMillis(
+          firstNonEmptyString(event.event_ts, targetMessageId) ??
+            targetMessageId,
+        ),
+        messageId: firstNonEmptyString(event.event_ts, targetMessageId),
+        threadId,
+        chatType,
+        isMention: false,
+        reaction: {
+          action,
+          emoji: event.reaction,
+          targetMessageId,
+          targetSenderId: isNonEmptyString(event.item_user)
+            ? event.item_user
+            : undefined,
+        },
+        raw: event,
+      };
+
+      try {
+        await adapter.onMessage(inbound);
+      } catch (error) {
+        console.error(`[Slack] Error handling reaction ${action}:`, error);
+      }
+    };
+
+    instance.event("reaction_added", async ({ event }) => {
+      await handleReactionEvent(event as SlackReactionEvent, "added");
+    });
+
+    instance.event("reaction_removed", async ({ event }) => {
+      await handleReactionEvent(event as SlackReactionEvent, "removed");
+    });
+
     app = instance;
     return instance;
   }
 
   const adapter: ChannelAdapter = {
-    id: "slack",
+    id: `slack:${config.accountId}`,
+    channelId: "slack",
+    accountId: config.accountId,
     name: "Slack",
 
     async start(): Promise<void> {
@@ -147,7 +459,6 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       }
 
       const slackApp = await ensureApp();
-      await slackApp.init();
       const auth = await slackApp.client.auth.test();
       await slackApp.start();
       running = true;
@@ -175,11 +486,49 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       msg: OutboundChannelMessage,
     ): Promise<{ messageId: string }> {
       const slackApp = await ensureApp();
+      if (msg.reaction) {
+        const targetMessageId = msg.targetMessageId ?? msg.replyToMessageId;
+        if (!targetMessageId) {
+          throw new Error(
+            "Slack reactions require message_id (or reply_to_message_id) to identify the target message.",
+          );
+        }
+        const emoji = normalizeSlackReactionName(msg.reaction);
+        if (!emoji) {
+          throw new Error("Slack reaction emoji cannot be empty.");
+        }
+        if (msg.removeReaction) {
+          await slackApp.client.reactions.remove({
+            channel: msg.chatId,
+            timestamp: targetMessageId,
+            name: emoji,
+          });
+        } else {
+          await slackApp.client.reactions.add({
+            channel: msg.chatId,
+            timestamp: targetMessageId,
+            name: emoji,
+          });
+        }
+        return { messageId: targetMessageId };
+      }
+
+      if (msg.mediaPath) {
+        return uploadSlackFile(slackApp, msg);
+      }
+
       const response = await slackApp.client.chat.postMessage({
         channel: msg.chatId,
         text: msg.text,
-        ...(msg.replyToMessageId ? { thread_ts: msg.replyToMessageId } : {}),
+        ...((msg.threadId ?? msg.replyToMessageId)
+          ? { thread_ts: msg.threadId ?? msg.replyToMessageId }
+          : {}),
       });
+
+      rememberMessageThread(
+        response.ts,
+        msg.threadId ?? msg.replyToMessageId ?? response.ts ?? null,
+      );
 
       return { messageId: response.ts ?? "" };
     },
@@ -190,13 +539,17 @@ export function createSlackAdapter(config: SlackChannelConfig): ChannelAdapter {
       options?: { replyToMessageId?: string },
     ): Promise<void> {
       const slackApp = await ensureApp();
-      await slackApp.client.chat.postMessage({
+      const response = await slackApp.client.chat.postMessage({
         channel: chatId,
         text,
         ...(options?.replyToMessageId
           ? { thread_ts: options.replyToMessageId }
           : {}),
       });
+      rememberMessageThread(
+        response.ts,
+        options?.replyToMessageId ?? response.ts ?? null,
+      );
     },
 
     onMessage: undefined,

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { getChannelDir } from "../config";
+import type { ChannelMessageAttachment } from "../types";
+
+const MAX_SLACK_ATTACHMENTS = 8;
+const MAX_SLACK_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const ALLOWED_SLACK_HOST_SUFFIXES = [
+  "slack.com",
+  "slack-edge.com",
+  "slack-files.com",
+] as const;
+
+type SlackFileLike = {
+  id?: string;
+  name?: string;
+  mimetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
+};
+
+type SlackAttachmentLike = {
+  image_url?: string;
+  files?: SlackFileLike[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeSlackFileLike(value: unknown): SlackFileLike | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  return {
+    id: isNonEmptyString(record.id) ? record.id : undefined,
+    name: isNonEmptyString(record.name) ? record.name : undefined,
+    mimetype: isNonEmptyString(record.mimetype) ? record.mimetype : undefined,
+    size: typeof record.size === "number" ? record.size : undefined,
+    url_private: isNonEmptyString(record.url_private)
+      ? record.url_private
+      : undefined,
+    url_private_download: isNonEmptyString(record.url_private_download)
+      ? record.url_private_download
+      : undefined,
+  };
+}
+
+function normalizeSlackAttachmentLike(
+  value: unknown,
+): SlackAttachmentLike | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const files = Array.isArray(record.files)
+    ? record.files
+        .map((entry) => normalizeSlackFileLike(entry))
+        .filter((entry): entry is SlackFileLike => Boolean(entry))
+    : undefined;
+
+  return {
+    image_url: isNonEmptyString(record.image_url)
+      ? record.image_url
+      : undefined,
+    files,
+  };
+}
+
+function isAllowedSlackHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return ALLOWED_SLACK_HOST_SUFFIXES.some(
+    (suffix) => normalized === suffix || normalized.endsWith(`.${suffix}`),
+  );
+}
+
+function assertSlackFileUrl(rawUrl: string): URL {
+  const parsed = new URL(rawUrl);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Unsupported Slack file protocol: ${parsed.protocol}`);
+  }
+  if (!isAllowedSlackHostname(parsed.hostname)) {
+    throw new Error(`Refusing non-Slack attachment host: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+function sanitizeFileName(name: string): string {
+  const normalized = name.trim().replace(/[^\w.-]+/g, "_");
+  return normalized.length > 0 ? normalized : "attachment";
+}
+
+function extensionForMimeType(mimeType?: string): string {
+  switch (mimeType?.toLowerCase()) {
+    case "image/png":
+      return ".png";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "application/pdf":
+      return ".pdf";
+    case "text/plain":
+      return ".txt";
+    default:
+      return "";
+  }
+}
+
+function resolveMimeType(name: string, fallback?: string): string | undefined {
+  if (fallback) {
+    return fallback;
+  }
+
+  switch (extname(name).toLowerCase()) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".pdf":
+      return "application/pdf";
+    case ".txt":
+    case ".md":
+      return "text/plain";
+    default:
+      return undefined;
+  }
+}
+
+async function fetchWithSlackAuth(
+  url: string,
+  token: string,
+): Promise<Response> {
+  const parsed = assertSlackFileUrl(url);
+  const authHeaders = { Authorization: `Bearer ${token}` };
+
+  const initial = await fetch(parsed.href, {
+    headers: authHeaders,
+    redirect: "manual",
+  });
+
+  if (initial.status < 300 || initial.status >= 400) {
+    return initial;
+  }
+
+  const redirectUrl = initial.headers.get("location");
+  if (!redirectUrl) {
+    return initial;
+  }
+
+  const resolved = new URL(redirectUrl, parsed.href);
+  if (resolved.origin === parsed.origin) {
+    return fetch(resolved.href, {
+      headers: authHeaders,
+      redirect: "follow",
+    });
+  }
+
+  return fetch(resolved.href, { redirect: "follow" });
+}
+
+async function saveSlackAttachment(params: {
+  accountId: string;
+  fileName: string;
+  buffer: Buffer;
+}): Promise<string> {
+  const inboundDir = join(
+    getChannelDir("slack"),
+    "inbound",
+    sanitizeFileName(params.accountId),
+  );
+  await mkdir(inboundDir, { recursive: true });
+
+  const filePath = join(
+    inboundDir,
+    `${Date.now()}-${randomUUID()}-${sanitizeFileName(params.fileName)}`,
+  );
+  await writeFile(filePath, params.buffer);
+  return filePath;
+}
+
+async function downloadSlackAttachment(params: {
+  accountId: string;
+  token: string;
+  file: SlackFileLike;
+}): Promise<ChannelMessageAttachment | null> {
+  const url = params.file.url_private_download ?? params.file.url_private;
+  if (!url) {
+    return null;
+  }
+
+  const response = await fetchWithSlackAuth(url, params.token);
+  if (!response.ok) {
+    return null;
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  if (arrayBuffer.byteLength > MAX_SLACK_ATTACHMENT_BYTES) {
+    return null;
+  }
+
+  const buffer = Buffer.from(arrayBuffer);
+  const hintedName =
+    params.file.name ??
+    basename(new URL(url).pathname) ??
+    `${params.file.id ?? "attachment"}${extensionForMimeType(params.file.mimetype)}`;
+  const mimeType = resolveMimeType(
+    hintedName,
+    response.headers.get("content-type")?.split(";")[0] ?? params.file.mimetype,
+  );
+  const fileName =
+    extname(hintedName) || !mimeType
+      ? hintedName
+      : `${hintedName}${extensionForMimeType(mimeType)}`;
+  const localPath = await saveSlackAttachment({
+    accountId: params.accountId,
+    fileName,
+    buffer,
+  });
+
+  const kind = mimeType?.startsWith("image/") ? "image" : "file";
+  return {
+    id: params.file.id,
+    name: fileName,
+    mimeType,
+    sizeBytes: buffer.byteLength,
+    kind,
+    localPath,
+    ...(kind === "image" ? { imageDataBase64: buffer.toString("base64") } : {}),
+  };
+}
+
+function collectSlackFiles(rawEvent: unknown): SlackFileLike[] {
+  const record = asRecord(rawEvent);
+  if (!record) {
+    return [];
+  }
+
+  const deduped = new Map<string, SlackFileLike>();
+
+  const push = (file: SlackFileLike | null) => {
+    if (!file) {
+      return;
+    }
+    const key =
+      file.id ??
+      file.url_private_download ??
+      file.url_private ??
+      `${file.name ?? "attachment"}:${file.mimetype ?? ""}`;
+    deduped.set(key, file);
+  };
+
+  if (Array.isArray(record.files)) {
+    for (const entry of record.files) {
+      push(normalizeSlackFileLike(entry));
+    }
+  }
+
+  if (Array.isArray(record.attachments)) {
+    record.attachments
+      .map((entry) => normalizeSlackAttachmentLike(entry))
+      .filter((entry): entry is SlackAttachmentLike => Boolean(entry))
+      .forEach((attachment, index) => {
+        for (const file of attachment.files ?? []) {
+          push(file);
+        }
+        if (attachment.image_url) {
+          push({
+            id: `attachment-image-${index}`,
+            name: `attachment-image-${index}.png`,
+            url_private: attachment.image_url,
+          });
+        }
+      });
+  }
+
+  return Array.from(deduped.values()).slice(0, MAX_SLACK_ATTACHMENTS);
+}
+
+export async function resolveSlackInboundAttachments(params: {
+  accountId: string;
+  token: string;
+  rawEvent: unknown;
+}): Promise<ChannelMessageAttachment[]> {
+  const files = collectSlackFiles(params.rawEvent);
+  if (files.length === 0) {
+    return [];
+  }
+
+  const resolved = await Promise.all(
+    files.map((file) =>
+      downloadSlackAttachment({
+        accountId: params.accountId,
+        token: params.token,
+        file,
+      }).catch(() => null),
+    ),
+  );
+
+  return resolved.filter((attachment): attachment is ChannelMessageAttachment =>
+    Boolean(attachment),
+  );
+}
+
+export async function readSlackAttachmentFile(
+  localPath: string,
+): Promise<Buffer> {
+  return readFile(localPath);
+}

--- a/src/channels/slack/messageActions.ts
+++ b/src/channels/slack/messageActions.ts
@@ -1,0 +1,85 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+} from "../pluginTypes";
+
+async function sendSlackMessage(
+  ctx: ChannelMessageActionContext,
+): Promise<string> {
+  const { request, route, adapter, formatText } = ctx;
+  const text = request.message ?? "";
+
+  if (text.trim().length === 0 && !request.mediaPath) {
+    return "Error: Slack send requires message or media.";
+  }
+
+  const formatted = formatText(text);
+  const result = await adapter.sendMessage({
+    channel: "slack",
+    accountId: route.accountId,
+    chatId: request.chatId,
+    text: formatted.text,
+    replyToMessageId: request.replyToMessageId,
+    threadId: request.replyToMessageId
+      ? null
+      : (request.threadId ?? route.threadId ?? null),
+    mediaPath: request.mediaPath,
+    fileName: request.filename,
+    title: request.title,
+    parseMode: formatted.parseMode,
+  });
+
+  return request.mediaPath
+    ? `Attachment sent to slack (message_id: ${result.messageId})`
+    : `Message sent to slack (message_id: ${result.messageId})`;
+}
+
+async function reactInSlack(ctx: ChannelMessageActionContext): Promise<string> {
+  const { request, route, adapter } = ctx;
+
+  if (!request.emoji?.trim()) {
+    return "Error: Slack react requires emoji.";
+  }
+  if (!request.messageId?.trim()) {
+    return "Error: Slack react requires messageId.";
+  }
+
+  const result = await adapter.sendMessage({
+    channel: "slack",
+    accountId: route.accountId,
+    chatId: request.chatId,
+    text: "",
+    targetMessageId: request.messageId,
+    reaction: request.emoji,
+    removeReaction: request.remove,
+    threadId: request.threadId ?? route.threadId ?? null,
+  });
+
+  return request.remove
+    ? `Reaction removed on slack (message_id: ${result.messageId})`
+    : `Reaction added on slack (message_id: ${result.messageId})`;
+}
+
+export const slackMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool() {
+    return {
+      actions: ["send", "react", "upload-file"],
+    };
+  },
+
+  async handleAction(ctx) {
+    switch (ctx.request.action) {
+      case "send":
+        return await sendSlackMessage(ctx);
+      case "upload-file":
+        if (!ctx.request.mediaPath?.trim()) {
+          return "Error: Slack upload-file requires media.";
+        }
+        return await sendSlackMessage(ctx);
+      case "react":
+        return await reactInSlack(ctx);
+      default:
+        return `Error: Action "${ctx.request.action}" is not supported on slack.`;
+    }
+  },
+};

--- a/src/channels/slack/plugin.ts
+++ b/src/channels/slack/plugin.ts
@@ -1,6 +1,7 @@
 import type { ChannelPlugin } from "../pluginTypes";
-import type { ChannelConfig, SlackChannelConfig } from "../types";
+import type { ChannelAccount, SlackChannelAccount } from "../types";
 import { createSlackAdapter } from "./adapter";
+import { slackMessageActions } from "./messageActions";
 import { runSlackSetup } from "./setup";
 
 export const slackChannelPlugin: ChannelPlugin = {
@@ -10,9 +11,10 @@ export const slackChannelPlugin: ChannelPlugin = {
     runtimePackages: ["@slack/bolt@4.7.0"],
     runtimeModules: ["@slack/bolt"],
   },
-  createAdapter(config: ChannelConfig) {
-    return createSlackAdapter(config as SlackChannelConfig);
+  createAdapter(account: ChannelAccount) {
+    return createSlackAdapter(account as SlackChannelAccount);
   },
+  messageActions: slackMessageActions,
   runSetup() {
     return runSlackSetup();
   },

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
-import { writeChannelConfig } from "../config";
-import type { DmPolicy, SlackChannelConfig } from "../types";
+import { upsertChannelAccount } from "../accounts";
+import type { DmPolicy, SlackChannelAccount } from "../types";
+import { resolveSlackAccountDisplayName } from "./adapter";
 import { ensureSlackRuntimeInstalled } from "./runtime";
 
 function isValidBotToken(token: string): boolean {
@@ -27,8 +29,13 @@ export async function runSlackSetup(): Promise<boolean> {
       "  3. Install the app to the workspace to get a bot token (xoxb-...)",
     );
     console.log(
-      "  4. Enable App Home messages and subscribe to app_mention + message.im\n",
+      "  4. Enable App Home messages and subscribe to app_mention + message.channels + message.groups + message.im + reaction_added + reaction_removed\n",
     );
+    console.log("Recommended bot token scopes:");
+    console.log(
+      "  app_mentions:read, channels:history, chat:write, groups:history, im:history, users:read",
+    );
+    console.log("  reactions:read, reactions:write, files:read, files:write\n");
 
     await ensureSlackRuntimeInstalled();
 
@@ -49,12 +56,11 @@ export async function runSlackSetup(): Promise<boolean> {
     }
 
     console.log("\nDM Policy — who can message this app directly?\n");
-    console.log("  pairing   — Users must pair with a code (recommended)");
     console.log("  allowlist — Only pre-approved Slack user IDs");
-    console.log("  open      — Anyone in DMs can message\n");
+    console.log("  open      — Anyone in DMs can message (recommended)\n");
 
-    const policyInput = await rl.question("DM policy [pairing]: ");
-    const policy = (policyInput.trim() || "pairing") as DmPolicy;
+    const policyInput = await rl.question("DM policy [open]: ");
+    const policy = (policyInput.trim() || "open") as DmPolicy;
     if (!["pairing", "allowlist", "open"].includes(policy)) {
       console.error(`Invalid policy "${policy}". Setup cancelled.`);
       return false;
@@ -71,24 +77,37 @@ export async function runSlackSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
-    const config: SlackChannelConfig = {
+    const now = new Date().toISOString();
+    let displayName: string | undefined;
+    try {
+      displayName = await resolveSlackAccountDisplayName(botToken, appToken);
+    } catch {}
+
+    const account: SlackChannelAccount = {
       channel: "slack",
+      accountId: randomUUID(),
+      displayName,
       enabled: true,
       mode: "socket",
       botToken,
       appToken,
+      agentId: null,
       dmPolicy: policy,
       allowedUsers,
+      createdAt: now,
+      updatedAt: now,
     };
 
-    writeChannelConfig("slack", config);
+    upsertChannelAccount("slack", account);
     console.log("\n✓ Slack app configured!");
-    console.log("Config written to: ~/.letta/channels/slack/config.yaml\n");
+    console.log("Config written to: ~/.letta/channels/slack/accounts.json\n");
     console.log("Next steps:");
     console.log("  1. Start the listener: letta server --channels slack");
-    console.log("  2. DM the app once to generate a pairing code");
-    console.log("  3. Mention the app in a Slack channel once to discover it");
-    console.log("  4. Bind the DM or channel from Letta Code\n");
+    console.log("  2. Open Channels > Slack in Letta Code");
+    console.log(
+      "  3. Choose which Letta agent this Slack app should represent",
+    );
+    console.log("  4. DM the app or @mention it in Slack to start chatting\n");
 
     return true;
   } finally {

--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getChannelDir, getChannelTargetsPath } from "./config";
 import type { ChannelBindableTarget } from "./types";
 
@@ -59,17 +60,30 @@ function saveTargetStore(channelId: string): void {
   );
 }
 
-export function listChannelTargets(channelId: string): ChannelBindableTarget[] {
-  return [...getStore(channelId).targets];
+export function listChannelTargets(
+  channelId: string,
+  accountId?: string,
+): ChannelBindableTarget[] {
+  const normalizedAccountId =
+    accountId === undefined ? undefined : normalizeAccountId(accountId);
+  return getStore(channelId).targets.filter(
+    (target) =>
+      normalizedAccountId === undefined ||
+      normalizeAccountId(target.accountId) === normalizedAccountId,
+  );
 }
 
 export function getChannelTarget(
   channelId: string,
   targetId: string,
+  accountId?: string,
 ): ChannelBindableTarget | null {
+  const normalizedAccountId = normalizeAccountId(accountId);
   return (
     getStore(channelId).targets.find(
-      (target) => target.targetId === targetId,
+      (target) =>
+        target.targetId === targetId &&
+        normalizeAccountId(target.accountId) === normalizedAccountId,
     ) ?? null
   );
 }
@@ -79,8 +93,11 @@ export function upsertChannelTarget(
   target: ChannelBindableTarget,
 ): ChannelBindableTarget {
   const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(target.accountId);
   const existingIndex = store.targets.findIndex(
-    (candidate) => candidate.targetId === target.targetId,
+    (candidate) =>
+      candidate.targetId === target.targetId &&
+      normalizeAccountId(candidate.accountId) === normalizedAccountId,
   );
 
   if (existingIndex >= 0) {
@@ -93,6 +110,7 @@ export function upsertChannelTarget(
     const merged: ChannelBindableTarget = {
       ...existing,
       ...target,
+      accountId: normalizedAccountId,
       discoveredAt: existing.discoveredAt,
       lastSeenAt: target.lastSeenAt,
     };
@@ -101,18 +119,30 @@ export function upsertChannelTarget(
     return merged;
   }
 
-  store.targets.push(target);
+  store.targets.push({
+    ...target,
+    accountId: normalizedAccountId,
+  });
   saveTargetStore(channelId);
-  return target;
+  return {
+    ...target,
+    accountId: normalizedAccountId,
+  };
 }
 
 export function removeChannelTarget(
   channelId: string,
   targetId: string,
+  accountId?: string,
 ): boolean {
   const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(accountId);
   const nextTargets = store.targets.filter(
-    (target) => target.targetId !== targetId,
+    (target) =>
+      !(
+        target.targetId === targetId &&
+        normalizeAccountId(target.accountId) === normalizedAccountId
+      ),
   );
   if (nextTargets.length === store.targets.length) {
     return false;
@@ -120,6 +150,24 @@ export function removeChannelTarget(
   store.targets = nextTargets;
   saveTargetStore(channelId);
   return true;
+}
+
+export function removeChannelTargetsForAccount(
+  channelId: string,
+  accountId: string,
+): number {
+  const store = getStore(channelId);
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const nextTargets = store.targets.filter(
+    (target) => normalizeAccountId(target.accountId) !== normalizedAccountId,
+  );
+  const removed = store.targets.length - nextTargets.length;
+  if (removed === 0) {
+    return 0;
+  }
+  store.targets = nextTargets;
+  saveTargetStore(channelId);
+  return removed;
 }
 
 export function clearTargetStores(): void {
@@ -138,4 +186,7 @@ export function __testOverrideSaveTargetStore(
   fn: ((channelId: string, store: ChannelTargetStore) => void) | null,
 ): void {
   saveTargetStoreOverride = fn;
+}
+function normalizeAccountId(accountId?: string): string {
+  return accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
 }

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -10,7 +10,7 @@ import type {
   ChannelAdapter,
   InboundChannelMessage,
   OutboundChannelMessage,
-  TelegramChannelConfig,
+  TelegramChannelAccount,
 } from "../types";
 import { loadGrammyModule } from "./runtime";
 
@@ -31,7 +31,7 @@ function resolveTelegramBotConstructor(
 }
 
 export function createTelegramAdapter(
-  config: TelegramChannelConfig,
+  config: TelegramChannelAccount,
 ): ChannelAdapter {
   let bot: TelegramBot | null = null;
   let running = false;
@@ -66,6 +66,7 @@ export function createTelegramAdapter(
 
       const inbound: InboundChannelMessage = {
         channel: "telegram",
+        accountId: config.accountId,
         chatId: String(msg.chat.id),
         senderId: String(msg.from.id),
         senderName: displayName || undefined,
@@ -107,7 +108,9 @@ export function createTelegramAdapter(
   }
 
   const adapter: ChannelAdapter = {
-    id: "telegram",
+    id: `telegram:${config.accountId}`,
+    channelId: "telegram",
+    accountId: config.accountId,
     name: "Telegram",
 
     async start(): Promise<void> {

--- a/src/channels/telegram/messageActions.ts
+++ b/src/channels/telegram/messageActions.ts
@@ -1,0 +1,32 @@
+import type { ChannelMessageActionAdapter } from "../pluginTypes";
+
+export const telegramMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool() {
+    return {
+      actions: ["send"],
+    };
+  },
+
+  async handleAction(ctx) {
+    const { request, route, adapter, formatText } = ctx;
+
+    if (request.action !== "send") {
+      return `Error: Action "${request.action}" is not supported on telegram.`;
+    }
+    if (!request.message?.trim()) {
+      return "Error: Telegram send requires message.";
+    }
+
+    const formatted = formatText(request.message);
+    const result = await adapter.sendMessage({
+      channel: "telegram",
+      accountId: route.accountId,
+      chatId: request.chatId,
+      text: formatted.text,
+      replyToMessageId: request.replyToMessageId,
+      parseMode: formatted.parseMode,
+    });
+
+    return `Message sent to telegram (message_id: ${result.messageId})`;
+  },
+};

--- a/src/channels/telegram/plugin.ts
+++ b/src/channels/telegram/plugin.ts
@@ -1,6 +1,7 @@
 import type { ChannelPlugin } from "../pluginTypes";
-import type { ChannelConfig, TelegramChannelConfig } from "../types";
+import type { ChannelAccount, TelegramChannelAccount } from "../types";
 import { createTelegramAdapter } from "./adapter";
+import { telegramMessageActions } from "./messageActions";
 import { runTelegramSetup } from "./setup";
 
 export const telegramChannelPlugin: ChannelPlugin = {
@@ -10,9 +11,10 @@ export const telegramChannelPlugin: ChannelPlugin = {
     runtimePackages: ["grammy@1.42.0"],
     runtimeModules: ["grammy"],
   },
-  createAdapter(config: ChannelConfig) {
-    return createTelegramAdapter(config as TelegramChannelConfig);
+  createAdapter(account: ChannelAccount) {
+    return createTelegramAdapter(account as TelegramChannelAccount);
   },
+  messageActions: telegramMessageActions,
   runSetup() {
     return runTelegramSetup();
   },

--- a/src/channels/telegram/setup.ts
+++ b/src/channels/telegram/setup.ts
@@ -5,15 +5,16 @@
  * 1. Prompt for bot token from @BotFather
  * 2. Validate via getMe()
  * 3. Choose DM policy
- * 4. Write config to ~/.letta/channels/telegram/config.yaml
+ * 4. Write config to ~/.letta/channels/telegram/accounts.json
  * 5. Start `letta server --channels telegram`
  * 6. Message the bot from Telegram to get a pairing code
  * 7. Run `/channels telegram pair <code>` in the target ADE/Desktop conversation
  */
 
+import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
-import { writeChannelConfig } from "../config";
-import type { DmPolicy, TelegramChannelConfig } from "../types";
+import { upsertChannelAccount } from "../accounts";
+import type { DmPolicy, TelegramChannelAccount } from "../types";
 import { validateTelegramToken } from "./adapter";
 import { ensureTelegramRuntimeInstalled } from "./runtime";
 
@@ -39,8 +40,10 @@ export async function runTelegramSetup(): Promise<boolean> {
 
     // Step 2: Validate token
     console.log("\nValidating token...");
+    let validatedUsername: string | undefined;
     try {
       const info = await validateTelegramToken(token.trim());
+      validatedUsername = info.username;
       console.log(`✓ Connected to @${info.username} (ID: ${info.id})\n`);
     } catch (err) {
       console.error(
@@ -75,18 +78,29 @@ export async function runTelegramSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
-    // Step 5: Write config
-    const config: TelegramChannelConfig = {
+    // Step 5: Write account
+    const now = new Date().toISOString();
+    const account: TelegramChannelAccount = {
       channel: "telegram",
+      accountId: randomUUID(),
+      displayName: validatedUsername ? `@${validatedUsername}` : undefined,
       enabled: true,
       token: token.trim(),
       dmPolicy: policy,
       allowedUsers,
+      binding: {
+        agentId: null,
+        conversationId: null,
+      },
+      createdAt: now,
+      updatedAt: now,
     };
 
-    writeChannelConfig("telegram", config);
+    upsertChannelAccount("telegram", account);
     console.log("\n✓ Telegram bot configured!");
-    console.log("Config written to: ~/.letta/channels/telegram/config.yaml\n");
+    console.log(
+      "Config written to: ~/.letta/channels/telegram/accounts.json\n",
+    );
     console.log("Next steps:");
     console.log("  1. Start the listener: letta server --channels telegram");
     console.log("  2. Message the bot from Telegram to get a pairing code");

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -11,11 +11,32 @@ export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack"] as const;
 export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
 export type ChannelChatType = "direct" | "channel";
 
+export interface ChannelMessageAttachment {
+  id?: string;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  kind: "image" | "file";
+  localPath: string;
+  imageDataBase64?: string;
+}
+
+export interface ChannelReactionNotification {
+  action: "added" | "removed";
+  emoji: string;
+  targetMessageId: string;
+  targetSenderId?: string;
+}
+
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {
   /** Platform identifier, e.g. "telegram", "slack". */
   readonly id: string;
+  /** Channel identifier, e.g. "telegram". */
+  readonly channelId?: SupportedChannelId;
+  /** Account identifier within the channel. */
+  readonly accountId?: string;
   /** Human-readable display name, e.g. "Telegram". */
   readonly name: string;
 
@@ -51,6 +72,8 @@ export interface ChannelAdapter {
 export interface InboundChannelMessage {
   /** Platform identifier, e.g. "telegram". */
   channel: string;
+  /** Channel account that received the inbound message. */
+  accountId?: string;
   /** Platform-specific chat/conversation ID. */
   chatId: string;
   /** Platform-specific sender user ID. */
@@ -65,30 +88,60 @@ export interface InboundChannelMessage {
   timestamp: number;
   /** Platform message ID for threading/replies. */
   messageId?: string;
+  /** Canonical thread identifier used for route selection, when applicable. */
+  threadId?: string | null;
   /** Raw platform-specific event data for future use. */
   raw?: unknown;
   /** Broad chat surface type used for routing/pairing decisions. */
   chatType?: ChannelChatType;
+  /** Whether this inbound message was explicitly addressed to the bot. */
+  isMention?: boolean;
+  /** Downloaded attachments/media associated with the inbound message. */
+  attachments?: ChannelMessageAttachment[];
+  /** Reaction metadata for non-text channel events (currently Slack). */
+  reaction?: ChannelReactionNotification;
 }
 
 export interface OutboundChannelMessage {
   /** Platform identifier. */
   channel: string;
+  /** Channel account that should send the outbound message. */
+  accountId?: string;
   /** Target chat/conversation ID. */
   chatId: string;
   /** Message text to send. */
   text: string;
   /** Optional: reply to a specific message. */
   replyToMessageId?: string;
+  /** Optional: canonical thread identifier used for threaded channels. */
+  threadId?: string | null;
   /** Optional: parse mode hint for the adapter (e.g. "HTML", "MarkdownV2"). */
   parseMode?: string;
+  /** Optional: attach a local file/media path (currently Slack only). */
+  mediaPath?: string;
+  /** Optional: override the uploaded filename for media attachments. */
+  fileName?: string;
+  /** Optional: override the uploaded title/caption metadata for media attachments. */
+  title?: string;
+  /** Optional: Slack reaction emoji to add/remove (e.g. "white_check_mark"). */
+  reaction?: string;
+  /** Optional: remove the Slack reaction instead of adding it. */
+  removeReaction?: boolean;
+  /** Optional: target message id for reactions. */
+  targetMessageId?: string;
 }
 
 // ── Routing ───────────────────────────────────────────────────────
 
 export interface ChannelRoute {
+  /** Channel account identifier. */
+  accountId?: string;
   /** Platform-specific chat ID. */
   chatId: string;
+  /** Broad chat surface type for this route. */
+  chatType?: ChannelChatType;
+  /** Canonical thread identifier for threaded channels, if any. */
+  threadId?: string | null;
   /** Letta agent ID this chat is bound to. */
   agentId: string;
   /** Letta conversation ID this chat is bound to. */
@@ -97,12 +150,29 @@ export interface ChannelRoute {
   enabled: boolean;
   /** ISO 8601 creation timestamp. */
   createdAt: string;
+  /** ISO 8601 update timestamp. */
+  updatedAt?: string;
 }
 
 // ── Config ────────────────────────────────────────────────────────
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
 export type SlackChannelMode = "socket";
+
+export interface ChannelAccountBinding {
+  agentId: string | null;
+  conversationId: string | null;
+}
+
+interface ChannelAccountBase {
+  accountId: string;
+  displayName?: string;
+  enabled: boolean;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+  createdAt: string;
+  updatedAt: string;
+}
 
 export interface TelegramChannelConfig {
   channel: "telegram";
@@ -124,9 +194,26 @@ export interface SlackChannelConfig {
 
 export type ChannelConfig = TelegramChannelConfig | SlackChannelConfig;
 
+export interface TelegramChannelAccount extends ChannelAccountBase {
+  channel: "telegram";
+  token: string;
+  binding: ChannelAccountBinding;
+}
+
+export interface SlackChannelAccount extends ChannelAccountBase {
+  channel: "slack";
+  mode: SlackChannelMode;
+  botToken: string;
+  appToken: string;
+  agentId: string | null;
+}
+
+export type ChannelAccount = TelegramChannelAccount | SlackChannelAccount;
+
 // ── Pairing ───────────────────────────────────────────────────────
 
 export interface PendingPairing {
+  accountId?: string;
   code: string;
   senderId: string;
   senderName?: string;
@@ -136,6 +223,7 @@ export interface PendingPairing {
 }
 
 export interface ApprovedUser {
+  accountId?: string;
   senderId: string;
   senderName?: string;
   approvedAt: string;
@@ -149,6 +237,7 @@ export interface PairingStore {
 // ── Discovered bind targets ───────────────────────────────────────
 
 export interface ChannelBindableTarget {
+  accountId?: string;
   targetId: string;
   targetType: "channel";
   chatId: string;

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -8,7 +8,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { getLocalTime } from "../cli/helpers/sessionContext";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
-import type { InboundChannelMessage } from "./types";
+import type { ChannelMessageAttachment, InboundChannelMessage } from "./types";
 
 /**
  * Escape special XML characters in text content.
@@ -33,16 +33,16 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const threadLine =
     msg.channel === "slack" &&
     msg.chatType === "channel" &&
-    msg.messageId?.trim()
-      ? `Use reply_to_message_id="${escapeXml(msg.messageId)}" if you want your reply to stay in the same Slack thread.`
+    (msg.threadId ?? msg.messageId)?.trim()
+      ? "Replies sent with MessageChannel will stay in the same Slack thread automatically."
       : null;
 
   const lines = [
     SYSTEM_REMINDER_OPEN,
     `This message originated from an external ${escapedChannel} channel.`,
     `If you want to ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
-    `Use channel="${escapedChannel}" and chat_id="${escapedChatId}" when calling MessageChannel.`,
-    "Only pass reply_to_message_id if you intentionally want the platform's quote/reply UI.",
+    `Use action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}" when calling MessageChannel, and put your reply text in message.`,
+    "Only pass replyTo if you intentionally want the platform's quote/reply UI.",
     `Current local time on this device: ${localTime}`,
     SYSTEM_REMINDER_CLOSE,
   ];
@@ -50,8 +50,62 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   if (threadLine) {
     lines.splice(lines.length - 2, 0, threadLine);
   }
+  if (msg.channel === "slack") {
+    lines.splice(
+      lines.length - 2,
+      0,
+      'On Slack, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
+    );
+  }
+  if (msg.attachments?.length) {
+    lines.splice(
+      lines.length - 2,
+      0,
+      "If this notification includes attachment local_path values, you can inspect those files with the Read tool.",
+    );
+  }
 
   return lines.join("\n");
+}
+
+function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
+  const attrs = [
+    `kind="${escapeXml(attachment.kind)}"`,
+    `local_path="${escapeXml(attachment.localPath)}"`,
+  ];
+
+  if (attachment.id) {
+    attrs.push(`attachment_id="${escapeXml(attachment.id)}"`);
+  }
+  if (attachment.name) {
+    attrs.push(`name="${escapeXml(attachment.name)}"`);
+  }
+  if (attachment.mimeType) {
+    attrs.push(`mime_type="${escapeXml(attachment.mimeType)}"`);
+  }
+  if (typeof attachment.sizeBytes === "number") {
+    attrs.push(`size_bytes="${attachment.sizeBytes}"`);
+  }
+
+  return `<attachment ${attrs.join(" ")} />`;
+}
+
+function buildReactionXml(msg: InboundChannelMessage): string | null {
+  if (!msg.reaction) {
+    return null;
+  }
+
+  const attrs = [
+    `action="${escapeXml(msg.reaction.action)}"`,
+    `emoji="${escapeXml(msg.reaction.emoji)}"`,
+    `target_message_id="${escapeXml(msg.reaction.targetMessageId)}"`,
+  ];
+
+  if (msg.reaction.targetSenderId) {
+    attrs.push(`target_sender_id="${escapeXml(msg.reaction.targetSenderId)}"`);
+  }
+
+  return `<reaction ${attrs.join(" ")} />`;
 }
 
 /**
@@ -81,10 +135,19 @@ export function buildChannelNotificationXml(
     attrs.push(`message_id="${escapeXml(msg.messageId)}"`);
   }
 
-  const attrString = attrs.join(" ");
-  const escapedText = escapeXml(msg.text);
+  if (msg.threadId) {
+    attrs.push(`thread_id="${escapeXml(msg.threadId)}"`);
+  }
 
-  return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
+  const attrString = attrs.join(" ");
+  const escapedText = msg.text ? escapeXml(msg.text) : "";
+  const reactionXml = buildReactionXml(msg);
+  const attachmentXml = (msg.attachments ?? []).map(buildAttachmentXml);
+  const body = [reactionXml, ...attachmentXml, escapedText]
+    .filter(Boolean)
+    .join("\n");
+
+  return `<channel-notification ${attrString}>\n${body}\n</channel-notification>`;
 }
 
 /**
@@ -100,5 +163,27 @@ export function formatChannelNotification(
   return [
     { type: "text", text: buildChannelReminderText(msg) },
     { type: "text", text: buildChannelNotificationXml(msg) },
+    ...(msg.attachments ?? []).flatMap((attachment) => {
+      if (
+        attachment.kind !== "image" ||
+        typeof attachment.imageDataBase64 !== "string" ||
+        attachment.imageDataBase64.length === 0 ||
+        typeof attachment.mimeType !== "string" ||
+        !attachment.mimeType.startsWith("image/")
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          type: "image" as const,
+          source: {
+            type: "base64" as const,
+            media_type: attachment.mimeType,
+            data: attachment.imageDataBase64,
+          },
+        },
+      ];
+    }),
   ] as MessageCreate["content"];
 }

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -12,7 +12,10 @@
  */
 
 import { parseArgs } from "node:util";
-import { readChannelConfig } from "../../channels/config";
+import {
+  getChannelAccount,
+  listChannelAccounts,
+} from "../../channels/accounts";
 import {
   getApprovedUsers,
   getPendingPairings,
@@ -36,6 +39,7 @@ import {
   getChannelRuntimeDir,
   isChannelRuntimeInstalled,
 } from "../../channels/runtimeDeps";
+import { listChannelAccountSnapshots } from "../../channels/service";
 import type { ChannelRoute, SupportedChannelId } from "../../channels/types";
 
 // ── Usage ───────────────────────────────────────────────────────────
@@ -54,12 +58,14 @@ Usage:
 
 Route add options:
   --channel <name>       Channel name (e.g. "telegram")
+  --account-id <id>      Channel account ID (required when multiple accounts exist)
   --chat-id <id>         Chat/conversation ID on the platform
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID)
 
 Pair options:
   --channel <name>       Channel name (e.g. "telegram")
+  --account-id <id>      Channel account ID (optional; inferred when only one account exists)
   --code <code>          Pairing code from the bot
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID)
@@ -80,7 +86,7 @@ Headless deploy flow:
   letta server --channels telegram --install-channel-runtimes
 
 State files:
-  ~/.letta/channels/telegram/config.yaml
+  ~/.letta/channels/telegram/accounts.json
   ~/.letta/channels/telegram/pairing.yaml
   ~/.letta/channels/telegram/routing.yaml
 
@@ -94,6 +100,7 @@ Output is JSON.
 const CHANNELS_OPTIONS = {
   help: { type: "boolean", short: "h" },
   channel: { type: "string" },
+  "account-id": { type: "string" },
   "chat-id": { type: "string" },
   agent: { type: "string" },
   conversation: { type: "string" },
@@ -123,6 +130,42 @@ function assertKnownChannelId(channel: string): SupportedChannelId {
     throw new Error(`Unknown channel: "${channel}". Supported: ${supported}`);
   }
   return channel;
+}
+
+function resolveSelectedAccountId(
+  channelId: SupportedChannelId,
+  explicitAccountId?: string,
+): string {
+  const normalizedAccountId = explicitAccountId?.trim();
+  if (normalizedAccountId) {
+    const account = getChannelAccount(channelId, normalizedAccountId);
+    if (!account) {
+      throw new Error(
+        `Unknown account "${normalizedAccountId}" for channel "${channelId}".`,
+      );
+    }
+    return normalizedAccountId;
+  }
+
+  const accounts = listChannelAccounts(channelId);
+  if (accounts.length === 0) {
+    throw new Error(
+      `Channel "${channelId}" has no configured accounts. Run letta channels configure ${channelId}.`,
+    );
+  }
+  if (accounts.length === 1) {
+    const accountId = accounts[0]?.accountId;
+    if (!accountId) {
+      throw new Error(
+        `Channel "${channelId}" account is missing an account ID.`,
+      );
+    }
+    return accountId;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple accounts. Pass --account-id.`,
+  );
 }
 
 // ── Handlers ────────────────────────────────────────────────────────
@@ -203,8 +246,8 @@ function handleStatus(): number {
   const result: Record<string, unknown> = {};
 
   for (const channelId of getSupportedChannelIds()) {
-    const config = readChannelConfig(channelId);
-    if (!config) {
+    const accounts = listChannelAccountSnapshots(channelId);
+    if (accounts.length === 0) {
       result[channelId] = {
         configured: false,
         runtimeInstalled: isChannelRuntimeInstalled(channelId),
@@ -220,9 +263,10 @@ function handleStatus(): number {
 
     result[channelId] = {
       configured: true,
-      enabled: config.enabled,
-      dmPolicy: config.dmPolicy,
+      enabled: accounts.some((account) => account.enabled),
+      dmPolicy: accounts[0]?.dmPolicy ?? null,
       runtimeInstalled: isChannelRuntimeInstalled(channelId),
+      accounts,
       routes: routes.length,
       pendingPairings: pending.length,
       approvedUsers: approved.length,
@@ -263,6 +307,7 @@ function handleRouteAdd(
   values: ReturnType<typeof parseChannelsArgs>["values"],
 ): number {
   const channelId = values.channel;
+  const accountId = values["account-id"];
   const chatId = values["chat-id"];
   const agentId = getAgentId(values.agent);
   const conversationId = getConversationId(values.conversation);
@@ -288,7 +333,16 @@ function handleRouteAdd(
     return 1;
   }
 
+  let resolvedAccountId: string;
+  try {
+    resolvedAccountId = resolveSelectedAccountId(channelId, accountId);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
   const route: ChannelRoute = {
+    accountId: resolvedAccountId,
     chatId,
     agentId,
     conversationId,
@@ -309,6 +363,7 @@ function handleRouteRemove(
   values: ReturnType<typeof parseChannelsArgs>["values"],
 ): number {
   const channelId = values.channel;
+  const accountId = values["account-id"];
   const chatId = values["chat-id"];
 
   if (!channelId) {
@@ -326,8 +381,16 @@ function handleRouteRemove(
     return 1;
   }
 
+  let resolvedAccountId: string;
+  try {
+    resolvedAccountId = resolveSelectedAccountId(channelId, accountId);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
   loadRoutes(channelId);
-  const removed = removeRoute(channelId, chatId);
+  const removed = removeRoute(channelId, chatId, resolvedAccountId);
   console.log(JSON.stringify({ success: removed }, null, 2));
   if (removed) {
     console.warn(
@@ -341,6 +404,7 @@ async function handlePair(
   values: ReturnType<typeof parseChannelsArgs>["values"],
 ): Promise<number> {
   const channelId = values.channel;
+  const accountId = values["account-id"];
   const code = values.code;
   const agentId = getAgentId(values.agent);
   const conversationId = getConversationId(values.conversation);
@@ -373,7 +437,13 @@ async function handlePair(
   );
   loadPairing(channelId);
 
-  const result = completePairing(channelId, code, agentId, conversationId);
+  const result = completePairing(
+    channelId,
+    code,
+    agentId,
+    conversationId,
+    accountId,
+  );
   console.log(JSON.stringify(result, null, 2));
   if (result.success) {
     console.warn(

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import { clearAllRoutes, setRouteInMemory } from "../../channels/routing";
+import type { ChannelAdapter } from "../../channels/types";
+import { message_channel } from "../../tools/impl/MessageChannel";
+
+describe("MessageChannel", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+  });
+
+  test("uses the routed account adapter for multi-account channels", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-msg-1" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "D123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "D123",
+      message: "hello from Letta",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "D123",
+      text: "hello from Letta",
+      replyToMessageId: undefined,
+      threadId: null,
+      parseMode: undefined,
+    });
+  });
+
+  test("defaults Slack replies back into the routed thread", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-msg-2" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-thread",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "C123",
+      message: "hello from thread",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(result).toContain("Message sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "C123",
+      text: "hello from thread",
+      replyToMessageId: undefined,
+      threadId: "1712790000.000050",
+      parseMode: undefined,
+    });
+  });
+
+  test("passes Slack reactions through MessageChannel with the routed account", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "1712800000.000100" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-thread",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "react",
+      channel: "slack",
+      chat_id: "C123",
+      emoji: "white_check_mark",
+      messageId: "1712800000.000100",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(result).toContain("Reaction added on slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "C123",
+      text: "",
+      replyToMessageId: undefined,
+      targetMessageId: "1712800000.000100",
+      reaction: "white_check_mark",
+      removeReaction: undefined,
+      mediaPath: undefined,
+      fileName: undefined,
+      title: undefined,
+      threadId: "1712790000.000050",
+      parseMode: undefined,
+    });
+  });
+
+  test("passes Slack file uploads through MessageChannel with the routed account", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "1712800000.000101" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-thread",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "upload-file",
+      channel: "slack",
+      chat_id: "C123",
+      message: "release notes",
+      media: "/tmp/release-notes.png",
+      filename: "release-notes.png",
+      title: "Release notes",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(result).toContain("Attachment sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "C123",
+      text: "release notes",
+      replyToMessageId: undefined,
+      threadId: "1712790000.000050",
+      mediaPath: "/tmp/release-notes.png",
+      fileName: "release-notes.png",
+      title: "Release notes",
+      parseMode: undefined,
+    });
+  });
+
+  test("formats and sends Telegram messages through the routed account adapter", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "telegram-msg-1" }));
+
+    const adapter: ChannelAdapter = {
+      id: "telegram:account-1",
+      channelId: "telegram",
+      accountId: "account-1",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("telegram", {
+      accountId: "account-1",
+      chatId: "7952253975",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "telegram",
+      chat_id: "7952253975",
+      message: "hello **world** & team",
+      replyTo: "42",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to telegram");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "account-1",
+      chatId: "7952253975",
+      text: "hello <b>world</b> &amp; team",
+      replyToMessageId: "42",
+      parseMode: "HTML",
+    });
+  });
+
+  test("rejects unsupported Telegram actions through the shared MessageChannel surface", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "telegram-msg-2" }));
+
+    const adapter: ChannelAdapter = {
+      id: "telegram:account-1",
+      channelId: "telegram",
+      accountId: "account-1",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("telegram", {
+      accountId: "account-1",
+      chatId: "7952253975",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "react",
+      channel: "telegram",
+      chat_id: "7952253975",
+      emoji: "thumbsup",
+      messageId: "99",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toBe('Error: Action "react" is not supported on telegram.');
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test("rejects legacy argument aliases so the tool contract stays canonical", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-msg-3" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "D123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "D123",
+      // @ts-expect-error intentionally asserting that legacy aliases are rejected at runtime too
+      text: "hello from legacy args",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toBe("Error: Slack send requires message or media.");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/channels/message-tool-architecture.test.ts
+++ b/src/tests/channels/message-tool-architecture.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAllLettaToolNames } from "../../tools/manager";
+
+describe("MessageChannel architecture", () => {
+  test("exposes one shared channel tool instead of provider-specific tools", () => {
+    const toolNames = new Set(getAllLettaToolNames());
+
+    expect(toolNames.has("MessageChannel")).toBe(true);
+
+    expect(toolNames.has("MessageSlackChannel")).toBe(false);
+    expect(toolNames.has("MessageTelegramChannel")).toBe(false);
+    expect(toolNames.has("slack")).toBe(false);
+    expect(toolNames.has("telegram")).toBe(false);
+  });
+});

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { buildDynamicMessageChannelSchema } from "../../channels/messageTool";
+import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import type { ChannelAdapter } from "../../channels/types";
+
+function createRunningAdapter(
+  channelId: "slack" | "telegram",
+  accountId: string,
+): ChannelAdapter {
+  return {
+    id: `${channelId}:${accountId}`,
+    channelId,
+    accountId,
+    name: channelId,
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    sendMessage: async () => ({ messageId: "msg-1" }),
+    sendDirectReply: async () => {},
+  };
+}
+
+describe("buildDynamicMessageChannelSchema", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+  });
+
+  test("injects active channel enum and plugin-owned actions", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    const schema = await buildDynamicMessageChannelSchema({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        channel: { type: "string" },
+        chat_id: { type: "string" },
+      },
+      required: ["action", "channel", "chat_id"],
+      additionalProperties: false,
+    });
+
+    const properties = schema.properties as Record<string, { enum?: string[] }>;
+    expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
+    expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
+  });
+
+  test("keeps Telegram-only tool actions narrowed to send", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    const schema = await buildDynamicMessageChannelSchema({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        channel: { type: "string" },
+        chat_id: { type: "string" },
+      },
+      required: ["action", "channel", "chat_id"],
+      additionalProperties: false,
+    });
+
+    const properties = schema.properties as Record<string, { enum?: string[] }>;
+    expect(properties.channel?.enum).toEqual(["telegram"]);
+    expect(properties.action?.enum).toEqual(["send"]);
+  });
+});

--- a/src/tests/channels/pairing.test.ts
+++ b/src/tests/channels/pairing.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
   clearPairingStores,
   consumePairingCode,
   createPairingCode,
@@ -10,8 +12,15 @@ import {
 } from "../../channels/pairing";
 
 describe("pairing", () => {
+  beforeEach(() => {
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
   afterEach(() => {
     clearPairingStores();
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
   });
 
   test("creates a pairing code for a user", () => {

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,16 +1,20 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
   clearPairingStores,
   createPairingCode,
   getPendingPairings,
   isUserApproved,
 } from "../../channels/pairing";
 import {
+  buildSlackConversationSummary,
   ChannelRegistry,
   completePairing,
   getChannelRegistry,
 } from "../../channels/registry";
 import {
+  __testOverrideLoadRoutes,
   __testOverrideSaveRoutes,
   addRoute,
   clearAllRoutes,
@@ -18,6 +22,13 @@ import {
 } from "../../channels/routing";
 
 describe("ChannelRegistry", () => {
+  beforeEach(() => {
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
   afterEach(async () => {
     const registry = getChannelRegistry();
     if (registry) {
@@ -25,7 +36,10 @@ describe("ChannelRegistry", () => {
     }
     clearAllRoutes();
     clearPairingStores();
+    __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
   });
 
   test("pause() stops delivery but keeps singleton alive", () => {
@@ -56,7 +70,69 @@ describe("ChannelRegistry", () => {
   });
 });
 
+describe("buildSlackConversationSummary", () => {
+  test("labels direct messages with the sender name", () => {
+    expect(
+      buildSlackConversationSummary({
+        chatId: "D123",
+        chatType: "direct",
+        senderId: "U123",
+        senderName: "Charles",
+        text: "hey there",
+      }),
+    ).toBe("[Slack] DM with Charles");
+  });
+
+  test("labels channel threads with a clipped text preview", () => {
+    expect(
+      buildSlackConversationSummary({
+        chatId: "C123",
+        chatType: "channel",
+        senderId: "U123",
+        senderName: "Charles",
+        text: "  what messages do you see in this thread right now?  ",
+      }),
+    ).toBe(
+      "[Slack] Thread: what messages do you see in this thread right now?",
+    );
+  });
+
+  test("includes the channel label when available", () => {
+    expect(
+      buildSlackConversationSummary({
+        chatId: "C123",
+        chatLabel: "#random",
+        chatType: "channel",
+        senderId: "U123",
+        senderName: "Charles",
+        text: "Need help with the deploy preview environment after lunch",
+      }),
+    ).toBe(
+      "[Slack] Thread in #random: Need help with the deploy preview environment after lunch",
+    );
+  });
+
+  test("falls back when a thread has no text preview", () => {
+    expect(
+      buildSlackConversationSummary({
+        chatId: "C123",
+        chatType: "channel",
+        senderId: "U123",
+        senderName: "Charles",
+        text: "   ",
+      }),
+    ).toBe("[Slack] Thread C123");
+  });
+});
+
 describe("completePairing", () => {
+  beforeEach(() => {
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
   afterEach(async () => {
     const registry = getChannelRegistry();
     if (registry) {
@@ -64,7 +140,10 @@ describe("completePairing", () => {
     }
     clearAllRoutes();
     clearPairingStores();
+    __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
   });
 
   test("successful pairing creates route", () => {

--- a/src/tests/channels/routing.test.ts
+++ b/src/tests/channels/routing.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
   addRoute,
   clearAllRoutes,
   getAllRoutes,
@@ -10,8 +12,15 @@ import {
 } from "../../channels/routing";
 
 describe("routing", () => {
+  beforeEach(() => {
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+  });
+
   afterEach(() => {
     clearAllRoutes();
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
   });
 
   test("adds and retrieves a route", () => {

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -382,6 +382,42 @@ describe("channel service", () => {
     expect(getChannelConfigSnapshot("telegram")).toEqual(snapshot);
   });
 
+  test("telegram account snapshots fall back to persisted routes when binding metadata is stale", () => {
+    createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "@boty_mc_lcd_bot",
+        enabled: true,
+        token: "telegram-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "bot-one" },
+    );
+
+    bindChannelPairing(
+      "telegram",
+      createPairingCode("telegram", "sender-1", "chat-1", "C P", "bot-one"),
+      "agent-telegram",
+      "conv-telegram",
+    );
+
+    updateChannelAccountLive("telegram", "bot-one", {
+      token: "telegram-token",
+      enabled: true,
+      dmPolicy: "pairing",
+    });
+
+    expect(getChannelAccountSnapshot("telegram", "bot-one")).toEqual(
+      expect.objectContaining({
+        accountId: "bot-one",
+        binding: {
+          agentId: "agent-telegram",
+          conversationId: "conv-telegram",
+        },
+      }),
+    );
+  });
+
   test("config helpers reject ambiguous singleton lookups once multiple accounts exist", () => {
     createChannelAccountLive(
       "telegram",

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -1,14 +1,37 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { clearPairingStores } from "../../channels/pairing";
 import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  LEGACY_CHANNEL_ACCOUNT_ID,
+} from "../../channels/accounts";
+import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
+  clearPairingStores,
+  createPairingCode,
+} from "../../channels/pairing";
+import {
+  __testOverrideLoadRoutes,
   __testOverrideSaveRoutes,
   clearAllRoutes,
   getRoute,
 } from "../../channels/routing";
 import {
+  __testOverrideResolveChannelAccountDisplayName,
+  bindChannelAccountLive,
+  bindChannelPairing,
   bindChannelTarget,
+  createChannelAccountLive,
+  getChannelAccountSnapshot,
+  getChannelConfigSnapshot,
   listChannelTargetSnapshots,
+  refreshChannelAccountDisplayNameLive,
+  removeChannelAccountLive,
+  setChannelConfigLive,
+  updateChannelAccountLive,
+  updateChannelRouteLive,
 } from "../../channels/service";
 import {
   __testOverrideLoadTargetStore,
@@ -18,17 +41,45 @@ import {
 } from "../../channels/targets";
 
 describe("channel service", () => {
+  function upsertTargetForRouteTest(chatId: string): string {
+    const targetId = `target-${chatId}`;
+    upsertChannelTarget("slack", {
+      targetId,
+      targetType: "channel",
+      chatId,
+      label: `#${chatId.toLowerCase()}`,
+      discoveredAt: "2026-04-11T00:00:00.000Z",
+      lastSeenAt: "2026-04-11T00:00:00.000Z",
+      lastMessageId: "1712790000.000100",
+      accountId: "docsbot",
+    });
+    return targetId;
+  }
+
   function resetState(): void {
+    clearChannelAccountStores();
     clearAllRoutes();
     clearPairingStores();
     clearTargetStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+    __testOverrideResolveChannelAccountDisplayName(null);
   }
 
   beforeEach(() => {
     resetState();
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
   });
 
   afterEach(() => {
@@ -93,5 +144,279 @@ describe("channel service", () => {
         }),
       ]),
     );
+  });
+
+  test("channel account lifecycle supports create, update, bind, and remove", async () => {
+    const created = createChannelAccountLive(
+      "slack",
+      {
+        displayName: "DocsBot Slack",
+        enabled: false,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "docsbot" },
+    );
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "docsbot",
+        displayName: "DocsBot Slack",
+        configured: true,
+        hasBotToken: true,
+        hasAppToken: true,
+      }),
+    );
+
+    const updated = updateChannelAccountLive("slack", "docsbot", {
+      displayName: "DocsBot Support",
+      enabled: true,
+    });
+    expect(updated.displayName).toBe("DocsBot Support");
+    expect(updated.enabled).toBe(true);
+
+    const bound = bindChannelAccountLive(
+      "slack",
+      "docsbot",
+      "agent-docs",
+      "conv-docs",
+    );
+    expect(bound.channelId).toBe("slack");
+    if (bound.channelId !== "slack") {
+      throw new Error("Expected Slack account snapshot");
+    }
+    expect(bound.agentId).toBe("agent-docs");
+
+    expect(getChannelAccountSnapshot("slack", "docsbot")).toEqual(
+      expect.objectContaining({
+        accountId: "docsbot",
+        displayName: "DocsBot Support",
+        agentId: "agent-docs",
+      }),
+    );
+
+    expect(await removeChannelAccountLive("slack", "docsbot")).toBe(true);
+    expect(getChannelAccountSnapshot("slack", "docsbot")).toBeNull();
+  });
+
+  test("updateChannelRouteLive updates the Slack route without changing the app's default agent", () => {
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "DocsBot Slack",
+        enabled: true,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "docsbot" },
+    );
+
+    bindChannelAccountLive("slack", "docsbot", "agent-old", "conv-old");
+    bindChannelTarget(
+      "slack",
+      upsertTargetForRouteTest("C-updatable"),
+      "agent-old",
+      "conv-old",
+      "docsbot",
+    );
+
+    const updated = updateChannelRouteLive(
+      "slack",
+      "C-updatable",
+      "agent-new",
+      "conv-new",
+      "docsbot",
+    );
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "docsbot",
+        chatId: "C-updatable",
+        agentId: "agent-new",
+        conversationId: "conv-new",
+      }),
+    );
+    expect(getRoute("slack", "C-updatable", "docsbot")).toEqual(
+      expect.objectContaining({
+        accountId: "docsbot",
+        agentId: "agent-new",
+        conversationId: "conv-new",
+      }),
+    );
+    expect(getChannelAccountSnapshot("slack", "docsbot")).toEqual(
+      expect.objectContaining({
+        agentId: "agent-old",
+      }),
+    );
+  });
+
+  test("updateChannelRouteLive leaves the Slack app's default agent unchanged when route save fails", () => {
+    createChannelAccountLive(
+      "slack",
+      {
+        enabled: true,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "docsbot" },
+    );
+
+    bindChannelAccountLive("slack", "docsbot", "agent-old", "conv-old");
+    bindChannelTarget(
+      "slack",
+      upsertTargetForRouteTest("C-rollback"),
+      "agent-old",
+      "conv-old",
+      "docsbot",
+    );
+
+    __testOverrideSaveRoutes(() => {
+      throw new Error("ENOSPC: no space left");
+    });
+
+    expect(() =>
+      updateChannelRouteLive(
+        "slack",
+        "C-rollback",
+        "agent-new",
+        "conv-new",
+        "docsbot",
+      ),
+    ).toThrow(/rolled back/i);
+
+    expect(getRoute("slack", "C-rollback", "docsbot")).toEqual(
+      expect.objectContaining({
+        accountId: "docsbot",
+        agentId: "agent-old",
+        conversationId: "conv-old",
+      }),
+    );
+    expect(getChannelAccountSnapshot("slack", "docsbot")).toEqual(
+      expect.objectContaining({
+        agentId: "agent-old",
+      }),
+    );
+  });
+
+  test("loaded generic placeholder account names are scrubbed from snapshots", () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "slack",
+        accountId: "legacy-slack",
+        displayName: "Slack app",
+        enabled: false,
+        mode: "socket",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        agentId: null,
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const snapshot = getChannelAccountSnapshot("slack", "legacy-slack");
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.displayName).toBeUndefined();
+  });
+
+  test("refreshChannelAccountDisplayNameLive hydrates a real platform name", async () => {
+    __testOverrideResolveChannelAccountDisplayName(async () => "Letta Code");
+
+    createChannelAccountLive(
+      "slack",
+      {
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+      },
+      { accountId: "slack-bot" },
+    );
+
+    const refreshed = await refreshChannelAccountDisplayNameLive(
+      "slack",
+      "slack-bot",
+    );
+
+    expect(refreshed.displayName).toBe("Letta Code");
+  });
+
+  test("forced display-name refresh clears stale labels when identity lookup returns empty", async () => {
+    __testOverrideResolveChannelAccountDisplayName(async () => undefined);
+
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Old Slack Name",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+      },
+      { accountId: "slack-bot" },
+    );
+
+    const refreshed = await refreshChannelAccountDisplayNameLive(
+      "slack",
+      "slack-bot",
+      { force: true },
+    );
+
+    expect(refreshed.displayName).toBeUndefined();
+  });
+
+  test("config helpers resolve the sole account instead of assuming a default id", async () => {
+    const snapshot = await setChannelConfigLive("telegram", {
+      token: "telegram-token",
+      dmPolicy: "pairing",
+    });
+
+    expect(snapshot.accountId).not.toBe(LEGACY_CHANNEL_ACCOUNT_ID);
+    expect(snapshot.accountId).not.toBe("default");
+    expect(snapshot.displayName).toBeUndefined();
+
+    expect(getChannelConfigSnapshot("telegram")).toEqual(snapshot);
+  });
+
+  test("config helpers reject ambiguous singleton lookups once multiple accounts exist", () => {
+    createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "@bot-one",
+        token: "token-one",
+      },
+      { accountId: "bot-one" },
+    );
+    createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "@bot-two",
+        token: "token-two",
+      },
+      { accountId: "bot-two" },
+    );
+
+    expect(() => getChannelConfigSnapshot("telegram")).toThrow(/account_id/i);
+  });
+
+  test("pairing bind resolves the account encoded in the pairing code", () => {
+    const code = createPairingCode(
+      "telegram",
+      "user-1",
+      "chat-1",
+      "john",
+      "bot-one",
+    );
+
+    const result = bindChannelPairing("telegram", code, "agent-a", "conv-1");
+    expect(result.route.accountId).toBe("bot-one");
+
+    const route = getRoute("telegram", "chat-1", "bot-one");
+    expect(route).not.toBeNull();
+    expect(route?.agentId).toBe("agent-a");
   });
 });

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChannelMessageAttachment } from "../../channels/types";
 
 type SlackMessageHandler = (args: {
   message: {
@@ -9,6 +13,7 @@ type SlackMessageHandler = (args: {
     thread_ts?: string;
     subtype?: string;
     bot_id?: string;
+    files?: Array<{ id?: string; name?: string }>;
   };
 }) => Promise<void>;
 
@@ -19,6 +24,14 @@ type SlackEventHandler = (args: {
     text?: string;
     ts?: string;
     thread_ts?: string;
+    item?: {
+      type?: string;
+      channel?: string;
+      ts?: string;
+    };
+    item_user?: string;
+    reaction?: string;
+    event_ts?: string;
   };
 }) => Promise<void>;
 
@@ -27,16 +40,46 @@ class FakeSlackApp {
 
   readonly client = {
     auth: {
-      test: mock(async () => ({ team: "Test Workspace" })),
+      test: mock(async () => ({
+        team: "Test Workspace",
+        user: "letta_code_charles_le",
+        user_id: "U0AS42PTEAX",
+      })),
+    },
+    users: {
+      info: mock(async () => ({
+        user: {
+          name: "letta_code_charles_le",
+          profile: {
+            display_name: "Letta Code (Charles Letta Code app test)",
+            real_name: "Letta Code",
+          },
+        },
+      })),
     },
     chat: {
       postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+    },
+    reactions: {
+      add: mock(async () => ({ ok: true })),
+      remove: mock(async () => ({ ok: true })),
+    },
+    files: {
+      getUploadURLExternal: mock(async () => ({
+        ok: true,
+        upload_url: "https://files.slack.com/upload/F123",
+        file_id: "F123",
+      })),
+      completeUploadExternal: mock(async () => ({ ok: true })),
     },
   };
 
   messageHandler: SlackMessageHandler | null = null;
   eventHandlers = new Map<string, SlackEventHandler>();
   errorHandler: ((error: Error) => Promise<void>) | null = null;
+  readonly init = mock(async () => {});
+  readonly start = mock(async () => {});
+  readonly stop = mock(async () => {});
 
   constructor(_options: Record<string, unknown>) {
     FakeSlackApp.instances.push(this);
@@ -53,13 +96,11 @@ class FakeSlackApp {
   error(handler: (error: Error) => Promise<void>): void {
     this.errorHandler = handler;
   }
-
-  async init(): Promise<void> {}
-
-  async start(): Promise<void> {}
-
-  async stop(): Promise<void> {}
 }
+
+const resolveSlackInboundAttachmentsMock = mock(
+  async (): Promise<ChannelMessageAttachment[]> => [],
+);
 
 mock.module("../../channels/slack/runtime", () => ({
   loadSlackBoltModule: async () => ({
@@ -67,21 +108,86 @@ mock.module("../../channels/slack/runtime", () => ({
   }),
 }));
 
-const { createSlackAdapter } = await import("../../channels/slack/adapter");
+mock.module("../../channels/slack/media", () => ({
+  resolveSlackInboundAttachments: resolveSlackInboundAttachmentsMock,
+}));
+
+const { createSlackAdapter, resolveSlackAccountDisplayName } = await import(
+  "../../channels/slack/adapter"
+);
+
+const slackAccountDefaults = {
+  accountId: "slack-test-account",
+  displayName: "Test Workspace",
+  agentId: null,
+  createdAt: "2026-04-11T00:00:00.000Z",
+  updatedAt: "2026-04-11T00:00:00.000Z",
+} as const;
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async () =>
+    new Response("uploaded", {
+      status: 200,
+    }),
+);
 
 beforeEach(() => {
   FakeSlackApp.instances.length = 0;
+  resolveSlackInboundAttachmentsMock.mockReset();
+  resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
+  fetchMock.mockClear();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
 });
 
 afterEach(() => {
   for (const instance of FakeSlackApp.instances) {
     instance.client.auth.test.mockClear();
+    instance.client.users.info.mockClear();
     instance.client.chat.postMessage.mockClear();
+    instance.client.reactions.add.mockClear();
+    instance.client.reactions.remove.mockClear();
+    instance.client.files.getUploadURLExternal.mockClear();
+    instance.client.files.completeUploadExternal.mockClear();
+    instance.init.mockClear();
+    instance.start.mockClear();
+    instance.stop.mockClear();
   }
+  globalThis.fetch = originalFetch;
 });
 
-test("slack adapter maps reply_to_message_id to thread_ts", async () => {
+test("slack adapter start does not re-run bolt init", async () => {
   const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const app = FakeSlackApp.instances[0];
+  expect(app).toBeDefined();
+  expect(app?.init).not.toHaveBeenCalled();
+  expect(app?.start).toHaveBeenCalledTimes(1);
+});
+
+test("resolveSlackAccountDisplayName prefers the Slack bot profile display name", async () => {
+  await expect(
+    resolveSlackAccountDisplayName(
+      "xoxb-test-token-1234567890",
+      "xapp-test-token-1234567890",
+    ),
+  ).resolves.toBe("Letta Code (Charles Letta Code app test)");
+});
+
+test("slack adapter maps thread metadata to thread_ts", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
     channel: "slack",
     enabled: true,
     mode: "socket",
@@ -96,7 +202,7 @@ test("slack adapter maps reply_to_message_id to thread_ts", async () => {
     channel: "slack",
     chatId: "C123",
     text: "hello",
-    replyToMessageId: "1712800000.000200",
+    threadId: "1712800000.000200",
   });
 
   const app = FakeSlackApp.instances[0];
@@ -110,6 +216,7 @@ test("slack adapter maps reply_to_message_id to thread_ts", async () => {
 
 test("slack adapter forwards DM messages as direct channel input", async () => {
   const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
     channel: "slack",
     enabled: true,
     mode: "socket",
@@ -152,6 +259,7 @@ test("slack adapter forwards DM messages as direct channel input", async () => {
 
 test("slack adapter forwards app mentions as channel input", async () => {
   const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
     channel: "slack",
     enabled: true,
     mode: "socket",
@@ -187,14 +295,265 @@ test("slack adapter forwards app mentions as channel input", async () => {
       chatId: "C123",
       senderId: "U123",
       text: "please help",
-      messageId: "1712790000.000050",
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
       chatType: "channel",
+      isMention: true,
     }),
   );
 });
 
+test("slack adapter forwards threaded channel replies as channel input", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "following up in thread",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "following up in thread",
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+    }),
+  );
+});
+
+test("slack adapter allows file_share subtype messages through", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  resolveSlackInboundAttachmentsMock.mockResolvedValueOnce([
+    {
+      id: "F123",
+      name: "screenshot.png",
+      mimeType: "image/png",
+      kind: "image",
+      localPath: "/tmp/screenshot.png",
+      imageDataBase64: "abc",
+    },
+  ]);
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+      subtype: "file_share",
+      files: [{ id: "F123", name: "screenshot.png" }],
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      chatId: "C123",
+      threadId: "1712790000.000050",
+      attachments: [
+        expect.objectContaining({
+          id: "F123",
+          name: "screenshot.png",
+        }),
+      ],
+    }),
+  );
+});
+
+test("slack adapter forwards reaction events into the routed Slack thread", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const messageHandler = app?.messageHandler;
+  const reactionHandler = app?.eventHandlers.get("reaction_added");
+  if (!messageHandler || !reactionHandler) {
+    throw new Error("Expected Slack message and reaction handlers");
+  }
+
+  await messageHandler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "following up in thread",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  onMessage.mockClear();
+
+  await reactionHandler({
+    event: {
+      user: "U555",
+      item_user: "U123",
+      reaction: "eyes",
+      event_ts: "1712800001.000200",
+      item: {
+        type: "message",
+        channel: "C123",
+        ts: "1712800000.000100",
+      },
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      text: "Slack reaction added: :eyes:",
+      reaction: {
+        action: "added",
+        emoji: "eyes",
+        targetMessageId: "1712800000.000100",
+        targetSenderId: "U123",
+      },
+    }),
+  );
+});
+
+test("slack adapter can add reactions to messages", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "slack",
+    chatId: "C123",
+    text: "",
+    reaction: ":white_check_mark:",
+    targetMessageId: "1712800000.000100",
+  });
+
+  const app = FakeSlackApp.instances[0];
+  expect(app?.client.reactions.add).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000100",
+    name: "white_check_mark",
+  });
+});
+
+test("slack adapter uploads local files through Slack's external upload flow", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "letta-slack-upload-"));
+  const mediaPath = join(tempDir, "chart.png");
+  await writeFile(mediaPath, "fake-image-data");
+
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  const result = await adapter.sendMessage({
+    channel: "slack",
+    chatId: "C123",
+    text: "latest chart",
+    mediaPath,
+    fileName: "chart.png",
+    title: "Chart",
+    threadId: "1712790000.000050",
+  });
+
+  const app = FakeSlackApp.instances[0];
+  expect(app?.client.files.getUploadURLExternal).toHaveBeenCalledWith({
+    filename: "chart.png",
+    length: "fake-image-data".length,
+  });
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://files.slack.com/upload/F123",
+    {
+      method: "POST",
+      headers: { "Content-Type": "image/png" },
+      body: expect.any(Uint8Array),
+    },
+  );
+  expect(app?.client.files.completeUploadExternal).toHaveBeenCalledWith({
+    files: [{ id: "F123", title: "Chart" }],
+    channel_id: "C123",
+    initial_comment: "latest chart",
+    thread_ts: "1712790000.000050",
+  });
+  expect(result).toEqual({ messageId: "F123" });
+});
+
 test("slack adapter preserves non-leading user mentions in app mention text", async () => {
   const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
     channel: "slack",
     enabled: true,
     mode: "socket",

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -74,6 +74,17 @@ const { createTelegramAdapter } = await import(
   "../../channels/telegram/adapter"
 );
 
+const telegramAccountDefaults = {
+  accountId: "telegram-test-account",
+  displayName: "@test_bot",
+  binding: {
+    agentId: null,
+    conversationId: null,
+  },
+  createdAt: "2026-04-11T00:00:00.000Z",
+  updatedAt: "2026-04-11T00:00:00.000Z",
+} as const;
+
 const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
 
@@ -97,6 +108,7 @@ afterEach(() => {
 
 test("telegram adapter logs unhandled grammY errors with update context", async () => {
   const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
     channel: "telegram",
     enabled: true,
     token: "test-token",
@@ -140,6 +152,7 @@ test("telegram adapter start waits until polling is live before resolving", asyn
   };
 
   const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
     channel: "telegram",
     enabled: true,
     token: "test-token",
@@ -174,6 +187,7 @@ test("telegram adapter logs and clears running state when polling exits unexpect
   };
 
   const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
     channel: "telegram",
     enabled: true,
     token: "test-token",
@@ -193,6 +207,7 @@ test("telegram adapter logs and clears running state when polling exits unexpect
 
 test("telegram adapter forwards parse mode and reply parameters", async () => {
   const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
     channel: "telegram",
     enabled: true,
     token: "test-token",

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -61,7 +61,9 @@ describe("formatChannelNotification", () => {
 
     expect(reminder).toContain("<system-reminder>");
     expect(reminder).toContain("must call the MessageChannel tool");
-    expect(reminder).toContain('channel="telegram" and chat_id="12345"');
+    expect(reminder).toContain(
+      'Use action="send", channel="telegram", and chat_id="12345"',
+    );
     expect(reminder).toContain("Current local time on this device:");
   });
 
@@ -73,13 +75,14 @@ describe("formatChannelNotification", () => {
       text: "ping",
       timestamp: Date.now(),
       messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
       chatType: "channel",
     };
 
     const reminder = buildChannelReminderText(msg);
 
-    expect(reminder).toContain('reply_to_message_id="1712800000.000100"');
-    expect(reminder).toContain("stay in the same Slack thread");
+    expect(reminder).toContain("stay in the same Slack thread automatically");
+    expect(reminder).not.toContain("reply_to_message_id");
   });
 
   test("escapes XML special characters in notification text", () => {
@@ -127,5 +130,81 @@ describe("formatChannelNotification", () => {
 
     expect(xml).not.toContain("sender_name=");
     expect(xml).not.toContain("message_id=");
+  });
+
+  test("includes Slack thread metadata in the notification xml", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "threaded hello",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain('thread_id="1712790000.000050"');
+  });
+
+  test("includes reaction metadata in the notification xml", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "Slack reaction added: :eyes:",
+      timestamp: Date.now(),
+      messageId: "1712800001.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      reaction: {
+        action: "added",
+        emoji: "eyes",
+        targetMessageId: "1712800000.000100",
+        targetSenderId: "U999",
+      },
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain(
+      '<reaction action="added" emoji="eyes" target_message_id="1712800000.000100" target_sender_id="U999" />',
+    );
+  });
+
+  test("emits image content parts for inbound image attachments", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "See screenshot",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      chatType: "channel",
+      attachments: [
+        {
+          id: "F123",
+          name: "screenshot.png",
+          mimeType: "image/png",
+          kind: "image",
+          localPath: "/tmp/screenshot.png",
+          imageDataBase64: "YWJj",
+        },
+      ],
+    };
+
+    const content = formatChannelNotification(msg);
+
+    expect(content).toHaveLength(3);
+    expect(content[2]).toEqual({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: "YWJj",
+      },
+    });
   });
 });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -83,6 +83,42 @@ afterEach(() => {
   __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
 });
 
+describe("listen-client channel command dispatch", () => {
+  test("recognizes account-scoped channel commands as detached channels commands", () => {
+    expect(
+      __listenClientTestUtils.isDetachedChannelsCommand({
+        type: "channel_accounts_list",
+        request_id: "channel-accounts-list-1",
+        channel_id: "telegram",
+      }),
+    ).toBe(true);
+
+    expect(
+      __listenClientTestUtils.isDetachedChannelsCommand({
+        type: "channel_account_create",
+        request_id: "channel-account-create-1",
+        channel_id: "slack",
+        account: {
+          display_name: "DocsBot Slack",
+          bot_token: "xoxb-test",
+          app_token: "xapp-test",
+          mode: "socket",
+          dm_policy: "pairing",
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      __listenClientTestUtils.isDetachedChannelsCommand({
+        type: "channel_account_start",
+        request_id: "channel-account-start-1",
+        channel_id: "telegram",
+        account_id: "bot-1",
+      }),
+    ).toBe(true);
+  });
+});
+
 function makeControlRequest(requestId: string): ControlRequest {
   return {
     type: "control_request",
@@ -410,6 +446,98 @@ describe("listen-client parseServerMessage", () => {
         }),
       ),
     );
+    const channelAccountsList = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_accounts_list",
+          request_id: "channel-accounts-list-1",
+          channel_id: "telegram",
+        }),
+      ),
+    );
+    const channelAccountCreate = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_create",
+          request_id: "channel-account-create-1",
+          channel_id: "slack",
+          account: {
+            display_name: "DocsBot Slack",
+            bot_token: "xoxb-test",
+            app_token: "xapp-test",
+            mode: "socket",
+            dm_policy: "pairing",
+            allowed_users: ["user-1"],
+          },
+        }),
+      ),
+    );
+    const channelAccountUpdate = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_update",
+          request_id: "channel-account-update-1",
+          channel_id: "telegram",
+          account_id: "bot-1",
+          patch: {
+            display_name: "@docsbot",
+            token: "telegram-token",
+            dm_policy: "open",
+          },
+        }),
+      ),
+    );
+    const channelAccountBind = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_bind",
+          request_id: "channel-account-bind-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+        }),
+      ),
+    );
+    const channelAccountUnbind = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_unbind",
+          request_id: "channel-account-unbind-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+        }),
+      ),
+    );
+    const channelAccountDelete = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_delete",
+          request_id: "channel-account-delete-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+        }),
+      ),
+    );
+    const channelAccountStart = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_start",
+          request_id: "channel-account-start-1",
+          channel_id: "telegram",
+          account_id: "bot-1",
+        }),
+      ),
+    );
+    const channelAccountStop = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "channel_account_stop",
+          request_id: "channel-account-stop-1",
+          channel_id: "telegram",
+          account_id: "bot-1",
+        }),
+      ),
+    );
     const channelSetConfig = parseServerMessage(
       Buffer.from(
         JSON.stringify({
@@ -508,6 +636,14 @@ describe("listen-client parseServerMessage", () => {
 
     expect(channelsList?.type).toBe("channels_list");
     expect(channelGetConfig?.type).toBe("channel_get_config");
+    expect(channelAccountsList?.type).toBe("channel_accounts_list");
+    expect(channelAccountCreate?.type).toBe("channel_account_create");
+    expect(channelAccountUpdate?.type).toBe("channel_account_update");
+    expect(channelAccountBind?.type).toBe("channel_account_bind");
+    expect(channelAccountUnbind?.type).toBe("channel_account_unbind");
+    expect(channelAccountDelete?.type).toBe("channel_account_delete");
+    expect(channelAccountStart?.type).toBe("channel_account_start");
+    expect(channelAccountStop?.type).toBe("channel_account_stop");
     expect(channelSetConfig?.type).toBe("channel_set_config");
     expect(channelStart?.type).toBe("channel_start");
     expect(channelStop?.type).toBe("channel_stop");
@@ -1004,6 +1140,78 @@ describe("listen-client channels command handling", () => {
     }
   });
 
+  test("returns typed channel account snapshots over WS", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
+      ...actualChannelsService,
+      listChannelAccountSnapshots: () => [
+        {
+          channelId: "telegram" as const,
+          accountId: "bot-1",
+          displayName: "@docsbot",
+          enabled: true,
+          configured: true,
+          running: true,
+          dmPolicy: "pairing" as const,
+          allowedUsers: [],
+          hasToken: true,
+          binding: {
+            agentId: "agent-1",
+            conversationId: "default",
+          },
+          createdAt: "2026-04-11T00:00:00.000Z",
+          updatedAt: "2026-04-11T01:00:00.000Z",
+        },
+      ],
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_accounts_list",
+          request_id: "channel-accounts-list-1",
+          channel_id: "telegram",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      expect(JSON.parse(socket.sentPayloads[0] as string)).toMatchObject({
+        type: "channel_accounts_list_response",
+        request_id: "channel-accounts-list-1",
+        success: true,
+        channel_id: "telegram",
+        accounts: [
+          {
+            channel_id: "telegram",
+            account_id: "bot-1",
+            display_name: "@docsbot",
+            enabled: true,
+            configured: true,
+            running: true,
+            dm_policy: "pairing",
+            has_token: true,
+            binding: {
+              agent_id: "agent-1",
+              conversation_id: "default",
+            },
+            created_at: "2026-04-11T00:00:00.000Z",
+            updated_at: "2026-04-11T01:00:00.000Z",
+          },
+        ],
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
   test("bind emits pairing, route, and channel update events", async () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();
@@ -1014,11 +1222,13 @@ describe("listen-client channels command handling", () => {
         chatId: "chat-42",
         route: {
           channelId: "telegram" as const,
+          accountId: "bot-1",
           chatId: "chat-42",
           agentId: "agent-1",
           conversationId: "conv-1",
           enabled: true,
           createdAt: "2026-04-09T00:00:00.000Z",
+          updatedAt: "2026-04-09T00:00:00.000Z",
         },
       }),
     }));
@@ -1092,11 +1302,13 @@ describe("listen-client channels command handling", () => {
         chatId: "C123",
         route: {
           channelId: "slack" as const,
+          accountId: "workspace-1",
           chatId: "C123",
           agentId: "agent-1",
           conversationId: "conv-1",
           enabled: true,
           createdAt: "2026-04-10T00:00:00.000Z",
+          updatedAt: "2026-04-10T00:00:00.000Z",
         },
       }),
       listChannelTargetSnapshots: () => [],
@@ -1156,6 +1368,400 @@ describe("listen-client channels command handling", () => {
       expect(messages[3]).toMatchObject({
         type: "channels_updated",
         channel_id: "slack",
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("route update emits account, route, and channel update events", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
+      ...actualChannelsService,
+      updateChannelRouteLive: () => ({
+        channelId: "slack" as const,
+        accountId: "acct-1",
+        chatId: "C123",
+        agentId: "agent-2",
+        conversationId: "conv-2",
+        enabled: true,
+        createdAt: "2026-04-11T03:00:00.000Z",
+        updatedAt: "2026-04-11T03:00:00.000Z",
+      }),
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_route_update",
+          request_id: "channel-route-update-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+          chat_id: "C123",
+          runtime: {
+            agent_id: "agent-2",
+            conversation_id: "conv-2",
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_route_update_response",
+        request_id: "channel-route-update-1",
+        success: true,
+        channel_id: "slack",
+        chat_id: "C123",
+        route: {
+          channel_id: "slack",
+          account_id: "acct-1",
+          chat_id: "C123",
+          agent_id: "agent-2",
+          conversation_id: "conv-2",
+          enabled: true,
+          created_at: "2026-04-11T03:00:00.000Z",
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "slack",
+        account_id: "acct-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channel_routes_updated",
+        channel_id: "slack",
+        agent_id: "agent-2",
+        conversation_id: "conv-2",
+      });
+      expect(messages[3]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "slack",
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("account bind and unbind emit account update events", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
+      ...actualChannelsService,
+      bindChannelAccountLive: () => ({
+        channelId: "slack" as const,
+        accountId: "acct-1",
+        displayName: "DocsBot Slack",
+        enabled: true,
+        configured: true,
+        running: false,
+        mode: "socket" as const,
+        dmPolicy: "pairing" as const,
+        allowedUsers: [],
+        hasBotToken: true,
+        hasAppToken: true,
+        agentId: "agent-1",
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T01:00:00.000Z",
+      }),
+      unbindChannelAccountLive: () => ({
+        channelId: "slack" as const,
+        accountId: "acct-1",
+        displayName: "DocsBot Slack",
+        enabled: true,
+        configured: true,
+        running: false,
+        mode: "socket" as const,
+        dmPolicy: "pairing" as const,
+        allowedUsers: [],
+        hasBotToken: true,
+        hasAppToken: true,
+        agentId: null,
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T02:00:00.000Z",
+      }),
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_bind",
+          request_id: "channel-account-bind-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      let messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_bind_response",
+        request_id: "channel-account-bind-1",
+        success: true,
+        channel_id: "slack",
+        account: {
+          account_id: "acct-1",
+          agent_id: "agent-1",
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "slack",
+        account_id: "acct-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "slack",
+      });
+
+      socket.sentPayloads.length = 0;
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_unbind",
+          request_id: "channel-account-unbind-1",
+          channel_id: "slack",
+          account_id: "acct-1",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_unbind_response",
+        request_id: "channel-account-unbind-1",
+        success: true,
+        channel_id: "slack",
+        account: {
+          account_id: "acct-1",
+          agent_id: null,
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "slack",
+        account_id: "acct-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "slack",
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("account create, start, and delete emit typed responses and updates", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
+      ...actualChannelsService,
+      createChannelAccountLive: () => ({
+        channelId: "telegram" as const,
+        accountId: "bot-1",
+        displayName: "@docsbot",
+        enabled: false,
+        configured: true,
+        running: false,
+        dmPolicy: "pairing" as const,
+        allowedUsers: [],
+        hasToken: true,
+        binding: {
+          agentId: null,
+          conversationId: null,
+        },
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      }),
+      startChannelAccountLive: async () => ({
+        channelId: "telegram" as const,
+        accountId: "bot-1",
+        displayName: "@docsbot",
+        enabled: true,
+        configured: true,
+        running: true,
+        dmPolicy: "pairing" as const,
+        allowedUsers: [],
+        hasToken: true,
+        binding: {
+          agentId: null,
+          conversationId: null,
+        },
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:05:00.000Z",
+      }),
+      removeChannelAccountLive: async () => true,
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_create",
+          request_id: "channel-account-create-1",
+          channel_id: "telegram",
+          account: {
+            display_name: "@docsbot",
+            token: "telegram-token",
+            dm_policy: "pairing",
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      let messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_create_response",
+        request_id: "channel-account-create-1",
+        success: true,
+        channel_id: "telegram",
+        account: {
+          account_id: "bot-1",
+          display_name: "@docsbot",
+          has_token: true,
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "telegram",
+        account_id: "bot-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "telegram",
+      });
+
+      socket.sentPayloads.length = 0;
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_start",
+          request_id: "channel-account-start-1",
+          channel_id: "telegram",
+          account_id: "bot-1",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_start_response",
+        request_id: "channel-account-start-1",
+        success: true,
+        channel_id: "telegram",
+        account: {
+          account_id: "bot-1",
+          enabled: true,
+          running: true,
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "telegram",
+        account_id: "bot-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "telegram",
+      });
+
+      socket.sentPayloads.length = 0;
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_delete",
+          request_id: "channel-account-delete-1",
+          channel_id: "telegram",
+          account_id: "bot-1",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_delete_response",
+        request_id: "channel-account-delete-1",
+        success: true,
+        channel_id: "telegram",
+        account_id: "bot-1",
+        deleted: true,
+      });
+      expect(messages[1]).toMatchObject({
+        type: "channel_accounts_updated",
+        channel_id: "telegram",
+        account_id: "bot-1",
+      });
+      expect(messages[2]).toMatchObject({
+        type: "channel_pairings_updated",
+        channel_id: "telegram",
+      });
+      expect(messages[3]).toMatchObject({
+        type: "channel_routes_updated",
+        channel_id: "telegram",
+      });
+      expect(messages[4]).toMatchObject({
+        type: "channel_targets_updated",
+        channel_id: "telegram",
+      });
+      expect(messages[5]).toMatchObject({
+        type: "channels_updated",
+        channel_id: "telegram",
       });
     } finally {
       __listenClientTestUtils.stopRuntime(runtime, true);

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -1,11 +1,28 @@
 # MessageChannel
 
-Send a message to an external channel (Telegram, Slack, etc.) in response to a channel notification.
+Send a message or channel action to an external channel (Telegram, Slack, etc.) in response to a channel notification.
 
-When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel (a normal assistant response is not delivered back to Telegram/Slack/etc). Extract the `source` and `chat_id` from the notification attributes and pass them as `channel` and `chat_id`.
+When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel. A normal assistant response is not delivered back to Telegram/Slack/etc.
+
+Preferred pattern:
+- `action="send"` to send a normal reply
+- `channel` + `chat_id` from the notification attributes
+- `message` for the text body
 
 Parameters:
+- `action`: The action to perform. Current built-in actions include `send`, `react`, and `upload-file`.
 - `channel`: The platform to send to (matches the `source` attribute)
 - `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
-- `text`: The message text to send
-- `reply_to_message_id`: (Optional) Reply to a specific message by its `message_id`. Omit this unless you intentionally want the platform's quote/reply UI.
+- `message`: The text to send for `action="send"`
+- `replyTo`: (Optional) Reply to a specific message ID. Omit this unless you intentionally want the platform's quote/reply UI.
+- `messageId`: (Optional) Target message id for actions like `react`
+- `emoji`: (Optional) Emoji reaction name for `action="react"`, e.g. `white_check_mark`
+- `remove`: (Optional) Set to `true` to remove the reaction instead of adding it
+- `media`: (Optional) Absolute local file path for `action="upload-file"`
+- `filename`: (Optional, Slack) Override the uploaded filename.
+- `title`: (Optional, Slack) Override the uploaded attachment title.
+
+Rules:
+- Always pass `action` explicitly, even for a normal reply.
+- `react` should be its own call.
+- `upload-file` can include both `media` and `message` so the uploaded file has a caption/comment when the channel supports it.

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -1,11 +1,23 @@
 /**
- * MessageChannel tool — sends messages to external channels.
+ * Shared MessageChannel tool — sends messages to external channels.
  *
  * Uses parentScope (injected per-execution by manager.ts executeTool())
  * for agent+conversation authorization. Does NOT use global context
  * singleton, which is unsafe in the listener's multi-runtime model.
+ *
+ * The public tool surface is intentionally shared across channels.
+ * Channel plugins own action discovery and dispatch underneath it via
+ * plugin.messageActions, following the OpenClaw-style architecture.
  */
 
+import {
+  isSupportedChannelId,
+  loadChannelPlugin,
+} from "../../channels/pluginRegistry";
+import type {
+  ChannelMessageActionName,
+  ChannelMessageActionRequest,
+} from "../../channels/pluginTypes";
 import { getChannelRegistry } from "../../channels/registry";
 import type {
   ChannelRoute,
@@ -443,11 +455,118 @@ export function formatOutboundChannelMessage(
 
 interface MessageChannelArgs {
   channel: string;
+  action: string;
   chat_id: string;
-  text: string;
-  reply_to_message_id?: string;
+  message?: string;
+  replyTo?: string;
+  threadId?: string;
+  messageId?: string;
+  emoji?: string;
+  remove?: boolean;
+  media?: string;
+  filename?: string;
+  title?: string;
   /** Injected by executeTool() — NOT read from global context. */
   parentScope?: { agentId: string; conversationId: string };
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function firstDefinedBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeChatTarget(value: string): string {
+  const trimmed = value.trim();
+  const parts = trimmed
+    .split(":")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 2 && /^[a-z_-]+$/i.test(parts[0] ?? "")) {
+    return parts[1] ?? trimmed;
+  }
+  if (
+    parts.length === 3 &&
+    /^[a-z_-]+$/i.test(parts[0] ?? "") &&
+    /^[a-z_-]+$/i.test(parts[1] ?? "")
+  ) {
+    return parts[2] ?? trimmed;
+  }
+  return trimmed;
+}
+
+function normalizeMessageAction(
+  rawAction: string,
+): ChannelMessageActionName | null {
+  const normalized = rawAction.trim().toLowerCase();
+
+  switch (normalized) {
+    case "send":
+      return "send";
+    case "react":
+      return "react";
+    case "upload-file":
+      return "upload-file";
+    default:
+      return null;
+  }
+}
+
+function normalizeMessageChannelRequest(
+  args: MessageChannelArgs,
+): ChannelMessageActionRequest | string {
+  const channel = firstNonEmptyString(args.channel)?.toLowerCase();
+  if (!channel) {
+    return "Error: MessageChannel requires channel.";
+  }
+  if (!isSupportedChannelId(channel)) {
+    return `Error: Unsupported channel "${channel}".`;
+  }
+
+  const rawAction = firstNonEmptyString(args.action);
+  if (!rawAction) {
+    return "Error: MessageChannel requires action.";
+  }
+
+  const action = normalizeMessageAction(rawAction);
+  if (!action) {
+    return `Error: Unsupported MessageChannel action "${args.action}".`;
+  }
+
+  const rawChatId = firstNonEmptyString(args.chat_id);
+  if (!rawChatId) {
+    return "Error: MessageChannel requires chat_id.";
+  }
+
+  return {
+    action,
+    channel,
+    chatId: normalizeChatTarget(rawChatId),
+    message: firstNonEmptyString(args.message),
+    replyToMessageId: firstNonEmptyString(args.replyTo),
+    threadId: firstNonEmptyString(args.threadId) ?? null,
+    messageId: firstNonEmptyString(args.messageId),
+    emoji: firstNonEmptyString(args.emoji),
+    remove: firstDefinedBoolean(args.remove),
+    mediaPath: firstNonEmptyString(args.media),
+    filename: firstNonEmptyString(args.filename),
+    title: firstNonEmptyString(args.title),
+  };
 }
 
 export async function message_channel(
@@ -458,15 +577,6 @@ export async function message_channel(
     return "Error: Channel system is not initialized. Start with --channels flag.";
   }
 
-  const adapter = registry.getAdapter(args.channel);
-  if (!adapter) {
-    return `Error: Channel "${args.channel}" is not configured or not running.`;
-  }
-
-  if (!adapter.isRunning()) {
-    return `Error: Channel "${args.channel}" is not currently running.`;
-  }
-
   // Per-agent+conversation authorization via injected scope.
   // parentScope comes from executeTool() options in manager.ts,
   // NOT the global context singleton (agent/context.ts).
@@ -475,35 +585,55 @@ export async function message_channel(
     return "Error: MessageChannel requires execution scope (agentId + conversationId).";
   }
 
-  const route: ChannelRoute | null = registry.getRoute(
-    args.channel,
-    args.chat_id,
+  const request = normalizeMessageChannelRequest(args);
+  if (typeof request === "string") {
+    return request;
+  }
+
+  const route: ChannelRoute | null = registry.getRouteForScope(
+    request.channel,
+    request.chatId,
+    scope.agentId,
+    scope.conversationId,
   );
-  if (
-    !route ||
-    route.agentId !== scope.agentId ||
-    route.conversationId !== scope.conversationId
-  ) {
-    return `Error: No route for chat_id "${args.chat_id}" on "${args.channel}" for this agent/conversation.`;
+  if (!route) {
+    return `Error: No route for chat_id "${request.chatId}" on "${request.channel}" for this agent/conversation.`;
+  }
+
+  const adapter = registry.getAdapter(request.channel, route.accountId);
+  if (!adapter) {
+    return `Error: Channel "${request.channel}" is not configured or not running.`;
+  }
+
+  if (!adapter.isRunning()) {
+    return `Error: Channel "${request.channel}" is not currently running.`;
   }
 
   try {
-    const formattedMessage = formatOutboundChannelMessage(
-      args.channel,
-      args.text,
-    );
+    const plugin = await loadChannelPlugin(request.channel);
+    if (!plugin.messageActions) {
+      return `Error: Channel "${request.channel}" does not expose MessageChannel actions.`;
+    }
 
-    const result = await adapter.sendMessage({
-      channel: args.channel,
-      chatId: args.chat_id,
-      text: formattedMessage.text,
-      replyToMessageId: args.reply_to_message_id,
-      parseMode: formattedMessage.parseMode,
+    const discovery = plugin.messageActions.describeMessageTool({
+      accountId: route.accountId ?? null,
     });
+    const supportedActions = new Set<string>(["send"]);
+    for (const action of discovery.actions ?? []) {
+      supportedActions.add(action);
+    }
+    if (!supportedActions.has(request.action)) {
+      return `Error: Action "${request.action}" is not supported on ${request.channel}.`;
+    }
 
-    return `Message sent to ${args.channel} (message_id: ${result.messageId})`;
+    return await plugin.messageActions.handleAction({
+      request,
+      route,
+      adapter,
+      formatText: (text) => formatOutboundChannelMessage(request.channel, text),
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "unknown error";
-    return `Error sending message to ${args.channel}: ${msg}`;
+    return `Error sending message to ${request.channel}: ${msg}`;
   }
 }

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1,6 +1,7 @@
 import { getDisplayableToolReturn } from "../agent/approval-execution";
 import { getModelInfo } from "../agent/model";
 import { getAllSubagentConfigs } from "../agent/subagents";
+import { buildDynamicMessageChannelSchema } from "../channels/messageTool";
 import { getActiveChannelIds } from "../channels/registry";
 import { refreshFileIndex } from "../cli/helpers/fileIndex";
 import { INTERRUPTED_BY_USER } from "../constants";
@@ -39,24 +40,17 @@ function maybeAppendChannelTools(toolNames: ToolName[]): ToolName[] {
 }
 
 /**
- * Inject channel enum into MessageChannel schema if channels are active.
+ * Inject dynamic channel-tool discovery into MessageChannel if channels are active.
  * Used by both buildRegistryForModel() and buildSpecificToolRegistry().
  */
-function maybeInjectChannelEnum(
+async function maybeInjectChannelSchema(
   name: string,
   schema: Record<string, unknown>,
-): Record<string, unknown> {
-  if (name !== "MessageChannel") return schema;
-  const activeChannels = getActiveChannelIds();
-  if (activeChannels.length === 0) return schema;
-  const injected = structuredClone(schema);
-  const props = injected.properties as
-    | Record<string, Record<string, unknown>>
-    | undefined;
-  if (props?.channel) {
-    props.channel.enum = activeChannels;
+): Promise<Record<string, unknown>> {
+  if (name !== "MessageChannel") {
+    return schema;
   }
-  return injected;
+  return await buildDynamicMessageChannelSchema(schema);
 }
 const STREAMING_SHELL_TOOLS = new Set([
   "Bash",
@@ -965,7 +959,10 @@ async function buildSpecificToolRegistry(
     const toolSchema: ToolSchema = {
       name: internalName,
       description: definition.description,
-      input_schema: maybeInjectChannelEnum(internalName, definition.schema),
+      input_schema: await maybeInjectChannelSchema(
+        internalName,
+        definition.schema,
+      ),
     };
 
     newRegistry.set(internalName, {
@@ -1058,7 +1055,7 @@ async function buildRegistryForModel(
       const toolSchema: ToolSchema = {
         name,
         description,
-        input_schema: maybeInjectChannelEnum(name, definition.schema),
+        input_schema: await maybeInjectChannelSchema(name, definition.schema),
       };
 
       newRegistry.set(name, {

--- a/src/tools/schemas/MessageChannel.json
+++ b/src/tools/schemas/MessageChannel.json
@@ -1,23 +1,55 @@
 {
   "type": "object",
   "properties": {
+    "action": {
+      "type": "string",
+      "description": "Action to perform. Prefer explicit values like 'send', 'react', or 'upload-file'."
+    },
     "channel": {
       "type": "string",
       "description": "The channel to send the message to (e.g., 'telegram')"
     },
     "chat_id": {
       "type": "string",
-      "description": "The chat/conversation ID to send to (from the channel-notification attributes)"
+      "description": "The chat/conversation ID to send to (from the channel-notification attributes)."
     },
-    "text": {
+    "message": {
       "type": "string",
-      "description": "The message text to send"
+      "description": "Text body for action='send'."
     },
-    "reply_to_message_id": {
+    "replyTo": {
       "type": "string",
-      "description": "Optional message ID to reply to"
+      "description": "Optional message ID to reply to. Omit unless you intentionally want the platform's quote/reply UI."
+    },
+    "threadId": {
+      "type": "string",
+      "description": "Optional thread identifier override for threaded channels."
+    },
+    "messageId": {
+      "type": "string",
+      "description": "Target message ID for actions like react."
+    },
+    "emoji": {
+      "type": "string",
+      "description": "Emoji name for action='react'."
+    },
+    "remove": {
+      "type": "boolean",
+      "description": "Set to true to remove the reaction instead of adding it."
+    },
+    "media": {
+      "type": "string",
+      "description": "Absolute local file path for action='upload-file'."
+    },
+    "filename": {
+      "type": "string",
+      "description": "Optional uploaded filename override for media attachments"
+    },
+    "title": {
+      "type": "string",
+      "description": "Optional uploaded title override for media attachments"
     }
   },
-  "required": ["channel", "chat_id", "text"],
+  "required": ["action", "channel", "chat_id"],
   "additionalProperties": false
 }

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -154,6 +154,8 @@ export interface ChannelSummary {
 export type ChannelConfigSnapshot =
   | {
       channel_id: "telegram";
+      account_id: string;
+      display_name?: string;
       enabled: boolean;
       dm_policy: DmPolicy;
       allowed_users: string[];
@@ -161,6 +163,8 @@ export type ChannelConfigSnapshot =
     }
   | {
       channel_id: "slack";
+      account_id: string;
+      display_name?: string;
       enabled: boolean;
       mode: SlackChannelMode;
       dm_policy: DmPolicy;
@@ -169,7 +173,43 @@ export type ChannelConfigSnapshot =
       has_app_token: boolean;
     };
 
+export type ChannelAccountSnapshot =
+  | {
+      channel_id: "telegram";
+      account_id: string;
+      display_name?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_token: boolean;
+      binding: {
+        agent_id: string | null;
+        conversation_id: string | null;
+      };
+      created_at: string;
+      updated_at: string;
+    }
+  | {
+      channel_id: "slack";
+      account_id: string;
+      display_name?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      mode: SlackChannelMode;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_bot_token: boolean;
+      has_app_token: boolean;
+      agent_id: string | null;
+      created_at: string;
+      updated_at: string;
+    };
+
 export interface ChannelPendingPairing {
+  account_id: string;
   code: string;
   sender_id: string;
   sender_name?: string;
@@ -180,15 +220,20 @@ export interface ChannelPendingPairing {
 
 export interface ChannelRouteSnapshot {
   channel_id: ChannelId;
+  account_id: string;
   chat_id: string;
+  chat_type?: "direct" | "channel";
+  thread_id?: string | null;
   agent_id: string;
   conversation_id: string;
   enabled: boolean;
   created_at: string;
+  updated_at: string;
 }
 
 export interface ChannelTargetSnapshot {
   channel_id: ChannelId;
+  account_id: string;
   target_id: string;
   target_type: "channel";
   chat_id: string;
@@ -806,16 +851,113 @@ export interface ChannelsListCommand {
   request_id: string;
 }
 
+export interface ChannelAccountsListCommand {
+  type: "channel_accounts_list";
+  request_id: string;
+  channel_id: ChannelId;
+}
+
+export type ChannelAccountCreatePayload =
+  | {
+      account_id?: string;
+      display_name?: string;
+      enabled?: boolean;
+      token?: string;
+      dm_policy?: DmPolicy;
+      allowed_users?: string[];
+    }
+  | {
+      account_id?: string;
+      display_name?: string;
+      enabled?: boolean;
+      bot_token?: string;
+      app_token?: string;
+      mode?: SlackChannelMode;
+      agent_id?: string | null;
+      dm_policy?: DmPolicy;
+      allowed_users?: string[];
+    };
+
+export interface ChannelAccountCreateCommand {
+  type: "channel_account_create";
+  request_id: string;
+  channel_id: ChannelId;
+  account: ChannelAccountCreatePayload;
+}
+
+export interface ChannelAccountUpdateCommand {
+  type: "channel_account_update";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+  patch:
+    | {
+        display_name?: string;
+        enabled?: boolean;
+        token?: string;
+        dm_policy?: DmPolicy;
+        allowed_users?: string[];
+      }
+    | {
+        display_name?: string;
+        enabled?: boolean;
+        bot_token?: string;
+        app_token?: string;
+        mode?: SlackChannelMode;
+        agent_id?: string | null;
+        dm_policy?: DmPolicy;
+        allowed_users?: string[];
+      };
+}
+
+export interface ChannelAccountBindCommand {
+  type: "channel_account_bind";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+  runtime: RuntimeScope;
+}
+
+export interface ChannelAccountUnbindCommand {
+  type: "channel_account_unbind";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+}
+
+export interface ChannelAccountDeleteCommand {
+  type: "channel_account_delete";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+}
+
+export interface ChannelAccountStartCommand {
+  type: "channel_account_start";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+}
+
+export interface ChannelAccountStopCommand {
+  type: "channel_account_stop";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id: string;
+}
+
 export interface ChannelGetConfigCommand {
   type: "channel_get_config";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelSetConfigCommand {
   type: "channel_set_config";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
   config:
     | {
         token?: string;
@@ -835,24 +977,28 @@ export interface ChannelStartCommand {
   type: "channel_start";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelStopCommand {
   type: "channel_stop";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelPairingsListCommand {
   type: "channel_pairings_list";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelPairingBindCommand {
   type: "channel_pairing_bind";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
   runtime: RuntimeScope;
   code: string;
 }
@@ -861,6 +1007,7 @@ export interface ChannelRoutesListCommand {
   type: "channel_routes_list";
   request_id: string;
   channel_id?: ChannelId;
+  account_id?: string;
   agent_id?: string;
   conversation_id?: string;
 }
@@ -869,12 +1016,14 @@ export interface ChannelTargetsListCommand {
   type: "channel_targets_list";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelTargetBindCommand {
   type: "channel_target_bind";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
   runtime: RuntimeScope;
   target_id: string;
 }
@@ -883,7 +1032,17 @@ export interface ChannelRouteRemoveCommand {
   type: "channel_route_remove";
   request_id: string;
   channel_id: ChannelId;
+  account_id?: string;
   chat_id: string;
+}
+
+export interface ChannelRouteUpdateCommand {
+  type: "channel_route_update";
+  request_id: string;
+  channel_id: ChannelId;
+  account_id?: string;
+  chat_id: string;
+  runtime: RuntimeScope;
 }
 
 export interface CronListResponseMessage {
@@ -971,6 +1130,79 @@ export interface ChannelsListResponseMessage {
   error?: string;
 }
 
+export interface ChannelAccountsListResponseMessage {
+  type: "channel_accounts_list_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  accounts: ChannelAccountSnapshot[];
+  error?: string;
+}
+
+export interface ChannelAccountCreateResponseMessage {
+  type: "channel_account_create_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelAccountUpdateResponseMessage {
+  type: "channel_account_update_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelAccountBindResponseMessage {
+  type: "channel_account_bind_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelAccountUnbindResponseMessage {
+  type: "channel_account_unbind_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelAccountDeleteResponseMessage {
+  type: "channel_account_delete_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account_id: string;
+  deleted: boolean;
+  error?: string;
+}
+
+export interface ChannelAccountStartResponseMessage {
+  type: "channel_account_start_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
+export interface ChannelAccountStopResponseMessage {
+  type: "channel_account_stop_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  account: ChannelAccountSnapshot | null;
+  error?: string;
+}
+
 export interface ChannelGetConfigResponseMessage {
   type: "channel_get_config_response";
   request_id: string;
@@ -1041,6 +1273,16 @@ export interface ChannelRouteRemoveResponseMessage {
   error?: string;
 }
 
+export interface ChannelRouteUpdateResponseMessage {
+  type: "channel_route_update_response";
+  request_id: string;
+  success: boolean;
+  channel_id: ChannelId;
+  chat_id: string;
+  route?: ChannelRouteSnapshot | null;
+  error?: string;
+}
+
 export interface ChannelTargetsListResponseMessage {
   type: "channel_targets_list_response";
   request_id: string;
@@ -1065,6 +1307,13 @@ export interface ChannelsUpdatedMessage {
   type: "channels_updated";
   timestamp: number;
   channel_id?: ChannelId;
+}
+
+export interface ChannelAccountsUpdatedMessage {
+  type: "channel_accounts_updated";
+  timestamp: number;
+  channel_id: ChannelId;
+  account_id?: string;
 }
 
 export interface ChannelPairingsUpdatedMessage {
@@ -1188,6 +1437,14 @@ export type WsProtocolCommand =
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
   | ChannelsListCommand
+  | ChannelAccountsListCommand
+  | ChannelAccountCreateCommand
+  | ChannelAccountUpdateCommand
+  | ChannelAccountBindCommand
+  | ChannelAccountUnbindCommand
+  | ChannelAccountDeleteCommand
+  | ChannelAccountStartCommand
+  | ChannelAccountStopCommand
   | ChannelGetConfigCommand
   | ChannelSetConfigCommand
   | ChannelStartCommand
@@ -1198,6 +1455,7 @@ export type WsProtocolCommand =
   | ChannelTargetsListCommand
   | ChannelTargetBindCommand
   | ChannelRouteRemoveCommand
+  | ChannelRouteUpdateCommand
   | ExecuteCommandCommand
   | SearchBranchesCommand
   | CheckoutBranchCommand;
@@ -1211,6 +1469,14 @@ export type WsProtocolMessage =
   | ListModelsResponseMessage
   | UpdateModelResponseMessage
   | ChannelsListResponseMessage
+  | ChannelAccountsListResponseMessage
+  | ChannelAccountCreateResponseMessage
+  | ChannelAccountUpdateResponseMessage
+  | ChannelAccountBindResponseMessage
+  | ChannelAccountUnbindResponseMessage
+  | ChannelAccountDeleteResponseMessage
+  | ChannelAccountStartResponseMessage
+  | ChannelAccountStopResponseMessage
   | ChannelGetConfigResponseMessage
   | ChannelSetConfigResponseMessage
   | ChannelStartResponseMessage
@@ -1221,7 +1487,9 @@ export type WsProtocolMessage =
   | ChannelTargetsListResponseMessage
   | ChannelTargetBindResponseMessage
   | ChannelRouteRemoveResponseMessage
+  | ChannelRouteUpdateResponseMessage
   | ChannelsUpdatedMessage
+  | ChannelAccountsUpdatedMessage
   | ChannelPairingsUpdatedMessage
   | ChannelRoutesUpdatedMessage
   | ChannelTargetsUpdatedMessage;

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -72,11 +72,20 @@ import type {
   AbortMessageCommand,
   ApprovalResponseBody,
   ChangeDeviceStateCommand,
+  ChannelAccountBindCommand,
+  ChannelAccountCreateCommand,
+  ChannelAccountDeleteCommand,
+  ChannelAccountStartCommand,
+  ChannelAccountStopCommand,
+  ChannelAccountsListCommand,
+  ChannelAccountUnbindCommand,
+  ChannelAccountUpdateCommand,
   ChannelGetConfigCommand,
   ChannelPairingBindCommand,
   ChannelPairingsListCommand,
   ChannelRouteRemoveCommand,
   ChannelRoutesListCommand,
+  ChannelRouteUpdateCommand,
   ChannelSetConfigCommand,
   ChannelStartCommand,
   ChannelStopCommand,
@@ -141,11 +150,20 @@ import {
   persistPermissionModeMapForRuntime,
 } from "./permissionMode";
 import {
+  isChannelAccountBindCommand,
+  isChannelAccountCreateCommand,
+  isChannelAccountDeleteCommand,
+  isChannelAccountStartCommand,
+  isChannelAccountStopCommand,
+  isChannelAccountsListCommand,
+  isChannelAccountUnbindCommand,
+  isChannelAccountUpdateCommand,
   isChannelGetConfigCommand,
   isChannelPairingBindCommand,
   isChannelPairingsListCommand,
   isChannelRouteRemoveCommand,
   isChannelRoutesListCommand,
+  isChannelRouteUpdateCommand,
   isChannelSetConfigCommand,
   isChannelStartCommand,
   isChannelStopCommand,
@@ -763,6 +781,14 @@ type ReflectionSettingsCommand =
 
 type ChannelsCommand =
   | ChannelsListCommand
+  | ChannelAccountsListCommand
+  | ChannelAccountCreateCommand
+  | ChannelAccountUpdateCommand
+  | ChannelAccountBindCommand
+  | ChannelAccountUnbindCommand
+  | ChannelAccountDeleteCommand
+  | ChannelAccountStartCommand
+  | ChannelAccountStopCommand
   | ChannelGetConfigCommand
   | ChannelSetConfigCommand
   | ChannelStartCommand
@@ -772,7 +798,33 @@ type ChannelsCommand =
   | ChannelRoutesListCommand
   | ChannelTargetsListCommand
   | ChannelTargetBindCommand
+  | ChannelRouteUpdateCommand
   | ChannelRouteRemoveCommand;
+
+function isDetachedChannelsCommand(parsed: unknown): parsed is ChannelsCommand {
+  return (
+    isChannelsListCommand(parsed) ||
+    isChannelAccountsListCommand(parsed) ||
+    isChannelAccountCreateCommand(parsed) ||
+    isChannelAccountUpdateCommand(parsed) ||
+    isChannelAccountBindCommand(parsed) ||
+    isChannelAccountUnbindCommand(parsed) ||
+    isChannelAccountDeleteCommand(parsed) ||
+    isChannelAccountStartCommand(parsed) ||
+    isChannelAccountStopCommand(parsed) ||
+    isChannelGetConfigCommand(parsed) ||
+    isChannelSetConfigCommand(parsed) ||
+    isChannelStartCommand(parsed) ||
+    isChannelStopCommand(parsed) ||
+    isChannelPairingsListCommand(parsed) ||
+    isChannelPairingBindCommand(parsed) ||
+    isChannelRoutesListCommand(parsed) ||
+    isChannelTargetsListCommand(parsed) ||
+    isChannelTargetBindCommand(parsed) ||
+    isChannelRouteUpdateCommand(parsed) ||
+    isChannelRouteRemoveCommand(parsed)
+  );
+}
 
 function emitCronsUpdated(
   socket: WebSocket,
@@ -803,6 +855,23 @@ function emitChannelsUpdated(
       type: "channels_updated",
       timestamp: Date.now(),
       ...(channelId ? { channel_id: channelId } : {}),
+    },
+    "listener_channels_send_failed",
+    "listener_channels_command",
+  );
+}
+
+function emitChannelAccountsUpdated(
+  socket: WebSocket,
+  params: { channelId: "telegram" | "slack"; accountId?: string },
+): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "channel_accounts_updated",
+      timestamp: Date.now(),
+      channel_id: params.channelId,
+      ...(params.accountId ? { account_id: params.accountId } : {}),
     },
     "listener_channels_send_failed",
     "listener_channels_command",
@@ -1071,16 +1140,26 @@ async function handleChannelsProtocolCommand(
 ): Promise<boolean> {
   const {
     bindChannelPairing,
+    bindChannelAccountLive,
     bindChannelTarget,
+    createChannelAccountLive,
+    refreshChannelAccountDisplayNameLive,
     getChannelConfigSnapshot,
+    listChannelAccountSnapshots,
     listChannelRouteSnapshots,
     listChannelSummaries,
     listPendingPairingSnapshots,
     listChannelTargetSnapshots,
+    removeChannelAccountLive,
     removeChannelRouteLive,
     setChannelConfigLive,
+    startChannelAccountLive,
     startChannelLive,
+    stopChannelAccountLive,
     stopChannelLive,
+    unbindChannelAccountLive,
+    updateChannelAccountLive,
+    updateChannelRouteLive,
   } = await loadChannelsService();
 
   const mapChannelSummary = (
@@ -1106,6 +1185,8 @@ async function handleChannelsProtocolCommand(
     if (snapshot.channelId === "telegram") {
       return {
         channel_id: snapshot.channelId,
+        account_id: snapshot.accountId,
+        display_name: snapshot.displayName,
         enabled: snapshot.enabled,
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
@@ -1114,6 +1195,8 @@ async function handleChannelsProtocolCommand(
     }
     return {
       channel_id: snapshot.channelId,
+      account_id: snapshot.accountId,
+      display_name: snapshot.displayName,
       enabled: snapshot.enabled,
       mode: snapshot.mode,
       dm_policy: snapshot.dmPolicy,
@@ -1123,21 +1206,67 @@ async function handleChannelsProtocolCommand(
     };
   };
 
+  const mapChannelAccount = (
+    snapshot: ReturnType<typeof listChannelAccountSnapshots>[number],
+  ) => {
+    if (snapshot.channelId === "telegram") {
+      return {
+        channel_id: snapshot.channelId,
+        account_id: snapshot.accountId,
+        display_name: snapshot.displayName,
+        enabled: snapshot.enabled,
+        configured: snapshot.configured,
+        running: snapshot.running,
+        dm_policy: snapshot.dmPolicy,
+        allowed_users: snapshot.allowedUsers,
+        has_token: snapshot.hasToken,
+        binding: {
+          agent_id: snapshot.binding.agentId,
+          conversation_id: snapshot.binding.conversationId,
+        },
+        created_at: snapshot.createdAt,
+        updated_at: snapshot.updatedAt,
+      };
+    }
+
+    return {
+      channel_id: snapshot.channelId,
+      account_id: snapshot.accountId,
+      display_name: snapshot.displayName,
+      enabled: snapshot.enabled,
+      configured: snapshot.configured,
+      running: snapshot.running,
+      mode: snapshot.mode,
+      dm_policy: snapshot.dmPolicy,
+      allowed_users: snapshot.allowedUsers,
+      has_bot_token: snapshot.hasBotToken,
+      has_app_token: snapshot.hasAppToken,
+      agent_id: snapshot.agentId,
+      created_at: snapshot.createdAt,
+      updated_at: snapshot.updatedAt,
+    };
+  };
+
   const mapRouteSnapshot = (
     route: ReturnType<typeof listChannelRouteSnapshots>[number],
   ) => ({
     channel_id: route.channelId,
+    account_id: route.accountId,
     chat_id: route.chatId,
+    chat_type: route.chatType,
+    thread_id: route.threadId ?? null,
     agent_id: route.agentId,
     conversation_id: route.conversationId,
     enabled: route.enabled,
     created_at: route.createdAt,
+    updated_at: route.updatedAt,
   });
 
   const mapTargetSnapshot = (
     target: ReturnType<typeof listChannelTargetSnapshots>[number],
   ) => ({
     channel_id: target.channelId,
+    account_id: target.accountId,
     target_id: target.targetId,
     target_type: target.targetType,
     chat_id: target.chatId,
@@ -1177,6 +1306,451 @@ async function handleChannelsProtocolCommand(
     return true;
   }
 
+  if (parsed.type === "channel_accounts_list") {
+    try {
+      const accounts = await Promise.all(
+        listChannelAccountSnapshots(parsed.channel_id).map((account) =>
+          parsed.channel_id === "slack"
+            ? refreshChannelAccountDisplayNameLive(
+                parsed.channel_id,
+                account.accountId,
+                { force: true },
+              )
+            : account.displayName
+              ? Promise.resolve(account)
+              : refreshChannelAccountDisplayNameLive(
+                  parsed.channel_id,
+                  account.accountId,
+                ),
+        ),
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_accounts_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          accounts: accounts.map(mapChannelAccount),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_accounts_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          accounts: [],
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to list channel accounts",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_create") {
+    try {
+      const created = createChannelAccountLive(
+        parsed.channel_id,
+        {
+          displayName:
+            "display_name" in parsed.account
+              ? parsed.account.display_name
+              : undefined,
+          enabled:
+            "enabled" in parsed.account ? parsed.account.enabled : undefined,
+          token: "token" in parsed.account ? parsed.account.token : undefined,
+          botToken:
+            "bot_token" in parsed.account
+              ? parsed.account.bot_token
+              : undefined,
+          appToken:
+            "app_token" in parsed.account
+              ? parsed.account.app_token
+              : undefined,
+          mode: "mode" in parsed.account ? parsed.account.mode : undefined,
+          agentId:
+            "agent_id" in parsed.account ? parsed.account.agent_id : undefined,
+          dmPolicy: parsed.account.dm_policy,
+          allowedUsers: parsed.account.allowed_users,
+        },
+        {
+          accountId:
+            "account_id" in parsed.account
+              ? parsed.account.account_id
+              : undefined,
+        },
+      );
+      const account =
+        "display_name" in parsed.account
+          ? created
+          : await refreshChannelAccountDisplayNameLive(
+              parsed.channel_id,
+              created.accountId,
+              { force: true },
+            );
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_create_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: account.accountId,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_create_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to create channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_update") {
+    try {
+      const updated = updateChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+        {
+          displayName:
+            "display_name" in parsed.patch
+              ? parsed.patch.display_name
+              : undefined,
+          enabled: "enabled" in parsed.patch ? parsed.patch.enabled : undefined,
+          token: "token" in parsed.patch ? parsed.patch.token : undefined,
+          botToken:
+            "bot_token" in parsed.patch ? parsed.patch.bot_token : undefined,
+          appToken:
+            "app_token" in parsed.patch ? parsed.patch.app_token : undefined,
+          mode: "mode" in parsed.patch ? parsed.patch.mode : undefined,
+          agentId:
+            "agent_id" in parsed.patch ? parsed.patch.agent_id : undefined,
+          dmPolicy: parsed.patch.dm_policy,
+          allowedUsers: parsed.patch.allowed_users,
+        },
+      );
+      const shouldRefreshDisplayName =
+        !("display_name" in parsed.patch) &&
+        (parsed.channel_id === "telegram"
+          ? "token" in parsed.patch
+          : "bot_token" in parsed.patch || "app_token" in parsed.patch);
+      const account = shouldRefreshDisplayName
+        ? await refreshChannelAccountDisplayNameLive(
+            parsed.channel_id,
+            parsed.account_id,
+            { force: true },
+          )
+        : updated;
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_update_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: parsed.account_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_update_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to update channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_bind") {
+    try {
+      const account = bindChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+      );
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_bind_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: parsed.account_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_bind_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to bind channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_unbind") {
+    try {
+      const account = unbindChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_unbind_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: parsed.account_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_unbind_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to unbind channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_delete") {
+    try {
+      const deleted = await removeChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
+
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_delete_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account_id: parsed.account_id,
+          deleted,
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      if (deleted) {
+        emitChannelAccountsUpdated(socket, {
+          channelId: parsed.channel_id,
+          accountId: parsed.account_id,
+        });
+        emitChannelPairingsUpdated(socket, parsed.channel_id);
+        emitChannelRoutesUpdated(socket, {
+          channelId: parsed.channel_id,
+        });
+        emitChannelTargetsUpdated(socket, parsed.channel_id);
+        emitChannelsUpdated(socket, parsed.channel_id);
+      }
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_delete_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account_id: parsed.account_id,
+          deleted: false,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to delete channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_start") {
+    try {
+      const account = await startChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
+      wireChannelIngress(
+        runtime,
+        socket,
+        opts as StartListenerOptions,
+        processQueuedTurn,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_start_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: parsed.account_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_start_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to start channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "channel_account_stop") {
+    try {
+      const account = await stopChannelAccountLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_stop_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          account: mapChannelAccount(account),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: parsed.account_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_account_stop_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          account: null,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to stop channel account",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
   if (parsed.type === "channel_get_config") {
     try {
       safeSocketSend(
@@ -1185,7 +1759,9 @@ async function handleChannelsProtocolCommand(
           type: "channel_get_config_response",
           request_id: parsed.request_id,
           success: true,
-          config: mapChannelConfig(getChannelConfigSnapshot(parsed.channel_id)),
+          config: mapChannelConfig(
+            getChannelConfigSnapshot(parsed.channel_id, parsed.account_id),
+          ),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1212,16 +1788,20 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_set_config") {
     try {
-      const snapshot = await setChannelConfigLive(parsed.channel_id, {
-        token: "token" in parsed.config ? parsed.config.token : undefined,
-        botToken:
-          "bot_token" in parsed.config ? parsed.config.bot_token : undefined,
-        appToken:
-          "app_token" in parsed.config ? parsed.config.app_token : undefined,
-        mode: "mode" in parsed.config ? parsed.config.mode : undefined,
-        dmPolicy: parsed.config.dm_policy,
-        allowedUsers: parsed.config.allowed_users,
-      });
+      const snapshot = await setChannelConfigLive(
+        parsed.channel_id,
+        {
+          token: "token" in parsed.config ? parsed.config.token : undefined,
+          botToken:
+            "bot_token" in parsed.config ? parsed.config.bot_token : undefined,
+          appToken:
+            "app_token" in parsed.config ? parsed.config.app_token : undefined,
+          mode: "mode" in parsed.config ? parsed.config.mode : undefined,
+          dmPolicy: parsed.config.dm_policy,
+          allowedUsers: parsed.config.allowed_users,
+        },
+        parsed.account_id,
+      );
 
       if (snapshot.enabled) {
         wireChannelIngress(
@@ -1243,6 +1823,10 @@ async function handleChannelsProtocolCommand(
         "listener_channels_send_failed",
         "listener_channels_command",
       );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: snapshot.accountId,
+      });
       emitChannelsUpdated(socket, parsed.channel_id);
     } catch (err) {
       safeSocketSend(
@@ -1266,7 +1850,10 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_start") {
     try {
-      const summary = await startChannelLive(parsed.channel_id);
+      const summary = await startChannelLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
       wireChannelIngress(
         runtime,
         socket,
@@ -1304,7 +1891,10 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_stop") {
     try {
-      const summary = await stopChannelLive(parsed.channel_id);
+      const summary = await stopChannelLive(
+        parsed.channel_id,
+        parsed.account_id,
+      );
       safeSocketSend(
         socket,
         {
@@ -1343,16 +1933,18 @@ async function handleChannelsProtocolCommand(
           request_id: parsed.request_id,
           success: true,
           channel_id: parsed.channel_id,
-          pending: listPendingPairingSnapshots(parsed.channel_id).map(
-            (pending) => ({
-              code: pending.code,
-              sender_id: pending.senderId,
-              sender_name: pending.senderName,
-              chat_id: pending.chatId,
-              created_at: pending.createdAt,
-              expires_at: pending.expiresAt,
-            }),
-          ),
+          pending: listPendingPairingSnapshots(
+            parsed.channel_id,
+            parsed.account_id,
+          ).map((pending) => ({
+            account_id: pending.accountId,
+            code: pending.code,
+            sender_id: pending.senderId,
+            sender_name: pending.senderName,
+            chat_id: pending.chatId,
+            created_at: pending.createdAt,
+            expires_at: pending.expiresAt,
+          })),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1385,6 +1977,7 @@ async function handleChannelsProtocolCommand(
         parsed.code,
         parsed.runtime.agent_id,
         parsed.runtime.conversation_id,
+        parsed.account_id,
       );
       safeSocketSend(
         socket,
@@ -1436,6 +2029,7 @@ async function handleChannelsProtocolCommand(
           channel_id: channelId,
           routes: listChannelRouteSnapshots({
             channelId,
+            accountId: parsed.account_id,
             agentId: parsed.agent_id,
             conversationId: parsed.conversation_id,
           }).map(mapRouteSnapshot),
@@ -1470,9 +2064,10 @@ async function handleChannelsProtocolCommand(
           request_id: parsed.request_id,
           success: true,
           channel_id: parsed.channel_id,
-          targets: listChannelTargetSnapshots(parsed.channel_id).map(
-            mapTargetSnapshot,
-          ),
+          targets: listChannelTargetSnapshots(
+            parsed.channel_id,
+            parsed.account_id,
+          ).map(mapTargetSnapshot),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
@@ -1505,6 +2100,7 @@ async function handleChannelsProtocolCommand(
         parsed.target_id,
         parsed.runtime.agent_id,
         parsed.runtime.conversation_id,
+        parsed.account_id,
       );
       safeSocketSend(
         socket,
@@ -1549,8 +2145,63 @@ async function handleChannelsProtocolCommand(
     return true;
   }
 
+  if (parsed.type === "channel_route_update") {
+    try {
+      const route = updateChannelRouteLive(
+        parsed.channel_id,
+        parsed.chat_id,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+        parsed.account_id,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_route_update_response",
+          request_id: parsed.request_id,
+          success: true,
+          channel_id: parsed.channel_id,
+          chat_id: parsed.chat_id,
+          route: mapRouteSnapshot(route),
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+      emitChannelAccountsUpdated(socket, {
+        channelId: parsed.channel_id,
+        accountId: route.accountId,
+      });
+      emitChannelRoutesUpdated(socket, {
+        channelId: parsed.channel_id,
+        agentId: parsed.runtime.agent_id,
+        conversationId: parsed.runtime.conversation_id,
+      });
+      emitChannelsUpdated(socket, parsed.channel_id);
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "channel_route_update_response",
+          request_id: parsed.request_id,
+          success: false,
+          channel_id: parsed.channel_id,
+          chat_id: parsed.chat_id,
+          route: null,
+          error: err instanceof Error ? err.message : "Failed to update route",
+        },
+        "listener_channels_send_failed",
+        "listener_channels_command",
+      );
+    }
+    return true;
+  }
+
   try {
-    const found = removeChannelRouteLive(parsed.channel_id, parsed.chat_id);
+    const found = removeChannelRouteLive(
+      parsed.channel_id,
+      parsed.chat_id,
+      parsed.account_id,
+    );
     safeSocketSend(
       socket,
       {
@@ -4208,19 +4859,7 @@ async function connectWithRetry(
       }
 
       // ── Channels management commands (device/live management) ─────────
-      if (
-        isChannelsListCommand(parsed) ||
-        isChannelGetConfigCommand(parsed) ||
-        isChannelSetConfigCommand(parsed) ||
-        isChannelStartCommand(parsed) ||
-        isChannelStopCommand(parsed) ||
-        isChannelPairingsListCommand(parsed) ||
-        isChannelPairingBindCommand(parsed) ||
-        isChannelRoutesListCommand(parsed) ||
-        isChannelTargetsListCommand(parsed) ||
-        isChannelTargetBindCommand(parsed) ||
-        isChannelRouteRemoveCommand(parsed)
-      ) {
+      if (isDetachedChannelsCommand(parsed)) {
         runDetachedListenerTask("channels_command", async () => {
           await handleChannelsProtocolCommand(
             parsed,
@@ -4907,6 +5546,7 @@ export const __listenClientTestUtils = {
   handleAbortMessageInput,
   handleChangeDeviceStateInput,
   handleCronCommand,
+  isDetachedChannelsCommand,
   handleChannelsProtocolCommand,
   handleSkillCommand,
   handleCreateAgentCommand,

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -408,7 +408,9 @@ async function handleChannelsCommand(
   }
 
   if (subCmd === "status") {
-    const { readChannelConfig } = await import("../../channels/config");
+    const { listChannelAccountSnapshots } = await import(
+      "../../channels/service"
+    );
     const { getRoutesForChannel, loadRoutes } = await import(
       "../../channels/routing"
     );
@@ -419,8 +421,8 @@ async function handleChannelsCommand(
     const lines: string[] = [];
 
     for (const ch of channels) {
-      const config = readChannelConfig(ch);
-      if (!config) {
+      const accounts = listChannelAccountSnapshots(ch);
+      if (accounts.length === 0) {
         lines.push(`${ch}: not configured`);
         continue;
       }
@@ -430,8 +432,8 @@ async function handleChannelsCommand(
       const pending = getPendingPairings(ch);
       const approved = getApprovedUsers(ch);
       lines.push(
-        `${ch}: enabled=${config.enabled}, policy=${config.dmPolicy}, ` +
-          `routes=${routes.length}, pending=${pending.length}, approved=${approved.length}`,
+        `${ch}: accounts=${accounts.length}, enabled=${accounts.some((account) => account.enabled)}, ` +
+          `policy=${accounts[0]?.dmPolicy ?? "unknown"}, routes=${routes.length}, pending=${pending.length}, approved=${approved.length}`,
       );
     }
 
@@ -439,6 +441,10 @@ async function handleChannelsCommand(
   }
 
   if (subCmd === "telegram") {
+    const accountIdFlag = rest.indexOf("--account-id");
+    const accountId =
+      accountIdFlag >= 0 ? (rest[accountIdFlag + 1] ?? undefined) : undefined;
+
     if (action === "pair") {
       const code = rest[0];
       if (!code) {
@@ -452,7 +458,13 @@ async function handleChannelsCommand(
       loadRoutes("telegram");
       loadPairingStore("telegram");
 
-      const result = completePairing("telegram", code, agentId, conversationId);
+      const result = completePairing(
+        "telegram",
+        code,
+        agentId,
+        conversationId,
+        accountId,
+      );
 
       if (result.success) {
         return `Pairing approved! Chat ${result.chatId} is now bound to this agent/conversation.`;
@@ -465,13 +477,37 @@ async function handleChannelsCommand(
       const chatId = chatIdFlag >= 0 ? rest[chatIdFlag + 1] : undefined;
 
       if (!chatId) {
-        return "Usage: /channels telegram enable --chat-id <id>";
+        return "Usage: /channels telegram enable --chat-id <id> [--account-id <id>]";
       }
 
+      const { getChannelAccount, listChannelAccounts } = await import(
+        "../../channels/accounts"
+      );
       const { addRoute, loadRoutes } = await import("../../channels/routing");
+
+      let resolvedAccountId = accountId?.trim();
+      if (resolvedAccountId) {
+        if (!getChannelAccount("telegram", resolvedAccountId)) {
+          return `Unknown Telegram account: ${resolvedAccountId}`;
+        }
+      } else {
+        const accounts = listChannelAccounts("telegram");
+        if (accounts.length === 0) {
+          return "Telegram is not configured yet.";
+        }
+        if (accounts.length > 1) {
+          return "Telegram has multiple accounts. Re-run with --account-id <id>.";
+        }
+        resolvedAccountId = accounts[0]?.accountId;
+      }
+
+      if (!resolvedAccountId) {
+        return "Could not resolve a Telegram account for this route.";
+      }
 
       loadRoutes("telegram");
       addRoute("telegram", {
+        accountId: resolvedAccountId,
         chatId,
         agentId,
         conversationId,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -2,11 +2,20 @@ import type WebSocket from "ws";
 import type {
   AbortMessageCommand,
   ChangeDeviceStateCommand,
+  ChannelAccountBindCommand,
+  ChannelAccountCreateCommand,
+  ChannelAccountDeleteCommand,
+  ChannelAccountStartCommand,
+  ChannelAccountStopCommand,
+  ChannelAccountsListCommand,
+  ChannelAccountUnbindCommand,
+  ChannelAccountUpdateCommand,
   ChannelGetConfigCommand,
   ChannelPairingBindCommand,
   ChannelPairingsListCommand,
   ChannelRouteRemoveCommand,
   ChannelRoutesListCommand,
+  ChannelRouteUpdateCommand,
   ChannelSetConfigCommand,
   ChannelStartCommand,
   ChannelStopCommand,
@@ -698,12 +707,230 @@ function isChannelId(value: unknown): value is "telegram" | "slack" {
   return value === "telegram" || value === "slack";
 }
 
+function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {
+  const hasValidDmPolicy =
+    config.dm_policy === undefined ||
+    config.dm_policy === "pairing" ||
+    config.dm_policy === "allowlist" ||
+    config.dm_policy === "open";
+  const hasValidAllowedUsers =
+    config.allowed_users === undefined ||
+    (Array.isArray(config.allowed_users) &&
+      config.allowed_users.every((entry) => typeof entry === "string"));
+  const hasValidDisplayName =
+    config.display_name === undefined ||
+    typeof config.display_name === "string";
+  const hasValidEnabled =
+    config.enabled === undefined || typeof config.enabled === "boolean";
+
+  return (
+    hasValidDmPolicy &&
+    hasValidAllowedUsers &&
+    hasValidDisplayName &&
+    hasValidEnabled
+  );
+}
+
 export function isChannelsListCommand(
   value: unknown,
 ): value is ChannelsListCommand {
   if (!value || typeof value !== "object") return false;
   const c = value as { type?: unknown; request_id?: unknown };
   return c.type === "channels_list" && typeof c.request_id === "string";
+}
+
+export function isChannelAccountsListCommand(
+  value: unknown,
+): value is ChannelAccountsListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+  };
+  return (
+    c.type === "channel_accounts_list" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id)
+  );
+}
+
+export function isChannelAccountCreateCommand(
+  value: unknown,
+): value is ChannelAccountCreateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account?: unknown;
+  };
+  if (
+    c.type !== "channel_account_create" ||
+    typeof c.request_id !== "string" ||
+    !isChannelId(c.channel_id) ||
+    !c.account ||
+    typeof c.account !== "object"
+  ) {
+    return false;
+  }
+
+  const account = c.account as Record<string, unknown>;
+  if (
+    (account.account_id !== undefined &&
+      typeof account.account_id !== "string") ||
+    !hasValidChannelPolicyFields(account)
+  ) {
+    return false;
+  }
+
+  if (c.channel_id === "telegram") {
+    return account.token === undefined || typeof account.token === "string";
+  }
+
+  return (
+    (account.bot_token === undefined ||
+      typeof account.bot_token === "string") &&
+    (account.app_token === undefined ||
+      typeof account.app_token === "string") &&
+    (account.mode === undefined || account.mode === "socket") &&
+    (account.agent_id === undefined ||
+      account.agent_id === null ||
+      typeof account.agent_id === "string")
+  );
+}
+
+export function isChannelAccountUpdateCommand(
+  value: unknown,
+): value is ChannelAccountUpdateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+    patch?: unknown;
+  };
+  if (
+    c.type !== "channel_account_update" ||
+    typeof c.request_id !== "string" ||
+    !isChannelId(c.channel_id) ||
+    typeof c.account_id !== "string" ||
+    !c.patch ||
+    typeof c.patch !== "object"
+  ) {
+    return false;
+  }
+
+  const patch = c.patch as Record<string, unknown>;
+  if (!hasValidChannelPolicyFields(patch)) {
+    return false;
+  }
+
+  if (c.channel_id === "telegram") {
+    return patch.token === undefined || typeof patch.token === "string";
+  }
+
+  return (
+    (patch.bot_token === undefined || typeof patch.bot_token === "string") &&
+    (patch.app_token === undefined || typeof patch.app_token === "string") &&
+    (patch.mode === undefined || patch.mode === "socket") &&
+    (patch.agent_id === undefined ||
+      patch.agent_id === null ||
+      typeof patch.agent_id === "string")
+  );
+}
+
+export function isChannelAccountBindCommand(
+  value: unknown,
+): value is ChannelAccountBindCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+    runtime?: unknown;
+  };
+  return (
+    c.type === "channel_account_bind" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.account_id === "string" &&
+    isRuntimeScope(c.runtime)
+  );
+}
+
+export function isChannelAccountUnbindCommand(
+  value: unknown,
+): value is ChannelAccountUnbindCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+  };
+  return (
+    c.type === "channel_account_unbind" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.account_id === "string"
+  );
+}
+
+export function isChannelAccountDeleteCommand(
+  value: unknown,
+): value is ChannelAccountDeleteCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+  };
+  return (
+    c.type === "channel_account_delete" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.account_id === "string"
+  );
+}
+
+export function isChannelAccountStartCommand(
+  value: unknown,
+): value is ChannelAccountStartCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+  };
+  return (
+    c.type === "channel_account_start" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.account_id === "string"
+  );
+}
+
+export function isChannelAccountStopCommand(
+  value: unknown,
+): value is ChannelAccountStopCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+  };
+  return (
+    c.type === "channel_account_stop" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    typeof c.account_id === "string"
+  );
 }
 
 export function isChannelGetConfigCommand(
@@ -714,11 +941,13 @@ export function isChannelGetConfigCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
   };
   return (
     c.type === "channel_get_config" &&
     typeof c.request_id === "string" &&
-    isChannelId(c.channel_id)
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string")
   );
 }
 
@@ -730,29 +959,21 @@ export function isChannelSetConfigCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
     config?: unknown;
   };
   if (
     c.type !== "channel_set_config" ||
     typeof c.request_id !== "string" ||
     !isChannelId(c.channel_id) ||
+    (c.account_id !== undefined && typeof c.account_id !== "string") ||
     !c.config ||
     typeof c.config !== "object"
   ) {
     return false;
   }
   const config = c.config as Record<string, unknown>;
-  const hasValidDmPolicy =
-    config.dm_policy === undefined ||
-    config.dm_policy === "pairing" ||
-    config.dm_policy === "allowlist" ||
-    config.dm_policy === "open";
-  const hasValidAllowedUsers =
-    config.allowed_users === undefined ||
-    (Array.isArray(config.allowed_users) &&
-      config.allowed_users.every((entry) => typeof entry === "string"));
-
-  if (!hasValidDmPolicy || !hasValidAllowedUsers) {
+  if (!hasValidChannelPolicyFields(config)) {
     return false;
   }
 
@@ -775,11 +996,13 @@ export function isChannelStartCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
   };
   return (
     c.type === "channel_start" &&
     typeof c.request_id === "string" &&
-    isChannelId(c.channel_id)
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string")
   );
 }
 
@@ -791,11 +1014,13 @@ export function isChannelStopCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
   };
   return (
     c.type === "channel_stop" &&
     typeof c.request_id === "string" &&
-    isChannelId(c.channel_id)
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string")
   );
 }
 
@@ -807,11 +1032,13 @@ export function isChannelPairingsListCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
   };
   return (
     c.type === "channel_pairings_list" &&
     typeof c.request_id === "string" &&
-    isChannelId(c.channel_id)
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string")
   );
 }
 
@@ -823,6 +1050,7 @@ export function isChannelPairingBindCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
     runtime?: unknown;
     code?: unknown;
   };
@@ -830,6 +1058,7 @@ export function isChannelPairingBindCommand(
     c.type === "channel_pairing_bind" &&
     typeof c.request_id === "string" &&
     isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string") &&
     isRuntimeScope(c.runtime) &&
     typeof c.code === "string" &&
     c.code.length > 0
@@ -844,6 +1073,7 @@ export function isChannelRoutesListCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
     agent_id?: unknown;
     conversation_id?: unknown;
   };
@@ -851,6 +1081,7 @@ export function isChannelRoutesListCommand(
     c.type === "channel_routes_list" &&
     typeof c.request_id === "string" &&
     (c.channel_id === undefined || isChannelId(c.channel_id)) &&
+    (c.account_id === undefined || typeof c.account_id === "string") &&
     (c.agent_id === undefined || typeof c.agent_id === "string") &&
     (c.conversation_id === undefined || typeof c.conversation_id === "string")
   );
@@ -864,14 +1095,39 @@ export function isChannelRouteRemoveCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
     chat_id?: unknown;
   };
   return (
     c.type === "channel_route_remove" &&
     typeof c.request_id === "string" &&
     isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string") &&
     typeof c.chat_id === "string" &&
     c.chat_id.length > 0
+  );
+}
+
+export function isChannelRouteUpdateCommand(
+  value: unknown,
+): value is ChannelRouteUpdateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    channel_id?: unknown;
+    account_id?: unknown;
+    chat_id?: unknown;
+    runtime?: unknown;
+  };
+  return (
+    c.type === "channel_route_update" &&
+    typeof c.request_id === "string" &&
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string") &&
+    typeof c.chat_id === "string" &&
+    c.chat_id.length > 0 &&
+    isRuntimeScope(c.runtime)
   );
 }
 
@@ -883,11 +1139,13 @@ export function isChannelTargetsListCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
   };
   return (
     c.type === "channel_targets_list" &&
     typeof c.request_id === "string" &&
-    isChannelId(c.channel_id)
+    isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string")
   );
 }
 
@@ -899,6 +1157,7 @@ export function isChannelTargetBindCommand(
     type?: unknown;
     request_id?: unknown;
     channel_id?: unknown;
+    account_id?: unknown;
     runtime?: unknown;
     target_id?: unknown;
   };
@@ -906,6 +1165,7 @@ export function isChannelTargetBindCommand(
     c.type === "channel_target_bind" &&
     typeof c.request_id === "string" &&
     isChannelId(c.channel_id) &&
+    (c.account_id === undefined || typeof c.account_id === "string") &&
     isRuntimeScope(c.runtime) &&
     typeof c.target_id === "string" &&
     c.target_id.length > 0
@@ -1004,6 +1264,14 @@ export function parseServerMessage(
       isGetReflectionSettingsCommand(parsed) ||
       isSetReflectionSettingsCommand(parsed) ||
       isChannelsListCommand(parsed) ||
+      isChannelAccountsListCommand(parsed) ||
+      isChannelAccountCreateCommand(parsed) ||
+      isChannelAccountUpdateCommand(parsed) ||
+      isChannelAccountBindCommand(parsed) ||
+      isChannelAccountUnbindCommand(parsed) ||
+      isChannelAccountDeleteCommand(parsed) ||
+      isChannelAccountStartCommand(parsed) ||
+      isChannelAccountStopCommand(parsed) ||
       isChannelGetConfigCommand(parsed) ||
       isChannelSetConfigCommand(parsed) ||
       isChannelStartCommand(parsed) ||
@@ -1013,6 +1281,7 @@ export function parseServerMessage(
       isChannelRoutesListCommand(parsed) ||
       isChannelTargetsListCommand(parsed) ||
       isChannelTargetBindCommand(parsed) ||
+      isChannelRouteUpdateCommand(parsed) ||
       isChannelRouteRemoveCommand(parsed) ||
       isExecuteCommandCommand(parsed) ||
       isSearchBranchesCommand(parsed) ||


### PR DESCRIPTION
## Summary
- introduce account-scoped channel management for Slack and Telegram, including account snapshots, targets, routes, and typed WS protocol updates
- keep a shared OpenClaw-style `MessageChannel` tool while moving action discovery/dispatch into channel-owned adapters
- harden Slack + Telegram channel behavior and add broader regression coverage across service, registry, listener protocol, and shared message tool flows

## Validation
- `bun test src/tests/channels src/tests/websocket/listen-client-protocol.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/channels src/tools/impl/MessageChannel.ts src/tools/manager.ts src/tests/channels src/tests/websocket/listen-client-protocol.test.ts src/cli/subcommands/channels.ts src/types/protocol_v2.ts src/websocket/listener/client.ts src/websocket/listener/commands.ts src/websocket/listener/protocol-inbound.ts`
- `bun run typecheck`
- manual smoke: booted Slack + Telegram together and sent a real outbound test message through each channel