### PR TITLE
fix(memory): separate memfs state from local checkout

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -67,6 +67,43 @@ export function ensureMemoryFilesystemDirs(
   }
 }
 
+/**
+ * Returns whether memfs is enabled for the agent on the server.
+ *
+ * This is a read-only check used by desktop/listener surfaces that need to
+ * distinguish "memfs disabled" from "enabled but local checkout missing"
+ * without mutating agent configuration.
+ */
+export async function isMemfsEnabledOnServer(
+  agentId: string,
+): Promise<boolean> {
+  const { getClient } = await import("./client");
+  const client = await getClient();
+  const agent = await client.agents.retrieve(agentId);
+  const { GIT_MEMORY_ENABLED_TAG } = await import("./memoryGit");
+  const enabled = agent.tags?.includes(GIT_MEMORY_ENABLED_TAG) ?? false;
+
+  const { settingsManager } = await import("../settings-manager");
+  settingsManager.setMemfsEnabled(agentId, enabled);
+
+  return enabled;
+}
+
+/**
+ * Ensures the local memfs checkout exists for an already-enabled agent.
+ *
+ * Unlike applyMemfsFlags(), this helper does not update prompts, tags, tools,
+ * or other agent configuration. It only materializes the local git checkout
+ * when the repo is missing.
+ */
+export async function ensureLocalMemfsCheckout(agentId: string): Promise<void> {
+  const { isGitRepo, cloneMemoryRepo } = await import("./memoryGit");
+  if (isGitRepo(agentId)) {
+    return;
+  }
+  await cloneMemoryRepo(agentId);
+}
+
 // ----- Path helpers -----
 
 export function labelFromRelativePath(relativePath: string): string {

--- a/src/agent/memoryScanner.ts
+++ b/src/agent/memoryScanner.ts
@@ -66,7 +66,7 @@ export function scanMemoryFilesystem(memoryRoot: string): TreeNode[] {
         return; // Skip if we can't stat
       }
 
-      const relativePath = relative(memoryRoot, fullPath);
+      const relativePath = relative(memoryRoot, fullPath).replace(/\\/g, "/");
       const isLast = index === sorted.length - 1;
 
       nodes.push({

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1085,6 +1085,103 @@ describe("listen-client cron command handling", () => {
   });
 });
 
+describe("listen-client memory command handling", () => {
+  test("returns explicit disabled state when memfs is not enabled for the agent", async () => {
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
+    const socket = new MockSocket(WebSocket.OPEN);
+    const ensureLocalMemfsCheckoutMock = mock(async () => {});
+
+    mock.module("../../agent/memoryFilesystem", () => ({
+      getMemoryFilesystemRoot: () => tempRoot,
+      isMemfsEnabledOnServer: mock(async () => false),
+      ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+    }));
+
+    try {
+      await __listenClientTestUtils.handleListMemoryCommand(
+        {
+          type: "list_memory",
+          request_id: "list-memory-disabled-1",
+          agent_id: "agent-1",
+          include_references: true,
+        },
+        socket as unknown as WebSocket,
+      );
+
+      expect(ensureLocalMemfsCheckoutMock).not.toHaveBeenCalled();
+      expect(JSON.parse(socket.sentPayloads[0] as string)).toMatchObject({
+        type: "list_memory_response",
+        request_id: "list-memory-disabled-1",
+        success: true,
+        done: true,
+        total: 0,
+        memfs_enabled: false,
+        memfs_initialized: false,
+        entries: [],
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("bootstraps only the local memfs checkout when memfs is already enabled", async () => {
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
+    const socket = new MockSocket(WebSocket.OPEN);
+    const ensureLocalMemfsCheckoutMock = mock(async () => {
+      await mkdir(join(tempRoot, ".git"), { recursive: true });
+      await mkdir(join(tempRoot, "system"), { recursive: true });
+      await writeFile(
+        join(tempRoot, "system", "persona.md"),
+        "---\ndescription: Persona\n---\nHello from memory\n",
+      );
+    });
+
+    mock.module("../../agent/memoryFilesystem", () => ({
+      getMemoryFilesystemRoot: () => tempRoot,
+      isMemfsEnabledOnServer: mock(async () => true),
+      ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+    }));
+
+    try {
+      await __listenClientTestUtils.handleListMemoryCommand(
+        {
+          type: "list_memory",
+          request_id: "list-memory-enabled-1",
+          agent_id: "agent-1",
+          include_references: true,
+        },
+        socket as unknown as WebSocket,
+      );
+
+      expect(ensureLocalMemfsCheckoutMock).toHaveBeenCalledTimes(1);
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: "list_memory_response",
+        request_id: "list-memory-enabled-1",
+        success: true,
+        done: true,
+        total: 1,
+        memfs_enabled: true,
+        memfs_initialized: true,
+      });
+      expect(messages[0].entries).toEqual([
+        expect.objectContaining({
+          relative_path: "system/persona.md",
+          is_system: true,
+          description: "Persona",
+          references: [],
+        }),
+      ]);
+      expect(messages[0].entries[0]?.content).toContain("Hello from memory");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("listen-client channels command handling", () => {
   test("returns typed channel summaries over WS", async () => {
     const socket = new MockSocket(WebSocket.OPEN);

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -87,6 +87,7 @@ const actualChannelsService = await import("../../channels/service");
 
 afterEach(() => {
   __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
+  mock.restore();
 });
 
 describe("listen-client channel command dispatch", () => {
@@ -1091,12 +1092,6 @@ describe("listen-client memory command handling", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const ensureLocalMemfsCheckoutMock = mock(async () => {});
 
-    mock.module("../../agent/memoryFilesystem", () => ({
-      getMemoryFilesystemRoot: () => tempRoot,
-      isMemfsEnabledOnServer: mock(async () => false),
-      ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
-    }));
-
     try {
       await __listenClientTestUtils.handleListMemoryCommand(
         {
@@ -1106,6 +1101,11 @@ describe("listen-client memory command handling", () => {
           include_references: true,
         },
         socket as unknown as WebSocket,
+        {
+          getMemoryFilesystemRoot: () => tempRoot,
+          isMemfsEnabledOnServer: async () => false,
+          ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+        },
       );
 
       expect(ensureLocalMemfsCheckoutMock).not.toHaveBeenCalled();
@@ -1136,12 +1136,6 @@ describe("listen-client memory command handling", () => {
       );
     });
 
-    mock.module("../../agent/memoryFilesystem", () => ({
-      getMemoryFilesystemRoot: () => tempRoot,
-      isMemfsEnabledOnServer: mock(async () => true),
-      ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
-    }));
-
     try {
       await __listenClientTestUtils.handleListMemoryCommand(
         {
@@ -1151,6 +1145,11 @@ describe("listen-client memory command handling", () => {
           include_references: true,
         },
         socket as unknown as WebSocket,
+        {
+          getMemoryFilesystemRoot: () => tempRoot,
+          isMemfsEnabledOnServer: async () => true,
+          ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+        },
       );
 
       expect(ensureLocalMemfsCheckoutMock).toHaveBeenCalledTimes(1);

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -99,6 +99,7 @@ import type {
   CronGetCommand,
   CronListCommand,
   GetReflectionSettingsCommand,
+  ListMemoryCommand,
   ListModelsResponseMessage,
   ListModelsResponseModelEntry,
   ReflectionSettingsScope,
@@ -937,6 +938,256 @@ function emitChannelTargetsUpdated(
     "listener_channels_send_failed",
     "listener_channels_command",
   );
+}
+
+async function handleListMemoryCommand(
+  parsed: ListMemoryCommand,
+  socket: WebSocket,
+): Promise<boolean> {
+  try {
+    const {
+      ensureLocalMemfsCheckout,
+      getMemoryFilesystemRoot,
+      isMemfsEnabledOnServer,
+    } = await import("../../agent/memoryFilesystem");
+    const { scanMemoryFilesystem, getFileNodes, readFileContent } =
+      await import("../../agent/memoryScanner");
+    const { parseFrontmatter } = await import("../../utils/frontmatter");
+
+    const { existsSync } = await import("node:fs");
+    const { join, posix } = await import("node:path");
+
+    const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
+    let memfsInitialized = existsSync(join(memoryRoot, ".git"));
+    const memfsEnabled = memfsInitialized
+      ? true
+      : await isMemfsEnabledOnServer(parsed.agent_id);
+
+    if (!memfsEnabled) {
+      safeSocketSend(
+        socket,
+        {
+          type: "list_memory_response",
+          request_id: parsed.request_id,
+          entries: [],
+          done: true,
+          total: 0,
+          success: true,
+          memfs_enabled: false,
+          memfs_initialized: false,
+        },
+        "listener_list_memory_send_failed",
+        "listener_list_memory",
+      );
+      return true;
+    }
+
+    if (!memfsInitialized) {
+      await ensureLocalMemfsCheckout(parsed.agent_id);
+      memfsInitialized = existsSync(join(memoryRoot, ".git"));
+    }
+
+    if (!memfsInitialized) {
+      throw new Error(
+        "MemFS is enabled, but the local memory checkout could not be initialized.",
+      );
+    }
+
+    const treeNodes = scanMemoryFilesystem(memoryRoot);
+    const fileNodes = getFileNodes(treeNodes).filter((n) =>
+      n.name.endsWith(".md"),
+    );
+    const includeReferences = parsed.include_references === true;
+
+    const allPaths = new Set(fileNodes.map((node) => node.relativePath));
+
+    const normalizeMemoryReference = (
+      rawReference: string,
+      sourcePath: string,
+    ): string | null => {
+      let target = rawReference.trim();
+      if (!target) {
+        return null;
+      }
+
+      if (
+        target.startsWith("http://") ||
+        target.startsWith("https://") ||
+        target.startsWith("mailto:")
+      ) {
+        return null;
+      }
+
+      target = target.replace(/^<|>$/g, "");
+      target = target.split("#")[0] ?? "";
+      target = target.split("?")[0] ?? "";
+      target = target.trim().replace(/\\/g, "/");
+
+      if (!target || target.startsWith("#")) {
+        return null;
+      }
+
+      if (target.includes("|")) {
+        target = target.split("|")[0] ?? "";
+      }
+
+      if (!target) {
+        return null;
+      }
+
+      const sourceDir = posix.dirname(sourcePath.replace(/\\/g, "/"));
+      const candidate =
+        target.startsWith("./") || target.startsWith("../")
+          ? posix.normalize(posix.join(sourceDir, target))
+          : posix.normalize(target.startsWith("/") ? target.slice(1) : target);
+
+      if (
+        !candidate ||
+        candidate.startsWith("../") ||
+        candidate === "." ||
+        candidate === ".."
+      ) {
+        return null;
+      }
+
+      const withExtension = candidate.endsWith(".md")
+        ? candidate
+        : `${candidate}.md`;
+
+      const candidates = new Set<string>([withExtension]);
+
+      const isExplicitRelative =
+        target.startsWith("./") || target.startsWith("../");
+      if (
+        !isExplicitRelative &&
+        !target.startsWith("/") &&
+        sourceDir &&
+        sourceDir !== "."
+      ) {
+        candidates.add(posix.normalize(posix.join(sourceDir, withExtension)));
+      }
+
+      if (!withExtension.startsWith("system/")) {
+        candidates.add(posix.normalize(`system/${withExtension}`));
+      }
+
+      for (const resolved of candidates) {
+        if (allPaths.has(resolved)) {
+          return resolved;
+        }
+      }
+
+      return null;
+    };
+
+    const extractMemoryReferences = (
+      body: string,
+      sourcePath: string,
+    ): string[] => {
+      if (!body.includes("[[")) {
+        return [];
+      }
+
+      const refs = new Set<string>();
+
+      for (const wikiMatch of body.matchAll(WIKI_LINK_REGEX)) {
+        const rawTarget = wikiMatch[1];
+        if (!rawTarget) continue;
+        const normalized = normalizeMemoryReference(rawTarget, sourcePath);
+        if (normalized && normalized !== sourcePath) {
+          refs.add(normalized);
+        }
+      }
+
+      return [...refs];
+    };
+
+    const CHUNK_SIZE = 5;
+    const total = fileNodes.length;
+
+    for (let i = 0; i < total; i += CHUNK_SIZE) {
+      const chunk = fileNodes.slice(i, i + CHUNK_SIZE);
+      const entries = chunk.map((node) => {
+        const raw = readFileContent(node.fullPath);
+        const { frontmatter, body } = parseFrontmatter(raw);
+        const desc = frontmatter.description;
+        return {
+          relative_path: node.relativePath,
+          is_system:
+            node.relativePath.startsWith("system/") ||
+            node.relativePath.startsWith("system\\"),
+          description: typeof desc === "string" ? desc : null,
+          content: body,
+          size: body.length,
+          ...(includeReferences
+            ? {
+                references: extractMemoryReferences(body, node.relativePath),
+              }
+            : {}),
+        };
+      });
+
+      const done = i + CHUNK_SIZE >= total;
+      const sent = safeSocketSend(
+        socket,
+        {
+          type: "list_memory_response",
+          request_id: parsed.request_id,
+          entries,
+          done,
+          total,
+          success: true,
+          memfs_enabled: true,
+          memfs_initialized: true,
+        },
+        "listener_list_memory_send_failed",
+        "listener_list_memory",
+      );
+      if (!sent) {
+        return true;
+      }
+    }
+
+    if (total === 0) {
+      safeSocketSend(
+        socket,
+        {
+          type: "list_memory_response",
+          request_id: parsed.request_id,
+          entries: [],
+          done: true,
+          total: 0,
+          success: true,
+          memfs_enabled: true,
+          memfs_initialized: true,
+        },
+        "listener_list_memory_send_failed",
+        "listener_list_memory",
+      );
+    }
+  } catch (err) {
+    trackListenerError(
+      "listener_list_memory_failed",
+      err,
+      "listener_memory_browser",
+    );
+    safeSocketSend(
+      socket,
+      {
+        type: "list_memory_response",
+        request_id: parsed.request_id,
+        entries: [],
+        done: true,
+        total: 0,
+        success: false,
+        error: err instanceof Error ? err.message : "Failed to list memory",
+      },
+      "listener_list_memory_send_failed",
+      "listener_list_memory",
+    );
+  }
+
+  return true;
 }
 
 async function handleCronCommand(
@@ -4458,249 +4709,7 @@ async function connectWithRetry(
       // ── Memory index (no runtime scope required) ─────────────────────
       if (isListMemoryCommand(parsed)) {
         runDetachedListenerTask("list_memory", async () => {
-          try {
-            const { getMemoryFilesystemRoot } = await import(
-              "../../agent/memoryFilesystem"
-            );
-            const { scanMemoryFilesystem, getFileNodes, readFileContent } =
-              await import("../../agent/memoryScanner");
-            const { parseFrontmatter } = await import(
-              "../../utils/frontmatter"
-            );
-
-            const { existsSync } = await import("node:fs");
-            const { join, posix } = await import("node:path");
-
-            const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
-
-            // If the memory directory doesn't have a git repo, memfs
-            // hasn't been initialized — tell the UI so it can show the
-            // enable button instead of an empty file list.
-            const memfsInitialized = existsSync(join(memoryRoot, ".git"));
-
-            if (!memfsInitialized) {
-              safeSocketSend(
-                socket,
-                {
-                  type: "list_memory_response",
-                  request_id: parsed.request_id,
-                  entries: [],
-                  done: true,
-                  total: 0,
-                  success: true,
-                  memfs_initialized: false,
-                },
-                "listener_list_memory_send_failed",
-                "listener_list_memory",
-              );
-              return;
-            }
-
-            const treeNodes = scanMemoryFilesystem(memoryRoot);
-            const fileNodes = getFileNodes(treeNodes).filter((n) =>
-              n.name.endsWith(".md"),
-            );
-            const includeReferences = parsed.include_references === true;
-
-            const allPaths = new Set(
-              fileNodes.map((node) => node.relativePath),
-            );
-
-            const normalizeMemoryReference = (
-              rawReference: string,
-              sourcePath: string,
-            ): string | null => {
-              let target = rawReference.trim();
-              if (!target) {
-                return null;
-              }
-
-              if (
-                target.startsWith("http://") ||
-                target.startsWith("https://") ||
-                target.startsWith("mailto:")
-              ) {
-                return null;
-              }
-
-              target = target.replace(/^<|>$/g, "");
-              target = target.split("#")[0] ?? "";
-              target = target.split("?")[0] ?? "";
-              target = target.trim().replace(/\\/g, "/");
-
-              if (!target || target.startsWith("#")) {
-                return null;
-              }
-
-              if (target.includes("|")) {
-                target = target.split("|")[0] ?? "";
-              }
-
-              if (!target) {
-                return null;
-              }
-
-              const sourceDir = posix.dirname(sourcePath.replace(/\\/g, "/"));
-              const candidate =
-                target.startsWith("./") || target.startsWith("../")
-                  ? posix.normalize(posix.join(sourceDir, target))
-                  : posix.normalize(
-                      target.startsWith("/") ? target.slice(1) : target,
-                    );
-
-              if (
-                !candidate ||
-                candidate.startsWith("../") ||
-                candidate === "." ||
-                candidate === ".."
-              ) {
-                return null;
-              }
-
-              const withExtension = candidate.endsWith(".md")
-                ? candidate
-                : `${candidate}.md`;
-
-              const candidates = new Set<string>([withExtension]);
-
-              const isExplicitRelative =
-                target.startsWith("./") || target.startsWith("../");
-              if (
-                !isExplicitRelative &&
-                !target.startsWith("/") &&
-                sourceDir &&
-                sourceDir !== "."
-              ) {
-                candidates.add(
-                  posix.normalize(posix.join(sourceDir, withExtension)),
-                );
-              }
-
-              if (!withExtension.startsWith("system/")) {
-                candidates.add(posix.normalize(`system/${withExtension}`));
-              }
-
-              for (const resolved of candidates) {
-                if (allPaths.has(resolved)) {
-                  return resolved;
-                }
-              }
-
-              return null;
-            };
-
-            const extractMemoryReferences = (
-              body: string,
-              sourcePath: string,
-            ): string[] => {
-              if (!body.includes("[[")) {
-                return [];
-              }
-
-              const refs = new Set<string>();
-
-              for (const wikiMatch of body.matchAll(WIKI_LINK_REGEX)) {
-                const rawTarget = wikiMatch[1];
-                if (!rawTarget) continue;
-                const normalized = normalizeMemoryReference(
-                  rawTarget,
-                  sourcePath,
-                );
-                if (normalized && normalized !== sourcePath) {
-                  refs.add(normalized);
-                }
-              }
-
-              return [...refs];
-            };
-
-            const CHUNK_SIZE = 5;
-            const total = fileNodes.length;
-
-            for (let i = 0; i < total; i += CHUNK_SIZE) {
-              const chunk = fileNodes.slice(i, i + CHUNK_SIZE);
-              const entries = chunk.map((node) => {
-                const raw = readFileContent(node.fullPath);
-                const { frontmatter, body } = parseFrontmatter(raw);
-                const desc = frontmatter.description;
-                return {
-                  relative_path: node.relativePath,
-                  is_system:
-                    node.relativePath.startsWith("system/") ||
-                    node.relativePath.startsWith("system\\"),
-                  description: typeof desc === "string" ? desc : null,
-                  content: body,
-                  size: body.length,
-                  ...(includeReferences
-                    ? {
-                        references: extractMemoryReferences(
-                          body,
-                          node.relativePath,
-                        ),
-                      }
-                    : {}),
-                };
-              });
-
-              const done = i + CHUNK_SIZE >= total;
-              const sent = safeSocketSend(
-                socket,
-                {
-                  type: "list_memory_response",
-                  request_id: parsed.request_id,
-                  entries,
-                  done,
-                  total,
-                  success: true,
-                  memfs_initialized: true,
-                },
-                "listener_list_memory_send_failed",
-                "listener_list_memory",
-              );
-              if (!sent) {
-                return;
-              }
-            }
-
-            // Edge case: no files at all (repo exists but empty)
-            if (total === 0) {
-              safeSocketSend(
-                socket,
-                {
-                  type: "list_memory_response",
-                  request_id: parsed.request_id,
-                  entries: [],
-                  done: true,
-                  total: 0,
-                  success: true,
-                  memfs_initialized: true,
-                },
-                "listener_list_memory_send_failed",
-                "listener_list_memory",
-              );
-            }
-          } catch (err) {
-            trackListenerError(
-              "listener_list_memory_failed",
-              err,
-              "listener_memory_browser",
-            );
-            safeSocketSend(
-              socket,
-              {
-                type: "list_memory_response",
-                request_id: parsed.request_id,
-                entries: [],
-                done: true,
-                total: 0,
-                success: false,
-                error:
-                  err instanceof Error ? err.message : "Failed to list memory",
-              },
-              "listener_list_memory_send_failed",
-              "listener_list_memory",
-            );
-          }
+          await handleListMemoryCommand(parsed, socket);
         });
         return;
       }
@@ -5679,6 +5688,7 @@ export const __listenClientTestUtils = {
   handleAbortMessageInput,
   handleChangeDeviceStateInput,
   handleCronCommand,
+  handleListMemoryCommand,
   isDetachedChannelsCommand,
   handleChannelsProtocolCommand,
   handleSkillCommand,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -940,16 +940,29 @@ function emitChannelTargetsUpdated(
   );
 }
 
+type ListMemoryCommandTestOverrides = {
+  ensureLocalMemfsCheckout?: (agentId: string) => Promise<void>;
+  getMemoryFilesystemRoot?: (agentId: string) => string;
+  isMemfsEnabledOnServer?: (agentId: string) => Promise<boolean>;
+};
+
 async function handleListMemoryCommand(
   parsed: ListMemoryCommand,
   socket: WebSocket,
+  overrides: ListMemoryCommandTestOverrides = {},
 ): Promise<boolean> {
   try {
     const {
-      ensureLocalMemfsCheckout,
-      getMemoryFilesystemRoot,
-      isMemfsEnabledOnServer,
+      ensureLocalMemfsCheckout: actualEnsureLocalMemfsCheckout,
+      getMemoryFilesystemRoot: actualGetMemoryFilesystemRoot,
+      isMemfsEnabledOnServer: actualIsMemfsEnabledOnServer,
     } = await import("../../agent/memoryFilesystem");
+    const ensureLocalMemfsCheckout =
+      overrides.ensureLocalMemfsCheckout ?? actualEnsureLocalMemfsCheckout;
+    const getMemoryFilesystemRoot =
+      overrides.getMemoryFilesystemRoot ?? actualGetMemoryFilesystemRoot;
+    const isMemfsEnabledOnServer =
+      overrides.isMemfsEnabledOnServer ?? actualIsMemfsEnabledOnServer;
     const { scanMemoryFilesystem, getFileNodes, readFileContent } =
       await import("../../agent/memoryScanner");
     const { parseFrontmatter } = await import("../../utils/frontmatter");


### PR DESCRIPTION
## Summary
- return explicit memfs enabled state from `list_memory_response`
- distinguish "memfs disabled" from "memfs enabled but local checkout missing"
- only bootstrap the local memfs checkout when the agent is already memfs-enabled on the server

## Testing
- bun run typecheck
- bun test src/tests/websocket/listen-client-protocol.test.ts

## Context
This is the backend half of the real fix for the desktop memory refresh/enable issue. A companion Letta Cloud PR updates the UI to key off explicit `memfs_enabled` state instead of treating a missing local checkout as "memfs disabled".