### PR TITLE
fix(slack): resolve Bolt App constructor from bundled runtime

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -11,9 +11,8 @@ import { resolveSlackInboundAttachments } from "./media";
 import { loadSlackBoltModule } from "./runtime";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
-type SlackBoltNamespace = Partial<typeof import("@slack/bolt")>;
 type SlackBoltModule = typeof import("@slack/bolt") & {
-  default?: Partial<typeof import("@slack/bolt")> | SlackAppConstructor;
+  default?: unknown;
 };
 type SlackReactionEvent = {
   item?: {
@@ -27,20 +26,44 @@ type SlackReactionEvent = {
   event_ts?: string;
 };
 
-function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
-  const defaultExport = mod.default;
-  const defaultNamespace =
-    defaultExport && typeof defaultExport === "object"
-      ? (defaultExport as SlackBoltNamespace)
-      : undefined;
-  const defaultExportApp = defaultNamespace?.App;
-  const App =
-    mod.App ??
-    (typeof defaultExport === "function" ? defaultExport : defaultExportApp);
-  if (!App) {
-    throw new Error('Installed Slack runtime did not export "App".');
+type Constructor = abstract new (...args: never[]) => unknown;
+
+function isConstructorFunction<T extends Constructor>(
+  value: unknown,
+): value is T {
+  return typeof value === "function";
+}
+
+function resolveSlackAppModule(value: unknown): SlackAppConstructor | null {
+  if (!value || typeof value !== "object") {
+    return null;
   }
-  return App as SlackAppConstructor;
+  const app = Reflect.get(value, "App");
+  return isConstructorFunction<SlackAppConstructor>(app) ? app : null;
+}
+
+function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
+  const defaultExport =
+    mod && typeof mod === "object" ? Reflect.get(mod, "default") : undefined;
+  const nestedDefault =
+    defaultExport && typeof defaultExport === "object"
+      ? Reflect.get(defaultExport, "default")
+      : undefined;
+
+  const App =
+    resolveSlackAppModule(mod) ??
+    resolveSlackAppModule(defaultExport) ??
+    resolveSlackAppModule(nestedDefault) ??
+    (isConstructorFunction<SlackAppConstructor>(defaultExport)
+      ? defaultExport
+      : null);
+
+  if (!App) {
+    throw new Error(
+      'Installed Slack runtime did not export constructor "App".',
+    );
+  }
+  return App;
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -11,6 +11,7 @@ import { resolveSlackInboundAttachments } from "./media";
 import { loadSlackBoltModule } from "./runtime";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
+type SlackBoltNamespace = Partial<typeof import("@slack/bolt")>;
 type SlackBoltModule = typeof import("@slack/bolt") & {
   default?: Partial<typeof import("@slack/bolt")> | SlackAppConstructor;
 };
@@ -28,9 +29,14 @@ type SlackReactionEvent = {
 
 function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
   const defaultExport = mod.default;
+  const defaultNamespace =
+    defaultExport && typeof defaultExport === "object"
+      ? (defaultExport as SlackBoltNamespace)
+      : undefined;
+  const defaultExportApp = defaultNamespace?.App;
   const App =
     mod.App ??
-    (typeof defaultExport === "function" ? defaultExport : defaultExport?.App);
+    (typeof defaultExport === "function" ? defaultExport : defaultExportApp);
   if (!App) {
     throw new Error('Installed Slack runtime did not export "App".');
   }

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -10,8 +10,10 @@ import type {
 import { resolveSlackInboundAttachments } from "./media";
 import { loadSlackBoltModule } from "./runtime";
 
-type SlackBoltModule = typeof import("@slack/bolt");
-type SlackAppConstructor = SlackBoltModule["default"];
+type SlackAppConstructor = typeof import("@slack/bolt").App;
+type SlackBoltModule = typeof import("@slack/bolt") & {
+  default?: Partial<typeof import("@slack/bolt")> | SlackAppConstructor;
+};
 type SlackReactionEvent = {
   item?: {
     type?: string;
@@ -25,11 +27,14 @@ type SlackReactionEvent = {
 };
 
 function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
-  const App = mod.default;
+  const defaultExport = mod.default;
+  const App =
+    mod.App ??
+    (typeof defaultExport === "function" ? defaultExport : defaultExport?.App);
   if (!App) {
-    throw new Error('Installed Slack runtime did not export default "App".');
+    throw new Error('Installed Slack runtime did not export "App".');
   }
-  return App;
+  return App as SlackAppConstructor;
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/src/tests/channels/slack-adapter-interop.test.ts
+++ b/src/tests/channels/slack-adapter-interop.test.ts
@@ -1,0 +1,77 @@
+import { expect, mock, test } from "bun:test";
+
+class FakeSlackApp {
+  readonly client = {
+    auth: {
+      test: mock(async () => ({
+        team: "Interop Workspace",
+        user: "interop_slack_bot",
+        user_id: "UINTEROP",
+      })),
+    },
+    users: {
+      info: mock(async () => ({
+        user: {
+          name: "interop_slack_bot",
+          profile: {
+            display_name: "Interop Slack Bot",
+          },
+        },
+      })),
+    },
+    chat: {
+      postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+    },
+    reactions: {
+      add: mock(async () => ({ ok: true })),
+      remove: mock(async () => ({ ok: true })),
+    },
+    files: {
+      getUploadURLExternal: mock(async () => ({
+        ok: true,
+        upload_url: "https://files.slack.com/upload/F123",
+        file_id: "F123",
+      })),
+      completeUploadExternal: mock(async () => ({ ok: true })),
+    },
+  };
+
+  readonly init = mock(async () => {});
+  readonly start = mock(async () => {});
+  readonly stop = mock(async () => {});
+
+  message(): void {}
+
+  event(): void {}
+
+  error(): void {}
+}
+
+mock.module("../../channels/slack/runtime", () => ({
+  loadSlackBoltModule: async () => ({
+    default: {
+      default: {
+        App: FakeSlackApp,
+      },
+    },
+  }),
+}));
+
+mock.module("../../channels/slack/media", () => ({
+  resolveSlackInboundAttachments: async () => [],
+}));
+
+test("resolveSlackAccountDisplayName supports nested default Slack Bolt exports", async () => {
+  const adapterModuleUrl = new URL(
+    "../../channels/slack/adapter.ts?interop=nested-default",
+    import.meta.url,
+  ).href;
+  const { resolveSlackAccountDisplayName } = await import(adapterModuleUrl);
+
+  await expect(
+    resolveSlackAccountDisplayName(
+      "xoxb-test-token-1234567890",
+      "xapp-test-token-1234567890",
+    ),
+  ).resolves.toBe("Interop Slack Bot");
+});

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -104,7 +104,10 @@ const resolveSlackInboundAttachmentsMock = mock(
 
 mock.module("../../channels/slack/runtime", () => ({
   loadSlackBoltModule: async () => ({
-    default: FakeSlackApp,
+    App: FakeSlackApp,
+    default: {
+      App: FakeSlackApp,
+    },
   }),
 }));
 


### PR DESCRIPTION
## Summary
- resolve the Slack Bolt constructor from the named `App` export first, with safe fallbacks for other module shapes
- stop assuming the bundled runtime exposes a callable default export
- update the Slack adapter test mock to match the real Bolt package shape used in desktop channel runtimes

## Testing
- `bun test src/tests/channels/slack-adapter.test.ts`
- `bun run lint`