### PR TITLE
feat(client): add x-letta-node header opt-in via LETTA_NODE env var

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -207,6 +207,9 @@ export async function getClient() {
     defaultHeaders: {
       "X-Letta-Source": "letta-code",
       "User-Agent": `letta-code/${packageJson.version}`,
+      ...(process.env.LETTA_NODE === "1" && {
+        "x-letta-node": "1",
+      }),
     },
     // Use instrumented fetch for timing logs when LETTA_DEBUG_TIMINGS is enabled
     ...(isTimingsEnabled() && { fetch: createTimingFetch(fetch) }),


### PR DESCRIPTION
## Summary
- When `LETTA_NODE=1` is set, the SDK client sends `x-letta-node: 1` on every request
## Usage
```bash
LETTA_NODE=1 bun run dev -p "hello" --agent agent-xxx --yolo
```

🤖 Generated with [Letta Code](https://letta.com)