### PR TITLE
fix(slack): disable outbound web client retries

### DIFF
--- a/src/channels/pluginRegistry.ts
+++ b/src/channels/pluginRegistry.ts
@@ -27,8 +27,8 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
     metadata: {
       id: "slack",
       displayName: "Slack",
-      runtimePackages: ["@slack/bolt@4.7.0"],
-      runtimeModules: ["@slack/bolt"],
+      runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
+      runtimeModules: ["@slack/bolt", "@slack/web-api"],
     },
     load: async () => {
       const { slackChannelPlugin } = await import("./slack/plugin");

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -12,10 +12,56 @@ import {
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
 } from "./media";
-import { loadSlackBoltModule } from "./runtime";
+import { loadSlackBoltModule, loadSlackWebApiModule } from "./runtime";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
 type SlackBoltModule = typeof import("@slack/bolt") & {
+  default?: unknown;
+};
+type SlackWriteClient = {
+  chat: {
+    postMessage: (args: {
+      channel: string;
+      text: string;
+      thread_ts?: string;
+    }) => Promise<{ ts?: string }>;
+  };
+  reactions: {
+    add: (args: {
+      channel: string;
+      timestamp: string;
+      name: string;
+    }) => Promise<unknown>;
+    remove: (args: {
+      channel: string;
+      timestamp: string;
+      name: string;
+    }) => Promise<unknown>;
+  };
+  files: {
+    getUploadURLExternal: (args: {
+      filename: string;
+      length: number;
+    }) => Promise<{
+      ok?: boolean;
+      upload_url?: string;
+      file_id?: string;
+      error?: string;
+    }>;
+    completeUploadExternal: (args: {
+      files: Array<{ id: string; title: string }>;
+      channel_id: string;
+      initial_comment?: string;
+      thread_ts?: string;
+    }) => Promise<{ ok?: boolean; error?: string }>;
+  };
+};
+type SlackWriteClientConstructor = new (
+  token: string,
+  options?: Record<string, unknown>,
+) => SlackWriteClient;
+type SlackWebApiModule = {
+  WebClient?: unknown;
   default?: unknown;
 };
 type SlackReactionEvent = {
@@ -69,6 +115,44 @@ function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
     );
   }
   return App;
