### PR TITLE
fix(slack): dedupe threaded mention ingress

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -62,6 +62,9 @@ function normalizeSlackReactionName(value: string): string {
   return value.trim().replace(/^:+|:+$/g, "");
 }
 
+const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
+const SLACK_INGRESS_DEDUPE_MAX = 2_000;
+
 function resolveUploadMimeType(filePath: string): string | undefined {
   switch (extname(filePath).toLowerCase()) {
     case ".png":
@@ -180,8 +183,72 @@ export function createSlackAdapter(
 ): ChannelAdapter {
   let app: SlackApp | null = null;
   let running = false;
+  let botUserId: string | null = null;
   const knownThreadIdsByMessageId = new Map<string, string | null>();
   const knownUserDisplayNames = new Map<string, string>();
+  const seenIngressMessageKeys = new Map<string, number>();
+
+  function buildIngressMessageKey(
+    channelId: string | undefined,
+    messageId: string | undefined,
+  ): string | null {
+    if (!isNonEmptyString(channelId) || !isNonEmptyString(messageId)) {
+      return null;
+    }
+    return `${channelId}:${messageId}`;
+  }
+
+  function pruneSeenIngressMessageKeys(now: number = Date.now()): void {
+    for (const [key, expiresAt] of seenIngressMessageKeys) {
+      if (expiresAt <= now) {
+        seenIngressMessageKeys.delete(key);
+      }
+    }
+
+    if (seenIngressMessageKeys.size <= SLACK_INGRESS_DEDUPE_MAX) {
+      return;
+    }
+
+    const oldestEntries = Array.from(seenIngressMessageKeys.entries()).sort(
+      (a, b) => a[1] - b[1],
+    );
+    const overflowCount =
+      seenIngressMessageKeys.size - SLACK_INGRESS_DEDUPE_MAX;
+    for (let index = 0; index < overflowCount; index += 1) {
+      const entry = oldestEntries[index];
+      if (entry) {
+        seenIngressMessageKeys.delete(entry[0]);
+      }
+    }
+  }
+
+  function markIngressMessageSeen(
+    channelId: string | undefined,
+    messageId: string | undefined,
+  ): boolean {
+    const key = buildIngressMessageKey(channelId, messageId);
+    if (!key) {
+      return false;
+    }
+
+    const now = Date.now();
+    pruneSeenIngressMessageKeys(now);
+
+    if (seenIngressMessageKeys.has(key)) {
+      return true;
+    }
+
+    seenIngressMessageKeys.set(key, now + SLACK_INGRESS_DEDUPE_TTL_MS);
+    return false;
+  }
+
+  function hasSlackMention(text: string, userId: string | null): boolean {
+    if (!isNonEmptyString(text) || !isNonEmptyString(userId)) {
+      return false;
+    }
+
+    return text.includes(`<@${userId}>`) || text.includes(`<@${userId}|`);
+  }
 
   function rememberMessageThread(
     messageId: string | undefined,
@@ -262,6 +329,7 @@ export function createSlackAdapter(
       }
 
       const text = isNonEmptyString(rawMessage.text) ? rawMessage.text : "";
+      const wasMentioned = hasSlackMention(text, botUserId);
       const attachments = await resolveSlackInboundAttachments({
         accountId: config.accountId,
         token: config.botToken,
@@ -276,6 +344,10 @@ export function createSlackAdapter(
       const senderName = await resolveUserName(instance, rawMessage.user);
 
       if (chatType === "direct") {
+        if (markIngressMessageSeen(channelId, rawMessage.ts)) {
+          return;
+        }
+
         const inbound: InboundChannelMessage = {
           channel: "slack",
           accountId: config.accountId,
@@ -287,7 +359,7 @@ export function createSlackAdapter(
           messageId: rawMessage.ts,
           threadId: null,
           chatType: "direct",
-          isMention: false,
+          isMention: wasMentioned,
           attachments,
           raw: message,
         };
@@ -304,6 +376,10 @@ export function createSlackAdapter(
         return;
       }
 
+      if (markIngressMessageSeen(channelId, rawMessage.ts)) {
+        return;
+      }
+
       const inbound: InboundChannelMessage = {
         channel: "slack",
         accountId: config.accountId,
@@ -311,12 +387,12 @@ export function createSlackAdapter(
         senderId: rawMessage.user,
         senderName,
         chatLabel: channelId,
-        text,
+        text: wasMentioned ? normalizeSlackText(text) : text,
         timestamp: slackTimestampToMillis(rawMessage.ts),
         messageId: rawMessage.ts,
         threadId,
         chatType: "channel",
-        isMention: false,
+        isMention: wasMentioned,
         attachments,
         raw: message,
       };
@@ -341,6 +417,10 @@ export function createSlackAdapter(
         !isNonEmptyString(event.user) ||
         !isNonEmptyString(event.ts)
       ) {
+        return;
+      }
+
+      if (markIngressMessageSeen(event.channel, event.ts)) {
         return;
       }
 
@@ -460,6 +540,7 @@ export function createSlackAdapter(
 
       const slackApp = await ensureApp();
       const auth = await slackApp.client.auth.test();
+      botUserId = isNonEmptyString(auth.user_id) ? auth.user_id : null;
       await slackApp.start();
       running = true;
 
@@ -475,6 +556,8 @@ export function createSlackAdapter(
       await app.stop();
       running = false;
       app = null;
+      botUserId = null;
+      seenIngressMessageKeys.clear();
       console.log("[Slack] App stopped");
     },
 

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -349,6 +349,122 @@ test("slack adapter forwards threaded channel replies as channel input", async (
   );
 });
 
+test("slack adapter dedupes threaded mentions delivered through message and app_mention", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const messageHandler = app?.messageHandler;
+  const mentionHandler = app?.eventHandlers.get("app_mention");
+  if (!messageHandler || !mentionHandler) {
+    throw new Error("Expected Slack message and mention handlers");
+  }
+
+  await messageHandler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U0AS42PTEAX> following up in thread",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  await mentionHandler({
+    event: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U0AS42PTEAX> following up in thread",
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledTimes(1);
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "following up in thread",
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: true,
+    }),
+  );
+});
+
+test("slack adapter dedupes threaded mentions when app_mention arrives first", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const messageHandler = app?.messageHandler;
+  const mentionHandler = app?.eventHandlers.get("app_mention");
+  if (!messageHandler || !mentionHandler) {
+    throw new Error("Expected Slack message and mention handlers");
+  }
+
+  await mentionHandler({
+    event: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U0AS42PTEAX> still there?",
+      ts: "1712800000.000101",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  await messageHandler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U0AS42PTEAX> still there?",
+      ts: "1712800000.000101",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledTimes(1);
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "still there?",
+      messageId: "1712800000.000101",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: true,
+    }),
+  );
+});
+
 test("slack adapter allows file_share subtype messages through", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,


### PR DESCRIPTION
## Summary
- dedupe Slack ingress by `(channel, ts)` so a threaded `message` event and matching `app_mention` only enqueue once
- teach the plain Slack `message` path to recognize bot mentions so it preserves mention semantics if that event wins the race
- add regression tests for both event orders

## Root Cause
Slack can emit both `message` and `app_mention` for the same user post in a channel thread when the message mentions the bot.

Our adapter handled both independently, so the same Slack message could be delivered into the Letta queue twice. That matches the duplicate behavior seen in the screenshots.

OpenClaw has explicit race handling here. This patch brings over the same core idea for Letta's adapter: treat `(channel, ts)` as one logical ingress message and allow only one winner.

## Testing
- `bun test src/tests/channels/slack-adapter.test.ts`
- `bun test src/tests/channels/message-channel.test.ts`
- `bun run lint`

## Notes
- `bun run lint` still reports the same two pre-existing repo warnings outside this patch (`src/agent/reconcileExistingAgentState.ts` and `src/web/generate-memory-viewer.ts`)
