### PR TITLE
Shelley/let 8514 hybrid file index directory listing

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -605,6 +605,16 @@ export interface ListInDirectoryCommand {
   request_id?: string;
 }
 
+export interface GetTreeCommand {
+  type: "get_tree";
+  /** Absolute path to the root of the subtree to fetch. */
+  path: string;
+  /** Maximum depth of the subtree to return (e.g. 3). */
+  depth: number;
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+}
+
 export interface ReadFileCommand {
   type: "read_file";
   /** Absolute path to the file to read. */
@@ -1439,6 +1449,7 @@ export type WsProtocolCommand =
   | TerminalKillCommand
   | SearchFilesCommand
   | ListInDirectoryCommand
+  | GetTreeCommand
   | ReadFileCommand
   | WriteFileCommand
   | WatchFileCommand

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -23,6 +23,7 @@ import { resetContextHistory } from "../../cli/helpers/contextTracker";
 import {
   ensureFileIndex,
   getIndexRoot,
+  refreshFileIndex,
   searchFileIndex,
   setIndexRoot,
 } from "../../cli/helpers/fileIndex";
@@ -4318,6 +4319,38 @@ async function connectWithRetry(
         );
         runDetachedListenerTask("list_in_directory", async () => {
           try {
+            // ── 1. Query file index first (instant, from memory) ──────────
+            let indexedNames: Set<string> | undefined;
+            const indexedFolders: string[] = [];
+            const indexedFiles: string[] = [];
+            try {
+              await ensureFileIndex();
+              const indexRoot = getIndexRoot();
+              const relPath = path.relative(indexRoot, parsed.path);
+              // Only query the index if the directory is within the index root
+              if (!relPath.startsWith("..")) {
+                const indexed = searchFileIndex({
+                  searchDir: relPath || ".",
+                  pattern: "",
+                  deep: false,
+                  maxResults: 10000,
+                });
+                indexedNames = new Set<string>();
+                for (const entry of indexed) {
+                  const name = entry.path.split(path.sep).pop() ?? entry.path;
+                  indexedNames.add(name);
+                  if (entry.type === "dir") {
+                    indexedFolders.push(name);
+                  } else {
+                    indexedFiles.push(name);
+                  }
+                }
+              }
+            } catch {
+              // Index not available — fall through to readdir only
+            }
+
+            // ── 2. readdir to fill gaps (entries not in the index) ────────
             const { readdir } = await import("node:fs/promises");
             console.log(`[Listen] Reading directory: ${parsed.path}`);
             const entries = await readdir(parsed.path, { withFileTypes: true });
@@ -4332,19 +4365,29 @@ async function connectWithRetry(
               ".gitignore",
               "Thumbs.db",
             ]);
-            const sortedEntries = entries
-              .filter((e) => !IGNORED_NAMES.has(e.name))
-              .sort((a, b) => a.name.localeCompare(b.name));
 
-            const allFolders: string[] = [];
-            const allFiles: string[] = [];
-            for (const e of sortedEntries) {
+            // Add entries that are NOT already in the index
+            const extraFolders: string[] = [];
+            const extraFiles: string[] = [];
+            for (const e of entries) {
+              if (IGNORED_NAMES.has(e.name)) continue;
+              if (indexedNames?.has(e.name)) continue; // already from index
               if (e.isDirectory()) {
-                allFolders.push(e.name);
+                extraFolders.push(e.name);
               } else if (parsed.include_files) {
-                allFiles.push(e.name);
+                extraFiles.push(e.name);
               }
             }
+
+            // ── 3. Merge: indexed entries + readdir extras ────────────────
+            const allFolders = [...indexedFolders, ...extraFolders].sort(
+              (a, b) => a.localeCompare(b),
+            );
+            const allFiles = parsed.include_files
+              ? [...indexedFiles, ...extraFiles].sort((a, b) =>
+                  a.localeCompare(b),
+                )
+              : [];
 
             const total = allFolders.length + allFiles.length;
             const offset = parsed.offset ?? 0;
@@ -4353,8 +4396,9 @@ async function connectWithRetry(
             // Paginate over the combined [folders, files] list
             const combined = [...allFolders, ...allFiles];
             const page = combined.slice(offset, offset + limit);
-            const folders = page.filter((name) => allFolders.includes(name));
-            const files = page.filter((name) => allFiles.includes(name));
+            const folderSet = new Set(allFolders);
+            const folders = page.filter((name) => folderSet.has(name));
+            const files = page.filter((name) => !folderSet.has(name));
 
             const response: Record<string, unknown> = {
               type: "list_in_directory_response",
@@ -4505,6 +4549,8 @@ async function connectWithRetry(
             console.log(
               `[Listen] write_file success: ${parsed.path} (${parsed.content.length} bytes)`,
             );
+            // Update the file index so the sidebar Merkle tree stays current
+            void refreshFileIndex();
             safeSocketSend(
               socket,
               {
@@ -4648,6 +4694,10 @@ async function connectWithRetry(
             console.log(
               `[Listen] edit_file success: ${result.replacements} replacement(s) at line ${result.startLine}`,
             );
+            // Update the file index so the sidebar Merkle tree stays current
+            if (result.replacements > 0) {
+              void refreshFileIndex();
+            }
 
             // Notify web clients of the new content so they can update live.
             if (result.replacements > 0) {
@@ -4724,6 +4774,8 @@ async function connectWithRetry(
               const { writeFile } = await import("node:fs/promises");
               const content = parsed.document_content as string;
               await writeFile(parsed.path, content, "utf-8");
+              // Update the file index so the sidebar Merkle tree stays current
+              void refreshFileIndex();
               console.log(
                 `[Listen] file_ops: wrote ${content.length} bytes to ${parsed.path}`,
               );

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -185,6 +185,7 @@ import {
   isExecuteCommandCommand,
   isFileOpsCommand,
   isGetReflectionSettingsCommand,
+  isGetTreeCommand,
   isListInDirectoryCommand,
   isListMemoryCommand,
   isListModelsCommand,
@@ -3786,6 +3787,14 @@ export async function startListenerClient(
   await connectWithRetry(runtime, opts);
 }
 
+/** File/directory names filtered from directory listings (OS/VCS noise). */
+const DIR_LISTING_IGNORED_NAMES = new Set([
+  ".DS_Store",
+  ".git",
+  ".gitignore",
+  "Thumbs.db",
+]);
+
 /**
  * Connect to WebSocket with exponential backoff retry.
  */
@@ -4358,19 +4367,11 @@ async function connectWithRetry(
               `[Listen] Directory read success, ${entries.length} entries`,
             );
 
-            // Filter out OS/VCS noise before sorting
-            const IGNORED_NAMES = new Set([
-              ".DS_Store",
-              ".git",
-              ".gitignore",
-              "Thumbs.db",
-            ]);
-
             // Add entries that are NOT already in the index
             const extraFolders: string[] = [];
             const extraFiles: string[] = [];
             for (const e of entries) {
-              if (IGNORED_NAMES.has(e.name)) continue;
+              if (DIR_LISTING_IGNORED_NAMES.has(e.name)) continue;
               if (indexedNames?.has(e.name)) continue; // already from index
               if (e.isDirectory()) {
                 extraFolders.push(e.name);
@@ -4446,6 +4447,161 @@ async function connectWithRetry(
               },
               "listener_list_directory_send_failed",
               "listener_list_in_directory",
+            );
+          }
+        });
+        return;
+      }
+
+      // ── Depth-limited subtree fetch (no runtime scope required) ──────
+      if (isGetTreeCommand(parsed)) {
+        console.log(
+          `[Listen] Received get_tree command: path=${parsed.path}, depth=${parsed.depth}`,
+        );
+        runDetachedListenerTask("get_tree", async () => {
+          try {
+            const { readdir } = await import("node:fs/promises");
+
+            // Walk the directory tree up to the requested depth, combining
+            // file index results with readdir to include non-indexed entries.
+            interface TreeEntry {
+              path: string;
+              type: "file" | "dir";
+            }
+            const results: TreeEntry[] = [];
+            let hasMoreDepth = false;
+
+            // Warm the file index once before walking the tree.
+            let indexRoot: string | undefined;
+            try {
+              await ensureFileIndex();
+              indexRoot = getIndexRoot();
+            } catch {
+              // Index not available — readdir only for all directories
+            }
+
+            // BFS queue: [absolutePath, relativePath, currentDepth]
+            const queue: [string, string, number][] = [[parsed.path, "", 0]];
+
+            while (queue.length > 0) {
+              const [absDir, relDir, depth] = queue.shift()!;
+
+              if (depth >= parsed.depth) {
+                // There are directories at the boundary — deeper content exists
+                if (depth === parsed.depth && relDir !== "") {
+                  hasMoreDepth = true;
+                }
+                continue;
+              }
+
+              // 1. Query file index for this directory
+              let indexedNames: Set<string> | undefined;
+              const indexedFolders: string[] = [];
+              const indexedFiles: string[] = [];
+              if (indexRoot !== undefined) {
+                const relPath = path.relative(indexRoot, absDir);
+                if (!relPath.startsWith("..")) {
+                  const indexed = searchFileIndex({
+                    searchDir: relPath || ".",
+                    pattern: "",
+                    deep: false,
+                    maxResults: 10000,
+                  });
+                  indexedNames = new Set<string>();
+                  for (const entry of indexed) {
+                    const name = entry.path.split(path.sep).pop() ?? entry.path;
+                    indexedNames.add(name);
+                    if (entry.type === "dir") {
+                      indexedFolders.push(name);
+                    } else {
+                      indexedFiles.push(name);
+                    }
+                  }
+                }
+              }
+
+              // 2. readdir to fill gaps
+              let dirEntries: import("node:fs").Dirent[];
+              try {
+                dirEntries = (await readdir(absDir, {
+                  withFileTypes: true,
+                })) as import("node:fs").Dirent[];
+              } catch {
+                // Can't read directory — skip
+                continue;
+              }
+
+              const extraFolders: string[] = [];
+              const extraFiles: string[] = [];
+              for (const e of dirEntries) {
+                if (DIR_LISTING_IGNORED_NAMES.has(e.name)) continue;
+                if (indexedNames?.has(e.name)) continue;
+                if (e.isDirectory()) {
+                  extraFolders.push(e.name);
+                } else {
+                  extraFiles.push(e.name);
+                }
+              }
+
+              // 3. Merge and collect entries
+              const allFolders = [...indexedFolders, ...extraFolders].sort(
+                (a, b) => a.localeCompare(b),
+              );
+              const allFiles = [...indexedFiles, ...extraFiles].sort((a, b) =>
+                a.localeCompare(b),
+              );
+
+              for (const name of allFolders) {
+                const entryRel = relDir === "" ? name : `${relDir}/${name}`;
+                results.push({ path: entryRel, type: "dir" });
+                // Enqueue for next depth level
+                queue.push([path.join(absDir, name), entryRel, depth + 1]);
+              }
+              for (const name of allFiles) {
+                const entryRel = relDir === "" ? name : `${relDir}/${name}`;
+                results.push({ path: entryRel, type: "file" });
+              }
+            }
+
+            console.log(
+              `[Listen] Sending get_tree_response: ${results.length} entries, has_more_depth=${hasMoreDepth}`,
+            );
+            safeSocketSend(
+              socket,
+              {
+                type: "get_tree_response",
+                path: parsed.path,
+                request_id: parsed.request_id,
+                entries: results,
+                has_more_depth: hasMoreDepth,
+                success: true,
+              },
+              "listener_get_tree_send_failed",
+              "listener_get_tree",
+            );
+          } catch (err) {
+            trackListenerError(
+              "listener_get_tree_failed",
+              err,
+              "listener_file_browser",
+            );
+            console.error(
+              `[Listen] get_tree error: ${err instanceof Error ? err.message : "Unknown error"}`,
+            );
+            safeSocketSend(
+              socket,
+              {
+                type: "get_tree_response",
+                path: parsed.path,
+                request_id: parsed.request_id,
+                entries: [],
+                has_more_depth: false,
+                success: false,
+                error:
+                  err instanceof Error ? err.message : "Failed to get tree",
+              },
+              "listener_get_tree_send_failed",
+              "listener_get_tree",
             );
           }
         });
@@ -4774,8 +4930,6 @@ async function connectWithRetry(
               const { writeFile } = await import("node:fs/promises");
               const content = parsed.document_content as string;
               await writeFile(parsed.path, content, "utf-8");
-              // Update the file index so the sidebar Merkle tree stays current
-              void refreshFileIndex();
               console.log(
                 `[Listen] file_ops: wrote ${content.length} bytes to ${parsed.path}`,
               );

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3791,7 +3791,6 @@ export async function startListenerClient(
 const DIR_LISTING_IGNORED_NAMES = new Set([
   ".DS_Store",
   ".git",
-  ".gitignore",
   "Thumbs.db",
 ]);
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3790,6 +3790,79 @@ export async function startListenerClient(
 /** File/directory names filtered from directory listings (OS/VCS noise). */
 const DIR_LISTING_IGNORED_NAMES = new Set([".DS_Store", ".git", "Thumbs.db"]);
 
+interface DirListing {
+  folders: string[];
+  files: string[];
+}
+
+/**
+ * List a single directory by merging the file index (instant) with readdir
+ * (to pick up `.lettaignore`'d entries). Shared by `list_in_directory` and
+ * `get_tree` handlers.
+ *
+ * @param absDir      Absolute path to the directory.
+ * @param indexRoot   Root of the file index (undefined if unavailable).
+ * @param includeFiles  Whether to include files (not just folders).
+ */
+async function listDirectoryHybrid(
+  absDir: string,
+  indexRoot: string | undefined,
+  includeFiles: boolean,
+): Promise<DirListing> {
+  // 1. Query file index (instant, from memory)
+  let indexedNames: Set<string> | undefined;
+  const indexedFolders: string[] = [];
+  const indexedFiles: string[] = [];
+
+  if (indexRoot !== undefined) {
+    const relPath = path.relative(indexRoot, absDir);
+    if (!relPath.startsWith("..")) {
+      const indexed = searchFileIndex({
+        searchDir: relPath || ".",
+        pattern: "",
+        deep: false,
+        maxResults: 10000,
+      });
+      indexedNames = new Set<string>();
+      for (const entry of indexed) {
+        const name = entry.path.split(path.sep).pop() ?? entry.path;
+        indexedNames.add(name);
+        if (entry.type === "dir") {
+          indexedFolders.push(name);
+        } else {
+          indexedFiles.push(name);
+        }
+      }
+    }
+  }
+
+  // 2. readdir to fill gaps (entries not in the index)
+  const { readdir } = await import("node:fs/promises");
+  const entries = await readdir(absDir, { withFileTypes: true });
+
+  const extraFolders: string[] = [];
+  const extraFiles: string[] = [];
+  for (const e of entries) {
+    if (DIR_LISTING_IGNORED_NAMES.has(e.name)) continue;
+    if (indexedNames?.has(e.name)) continue;
+    if (e.isDirectory()) {
+      extraFolders.push(e.name);
+    } else if (includeFiles) {
+      extraFiles.push(e.name);
+    }
+  }
+
+  // 3. Merge and sort
+  return {
+    folders: [...indexedFolders, ...extraFolders].sort((a, b) =>
+      a.localeCompare(b),
+    ),
+    files: includeFiles
+      ? [...indexedFiles, ...extraFiles].sort((a, b) => a.localeCompare(b))
+      : [],
+  };
+}
+
 /**
  * Connect to WebSocket with exponential backoff retry.
  */
@@ -4323,67 +4396,21 @@ async function connectWithRetry(
         );
         runDetachedListenerTask("list_in_directory", async () => {
           try {
-            // ── 1. Query file index first (instant, from memory) ──────────
-            let indexedNames: Set<string> | undefined;
-            const indexedFolders: string[] = [];
-            const indexedFiles: string[] = [];
+            let indexRoot: string | undefined;
             try {
               await ensureFileIndex();
-              const indexRoot = getIndexRoot();
-              const relPath = path.relative(indexRoot, parsed.path);
-              // Only query the index if the directory is within the index root
-              if (!relPath.startsWith("..")) {
-                const indexed = searchFileIndex({
-                  searchDir: relPath || ".",
-                  pattern: "",
-                  deep: false,
-                  maxResults: 10000,
-                });
-                indexedNames = new Set<string>();
-                for (const entry of indexed) {
-                  const name = entry.path.split(path.sep).pop() ?? entry.path;
-                  indexedNames.add(name);
-                  if (entry.type === "dir") {
-                    indexedFolders.push(name);
-                  } else {
-                    indexedFiles.push(name);
-                  }
-                }
-              }
+              indexRoot = getIndexRoot();
             } catch {
-              // Index not available — fall through to readdir only
+              // Index not available — readdir only
             }
 
-            // ── 2. readdir to fill gaps (entries not in the index) ────────
-            const { readdir } = await import("node:fs/promises");
             console.log(`[Listen] Reading directory: ${parsed.path}`);
-            const entries = await readdir(parsed.path, { withFileTypes: true });
-            console.log(
-              `[Listen] Directory read success, ${entries.length} entries`,
-            );
-
-            // Add entries that are NOT already in the index
-            const extraFolders: string[] = [];
-            const extraFiles: string[] = [];
-            for (const e of entries) {
-              if (DIR_LISTING_IGNORED_NAMES.has(e.name)) continue;
-              if (indexedNames?.has(e.name)) continue; // already from index
-              if (e.isDirectory()) {
-                extraFolders.push(e.name);
-              } else if (parsed.include_files) {
-                extraFiles.push(e.name);
-              }
-            }
-
-            // ── 3. Merge: indexed entries + readdir extras ────────────────
-            const allFolders = [...indexedFolders, ...extraFolders].sort(
-              (a, b) => a.localeCompare(b),
-            );
-            const allFiles = parsed.include_files
-              ? [...indexedFiles, ...extraFiles].sort((a, b) =>
-                  a.localeCompare(b),
-                )
-              : [];
+            const { folders: allFolders, files: allFiles } =
+              await listDirectoryHybrid(
+                parsed.path,
+                indexRoot,
+                !!parsed.include_files,
+              );
 
             const total = allFolders.length + allFiles.length;
             const offset = parsed.offset ?? 0;
@@ -4455,8 +4482,6 @@ async function connectWithRetry(
         );
         runDetachedListenerTask("get_tree", async () => {
           try {
-            const { readdir } = await import("node:fs/promises");
-
             // Walk the directory tree up to the requested depth, combining
             // file index results with readdir to include non-indexed entries.
             interface TreeEntry {
@@ -4476,85 +4501,37 @@ async function connectWithRetry(
             }
 
             // BFS queue: [absolutePath, relativePath, currentDepth]
+            // Uses an index pointer for O(1) dequeue instead of shift().
             const queue: [string, string, number][] = [[parsed.path, "", 0]];
+            let qi = 0;
 
-            while (queue.length > 0) {
-              const next = queue.shift();
-              if (!next) break;
-              const [absDir, relDir, depth] = next;
+            while (qi < queue.length) {
+              const item = queue[qi++];
+              if (!item) break;
+              const [absDir, relDir, depth] = item;
 
               if (depth >= parsed.depth) {
-                // There are directories at the boundary — deeper content exists
                 if (depth === parsed.depth && relDir !== "") {
                   hasMoreDepth = true;
                 }
                 continue;
               }
 
-              // 1. Query file index for this directory
-              let indexedNames: Set<string> | undefined;
-              const indexedFolders: string[] = [];
-              const indexedFiles: string[] = [];
-              if (indexRoot !== undefined) {
-                const relPath = path.relative(indexRoot, absDir);
-                if (!relPath.startsWith("..")) {
-                  const indexed = searchFileIndex({
-                    searchDir: relPath || ".",
-                    pattern: "",
-                    deep: false,
-                    maxResults: 10000,
-                  });
-                  indexedNames = new Set<string>();
-                  for (const entry of indexed) {
-                    const name = entry.path.split(path.sep).pop() ?? entry.path;
-                    indexedNames.add(name);
-                    if (entry.type === "dir") {
-                      indexedFolders.push(name);
-                    } else {
-                      indexedFiles.push(name);
-                    }
-                  }
-                }
-              }
-
-              // 2. readdir to fill gaps
-              let dirEntries: import("node:fs").Dirent[];
+              let listing: DirListing;
               try {
-                dirEntries = (await readdir(absDir, {
-                  withFileTypes: true,
-                })) as import("node:fs").Dirent[];
+                listing = await listDirectoryHybrid(absDir, indexRoot, true);
               } catch {
                 // Can't read directory — skip
                 continue;
               }
 
-              const extraFolders: string[] = [];
-              const extraFiles: string[] = [];
-              for (const e of dirEntries) {
-                if (DIR_LISTING_IGNORED_NAMES.has(e.name)) continue;
-                if (indexedNames?.has(e.name)) continue;
-                if (e.isDirectory()) {
-                  extraFolders.push(e.name);
-                } else {
-                  extraFiles.push(e.name);
-                }
-              }
-
-              // 3. Merge and collect entries
-              const allFolders = [...indexedFolders, ...extraFolders].sort(
-                (a, b) => a.localeCompare(b),
-              );
-              const allFiles = [...indexedFiles, ...extraFiles].sort((a, b) =>
-                a.localeCompare(b),
-              );
-
-              for (const name of allFolders) {
+              // Relative paths always use '/' (converted to OS separator on the frontend)
+              for (const name of listing.folders) {
                 const entryRel = relDir === "" ? name : `${relDir}/${name}`;
                 results.push({ path: entryRel, type: "dir" });
-                // Enqueue for next depth level
                 queue.push([path.join(absDir, name), entryRel, depth + 1]);
               }
-              for (const name of allFiles) {
+              for (const name of listing.files) {
                 const entryRel = relDir === "" ? name : `${relDir}/${name}`;
                 results.push({ path: entryRel, type: "file" });
               }

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3788,11 +3788,7 @@ export async function startListenerClient(
 }
 
 /** File/directory names filtered from directory listings (OS/VCS noise). */
-const DIR_LISTING_IGNORED_NAMES = new Set([
-  ".DS_Store",
-  ".git",
-  "Thumbs.db",
-]);
+const DIR_LISTING_IGNORED_NAMES = new Set([".DS_Store", ".git", "Thumbs.db"]);
 
 /**
  * Connect to WebSocket with exponential backoff retry.
@@ -4483,7 +4479,9 @@ async function connectWithRetry(
             const queue: [string, string, number][] = [[parsed.path, "", 0]];
 
             while (queue.length > 0) {
-              const [absDir, relDir, depth] = queue.shift()!;
+              const next = queue.shift();
+              if (!next) break;
+              const [absDir, relDir, depth] = next;
 
               if (depth >= parsed.depth) {
                 // There are directories at the boundary — deeper content exists

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -34,6 +34,7 @@ import type {
   ExecuteCommandCommand,
   FileOpsCommand,
   GetReflectionSettingsCommand,
+  GetTreeCommand,
   InputCommand,
   ListInDirectoryCommand,
   ListMemoryCommand,
@@ -305,6 +306,22 @@ export function isListInDirectoryCommand(
   if (!value || typeof value !== "object") return false;
   const c = value as { type?: unknown; path?: unknown };
   return c.type === "list_in_directory" && typeof c.path === "string";
+}
+
+export function isGetTreeCommand(value: unknown): value is GetTreeCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    path?: unknown;
+    depth?: unknown;
+    request_id?: unknown;
+  };
+  return (
+    c.type === "get_tree" &&
+    typeof c.path === "string" &&
+    typeof c.depth === "number" &&
+    typeof c.request_id === "string"
+  );
 }
 
 export function isReadFileCommand(value: unknown): value is ReadFileCommand {
@@ -1261,6 +1278,7 @@ export function parseServerMessage(
       isTerminalKillCommand(parsed) ||
       isSearchFilesCommand(parsed) ||
       isListInDirectoryCommand(parsed) ||
+      isGetTreeCommand(parsed) ||
       isReadFileCommand(parsed) ||
       isWriteFileCommand(parsed) ||
       isWatchFileCommand(parsed) ||


### PR DESCRIPTION
  **Summary**

  - Add get_tree command — a depth-limited subtree fetch that returns up
    to N levels of the directory tree in a single request, replacing
    per-folder list_in_directory roundtrips for the sidebar. This
    minimizes network latency for letta server remote access.
  - Upgrade list_in_directory to a hybrid approach: query the file index
    first (instant, from memory), then readdir to fill gaps from
    .lettaignore'd entries (e.g. node_modules). Both handlers share this
    pattern.
  - Extract DIR_LISTING_IGNORED_NAMES to a shared module-level constant
    (.DS_Store, .git, Thumbs.db).
  - Add refreshFileIndex() calls after write_file and edit_file so the
    file index stays current after mutations.