### PR TITLE
feat(channels): support native approval prompts in Slack and Telegram

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -38,6 +38,8 @@ import {
 import { loadTargetStore, upsertChannelTarget } from "./targets";
 import type {
   ChannelAdapter,
+  ChannelApprovalEvent,
+  ChannelApprovalResponse,
   ChannelRoute,
   ChannelTurnLifecycleEvent,
   ChannelTurnSource,
@@ -114,7 +116,14 @@ function buildChannelTurnSource(
   route: ChannelRoute,
   msg: Pick<
     InboundChannelMessage,
-    "channel" | "accountId" | "chatId" | "chatType" | "messageId" | "threadId"
+    | "channel"
+    | "accountId"
+    | "chatId"
+    | "chatType"
+    | "messageId"
+    | "threadId"
+    | "senderId"
+    | "senderName"
   >,
 ): ChannelTurnSource {
   return {
@@ -124,6 +133,8 @@ function buildChannelTurnSource(
     chatType: msg.chatType,
     messageId: msg.messageId,
     threadId: msg.threadId,
+    senderId: msg.senderId,
+    senderName: msg.senderName,
     agentId: route.agentId,
     conversationId: route.conversationId,
   };
@@ -180,8 +191,15 @@ export class ChannelRegistry {
   private readonly adapters = new Map<string, ChannelAdapter>();
   private ready = false;
   private messageHandler: ChannelMessageHandler | null = null;
+  private approvalResponseHandler:
+    | ((response: ChannelApprovalResponse) => Promise<boolean>)
+    | null = null;
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
+  private readonly pendingApprovalEvents = new Map<
+    string,
+    Extract<ChannelApprovalEvent, { type: "requested" }>
+  >();
 
   constructor() {
     if (instance) {
@@ -210,6 +228,12 @@ export class ChannelRegistry {
     // Wire the adapter's onMessage to our ingress pipeline
     adapter.onMessage = async (msg: InboundChannelMessage) => {
       await this.handleInboundMessage(msg);
+    };
+    adapter.onApprovalResponse = async (response: ChannelApprovalResponse) => {
+      if (!this.approvalResponseHandler) {
+        return false;
+      }
+      return this.approvalResponseHandler(response);
     };
   }
 
@@ -291,6 +315,63 @@ export class ChannelRegistry {
     }
   }
 
+  async dispatchApprovalEvent(event: ChannelApprovalEvent): Promise<void> {
+    if (event.type === "requested") {
+      this.pendingApprovalEvents.set(event.controlRequest.request_id, event);
+    } else {
+      this.pendingApprovalEvents.delete(event.controlRequest.request_id);
+    }
+
+    const groups = new Map<
+      string,
+      {
+        adapter: ChannelAdapter;
+        sources: ChannelTurnSource[];
+      }
+    >();
+
+    for (const source of event.sources) {
+      const adapter = this.getAdapter(
+        source.channel,
+        source.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+      );
+      if (!adapter?.handleApprovalEvent) {
+        continue;
+      }
+      const groupKey = this.getAdapterKey(
+        source.channel,
+        source.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+      );
+      const existing = groups.get(groupKey);
+      if (existing) {
+        existing.sources.push(source);
+        continue;
+      }
+      groups.set(groupKey, {
+        adapter,
+        sources: [source],
+      });
+    }
+
+    for (const { adapter, sources } of groups.values()) {
+      const handleApprovalEvent = adapter.handleApprovalEvent;
+      if (!handleApprovalEvent) {
+        continue;
+      }
+      try {
+        await handleApprovalEvent({
+          ...event,
+          sources,
+        });
+      } catch (error) {
+        console.error(
+          `[Channels] Failed to handle ${event.type} approval event for ${adapter.channelId ?? adapter.id}/${adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+  }
+
   // ── Readiness / ingress handler ───────────────────────────────
 
   /**
@@ -305,6 +386,12 @@ export class ChannelRegistry {
     handler: ((event: ChannelRegistryEvent) => void) | null,
   ): void {
     this.eventHandler = handler;
+  }
+
+  setApprovalResponseHandler(
+    handler: ((response: ChannelApprovalResponse) => Promise<boolean>) | null,
+  ): void {
+    this.approvalResponseHandler = handler;
   }
 
   /**
@@ -410,6 +497,7 @@ export class ChannelRegistry {
     const adapter = await plugin.createAdapter(account);
     this.registerAdapter(adapter);
     await adapter.start();
+    await this.replayPendingApprovalsForAdapter(adapter);
     return true;
   }
 
@@ -458,6 +546,7 @@ export class ChannelRegistry {
       if (!adapter.isRunning()) {
         await adapter.start();
       }
+      await this.replayPendingApprovalsForAdapter(adapter);
     }
   }
 
@@ -469,6 +558,7 @@ export class ChannelRegistry {
   pause(): void {
     this.ready = false;
     this.messageHandler = null;
+    this.approvalResponseHandler = null;
     this.eventHandler = null;
   }
 
@@ -484,8 +574,43 @@ export class ChannelRegistry {
     }
     this.ready = false;
     this.messageHandler = null;
+    this.approvalResponseHandler = null;
     this.eventHandler = null;
     instance = null;
+  }
+
+  private async replayPendingApprovalsForAdapter(
+    adapter: ChannelAdapter,
+  ): Promise<void> {
+    const handleApprovalEvent = adapter.handleApprovalEvent;
+    if (!handleApprovalEvent || !adapter.isRunning()) {
+      return;
+    }
+
+    const channelId = adapter.channelId ?? adapter.id;
+    const accountId = adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+
+    for (const event of this.pendingApprovalEvents.values()) {
+      const sources = event.sources.filter(
+        (source) =>
+          source.channel === channelId &&
+          (source.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID) === accountId,
+      );
+      if (sources.length === 0) {
+        continue;
+      }
+      try {
+        await handleApprovalEvent({
+          ...event,
+          sources,
+        });
+      } catch (error) {
+        console.error(
+          `[Channels] Failed to replay pending approval for ${channelId}/${accountId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
   }
 
   // ── Inbound message pipeline ──────────────────────────────────

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -3,6 +3,7 @@ import { basename, extname } from "node:path";
 import type SlackApp from "@slack/bolt";
 import type {
   ChannelAdapter,
+  ChannelApprovalEvent,
   ChannelTurnLifecycleEvent,
   ChannelTurnSource,
   InboundChannelMessage,
@@ -27,7 +28,20 @@ type SlackWriteClient = {
       channel: string;
       text: string;
       thread_ts?: string;
+      blocks?: unknown[];
     }) => Promise<{ ts?: string }>;
+    update: (args: {
+      channel: string;
+      ts: string;
+      text: string;
+      blocks?: unknown[];
+    }) => Promise<{ ts?: string }>;
+    postEphemeral: (args: {
+      channel: string;
+      user: string;
+      text: string;
+      thread_ts?: string;
+    }) => Promise<unknown>;
   };
   reactions: {
     add: (args: {
@@ -77,6 +91,16 @@ type SlackReactionEvent = {
   item_user?: string;
   reaction?: string;
   event_ts?: string;
+};
+type SlackBlockActionPayload = {
+  requestId?: string;
+  decision?: "allow" | "deny";
+};
+type SlackApprovalPromptState = {
+  chatId: string;
+  threadId: string | null;
+  messageTs: string;
+  allowedSenderIds: Set<string>;
 };
 
 type Constructor = abstract new (...args: never[]) => unknown;
@@ -188,10 +212,129 @@ function normalizeSlackReactionName(value: string): string {
   return value.trim().replace(/^:+|:+$/g, "");
 }
 
+function truncateSlackPreview(text: string, maxLength = 900): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function buildSlackApprovalPromptText(
+  event: Extract<ChannelApprovalEvent, { type: "requested" }>,
+): string {
+  const request = event.controlRequest.request;
+  const source = event.sources[0];
+  const toolName = request.tool_name || "tool";
+  const inputPreview = truncateSlackPreview(
+    JSON.stringify(request.input, null, 2),
+  );
+  const chatLabel =
+    source?.chatType === "channel"
+      ? "this Slack thread"
+      : "this Slack conversation";
+  return [
+    `Permission request for ${chatLabel}`,
+    "",
+    `Allow the agent to run \`${toolName}\`?`,
+    "",
+    "```json",
+    inputPreview,
+    "```",
+    "",
+    "Choose *Approve* or *Deny* to continue.",
+  ].join("\n");
+}
+
+function buildSlackApprovalResolvedText(params: {
+  event: Extract<ChannelApprovalEvent, { type: "resolved" }>;
+  actorId?: string;
+}): string {
+  const decision =
+    "decision" in params.event.response ? params.event.response.decision : null;
+  const actorSuffix = params.actorId ? ` by <@${params.actorId}>` : "";
+  if (decision?.behavior === "allow") {
+    return `Approved${actorSuffix}.`;
+  }
+  if (decision?.behavior === "deny") {
+    return `Denied${actorSuffix}${decision.message ? `: ${decision.message}` : "."}`;
+  }
+  if ("error" in params.event.response) {
+    return params.event.response.error
+      ? `Approval is no longer available: ${params.event.response.error}`
+      : "Approval is no longer available.";
+  }
+  return "Approval is no longer available.";
+}
+
+function buildSlackApprovalBlocks(
+  requestId: string,
+): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: SLACK_APPROVAL_ACTION_ID,
+          text: {
+            type: "plain_text",
+            text: "Approve",
+            emoji: true,
+          },
+          style: "primary",
+          value: JSON.stringify({
+            requestId,
+            decision: "allow",
+          } satisfies SlackBlockActionPayload),
+        },
+        {
+          type: "button",
+          action_id: SLACK_APPROVAL_ACTION_ID,
+          text: {
+            type: "plain_text",
+            text: "Deny",
+            emoji: true,
+          },
+          style: "danger",
+          value: JSON.stringify({
+            requestId,
+            decision: "deny",
+          } satisfies SlackBlockActionPayload),
+        },
+      ],
+    },
+  ];
+}
+
+function parseSlackApprovalActionPayload(
+  value: unknown,
+): { requestId: string; decision: "allow" | "deny" } | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as SlackBlockActionPayload;
+    if (
+      !isNonEmptyString(parsed.requestId) ||
+      (parsed.decision !== "allow" && parsed.decision !== "deny")
+    ) {
+      return null;
+    }
+    return {
+      requestId: parsed.requestId,
+      decision: parsed.decision,
+    };
+  } catch {
+    return null;
+  }
+}
+
 const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
 const SLACK_INGRESS_DEDUPE_MAX = 2_000;
 const SLACK_LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_LIFECYCLE_STATE_MAX = 2_000;
+const SLACK_APPROVAL_ACTION_ID = "letta_channel_approval";
 
 type SlackLifecycleState = "queued" | "completed" | "error" | "cancelled";
 
@@ -370,6 +513,7 @@ export function createSlackAdapter(
     { state: SlackLifecycleState; updatedAt: number }
   >();
   const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
+  const approvalPromptByRequestId = new Map<string, SlackApprovalPromptState>();
 
   function buildIngressMessageKey(
     channelId: string | undefined,
@@ -567,6 +711,12 @@ export function createSlackAdapter(
       return;
     }
     knownThreadIdsByMessageId.set(messageId, threadId);
+  }
+
+  function resolveApprovalTargetThreadId(
+    source: ChannelTurnSource,
+  ): string | null {
+    return source.threadId ?? source.messageId ?? null;
   }
 
   async function resolveUserName(
@@ -832,6 +982,77 @@ export function createSlackAdapter(
       await handleReactionEvent(event as SlackReactionEvent, "removed");
     });
 
+    instance.action(SLACK_APPROVAL_ACTION_ID, async ({ ack, body, action }) => {
+      await ack();
+
+      if (!adapter.onApprovalResponse) {
+        return;
+      }
+
+      const parsed = parseSlackApprovalActionPayload(asRecord(action)?.value);
+      if (!parsed) {
+        return;
+      }
+
+      const promptState = approvalPromptByRequestId.get(parsed.requestId);
+      if (!promptState) {
+        return;
+      }
+
+      const actorId = firstNonEmptyString(asRecord(asRecord(body)?.user)?.id);
+      if (
+        promptState.allowedSenderIds.size > 0 &&
+        (!actorId || !promptState.allowedSenderIds.has(actorId))
+      ) {
+        try {
+          const slackClient = await ensureWriteClient();
+          if (actorId) {
+            await slackClient.chat.postEphemeral({
+              channel: promptState.chatId,
+              user: actorId,
+              text: "Only the person who triggered this request can approve or deny it.",
+              ...(promptState.threadId
+                ? { thread_ts: promptState.threadId }
+                : {}),
+            });
+          }
+        } catch {}
+        return;
+      }
+
+      const accepted = await adapter.onApprovalResponse({
+        requestId: parsed.requestId,
+        decision:
+          parsed.decision === "allow"
+            ? {
+                behavior: "allow",
+                message: actorId
+                  ? `Approved from Slack by ${actorId}`
+                  : "Approved from Slack",
+              }
+            : {
+                behavior: "deny",
+                message: actorId
+                  ? `Denied from Slack by ${actorId}`
+                  : "Denied from Slack",
+              },
+      });
+
+      if (accepted || !actorId) {
+        return;
+      }
+
+      try {
+        const slackClient = await ensureWriteClient();
+        await slackClient.chat.postEphemeral({
+          channel: promptState.chatId,
+          user: actorId,
+          text: "That approval request is no longer available.",
+          ...(promptState.threadId ? { thread_ts: promptState.threadId } : {}),
+        });
+      } catch {}
+    });
+
     app = instance;
     return instance;
   }
@@ -885,6 +1106,7 @@ export function createSlackAdapter(
       seenIngressMessageKeys.clear();
       lifecycleStateByMessageKey.clear();
       lifecycleOperationByMessageKey.clear();
+      approvalPromptByRequestId.clear();
       console.log("[Slack] App stopped");
     },
 
@@ -920,6 +1142,73 @@ export function createSlackAdapter(
           scheduleLifecycleTransition(source, nextState),
         ),
       );
+    },
+
+    async handleApprovalEvent(event: ChannelApprovalEvent): Promise<void> {
+      if (!running) {
+        return;
+      }
+
+      await ensureApp();
+      const slackClient = await ensureWriteClient();
+
+      if (event.type === "requested") {
+        if (approvalPromptByRequestId.has(event.controlRequest.request_id)) {
+          return;
+        }
+
+        const source = event.sources[0];
+        if (!source) {
+          return;
+        }
+
+        const threadId = resolveApprovalTargetThreadId(source);
+        const response = await slackClient.chat.postMessage({
+          channel: source.chatId,
+          text: buildSlackApprovalPromptText(event),
+          ...(threadId ? { thread_ts: threadId } : {}),
+          blocks: buildSlackApprovalBlocks(event.controlRequest.request_id),
+        });
+
+        if (!isNonEmptyString(response.ts)) {
+          return;
+        }
+
+        approvalPromptByRequestId.set(event.controlRequest.request_id, {
+          chatId: source.chatId,
+          threadId,
+          messageTs: response.ts,
+          allowedSenderIds: new Set(
+            event.sources
+              .map((entry) => entry.senderId)
+              .filter((value): value is string => isNonEmptyString(value)),
+          ),
+        });
+        return;
+      }
+
+      const promptState = approvalPromptByRequestId.get(
+        event.controlRequest.request_id,
+      );
+      if (!promptState) {
+        return;
+      }
+
+      const actorId =
+        "decision" in event.response &&
+        typeof event.response.decision?.message === "string"
+          ? event.response.decision.message.match(
+              /(?:Approved|Denied) from Slack by ([A-Z0-9]+)/i,
+            )?.[1]
+          : undefined;
+
+      await slackClient.chat.update({
+        channel: promptState.chatId,
+        ts: promptState.messageTs,
+        text: buildSlackApprovalResolvedText({ event, actorId }),
+        blocks: [],
+      });
+      approvalPromptByRequestId.delete(event.controlRequest.request_id);
     },
 
     async sendMessage(

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -8,6 +8,7 @@ import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
 import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import type {
   ChannelAdapter,
+  ChannelApprovalEvent,
   InboundChannelMessage,
   OutboundChannelMessage,
   TelegramChannelAccount,
@@ -66,6 +67,15 @@ type TelegramReactionUpdate = {
   date: number;
   old_reaction: TelegramReactionType[];
   new_reaction: TelegramReactionType[];
+};
+type TelegramApprovalCallbackPayload = {
+  requestId: string;
+  decision: "allow" | "deny";
+};
+type TelegramApprovalPromptState = {
+  chatId: string;
+  messageId: number;
+  allowedSenderIds: Set<string>;
 };
 
 function resolveTelegramBotConstructor(
@@ -189,6 +199,48 @@ function getTelegramChatType(chat: { type?: string }): "direct" | "channel" {
   return chat.type === "private" ? "direct" : "channel";
 }
 
+function truncateTelegramApprovalPreview(
+  text: string,
+  maxLength = 900,
+): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function buildTelegramApprovalPromptText(
+  event: Extract<ChannelApprovalEvent, { type: "requested" }>,
+): string {
+  const request = event.controlRequest.request;
+  const toolName = request.tool_name || "tool";
+  const inputPreview = truncateTelegramApprovalPreview(
+    JSON.stringify(request.input, null, 2),
+  );
+  return [
+    `Permission request`,
+    "",
+    `Allow the agent to run ${toolName}?`,
+    "",
+    "Input:",
+    inputPreview,
+  ].join("\n");
+}
+
+function buildTelegramApprovalResolvedText(
+  event: Extract<ChannelApprovalEvent, { type: "resolved" }>,
+): string {
+  if ("decision" in event.response) {
+    return event.response.decision.behavior === "allow"
+      ? "Approved."
+      : `Denied: ${event.response.decision.message}`;
+  }
+  return event.response.error
+    ? `Approval is no longer available: ${event.response.error}`
+    : "Approval is no longer available.";
+}
+
 export function createTelegramAdapter(
   config: TelegramChannelAccount,
 ): ChannelAdapter {
@@ -196,6 +248,48 @@ export function createTelegramAdapter(
   let botModule: GrammYModule | null = null;
   let running = false;
   const bufferedMediaGroups = new Map<string, BufferedMediaGroup>();
+  const approvalPromptByRequestId = new Map<
+    string,
+    TelegramApprovalPromptState
+  >();
+  const approvalCallbackByToken = new Map<
+    string,
+    TelegramApprovalCallbackPayload
+  >();
+
+  function createApprovalCallbackToken(
+    requestId: string,
+    decision: "allow" | "deny",
+  ): string {
+    const token = crypto.randomUUID().replace(/-/g, "").slice(0, 24);
+    approvalCallbackByToken.set(token, {
+      requestId,
+      decision,
+    });
+    return `lcapp:${token}`;
+  }
+
+  function resolveApprovalCallbackPayload(
+    data: string,
+  ): TelegramApprovalCallbackPayload | null {
+    const prefix = "lcapp:";
+    if (!data.startsWith(prefix)) {
+      return null;
+    }
+    const token = data.slice(prefix.length).trim();
+    if (!token) {
+      return null;
+    }
+    return approvalCallbackByToken.get(token) ?? null;
+  }
+
+  function clearApprovalCallbackTokens(requestId: string): void {
+    for (const [token, payload] of approvalCallbackByToken) {
+      if (payload.requestId === requestId) {
+        approvalCallbackByToken.delete(token);
+      }
+    }
+  }
 
   async function ensureModule(): Promise<GrammYModule> {
     if (!botModule) {
@@ -380,6 +474,74 @@ export function createTelegramAdapter(
       }
     });
 
+    instance.on("callback_query:data", async (ctx) => {
+      const data =
+        typeof ctx.callbackQuery?.data === "string"
+          ? ctx.callbackQuery.data
+          : "";
+      const parsed = resolveApprovalCallbackPayload(data);
+      if (!parsed) {
+        return;
+      }
+
+      const promptState = approvalPromptByRequestId.get(parsed.requestId);
+      if (!promptState) {
+        await ctx.answerCallbackQuery({
+          text: "This approval request is no longer available.",
+          show_alert: true,
+        });
+        return;
+      }
+
+      const actorId =
+        ctx.from?.id !== undefined ? String(ctx.from.id) : undefined;
+      if (
+        promptState.allowedSenderIds.size > 0 &&
+        (!actorId || !promptState.allowedSenderIds.has(actorId))
+      ) {
+        await ctx.answerCallbackQuery({
+          text: "Only the person who triggered this request can approve or deny it.",
+          show_alert: true,
+        });
+        return;
+      }
+
+      if (!adapter.onApprovalResponse) {
+        await ctx.answerCallbackQuery({
+          text: "Approvals are unavailable right now. Try again in a moment.",
+          show_alert: true,
+        });
+        return;
+      }
+
+      const accepted = await adapter.onApprovalResponse({
+        requestId: parsed.requestId,
+        decision:
+          parsed.decision === "allow"
+            ? {
+                behavior: "allow",
+                message: actorId
+                  ? `Approved from Telegram by ${actorId}`
+                  : "Approved from Telegram",
+              }
+            : {
+                behavior: "deny",
+                message: actorId
+                  ? `Denied from Telegram by ${actorId}`
+                  : "Denied from Telegram",
+              },
+      });
+
+      await ctx.answerCallbackQuery({
+        text: accepted
+          ? parsed.decision === "allow"
+            ? "Approved"
+            : "Denied"
+          : "This approval request is no longer available.",
+        show_alert: !accepted,
+      });
+    });
+
     instance.command("start", async (ctx) => {
       await ctx.reply(
         "Welcome! This bot is connected to Letta Code.\n\n" +
@@ -422,7 +584,7 @@ export function createTelegramAdapter(
 
         void telegramBot
           .start({
-            allowed_updates: ["message", "message_reaction"],
+            allowed_updates: ["message", "message_reaction", "callback_query"],
             onStart: () => {
               running = true;
               started = true;
@@ -450,6 +612,8 @@ export function createTelegramAdapter(
         clearTimeout(entry.timer);
       }
       bufferedMediaGroups.clear();
+      approvalPromptByRequestId.clear();
+      approvalCallbackByToken.clear();
 
       if (!running || !bot) return;
       await bot.stop();
@@ -459,6 +623,89 @@ export function createTelegramAdapter(
 
     isRunning(): boolean {
       return running;
+    },
+
+    async handleApprovalEvent(event: ChannelApprovalEvent): Promise<void> {
+      const telegramBot = await ensureBot();
+      if (!running) {
+        return;
+      }
+
+      if (event.type === "requested") {
+        if (approvalPromptByRequestId.has(event.controlRequest.request_id)) {
+          return;
+        }
+
+        const source = event.sources[0];
+        if (!source) {
+          return;
+        }
+
+        const response = await telegramBot.api.sendMessage(
+          source.chatId,
+          buildTelegramApprovalPromptText(event),
+          {
+            ...(source.messageId
+              ? {
+                  reply_parameters: {
+                    message_id: Number(source.messageId),
+                  },
+                }
+              : {}),
+            reply_markup: {
+              inline_keyboard: [
+                [
+                  {
+                    text: "Approve",
+                    callback_data: createApprovalCallbackToken(
+                      event.controlRequest.request_id,
+                      "allow",
+                    ),
+                  },
+                  {
+                    text: "Deny",
+                    callback_data: createApprovalCallbackToken(
+                      event.controlRequest.request_id,
+                      "deny",
+                    ),
+                  },
+                ],
+              ],
+            },
+          },
+        );
+
+        approvalPromptByRequestId.set(event.controlRequest.request_id, {
+          chatId: source.chatId,
+          messageId: response.message_id,
+          allowedSenderIds: new Set(
+            event.sources
+              .map((entry) => entry.senderId)
+              .filter((value): value is string => typeof value === "string"),
+          ),
+        });
+        return;
+      }
+
+      const promptState = approvalPromptByRequestId.get(
+        event.controlRequest.request_id,
+      );
+      if (!promptState) {
+        return;
+      }
+
+      await telegramBot.api.editMessageText(
+        promptState.chatId,
+        promptState.messageId,
+        buildTelegramApprovalResolvedText(event),
+        {
+          reply_markup: {
+            inline_keyboard: [],
+          },
+        },
+      );
+      approvalPromptByRequestId.delete(event.controlRequest.request_id);
+      clearApprovalCallbackTokens(event.controlRequest.request_id);
     },
 
     async sendMessage(

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,6 +7,12 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
+import type {
+  ApprovalResponseBody,
+  ApprovalResponseDecision,
+  ControlRequest,
+} from "../types/protocol_v2";
+
 export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack"] as const;
 export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
 export type ChannelChatType = "direct" | "channel";
@@ -52,6 +58,8 @@ export interface ChannelTurnSource {
   chatType?: ChannelChatType;
   messageId?: string;
   threadId?: string | null;
+  senderId?: string;
+  senderName?: string;
   agentId: string;
   conversationId: string;
 }
@@ -75,6 +83,27 @@ export type ChannelTurnLifecycleEvent =
       outcome: ChannelTurnOutcome;
       error?: string;
     };
+
+export type ChannelApprovalEvent =
+  | {
+      type: "requested";
+      controlRequest: ControlRequest;
+      sources: ChannelTurnSource[];
+    }
+  | {
+      type: "resolved";
+      controlRequest: ControlRequest;
+      sources: ChannelTurnSource[];
+      response: ApprovalResponseBody;
+    };
+
+export interface ChannelApprovalResponse {
+  requestId: string;
+  decision?: ApprovalResponseDecision;
+  error?: string;
+  agentId?: string | null;
+  conversationId?: string | null;
+}
 
 // ── Adapter interface ─────────────────────────────────────────────
 
@@ -126,10 +155,24 @@ export interface ChannelAdapter {
   handleTurnLifecycleEvent?(event: ChannelTurnLifecycleEvent): Promise<void>;
 
   /**
+   * Optional lifecycle hook for permission/tool approval requests that
+   * originated from channel-delivered turns. Adapters can surface native
+   * approve/deny affordances in the external channel and feed the result back
+   * into the listener through onApprovalResponse.
+   */
+  handleApprovalEvent?(event: ChannelApprovalEvent): Promise<void>;
+
+  /**
    * Called by the registry when the adapter receives an inbound message.
    * Set by ChannelRegistry during initialization.
    */
   onMessage?: (msg: InboundChannelMessage) => Promise<void>;
+
+  /**
+   * Called by the adapter when a channel-native approval UI is resolved.
+   * Set by ChannelRegistry during initialization.
+   */
+  onApprovalResponse?: (response: ChannelApprovalResponse) => Promise<boolean>;
 }
 
 // ── Message types ─────────────────────────────────────────────────

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
@@ -20,6 +20,7 @@ import {
   clearAllRoutes,
   getRoute,
 } from "../../channels/routing";
+import type { ChannelAdapter } from "../../channels/types";
 
 describe("ChannelRegistry", () => {
   beforeEach(() => {
@@ -67,6 +68,92 @@ describe("ChannelRegistry", () => {
 
     await registry.stopAll();
     expect(getChannelRegistry()).toBeNull();
+  });
+
+  test("approval events are grouped per adapter and approval responses flow back through the registry handler", async () => {
+    const registry = new ChannelRegistry();
+    const handleApprovalEvent = mock(async () => {});
+    const adapter: ChannelAdapter = {
+      id: "slack:acct-1",
+      channelId: "slack",
+      accountId: "acct-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async () => {},
+      handleApprovalEvent,
+    };
+
+    registry.registerAdapter(adapter);
+
+    await registry.dispatchApprovalEvent({
+      type: "requested",
+      controlRequest: {
+        request_id: "req-1",
+        request: {
+          tool_name: "Bash",
+          input: {
+            command: "ls",
+          },
+        },
+      } as never,
+      sources: [
+        {
+          channel: "slack",
+          accountId: "acct-1",
+          chatId: "C123",
+          chatType: "channel",
+          messageId: "1712800000.000100",
+          senderId: "U123",
+          senderName: "Charles",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+        {
+          channel: "slack",
+          accountId: "acct-1",
+          chatId: "C123",
+          chatType: "channel",
+          messageId: "1712800000.000100",
+          senderId: "U999",
+          senderName: "Teammate",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      ],
+    });
+
+    expect(handleApprovalEvent).toHaveBeenCalledTimes(1);
+    expect(handleApprovalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "requested",
+        sources: [
+          expect.objectContaining({ senderId: "U123" }),
+          expect.objectContaining({ senderId: "U999" }),
+        ],
+      }),
+    );
+
+    const approvalResponseHandler = mock(async () => true);
+    registry.setApprovalResponseHandler(approvalResponseHandler);
+    const accepted = await adapter.onApprovalResponse?.({
+      requestId: "req-1",
+      decision: {
+        behavior: "allow",
+        message: "approved",
+      },
+    });
+
+    expect(accepted).toBe(true);
+    expect(approvalResponseHandler).toHaveBeenCalledWith({
+      requestId: "req-1",
+      decision: {
+        behavior: "allow",
+        message: "approved",
+      },
+    });
   });
 });
 

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -59,6 +59,8 @@ class FakeSlackApp {
     },
     chat: {
       postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+      postEphemeral: mock(async () => ({ ok: true })),
+      update: mock(async () => ({ ok: true })),
     },
     conversations: {
       history: mock(async () => ({ messages: [] })),
@@ -80,6 +82,14 @@ class FakeSlackApp {
 
   messageHandler: SlackMessageHandler | null = null;
   eventHandlers = new Map<string, SlackEventHandler>();
+  actionHandlers = new Map<
+    string,
+    (args: {
+      ack: () => Promise<void>;
+      body: Record<string, unknown>;
+      action: Record<string, unknown>;
+    }) => Promise<void>
+  >();
   errorHandler: ((error: Error) => Promise<void>) | null = null;
   readonly init = mock(async () => {});
   readonly start = mock(async () => {});
@@ -97,6 +107,17 @@ class FakeSlackApp {
     this.eventHandlers.set(name, handler);
   }
 
+  action(
+    name: string,
+    handler: (args: {
+      ack: () => Promise<void>;
+      body: Record<string, unknown>;
+      action: Record<string, unknown>;
+    }) => Promise<void>,
+  ): void {
+    this.actionHandlers.set(name, handler);
+  }
+
   error(handler: (error: Error) => Promise<void>): void {
     this.errorHandler = handler;
   }
@@ -109,6 +130,8 @@ class FakeSlackWriteClient {
   readonly options: Record<string, unknown> | undefined;
   readonly chat = {
     postMessage: mock(async () => ({ ts: "1712800000.000100" })),
+    postEphemeral: mock(async () => ({ ok: true })),
+    update: mock(async () => ({ ok: true })),
   };
   readonly reactions = {
     add: mock(async () => ({ ok: true })),
@@ -226,6 +249,8 @@ afterEach(() => {
     instance.client.users.info.mockClear();
     instance.client.chat.postMessage.mockClear();
     instance.client.conversations.history.mockClear();
+    instance.client.chat.postEphemeral.mockClear();
+    instance.client.chat.update.mockClear();
     instance.client.conversations.replies.mockClear();
     instance.client.reactions.add.mockClear();
     instance.client.reactions.remove.mockClear();
@@ -237,6 +262,8 @@ afterEach(() => {
   }
   for (const instance of FakeSlackWriteClient.instances) {
     instance.chat.postMessage.mockClear();
+    instance.chat.postEphemeral.mockClear();
+    instance.chat.update.mockClear();
     instance.reactions.add.mockClear();
     instance.reactions.remove.mockClear();
     instance.files.getUploadURLExternal.mockClear();
@@ -1081,4 +1108,186 @@ test("slack adapter preserves non-leading user mentions in app mention text", as
       text: "ask <@U555> for help",
     }),
   );
+});
+
+test("slack adapter renders approval prompts and forwards block actions", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onApprovalResponse = mock(async () => true);
+  adapter.onApprovalResponse = onApprovalResponse;
+
+  await adapter.start();
+
+  await adapter.handleApprovalEvent?.({
+    type: "requested",
+    controlRequest: {
+      request_id: "req-1",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "rm -rf /tmp/nope",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000100",
+        threadId: "1712790000.000050",
+        senderId: "U123",
+        senderName: "Charles",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "C123",
+      thread_ts: "1712790000.000050",
+      text: expect.stringContaining("Allow the agent to run `Bash`?"),
+      blocks: expect.any(Array),
+    }),
+  );
+
+  const postMessageCall = writeClient?.chat.postMessage.mock.calls[0] as
+    | [Record<string, unknown>]
+    | undefined;
+  expect(postMessageCall).toBeDefined();
+  if (!postMessageCall) {
+    throw new Error("Expected Slack approval prompt postMessage call");
+  }
+
+  const blocks = postMessageCall[0].blocks as Array<{
+    elements?: Array<{ value?: string }>;
+  }>;
+  const actionValue = blocks[0]?.elements?.[0]?.value;
+  expect(typeof actionValue).toBe("string");
+
+  const app = FakeSlackApp.instances[0];
+  const actionHandler = app?.actionHandlers.get("letta_channel_approval");
+  expect(actionHandler).toBeDefined();
+  if (!actionHandler) {
+    throw new Error("Expected Slack approval action handler");
+  }
+
+  const ack = mock(async () => {});
+  await actionHandler({
+    ack,
+    body: {
+      user: {
+        id: "U123",
+      },
+    },
+    action: {
+      value: actionValue,
+    },
+  });
+
+  expect(ack).toHaveBeenCalledTimes(1);
+  expect(onApprovalResponse).toHaveBeenCalledWith({
+    requestId: "req-1",
+    decision: {
+      behavior: "allow",
+      message: "Approved from Slack by U123",
+    },
+  });
+});
+
+test("slack adapter resolves approval prompts by updating the original message", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleApprovalEvent?.({
+    type: "requested",
+    controlRequest: {
+      request_id: "req-2",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "ls",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "D123",
+        chatType: "direct",
+        messageId: "1712800000.000200",
+        threadId: null,
+        senderId: "U123",
+        senderName: "Charles",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  await adapter.handleApprovalEvent?.({
+    type: "resolved",
+    controlRequest: {
+      request_id: "req-2",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "ls",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "D123",
+        chatType: "direct",
+        messageId: "1712800000.000200",
+        threadId: null,
+        senderId: "U123",
+        senderName: "Charles",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+    response: {
+      request_id: "req-2",
+      decision: {
+        behavior: "deny",
+        message: "Denied from Slack by U123",
+      },
+    },
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.update).toHaveBeenCalledWith({
+    channel: "D123",
+    ts: "1712800000.000100",
+    text: "Denied by <@U123>: Denied from Slack by U123",
+    blocks: [],
+  });
 });

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -50,6 +50,7 @@ class FakeBot {
   readonly handlers = new Map<string, FakeHandler[]>();
   readonly api = {
     sendMessage: mock(async () => ({ message_id: 999 })),
+    editMessageText: mock(async () => true),
     setMessageReaction: mock(async () => true),
     sendPhoto: mock(async () => ({ message_id: 1001 })),
     sendDocument: mock(async () => ({ message_id: 1002 })),
@@ -524,4 +525,185 @@ test("telegram adapter batches media groups and downloads inbound images", async
     rmSync(channelRoot, { recursive: true, force: true });
     channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
   }
+});
+
+test("telegram adapter renders approval prompts and forwards callback decisions", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onApprovalResponse = mock(async () => true);
+  adapter.onApprovalResponse = onApprovalResponse;
+
+  await adapter.start();
+
+  await adapter.handleApprovalEvent?.({
+    type: "requested",
+    controlRequest: {
+      request_id: "req-1",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "rm -rf /tmp/nope",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "telegram",
+        accountId: "telegram-test-account",
+        chatId: "123",
+        senderId: "456",
+        senderName: "alice",
+        messageId: "77",
+        chatType: "direct",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendMessage).toHaveBeenCalledTimes(1);
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "123",
+    expect.stringContaining("Allow the agent to run Bash?"),
+    expect.objectContaining({
+      reply_parameters: { message_id: 77 },
+      reply_markup: {
+        inline_keyboard: [
+          [
+            expect.objectContaining({ text: "Approve" }),
+            expect.objectContaining({ text: "Deny" }),
+          ],
+        ],
+      },
+    }),
+  );
+
+  const sendMessageCall = bot?.api.sendMessage.mock.calls[0] as
+    | [string, string, Record<string, unknown>]
+    | undefined;
+  expect(sendMessageCall).toBeDefined();
+  if (!sendMessageCall) {
+    throw new Error("Expected Telegram approval prompt send call");
+  }
+
+  const keyboard = (
+    sendMessageCall[2].reply_markup as {
+      inline_keyboard: Array<Array<{ callback_data?: string; text?: string }>>;
+    }
+  ).inline_keyboard;
+  const approveToken = keyboard[0]?.[0]?.callback_data;
+  expect(typeof approveToken).toBe("string");
+
+  const answerCallbackQuery = mock(async () => true);
+  await bot?.emit("callback_query:data", {
+    callbackQuery: {
+      data: approveToken,
+    },
+    from: { id: 456 },
+    answerCallbackQuery,
+  });
+
+  expect(onApprovalResponse).toHaveBeenCalledWith({
+    requestId: "req-1",
+    decision: {
+      behavior: "allow",
+      message: "Approved from Telegram by 456",
+    },
+  });
+  expect(answerCallbackQuery).toHaveBeenCalledWith({
+    text: "Approved",
+    show_alert: false,
+  });
+});
+
+test("telegram adapter resolves approval prompts by editing the original message", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleApprovalEvent?.({
+    type: "requested",
+    controlRequest: {
+      request_id: "req-2",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "ls",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "telegram",
+        accountId: "telegram-test-account",
+        chatId: "123",
+        senderId: "456",
+        senderName: "alice",
+        messageId: "77",
+        chatType: "direct",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  await adapter.handleApprovalEvent?.({
+    type: "resolved",
+    controlRequest: {
+      request_id: "req-2",
+      request: {
+        tool_name: "Bash",
+        input: {
+          command: "ls",
+        },
+      },
+    } as never,
+    sources: [
+      {
+        channel: "telegram",
+        accountId: "telegram-test-account",
+        chatId: "123",
+        senderId: "456",
+        senderName: "alice",
+        messageId: "77",
+        chatType: "direct",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+    response: {
+      request_id: "req-2",
+      decision: {
+        behavior: "allow",
+        message: "Approved from Telegram by 456",
+      },
+    },
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.editMessageText).toHaveBeenCalledWith(
+    "123",
+    999,
+    "Approved.",
+    {
+      reply_markup: {
+        inline_keyboard: [],
+      },
+    },
+  );
 });

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -1,5 +1,6 @@
 import WebSocket from "ws";
 import type { ApprovalResult } from "../../agent/approval-execution";
+import { getChannelRegistry } from "../../channels/registry";
 import type {
   ApprovalResponseBody,
   ControlRequest,
@@ -11,6 +12,48 @@ import {
 } from "./protocol-outbound";
 import { evictConversationRuntimeIfIdle } from "./runtime";
 import type { ConversationRuntime } from "./types";
+
+async function dispatchChannelApprovalEvent(
+  runtime: ConversationRuntime,
+  event: {
+    type: "requested" | "resolved";
+    controlRequest: ControlRequest;
+    response?: ApprovalResponseBody;
+  },
+): Promise<void> {
+  const sources =
+    runtime.pendingApprovalSourcesByRequestId.get(
+      event.controlRequest.request_id,
+    ) ?? [];
+  if (sources.length === 0) {
+    return;
+  }
+
+  const registry = getChannelRegistry();
+  if (!registry) {
+    return;
+  }
+
+  if (event.type === "requested") {
+    await registry.dispatchApprovalEvent({
+      type: "requested",
+      controlRequest: event.controlRequest,
+      sources,
+    });
+    return;
+  }
+
+  if (!event.response) {
+    return;
+  }
+
+  await registry.dispatchApprovalEvent({
+    type: "resolved",
+    controlRequest: event.controlRequest,
+    sources,
+    response: event.response,
+  });
+}
 
 export function rememberPendingApprovalBatchIds(
   runtime: ConversationRuntime,
@@ -194,7 +237,21 @@ export function resolvePendingApprovalResolver(
     return false;
   }
 
+  if (pending.controlRequest) {
+    void dispatchChannelApprovalEvent(runtime, {
+      type: "resolved",
+      controlRequest: pending.controlRequest,
+      response,
+    }).catch((error) => {
+      console.error(
+        "[Channels] Failed to dispatch resolved approval event:",
+        error instanceof Error ? error.message : error,
+      );
+    });
+  }
+
   runtime.pendingApprovalResolvers.delete(requestId);
+  runtime.pendingApprovalSourcesByRequestId.delete(requestId);
   runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
   if (runtime.pendingApprovalResolvers.size === 0 && !runtime.isProcessing) {
     setLoopStatus(runtime, "WAITING_ON_INPUT");
@@ -216,10 +273,26 @@ export function rejectPendingApprovalResolvers(
   runtime: ConversationRuntime,
   reason: string,
 ): void {
-  for (const [, pending] of runtime.pendingApprovalResolvers) {
+  for (const [requestId, pending] of runtime.pendingApprovalResolvers) {
+    if (pending.controlRequest) {
+      void dispatchChannelApprovalEvent(runtime, {
+        type: "resolved",
+        controlRequest: pending.controlRequest,
+        response: {
+          request_id: requestId,
+          error: reason,
+        },
+      }).catch((error) => {
+        console.error(
+          "[Channels] Failed to dispatch rejected approval event:",
+          error instanceof Error ? error.message : error,
+        );
+      });
+    }
     pending.reject(new Error(reason));
   }
   runtime.pendingApprovalResolvers.clear();
+  runtime.pendingApprovalSourcesByRequestId.clear();
   for (const [requestId, runtimeKey] of runtime.listener
     .approvalRuntimeKeyByRequestId) {
     if (runtimeKey === runtime.key) {
@@ -278,7 +351,23 @@ export function requestApprovalOverWS(
       reject(error);
     };
     const handleAbort = () => {
+      if (controlRequest) {
+        void dispatchChannelApprovalEvent(runtime, {
+          type: "resolved",
+          controlRequest,
+          response: {
+            request_id: requestId,
+            error: "Cancelled by user",
+          },
+        }).catch((error) => {
+          console.error(
+            "[Channels] Failed to dispatch aborted approval event:",
+            error instanceof Error ? error.message : error,
+          );
+        });
+      }
       runtime.pendingApprovalResolvers.delete(requestId);
+      runtime.pendingApprovalSourcesByRequestId.delete(requestId);
       runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
       wrappedReject(new Error("Cancelled by user"));
     };
@@ -294,6 +383,21 @@ export function requestApprovalOverWS(
       reject: wrappedReject,
       controlRequest,
     });
+    const channelTurnSources = runtime.activeChannelTurnSources ?? [];
+    if (channelTurnSources.length > 0) {
+      runtime.pendingApprovalSourcesByRequestId.set(requestId, [
+        ...channelTurnSources,
+      ]);
+      void dispatchChannelApprovalEvent(runtime, {
+        type: "requested",
+        controlRequest,
+      }).catch((error) => {
+        console.error(
+          "[Channels] Failed to dispatch requested approval event:",
+          error instanceof Error ? error.message : error,
+        );
+      });
+    }
     runtime.listener.approvalRuntimeKeyByRequestId.set(requestId, runtime.key);
     if (isInterrupted()) {
       handleAbort();

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3021,6 +3021,31 @@ function wireChannelIngress(
     scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
   });
 
+  registry.setApprovalResponseHandler(async (response) => {
+    const approvalResponse: ApprovalResponseBody = {
+      request_id: response.requestId,
+      ...(response.error
+        ? { error: response.error }
+        : response.decision
+          ? { decision: response.decision }
+          : { error: "Missing approval decision" }),
+    };
+
+    return handleApprovalResponseInput(listener, {
+      runtime: {
+        agent_id: response.agentId,
+        conversation_id: response.conversationId,
+      },
+      response: approvalResponse,
+      socket,
+      opts: {
+        onStatusChange: opts.onStatusChange,
+        connectionId: opts.connectionId,
+      },
+      processQueuedTurn,
+    });
+  });
+
   registry.setEventHandler((event) => {
     handleChannelRegistryEvent(event, socket, listener);
   });

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -517,6 +517,7 @@ async function drainQueuedMessages(
 
       let turnError: string | undefined;
       let didThrow = false;
+      runtime.activeChannelTurnSources = channelTurnSources;
       try {
         await processQueuedTurn(queuedTurn, dequeuedBatch);
       } catch (error) {
@@ -524,6 +525,7 @@ async function drainQueuedMessages(
         turnError = error instanceof Error ? error.message : String(error);
         throw error;
       } finally {
+        runtime.activeChannelTurnSources = null;
         if (channelTurnSources.length > 0) {
           await dispatchChannelTurnLifecycleEvent({
             type: "finished",

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -65,6 +65,7 @@ export function evictConversationRuntimeIfIdle(
     runtime.queuePumpScheduled ||
     runtime.pendingTurns > 0 ||
     runtime.pendingApprovalResolvers.size > 0 ||
+    runtime.pendingApprovalSourcesByRequestId.size > 0 ||
     runtime.pendingApprovalBatchByToolCallId.size > 0 ||
     runtime.recoveredApprovalState !== null ||
     runtime.pendingInterruptedResults !== null ||
@@ -161,6 +162,7 @@ export function createConversationRuntime(
     conversationId: normalizedConversationId,
     messageQueue: Promise.resolve(),
     pendingApprovalResolvers: new Map(),
+    pendingApprovalSourcesByRequestId: new Map(),
     recoveredApprovalState: null,
     lastStopReason: null,
     isProcessing: false,
@@ -185,6 +187,7 @@ export function createConversationRuntime(
     continuationEpoch: 0,
     activeExecutingToolCallIds: [],
     pendingInterruptedToolCallIds: null,
+    activeChannelTurnSources: null,
     reminderState:
       listener.reminderStateByConversation.get(runtimeKey) ??
       (() => {
@@ -255,9 +258,11 @@ export function clearConversationRuntimeState(
     runtime.activeAbortController.abort();
   }
   runtime.pendingApprovalBatchByToolCallId.clear();
+  runtime.pendingApprovalSourcesByRequestId.clear();
   runtime.pendingInterruptedResults = null;
   runtime.pendingInterruptedContext = null;
   runtime.pendingInterruptedToolCallIds = null;
+  runtime.activeChannelTurnSources = null;
   runtime.activeExecutingToolCallIds = [];
   runtime.loopStatus = "WAITING_ON_INPUT";
   runtime.continuationEpoch += 1;

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -114,6 +114,7 @@ export type ConversationRuntime = {
   conversationId: string;
   messageQueue: Promise<void>;
   pendingApprovalResolvers: Map<string, PendingApprovalResolver>;
+  pendingApprovalSourcesByRequestId: Map<string, ChannelTurnSource[]>;
   recoveredApprovalState: RecoveredApprovalState | null;
   lastStopReason: string | null;
   isProcessing: boolean;
@@ -142,6 +143,7 @@ export type ConversationRuntime = {
   continuationEpoch: number;
   activeExecutingToolCallIds: string[];
   pendingInterruptedToolCallIds: string[] | null;
+  activeChannelTurnSources: ChannelTurnSource[] | null;
   /** Per-conversation reminder state (session-context, agent-info, etc.). */
   reminderState: SharedReminderState;
   /** Per-conversation tracker for compaction/reflection cadence. */


### PR DESCRIPTION
## Summary
- add a channel-native approval event seam so listener approval requests can be surfaced through external channels
- render native approve/deny prompts in Slack and Telegram, then route the response back into Letta's existing approval resolver flow
- cover the new approval plumbing with registry, adapter, and listener concurrency tests

## Testing
- bun test src/tests/channels/slack-adapter.test.ts src/tests/channels/telegram-adapter.test.ts src/tests/channels/registry.test.ts
- bun test src/tests/websocket/listen-client-concurrency.test.ts
- bun run lint
- bunx tsc --noEmit