+}
+
+function resolveSlackWebClientModule(
+  value: unknown,
+): SlackWriteClientConstructor | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const webClient = Reflect.get(value, "WebClient");
+  return isConstructorFunction<SlackWriteClientConstructor>(webClient)
+    ? webClient
+    : null;
+}
+
+function resolveSlackWebClientConstructor(
+  mod: SlackWebApiModule,
+): SlackWriteClientConstructor {
+  const defaultExport =
+    mod && typeof mod === "object" ? Reflect.get(mod, "default") : undefined;
+  const nestedDefault =
+    defaultExport && typeof defaultExport === "object"
+      ? Reflect.get(defaultExport, "default")
+      : undefined;
+
+  const WebClient =
+    resolveSlackWebClientModule(mod) ??
+    resolveSlackWebClientModule(defaultExport) ??
+    resolveSlackWebClientModule(nestedDefault) ??
+    (isConstructorFunction<SlackWriteClientConstructor>(defaultExport)
+      ? defaultExport
+      : null);
+
+  if (!WebClient) {
+    throw new Error(
+      'Installed Slack runtime did not export constructor "WebClient".',
+    );
+  }
+  return WebClient;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -127,7 +211,7 @@ function resolveUploadMimeType(filePath: string): string | undefined {
 }
 
 async function uploadSlackFile(
-  slackApp: SlackApp,
+  slackClient: SlackWriteClient,
   msg: OutboundChannelMessage,
 ): Promise<{ messageId: string }> {
   if (!msg.mediaPath) {
@@ -138,7 +222,7 @@ async function uploadSlackFile(
   const uploadFileName = msg.fileName ?? basename(msg.mediaPath);
   const uploadTitle = msg.title ?? uploadFileName;
   const uploadMimeType = resolveUploadMimeType(uploadFileName);
-  const uploadUrlResp = await slackApp.client.files.getUploadURLExternal({
+  const uploadUrlResp = await slackClient.files.getUploadURLExternal({
     filename: uploadFileName,
     length: buffer.length,
   });
@@ -162,7 +246,7 @@ async function uploadSlackFile(
     throw new Error(`Failed to upload Slack file: HTTP ${uploadResp.status}`);
   }
 
-  const completeResp = await slackApp.client.files.completeUploadExternal({
+  const completeResp = await slackClient.files.completeUploadExternal({
     files: [{ id: uploadUrlResp.file_id, title: uploadTitle }],
     channel_id: msg.chatId,
     ...(msg.text.trim() ? { initial_comment: msg.text } : {}),
@@ -251,6 +335,7 @@ export function createSlackAdapter(
   config: SlackChannelAccount,
 ): ChannelAdapter {
   let app: SlackApp | null = null;
+  let writeClient: SlackWriteClient | null = null;
   let running = false;
   let botUserId: string | null = null;
   const knownThreadIdsByMessageId = new Map<string, string | null>();
@@ -596,6 +681,21 @@ export function createSlackAdapter(
     return instance;
   }
 
+  async function ensureWriteClient(): Promise<SlackWriteClient> {
+    if (writeClient) {
+      return writeClient;
+    }
+
+    const webApi = await loadSlackWebApiModule();
+    const WebClient = resolveSlackWebClientConstructor(webApi);
+    writeClient = new WebClient(config.botToken, {
+      retryConfig: {
+        retries: 0,
+      },
+    });
+    return writeClient;
+  }
+
   const adapter: ChannelAdapter = {
     id: `slack:${config.accountId}`,
     channelId: "slack",
@@ -625,6 +725,7 @@ export function createSlackAdapter(
       await app.stop();
       running = false;
       app = null;
+      writeClient = null;
       botUserId = null;
       seenIngressMessageKeys.clear();
       console.log("[Slack] App stopped");
@@ -637,7 +738,8 @@ export function createSlackAdapter(
     async sendMessage(
       msg: OutboundChannelMessage,
     ): Promise<{ messageId: string }> {
-      const slackApp = await ensureApp();
+      await ensureApp();
+      const slackClient = await ensureWriteClient();
       if (msg.reaction) {
         const targetMessageId = msg.targetMessageId ?? msg.replyToMessageId;
         if (!targetMessageId) {
@@ -650,13 +752,13 @@ export function createSlackAdapter(
           throw new Error("Slack reaction emoji cannot be empty.");
         }
         if (msg.removeReaction) {
-          await slackApp.client.reactions.remove({
+          await slackClient.reactions.remove({
             channel: msg.chatId,
             timestamp: targetMessageId,
             name: emoji,
           });
         } else {
-          await slackApp.client.reactions.add({
+          await slackClient.reactions.add({
             channel: msg.chatId,
             timestamp: targetMessageId,
             name: emoji,
@@ -666,10 +768,10 @@ export function createSlackAdapter(
       }
 
       if (msg.mediaPath) {
-        return uploadSlackFile(slackApp, msg);
+        return uploadSlackFile(slackClient, msg);
       }
 
-      const response = await slackApp.client.chat.postMessage({
+      const response = await slackClient.chat.postMessage({
         channel: msg.chatId,
         text: msg.text,
         ...((msg.threadId ?? msg.replyToMessageId)
@@ -690,8 +792,9 @@ export function createSlackAdapter(
       text: string,
       options?: { replyToMessageId?: string },
     ): Promise<void> {
-      const slackApp = await ensureApp();
-      const response = await slackApp.client.chat.postMessage({
+      await ensureApp();
+      const slackClient = await ensureWriteClient();
+      const response = await slackClient.chat.postMessage({
         channel: chatId,
         text,
         ...(options?.replyToMessageId

--- a/src/channels/slack/plugin.ts
+++ b/src/channels/slack/plugin.ts
@@ -8,8 +8,8 @@ export const slackChannelPlugin: ChannelPlugin = {
   metadata: {
     id: "slack",
     displayName: "Slack",
-    runtimePackages: ["@slack/bolt@4.7.0"],
-    runtimeModules: ["@slack/bolt"],
+    runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
+    runtimeModules: ["@slack/bolt", "@slack/web-api"],
   },
   createAdapter(account: ChannelAccount) {
     return createSlackAdapter(account as SlackChannelAccount);

--- a/src/channels/slack/runtime.ts
+++ b/src/channels/slack/runtime.ts
@@ -14,6 +14,15 @@ export async function loadSlackBoltModule(): Promise<
   );
 }
 
+export async function loadSlackWebApiModule(): Promise<
+  typeof import("@slack/web-api")
+> {
+  return loadChannelRuntimeModule<typeof import("@slack/web-api")>(
+    "slack",
+    "@slack/web-api",
+  );
+}
+
 export function isSlackRuntimeInstalled(): boolean {
   return isChannelRuntimeInstalled("slack");
 }

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -101,6 +101,34 @@ class FakeSlackApp {
   }
 }
 
+class FakeSlackWriteClient {
+  static instances: FakeSlackWriteClient[] = [];
+
+  readonly token: string;
+  readonly options: Record<string, unknown> | undefined;
+  readonly chat = {
+    postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+  };
+  readonly reactions = {
+    add: mock(async () => ({ ok: true })),
+    remove: mock(async () => ({ ok: true })),
+  };
+  readonly files = {
+    getUploadURLExternal: mock(async () => ({
+      ok: true,
+      upload_url: "https://files.slack.com/upload/F123",
+      file_id: "F123",
+    })),
+    completeUploadExternal: mock(async () => ({ ok: true })),
+  };
+
+  constructor(token: string, options?: Record<string, unknown>) {
+    this.token = token;
+    this.options = options;
+    FakeSlackWriteClient.instances.push(this);
+  }
+}
+
 const resolveSlackInboundAttachmentsMock = mock(
   async (): Promise<ChannelMessageAttachment[]> => [],
 );
@@ -128,6 +156,12 @@ mock.module("../../channels/slack/runtime", () => ({
     App: FakeSlackApp,
     default: {
       App: FakeSlackApp,
+    },
+  }),
+  loadSlackWebApiModule: async () => ({
+    WebClient: FakeSlackWriteClient,
+    default: {
+      WebClient: FakeSlackWriteClient,
     },
   }),
 }));
@@ -160,6 +194,7 @@ const fetchMock = mock(
 
 beforeEach(() => {
   FakeSlackApp.instances.length = 0;
+  FakeSlackWriteClient.instances.length = 0;
   resolveSlackInboundAttachmentsMock.mockReset();
   resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
   resolveSlackThreadStarterMock.mockReset();
@@ -183,6 +218,13 @@ afterEach(() => {
     instance.init.mockClear();
     instance.start.mockClear();
     instance.stop.mockClear();
+  }
+  for (const instance of FakeSlackWriteClient.instances) {
+    instance.chat.postMessage.mockClear();
+    instance.reactions.add.mockClear();
+    instance.reactions.remove.mockClear();
+    instance.files.getUploadURLExternal.mockClear();
+    instance.files.completeUploadExternal.mockClear();
   }
   globalThis.fetch = originalFetch;
 });
@@ -236,11 +278,41 @@ test("slack adapter maps thread metadata to thread_ts", async () => {
     threadId: "1712800000.000200",
   });
 
-  const app = FakeSlackApp.instances[0];
-  expect(app).toBeDefined();
-  expect(app?.client.chat.postMessage).toHaveBeenCalledWith({
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient).toBeDefined();
+  expect(writeClient?.options).toEqual({
+    retryConfig: {
+      retries: 0,
+    },
+  });
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
     channel: "C123",
     text: "hello",
+    thread_ts: "1712800000.000200",
+  });
+});
+
+test("slack adapter sendDirectReply uses the dedicated write client", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendDirectReply("C123", "reply text", {
+    replyToMessageId: "1712800000.000200",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "reply text",
     thread_ts: "1712800000.000200",
   });
 });
@@ -710,8 +782,8 @@ test("slack adapter can add reactions to messages", async () => {
     targetMessageId: "1712800000.000100",
   });
 
-  const app = FakeSlackApp.instances[0];
-  expect(app?.client.reactions.add).toHaveBeenCalledWith({
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.add).toHaveBeenCalledWith({
     channel: "C123",
     timestamp: "1712800000.000100",
     name: "white_check_mark",
@@ -745,8 +817,8 @@ test("slack adapter uploads local files through Slack's external upload flow", a
     threadId: "1712790000.000050",
   });
 
-  const app = FakeSlackApp.instances[0];
-  expect(app?.client.files.getUploadURLExternal).toHaveBeenCalledWith({
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.files.getUploadURLExternal).toHaveBeenCalledWith({
     filename: "chart.png",
     length: "fake-image-data".length,
   });
@@ -758,7 +830,7 @@ test("slack adapter uploads local files through Slack's external upload flow", a
       body: expect.any(Uint8Array),
     },
   );
-  expect(app?.client.files.completeUploadExternal).toHaveBeenCalledWith({
+  expect(writeClient?.files.completeUploadExternal).toHaveBeenCalledWith({
     files: [{ id: "F123", title: "Chart" }],
     channel_id: "C123",
     initial_comment: "latest chart",


### PR DESCRIPTION
## Summary
- load the Slack Web API runtime alongside Bolt
- send outbound Slack writes through a dedicated WebClient with retries disabled
- cover sends, direct replies, reactions, and uploads with adapter tests

## Why
Slack duplicate outbound messages were likely coming from Bolt/WebClient retry behavior on write calls. OpenClaw avoids this by splitting inbound monitor traffic from outbound write traffic and setting write retries to zero. This patch matches that pattern for Letta Code's Slack adapter.

## Testing
- bun test src/tests/channels/slack-adapter.test.ts
- bun run lint