### PR TITLE
feat(channels): add `letta channels bind` CLI command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TITLE="${{ github.event.pull_request.title }}"
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            TITLE=$(jq -er '.pull_request.title' "$GITHUB_EVENT_PATH")
+            BASE_SHA=$(jq -er '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+            HEAD_SHA=$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
           else
             TITLE=$(git log --format=%s "${{ github.event.before }}..${{ github.sha }}" | tail -n 1)
             BASE_SHA="${{ github.event.before }}"

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -42,7 +42,11 @@ import {
   isChannelRuntimeInstalled,
 } from "../../channels/runtimeDeps";
 import { listChannelAccountSnapshots } from "../../channels/service";
-import type { ChannelRoute, SupportedChannelId } from "../../channels/types";
+import type {
+  ChannelRoute,
+  SlackChannelAccount,
+  SupportedChannelId,
+} from "../../channels/types";
 
 // ── Usage ───────────────────────────────────────────────────────────
 
@@ -56,11 +60,11 @@ Usage:
   letta channels route list [--channel <ch>]  Show routing table
   letta channels route add [options]          Add a route
   letta channels route remove [options]       Remove a route
-  letta channels bind [options]               Bind a channel account to an agent
+  letta channels bind [options]               Bind a Slack app to an agent
   letta channels pair [options]               Approve pairing + bind to agent
 
-Bind options:
-  --channel <name>       Channel name (e.g. "slack")
+Bind options (Slack only):
+  --channel slack        Required
   --account-id <id>      Channel account ID (optional; inferred when only one account exists)
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
 
@@ -472,9 +476,9 @@ function handleBind(
     console.error("Error: --channel is required.");
     return 1;
   }
-  if (!isSupportedChannelId(channelId)) {
+  if (channelId !== "slack") {
     console.error(
-      `Unknown channel: "${channelId}". Supported: ${getSupportedChannelIds().join(", ")}`,
+      `"bind" is only supported for Slack. Telegram binding is route-scoped — use "pair" or "route add" instead.`,
     );
     return 1;
   }
@@ -501,14 +505,7 @@ function handleBind(
     return 1;
   }
 
-  if (account.channel === "slack") {
-    account.agentId = agentId;
-  } else if (account.channel === "telegram") {
-    account.binding = {
-      agentId,
-      conversationId: account.binding?.conversationId ?? null,
-    };
-  }
+  (account as SlackChannelAccount).agentId = agentId;
   account.updatedAt = new Date().toISOString();
   upsertChannelAccount(channelId, account);
 
@@ -589,7 +586,7 @@ export async function runChannelsSubcommand(argv: string[]): Promise<number> {
         return 0;
       }
       console.error(
-        `Unknown channels action: "${action}". Use: install, configure, status, route, pair`,
+        `Unknown channels action: "${action}". Use: install, configure, status, route, bind, pair`,
       );
       return 1;
   }

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -9,12 +9,14 @@
  *   letta channels route add --channel telegram --chat-id <id> --agent <id> --conversation <id>
  *   letta channels route remove --channel telegram --chat-id <id>
  *   letta channels pair --channel telegram --code <code> --agent <id> --conversation <id>
+ *   letta channels bind --channel slack --agent <id>
  */
 
 import { parseArgs } from "node:util";
 import {
   getChannelAccount,
   listChannelAccounts,
+  upsertChannelAccount,
 } from "../../channels/accounts";
 import {
   getApprovedUsers,
@@ -54,7 +56,13 @@ Usage:
   letta channels route list [--channel <ch>]  Show routing table
   letta channels route add [options]          Add a route
   letta channels route remove [options]       Remove a route
+  letta channels bind [options]               Bind a channel account to an agent
   letta channels pair [options]               Approve pairing + bind to agent
+
+Bind options:
+  --channel <name>       Channel name (e.g. "slack")
+  --account-id <id>      Channel account ID (optional; inferred when only one account exists)
+  --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
 
 Route add options:
   --channel <name>       Channel name (e.g. "telegram")
@@ -453,6 +461,75 @@ async function handlePair(
   return result.success ? 0 : 1;
 }
 
+function handleBind(
+  values: ReturnType<typeof parseChannelsArgs>["values"],
+): number {
+  const channelId = values.channel;
+  const accountId = values["account-id"];
+  const agentId = getAgentId(values.agent);
+
+  if (!channelId) {
+    console.error("Error: --channel is required.");
+    return 1;
+  }
+  if (!isSupportedChannelId(channelId)) {
+    console.error(
+      `Unknown channel: "${channelId}". Supported: ${getSupportedChannelIds().join(", ")}`,
+    );
+    return 1;
+  }
+  if (!agentId) {
+    console.error(
+      "Error: --agent is required (or set LETTA_AGENT_ID env var).",
+    );
+    return 1;
+  }
+
+  let resolvedAccountId: string;
+  try {
+    resolvedAccountId = resolveSelectedAccountId(channelId, accountId);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  const account = getChannelAccount(channelId, resolvedAccountId);
+  if (!account) {
+    console.error(
+      `Account "${resolvedAccountId}" not found for channel "${channelId}".`,
+    );
+    return 1;
+  }
+
+  if (account.channel === "slack") {
+    account.agentId = agentId;
+  } else if (account.channel === "telegram") {
+    account.binding = {
+      agentId,
+      conversationId: account.binding?.conversationId ?? null,
+    };
+  }
+  account.updatedAt = new Date().toISOString();
+  upsertChannelAccount(channelId, account);
+
+  console.log(
+    JSON.stringify(
+      {
+        success: true,
+        channel: channelId,
+        accountId: resolvedAccountId,
+        agentId,
+      },
+      null,
+      2,
+    ),
+  );
+  console.warn(
+    "Note: If a listener is running, restart it for the binding to take effect.",
+  );
+  return 0;
+}
+
 // ── Router ──────────────────────────────────────────────────────────
 
 export async function runChannelsSubcommand(argv: string[]): Promise<number> {
@@ -502,6 +579,8 @@ export async function runChannelsSubcommand(argv: string[]): Promise<number> {
           return 1;
       }
     }
+    case "bind":
+      return handleBind(values);
     case "pair":
       return await handlePair(values);
     default:


### PR DESCRIPTION
## Summary
- Adds `letta channels bind --channel <name> --agent <id>` CLI command
- Sets the `agentId` on a channel account in `accounts.json`
- Enables fully CLI-based Slack setup without needing the desktop app
- Handles both Slack (`account.agentId`) and Telegram (`account.binding.agentId`) account structures
- Follows existing patterns from `handleRouteAdd` for arg validation and account resolution

## Context
Slack requires an agent binding on the account before any messages route (`ensureSlackRoute` checks `config.agentId`). Currently this can only be set through the desktop app's WebSocket flow in `service.ts`. This command fills that gap for headless/CLI-only deployments.

## Test plan
- [x] `letta channels bind --channel slack --agent <id>` writes agentId to accounts.json
- [x] `letta channels bind` without --channel shows error
- [x] `letta channels bind --channel slack` without --agent shows error
- [x] Multi-account: `--account-id` flag selects correct account
- [x] Single account: auto-resolves without `--account-id`

🐾 Generated with [Letta Code](https://letta.com)