### PR TITLE
fix(channels): unify MessageChannel discovery

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -10,8 +10,8 @@ import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { INTERRUPTED_BY_USER } from "../constants";
 import {
-  captureToolExecutionContext,
   executeTool,
+  prepareCurrentToolExecutionContext,
   type ToolExecutionResult,
   type ToolReturnContent,
 } from "../tools/manager";
@@ -383,7 +383,11 @@ export async function executeApprovalBatch(
   const toolContextId =
     options?.toolContextId ??
     (options?.workingDirectory
-      ? captureToolExecutionContext(options.workingDirectory).contextId
+      ? (
+          await prepareCurrentToolExecutionContext({
+            workingDirectory: options.workingDirectory,
+          })
+        ).contextId
       : undefined);
 
   // Pre-allocate results array to maintain original order

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -11,9 +11,9 @@ import type {
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import {
   type ClientTool,
-  captureToolExecutionContext,
   type PermissionModeState,
   type PreparedToolExecutionContext,
+  prepareCurrentToolExecutionContext,
   waitForToolsetReady,
 } from "../tools/manager";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
@@ -140,10 +140,10 @@ export async function sendMessageStream(
         // Wait for any in-progress toolset switch to complete before reading tools
         // This prevents sending messages with stale tools during a switch
         await waitForToolsetReady();
-        return captureToolExecutionContext(
-          opts.workingDirectory,
-          opts.permissionModeState,
-        );
+        return await prepareCurrentToolExecutionContext({
+          workingDirectory: opts.workingDirectory,
+          permissionModeState: opts.permissionModeState,
+        });
       })();
   const { clientTools, contextId } = preparedToolContext;
   const { clientSkills, errors: clientSkillDiscoveryErrors } =

--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -1,10 +1,25 @@
-import { loadChannelPlugin } from "./pluginRegistry";
+import { getChannelDisplayName, loadChannelPlugin } from "./pluginRegistry";
 import type {
   ChannelMessageToolDiscovery,
   ChannelMessageToolSchemaContribution,
 } from "./pluginTypes";
 import { getActiveChannelIds } from "./registry";
 import type { SupportedChannelId } from "./types";
+
+type ResolvedMessageChannelToolDiscovery = {
+  activeChannels: SupportedChannelId[];
+  actions: string[];
+  schemaContributions: ChannelMessageToolSchemaContribution[];
+};
+
+type CachedDynamicMessageChannelTool = {
+  description: string;
+  schema: Record<string, unknown>;
+};
+
+const loggedDiscoveryErrors = new Set<string>();
+let cachedDynamicMessageChannelTool: CachedDynamicMessageChannelTool | null =
+  null;
 
 /**
  * Build the public schema for the shared MessageChannel tool by merging
@@ -48,9 +63,25 @@ function collectDiscoveryActions(
   return discovery?.actions ? Array.from(discovery.actions) : [];
 }
 
-export async function buildDynamicMessageChannelSchema(
+function logDiscoveryError(
+  channelId: SupportedChannelId,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const key = `${channelId}:${message}`;
+  if (loggedDiscoveryErrors.has(key)) {
+    return;
+  }
+  loggedDiscoveryErrors.add(key);
+  console.error(
+    `[Channels] ${channelId} MessageChannel discovery failed: ${message}`,
+  );
+}
+
+function buildDynamicMessageChannelSchemaFromDiscovery(
   baseSchema: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
+  discovery: ResolvedMessageChannelToolDiscovery,
+): Record<string, unknown> {
   const schema = structuredClone(baseSchema);
   const properties = schema.properties as
     | Record<string, Record<string, unknown>>
@@ -59,29 +90,102 @@ export async function buildDynamicMessageChannelSchema(
     return schema;
   }
 
-  const activeChannels = getActiveChannelIds();
-  if (properties.channel && activeChannels.length > 0) {
-    properties.channel.enum = activeChannels;
-  }
-
-  const actionEnum = new Set<string>(["send"]);
-  const contributions: ChannelMessageToolSchemaContribution[] = [];
-
-  for (const channelId of activeChannels) {
-    const plugin = await loadChannelPlugin(channelId as SupportedChannelId);
-    const discovery = plugin.messageActions?.describeMessageTool({
-      accountId: null,
-    });
-
-    for (const action of collectDiscoveryActions(discovery)) {
-      actionEnum.add(action);
-    }
-    contributions.push(...asSchemaContributionArray(discovery?.schema));
+  if (properties.channel && discovery.activeChannels.length > 0) {
+    properties.channel.enum = [...discovery.activeChannels];
   }
 
   if (properties.action) {
-    properties.action.enum = Array.from(actionEnum);
+    properties.action.enum = [...discovery.actions];
   }
 
-  return mergeSchemaContributions(schema, contributions);
+  return mergeSchemaContributions(schema, discovery.schemaContributions);
+}
+
+function buildDynamicMessageChannelDescriptionFromDiscovery(
+  baseDescription: string,
+  discovery: ResolvedMessageChannelToolDiscovery,
+): string {
+  const description = baseDescription.trim();
+  if (discovery.activeChannels.length === 0) {
+    return `${description}\n\nNo external channel adapters are currently running.`;
+  }
+
+  const channelList = discovery.activeChannels
+    .map((channelId) => getChannelDisplayName(channelId))
+    .join(", ");
+  const actionList = discovery.actions.join(", ");
+
+  return `${description}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+}
+
+export async function resolveMessageChannelToolDiscovery(): Promise<ResolvedMessageChannelToolDiscovery> {
+  const activeChannels = getActiveChannelIds() as SupportedChannelId[];
+  const actions = new Set<string>(["send"]);
+  const schemaContributions: ChannelMessageToolSchemaContribution[] = [];
+
+  for (const channelId of activeChannels) {
+    try {
+      const plugin = await loadChannelPlugin(channelId);
+      const discovery = plugin.messageActions?.describeMessageTool({
+        accountId: null,
+      });
+
+      for (const action of collectDiscoveryActions(discovery)) {
+        actions.add(action);
+      }
+      schemaContributions.push(...asSchemaContributionArray(discovery?.schema));
+    } catch (error) {
+      logDiscoveryError(channelId, error);
+    }
+  }
+
+  return {
+    activeChannels,
+    actions: Array.from(actions),
+    schemaContributions,
+  };
+}
+
+export async function buildDynamicMessageChannelSchema(
+  baseSchema: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const discovery = await resolveMessageChannelToolDiscovery();
+  return buildDynamicMessageChannelSchemaFromDiscovery(baseSchema, discovery);
+}
+
+export async function buildDynamicMessageChannelToolDefinition(
+  baseDescription: string,
+  baseSchema: Record<string, unknown>,
+): Promise<CachedDynamicMessageChannelTool> {
+  const discovery = await resolveMessageChannelToolDiscovery();
+  const resolved = {
+    description: buildDynamicMessageChannelDescriptionFromDiscovery(
+      baseDescription,
+      discovery,
+    ),
+    schema: buildDynamicMessageChannelSchemaFromDiscovery(
+      baseSchema,
+      discovery,
+    ),
+  };
+  cachedDynamicMessageChannelTool = {
+    description: resolved.description,
+    schema: structuredClone(resolved.schema),
+  };
+  return resolved;
+}
+
+export function getCachedDynamicMessageChannelToolDefinition(): CachedDynamicMessageChannelTool | null {
+  if (!cachedDynamicMessageChannelTool) {
+    return null;
+  }
+  return {
+    description: cachedDynamicMessageChannelTool.description,
+    schema: structuredClone(cachedDynamicMessageChannelTool.schema),
+  };
+}
+
+export function clearDynamicMessageChannelToolCache(): void {
+  cachedDynamicMessageChannelTool = null;
+  loggedDiscoveryErrors.clear();
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { refreshDynamicChannelToolsInLoadedRegistry } from "../tools/manager";
 import {
   getChannelAccount,
   LEGACY_CHANNEL_ACCOUNT_ID,
@@ -118,6 +119,10 @@ export interface ChannelTargetSnapshot {
   discoveredAt: string;
   lastSeenAt: string;
   lastMessageId?: string;
+}
+
+async function refreshLoadedMessageChannelTool(): Promise<void> {
+  await refreshDynamicChannelToolsInLoadedRegistry();
 }
 
 export type ChannelAccountSnapshot =
@@ -639,6 +644,7 @@ export async function setChannelConfigLive(
   if (!snapshot) {
     throw new Error(`Failed to write ${channelId} channel config`);
   }
+  await refreshLoadedMessageChannelTool();
   return snapshot;
 }
 
@@ -687,6 +693,7 @@ export async function startChannelLive(
   if (!summary) {
     throw new Error(`Channel "${channelId}" summary not found after start`);
   }
+  await refreshLoadedMessageChannelTool();
   return summary;
 }
 
@@ -717,6 +724,7 @@ export async function stopChannelLive(
   if (!summary) {
     throw new Error(`Channel "${channelId}" summary not found after stop`);
   }
+  await refreshLoadedMessageChannelTool();
   return summary;
 }
 
@@ -909,9 +917,15 @@ export async function startChannelAccountLive(
   }
 
   await ensureChannelRegistry().startChannelAccount(channelId, accountId);
-  return refreshChannelAccountDisplayNameLive(channelId, accountId, {
-    force: channelId === "slack",
-  });
+  const snapshot = await refreshChannelAccountDisplayNameLive(
+    channelId,
+    accountId,
+    {
+      force: channelId === "slack",
+    },
+  );
+  await refreshLoadedMessageChannelTool();
+  return snapshot;
 }
 
 export async function stopChannelAccountLive(
@@ -935,6 +949,7 @@ export async function stopChannelAccountLive(
     : existing;
 
   await getChannelRegistry()?.stopChannelAccount(channelId, accountId);
+  await refreshLoadedMessageChannelTool();
   return toAccountSnapshot(next);
 }
 
@@ -955,7 +970,9 @@ export async function removeChannelAccountLive(
   removeRoutesForAccount(channelId, accountId);
   removeChannelTargetsForAccount(channelId, accountId);
   removePairingStateForAccount(channelId, accountId);
-  return removeChannelAccount(channelId, accountId);
+  const removed = removeChannelAccount(channelId, accountId);
+  await refreshLoadedMessageChannelTool();
+  return removed;
 }
 
 export function listPendingPairingSnapshots(

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { buildDynamicMessageChannelSchema } from "../../channels/messageTool";
+import {
+  buildDynamicMessageChannelSchema,
+  buildDynamicMessageChannelToolDefinition,
+  clearDynamicMessageChannelToolCache,
+} from "../../channels/messageTool";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
 import type { ChannelAdapter } from "../../channels/types";
 
@@ -27,6 +31,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     if (registry) {
       await registry.stopAll();
     }
+    clearDynamicMessageChannelToolCache();
   });
 
   test("injects active channel enum and plugin-owned actions", async () => {
@@ -67,6 +72,39 @@ describe("buildDynamicMessageChannelSchema", () => {
 
     const properties = schema.properties as Record<string, { enum?: string[] }>;
     expect(properties.channel?.enum).toEqual(["telegram"]);
+    expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
+  });
+
+  test("builds description from the same discovery result as the schema", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    const resolved = await buildDynamicMessageChannelToolDefinition(
+      "Base MessageChannel description.",
+      {
+        type: "object",
+        properties: {
+          action: { type: "string" },
+          channel: { type: "string" },
+          chat_id: { type: "string" },
+        },
+        required: ["action", "channel", "chat_id"],
+        additionalProperties: false,
+      },
+    );
+
+    const properties = resolved.schema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(resolved.description).toContain(
+      "Currently active channels: Slack, Telegram.",
+    );
+    expect(resolved.description).toContain(
+      "Available actions across the active channels: send, react, upload-file.",
+    );
+    expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
   });
 });

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -1,4 +1,14 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { clearDynamicMessageChannelToolCache } from "../../channels/messageTool";
+import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import type { ChannelAdapter } from "../../channels/types";
 import {
   captureToolExecutionContext,
   clearCapturedToolExecutionContexts,
@@ -6,8 +16,11 @@ import {
   clearTools,
   executeTool,
   getToolNames,
+  getToolSchema,
   loadSpecificTools,
+  prepareCurrentToolExecutionContext,
   prepareToolExecutionContextForSpecificTools,
+  refreshDynamicChannelToolsInLoadedRegistry,
 } from "../../tools/manager";
 
 function asText(
@@ -21,12 +34,37 @@ function asText(
 describe("tool execution context snapshot", () => {
   let initialTools: string[] = [];
 
+  function createRunningAdapter(
+    channelId: "slack" | "telegram",
+    accountId: string,
+  ): ChannelAdapter {
+    return {
+      id: `${channelId}:${accountId}`,
+      channelId,
+      accountId,
+      name: channelId,
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async () => {},
+    };
+  }
+
   beforeAll(() => {
     initialTools = getToolNames();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
+  });
+
+  afterAll(async () => {
     clearExternalTools();
     if (initialTools.length > 0) {
       await loadSpecificTools(initialTools);
@@ -94,5 +132,57 @@ describe("tool execution context snapshot", () => {
     );
 
     expect(withPreparedContext.status).toBe("success");
+  });
+
+  test("prepares current tool snapshots with fresh MessageChannel discovery", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+
+    const prepared = await prepareCurrentToolExecutionContext();
+    const messageChannel = prepared.clientTools.find(
+      (tool) => tool.name === "MessageChannel",
+    );
+
+    expect(prepared.loadedToolNames).toContain("MessageChannel");
+    expect(messageChannel).toBeDefined();
+    expect(messageChannel?.description).toContain(
+      "Currently active channels: Slack.",
+    );
+
+    if (!messageChannel) {
+      throw new Error("MessageChannel tool was not prepared");
+    }
+
+    if (!messageChannel.parameters) {
+      throw new Error("MessageChannel tool is missing parameters");
+    }
+
+    const actionParameter = (
+      messageChannel.parameters.properties as Record<
+        string,
+        { enum?: string[] }
+      >
+    ).action;
+
+    expect(actionParameter?.enum).toEqual(["send", "react", "upload-file"]);
+  });
+
+  test("refreshes the loaded MessageChannel schema for synchronous readers", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    await refreshDynamicChannelToolsInLoadedRegistry();
+
+    const schema = getToolSchema("MessageChannel");
+    expect(schema?.description).toContain(
+      "Currently active channels: Telegram.",
+    );
+    expect(
+      (schema?.input_schema.properties?.channel as { enum?: string[] }).enum,
+    ).toEqual(["telegram"]);
   });
 });

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -1,8 +1,8 @@
 # MessageChannel
 
-Send a message or channel action to an external channel (Telegram, Slack, etc.) in response to a channel notification.
+Send a message or channel action to an external channel in response to a channel notification.
 
-When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel. A normal assistant response is not delivered back to Telegram/Slack/etc.
+When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel. A normal assistant response is not delivered back to the external channel automatically.
 
 Preferred pattern:
 - `action="send"` to send a normal reply
@@ -10,17 +10,17 @@ Preferred pattern:
 - `message` for the text body
 
 Parameters:
-- `action`: The action to perform. Current built-in actions include `send`, `react`, and `upload-file`.
+- `action`: The action to perform. The exact available actions depend on the active channel plugins and are reflected in the JSON schema.
 - `channel`: The platform to send to (matches the `source` attribute)
 - `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
 - `message`: The text to send for `action="send"`
 - `replyTo`: (Optional) Reply to a specific message ID. Omit this unless you intentionally want the platform's quote/reply UI.
-- `messageId`: (Optional) Target message id for actions like `react`
-- `emoji`: (Optional) Emoji reaction for `action="react"`; Slack uses names like `white_check_mark`, Telegram uses native emoji like `👍`
+- `messageId`: (Optional) Target message id for message-scoped actions like reactions.
+- `emoji`: (Optional) Reaction payload for channels that support reactions.
 - `remove`: (Optional) Set to `true` to remove the reaction instead of adding it
-- `media`: (Optional) Absolute local file path for `action="upload-file"`
-- `filename`: (Optional, Slack) Override the uploaded filename.
-- `title`: (Optional, Slack) Override the uploaded attachment title.
+- `media`: (Optional) Absolute local file path for file/media uploads on channels that support uploads.
+- `filename`: (Optional) Override the uploaded filename when supported by the channel.
+- `title`: (Optional) Override the uploaded attachment title when supported by the channel.
 
 Rules:
 - Always pass `action` explicitly, even for a normal reply.

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -3,7 +3,10 @@ import * as nodePath from "node:path";
 import { getDisplayableToolReturn } from "../agent/approval-execution";
 import { getModelInfo } from "../agent/model";
 import { getAllSubagentConfigs } from "../agent/subagents";
-import { buildDynamicMessageChannelSchema } from "../channels/messageTool";
+import {
+  buildDynamicMessageChannelToolDefinition,
+  getCachedDynamicMessageChannelToolDefinition,
+} from "../channels/messageTool";
 import { getActiveChannelIds } from "../channels/registry";
 import { refreshFileIndex } from "../cli/helpers/fileIndex";
 import { INTERRUPTED_BY_USER } from "../constants";
@@ -45,14 +48,51 @@ function maybeAppendChannelTools(toolNames: ToolName[]): ToolName[] {
  * Inject dynamic channel-tool discovery into MessageChannel if channels are active.
  * Used by both buildRegistryForModel() and buildSpecificToolRegistry().
  */
-async function maybeInjectChannelSchema(
+async function maybeResolveDynamicChannelTool(
   name: string,
+  description: string,
   schema: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
+): Promise<{ description: string; input_schema: Record<string, unknown> }> {
   if (name !== "MessageChannel") {
-    return schema;
+    return {
+      description,
+      input_schema: schema,
+    };
   }
-  return await buildDynamicMessageChannelSchema(schema);
+  const resolved = await buildDynamicMessageChannelToolDefinition(
+    description,
+    schema,
+  );
+  return {
+    description: resolved.description,
+    input_schema: resolved.schema,
+  };
+}
+
+function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
+  const nextRegistry = new Map(registry);
+  if (getActiveChannelIds().length === 0) {
+    nextRegistry.delete("MessageChannel");
+    return nextRegistry;
+  }
+
+  const cachedMessageChannel = getCachedDynamicMessageChannelToolDefinition();
+  if (!cachedMessageChannel) {
+    return nextRegistry;
+  }
+
+  const existing = nextRegistry.get("MessageChannel");
+  nextRegistry.set("MessageChannel", {
+    schema: {
+      name: "MessageChannel",
+      description: cachedMessageChannel.description,
+      input_schema: cachedMessageChannel.schema as JsonSchema,
+    },
+    fn:
+      existing?.fn ??
+      (TOOL_DEFINITIONS.MessageChannel.impl as ToolDefinition["fn"]),
+  });
+  return nextRegistry;
 }
 const STREAMING_SHELL_TOOLS = new Set([
   "Bash",
@@ -645,7 +685,10 @@ export async function executeExternalTool(
  * Includes both built-in tools and external tools.
  */
 export function getClientToolsFromRegistry(): ClientTool[] {
-  return buildClientToolsFromSnapshot(toolRegistry, getExternalToolsRegistry());
+  return buildClientToolsFromSnapshot(
+    withDynamicMessageChannelCache(toolRegistry),
+    getExternalToolsRegistry(),
+  );
 }
 
 function buildClientToolsFromSnapshot(
@@ -709,7 +752,7 @@ function capturePreparedToolExecutionContext(
   },
 ): PreparedToolExecutionContext {
   const executionSnapshot: ToolExecutionContextSnapshot = {
-    toolRegistry: new Map(snapshot.toolRegistry),
+    toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
     externalTools: new Map(snapshot.externalTools),
     externalExecutor: snapshot.externalExecutor,
     workingDirectory:
@@ -749,6 +792,26 @@ export function captureToolExecutionContext(
       workingDirectory,
       permissionModeState,
     },
+  );
+}
+
+export async function prepareCurrentToolExecutionContext(options?: {
+  workingDirectory?: string;
+  permissionModeState?: PermissionModeState;
+}): Promise<PreparedToolExecutionContext> {
+  await waitForToolsetReady();
+  const currentToolNames = maybeAppendChannelTools(
+    Array.from(toolRegistry.keys()) as ToolName[],
+  );
+  const toolRegistrySnapshot =
+    await buildSpecificToolRegistry(currentToolNames);
+  return capturePreparedToolExecutionContext(
+    {
+      toolRegistry: toolRegistrySnapshot,
+      externalTools: new Map(getExternalToolsRegistry()),
+      externalExecutor: getExternalToolExecutor(),
+    },
+    options,
   );
 }
 
@@ -961,13 +1024,16 @@ async function buildSpecificToolRegistry(
       throw new Error(`Tool implementation not found for ${internalName}`);
     }
 
+    const resolvedTool = await maybeResolveDynamicChannelTool(
+      internalName,
+      definition.description,
+      definition.schema,
+    );
+
     const toolSchema: ToolSchema = {
       name: internalName,
-      description: definition.description,
-      input_schema: await maybeInjectChannelSchema(
-        internalName,
-        definition.schema,
-      ),
+      description: resolvedTool.description,
+      input_schema: resolvedTool.input_schema as JsonSchema,
     };
 
     newRegistry.set(internalName, {
@@ -1057,10 +1123,16 @@ async function buildRegistryForModel(
         );
       }
 
-      const toolSchema: ToolSchema = {
+      const resolvedTool = await maybeResolveDynamicChannelTool(
         name,
         description,
-        input_schema: await maybeInjectChannelSchema(name, definition.schema),
+        definition.schema,
+      );
+
+      const toolSchema: ToolSchema = {
+        name,
+        description: resolvedTool.description,
+        input_schema: resolvedTool.input_schema as JsonSchema,
       };
 
       newRegistry.set(name, {
@@ -1769,7 +1841,9 @@ export function getAllLettaToolNames(): string[] {
  * @returns Array of tool schemas
  */
 export function getToolSchemas(): ToolSchema[] {
-  return Array.from(toolRegistry.values()).map((tool) => tool.schema);
+  return Array.from(withDynamicMessageChannelCache(toolRegistry).values()).map(
+    (tool) => tool.schema,
+  );
 }
 
 /**
@@ -1781,7 +1855,34 @@ export function getToolSchemas(): ToolSchema[] {
 export function getToolSchema(name: string): ToolSchema | undefined {
   const internalName = resolveInternalToolName(name);
   if (!internalName) return undefined;
-  return toolRegistry.get(internalName)?.schema;
+  return withDynamicMessageChannelCache(toolRegistry).get(internalName)?.schema;
+}
+
+export async function refreshDynamicChannelToolsInLoadedRegistry(): Promise<void> {
+  const activeChannels = getActiveChannelIds();
+  if (activeChannels.length === 0) {
+    toolRegistry.delete("MessageChannel");
+    return;
+  }
+
+  const definition = TOOL_DEFINITIONS.MessageChannel;
+  if (!definition?.impl) {
+    throw new Error("Tool implementation not found for MessageChannel");
+  }
+
+  const resolvedTool = await maybeResolveDynamicChannelTool(
+    "MessageChannel",
+    definition.description,
+    definition.schema,
+  );
+  toolRegistry.set("MessageChannel", {
+    schema: {
+      name: "MessageChannel",
+      description: resolvedTool.description,
+      input_schema: resolvedTool.input_schema as JsonSchema,
+    },
+    fn: definition.impl,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- unify `MessageChannel` schema and description generation so both come from the same live channel discovery result
- refresh `MessageChannel` tool snapshots when channels start/stop or account state changes so new turns do not reuse stale schemas
- add tests covering unified discovery plus fresh execution-context and synchronous-registry refresh behavior

## Root Cause
We had a split-brain `MessageChannel` setup:
- dynamic schema/action injection came from channel discovery
- descriptive prose could still come from a different path
- some execution paths reused cached tool snapshots after channel state changed

That made it possible for the model-facing tool description to mention Telegram/Slack capabilities while the schema exposed to the model was stale or missing the matching fields.

This patch follows the same high-level pattern OpenClaw uses for its shared message tool: one discovery source drives the shared tool metadata, and refreshed snapshots are taken when runtime channel state changes.

## Testing
- `bun test src/tests/channels/message-tool-schema.test.ts`
- `bun test src/tests/tools/tool-execution-context.test.ts`
- `bun test src/tests/channels/message-channel.test.ts`
- `bun run lint`

## Notes
- `bun run lint` still reports the same two pre-existing repo warnings outside this patch (`src/agent/reconcileExistingAgentState.ts` and `src/web/generate-memory-viewer.ts`)
