### PR TITLE
fix(slack): hydrate prior thread context on first mention

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -405,11 +405,19 @@ export class ChannelRegistry {
     if (!config) return;
 
     if (msg.channel === "slack" && config.channel === "slack") {
-      const slackRoute = await this.ensureSlackRoute(adapter, msg, config);
-      if (!slackRoute) {
+      const slackResult = await this.ensureSlackRoute(adapter, msg, config);
+      if (!slackResult) {
         return;
       }
-      this.deliverOrBuffer(slackRoute, formatChannelNotification(msg));
+      const preparedMessage = adapter.prepareInboundMessage
+        ? await adapter.prepareInboundMessage(msg, {
+            isFirstRouteTurn: slackResult.isFirstRouteTurn,
+          })
+        : msg;
+      this.deliverOrBuffer(
+        slackResult.route,
+        formatChannelNotification(preparedMessage),
+      );
       return;
     }
 
@@ -529,7 +537,10 @@ export class ChannelRegistry {
     adapter: ChannelAdapter,
     msg: InboundChannelMessage,
     config: SlackChannelAccount,
-  ): Promise<ChannelRoute | null> {
+  ): Promise<{
+    route: ChannelRoute;
+    isFirstRouteTurn: boolean;
+  } | null> {
     if (!config.agentId) {
       await adapter.sendDirectReply(
         msg.chatId,
@@ -576,7 +587,10 @@ export class ChannelRegistry {
     }
 
     if (route) {
-      return route;
+      return {
+        route,
+        isFirstRouteTurn: false,
+      };
     }
 
     if (msg.chatType === "channel" && !msg.isMention) {
@@ -600,7 +614,10 @@ export class ChannelRegistry {
       channelId: msg.channel,
     });
 
-    return this.createSlackRoute(config, msg);
+    return {
+      route: await this.createSlackRoute(config, msg),
+      isFirstRouteTurn: true,
+    };
   }
 
   private deliverOrBuffer(

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -7,7 +7,11 @@ import type {
   OutboundChannelMessage,
   SlackChannelAccount,
 } from "../types";
-import { resolveSlackInboundAttachments } from "./media";
+import {
+  resolveSlackInboundAttachments,
+  resolveSlackThreadHistory,
+  resolveSlackThreadStarter,
+} from "./media";
 import { loadSlackBoltModule } from "./runtime";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
@@ -41,6 +45,7 @@ function resolveSlackAppModule(value: unknown): SlackAppConstructor | null {
   const app = Reflect.get(value, "App");
   return isConstructorFunction<SlackAppConstructor>(app) ? app : null;
 }
+const INITIAL_SLACK_THREAD_HISTORY_LIMIT = 20;
 
 function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
   const defaultExport =
@@ -183,6 +188,36 @@ function resolveSlackUserDisplayName(userInfo: unknown): string | undefined {
     profile?.real_name,
     user?.name,
   );
+}
+
+function truncateSlackThreadLabel(text: string, maxLength = 80): string | null {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function buildSlackThreadLabel(
+  msg: InboundChannelMessage,
+  starterText?: string,
+): string | undefined {
+  if (msg.chatType !== "channel") {
+    return undefined;
+  }
+
+  const roomLabel =
+    isNonEmptyString(msg.chatLabel) && msg.chatLabel !== msg.chatId
+      ? ` in ${msg.chatLabel}`
+      : "";
+  const preview = truncateSlackThreadLabel(starterText ?? msg.text);
+  if (preview) {
+    return `Slack thread${roomLabel}: ${preview}`;
+  }
+  return roomLabel ? `Slack thread${roomLabel}` : `Slack thread ${msg.chatId}`;
 }
 
 export async function resolveSlackAccountDisplayName(
@@ -667,6 +702,102 @@ export function createSlackAdapter(
         response.ts,
         options?.replyToMessageId ?? response.ts ?? null,
       );
+    },
+
+    async prepareInboundMessage(
+      msg: InboundChannelMessage,
+      options?: { isFirstRouteTurn?: boolean },
+    ): Promise<InboundChannelMessage> {
+      if (
+        !options?.isFirstRouteTurn ||
+        msg.channel !== "slack" ||
+        msg.chatType !== "channel" ||
+        !isNonEmptyString(msg.threadId) ||
+        !isNonEmptyString(msg.messageId) ||
+        msg.threadId === msg.messageId
+      ) {
+        return msg;
+      }
+
+      const slackApp = await ensureApp();
+      const starter = await resolveSlackThreadStarter({
+        channelId: msg.chatId,
+        threadTs: msg.threadId,
+        client: slackApp.client,
+      });
+      const history = await resolveSlackThreadHistory({
+        channelId: msg.chatId,
+        threadTs: msg.threadId,
+        client: slackApp.client,
+        currentMessageTs: msg.messageId,
+        limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+      });
+
+      if (!starter && history.length === 0) {
+        return msg;
+      }
+
+      const uniqueUserIds = new Set<string>();
+      if (isNonEmptyString(starter?.userId)) {
+        uniqueUserIds.add(starter.userId);
+      }
+      for (const entry of history) {
+        if (isNonEmptyString(entry.userId)) {
+          uniqueUserIds.add(entry.userId);
+        }
+      }
+
+      await Promise.all(
+        Array.from(uniqueUserIds).map(async (userId) => {
+          await resolveUserName(slackApp, userId);
+        }),
+      );
+
+      const resolveThreadSenderName = (
+        userId?: string,
+        botId?: string,
+      ): string | undefined => {
+        if (isNonEmptyString(userId)) {
+          return knownUserDisplayNames.get(userId) ?? userId;
+        }
+        if (isNonEmptyString(botId)) {
+          return `Bot (${botId})`;
+        }
+        return undefined;
+      };
+
+      return {
+        ...msg,
+        threadContext: {
+          label: buildSlackThreadLabel(msg, starter?.text),
+          ...(starter
+            ? {
+                starter: {
+                  messageId: starter.ts,
+                  senderId: starter.userId ?? starter.botId,
+                  senderName: resolveThreadSenderName(
+                    starter.userId,
+                    starter.botId,
+                  ),
+                  text: starter.text,
+                },
+              }
+            : {}),
+          ...(history.length > 0
+            ? {
+                history: history.map((entry) => ({
+                  messageId: entry.ts,
+                  senderId: entry.userId ?? entry.botId,
+                  senderName: resolveThreadSenderName(
+                    entry.userId,
+                    entry.botId,
+                  ),
+                  text: entry.text,
+                })),
+              }
+            : {}),
+        },
+      };
     },
 
     onMessage: undefined,

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -26,6 +26,38 @@ type SlackAttachmentLike = {
   files?: SlackFileLike[];
 };
 
+type SlackRepliesClient = {
+  conversations: {
+    replies(args: {
+      channel: string;
+      ts: string;
+      limit?: number;
+      inclusive?: boolean;
+      cursor?: string;
+    }): Promise<unknown>;
+  };
+};
+
+type SlackRepliesPageMessage = {
+  text?: string;
+  user?: string;
+  bot_id?: string;
+  ts?: string;
+  files?: unknown[];
+};
+
+type SlackRepliesPage = {
+  messages?: SlackRepliesPageMessage[];
+  response_metadata?: { next_cursor?: string };
+};
+
+export type SlackThreadMessage = {
+  text: string;
+  userId?: string;
+  botId?: string;
+  ts?: string;
+};
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
@@ -76,6 +108,28 @@ function normalizeSlackAttachmentLike(
       : undefined,
     files,
   };
+}
+
+function resolveSlackThreadMessageText(
+  message: SlackRepliesPageMessage,
+): string {
+  const text = typeof message.text === "string" ? message.text.trim() : "";
+  if (text) {
+    return text;
+  }
+
+  const files = Array.isArray(message.files)
+    ? message.files
+        .map((entry) => normalizeSlackFileLike(entry))
+        .filter((entry): entry is SlackFileLike => Boolean(entry))
+    : [];
+
+  if (files.length === 0) {
+    return "";
+  }
+
+  const fileNames = files.map((file) => file.name ?? "file").join(", ");
+  return `[attached: ${fileNames}]`;
 }
 
 function isAllowedSlackHostname(hostname: string): boolean {
@@ -324,4 +378,100 @@ export async function readSlackAttachmentFile(
   localPath: string,
 ): Promise<Buffer> {
   return readFile(localPath);
+}
+
+export async function resolveSlackThreadStarter(params: {
+  channelId: string;
+  threadTs: string;
+  client: SlackRepliesClient;
+}): Promise<SlackThreadMessage | null> {
+  try {
+    const response = (await params.client.conversations.replies({
+      channel: params.channelId,
+      ts: params.threadTs,
+      limit: 1,
+      inclusive: true,
+    })) as SlackRepliesPage;
+
+    const message = response.messages?.[0];
+    if (!message) {
+      return null;
+    }
+
+    const text = resolveSlackThreadMessageText(message);
+    if (!text) {
+      return null;
+    }
+
+    return {
+      text,
+      userId: isNonEmptyString(message.user) ? message.user : undefined,
+      botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
+      ts: isNonEmptyString(message.ts) ? message.ts : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveSlackThreadHistory(params: {
+  channelId: string;
+  threadTs: string;
+  client: SlackRepliesClient;
+  currentMessageTs?: string;
+  limit?: number;
+}): Promise<SlackThreadMessage[]> {
+  const maxMessages = params.limit ?? 20;
+  if (!Number.isFinite(maxMessages) || maxMessages <= 0) {
+    return [];
+  }
+
+  const fetchLimit = 200;
+  const retained: SlackRepliesPageMessage[] = [];
+  let cursor: string | undefined;
+
+  try {
+    do {
+      const response = (await params.client.conversations.replies({
+        channel: params.channelId,
+        ts: params.threadTs,
+        limit: fetchLimit,
+        inclusive: true,
+        ...(cursor ? { cursor } : {}),
+      })) as SlackRepliesPage;
+
+      for (const message of response.messages ?? []) {
+        const text = resolveSlackThreadMessageText(message);
+        if (!text) {
+          continue;
+        }
+        if (params.currentMessageTs && message.ts === params.currentMessageTs) {
+          continue;
+        }
+        if (message.ts === params.threadTs) {
+          continue;
+        }
+
+        retained.push(message);
+        if (retained.length > maxMessages) {
+          retained.shift();
+        }
+      }
+
+      const nextCursor = response.response_metadata?.next_cursor;
+      cursor =
+        typeof nextCursor === "string" && nextCursor.trim().length > 0
+          ? nextCursor.trim()
+          : undefined;
+    } while (cursor);
+
+    return retained.map((message) => ({
+      text: resolveSlackThreadMessageText(message),
+      userId: isNonEmptyString(message.user) ? message.user : undefined,
+      botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
+      ts: isNonEmptyString(message.ts) ? message.ts : undefined,
+    }));
+  } catch {
+    return [];
+  }
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -28,6 +28,19 @@ export interface ChannelReactionNotification {
   targetSenderId?: string;
 }
 
+export interface ChannelThreadContextEntry {
+  messageId?: string;
+  senderId?: string;
+  senderName?: string;
+  text: string;
+}
+
+export interface ChannelThreadContext {
+  label?: string;
+  starter?: ChannelThreadContextEntry;
+  history?: ChannelThreadContextEntry[];
+}
+
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {
@@ -59,6 +72,16 @@ export interface ChannelAdapter {
     text: string,
     options?: { replyToMessageId?: string },
   ): Promise<void>;
+
+  /**
+   * Optionally enrich an inbound message with additional context before it is
+   * formatted for the agent. Slack uses this to hydrate older thread context
+   * the first time a Letta conversation is created for an existing thread.
+   */
+  prepareInboundMessage?(
+    msg: InboundChannelMessage,
+    options?: { isFirstRouteTurn?: boolean },
+  ): Promise<InboundChannelMessage>;
 
   /**
    * Called by the registry when the adapter receives an inbound message.
@@ -100,6 +123,8 @@ export interface InboundChannelMessage {
   attachments?: ChannelMessageAttachment[];
   /** Reaction metadata for non-text channel events. */
   reaction?: ChannelReactionNotification;
+  /** Supplemental thread context captured before the triggering message. */
+  threadContext?: ChannelThreadContext;
 }
 
 export interface OutboundChannelMessage {

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -8,7 +8,11 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { getLocalTime } from "../cli/helpers/sessionContext";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../constants";
-import type { ChannelMessageAttachment, InboundChannelMessage } from "./types";
+import type {
+  ChannelMessageAttachment,
+  ChannelThreadContextEntry,
+  InboundChannelMessage,
+} from "./types";
 
 /**
  * Escape XML text-node content without over-escaping quotes that should remain
@@ -122,6 +126,60 @@ function buildReactionXml(msg: InboundChannelMessage): string | null {
   return `<reaction ${attrs.join(" ")} />`;
 }
 
+function buildThreadContextEntryXml(
+  tagName: string,
+  entry: ChannelThreadContextEntry,
+): string {
+  const attrs: string[] = [];
+  if (entry.senderId) {
+    attrs.push(`sender_id="${escapeXmlAttribute(entry.senderId)}"`);
+  }
+  if (entry.senderName) {
+    attrs.push(`sender_name="${escapeXmlAttribute(entry.senderName)}"`);
+  }
+  if (entry.messageId) {
+    attrs.push(`message_id="${escapeXmlAttribute(entry.messageId)}"`);
+  }
+
+  const attrString = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+  return `<${tagName}${attrString}>\n${escapeXmlText(entry.text)}\n</${tagName}>`;
+}
+
+function buildThreadContextXml(msg: InboundChannelMessage): string | null {
+  const threadContext = msg.threadContext;
+  if (!threadContext) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (threadContext.starter) {
+    parts.push(
+      buildThreadContextEntryXml("thread-starter", threadContext.starter),
+    );
+  }
+  const historyEntries = threadContext.history ?? [];
+  if (historyEntries.length > 0) {
+    parts.push(
+      [
+        "<thread-history>",
+        ...historyEntries.map((entry) =>
+          buildThreadContextEntryXml("thread-message", entry),
+        ),
+        "</thread-history>",
+      ].join("\n"),
+    );
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const attrs = threadContext.label
+    ? ` label="${escapeXmlAttribute(threadContext.label)}"`
+    : "";
+  return [`<thread-context${attrs}>`, ...parts, "</thread-context>"].join("\n");
+}
+
 /**
  * Format an inbound channel message as XML for the agent.
  *
@@ -156,8 +214,9 @@ export function buildChannelNotificationXml(
   const attrString = attrs.join(" ");
   const escapedText = msg.text ? escapeXmlText(msg.text) : "";
   const reactionXml = buildReactionXml(msg);
+  const threadContextXml = buildThreadContextXml(msg);
   const attachmentXml = (msg.attachments ?? []).map(buildAttachmentXml);
-  const body = [reactionXml, ...attachmentXml, escapedText]
+  const body = [threadContextXml, reactionXml, ...attachmentXml, escapedText]
     .filter(Boolean)
     .join("\n");
 

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -60,6 +60,9 @@ class FakeSlackApp {
     chat: {
       postMessage: mock(async () => ({ ts: "1712800000.000100" })),
     },
+    conversations: {
+      replies: mock(async () => ({ messages: [] })),
+    },
     reactions: {
       add: mock(async () => ({ ok: true })),
       remove: mock(async () => ({ ok: true })),
@@ -101,6 +104,24 @@ class FakeSlackApp {
 const resolveSlackInboundAttachmentsMock = mock(
   async (): Promise<ChannelMessageAttachment[]> => [],
 );
+const resolveSlackThreadStarterMock = mock(
+  async (): Promise<{
+    text: string;
+    userId?: string;
+    botId?: string;
+    ts?: string;
+  } | null> => null,
+);
+const resolveSlackThreadHistoryMock = mock(
+  async (): Promise<
+    Array<{
+      text: string;
+      userId?: string;
+      botId?: string;
+      ts?: string;
+    }>
+  > => [],
+);
 
 mock.module("../../channels/slack/runtime", () => ({
   loadSlackBoltModule: async () => ({
@@ -113,6 +134,8 @@ mock.module("../../channels/slack/runtime", () => ({
 
 mock.module("../../channels/slack/media", () => ({
   resolveSlackInboundAttachments: resolveSlackInboundAttachmentsMock,
+  resolveSlackThreadStarter: resolveSlackThreadStarterMock,
+  resolveSlackThreadHistory: resolveSlackThreadHistoryMock,
 }));
 
 const { createSlackAdapter, resolveSlackAccountDisplayName } = await import(
@@ -139,6 +162,10 @@ beforeEach(() => {
   FakeSlackApp.instances.length = 0;
   resolveSlackInboundAttachmentsMock.mockReset();
   resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
+  resolveSlackThreadStarterMock.mockReset();
+  resolveSlackThreadStarterMock.mockImplementation(async () => null);
+  resolveSlackThreadHistoryMock.mockReset();
+  resolveSlackThreadHistoryMock.mockImplementation(async () => []);
   fetchMock.mockClear();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
 });
@@ -148,6 +175,7 @@ afterEach(() => {
     instance.client.auth.test.mockClear();
     instance.client.users.info.mockClear();
     instance.client.chat.postMessage.mockClear();
+    instance.client.conversations.replies.mockClear();
     instance.client.reactions.add.mockClear();
     instance.client.reactions.remove.mockClear();
     instance.client.files.getUploadURLExternal.mockClear();
@@ -350,6 +378,75 @@ test("slack adapter forwards threaded channel replies as channel input", async (
       isMention: false,
     }),
   );
+});
+
+test("slack adapter hydrates prior Slack thread context on the first routed turn", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  if (!app) {
+    throw new Error("Expected Slack app instance");
+  }
+
+  resolveSlackThreadStarterMock.mockResolvedValueOnce({
+    text: "Original question from the thread root",
+    userId: "U111",
+    ts: "1712790000.000050",
+  });
+  resolveSlackThreadHistoryMock.mockResolvedValueOnce([
+    {
+      text: "Some follow-up before the bot was tagged",
+      userId: "U222",
+      ts: "1712795000.000060",
+    },
+  ]);
+
+  const prepared = await adapter.prepareInboundMessage?.(
+    {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatLabel: "#random",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "please help",
+      timestamp: 1712800000100,
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: true,
+    },
+    { isFirstRouteTurn: true },
+  );
+
+  expect(prepared).toBeDefined();
+  expect(prepared?.threadContext?.starter).toEqual(
+    expect.objectContaining({
+      messageId: "1712790000.000050",
+      senderId: "U111",
+      text: "Original question from the thread root",
+    }),
+  );
+  expect(prepared?.threadContext?.history).toEqual([
+    expect.objectContaining({
+      messageId: "1712795000.000060",
+      senderId: "U222",
+      text: "Some follow-up before the bot was tagged",
+    }),
+  ]);
+  expect(prepared?.threadContext?.label).toContain("Slack thread in #random");
+  expect(resolveSlackThreadStarterMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
 });
 
 test("slack adapter dedupes threaded mentions delivered through message and app_mention", async () => {

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -175,6 +175,55 @@ describe("formatChannelNotification", () => {
     );
   });
 
+  test("includes Slack thread starter and history context in the notification xml", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "please help",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      threadContext: {
+        label:
+          "Slack thread in #random: Original question from the thread root",
+        starter: {
+          messageId: "1712790000.000050",
+          senderId: "U111",
+          senderName: "Alice",
+          text: "Original question from the thread root",
+        },
+        history: [
+          {
+            messageId: "1712795000.000060",
+            senderId: "U222",
+            senderName: "Bob",
+            text: "Some follow-up before the bot was tagged",
+          },
+        ],
+      },
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain("<thread-context");
+    expect(xml).toContain(
+      'label="Slack thread in #random: Original question from the thread root"',
+    );
+    expect(xml).toContain(
+      '<thread-starter sender_id="U111" sender_name="Alice" message_id="1712790000.000050">',
+    );
+    expect(xml).toContain("Original question from the thread root");
+    expect(xml).toContain("<thread-history>");
+    expect(xml).toContain(
+      '<thread-message sender_id="U222" sender_name="Bob" message_id="1712795000.000060">',
+    );
+    expect(xml).toContain("Some follow-up before the bot was tagged");
+    expect(xml).toContain("please help");
+  });
+
   test("emits image content parts for inbound image attachments", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",


### PR DESCRIPTION
## Summary
- hydrate Slack thread root + prior replies when a Letta thread route is created from an existing Slack thread mention
- include that thread context in the inbound channel notification payload so the agent sees what happened before it was tagged
- add targeted Slack adapter and XML coverage for the new first-turn thread hydration path

## Testing
- bun test src/tests/channels/slack-adapter.test.ts
- bun test src/tests/channels/xml.test.ts
- bun test src/tests/channels/registry.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/channels/types.ts src/channels/slack/media.ts src/channels/slack/adapter.ts src/channels/registry.ts src/channels/xml.ts src/tests/channels/slack-adapter.test.ts src/tests/channels/xml.test.ts