### PR TITLE
feat(channels): add Slack default permission mode

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -7,6 +7,7 @@ import {
 import type {
   ChannelAccount,
   SlackChannelAccount,
+  SlackDefaultPermissionMode,
   SupportedChannelId,
   TelegramChannelAccount,
 } from "./types";
@@ -51,6 +52,11 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   ) {
     next.displayName = undefined;
   }
+  if (next.channel === "slack") {
+    (next as SlackChannelAccount).defaultPermissionMode = ((
+      next as SlackChannelAccount
+    ).defaultPermissionMode ?? "default") as SlackDefaultPermissionMode;
+  }
   return next;
 }
 
@@ -91,6 +97,7 @@ function makeDefaultLegacyAccount(
     dmPolicy: config.dmPolicy,
     allowedUsers: [...config.allowedUsers],
     agentId: null,
+    defaultPermissionMode: "default",
     createdAt: now,
     updatedAt: now,
   };

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -43,6 +43,7 @@ import type {
   ChannelTurnSource,
   InboundChannelMessage,
   SlackChannelAccount,
+  SlackDefaultPermissionMode,
 } from "./types";
 import { formatChannelNotification } from "./xml";
 
@@ -163,6 +164,14 @@ export type ChannelRegistryEvent =
   | {
       type: "targets_updated";
       channelId: string;
+    }
+  | {
+      type: "slack_conversation_created";
+      channelId: "slack";
+      accountId: string;
+      agentId: string;
+      conversationId: string;
+      defaultPermissionMode: SlackDefaultPermissionMode;
     };
 
 // ── Registry ──────────────────────────────────────────────────────
@@ -623,6 +632,16 @@ export class ChannelRegistry {
     };
 
     addRoute(msg.channel, route);
+    if (config.defaultPermissionMode !== "default") {
+      this.eventHandler?.({
+        type: "slack_conversation_created",
+        channelId: "slack",
+        accountId: config.accountId,
+        agentId: config.agentId,
+        conversationId,
+        defaultPermissionMode: config.defaultPermissionMode,
+      });
+    }
     return route;
   }
 

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -49,6 +49,7 @@ import type {
   DmPolicy,
   PendingPairing,
   SlackChannelMode,
+  SlackDefaultPermissionMode,
   SupportedChannelId,
 } from "./types";
 
@@ -156,6 +157,7 @@ export type ChannelAccountSnapshot =
       hasBotToken: boolean;
       hasAppToken: boolean;
       agentId: string | null;
+      defaultPermissionMode: SlackDefaultPermissionMode;
       createdAt: string;
       updatedAt: string;
     };
@@ -177,6 +179,7 @@ export interface ChannelAccountPatch {
   appToken?: string;
   mode?: SlackChannelMode;
   agentId?: string | null;
+  defaultPermissionMode?: SlackDefaultPermissionMode;
   dmPolicy?: DmPolicy;
   allowedUsers?: string[];
 }
@@ -417,6 +420,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
+    defaultPermissionMode: account.defaultPermissionMode ?? "default",
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
   };
