### PR TITLE
fix(channels): return account snapshots before live refresh

### DIFF
--- a/src/tests/websocket/listen-client-channel-accounts.test.ts
+++ b/src/tests/websocket/listen-client-channel-accounts.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import { __listenClientTestUtils } from "../../websocket/listener/client";
+
+class MockSocket {
+  public sentPayloads: string[] = [];
+
+  constructor(public readyState: number) {}
+
+  send(payload: string): void {
+    this.sentPayloads.push(payload);
+  }
+}
+
+const actualChannelsService = await import("../../channels/service");
+
+afterEach(() => {
+  __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
+});
+
+describe("channel account list responses", () => {
+  test("return cached account snapshots without waiting for live display-name refresh", async () => {
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    let releaseRefresh: () => void = () => {};
+
+    __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
+      ...actualChannelsService,
+      listChannelAccountSnapshots: () => [
+        {
+          channelId: "slack" as const,
+          accountId: "slack-app-1",
+          displayName: undefined,
+          enabled: true,
+          configured: true,
+          running: false,
+          mode: "socket" as const,
+          dmPolicy: "pairing" as const,
+          allowedUsers: [],
+          hasBotToken: true,
+          hasAppToken: true,
+          agentId: "agent-1",
+          createdAt: "2026-04-13T00:00:00.000Z",
+          updatedAt: "2026-04-13T00:00:00.000Z",
+        },
+      ],
+      refreshChannelAccountDisplayNameLive: () =>
+        new Promise((resolve) => {
+          releaseRefresh = () =>
+            resolve({
+              channelId: "slack" as const,
+              accountId: "slack-app-1",
+              displayName: "Slack Bot",
+              enabled: true,
+              configured: true,
+              running: false,
+              mode: "socket" as const,
+              dmPolicy: "pairing" as const,
+              allowedUsers: [],
+              hasBotToken: true,
+              hasAppToken: true,
+              agentId: "agent-1",
+              createdAt: "2026-04-13T00:00:00.000Z",
+              updatedAt: "2026-04-13T00:00:00.000Z",
+            });
+        }),
+    }));
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_accounts_list",
+          request_id: "channel-accounts-list-fast-1",
+          channel_id: "slack",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      expect(JSON.parse(socket.sentPayloads[0] as string)).toMatchObject({
+        type: "channel_accounts_list_response",
+        request_id: "channel-accounts-list-fast-1",
+        success: true,
+        channel_id: "slack",
+        accounts: [
+          {
+            channel_id: "slack",
+            account_id: "slack-app-1",
+            enabled: true,
+            configured: true,
+            running: false,
+            mode: "socket",
+            dm_policy: "pairing",
+            allowed_users: [],
+            has_bot_token: true,
+            has_app_token: true,
+            agent_id: "agent-1",
+            created_at: "2026-04-13T00:00:00.000Z",
+            updated_at: "2026-04-13T00:00:00.000Z",
+          },
+        ],
+      });
+    } finally {
+      releaseRefresh();
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+});

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -1313,22 +1313,7 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_accounts_list") {
     try {
-      const accounts = await Promise.all(
-        listChannelAccountSnapshots(parsed.channel_id).map((account) =>
-          parsed.channel_id === "slack"
-            ? refreshChannelAccountDisplayNameLive(
-                parsed.channel_id,
-                account.accountId,
-                { force: true },
-              )
-            : account.displayName
-              ? Promise.resolve(account)
-              : refreshChannelAccountDisplayNameLive(
-                  parsed.channel_id,
-                  account.accountId,
-                ),
-        ),
-      );
+      const accounts = listChannelAccountSnapshots(parsed.channel_id);
       safeSocketSend(
         socket,
         {
@@ -1341,6 +1326,43 @@ async function handleChannelsProtocolCommand(
         "listener_channels_send_failed",
         "listener_channels_command",
       );
+
+      const accountsNeedingRefresh = accounts.filter((account) =>
+        parsed.channel_id === "slack" ? true : !account.displayName,
+      );
+
+      if (accountsNeedingRefresh.length > 0) {
+        runDetachedListenerTask("channel_accounts_refresh", async () => {
+          const refreshResults = await Promise.allSettled(
+            accountsNeedingRefresh.map(async (account) => {
+              const refreshed =
+                parsed.channel_id === "slack"
+                  ? await refreshChannelAccountDisplayNameLive(
+                      parsed.channel_id,
+                      account.accountId,
+                      { force: true },
+                    )
+                  : await refreshChannelAccountDisplayNameLive(
+                      parsed.channel_id,
+                      account.accountId,
+                    );
+
+              return refreshed.displayName !== account.displayName;
+            }),
+          );
+
+          if (
+            refreshResults.some(
+              (result) => result.status === "fulfilled" && result.value,
+            )
+          ) {
+            emitChannelAccountsUpdated(socket, {
+              channelId: parsed.channel_id,
+            });
+            emitChannelsUpdated(socket, parsed.channel_id);
+          }
+        });
+      }
     } catch (err) {
       safeSocketSend(
         socket,


### PR DESCRIPTION
## Summary
- return channel account snapshots immediately instead of blocking the response on live Slack and Telegram display-name refreshes
- move display-name refresh into a detached background task and emit account/channel updates only if names actually change
- add a regression test proving channel_accounts_list responds from cached data without waiting on the live refresh path

## Testing
- bun test src/tests/websocket/listen-client-channel-accounts.test.ts src/tests/websocket/listen-client-protocol.test.ts
- bun run lint