### PR TITLE
feat(channels): auto-transcribe Telegram voice memos via Whisper

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -78,6 +78,7 @@ function makeDefaultLegacyAccount(
       token: config.token,
       dmPolicy: config.dmPolicy,
       allowedUsers: [...config.allowedUsers],
+      transcribeVoice: config.transcribeVoice === true,
       binding: {
         agentId: null,
         conversationId: null,

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -132,6 +132,7 @@ const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
       token: String(parsed.token ?? ""),
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
+      transcribeVoice: parsed.transcribe_voice === true,
     };
   },
 };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -132,7 +132,6 @@ const telegramConfigCodec: ChannelConfigCodec<TelegramChannelConfig> = {
       token: String(parsed.token ?? ""),
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
-      transcribeVoice: parsed.transcribe_voice === true,
     };
   },
 };

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -137,6 +137,7 @@ export type ChannelAccountSnapshot =
       dmPolicy: DmPolicy;
       allowedUsers: string[];
       hasToken: boolean;
+      transcribeVoice: boolean;
       binding: {
         agentId: string | null;
         conversationId: string | null;
@@ -182,6 +183,7 @@ export interface ChannelAccountPatch {
   defaultPermissionMode?: SlackDefaultPermissionMode;
   dmPolicy?: DmPolicy;
   allowedUsers?: string[];
+  transcribeVoice?: boolean;
 }
 
 let resolveChannelAccountDisplayNameOverride:
@@ -401,6 +403,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
       hasToken: account.token.trim().length > 0,
+      transcribeVoice: account.transcribeVoice === true,
       binding,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
@@ -441,6 +444,7 @@ function createAccountFromPatch(
       token: patch.token ?? "",
       dmPolicy: patch.dmPolicy ?? "pairing",
       allowedUsers: patch.allowedUsers ?? [],
+      transcribeVoice: patch.transcribeVoice === true,
       binding: {
         agentId: null,
         conversationId: null,
@@ -483,6 +487,8 @@ function mergeAccountPatch(
       token: patch.token ?? existing.token,
       dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
       allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+      transcribeVoice:
+        patch.transcribeVoice ?? existing.transcribeVoice ?? false,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -225,7 +225,6 @@ export function createTelegramAdapter(
       token: config.token,
       bot: telegramBot,
       messages,
-      transcribeVoice: config.transcribeVoice,
     });
 
     if (text.length === 0 && attachments.length === 0) {

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -225,6 +225,7 @@ export function createTelegramAdapter(
       token: config.token,
       bot: telegramBot,
       messages,
+      transcribeVoice: config.transcribeVoice,
     });
 
     if (text.length === 0 && attachments.length === 0) {

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -500,6 +500,7 @@ async function downloadTelegramAttachment(params: {
   token: string;
   bot: TelegramFileLookup;
   candidate: TelegramAttachmentCandidate;
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment | null> {
   const { candidate } = params;
 
@@ -575,8 +576,8 @@ async function downloadTelegramAttachment(params: {
       : {}),
   };
 
-  // Auto-transcribe voice memos when an API key is available.
-  if (candidate.isVoice) {
+  // Auto-transcribe voice memos when enabled and an API key is available.
+  if (candidate.isVoice && params.transcribeVoice) {
     const { isTranscriptionConfigured, transcribeAudioFile } = await import(
       "../transcription/index"
     );
@@ -596,6 +597,7 @@ export async function resolveTelegramInboundAttachments(params: {
   token: string;
   bot: TelegramFileLookup;
   messages: TelegramLikeMessage[];
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
   const deduped = new Map<string, TelegramAttachmentCandidate>();
 
@@ -616,6 +618,7 @@ export async function resolveTelegramInboundAttachments(params: {
         token: params.token,
         bot: params.bot,
         candidate,
+        transcribeVoice: params.transcribeVoice,
       }).catch(() => null),
     ),
   );

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -83,6 +83,8 @@ export type TelegramAttachmentCandidate = {
   name?: string;
   mimeType?: string;
   sizeBytes?: number;
+  /** True when the attachment originated from a Telegram voice memo. */
+  isVoice?: boolean;
 };
 
 export type TelegramUploadMethod =
@@ -261,6 +263,7 @@ export function collectTelegramAttachmentCandidates(
       name: `voice-${message.voice.file_unique_id ?? message.voice.file_id}.ogg`,
       mimeType: message.voice.mime_type,
       sizeBytes: coerceSizeBytes(message.voice.file_size),
+      isVoice: true,
     });
   }
 
@@ -497,6 +500,7 @@ async function downloadTelegramAttachment(params: {
   token: string;
   bot: TelegramFileLookup;
   candidate: TelegramAttachmentCandidate;
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment | null> {
   const { candidate } = params;
 
@@ -560,7 +564,7 @@ async function downloadTelegramAttachment(params: {
     buffer,
   });
 
-  return {
+  const attachment: ChannelMessageAttachment = {
     id: candidate.fileId,
     name: fileName,
     mimeType,
@@ -571,6 +575,21 @@ async function downloadTelegramAttachment(params: {
       ? { imageDataBase64: buffer.toString("base64") }
       : {}),
   };
+
+  // Auto-transcribe voice memos when enabled and an API key is available.
+  if (candidate.isVoice && params.transcribeVoice) {
+    const { isTranscriptionConfigured, transcribeAudioFile } = await import(
+      "../transcription/index"
+    );
+    if (isTranscriptionConfigured()) {
+      const result = await transcribeAudioFile(localPath);
+      if (result.success && result.text) {
+        attachment.transcription = result.text;
+      }
+    }
+  }
+
+  return attachment;
 }
 
 export async function resolveTelegramInboundAttachments(params: {
@@ -578,6 +597,7 @@ export async function resolveTelegramInboundAttachments(params: {
   token: string;
   bot: TelegramFileLookup;
   messages: TelegramLikeMessage[];
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
   const deduped = new Map<string, TelegramAttachmentCandidate>();
 
@@ -598,6 +618,7 @@ export async function resolveTelegramInboundAttachments(params: {
         token: params.token,
         bot: params.bot,
         candidate,
+        transcribeVoice: params.transcribeVoice,
       }).catch(() => null),
     ),
   );

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -500,7 +500,6 @@ async function downloadTelegramAttachment(params: {
   token: string;
   bot: TelegramFileLookup;
   candidate: TelegramAttachmentCandidate;
-  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment | null> {
   const { candidate } = params;
 
@@ -576,8 +575,8 @@ async function downloadTelegramAttachment(params: {
       : {}),
   };
 
-  // Auto-transcribe voice memos when enabled and an API key is available.
-  if (candidate.isVoice && params.transcribeVoice) {
+  // Auto-transcribe voice memos when an API key is available.
+  if (candidate.isVoice) {
     const { isTranscriptionConfigured, transcribeAudioFile } = await import(
       "../transcription/index"
     );
@@ -597,7 +596,6 @@ export async function resolveTelegramInboundAttachments(params: {
   token: string;
   bot: TelegramFileLookup;
   messages: TelegramLikeMessage[];
-  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
   const deduped = new Map<string, TelegramAttachmentCandidate>();
 
@@ -618,7 +616,6 @@ export async function resolveTelegramInboundAttachments(params: {
         token: params.token,
         bot: params.bot,
         candidate,
-        transcribeVoice: params.transcribeVoice,
       }).catch(() => null),
     ),
   );

--- a/src/channels/telegram/setup.ts
+++ b/src/channels/telegram/setup.ts
@@ -78,6 +78,11 @@ export async function runTelegramSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
+    const transcriptionInput = await rl.question(
+      "Auto-transcribe voice memos when OPENAI_API_KEY is set? [y/N]: ",
+    );
+    const transcribeVoice = /^(y|yes)$/i.test(transcriptionInput.trim());
+
     // Step 5: Write account
     const now = new Date().toISOString();
     const account: TelegramChannelAccount = {
@@ -88,6 +93,7 @@ export async function runTelegramSetup(): Promise<boolean> {
       token: token.trim(),
       dmPolicy: policy,
       allowedUsers,
+      transcribeVoice,
       binding: {
         agentId: null,
         conversationId: null,

--- a/src/channels/transcription/index.ts
+++ b/src/channels/transcription/index.ts
@@ -15,6 +15,7 @@ export interface TranscriptionResult {
 }
 
 const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
+const TRANSCRIPTION_TIMEOUT_MS = 10_000;
 
 /** Check whether an API key is available for transcription. */
 export function isTranscriptionConfigured(): boolean {
@@ -49,7 +50,10 @@ export async function transcribeAudioFile(
     formData.append("model", "whisper-1");
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
+    const timeout = setTimeout(
+      () => controller.abort(),
+      TRANSCRIPTION_TIMEOUT_MS,
+    );
 
     try {
       const response = await fetch(WHISPER_API_URL, {

--- a/src/channels/transcription/index.ts
+++ b/src/channels/transcription/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Voice memo transcription via OpenAI Whisper.
+ *
+ * Minimal: one API call, no format conversion, no chunking.
+ * Telegram voice memos are .ogg/opus which Whisper supports natively.
+ */
+
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+export interface TranscriptionResult {
+  success: boolean;
+  text?: string;
+  error?: string;
+}
+
+const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
+
+/** Check whether an API key is available for transcription. */
+export function isTranscriptionConfigured(): boolean {
+  return !!process.env.OPENAI_API_KEY;
+}
+
+/**
+ * Transcribe a local audio file using OpenAI Whisper.
+ * Never throws; returns { success: false, error } on failure.
+ */
+export async function transcribeAudioFile(
+  localPath: string,
+): Promise<TranscriptionResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return {
+      success: false,
+      error: "OPENAI_API_KEY not set; transcription skipped.",
+    };
+  }
+
+  try {
+    const buffer = readFileSync(localPath);
+    const filename = basename(localPath);
+
+    const file = new File([new Uint8Array(buffer)], filename, {
+      type: "audio/ogg",
+    });
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("model", "whisper-1");
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+
+    try {
+      const response = await fetch(WHISPER_API_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: formData,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Whisper API error (${response.status}): ${errorText}`,
+        };
+      }
+
+      const data = (await response.json()) as { text: string };
+      return { success: true, text: data.text };
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/channels/transcription/index.ts
+++ b/src/channels/transcription/index.ts
@@ -41,12 +41,9 @@ export async function transcribeAudioFile(
     const buffer = readFileSync(localPath);
     const filename = basename(localPath);
 
-    const file = new File([new Uint8Array(buffer)], filename, {
-      type: "audio/ogg",
-    });
-
     const formData = new FormData();
-    formData.append("file", file);
+    const blob = new Blob([buffer], { type: "audio/ogg" });
+    formData.append("file", blob, filename);
     formData.append("model", "whisper-1");
 
     const controller = new AbortController();

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -19,6 +19,8 @@ export interface ChannelMessageAttachment {
   kind: "image" | "file" | "audio" | "video";
   localPath: string;
   imageDataBase64?: string;
+  /** Best-effort speech-to-text transcription (voice memos only). */
+  transcription?: string;
 }
 
 export interface ChannelReactionNotification {
@@ -180,6 +182,8 @@ export interface TelegramChannelConfig {
   token: string;
   dmPolicy: DmPolicy;
   allowedUsers: string[];
+  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. Defaults to false. */
+  transcribeVoice: boolean;
 }
 
 export interface SlackChannelConfig {
@@ -198,6 +202,8 @@ export interface TelegramChannelAccount extends ChannelAccountBase {
   channel: "telegram";
   token: string;
   binding: ChannelAccountBinding;
+  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
+  transcribeVoice?: boolean;
 }
 
 export interface SlackChannelAccount extends ChannelAccountBase {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -249,6 +249,8 @@ export interface TelegramChannelConfig {
   token: string;
   dmPolicy: DmPolicy;
   allowedUsers: string[];
+  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
+  transcribeVoice?: boolean;
 }
 
 export interface SlackChannelConfig {
@@ -267,6 +269,8 @@ export interface TelegramChannelAccount extends ChannelAccountBase {
   channel: "telegram";
   token: string;
   binding: ChannelAccountBinding;
+  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
+  transcribeVoice?: boolean;
 }
 
 export interface SlackChannelAccount extends ChannelAccountBase {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -182,8 +182,6 @@ export interface TelegramChannelConfig {
   token: string;
   dmPolicy: DmPolicy;
   allowedUsers: string[];
-  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. Defaults to false. */
-  transcribeVoice: boolean;
 }
 
 export interface SlackChannelConfig {
@@ -202,8 +200,6 @@ export interface TelegramChannelAccount extends ChannelAccountBase {
   channel: "telegram";
   token: string;
   binding: ChannelAccountBinding;
-  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
-  transcribeVoice?: boolean;
 }
 
 export interface SlackChannelAccount extends ChannelAccountBase {

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -99,6 +99,11 @@ function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
     attrs.push(`size_bytes="${attachment.sizeBytes}"`);
   }
 
+  if (attachment.transcription) {
+    const escapedTranscription = escapeXmlText(attachment.transcription);
+    return `<attachment ${attrs.join(" ")}>\n  <attempted_transcription>${escapedTranscription}</attempted_transcription>\n</attachment>`;
+  }
+
   return `<attachment ${attrs.join(" ")} />`;
 }
 

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -431,6 +431,7 @@ describe("channel service", () => {
         enabled: true,
         token: "telegram-token",
         dmPolicy: "pairing",
+        transcribeVoice: true,
       },
       { accountId: "bot-one" },
     );
@@ -446,15 +447,56 @@ describe("channel service", () => {
       token: "telegram-token",
       enabled: true,
       dmPolicy: "pairing",
+      transcribeVoice: true,
     });
 
     expect(getChannelAccountSnapshot("telegram", "bot-one")).toEqual(
       expect.objectContaining({
         accountId: "bot-one",
+        transcribeVoice: true,
         binding: {
           agentId: "agent-telegram",
           conversationId: "conv-telegram",
         },
+      }),
+    );
+  });
+
+  test("telegram live account helpers preserve the transcribeVoice opt-in", () => {
+    const created = createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "@voice-bot",
+        enabled: true,
+        token: "telegram-token",
+        dmPolicy: "pairing",
+        transcribeVoice: true,
+      },
+      { accountId: "voice-bot" },
+    );
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        accountId: "voice-bot",
+        transcribeVoice: true,
+      }),
+    );
+
+    const updated = updateChannelAccountLive("telegram", "voice-bot", {
+      transcribeVoice: false,
+    });
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        accountId: "voice-bot",
+        transcribeVoice: false,
+      }),
+    );
+
+    expect(getChannelAccountSnapshot("telegram", "voice-bot")).toEqual(
+      expect.objectContaining({
+        accountId: "voice-bot",
+        transcribeVoice: false,
       }),
     );
   });

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -136,6 +136,7 @@ const telegramAccountDefaults = {
 const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
 const originalFetch = globalThis.fetch;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 beforeEach(() => {
   channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
@@ -154,11 +155,17 @@ beforeEach(() => {
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
   globalThis.fetch = originalFetch;
+  delete process.env.OPENAI_API_KEY;
 });
 
 afterEach(() => {
   console.error = originalConsoleError;
   globalThis.fetch = originalFetch;
+  if (originalOpenAiApiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  }
   rmSync(channelRoot, { recursive: true, force: true });
 });
 
@@ -387,6 +394,78 @@ test("telegram adapter forwards plain text messages through onMessage", async ()
     attachments: undefined,
     raw: expect.objectContaining({ message_id: 77 }),
   });
+});
+
+test("telegram adapter auto-transcribes inbound voice memos when OPENAI_API_KEY is set", async () => {
+  process.env.OPENAI_API_KEY = "sk-test";
+
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const href = typeof url === "string" ? url : url.toString();
+
+    if (href.includes("/file/bottest-token/voice/voice1.ogg")) {
+      return new Response(Buffer.from("voice-bytes"), {
+        status: 200,
+        headers: { "content-type": "audio/ogg" },
+      });
+    }
+
+    if (href === "https://api.openai.com/v1/audio/transcriptions") {
+      return new Response(JSON.stringify({ text: "Transcribed voice memo" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${href}`);
+  }) as unknown as typeof fetch;
+
+  FakeBot.nextGetFileImpl = async () => ({
+    file_path: "voice/voice1.ogg",
+  });
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  await bot?.emit("message", {
+    message: {
+      chat: { id: 123 },
+      from: { id: 456, username: "alice", first_name: "Alice" },
+      text: "",
+      date: 1_736_380_800,
+      message_id: 77,
+      voice: {
+        file_id: "voice1",
+        file_unique_id: "voice-unique-1",
+        mime_type: "audio/ogg",
+        file_size: 12,
+      },
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledTimes(1);
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      attachments: [
+        expect.objectContaining({
+          kind: "audio",
+          mimeType: "audio/ogg",
+          transcription: "Transcribed voice memo",
+        }),
+      ],
+    }),
+  );
 });
 
 test("telegram adapter forwards reaction updates through onMessage", async () => {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -396,7 +396,7 @@ test("telegram adapter forwards plain text messages through onMessage", async ()
   });
 });
 
-test("telegram adapter auto-transcribes inbound voice memos when OPENAI_API_KEY is set", async () => {
+test("telegram adapter transcribes inbound voice memos when opt-in is enabled", async () => {
   process.env.OPENAI_API_KEY = "sk-test";
 
   globalThis.fetch = mock(async (url: string | URL | Request) => {
@@ -414,6 +414,78 @@ test("telegram adapter auto-transcribes inbound voice memos when OPENAI_API_KEY 
         status: 200,
         headers: { "content-type": "application/json" },
       });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${href}`);
+  }) as unknown as typeof fetch;
+
+  FakeBot.nextGetFileImpl = async () => ({
+    file_path: "voice/voice1.ogg",
+  });
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    transcribeVoice: true,
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  await bot?.emit("message", {
+    message: {
+      chat: { id: 123 },
+      from: { id: 456, username: "alice", first_name: "Alice" },
+      text: "",
+      date: 1_736_380_800,
+      message_id: 77,
+      voice: {
+        file_id: "voice1",
+        file_unique_id: "voice-unique-1",
+        mime_type: "audio/ogg",
+        file_size: 12,
+      },
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledTimes(1);
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      attachments: [
+        expect.objectContaining({
+          kind: "audio",
+          mimeType: "audio/ogg",
+          transcription: "Transcribed voice memo",
+        }),
+      ],
+    }),
+  );
+});
+
+test("telegram adapter skips voice transcription unless opt-in is enabled", async () => {
+  process.env.OPENAI_API_KEY = "sk-test";
+
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const href = typeof url === "string" ? url : url.toString();
+
+    if (href.includes("/file/bottest-token/voice/voice1.ogg")) {
+      return new Response(Buffer.from("voice-bytes"), {
+        status: 200,
+        headers: { "content-type": "audio/ogg" },
+      });
+    }
+
+    if (href === "https://api.openai.com/v1/audio/transcriptions") {
+      throw new Error(
+        "Whisper should not be called when transcription is disabled",
+      );
     }
 
     throw new Error(`Unexpected fetch URL: ${href}`);
@@ -458,10 +530,8 @@ test("telegram adapter auto-transcribes inbound voice memos when OPENAI_API_KEY 
   expect(onMessage).toHaveBeenCalledWith(
     expect.objectContaining({
       attachments: [
-        expect.objectContaining({
-          kind: "audio",
-          mimeType: "audio/ogg",
-          transcription: "Transcribed voice memo",
+        expect.not.objectContaining({
+          transcription: expect.any(String),
         }),
       ],
     }),

--- a/src/tests/channels/transcription.test.ts
+++ b/src/tests/channels/transcription.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+describe("isTranscriptionConfigured", () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+  });
+
+  test("returns false when OPENAI_API_KEY is not set", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const { isTranscriptionConfigured } = await import(
+      "../../channels/transcription/index"
+    );
+    expect(isTranscriptionConfigured()).toBe(false);
+  });
+
+  test("returns true when OPENAI_API_KEY is set", async () => {
+    process.env.OPENAI_API_KEY = "sk-test-key";
+    const { isTranscriptionConfigured } = await import(
+      "../../channels/transcription/index"
+    );
+    expect(isTranscriptionConfigured()).toBe(true);
+  });
+});
+
+describe("transcribeAudioFile", () => {
+  let originalKey: string | undefined;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    originalKey = process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns error when OPENAI_API_KEY is not set", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const { transcribeAudioFile } = await import(
+      "../../channels/transcription/index"
+    );
+    const result = await transcribeAudioFile("/tmp/nonexistent.ogg");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("OPENAI_API_KEY");
+  });
+
+  test("returns error when file does not exist", async () => {
+    process.env.OPENAI_API_KEY = "sk-test-key";
+    const { transcribeAudioFile } = await import(
+      "../../channels/transcription/index"
+    );
+    const result = await transcribeAudioFile(
+      "/tmp/definitely-does-not-exist-12345.ogg",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  test("calls Whisper API and returns transcribed text", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    const fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ text: "Hello world" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // Write a temp file so readFileSync succeeds
+    const { writeFileSync, unlinkSync } = await import("node:fs");
+    const path = "/tmp/letta-test-voice.ogg";
+    writeFileSync(path, "fake audio data");
+
+    try {
+      const { transcribeAudioFile } = await import(
+        "../../channels/transcription/index"
+      );
+      const result = await transcribeAudioFile(path);
+
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("Hello world");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const [url, options] = fetchMock.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(url).toBe("https://api.openai.com/v1/audio/transcriptions");
+      expect(options.method).toBe("POST");
+      expect(options.headers).toEqual(
+        expect.objectContaining({ Authorization: "Bearer sk-test" }),
+      );
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test("returns error on API failure", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    globalThis.fetch = mock(async () => {
+      return new Response("Rate limited", { status: 429 });
+    }) as unknown as typeof fetch;
+
+    const { writeFileSync, unlinkSync } = await import("node:fs");
+    const path = "/tmp/letta-test-voice-fail.ogg";
+    writeFileSync(path, "fake audio data");
+
+    try {
+      const { transcribeAudioFile } = await import(
+        "../../channels/transcription/index"
+      );
+      const result = await transcribeAudioFile(path);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("429");
+    } finally {
+      unlinkSync(path);
+    }
+  });
+});

--- a/src/tests/channels/transcription.test.ts
+++ b/src/tests/channels/transcription.test.ts
@@ -82,9 +82,12 @@ describe("transcribeAudioFile", () => {
     });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    // Write a temp file so readFileSync succeeds
-    const { writeFileSync, unlinkSync } = await import("node:fs");
-    const path = "/tmp/letta-test-voice.ogg";
+    // Write a temp file so readFileSync succeeds.
+    const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "letta-test-voice-"));
+    const path = join(dir, "voice.ogg");
     writeFileSync(path, "fake audio data");
 
     try {
@@ -107,7 +110,7 @@ describe("transcribeAudioFile", () => {
         expect.objectContaining({ Authorization: "Bearer sk-test" }),
       );
     } finally {
-      unlinkSync(path);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
@@ -118,8 +121,11 @@ describe("transcribeAudioFile", () => {
       return new Response("Rate limited", { status: 429 });
     }) as unknown as typeof fetch;
 
-    const { writeFileSync, unlinkSync } = await import("node:fs");
-    const path = "/tmp/letta-test-voice-fail.ogg";
+    const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "letta-test-voice-fail-"));
+    const path = join(dir, "voice.ogg");
     writeFileSync(path, "fake audio data");
 
     try {
@@ -131,7 +137,7 @@ describe("transcribeAudioFile", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("429");
     } finally {
-      unlinkSync(path);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -175,6 +175,83 @@ describe("formatChannelNotification", () => {
     );
   });
 
+  test("renders attempted_transcription child node when transcription is present", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "",
+      timestamp: Date.now(),
+      attachments: [
+        {
+          kind: "audio",
+          localPath: "/tmp/voice.ogg",
+          name: "voice.ogg",
+          mimeType: "audio/ogg",
+          transcription: "Hello, this is a voice memo test.",
+        },
+      ],
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain(
+      "<attempted_transcription>Hello, this is a voice memo test.</attempted_transcription>",
+    );
+    expect(xml).toContain("</attachment>");
+    // Verify it's not self-closing
+    expect(xml).not.toMatch(/<attachment[^>]*\/>/);
+    // Verify it has an opening tag (non-self-closing)
+    expect(xml).toMatch(/<attachment[^>]*>\n/);
+  });
+
+  test("renders self-closing attachment when transcription is absent", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "",
+      timestamp: Date.now(),
+      attachments: [
+        {
+          kind: "audio",
+          localPath: "/tmp/voice.ogg",
+          name: "voice.ogg",
+          mimeType: "audio/ogg",
+        },
+      ],
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toMatch(/<attachment[^>]*\/>/);
+    expect(xml).not.toContain("<attempted_transcription>");
+    expect(xml).not.toContain("</attachment>");
+  });
+
+  test("escapes XML in transcription text", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "",
+      timestamp: Date.now(),
+      attachments: [
+        {
+          kind: "audio",
+          localPath: "/tmp/voice.ogg",
+          transcription: "He said <hello> & goodbye",
+        },
+      ],
+    };
+
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(xml).toContain("&lt;hello&gt;");
+    expect(xml).toContain("&amp;");
+    expect(xml).not.toContain("<hello>");
+  });
+
   test("emits image content parts for inbound image attachments", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1259,6 +1259,7 @@ describe("listen-client channels command handling", () => {
           dmPolicy: "pairing" as const,
           allowedUsers: [],
           hasToken: true,
+          transcribeVoice: false,
           binding: {
             agentId: "agent-1",
             conversationId: "default",
@@ -1705,6 +1706,7 @@ describe("listen-client channels command handling", () => {
         dmPolicy: "pairing" as const,
         allowedUsers: [],
         hasToken: true,
+        transcribeVoice: false,
         binding: {
           agentId: null,
           conversationId: null,
@@ -1722,6 +1724,7 @@ describe("listen-client channels command handling", () => {
         dmPolicy: "pairing" as const,
         allowedUsers: [],
         hasToken: true,
+        transcribeVoice: false,
         binding: {
           agentId: null,
           conversationId: null,


### PR DESCRIPTION
## Summary

- Add Telegram voice memo transcription via OpenAI Whisper as an opt-in per-account setting
- Prompt for `transcribeVoice` during Telegram setup and carry the flag through legacy config/account loading
- Surface best-effort transcription as an `<attempted_transcription>` child node in attachment XML so the agent sees the text inline
- Distinguish Telegram voice memos from generic audio uploads with `isVoice`, and skip transcription unless both `transcribeVoice` and `OPENAI_API_KEY` are set
- Add targeted coverage for transcription behavior, XML rendering, Telegram adapter opt-in behavior, and cross-platform temp-file handling

Written by Cameron ◯ Letta Code

> "Memory is the foundation, not a feature."
