### PR TITLE
fix: use correct issue title for Terminal-Bench tracker

### DIFF
--- a/benchmarks/terminal_bench/report.py
+++ b/benchmarks/terminal_bench/report.py
@@ -367,7 +367,7 @@ def main() -> None:
     if gh_token:
         update_github_issue(
             repo=args.repo,
-            title="Terminal-Bench Regression Tracker",
+            title="Terminal-Bench tracker",
             body=body,
         )
     else:


### PR DESCRIPTION
## Summary
- Updates `report.py` to use the correct issue title `"Terminal-Bench tracker"` (matching #1404) instead of the old `"Terminal-Bench Regression Tracker"` which caused a duplicate issue (#1671) to be created
- Reports from #1671 have been moved to #1404, and #1671 has been closed

## Test plan
- [ ] Verify the next scheduled Terminal-Bench workflow run posts to #1404 instead of creating a new issue

🤖 Generated with [Letta Code](https://letta.com)