### PR TITLE
feat(reflection): filter reflection payload and switch to JSON format

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10556,9 +10556,22 @@ export default function App({
 
           try {
             const reflectionConversationId = conversationIdRef.current;
+
+            // Fetch the agent's system prompt so the reflection payload includes
+            // the core behavioural instructions (filtered to strip dynamic content).
+            let systemPrompt: string | undefined;
+            try {
+              const client = await getClient();
+              const agent = await client.agents.retrieve(agentId);
+              systemPrompt = agent.system ?? undefined;
+            } catch {
+              // Non-fatal — the reflection payload will just omit the system prompt.
+            }
+
             const autoPayload = await buildAutoReflectionPayload(
               agentId,
               reflectionConversationId,
+              systemPrompt,
             );
 
             if (!autoPayload) {
@@ -11027,9 +11040,22 @@ ${SYSTEM_REMINDER_CLOSE}
         }
         try {
           const reflectionConversationId = conversationIdRef.current;
+
+          // Fetch the agent's system prompt so the reflection payload includes
+          // the core behavioural instructions (filtered to strip dynamic content).
+          let systemPrompt: string | undefined;
+          try {
+            const client = await getClient();
+            const agent = await client.agents.retrieve(agentId);
+            systemPrompt = agent.system ?? undefined;
+          } catch {
+            // Non-fatal — the reflection payload will just omit the system prompt.
+          }
+
           const autoPayload = await buildAutoReflectionPayload(
             agentId,
             reflectionConversationId,
+            systemPrompt,
           );
           if (!autoPayload) {
             debugLog(

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -389,8 +389,7 @@ type ReflectionMessage =
  * Serialize transcript entries (and optional filtered system prompt) into a
  * JSON message array for the reflection subagent.
  *
- * Format mirrors ~/Downloads/example_1.json — a flat array of
- * `{ role, content, tool_calls? }` objects.
+ * Output is a flat array of `{ role, content, tool_calls? }` objects.
  */
 function formatTaggedTranscript(
   entries: TranscriptEntry[],

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -593,10 +593,10 @@ export async function appendTranscriptDeltaJsonl(
  * Strip dynamic / noisy sections from a system prompt so the reflection agent
  * sees only the core behavioural instructions.
  *
- * Removes: memory blocks (`<memory>…</memory>`, `<self>…</self>`, `<human>…</human>`),
- * skill listings (`<available_skills>…</available_skills>`),
- * system reminders (`<system-reminder>…</system-reminder>`),
- * and memory metadata (`<memory_metadata>…</memory_metadata>`).
+ * Removes:
+ * - XML blocks: `<memory>`, `<self>`, `<human>`, `<available_skills>`,
+ *   `<system-reminder>`, `<memory_metadata>`
+ * - The `# Memory` markdown section (operational memory-filesystem docs)
  */
 export function filterSystemPromptForReflection(raw: string): string {
   // Remove XML-style blocks that carry dynamic/ephemeral content.
@@ -616,6 +616,10 @@ export function filterSystemPromptForReflection(raw: string): string {
       "",
     );
   }
+  // Strip the "# Memory" markdown section (and everything after it).
+  // This section contains operational memory-filesystem docs that the
+  // reflection agent doesn't need.
+  filtered = filtered.replace(/\n# Memory\n[\s\S]*$/, "");
   // Collapse runs of 3+ blank lines into 2
   filtered = filtered.replace(/\n{3,}/g, "\n\n");
   return filtered.trim();

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -341,19 +341,51 @@ function defaultState(): ReflectionTranscriptState {
   return { auto_cursor_line: 0 };
 }
 
+/** Maximum characters to keep for tool-call arguments in the reflection payload. */
+const TOOL_ARGS_TRUNCATE_LIMIT = 300;
+
+/**
+ * Truncate text to a character limit, appending a marker when content is cut.
+ */
+function truncateArgs(
+  text: string | undefined,
+  limit: number,
+): string | undefined {
+  if (text === undefined) return undefined;
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}…[truncated]`;
+}
+
+/**
+ * Strip inline base64 image data and data-URI image references from text.
+ * This is a safety net — the accumulator's `extractTextPart` already drops
+ * multimodal image_url parts, but pasted/inline base64 could still appear.
+ */
+function stripImagesFromText(text: string): string {
+  // Strip data:image URIs (including surrounding markdown image syntax)
+  return text.replace(
+    /!\[[^\]]*\]\(data:image\/[^)]+\)|data:image\/[^\s"')]+/g,
+    "[image]",
+  );
+}
+
 function formatTaggedTranscript(entries: TranscriptEntry[]): string {
   const lines: Line[] = [];
   for (const [index, entry] of entries.entries()) {
     const id = `transcript-${index}`;
     switch (entry.kind) {
       case "user":
-        lines.push({ kind: "user", id, text: entry.text });
+        lines.push({
+          kind: "user",
+          id,
+          text: stripImagesFromText(entry.text),
+        });
         break;
       case "assistant":
         lines.push({
           kind: "assistant",
           id,
-          text: entry.text,
+          text: stripImagesFromText(entry.text),
           phase: "finished",
         });
         break;
@@ -373,9 +405,9 @@ function formatTaggedTranscript(entries: TranscriptEntry[]): string {
           kind: "tool_call",
           id,
           name: entry.name,
-          argsText: entry.argsText,
-          resultText: entry.resultText,
-          resultOk: entry.resultOk,
+          argsText: truncateArgs(entry.argsText, TOOL_ARGS_TRUNCATE_LIMIT),
+          // resultText and resultOk intentionally omitted — tool outputs
+          // generally don't contribute to reflection and add significant noise.
           phase: "finished",
         });
         break;
@@ -536,9 +568,42 @@ export async function appendTranscriptDeltaJsonl(
   return entries.length;
 }
 
+/**
+ * Strip dynamic / noisy sections from a system prompt so the reflection agent
+ * sees only the core behavioural instructions.
+ *
+ * Removes: memory blocks (`<memory>…</memory>`, `<self>…</self>`, `<human>…</human>`),
+ * skill listings (`<available_skills>…</available_skills>`),
+ * system reminders (`<system-reminder>…</system-reminder>`),
+ * and memory metadata (`<memory_metadata>…</memory_metadata>`).
+ */
+export function filterSystemPromptForReflection(raw: string): string {
+  // Remove XML-style blocks that carry dynamic/ephemeral content.
+  // Using [\s\S] instead of . so we cross newlines.
+  const tagsToStrip = [
+    "memory",
+    "self",
+    "human",
+    "available_skills",
+    "system-reminder",
+    "memory_metadata",
+  ];
+  let filtered = raw;
+  for (const tag of tagsToStrip) {
+    filtered = filtered.replace(
+      new RegExp(`<${tag}>[\\s\\S]*?</${tag}>`, "g"),
+      "",
+    );
+  }
+  // Collapse runs of 3+ blank lines into 2
+  filtered = filtered.replace(/\n{3,}/g, "\n\n");
+  return filtered.trim();
+}
+
 export async function buildAutoReflectionPayload(
   agentId: string,
   conversationId: string,
+  systemPrompt?: string,
 ): Promise<AutoReflectionPayload | null> {
   const paths = getReflectionTranscriptPaths(agentId, conversationId);
   await ensurePaths(paths);
@@ -572,8 +637,18 @@ export async function buildAutoReflectionPayload(
     return null;
   }
 
+  // Build the final payload: optional filtered system prompt + conversation transcript
+  const payloadParts: string[] = [];
+  if (systemPrompt) {
+    const filtered = filterSystemPromptForReflection(systemPrompt);
+    if (filtered) {
+      payloadParts.push(`<system_prompt>\n${filtered}\n</system_prompt>`);
+    }
+  }
+  payloadParts.push(transcript);
+
   const payloadPath = buildPayloadPath("auto");
-  await writeFile(payloadPath, transcript, "utf-8");
+  await writeFile(payloadPath, payloadParts.join("\n\n"), "utf-8");
 
   state.last_auto_reflection_started_at = new Date().toISOString();
   await writeState(paths, state);

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { MEMORY_SYSTEM_DIR } from "../../agent/memoryFilesystem";
 import { getDirectoryLimits } from "../../utils/directoryLimits";
 import { parseFrontmatter } from "../../utils/frontmatter";
-import { type Line, linesToTranscript } from "./accumulator";
+import type { Line } from "./accumulator";
 
 const TRANSCRIPT_ROOT_ENV = "LETTA_TRANSCRIPT_ROOT";
 const DEFAULT_TRANSCRIPT_DIR = "transcripts";
@@ -369,51 +369,72 @@ function stripImagesFromText(text: string): string {
   );
 }
 
-function formatTaggedTranscript(entries: TranscriptEntry[]): string {
-  const lines: Line[] = [];
-  for (const [index, entry] of entries.entries()) {
-    const id = `transcript-${index}`;
+/**
+ * JSON message entry for the reflection payload.
+ * Follows the ChatML-style format from the reference transcript spec.
+ */
+type ReflectionMessage =
+  | { role: "system" | "user" | "reasoning" | "error"; content: string }
+  | {
+      role: "assistant";
+      content: string;
+    }
+  | {
+      role: "assistant";
+      content: null;
+      tool_calls: Array<{ name: string; args: string }>;
+    };
+
+/**
+ * Serialize transcript entries (and optional filtered system prompt) into a
+ * JSON message array for the reflection subagent.
+ *
+ * Format mirrors ~/Downloads/example_1.json — a flat array of
+ * `{ role, content, tool_calls? }` objects.
+ */
+function formatTaggedTranscript(
+  entries: TranscriptEntry[],
+  filteredSystemPrompt?: string,
+): string {
+  const messages: ReflectionMessage[] = [];
+
+  if (filteredSystemPrompt) {
+    messages.push({ role: "system", content: filteredSystemPrompt });
+  }
+
+  for (const entry of entries) {
     switch (entry.kind) {
       case "user":
-        lines.push({
-          kind: "user",
-          id,
-          text: stripImagesFromText(entry.text),
+        messages.push({
+          role: "user",
+          content: stripImagesFromText(entry.text),
         });
         break;
       case "assistant":
-        lines.push({
-          kind: "assistant",
-          id,
-          text: stripImagesFromText(entry.text),
-          phase: "finished",
+        messages.push({
+          role: "assistant",
+          content: stripImagesFromText(entry.text),
         });
         break;
       case "reasoning":
-        lines.push({
-          kind: "reasoning",
-          id,
-          text: entry.text,
-          phase: "finished",
-        });
+        messages.push({ role: "reasoning", content: entry.text });
         break;
       case "error":
-        lines.push({ kind: "error", id, text: entry.text });
+        messages.push({ role: "error", content: entry.text });
         break;
-      case "tool_call":
-        lines.push({
-          kind: "tool_call",
-          id,
-          name: entry.name,
-          argsText: truncateArgs(entry.argsText, TOOL_ARGS_TRUNCATE_LIMIT),
-          // resultText and resultOk intentionally omitted — tool outputs
-          // generally don't contribute to reflection and add significant noise.
-          phase: "finished",
+      case "tool_call": {
+        const args =
+          truncateArgs(entry.argsText, TOOL_ARGS_TRUNCATE_LIMIT) ?? "{}";
+        messages.push({
+          role: "assistant",
+          content: null,
+          tool_calls: [{ name: entry.name ?? "unknown", args }],
         });
         break;
+      }
     }
   }
-  return linesToTranscript(lines);
+  return JSON.stringify(messages, null, 2);
 }
 
 function lineToTranscriptEntry(
@@ -632,23 +653,16 @@ export async function buildAutoReflectionPayload(
     .filter((id): id is string => typeof id === "string" && id.length > 0);
   const startMessageId = messageIds[0];
   const endMessageId = messageIds[messageIds.length - 1];
-  const transcript = formatTaggedTranscript(entries);
-  if (!transcript) {
+  const filteredSystemPrompt = systemPrompt
+    ? filterSystemPromptForReflection(systemPrompt) || undefined
+    : undefined;
+  const transcript = formatTaggedTranscript(entries, filteredSystemPrompt);
+  if (!transcript || transcript === "[]") {
     return null;
   }
 
-  // Build the final payload: optional filtered system prompt + conversation transcript
-  const payloadParts: string[] = [];
-  if (systemPrompt) {
-    const filtered = filterSystemPromptForReflection(systemPrompt);
-    if (filtered) {
-      payloadParts.push(`<system_prompt>\n${filtered}\n</system_prompt>`);
-    }
-  }
-  payloadParts.push(transcript);
-
   const payloadPath = buildPayloadPath("auto");
-  await writeFile(payloadPath, payloadParts.join("\n\n"), "utf-8");
+  await writeFile(payloadPath, transcript, "utf-8");
 
   state.last_auto_reflection_started_at = new Date().toISOString();
   await writeState(paths, state);

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -8,6 +8,7 @@ import {
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
+  filterSystemPromptForReflection,
   finalizeAutoReflectionPayload,
   getReflectionTranscriptPaths,
 } from "../../cli/helpers/reflectionTranscript";
@@ -255,5 +256,148 @@ describe("reflectionTranscript helper", () => {
       "Additional memory files (such as skills and external memory) may also be read and modified.",
     );
     expect(prompt).toContain("<parent_memory>snapshot</parent_memory>");
+  });
+
+  test("reflection payload drops tool call results and truncates args", async () => {
+    const longArgs = "a".repeat(500);
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      { kind: "user", id: "u1", text: "run a search" },
+      {
+        kind: "tool_call",
+        id: "tc1",
+        toolCallId: "tc1",
+        name: "Grep",
+        argsText: longArgs,
+        resultText: "found 42 matches in 10 files",
+        resultOk: true,
+        phase: "finished",
+      },
+      {
+        kind: "assistant",
+        id: "a1",
+        text: "Found results",
+        phase: "finished",
+      },
+    ]);
+
+    const payload = await buildAutoReflectionPayload(agentId, conversationId);
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    const payloadText = await readFile(payload.payloadPath, "utf-8");
+
+    // Tool call name and truncated args should be present
+    expect(payloadText).toContain('<tool_call name="Grep">');
+    expect(payloadText).toContain("…[truncated]");
+    // Full 500-char args should NOT be present
+    expect(payloadText).not.toContain(longArgs);
+    // Tool result should NOT be present
+    expect(payloadText).not.toContain("found 42 matches");
+    expect(payloadText).not.toContain("<tool_result>");
+    // User and assistant messages should be present
+    expect(payloadText).toContain("<user>run a search</user>");
+    expect(payloadText).toContain("<assistant>Found results</assistant>");
+  });
+
+  test("reflection payload strips inline base64 images from text", async () => {
+    const userTextWithImage =
+      "Check this: ![screenshot](data:image/png;base64,iVBORw0KGgoAAAANS) and tell me what you see";
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      { kind: "user", id: "u1", text: userTextWithImage },
+    ]);
+
+    const payload = await buildAutoReflectionPayload(agentId, conversationId);
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    const payloadText = await readFile(payload.payloadPath, "utf-8");
+    expect(payloadText).not.toContain("data:image/png;base64");
+    expect(payloadText).toContain("[image]");
+    expect(payloadText).toContain("Check this:");
+    expect(payloadText).toContain("and tell me what you see");
+  });
+
+  test("reflection payload prepends filtered system prompt when provided", async () => {
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      { kind: "user", id: "u1", text: "hello" },
+    ]);
+
+    const systemPrompt = [
+      "You are a helpful coding assistant.",
+      "",
+      "<memory>",
+      "<self>I am a persona block</self>",
+      "<human>User info here</human>",
+      "</memory>",
+      "",
+      "<available_skills>",
+      "skill1, skill2",
+      "</available_skills>",
+      "",
+      "Always be concise.",
+    ].join("\n");
+
+    const payload = await buildAutoReflectionPayload(
+      agentId,
+      conversationId,
+      systemPrompt,
+    );
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    const payloadText = await readFile(payload.payloadPath, "utf-8");
+    // Filtered system prompt should be present
+    expect(payloadText).toContain("<system_prompt>");
+    expect(payloadText).toContain("You are a helpful coding assistant.");
+    expect(payloadText).toContain("Always be concise.");
+    // Dynamic sections should be stripped
+    expect(payloadText).not.toContain("I am a persona block");
+    expect(payloadText).not.toContain("User info here");
+    expect(payloadText).not.toContain("skill1, skill2");
+    expect(payloadText).not.toContain("<available_skills>");
+    // Transcript should still follow
+    expect(payloadText).toContain("<user>hello</user>");
+  });
+
+  test("filterSystemPromptForReflection strips all dynamic sections", () => {
+    const raw = [
+      "Core instructions here.",
+      "<memory><self>persona</self><human>user data</human></memory>",
+      "<system-reminder>This is a reminder</system-reminder>",
+      "<memory_metadata>agent-id: foo</memory_metadata>",
+      "<available_skills>skill list</available_skills>",
+      "Final instructions.",
+    ].join("\n");
+
+    const filtered = filterSystemPromptForReflection(raw);
+    expect(filtered).toContain("Core instructions here.");
+    expect(filtered).toContain("Final instructions.");
+    expect(filtered).not.toContain("persona");
+    expect(filtered).not.toContain("user data");
+    expect(filtered).not.toContain("This is a reminder");
+    expect(filtered).not.toContain("agent-id: foo");
+    expect(filtered).not.toContain("skill list");
+  });
+
+  test("filterSystemPromptForReflection strips standalone memory sub-tags", () => {
+    const raw = [
+      "You are Letta Code.",
+      "",
+      "<self>",
+      "I'm a coding assistant.",
+      "</self>",
+      "",
+      "<human>",
+      "The user likes TypeScript.",
+      "</human>",
+      "",
+      "# Memory section",
+    ].join("\n");
+
+    const filtered = filterSystemPromptForReflection(raw);
+    expect(filtered).toContain("You are Letta Code.");
+    expect(filtered).toContain("# Memory section");
+    expect(filtered).not.toContain("I'm a coding assistant.");
+    expect(filtered).not.toContain("The user likes TypeScript.");
   });
 });

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -404,13 +404,49 @@ describe("reflectionTranscript helper", () => {
       "The user likes TypeScript.",
       "</human>",
       "",
-      "# Memory section",
+      "Keep being helpful.",
     ].join("\n");
 
     const filtered = filterSystemPromptForReflection(raw);
     expect(filtered).toContain("You are Letta Code.");
-    expect(filtered).toContain("# Memory section");
+    expect(filtered).toContain("Keep being helpful.");
     expect(filtered).not.toContain("I'm a coding assistant.");
     expect(filtered).not.toContain("The user likes TypeScript.");
+  });
+
+  test("filterSystemPromptForReflection strips the # Memory markdown section", () => {
+    const raw = [
+      "You are a persistent coding agent.",
+      "",
+      "# How you work",
+      "",
+      "Never modify code you haven't read.",
+      "",
+      "# Memory",
+      "",
+      "Your memory is projected onto the local memory filesystem.",
+      "",
+      "## Memory structure",
+      "",
+      "Files in system/ are pinned into your prompt.",
+      "",
+      "## Syncing",
+      "",
+      "```bash",
+      "git push",
+      "```",
+    ].join("\n");
+
+    const filtered = filterSystemPromptForReflection(raw);
+    expect(filtered).toContain("You are a persistent coding agent.");
+    expect(filtered).toContain("# How you work");
+    expect(filtered).toContain("Never modify code you haven't read.");
+    // Everything from "# Memory" onward should be stripped
+    expect(filtered).not.toContain("# Memory");
+    expect(filtered).not.toContain("memory filesystem");
+    expect(filtered).not.toContain("Memory structure");
+    expect(filtered).not.toContain("pinned into your prompt");
+    expect(filtered).not.toContain("Syncing");
+    expect(filtered).not.toContain("git push");
   });
 });

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -64,8 +64,10 @@ describe("reflectionTranscript helper", () => {
     expect(payload.endMessageId).toBe("a1");
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
-    expect(payloadText).toContain("<user>hello</user>");
-    expect(payloadText).toContain("<assistant>hi there</assistant>");
+    const messages = JSON.parse(payloadText);
+    expect(messages).toBeArray();
+    expect(messages).toContainEqual({ role: "user", content: "hello" });
+    expect(messages).toContainEqual({ role: "assistant", content: "hi there" });
 
     await finalizeAutoReflectionPayload(
       agentId,
@@ -153,7 +155,8 @@ describe("reflectionTranscript helper", () => {
     expect(secondAttempt.endMessageId).toBe("a2");
 
     const payloadText = await readFile(secondAttempt.payloadPath, "utf-8");
-    expect(payloadText).toContain("<assistant>second</assistant>");
+    const messages = JSON.parse(payloadText);
+    expect(messages).toContainEqual({ role: "assistant", content: "second" });
   });
 
   test("buildParentMemorySnapshot renders tree descriptions and system <memory> blocks", async () => {
@@ -285,18 +288,24 @@ describe("reflectionTranscript helper", () => {
     if (!payload) return;
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
+    const messages = JSON.parse(payloadText);
 
-    // Tool call name and truncated args should be present
-    expect(payloadText).toContain('<tool_call name="Grep">');
-    expect(payloadText).toContain("…[truncated]");
-    // Full 500-char args should NOT be present
-    expect(payloadText).not.toContain(longArgs);
-    // Tool result should NOT be present
+    // Tool call should be present with truncated args
+    const toolMsg = messages.find(
+      (m: { tool_calls?: unknown[] }) => m.tool_calls,
+    );
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg.tool_calls[0].name).toBe("Grep");
+    expect(toolMsg.tool_calls[0].args).toContain("…[truncated]");
+    expect(toolMsg.tool_calls[0].args.length).toBeLessThan(longArgs.length);
+    // Tool result should NOT be present anywhere
     expect(payloadText).not.toContain("found 42 matches");
-    expect(payloadText).not.toContain("<tool_result>");
     // User and assistant messages should be present
-    expect(payloadText).toContain("<user>run a search</user>");
-    expect(payloadText).toContain("<assistant>Found results</assistant>");
+    expect(messages).toContainEqual({ role: "user", content: "run a search" });
+    expect(messages).toContainEqual({
+      role: "assistant",
+      content: "Found results",
+    });
   });
 
   test("reflection payload strips inline base64 images from text", async () => {
@@ -311,10 +320,12 @@ describe("reflectionTranscript helper", () => {
     if (!payload) return;
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
-    expect(payloadText).not.toContain("data:image/png;base64");
-    expect(payloadText).toContain("[image]");
-    expect(payloadText).toContain("Check this:");
-    expect(payloadText).toContain("and tell me what you see");
+    const messages = JSON.parse(payloadText);
+    const userMsg = messages.find((m: { role: string }) => m.role === "user");
+    expect(userMsg.content).not.toContain("data:image/png;base64");
+    expect(userMsg.content).toContain("[image]");
+    expect(userMsg.content).toContain("Check this:");
+    expect(userMsg.content).toContain("and tell me what you see");
   });
 
   test("reflection payload prepends filtered system prompt when provided", async () => {
@@ -346,17 +357,19 @@ describe("reflectionTranscript helper", () => {
     if (!payload) return;
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
-    // Filtered system prompt should be present
-    expect(payloadText).toContain("<system_prompt>");
-    expect(payloadText).toContain("You are a helpful coding assistant.");
-    expect(payloadText).toContain("Always be concise.");
+    const messages = JSON.parse(payloadText);
+    // Filtered system prompt should be the first message
+    const systemMsg = messages[0];
+    expect(systemMsg.role).toBe("system");
+    expect(systemMsg.content).toContain("You are a helpful coding assistant.");
+    expect(systemMsg.content).toContain("Always be concise.");
     // Dynamic sections should be stripped
-    expect(payloadText).not.toContain("I am a persona block");
-    expect(payloadText).not.toContain("User info here");
-    expect(payloadText).not.toContain("skill1, skill2");
-    expect(payloadText).not.toContain("<available_skills>");
-    // Transcript should still follow
-    expect(payloadText).toContain("<user>hello</user>");
+    expect(systemMsg.content).not.toContain("I am a persona block");
+    expect(systemMsg.content).not.toContain("User info here");
+    expect(systemMsg.content).not.toContain("skill1, skill2");
+    expect(systemMsg.content).not.toContain("<available_skills>");
+    // Transcript should follow
+    expect(messages).toContainEqual({ role: "user", content: "hello" });
   });
 
   test("filterSystemPromptForReflection strips all dynamic sections", () => {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -182,9 +182,25 @@ function buildMaybeLaunchReflectionSubagent(params: {
     }
 
     try {
+      // Fetch the agent's system prompt so the reflection payload includes
+      // the core behavioural instructions (filtered to strip dynamic content).
+      let systemPrompt: string | undefined;
+      try {
+        const client = await getClient();
+        const agent = await client.agents.retrieve(agentId);
+        systemPrompt = agent.system ?? undefined;
+      } catch {
+        // Non-fatal — the reflection payload will just omit the system prompt.
+        debugLog(
+          "memory",
+          "Failed to fetch agent system prompt for reflection payload",
+        );
+      }
+
       const autoPayload = await buildAutoReflectionPayload(
         agentId,
         conversationId,
+        systemPrompt,
       );
       if (!autoPayload) {
         debugLog(


### PR DESCRIPTION
## Summary
- **Switch payload format from XML to JSON** — the reflection transcript now uses a ChatML-style JSON message array (`[{ role, content, tool_calls? }, ...]`) instead of XML tags
- **Drop tool call results/outputs** from the payload — these don't contribute to reflection and add significant noise
- **Truncate tool call args to 300 chars** to keep the payload focused on intent rather than raw data
- **Strip inline base64 image data** from user/assistant text entries
- **Prepend a filtered system prompt** (core behavioral instructions only, with memory blocks, skills, system reminders, and metadata stripped) so the reflection agent has context about the agent's instructions

## Details

All filtering happens at **payload build time** — the local JSONL transcript storage remains unchanged at full fidelity. Changes are in `formatTaggedTranscript()` and `buildAutoReflectionPayload()` in `reflectionTranscript.ts`, with callers in `App.tsx` and `turn.ts` updated to fetch and pass the agent's system prompt.

### JSON payload format

```json
[
  { "role": "system", "content": "...filtered core instructions..." },
  { "role": "user", "content": "fix the auth bug" },
  { "role": "reasoning", "content": "The issue is in the token validation..." },
  { "role": "assistant", "content": "Let me check the auth module." },
  { "role": "assistant", "content": null, "tool_calls": [{ "name": "Read", "args": "{\"file_path\": \"/src/auth.ts\"}" }] },
  { "role": "assistant", "content": "Found it." }
]
```

### Filtering rules
| Content | Action |
|---------|--------|
| Tool call results (`resultText`, `resultOk`) | Dropped entirely |
| Tool call args | Truncated to 300 chars with `…[truncated]` marker |
| Inline base64 images | Replaced with `[image]` |
| System prompt `<memory>`, `<self>`, `<human>` blocks | Stripped |
| System prompt `<available_skills>`, `<system-reminder>`, `<memory_metadata>` | Stripped |

### New exports
- `filterSystemPromptForReflection()` — strips dynamic XML sections from a system prompt string

## Test plan
- [x] All 11 reflection transcript tests pass (5 new tests added)
- [x] Reflection auto-launch wiring tests pass
- [x] Listen reflection wiring/runtime tests pass
- [x] TypeScript type check clean (`tsc --noEmit`)
- [ ] Manual: trigger `/reflect` and verify the reflection agent reads the JSON payload correctly

🐾 Generated with [Letta Code](https://letta.com)