### PR TITLE
feat: create hidden conversations for agent-to-agent and forked-subagent paths

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1304,11 +1304,21 @@ export async function handleHeadlessCommand(
       }
     }
   } else if (forceNewConversation) {
-    // --new flag: create a new conversation (for concurrent sessions)
-    const conversation = await client.conversations.create({
+    // --new flag: create a new conversation (for concurrent sessions).
+    // When --from-agent is set (agent-to-agent messaging), mark the new
+    // conversation as hidden so it doesn't clutter the target agent's
+    // default conversation list in the ADE. The `hidden` field is still
+    // missing from @letta-ai/letta-client@1.10.1 types, but the core
+    // endpoint accepts it and the SDK's create impl forwards unknown
+    // body fields unchanged — remove the cast once the SDK is bumped.
+    const createParams: Parameters<typeof client.conversations.create>[0] = {
       agent_id: agent.id,
       isolated_block_labels: isolatedBlockLabels,
-    });
+    };
+    if (fromAgentId) {
+      (createParams as { hidden?: boolean }).hidden = true;
+    }
+    const conversation = await client.conversations.create(createParams);
     conversationId = conversation.id;
   } else if (isSubagent) {
     // Freshly created subagents have no concurrency risk — use the default

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -129,6 +129,17 @@ If you need to share detailed information, include it in your response text.
 
 This helps the target agent understand the context and format their response appropriately.
 
+## Hidden Conversations
+
+Agent-to-agent conversations (started via `--from-agent`) are created **hidden** on the target agent. They don't appear in the target's default conversation list in the ADE, so automated inter-agent chatter doesn't clutter the UI.
+
+To inspect them:
+- List hidden conversations via the API with `archive_status=archived` (or `all`)
+- Pull the transcript directly with `letta messages transcript --conversation <id>`
+- The `conversation_id` returned when you sent the message is the handle you need
+
+Continuing a hidden conversation with `--conversation <id>` keeps it hidden — only archive status is affected, messaging still works normally.
+
 ## Related Skills
 
 - **finding-agents**: Find agents by name, tags, or fuzzy search

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -606,10 +606,17 @@ export async function task(args: TaskArgs): Promise<string> {
       const client = await getClient();
       const parentAgentId = getCurrentAgentId();
       const parentConvId = getConversationId() ?? "default";
+      // Mark the forked conversation as hidden so it doesn't clutter the
+      // parent agent's conversation list in the ADE. The subagent still
+      // reads/writes this conversation normally — only archive status is
+      // affected.
       const forkedConv = (await client.post(
         `/v1/conversations/${encodeURIComponent(parentConvId)}/fork`,
         {
-          query: parentConvId === "default" ? { agent_id: parentAgentId } : {},
+          query: {
+            ...(parentConvId === "default" ? { agent_id: parentAgentId } : {}),
+            hidden: true,
+          },
         },
       )) as { id: string };
       effectiveAgentId = parentAgentId;


### PR DESCRIPTION
## Summary
- **`--from-agent` (agent-to-agent messaging):** When `letta -p --from-agent <sender> --agent <target>` creates a new conversation on the target agent, pass `hidden: true` so the conversation is archived at creation and doesn't clutter the target's default conversation list in the ADE.
- **Forked subagents (Task tool with `fork: true`):** When the Task tool forks the parent conversation for a subagent, pass `hidden=true` on the `/fork` endpoint so the forked conversation is archived at creation. The subagent continues to read/write the forked conversation normally — only archive status is affected.
- Documents the agent-to-agent behavior in the `messaging-agents` skill, including how to inspect hidden conversations via `archive_status=archived|all` or `letta messages transcript`.

## Scope
- `--from-agent` path only — the `--new` (human) and default-headless fallback paths still create visible conversations. Freshly spawned subagents without `fork: true` still use the default conversation on their new agent and are untouched.
- `Task` with `fork: true` only (e.g. `subagent_type: "fork"`). Non-forking subagents (`explore`, `general-purpose`) don't create a conversation, so nothing to change there.

## Dependencies
- Core support for `CreateConversation.hidden` landed in letta-cloud#10940 (`feat(core): allow creating hidden conversations`).
- The `/v1/conversations/{id}/fork` endpoint already accepts a `hidden` query param (landed earlier alongside archive_status filtering).
- Pinned `@letta-ai/letta-client@1.10.1` types don't expose `hidden` on `CreateConversation` yet. The call site uses a narrow `as { hidden?: boolean }` cast; the SDK's `create` impl forwards unknown body fields unchanged, so the field reaches the API at runtime. Cast can be removed once the SDK is bumped — inline comment flags it.

## Test plan
- [x] `bun run check` (biome + tsc) passes
- [ ] Manual: `letta -p --from-agent <A> --agent <B> "hi"` against a dev server with core ≥ #10940, then `GET /v1/conversations?agent_id=<B>&archive_status=archived` shows the new conversation with `archived=true`; default listing does not
- [ ] Manual: dispatch a `fork` subagent (e.g. `Task({ subagent_type: "fork", ... })`) and verify the parent agent's default conversation list does NOT show the forked conversation, but `archive_status=archived` does

👾 Generated with [Letta Code](https://letta.com)