### PR TITLE
fix: add --no-bin-links on Windows for channel runtime installs

### DIFF
--- a/src/channels/runtimeDeps.ts
+++ b/src/channels/runtimeDeps.ts
@@ -165,17 +165,35 @@ function getPackageManagerExecutable(
   return packageManager;
 }
 
+function resolveInstallPlatform(): NodeJS.Platform {
+  return platformOverride ?? process.platform;
+}
+
 function getInstallArgs(
   packageManager: RuntimePackageManager,
   installPackages: string[],
 ): string[] {
+  // On Windows, npm/pnpm create .bin symlinks (junctions) that break
+  // 7-Zip during Electron/NSIS packaging. --no-bin-links avoids this.
+  const noBinLinks =
+    resolveInstallPlatform() === "win32" && packageManager !== "bun";
+
   switch (packageManager) {
     case "bun":
       return ["add", "--no-save", ...installPackages];
     case "pnpm":
-      return ["add", ...installPackages];
+      return [
+        "add",
+        ...(noBinLinks ? ["--no-bin-links"] : []),
+        ...installPackages,
+      ];
     case "npm":
-      return ["install", "--no-save", ...installPackages];
+      return [
+        "install",
+        "--no-save",
+        ...(noBinLinks ? ["--no-bin-links"] : []),
+        ...installPackages,
+      ];
   }
 }
 

--- a/src/tests/channels/runtimeDeps.test.ts
+++ b/src/tests/channels/runtimeDeps.test.ts
@@ -130,6 +130,7 @@ test("installChannelRuntime writes a manifest and invokes npm in the runtime dir
     runtimeRoot,
     spawnImpl: spawnImpl as never,
     packageManager: "npm",
+    platform: "linux",
   });
 
   await installChannelRuntime("telegram");
@@ -149,7 +150,7 @@ test("installChannelRuntime writes a manifest and invokes npm in the runtime dir
   );
   expect(spawnCalls).toEqual([
     {
-      cmd: expectedPackageManagerCommand("npm"),
+      cmd: "npm",
       args: ["install", "--no-save", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
     },
@@ -213,13 +214,14 @@ test("installChannelRuntime uses pnpm add for pnpm installs", async () => {
     runtimeRoot,
     spawnImpl: spawnImpl as never,
     packageManager: "pnpm",
+    platform: "linux",
   });
 
   await installChannelRuntime("telegram");
 
   expect(spawnCalls).toEqual([
     {
-      cmd: expectedPackageManagerCommand("pnpm"),
+      cmd: "pnpm",
       args: ["add", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
     },

--- a/src/tests/channels/runtimeDeps.test.ts
+++ b/src/tests/channels/runtimeDeps.test.ts
@@ -256,7 +256,7 @@ test("installChannelRuntime uses cmd shims for npm on Windows", async () => {
   expect(spawnCalls).toEqual([
     {
       cmd: "npm.cmd",
-      args: ["install", "--no-save", "grammy@1.42.0"],
+      args: ["install", "--no-save", "--no-bin-links", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
     },
   ]);
@@ -292,7 +292,7 @@ test("installChannelRuntime uses cmd shims for pnpm on Windows", async () => {
   expect(spawnCalls).toEqual([
     {
       cmd: "pnpm.cmd",
-      args: ["add", "grammy@1.42.0"],
+      args: ["add", "--no-bin-links", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
     },
   ]);


### PR DESCRIPTION
On Windows, npm/pnpm create .bin symlinks (junctions) that 7-Zip cannot archive during Electron/NSIS packaging, causing the build to fail with "The directory name is invalid" warnings and exit code 1.

Pass --no-bin-links to npm install and pnpm add when the platform is win32. The .bin shims are unused — the runtime modules are resolved directly via createRequire.

🤖 Generated with [Letta Code](https://letta.com)