### PR TITLE
fix(cron): remove 3-day auto-expiry for recurring tasks

### DIFF
--- a/src/cron/cronFile.ts
+++ b/src/cron/cronFile.ts
@@ -53,7 +53,7 @@ export interface CronTask {
   // Lifecycle
   status: CronTaskStatus;
   created_at: string; // ISO
-  expires_at: string | null; // 3-day TTL for recurring; null for one-shot
+  expires_at: string | null; // null for all tasks now (no auto-expiry)
   last_fired_at: string | null;
   fire_count: number;
   cancel_reason: CancelReason | null;
@@ -81,7 +81,9 @@ const LOCK_RETRY_MS = 50;
 const LOCK_STALE_AGE_MS = 30_000;
 const MAX_ACTIVE_TASKS_PER_AGENT = 50;
 const TASK_ID_BYTES = 4; // 8 hex chars
-const DEFAULT_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+// Recurring tasks no longer auto-expire. They remain active until explicitly
+// cancelled. GC still removes terminal tasks (fired, missed, cancelled) after 24h.
+// One-shot tasks already use null for expires_at and are handled separately.
 const GC_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // ── Paths ───────────────────────────────────────────────────────────
@@ -367,9 +369,9 @@ export function addTask(input: AddTaskInput): AddTaskResult {
       prompt: input.prompt,
       status: "active",
       created_at: now.toISOString(),
-      expires_at: input.recurring
-        ? new Date(now.getTime() + DEFAULT_TTL_MS).toISOString()
-        : null,
+      // Recurring tasks do not auto-expire (expires_at: null)
+      // One-shot tasks also use null (handled by scheduled_for)
+      expires_at: null,
       last_fired_at: null,
       fire_count: 0,
       cancel_reason: null,

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -99,13 +99,6 @@ function refreshTaskCache(state: SchedulerState): void {
 }
 
 function shouldFireTask(task: CronTask, now: Date): boolean {
-  // Check expiry for recurring tasks
-  if (task.recurring && task.expires_at) {
-    if (new Date(task.expires_at).getTime() <= now.getTime()) {
-      return false; // Will be handled by expiry check
-    }
-  }
-
   // One-shot: check if scheduled_for is now or past (jitter applied to scheduled time)
   if (!task.recurring && task.scheduled_for) {
     const scheduledMs =
@@ -174,16 +167,6 @@ function fireCronTask(
   }
 }
 
-function handleExpiredRecurring(task: CronTask, now: Date): void {
-  if (!task.recurring || !task.expires_at) return;
-  if (new Date(task.expires_at).getTime() <= now.getTime()) {
-    updateTask(task.id, (t) => {
-      t.status = "cancelled";
-      t.cancel_reason = "expired";
-    });
-  }
-}
-
 /** Returns true if the task was marked as missed (caller should skip firing). */
 function handleMissedOneShot(task: CronTask, now: Date): boolean {
   if (task.recurring || !task.scheduled_for) return false;
@@ -225,10 +208,6 @@ function tick(
   refreshTaskCache(state);
 
   for (const task of state.cachedTasks) {
-    if (task.status !== "active") continue;
-
-    // Handle expiry
-    handleExpiredRecurring(task, now);
     if (task.status !== "active") continue;
 
     // Handle missed one-shots (skip firing if marked missed)

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -141,7 +141,7 @@ Include context about what the user originally asked for, so you can give a help
 ## Important Notes
 
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
-- **Recurring TTL**: Recurring tasks auto-expire after 3 days. The user would need to re-create them or you can note this limitation.
+- **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup**: One-shot tasks are garbage-collected 24 hours after firing.
 - **Timezone**: Tasks use the user's local timezone by default.
 - **Scheduler requirement**: Tasks only fire while a Letta session is running (a WS listener must be active). If no session is running, tasks will be marked as missed.


### PR DESCRIPTION
## Summary
- Removes the 3-day auto-expiry for recurring scheduled tasks
- Recurring tasks now persist until explicitly cancelled
- GC still removes terminal tasks (fired, missed, cancelled) after 24h

## Problem
Recurring scheduled tasks were auto-expiring after 3 days, which is inappropriate for long-running scheduled jobs like daily reports, reminders, or periodic check-ins. Users would unexpectedly lose their scheduled tasks.

## Changes
- Removed `DEFAULT_TTL_MS` constant and associated expiry logic
- Set `expires_at` to `null` for all tasks (recurring and one-shot)
- Removed `handleExpiredRecurring()` from scheduler tick loop
- Updated skill docs to reflect the new behavior
- GC still works as before (removes completed/terminal tasks after 24h)

## Test Plan
- All 157 cron and headless tests pass
- Existing test suite covers task lifecycle, deduplication, and GC
- The expiry logic that was removed had no dedicated tests, suggesting it was not a critical path

Written by Cameron ◯ Letta Code