### PR TITLE
feat(models): add sonnet-4.6-high explicit id

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -96,6 +96,19 @@
       }
     },
     {
+      "id": "sonnet-4.6-high",
+      "handle": "anthropic/claude-sonnet-4-6",
+      "label": "Sonnet 4.6",
+      "description": "Sonnet 4.6 (high reasoning)",
+      "updateArgs": {
+        "context_window": 200000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "high",
+        "enable_reasoner": true,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "sonnet-4.6-xhigh",
       "handle": "anthropic/claude-sonnet-4-6",
       "label": "Sonnet 4.6",


### PR DESCRIPTION
## Summary
- Adds `sonnet-4.6-high` to `src/models.json`, completing the Sonnet 4.6 reasoning-tier series (low/medium/high/xhigh).
- Mirrors the existing `sonnet` entry's high-reasoning config (200k ctx, 128k max output, `reasoning_effort: high`, `enable_reasoner: true`), without `isFeatured`.

## Test plan
- [ ] `bun run src/index.ts --new --model sonnet-4.6-high -p "hi, what model are you?"`

👾 Generated with [Letta Code](https://letta.com)