### PR TITLE
feat(channels): add channel turn lifecycle hooks

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -39,6 +39,8 @@ import { loadTargetStore, upsertChannelTarget } from "./targets";
 import type {
   ChannelAdapter,
   ChannelRoute,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
   InboundChannelMessage,
   SlackChannelAccount,
 } from "./types";
@@ -107,6 +109,25 @@ export function buildSlackConversationSummary(
   return `[Slack] Thread${channelLabel || ` ${msg.chatId}`}`;
 }
 
+function buildChannelTurnSource(
+  route: ChannelRoute,
+  msg: Pick<
+    InboundChannelMessage,
+    "channel" | "accountId" | "chatId" | "chatType" | "messageId" | "threadId"
+  >,
+): ChannelTurnSource {
+  return {
+    channel: msg.channel as ChannelTurnSource["channel"],
+    accountId: msg.accountId,
+    chatId: msg.chatId,
+    chatType: msg.chatType,
+    messageId: msg.messageId,
+    threadId: msg.threadId,
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+  };
+}
+
 // ── Singleton ─────────────────────────────────────────────────────
 
 let instance: ChannelRegistry | null = null;
@@ -126,10 +147,13 @@ export function getActiveChannelIds(): string[] {
 
 // ── Types ─────────────────────────────────────────────────────────
 
-export type ChannelMessageHandler = (
-  route: ChannelRoute,
-  content: MessageCreate["content"],
-) => void;
+export interface ChannelInboundDelivery {
+  route: ChannelRoute;
+  content: MessageCreate["content"];
+  turnSources?: ChannelTurnSource[];
+}
+
+export type ChannelMessageHandler = (delivery: ChannelInboundDelivery) => void;
 
 export type ChannelRegistryEvent =
   | {
@@ -148,10 +172,7 @@ export class ChannelRegistry {
   private ready = false;
   private messageHandler: ChannelMessageHandler | null = null;
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
-  private readonly buffer: Array<{
-    route: ChannelRoute;
-    content: MessageCreate["content"];
-  }> = [];
+  private readonly buffer: ChannelInboundDelivery[] = [];
 
   constructor() {
     if (instance) {
@@ -194,6 +215,71 @@ export class ChannelRegistry {
     return Array.from(this.adapters.values())
       .filter((adapter) => adapter.isRunning())
       .map((adapter) => adapter.channelId ?? adapter.id);
+  }
+
+  async dispatchTurnLifecycleEvent(
+    event: ChannelTurnLifecycleEvent,
+  ): Promise<void> {
+    const groups = new Map<
+      string,
+      {
+        adapter: ChannelAdapter;
+        sources: ChannelTurnSource[];
+      }
+    >();
+
+    const sources = event.type === "queued" ? [event.source] : event.sources;
+    for (const source of sources) {
+      const adapter = this.getAdapter(
+        source.channel,
+        source.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+      );
+      if (!adapter?.handleTurnLifecycleEvent) {
+        continue;
+      }
+      const groupKey = this.getAdapterKey(
+        source.channel,
+        source.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+      );
+      const existing = groups.get(groupKey);
+      if (existing) {
+        existing.sources.push(source);
+        continue;
+      }
+      groups.set(groupKey, {
+        adapter,
+        sources: [source],
+      });
+    }
+
+    for (const { adapter, sources: groupedSources } of groups.values()) {
+      const handleTurnLifecycleEvent = adapter.handleTurnLifecycleEvent;
+      if (!handleTurnLifecycleEvent) {
+        continue;
+      }
+      try {
+        if (event.type === "queued") {
+          const [firstSource] = groupedSources;
+          if (!firstSource) {
+            continue;
+          }
+          await handleTurnLifecycleEvent({
+            type: "queued",
+            source: firstSource,
+          });
+          continue;
+        }
+        await handleTurnLifecycleEvent({
+          ...event,
+          sources: groupedSources,
+        });
+      } catch (error) {
+        console.error(
+          `[Channels] Failed to handle ${event.type} lifecycle event for ${adapter.channelId ?? adapter.id}/${adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
   }
 
   // ── Readiness / ingress handler ───────────────────────────────
@@ -414,10 +500,13 @@ export class ChannelRegistry {
             isFirstRouteTurn: slackResult.isFirstRouteTurn,
           })
         : msg;
-      this.deliverOrBuffer(
-        slackResult.route,
-        formatChannelNotification(preparedMessage),
-      );
+      this.deliverOrBuffer({
+        route: slackResult.route,
+        content: formatChannelNotification(preparedMessage),
+        turnSources: [
+          buildChannelTurnSource(slackResult.route, preparedMessage),
+        ],
+      });
       return;
     }
 
@@ -485,7 +574,11 @@ export class ChannelRegistry {
     const content = formatChannelNotification(msg);
 
     // 4. Deliver or buffer
-    this.deliverOrBuffer(route, content);
+    this.deliverOrBuffer({
+      route,
+      content,
+      turnSources: [buildChannelTurnSource(route, msg)],
+    });
   }
 
   private async createConversationForAgent(
@@ -620,16 +713,13 @@ export class ChannelRegistry {
     };
   }
 
-  private deliverOrBuffer(
-    route: ChannelRoute,
-    content: MessageCreate["content"],
-  ): void {
+  private deliverOrBuffer(delivery: ChannelInboundDelivery): void {
     if (this.isReady()) {
-      this.messageHandler?.(route, content);
+      this.messageHandler?.(delivery);
       return;
     }
 
-    this.buffer.push({ route, content });
+    this.buffer.push(delivery);
   }
 
   private flushBuffer(): void {
@@ -638,7 +728,7 @@ export class ChannelRegistry {
     while (this.buffer.length > 0) {
       const item = this.buffer.shift();
       if (item) {
-        this.messageHandler(item.route, item.content);
+        this.messageHandler(item);
       }
     }
   }

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -3,6 +3,8 @@ import { basename, extname } from "node:path";
 import type SlackApp from "@slack/bolt";
 import type {
   ChannelAdapter,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
   InboundChannelMessage,
   OutboundChannelMessage,
   SlackChannelAccount,
@@ -187,6 +189,10 @@ function normalizeSlackReactionName(value: string): string {
 
 const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
 const SLACK_INGRESS_DEDUPE_MAX = 2_000;
+const SLACK_LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
+const SLACK_LIFECYCLE_STATE_MAX = 2_000;
+
+type SlackLifecycleState = "queued" | "completed" | "error" | "cancelled";
 
 function resolveUploadMimeType(filePath: string): string | undefined {
   switch (extname(filePath).toLowerCase()) {
@@ -341,6 +347,11 @@ export function createSlackAdapter(
   const knownThreadIdsByMessageId = new Map<string, string | null>();
   const knownUserDisplayNames = new Map<string, string>();
   const seenIngressMessageKeys = new Map<string, number>();
+  const lifecycleStateByMessageKey = new Map<
+    string,
+    { state: SlackLifecycleState; updatedAt: number }
+  >();
+  const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
 
   function buildIngressMessageKey(
     channelId: string | undefined,
@@ -374,6 +385,132 @@ export function createSlackAdapter(
         seenIngressMessageKeys.delete(entry[0]);
       }
     }
+  }
+
+  function getLifecycleMessageKey(source: ChannelTurnSource): string | null {
+    if (
+      source.channel !== "slack" ||
+      !isNonEmptyString(source.chatId) ||
+      !isNonEmptyString(source.messageId)
+    ) {
+      return null;
+    }
+    return `${source.chatId}:${source.messageId}`;
+  }
+
+  function pruneLifecycleState(now: number = Date.now()): void {
+    for (const [key, entry] of lifecycleStateByMessageKey) {
+      if (entry.updatedAt + SLACK_LIFECYCLE_STATE_TTL_MS <= now) {
+        lifecycleStateByMessageKey.delete(key);
+      }
+    }
+
+    if (lifecycleStateByMessageKey.size <= SLACK_LIFECYCLE_STATE_MAX) {
+      return;
+    }
+
+    const oldestEntries = Array.from(lifecycleStateByMessageKey.entries()).sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt,
+    );
+    const overflowCount =
+      lifecycleStateByMessageKey.size - SLACK_LIFECYCLE_STATE_MAX;
+    for (let index = 0; index < overflowCount; index += 1) {
+      const entry = oldestEntries[index];
+      if (entry) {
+        lifecycleStateByMessageKey.delete(entry[0]);
+      }
+    }
+  }
+
+  async function sendLifecycleReaction(
+    source: ChannelTurnSource,
+    emoji: string,
+    removeReaction = false,
+  ): Promise<void> {
+    if (!isNonEmptyString(source.messageId)) {
+      return;
+    }
+    await ensureApp();
+    const slackClient = await ensureWriteClient();
+    if (removeReaction) {
+      await slackClient.reactions.remove({
+        channel: source.chatId,
+        timestamp: source.messageId,
+        name: emoji,
+      });
+      return;
+    }
+    await slackClient.reactions.add({
+      channel: source.chatId,
+      timestamp: source.messageId,
+      name: emoji,
+    });
+  }
+
+  function scheduleLifecycleTransition(
+    source: ChannelTurnSource,
+    nextState: SlackLifecycleState,
+  ): Promise<void> | null {
+    const key = getLifecycleMessageKey(source);
+    if (!key) {
+      return null;
+    }
+
+    const previous =
+      lifecycleOperationByMessageKey.get(key) ?? Promise.resolve();
+    const operation = previous
+      .catch(() => {})
+      .then(async () => {
+        pruneLifecycleState();
+        const currentState = lifecycleStateByMessageKey.get(key)?.state;
+        if (currentState === nextState) {
+          lifecycleStateByMessageKey.set(key, {
+            state: nextState,
+            updatedAt: Date.now(),
+          });
+          return;
+        }
+
+        if (nextState === "queued") {
+          if (!currentState) {
+            await sendLifecycleReaction(source, "eyes");
+            lifecycleStateByMessageKey.set(key, {
+              state: nextState,
+              updatedAt: Date.now(),
+            });
+          }
+          return;
+        }
+
+        if (currentState === "queued") {
+          try {
+            await sendLifecycleReaction(source, "eyes", true);
+          } catch {}
+        }
+
+        await sendLifecycleReaction(
+          source,
+          nextState === "completed" ? "white_check_mark" : "x",
+        );
+        lifecycleStateByMessageKey.set(key, {
+          state: nextState,
+          updatedAt: Date.now(),
+        });
+      })
+      .catch((error) => {
+        console.warn(
+          `[Slack] Failed to update lifecycle reaction for ${key}:`,
+          error instanceof Error ? error.message : error,
+        );
+      })
+      .finally(() => {
+        if (lifecycleOperationByMessageKey.get(key) === operation) {
+          lifecycleOperationByMessageKey.delete(key);
+        }
+      });
+
+    lifecycleOperationByMessageKey.set(key, operation);
+    return operation;
   }
 
   function markIngressMessageSeen(
@@ -728,11 +865,43 @@ export function createSlackAdapter(
       writeClient = null;
       botUserId = null;
       seenIngressMessageKeys.clear();
+      lifecycleStateByMessageKey.clear();
+      lifecycleOperationByMessageKey.clear();
       console.log("[Slack] App stopped");
     },
 
     isRunning(): boolean {
       return running;
+    },
+
+    async handleTurnLifecycleEvent(
+      event: ChannelTurnLifecycleEvent,
+    ): Promise<void> {
+      if (!running) {
+        return;
+      }
+
+      if (event.type === "queued") {
+        await scheduleLifecycleTransition(event.source, "queued");
+        return;
+      }
+
+      if (event.type === "processing") {
+        return;
+      }
+
+      const nextState: SlackLifecycleState =
+        event.outcome === "completed"
+          ? "completed"
+          : event.outcome === "cancelled"
+            ? "cancelled"
+            : "error";
+
+      await Promise.all(
+        event.sources.map((source) =>
+          scheduleLifecycleTransition(source, nextState),
+        ),
+      );
     },
 
     async sendMessage(

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -41,6 +41,37 @@ export interface ChannelThreadContext {
   history?: ChannelThreadContextEntry[];
 }
 
+export interface ChannelTurnSource {
+  channel: SupportedChannelId;
+  accountId?: string;
+  chatId: string;
+  chatType?: ChannelChatType;
+  messageId?: string;
+  threadId?: string | null;
+  agentId: string;
+  conversationId: string;
+}
+
+export type ChannelTurnOutcome = "completed" | "error" | "cancelled";
+
+export type ChannelTurnLifecycleEvent =
+  | {
+      type: "queued";
+      source: ChannelTurnSource;
+    }
+  | {
+      type: "processing";
+      batchId: string;
+      sources: ChannelTurnSource[];
+    }
+  | {
+      type: "finished";
+      batchId: string;
+      sources: ChannelTurnSource[];
+      outcome: ChannelTurnOutcome;
+      error?: string;
+    };
+
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {
@@ -82,6 +113,13 @@ export interface ChannelAdapter {
     msg: InboundChannelMessage,
     options?: { isFirstRouteTurn?: boolean },
   ): Promise<InboundChannelMessage>;
+
+  /**
+   * Optional lifecycle hook for channel-originated turns. Adapters can use
+   * this to surface lightweight UX feedback (for example, Slack reactions)
+   * without coupling queue/lifecycle state to a specific channel.
+   */
+  handleTurnLifecycleEvent?(event: ChannelTurnLifecycleEvent): Promise<void>;
 
   /**
    * Called by the registry when the adapter receives an inbound message.

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -790,6 +790,129 @@ test("slack adapter can add reactions to messages", async () => {
   });
 });
 
+test("slack adapter adds eyes while a queued turn is processing, then swaps to checkmark on completion", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatType: "channel",
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000100",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.add).toHaveBeenNthCalledWith(1, {
+    channel: "C123",
+    timestamp: "1712800000.000100",
+    name: "eyes",
+  });
+  expect(writeClient?.reactions.remove).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000100",
+    name: "eyes",
+  });
+  expect(writeClient?.reactions.add).toHaveBeenNthCalledWith(2, {
+    channel: "C123",
+    timestamp: "1712800000.000100",
+    name: "white_check_mark",
+  });
+});
+
+test("slack adapter swaps queued turns to x when the turn fails", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "D123",
+      chatType: "direct",
+      messageId: "1712800000.000200",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-2",
+    outcome: "error",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "D123",
+        chatType: "direct",
+        messageId: "1712800000.000200",
+        threadId: null,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.remove).toHaveBeenCalledWith({
+    channel: "D123",
+    timestamp: "1712800000.000200",
+    name: "eyes",
+  });
+  expect(writeClient?.reactions.add).toHaveBeenNthCalledWith(2, {
+    channel: "D123",
+    timestamp: "1712800000.000200",
+    name: "x",
+  });
+});
+
 test("slack adapter uploads local files through Slack's external upload flow", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "letta-slack-upload-"));
   const mediaPath = join(tempDir, "chart.png");

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { APIError } from "@letta-ai/letta-client/error";
 import WebSocket from "ws";
 import type { ResumeData } from "../../agent/check-approval";
+import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import type { ChannelAdapter } from "../../channels/types";
 import { permissionMode } from "../../permissions/mode";
 import type {
   MessageQueueItem,
@@ -318,6 +320,13 @@ describe("listen-client multi-worker concurrency", () => {
   afterEach(() => {
     permissionMode.reset();
     __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
   });
 
   test("processes simultaneous turns for two named conversations under one agent", async () => {
@@ -876,6 +885,92 @@ describe("listen-client multi-worker concurrency", () => {
     expect(dequeuedUserDelta?.delta?.otid).toBe(queuedPayload.otid);
     expect(runtime.queueRuntime.length).toBe(0);
     expect(runtime.queuedMessagesByItemId.size).toBe(0);
+  });
+
+  test("channel queue batches emit lifecycle events for the originating channel sources", async () => {
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const registry = new ChannelRegistry();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async () => {},
+      handleTurnLifecycleEvent: async (event) => {
+        lifecycleEvents.push(event as unknown as Record<string, unknown>);
+      },
+    } satisfies ChannelAdapter);
+
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-channel",
+    );
+    const socket = new MockSocket();
+    const processed: IncomingMessage[] = [];
+    const channelContent = [
+      {
+        type: "text" as const,
+        text: '<channel-notification source="slack" chat_id="C123">hello from slack</channel-notification>',
+      },
+    ];
+    const channelTurnSources = [
+      {
+        channel: "slack" as const,
+        accountId: "acct-slack",
+        chatId: "C123",
+        chatType: "channel" as const,
+        messageId: "1712800000.000100",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-channel",
+      },
+    ];
+
+    const enqueuedItem = __listenClientTestUtils.enqueueChannelTurn(
+      runtime,
+      {
+        agentId: "agent-1",
+        conversationId: "conv-channel",
+      },
+      channelContent,
+      channelTurnSources,
+    );
+
+    expect(enqueuedItem).not.toBeNull();
+
+    __listenClientTestUtils.scheduleQueuePump(
+      runtime,
+      socket as unknown as WebSocket,
+      {
+        connectionId: "conn-1",
+        onStatusChange: undefined,
+      } as never,
+      async (queuedTurn: IncomingMessage) => {
+        processed.push(queuedTurn);
+      },
+    );
+
+    await waitFor(() => processed.length === 1 && lifecycleEvents.length === 2);
+
+    expect(processed[0]?.channelTurnSources).toEqual(channelTurnSources);
+    expect(lifecycleEvents[0]).toEqual({
+      type: "processing",
+      batchId: "batch-1",
+      sources: channelTurnSources,
+    });
+    expect(lifecycleEvents[1]).toEqual({
+      type: "finished",
+      batchId: "batch-1",
+      sources: channelTurnSources,
+      outcome: "completed",
+    });
   });
 
   test("task_notification-only queue items re-enter the listener loop as standalone turns", async () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -18,6 +18,7 @@ import {
   updateConversationLLMConfig,
 } from "../../agent/modify";
 import { getChannelRegistry } from "../../channels/registry";
+import type { ChannelTurnSource } from "../../channels/types";
 import { resetContextHistory } from "../../cli/helpers/contextTracker";
 import {
   ensureFileIndex,
@@ -2967,12 +2968,12 @@ function wireChannelIngress(
   const registry = getChannelRegistry();
   if (!registry) return;
 
-  registry.setMessageHandler((route, messageContent) => {
+  registry.setMessageHandler((delivery) => {
     // Follow the same pattern as cron/scheduler.ts:131-157
     const rawRuntime = getOrCreateConversationRuntime(
       listener,
-      route.agentId,
-      route.conversationId,
+      delivery.route.agentId,
+      delivery.route.conversationId,
     );
     if (!rawRuntime) return;
 
@@ -2981,7 +2982,22 @@ function wireChannelIngress(
       rawRuntime,
     );
 
-    enqueueChannelTurn(conversationRuntime, route, messageContent);
+    const enqueuedItem = enqueueChannelTurn(
+      conversationRuntime,
+      delivery.route,
+      delivery.content,
+      delivery.turnSources,
+    );
+    if (!enqueuedItem) {
+      return;
+    }
+
+    for (const turnSource of delivery.turnSources ?? []) {
+      void registry.dispatchTurnLifecycleEvent({
+        type: "queued",
+        source: turnSource,
+      });
+    }
 
     scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
   });
@@ -3039,6 +3055,7 @@ function enqueueChannelTurn(
     conversationId: string;
   },
   messageContent: MessageCreate["content"],
+  turnSources?: ChannelTurnSource[],
 ): { id: string } | null {
   const clientMessageId = `cm-channel-${crypto.randomUUID()}`;
   const enqueuedItem = runtime.queueRuntime.enqueue({
@@ -3063,6 +3080,7 @@ function enqueueChannelTurn(
       type: "message",
       agentId: route.agentId,
       conversationId: route.conversationId,
+      ...(turnSources?.length ? { channelTurnSources: turnSources } : {}),
       messages: [
         {
           role: "user",

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -1,5 +1,10 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type WebSocket from "ws";
+import { getChannelRegistry } from "../../channels/registry";
+import type {
+  ChannelTurnOutcome,
+  ChannelTurnSource,
+} from "../../channels/types";
 import { resizeImageIfNeeded } from "../../cli/helpers/imageResize";
 import type {
   DequeuedBatch,
@@ -103,6 +108,94 @@ function mergeDequeuedBatchContent(
   return mergeQueuedTurnInput(queuedInputs, {
     normalizeUserContent: (content) => content,
   });
+}
+
+function getChannelTurnSourceKey(source: ChannelTurnSource): string {
+  return [
+    source.channel,
+    source.accountId ?? "",
+    source.chatId,
+    source.messageId ?? "",
+    source.threadId ?? "",
+    source.agentId,
+    source.conversationId,
+  ].join(":");
+}
+
+function collectBatchChannelTurnSources(
+  runtime: ConversationRuntime,
+  batch: DequeuedBatch,
+): ChannelTurnSource[] | undefined {
+  const seen = new Set<string>();
+  const sources: ChannelTurnSource[] = [];
+
+  for (const item of batch.items) {
+    const template = runtime.queuedMessagesByItemId.get(item.id);
+    for (const source of template?.channelTurnSources ?? []) {
+      const key = getChannelTurnSourceKey(source);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      sources.push(source);
+    }
+  }
+
+  return sources.length > 0 ? sources : undefined;
+}
+
+async function dispatchChannelTurnLifecycleEvent(
+  event:
+    | {
+        type: "processing";
+        batchId: string;
+        sources: ChannelTurnSource[];
+      }
+    | {
+        type: "finished";
+        batchId: string;
+        sources: ChannelTurnSource[];
+        outcome: ChannelTurnOutcome;
+        error?: string;
+      },
+): Promise<void> {
+  if (event.sources.length === 0) {
+    return;
+  }
+
+  const registry = getChannelRegistry();
+  if (!registry) {
+    return;
+  }
+
+  if (event.type === "processing") {
+    await registry.dispatchTurnLifecycleEvent(event);
+    return;
+  }
+
+  await registry.dispatchTurnLifecycleEvent({
+    type: "finished",
+    batchId: event.batchId,
+    sources: event.sources,
+    outcome: event.outcome,
+    ...(event.error ? { error: event.error } : {}),
+  });
+}
+
+function mapTurnLifecycleOutcome(
+  lastStopReason: string | null,
+  didThrow: boolean,
+): ChannelTurnOutcome {
+  if (didThrow) {
+    return "error";
+  }
+  if (lastStopReason === "cancelled") {
+    return "cancelled";
+  }
+  if (lastStopReason && lastStopReason !== "end_turn") {
+    return "error";
+  }
+  return "completed";
 }
 
 function isBase64ImageContentPart(part: unknown): part is {
@@ -217,6 +310,7 @@ function buildQueuedTurnMessage(
   runtime: ConversationRuntime,
   batch: DequeuedBatch,
 ): IncomingMessage | null {
+  const channelTurnSources = collectBatchChannelTurnSources(runtime, batch);
   const primaryItem = getPrimaryQueueMessageItem(batch.items);
   if (!primaryItem) {
     // No user message in the batch — this is a notification-only batch.
@@ -236,6 +330,7 @@ function buildQueuedTurnMessage(
       type: "message",
       agentId: scopeItem?.agentId ?? runtime.agentId ?? undefined,
       conversationId: scopeItem?.conversationId ?? runtime.conversationId,
+      ...(channelTurnSources ? { channelTurnSources } : {}),
       messages: [
         {
           role: "user",
@@ -278,6 +373,7 @@ function buildQueuedTurnMessage(
 
   return {
     ...template,
+    ...(channelTurnSources ? { channelTurnSources } : {}),
     messages,
   };
 }
@@ -396,6 +492,7 @@ async function drainQueuedMessages(
       }
 
       const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
+      const channelTurnSources = queuedTurn.channelTurnSources ?? [];
 
       emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
 
@@ -410,7 +507,33 @@ async function drainQueuedMessages(
         runtime.listener.lastEmittedStatus = preTurnStatus;
         opts.onStatusChange?.(preTurnStatus, opts.connectionId);
       }
-      await processQueuedTurn(queuedTurn, dequeuedBatch);
+      if (channelTurnSources.length > 0) {
+        await dispatchChannelTurnLifecycleEvent({
+          type: "processing",
+          batchId: dequeuedBatch.batchId,
+          sources: channelTurnSources,
+        });
+      }
+
+      let turnError: string | undefined;
+      let didThrow = false;
+      try {
+        await processQueuedTurn(queuedTurn, dequeuedBatch);
+      } catch (error) {
+        didThrow = true;
+        turnError = error instanceof Error ? error.message : String(error);
+        throw error;
+      } finally {
+        if (channelTurnSources.length > 0) {
+          await dispatchChannelTurnLifecycleEvent({
+            type: "finished",
+            batchId: dequeuedBatch.batchId,
+            sources: channelTurnSources,
+            outcome: mapTurnLifecycleOutcome(runtime.lastStopReason, didThrow),
+            ...(turnError ? { error: turnError } : {}),
+          });
+        }
+      }
       emitListenerStatus(
         runtime.listener,
         opts.onStatusChange,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalDecision,
   ApprovalResult,
 } from "../../agent/approval-execution";
+import type { ChannelTurnSource } from "../../channels/types";
 import type { ContextTracker } from "../../cli/helpers/contextTracker";
 import type { ApprovalRequest } from "../../cli/helpers/stream";
 import type { ApprovalContext } from "../../permissions/analyzer";
@@ -54,6 +55,7 @@ export interface IncomingMessage {
   type: "message";
   agentId?: string;
   conversationId?: string;
+  channelTurnSources?: ChannelTurnSource[];
   messages: Array<
     (MessageCreate & { client_message_id?: string }) | ApprovalCreate
   >;


### PR DESCRIPTION
## Summary
- add a generic channel turn lifecycle hook seam for adapters
- thread channel-origin metadata through the listener queue so channel turns can emit queued/processing/finished events
- make Slack consume those lifecycle events to show `:eyes:` while queued, then swap to `:white_check_mark:` or `:x:` when the turn finishes

## Why
This gives us a clean, reusable channel hook surface without hardcoding Slack behavior into the queue. It's a narrow first step toward richer channel integrations like:
- Slack/Telegram processing feedback
- interactive tool forwarding
- optional intermediate event streaming to channels later

## Testing
- `bun test src/tests/channels/slack-adapter.test.ts`
- `bun test src/tests/websocket/listen-client-concurrency.test.ts`
- `bunx tsc --noEmit`
- `bun run lint` (only existing unrelated repo warnings)
