### PR TITLE
fix(channels): scope MessageChannel to bound conversations

### DIFF
--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -6,6 +6,15 @@ import type {
 import { getActiveChannelIds } from "./registry";
 import type { SupportedChannelId } from "./types";
 
+export type MessageChannelToolScopeEntry = {
+  channelId: SupportedChannelId;
+  accountId?: string | null;
+};
+
+export type MessageChannelToolDiscoveryScope = {
+  channels: MessageChannelToolScopeEntry[];
+};
+
 type ResolvedMessageChannelToolDiscovery = {
   activeChannels: SupportedChannelId[];
   actions: string[];
@@ -118,16 +127,28 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
   return `${description}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
-export async function resolveMessageChannelToolDiscovery(): Promise<ResolvedMessageChannelToolDiscovery> {
-  const activeChannels = getActiveChannelIds() as SupportedChannelId[];
+export async function resolveMessageChannelToolDiscovery(
+  scope?: MessageChannelToolDiscoveryScope | null,
+): Promise<ResolvedMessageChannelToolDiscovery> {
+  const scopedChannels = scope?.channels ?? [];
+  const discoveryTargets =
+    scopedChannels.length > 0
+      ? scopedChannels
+      : (getActiveChannelIds() as SupportedChannelId[]).map((channelId) => ({
+          channelId,
+          accountId: null,
+        }));
+  const activeChannels = Array.from(
+    new Set(discoveryTargets.map(({ channelId }) => channelId)),
+  );
   const actions = new Set<string>(["send"]);
   const schemaContributions: ChannelMessageToolSchemaContribution[] = [];
 
-  for (const channelId of activeChannels) {
+  for (const { channelId, accountId } of discoveryTargets) {
     try {
       const plugin = await loadChannelPlugin(channelId);
       const discovery = plugin.messageActions?.describeMessageTool({
-        accountId: null,
+        accountId: accountId ?? null,
       });
 
       for (const action of collectDiscoveryActions(discovery)) {
@@ -148,16 +169,18 @@ export async function resolveMessageChannelToolDiscovery(): Promise<ResolvedMess
 
 export async function buildDynamicMessageChannelSchema(
   baseSchema: Record<string, unknown>,
+  scope?: MessageChannelToolDiscoveryScope | null,
 ): Promise<Record<string, unknown>> {
-  const discovery = await resolveMessageChannelToolDiscovery();
+  const discovery = await resolveMessageChannelToolDiscovery(scope);
   return buildDynamicMessageChannelSchemaFromDiscovery(baseSchema, discovery);
 }
 
 export async function buildDynamicMessageChannelToolDefinition(
   baseDescription: string,
   baseSchema: Record<string, unknown>,
+  scope?: MessageChannelToolDiscoveryScope | null,
 ): Promise<CachedDynamicMessageChannelTool> {
-  const discovery = await resolveMessageChannelToolDiscovery();
+  const discovery = await resolveMessageChannelToolDiscovery(scope);
   const resolved = {
     description: buildDynamicMessageChannelDescriptionFromDiscovery(
       baseDescription,
@@ -168,10 +191,12 @@ export async function buildDynamicMessageChannelToolDefinition(
       discovery,
     ),
   };
-  cachedDynamicMessageChannelTool = {
-    description: resolved.description,
-    schema: structuredClone(resolved.schema),
-  };
+  if (!scope || scope.channels.length === 0) {
+    cachedDynamicMessageChannelTool = {
+      description: resolved.description,
+      schema: structuredClone(resolved.schema),
+    };
+  }
   return resolved;
 }
 

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -107,4 +107,36 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
   });
+
+  test("can narrow discovery to the channels bound for the current conversation scope", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    const resolved = await buildDynamicMessageChannelToolDefinition(
+      "Base MessageChannel description.",
+      {
+        type: "object",
+        properties: {
+          action: { type: "string" },
+          channel: { type: "string" },
+          chat_id: { type: "string" },
+        },
+        required: ["action", "channel", "chat_id"],
+        additionalProperties: false,
+      },
+      {
+        channels: [{ channelId: "slack", accountId: "acct-slack" }],
+      },
+    );
+
+    const properties = resolved.schema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(resolved.description).toContain("Currently active channels: Slack.");
+    expect(resolved.description).not.toContain("Telegram");
+    expect(properties.channel?.enum).toEqual(["slack"]);
+    expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
+  });
 });

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -19,6 +19,7 @@ import {
   getToolSchema,
   loadSpecificTools,
   prepareCurrentToolExecutionContext,
+  prepareToolExecutionContextForModel,
   prepareToolExecutionContextForSpecificTools,
   refreshDynamicChannelToolsInLoadedRegistry,
 } from "../../tools/manager";
@@ -184,5 +185,60 @@ describe("tool execution context snapshot", () => {
     expect(
       (schema?.input_schema.properties?.channel as { enum?: string[] }).enum,
     ).toEqual(["telegram"]);
+  });
+
+  test("omits MessageChannel from scoped snapshots when the conversation has no bound channel routes", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        channelToolScope: { channels: [] },
+      },
+    );
+
+    expect(prepared.loadedToolNames).not.toContain("MessageChannel");
+    expect(
+      prepared.clientTools.some((tool) => tool.name === "MessageChannel"),
+    ).toBe(false);
+  });
+
+  test("preserves scoped MessageChannel discovery even when the global cache was seeded differently", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    await refreshDynamicChannelToolsInLoadedRegistry();
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        channelToolScope: {
+          channels: [{ channelId: "slack", accountId: "acct-slack" }],
+        },
+      },
+    );
+    const messageChannel = prepared.clientTools.find(
+      (tool) => tool.name === "MessageChannel",
+    );
+
+    expect(prepared.loadedToolNames).toContain("MessageChannel");
+    expect(messageChannel?.description).toContain(
+      "Currently active channels: Slack.",
+    );
+    expect(messageChannel?.description).not.toContain("Telegram");
+    expect(
+      (
+        messageChannel?.parameters?.properties as Record<
+          string,
+          { enum?: string[] }
+        >
+      ).channel?.enum,
+    ).toEqual(["slack"]);
   });
 });

--- a/src/tests/websocket/listen-model-update.test.ts
+++ b/src/tests/websocket/listen-model-update.test.ts
@@ -153,9 +153,8 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
     expect(source).toContain(
       "await ensureCorrectMemoryTool(agentId, model.handle)",
     );
-    expect(source).toContain(
-      "await prepareToolExecutionContextForResolvedTarget({",
-    );
+    expect(source).toContain("await prepareToolExecutionContextForScope({");
+    expect(source).toContain("overrideModel: model.handle");
     expect(source).toContain(
       "scopedRuntime.currentLoadedTools = nextLoadedTools;",
     );

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -6,6 +6,7 @@ import { getAllSubagentConfigs } from "../agent/subagents";
 import {
   buildDynamicMessageChannelToolDefinition,
   getCachedDynamicMessageChannelToolDefinition,
+  type MessageChannelToolDiscoveryScope,
 } from "../channels/messageTool";
 import { getActiveChannelIds } from "../channels/registry";
 import { refreshFileIndex } from "../cli/helpers/fileIndex";
@@ -34,9 +35,16 @@ export const TOOL_NAMES = Object.keys(TOOL_DEFINITIONS) as ToolName[];
  * Append MessageChannel tool if any channels are active.
  * Used by both resolveBaseToolNamesForModel() and getToolNamesForToolset().
  */
-function maybeAppendChannelTools(toolNames: ToolName[]): ToolName[] {
+function maybeAppendChannelTools(
+  toolNames: ToolName[],
+  channelToolScope?: MessageChannelToolDiscoveryScope | null,
+): ToolName[] {
+  const hasActiveChannelTools =
+    channelToolScope !== undefined
+      ? (channelToolScope?.channels.length ?? 0) > 0
+      : getActiveChannelIds().length > 0;
   if (
-    getActiveChannelIds().length > 0 &&
+    hasActiveChannelTools &&
     !toolNames.includes("MessageChannel" as ToolName)
   ) {
     return [...toolNames, "MessageChannel" as ToolName];
@@ -52,6 +60,7 @@ async function maybeResolveDynamicChannelTool(
   name: string,
   description: string,
   schema: Record<string, unknown>,
+  channelToolScope?: MessageChannelToolDiscoveryScope | null,
 ): Promise<{ description: string; input_schema: Record<string, unknown> }> {
   if (name !== "MessageChannel") {
     return {
@@ -62,6 +71,7 @@ async function maybeResolveDynamicChannelTool(
   const resolved = await buildDynamicMessageChannelToolDefinition(
     description,
     schema,
+    channelToolScope,
   );
   return {
     description: resolved.description,
@@ -71,6 +81,14 @@ async function maybeResolveDynamicChannelTool(
 
 function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
   const nextRegistry = new Map(registry);
+  const existing = nextRegistry.get("MessageChannel");
+  if (
+    existing &&
+    existing.schema.description !== TOOL_DEFINITIONS.MessageChannel.description
+  ) {
+    return nextRegistry;
+  }
+
   if (getActiveChannelIds().length === 0) {
     nextRegistry.delete("MessageChannel");
     return nextRegistry;
@@ -81,7 +99,6 @@ function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
     return nextRegistry;
   }
 
-  const existing = nextRegistry.get("MessageChannel");
   nextRegistry.set("MessageChannel", {
     schema: {
       name: "MessageChannel",
@@ -820,9 +837,13 @@ export async function prepareToolExecutionContextForSpecificTools(
   options?: {
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<PreparedToolExecutionContext> {
-  const toolRegistrySnapshot = await buildSpecificToolRegistry(toolNames);
+  const toolRegistrySnapshot = await buildSpecificToolRegistry(
+    toolNames,
+    options?.channelToolScope,
+  );
   return capturePreparedToolExecutionContext(
     {
       toolRegistry: toolRegistrySnapshot,
@@ -839,6 +860,7 @@ export async function prepareToolExecutionContextForModel(
     exclude?: ToolName[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<PreparedToolExecutionContext> {
   const toolRegistrySnapshot = await buildRegistryForModel(
@@ -1002,6 +1024,7 @@ function maybeApplyLspReadOverride(registry: ToolRegistry): void {
 
 async function buildSpecificToolRegistry(
   toolNames: string[],
+  channelToolScope?: MessageChannelToolDiscoveryScope | null,
 ): Promise<ToolRegistry> {
   const { toolFilter } = await import("./filter");
   const newRegistry: ToolRegistry = new Map();
@@ -1028,6 +1051,7 @@ async function buildSpecificToolRegistry(
       internalName,
       definition.description,
       definition.schema,
+      channelToolScope,
     );
 
     const toolSchema: ToolSchema = {
@@ -1048,7 +1072,10 @@ async function buildSpecificToolRegistry(
 
 async function resolveBaseToolNamesForModel(
   modelIdentifier?: string,
-  options?: { exclude?: ToolName[] },
+  options?: {
+    exclude?: ToolName[];
+    channelToolScope?: MessageChannelToolDiscoveryScope | null;
+  },
 ): Promise<ToolName[]> {
   const { toolFilter } = await import("./filter");
   let baseToolNames: ToolName[];
@@ -1076,14 +1103,20 @@ async function resolveBaseToolNamesForModel(
   }
 
   // Append channel tool if channels are active
-  baseToolNames = maybeAppendChannelTools(baseToolNames);
+  baseToolNames = maybeAppendChannelTools(
+    baseToolNames,
+    options?.channelToolScope,
+  );
 
   return baseToolNames;
 }
 
 async function buildRegistryForModel(
   modelIdentifier?: string,
-  options?: { exclude?: ToolName[] },
+  options?: {
+    exclude?: ToolName[];
+    channelToolScope?: MessageChannelToolDiscoveryScope | null;
+  },
 ): Promise<ToolRegistry> {
   const { toolFilter } = await import("./filter");
   const allSubagentConfigs = await getAllSubagentConfigs();
@@ -1127,6 +1160,7 @@ async function buildRegistryForModel(
         name,
         description,
         definition.schema,
+        options?.channelToolScope,
       );
 
       const toolSchema: ToolSchema = {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -1,7 +1,13 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getClient } from "../agent/client";
 import { resolveModel } from "../agent/model";
-import { getActiveChannelIds } from "../channels/registry";
+import type { MessageChannelToolDiscoveryScope } from "../channels/messageTool";
+import { getChannelRegistry } from "../channels/registry";
+import { getRoutesForChannel, loadRoutes } from "../channels/routing";
+import {
+  SUPPORTED_CHANNEL_IDS,
+  type SupportedChannelId,
+} from "../channels/types";
 import { settingsManager } from "../settings-manager";
 import { toolFilter } from "./filter";
 import {
@@ -93,7 +99,10 @@ function getPreferredAgentModelHandle(
   return buildModelHandleFromLlmConfig(agent.llm_config);
 }
 
-function getToolNamesForToolset(toolsetName: ToolsetName): ToolName[] {
+function getToolNamesForToolset(
+  toolsetName: ToolsetName,
+  channelToolScope?: MessageChannelToolDiscoveryScope | null,
+): ToolName[] {
   let tools: ToolName[];
   switch (toolsetName) {
     case "codex":
@@ -115,11 +124,13 @@ function getToolNamesForToolset(toolsetName: ToolsetName): ToolName[] {
       break;
   }
 
+  const hasScopedChannelTool =
+    channelToolScope !== undefined
+      ? (channelToolScope?.channels.length ?? 0) > 0
+      : (getChannelRegistry()?.getActiveChannelIds().length ?? 0) > 0;
+
   // Append channel tool if channels are active (covers ALL pinned toolsets)
-  if (
-    getActiveChannelIds().length > 0 &&
-    !tools.includes("MessageChannel" as ToolName)
-  ) {
+  if (hasScopedChannelTool && !tools.includes("MessageChannel" as ToolName)) {
     tools.push("MessageChannel" as ToolName);
   }
 
@@ -132,6 +143,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   exclude?: ToolName[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  channelToolScope?: MessageChannelToolDiscoveryScope | null;
 }): Promise<PreparedScopeToolContext> {
   const {
     modelIdentifier,
@@ -139,6 +151,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    channelToolScope,
   } = params;
   const effectiveModel =
     modelIdentifier && modelIdentifier.length > 0
@@ -152,6 +165,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
         exclude,
         workingDirectory,
         permissionModeState,
+        channelToolScope,
       },
     );
 
@@ -166,12 +180,13 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   }
 
   const preparedToolContext = await prepareToolExecutionContextForSpecificTools(
-    getToolNamesForToolset(toolsetPreference).filter((toolName) =>
-      exclude ? !exclude.includes(toolName) : true,
+    getToolNamesForToolset(toolsetPreference, channelToolScope).filter(
+      (toolName) => (exclude ? !exclude.includes(toolName) : true),
     ),
     {
       workingDirectory,
       permissionModeState,
+      channelToolScope,
     },
   );
 
@@ -181,6 +196,52 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     toolsetPreference,
     effectiveModel,
   };
+}
+
+function resolveConversationChannelToolScope(
+  agentId: string,
+  conversationId: string,
+): MessageChannelToolDiscoveryScope {
+  const registry = getChannelRegistry();
+  if (!registry) {
+    return { channels: [] };
+  }
+
+  const channels: Array<{
+    channelId: SupportedChannelId;
+    accountId?: string | null;
+  }> = [];
+  const seen = new Set<string>();
+
+  for (const channelId of SUPPORTED_CHANNEL_IDS) {
+    loadRoutes(channelId);
+    for (const route of getRoutesForChannel(channelId)) {
+      if (
+        route.agentId !== agentId ||
+        route.conversationId !== conversationId ||
+        !route.enabled
+      ) {
+        continue;
+      }
+
+      const adapter = registry.getAdapter(channelId, route.accountId);
+      if (!adapter?.isRunning()) {
+        continue;
+      }
+
+      const key = `${channelId}:${route.accountId ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      channels.push({
+        channelId,
+        accountId: route.accountId ?? null,
+      });
+    }
+  }
+
+  return { channels };
 }
 
 export async function prepareToolExecutionContextForScope(params: {
@@ -233,6 +294,10 @@ export async function prepareToolExecutionContextForScope(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    channelToolScope: resolveConversationChannelToolScope(
+      agentId,
+      conversationId ?? "default",
+    ),
   });
 }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -64,7 +64,7 @@ import { trackBoundaryError } from "../../telemetry/errorReporting";
 import { loadTools } from "../../tools/manager";
 import {
   ensureCorrectMemoryTool,
-  prepareToolExecutionContextForResolvedTarget,
+  prepareToolExecutionContextForScope,
   type ToolsetName,
 } from "../../tools/toolset";
 import { formatToolsetName } from "../../tools/toolset-labels";
