### PR TITLE
fix(channels): restore enabled channel adapters on startup

### DIFF
--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -530,6 +530,12 @@ export function listChannelSummaries(): ChannelSummary[] {
   });
 }
 
+export function listEnabledChannelIds(): SupportedChannelId[] {
+  return getSupportedChannelIds().filter((channelId) =>
+    listChannelAccounts(channelId).some((account) => account.enabled),
+  );
+}
+
 export function getChannelConfigSnapshot(
   channelId: string,
   accountId?: string,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -320,35 +320,39 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   // Load local project settings to access saved environment name
   await settingsManager.loadLocalProjectSettings();
 
-  // Initialize channels if --channels flag provided
-  if (values.channels) {
-    const channelNames = values.channels
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (channelNames.length > 0) {
-      if (values["install-channel-runtimes"]) {
-        const { ensureChannelRuntimeInstalled } = await import(
-          "../../channels/runtimeDeps"
-        );
-        const { isSupportedChannelId } = await import(
-          "../../channels/pluginRegistry"
-        );
+  // Initialize channels if explicitly requested, or restore persisted enabled
+  // channels when a desktop wrapper opts into boot-time channel restore.
+  const channelNames = values.channels
+    ? values.channels
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : process.env.LETTA_RESTORE_ENABLED_CHANNELS === "1"
+      ? (await import("../../channels/service")).listEnabledChannelIds()
+      : [];
 
-        for (const channelName of channelNames) {
-          if (!isSupportedChannelId(channelName)) {
-            console.error(
-              `Unknown channel "${channelName}" passed to --channels.`,
-            );
-            return 1;
-          }
-          await ensureChannelRuntimeInstalled(channelName);
+  if (channelNames.length > 0) {
+    if (values.channels && values["install-channel-runtimes"]) {
+      const { ensureChannelRuntimeInstalled } = await import(
+        "../../channels/runtimeDeps"
+      );
+      const { isSupportedChannelId } = await import(
+        "../../channels/pluginRegistry"
+      );
+
+      for (const channelName of channelNames) {
+        if (!isSupportedChannelId(channelName)) {
+          console.error(
+            `Unknown channel "${channelName}" passed to --channels.`,
+          );
+          return 1;
         }
+        await ensureChannelRuntimeInstalled(channelName);
       }
-
-      const { initializeChannels } = await import("../../channels/registry");
-      await initializeChannels(channelNames);
     }
+
+    const { initializeChannels } = await import("../../channels/registry");
+    await initializeChannels(channelNames);
   }
 
   // Determine connection name

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -27,6 +27,7 @@ import {
   getChannelAccountSnapshot,
   getChannelConfigSnapshot,
   listChannelTargetSnapshots,
+  listEnabledChannelIds,
   refreshChannelAccountDisplayNameLive,
   removeChannelAccountLive,
   setChannelConfigLive,
@@ -199,6 +200,33 @@ describe("channel service", () => {
 
     expect(await removeChannelAccountLive("slack", "docsbot")).toBe(true);
     expect(getChannelAccountSnapshot("slack", "docsbot")).toBeNull();
+  });
+
+  test("listEnabledChannelIds returns only channels with enabled accounts", () => {
+    createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "Telegram Bot",
+        enabled: true,
+        token: "telegram-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "telegram-1" },
+    );
+
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Slack App",
+        enabled: false,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "slack-1" },
+    );
+
+    expect(listEnabledChannelIds()).toEqual(["telegram"]);
   });
 
   test("updateChannelRouteLive updates the Slack route without changing the app's default agent", () => {


### PR DESCRIPTION
## Summary
- add a helper to discover which channels have persisted enabled accounts
- restore those channel adapters automatically on listener startup when the host opts in
- cover the enabled-channel lookup with a regression test

## Why
Channel account `enabled` state was already persisted, but a cold listener start did not rehydrate those adapters unless the process was launched with explicit `--channels` args. This made desktop channel on/off state feel lost across app restarts even though the underlying setting was saved.

## Validation
- `bun test src/tests/channels/service.test.ts src/tests/channels/registry.test.ts src/tests/cli/listen-subcommand-auth.test.ts src/tests/cli/listen-subcommand-telemetry.test.ts`