### PR TITLE
fix(listener): preserve queued user OTIDs across dequeue and send

### DIFF
--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -843,6 +843,11 @@ describe("listen-client multi-worker concurrency", () => {
 
     await waitFor(() => processed.length === 1);
 
+    const queuedPayload = processed[0]?.messages[0];
+    if (!queuedPayload || !("content" in queuedPayload)) {
+      throw new Error("Expected queued user payload");
+    }
+
     expect(processed[0]).toEqual(
       expect.objectContaining({
         type: "message",
@@ -853,10 +858,22 @@ describe("listen-client multi-worker concurrency", () => {
             role: "user",
             content: channelContent,
             client_message_id: expect.stringMatching(/^cm-channel-/),
+            otid: expect.stringMatching(/^cm-channel-/),
           }),
         ],
       }),
     );
+    expect(queuedPayload.otid).toBe(queuedPayload.client_message_id);
+
+    const emittedMessages = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload as string),
+    );
+    const dequeuedUserDelta = emittedMessages.find(
+      (message) =>
+        message.type === "stream_delta" &&
+        message.delta?.message_type === "user_message",
+    );
+    expect(dequeuedUserDelta?.delta?.otid).toBe(queuedPayload.otid);
     expect(runtime.queueRuntime.length).toBe(0);
     expect(runtime.queuedMessagesByItemId.size).toBe(0);
   });
@@ -2039,6 +2056,42 @@ describe("listen-client multi-worker concurrency", () => {
     });
 
     await turnPromise;
+  });
+
+  test("handleIncomingMessage reuses client_message_id as the message otid", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-client-message-id",
+      "conv-client-message-id",
+    );
+    const socket = new MockSocket();
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      {
+        type: "message",
+        agentId: "agent-client-message-id",
+        conversationId: "conv-client-message-id",
+        messages: [
+          {
+            role: "user",
+            content: "hello",
+            client_message_id: "cm-user-otid",
+          } as IncomingMessage["messages"][number],
+        ],
+      },
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    const [, sentMessages] = sendMessageStreamMock.mock.calls[0] ?? [];
+    expect(sentMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "hello",
+        otid: "cm-user-otid",
+      }),
+    ]);
   });
 
   test("pre-stream 409 resume on default conversation includes agent_id", async () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -2716,6 +2716,36 @@ function wireChannelIngress(
   registry.setReady();
 }
 
+function stampInboundUserMessageOtids(
+  incoming: IncomingMessage,
+): IncomingMessage {
+  let didChange = false;
+  const messages = incoming.messages.map((payload) => {
+    if (!("content" in payload) || payload.otid) {
+      return payload;
+    }
+
+    didChange = true;
+    return {
+      ...payload,
+      otid:
+        "client_message_id" in payload &&
+        typeof payload.client_message_id === "string"
+          ? payload.client_message_id
+          : crypto.randomUUID(),
+    } satisfies MessageCreate & { client_message_id?: string };
+  });
+
+  if (!didChange) {
+    return incoming;
+  }
+
+  return {
+    ...incoming,
+    messages,
+  };
+}
+
 function enqueueChannelTurn(
   runtime: ConversationRuntime,
   route: {
@@ -2741,18 +2771,21 @@ function enqueueChannelTurn(
     return null;
   }
 
-  runtime.queuedMessagesByItemId.set(enqueuedItem.id, {
-    type: "message",
-    agentId: route.agentId,
-    conversationId: route.conversationId,
-    messages: [
-      {
-        role: "user",
-        content: messageContent,
-        client_message_id: clientMessageId,
-      } satisfies MessageCreate & { client_message_id?: string },
-    ],
-  });
+  runtime.queuedMessagesByItemId.set(
+    enqueuedItem.id,
+    stampInboundUserMessageOtids({
+      type: "message",
+      agentId: route.agentId,
+      conversationId: route.conversationId,
+      messages: [
+        {
+          role: "user",
+          content: messageContent,
+          client_message_id: clientMessageId,
+        } satisfies MessageCreate & { client_message_id?: string },
+      ],
+    }),
+  );
 
   return enqueuedItem;
 }
@@ -3814,7 +3847,8 @@ async function connectWithRetry(
         );
 
         if (shouldQueueInboundMessage(incoming)) {
-          const firstUserPayload = incoming.messages.find(
+          const queuedIncoming = stampInboundUserMessageOtids(incoming);
+          const firstUserPayload = queuedIncoming.messages.find(
             (
               payload,
             ): payload is MessageCreate & { client_message_id?: string } =>
@@ -3834,7 +3868,7 @@ async function connectWithRetry(
             if (enqueuedItem) {
               scopedRuntime.queuedMessagesByItemId.set(
                 enqueuedItem.id,
-                incoming,
+                queuedIncoming,
               );
             }
           }

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -552,7 +552,10 @@ export function emitDequeuedUserMessage(
       : Array.isArray(content) && content.length > 0;
   if (!hasContent) return;
 
-  const otid = firstUserPayload.client_message_id ?? batch.batchId;
+  const otid =
+    firstUserPayload.otid ??
+    firstUserPayload.client_message_id ??
+    batch.batchId;
 
   emitCanonicalMessageDelta(
     socket,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -452,7 +452,16 @@ export async function handleIncomingMessage(
 
     messagesToSend.push(
       ...normalizedMessages.map((m) =>
-        "content" in m && !m.otid ? { ...m, otid: crypto.randomUUID() } : m,
+        "content" in m && !m.otid
+          ? {
+              ...m,
+              otid:
+                "client_message_id" in m &&
+                typeof m.client_message_id === "string"
+                  ? m.client_message_id
+                  : crypto.randomUUID(),
+            }
+          : m,
       ),
     );
 


### PR DESCRIPTION
## Summary
- stamp an OTID onto queued inbound user messages as they enter the listener queue
- make dequeued synthetic user message emission prefer the stamped OTID instead of recomputing from queue metadata
- make the direct send path fall back to `client_message_id` before minting a fresh OTID
- add regression coverage for channel queue ingress and direct `client_message_id` OTID reuse

## Why
Slack/channel backfill in UMI deduplicates user messages by OTID. We were emitting the synthetic dequeued user row with an OTID derived from `client_message_id`, but then sending the real request with a fresh random OTID. That made the same logical user message look like two different rows until a cold reload.

This patch establishes one OTID at queue ingress and preserves it through dequeue rendering and the real send path.

## Validation
- `bun install`
- `bun test src/tests/websocket/listen-client-concurrency.test.ts`
- `bun test src/tests/websocket/listen-client-protocol.test.ts`
- `bun run typecheck`
- `bun run lint` still reports pre-existing repo issues outside this patch (`src/agent/reconcileExistingAgentState.ts`, `src/web/generate-memory-viewer.ts`)