### PR TITLE
fix(subagent): route memory-mode subagents to the parent memfs repo [LET-8582]

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -148,6 +148,67 @@ export async function maybeUpdateMemoryRemoteOrigin(
   );
 }
 
+/**
+ * Constrain a local memory repo so both fetch and push target the expected
+ * memfs remote for the given agent.
+ *
+ * Unlike maybeUpdateMemoryRemoteOrigin(), this will actively rewrite a wrong
+ * origin instead of silently leaving it in place.
+ */
+export async function constrainMemoryRemoteOrigin(
+  repoDir: string,
+  agentId: string,
+): Promise<void> {
+  const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
+
+  let currentOrigin = "";
+  try {
+    const { stdout } = await runGit(repoDir, ["remote", "get-url", "origin"]);
+    currentOrigin = stdout.trim();
+  } catch {
+    throw new Error(
+      `Memory repo at ${repoDir} is missing an origin remote; expected ${expectedOrigin}`,
+    );
+  }
+
+  if (!currentOrigin) {
+    throw new Error(
+      `Memory repo at ${repoDir} has an empty origin remote; expected ${expectedOrigin}`,
+    );
+  }
+
+  const normalizedCurrent = normalizeRemoteUrl(currentOrigin);
+  if (normalizedCurrent !== expectedOrigin) {
+    await runGit(repoDir, ["remote", "set-url", "origin", expectedOrigin]);
+    debugLog(
+      "memfs-git",
+      `Constrained origin remote for ${agentId}: ${normalizedCurrent} -> ${expectedOrigin}`,
+    );
+  }
+
+  await runGit(repoDir, [
+    "remote",
+    "set-url",
+    "--push",
+    "origin",
+    expectedOrigin,
+  ]);
+
+  const { stdout: pushUrlStdout } = await runGit(repoDir, [
+    "remote",
+    "get-url",
+    "--push",
+    "origin",
+  ]);
+  const normalizedPushUrl = normalizeRemoteUrl(pushUrlStdout.trim());
+
+  if (normalizedPushUrl !== expectedOrigin) {
+    throw new Error(
+      `Failed to constrain push target for ${agentId}: expected ${expectedOrigin}, got ${normalizedPushUrl || "<empty>"}`,
+    );
+  }
+}
+
 /** Git remote URL for the agent's state repo */
 function getMemoryRemoteUrl(agentId: string): string {
   return getGitRemoteUrl(agentId);
@@ -617,7 +678,7 @@ export async function pushMemory(agentId: string): Promise<void> {
   const token = await getAuthToken();
   const dir = getMemoryRepoDir(agentId);
 
-  await maybeUpdateMemoryRemoteOrigin(dir, agentId);
+  await constrainMemoryRemoteOrigin(dir, agentId);
 
   await configureLocalCredentialHelper(dir, token);
 

--- a/src/agent/subagents/builtin/memory.md
+++ b/src/agent/subagents/builtin/memory.md
@@ -26,7 +26,7 @@ You achieve this by:
 
 ## Directory Structure
 
-The memory directory is at `~/.letta/agents/$LETTA_AGENT_ID/memory/`:
+The parent agent's memory directory is at `~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory/`:
 
 ```
 memory/
@@ -64,11 +64,11 @@ Do **not** edit:
 ### Phase 0: Setup
 
 The memory directory is at:
-`~/.letta/agents/$LETTA_AGENT_ID/memory/`
+`~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory/`
 
 ```bash
-MEMORY_DIR=~/.letta/agents/$LETTA_AGENT_ID/memory
-WORKTREE_DIR=~/.letta/agents/$LETTA_AGENT_ID/memory-worktrees
+MEMORY_DIR=~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory
+WORKTREE_DIR=~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory-worktrees
 ```
 
 The memory directory should already be a git repo
@@ -190,8 +190,8 @@ step. Without at least a merge to main, your work is lost.
 **Step 5a: Commit in worktree**
 
 ```bash
-MEMORY_DIR=~/.letta/agents/$LETTA_AGENT_ID/memory
-WORKTREE_DIR=~/.letta/agents/$LETTA_AGENT_ID/memory-worktrees
+MEMORY_DIR=~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory
+WORKTREE_DIR=~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory-worktrees
 cd $WORKTREE_DIR/$BRANCH
 git add -A
 ```
@@ -300,7 +300,7 @@ If anything goes wrong at any phase:
    - Whether main has uncommitted/dirty state
    - Concrete resume commands, e.g.:
      ```bash
-     cd ~/.letta/agents/$LETTA_AGENT_ID/memory
+     cd ~/.letta/agents/$LETTA_PARENT_AGENT_ID/memory
      git merge <branch-name> --no-edit
      git push
      git worktree remove ../memory-worktrees/<branch-name>

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -96,7 +96,8 @@ echo "PARENT_AGENT_ID=$LETTA_PARENT_AGENT_ID"
 Use the printed values (e.g., `agent-abc123...`) in the trailers. If a variable is empty or unset, omit that trailer. Never write a literal variable name like `$LETTA_AGENT_ID` or `$AGENT_ID` in the commit message.
 
 ```bash
-cd $MEMORY_DIR
+TARGET_MEMORY_DIR="${PARENT_MEMORY_DIR:-$MEMORY_DIR}"
+cd "$TARGET_MEMORY_DIR"
 git add -A
 git commit --author="Reflection Subagent <<ACTUAL_AGENT_ID>@letta.com>" -m "<type>(reflection): <summary> 🔮
 

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -21,7 +21,6 @@ import {
   SYSTEM_REMINDER_OPEN,
 } from "../../constants";
 import { cliPermissions } from "../../permissions/cli";
-import { resolveAllowedMemoryRoots } from "../../permissions/memoryScope";
 import { permissionMode } from "../../permissions/mode";
 import { sessionPermissions } from "../../permissions/session";
 import { settingsManager } from "../../settings-manager";
@@ -30,6 +29,7 @@ import { getErrorMessage } from "../../utils/error";
 import { getAvailableModelHandles } from "../available-models";
 import { getClient } from "../client";
 import { getCurrentAgentId } from "../context";
+import { getMemoryFilesystemRoot } from "../memoryFilesystem";
 import { getDefaultModelForTier, resolveModel } from "../model";
 import recallSubagentPrompt from "../prompts/recall_subagent.md";
 
@@ -653,6 +653,27 @@ export function buildSubagentArgs(
   return args;
 }
 
+export function resolveMemorySubagentTargetDir(
+  parentAgentId?: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir?: string,
+): string | null {
+  const explicitParentMemoryDir = env.PARENT_MEMORY_DIR?.trim();
+  if (explicitParentMemoryDir) {
+    return explicitParentMemoryDir;
+  }
+
+  const resolvedParentAgentId =
+    parentAgentId?.trim() || env.LETTA_PARENT_AGENT_ID?.trim();
+  if (resolvedParentAgentId) {
+    return getMemoryFilesystemRoot(resolvedParentAgentId, homeDir);
+  }
+
+  const inheritedMemoryDir =
+    env.MEMORY_DIR?.trim() || env.LETTA_MEMORY_DIR?.trim();
+  return inheritedMemoryDir || null;
+}
+
 /**
  * Execute a subagent and collect its final report by spawning letta in headless mode
  */
@@ -712,7 +733,6 @@ async function executeSubagent(
     const inheritedBaseUrl =
       process.env.LETTA_BASE_URL || settings.env?.LETTA_BASE_URL;
     const subagentWorkingDirectory = resolveSubagentWorkingDirectory();
-    const inheritedMemoryRoots = resolveAllowedMemoryRoots();
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,
       ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
@@ -722,19 +742,14 @@ async function executeSubagent(
     };
 
     if (config.permissionMode === "memory") {
-      if (inheritedMemoryRoots.primaryRoot) {
-        childEnv.MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
-        childEnv.LETTA_MEMORY_DIR = inheritedMemoryRoots.primaryRoot;
+      const parentMemoryDir = resolveMemorySubagentTargetDir(parentAgentId);
+      if (parentMemoryDir) {
+        childEnv.MEMORY_DIR = parentMemoryDir;
+        childEnv.LETTA_MEMORY_DIR = parentMemoryDir;
+        childEnv.PARENT_MEMORY_DIR = parentMemoryDir;
       } else {
         delete childEnv.MEMORY_DIR;
         delete childEnv.LETTA_MEMORY_DIR;
-      }
-
-      const parentMemoryDir =
-        process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-      if (parentMemoryDir && parentMemoryDir.trim().length > 0) {
-        childEnv.PARENT_MEMORY_DIR = parentMemoryDir;
-      } else {
         delete childEnv.PARENT_MEMORY_DIR;
       }
     }

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -30,6 +30,7 @@ import { getAvailableModelHandles } from "../available-models";
 import { getClient } from "../client";
 import { getCurrentAgentId } from "../context";
 import { getMemoryFilesystemRoot } from "../memoryFilesystem";
+import { constrainMemoryRemoteOrigin } from "../memoryGit";
 import { getDefaultModelForTier, resolveModel } from "../model";
 import recallSubagentPrompt from "../prompts/recall_subagent.md";
 
@@ -658,15 +659,15 @@ export function resolveMemorySubagentTargetDir(
   env: NodeJS.ProcessEnv = process.env,
   homeDir?: string,
 ): string | null {
-  const explicitParentMemoryDir = env.PARENT_MEMORY_DIR?.trim();
-  if (explicitParentMemoryDir) {
-    return explicitParentMemoryDir;
-  }
-
   const resolvedParentAgentId =
     parentAgentId?.trim() || env.LETTA_PARENT_AGENT_ID?.trim();
   if (resolvedParentAgentId) {
     return getMemoryFilesystemRoot(resolvedParentAgentId, homeDir);
+  }
+
+  const explicitParentMemoryDir = env.PARENT_MEMORY_DIR?.trim();
+  if (explicitParentMemoryDir) {
+    return explicitParentMemoryDir;
   }
 
   const inheritedMemoryDir =
@@ -744,6 +745,9 @@ async function executeSubagent(
     if (config.permissionMode === "memory") {
       const parentMemoryDir = resolveMemorySubagentTargetDir(parentAgentId);
       if (parentMemoryDir) {
+        if (parentAgentId) {
+          await constrainMemoryRemoteOrigin(parentMemoryDir, parentAgentId);
+        }
         childEnv.MEMORY_DIR = parentMemoryDir;
         childEnv.LETTA_MEMORY_DIR = parentMemoryDir;
         childEnv.PARENT_MEMORY_DIR = parentMemoryDir;

--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -1106,10 +1106,25 @@ function parseScopedGitInvocation(
 
     const worktreeSubcommand =
       subcommand === "worktree" ? (tokens[index + 1] ?? null) : null;
+    const remoteSubcommand =
+      subcommand === "remote" ? (tokens[index + 1] ?? null) : null;
     if (
       subcommand === "worktree" &&
       worktreeSubcommand &&
       !new Set(["add", "remove", "list"]).has(worktreeSubcommand)
+    ) {
+      return {
+        subcommand,
+        worktreeSubcommand,
+        resolvedCwd,
+        isSafe: false,
+      };
+    }
+
+    if (
+      subcommand === "remote" &&
+      remoteSubcommand &&
+      !new Set(["-v", "show", "get-url"]).has(remoteSubcommand)
     ) {
       return {
         subcommand,

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import type { SubagentConfig } from "../../agent/subagents";
 import {
   buildSubagentArgs,
+  resolveMemorySubagentTargetDir,
   resolveSubagentLauncher,
   resolveSubagentModel,
   resolveSubagentWorkingDirectory,
@@ -192,6 +194,32 @@ describe("buildSubagentArgs", () => {
 
     expect(args).toContain("--permission-mode");
     expect(args).toContain("memory");
+  });
+});
+
+describe("resolveMemorySubagentTargetDir", () => {
+  test("prefers the parent agent's memfs root over inherited MEMORY_DIR", () => {
+    const targetDir = resolveMemorySubagentTargetDir(
+      "agent-parent",
+      {
+        MEMORY_DIR: "/tmp/stale-memory-dir",
+        LETTA_MEMORY_DIR: "/tmp/stale-memory-dir",
+      } as NodeJS.ProcessEnv,
+      "/Users/test",
+    );
+
+    expect(targetDir).toBe(
+      getMemoryFilesystemRoot("agent-parent", "/Users/test"),
+    );
+  });
+
+  test("falls back to PARENT_MEMORY_DIR when provided explicitly", () => {
+    const targetDir = resolveMemorySubagentTargetDir("agent-parent", {
+      PARENT_MEMORY_DIR: "/tmp/parent-memory",
+      MEMORY_DIR: "/tmp/stale-memory-dir",
+    } as NodeJS.ProcessEnv);
+
+    expect(targetDir).toBe("/tmp/parent-memory");
   });
 });
 

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -213,8 +213,23 @@ describe("resolveMemorySubagentTargetDir", () => {
     );
   });
 
-  test("falls back to PARENT_MEMORY_DIR when provided explicitly", () => {
-    const targetDir = resolveMemorySubagentTargetDir("agent-parent", {
+  test("prefers the parent agent's memfs root over explicit PARENT_MEMORY_DIR", () => {
+    const targetDir = resolveMemorySubagentTargetDir(
+      "agent-parent",
+      {
+        PARENT_MEMORY_DIR: "/tmp/parent-memory",
+        MEMORY_DIR: "/tmp/stale-memory-dir",
+      } as NodeJS.ProcessEnv,
+      "/Users/test",
+    );
+
+    expect(targetDir).toBe(
+      getMemoryFilesystemRoot("agent-parent", "/Users/test"),
+    );
+  });
+
+  test("falls back to PARENT_MEMORY_DIR when parent agent id is unavailable", () => {
+    const targetDir = resolveMemorySubagentTargetDir(undefined, {
       PARENT_MEMORY_DIR: "/tmp/parent-memory",
       MEMORY_DIR: "/tmp/stale-memory-dir",
     } as NodeJS.ProcessEnv);

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -68,6 +68,15 @@ describe("isReadOnlyShellCommand", () => {
         ).toBe(true);
       });
 
+      test("denies git remote mutation in memory-scoped commands", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git remote set-url origin https://api.letta.com/v1/git/agent-2/state.git",
+            roots,
+          ),
+        ).toBe(false);
+      });
+
       test("allows env-based memory/worktree commands used by builtins", () => {
         expect(
           isScopedMemoryShellCommand(

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -253,3 +253,34 @@ test("getShellEnv injects MEMORY_DIR aliases when memfs is enabled", () => {
     }
   });
 });
+
+test("getShellEnv preserves parent memory root for memory-mode subagents", () => {
+  withTemporaryAgentEnv(`agent-test-${Date.now()}`, () => {
+    const originalIsMemfsEnabled =
+      settingsManager.isMemfsEnabled.bind(settingsManager);
+    const originalParentMemoryDir = process.env.PARENT_MEMORY_DIR;
+    process.env.PARENT_MEMORY_DIR = "/tmp/parent-memory-dir";
+    (
+      settingsManager as unknown as { isMemfsEnabled: (id: string) => boolean }
+    ).isMemfsEnabled = () => false;
+
+    try {
+      const env = getShellEnv();
+      expect(env.PARENT_MEMORY_DIR).toBe("/tmp/parent-memory-dir");
+      expect(env.LETTA_MEMORY_DIR).toBe("/tmp/parent-memory-dir");
+      expect(env.MEMORY_DIR).toBe("/tmp/parent-memory-dir");
+    } finally {
+      (
+        settingsManager as unknown as {
+          isMemfsEnabled: (id: string) => boolean;
+        }
+      ).isMemfsEnabled = originalIsMemfsEnabled;
+
+      if (originalParentMemoryDir === undefined) {
+        delete process.env.PARENT_MEMORY_DIR;
+      } else {
+        process.env.PARENT_MEMORY_DIR = originalParentMemoryDir;
+      }
+    }
+  });
+});

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -259,7 +259,9 @@ test("getShellEnv preserves parent memory root for memory-mode subagents", () =>
     const originalIsMemfsEnabled =
       settingsManager.isMemfsEnabled.bind(settingsManager);
     const originalParentMemoryDir = process.env.PARENT_MEMORY_DIR;
+    const originalParentAgentId = process.env.LETTA_PARENT_AGENT_ID;
     process.env.PARENT_MEMORY_DIR = "/tmp/parent-memory-dir";
+    process.env.LETTA_PARENT_AGENT_ID = "agent-parent";
     (
       settingsManager as unknown as { isMemfsEnabled: (id: string) => boolean }
     ).isMemfsEnabled = () => false;
@@ -269,6 +271,13 @@ test("getShellEnv preserves parent memory root for memory-mode subagents", () =>
       expect(env.PARENT_MEMORY_DIR).toBe("/tmp/parent-memory-dir");
       expect(env.LETTA_MEMORY_DIR).toBe("/tmp/parent-memory-dir");
       expect(env.MEMORY_DIR).toBe("/tmp/parent-memory-dir");
+      expect(env.GIT_CONFIG_COUNT).toBe("2");
+      expect(env.GIT_CONFIG_KEY_0).toBe("remote.origin.url");
+      expect(env.GIT_CONFIG_VALUE_0).toContain(
+        "/v1/git/agent-parent/state.git",
+      );
+      expect(env.GIT_CONFIG_KEY_1).toBe("remote.origin.pushurl");
+      expect(env.GIT_CONFIG_VALUE_1).toBe(env.GIT_CONFIG_VALUE_0);
     } finally {
       (
         settingsManager as unknown as {
@@ -280,6 +289,12 @@ test("getShellEnv preserves parent memory root for memory-mode subagents", () =>
         delete process.env.PARENT_MEMORY_DIR;
       } else {
         process.env.PARENT_MEMORY_DIR = originalParentMemoryDir;
+      }
+
+      if (originalParentAgentId === undefined) {
+        delete process.env.LETTA_PARENT_AGENT_ID;
+      } else {
+        process.env.LETTA_PARENT_AGENT_ID = originalParentAgentId;
       }
     }
   });

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -14,7 +14,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
+import { constrainMemoryRemoteOrigin } from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
 
 const execFile = promisify(execFileCb);
@@ -590,7 +590,7 @@ async function commitAndPush(
   const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
   const sha = head.stdout.trim();
 
-  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
+  await constrainMemoryRemoteOrigin(memoryDir, agentId);
 
   try {
     await runGit(memoryDir, ["push"]);

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -14,7 +14,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
+import { constrainMemoryRemoteOrigin } from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
 
 const execFile = promisify(execFileCb);
@@ -769,7 +769,7 @@ async function commitAndPush(
   const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
   const sha = head.stdout.trim();
 
-  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
+  await constrainMemoryRemoteOrigin(memoryDir, agentId);
 
   try {
     await runGit(memoryDir, ["push"]);

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -214,23 +214,33 @@ export function getShellEnv(): NodeJS.ProcessEnv {
     }
   }
 
+  const parentMemoryDir = env.PARENT_MEMORY_DIR?.trim();
+
   if (agentId) {
     env.LETTA_AGENT_ID = agentId;
     env.AGENT_ID = agentId;
 
-    try {
-      if (settingsManager.isMemfsEnabled(agentId)) {
-        const memoryDir = getMemoryFilesystemRoot(agentId);
-        env.LETTA_MEMORY_DIR = memoryDir;
-        env.MEMORY_DIR = memoryDir;
-      } else {
-        // Clear inherited/stale memory-dir vars for non-memfs agents.
-        delete env.LETTA_MEMORY_DIR;
-        delete env.MEMORY_DIR;
+    if (parentMemoryDir) {
+      env.LETTA_MEMORY_DIR = parentMemoryDir;
+      env.MEMORY_DIR = parentMemoryDir;
+    } else {
+      try {
+        if (settingsManager.isMemfsEnabled(agentId)) {
+          const memoryDir = getMemoryFilesystemRoot(agentId);
+          env.LETTA_MEMORY_DIR = memoryDir;
+          env.MEMORY_DIR = memoryDir;
+        } else {
+          // Clear inherited/stale memory-dir vars for non-memfs agents.
+          delete env.LETTA_MEMORY_DIR;
+          delete env.MEMORY_DIR;
+        }
+      } catch {
+        // Settings may not be initialized in tests/startup; preserve inherited values.
       }
-    } catch {
-      // Settings may not be initialized in tests/startup; preserve inherited values.
     }
+  } else if (parentMemoryDir) {
+    env.LETTA_MEMORY_DIR = parentMemoryDir;
+    env.MEMORY_DIR = parentMemoryDir;
   }
   // Inject conversation ID if available
   let convId: string | undefined;

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { getServerUrl } from "../../agent/client";
 import { getConversationId, getCurrentAgentId } from "../../agent/context";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { getGitRemoteUrl } from "../../agent/memoryGit";
 import { settingsManager } from "../../settings-manager";
 
 /**
@@ -162,6 +163,32 @@ export function ensureLettaShimDir(invocation: LettaInvocation): string | null {
   return shimDir;
 }
 
+function appendGitConfigOverride(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  value: string,
+): void {
+  const rawCount = Number.parseInt(env.GIT_CONFIG_COUNT || "0", 10);
+  const nextIndex = Number.isFinite(rawCount) && rawCount >= 0 ? rawCount : 0;
+
+  env[`GIT_CONFIG_KEY_${nextIndex}`] = key;
+  env[`GIT_CONFIG_VALUE_${nextIndex}`] = value;
+  env.GIT_CONFIG_COUNT = String(nextIndex + 1);
+}
+
+function getMemoryRemoteBaseUrl(env: NodeJS.ProcessEnv): string {
+  const explicitBaseUrl = env.LETTA_BASE_URL?.trim();
+  if (explicitBaseUrl) {
+    return explicitBaseUrl;
+  }
+
+  try {
+    return getServerUrl();
+  } catch {
+    return "https://api.letta.com";
+  }
+}
+
 /**
  * Get enhanced environment variables for shell execution.
  * Includes bundled tools (like ripgrep) in PATH and Letta context for skill scripts.
@@ -215,6 +242,7 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   }
 
   const parentMemoryDir = env.PARENT_MEMORY_DIR?.trim();
+  const parentAgentId = env.LETTA_PARENT_AGENT_ID?.trim();
 
   if (agentId) {
     env.LETTA_AGENT_ID = agentId;
@@ -241,6 +269,15 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   } else if (parentMemoryDir) {
     env.LETTA_MEMORY_DIR = parentMemoryDir;
     env.MEMORY_DIR = parentMemoryDir;
+  }
+
+  if (parentMemoryDir && parentAgentId) {
+    const expectedRemoteUrl = getGitRemoteUrl(
+      parentAgentId,
+      getMemoryRemoteBaseUrl(env),
+    );
+    appendGitConfigOverride(env, "remote.origin.url", expectedRemoteUrl);
+    appendGitConfigOverride(env, "remote.origin.pushurl", expectedRemoteUrl);
   }
   // Inject conversation ID if available
   let convId: string | undefined;


### PR DESCRIPTION
## Summary
- resolve memory-mode subagent memfs targets from the parent agent scope instead of inheriting stale child memory roots
- preserve `PARENT_MEMORY_DIR` in shell env so reflection commits keep writing to the parent memfs checkout
- update the reflection/memory subagent guidance and add regression coverage for parent memfs routing

## Test plan
- [x] `bun test src/tests/agent/subagent-model-resolution.test.ts src/tests/tools/shell-env.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/agent/subagents/manager.ts src/tools/impl/shellEnv.ts src/tests/agent/subagent-model-resolution.test.ts src/tests/tools/shell-env.test.ts`
- [ ] `bun run check` *(fails on pre-existing lint errors in `src/agent/reconcileExistingAgentState.ts`, `src/tests/channels/runtimeDeps.test.ts`, and `src/web/generate-memory-viewer.ts`)*

👾 Generated with [Letta Code](https://letta.com)