### PR TITLE
fix: clarify opus 4.7 reasoning tiers

### DIFF
--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -12,7 +12,8 @@ export type ModelReasoningEffort =
   | "low"
   | "medium"
   | "high"
-  | "xhigh";
+  | "xhigh"
+  | "max";
 
 const REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
   "none",
@@ -21,6 +22,7 @@ const REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
   "medium",
   "high",
   "xhigh",
+  "max",
 ];
 
 function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
@@ -182,6 +184,15 @@ export function getModelInfoForLlmConfig(
           ?.reasoning_effort === effort,
     );
     if (match) return match;
+
+    if (effort === "max") {
+      const legacyXHighMatch = candidates.find(
+        (m) =>
+          (m.updateArgs as { reasoning_effort?: unknown } | undefined)
+            ?.reasoning_effort === "xhigh",
+      );
+      if (legacyXHighMatch) return legacyXHighMatch;
+    }
   }
 
   // Anthropic-style toggle (best-effort; llm_config may not always include it)

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -19,6 +19,10 @@ type ModelSettings =
   | GoogleAIModelSettings
   | Record<string, unknown>;
 
+function supportsDistinctAnthropicXHighEffort(modelHandle: string): boolean {
+  return modelHandle.includes("claude-opus-4-7");
+}
+
 /**
  * Builds model_settings from updateArgs based on provider type.
  * Always ensures parallel_tool_calls is enabled.
@@ -77,11 +81,17 @@ function buildModelSettings(
     };
     // Map reasoning_effort to Anthropic's effort field (controls token spending via output_config)
     const effort = updateArgs?.reasoning_effort;
+    const hasDistinctXHigh = supportsDistinctAnthropicXHighEffort(modelHandle);
     if (effort === "low" || effort === "medium" || effort === "high") {
       anthropicSettings.effort = effort;
     } else if (effort === "xhigh") {
+      // "xhigh" is only distinct on Opus 4.7; older Anthropic models map it to backend "max".
+      (anthropicSettings as Record<string, unknown>).effort = hasDistinctXHigh
+        ? "xhigh"
+        : "max";
+    } else if (effort === "max") {
       // "max" is valid on the backend but the SDK type hasn't caught up yet
-      (anthropicSettings as Record<string, unknown>).effort = "max";
+      (anthropicSettings as Record<string, unknown>).effort = effort;
     }
     // Build thinking config if either enable_reasoner or max_reasoning_tokens is specified
     if (
@@ -144,10 +154,13 @@ function buildModelSettings(
     };
     // Map reasoning_effort to Anthropic's effort field (Bedrock runs Claude models)
     const effort = updateArgs?.reasoning_effort;
+    const hasDistinctXHigh = supportsDistinctAnthropicXHighEffort(modelHandle);
     if (effort === "low" || effort === "medium" || effort === "high") {
       bedrockSettings.effort = effort;
     } else if (effort === "xhigh") {
-      bedrockSettings.effort = "max";
+      bedrockSettings.effort = hasDistinctXHigh ? "xhigh" : "max";
+    } else if (effort === "max") {
+      bedrockSettings.effort = effort;
     }
     // Build thinking config if either enable_reasoner or max_reasoning_tokens is specified
     if (

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -457,20 +457,22 @@ function deriveReasoningEffort(
       const effort = (modelSettings as { effort?: string | null }).effort;
       if (effort === "low" || effort === "medium" || effort === "high")
         return effort;
-      if (effort === "max") return "xhigh";
+      if (effort === "xhigh" || effort === "max")
+        return effort as ModelReasoningEffort;
     }
   }
   // Fallback: deprecated llm_config fields
-  const re = llmConfig?.reasoning_effort;
+  const re = llmConfig?.reasoning_effort as string | null | undefined;
   if (
     re === "none" ||
     re === "minimal" ||
     re === "low" ||
     re === "medium" ||
     re === "high" ||
-    re === "xhigh"
+    re === "xhigh" ||
+    re === "max"
   )
-    return re;
+    return re as ModelReasoningEffort;
   if (
     (llmConfig as { enable_reasoner?: boolean | null })?.enable_reasoner ===
     false
@@ -496,7 +498,8 @@ function inferReasoningEffortFromModelPreset(
     presetEffort === "low" ||
     presetEffort === "medium" ||
     presetEffort === "high" ||
-    presetEffort === "xhigh"
+    presetEffort === "xhigh" ||
+    presetEffort === "max"
   ) {
     return presetEffort;
   }
@@ -3689,7 +3692,7 @@ export default function App({
           ...(typeof resolvedConversationContextWindowLimit === "number"
             ? { context_window: resolvedConversationContextWindowLimit }
             : {}),
-        });
+        } as LlmConfig);
       } catch (error) {
         if (cancelled) return;
         debugLog(
@@ -12693,7 +12696,9 @@ ${SYSTEM_REMINDER_CLOSE}
             ? rawReasoningEffort === "none"
               ? "no"
               : rawReasoningEffort === "xhigh"
-                ? "max"
+                ? model.label.includes("Opus 4.7")
+                  ? "extra-high"
+                  : "max"
                 : rawReasoningEffort
             : modelUpdateArgs?.enable_reasoner === false
               ? "no"
@@ -12863,7 +12868,7 @@ ${SYSTEM_REMINDER_CLOSE}
             ...(typeof resolvedContextWindow === "number"
               ? { context_window: resolvedContextWindow }
               : {}),
-          });
+          } as LlmConfig);
           setCurrentModelId(modelId);
           setTempModelOverride(null);
 
@@ -13857,7 +13862,7 @@ ${SYSTEM_REMINDER_CLOSE}
             ...(typeof resolvedConversationContextWindowLimit === "number"
               ? { context_window: resolvedConversationContextWindowLimit }
               : {}),
-          });
+          } as LlmConfig);
           setCurrentModelId(desired.modelId);
           setCurrentModelHandle(desired.modelHandle);
 
@@ -13963,7 +13968,19 @@ ${SYSTEM_REMINDER_CLOSE}
       // Only enable cycling when there are multiple tiers for the same handle.
       if (tiers.length < 2) return;
 
-      const order = ["none", "minimal", "low", "medium", "high", "xhigh"];
+      const anthropicXHighEffort = modelHandle.includes("claude-opus-4-7")
+        ? "xhigh"
+        : "max";
+
+      const order = [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+      ];
       const rank = (effort: string): number => {
         const idx = order.indexOf(effort);
         return idx >= 0 ? idx : 999;
@@ -14017,15 +14034,14 @@ ${SYSTEM_REMINDER_CLOSE}
             ms.provider_type === "anthropic" ||
             ms.provider_type === "bedrock"
           ) {
-            // Map "xhigh" → "max": footer derivation only recognizes "max" for Anthropic effort.
-            // Cast needed: "max" is valid on the backend but not yet in the SDK type.
-            const anthropicEffort =
-              next.effort === "xhigh" ? "max" : next.effort;
+            // "xhigh" is only distinct on Opus 4.7; older Anthropic models map it to backend "max".
             return {
               ...prev,
               model_settings: {
                 ...ms,
-                effort: anthropicEffort as "low" | "medium" | "high" | "max",
+                effort: (next.effort === "xhigh"
+                  ? anthropicXHighEffort
+                  : next.effort) as "low" | "medium" | "high" | "xhigh" | "max",
               },
             } as AgentState;
           }

--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -40,7 +40,8 @@ function formatReasoningLabel(
   effort: ModelReasoningEffort | null | undefined,
 ): string | null {
   if (effort === "none") return null;
-  if (effort === "xhigh") return "max";
+  if (effort === "xhigh") return "xhigh";
+  if (effort === "max") return "max";
   if (effort === "minimal") return "minimal";
   if (effort === "low") return "low";
   if (effort === "medium") return "medium";

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -64,7 +64,8 @@ function getReasoningEffortTag(
   effort: ModelReasoningEffort | null | undefined,
 ): string | null {
   if (effort === "none") return null;
-  if (effort === "xhigh") return "max";
+  if (effort === "xhigh") return "xhigh";
+  if (effort === "max") return "max";
   if (effort === "minimal") return "minimal";
   if (effort === "low") return "low";
   if (effort === "medium") return "medium";

--- a/src/cli/components/ModelReasoningSelector.tsx
+++ b/src/cli/components/ModelReasoningSelector.tsx
@@ -21,9 +21,13 @@ interface ModelReasoningSelectorProps {
   onCancel: () => void;
 }
 
-function formatEffortLabel(effort: ModelReasoningEffort): string {
+function formatEffortLabel(
+  effort: ModelReasoningEffort,
+  hasDistinctMaxTier: boolean,
+): string {
   if (effort === "none") return "Off";
-  if (effort === "xhigh") return "Max";
+  if (effort === "xhigh") return hasDistinctMaxTier ? "Extra-High" : "Max";
+  if (effort === "max") return "Max";
   if (effort === "minimal") return "Minimal";
   return effort.charAt(0).toUpperCase() + effort.slice(1);
 }
@@ -56,6 +60,10 @@ export function ModelReasoningSelector({
   const selectedOption = options[selectedIndex] ?? options[0];
   const effortOptions = useMemo(
     () => options.filter((option) => option.effort !== "none"),
+    [options],
+  );
+  const hasDistinctMaxTier = useMemo(
+    () => options.some((option) => option.effort === "max"),
     [options],
   );
   const totalBars = Math.max(effortOptions.length, 1);
@@ -106,7 +114,7 @@ export function ModelReasoningSelector({
   });
 
   const effortLabel = selectedOption
-    ? formatEffortLabel(selectedOption.effort)
+    ? formatEffortLabel(selectedOption.effort, hasDistinctMaxTier)
     : "Medium";
   const selectedText =
     selectedBars > 0 ? EFFORT_BLOCK.repeat(selectedBars) : "";

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -163,6 +163,26 @@ describe("getReasoningTierOptionsForHandle", () => {
     ]);
   });
 
+  test("returns reasoning options for anthropic opus 4.7", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "anthropic/claude-opus-4-7",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "opus-4.7-low",
+      "opus-4.7", // featured entry uses medium; wins first-seen dedup
+      "opus-4.7-high",
+      "opus-4.7-xhigh",
+      "opus-4.7-max",
+    ]);
+  });
+
   test("returns reasoning options for anthropic opus 4.5", () => {
     const options = getReasoningTierOptionsForHandle(
       "anthropic/claude-opus-4-5-20251101",

--- a/src/tests/websocket/listen-model-update.test.ts
+++ b/src/tests/websocket/listen-model-update.test.ts
@@ -81,7 +81,7 @@ describe("listen-client model update status message", () => {
     expect(result.message).toBe("Model updated to Opus 4.6 (No Reasoning).");
   });
 
-  test("shows Max for reasoning_effort xhigh", () => {
+  test("shows Max for reasoning_effort xhigh on older Anthropic models", () => {
     const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
       modelLabel: "Opus 4.6",
       toolsetChanged: false,
@@ -92,6 +92,19 @@ describe("listen-client model update status message", () => {
     });
 
     expect(result.message).toBe("Model updated to Opus 4.6 (Max).");
+  });
+
+  test("shows Extra-High for reasoning_effort xhigh on Opus 4.7", () => {
+    const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
+      modelLabel: "Opus 4.7",
+      toolsetChanged: false,
+      toolsetError: null,
+      nextToolset: "default",
+      toolsetPreference: "auto",
+      updateArgs: { reasoning_effort: "xhigh" },
+    });
+
+    expect(result.message).toBe("Model updated to Opus 4.7 (Extra-High).");
   });
 
   test("omits effort when updateArgs has no reasoning_effort", () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -561,16 +561,21 @@ function formatToolsetStatusMessageForModelUpdate(params: {
   );
 }
 
-function formatEffortSuffix(updateArgs?: Record<string, unknown>): string {
+function formatEffortSuffix(
+  modelLabel: string,
+  updateArgs?: Record<string, unknown>,
+): string {
   if (!updateArgs) return "";
   const effort = updateArgs.reasoning_effort;
   if (typeof effort !== "string" || effort.length === 0) return "";
+  const xhighLabel = modelLabel.includes("Opus 4.7") ? "Extra-High" : "Max";
   const labels: Record<string, string> = {
     none: "No Reasoning",
     low: "Low",
     medium: "Medium",
     high: "High",
-    xhigh: "Max",
+    xhigh: xhighLabel,
+    max: "Max",
   };
   return ` (${labels[effort] ?? effort})`;
 }
@@ -591,7 +596,7 @@ function buildModelUpdateStatusMessage(params: {
     toolsetPreference,
     updateArgs,
   } = params;
-  let message = `Model updated to ${modelLabel}${formatEffortSuffix(updateArgs)}.`;
+  let message = `Model updated to ${modelLabel}${formatEffortSuffix(modelLabel, updateArgs)}.`;
   if (toolsetError) {
     message += ` Warning: toolset switch failed (${toolsetError}).`;
     return { message, level: "warning" };


### PR DESCRIPTION
## Summary
- treat Opus 4.7 `xhigh` as a distinct Extra-High tier while preserving legacy Anthropic `xhigh -> max` behavior for older models
- update selector, optimistic model state, and model update status text so Opus 4.7 shows Extra-High and older Anthropic models still show Max
- add coverage for Opus 4.7 reasoning tiers and model update messaging across the old/new Anthropic effort semantics

## Test plan
- [x] `bun test src/tests/model-tier-selection.test.ts src/tests/websocket/listen-model-update.test.ts`
- [x] `tsc --noEmit` via pre-commit hook

👾 Generated with [Letta Code](https://letta.com)