### PR TITLE
feat(channels): add Discord channel plugin

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -6,6 +6,7 @@ import {
 } from "./config";
 import type {
   ChannelAccount,
+  DiscordChannelAccount,
   SlackChannelAccount,
   SlackDefaultPermissionMode,
   SupportedChannelId,
@@ -48,7 +49,10 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
         next.displayName === "Migrated Telegram bot")) ||
     (next.channel === "slack" &&
       (next.displayName === "Slack app" ||
-        next.displayName === "Migrated Slack app"))
+        next.displayName === "Migrated Slack app")) ||
+    (next.channel === "discord" &&
+      (next.displayName === "Discord bot" ||
+        next.displayName === "Migrated Discord bot"))
   ) {
     next.displayName = undefined;
   }
@@ -62,7 +66,7 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
 
 function makeDefaultLegacyAccount(
   channelId: SupportedChannelId,
-): TelegramChannelAccount | SlackChannelAccount {
+): ChannelAccount {
   const config = readChannelConfig(channelId);
   const now = new Date().toISOString();
 
@@ -82,6 +86,20 @@ function makeDefaultLegacyAccount(
         agentId: null,
         conversationId: null,
       },
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  if (config.channel === "discord") {
+    return {
+      channel: "discord",
+      accountId: LEGACY_CHANNEL_ACCOUNT_ID,
+      enabled: config.enabled,
+      token: config.token,
+      dmPolicy: config.dmPolicy,
+      allowedUsers: [...config.allowedUsers],
+      agentId: null,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -10,6 +10,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
   ChannelConfig,
+  DiscordChannelConfig,
   DmPolicy,
   SlackChannelConfig,
   TelegramChannelConfig,
@@ -154,11 +155,24 @@ const slackConfigCodec: ChannelConfigCodec<SlackChannelConfig> = {
   },
 };
 
+const discordConfigCodec: ChannelConfigCodec<DiscordChannelConfig> = {
+  parse(parsed) {
+    return {
+      channel: "discord",
+      enabled: parsed.enabled !== false,
+      token: String(parsed.token ?? ""),
+      dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
+      allowedUsers: (parsed.allowed_users as string[]) ?? [],
+    };
+  },
+};
+
 const CHANNEL_CONFIG_CODECS: Partial<
   Record<string, ChannelConfigCodec<ChannelConfig>>
 > = {
   telegram: telegramConfigCodec as ChannelConfigCodec<ChannelConfig>,
   slack: slackConfigCodec as ChannelConfigCodec<ChannelConfig>,
+  discord: discordConfigCodec as ChannelConfigCodec<ChannelConfig>,
 };
 
 function getChannelConfigCodec(

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -1,0 +1,806 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import type {
+  ChannelAdapter,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
+  DiscordChannelAccount,
+  InboundChannelMessage,
+  OutboundChannelMessage,
+} from "../types";
+import {
+  resolveDiscordInboundAttachments,
+  resolveDiscordThreadHistory,
+  resolveDiscordThreadStarter,
+} from "./media";
+import { loadDiscordModule } from "./runtime";
+
+// discord.js is a runtime dependency, not installed at build time.
+// Use structural types instead of direct module imports.
+// biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
+type DiscordClient = any;
+// biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
+type DiscordMessage = any;
+
+const DISCORD_MAX_LENGTH = 2000;
+const DISCORD_SPLIT_THRESHOLD = 1900;
+const INGRESS_DEDUPE_TTL_MS = 60_000;
+const INGRESS_DEDUPE_MAX = 2_000;
+const LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
+const LIFECYCLE_STATE_MAX = 2_000;
+const INITIAL_THREAD_HISTORY_LIMIT = 20;
+
+type LifecycleState = "queued" | "completed" | "error" | "cancelled";
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function splitMessageText(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+    // Try to split at a newline boundary
+    let splitAt = remaining.lastIndexOf("\n", maxLength);
+    if (splitAt <= 0) {
+      splitAt = remaining.lastIndexOf(" ", maxLength);
+    }
+    if (splitAt <= 0) {
+      splitAt = maxLength;
+    }
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+  return chunks;
+}
+
+function normalizeDiscordMentionText(
+  text: string,
+  botUserId: string | null,
+): string {
+  if (!botUserId) return text;
+  return text.replace(new RegExp(`<@!?${botUserId}>\\s*`, "g"), "").trim();
+}
+
+function resolveDiscordChatType(
+  guildId: string | null | undefined,
+): "direct" | "channel" {
+  return guildId ? "channel" : "direct";
+}
+
+/**
+ * Resolve native emoji for Discord reactions.
+ * Discord uses native Unicode emoji directly (not names like Slack).
+ * Strip colons for common named patterns.
+ */
+function resolveDiscordReactionEmoji(value: string): string {
+  const trimmed = value.trim().replace(/^:+|:+$/g, "");
+  // Common name-to-emoji mappings for parity with Slack lifecycle reactions
+  const nameMap: Record<string, string> = {
+    eyes: "👀",
+    white_check_mark: "✅",
+    x: "❌",
+  };
+  return nameMap[trimmed] ?? trimmed;
+}
+
+export async function resolveDiscordAccountDisplayName(
+  token: string,
+): Promise<string | undefined> {
+  const discord = await loadDiscordModule();
+  const client = new discord.Client({
+    intents: [discord.GatewayIntentBits.Guilds],
+  });
+  try {
+    await client.login(token);
+    const tag = client.user?.tag ?? client.user?.username;
+    client.destroy();
+    return tag;
+  } catch {
+    try {
+      client.destroy();
+    } catch {}
+    return undefined;
+  }
+}
+
+export function createDiscordAdapter(
+  config: DiscordChannelAccount,
+): ChannelAdapter {
+  let client: DiscordClient | null = null;
+  let running = false;
+  let botUserId: string | null = null;
+  const knownUserDisplayNames = new Map<string, string>();
+  const seenIngressMessageKeys = new Map<string, number>();
+  const lifecycleStateByMessageKey = new Map<
+    string,
+    { state: LifecycleState; updatedAt: number }
+  >();
+  const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
+
+  function buildIngressMessageKey(
+    channelId: string | undefined,
+    messageId: string | undefined,
+  ): string | null {
+    if (!isNonEmptyString(channelId) || !isNonEmptyString(messageId)) {
+      return null;
+    }
+    return `${channelId}:${messageId}`;
+  }
+
+  function pruneSeenIngressMessageKeys(now: number = Date.now()): void {
+    for (const [key, expiresAt] of seenIngressMessageKeys) {
+      if (expiresAt <= now) {
+        seenIngressMessageKeys.delete(key);
+      }
+    }
+    if (seenIngressMessageKeys.size <= INGRESS_DEDUPE_MAX) {
+      return;
+    }
+    const oldestEntries = Array.from(seenIngressMessageKeys.entries()).sort(
+      (a, b) => a[1] - b[1],
+    );
+    const overflowCount = seenIngressMessageKeys.size - INGRESS_DEDUPE_MAX;
+    for (let index = 0; index < overflowCount; index += 1) {
+      const entry = oldestEntries[index];
+      if (entry) {
+        seenIngressMessageKeys.delete(entry[0]);
+      }
+    }
+  }
+
+  function markIngressMessageSeen(
+    channelId: string | undefined,
+    messageId: string | undefined,
+  ): boolean {
+    const key = buildIngressMessageKey(channelId, messageId);
+    if (!key) return false;
+    const now = Date.now();
+    pruneSeenIngressMessageKeys(now);
+    if (seenIngressMessageKeys.has(key)) return true;
+    seenIngressMessageKeys.set(key, now + INGRESS_DEDUPE_TTL_MS);
+    return false;
+  }
+
+  function getLifecycleMessageKey(source: ChannelTurnSource): string | null {
+    if (
+      source.channel !== "discord" ||
+      !isNonEmptyString(source.chatId) ||
+      !isNonEmptyString(source.messageId)
+    ) {
+      return null;
+    }
+    return `${source.chatId}:${source.messageId}`;
+  }
+
+  function pruneLifecycleState(now: number = Date.now()): void {
+    for (const [key, entry] of lifecycleStateByMessageKey) {
+      if (entry.updatedAt + LIFECYCLE_STATE_TTL_MS <= now) {
+        lifecycleStateByMessageKey.delete(key);
+      }
+    }
+    if (lifecycleStateByMessageKey.size <= LIFECYCLE_STATE_MAX) {
+      return;
+    }
+    const oldestEntries = Array.from(lifecycleStateByMessageKey.entries()).sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt,
+    );
+    const overflowCount = lifecycleStateByMessageKey.size - LIFECYCLE_STATE_MAX;
+    for (let index = 0; index < overflowCount; index += 1) {
+      const entry = oldestEntries[index];
+      if (entry) {
+        lifecycleStateByMessageKey.delete(entry[0]);
+      }
+    }
+  }
+
+  async function sendLifecycleReaction(
+    source: ChannelTurnSource,
+    emoji: string,
+    remove = false,
+  ): Promise<void> {
+    if (!client || !isNonEmptyString(source.messageId)) return;
+    try {
+      const channel = await client.channels.fetch(source.chatId);
+      if (!channel?.isTextBased()) return;
+      const textChannel = channel as {
+        messages: {
+          fetch: (id: string) => Promise<{
+            react: (emoji: string) => Promise<unknown>;
+            reactions: {
+              cache: Map<
+                string,
+                { me: boolean; remove: () => Promise<unknown> }
+              >;
+            };
+          }>;
+        };
+      };
+      const message = await textChannel.messages.fetch(source.messageId);
+      const resolvedEmoji = resolveDiscordReactionEmoji(emoji);
+      if (remove) {
+        // Find our own reaction and remove it
+        for (const [, reaction] of message.reactions.cache) {
+          if (reaction.me) {
+            await reaction.remove();
+          }
+        }
+        return;
+      }
+      await message.react(resolvedEmoji);
+    } catch (error) {
+      console.warn(
+        `[Discord] Failed to ${remove ? "remove" : "add"} lifecycle reaction:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  function scheduleLifecycleTransition(
+    source: ChannelTurnSource,
+    nextState: LifecycleState,
+  ): Promise<void> | null {
+    const key = getLifecycleMessageKey(source);
+    if (!key) return null;
+    const previous =
+      lifecycleOperationByMessageKey.get(key) ?? Promise.resolve();
+    const operation = previous
+      .catch(() => {})
+      .then(async () => {
+        pruneLifecycleState();
+        const currentState = lifecycleStateByMessageKey.get(key)?.state;
+        if (currentState === nextState) {
+          lifecycleStateByMessageKey.set(key, {
+            state: nextState,
+            updatedAt: Date.now(),
+          });
+          return;
+        }
+        if (nextState === "queued") {
+          if (!currentState) {
+            await sendLifecycleReaction(source, "eyes");
+            lifecycleStateByMessageKey.set(key, {
+              state: nextState,
+              updatedAt: Date.now(),
+            });
+          }
+          return;
+        }
+        if (currentState === "queued") {
+          try {
+            await sendLifecycleReaction(source, "eyes", true);
+          } catch {}
+        }
+        await sendLifecycleReaction(
+          source,
+          nextState === "completed" ? "white_check_mark" : "x",
+        );
+        lifecycleStateByMessageKey.set(key, {
+          state: nextState,
+          updatedAt: Date.now(),
+        });
+      })
+      .catch((error) => {
+        console.warn(
+          `[Discord] Failed to update lifecycle reaction for ${key}:`,
+          error instanceof Error ? error.message : error,
+        );
+      })
+      .finally(() => {
+        if (lifecycleOperationByMessageKey.get(key) === operation) {
+          lifecycleOperationByMessageKey.delete(key);
+        }
+      });
+    lifecycleOperationByMessageKey.set(key, operation);
+    return operation;
+  }
+
+  function resolveDisplayName(message: DiscordMessage): string {
+    return (
+      (message.member?.displayName as string | undefined) ??
+      message.author.globalName ??
+      message.author.username
+    );
+  }
+
+  function hasBotMention(message: DiscordMessage): boolean {
+    if (!client?.user) return false;
+    return message.mentions.has(client.user);
+  }
+
+  function isThreadMessage(message: DiscordMessage): boolean {
+    const ch = message.channel as { isThread?: () => boolean };
+    return typeof ch.isThread === "function" && ch.isThread();
+  }
+
+  function getParentChannelId(message: DiscordMessage): string | undefined {
+    const ch = message.channel as { parentId?: string | null };
+    return ch.parentId ?? undefined;
+  }
+
+  async function createThreadForMention(
+    message: DiscordMessage,
+    seedText: string,
+  ): Promise<{ id: string; name?: string } | null> {
+    const normalized = seedText.replace(/<@!?\d+>/g, "").trim();
+    const firstLine = normalized.split("\n")[0]?.trim();
+    const threadName = (
+      firstLine || `${message.author.username} question`
+    ).slice(0, 100);
+    try {
+      const thread = await message.startThread({
+        name: threadName,
+        reason: "letta-code discord mention trigger",
+      });
+      return { id: thread.id, name: thread.name };
+    } catch (error) {
+      console.warn(
+        "[Discord] Failed to create thread for mention:",
+        error instanceof Error ? error.message : error,
+      );
+      return null;
+    }
+  }
+
+  async function collectAttachments(
+    rawAttachments: Map<string, Record<string, unknown>>,
+    chatId: string,
+  ): Promise<InboundChannelMessage["attachments"]> {
+    const list = Array.from(rawAttachments.values());
+    if (list.length === 0) return [];
+    return resolveDiscordInboundAttachments({
+      accountId: config.accountId,
+      rawAttachments: list.map((a: Record<string, unknown>) => ({
+        id: a.id as string,
+        name: (a.name as string) ?? null,
+        contentType: (a.contentType as string) ?? null,
+        size: (a.size as number) ?? 0,
+        url: a.url as string,
+      })),
+      chatId,
+    });
+  }
+
+  const adapter: ChannelAdapter = {
+    id: `discord:${config.accountId}`,
+    channelId: "discord",
+    accountId: config.accountId,
+    name: "Discord",
+
+    async start(): Promise<void> {
+      if (running) return;
+
+      const discord = await loadDiscordModule();
+      const GatewayIntentBits = discord.GatewayIntentBits;
+      const Partials = discord.Partials;
+
+      client = new discord.Client({
+        intents: [
+          GatewayIntentBits.Guilds,
+          GatewayIntentBits.GuildMessages,
+          GatewayIntentBits.GuildMessageReactions,
+          GatewayIntentBits.MessageContent,
+          GatewayIntentBits.DirectMessages,
+          GatewayIntentBits.DirectMessageReactions,
+        ],
+        partials: [
+          Partials.Channel,
+          Partials.Message,
+          Partials.Reaction,
+          Partials.User,
+        ],
+      });
+
+      client.once("ready", () => {
+        botUserId = client?.user?.id ?? null;
+        const tag = client?.user?.tag ?? "(unknown)";
+        console.log(
+          `[Discord] Bot logged in as ${tag} (dm_policy: ${config.dmPolicy})`,
+        );
+        running = true;
+      });
+
+      client.on("messageCreate", async (message: DiscordMessage) => {
+        if (!adapter.onMessage) return;
+
+        // Ignore bot messages (including self)
+        if (message.author.bot) return;
+
+        const content = (message.content ?? "").trim();
+        const userId = message.author.id;
+        if (!userId) return;
+
+        const chatType = resolveDiscordChatType(message.guildId);
+        const isThread = isThreadMessage(message);
+        const wasMentioned = chatType === "channel" && hasBotMention(message);
+
+        // ── DM handling ──────────────────────────────────────────
+        if (chatType === "direct") {
+          if (markIngressMessageSeen(message.channelId, message.id)) return;
+
+          const attachments = await collectAttachments(
+            message.attachments,
+            message.channelId,
+          );
+          if (!content && (!attachments || attachments.length === 0)) return;
+
+          const inbound: InboundChannelMessage = {
+            channel: "discord",
+            accountId: config.accountId,
+            chatId: message.channelId,
+            senderId: userId,
+            senderName: resolveDisplayName(message),
+            text: content,
+            timestamp: message.createdTimestamp,
+            messageId: message.id,
+            threadId: null,
+            chatType: "direct",
+            isMention: false,
+            attachments,
+            raw: message,
+          };
+
+          try {
+            await adapter.onMessage(inbound);
+          } catch (error) {
+            console.error("[Discord] Error handling DM:", error);
+          }
+          return;
+        }
+
+        // ── Guild handling (mention-gated) ───────────────────────
+        // In a thread: always process (agent is already engaged).
+        // Outside a thread: only process @mentions (auto-create thread).
+        if (!isThread && !wasMentioned) return;
+
+        if (markIngressMessageSeen(message.channelId, message.id)) return;
+
+        let effectiveChatId = message.channelId;
+        let effectiveThreadId: string | null = isThread
+          ? message.channelId
+          : null;
+
+        // If mentioned outside a thread, create one
+        if (!isThread && wasMentioned) {
+          const createdThread = await createThreadForMention(message, content);
+          if (!createdThread) return;
+          effectiveChatId = createdThread.id;
+          effectiveThreadId = createdThread.id;
+        }
+
+        const attachments = await collectAttachments(
+          message.attachments,
+          effectiveChatId,
+        );
+        const normalizedText = wasMentioned
+          ? normalizeDiscordMentionText(content, botUserId)
+          : content;
+        if (!normalizedText && (!attachments || attachments.length === 0))
+          return;
+
+        const inbound: InboundChannelMessage = {
+          channel: "discord",
+          accountId: config.accountId,
+          chatId: effectiveChatId,
+          senderId: userId,
+          senderName: resolveDisplayName(message),
+          chatLabel:
+            "name" in message.channel
+              ? (message.channel.name ?? undefined)
+              : undefined,
+          text: normalizedText,
+          timestamp: message.createdTimestamp,
+          messageId: message.id,
+          threadId: effectiveThreadId,
+          chatType: "channel",
+          isMention: wasMentioned,
+          attachments,
+          raw: message,
+        };
+
+        try {
+          await adapter.onMessage(inbound);
+        } catch (error) {
+          console.error("[Discord] Error handling guild message:", error);
+        }
+      });
+
+      // ── Reaction events ──────────────────────────────────────
+      // biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
+      const handleReactionEvent = async (
+        reaction: any,
+        user: any,
+        action: "added" | "removed",
+      ) => {
+        if (!adapter.onMessage) return;
+        // Ignore bot reactions
+        if ("bot" in user && user.bot) return;
+        if (user.id === botUserId) return;
+
+        try {
+          if (reaction.partial) await reaction.fetch();
+          if (reaction.message.partial) await reaction.message.fetch();
+        } catch {
+          return;
+        }
+
+        const msg = reaction.message;
+        const channelId = msg.channelId;
+        if (!channelId) return;
+
+        const emoji = reaction.emoji.id
+          ? reaction.emoji.toString()
+          : (reaction.emoji.name ?? reaction.emoji.toString());
+        if (!emoji) return;
+
+        const chatType = resolveDiscordChatType(msg.guildId);
+        const isThread =
+          msg.channel &&
+          "isThread" in msg.channel &&
+          typeof msg.channel.isThread === "function" &&
+          msg.channel.isThread();
+
+        // In guilds, only react on messages in threads we're tracking
+        if (chatType === "channel" && !isThread) return;
+
+        const inbound: InboundChannelMessage = {
+          channel: "discord",
+          accountId: config.accountId,
+          chatId: channelId,
+          senderId: user.id,
+          senderName:
+            "username" in user ? (user.username ?? undefined) : undefined,
+          text: "",
+          timestamp: Date.now(),
+          messageId: msg.id,
+          threadId: isThread ? channelId : null,
+          chatType,
+          isMention: false,
+          reaction: {
+            action,
+            emoji,
+            targetMessageId: msg.id,
+            targetSenderId: msg.author?.id,
+          },
+          raw: { reaction, user },
+        };
+
+        try {
+          await adapter.onMessage(inbound);
+        } catch (error) {
+          console.error(`[Discord] Error handling reaction ${action}:`, error);
+        }
+      };
+
+      client.on(
+        "messageReactionAdd",
+        async (reaction: unknown, user: unknown) => {
+          await handleReactionEvent(reaction, user, "added");
+        },
+      );
+
+      client.on(
+        "messageReactionRemove",
+        async (reaction: unknown, user: unknown) => {
+          await handleReactionEvent(reaction, user, "removed");
+        },
+      );
+
+      client.on("error", (err: unknown) => {
+        console.error("[Discord] Client error:", err);
+      });
+
+      await client.login(config.token);
+    },
+
+    async stop(): Promise<void> {
+      if (!running || !client) return;
+      client.destroy();
+      client = null;
+      running = false;
+      botUserId = null;
+      seenIngressMessageKeys.clear();
+      lifecycleStateByMessageKey.clear();
+      lifecycleOperationByMessageKey.clear();
+      console.log("[Discord] Bot stopped");
+    },
+
+    isRunning(): boolean {
+      return running;
+    },
+
+    async handleTurnLifecycleEvent(
+      event: ChannelTurnLifecycleEvent,
+    ): Promise<void> {
+      if (!running) return;
+      if (event.type === "queued") {
+        await scheduleLifecycleTransition(event.source, "queued");
+        return;
+      }
+      if (event.type === "processing") return;
+      const nextState: LifecycleState =
+        event.outcome === "completed"
+          ? "completed"
+          : event.outcome === "cancelled"
+            ? "cancelled"
+            : "error";
+      await Promise.all(
+        event.sources.map((source) =>
+          scheduleLifecycleTransition(source, nextState),
+        ),
+      );
+    },
+
+    async sendMessage(
+      msg: OutboundChannelMessage,
+    ): Promise<{ messageId: string }> {
+      if (!client) throw new Error("Discord not started");
+
+      // Handle reactions
+      if (msg.reaction) {
+        const targetMessageId = msg.targetMessageId ?? msg.replyToMessageId;
+        if (!targetMessageId) {
+          throw new Error("Discord reactions require a target message ID.");
+        }
+        const emoji = resolveDiscordReactionEmoji(msg.reaction);
+        const channel = await client.channels.fetch(msg.chatId);
+        if (!channel?.isTextBased()) {
+          throw new Error(
+            `Discord channel not found or not text-based: ${msg.chatId}`,
+          );
+        }
+        const textChannel = channel as {
+          messages: {
+            fetch: (id: string) => Promise<{
+              react: (emoji: string) => Promise<unknown>;
+              reactions: {
+                resolve: (emoji: string) => {
+                  users: { remove: (id: string) => Promise<unknown> };
+                } | null;
+              };
+            }>;
+          };
+        };
+        const message = await textChannel.messages.fetch(targetMessageId);
+        if (msg.removeReaction) {
+          const resolved = message.reactions.resolve(emoji);
+          if (resolved && botUserId) {
+            await resolved.users.remove(botUserId);
+          }
+        } else {
+          await message.react(emoji);
+        }
+        return { messageId: targetMessageId };
+      }
+
+      // Handle file uploads
+      if (msg.mediaPath) {
+        const targetChannelId = msg.threadId ?? msg.chatId;
+        const channel = await client.channels.fetch(targetChannelId);
+        if (!channel || !channel.isTextBased() || !("send" in channel)) {
+          throw new Error(
+            `Discord channel not found or not text-based: ${targetChannelId}`,
+          );
+        }
+        const sendable = channel as {
+          send: (options: Record<string, unknown>) => Promise<{ id: string }>;
+        };
+        const result = await sendable.send({
+          content: msg.text?.trim() || undefined,
+          files: [
+            {
+              attachment: msg.mediaPath,
+              name: msg.fileName ?? basename(msg.mediaPath),
+            },
+          ],
+        });
+        return { messageId: result.id };
+      }
+
+      // Handle text messages
+      const targetChannelId = msg.threadId ?? msg.chatId;
+      const channel = await client.channels.fetch(targetChannelId);
+      if (!channel || !channel.isTextBased() || !("send" in channel)) {
+        throw new Error(
+          `Discord channel not found or not text-based: ${targetChannelId}`,
+        );
+      }
+      const sendable = channel as {
+        send: (content: string) => Promise<{ id: string }>;
+      };
+      const chunks = splitMessageText(msg.text, DISCORD_SPLIT_THRESHOLD);
+      let lastMessageId = "";
+      for (const chunk of chunks) {
+        const result = await sendable.send(chunk);
+        lastMessageId = result.id;
+      }
+      return { messageId: lastMessageId };
+    },
+
+    async sendDirectReply(
+      chatId: string,
+      text: string,
+      options?: { replyToMessageId?: string },
+    ): Promise<void> {
+      if (!client) throw new Error("Discord not started");
+      const channel = await client.channels.fetch(chatId);
+      if (!channel || !channel.isTextBased() || !("send" in channel)) {
+        return;
+      }
+      const sendable = channel as {
+        send: (content: string) => Promise<unknown>;
+      };
+      await sendable.send(text);
+    },
+
+    async prepareInboundMessage(
+      msg: InboundChannelMessage,
+      options?: { isFirstRouteTurn?: boolean },
+    ): Promise<InboundChannelMessage> {
+      if (
+        !options?.isFirstRouteTurn ||
+        msg.channel !== "discord" ||
+        msg.chatType !== "channel" ||
+        !isNonEmptyString(msg.threadId) ||
+        !client
+      ) {
+        return msg;
+      }
+
+      const starter = await resolveDiscordThreadStarter({
+        client,
+        threadChannelId: msg.threadId,
+      });
+      const history = await resolveDiscordThreadHistory({
+        client,
+        threadChannelId: msg.threadId,
+        currentMessageId: msg.messageId,
+        limit: INITIAL_THREAD_HISTORY_LIMIT,
+      });
+
+      if (!starter && history.length === 0) {
+        return msg;
+      }
+
+      const label = msg.chatLabel
+        ? `Discord thread in ${msg.chatLabel}`
+        : `Discord thread ${msg.chatId}`;
+
+      return {
+        ...msg,
+        threadContext: {
+          label,
+          ...(starter
+            ? {
+                starter: {
+                  messageId: starter.id,
+                  senderId: starter.userId ?? starter.botId,
+                  text: starter.text,
+                },
+              }
+            : {}),
+          ...(history.length > 0
+            ? {
+                history: history.map((entry) => ({
+                  messageId: entry.id,
+                  senderId: entry.userId ?? entry.botId,
+                  text: entry.text,
+                })),
+              }
+            : {}),
+        },
+      };
+    },
+
+    onMessage: undefined,
+  };
+
+  return adapter;
+}

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -81,14 +81,33 @@ function resolveDiscordChatType(
  * Strip colons for common named patterns.
  */
 function resolveDiscordReactionEmoji(value: string): string {
-  const trimmed = value.trim().replace(/^:+|:+$/g, "");
+  const trimmed = value.trim();
+  if (trimmed.startsWith("<:") || trimmed.startsWith("<a:")) {
+    return trimmed;
+  }
+  const normalized = trimmed.replace(/^:+|:+$/g, "");
   // Common name-to-emoji mappings for parity with Slack lifecycle reactions
   const nameMap: Record<string, string> = {
     eyes: "👀",
     white_check_mark: "✅",
     x: "❌",
   };
-  return nameMap[trimmed] ?? trimmed;
+  return nameMap[normalized] ?? normalized;
+}
+
+function buildDiscordReplyOptions(
+  replyToMessageId: string | undefined,
+  channelId: string,
+): { reply: { messageReference: string } } | undefined {
+  const trimmed = replyToMessageId?.trim();
+  if (!trimmed || trimmed === channelId) {
+    return undefined;
+  }
+  return {
+    reply: {
+      messageReference: trimmed,
+    },
+  };
 }
 
 export async function resolveDiscordAccountDisplayName(
@@ -650,10 +669,11 @@ export function createDiscordAdapter(
           throw new Error("Discord reactions require a target message ID.");
         }
         const emoji = resolveDiscordReactionEmoji(msg.reaction);
-        const channel = await client.channels.fetch(msg.chatId);
+        const targetChannelId = msg.threadId ?? msg.chatId;
+        const channel = await client.channels.fetch(targetChannelId);
         if (!channel?.isTextBased()) {
           throw new Error(
-            `Discord channel not found or not text-based: ${msg.chatId}`,
+            `Discord channel not found or not text-based: ${targetChannelId}`,
           );
         }
         const textChannel = channel as {
@@ -689,11 +709,16 @@ export function createDiscordAdapter(
             `Discord channel not found or not text-based: ${targetChannelId}`,
           );
         }
+        const reply = buildDiscordReplyOptions(
+          msg.replyToMessageId,
+          targetChannelId,
+        );
         const sendable = channel as {
           send: (options: Record<string, unknown>) => Promise<{ id: string }>;
         };
         const result = await sendable.send({
           content: msg.text?.trim() || undefined,
+          ...(reply ?? {}),
           files: [
             {
               attachment: msg.mediaPath,
@@ -712,13 +737,22 @@ export function createDiscordAdapter(
           `Discord channel not found or not text-based: ${targetChannelId}`,
         );
       }
+      const reply = buildDiscordReplyOptions(
+        msg.replyToMessageId,
+        targetChannelId,
+      );
       const sendable = channel as {
-        send: (content: string) => Promise<{ id: string }>;
+        send: (
+          options: string | Record<string, unknown>,
+        ) => Promise<{ id: string }>;
       };
       const chunks = splitMessageText(msg.text, DISCORD_SPLIT_THRESHOLD);
       let lastMessageId = "";
       for (const chunk of chunks) {
-        const result = await sendable.send(chunk);
+        const result = await sendable.send({
+          content: chunk,
+          ...(reply ?? {}),
+        });
         lastMessageId = result.id;
       }
       return { messageId: lastMessageId };
@@ -734,10 +768,14 @@ export function createDiscordAdapter(
       if (!channel || !channel.isTextBased() || !("send" in channel)) {
         return;
       }
+      const reply = buildDiscordReplyOptions(options?.replyToMessageId, chatId);
       const sendable = channel as {
-        send: (content: string) => Promise<unknown>;
+        send: (content: string | Record<string, unknown>) => Promise<unknown>;
       };
-      await sendable.send(text);
+      await sendable.send({
+        content: text,
+        ...(reply ?? {}),
+      });
     },
 
     async prepareInboundMessage(

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { basename, extname } from "node:path";
+import { basename } from "node:path";
 import type {
   ChannelAdapter,
   ChannelTurnLifecycleEvent,
@@ -13,14 +12,131 @@ import {
   resolveDiscordThreadHistory,
   resolveDiscordThreadStarter,
 } from "./media";
-import { loadDiscordModule } from "./runtime";
+import { type DiscordRuntimeModuleLike, loadDiscordModule } from "./runtime";
 
-// discord.js is a runtime dependency, not installed at build time.
-// Use structural types instead of direct module imports.
-// biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
-type DiscordClient = any;
-// biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
-type DiscordMessage = any;
+type DiscordEventHandlerResult = void | Promise<void>;
+
+interface DiscordUserLike {
+  id: string;
+  username?: string | null;
+  globalName?: string | null;
+  tag?: string | null;
+  bot?: boolean;
+}
+
+interface DiscordGuildMemberLike {
+  displayName?: string | null;
+}
+
+interface DiscordAttachmentLike {
+  id: string;
+  name?: string | null;
+  contentType?: string | null;
+  size?: number;
+  url: string;
+}
+
+interface DiscordMentionsLike {
+  has: (user: DiscordUserLike | null | undefined) => boolean;
+}
+
+interface DiscordReactionResolutionLike {
+  me?: boolean;
+  remove?: () => Promise<unknown>;
+  users: {
+    remove: (userId: string) => Promise<unknown>;
+  };
+}
+
+interface DiscordReactionStoreLike {
+  cache: Map<string, DiscordReactionResolutionLike>;
+  resolve?: (emoji: string) => DiscordReactionResolutionLike | null;
+}
+
+interface DiscordFetchedMessageLike {
+  id: string;
+  content?: string | null;
+  author?: DiscordUserLike;
+  partial?: boolean;
+  fetch?: () => Promise<DiscordFetchedMessageLike>;
+  react: (emoji: string) => Promise<unknown>;
+  reactions: DiscordReactionStoreLike;
+}
+
+interface DiscordThreadLike {
+  id: string;
+  name?: string | null;
+}
+
+interface DiscordChannelLike {
+  name?: string | null;
+  parentId?: string | null;
+  isTextBased?: () => boolean;
+  isThread?: () => boolean;
+  send?: (options: string | Record<string, unknown>) => Promise<{ id: string }>;
+  messages?: {
+    fetch: (id: string) => Promise<DiscordFetchedMessageLike>;
+  };
+}
+
+interface DiscordMessageLike extends DiscordFetchedMessageLike {
+  channelId: string;
+  guildId?: string | null;
+  author: DiscordUserLike;
+  member?: DiscordGuildMemberLike | null;
+  channel: DiscordChannelLike;
+  mentions: DiscordMentionsLike;
+  attachments: Map<string, DiscordAttachmentLike>;
+  createdTimestamp: number;
+  startThread: (options: {
+    name: string;
+    reason?: string;
+  }) => Promise<DiscordThreadLike>;
+}
+
+interface DiscordReactionLike {
+  partial?: boolean;
+  fetch: () => Promise<unknown>;
+  message: DiscordMessageLike;
+  emoji: {
+    id?: string | null;
+    name?: string | null;
+    toString: () => string;
+  };
+}
+
+interface DiscordEventHandlerMap {
+  ready: () => DiscordEventHandlerResult;
+  messageCreate: (message: DiscordMessageLike) => DiscordEventHandlerResult;
+  messageReactionAdd: (
+    reaction: DiscordReactionLike,
+    user: DiscordUserLike,
+  ) => DiscordEventHandlerResult;
+  messageReactionRemove: (
+    reaction: DiscordReactionLike,
+    user: DiscordUserLike,
+  ) => DiscordEventHandlerResult;
+  error: (error: unknown) => DiscordEventHandlerResult;
+}
+
+interface DiscordClient {
+  user?: DiscordUserLike | null;
+  channels: {
+    fetch: (id: string) => Promise<DiscordChannelLike | null>;
+  };
+  once<K extends keyof DiscordEventHandlerMap>(
+    event: K,
+    handler: DiscordEventHandlerMap[K],
+  ): DiscordClient;
+  on<K extends keyof DiscordEventHandlerMap>(
+    event: K,
+    handler: DiscordEventHandlerMap[K],
+  ): DiscordClient;
+  login: (token: string) => Promise<unknown>;
+  destroy: () => void;
+}
+
+type DiscordMessage = DiscordMessageLike;
 
 const DISCORD_MAX_LENGTH = 2000;
 const DISCORD_SPLIT_THRESHOLD = 1900;
@@ -34,6 +150,38 @@ type LifecycleState = "queued" | "completed" | "error" | "cancelled";
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function isDiscordTextChannel(
+  channel: DiscordChannelLike | null,
+): channel is DiscordChannelLike & {
+  isTextBased: () => boolean;
+} {
+  return typeof channel?.isTextBased === "function" && channel.isTextBased();
+}
+
+function hasDiscordMessageFetcher(
+  channel: DiscordChannelLike | null,
+): channel is DiscordChannelLike & {
+  isTextBased: () => boolean;
+  messages: {
+    fetch: (id: string) => Promise<DiscordFetchedMessageLike>;
+  };
+} {
+  return (
+    isDiscordTextChannel(channel) &&
+    !!channel.messages &&
+    typeof channel.messages.fetch === "function"
+  );
+}
+
+function isDiscordSendableChannel(
+  channel: DiscordChannelLike | null,
+): channel is DiscordChannelLike & {
+  isTextBased: () => boolean;
+  send: (options: string | Record<string, unknown>) => Promise<{ id: string }>;
+} {
+  return isDiscordTextChannel(channel) && typeof channel.send === "function";
 }
 
 function splitMessageText(text: string, maxLength: number): string[] {
@@ -116,12 +264,12 @@ export async function resolveDiscordAccountDisplayName(
   const discord = await loadDiscordModule();
   const client = new discord.Client({
     intents: [discord.GatewayIntentBits.Guilds],
-  });
+  }) as DiscordClient;
   try {
     await client.login(token);
     const tag = client.user?.tag ?? client.user?.username;
     client.destroy();
-    return tag;
+    return tag ?? undefined;
   } catch {
     try {
       client.destroy();
@@ -228,21 +376,8 @@ export function createDiscordAdapter(
     if (!client || !isNonEmptyString(source.messageId)) return;
     try {
       const channel = await client.channels.fetch(source.chatId);
-      if (!channel?.isTextBased()) return;
-      const textChannel = channel as {
-        messages: {
-          fetch: (id: string) => Promise<{
-            react: (emoji: string) => Promise<unknown>;
-            reactions: {
-              cache: Map<
-                string,
-                { me: boolean; remove: () => Promise<unknown> }
-              >;
-            };
-          }>;
-        };
-      };
-      const message = await textChannel.messages.fetch(source.messageId);
+      if (!hasDiscordMessageFetcher(channel)) return;
+      const message = await channel.messages.fetch(source.messageId);
       const resolvedEmoji = resolveDiscordReactionEmoji(emoji);
       if (remove) {
         const resolved =
@@ -327,7 +462,8 @@ export function createDiscordAdapter(
     return (
       (message.member?.displayName as string | undefined) ??
       message.author.globalName ??
-      message.author.username
+      message.author.username ??
+      message.author.id
     );
   }
 
@@ -360,7 +496,7 @@ export function createDiscordAdapter(
         name: threadName,
         reason: "letta-code discord mention trigger",
       });
-      return { id: thread.id, name: thread.name };
+      return { id: thread.id, name: thread.name ?? undefined };
     } catch (error) {
       console.warn(
         "[Discord] Failed to create thread for mention:",
@@ -371,19 +507,19 @@ export function createDiscordAdapter(
   }
 
   async function collectAttachments(
-    rawAttachments: Map<string, Record<string, unknown>>,
+    rawAttachments: Map<string, DiscordAttachmentLike>,
     chatId: string,
   ): Promise<InboundChannelMessage["attachments"]> {
     const list = Array.from(rawAttachments.values());
     if (list.length === 0) return [];
     return resolveDiscordInboundAttachments({
       accountId: config.accountId,
-      rawAttachments: list.map((a: Record<string, unknown>) => ({
-        id: a.id as string,
-        name: (a.name as string) ?? null,
-        contentType: (a.contentType as string) ?? null,
-        size: (a.size as number) ?? 0,
-        url: a.url as string,
+      rawAttachments: list.map((a) => ({
+        id: a.id,
+        name: a.name ?? null,
+        contentType: a.contentType ?? null,
+        size: a.size ?? 0,
+        url: a.url,
       })),
       chatId,
     });
@@ -398,7 +534,7 @@ export function createDiscordAdapter(
     async start(): Promise<void> {
       if (running) return;
 
-      const discord = await loadDiscordModule();
+      const discord: DiscordRuntimeModuleLike = await loadDiscordModule();
       const GatewayIntentBits = discord.GatewayIntentBits;
       const Partials = discord.Partials;
 
@@ -417,7 +553,7 @@ export function createDiscordAdapter(
           Partials.Reaction,
           Partials.User,
         ],
-      });
+      }) as DiscordClient;
 
       client.once("ready", () => {
         botUserId = client?.user?.id ?? null;
@@ -535,20 +671,19 @@ export function createDiscordAdapter(
       });
 
       // ── Reaction events ──────────────────────────────────────
-      // biome-ignore lint/suspicious/noExplicitAny: runtime-loaded discord.js types
       const handleReactionEvent = async (
-        reaction: any,
-        user: any,
+        reaction: DiscordReactionLike,
+        user: DiscordUserLike,
         action: "added" | "removed",
       ) => {
         if (!adapter.onMessage) return;
         // Ignore bot reactions
-        if ("bot" in user && user.bot) return;
+        if (user.bot) return;
         if (user.id === botUserId) return;
 
         try {
           if (reaction.partial) await reaction.fetch();
-          if (reaction.message.partial) await reaction.message.fetch();
+          if (reaction.message.partial) await reaction.message.fetch?.();
         } catch {
           return;
         }
@@ -577,8 +712,7 @@ export function createDiscordAdapter(
           accountId: config.accountId,
           chatId: channelId,
           senderId: user.id,
-          senderName:
-            "username" in user ? (user.username ?? undefined) : undefined,
+          senderName: user.username ?? undefined,
           text: "",
           timestamp: Date.now(),
           messageId: msg.id,
@@ -603,14 +737,14 @@ export function createDiscordAdapter(
 
       client.on(
         "messageReactionAdd",
-        async (reaction: unknown, user: unknown) => {
+        async (reaction: DiscordReactionLike, user: DiscordUserLike) => {
           await handleReactionEvent(reaction, user, "added");
         },
       );
 
       client.on(
         "messageReactionRemove",
-        async (reaction: unknown, user: unknown) => {
+        async (reaction: DiscordReactionLike, user: DiscordUserLike) => {
           await handleReactionEvent(reaction, user, "removed");
         },
       );
@@ -674,26 +808,14 @@ export function createDiscordAdapter(
         const emoji = resolveDiscordReactionEmoji(msg.reaction);
         const targetChannelId = msg.threadId ?? msg.chatId;
         const channel = await client.channels.fetch(targetChannelId);
-        if (!channel?.isTextBased()) {
+        if (!hasDiscordMessageFetcher(channel)) {
           throw new Error(
             `Discord channel not found or not text-based: ${targetChannelId}`,
           );
         }
-        const textChannel = channel as {
-          messages: {
-            fetch: (id: string) => Promise<{
-              react: (emoji: string) => Promise<unknown>;
-              reactions: {
-                resolve: (emoji: string) => {
-                  users: { remove: (id: string) => Promise<unknown> };
-                } | null;
-              };
-            }>;
-          };
-        };
-        const message = await textChannel.messages.fetch(targetMessageId);
+        const message = await channel.messages.fetch(targetMessageId);
         if (msg.removeReaction) {
-          const resolved = message.reactions.resolve(emoji);
+          const resolved = message.reactions.resolve?.(emoji) ?? null;
           if (resolved && botUserId) {
             await resolved.users.remove(botUserId);
           }
@@ -707,7 +829,7 @@ export function createDiscordAdapter(
       if (msg.mediaPath) {
         const targetChannelId = msg.threadId ?? msg.chatId;
         const channel = await client.channels.fetch(targetChannelId);
-        if (!channel || !channel.isTextBased() || !("send" in channel)) {
+        if (!isDiscordSendableChannel(channel)) {
           throw new Error(
             `Discord channel not found or not text-based: ${targetChannelId}`,
           );
@@ -716,10 +838,7 @@ export function createDiscordAdapter(
           msg.replyToMessageId,
           targetChannelId,
         );
-        const sendable = channel as {
-          send: (options: Record<string, unknown>) => Promise<{ id: string }>;
-        };
-        const result = await sendable.send({
+        const result = await channel.send({
           content: msg.text?.trim() || undefined,
           ...(reply ?? {}),
           files: [
@@ -735,7 +854,7 @@ export function createDiscordAdapter(
       // Handle text messages
       const targetChannelId = msg.threadId ?? msg.chatId;
       const channel = await client.channels.fetch(targetChannelId);
-      if (!channel || !channel.isTextBased() || !("send" in channel)) {
+      if (!isDiscordSendableChannel(channel)) {
         throw new Error(
           `Discord channel not found or not text-based: ${targetChannelId}`,
         );
@@ -744,15 +863,10 @@ export function createDiscordAdapter(
         msg.replyToMessageId,
         targetChannelId,
       );
-      const sendable = channel as {
-        send: (
-          options: string | Record<string, unknown>,
-        ) => Promise<{ id: string }>;
-      };
       const chunks = splitMessageText(msg.text, DISCORD_SPLIT_THRESHOLD);
       let lastMessageId = "";
       for (const chunk of chunks) {
-        const result = await sendable.send({
+        const result = await channel.send({
           content: chunk,
           ...(reply ?? {}),
         });
@@ -768,14 +882,11 @@ export function createDiscordAdapter(
     ): Promise<void> {
       if (!client) throw new Error("Discord not started");
       const channel = await client.channels.fetch(chatId);
-      if (!channel || !channel.isTextBased() || !("send" in channel)) {
+      if (!isDiscordSendableChannel(channel)) {
         return;
       }
       const reply = buildDiscordReplyOptions(options?.replyToMessageId, chatId);
-      const sendable = channel as {
-        send: (content: string | Record<string, unknown>) => Promise<unknown>;
-      };
-      await sendable.send({
+      await channel.send({
         content: text,
         ...(reply ?? {}),
       });

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -284,7 +284,6 @@ export function createDiscordAdapter(
   let client: DiscordClient | null = null;
   let running = false;
   let botUserId: string | null = null;
-  const knownUserDisplayNames = new Map<string, string>();
   const seenIngressMessageKeys = new Map<string, number>();
   const lifecycleStateByMessageKey = new Map<
     string,
@@ -475,11 +474,6 @@ export function createDiscordAdapter(
   function isThreadMessage(message: DiscordMessage): boolean {
     const ch = message.channel as { isThread?: () => boolean };
     return typeof ch.isThread === "function" && ch.isThread();
-  }
-
-  function getParentChannelId(message: DiscordMessage): string | undefined {
-    const ch = message.channel as { parentId?: string | null };
-    return ch.parentId ?? undefined;
   }
 
   async function createThreadForMention(

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -245,11 +245,13 @@ export function createDiscordAdapter(
       const message = await textChannel.messages.fetch(source.messageId);
       const resolvedEmoji = resolveDiscordReactionEmoji(emoji);
       if (remove) {
-        // Find our own reaction and remove it
-        for (const [, reaction] of message.reactions.cache) {
-          if (reaction.me) {
-            await reaction.remove();
-          }
+        const resolved =
+          "resolve" in message.reactions &&
+          typeof message.reactions.resolve === "function"
+            ? message.reactions.resolve(resolvedEmoji)
+            : null;
+        if (resolved && botUserId) {
+          await resolved.users.remove(botUserId);
         }
         return;
       }
@@ -474,9 +476,10 @@ export function createDiscordAdapter(
           return;
         }
 
-        // ── Guild handling (mention-gated) ───────────────────────
-        // In a thread: always process (agent is already engaged).
+        // ── Guild handling ────────────────────────────────────────
         // Outside a thread: only process @mentions (auto-create thread).
+        // Inside a thread: surface messages and let the registry decide whether
+        // the thread is already routed, or whether a new mention is required.
         if (!isThread && !wasMentioned) return;
 
         if (markIngressMessageSeen(message.channelId, message.id)) return;

--- a/src/channels/discord/media.ts
+++ b/src/channels/discord/media.ts
@@ -1,0 +1,194 @@
+import { mkdirSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, extname, join } from "node:path";
+import type { ChannelMessageAttachment } from "../types";
+
+const DISCORD_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 15_000;
+const DISCORD_ATTACHMENTS_DIR = join(tmpdir(), "letta-discord-attachments");
+
+function ensureAttachmentsDir(): string {
+  mkdirSync(DISCORD_ATTACHMENTS_DIR, { recursive: true });
+  return DISCORD_ATTACHMENTS_DIR;
+}
+
+function resolveAttachmentKind(
+  contentType: string | null | undefined,
+): "image" | "audio" | "video" | "file" {
+  if (!contentType) return "file";
+  if (contentType.startsWith("image/")) return "image";
+  if (contentType.startsWith("audio/")) return "audio";
+  if (contentType.startsWith("video/")) return "video";
+  return "file";
+}
+
+interface DiscordRawAttachment {
+  id: string;
+  name: string | null;
+  contentType: string | null;
+  size: number;
+  url: string;
+}
+
+export async function resolveDiscordInboundAttachments(params: {
+  accountId: string;
+  rawAttachments: DiscordRawAttachment[];
+  chatId: string;
+}): Promise<ChannelMessageAttachment[]> {
+  if (params.rawAttachments.length === 0) {
+    return [];
+  }
+
+  const dir = ensureAttachmentsDir();
+  const results: ChannelMessageAttachment[] = [];
+
+  for (const attachment of params.rawAttachments) {
+    const name = attachment.name ?? `attachment-${attachment.id}`;
+    const kind = resolveAttachmentKind(attachment.contentType);
+    const localFileName = `${params.accountId}-${params.chatId}-${attachment.id}-${name}`;
+    const localPath = join(dir, localFileName);
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(),
+        DISCORD_ATTACHMENT_DOWNLOAD_TIMEOUT_MS,
+      );
+      const response = await fetch(attachment.url, {
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      if (!response.ok) {
+        console.warn(
+          `[Discord] Failed to download attachment ${name}: HTTP ${response.status}`,
+        );
+        continue;
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+      await writeFile(localPath, buffer);
+
+      const entry: ChannelMessageAttachment = {
+        id: attachment.id,
+        name,
+        mimeType: attachment.contentType ?? undefined,
+        sizeBytes: attachment.size,
+        kind,
+        localPath,
+      };
+
+      // Encode images as base64 for vision
+      if (kind === "image" && attachment.contentType?.startsWith("image/")) {
+        entry.imageDataBase64 = buffer.toString("base64");
+      }
+
+      results.push(entry);
+    } catch (error) {
+      console.warn(
+        `[Discord] Failed to download attachment ${name}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  return results;
+}
+
+interface DiscordThreadMessage {
+  id: string;
+  userId?: string;
+  botId?: string;
+  text: string;
+}
+
+/**
+ * Fetch the starter message for a Discord thread.
+ * In Discord, threads have a "starter message" that is the parent message.
+ */
+export async function resolveDiscordThreadStarter(params: {
+  client: { channels: { fetch: (id: string) => Promise<unknown> } };
+  threadChannelId: string;
+}): Promise<DiscordThreadMessage | null> {
+  try {
+    const channel = (await params.client.channels.fetch(
+      params.threadChannelId,
+    )) as {
+      isThread?: () => boolean;
+      fetchStarterMessage?: () => Promise<{
+        id: string;
+        author?: { id?: string; bot?: boolean };
+        content?: string;
+      } | null>;
+    } | null;
+
+    if (!channel?.isThread?.() || !channel.fetchStarterMessage) {
+      return null;
+    }
+
+    const starter = await channel.fetchStarterMessage();
+    if (!starter) {
+      return null;
+    }
+
+    return {
+      id: starter.id,
+      userId: starter.author?.bot ? undefined : starter.author?.id,
+      botId: starter.author?.bot ? starter.author?.id : undefined,
+      text: starter.content ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch recent thread history for first-turn context hydration.
+ */
+export async function resolveDiscordThreadHistory(params: {
+  client: { channels: { fetch: (id: string) => Promise<unknown> } };
+  threadChannelId: string;
+  currentMessageId?: string;
+  limit?: number;
+}): Promise<DiscordThreadMessage[]> {
+  const limit = params.limit ?? 20;
+  try {
+    const channel = (await params.client.channels.fetch(
+      params.threadChannelId,
+    )) as {
+      isThread?: () => boolean;
+      messages?: {
+        fetch: (opts: { limit: number; before?: string }) => Promise<
+          Map<
+            string,
+            {
+              id: string;
+              author?: { id?: string; bot?: boolean };
+              content?: string;
+            }
+          >
+        >;
+      };
+    } | null;
+
+    if (!channel?.isThread?.() || !channel.messages) {
+      return [];
+    }
+
+    const messages = await channel.messages.fetch({
+      limit,
+      ...(params.currentMessageId ? { before: params.currentMessageId } : {}),
+    });
+
+    return Array.from(messages.values())
+      .reverse()
+      .map((msg) => ({
+        id: msg.id,
+        userId: msg.author?.bot ? undefined : msg.author?.id,
+        botId: msg.author?.bot ? msg.author?.id : undefined,
+        text: msg.content ?? "",
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/src/channels/discord/media.ts
+++ b/src/channels/discord/media.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, extname, join } from "node:path";
+import { join } from "node:path";
 import type { ChannelMessageAttachment } from "../types";
 
 const DISCORD_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 15_000;

--- a/src/channels/discord/media.ts
+++ b/src/channels/discord/media.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -6,10 +7,18 @@ import type { ChannelMessageAttachment } from "../types";
 
 const DISCORD_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 15_000;
 const DISCORD_ATTACHMENTS_DIR = join(tmpdir(), "letta-discord-attachments");
+const MAX_DISCORD_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 function ensureAttachmentsDir(): string {
   mkdirSync(DISCORD_ATTACHMENTS_DIR, { recursive: true });
   return DISCORD_ATTACHMENTS_DIR;
+}
+
+function sanitizeDiscordPathSegment(input: string): string {
+  const cleaned = input
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "attachment";
 }
 
 function resolveAttachmentKind(
@@ -45,7 +54,14 @@ export async function resolveDiscordInboundAttachments(params: {
   for (const attachment of params.rawAttachments) {
     const name = attachment.name ?? `attachment-${attachment.id}`;
     const kind = resolveAttachmentKind(attachment.contentType);
-    const localFileName = `${params.accountId}-${params.chatId}-${attachment.id}-${name}`;
+    const localFileName = [
+      Date.now(),
+      randomUUID(),
+      sanitizeDiscordPathSegment(params.accountId),
+      sanitizeDiscordPathSegment(params.chatId),
+      sanitizeDiscordPathSegment(attachment.id),
+      sanitizeDiscordPathSegment(name),
+    ].join("-");
     const localPath = join(dir, localFileName);
 
     try {
@@ -66,7 +82,27 @@ export async function resolveDiscordInboundAttachments(params: {
         continue;
       }
 
+      const contentLength = response.headers.get("content-length");
+      if (contentLength) {
+        const parsedLength = Number(contentLength);
+        if (
+          Number.isFinite(parsedLength) &&
+          parsedLength > MAX_DISCORD_ATTACHMENT_BYTES
+        ) {
+          console.warn(
+            `[Discord] Skipping oversized attachment ${name}: ${parsedLength} bytes`,
+          );
+          continue;
+        }
+      }
+
       const buffer = Buffer.from(await response.arrayBuffer());
+      if (buffer.byteLength > MAX_DISCORD_ATTACHMENT_BYTES) {
+        console.warn(
+          `[Discord] Skipping oversized attachment ${name}: ${buffer.byteLength} bytes`,
+        );
+        continue;
+      }
       await writeFile(localPath, buffer);
 
       const entry: ChannelMessageAttachment = {

--- a/src/channels/discord/messageActions.ts
+++ b/src/channels/discord/messageActions.ts
@@ -1,0 +1,87 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+} from "../pluginTypes";
+
+async function sendDiscordMessage(
+  ctx: ChannelMessageActionContext,
+): Promise<string> {
+  const { request, route, adapter, formatText } = ctx;
+  const text = request.message ?? "";
+
+  if (text.trim().length === 0 && !request.mediaPath) {
+    return "Error: Discord send requires message or media.";
+  }
+
+  const formatted = formatText(text);
+  const result = await adapter.sendMessage({
+    channel: "discord",
+    accountId: route.accountId,
+    chatId: request.chatId,
+    text: formatted.text,
+    replyToMessageId: request.replyToMessageId,
+    threadId: request.replyToMessageId
+      ? null
+      : (request.threadId ?? route.threadId ?? null),
+    mediaPath: request.mediaPath,
+    fileName: request.filename,
+    title: request.title,
+    parseMode: formatted.parseMode,
+  });
+
+  return request.mediaPath
+    ? `Attachment sent to discord (message_id: ${result.messageId})`
+    : `Message sent to discord (message_id: ${result.messageId})`;
+}
+
+async function reactInDiscord(
+  ctx: ChannelMessageActionContext,
+): Promise<string> {
+  const { request, route, adapter } = ctx;
+
+  if (!request.emoji?.trim()) {
+    return "Error: Discord react requires emoji.";
+  }
+  if (!request.messageId?.trim()) {
+    return "Error: Discord react requires messageId.";
+  }
+
+  const result = await adapter.sendMessage({
+    channel: "discord",
+    accountId: route.accountId,
+    chatId: request.chatId,
+    text: "",
+    targetMessageId: request.messageId,
+    reaction: request.emoji,
+    removeReaction: request.remove,
+    threadId: request.threadId ?? route.threadId ?? null,
+  });
+
+  return request.remove
+    ? `Reaction removed on discord (message_id: ${result.messageId})`
+    : `Reaction added on discord (message_id: ${result.messageId})`;
+}
+
+export const discordMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool() {
+    return {
+      actions: ["send", "react", "upload-file"],
+    };
+  },
+
+  async handleAction(ctx) {
+    switch (ctx.request.action) {
+      case "send":
+        return await sendDiscordMessage(ctx);
+      case "upload-file":
+        if (!ctx.request.mediaPath?.trim()) {
+          return "Error: Discord upload-file requires media.";
+        }
+        return await sendDiscordMessage(ctx);
+      case "react":
+        return await reactInDiscord(ctx);
+      default:
+        return `Error: Action "${ctx.request.action}" is not supported on discord.`;
+    }
+  },
+};

--- a/src/channels/discord/messageActions.ts
+++ b/src/channels/discord/messageActions.ts
@@ -20,9 +20,7 @@ async function sendDiscordMessage(
     chatId: request.chatId,
     text: formatted.text,
     replyToMessageId: request.replyToMessageId,
-    threadId: request.replyToMessageId
-      ? null
-      : (request.threadId ?? route.threadId ?? null),
+    threadId: request.threadId ?? route.threadId ?? null,
     mediaPath: request.mediaPath,
     fileName: request.filename,
     title: request.title,

--- a/src/channels/discord/plugin.ts
+++ b/src/channels/discord/plugin.ts
@@ -1,0 +1,21 @@
+import type { ChannelPlugin } from "../pluginTypes";
+import type { ChannelAccount, DiscordChannelAccount } from "../types";
+import { createDiscordAdapter } from "./adapter";
+import { discordMessageActions } from "./messageActions";
+import { runDiscordSetup } from "./setup";
+
+export const discordChannelPlugin: ChannelPlugin = {
+  metadata: {
+    id: "discord",
+    displayName: "Discord",
+    runtimePackages: ["discord.js@14.18.0"],
+    runtimeModules: ["discord.js"],
+  },
+  createAdapter(account: ChannelAccount) {
+    return createDiscordAdapter(account as DiscordChannelAccount);
+  },
+  messageActions: discordMessageActions,
+  runSetup() {
+    return runDiscordSetup();
+  },
+};

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -1,0 +1,23 @@
+import {
+  ensureChannelRuntimeInstalled,
+  installChannelRuntime,
+  isChannelRuntimeInstalled,
+  loadChannelRuntimeModule,
+} from "../runtimeDeps";
+
+// biome-ignore lint/suspicious/noExplicitAny: discord.js is a runtime dependency
+export async function loadDiscordModule(): Promise<any> {
+  return loadChannelRuntimeModule("discord", "discord.js");
+}
+
+export function isDiscordRuntimeInstalled(): boolean {
+  return isChannelRuntimeInstalled("discord");
+}
+
+export async function installDiscordRuntime(): Promise<void> {
+  await installChannelRuntime("discord");
+}
+
+export async function ensureDiscordRuntimeInstalled(): Promise<boolean> {
+  return ensureChannelRuntimeInstalled("discord");
+}

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -5,9 +5,36 @@ import {
   loadChannelRuntimeModule,
 } from "../runtimeDeps";
 
-// biome-ignore lint/suspicious/noExplicitAny: discord.js is a runtime dependency
-export async function loadDiscordModule(): Promise<any> {
-  return loadChannelRuntimeModule("discord", "discord.js");
+export interface DiscordGatewayIntentBitsLike {
+  Guilds: unknown;
+  GuildMessages: unknown;
+  GuildMessageReactions: unknown;
+  MessageContent: unknown;
+  DirectMessages: unknown;
+  DirectMessageReactions: unknown;
+}
+
+export interface DiscordPartialsLike {
+  Channel: unknown;
+  Message: unknown;
+  Reaction: unknown;
+  User: unknown;
+}
+
+export interface DiscordRuntimeModuleLike {
+  Client: new (options: {
+    intents: unknown[];
+    partials?: unknown[];
+  }) => unknown;
+  GatewayIntentBits: DiscordGatewayIntentBitsLike;
+  Partials: DiscordPartialsLike;
+}
+
+export async function loadDiscordModule(): Promise<DiscordRuntimeModuleLike> {
+  return loadChannelRuntimeModule<DiscordRuntimeModuleLike>(
+    "discord",
+    "discord.js",
+  );
 }
 
 export function isDiscordRuntimeInstalled(): boolean {

--- a/src/channels/discord/setup.ts
+++ b/src/channels/discord/setup.ts
@@ -64,13 +64,46 @@ export async function runDiscordSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
+    // Agent binding — required for guild @mention routing to work.
+    // Without this, the bot won't know which agent to create threads for.
+    const envAgentId = process.env.LETTA_AGENT_ID || "";
+    let agentId: string | null = null;
+
+    if (envAgentId) {
+      const useEnv = await rl.question(
+        `\nBind to agent ${envAgentId}? [Y/n]: `,
+      );
+      if (!useEnv.trim() || useEnv.trim().toLowerCase() === "y") {
+        agentId = envAgentId;
+      }
+    }
+
+    if (!agentId) {
+      const agentInput = await rl.question(
+        "\nAgent ID to bind this bot to (required for @mention routing): ",
+      );
+      agentId = agentInput.trim() || null;
+    }
+
+    if (!agentId) {
+      console.log(
+        "\nWarning: No agent bound. DM pairing will still work, but guild @mentions won't route until you bind an agent.",
+      );
+      console.log(
+        "  You can bind later: letta channels pair --channel discord --agent <id>",
+      );
+      console.log(
+        "  Or set agentId in ~/.letta/channels/discord/accounts.json\n",
+      );
+    }
+
     const now = new Date().toISOString();
     const account: DiscordChannelAccount = {
       channel: "discord",
       accountId: randomUUID(),
       enabled: true,
       token,
-      agentId: null,
+      agentId,
       dmPolicy: policy,
       allowedUsers,
       createdAt: now,
@@ -82,12 +115,8 @@ export async function runDiscordSetup(): Promise<boolean> {
     console.log("Config written to: ~/.letta/channels/discord/accounts.json\n");
     console.log("Next steps:");
     console.log("  1. Start the listener: letta server --channels discord");
-    console.log("  2. Open Channels > Discord in Letta Code");
     console.log(
-      "  3. Choose which Letta agent this Discord bot should represent",
-    );
-    console.log(
-      "  4. DM the bot or @mention it in a Discord server to start chatting\n",
+      "  2. DM the bot or @mention it in a Discord server to start chatting\n",
     );
 
     return true;

--- a/src/channels/discord/setup.ts
+++ b/src/channels/discord/setup.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline/promises";
+import { upsertChannelAccount } from "../accounts";
+import type { DiscordChannelAccount, DmPolicy } from "../types";
+import { ensureDiscordRuntimeInstalled } from "./runtime";
+
+function isValidBotToken(token: string): boolean {
+  // Discord bot tokens are base64-encoded and typically 59-72 chars
+  return token.length >= 50 && token.includes(".");
+}
+
+export async function runDiscordSetup(): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log("\n🎮 Discord Bot Setup\n");
+    console.log("You'll need a Discord bot application with a bot token.");
+    console.log("Recommended setup:");
+    console.log("  1. Create an application at https://discord.com/developers");
+    console.log("  2. Go to Bot settings and create a bot");
+    console.log(
+      "  3. Enable the MESSAGE CONTENT privileged intent under Bot settings",
+    );
+    console.log("  4. Copy the bot token");
+    console.log(
+      "  5. Invite the bot to your server using OAuth2 URL Generator",
+    );
+    console.log("     Required scopes: bot");
+    console.log(
+      "     Required permissions: Send Messages, Read Message History, Add Reactions, Create Public Threads, Send Messages in Threads, Attach Files\n",
+    );
+
+    await ensureDiscordRuntimeInstalled();
+
+    const token = (await rl.question("Enter your Discord bot token: ")).trim();
+    if (!isValidBotToken(token)) {
+      console.error("Invalid Discord bot token.");
+      return false;
+    }
+
+    console.log("\nDM Policy — who can message this bot directly?\n");
+    console.log("  pairing   — Require a pairing code (recommended)");
+    console.log("  allowlist — Only pre-approved Discord user IDs");
+    console.log("  open      — Anyone who can DM the bot\n");
+
+    const policyInput = await rl.question("DM policy [pairing]: ");
+    const policy = (policyInput.trim() || "pairing") as DmPolicy;
+    if (!["pairing", "allowlist", "open"].includes(policy)) {
+      console.error(`Invalid policy "${policy}". Setup cancelled.`);
+      return false;
+    }
+
+    let allowedUsers: string[] = [];
+    if (policy === "allowlist") {
+      const usersInput = await rl.question(
+        "Enter allowed Discord user IDs (comma-separated): ",
+      );
+      allowedUsers = usersInput
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+
+    const now = new Date().toISOString();
+    const account: DiscordChannelAccount = {
+      channel: "discord",
+      accountId: randomUUID(),
+      enabled: true,
+      token,
+      agentId: null,
+      dmPolicy: policy,
+      allowedUsers,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    upsertChannelAccount("discord", account);
+    console.log("\n✓ Discord bot configured!");
+    console.log("Config written to: ~/.letta/channels/discord/accounts.json\n");
+    console.log("Next steps:");
+    console.log("  1. Start the listener: letta server --channels discord");
+    console.log("  2. Open Channels > Discord in Letta Code");
+    console.log(
+      "  3. Choose which Letta agent this Discord bot should represent",
+    );
+    console.log(
+      "  4. DM the bot or @mention it in a Discord server to start chatting\n",
+    );
+
+    return true;
+  } finally {
+    rl.close();
+  }
+}

--- a/src/channels/discord/setup.ts
+++ b/src/channels/discord/setup.ts
@@ -90,7 +90,7 @@ export async function runDiscordSetup(): Promise<boolean> {
         "\nWarning: No agent bound. DM pairing will still work, but guild @mentions won't route until you bind an agent.",
       );
       console.log(
-        "  You can bind later: letta channels pair --channel discord --agent <id>",
+        "  You can bind later: letta channels bind --channel discord --agent <id>",
       );
       console.log(
         "  Or set agentId in ~/.letta/channels/discord/accounts.json\n",

--- a/src/channels/pluginRegistry.ts
+++ b/src/channels/pluginRegistry.ts
@@ -35,6 +35,18 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
       return slackChannelPlugin;
     },
   },
+  discord: {
+    metadata: {
+      id: "discord",
+      displayName: "Discord",
+      runtimePackages: ["discord.js@14.18.0"],
+      runtimeModules: ["discord.js"],
+    },
+    load: async () => {
+      const { discordChannelPlugin } = await import("./discord/plugin");
+      return discordChannelPlugin;
+    },
+  },
 };
 
 export function isSupportedChannelId(

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -52,14 +52,21 @@ import type {
   ChannelRoute,
   ChannelTurnLifecycleEvent,
   ChannelTurnSource,
+  DiscordChannelAccount,
   InboundChannelMessage,
   SlackChannelAccount,
   SlackDefaultPermissionMode,
 } from "./types";
 import { formatChannelNotification } from "./xml";
 
+function channelDisplayName(channelId: string): string {
+  if (channelId === "slack") return "Slack";
+  if (channelId === "discord") return "Discord";
+  return "Telegram";
+}
+
 function buildPairingInstructions(channelId: string, code: string): string {
-  const displayName = channelId === "slack" ? "Slack" : "Telegram";
+  const displayName = channelDisplayName(channelId);
   return (
     `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
     `Pairing code: ${code}\n\n` +
@@ -71,7 +78,7 @@ function buildUnboundRouteInstructions(
   channelId: string,
   chatId: string,
 ): string {
-  const displayName = channelId === "slack" ? "Slack" : "Telegram";
+  const displayName = channelDisplayName(channelId);
   return (
     `This chat isn't bound to a Letta Code agent yet.\n\n` +
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +
@@ -754,6 +761,32 @@ export class ChannelRegistry {
       return;
     }
 
+    // Discord guild messages use auto-routing (like Slack).
+    // DMs fall through to the standard pairing flow below.
+    if (
+      msg.channel === "discord" &&
+      config.channel === "discord" &&
+      msg.chatType === "channel"
+    ) {
+      const discordResult = await this.ensureDiscordRoute(adapter, msg, config);
+      if (!discordResult) {
+        return;
+      }
+      const preparedMessage = adapter.prepareInboundMessage
+        ? await adapter.prepareInboundMessage(msg, {
+            isFirstRouteTurn: discordResult.isFirstRouteTurn,
+          })
+        : msg;
+      this.deliverOrBuffer({
+        route: discordResult.route,
+        content: formatChannelNotification(preparedMessage),
+        turnSources: [
+          buildChannelTurnSource(discordResult.route, preparedMessage),
+        ],
+      });
+      return;
+    }
+
     // 1. Check pairing/allowlist policy
     if (config.dmPolicy === "allowlist") {
       if (!config.allowedUsers.includes(msg.senderId)) {
@@ -963,6 +996,86 @@ export class ChannelRegistry {
 
     return {
       route: await this.createSlackRoute(config, msg),
+      isFirstRouteTurn: true,
+    };
+  }
+
+  private async createDiscordRoute(
+    config: DiscordChannelAccount,
+    msg: InboundChannelMessage,
+  ): Promise<ChannelRoute> {
+    if (!config.agentId) {
+      throw new Error("Discord bot is missing an agent binding.");
+    }
+
+    const conversationId = await this.createConversationForAgent(
+      config.agentId,
+      `[Discord] Thread ${msg.chatLabel ?? msg.chatId}`,
+    );
+    const now = new Date().toISOString();
+    const route: ChannelRoute = {
+      accountId: config.accountId,
+      chatId: msg.chatId,
+      chatType: msg.chatType,
+      threadId: msg.threadId ?? null,
+      agentId: config.agentId,
+      conversationId,
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    addRoute(msg.channel, route);
+    return route;
+  }
+
+  private async ensureDiscordRoute(
+    adapter: ChannelAdapter,
+    msg: InboundChannelMessage,
+    config: DiscordChannelAccount,
+  ): Promise<{
+    route: ChannelRoute;
+    isFirstRouteTurn: boolean;
+  } | null> {
+    if (!config.agentId) {
+      await adapter.sendDirectReply(
+        msg.chatId,
+        "This Discord bot isn't connected to a Letta agent yet.\n\n" +
+          "Open Channels > Discord in Letta Code, choose which agent this bot should represent, and try again.",
+      );
+      return null;
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const routeThreadId = msg.threadId ?? null;
+    let route = getRouteFromStore(
+      msg.channel,
+      msg.chatId,
+      accountId,
+      routeThreadId,
+    );
+    if (!route) {
+      loadRoutes(msg.channel);
+      route = getRouteFromStore(
+        msg.channel,
+        msg.chatId,
+        accountId,
+        routeThreadId,
+      );
+    }
+
+    if (route) {
+      return { route, isFirstRouteTurn: false };
+    }
+
+    // Only create routes for mentions (the adapter already filters this,
+    // but double-check) or for messages in threads we should be tracking.
+    if (!msg.isMention && !msg.threadId) {
+      return null;
+    }
+
+    return {
+      route: await this.createDiscordRoute(config, msg),
       isFirstRouteTurn: true,
     };
   }

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1074,9 +1074,9 @@ export class ChannelRegistry {
       return { route, isFirstRouteTurn: false };
     }
 
-    // Only create routes for mentions (the adapter already filters this,
-    // but double-check) or for messages in threads we should be tracking.
-    if (!msg.isMention && !msg.threadId) {
+    // Only create routes from explicit mentions.
+    // Existing routed threads continue above via the route lookup path.
+    if (!msg.isMention) {
       return null;
     }
 

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -790,6 +790,9 @@ export class ChannelRegistry {
     // 1. Check pairing/allowlist policy
     if (config.dmPolicy === "allowlist") {
       if (!config.allowedUsers.includes(msg.senderId)) {
+        if (msg.reaction) {
+          return;
+        }
         await adapter.sendDirectReply(
           msg.chatId,
           "You are not on the allowed users list for this bot.",
@@ -802,6 +805,9 @@ export class ChannelRegistry {
         loadPairingStore(msg.channel);
       }
       if (!isUserApproved(msg.channel, msg.senderId, accountId)) {
+        if (msg.reaction) {
+          return;
+        }
         // Generate pairing code
         const code = createPairingCode(
           msg.channel,

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -7,6 +7,7 @@ import {
   removeChannelAccount,
   upsertChannelAccount,
 } from "./accounts";
+import { resolveDiscordAccountDisplayName } from "./discord/adapter";
 import {
   getApprovedUsers,
   getPendingPairings,
@@ -85,6 +86,15 @@ export type ChannelConfigSnapshot =
       allowedUsers: string[];
       hasBotToken: boolean;
       hasAppToken: boolean;
+    }
+  | {
+      channelId: "discord";
+      accountId: string;
+      displayName?: string;
+      enabled: boolean;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasToken: boolean;
     };
 
 export interface PendingPairingSnapshot {
@@ -160,6 +170,20 @@ export type ChannelAccountSnapshot =
       defaultPermissionMode: SlackDefaultPermissionMode;
       createdAt: string;
       updatedAt: string;
+    }
+  | {
+      channelId: "discord";
+      accountId: string;
+      displayName?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      dmPolicy: DmPolicy;
+      allowedUsers: string[];
+      hasToken: boolean;
+      agentId: string | null;
+      createdAt: string;
+      updatedAt: string;
     };
 
 export interface ChannelConfigPatch {
@@ -224,6 +248,15 @@ async function resolveChannelAccountDisplayName(
       const info = await validateTelegramToken(account.token);
       return normalizeDisplayName(
         info.username ? `@${info.username}` : undefined,
+      );
+    }
+
+    if (account.channel === "discord") {
+      if (!account.token.trim()) {
+        return undefined;
+      }
+      return normalizeDisplayName(
+        await resolveDiscordAccountDisplayName(account.token),
       );
     }
 
@@ -364,6 +397,10 @@ function isAccountConfigured(account: ChannelAccount): boolean {
     return account.token.trim().length > 0;
   }
 
+  if (account.channel === "discord") {
+    return account.token.trim().length > 0;
+  }
+
   return (
     account.botToken.trim().length > 0 && account.appToken.trim().length > 0
   );
@@ -402,6 +439,23 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       allowedUsers: [...account.allowedUsers],
       hasToken: account.token.trim().length > 0,
       binding,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+    };
+  }
+
+  if (account.channel === "discord") {
+    return {
+      channelId: "discord",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      configured: isAccountConfigured(account),
+      running,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      hasToken: account.token.trim().length > 0,
+      agentId: account.agentId,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -450,6 +504,21 @@ function createAccountFromPatch(
     };
   }
 
+  if (channelId === "discord") {
+    return {
+      channel: "discord",
+      accountId,
+      displayName: normalizeDisplayName(patch.displayName),
+      enabled: patch.enabled ?? false,
+      token: patch.token ?? "",
+      agentId: patch.agentId ?? null,
+      dmPolicy: patch.dmPolicy ?? "pairing",
+      allowedUsers: patch.allowedUsers ?? [],
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
   return {
     channel: "slack",
     accountId,
@@ -481,6 +550,22 @@ function mergeAccountPatch(
           : existing.displayName,
       enabled: patch.enabled ?? existing.enabled,
       token: patch.token ?? existing.token,
+      dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+      updatedAt: nextUpdatedAt,
+    };
+  }
+
+  if (existing.channel === "discord") {
+    return {
+      ...existing,
+      displayName:
+        patch.displayName !== undefined
+          ? normalizeDisplayName(patch.displayName)
+          : existing.displayName,
+      enabled: patch.enabled ?? existing.enabled,
+      token: patch.token ?? existing.token,
+      agentId: patch.agentId ?? existing.agentId,
       dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
       allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
       updatedAt: nextUpdatedAt,
@@ -571,6 +656,18 @@ export function getChannelConfigSnapshot(
     };
   }
 
+  if (account.channel === "discord") {
+    return {
+      channelId: "discord",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      hasToken: account.token.trim().length > 0,
+    };
+  }
+
   return {
     channelId: "slack",
     accountId: account.accountId,
@@ -605,7 +702,7 @@ export async function setChannelConfigLive(
       displayName: existing.displayName,
     });
     shouldRefreshDisplayName =
-      channelId === "telegram"
+      channelId === "telegram" || channelId === "discord"
         ? patch.token !== undefined
         : patch.botToken !== undefined || patch.appToken !== undefined;
   } else {
@@ -675,6 +772,11 @@ export async function startChannelLive(
         'Channel "telegram" is missing a token. Configure it first.',
       );
     }
+    if (existing.channel === "discord") {
+      throw new Error(
+        'Channel "discord" is missing a token. Configure it first.',
+      );
+    }
     throw new Error(
       'Channel "slack" is missing a bot token or app token. Configure it first.',
     );
@@ -693,7 +795,7 @@ export async function startChannelLive(
     existing.accountId,
   );
   await refreshChannelAccountDisplayNameLive(channelId, existing.accountId, {
-    force: channelId === "slack",
+    force: channelId === "slack" || channelId === "discord",
   });
 
   const summary = listChannelSummaries().find(
@@ -845,21 +947,21 @@ export function bindChannelAccountLive(
     );
   }
 
-  const updated =
-    existing.channel === "telegram"
-      ? upsertChannelAccount(channelId, {
-          ...existing,
-          binding: {
-            agentId,
-            conversationId,
-          },
-          updatedAt: new Date().toISOString(),
-        })
-      : upsertChannelAccount(channelId, {
-          ...existing,
-          agentId,
-          updatedAt: new Date().toISOString(),
-        });
+  let updated: ChannelAccount;
+  if (existing.channel === "telegram") {
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
+      binding: { agentId, conversationId },
+      updatedAt: new Date().toISOString(),
+    });
+  } else {
+    // Slack and Discord both use a top-level agentId
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
+      agentId,
+      updatedAt: new Date().toISOString(),
+    });
+  }
 
   return toAccountSnapshot(updated);
 }
@@ -876,21 +978,21 @@ export function unbindChannelAccountLive(
     );
   }
 
-  const updated =
-    existing.channel === "telegram"
-      ? upsertChannelAccount(channelId, {
-          ...existing,
-          binding: {
-            agentId: null,
-            conversationId: null,
-          },
-          updatedAt: new Date().toISOString(),
-        })
-      : upsertChannelAccount(channelId, {
-          ...existing,
-          agentId: null,
-          updatedAt: new Date().toISOString(),
-        });
+  let updated: ChannelAccount;
+  if (existing.channel === "telegram") {
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
+      binding: { agentId: null, conversationId: null },
+      updatedAt: new Date().toISOString(),
+    });
+  } else {
+    // Slack and Discord both use a top-level agentId
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
+      agentId: null,
+      updatedAt: new Date().toISOString(),
+    });
+  }
 
   return toAccountSnapshot(updated);
 }
@@ -912,6 +1014,11 @@ export async function startChannelAccountLive(
         'Channel "telegram" account is missing a token. Configure it first.',
       );
     }
+    if (existing.channel === "discord") {
+      throw new Error(
+        'Channel "discord" account is missing a token. Configure it first.',
+      );
+    }
     throw new Error(
       'Channel "slack" account is missing a bot token or app token. Configure it first.',
     );
@@ -930,7 +1037,7 @@ export async function startChannelAccountLive(
     channelId,
     accountId,
     {
-      force: channelId === "slack",
+      force: channelId === "slack" || channelId === "discord",
     },
   );
   await refreshLoadedMessageChannelTool();

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1342,7 +1342,7 @@ export function removeChannelRouteLive(
   if (!route) {
     return false;
   }
-  return removeRoute(channelId, chatId, route.accountId);
+  return removeRoute(channelId, chatId, route.accountId, route.threadId);
 }
 
 export function __testOverrideResolveChannelAccountDisplayName(

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,7 +7,7 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
-export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack"] as const;
+export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack", "discord"] as const;
 export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
 export type ChannelChatType = "direct" | "channel";
 export type SlackDefaultPermissionMode =
@@ -282,7 +282,18 @@ export interface SlackChannelConfig {
   allowedUsers: string[];
 }
 
-export type ChannelConfig = TelegramChannelConfig | SlackChannelConfig;
+export interface DiscordChannelConfig {
+  channel: "discord";
+  enabled: boolean;
+  token: string;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+}
+
+export type ChannelConfig =
+  | TelegramChannelConfig
+  | SlackChannelConfig
+  | DiscordChannelConfig;
 
 export interface TelegramChannelAccount extends ChannelAccountBase {
   channel: "telegram";
@@ -299,7 +310,17 @@ export interface SlackChannelAccount extends ChannelAccountBase {
   defaultPermissionMode: SlackDefaultPermissionMode;
 }
 
-export type ChannelAccount = TelegramChannelAccount | SlackChannelAccount;
+export interface DiscordChannelAccount extends ChannelAccountBase {
+  channel: "discord";
+  token: string;
+  /** Agent ID used for guild auto-routing (like Slack's agentId). */
+  agentId: string | null;
+}
+
+export type ChannelAccount =
+  | TelegramChannelAccount
+  | SlackChannelAccount
+  | DiscordChannelAccount;
 
 // ── Pairing ───────────────────────────────────────────────────────
 

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -73,6 +73,13 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
       'On Telegram, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
     );
   }
+  if (msg.channel === "discord") {
+    lines.splice(
+      lines.length - 2,
+      0,
+      'On Discord, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Discord uses native Unicode emoji for reactions.',
+    );
+  }
   if (msg.attachments?.length) {
     lines.splice(
       lines.length - 2,

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -77,7 +77,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     lines.splice(
       lines.length - 2,
       0,
-      'On Discord, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Discord uses native Unicode emoji for reactions.',
+      'On Discord, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Discord reactions accept native Unicode emoji and custom emoji syntax like <:name:id>.',
     );
   }
   if (msg.attachments?.length) {

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -476,9 +476,9 @@ function handleBind(
     console.error("Error: --channel is required.");
     return 1;
   }
-  if (channelId !== "slack") {
+  if (channelId !== "slack" && channelId !== "discord") {
     console.error(
-      `"bind" is only supported for Slack. Telegram binding is route-scoped — use "pair" or "route add" instead.`,
+      `"bind" is only supported for Slack and Discord. Telegram binding is route-scoped — use "pair" or "route add" instead.`,
     );
     return 1;
   }

--- a/src/cli/subcommands/channels.ts
+++ b/src/cli/subcommands/channels.ts
@@ -402,7 +402,32 @@ function handleRouteRemove(
   }
 
   loadRoutes(channelId);
-  const removed = removeRoute(channelId, chatId, resolvedAccountId);
+  const routes = getRoutesForChannel(channelId, resolvedAccountId).filter(
+    (route) => route.chatId === chatId,
+  );
+  if (routes.length === 0) {
+    console.log(JSON.stringify({ success: false }, null, 2));
+    return 1;
+  }
+  if (routes.length > 1) {
+    console.error(
+      `Channel "${channelId}" has multiple routes for chat "${chatId}". Remove the route from Letta Code so thread_id can be selected explicitly.`,
+    );
+    return 1;
+  }
+
+  const route = routes[0];
+  if (!route) {
+    console.log(JSON.stringify({ success: false }, null, 2));
+    return 1;
+  }
+
+  const removed = removeRoute(
+    channelId,
+    chatId,
+    resolvedAccountId,
+    route.threadId,
+  );
   console.log(JSON.stringify({ success: removed }, null, 2));
   if (removed) {
     console.warn(

--- a/src/tests/channels/discord-adapter.test.ts
+++ b/src/tests/channels/discord-adapter.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+
+// The Discord adapter's internal helpers are not exported, but we can test
+// the equivalent logic by reimplementing the pure functions here and verifying
+// they match the adapter's behavior. These are regression tests for the
+// algorithms used in adapter.ts.
+
+// ── splitMessageText ──────────────────────────────────────────────────────
+
+function splitMessageText(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitAt = remaining.lastIndexOf("\n", maxLength);
+    if (splitAt <= 0) {
+      splitAt = remaining.lastIndexOf(" ", maxLength);
+    }
+    if (splitAt <= 0) {
+      splitAt = maxLength;
+    }
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+  return chunks;
+}
+
+describe("splitMessageText", () => {
+  test("short messages pass through as-is", () => {
+    expect(splitMessageText("hello", 2000)).toEqual(["hello"]);
+  });
+
+  test("empty string returns single chunk", () => {
+    expect(splitMessageText("", 2000)).toEqual([""]);
+  });
+
+  test("splits at newline boundary when possible", () => {
+    const line = "a".repeat(900);
+    const text = `${line}\n${line}\n${line}`;
+    const chunks = splitMessageText(text, 1900);
+    expect(chunks.length).toBeGreaterThan(1);
+    // First chunk should split at the newline (position 900), not mid-content
+    expect(chunks[0]!.length).toBeLessThanOrEqual(1900);
+    // The split should happen at a \n boundary, so first chunk should be
+    // exactly 900+1 chars (the first line plus the newline)
+    expect(chunks[0]).toBe(`${line}\n${line}`);
+  });
+
+  test("splits at space boundary when no newlines available", () => {
+    const words = Array(500).fill("word").join(" ");
+    const chunks = splitMessageText(words, 1900);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(1900);
+    }
+  });
+
+  test("hard-splits when no whitespace available", () => {
+    const solid = "x".repeat(5000);
+    const chunks = splitMessageText(solid, 1900);
+    expect(chunks.length).toBe(3); // 1900 + 1900 + 1200
+    expect(chunks[0]!.length).toBe(1900);
+    expect(chunks[1]!.length).toBe(1900);
+    expect(chunks[2]!.length).toBe(1200);
+  });
+
+  test("reconstructed text matches original content", () => {
+    const text = Array(100)
+      .fill("The quick brown fox jumps over the lazy dog.")
+      .join("\n");
+    const chunks = splitMessageText(text, 1900);
+    // When we split at boundaries and trimStart remaining, some whitespace
+    // may be consumed. Verify all non-whitespace content is preserved.
+    const originalNonWs = text.replace(/\s+/g, "");
+    const reconstructedNonWs = chunks.join("").replace(/\s+/g, "");
+    expect(reconstructedNonWs).toBe(originalNonWs);
+  });
+});
+
+// ── normalizeDiscordMentionText ──────────────────────────────────────────
+
+function normalizeDiscordMentionText(
+  text: string,
+  botUserId: string | null,
+): string {
+  if (!botUserId) return text;
+  return text.replace(new RegExp(`<@!?${botUserId}>\\s*`, "g"), "").trim();
+}
+
+describe("normalizeDiscordMentionText", () => {
+  test("strips <@botId> mention", () => {
+    expect(normalizeDiscordMentionText("<@123> hello", "123")).toBe("hello");
+  });
+
+  test("strips <@!botId> mention (nickname variant)", () => {
+    expect(normalizeDiscordMentionText("<@!123> hello", "123")).toBe("hello");
+  });
+
+  test("strips multiple mentions of the bot", () => {
+    expect(normalizeDiscordMentionText("<@123> hey <@123> there", "123")).toBe(
+      "hey there",
+    );
+  });
+
+  test("preserves mentions of other users", () => {
+    expect(normalizeDiscordMentionText("<@456> hello", "123")).toBe(
+      "<@456> hello",
+    );
+  });
+
+  test("returns text unchanged when botUserId is null", () => {
+    expect(normalizeDiscordMentionText("<@123> hello", null)).toBe(
+      "<@123> hello",
+    );
+  });
+
+  test("handles mention at end of text", () => {
+    expect(normalizeDiscordMentionText("hey <@123>", "123")).toBe("hey");
+  });
+
+  test("handles text that is only a mention", () => {
+    expect(normalizeDiscordMentionText("<@123>", "123")).toBe("");
+  });
+});
+
+// ── resolveDiscordReactionEmoji ──────────────────────────────────────────
+
+function resolveDiscordReactionEmoji(value: string): string {
+  const trimmed = value.trim().replace(/^:+|:+$/g, "");
+  const nameMap: Record<string, string> = {
+    eyes: "👀",
+    white_check_mark: "✅",
+    x: "❌",
+  };
+  return nameMap[trimmed] ?? trimmed;
+}
+
+describe("resolveDiscordReactionEmoji", () => {
+  test("maps :eyes: to 👀", () => {
+    expect(resolveDiscordReactionEmoji(":eyes:")).toBe("👀");
+  });
+
+  test("maps :white_check_mark: to ✅", () => {
+    expect(resolveDiscordReactionEmoji(":white_check_mark:")).toBe("✅");
+  });
+
+  test("maps :x: to ❌", () => {
+    expect(resolveDiscordReactionEmoji(":x:")).toBe("❌");
+  });
+
+  test("passes through native unicode emoji", () => {
+    expect(resolveDiscordReactionEmoji("🔥")).toBe("🔥");
+  });
+
+  test("passes through unicode emoji with whitespace trimmed", () => {
+    expect(resolveDiscordReactionEmoji("  👍  ")).toBe("👍");
+  });
+
+  test("strips colons from named input", () => {
+    expect(resolveDiscordReactionEmoji("eyes")).toBe("👀");
+  });
+
+  test("passes through unknown names as-is", () => {
+    expect(resolveDiscordReactionEmoji("custom_emoji")).toBe("custom_emoji");
+  });
+});
+
+// ── resolveDiscordChatType ──────────────────────────────────────────────
+
+function resolveDiscordChatType(
+  guildId: string | null | undefined,
+): "direct" | "channel" {
+  return guildId ? "channel" : "direct";
+}
+
+describe("resolveDiscordChatType", () => {
+  test("null guildId is direct", () => {
+    expect(resolveDiscordChatType(null)).toBe("direct");
+  });
+
+  test("undefined guildId is direct", () => {
+    expect(resolveDiscordChatType(undefined)).toBe("direct");
+  });
+
+  test("non-empty guildId is channel", () => {
+    expect(resolveDiscordChatType("guild-123")).toBe("channel");
+  });
+});

--- a/src/tests/channels/discord-adapter.test.ts
+++ b/src/tests/channels/discord-adapter.test.ts
@@ -132,13 +132,17 @@ describe("normalizeDiscordMentionText", () => {
 // ── resolveDiscordReactionEmoji ──────────────────────────────────────────
 
 function resolveDiscordReactionEmoji(value: string): string {
-  const trimmed = value.trim().replace(/^:+|:+$/g, "");
+  const trimmed = value.trim();
+  if (trimmed.startsWith("<:") || trimmed.startsWith("<a:")) {
+    return trimmed;
+  }
+  const normalized = trimmed.replace(/^:+|:+$/g, "");
   const nameMap: Record<string, string> = {
     eyes: "👀",
     white_check_mark: "✅",
     x: "❌",
   };
-  return nameMap[trimmed] ?? trimmed;
+  return nameMap[normalized] ?? normalized;
 }
 
 describe("resolveDiscordReactionEmoji", () => {
@@ -168,6 +172,15 @@ describe("resolveDiscordReactionEmoji", () => {
 
   test("passes through unknown names as-is", () => {
     expect(resolveDiscordReactionEmoji("custom_emoji")).toBe("custom_emoji");
+  });
+
+  test("passes through Discord custom emoji syntax unchanged", () => {
+    expect(resolveDiscordReactionEmoji("<:custom:123456>")).toBe(
+      "<:custom:123456>",
+    );
+    expect(resolveDiscordReactionEmoji("<a:animated:654321>")).toBe(
+      "<a:animated:654321>",
+    );
   });
 });
 

--- a/src/tests/channels/discord-message-channel.test.ts
+++ b/src/tests/channels/discord-message-channel.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import { clearAllRoutes, setRouteInMemory } from "../../channels/routing";
+import type { ChannelAdapter } from "../../channels/types";
+import { message_channel } from "../../tools/impl/MessageChannel";
+
+describe("message_channel (discord)", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+  });
+
+  test("send routes through discord adapter", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "discord",
+      chat_id: "DM-123",
+      message: "hello from Letta",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to discord");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "discord",
+      accountId: "discord-1",
+      chatId: "DM-123",
+      text: "hello from Letta",
+      replyToMessageId: undefined,
+      threadId: null,
+      parseMode: undefined,
+    });
+  });
+
+  test("react routes through discord adapter", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "react",
+      channel: "discord",
+      chat_id: "DM-123",
+      emoji: "🔥",
+      messageId: "msg-1",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("discord");
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(call.reaction).toBe("🔥");
+    expect(call.targetMessageId).toBe("msg-1");
+  });
+
+  test("upload-file routes through discord adapter", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "upload-file",
+      channel: "discord",
+      chat_id: "DM-123",
+      media: "/tmp/photo.png",
+      message: "check this",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("discord");
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(call.mediaPath).toBe("/tmp/photo.png");
+  });
+
+  test("replies default to routed thread", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      threadId: "thread-abc",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    await message_channel({
+      action: "send",
+      channel: "discord",
+      chat_id: "DM-123",
+      message: "hello",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(call.threadId).toBe("thread-abc");
+  });
+});

--- a/src/tests/channels/discord-message-channel.test.ts
+++ b/src/tests/channels/discord-message-channel.test.ts
@@ -206,4 +206,56 @@ describe("message_channel (discord)", () => {
     >;
     expect(call.threadId).toBe("thread-abc");
   });
+
+  test("replyTo keeps the routed thread on discord sends", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "channel-123",
+      threadId: "thread-abc",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    await message_channel({
+      action: "send",
+      channel: "discord",
+      chat_id: "channel-123",
+      message: "hello",
+      replyTo: "msg-42",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "discord",
+      accountId: "discord-1",
+      chatId: "channel-123",
+      text: "hello",
+      replyToMessageId: "msg-42",
+      threadId: "thread-abc",
+      parseMode: undefined,
+    });
+  });
 });

--- a/src/tests/channels/discord-protocol.test.ts
+++ b/src/tests/channels/discord-protocol.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isChannelAccountCreateCommand,
+  isChannelAccountUpdateCommand,
+  isChannelSetConfigCommand,
+} from "../../websocket/listener/protocol-inbound";
+
+describe("discord protocol-inbound validators", () => {
+  test("valid discord account create passes", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: { token: "test-token" },
+    };
+    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+  });
+
+  test("valid discord account create with agent_id passes", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: { token: "test-token", agent_id: "a-1" },
+    };
+    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+  });
+
+  test("discord account create without discord fields still passes (validator only checks discord-specific fields)", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: { bot_token: "xoxb-test" },
+    };
+    // validator only rejects discord-specific-field violations; Slack-style
+    // extra fields should not cause rejection by the discord validator.
+    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+  });
+
+  test("valid discord account update passes", () => {
+    const msg = {
+      type: "channel_account_update",
+      channel_id: "discord",
+      account_id: "acc-1",
+      request_id: "r1",
+      patch: { token: "new-token" },
+    };
+    expect(isChannelAccountUpdateCommand(msg)).toBe(true);
+  });
+
+  test("valid discord config set passes", () => {
+    const msg = {
+      type: "channel_set_config",
+      channel_id: "discord",
+      request_id: "r1",
+      config: { token: "new-token" },
+    };
+    expect(isChannelSetConfigCommand(msg)).toBe(true);
+  });
+
+  test("discord channel_id is accepted by isChannelAccountCreateCommand", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: { token: "t" },
+    };
+    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+  });
+});

--- a/src/tests/channels/discord-registry.test.ts
+++ b/src/tests/channels/discord-registry.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "../../channels/accounts";
+import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
+  clearPairingStores,
+} from "../../channels/pairing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRoute,
+} from "../../channels/routing";
+import type {
+  ChannelAdapter,
+  InboundChannelMessage,
+} from "../../channels/types";
+
+const createConversation = mock(async () => ({ id: "conv-discord" }));
+
+mock.module("../../agent/client", () => ({
+  getClient: async () => ({
+    conversations: {
+      create: createConversation,
+    },
+  }),
+}));
+
+describe("discord channel registry", () => {
+  function resetState(): void {
+    clearChannelAccountStores();
+    clearAllRoutes();
+    clearPairingStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
+    createConversation.mockReset();
+    createConversation.mockResolvedValue({ id: "conv-discord" });
+  }
+
+  function createInboundMessage(
+    overrides: Partial<InboundChannelMessage> = {},
+  ): InboundChannelMessage {
+    return {
+      channel: "discord",
+      accountId: "discord-bot",
+      chatId: "thread-1",
+      senderId: "user-1",
+      senderName: "Cameron",
+      text: "hello",
+      timestamp: Date.now(),
+      messageId: "msg-1",
+      threadId: "thread-1",
+      chatType: "channel",
+      isMention: false,
+      ...overrides,
+    };
+  }
+
+  function createAdapter(): ChannelAdapter {
+    return {
+      id: "discord:discord-bot",
+      channelId: "discord",
+      accountId: "discord-bot",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "outbound-1" }),
+      sendDirectReply: async () => {},
+    };
+  }
+
+  beforeEach(() => {
+    resetState();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        enabled: true,
+        token: "discord-token",
+        agentId: "agent-1",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
+  afterEach(async () => {
+    const { getChannelRegistry } = await import("../../channels/registry");
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    resetState();
+  });
+
+  test("does not auto-create a route for non-mentioned traffic in an untracked thread", async () => {
+    const { ChannelRegistry } = await import("../../channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(createInboundMessage());
+
+    expect(deliveries).toHaveLength(0);
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(getRoute("discord", "thread-1", "discord-bot", "thread-1")).toBe(
+      null,
+    );
+  });
+
+  test("creates a route when first contact in an untracked thread is an explicit mention", async () => {
+    const { ChannelRegistry } = await import("../../channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "@Loop hi",
+      }),
+    );
+
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(getRoute("discord", "thread-1", "discord-bot", "thread-1")).not.toBe(
+      null,
+    );
+    expect(deliveries).toHaveLength(1);
+  });
+});

--- a/src/tests/channels/discord-service.test.ts
+++ b/src/tests/channels/discord-service.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "../../channels/accounts";
+import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
+  clearPairingStores,
+} from "../../channels/pairing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+} from "../../channels/routing";
+import {
+  __testOverrideResolveChannelAccountDisplayName,
+  bindChannelAccountLive,
+  createChannelAccountLive,
+  getChannelAccountSnapshot,
+  getChannelConfigSnapshot,
+  listEnabledChannelIds,
+  setChannelConfigLive,
+  unbindChannelAccountLive,
+  updateChannelAccountLive,
+} from "../../channels/service";
+import {
+  __testOverrideLoadTargetStore,
+  __testOverrideSaveTargetStore,
+  clearTargetStores,
+} from "../../channels/targets";
+
+describe("discord channel service", () => {
+  function resetState(): void {
+    clearChannelAccountStores();
+    clearAllRoutes();
+    clearPairingStores();
+    clearTargetStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
+    __testOverrideLoadTargetStore(null);
+    __testOverrideSaveTargetStore(null);
+    __testOverrideResolveChannelAccountDisplayName(null);
+  }
+
+  beforeEach(() => {
+    resetState();
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
+  afterEach(() => {
+    resetState();
+  });
+
+  test("create / update / bind / unbind lifecycle", () => {
+    const created = createChannelAccountLive(
+      "discord",
+      { token: "test-token", dmPolicy: "pairing" },
+      { accountId: "discord-bot" },
+    );
+
+    expect(created.channelId).toBe("discord");
+    expect(created.configured).toBe(true);
+    expect(created.accountId).toBe("discord-bot");
+
+    if (created.channelId !== "discord") throw new Error("wrong channel");
+    expect(created.hasToken).toBe(true);
+    expect(created.agentId).toBeNull();
+
+    const updated = updateChannelAccountLive("discord", "discord-bot", {
+      displayName: "My Bot",
+    });
+    expect(updated.displayName).toBe("My Bot");
+
+    const bound = bindChannelAccountLive(
+      "discord",
+      "discord-bot",
+      "agent-123",
+      "conv-123",
+    );
+    if (bound.channelId !== "discord") throw new Error("wrong channel");
+    expect(bound.agentId).toBe("agent-123");
+
+    const snapshot = getChannelAccountSnapshot("discord", "discord-bot");
+    if (!snapshot || snapshot.channelId !== "discord")
+      throw new Error("wrong channel");
+    expect(snapshot.agentId).toBe("agent-123");
+    // Discord uses top-level agentId, not a binding object
+    expect((snapshot as Record<string, unknown>).binding).toBeUndefined();
+
+    unbindChannelAccountLive("discord", "discord-bot");
+    const unbound = getChannelAccountSnapshot("discord", "discord-bot");
+    if (!unbound || unbound.channelId !== "discord")
+      throw new Error("wrong channel");
+    expect(unbound.agentId).toBeNull();
+  });
+
+  test("getChannelConfigSnapshot returns discord-shaped config", () => {
+    createChannelAccountLive(
+      "discord",
+      { token: "test-token", dmPolicy: "pairing" },
+      { accountId: "discord-bot" },
+    );
+
+    const snapshot = getChannelConfigSnapshot("discord");
+    expect(snapshot).not.toBeNull();
+    if (!snapshot || snapshot.channelId !== "discord")
+      throw new Error("wrong channel");
+
+    expect(snapshot.hasToken).toBe(true);
+    expect(snapshot.dmPolicy).toBe("pairing");
+
+    // Should NOT have Slack-specific fields
+    expect((snapshot as Record<string, unknown>).mode).toBeUndefined();
+    expect((snapshot as Record<string, unknown>).hasBotToken).toBeUndefined();
+  });
+
+  test("listEnabledChannelIds includes enabled discord, excludes disabled telegram", () => {
+    createChannelAccountLive(
+      "discord",
+      { token: "discord-token", dmPolicy: "pairing", enabled: true },
+      { accountId: "discord-bot" },
+    );
+
+    createChannelAccountLive(
+      "telegram",
+      { token: "telegram-token", enabled: false },
+      { accountId: "telegram-bot" },
+    );
+
+    const enabled = listEnabledChannelIds();
+    expect(enabled).toContain("discord");
+    expect(enabled).not.toContain("telegram");
+  });
+
+  test("setChannelConfigLive creates discord account and returns snapshot", async () => {
+    const snapshot = await setChannelConfigLive("discord", {
+      token: "new-token",
+      dmPolicy: "allowlist",
+    });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.channelId).toBe("discord");
+    if (snapshot.channelId !== "discord") throw new Error("wrong channel");
+    expect(snapshot.hasToken).toBe(true);
+    expect(snapshot.dmPolicy).toBe("allowlist");
+  });
+
+  test("default dmPolicy is 'pairing' when not specified", () => {
+    const created = createChannelAccountLive(
+      "discord",
+      { token: "test-token" },
+      { accountId: "discord-bot" },
+    );
+
+    expect(created.channelId).toBe("discord");
+    if (created.channelId !== "discord") throw new Error("wrong channel");
+    expect(created.dmPolicy).toBe("pairing");
+  });
+
+  test("placeholder display names are scrubbed", () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        displayName: "Discord bot",
+        enabled: false,
+        token: "test-token",
+        agentId: null,
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const snapshot = getChannelAccountSnapshot("discord", "discord-bot");
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.displayName).toBeUndefined();
+  });
+
+  test("bind sets top-level agentId, not a binding object", () => {
+    createChannelAccountLive(
+      "discord",
+      { token: "test-token", dmPolicy: "pairing" },
+      { accountId: "discord-bot" },
+    );
+
+    const bound = bindChannelAccountLive(
+      "discord",
+      "discord-bot",
+      "agent-456",
+      "conv-456",
+    );
+
+    if (bound.channelId !== "discord") throw new Error("wrong channel");
+    expect(bound.agentId).toBe("agent-456");
+    expect((bound as Record<string, unknown>).binding).toBeUndefined();
+
+    const snapshot = getChannelAccountSnapshot("discord", "discord-bot");
+    if (!snapshot || snapshot.channelId !== "discord")
+      throw new Error("wrong channel");
+    expect(snapshot.agentId).toBe("agent-456");
+    expect((snapshot as Record<string, unknown>).binding).toBeUndefined();
+  });
+});

--- a/src/tests/channels/discord-service.test.ts
+++ b/src/tests/channels/discord-service.test.ts
@@ -12,7 +12,9 @@ import {
 import {
   __testOverrideLoadRoutes,
   __testOverrideSaveRoutes,
+  addRoute,
   clearAllRoutes,
+  getRoute,
 } from "../../channels/routing";
 import {
   __testOverrideResolveChannelAccountDisplayName,
@@ -21,6 +23,7 @@ import {
   getChannelAccountSnapshot,
   getChannelConfigSnapshot,
   listEnabledChannelIds,
+  removeChannelRouteLive,
   setChannelConfigLive,
   unbindChannelAccountLive,
   updateChannelAccountLive,
@@ -213,5 +216,27 @@ describe("discord channel service", () => {
       throw new Error("wrong channel");
     expect(snapshot.agentId).toBe("agent-456");
     expect((snapshot as Record<string, unknown>).binding).toBeUndefined();
+  });
+
+  test("removeChannelRouteLive removes threaded Discord routes", () => {
+    addRoute("discord", {
+      accountId: "discord-bot",
+      chatId: "thread-1",
+      threadId: "thread-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    expect(getRoute("discord", "thread-1", "discord-bot", "thread-1")).not.toBe(
+      null,
+    );
+    expect(removeChannelRouteLive("discord", "thread-1", "discord-bot")).toBe(
+      true,
+    );
+    expect(getRoute("discord", "thread-1", "discord-bot", "thread-1")).toBe(
+      null,
+    );
   });
 });

--- a/src/tests/channels/discord-xml.test.ts
+++ b/src/tests/channels/discord-xml.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { InboundChannelMessage } from "../../channels/types";
+import {
+  buildChannelNotificationXml,
+  buildChannelReminderText,
+  formatChannelNotification,
+} from "../../channels/xml";
+
+describe("discord xml", () => {
+  test("notification XML has source=discord", () => {
+    const message: InboundChannelMessage = {
+      channel: "discord",
+      chatId: "channel-123",
+      senderId: "user-1",
+      senderName: "alice",
+      messageId: "msg-1",
+      text: "hello discord",
+      timestamp: Date.now(),
+    };
+    const xml = buildChannelNotificationXml(message);
+    expect(xml).toContain('source="discord"');
+  });
+
+  test("reminder text includes discord-specific capability hints", () => {
+    const message: InboundChannelMessage = {
+      channel: "discord",
+      chatId: "channel-123",
+      senderId: "user-1",
+      senderName: "alice",
+      messageId: "msg-1",
+      text: "hey",
+      timestamp: Date.now(),
+    };
+    const reminder = buildChannelReminderText(message);
+    expect(reminder).toContain("discord");
+    expect(reminder.toLowerCase()).toContain("react");
+    expect(reminder).toContain("upload-file");
+    // Mentions native Unicode emoji in the capability hint text
+    expect(reminder).toContain("native Unicode emoji");
+  });
+
+  test("thread metadata appears in XML as thread_id", () => {
+    const message: InboundChannelMessage = {
+      channel: "discord",
+      chatId: "channel-123",
+      senderId: "user-1",
+      senderName: "alice",
+      messageId: "msg-1",
+      text: "in a thread",
+      threadId: "thread-999",
+      timestamp: Date.now(),
+    };
+    const xml = buildChannelNotificationXml(message);
+    expect(xml).toContain("thread-999");
+    expect(xml).toMatch(/thread_id\s*=\s*"thread-999"/);
+  });
+
+  test("thread context renders thread-context, thread-starter, thread-history", () => {
+    const message: InboundChannelMessage = {
+      channel: "discord",
+      chatId: "channel-123",
+      senderId: "user-1",
+      senderName: "alice",
+      messageId: "msg-1",
+      text: "replying in thread",
+      threadId: "thread-999",
+      timestamp: Date.now(),
+      threadContext: {
+        label: "Project Questions",
+        starter: {
+          messageId: "msg-0",
+          senderId: "user-0",
+          senderName: "bob",
+          text: "How should we handle retries?",
+        },
+        history: [
+          {
+            messageId: "msg-0a",
+            senderId: "user-2",
+            senderName: "carol",
+            text: "I'd exponential-backoff.",
+          },
+        ],
+      },
+    };
+    const xml = buildChannelNotificationXml(message);
+    expect(xml).toContain("<thread-context");
+    expect(xml).toContain("<thread-starter");
+    expect(xml).toContain("<thread-history>");
+  });
+
+  test("reaction metadata appears in XML", () => {
+    const message: InboundChannelMessage = {
+      channel: "discord",
+      chatId: "channel-123",
+      senderId: "user-1",
+      senderName: "alice",
+      messageId: "msg-1",
+      text: "",
+      timestamp: Date.now(),
+      reaction: {
+        action: "added",
+        emoji: "🔥",
+        targetMessageId: "msg-1",
+      },
+    };
+    const xml = buildChannelNotificationXml(message);
+    expect(xml).toContain("reaction");
+    expect(xml).toContain("🔥");
+    expect(xml).toContain("msg-1");
+    expect(xml).toContain("added");
+  });
+});

--- a/src/tests/channels/discord-xml.test.ts
+++ b/src/tests/channels/discord-xml.test.ts
@@ -35,8 +35,8 @@ describe("discord xml", () => {
     expect(reminder).toContain("discord");
     expect(reminder.toLowerCase()).toContain("react");
     expect(reminder).toContain("upload-file");
-    // Mentions native Unicode emoji in the capability hint text
     expect(reminder).toContain("native Unicode emoji");
+    expect(reminder).toContain("<:name:id>");
   });
 
   test("thread metadata appears in XML as thread_id", () => {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -141,7 +141,7 @@ export interface ReflectionSettingsSnapshot {
   step_count: number;
 }
 
-export type ChannelId = "telegram" | "slack";
+export type ChannelId = "telegram" | "slack" | "discord";
 
 export interface ChannelSummary {
   channel_id: ChannelId;
@@ -175,6 +175,15 @@ export type ChannelConfigSnapshot =
       allowed_users: string[];
       has_bot_token: boolean;
       has_app_token: boolean;
+    }
+  | {
+      channel_id: "discord";
+      account_id: string;
+      display_name?: string;
+      enabled: boolean;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_token: boolean;
     };
 
 export type ChannelAccountSnapshot =
@@ -209,6 +218,20 @@ export type ChannelAccountSnapshot =
       has_app_token: boolean;
       agent_id: string | null;
       default_permission_mode: SlackDefaultPermissionMode;
+      created_at: string;
+      updated_at: string;
+    }
+  | {
+      channel_id: "discord";
+      account_id: string;
+      display_name?: string;
+      enabled: boolean;
+      configured: boolean;
+      running: boolean;
+      dm_policy: DmPolicy;
+      allowed_users: string[];
+      has_token: boolean;
+      agent_id: string | null;
       created_at: string;
       updated_at: string;
     };

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -86,6 +86,7 @@ import type {
   ChannelAccountUnbindCommand,
   ChannelAccountUpdateCommand,
   ChannelGetConfigCommand,
+  ChannelId,
   ChannelPairingBindCommand,
   ChannelPairingsListCommand,
   ChannelRouteRemoveCommand,
@@ -964,10 +965,7 @@ function emitCronsUpdated(
   );
 }
 
-function emitChannelsUpdated(
-  socket: WebSocket,
-  channelId?: "telegram" | "slack",
-): void {
+function emitChannelsUpdated(socket: WebSocket, channelId?: ChannelId): void {
   safeSocketSend(
     socket,
     {
@@ -982,7 +980,7 @@ function emitChannelsUpdated(
 
 function emitChannelAccountsUpdated(
   socket: WebSocket,
-  params: { channelId: "telegram" | "slack"; accountId?: string },
+  params: { channelId: ChannelId; accountId?: string },
 ): void {
   safeSocketSend(
     socket,
@@ -999,7 +997,7 @@ function emitChannelAccountsUpdated(
 
 function emitChannelPairingsUpdated(
   socket: WebSocket,
-  channelId: "telegram" | "slack",
+  channelId: ChannelId,
 ): void {
   safeSocketSend(
     socket,
@@ -1016,7 +1014,7 @@ function emitChannelPairingsUpdated(
 function emitChannelRoutesUpdated(
   socket: WebSocket,
   params: {
-    channelId: "telegram" | "slack";
+    channelId: ChannelId;
     agentId?: string;
     conversationId?: string | null;
   },
@@ -1039,7 +1037,7 @@ function emitChannelRoutesUpdated(
 
 function emitChannelTargetsUpdated(
   socket: WebSocket,
-  channelId: "telegram" | "slack",
+  channelId: ChannelId,
 ): void {
   safeSocketSend(
     socket,
@@ -1575,6 +1573,17 @@ async function handleChannelsProtocolCommand(
         has_token: snapshot.hasToken,
       };
     }
+    if (snapshot.channelId === "discord") {
+      return {
+        channel_id: snapshot.channelId,
+        account_id: snapshot.accountId,
+        display_name: snapshot.displayName,
+        enabled: snapshot.enabled,
+        dm_policy: snapshot.dmPolicy,
+        allowed_users: snapshot.allowedUsers,
+        has_token: snapshot.hasToken,
+      };
+    }
     return {
       channel_id: snapshot.channelId,
       account_id: snapshot.accountId,
@@ -1606,6 +1615,23 @@ async function handleChannelsProtocolCommand(
           agent_id: snapshot.binding.agentId,
           conversation_id: snapshot.binding.conversationId,
         },
+        created_at: snapshot.createdAt,
+        updated_at: snapshot.updatedAt,
+      };
+    }
+
+    if (snapshot.channelId === "discord") {
+      return {
+        channel_id: snapshot.channelId,
+        account_id: snapshot.accountId,
+        display_name: snapshot.displayName,
+        enabled: snapshot.enabled,
+        configured: snapshot.configured,
+        running: snapshot.running,
+        dm_policy: snapshot.dmPolicy,
+        allowed_users: snapshot.allowedUsers,
+        has_token: snapshot.hasToken,
+        agent_id: snapshot.agentId,
         created_at: snapshot.createdAt,
         updated_at: snapshot.updatedAt,
       };

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3174,14 +3174,14 @@ function handleChannelRegistryEvent(
   runtime: ListenerRuntime,
 ): void {
   if (event.type === "pairings_updated") {
-    emitChannelPairingsUpdated(socket, event.channelId as "telegram" | "slack");
-    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+    emitChannelPairingsUpdated(socket, event.channelId as ChannelId);
+    emitChannelsUpdated(socket, event.channelId as ChannelId);
     return;
   }
 
   if (event.type === "targets_updated") {
-    emitChannelTargetsUpdated(socket, event.channelId as "telegram" | "slack");
-    emitChannelsUpdated(socket, event.channelId as "telegram" | "slack");
+    emitChannelTargetsUpdated(socket, event.channelId as ChannelId);
+    emitChannelsUpdated(socket, event.channelId as ChannelId);
     return;
   }
 

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -739,8 +739,10 @@ export function isSetReflectionSettingsCommand(
   );
 }
 
-function isChannelId(value: unknown): value is "telegram" | "slack" {
-  return value === "telegram" || value === "slack";
+function isChannelId(
+  value: unknown,
+): value is "telegram" | "slack" | "discord" {
+  return value === "telegram" || value === "slack" || value === "discord";
 }
 
 function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {
@@ -824,6 +826,15 @@ export function isChannelAccountCreateCommand(
     return account.token === undefined || typeof account.token === "string";
   }
 
+  if (c.channel_id === "discord") {
+    return (
+      (account.token === undefined || typeof account.token === "string") &&
+      (account.agent_id === undefined ||
+        account.agent_id === null ||
+        typeof account.agent_id === "string")
+    );
+  }
+
   return (
     (account.bot_token === undefined ||
       typeof account.bot_token === "string") &&
@@ -865,6 +876,15 @@ export function isChannelAccountUpdateCommand(
 
   if (c.channel_id === "telegram") {
     return patch.token === undefined || typeof patch.token === "string";
+  }
+
+  if (c.channel_id === "discord") {
+    return (
+      (patch.token === undefined || typeof patch.token === "string") &&
+      (patch.agent_id === undefined ||
+        patch.agent_id === null ||
+        typeof patch.agent_id === "string")
+    );
   }
 
   return (
@@ -1014,6 +1034,10 @@ export function isChannelSetConfigCommand(
   }
 
   if (c.channel_id === "telegram") {
+    return config.token === undefined || typeof config.token === "string";
+  }
+
+  if (c.channel_id === "discord") {
     return config.token === undefined || typeof config.token === "string";
   }
 


### PR DESCRIPTION
## Summary

- Adds Discord as a third channel plugin alongside Telegram and Slack
- DMs with pairing/allowlist/open policies, guild threads with mention-gated auto-thread creation
- discord.js@14.18.0 via runtime deps lazy install
- Supports text, attachments, reactions, file uploads, thread context hydration, lifecycle reactions, message splitting (2000-char limit)
- Full MessageChannel tool integration: send, react, upload-file

## Files

**New** (6): `src/channels/discord/{adapter,media,messageActions,plugin,runtime,setup}.ts`

**Modified** (10): types, pluginRegistry, config, service, registry, accounts, xml, protocol_v2, protocol-inbound, client

Written by Cameron ◯ Letta Code

"One must still have chaos in oneself to be able to give birth to a dancing star." — Nietzsche