@@ -455,6 +459,7 @@ function createAccountFromPatch(
     botToken: patch.botToken ?? "",
     appToken: patch.appToken ?? "",
     agentId: patch.agentId ?? null,
+    defaultPermissionMode: patch.defaultPermissionMode ?? "default",
     dmPolicy: patch.dmPolicy ?? "open",
     allowedUsers: patch.allowedUsers ?? [],
     createdAt: now,
@@ -493,6 +498,10 @@ function mergeAccountPatch(
     botToken: patch.botToken ?? existing.botToken,
     appToken: patch.appToken ?? existing.appToken,
     agentId: patch.agentId ?? existing.agentId,
+    defaultPermissionMode:
+      patch.defaultPermissionMode ??
+      existing.defaultPermissionMode ??
+      "default",
     dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
     allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
     updatedAt: nextUpdatedAt,

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -92,6 +92,7 @@ export async function runSlackSetup(): Promise<boolean> {
       botToken,
       appToken,
       agentId: null,
+      defaultPermissionMode: "default",
       dmPolicy: policy,
       allowedUsers,
       createdAt: now,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -10,6 +10,10 @@
 export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack"] as const;
 export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
 export type ChannelChatType = "direct" | "channel";
+export type SlackDefaultPermissionMode =
+  | "default"
+  | "acceptEdits"
+  | "bypassPermissions";
 
 export interface ChannelMessageAttachment {
   id?: string;
@@ -269,6 +273,7 @@ export interface SlackChannelAccount extends ChannelAccountBase {
   botToken: string;
   appToken: string;
   agentId: string | null;
+  defaultPermissionMode: SlackDefaultPermissionMode;
 }
 
 export type ChannelAccount = TelegramChannelAccount | SlackChannelAccount;

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -168,15 +168,22 @@ describe("channel service", () => {
         configured: true,
         hasBotToken: true,
         hasAppToken: true,
+        defaultPermissionMode: "default",
       }),
     );
 
     const updated = updateChannelAccountLive("slack", "docsbot", {
       displayName: "DocsBot Support",
       enabled: true,
+      defaultPermissionMode: "bypassPermissions",
     });
     expect(updated.displayName).toBe("DocsBot Support");
     expect(updated.enabled).toBe(true);
+    expect(updated.channelId).toBe("slack");
+    if (updated.channelId !== "slack") {
+      throw new Error("Expected Slack account snapshot");
+    }
+    expect(updated.defaultPermissionMode).toBe("bypassPermissions");
 
     const bound = bindChannelAccountLive(
       "slack",
@@ -195,6 +202,7 @@ describe("channel service", () => {
         accountId: "docsbot",
         displayName: "DocsBot Support",
         agentId: "agent-docs",
+        defaultPermissionMode: "bypassPermissions",
       }),
     );
 
@@ -345,6 +353,7 @@ describe("channel service", () => {
         dmPolicy: "pairing",
         allowedUsers: [],
         agentId: null,
+        defaultPermissionMode: "default",
         createdAt: "2026-04-11T00:00:00.000Z",
         updatedAt: "2026-04-11T00:00:00.000Z",
       },
@@ -353,6 +362,10 @@ describe("channel service", () => {
     const snapshot = getChannelAccountSnapshot("slack", "legacy-slack");
     expect(snapshot).not.toBeNull();
     expect(snapshot?.displayName).toBeUndefined();
+    expect(snapshot?.channelId).toBe("slack");
+    if (snapshot?.channelId === "slack") {
+      expect(snapshot.defaultPermissionMode).toBe("default");
+    }
   });
 
   test("refreshChannelAccountDisplayNameLive hydrates a real platform name", async () => {

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -180,6 +180,7 @@ const slackAccountDefaults = {
   accountId: "slack-test-account",
   displayName: "Test Workspace",
   agentId: null,
+  defaultPermissionMode: "default",
   createdAt: "2026-04-11T00:00:00.000Z",
   updatedAt: "2026-04-11T00:00:00.000Z",
 } as const;

--- a/src/tests/websocket/listen-client-channel-accounts.test.ts
+++ b/src/tests/websocket/listen-client-channel-accounts.test.ts
@@ -40,6 +40,7 @@ describe("channel account list responses", () => {
           hasBotToken: true,
           hasAppToken: true,
           agentId: "agent-1",
+          defaultPermissionMode: "acceptEdits" as const,
           createdAt: "2026-04-13T00:00:00.000Z",
           updatedAt: "2026-04-13T00:00:00.000Z",
         },
@@ -60,6 +61,7 @@ describe("channel account list responses", () => {
               hasBotToken: true,
               hasAppToken: true,
               agentId: "agent-1",
+              defaultPermissionMode: "acceptEdits" as const,
               createdAt: "2026-04-13T00:00:00.000Z",
               updatedAt: "2026-04-13T00:00:00.000Z",
             });
@@ -100,6 +102,7 @@ describe("channel account list responses", () => {
             has_bot_token: true,
             has_app_token: true,
             agent_id: "agent-1",
+            default_permission_mode: "acceptEdits",
             created_at: "2026-04-13T00:00:00.000Z",
             updated_at: "2026-04-13T00:00:00.000Z",
           },

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1575,6 +1575,7 @@ describe("listen-client channels command handling", () => {
         hasBotToken: true,
         hasAppToken: true,
         agentId: "agent-1",
+        defaultPermissionMode: "acceptEdits" as const,
         createdAt: "2026-04-11T00:00:00.000Z",
         updatedAt: "2026-04-11T01:00:00.000Z",
       }),
@@ -1591,6 +1592,7 @@ describe("listen-client channels command handling", () => {
         hasBotToken: true,
         hasAppToken: true,
         agentId: null,
+        defaultPermissionMode: "acceptEdits" as const,
         createdAt: "2026-04-11T00:00:00.000Z",
         updatedAt: "2026-04-11T02:00:00.000Z",
       }),
@@ -1628,6 +1630,7 @@ describe("listen-client channels command handling", () => {
         account: {
           account_id: "acct-1",
           agent_id: "agent-1",
+          default_permission_mode: "acceptEdits",
         },
       });
       expect(messages[1]).toMatchObject({
@@ -1669,6 +1672,7 @@ describe("listen-client channels command handling", () => {
         account: {
           account_id: "acct-1",
           agent_id: null,
+          default_permission_mode: "acceptEdits",
         },
       });
       expect(messages[1]).toMatchObject({
@@ -2050,6 +2054,38 @@ describe("listen-client permission mode scope keys", () => {
         "agent:__unknown__::conversation:default",
       ),
     ).toBe(false);
+  });
+
+  test("slack conversation created event seeds the new conversation permission mode", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    __listenClientTestUtils.handleChannelRegistryEvent(
+      {
+        type: "slack_conversation_created",
+        channelId: "slack",
+        accountId: "acct-1",
+        agentId: "agent-123",
+        conversationId: "conv-slack-1",
+        defaultPermissionMode: "bypassPermissions",
+      },
+      socket as unknown as WebSocket,
+      listener,
+    );
+
+    const status = __listenClientTestUtils.buildDeviceStatus(listener, {
+      agent_id: "agent-123",
+      conversation_id: "conv-slack-1",
+    });
+
+    expect(status.current_permission_mode).toBe("bypassPermissions");
+    expect(
+      listener.permissionModeByConversation.get("conversation:conv-slack-1"),
+    ).toEqual({
+      mode: "bypassPermissions",
+      planFilePath: null,
+      modeBeforePlan: null,
+    });
   });
 });
 

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -9,7 +9,11 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import type { DmPolicy, SlackChannelMode } from "../channels/types";
+import type {
+  DmPolicy,
+  SlackChannelMode,
+  SlackDefaultPermissionMode,
+} from "../channels/types";
 import type { CronTask } from "../cron";
 
 /**
@@ -204,6 +208,7 @@ export type ChannelAccountSnapshot =
       has_bot_token: boolean;
       has_app_token: boolean;
       agent_id: string | null;
+      default_permission_mode: SlackDefaultPermissionMode;
       created_at: string;
       updated_at: string;
     };
@@ -898,6 +903,7 @@ export type ChannelAccountCreatePayload =
       app_token?: string;
       mode?: SlackChannelMode;
       agent_id?: string | null;
+      default_permission_mode?: SlackDefaultPermissionMode;
       dm_policy?: DmPolicy;
       allowed_users?: string[];
     };
@@ -929,6 +935,7 @@ export interface ChannelAccountUpdateCommand {
         app_token?: string;
         mode?: SlackChannelMode;
         agent_id?: string | null;
+        default_permission_mode?: SlackDefaultPermissionMode;
         dm_policy?: DmPolicy;
         allowed_users?: string[];
       };

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -17,7 +17,10 @@ import {
   updateAgentLLMConfig,
   updateConversationLLMConfig,
 } from "../../agent/modify";
-import { getChannelRegistry } from "../../channels/registry";
+import {
+  type ChannelRegistryEvent,
+  getChannelRegistry,
+} from "../../channels/registry";
 import type { ChannelTurnSource } from "../../channels/types";
 import { resetContextHistory } from "../../cli/helpers/contextTracker";
 import {
@@ -1512,6 +1515,7 @@ async function handleChannelsProtocolCommand(
       has_bot_token: snapshot.hasBotToken,
       has_app_token: snapshot.hasAppToken,
       agent_id: snapshot.agentId,
+      default_permission_mode: snapshot.defaultPermissionMode,
       created_at: snapshot.createdAt,
       updated_at: snapshot.updatedAt,
     };
@@ -1672,6 +1676,10 @@ async function handleChannelsProtocolCommand(
           mode: "mode" in parsed.account ? parsed.account.mode : undefined,
           agentId:
             "agent_id" in parsed.account ? parsed.account.agent_id : undefined,
+          defaultPermissionMode:
+            "default_permission_mode" in parsed.account
+              ? parsed.account.default_permission_mode
+              : undefined,
           dmPolicy: parsed.account.dm_policy,
           allowedUsers: parsed.account.allowed_users,
         },
@@ -1748,6 +1756,10 @@ async function handleChannelsProtocolCommand(
           mode: "mode" in parsed.patch ? parsed.patch.mode : undefined,
           agentId:
             "agent_id" in parsed.patch ? parsed.patch.agent_id : undefined,
+          defaultPermissionMode:
+            "default_permission_mode" in parsed.patch
+              ? parsed.patch.default_permission_mode
+              : undefined,
           dmPolicy: parsed.patch.dm_policy,
           allowedUsers: parsed.patch.allowed_users,
         },
@@ -3003,19 +3015,38 @@ function wireChannelIngress(
   });
 
   registry.setEventHandler((event) => {
-    if (event.type === "pairings_updated") {
-      emitChannelPairingsUpdated(
-        socket,
-        event.channelId as "telegram" | "slack",
-      );
-      emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
-      return;
-    }
-    emitChannelTargetsUpdated(socket, event.channelId as "telegram" | "slack");
-    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+    handleChannelRegistryEvent(event, socket, listener);
   });
 
   registry.setReady();
+}
+
+function handleChannelRegistryEvent(
+  event: ChannelRegistryEvent,
+  socket: WebSocket,
+  runtime: ListenerRuntime,
+): void {
+  if (event.type === "pairings_updated") {
+    emitChannelPairingsUpdated(socket, event.channelId as "telegram" | "slack");
+    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+    return;
+  }
+
+  if (event.type === "targets_updated") {
+    emitChannelTargetsUpdated(socket, event.channelId as "telegram" | "slack");
+    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+    return;
+  }
+
+  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+    runtime,
+    event.agentId,
+    event.conversationId,
+  );
+  permissionModeState.mode = event.defaultPermissionMode;
+  permissionModeState.planFilePath = null;
+  permissionModeState.modeBeforePlan = null;
+  persistPermissionModeMapForRuntime(runtime);
 }
 
 function stampInboundUserMessageOtids(
@@ -5722,6 +5753,7 @@ export const __listenClientTestUtils = {
   handleListMemoryCommand,
   isDetachedChannelsCommand,
   handleChannelsProtocolCommand,
+  handleChannelRegistryEvent,
   handleSkillCommand,
   handleCreateAgentCommand,
   handleReflectionSettingsCommand,


### PR DESCRIPTION
## Summary
- add a Slack account-level default permission mode that is stored with the account snapshot and exposed over the desktop listener protocol
- seed newly auto-created Slack conversations with that permission mode when a DM or mention spins up a fresh conversation for the bound agent
- cover the new protocol mapping and permission-mode seeding behavior in channel service and listener tests

👾 Generated with [Letta Code](https://letta.com)