### PR TITLE
feat: add update_toolset WebSocket command for desktop UI

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -707,6 +707,22 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed).toBeNull();
   });
 
+  test("parses update_toolset command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "update_toolset",
+          request_id: "update-toolset-1",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          toolset_preference: "gemini",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("update_toolset");
+  });
+
   test("parses skill enable/disable commands", () => {
     const skillEnable = parseServerMessage(
       Buffer.from(

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -859,6 +859,26 @@ export interface UpdateModelResponseMessage {
   error?: string;
 }
 
+export interface UpdateToolsetCommand {
+  type: "update_toolset";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Runtime scope — identifies which agent + conversation this targets */
+  runtime: RuntimeScope;
+  /** The toolset preference to apply (e.g. "auto", "default", "codex", "gemini") */
+  toolset_preference: ToolsetPreference;
+}
+
+export interface UpdateToolsetResponseMessage {
+  type: "update_toolset_response";
+  request_id: string;
+  success: boolean;
+  runtime?: RuntimeScope;
+  current_toolset?: ToolsetName;
+  current_toolset_preference?: ToolsetPreference;
+  error?: string;
+}
+
 export interface CronListCommand {
   type: "cron_list";
   /** Echoed back in the response for request correlation. */
@@ -1538,6 +1558,7 @@ export type WsProtocolCommand =
   | EnableMemfsCommand
   | ListModelsCommand
   | UpdateModelCommand
+  | UpdateToolsetCommand
   | CronListCommand
   | CronAddCommand
   | CronGetCommand
@@ -1580,6 +1601,7 @@ export type WsProtocolMessage =
   | SubagentStateUpdateMessage
   | ListModelsResponseMessage
   | UpdateModelResponseMessage
+  | UpdateToolsetResponseMessage
   | ChannelsListResponseMessage
   | ChannelAccountsListResponseMessage
   | ChannelAccountCreateResponseMessage

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -71,6 +71,7 @@ import {
   ensureCorrectMemoryTool,
   prepareToolExecutionContextForScope,
   type ToolsetName,
+  type ToolsetPreference,
 } from "../../tools/toolset";
 import { formatToolsetName } from "../../tools/toolset-labels";
 import type {
@@ -113,6 +114,7 @@ import type {
   SkillDisableCommand,
   SkillEnableCommand,
   UpdateModelResponseMessage,
+  UpdateToolsetResponseMessage,
 } from "../../types/protocol_v2";
 import { isDebugEnabled } from "../../utils/debug";
 import {
@@ -205,6 +207,7 @@ import {
   isSkillEnableCommand,
   isUnwatchFileCommand,
   isUpdateModelCommand,
+  isUpdateToolsetCommand,
   isWatchFileCommand,
   isWriteFileCommand,
   parseServerMessage,
@@ -841,6 +844,88 @@ async function applyModelUpdateForRuntime(params: {
     model_id: model.id,
     model_handle: model.handle,
     model_settings: modelSettings,
+  };
+}
+
+async function applyToolsetUpdateForRuntime(params: {
+  socket: WebSocket;
+  listener: ListenerRuntime;
+  scopedRuntime: ConversationRuntime;
+  requestId: string;
+  toolsetPreference: ToolsetPreference;
+}): Promise<UpdateToolsetResponseMessage> {
+  const { socket, listener, scopedRuntime, requestId, toolsetPreference } =
+    params;
+  const agentId = scopedRuntime.agentId;
+  const conversationId = scopedRuntime.conversationId;
+
+  if (!agentId) {
+    return {
+      type: "update_toolset_response",
+      request_id: requestId,
+      success: false,
+      error: "Missing agent_id in runtime scope",
+    };
+  }
+
+  const previousToolNames = scopedRuntime.currentLoadedTools;
+  let nextToolset: ToolsetName;
+  const previousToolsetPreference = (() => {
+    try {
+      return settingsManager.getToolsetPreference(agentId);
+    } catch {
+      return scopedRuntime.currentToolsetPreference;
+    }
+  })();
+
+  try {
+    settingsManager.setToolsetPreference(agentId, toolsetPreference);
+    const preparedToolContext = await prepareToolExecutionContextForScope({
+      agentId,
+      conversationId,
+    });
+    nextToolset = preparedToolContext.toolset;
+    scopedRuntime.currentToolset = preparedToolContext.toolset;
+    scopedRuntime.currentToolsetPreference =
+      preparedToolContext.toolsetPreference;
+    scopedRuntime.currentLoadedTools =
+      preparedToolContext.preparedToolContext.loadedToolNames;
+  } catch (error) {
+    settingsManager.setToolsetPreference(agentId, previousToolsetPreference);
+    throw error;
+  }
+
+  const toolsChanged =
+    JSON.stringify(previousToolNames) !==
+    JSON.stringify(scopedRuntime.currentLoadedTools);
+
+  const statusMessage =
+    toolsetPreference === "auto"
+      ? `Toolset mode set to auto (currently ${formatToolsetName(nextToolset)}).`
+      : `Switched toolset to ${formatToolsetName(nextToolset)} (manual override).`;
+
+  emitStatusDelta(socket, scopedRuntime, {
+    message: statusMessage,
+    level: toolsChanged ? "info" : "info",
+    agentId,
+    conversationId,
+  });
+
+  emitRuntimeStateUpdates(listener, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
+
+  return {
+    type: "update_toolset_response",
+    request_id: requestId,
+    success: true,
+    runtime: {
+      agent_id: agentId,
+      conversation_id: conversationId,
+    },
+    current_toolset: nextToolset,
+    current_toolset_preference: toolsetPreference,
   };
 }
 
@@ -5329,7 +5414,55 @@ async function connectWithRetry(
         return;
       }
 
-      // ── Memory history (git log, optionally scoped to a file) ─────────
+      // ── Toolset update command (runtime scoped) ──────────────────────
+      if (isUpdateToolsetCommand(parsed)) {
+        runDetachedListenerTask("update_toolset", async () => {
+          const scopedRuntime = getOrCreateScopedRuntime(
+            runtime,
+            parsed.runtime.agent_id,
+            parsed.runtime.conversation_id,
+          );
+
+          try {
+            const response = await applyToolsetUpdateForRuntime({
+              socket,
+              listener: runtime,
+              scopedRuntime,
+              requestId: parsed.request_id,
+              toolsetPreference: parsed.toolset_preference,
+            });
+            safeSocketSend(
+              socket,
+              response,
+              "listener_update_toolset_send_failed",
+              "listener_update_toolset",
+            );
+          } catch (error) {
+            const failure: UpdateToolsetResponseMessage = {
+              type: "update_toolset_response",
+              request_id: parsed.request_id,
+              success: false,
+              runtime: {
+                agent_id: parsed.runtime.agent_id,
+                conversation_id: parsed.runtime.conversation_id,
+              },
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to update toolset",
+            };
+            safeSocketSend(
+              socket,
+              failure,
+              "listener_update_toolset_send_failed",
+              "listener_update_toolset",
+            );
+          }
+        });
+        return;
+      }
+
+      // ── Memory history (git log for a specific file) ─────────────────
       if (isMemoryHistoryCommand(parsed)) {
         runDetachedListenerTask("memory_history", async () => {
           const { getMemoryFilesystemRoot } = await import(

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -38,6 +38,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "init",
   "remember",
   "channels",
+  "toolset",
 ];
 
 /**

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -56,6 +56,7 @@ import type {
   TerminalSpawnCommand,
   UnwatchFileCommand,
   UpdateModelCommand,
+  UpdateToolsetCommand,
   WatchFileCommand,
   WriteFileCommand,
   WsProtocolCommand,
@@ -547,6 +548,24 @@ export function isUpdateModelCommand(
     typeof payload.model_handle === "string";
 
   return hasModelId && hasModelHandle && hasAtLeastOne;
+}
+
+export function isUpdateToolsetCommand(
+  value: unknown,
+): value is UpdateToolsetCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    runtime?: unknown;
+    toolset_preference?: unknown;
+  };
+  return (
+    c.type === "update_toolset" &&
+    typeof c.request_id === "string" &&
+    isRuntimeScope(c.runtime) &&
+    typeof c.toolset_preference === "string"
+  );
 }
 
 export function isCronListCommand(value: unknown): value is CronListCommand {
@@ -1329,6 +1348,7 @@ export function parseServerMessage(
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||
       isUpdateModelCommand(parsed) ||
+      isUpdateToolsetCommand(parsed) ||
       isCronListCommand(parsed) ||
       isCronAddCommand(parsed) ||
       isCronGetCommand(parsed) ||


### PR DESCRIPTION
Adds protocol support for switching toolsets from the web UI via the `update_toolset` command, supporting both auto and manual override modes.

🤖 Generated with [Letta Code](https://letta.com)