### PR TITLE
feat(channels): add Telegram media and reaction parity

### DIFF
--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -2,9 +2,9 @@
  * Telegram channel adapter using grammY.
  *
  * Uses long-polling (no webhook setup needed).
- * Reference: lettabot src/channels/telegram.ts
  */
 
+import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
 import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import type {
   ChannelAdapter,
@@ -12,6 +12,14 @@ import type {
   OutboundChannelMessage,
   TelegramChannelAccount,
 } from "../types";
+import {
+  detectTelegramUploadMethod,
+  extractTelegramMessageText,
+  getTelegramSenderName,
+  resolveTelegramInboundAttachments,
+  TELEGRAM_MEDIA_GROUP_FLUSH_MS,
+  type TelegramLikeMessage,
+} from "./media";
 import { loadGrammyModule } from "./runtime";
 
 type TelegramBot = GrammYBot<GrammYContext>;
@@ -19,6 +27,46 @@ type GrammYModule = typeof import("grammy") & {
   default?: Partial<typeof import("grammy")>;
 };
 type TelegramBotConstructor = typeof import("grammy").Bot;
+type TelegramInputFileConstructor = typeof import("grammy").InputFile;
+type BufferedMediaGroup = {
+  messages: TelegramLikeMessage[];
+  timer: ReturnType<typeof setTimeout>;
+};
+type TelegramReactionType =
+  | {
+      type?: "emoji";
+      emoji?: string;
+    }
+  | {
+      type?: "custom_emoji";
+      custom_emoji_id?: string;
+    }
+  | {
+      type?: "paid";
+    };
+type TelegramReactionUpdate = {
+  chat: {
+    id: string | number;
+    type?: string;
+    title?: string;
+    username?: string;
+  };
+  message_id: string | number;
+  user?: {
+    id: string | number;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+  actor_chat?: {
+    id: string | number;
+    username?: string;
+    title?: string;
+  };
+  date: number;
+  old_reaction: TelegramReactionType[];
+  new_reaction: TelegramReactionType[];
+};
 
 function resolveTelegramBotConstructor(
   mod: GrammYModule,
@@ -30,18 +78,206 @@ function resolveTelegramBotConstructor(
   return Bot as TelegramBotConstructor;
 }
 
+function resolveTelegramInputFileConstructor(
+  mod: GrammYModule,
+): TelegramInputFileConstructor {
+  const InputFile = mod.InputFile ?? mod.default?.InputFile;
+  if (!InputFile) {
+    throw new Error('Installed Telegram runtime did not export "InputFile".');
+  }
+  return InputFile as TelegramInputFileConstructor;
+}
+
+function buildTelegramReplyOptions(
+  msg: Pick<
+    OutboundChannelMessage,
+    "replyToMessageId" | "parseMode" | "text" | "title"
+  >,
+): Record<string, unknown> {
+  const options: Record<string, unknown> = {};
+  if (msg.replyToMessageId) {
+    options.reply_parameters = {
+      message_id: Number(msg.replyToMessageId),
+    };
+  }
+  if (msg.text.trim().length > 0) {
+    options.caption = msg.text;
+    if (msg.parseMode) {
+      options.parse_mode = msg.parseMode;
+    }
+  }
+  if (msg.title?.trim()) {
+    options.title = msg.title.trim();
+  }
+  return options;
+}
+
+function getTelegramReactionToken(
+  reaction: TelegramReactionType,
+): string | null {
+  switch (reaction.type) {
+    case "emoji":
+      return reaction.emoji?.trim() || null;
+    case "custom_emoji":
+      return reaction.custom_emoji_id?.trim()
+        ? `custom_emoji:${reaction.custom_emoji_id.trim()}`
+        : null;
+    case "paid":
+      return "paid";
+    default:
+      return null;
+  }
+}
+
+function parseTelegramReactionInput(reaction: string): ReactionType | null {
+  const trimmed = reaction.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const customEmojiPrefix = "custom_emoji:";
+  if (trimmed.startsWith(customEmojiPrefix)) {
+    const customEmojiId = trimmed.slice(customEmojiPrefix.length).trim();
+    if (!customEmojiId) {
+      return null;
+    }
+    return {
+      type: "custom_emoji",
+      custom_emoji_id: customEmojiId,
+    };
+  }
+
+  return {
+    type: "emoji",
+    emoji: trimmed as ReactionTypeEmoji["emoji"],
+  };
+}
+
+function getTelegramReactionSenderName(
+  update: TelegramReactionUpdate,
+): string | undefined {
+  if (update.user) {
+    return getTelegramSenderName({
+      from: update.user,
+    } as TelegramLikeMessage);
+  }
+
+  if (update.actor_chat?.username?.trim()) {
+    return update.actor_chat.username.trim();
+  }
+
+  if (update.actor_chat?.title?.trim()) {
+    return update.actor_chat.title.trim();
+  }
+
+  return undefined;
+}
+
+function getTelegramReactionSenderId(
+  update: TelegramReactionUpdate,
+): string | null {
+  if (update.user?.id !== undefined) {
+    return String(update.user.id);
+  }
+  if (update.actor_chat?.id !== undefined) {
+    return String(update.actor_chat.id);
+  }
+  return null;
+}
+
+function getTelegramChatType(chat: { type?: string }): "direct" | "channel" {
+  return chat.type === "private" ? "direct" : "channel";
+}
+
 export function createTelegramAdapter(
   config: TelegramChannelAccount,
 ): ChannelAdapter {
   let bot: TelegramBot | null = null;
+  let botModule: GrammYModule | null = null;
   let running = false;
+  const bufferedMediaGroups = new Map<string, BufferedMediaGroup>();
+
+  async function ensureModule(): Promise<GrammYModule> {
+    if (!botModule) {
+      botModule = await loadGrammyModule();
+    }
+    return botModule;
+  }
+
+  async function emitInboundMessages(
+    telegramBot: TelegramBot,
+    messages: TelegramLikeMessage[],
+  ): Promise<void> {
+    if (!adapter.onMessage) {
+      return;
+    }
+
+    const primaryMessage =
+      messages.find((message) => extractTelegramMessageText(message).trim()) ??
+      messages[0];
+    if (!primaryMessage?.from) {
+      return;
+    }
+
+    const text = extractTelegramMessageText(primaryMessage);
+    const attachments = await resolveTelegramInboundAttachments({
+      accountId: config.accountId,
+      token: config.token,
+      bot: telegramBot,
+      messages,
+    });
+
+    if (text.length === 0 && attachments.length === 0) {
+      return;
+    }
+
+    const inbound: InboundChannelMessage = {
+      channel: "telegram",
+      accountId: config.accountId,
+      chatId: String(primaryMessage.chat.id),
+      senderId: String(primaryMessage.from.id),
+      senderName: getTelegramSenderName(primaryMessage),
+      text,
+      timestamp: primaryMessage.date * 1000,
+      messageId: String(primaryMessage.message_id),
+      chatType: "direct",
+      attachments: attachments.length > 0 ? attachments : undefined,
+      raw: messages.length === 1 ? primaryMessage : messages,
+    };
+
+    try {
+      await adapter.onMessage(inbound);
+    } catch (error) {
+      console.error("[Telegram] Error handling inbound message:", error);
+    }
+  }
+
+  function scheduleBufferedMediaGroupFlush(
+    telegramBot: TelegramBot,
+    mediaGroupId: string,
+  ): void {
+    const entry = bufferedMediaGroups.get(mediaGroupId);
+    if (!entry) {
+      return;
+    }
+
+    clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => {
+      const buffered = bufferedMediaGroups.get(mediaGroupId);
+      if (!buffered) {
+        return;
+      }
+      bufferedMediaGroups.delete(mediaGroupId);
+      void emitInboundMessages(telegramBot, buffered.messages);
+    }, TELEGRAM_MEDIA_GROUP_FLUSH_MS);
+  }
 
   async function ensureBot(): Promise<TelegramBot> {
     if (bot) {
       return bot;
     }
 
-    const grammy = await loadGrammyModule();
+    const grammy = await ensureModule();
     const Bot = resolveTelegramBotConstructor(grammy);
     const instance = new Bot(config.token);
 
@@ -54,34 +290,92 @@ export function createTelegramAdapter(
       console.error(prefix, error.error);
     });
 
-    instance.on("message:text", async (ctx) => {
-      const msg = ctx.message;
-      if (!msg.text || !msg.from) {
+    instance.on("message", async (ctx) => {
+      const msg = ctx.message as TelegramLikeMessage | undefined;
+      if (!msg?.from) {
         return;
       }
 
-      const displayName =
-        msg.from.username ??
-        [msg.from.first_name, msg.from.last_name].filter(Boolean).join(" ");
+      const mediaGroupId =
+        typeof msg.media_group_id === "string" ? msg.media_group_id : null;
+      if (mediaGroupId) {
+        const existing = bufferedMediaGroups.get(mediaGroupId);
+        if (existing) {
+          existing.messages.push(msg);
+        } else {
+          bufferedMediaGroups.set(mediaGroupId, {
+            messages: [msg],
+            timer: setTimeout(() => undefined, TELEGRAM_MEDIA_GROUP_FLUSH_MS),
+          });
+        }
+        scheduleBufferedMediaGroupFlush(instance, mediaGroupId);
+        return;
+      }
 
-      const inbound: InboundChannelMessage = {
-        channel: "telegram",
-        accountId: config.accountId,
-        chatId: String(msg.chat.id),
-        senderId: String(msg.from.id),
-        senderName: displayName || undefined,
-        text: msg.text,
-        timestamp: msg.date * 1000,
-        messageId: String(msg.message_id),
-        chatType: "direct",
-        raw: msg,
-      };
+      await emitInboundMessages(instance, [msg]);
+    });
 
-      if (adapter.onMessage) {
+    instance.on("message_reaction", async (ctx) => {
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      const update = ctx.messageReaction as TelegramReactionUpdate | undefined;
+      if (!update) {
+        return;
+      }
+
+      const senderId = getTelegramReactionSenderId(update);
+      if (!senderId) {
+        return;
+      }
+
+      const oldTokens = new Set(
+        update.old_reaction
+          .map((reaction) => getTelegramReactionToken(reaction))
+          .filter((value): value is string => typeof value === "string"),
+      );
+      const newTokens = new Set(
+        update.new_reaction
+          .map((reaction) => getTelegramReactionToken(reaction))
+          .filter((value): value is string => typeof value === "string"),
+      );
+
+      const events: Array<{ action: "added" | "removed"; emoji: string }> = [];
+
+      for (const emoji of oldTokens) {
+        if (!newTokens.has(emoji)) {
+          events.push({ action: "removed", emoji });
+        }
+      }
+
+      for (const emoji of newTokens) {
+        if (!oldTokens.has(emoji)) {
+          events.push({ action: "added", emoji });
+        }
+      }
+
+      for (const event of events) {
         try {
-          await adapter.onMessage(inbound);
-        } catch (err) {
-          console.error("[Telegram] Error handling inbound message:", err);
+          await adapter.onMessage({
+            channel: "telegram",
+            accountId: config.accountId,
+            chatId: String(update.chat.id),
+            senderId,
+            senderName: getTelegramReactionSenderName(update),
+            text: `Telegram reaction ${event.action}: ${event.emoji}`,
+            timestamp: update.date * 1000,
+            messageId: String(update.message_id),
+            chatType: getTelegramChatType(update.chat),
+            reaction: {
+              action: event.action,
+              emoji: event.emoji,
+              targetMessageId: String(update.message_id),
+            },
+            raw: update,
+          });
+        } catch (error) {
+          console.error("[Telegram] Error handling reaction update:", error);
         }
       }
     });
@@ -128,6 +422,7 @@ export function createTelegramAdapter(
 
         void telegramBot
           .start({
+            allowed_updates: ["message", "message_reaction"],
             onStart: () => {
               running = true;
               started = true;
@@ -151,6 +446,11 @@ export function createTelegramAdapter(
     },
 
     async stop(): Promise<void> {
+      for (const entry of bufferedMediaGroups.values()) {
+        clearTimeout(entry.timer);
+      }
+      bufferedMediaGroups.clear();
+
       if (!running || !bot) return;
       await bot.stop();
       running = false;
@@ -165,6 +465,90 @@ export function createTelegramAdapter(
       msg: OutboundChannelMessage,
     ): Promise<{ messageId: string }> {
       const telegramBot = await ensureBot();
+
+      if (msg.reaction || msg.removeReaction) {
+        const targetMessageId = msg.targetMessageId ?? msg.replyToMessageId;
+        if (!targetMessageId) {
+          throw new Error(
+            "Telegram reactions require message_id (or reply_to_message_id) to identify the target message.",
+          );
+        }
+
+        if (!msg.removeReaction) {
+          const reaction = parseTelegramReactionInput(msg.reaction ?? "");
+          if (!reaction) {
+            throw new Error("Telegram reaction emoji cannot be empty.");
+          }
+
+          await telegramBot.api.setMessageReaction(
+            msg.chatId,
+            Number(targetMessageId),
+            [reaction],
+          );
+        } else {
+          await telegramBot.api.setMessageReaction(
+            msg.chatId,
+            Number(targetMessageId),
+            [],
+          );
+        }
+
+        return { messageId: targetMessageId };
+      }
+
+      if (msg.mediaPath) {
+        const grammy = await ensureModule();
+        const InputFile = resolveTelegramInputFileConstructor(grammy);
+        const mediaPath = msg.mediaPath;
+        const fileName = msg.fileName;
+        const inputFile = new InputFile(mediaPath, fileName);
+        const options = buildTelegramReplyOptions(msg);
+        const uploadMethod = detectTelegramUploadMethod(mediaPath, fileName);
+
+        const result = await (async () => {
+          switch (uploadMethod) {
+            case "photo":
+              return await telegramBot.api.sendPhoto(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+            case "video":
+              return await telegramBot.api.sendVideo(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+            case "audio":
+              return await telegramBot.api.sendAudio(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+            case "voice":
+              return await telegramBot.api.sendVoice(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+            case "animation":
+              return await telegramBot.api.sendAnimation(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+            default:
+              return await telegramBot.api.sendDocument(
+                msg.chatId,
+                inputFile,
+                options,
+              );
+          }
+        })();
+
+        return { messageId: String(result.message_id) };
+      }
+
       const opts: Record<string, unknown> = {};
       if (msg.replyToMessageId) {
         opts.reply_parameters = {

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -1,0 +1,608 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { getChannelDir } from "../config";
+import type { ChannelMessageAttachment } from "../types";
+
+export const TELEGRAM_MEDIA_GROUP_FLUSH_MS = 150;
+export const TELEGRAM_DOWNLOAD_TIMEOUT_MS = 15_000;
+export const MAX_TELEGRAM_DOWNLOAD_BYTES = 50 * 1024 * 1024;
+export const MAX_TELEGRAM_INLINE_IMAGE_BYTES = 5 * 1024 * 1024;
+
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
+const ANIMATION_EXTENSIONS = new Set([".gif"]);
+const VIDEO_EXTENSIONS = new Set([".mp4", ".m4v", ".mov", ".webm"]);
+const AUDIO_EXTENSIONS = new Set([".mp3", ".m4a"]);
+const VOICE_EXTENSIONS = new Set([".ogg", ".oga", ".opus"]);
+const STATIC_STICKER_EXTENSIONS = new Set([".webp"]);
+
+export type TelegramLikeMessage = {
+  media_group_id?: string;
+  message_id: number | string;
+  date: number;
+  text?: string;
+  caption?: string;
+  chat: { id: number | string };
+  from?: {
+    id: number | string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+  photo?: Array<{
+    file_id: string;
+    file_unique_id?: string;
+    file_size?: number;
+  }>;
+  document?: {
+    file_id: string;
+    file_name?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  video?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  audio?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  voice?: {
+    file_id: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  animation?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+  sticker?: {
+    file_id: string;
+    file_unique_id?: string;
+    mime_type?: string;
+    file_size?: number;
+    is_animated?: boolean;
+    is_video?: boolean;
+  };
+};
+
+export type TelegramAttachmentCandidate = {
+  fileId: string;
+  kind: ChannelMessageAttachment["kind"];
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+};
+
+export type TelegramUploadMethod =
+  | "photo"
+  | "document"
+  | "video"
+  | "audio"
+  | "voice"
+  | "animation";
+
+type TelegramFileLookup = {
+  api: {
+    getFile(fileId: string): Promise<{ file_path?: string }>;
+  };
+};
+
+export function normalizeTelegramMimeType(
+  mimeType?: string,
+): string | undefined {
+  const normalized = mimeType?.split(";")[0]?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+export function sanitizeTelegramPathSegment(input: string): string {
+  const cleaned = input
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "attachment";
+}
+
+function coerceSizeBytes(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function isImageMimeType(mimeType?: string): boolean {
+  return normalizeTelegramMimeType(mimeType)?.startsWith("image/") ?? false;
+}
+
+function isAudioMimeType(mimeType?: string): boolean {
+  return normalizeTelegramMimeType(mimeType)?.startsWith("audio/") ?? false;
+}
+
+function isVideoMimeType(mimeType?: string): boolean {
+  return normalizeTelegramMimeType(mimeType)?.startsWith("video/") ?? false;
+}
+
+function inferAttachmentKind(params: {
+  mimeType?: string;
+  fileName?: string;
+  fallback: ChannelMessageAttachment["kind"];
+}): ChannelMessageAttachment["kind"] {
+  if (isImageMimeType(params.mimeType)) {
+    return "image";
+  }
+  if (isAudioMimeType(params.mimeType)) {
+    return "audio";
+  }
+  if (isVideoMimeType(params.mimeType)) {
+    return "video";
+  }
+
+  const lowerName = params.fileName?.toLowerCase();
+  if (lowerName) {
+    const extension = extname(lowerName);
+    if (
+      IMAGE_EXTENSIONS.has(extension) ||
+      STATIC_STICKER_EXTENSIONS.has(extension)
+    ) {
+      return "image";
+    }
+    if (AUDIO_EXTENSIONS.has(extension) || VOICE_EXTENSIONS.has(extension)) {
+      return "audio";
+    }
+    if (
+      VIDEO_EXTENSIONS.has(extension) ||
+      ANIMATION_EXTENSIONS.has(extension)
+    ) {
+      return "video";
+    }
+  }
+
+  return params.fallback;
+}
+
+export function extractTelegramMessageText(
+  message: TelegramLikeMessage,
+): string {
+  if (typeof message.text === "string") {
+    return message.text;
+  }
+  if (typeof message.caption === "string") {
+    return message.caption;
+  }
+  return "";
+}
+
+export function getTelegramSenderName(
+  message: TelegramLikeMessage,
+): string | undefined {
+  if (!message.from) {
+    return undefined;
+  }
+
+  return (
+    message.from.username ??
+    ([message.from.first_name, message.from.last_name]
+      .filter(Boolean)
+      .join(" ") ||
+      undefined)
+  );
+}
+
+export function collectTelegramAttachmentCandidates(
+  message: TelegramLikeMessage,
+): TelegramAttachmentCandidate[] {
+  const attachments: TelegramAttachmentCandidate[] = [];
+
+  if (Array.isArray(message.photo) && message.photo.length > 0) {
+    const photo = message.photo[message.photo.length - 1];
+    if (photo?.file_id) {
+      attachments.push({
+        fileId: photo.file_id,
+        kind: "image",
+        name: `photo-${photo.file_unique_id ?? photo.file_id}.jpg`,
+        mimeType: "image/jpeg",
+        sizeBytes: coerceSizeBytes(photo.file_size),
+      });
+    }
+  }
+
+  if (message.document?.file_id) {
+    attachments.push({
+      fileId: message.document.file_id,
+      kind: inferAttachmentKind({
+        mimeType: message.document.mime_type,
+        fileName: message.document.file_name,
+        fallback: "file",
+      }),
+      name: message.document.file_name,
+      mimeType: message.document.mime_type,
+      sizeBytes: coerceSizeBytes(message.document.file_size),
+    });
+  }
+
+  if (message.video?.file_id) {
+    attachments.push({
+      fileId: message.video.file_id,
+      kind: "video",
+      name:
+        message.video.file_name ??
+        `video-${message.video.file_unique_id ?? message.video.file_id}.mp4`,
+      mimeType: message.video.mime_type,
+      sizeBytes: coerceSizeBytes(message.video.file_size),
+    });
+  }
+
+  if (message.audio?.file_id) {
+    attachments.push({
+      fileId: message.audio.file_id,
+      kind: "audio",
+      name:
+        message.audio.file_name ??
+        `audio-${message.audio.file_unique_id ?? message.audio.file_id}.mp3`,
+      mimeType: message.audio.mime_type,
+      sizeBytes: coerceSizeBytes(message.audio.file_size),
+    });
+  }
+
+  if (message.voice?.file_id) {
+    attachments.push({
+      fileId: message.voice.file_id,
+      kind: "audio",
+      name: `voice-${message.voice.file_unique_id ?? message.voice.file_id}.ogg`,
+      mimeType: message.voice.mime_type,
+      sizeBytes: coerceSizeBytes(message.voice.file_size),
+    });
+  }
+
+  if (message.animation?.file_id) {
+    attachments.push({
+      fileId: message.animation.file_id,
+      kind: "video",
+      name:
+        message.animation.file_name ??
+        `animation-${message.animation.file_unique_id ?? message.animation.file_id}.gif`,
+      mimeType: message.animation.mime_type,
+      sizeBytes: coerceSizeBytes(message.animation.file_size),
+    });
+  }
+
+  if (
+    message.sticker?.file_id &&
+    !message.sticker.is_animated &&
+    !message.sticker.is_video
+  ) {
+    attachments.push({
+      fileId: message.sticker.file_id,
+      kind: "image",
+      name: `sticker-${message.sticker.file_unique_id ?? message.sticker.file_id}.webp`,
+      mimeType: message.sticker.mime_type ?? "image/webp",
+      sizeBytes: coerceSizeBytes(message.sticker.file_size),
+    });
+  }
+
+  return attachments;
+}
+
+function inferUploadMethodFromMimeType(
+  mimeType?: string,
+): TelegramUploadMethod | null {
+  const normalized = normalizeTelegramMimeType(mimeType);
+  if (!normalized) {
+    return null;
+  }
+
+  if (["image/png", "image/jpeg"].includes(normalized)) {
+    return "photo";
+  }
+  if (normalized === "image/gif") {
+    return "animation";
+  }
+  if (normalized === "image/webp") {
+    return "document";
+  }
+  if (normalized.startsWith("video/")) {
+    return "video";
+  }
+  if (["audio/ogg", "audio/opus"].includes(normalized)) {
+    return "voice";
+  }
+  if (normalized.startsWith("audio/")) {
+    return "audio";
+  }
+
+  return null;
+}
+
+export function detectTelegramUploadMethod(
+  filePath: string,
+  fileName?: string,
+): TelegramUploadMethod {
+  const inferredName = (fileName ?? basename(filePath)).toLowerCase();
+  const extension = extname(inferredName);
+  const mimeType = inferMimeTypeFromName(inferredName);
+
+  const byMimeType = inferUploadMethodFromMimeType(mimeType);
+  if (byMimeType) {
+    return byMimeType;
+  }
+
+  if (ANIMATION_EXTENSIONS.has(extension)) {
+    return "animation";
+  }
+  if (VIDEO_EXTENSIONS.has(extension)) {
+    return "video";
+  }
+  if (VOICE_EXTENSIONS.has(extension)) {
+    return "voice";
+  }
+  if (AUDIO_EXTENSIONS.has(extension)) {
+    return "audio";
+  }
+
+  return "document";
+}
+
+export function inferMimeTypeFromName(name: string): string | undefined {
+  const normalized = name.toLowerCase();
+  const extension = extname(normalized);
+
+  if (IMAGE_EXTENSIONS.has(extension)) {
+    return extension === ".png" ? "image/png" : "image/jpeg";
+  }
+  if (ANIMATION_EXTENSIONS.has(extension)) {
+    return "image/gif";
+  }
+  if (STATIC_STICKER_EXTENSIONS.has(extension)) {
+    return "image/webp";
+  }
+  if (extension === ".mp4" || extension === ".m4v") {
+    return "video/mp4";
+  }
+  if (extension === ".mov") {
+    return "video/quicktime";
+  }
+  if (extension === ".webm") {
+    return "video/webm";
+  }
+  if (extension === ".mp3") {
+    return "audio/mpeg";
+  }
+  if (extension === ".m4a") {
+    return "audio/mp4";
+  }
+  if (VOICE_EXTENSIONS.has(extension)) {
+    return "audio/ogg";
+  }
+  if (extension === ".pdf") {
+    return "application/pdf";
+  }
+  if (extension === ".txt") {
+    return "text/plain";
+  }
+  if (extension === ".md") {
+    return "text/markdown";
+  }
+  if (extension === ".json") {
+    return "application/json";
+  }
+
+  return undefined;
+}
+
+function extensionForMimeType(mimeType?: string): string {
+  switch (normalizeTelegramMimeType(mimeType)) {
+    case "image/png":
+      return ".png";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "video/mp4":
+      return ".mp4";
+    case "video/quicktime":
+      return ".mov";
+    case "video/webm":
+      return ".webm";
+    case "audio/mpeg":
+      return ".mp3";
+    case "audio/mp4":
+      return ".m4a";
+    case "audio/ogg":
+    case "audio/opus":
+      return ".ogg";
+    case "application/pdf":
+      return ".pdf";
+    case "text/plain":
+      return ".txt";
+    case "text/markdown":
+      return ".md";
+    case "application/json":
+      return ".json";
+    default:
+      return "";
+  }
+}
+
+function buildTelegramFileUrl(token: string, filePath: string): string {
+  return `https://api.telegram.org/file/bot${token}/${filePath}`;
+}
+
+function inferAttachmentFileName(params: {
+  candidate: TelegramAttachmentCandidate;
+  remotePath: string;
+  responseMimeType?: string;
+}): string {
+  const hintedName =
+    params.candidate.name?.trim() ||
+    basename(params.remotePath) ||
+    "attachment";
+  if (extname(hintedName)) {
+    return hintedName;
+  }
+
+  const extension =
+    extensionForMimeType(params.responseMimeType) ||
+    extensionForMimeType(params.candidate.mimeType);
+  return extension ? `${hintedName}${extension}` : hintedName;
+}
+
+async function saveTelegramAttachment(params: {
+  accountId: string;
+  fileName: string;
+  buffer: Buffer;
+}): Promise<string> {
+  const inboundDir = join(
+    getChannelDir("telegram"),
+    "inbound",
+    sanitizeTelegramPathSegment(params.accountId),
+  );
+  await mkdir(inboundDir, { recursive: true });
+
+  const filePath = join(
+    inboundDir,
+    `${Date.now()}-${randomUUID()}-${sanitizeTelegramPathSegment(params.fileName)}`,
+  );
+  await writeFile(filePath, params.buffer);
+  return filePath;
+}
+
+async function fetchTelegramFile(
+  url: string,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function downloadTelegramAttachment(params: {
+  accountId: string;
+  token: string;
+  bot: TelegramFileLookup;
+  candidate: TelegramAttachmentCandidate;
+}): Promise<ChannelMessageAttachment | null> {
+  const { candidate } = params;
+
+  if (
+    typeof candidate.sizeBytes === "number" &&
+    candidate.sizeBytes > MAX_TELEGRAM_DOWNLOAD_BYTES
+  ) {
+    return null;
+  }
+
+  const file = await params.bot.api.getFile(candidate.fileId);
+  const remotePath = file.file_path;
+  if (!remotePath) {
+    return null;
+  }
+
+  const response = await fetchTelegramFile(
+    buildTelegramFileUrl(params.token, remotePath),
+    TELEGRAM_DOWNLOAD_TIMEOUT_MS,
+  );
+  if (!response.ok) {
+    return null;
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (
+      Number.isFinite(parsedLength) &&
+      parsedLength > MAX_TELEGRAM_DOWNLOAD_BYTES
+    ) {
+      return null;
+    }
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.byteLength > MAX_TELEGRAM_DOWNLOAD_BYTES) {
+    return null;
+  }
+
+  const responseMimeType = normalizeTelegramMimeType(
+    response.headers.get("content-type") ?? undefined,
+  );
+  const fileName = inferAttachmentFileName({
+    candidate,
+    remotePath,
+    responseMimeType,
+  });
+  const mimeType =
+    responseMimeType ??
+    normalizeTelegramMimeType(candidate.mimeType) ??
+    inferMimeTypeFromName(fileName);
+  const kind = inferAttachmentKind({
+    mimeType,
+    fileName,
+    fallback: candidate.kind,
+  });
+  const localPath = await saveTelegramAttachment({
+    accountId: params.accountId,
+    fileName,
+    buffer,
+  });
+
+  return {
+    id: candidate.fileId,
+    name: fileName,
+    mimeType,
+    sizeBytes: buffer.byteLength,
+    kind,
+    localPath,
+    ...(kind === "image" && buffer.byteLength <= MAX_TELEGRAM_INLINE_IMAGE_BYTES
+      ? { imageDataBase64: buffer.toString("base64") }
+      : {}),
+  };
+}
+
+export async function resolveTelegramInboundAttachments(params: {
+  accountId: string;
+  token: string;
+  bot: TelegramFileLookup;
+  messages: TelegramLikeMessage[];
+}): Promise<ChannelMessageAttachment[]> {
+  const deduped = new Map<string, TelegramAttachmentCandidate>();
+
+  for (const message of params.messages) {
+    for (const candidate of collectTelegramAttachmentCandidates(message)) {
+      deduped.set(candidate.fileId, candidate);
+    }
+  }
+
+  if (deduped.size === 0) {
+    return [];
+  }
+
+  const resolved = await Promise.all(
+    Array.from(deduped.values()).map((candidate) =>
+      downloadTelegramAttachment({
+        accountId: params.accountId,
+        token: params.token,
+        bot: params.bot,
+        candidate,
+      }).catch(() => null),
+    ),
+  );
+
+  return resolved.filter((attachment): attachment is ChannelMessageAttachment =>
+    Boolean(attachment),
+  );
+}

--- a/src/channels/telegram/messageActions.ts
+++ b/src/channels/telegram/messageActions.ts
@@ -3,30 +3,68 @@ import type { ChannelMessageActionAdapter } from "../pluginTypes";
 export const telegramMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool() {
     return {
-      actions: ["send"],
+      actions: ["send", "react", "upload-file"],
     };
   },
 
   async handleAction(ctx) {
     const { request, route, adapter, formatText } = ctx;
 
-    if (request.action !== "send") {
+    if (
+      request.action !== "send" &&
+      request.action !== "react" &&
+      request.action !== "upload-file"
+    ) {
       return `Error: Action "${request.action}" is not supported on telegram.`;
     }
-    if (!request.message?.trim()) {
+    if (request.action === "react") {
+      if (!request.emoji?.trim() && !request.remove) {
+        return "Error: Telegram react requires emoji.";
+      }
+      if (!request.messageId?.trim()) {
+        return "Error: Telegram react requires messageId.";
+      }
+
+      const result = await adapter.sendMessage({
+        channel: "telegram",
+        accountId: route.accountId,
+        chatId: request.chatId,
+        text: "",
+        targetMessageId: request.messageId,
+        reaction: request.emoji,
+        removeReaction: request.remove,
+      });
+
+      return request.remove
+        ? `Reaction removed on telegram (message_id: ${result.messageId})`
+        : `Reaction added on telegram (message_id: ${result.messageId})`;
+    }
+
+    if (!request.message?.trim() && !request.mediaPath?.trim()) {
+      return "Error: Telegram send requires message or media.";
+    }
+    if (request.action === "upload-file" && !request.mediaPath?.trim()) {
+      return "Error: Telegram upload-file requires media.";
+    }
+    if (request.action === "send" && !request.message?.trim()) {
       return "Error: Telegram send requires message.";
     }
 
-    const formatted = formatText(request.message);
+    const formatted = formatText(request.message ?? "");
     const result = await adapter.sendMessage({
       channel: "telegram",
       accountId: route.accountId,
       chatId: request.chatId,
       text: formatted.text,
       replyToMessageId: request.replyToMessageId,
+      mediaPath: request.mediaPath,
+      fileName: request.filename,
+      title: request.title,
       parseMode: formatted.parseMode,
     });
 
-    return `Message sent to telegram (message_id: ${result.messageId})`;
+    return request.mediaPath
+      ? `Attachment sent to telegram (message_id: ${result.messageId})`
+      : `Message sent to telegram (message_id: ${result.messageId})`;
   },
 };

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -16,7 +16,7 @@ export interface ChannelMessageAttachment {
   name?: string;
   mimeType?: string;
   sizeBytes?: number;
-  kind: "image" | "file";
+  kind: "image" | "file" | "audio" | "video";
   localPath: string;
   imageDataBase64?: string;
 }
@@ -98,7 +98,7 @@ export interface InboundChannelMessage {
   isMention?: boolean;
   /** Downloaded attachments/media associated with the inbound message. */
   attachments?: ChannelMessageAttachment[];
-  /** Reaction metadata for non-text channel events (currently Slack). */
+  /** Reaction metadata for non-text channel events. */
   reaction?: ChannelReactionNotification;
 }
 
@@ -117,15 +117,15 @@ export interface OutboundChannelMessage {
   threadId?: string | null;
   /** Optional: parse mode hint for the adapter (e.g. "HTML", "MarkdownV2"). */
   parseMode?: string;
-  /** Optional: attach a local file/media path (currently Slack only). */
+  /** Optional: attach a local file/media path for channels that support uploads. */
   mediaPath?: string;
   /** Optional: override the uploaded filename for media attachments. */
   fileName?: string;
   /** Optional: override the uploaded title/caption metadata for media attachments. */
   title?: string;
-  /** Optional: Slack reaction emoji to add/remove (e.g. "white_check_mark"). */
+  /** Optional: reaction emoji to add/remove. Slack uses names; Telegram uses native emoji or custom_emoji:<id>. */
   reaction?: string;
-  /** Optional: remove the Slack reaction instead of adding it. */
+  /** Optional: remove the channel reaction instead of adding it. */
   removeReaction?: boolean;
   /** Optional: target message id for reactions. */
   targetMessageId?: string;

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -11,25 +11,30 @@ import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
 import type { ChannelMessageAttachment, InboundChannelMessage } from "./types";
 
 /**
- * Escape special XML characters in text content.
- * Reference: src/cli/helpers/taskNotifications.ts uses similar escaping.
+ * Escape XML text-node content without over-escaping quotes that should remain
+ * readable inside the rendered message body.
  */
-function escapeXml(text: string): string {
+function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape XML attribute values, including quotes.
+ */
+function escapeXmlAttribute(text: string): string {
+  return escapeXmlText(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
 
 /**
  * Format the reminder text that explains channel reply semantics to the agent.
  */
 export function buildChannelReminderText(msg: InboundChannelMessage): string {
-  const localTime = escapeXml(getLocalTime());
-  const escapedChannel = escapeXml(msg.channel);
-  const escapedChatId = escapeXml(msg.chatId);
+  const localTime = escapeXmlText(getLocalTime());
+  const escapedChannel = escapeXmlText(msg.channel);
+  const escapedChatId = escapeXmlText(msg.chatId);
   const threadLine =
     msg.channel === "slack" &&
     msg.chatType === "channel" &&
@@ -57,6 +62,13 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
       'On Slack, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
     );
   }
+  if (msg.channel === "telegram") {
+    lines.splice(
+      lines.length - 2,
+      0,
+      'On Telegram, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
+    );
+  }
   if (msg.attachments?.length) {
     lines.splice(
       lines.length - 2,
@@ -70,18 +82,18 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
 
 function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
   const attrs = [
-    `kind="${escapeXml(attachment.kind)}"`,
-    `local_path="${escapeXml(attachment.localPath)}"`,
+    `kind="${escapeXmlAttribute(attachment.kind)}"`,
+    `local_path="${escapeXmlAttribute(attachment.localPath)}"`,
   ];
 
   if (attachment.id) {
-    attrs.push(`attachment_id="${escapeXml(attachment.id)}"`);
+    attrs.push(`attachment_id="${escapeXmlAttribute(attachment.id)}"`);
   }
   if (attachment.name) {
-    attrs.push(`name="${escapeXml(attachment.name)}"`);
+    attrs.push(`name="${escapeXmlAttribute(attachment.name)}"`);
   }
   if (attachment.mimeType) {
-    attrs.push(`mime_type="${escapeXml(attachment.mimeType)}"`);
+    attrs.push(`mime_type="${escapeXmlAttribute(attachment.mimeType)}"`);
   }
   if (typeof attachment.sizeBytes === "number") {
     attrs.push(`size_bytes="${attachment.sizeBytes}"`);
@@ -96,13 +108,15 @@ function buildReactionXml(msg: InboundChannelMessage): string | null {
   }
 
   const attrs = [
-    `action="${escapeXml(msg.reaction.action)}"`,
-    `emoji="${escapeXml(msg.reaction.emoji)}"`,
-    `target_message_id="${escapeXml(msg.reaction.targetMessageId)}"`,
+    `action="${escapeXmlAttribute(msg.reaction.action)}"`,
+    `emoji="${escapeXmlAttribute(msg.reaction.emoji)}"`,
+    `target_message_id="${escapeXmlAttribute(msg.reaction.targetMessageId)}"`,
   ];
 
   if (msg.reaction.targetSenderId) {
-    attrs.push(`target_sender_id="${escapeXml(msg.reaction.targetSenderId)}"`);
+    attrs.push(
+      `target_sender_id="${escapeXmlAttribute(msg.reaction.targetSenderId)}"`,
+    );
   }
 
   return `<reaction ${attrs.join(" ")} />`;
@@ -122,25 +136,25 @@ export function buildChannelNotificationXml(
   msg: InboundChannelMessage,
 ): string {
   const attrs: string[] = [
-    `source="${escapeXml(msg.channel)}"`,
-    `chat_id="${escapeXml(msg.chatId)}"`,
-    `sender_id="${escapeXml(msg.senderId)}"`,
+    `source="${escapeXmlAttribute(msg.channel)}"`,
+    `chat_id="${escapeXmlAttribute(msg.chatId)}"`,
+    `sender_id="${escapeXmlAttribute(msg.senderId)}"`,
   ];
 
   if (msg.senderName) {
-    attrs.push(`sender_name="${escapeXml(msg.senderName)}"`);
+    attrs.push(`sender_name="${escapeXmlAttribute(msg.senderName)}"`);
   }
 
   if (msg.messageId) {
-    attrs.push(`message_id="${escapeXml(msg.messageId)}"`);
+    attrs.push(`message_id="${escapeXmlAttribute(msg.messageId)}"`);
   }
 
   if (msg.threadId) {
-    attrs.push(`thread_id="${escapeXml(msg.threadId)}"`);
+    attrs.push(`thread_id="${escapeXmlAttribute(msg.threadId)}"`);
   }
 
   const attrString = attrs.join(" ");
-  const escapedText = msg.text ? escapeXml(msg.text) : "";
+  const escapedText = msg.text ? escapeXmlText(msg.text) : "";
   const reactionXml = buildReactionXml(msg);
   const attachmentXml = (msg.attachments ?? []).map(buildAttachmentXml);
   const body = [reactionXml, ...attachmentXml, escapedText]

--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -83,3 +83,15 @@ test("renders markdown links with balanced parentheses and escaped attributes", 
 test("does not treat spaced arithmetic operators as italic markup", () => {
   expect(markdownToTelegramHtml("2 * 3 * 4")).toBe("2 * 3 * 4");
 });
+
+test("decodes basic xml entities before channel formatting", () => {
+  expect(
+    formatOutboundChannelMessage(
+      "telegram",
+      "Fish &amp; chips &lt;3 &quot;yes&quot;",
+    ),
+  ).toEqual({
+    text: 'Fish &amp; chips &lt;3 "yes"',
+    parseMode: "HTML",
+  });
+});

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -292,7 +292,64 @@ describe("MessageChannel", () => {
     });
   });
 
-  test("rejects unsupported Telegram actions through the shared MessageChannel surface", async () => {
+  test("uploads Telegram media through the routed account adapter", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "telegram-media-1" }));
+
+    const adapter: ChannelAdapter = {
+      id: "telegram:account-1",
+      channelId: "telegram",
+      accountId: "account-1",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("telegram", {
+      accountId: "account-1",
+      chatId: "7952253975",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "upload-file",
+      channel: "telegram",
+      chat_id: "7952253975",
+      message: "see attached",
+      media: "/tmp/screenshot.png",
+      filename: "screenshot.png",
+      title: "Screenshot",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Attachment sent to telegram");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "account-1",
+      chatId: "7952253975",
+      text: "see attached",
+      replyToMessageId: undefined,
+      mediaPath: "/tmp/screenshot.png",
+      fileName: "screenshot.png",
+      title: "Screenshot",
+      parseMode: "HTML",
+    });
+  });
+
+  test("passes Telegram reactions through MessageChannel with the routed account", async () => {
     const registry = new ChannelRegistry();
 
     const sendMessage = mock(async () => ({ messageId: "telegram-msg-2" }));
@@ -325,7 +382,7 @@ describe("MessageChannel", () => {
       action: "react",
       channel: "telegram",
       chat_id: "7952253975",
-      emoji: "thumbsup",
+      emoji: "👍",
       messageId: "99",
       parentScope: {
         agentId: "agent-1",
@@ -333,8 +390,16 @@ describe("MessageChannel", () => {
       },
     });
 
-    expect(result).toBe('Error: Action "react" is not supported on telegram.');
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result).toContain("Reaction added on telegram");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "account-1",
+      chatId: "7952253975",
+      text: "",
+      targetMessageId: "99",
+      reaction: "👍",
+      removeReaction: undefined,
+    });
   });
 
   test("rejects legacy argument aliases so the tool contract stays canonical", async () => {

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -50,7 +50,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
   });
 
-  test("keeps Telegram-only tool actions narrowed to send", async () => {
+  test("keeps Telegram-only tool actions narrowed to Telegram-supported actions", async () => {
     const registry = new ChannelRegistry();
     registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
 
@@ -67,6 +67,6 @@ describe("buildDynamicMessageChannelSchema", () => {
 
     const properties = schema.properties as Record<string, { enum?: string[] }>;
     expect(properties.channel?.enum).toEqual(["telegram"]);
-    expect(properties.action?.enum).toEqual(["send"]);
+    expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
   });
 });

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -1,11 +1,31 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { InboundChannelMessage } from "../../channels/types";
 
 type FakeBotStartOptions = {
   onStart?: (botInfo: {
     username?: string;
     id: number;
   }) => void | Promise<void>;
+  allowed_updates?: string[];
 };
+
+type FakeHandler = (ctx: unknown) => unknown | Promise<unknown>;
+
+let channelRoot = join(tmpdir(), "letta-telegram-test-root");
+
+class FakeInputFile {
+  readonly file: string;
+  readonly filename?: string;
+
+  constructor(file: string, filename?: string) {
+    this.file = file;
+    this.filename = filename;
+  }
+}
 
 class FakeBot {
   static instances: FakeBot[] = [];
@@ -20,11 +40,24 @@ class FakeBot {
       },
     );
   };
+  static nextGetFileImpl: (fileId: string) => Promise<{ file_path?: string }> =
+    async (fileId) => ({
+      file_path: `photos/${fileId}.jpg`,
+    });
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
+  readonly handlers = new Map<string, FakeHandler[]>();
   readonly api = {
     sendMessage: mock(async () => ({ message_id: 999 })),
+    setMessageReaction: mock(async () => true),
+    sendPhoto: mock(async () => ({ message_id: 1001 })),
+    sendDocument: mock(async () => ({ message_id: 1002 })),
+    sendVideo: mock(async () => ({ message_id: 1003 })),
+    sendAudio: mock(async () => ({ message_id: 1004 })),
+    sendVoice: mock(async () => ({ message_id: 1005 })),
+    sendAnimation: mock(async () => ({ message_id: 1006 })),
+    getFile: mock(async (fileId: string) => FakeBot.nextGetFileImpl(fileId)),
   };
   catchHandler:
     | ((error: {
@@ -38,11 +71,14 @@ class FakeBot {
     FakeBot.instances.push(this);
   }
 
-  on(): this {
+  on(event: string, handler: FakeHandler): this {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler);
+    this.handlers.set(event, existing);
     return this;
   }
 
-  command(): this {
+  command(_command: string, _handler: FakeHandler): this {
     return this;
   }
 
@@ -62,11 +98,23 @@ class FakeBot {
   ): void {
     this.catchHandler = handler;
   }
+
+  async emit(event: string, ctx: unknown): Promise<void> {
+    const handlers = this.handlers.get(event) ?? [];
+    for (const handler of handlers) {
+      await handler(ctx);
+    }
+  }
 }
+
+mock.module("../../channels/config", () => ({
+  getChannelDir: (channelId: string) => join(channelRoot, channelId),
+}));
 
 mock.module("../../channels/telegram/runtime", () => ({
   loadGrammyModule: async () => ({
     Bot: FakeBot,
+    InputFile: FakeInputFile,
   }),
 }));
 
@@ -87,8 +135,10 @@ const telegramAccountDefaults = {
 
 const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
+const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
+  channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
   FakeBot.instances.length = 0;
   FakeBot.nextStartImpl = async (options, botInfo) => {
     await options?.onStart?.(
@@ -98,12 +148,18 @@ beforeEach(() => {
       },
     );
   };
+  FakeBot.nextGetFileImpl = async (fileId) => ({
+    file_path: `photos/${fileId}.jpg`,
+  });
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
+  globalThis.fetch = originalFetch;
 });
 
 afterEach(() => {
   console.error = originalConsoleError;
+  globalThis.fetch = originalFetch;
+  rmSync(channelRoot, { recursive: true, force: true });
 });
 
 test("telegram adapter logs unhandled grammY errors with update context", async () => {
@@ -230,4 +286,242 @@ test("telegram adapter forwards parse mode and reply parameters", async () => {
     parse_mode: "HTML",
     reply_parameters: { message_id: 456 },
   });
+});
+
+test("telegram adapter uploads outbound media with a caption", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "123",
+    text: "<b>see image</b>",
+    parseMode: "HTML",
+    replyToMessageId: "456",
+    mediaPath: "/tmp/screenshot.png",
+    fileName: "screenshot.png",
+    title: "Screenshot",
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendPhoto).toHaveBeenCalledWith(
+    "123",
+    expect.any(FakeInputFile),
+    {
+      caption: "<b>see image</b>",
+      parse_mode: "HTML",
+      reply_parameters: { message_id: 456 },
+      title: "Screenshot",
+    },
+  );
+});
+
+test("telegram adapter can add reactions to messages", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "123",
+    text: "",
+    reaction: "👍",
+    targetMessageId: "456",
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.setMessageReaction).toHaveBeenCalledWith("123", 456, [
+    { type: "emoji", emoji: "👍" },
+  ]);
+});
+
+test("telegram adapter forwards plain text messages through onMessage", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  await bot?.emit("message", {
+    message: {
+      chat: { id: 123 },
+      from: { id: 456, username: "alice", first_name: "Alice" },
+      text: "Hello from Telegram",
+      date: 1_736_380_800,
+      message_id: 77,
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith({
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "123",
+    senderId: "456",
+    senderName: "alice",
+    text: "Hello from Telegram",
+    timestamp: 1_736_380_800_000,
+    messageId: "77",
+    chatType: "direct",
+    attachments: undefined,
+    raw: expect.objectContaining({ message_id: 77 }),
+  });
+});
+
+test("telegram adapter forwards reaction updates through onMessage", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  await bot?.emit("message_reaction", {
+    messageReaction: {
+      chat: { id: 123, type: "private" },
+      user: { id: 456, username: "alice", first_name: "Alice" },
+      date: 1_736_380_800,
+      message_id: 77,
+      old_reaction: [],
+      new_reaction: [{ type: "emoji", emoji: "👍" }],
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith({
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "123",
+    senderId: "456",
+    senderName: "alice",
+    text: "Telegram reaction added: 👍",
+    timestamp: 1_736_380_800_000,
+    messageId: "77",
+    chatType: "direct",
+    reaction: {
+      action: "added",
+      emoji: "👍",
+      targetMessageId: "77",
+    },
+    raw: expect.objectContaining({ message_id: 77 }),
+  });
+});
+
+test("telegram adapter batches media groups and downloads inbound images", async () => {
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const href = typeof url === "string" ? url : url.toString();
+    const fileName = href.endsWith("photo2.jpg") ? "second" : "first";
+    const content = Buffer.from(`image-${fileName}`);
+    return new Response(content, {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+  }) as unknown as typeof fetch;
+
+  FakeBot.nextGetFileImpl = async (fileId) => ({
+    file_path: fileId === "photo2" ? "photos/photo2.jpg" : "photos/photo1.jpg",
+  });
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  try {
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        caption: "Vacation photos",
+        date: 1_736_380_800,
+        message_id: 10,
+        media_group_id: "album-1",
+        photo: [
+          { file_id: "photo1", file_unique_id: "unique-1", file_size: 12 },
+        ],
+      },
+    });
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        date: 1_736_380_801,
+        message_id: 11,
+        media_group_id: "album-1",
+        photo: [
+          { file_id: "photo2", file_unique_id: "unique-2", file_size: 13 },
+        ],
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 220));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const firstCall = onMessage.mock.calls[0] as unknown as
+      | [InboundChannelMessage]
+      | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("Expected inbound Telegram album to emit a message");
+    }
+
+    const [inbound] = firstCall;
+
+    expect(inbound.text).toBe("Vacation photos");
+    expect(inbound.attachments).toHaveLength(2);
+    expect(
+      inbound.attachments?.every((attachment) => attachment.kind === "image"),
+    ).toBe(true);
+
+    const localPaths = inbound.attachments
+      ?.map((attachment) => attachment.localPath)
+      .filter((value): value is string => typeof value === "string");
+    expect(localPaths).toHaveLength(2);
+
+    for (const localPath of localPaths ?? []) {
+      expect(existsSync(localPath)).toBe(true);
+      expect(readFileSync(localPath, "utf-8").startsWith("image-")).toBe(true);
+    }
+  } finally {
+    rmSync(channelRoot, { recursive: true, force: true });
+    channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
+  }
 });

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -64,6 +64,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain(
       'Use action="send", channel="telegram", and chat_id="12345"',
     );
+    expect(reminder).toContain('action="react"');
     expect(reminder).toContain("Current local time on this device:");
   });
 
@@ -85,7 +86,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).not.toContain("reply_to_message_id");
   });
 
-  test("escapes XML special characters in notification text", () => {
+  test("escapes XML special characters in notification text without over-escaping quotes", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "123",
@@ -98,8 +99,8 @@ describe("formatChannelNotification", () => {
 
     expect(xml).toContain("&lt;world&gt;");
     expect(xml).toContain("&amp;");
-    expect(xml).toContain("&quot;friends&quot;");
-    expect(xml).toContain("&apos;here&apos;");
+    expect(xml).toContain('"friends"');
+    expect(xml).toContain("'here'");
   });
 
   test("escapes XML special characters in notification attributes", () => {

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -16,7 +16,7 @@ Parameters:
 - `message`: The text to send for `action="send"`
 - `replyTo`: (Optional) Reply to a specific message ID. Omit this unless you intentionally want the platform's quote/reply UI.
 - `messageId`: (Optional) Target message id for actions like `react`
-- `emoji`: (Optional) Emoji reaction name for `action="react"`, e.g. `white_check_mark`
+- `emoji`: (Optional) Emoji reaction for `action="react"`; Slack uses names like `white_check_mark`, Telegram uses native emoji like `👍`
 - `remove`: (Optional) Set to `true` to remove the reaction instead of adding it
 - `media`: (Optional) Absolute local file path for `action="upload-file"`
 - `filename`: (Optional, Slack) Override the uploaded filename.

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -37,6 +37,16 @@ type OutboundChannelFormatter = (
   text: string,
 ) => Pick<OutboundChannelMessage, "text" | "parseMode">;
 
+function decodeBasicXmlEntities(text: string): string {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
 function escapeTelegramHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -446,11 +456,12 @@ export function formatOutboundChannelMessage(
   channel: string,
   text: string,
 ): Pick<OutboundChannelMessage, "text" | "parseMode"> {
+  const normalizedText = decodeBasicXmlEntities(text);
   const formatter = CHANNEL_OUTBOUND_FORMATTERS[channel];
   if (!formatter) {
-    return { text };
+    return { text: normalizedText };
   }
-  return formatter(text);
+  return formatter(normalizedText);
 }
 
 interface MessageChannelArgs {


### PR DESCRIPTION
## Summary
- add Telegram inbound media normalization for photos, files, audio, video, voice notes, animations, stickers, and media groups
- add Telegram outbound media uploads through `MessageChannel action=\"upload-file\"`
- add Telegram reaction parity for both outbound `MessageChannel action=\"react\"` and inbound `message_reaction` updates
- tighten channel notification / formatting coverage, including XML entity decoding before outbound channel formatting

## Notes
- This supersedes the older pre-refactor Telegram media/reaction workstreams rather than trying to merge their stale diffs directly.
- Slack behavior is unchanged here; this PR brings Telegram up to the same shared tool surface for `send`, `react`, and `upload-file`.

## Validation
- `bun test src/tests/channels/telegram-adapter.test.ts src/tests/channels/message-channel.test.ts src/tests/channels/message-tool-schema.test.ts src/tests/channels/xml.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/channels/telegram/adapter.ts src/channels/telegram/messageActions.ts src/channels/types.ts src/channels/xml.ts src/tools/descriptions/MessageChannel.md src/tests/channels/telegram-adapter.test.ts src/tests/channels/message-tool-schema.test.ts src/tests/channels/message-channel.test.ts src/tests/channels/xml.test.ts`