@@ -669,11 +669,11 @@ async function applyModelUpdateForRuntime(params: {
 
   try {
     await ensureCorrectMemoryTool(agentId, model.handle);
-    const preparedToolContext =
-      await prepareToolExecutionContextForResolvedTarget({
-        modelIdentifier: model.handle,
-        toolsetPreference,
-      });
+    const preparedToolContext = await prepareToolExecutionContextForScope({
+      agentId,
+      conversationId,
+      overrideModel: model.handle,
+    });
     nextToolset = preparedToolContext.toolset;
     nextLoadedTools = preparedToolContext.preparedToolContext.loadedToolNames;
     scopedRuntime.currentToolset = preparedToolContext.toolset;


### PR DESCRIPTION
## Summary
- scope MessageChannel discovery to the active routes bound for the current agent/conversation instead of any globally-running channel adapter
- use that scoped channel set both when deciding whether MessageChannel should exist at all and when building its dynamic schema/description
- make model-update tool refreshes rebuild the tool snapshot from conversation scope so desktop status/toolset updates stay aligned with the selected conversation
- add regressions for empty scoped snapshots, scoped schema narrowing, and preserving scoped MessageChannel definitions even when the global cache was seeded differently

## Why
We were appending MessageChannel whenever any Slack/Telegram adapter was active globally. That leaked the tool into unrelated conversations and could also give a conversation the wrong schema/description if another active channel set had already primed the dynamic cache.

This patch makes MessageChannel conversation-scoped: it only appears when that specific conversation has enabled bound routes on a running channel account.

## Validation
- `bun run typecheck`
- `bun test src/tests/channels/message-tool-schema.test.ts src/tests/tools/tool-execution-context.test.ts src/tests/websocket/listen-model-update.test.ts`
- `bun run lint` reports only pre-existing repo warnings outside this patch (`src/agent/reconcileExistingAgentState.ts`, `src/web/generate-memory-viewer.ts`)