### PR TITLE
fix(slack): bootstrap mention-created thread context

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -10,6 +10,7 @@ import type {
   SlackChannelAccount,
 } from "../types";
 import {
+  resolveSlackChannelHistory,
   resolveSlackInboundAttachments,
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
@@ -308,6 +309,23 @@ function buildSlackThreadLabel(
     return `Slack thread${roomLabel}: ${preview}`;
   }
   return roomLabel ? `Slack thread${roomLabel}` : `Slack thread ${msg.chatId}`;
+}
+
+function buildSlackChannelContextLabel(
+  msg: InboundChannelMessage,
+): string | undefined {
+  if (msg.chatType !== "channel") {
+    return undefined;
+  }
+
+  const roomLabel =
+    isNonEmptyString(msg.chatLabel) && msg.chatLabel !== msg.chatId
+      ? ` in ${msg.chatLabel}`
+      : "";
+
+  return roomLabel
+    ? `Slack channel context${roomLabel} before thread start`
+    : `Slack channel context before thread start`;
 }
 
 export async function resolveSlackAccountDisplayName(
@@ -985,25 +1003,44 @@ export function createSlackAdapter(
         msg.channel !== "slack" ||
         msg.chatType !== "channel" ||
         !isNonEmptyString(msg.threadId) ||
-        !isNonEmptyString(msg.messageId) ||
-        msg.threadId === msg.messageId
+        !isNonEmptyString(msg.messageId)
+      ) {
+        return msg;
+      }
+
+      const shouldHydrateExistingThreadContext = msg.threadId !== msg.messageId;
+      const shouldHydrateChannelBootstrapContext =
+        msg.isMention === true && msg.threadId === msg.messageId;
+
+      if (
+        !shouldHydrateExistingThreadContext &&
+        !shouldHydrateChannelBootstrapContext
       ) {
         return msg;
       }
 
       const slackApp = await ensureApp();
-      const starter = await resolveSlackThreadStarter({
-        channelId: msg.chatId,
-        threadTs: msg.threadId,
-        client: slackApp.client,
-      });
-      const history = await resolveSlackThreadHistory({
-        channelId: msg.chatId,
-        threadTs: msg.threadId,
-        client: slackApp.client,
-        currentMessageTs: msg.messageId,
-        limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
-      });
+      const starter = shouldHydrateExistingThreadContext
+        ? await resolveSlackThreadStarter({
+            channelId: msg.chatId,
+            threadTs: msg.threadId,
+            client: slackApp.client,
+          })
+        : null;
+      const history = shouldHydrateExistingThreadContext
+        ? await resolveSlackThreadHistory({
+            channelId: msg.chatId,
+            threadTs: msg.threadId,
+            client: slackApp.client,
+            currentMessageTs: msg.messageId,
+            limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+          })
+        : await resolveSlackChannelHistory({
+            channelId: msg.chatId,
+            beforeTs: msg.messageId,
+            client: slackApp.client,
+            limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+          });
 
       if (!starter && history.length === 0) {
         return msg;
@@ -1041,7 +1078,9 @@ export function createSlackAdapter(
       return {
         ...msg,
         threadContext: {
-          label: buildSlackThreadLabel(msg, starter?.text),
+          label: shouldHydrateExistingThreadContext
+            ? buildSlackThreadLabel(msg, starter?.text)
+            : buildSlackChannelContextLabel(msg),
           ...(starter
             ? {
                 starter: {

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -28,6 +28,12 @@ type SlackAttachmentLike = {
 
 type SlackRepliesClient = {
   conversations: {
+    history(args: {
+      channel: string;
+      latest?: string;
+      limit?: number;
+      inclusive?: boolean;
+    }): Promise<unknown>;
     replies(args: {
       channel: string;
       ts: string;
@@ -57,6 +63,17 @@ export type SlackThreadMessage = {
   botId?: string;
   ts?: string;
 };
+
+function mapSlackThreadMessage(
+  message: SlackRepliesPageMessage,
+): SlackThreadMessage {
+  return {
+    text: resolveSlackThreadMessageText(message),
+    userId: isNonEmptyString(message.user) ? message.user : undefined,
+    botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
+    ts: isNonEmptyString(message.ts) ? message.ts : undefined,
+  };
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object"
@@ -465,12 +482,45 @@ export async function resolveSlackThreadHistory(params: {
           : undefined;
     } while (cursor);
 
-    return retained.map((message) => ({
-      text: resolveSlackThreadMessageText(message),
-      userId: isNonEmptyString(message.user) ? message.user : undefined,
-      botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
-      ts: isNonEmptyString(message.ts) ? message.ts : undefined,
-    }));
+    return retained.map(mapSlackThreadMessage);
+  } catch {
+    return [];
+  }
+}
+
+export async function resolveSlackChannelHistory(params: {
+  channelId: string;
+  beforeTs: string;
+  client: SlackRepliesClient;
+  limit?: number;
+}): Promise<SlackThreadMessage[]> {
+  const maxMessages = params.limit ?? 20;
+  if (!Number.isFinite(maxMessages) || maxMessages <= 0) {
+    return [];
+  }
+
+  const fetchLimit = Math.min(Math.max(maxMessages * 3, maxMessages), 100);
+
+  try {
+    const response = (await params.client.conversations.history({
+      channel: params.channelId,
+      latest: params.beforeTs,
+      inclusive: false,
+      limit: fetchLimit,
+    })) as SlackRepliesPage;
+
+    const retained = (response.messages ?? [])
+      .filter((message) => {
+        if (message.ts === params.beforeTs) {
+          return false;
+        }
+
+        return Boolean(resolveSlackThreadMessageText(message));
+      })
+      .slice(0, fetchLimit)
+      .reverse();
+
+    return retained.slice(-maxMessages).map(mapSlackThreadMessage);
   } catch {
     return [];
   }

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -61,6 +61,7 @@ class FakeSlackApp {
       postMessage: mock(async () => ({ ts: "1712800000.000100" })),
     },
     conversations: {
+      history: mock(async () => ({ messages: [] })),
       replies: mock(async () => ({ messages: [] })),
     },
     reactions: {
@@ -150,6 +151,16 @@ const resolveSlackThreadHistoryMock = mock(
     }>
   > => [],
 );
+const resolveSlackChannelHistoryMock = mock(
+  async (): Promise<
+    Array<{
+      text: string;
+      userId?: string;
+      botId?: string;
+      ts?: string;
+    }>
+  > => [],
+);
 
 mock.module("../../channels/slack/runtime", () => ({
   loadSlackBoltModule: async () => ({
@@ -167,6 +178,7 @@ mock.module("../../channels/slack/runtime", () => ({
 }));
 
 mock.module("../../channels/slack/media", () => ({
+  resolveSlackChannelHistory: resolveSlackChannelHistoryMock,
   resolveSlackInboundAttachments: resolveSlackInboundAttachmentsMock,
   resolveSlackThreadStarter: resolveSlackThreadStarterMock,
   resolveSlackThreadHistory: resolveSlackThreadHistoryMock,
@@ -201,6 +213,8 @@ beforeEach(() => {
   resolveSlackThreadStarterMock.mockImplementation(async () => null);
   resolveSlackThreadHistoryMock.mockReset();
   resolveSlackThreadHistoryMock.mockImplementation(async () => []);
+  resolveSlackChannelHistoryMock.mockReset();
+  resolveSlackChannelHistoryMock.mockImplementation(async () => []);
   fetchMock.mockClear();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
 });
@@ -210,6 +224,7 @@ afterEach(() => {
     instance.client.auth.test.mockClear();
     instance.client.users.info.mockClear();
     instance.client.chat.postMessage.mockClear();
+    instance.client.conversations.history.mockClear();
     instance.client.conversations.replies.mockClear();
     instance.client.reactions.add.mockClear();
     instance.client.reactions.remove.mockClear();
@@ -519,6 +534,73 @@ test("slack adapter hydrates prior Slack thread context on the first routed turn
   expect(prepared?.threadContext?.label).toContain("Slack thread in #random");
   expect(resolveSlackThreadStarterMock).toHaveBeenCalledTimes(1);
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
+});
+
+test("slack adapter hydrates recent channel context when a mention creates a new thread", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  resolveSlackChannelHistoryMock.mockResolvedValueOnce([
+    {
+      text: "Earlier channel context before the mention",
+      userId: "U111",
+      ts: "1712799000.000040",
+    },
+    {
+      text: "More recent channel context before the mention",
+      userId: "U222",
+      ts: "1712799500.000045",
+    },
+  ]);
+
+  const prepared = await adapter.prepareInboundMessage?.(
+    {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatLabel: "#random",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "please help",
+      timestamp: 1712800000100,
+      messageId: "1712800000.000100",
+      threadId: "1712800000.000100",
+      chatType: "channel",
+      isMention: true,
+    },
+    { isFirstRouteTurn: true },
+  );
+
+  expect(prepared).toBeDefined();
+  expect(prepared?.threadContext?.starter).toBeUndefined();
+  expect(prepared?.threadContext?.history).toEqual([
+    expect.objectContaining({
+      messageId: "1712799000.000040",
+      senderId: "U111",
+      text: "Earlier channel context before the mention",
+    }),
+    expect.objectContaining({
+      messageId: "1712799500.000045",
+      senderId: "U222",
+      text: "More recent channel context before the mention",
+    }),
+  ]);
+  expect(prepared?.threadContext?.label).toContain(
+    "Slack channel context in #random before thread start",
+  );
+  expect(resolveSlackChannelHistoryMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackThreadStarterMock).not.toHaveBeenCalled();
+  expect(resolveSlackThreadHistoryMock).not.toHaveBeenCalled();
 });
 
 test("slack adapter dedupes threaded mentions delivered through message and app_mention", async () => {


### PR DESCRIPTION
## Summary
- hydrate recent channel history when a Slack mention starts a brand-new thread, instead of only hydrating existing threaded replies
- keep the existing thread hydration path for prior Slack threads while adding a separate channel-history bootstrap path for first-turn mentions
- cover the new bootstrap behavior in the Slack adapter tests so mention-created threads stay wired to channel context going forward

👾 Generated with [Letta Code](https://letta.com)