### PR TITLE
fix(channels): normalize XML entities in channel replies

### DIFF
--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -11,30 +11,36 @@ import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
 import type { InboundChannelMessage } from "./types";
 
 /**
- * Escape special XML characters in text content.
- * Reference: src/cli/helpers/taskNotifications.ts uses similar escaping.
+ * Escape special XML characters in text nodes.
+ * Quotes do not need escaping in text content, and preserving them avoids
+ * leaking XML entity sequences like &apos; back into downstream channel replies.
  */
-function escapeXml(text: string): string {
+function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape special XML characters in attribute values.
+ */
+function escapeXmlAttribute(text: string): string {
+  return escapeXmlText(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
 
 /**
  * Format the reminder text that explains channel reply semantics to the agent.
  */
 export function buildChannelReminderText(msg: InboundChannelMessage): string {
-  const localTime = escapeXml(getLocalTime());
-  const escapedChannel = escapeXml(msg.channel);
-  const escapedChatId = escapeXml(msg.chatId);
+  const localTime = escapeXmlText(getLocalTime());
+  const escapedChannel = escapeXmlText(msg.channel);
+  const escapedChatId = escapeXmlText(msg.chatId);
   const threadLine =
     msg.channel === "slack" &&
     msg.chatType === "channel" &&
     msg.messageId?.trim()
-      ? `Use reply_to_message_id="${escapeXml(msg.messageId)}" if you want your reply to stay in the same Slack thread.`
+      ? `Use reply_to_message_id="${escapeXmlText(msg.messageId)}" if you want your reply to stay in the same Slack thread.`
       : null;
 
   const lines = [
@@ -68,21 +74,21 @@ export function buildChannelNotificationXml(
   msg: InboundChannelMessage,
 ): string {
   const attrs: string[] = [
-    `source="${escapeXml(msg.channel)}"`,
-    `chat_id="${escapeXml(msg.chatId)}"`,
-    `sender_id="${escapeXml(msg.senderId)}"`,
+    `source="${escapeXmlAttribute(msg.channel)}"`,
+    `chat_id="${escapeXmlAttribute(msg.chatId)}"`,
+    `sender_id="${escapeXmlAttribute(msg.senderId)}"`,
   ];
 
   if (msg.senderName) {
-    attrs.push(`sender_name="${escapeXml(msg.senderName)}"`);
+    attrs.push(`sender_name="${escapeXmlAttribute(msg.senderName)}"`);
   }
 
   if (msg.messageId) {
-    attrs.push(`message_id="${escapeXml(msg.messageId)}"`);
+    attrs.push(`message_id="${escapeXmlAttribute(msg.messageId)}"`);
   }
 
   const attrString = attrs.join(" ");
-  const escapedText = escapeXml(msg.text);
+  const escapedText = escapeXmlText(msg.text);
 
   return `<channel-notification ${attrString}>\n${escapedText}\n</channel-notification>`;
 }

--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -18,6 +18,18 @@ test("formats Telegram markdown as HTML", () => {
   });
 });
 
+test("normalizes basic XML entities before Telegram formatting", () => {
+  const formatted = formatOutboundChannelMessage(
+    "telegram",
+    "I&apos;ll keep &lt;this&gt; &amp; that",
+  );
+
+  expect(formatted).toEqual({
+    text: "I'll keep &lt;this&gt; &amp; that",
+    parseMode: "HTML",
+  });
+});
+
 test("formats Slack markdown as mrkdwn", () => {
   expect(formatOutboundChannelMessage("slack", "**bold**")).toEqual({
     text: "*bold*",

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -82,7 +82,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain("stay in the same Slack thread");
   });
 
-  test("escapes XML special characters in notification text", () => {
+  test("escapes only structural XML characters in notification text", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "123",
@@ -95,8 +95,8 @@ describe("formatChannelNotification", () => {
 
     expect(xml).toContain("&lt;world&gt;");
     expect(xml).toContain("&amp;");
-    expect(xml).toContain("&quot;friends&quot;");
-    expect(xml).toContain("&apos;here&apos;");
+    expect(xml).toContain('"friends"');
+    expect(xml).toContain("'here'");
   });
 
   test("escapes XML special characters in notification attributes", () => {

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -25,6 +25,16 @@ type OutboundChannelFormatter = (
   text: string,
 ) => Pick<OutboundChannelMessage, "text" | "parseMode">;
 
+function decodeBasicXmlEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
 function escapeTelegramHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -434,11 +444,12 @@ export function formatOutboundChannelMessage(
   channel: string,
   text: string,
 ): Pick<OutboundChannelMessage, "text" | "parseMode"> {
+  const normalizedText = decodeBasicXmlEntities(text);
   const formatter = CHANNEL_OUTBOUND_FORMATTERS[channel];
   if (!formatter) {
-    return { text };
+    return { text: normalizedText };
   }
-  return formatter(text);
+  return formatter(normalizedText);
 }
 
 interface MessageChannelArgs {


### PR DESCRIPTION
## Summary
- preserve quotes in inbound channel notification text nodes while keeping attribute escaping intact
- normalize basic XML entities before outbound Telegram and Slack formatting so escaped text is not echoed back literally
- add regression coverage for the channel XML escaping and outbound formatting paths

## Test plan
- [x] bun test src/tests/channels/xml.test.ts src/tests/channels/message-channel-formatting.test.ts
- [x] bun run typecheck

Written by Cameron ◯ Letta Code