### PR TITLE
fix(cli): warn when /logout leaves env API key in place

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -263,6 +263,7 @@ import {
   type ReflectionSettings,
 } from "./helpers/memoryReminder";
 import { handleMemorySubagentCompletion } from "./helpers/memorySubagentCompletion";
+import { buildLogoutSuccessMessage } from "./helpers/logoutMessage";
 import {
   type QueuedMessage,
   setMessageQueueAdder,
@@ -8926,7 +8927,7 @@ export default function App({
             await settingsManager.logout();
 
             cmd.finish(
-              "✓ Logged out successfully. Run 'letta' to re-authenticate.",
+              buildLogoutSuccessMessage(Boolean(process.env.LETTA_API_KEY)),
               true,
             );
 

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -256,6 +256,7 @@ import {
   buildInitMessage,
   gatherInitGitContext,
 } from "./helpers/initCommand";
+import { buildLogoutSuccessMessage } from "./helpers/logoutMessage";
 import {
   getReflectionSettings,
   parseMemoryPreference,
@@ -263,7 +264,6 @@ import {
   type ReflectionSettings,
 } from "./helpers/memoryReminder";
 import { handleMemorySubagentCompletion } from "./helpers/memorySubagentCompletion";
-import { buildLogoutSuccessMessage } from "./helpers/logoutMessage";
 import {
   type QueuedMessage,
   setMessageQueueAdder,

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -490,7 +490,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/logout": {
-    desc: "Clear credentials and exit",
+    desc: "Clear saved credentials and exit",
     order: 44,
     noArgs: true,
     handler: () => {

--- a/src/cli/helpers/logoutMessage.ts
+++ b/src/cli/helpers/logoutMessage.ts
@@ -1,0 +1,13 @@
+export function buildLogoutSuccessMessage(hasEnvApiKey: boolean): string {
+  if (!hasEnvApiKey) {
+    return "✓ Logged out successfully. Run 'letta' to re-authenticate.";
+  }
+
+  return [
+    "✓ Cleared saved Letta credentials.",
+    "",
+    "Note: LETTA_API_KEY is still set in your shell or system environment.",
+    "/logout does not clear environment variables. Remove it manually if you",
+    "want to stop authenticating with that key.",
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ EXAMPLES
   /profiles                # Open profile selector
   /pin                     # Pin current profile to project
   /unpin                   # Unpin profile from project
-  /logout                  # Clear credentials and exit
+  /logout                  # Clear saved credentials and exit
 
   # headless with JSON output (includes stats)
   letta -p "hello" --output-format json

--- a/src/tests/cli/logout-command-wiring.test.ts
+++ b/src/tests/cli/logout-command-wiring.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function readAppSource(): string {
+  const appPath = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+  return readFileSync(appPath, "utf-8");
+}
+
+describe("logout command wiring", () => {
+  test("uses a dedicated logout message helper and checks process env", () => {
+    const source = readAppSource();
+
+    expect(source).toContain(
+      'import { buildLogoutSuccessMessage } from "./helpers/logoutMessage";',
+    );
+    expect(source).toContain(
+      "buildLogoutSuccessMessage(Boolean(process.env.LETTA_API_KEY))",
+    );
+  });
+});

--- a/src/tests/cli/logout-message.test.ts
+++ b/src/tests/cli/logout-message.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { buildLogoutSuccessMessage } from "../../cli/helpers/logoutMessage";
+
+describe("buildLogoutSuccessMessage", () => {
+  test("uses the standard success message when no env API key is set", () => {
+    expect(buildLogoutSuccessMessage(false)).toBe(
+      "✓ Logged out successfully. Run 'letta' to re-authenticate.",
+    );
+  });
+
+  test("warns when LETTA_API_KEY remains set in the environment", () => {
+    const message = buildLogoutSuccessMessage(true);
+
+    expect(message).toContain("✓ Cleared saved Letta credentials.");
+    expect(message).toContain("LETTA_API_KEY is still set");
+    expect(message).toContain("/logout does not clear environment variables");
+    expect(message).not.toContain("Run 'letta' to re-authenticate.");
+  });
+});


### PR DESCRIPTION
## Summary
- warn after `/logout` when `LETTA_API_KEY` is still set in the shell or system environment
- clarify command/help text to say `/logout` clears saved credentials, not environment variables
- add focused tests for the logout message helper and wiring in `App.tsx`

Written by Cameron ◯ Letta Code

"The limits of my language mean the limits of my world." — Ludwig Wittgenstein