### PR TITLE
feat(permissions): add cross-agent memory guard

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -21,7 +21,10 @@ import {
   SYSTEM_REMINDER_OPEN,
 } from "../../constants";
 import { cliPermissions } from "../../permissions/cli";
-import { resolveAllowedMemoryRoots } from "../../permissions/memoryScope";
+import {
+  parseScopeList,
+  resolveAllowedMemoryRoots,
+} from "../../permissions/memoryScope";
 import { permissionMode } from "../../permissions/mode";
 import { sessionPermissions } from "../../permissions/session";
 import { settingsManager } from "../../settings-manager";
@@ -719,10 +722,7 @@ async function executeSubagent(
       // Authorize the child to write the parent's memory via the
       // cross-agent guard. Compose the scope transitively so that
       // grandchildren also see the full ancestor chain.
-      const inheritedScope = (process.env.LETTA_MEMORY_SCOPE ?? "")
-        .split(/[\s,]+/)
-        .filter(Boolean);
-      const nextScope = new Set(inheritedScope);
+      const nextScope = new Set(parseScopeList(process.env.LETTA_MEMORY_SCOPE));
       if (parentAgentId) {
         nextScope.add(parentAgentId);
       }

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -731,11 +731,6 @@ async function executeSubagent(
       } else {
         delete childEnv.LETTA_MEMORY_SCOPE;
       }
-
-      // PARENT_MEMORY_DIR is no longer authoritative for permissions;
-      // the guard uses LETTA_MEMORY_SCOPE instead. Ensure we do not
-      // propagate a stale parent-memory path from the outer env.
-      delete childEnv.PARENT_MEMORY_DIR;
     }
 
     const proc = spawn(launcher.command, launcher.args, {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -716,13 +716,26 @@ async function executeSubagent(
         delete childEnv.LETTA_MEMORY_DIR;
       }
 
-      const parentMemoryDir =
-        process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-      if (parentMemoryDir && parentMemoryDir.trim().length > 0) {
-        childEnv.PARENT_MEMORY_DIR = parentMemoryDir;
-      } else {
-        delete childEnv.PARENT_MEMORY_DIR;
+      // Authorize the child to write the parent's memory via the
+      // cross-agent guard. Compose the scope transitively so that
+      // grandchildren also see the full ancestor chain.
+      const inheritedScope = (process.env.LETTA_MEMORY_SCOPE ?? "")
+        .split(/[\s,]+/)
+        .filter(Boolean);
+      const nextScope = new Set(inheritedScope);
+      if (parentAgentId) {
+        nextScope.add(parentAgentId);
       }
+      if (nextScope.size > 0) {
+        childEnv.LETTA_MEMORY_SCOPE = [...nextScope].join(",");
+      } else {
+        delete childEnv.LETTA_MEMORY_SCOPE;
+      }
+
+      // PARENT_MEMORY_DIR is no longer authoritative for permissions;
+      // the guard uses LETTA_MEMORY_SCOPE instead. Ensure we do not
+      // propagate a stale parent-memory path from the outer env.
+      delete childEnv.PARENT_MEMORY_DIR;
     }
 
     const proc = spawn(launcher.command, launcher.args, {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -129,6 +129,19 @@ export const CLI_FLAG_CATALOG = {
   allowedTools: { parser: { type: "string" }, mode: "both" },
   disallowedTools: { parser: { type: "string" }, mode: "both" },
   "permission-mode": { parser: { type: "string" }, mode: "both" },
+  "memory-scope": {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<ids>",
+      description:
+        "Comma-separated agent IDs this session may access in addition to self.",
+      continuationLines: [
+        "Example: --memory-scope agent-abc,agent-def",
+        "Required to read or write another agent's memory directory.",
+      ],
+    },
+  },
   yolo: { parser: { type: "boolean" }, mode: "both" },
   "output-format": {
     parser: { type: "string" },

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -448,13 +448,16 @@ export async function handleHeadlessCommand(
   }
 
   // Set CLI permission overrides if provided (inherited from parent agent)
-  if (values.allowedTools || values.disallowedTools) {
+  if (values.allowedTools || values.disallowedTools || values["memory-scope"]) {
     const { cliPermissions } = await import("./permissions/cli");
     if (values.allowedTools) {
       cliPermissions.setAllowedTools(values.allowedTools);
     }
     if (values.disallowedTools) {
       cliPermissions.setDisallowedTools(values.disallowedTools);
+    }
+    if (values["memory-scope"]) {
+      cliPermissions.setMemoryScope(values["memory-scope"]);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -917,13 +917,16 @@ async function main(): Promise<void> {
   }
 
   // Set CLI permission overrides if provided
-  if (values.allowedTools || values.disallowedTools) {
+  if (values.allowedTools || values.disallowedTools || values["memory-scope"]) {
     const { cliPermissions } = await import("./permissions/cli");
     if (values.allowedTools) {
       cliPermissions.setAllowedTools(values.allowedTools);
     }
     if (values.disallowedTools) {
       cliPermissions.setDisallowedTools(values.disallowedTools);
+    }
+    if (values["memory-scope"]) {
+      cliPermissions.setMemoryScope(values["memory-scope"]);
     }
   }
 

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -7,7 +7,7 @@ import { runPermissionRequestHooks } from "../hooks";
 import type { PermissionModeState } from "../tools/manager";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli";
-import { evaluateCrossAgentGuard } from "./crossAgentGuard";
+import { evaluateCrossAgentGuard, extractFilePath } from "./crossAgentGuard";
 import {
   type MatcherOptions,
   matchesBashPattern,
@@ -262,9 +262,9 @@ function checkPermissionForEngine(
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
 
-  // Step 0: Cross-agent guard — unbypassable. If this tool call targets
-  // another agent's memory and that agent isn't in the allowed set, deny
-  // before any other rule/mode/flag can override it.
+  // Cross-agent guard — denies any tool call targeting another agent's
+  // memory unless that agent is in the allowed set. Unbypassable by any
+  // mode, rule, or flag.
   const guardResult = evaluateCrossAgentGuard(
     toolName,
     toolArgs,
@@ -539,26 +539,6 @@ function checkPermissionForEngine(
     },
     trace,
   };
-}
-
-/**
- * Extract file path from tool arguments
- */
-function extractFilePath(toolArgs: ToolArgs): string | null {
-  // Different tools use different parameter names
-  if (typeof toolArgs.file_path === "string" && toolArgs.file_path.length > 0) {
-    return toolArgs.file_path;
-  }
-  if (typeof toolArgs.path === "string" && toolArgs.path.length > 0) {
-    return toolArgs.path;
-  }
-  if (
-    typeof toolArgs.notebook_path === "string" &&
-    toolArgs.notebook_path.length > 0
-  ) {
-    return toolArgs.notebook_path;
-  }
-  return null;
 }
 
 /**

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -7,6 +7,7 @@ import { runPermissionRequestHooks } from "../hooks";
 import type { PermissionModeState } from "../tools/manager";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli";
+import { evaluateCrossAgentGuard } from "./crossAgentGuard";
 import {
   type MatcherOptions,
   matchesBashPattern,
@@ -114,6 +115,9 @@ function shouldAttachTrace(result: PermissionCheckResult): boolean {
  * Check permission for a tool execution.
  *
  * Decision logic:
+ * 0. Cross-agent guard (unbypassable) → DENY any tool call targeting
+ *    another agent's memory dir unless that agent is in allowed_agents
+ *    (self ∪ LETTA_MEMORY_SCOPE ∪ --memory-scope)
  * 1. Check deny rules from settings (first match wins) → DENY
  * 2. Check CLI disallowedTools (--disallowedTools flag) → DENY
  * 3. Check permission mode (--permission-mode flag) → ALLOW or DENY
@@ -257,6 +261,26 @@ function checkPermissionForEngine(
   const sessionRules = sessionPermissions.getRules();
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
+
+  // Step 0: Cross-agent guard — unbypassable. If this tool call targets
+  // another agent's memory and that agent isn't in the allowed set, deny
+  // before any other rule/mode/flag can override it.
+  const guardResult = evaluateCrossAgentGuard(
+    toolName,
+    toolArgs,
+    workingDirectory,
+  );
+  if (guardResult) {
+    traceEvent(trace, "cross-agent-guard", guardResult.reason);
+    return {
+      result: {
+        decision: "deny",
+        matchedRule: guardResult.matchedRule,
+        reason: guardResult.reason,
+      },
+      trace,
+    };
+  }
 
   if (permissions.deny) {
     for (const pattern of permissions.deny) {

--- a/src/permissions/cli.ts
+++ b/src/permissions/cli.ts
@@ -7,6 +7,7 @@ import {
   isFileToolName,
   isShellToolName,
 } from "./canonical";
+import { parseScopeList } from "./memoryScope";
 import { normalizePermissionRule } from "./rule-normalization";
 
 /**
@@ -42,14 +43,7 @@ class CliPermissions {
    *   --memory-scope "agent-abc agent-def"
    */
   setMemoryScope(scopeString: string): void {
-    if (!scopeString) {
-      this.memoryScope = [];
-      return;
-    }
-    this.memoryScope = scopeString
-      .split(/[\s,]+/)
-      .map((id) => id.trim())
-      .filter((id) => id.length > 0);
+    this.memoryScope = parseScopeList(scopeString);
   }
 
   /**

--- a/src/permissions/cli.ts
+++ b/src/permissions/cli.ts
@@ -16,6 +16,7 @@ import { normalizePermissionRule } from "./rule-normalization";
 class CliPermissions {
   private allowedTools: string[] = [];
   private disallowedTools: string[] = [];
+  private memoryScope: string[] = [];
 
   /**
    * Parse and set allowed tools from CLI flag
@@ -31,6 +32,24 @@ class CliPermissions {
    */
   setDisallowedTools(toolsString: string): void {
     this.disallowedTools = this.parseToolList(toolsString);
+  }
+
+  /**
+   * Parse and set the memory-scope flag — a list of agent IDs whose memory
+   * this session is allowed to access (in addition to the current agent).
+   * Format: comma- or whitespace-separated agent IDs, e.g.
+   *   --memory-scope "agent-abc, agent-def"
+   *   --memory-scope "agent-abc agent-def"
+   */
+  setMemoryScope(scopeString: string): void {
+    if (!scopeString) {
+      this.memoryScope = [];
+      return;
+    }
+    this.memoryScope = scopeString
+      .split(/[\s,]+/)
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
   }
 
   /**
@@ -122,10 +141,28 @@ class CliPermissions {
   }
 
   /**
+   * Get the CLI-supplied memory-scope list (agent IDs).
+   */
+  getMemoryScope(): string[] {
+    return [...this.memoryScope];
+  }
+
+  /**
+   * Whether --memory-scope was set on the CLI.
+   */
+  hasMemoryScope(): boolean {
+    return this.memoryScope.length > 0;
+  }
+
+  /**
    * Check if any CLI overrides are set
    */
   hasOverrides(): boolean {
-    return this.allowedTools.length > 0 || this.disallowedTools.length > 0;
+    return (
+      this.allowedTools.length > 0 ||
+      this.disallowedTools.length > 0 ||
+      this.memoryScope.length > 0
+    );
   }
 
   /**
@@ -134,6 +171,7 @@ class CliPermissions {
   clear(): void {
     this.allowedTools = [];
     this.disallowedTools = [];
+    this.memoryScope = [];
   }
 }
 

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -1,0 +1,431 @@
+// src/permissions/crossAgentGuard.ts
+// Cross-agent guard: hard-denies any tool call whose target resolves under
+// another agent's memory directory unless the caller has explicitly opted in.
+//
+// The guard runs BEFORE any other permission logic (mode overrides, CLI
+// allow/deny rules, settings rules). Its deny is unbypassable — no mode,
+// no rule, no flag can override it.
+//
+// Sources for the allowed-agents set (additive, deduped):
+//   - self:  current AGENT_ID
+//   - env:   LETTA_MEMORY_SCOPE (comma- or whitespace-separated agent IDs)
+//   - cli:   --memory-scope flag (via cliPermissions.getMemoryScope())
+
+import { homedir } from "node:os";
+import { getCurrentAgentId } from "../agent/context";
+import { canonicalToolName, isShellToolName } from "./canonical";
+import { cliPermissions } from "./cli";
+import { normalizeScopedPath, resolveScopedTargetPath } from "./memoryScope";
+import { splitShellSegments, tokenizeShellWords } from "./shellAnalysis";
+
+// --------------------------------------------------------------------------
+// Allowed agents
+// --------------------------------------------------------------------------
+
+export interface AllowedAgentsOptions {
+  env?: NodeJS.ProcessEnv;
+  currentAgentId?: string | null;
+  cliMemoryScope?: string[];
+}
+
+export interface ResolvedAllowedAgents {
+  ids: Set<string>;
+  sources: {
+    self: string | null;
+    env: string[];
+    cli: string[];
+  };
+}
+
+function parseScopeList(value: string | undefined | null): string[] {
+  if (!value) return [];
+  return value
+    .split(/[\s,]+/)
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+function deriveSelfAgentId(
+  env: NodeJS.ProcessEnv,
+  explicit?: string | null,
+): string | null {
+  const fromArg = explicit?.trim();
+  if (fromArg) return fromArg;
+
+  const fromEnv = (env.AGENT_ID || env.LETTA_AGENT_ID || "").trim();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const fromContext = getCurrentAgentId().trim();
+    return fromContext || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the set of agent IDs the current process is allowed to operate
+ * against. Additive union of three sources.
+ */
+export function resolveAllowedAgents(
+  options: AllowedAgentsOptions = {},
+): ResolvedAllowedAgents {
+  const env = options.env ?? process.env;
+
+  const self = deriveSelfAgentId(env, options.currentAgentId);
+  const envScope = parseScopeList(env.LETTA_MEMORY_SCOPE);
+  const cliScope = options.cliMemoryScope ?? cliPermissions.getMemoryScope();
+
+  const ids = new Set<string>();
+  if (self) ids.add(self);
+  for (const id of envScope) ids.add(id);
+  for (const id of cliScope) ids.add(id);
+
+  return {
+    ids,
+    sources: {
+      self,
+      env: envScope,
+      cli: [...cliScope],
+    },
+  };
+}
+
+// --------------------------------------------------------------------------
+// Target path extraction
+// --------------------------------------------------------------------------
+
+type ToolArgs = Record<string, unknown>;
+
+export interface CrossAgentTargets {
+  /** Agent IDs extracted from any path references in the tool args. */
+  agentIds: Set<string>;
+  /**
+   * True iff at least one target path resolved under
+   * ~/.letta/agents/<id>/memory(-worktrees)?/... — the only case where
+   * the guard is concerned at all.
+   */
+  anyAgentScoped: boolean;
+}
+
+/**
+ * Build the regex that matches an agent-scoped memory path prefix on the
+ * current machine. Capture group 1 is the agent ID.
+ *
+ * Uses the canonical home dir so we only need to compile once per call.
+ */
+function buildAgentScopedRegex(homeDir: string): RegExp {
+  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
+  const escaped = normalizedHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `^${escaped}/\\.letta/agents/([^/]+)/memory(?:-worktrees)?(?:/.*)?$`,
+  );
+}
+
+/**
+ * If the given path is agent-scoped on this machine, return the agent ID.
+ */
+function matchAgentScopedPath(path: string, homeDir: string): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  const regex = buildAgentScopedRegex(homeDir);
+  const match = normalized.match(regex);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Extract file directives from an apply_patch / memory_apply_patch input.
+ *
+ * Exported so `mode.ts` can also share this helper (single source of truth
+ * for the directive syntax).
+ */
+export function extractApplyPatchPaths(input: string): string[] {
+  const paths: string[] = [];
+  const fileDirectivePattern = /\*\*\* (?:Add|Update|Delete) File:\s*(.+)/g;
+  const moveDirectivePattern = /\*\*\* Move to:\s*(.+)/g;
+
+  for (const match of input.matchAll(fileDirectivePattern)) {
+    const matchPath = match[1]?.trim();
+    if (matchPath) paths.push(matchPath);
+  }
+  for (const match of input.matchAll(moveDirectivePattern)) {
+    const matchPath = match[1]?.trim();
+    if (matchPath) paths.push(matchPath);
+  }
+
+  return paths;
+}
+
+function extractFilePath(toolArgs: ToolArgs): string | null {
+  if (typeof toolArgs.file_path === "string" && toolArgs.file_path.length > 0) {
+    return toolArgs.file_path;
+  }
+  if (typeof toolArgs.path === "string" && toolArgs.path.length > 0) {
+    return toolArgs.path;
+  }
+  if (
+    typeof toolArgs.notebook_path === "string" &&
+    toolArgs.notebook_path.length > 0
+  ) {
+    return toolArgs.notebook_path;
+  }
+  return null;
+}
+
+function extractMultiEditPaths(toolArgs: ToolArgs): string[] {
+  // MultiEdit uses file_path (singular), but callers occasionally pass an
+  // `edits` array. Either way the paths come from the top-level `file_path`.
+  const single = extractFilePath(toolArgs);
+  return single ? [single] : [];
+}
+
+function extractShellCommand(toolArgs: ToolArgs): string | null {
+  const command = toolArgs.command;
+  if (typeof command === "string") return command;
+  if (Array.isArray(command)) {
+    return command.map((c) => String(c)).join(" ");
+  }
+  return null;
+}
+
+/**
+ * Expand env variables ($VAR, ${VAR}, $HOME, ~/) in a shell token.
+ * Returns null when an unresolved variable is encountered.
+ *
+ * Mirrors the expansion used by `readOnlyShell.ts#expandScopedVariables`
+ * but is self-contained here to keep the dependency graph simple.
+ */
+function expandShellToken(
+  token: string,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): string | null {
+  let result = token;
+
+  if (result.startsWith("~/")) {
+    result = `${homeDir}/${result.slice(2)}`;
+  } else if (result === "~") {
+    result = homeDir;
+  }
+
+  let unresolved = false;
+  result = result.replace(
+    /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    (_match, bracedName: string | undefined, bareName: string | undefined) => {
+      const name = bracedName || bareName;
+      if (!name) {
+        unresolved = true;
+        return "";
+      }
+      if (name === "HOME") {
+        return homeDir;
+      }
+      const envValue = env[name];
+      if (typeof envValue === "string") {
+        return envValue;
+      }
+      unresolved = true;
+      return "";
+    },
+  );
+
+  return unresolved ? null : result;
+}
+
+/**
+ * Walk a shell command and collect every token that expands to an
+ * agent-scoped memory path on this machine. Returns the map of
+ * token → agent ID.
+ */
+function collectShellAgentTargets(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): Map<string, string> {
+  const targets = new Map<string, string>();
+  const segments = splitShellSegments(command);
+  if (!segments) {
+    // Split was refused due to dangerous operator (command substitution,
+    // redirect to non-/dev/null, etc.). Still scan the raw tokens of the
+    // whole command as best-effort — if any agent-scoped path shows up,
+    // we want to catch it.
+    const tokens = tokenizeShellWords(command);
+    for (const token of tokens) {
+      scanToken(token, env, homeDir, targets);
+    }
+    return targets;
+  }
+
+  for (const segment of segments) {
+    const tokens = tokenizeShellWords(segment);
+    for (const token of tokens) {
+      scanToken(token, env, homeDir, targets);
+    }
+  }
+  return targets;
+}
+
+function scanToken(
+  rawToken: string,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+  out: Map<string, string>,
+): void {
+  if (!rawToken) return;
+
+  // Strip leading assignment prefix (FOO=...) so we also catch values
+  // assigned to env variables inline.
+  const assignmentMatch = rawToken.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+  const candidateValue = assignmentMatch
+    ? (assignmentMatch[2] ?? "")
+    : rawToken;
+  const candidates = [rawToken, candidateValue].filter((v) => v.length > 0);
+
+  for (const value of candidates) {
+    const expanded = expandShellToken(value, env, homeDir);
+    if (expanded === null) continue;
+    const normalized = normalizeScopedPath(expanded);
+    const agentId = matchAgentScopedPath(normalized, homeDir);
+    if (agentId) {
+      out.set(value, agentId);
+    }
+  }
+}
+
+/**
+ * Extract the agent IDs referenced by the targets of a tool call.
+ * Returns `anyAgentScoped: false` for tool calls that don't touch
+ * agent memory at all (the guard's fast path).
+ */
+export function extractTargetAgentPaths(
+  toolName: string,
+  toolArgs: ToolArgs,
+  workingDirectory: string,
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir(),
+): CrossAgentTargets {
+  const agentIds = new Set<string>();
+  let anyAgentScoped = false;
+
+  const addFromPath = (rawPath: string | null | undefined) => {
+    if (!rawPath || typeof rawPath !== "string") return;
+    const resolvedPath = resolveScopedTargetPath(rawPath, workingDirectory);
+    if (!resolvedPath) return;
+    const id = matchAgentScopedPath(resolvedPath, homeDir);
+    if (id) {
+      anyAgentScoped = true;
+      agentIds.add(id);
+    }
+  };
+
+  const canonical = canonicalToolName(toolName);
+
+  // Patch tools: extract every file directive.
+  if (
+    toolName === "ApplyPatch" ||
+    toolName === "apply_patch" ||
+    toolName === "memory_apply_patch"
+  ) {
+    if (typeof toolArgs.input === "string") {
+      for (const p of extractApplyPatchPaths(toolArgs.input)) {
+        addFromPath(p);
+      }
+    }
+    return { agentIds, anyAgentScoped };
+  }
+
+  // Shell tools: tokenize + expand.
+  if (isShellToolName(toolName) || canonical === "Bash") {
+    const command = extractShellCommand(toolArgs);
+    if (command) {
+      const hits = collectShellAgentTargets(command, env, homeDir);
+      for (const id of hits.values()) {
+        anyAgentScoped = true;
+        agentIds.add(id);
+      }
+    }
+    return { agentIds, anyAgentScoped };
+  }
+
+  // MultiEdit: same path semantics as Edit.
+  if (toolName === "MultiEdit") {
+    for (const p of extractMultiEditPaths(toolArgs)) {
+      addFromPath(p);
+    }
+    return { agentIds, anyAgentScoped };
+  }
+
+  // All other file-oriented tools: Read/Write/Edit/NotebookEdit/Glob/
+  // Grep/ListDir/LS + Gemini + Codex aliases.
+  addFromPath(extractFilePath(toolArgs));
+
+  return { agentIds, anyAgentScoped };
+}
+
+// --------------------------------------------------------------------------
+// Guard evaluation
+// --------------------------------------------------------------------------
+
+export interface CrossAgentGuardResult {
+  matchedRule: "cross-agent guard";
+  reason: string;
+  offendingAgentId: string;
+  offendingAgentIds: string[];
+}
+
+function buildReason(
+  offending: string[],
+  allowed: ResolvedAllowedAgents,
+): string {
+  const allowedList = [...allowed.ids];
+  const allowedDesc =
+    allowedList.length > 0 ? allowedList.join(", ") : "(none)";
+  const offendingDesc = offending.join(", ");
+  const plural = offending.length > 1 ? "agents" : "agent";
+  return (
+    `Cross-agent guard: refusing to touch memory belonging to ${plural} ` +
+    `${offendingDesc}. Allowed agents: ${allowedDesc}. ` +
+    `Set LETTA_MEMORY_SCOPE or pass --memory-scope to opt in.`
+  );
+}
+
+/**
+ * Evaluate whether a tool call should be hard-denied because it targets
+ * another agent's memory. Returns null when the guard is not concerned.
+ */
+export function evaluateCrossAgentGuard(
+  toolName: string,
+  toolArgs: ToolArgs,
+  workingDirectory: string,
+  options: AllowedAgentsOptions = {},
+): CrossAgentGuardResult | null {
+  const env = options.env ?? process.env;
+  const targets = extractTargetAgentPaths(
+    toolName,
+    toolArgs,
+    workingDirectory,
+    env,
+  );
+
+  if (!targets.anyAgentScoped) {
+    return null;
+  }
+
+  const allowed = resolveAllowedAgents(options);
+  const offending: string[] = [];
+  for (const id of targets.agentIds) {
+    if (!allowed.ids.has(id)) {
+      offending.push(id);
+    }
+  }
+
+  if (offending.length === 0) {
+    return null;
+  }
+
+  return {
+    matchedRule: "cross-agent guard",
+    reason: buildReason(offending, allowed),
+    offendingAgentId: offending[0] ?? "",
+    offendingAgentIds: offending,
+  };
+}

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -586,14 +586,13 @@ function buildReason(
   offending: string[],
   allowed: ResolvedAllowedAgents,
 ): string {
+  const offendingDesc = offending.join(", ");
   const allowedList = [...allowed.ids];
   const allowedDesc =
     allowedList.length > 0 ? allowedList.join(", ") : "(none)";
-  const offendingDesc = offending.join(", ");
-  const plural = offending.length > 1 ? "agents" : "agent";
   return (
-    `Cross-agent guard: refusing to touch memory belonging to ${plural} ` +
-    `${offendingDesc}. Allowed agents: ${allowedDesc}. ` +
+    `Permission denied by cross-agent memory guard (${offendingDesc}). ` +
+    `Allowed: ${allowedDesc}. ` +
     `Set LETTA_MEMORY_SCOPE or pass --memory-scope to opt in.`
   );
 }

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -87,36 +87,72 @@ export interface CrossAgentTargets {
 }
 
 /**
- * Build the regex that matches an agent-scoped memory path prefix on the
- * current machine. Capture group 1 is the agent ID.
- *
- * Uses the canonical home dir so we only need to compile once per call.
+ * The agents-tree root on this machine, e.g. `/home/user/.letta/agents`,
+ * normalized (forward slashes, no trailing slash).
  */
-function buildAgentScopedRegex(homeDir: string): RegExp {
+function getAgentsTreeRoot(homeDir: string): string {
   const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
-  const escaped = normalizedHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(
-    `^${escaped}/\\.letta/agents/([^/]+)/memory(?:-worktrees)?(?:/.*)?$`,
-  );
-}
-
-let _cachedHomeDir: string | null = null;
-let _cachedRegex: RegExp | null = null;
-
-function getAgentScopedRegex(homeDir: string): RegExp {
-  if (_cachedHomeDir === homeDir && _cachedRegex) return _cachedRegex;
-  _cachedRegex = buildAgentScopedRegex(homeDir);
-  _cachedHomeDir = homeDir;
-  return _cachedRegex;
+  return `${normalizedHome}/.letta/agents`;
 }
 
 /**
- * If the given path is agent-scoped on this machine, return the agent ID.
+ * Normalize a path for structural comparison: forward slashes, no
+ * trailing slash, preserving a bare `/` as root.
  */
-function matchAgentScopedPath(path: string, homeDir: string): string | null {
-  const normalized = path.replace(/\\/g, "/");
-  const match = normalized.match(getAgentScopedRegex(homeDir));
-  return match?.[1] ?? null;
+function normalizePathForCompare(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.length === 0 ? "/" : normalized;
+}
+
+/**
+ * Classification of a path relative to the agents tree:
+ *  - `outside`     — path is unrelated to the agents tree.
+ *  - `agents-root` — path is exactly `<home>/.letta/agents` (enumeration of
+ *                    every agent on the machine).
+ *  - `ancestor`    — path is an ancestor of the agents tree (e.g. `$HOME`,
+ *                    `/`). Recursive tools (Grep/Glob) entering this path
+ *                    would walk into other agents' directories.
+ *  - `agent`       — path is inside a specific agent's directory (any
+ *                    depth, including the bare agent dir, not just
+ *                    `/memory`). The `id` is the agent ID component.
+ */
+export type AgentsTreeClassification =
+  | { kind: "outside" }
+  | { kind: "agents-root" }
+  | { kind: "ancestor" }
+  | { kind: "agent"; id: string };
+
+/**
+ * Classify a path relative to the agents tree. See
+ * {@link AgentsTreeClassification} for the kinds.
+ */
+export function classifyAgentsTreePath(
+  path: string,
+  homeDir: string,
+): AgentsTreeClassification {
+  const root = getAgentsTreeRoot(homeDir);
+  const normalized = normalizePathForCompare(path);
+
+  if (normalized === root) {
+    return { kind: "agents-root" };
+  }
+
+  if (normalized.startsWith(`${root}/`)) {
+    const rest = normalized.slice(root.length + 1);
+    const slash = rest.indexOf("/");
+    const id = slash === -1 ? rest : rest.slice(0, slash);
+    return { kind: "agent", id };
+  }
+
+  // Is `normalized` an ancestor of the agents-tree root?
+  // A recursive walk starting at `normalized` would eventually enter
+  // `<root>/`, exposing every agent on the machine.
+  const prefix = normalized === "/" ? "/" : `${normalized}/`;
+  if (root.startsWith(prefix)) {
+    return { kind: "ancestor" };
+  }
+
+  return { kind: "outside" };
 }
 
 /**
@@ -310,10 +346,17 @@ function scanToken(
     const expanded = expandShellToken(value, env, homeDir);
     if (expanded === null) continue;
     const normalized = normalizeScopedPath(expanded);
-    const agentId = matchAgentScopedPath(normalized, homeDir);
-    if (agentId) {
-      out.set(value, agentId);
+    const classification = classifyAgentsTreePath(normalized, homeDir);
+    if (classification.kind === "agent") {
+      out.set(value, classification.id);
+    } else if (classification.kind === "agents-root") {
+      // Bare agents-tree root in a shell token — enumeration.
+      out.set(value, UNRESOLVED_AGENT_ID);
     }
+    // "ancestor" is intentionally ignored for shell tokens: the Bash
+    // raw-command scan handles those cases, and most legitimate shell
+    // commands have tokens that are ancestors of the agents tree
+    // (e.g. `$HOME`, `/`) without being a threat by themselves.
   }
 }
 
@@ -405,6 +448,37 @@ function expandCommandVariables(
 }
 
 /**
+ * Sentinel ID used when a path touches the agents tree but we can't
+ * resolve it to a single agent — e.g. the bare agents-tree root (an
+ * enumeration attempt) or a recursive-search root that would walk into
+ * the tree. The guard treats `<unresolved>` as never-allowed, so any
+ * such path is denied unless upstream knew what agent to filter to.
+ */
+const UNRESOLVED_AGENT_ID = "<unresolved>";
+
+/**
+ * Tools whose semantics imply a recursive walk from the given path
+ * (as opposed to touching a single file). When one of these is pointed
+ * at an *ancestor* of the agents tree, the walk would expose every
+ * agent on disk — so we treat ancestor paths as hits for these tools.
+ */
+const RECURSIVE_PATH_TOOLS = new Set<string>([
+  "Grep",
+  "Glob",
+  "ListDir",
+  "LS",
+  "list_dir",
+  "grep",
+  "glob",
+]);
+
+function isRecursivePathTool(toolName: string): boolean {
+  if (RECURSIVE_PATH_TOOLS.has(toolName)) return true;
+  const canonical = canonicalToolName(toolName);
+  return RECURSIVE_PATH_TOOLS.has(canonical);
+}
+
+/**
  * Extract the agent IDs referenced by the targets of a tool call.
  * Returns `anyAgentScoped: false` for tool calls that don't touch
  * agent memory at all (the guard's fast path).
@@ -418,17 +492,34 @@ export function extractTargetAgentPaths(
 ): CrossAgentTargets {
   const agentIds = new Set<string>();
   let anyAgentScoped = false;
+  const recursive = isRecursivePathTool(toolName);
 
   const addFromPath = (rawPath: string | null | undefined) => {
     if (!rawPath || typeof rawPath !== "string") return;
     const resolvedPath = resolveScopedTargetPath(rawPath, workingDirectory);
     if (!resolvedPath) return;
-    // Fast exit: skip regex if the path can't possibly be agent-scoped.
-    if (!resolvedPath.includes("/.letta/agents/")) return;
-    const id = matchAgentScopedPath(resolvedPath, homeDir);
-    if (id) {
-      anyAgentScoped = true;
-      agentIds.add(id);
+    const classification = classifyAgentsTreePath(resolvedPath, homeDir);
+    switch (classification.kind) {
+      case "outside":
+        return;
+      case "agents-root":
+        // Targeting the agents tree root itself — enumeration.
+        anyAgentScoped = true;
+        agentIds.add(UNRESOLVED_AGENT_ID);
+        return;
+      case "ancestor":
+        // Only dangerous for tools that recursively walk from the
+        // given path (Grep/Glob/ListDir). Single-file tools like Read
+        // can't escape their target.
+        if (recursive) {
+          anyAgentScoped = true;
+          agentIds.add(UNRESOLVED_AGENT_ID);
+        }
+        return;
+      case "agent":
+        anyAgentScoped = true;
+        agentIds.add(classification.id);
+        return;
     }
   };
 
@@ -472,6 +563,13 @@ export function extractTargetAgentPaths(
   // All other file-oriented tools: Read/Write/Edit/NotebookEdit/Glob/
   // Grep/ListDir/LS + Gemini + Codex aliases.
   addFromPath(extractFilePath(toolArgs));
+
+  // Grep / Glob also accept a `pattern` arg. An absolute pattern like
+  // `/home/user/.letta/agents/**/*.md` would bypass the `path` check
+  // entirely. Run the pattern through the same resolver.
+  if (recursive && typeof toolArgs.pattern === "string") {
+    addFromPath(toolArgs.pattern);
+  }
 
   return { agentIds, anyAgentScoped };
 }

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -12,10 +12,14 @@
 //   - cli:   --memory-scope flag (via cliPermissions.getMemoryScope())
 
 import { homedir } from "node:os";
-import { getCurrentAgentId } from "../agent/context";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli";
-import { normalizeScopedPath, resolveScopedTargetPath } from "./memoryScope";
+import {
+  deriveAgentId,
+  normalizeScopedPath,
+  parseScopeList,
+  resolveScopedTargetPath,
+} from "./memoryScope";
 import { splitShellSegments, tokenizeShellWords } from "./shellAnalysis";
 
 // --------------------------------------------------------------------------
@@ -37,32 +41,6 @@ export interface ResolvedAllowedAgents {
   };
 }
 
-function parseScopeList(value: string | undefined | null): string[] {
-  if (!value) return [];
-  return value
-    .split(/[\s,]+/)
-    .map((id) => id.trim())
-    .filter((id) => id.length > 0);
-}
-
-function deriveSelfAgentId(
-  env: NodeJS.ProcessEnv,
-  explicit?: string | null,
-): string | null {
-  const fromArg = explicit?.trim();
-  if (fromArg) return fromArg;
-
-  const fromEnv = (env.AGENT_ID || env.LETTA_AGENT_ID || "").trim();
-  if (fromEnv) return fromEnv;
-
-  try {
-    const fromContext = getCurrentAgentId().trim();
-    return fromContext || null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Resolve the set of agent IDs the current process is allowed to operate
  * against. Additive union of three sources.
@@ -72,7 +50,7 @@ export function resolveAllowedAgents(
 ): ResolvedAllowedAgents {
   const env = options.env ?? process.env;
 
-  const self = deriveSelfAgentId(env, options.currentAgentId);
+  const self = deriveAgentId(env, options.currentAgentId);
   const envScope = parseScopeList(env.LETTA_MEMORY_SCOPE);
   const cliScope = options.cliMemoryScope ?? cliPermissions.getMemoryScope();
 
@@ -188,8 +166,30 @@ function extractShellCommand(toolArgs: ToolArgs): string | null {
 }
 
 /**
+ * Regex that matches `$NAME` or `${NAME}` shell variable references.
+ * Capture group 1 is the braced name, group 2 is the bare name.
+ */
+const SHELL_VAR_REGEX =
+  /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+/**
+ * Look up a shell variable name. Returns the env value, or `homeDir` for
+ * the `HOME` special-case, or undefined if unresolved.
+ */
+function lookupShellVar(
+  name: string,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): string | undefined {
+  if (name === "HOME") return homeDir;
+  const value = env[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
  * Expand env variables ($VAR, ${VAR}, $HOME, ~/) in a shell token.
- * Returns null when an unresolved variable is encountered.
+ * Returns null when an unresolved variable is encountered (so the caller
+ * skips the token rather than scanning a partially-resolved string).
  *
  * Mirrors the expansion used by `readOnlyShell.ts#expandScopedVariables`
  * but is self-contained here to keep the dependency graph simple.
@@ -209,22 +209,19 @@ function expandShellToken(
 
   let unresolved = false;
   result = result.replace(
-    /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    SHELL_VAR_REGEX,
     (_match, bracedName: string | undefined, bareName: string | undefined) => {
       const name = bracedName || bareName;
       if (!name) {
         unresolved = true;
         return "";
       }
-      if (name === "HOME") {
-        return homeDir;
+      const value = lookupShellVar(name, env, homeDir);
+      if (value === undefined) {
+        unresolved = true;
+        return "";
       }
-      const envValue = env[name];
-      if (typeof envValue === "string") {
-        return envValue;
-      }
-      unresolved = true;
-      return "";
+      return value;
     },
   );
 
@@ -375,30 +372,27 @@ function scanRawCommandForUnresolvedAgentRefs(
 }
 
 /**
- * Expand env vars on the raw command string (best effort). Leaves
- * unresolved variables intact so they still register as "unresolved"
- * during the raw scan.
+ * Expand env vars on the raw command string (best effort). Unlike
+ * `expandShellToken`, this leaves unresolved `$VAR` references intact
+ * so they still register as "unresolved" during the raw scan.
  */
 function expandCommandVariables(
   command: string,
   env: NodeJS.ProcessEnv,
   homeDir: string,
 ): string {
-  let result = command;
-  // Replace ~/ only when it follows whitespace, a quote, `=`, or start.
-  result = result.replace(
+  // Replace ~/ only when it follows whitespace, a quote, `=`, `:`, or start.
+  let result = command.replace(
     /(^|[\s="'`:])~\//g,
     (_match, prefix: string) => `${prefix}${homeDir}/`,
   );
-  // Replace $VAR and ${VAR} with env values when known.
+  // Replace $VAR / ${VAR} with env values when known; keep literal otherwise.
   result = result.replace(
-    /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    SHELL_VAR_REGEX,
     (match, bracedName: string | undefined, bareName: string | undefined) => {
       const name = bracedName || bareName;
       if (!name) return match;
-      if (name === "HOME") return homeDir;
-      const value = env[name];
-      return typeof value === "string" ? value : match;
+      return lookupShellVar(name, env, homeDir) ?? match;
     },
   );
   return result;

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -264,6 +264,26 @@ function collectShellAgentTargets(
   return targets;
 }
 
+/**
+ * Strip every matched pair of surrounding quotes from a value.
+ *
+ * Shell tokens may come through as `"$TARGET"`, `'$TARGET'`, or nested
+ * `""$TARGET""` depending on how the command was written. The upstream
+ * `stripShellQuotes` only strips a single outer pair; we loop to handle
+ * repeated wrappings so the anchored path regex can still match.
+ */
+function stripAllOuterQuotes(value: string): string {
+  let result = value;
+  while (
+    result.length >= 2 &&
+    ((result.startsWith('"') && result.endsWith('"')) ||
+      (result.startsWith("'") && result.endsWith("'")))
+  ) {
+    result = result.slice(1, -1);
+  }
+  return result;
+}
+
 function scanToken(
   rawToken: string,
   env: NodeJS.ProcessEnv,
@@ -278,7 +298,10 @@ function scanToken(
   const candidateValue = assignmentMatch
     ? (assignmentMatch[2] ?? "")
     : rawToken;
-  const candidates = [rawToken, candidateValue].filter((v) => v.length > 0);
+  const candidates = [rawToken, candidateValue]
+    .filter((v) => v.length > 0)
+    // Remove matched outer quotes so the anchored path regex matches.
+    .map((v) => stripAllOuterQuotes(v));
 
   for (const value of candidates) {
     const expanded = expandShellToken(value, env, homeDir);
@@ -289,6 +312,96 @@ function scanToken(
       out.set(value, agentId);
     }
   }
+}
+
+/**
+ * Conservative scan of the raw shell command for any reference to the
+ * agents tree. Complements the tokenizer by catching patterns that
+ * static analysis can't resolve:
+ *   - `ls ~/.letta/agents` (enumeration)
+ *   - `find $HOME/.letta/agents -type d` (globbing)
+ *   - `TARGET="$(find ~/.letta/agents ...)"; cat "$TARGET/..."` (command
+ *     substitution — tokenizer can't follow)
+ *   - assignment-then-use where the literal agent ID appears in the raw
+ *     string even if our static expander can't trace the variable.
+ *
+ * The scan is home-anchored: only references to agent paths under the
+ * current user's home dir trigger it. References to other homes (e.g.
+ * test fixtures under `/Users/test/.letta/agents/...`) are ignored —
+ * they can't possibly touch real data on this machine.
+ *
+ * Any occurrence of `<home>/.letta/agents/<id>` where `<id>` is not in
+ * `allowedAgentIds` (or is empty / a shell variable / a glob) produces
+ * an entry in the returned list. The guard then hard-denies.
+ */
+function scanRawCommandForUnresolvedAgentRefs(
+  rawCommand: string,
+  allowedAgentIds: Set<string>,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): string[] {
+  // Pre-expand $VAR / ${VAR} / $HOME / ~ on the whole command so that
+  // self-targeting references like `~/.letta/agents/${AGENT_ID}/memory`
+  // don't falsely trip the scan.
+  const expanded = expandCommandVariables(rawCommand, env, homeDir);
+
+  // Home-anchored pattern: match only references rooted at the current
+  // user's home. Group 1 is the agent-ID candidate (optional).
+  //
+  // The terminator class includes `/`, whitespace, quotes, common shell
+  // syntax (`$`, `(`, `)`, `{`, `}`, `[`, `]`, `;`, `|`, `&`, `,`, `\``,
+  // and `#`) so we stop at a word boundary.
+  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
+  const escapedHome = normalizedHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `${escapedHome}/\\.letta/agents(?:/([^/\\s"'\`$(){}\\[\\]|&;,#]*))?`,
+    "g",
+  );
+
+  const unresolved: string[] = [];
+  for (const match of expanded.matchAll(pattern)) {
+    const candidate = (match[1] ?? "").trim();
+    if (candidate.length === 0) {
+      // Bare `<home>/.letta/agents` or `.../agents/` — enumeration of
+      // the whole agents tree. Always suspicious.
+      unresolved.push("<unresolved>");
+      continue;
+    }
+    if (!allowedAgentIds.has(candidate)) {
+      unresolved.push(candidate);
+    }
+  }
+  return unresolved;
+}
+
+/**
+ * Expand env vars on the raw command string (best effort). Leaves
+ * unresolved variables intact so they still register as "unresolved"
+ * during the raw scan.
+ */
+function expandCommandVariables(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+): string {
+  let result = command;
+  // Replace ~/ only when it follows whitespace, a quote, `=`, or start.
+  result = result.replace(
+    /(^|[\s="'`:])~\//g,
+    (_match, prefix: string) => `${prefix}${homeDir}/`,
+  );
+  // Replace $VAR and ${VAR} with env values when known.
+  result = result.replace(
+    /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g,
+    (match, bracedName: string | undefined, bareName: string | undefined) => {
+      const name = bracedName || bareName;
+      if (!name) return match;
+      if (name === "HOME") return homeDir;
+      const value = env[name];
+      return typeof value === "string" ? value : match;
+    },
+  );
+  return result;
 }
 
 /**
@@ -391,6 +504,13 @@ function buildReason(
 /**
  * Evaluate whether a tool call should be hard-denied because it targets
  * another agent's memory. Returns null when the guard is not concerned.
+ *
+ * Shell tools are checked twice:
+ *   1. Token-level extraction of statically-resolvable paths.
+ *   2. Raw-command regex scan that denies any unresolved / not-allowed
+ *      `.letta/agents/<id>` reference, catching command substitution,
+ *      globbing, and enumeration patterns that static analysis can't
+ *      reliably trace.
  */
 export function evaluateCrossAgentGuard(
   toolName: string,
@@ -399,33 +519,51 @@ export function evaluateCrossAgentGuard(
   options: AllowedAgentsOptions = {},
 ): CrossAgentGuardResult | null {
   const env = options.env ?? process.env;
+  const homeDir = env.HOME ?? homedir();
+
   const targets = extractTargetAgentPaths(
     toolName,
     toolArgs,
     workingDirectory,
     env,
+    homeDir,
   );
 
-  if (!targets.anyAgentScoped) {
-    return null;
-  }
-
   const allowed = resolveAllowedAgents(options);
-  const offending: string[] = [];
+  const offending = new Set<string>();
+
   for (const id of targets.agentIds) {
     if (!allowed.ids.has(id)) {
-      offending.push(id);
+      offending.add(id);
     }
   }
 
-  if (offending.length === 0) {
+  // Shell tools additionally get a conservative raw-command scan.
+  const canonical = canonicalToolName(toolName);
+  if (isShellToolName(toolName) || canonical === "Bash") {
+    const command = extractShellCommand(toolArgs);
+    if (command) {
+      const unresolved = scanRawCommandForUnresolvedAgentRefs(
+        command,
+        allowed.ids,
+        env,
+        homeDir,
+      );
+      for (const id of unresolved) {
+        offending.add(id);
+      }
+    }
+  }
+
+  if (offending.size === 0) {
     return null;
   }
 
+  const offendingList = [...offending];
   return {
     matchedRule: "cross-agent guard",
-    reason: buildReason(offending, allowed),
-    offendingAgentId: offending[0] ?? "",
-    offendingAgentIds: offending,
+    reason: buildReason(offendingList, allowed),
+    offendingAgentId: offendingList[0] ?? "",
+    offendingAgentIds: offendingList,
   };
 }

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -100,21 +100,27 @@ function buildAgentScopedRegex(homeDir: string): RegExp {
   );
 }
 
+let _cachedHomeDir: string | null = null;
+let _cachedRegex: RegExp | null = null;
+
+function getAgentScopedRegex(homeDir: string): RegExp {
+  if (_cachedHomeDir === homeDir && _cachedRegex) return _cachedRegex;
+  _cachedRegex = buildAgentScopedRegex(homeDir);
+  _cachedHomeDir = homeDir;
+  return _cachedRegex;
+}
+
 /**
  * If the given path is agent-scoped on this machine, return the agent ID.
  */
 function matchAgentScopedPath(path: string, homeDir: string): string | null {
   const normalized = path.replace(/\\/g, "/");
-  const regex = buildAgentScopedRegex(homeDir);
-  const match = normalized.match(regex);
+  const match = normalized.match(getAgentScopedRegex(homeDir));
   return match?.[1] ?? null;
 }
 
 /**
  * Extract file directives from an apply_patch / memory_apply_patch input.
- *
- * Exported so `mode.ts` can also share this helper (single source of truth
- * for the directive syntax).
  */
 export function extractApplyPatchPaths(input: string): string[] {
   const paths: string[] = [];
@@ -133,7 +139,7 @@ export function extractApplyPatchPaths(input: string): string[] {
   return paths;
 }
 
-function extractFilePath(toolArgs: ToolArgs): string | null {
+export function extractFilePath(toolArgs: ToolArgs): string | null {
   if (typeof toolArgs.file_path === "string" && toolArgs.file_path.length > 0) {
     return toolArgs.file_path;
   }
@@ -417,6 +423,8 @@ export function extractTargetAgentPaths(
     if (!rawPath || typeof rawPath !== "string") return;
     const resolvedPath = resolveScopedTargetPath(rawPath, workingDirectory);
     if (!resolvedPath) return;
+    // Fast exit: skip regex if the path can't possibly be agent-scoped.
+    if (!resolvedPath.includes("/.letta/agents/")) return;
     const id = matchAgentScopedPath(resolvedPath, homeDir);
     if (id) {
       anyAgentScoped = true;
@@ -475,7 +483,6 @@ export function extractTargetAgentPaths(
 export interface CrossAgentGuardResult {
   matchedRule: "cross-agent guard";
   reason: string;
-  offendingAgentId: string;
   offendingAgentIds: string[];
 }
 
@@ -557,7 +564,6 @@ export function evaluateCrossAgentGuard(
   return {
     matchedRule: "cross-agent guard",
     reason: buildReason(offendingList, allowed),
-    offendingAgentId: offendingList[0] ?? "",
     offendingAgentIds: offendingList,
   };
 }

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -87,6 +87,22 @@ export interface CrossAgentTargets {
 }
 
 /**
+ * Sentinel ID used when a path touches the agents tree but we can't
+ * resolve it to a single agent — e.g. the bare agents-tree root (an
+ * enumeration attempt) or a recursive-search root that would walk into
+ * the tree. The guard treats this as never-allowed, so any such path
+ * is denied unless upstream knew what agent to filter to.
+ */
+const UNRESOLVED_AGENT_ID = "<unresolved>";
+
+/**
+ * Escape a string for use inside a regex.
+ */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * The agents-tree root on this machine, e.g. `/home/user/.letta/agents`,
  * normalized (forward slashes, no trailing slash).
  */
@@ -274,6 +290,11 @@ function expandShellToken(
  * Walk a shell command and collect every token that expands to an
  * agent-scoped memory path on this machine. Returns the map of
  * token → agent ID.
+ *
+ * If `splitShellSegments` refuses the command (dangerous operator,
+ * command substitution, non-/dev/null redirect, etc.), we still scan
+ * the raw tokens of the whole command as a best-effort safety net —
+ * any agent-scoped path in there is still a hit.
  */
 function collectShellAgentTargets(
   command: string,
@@ -281,22 +302,9 @@ function collectShellAgentTargets(
   homeDir: string,
 ): Map<string, string> {
   const targets = new Map<string, string>();
-  const segments = splitShellSegments(command);
-  if (!segments) {
-    // Split was refused due to dangerous operator (command substitution,
-    // redirect to non-/dev/null, etc.). Still scan the raw tokens of the
-    // whole command as best-effort — if any agent-scoped path shows up,
-    // we want to catch it.
-    const tokens = tokenizeShellWords(command);
-    for (const token of tokens) {
-      scanToken(token, env, homeDir, targets);
-    }
-    return targets;
-  }
-
+  const segments = splitShellSegments(command) ?? [command];
   for (const segment of segments) {
-    const tokens = tokenizeShellWords(segment);
-    for (const token of tokens) {
+    for (const token of tokenizeShellWords(segment)) {
       scanToken(token, env, homeDir, targets);
     }
   }
@@ -392,15 +400,14 @@ function scanRawCommandForUnresolvedAgentRefs(
   const expanded = expandCommandVariables(rawCommand, env, homeDir);
 
   // Home-anchored pattern: match only references rooted at the current
-  // user's home. Group 1 is the agent-ID candidate (optional).
+  // user's agents tree. Group 1 is the agent-ID candidate (optional).
   //
   // The terminator class includes `/`, whitespace, quotes, common shell
   // syntax (`$`, `(`, `)`, `{`, `}`, `[`, `]`, `;`, `|`, `&`, `,`, `\``,
   // and `#`) so we stop at a word boundary.
-  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
-  const escapedHome = normalizedHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedRoot = escapeRegex(getAgentsTreeRoot(homeDir));
   const pattern = new RegExp(
-    `${escapedHome}/\\.letta/agents(?:/([^/\\s"'\`$(){}\\[\\]|&;,#]*))?`,
+    `${escapedRoot}(?:/([^/\\s"'\`$(){}\\[\\]|&;,#]*))?`,
     "g",
   );
 
@@ -410,7 +417,7 @@ function scanRawCommandForUnresolvedAgentRefs(
     if (candidate.length === 0) {
       // Bare `<home>/.letta/agents` or `.../agents/` — enumeration of
       // the whole agents tree. Always suspicious.
-      unresolved.push("<unresolved>");
+      unresolved.push(UNRESOLVED_AGENT_ID);
       continue;
     }
     if (!allowedAgentIds.has(candidate)) {
@@ -446,15 +453,6 @@ function expandCommandVariables(
   );
   return result;
 }
-
-/**
- * Sentinel ID used when a path touches the agents tree but we can't
- * resolve it to a single agent — e.g. the bare agents-tree root (an
- * enumeration attempt) or a recursive-search root that would walk into
- * the tree. The guard treats `<unresolved>` as never-allowed, so any
- * such path is denied unless upstream knew what agent to filter to.
- */
-const UNRESOLVED_AGENT_ID = "<unresolved>";
 
 /**
  * Tools whose semantics imply a recursive walk from the given path

--- a/src/permissions/memoryScope.ts
+++ b/src/permissions/memoryScope.ts
@@ -3,6 +3,7 @@ import { basename, dirname, isAbsolute, resolve } from "node:path";
 
 import { getCurrentAgentId } from "../agent/context";
 import { getMemoryFilesystemRoot } from "../agent/memoryFilesystem";
+import { cliPermissions } from "./cli";
 
 export interface ResolveAllowedMemoryRootsOptions {
   env?: NodeJS.ProcessEnv;
@@ -84,20 +85,39 @@ function addRootAndSiblingWorktree(root: string, acc: Set<string>): void {
   }
 }
 
+function parseScopeIds(value: string | undefined | null): string[] {
+  if (!value) return [];
+  return value
+    .split(/[\s,]+/)
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
 function getExplicitEnvRoots(
   env: NodeJS.ProcessEnv,
+  homeDir: string,
 ): Pick<ResolvedMemoryScope, "explicitRoots" | "primaryRoot"> {
-  const orderedRoots = [
-    env.MEMORY_DIR,
-    env.LETTA_MEMORY_DIR,
-    env.PARENT_MEMORY_DIR,
-  ]
+  const orderedRoots = [env.MEMORY_DIR, env.LETTA_MEMORY_DIR]
     .map((value) => value?.trim() ?? "")
     .filter((value) => value.length > 0);
 
   const explicitRootSet = new Set<string>();
   for (const root of orderedRoots) {
     addRootAndSiblingWorktree(root, explicitRootSet);
+  }
+
+  // Include memory roots for every agent ID in the cross-agent scope
+  // (env LETTA_MEMORY_SCOPE + CLI --memory-scope). This keeps memory-mode
+  // write permissions aligned with the cross-agent guard.
+  const scopeIds = new Set<string>([
+    ...parseScopeIds(env.LETTA_MEMORY_SCOPE),
+    ...cliPermissions.getMemoryScope(),
+  ]);
+  for (const id of scopeIds) {
+    addRootAndSiblingWorktree(
+      getMemoryFilesystemRoot(id, homeDir),
+      explicitRootSet,
+    );
   }
 
   return {
@@ -176,7 +196,7 @@ export function resolveAllowedMemoryRoots(
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? homedir();
 
-  const explicit = getExplicitEnvRoots(env);
+  const explicit = getExplicitEnvRoots(env, homeDir);
   if (explicit.explicitRoots.length > 0) {
     return {
       roots: explicit.explicitRoots,

--- a/src/permissions/memoryScope.ts
+++ b/src/permissions/memoryScope.ts
@@ -14,7 +14,6 @@ export interface ResolveAllowedMemoryRootsOptions {
 
 export interface ResolvedMemoryScope {
   roots: string[];
-  explicitRoots: string[];
   primaryRoot: string | null;
   usedFallback: boolean;
 }
@@ -85,7 +84,11 @@ function addRootAndSiblingWorktree(root: string, acc: Set<string>): void {
   }
 }
 
-function parseScopeIds(value: string | undefined | null): string[] {
+/**
+ * Parse a comma- or whitespace-separated list of agent IDs.
+ * Used for both `LETTA_MEMORY_SCOPE` env var and `--memory-scope` CLI flag.
+ */
+export function parseScopeList(value: string | undefined | null): string[] {
   if (!value) return [];
   return value
     .split(/[\s,]+/)
@@ -93,35 +96,37 @@ function parseScopeIds(value: string | undefined | null): string[] {
     .filter((id) => id.length > 0);
 }
 
+interface ExplicitEnvRoots {
+  roots: string[];
+  primaryRoot: string | null;
+}
+
 function getExplicitEnvRoots(
   env: NodeJS.ProcessEnv,
   homeDir: string,
-): Pick<ResolvedMemoryScope, "explicitRoots" | "primaryRoot"> {
+): ExplicitEnvRoots {
   const orderedRoots = [env.MEMORY_DIR, env.LETTA_MEMORY_DIR]
     .map((value) => value?.trim() ?? "")
     .filter((value) => value.length > 0);
 
-  const explicitRootSet = new Set<string>();
+  const rootSet = new Set<string>();
   for (const root of orderedRoots) {
-    addRootAndSiblingWorktree(root, explicitRootSet);
+    addRootAndSiblingWorktree(root, rootSet);
   }
 
   // Include memory roots for every agent ID in the cross-agent scope
   // (env LETTA_MEMORY_SCOPE + CLI --memory-scope). This keeps memory-mode
   // write permissions aligned with the cross-agent guard.
   const scopeIds = new Set<string>([
-    ...parseScopeIds(env.LETTA_MEMORY_SCOPE),
+    ...parseScopeList(env.LETTA_MEMORY_SCOPE),
     ...cliPermissions.getMemoryScope(),
   ]);
   for (const id of scopeIds) {
-    addRootAndSiblingWorktree(
-      getMemoryFilesystemRoot(id, homeDir),
-      explicitRootSet,
-    );
+    addRootAndSiblingWorktree(getMemoryFilesystemRoot(id, homeDir), rootSet);
   }
 
   return {
-    explicitRoots: [...explicitRootSet],
+    roots: [...rootSet],
     primaryRoot:
       orderedRoots.length > 0
         ? normalizeScopedPath(orderedRoots[0] as string)
@@ -129,25 +134,32 @@ function getExplicitEnvRoots(
   };
 }
 
-function deriveAgentId(
+/**
+ * Resolve the current agent ID from: (1) the explicit argument, (2) the
+ * `AGENT_ID` / `LETTA_AGENT_ID` env vars, or (3) the in-process agent
+ * context. Returns null when none of those sources yields a non-empty ID.
+ */
+export function deriveAgentId(
   env: NodeJS.ProcessEnv,
   explicitAgentId?: string | null,
 ): string | null {
   const explicit = explicitAgentId?.trim();
-  if (explicit) {
-    return explicit;
-  }
+  if (explicit) return explicit;
 
   const envAgentId = (env.AGENT_ID || env.LETTA_AGENT_ID || "").trim();
-  if (envAgentId) {
-    return envAgentId;
-  }
+  if (envAgentId) return envAgentId;
 
   try {
-    return getCurrentAgentId().trim();
+    const fromContext = getCurrentAgentId().trim();
+    return fromContext || null;
   } catch {
     return null;
   }
+}
+
+interface FallbackRoots {
+  roots: string[];
+  primaryRoot: string | null;
 }
 
 function getFallbackRoots(
@@ -155,7 +167,7 @@ function getFallbackRoots(
   homeDir: string,
   currentAgentId?: string | null,
   parentAgentId?: string | null,
-): Pick<ResolvedMemoryScope, "roots" | "primaryRoot"> {
+): FallbackRoots {
   const fallbackRoots = new Set<string>();
 
   const resolvedCurrentAgentId = deriveAgentId(env, currentAgentId);
@@ -197,10 +209,9 @@ export function resolveAllowedMemoryRoots(
   const homeDir = options.homeDir ?? homedir();
 
   const explicit = getExplicitEnvRoots(env, homeDir);
-  if (explicit.explicitRoots.length > 0) {
+  if (explicit.roots.length > 0) {
     return {
-      roots: explicit.explicitRoots,
-      explicitRoots: explicit.explicitRoots,
+      roots: explicit.roots,
       primaryRoot: explicit.primaryRoot,
       usedFallback: false,
     };
@@ -215,7 +226,6 @@ export function resolveAllowedMemoryRoots(
 
   return {
     roots: fallback.roots,
-    explicitRoots: [],
     primaryRoot: fallback.primaryRoot,
     usedFallback: fallback.roots.length > 0,
   };

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -3,6 +3,7 @@
 
 import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
+import { extractApplyPatchPaths } from "./crossAgentGuard";
 import {
   isPathWithinRoots,
   resolveAllowedMemoryRoots,
@@ -91,23 +92,6 @@ function isPathInPlansDir(path: string, plansDir: string): boolean {
   if (!path.endsWith(".md")) return false;
   const rel = relative(plansDir, path);
   return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
-}
-
-function extractApplyPatchPaths(input: string): string[] {
-  const paths: string[] = [];
-  const fileDirectivePattern = /\*\*\* (?:Add|Update|Delete) File:\s*(.+)/g;
-  const moveDirectivePattern = /\*\*\* Move to:\s*(.+)/g;
-
-  for (const match of input.matchAll(fileDirectivePattern)) {
-    const matchPath = match[1]?.trim();
-    if (matchPath) paths.push(matchPath);
-  }
-  for (const match of input.matchAll(moveDirectivePattern)) {
-    const matchPath = match[1]?.trim();
-    if (matchPath) paths.push(matchPath);
-  }
-
-  return paths;
 }
 
 function stripMatchingQuotes(value: string): string {

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -611,35 +611,49 @@ test("memory mode - denies Write outside memory roots", () => {
   }
 });
 
-test("memory mode - allows Write inside PARENT_MEMORY_DIR", () => {
+test("memory mode - allows Write inside parent memory when LETTA_MEMORY_SCOPE grants it", () => {
   permissionMode.setMode("memory");
-  const originalParentMemoryDir = process.env.PARENT_MEMORY_DIR;
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  const originalMemoryScope = process.env.LETTA_MEMORY_SCOPE;
+  const originalAgentId = process.env.AGENT_ID;
+  const home = homedir();
+  const parentMemoryPath = join(
+    home,
+    ".letta",
+    "agents",
+    "agent-parent",
+    "memory",
+  );
   delete process.env.MEMORY_DIR;
-  process.env.PARENT_MEMORY_DIR =
-    "/Users/test/.letta/agents/agent-parent/memory";
+  process.env.LETTA_MEMORY_SCOPE = "agent-parent";
+  process.env.AGENT_ID = "agent-self";
 
   try {
     const result = checkPermission(
       "Write",
       { file_path: "system/parent.md" },
       { allow: [], deny: [], ask: [] },
-      "/Users/test/.letta/agents/agent-parent/memory",
+      parentMemoryPath,
     );
 
     expect(result.decision).toBe("allow");
   } finally {
-    if (originalParentMemoryDir === undefined)
-      delete process.env.PARENT_MEMORY_DIR;
-    else process.env.PARENT_MEMORY_DIR = originalParentMemoryDir;
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+    if (originalMemoryScope === undefined)
+      delete process.env.LETTA_MEMORY_SCOPE;
+    else process.env.LETTA_MEMORY_SCOPE = originalMemoryScope;
+    if (originalAgentId === undefined) delete process.env.AGENT_ID;
+    else process.env.AGENT_ID = originalAgentId;
   }
 });
 
 test("memory mode - no roots allows reads but denies mutations", () => {
   permissionMode.setMode("memory");
   const originalMemoryDir = process.env.MEMORY_DIR;
-  const originalParentMemoryDir = process.env.PARENT_MEMORY_DIR;
+  const originalMemoryScope = process.env.LETTA_MEMORY_SCOPE;
   delete process.env.MEMORY_DIR;
-  delete process.env.PARENT_MEMORY_DIR;
+  delete process.env.LETTA_MEMORY_SCOPE;
 
   try {
     const readResult = checkPermission(
@@ -660,9 +674,9 @@ test("memory mode - no roots allows reads but denies mutations", () => {
   } finally {
     if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
     else process.env.MEMORY_DIR = originalMemoryDir;
-    if (originalParentMemoryDir === undefined)
-      delete process.env.PARENT_MEMORY_DIR;
-    else process.env.PARENT_MEMORY_DIR = originalParentMemoryDir;
+    if (originalMemoryScope === undefined)
+      delete process.env.LETTA_MEMORY_SCOPE;
+    else process.env.LETTA_MEMORY_SCOPE = originalMemoryScope;
   }
 });
 

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -507,6 +507,10 @@ describe("checkPermission integration", () => {
 
 // ---------------------------------------------------------------------------
 // Regression tests: known bypass patterns (from real exploit attempts)
+//
+// Command fixtures below contain shell brace-variable syntax inside plain
+// strings. Biome's noTemplateCurlyInString rule flags these, but they are
+// intentional: they're shell commands, not mistaken template literals.
 // ---------------------------------------------------------------------------
 
 describe("shell bypass regression tests", () => {

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -319,7 +319,7 @@ describe("evaluateCrossAgentGuard", () => {
     expect(result).not.toBeNull();
     expect(result?.matchedRule).toBe("cross-agent guard");
     expect(result?.offendingAgentIds).toEqual([OTHER]);
-    expect(result?.reason).toMatch(/Cross-agent guard/);
+    expect(result?.reason).toMatch(/cross-agent memory guard/);
   });
 
   test("passes through when other agent is in LETTA_MEMORY_SCOPE", () => {

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -1,0 +1,507 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { checkPermission } from "../../permissions/checker";
+import { cliPermissions } from "../../permissions/cli";
+import {
+  evaluateCrossAgentGuard,
+  extractTargetAgentPaths,
+  resolveAllowedAgents,
+} from "../../permissions/crossAgentGuard";
+import { permissionMode } from "../../permissions/mode";
+
+const HOME = homedir();
+const SELF = "agent-self";
+const OTHER = "agent-other";
+const THIRD = "agent-third";
+
+function selfMemory(rel = ""): string {
+  return join(HOME, ".letta", "agents", SELF, "memory", rel);
+}
+
+function otherMemory(rel = ""): string {
+  return join(HOME, ".letta", "agents", OTHER, "memory", rel);
+}
+
+function otherWorktree(rel = ""): string {
+  return join(HOME, ".letta", "agents", OTHER, "memory-worktrees", rel);
+}
+
+function thirdMemory(rel = ""): string {
+  return join(HOME, ".letta", "agents", THIRD, "memory", rel);
+}
+
+const ENV_KEYS_TO_RESET = [
+  "AGENT_ID",
+  "LETTA_AGENT_ID",
+  "LETTA_PARENT_AGENT_ID",
+  "LETTA_MEMORY_SCOPE",
+  "MEMORY_DIR",
+  "LETTA_MEMORY_DIR",
+  "PARENT_MEMORY_DIR",
+] as const;
+
+function snapshotEnv(): Partial<
+  Record<(typeof ENV_KEYS_TO_RESET)[number], string>
+> {
+  const snapshot: Record<string, string> = {};
+  for (const key of ENV_KEYS_TO_RESET) {
+    const value = process.env[key];
+    if (value !== undefined) snapshot[key] = value;
+  }
+  return snapshot;
+}
+
+function restoreEnv(
+  snapshot: Partial<Record<(typeof ENV_KEYS_TO_RESET)[number], string>>,
+): void {
+  for (const key of ENV_KEYS_TO_RESET) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+}
+
+let baselineEnv: ReturnType<typeof snapshotEnv>;
+
+beforeEach(() => {
+  baselineEnv = snapshotEnv();
+  for (const key of ENV_KEYS_TO_RESET) delete process.env[key];
+  process.env.AGENT_ID = SELF;
+  cliPermissions.clear();
+  permissionMode.reset();
+});
+
+afterEach(() => {
+  restoreEnv(baselineEnv);
+  cliPermissions.clear();
+  permissionMode.reset();
+});
+
+// ---------------------------------------------------------------------------
+// resolveAllowedAgents
+// ---------------------------------------------------------------------------
+
+describe("resolveAllowedAgents", () => {
+  test("self-only when no scope is configured", () => {
+    const allowed = resolveAllowedAgents();
+    expect([...allowed.ids]).toEqual([SELF]);
+    expect(allowed.sources.self).toBe(SELF);
+    expect(allowed.sources.env).toEqual([]);
+    expect(allowed.sources.cli).toEqual([]);
+  });
+
+  test("LETTA_MEMORY_SCOPE (comma-separated) adds to allowed set", () => {
+    process.env.LETTA_MEMORY_SCOPE = "agent-a,agent-b";
+    const allowed = resolveAllowedAgents();
+    expect(allowed.ids).toEqual(new Set([SELF, "agent-a", "agent-b"]));
+    expect(allowed.sources.env).toEqual(["agent-a", "agent-b"]);
+  });
+
+  test("LETTA_MEMORY_SCOPE (whitespace-separated) also works", () => {
+    process.env.LETTA_MEMORY_SCOPE = "agent-a  agent-b";
+    const allowed = resolveAllowedAgents();
+    expect(allowed.ids).toEqual(new Set([SELF, "agent-a", "agent-b"]));
+  });
+
+  test("--memory-scope CLI flag adds to allowed set", () => {
+    cliPermissions.setMemoryScope("agent-cli1,agent-cli2");
+    const allowed = resolveAllowedAgents();
+    expect(allowed.ids).toEqual(new Set([SELF, "agent-cli1", "agent-cli2"]));
+    expect(allowed.sources.cli).toEqual(["agent-cli1", "agent-cli2"]);
+  });
+
+  test("all three sources combine without duplicates", () => {
+    process.env.LETTA_MEMORY_SCOPE = "agent-a,agent-shared";
+    cliPermissions.setMemoryScope("agent-shared agent-b");
+    const allowed = resolveAllowedAgents();
+    expect(allowed.ids).toEqual(
+      new Set([SELF, "agent-a", "agent-shared", "agent-b"]),
+    );
+  });
+
+  test("explicit currentAgentId overrides env lookup", () => {
+    process.env.AGENT_ID = "env-agent";
+    const allowed = resolveAllowedAgents({ currentAgentId: "explicit-agent" });
+    expect(allowed.sources.self).toBe("explicit-agent");
+    expect(allowed.ids.has("explicit-agent")).toBe(true);
+    expect(allowed.ids.has("env-agent")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTargetAgentPaths
+// ---------------------------------------------------------------------------
+
+describe("extractTargetAgentPaths", () => {
+  test("file-tool targeting own memory", () => {
+    const result = extractTargetAgentPaths(
+      "Write",
+      { file_path: selfMemory("system/persona.md") },
+      "/tmp",
+    );
+    expect(result.anyAgentScoped).toBe(true);
+    expect(result.agentIds).toEqual(new Set([SELF]));
+  });
+
+  test("file-tool targeting another agent's memory", () => {
+    const result = extractTargetAgentPaths(
+      "Write",
+      { file_path: otherMemory("system/persona.md") },
+      "/tmp",
+    );
+    expect(result.anyAgentScoped).toBe(true);
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("file-tool targeting a non-agent path", () => {
+    const result = extractTargetAgentPaths(
+      "Write",
+      { file_path: "/tmp/some-project/src/index.ts" },
+      "/tmp/some-project",
+    );
+    expect(result.anyAgentScoped).toBe(false);
+    expect(result.agentIds.size).toBe(0);
+  });
+
+  test("tilde-based paths resolve against home dir", () => {
+    const result = extractTargetAgentPaths(
+      "Read",
+      { file_path: `~/.letta/agents/${OTHER}/memory/system/x.md` },
+      "/tmp",
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("memory-worktrees paths are also agent-scoped", () => {
+    const result = extractTargetAgentPaths(
+      "Write",
+      { file_path: otherWorktree("defrag-12345/system/x.md") },
+      "/tmp",
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("NotebookEdit uses notebook_path", () => {
+    const result = extractTargetAgentPaths(
+      "NotebookEdit",
+      { notebook_path: otherMemory("notebook.ipynb") },
+      "/tmp",
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("ApplyPatch parses all file directives", () => {
+    const patch = [
+      "*** Begin Patch",
+      `*** Add File: ${selfMemory("system/a.md")}`,
+      `*** Update File: ${otherMemory("system/b.md")}`,
+      `*** Delete File: ${thirdMemory("system/c.md")}`,
+      "*** End Patch",
+    ].join("\n");
+
+    const result = extractTargetAgentPaths(
+      "ApplyPatch",
+      { input: patch },
+      "/tmp",
+    );
+
+    expect(result.agentIds).toEqual(new Set([SELF, OTHER, THIRD]));
+    expect(result.anyAgentScoped).toBe(true);
+  });
+
+  test("memory_apply_patch behaves like ApplyPatch", () => {
+    const patch = `*** Begin Patch\n*** Update File: ${otherMemory("system/x.md")}\n*** End Patch`;
+    const result = extractTargetAgentPaths(
+      "memory_apply_patch",
+      { input: patch },
+      "/tmp",
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("Bash command referencing another agent's memory literally", () => {
+    const result = extractTargetAgentPaths(
+      "Bash",
+      { command: `cat ${otherMemory("system/persona.md")}` },
+      "/tmp",
+    );
+    expect(result.anyAgentScoped).toBe(true);
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("Bash command with MEMORY_DIR env var pointing at another agent", () => {
+    const result = extractTargetAgentPaths(
+      "Bash",
+      { command: "rm -rf $MEMORY_DIR/system" },
+      "/tmp",
+      { ...process.env, MEMORY_DIR: otherMemory() } as NodeJS.ProcessEnv,
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("Bash read-only inspection against another agent's memory still trips the guard", () => {
+    const result = extractTargetAgentPaths(
+      "Bash",
+      { command: `ls ${otherMemory()}` },
+      "/tmp",
+    );
+    expect(result.agentIds).toEqual(new Set([OTHER]));
+  });
+
+  test("Bash command against /tmp does not trip the guard", () => {
+    const result = extractTargetAgentPaths(
+      "Bash",
+      { command: "ls /tmp && echo ok" },
+      "/tmp",
+    );
+    expect(result.anyAgentScoped).toBe(false);
+  });
+
+  test("Glob/Grep against another agent's memory", () => {
+    expect(
+      extractTargetAgentPaths("Glob", { path: otherMemory() }, "/tmp").agentIds,
+    ).toEqual(new Set([OTHER]));
+    expect(
+      extractTargetAgentPaths("Grep", { path: otherMemory() }, "/tmp").agentIds,
+    ).toEqual(new Set([OTHER]));
+  });
+
+  test("shell tool aliases (run_shell_command, shell_command) work", () => {
+    expect(
+      extractTargetAgentPaths(
+        "run_shell_command",
+        { command: `cat ${otherMemory()}/x.md` },
+        "/tmp",
+      ).agentIds,
+    ).toEqual(new Set([OTHER]));
+    expect(
+      extractTargetAgentPaths(
+        "shell_command",
+        { command: `ls ${otherMemory()}` },
+        "/tmp",
+      ).agentIds,
+    ).toEqual(new Set([OTHER]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateCrossAgentGuard
+// ---------------------------------------------------------------------------
+
+describe("evaluateCrossAgentGuard", () => {
+  test("returns null for own memory", () => {
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: selfMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-agent paths", () => {
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: "/tmp/project/foo.md" },
+      "/tmp/project",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("denies when targeting another agent's memory with no scope", () => {
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.matchedRule).toBe("cross-agent guard");
+    expect(result?.offendingAgentId).toBe(OTHER);
+    expect(result?.offendingAgentIds).toEqual([OTHER]);
+    expect(result?.reason).toMatch(/Cross-agent guard/);
+  });
+
+  test("passes through when other agent is in LETTA_MEMORY_SCOPE", () => {
+    process.env.LETTA_MEMORY_SCOPE = OTHER;
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("passes through when other agent is in --memory-scope", () => {
+    cliPermissions.setMemoryScope(OTHER);
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("partial scope: denies when any target is outside allowed set", () => {
+    process.env.LETTA_MEMORY_SCOPE = OTHER; // only OTHER is allowed
+    const patch = [
+      "*** Begin Patch",
+      `*** Add File: ${otherMemory("ok.md")}`,
+      `*** Add File: ${thirdMemory("bad.md")}`,
+      "*** End Patch",
+    ].join("\n");
+    const result = evaluateCrossAgentGuard(
+      "ApplyPatch",
+      { input: patch },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.offendingAgentIds).toEqual([THIRD]);
+  });
+
+  test("reads are gated (not just writes)", () => {
+    const result = evaluateCrossAgentGuard(
+      "Read",
+      { file_path: otherMemory("system/x.md") },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("bash read-only against other agent's memory is gated", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      { command: `cat ${otherMemory()}/system/x.md` },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with checkPermission — guard is unbypassable by any mode
+// ---------------------------------------------------------------------------
+
+describe("checkPermission integration", () => {
+  const permissions = { allow: [], deny: [], ask: [] };
+
+  test("bypassPermissions mode does NOT let you write another agent's memory", () => {
+    permissionMode.setMode("bypassPermissions");
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("acceptEdits mode does NOT let you write another agent's memory", () => {
+    permissionMode.setMode("acceptEdits");
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("memory mode does NOT let you write another agent's memory without scope", () => {
+    permissionMode.setMode("memory");
+    process.env.MEMORY_DIR = selfMemory();
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      selfMemory(),
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("memory mode DOES allow writes to scoped agent's memory", () => {
+    permissionMode.setMode("memory");
+    process.env.LETTA_MEMORY_SCOPE = OTHER;
+    process.env.MEMORY_DIR = otherMemory();
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      otherMemory(),
+    );
+    expect(result.decision).toBe("allow");
+  });
+
+  test("reads against another agent's memory are denied across all modes", () => {
+    const modes = [
+      "default",
+      "acceptEdits",
+      "plan",
+      "memory",
+      "bypassPermissions",
+    ] as const;
+    for (const mode of modes) {
+      permissionMode.setMode(mode);
+      const result = checkPermission(
+        "Read",
+        { file_path: otherMemory("system/a.md") },
+        permissions,
+        "/tmp",
+      );
+      expect(result.decision).toBe("deny");
+      expect(result.matchedRule).toBe("cross-agent guard");
+    }
+  });
+
+  test("own-memory access is unaffected by guard in every mode", () => {
+    process.env.MEMORY_DIR = selfMemory();
+    const modes = [
+      "default",
+      "acceptEdits",
+      "memory",
+      "bypassPermissions",
+    ] as const;
+    for (const mode of modes) {
+      permissionMode.setMode(mode);
+      const result = checkPermission(
+        "Read",
+        { file_path: selfMemory("system/a.md") },
+        permissions,
+        selfMemory(),
+      );
+      // Read on own memory should not be guard-denied (guard returns null,
+      // other rules decide; Read defaults to allow).
+      expect(result.matchedRule).not.toBe("cross-agent guard");
+    }
+  });
+
+  test("bash against another agent's memory is denied even in bypassPermissions", () => {
+    permissionMode.setMode("bypassPermissions");
+    const result = checkPermission(
+      "Bash",
+      { command: `git -C ${otherMemory()} log` },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("CLI --memory-scope opens access in acceptEdits mode", () => {
+    permissionMode.setMode("acceptEdits");
+    cliPermissions.setMemoryScope(OTHER);
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    // acceptEdits allows writes, and the guard passes since OTHER is scoped.
+    expect(result.decision).toBe("allow");
+  });
+});

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -613,3 +613,140 @@ describe("shell bypass regression tests", () => {
     expect(result).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression tests: Grep / Glob ancestor-path bypass.
+//
+// The classifier used to require `<home>/.letta/agents/<id>/memory` to
+// match, so pointing Grep or Glob at `.letta/agents` (the tree root)
+// slipped through entirely — leaking file contents and enumerating every
+// agent on disk.
+// ---------------------------------------------------------------------------
+
+describe("Grep/Glob ancestor-path regression tests", () => {
+  const agentsTreeRoot = join(HOME, ".letta", "agents");
+
+  test("Glob with path='<home>/.letta/agents' is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      { pattern: "**/*.md", path: agentsTreeRoot },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("Grep with path='<home>/.letta/agents' is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Grep",
+      { pattern: "password|secret|token|api_key", path: agentsTreeRoot },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("Glob pointed at a specific foreign agent's root (no /memory) is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      { pattern: "**/*.md", path: join(agentsTreeRoot, OTHER) },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.offendingAgentIds).toContain(OTHER);
+  });
+
+  test("Glob pointed at a foreign agent's settings.json (no /memory) is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Read",
+      { file_path: join(agentsTreeRoot, OTHER, "settings.json") },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.offendingAgentIds).toContain(OTHER);
+  });
+
+  test("Grep with absolute pattern referencing the agents tree is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      {
+        pattern: join(agentsTreeRoot, "*", "memory", "**", "*.md"),
+      },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("Glob with path=$HOME (ancestor of agents tree) is denied — recursive walk would enter it", () => {
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      { pattern: "**/*.md", path: HOME },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("Grep with path='/' is denied for the same reason", () => {
+    const result = evaluateCrossAgentGuard(
+      "Grep",
+      { pattern: "secret", path: "/" },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("Glob on self memory is allowed", () => {
+    process.env.AGENT_ID = SELF;
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      { pattern: "**/*.md", path: selfMemory() },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("Glob on self agent root (not under /memory) is allowed", () => {
+    process.env.AGENT_ID = SELF;
+    const result = evaluateCrossAgentGuard(
+      "Glob",
+      { pattern: "**/*", path: join(agentsTreeRoot, SELF) },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("Grep on a foreign agent is allowed when scoped via LETTA_MEMORY_SCOPE", () => {
+    process.env.LETTA_MEMORY_SCOPE = OTHER;
+    const result = evaluateCrossAgentGuard(
+      "Grep",
+      { pattern: "password", path: otherMemory() },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("Read on a single foreign file (not recursive) is still denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Read",
+      { file_path: otherMemory("system/persona.md") },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.offendingAgentIds).toContain(OTHER);
+  });
+
+  test("Read on $HOME (ancestor) is not a cross-agent hit — Read targets a single file, not a tree", () => {
+    const result = evaluateCrossAgentGuard("Read", { file_path: HOME }, "/tmp");
+    // Read on a dir would fail at the tool level anyway; guard shouldn't
+    // block generic home-dir file reads.
+    expect(result).toBeNull();
+  });
+
+  test("ListDir on the agents tree is denied (ListDir is recursive-like for our purposes)", () => {
+    const result = evaluateCrossAgentGuard(
+      "ListDir",
+      { path: agentsTreeRoot },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -318,7 +318,6 @@ describe("evaluateCrossAgentGuard", () => {
     );
     expect(result).not.toBeNull();
     expect(result?.matchedRule).toBe("cross-agent guard");
-    expect(result?.offendingAgentId).toBe(OTHER);
     expect(result?.offendingAgentIds).toEqual([OTHER]);
     expect(result?.reason).toMatch(/Cross-agent guard/);
   });

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 
 import { checkPermission } from "../../permissions/checker";
 import { cliPermissions } from "../../permissions/cli";
@@ -685,10 +685,14 @@ describe("Grep/Glob ancestor-path regression tests", () => {
     expect(result).not.toBeNull();
   });
 
-  test("Grep with path='/' is denied for the same reason", () => {
+  test("Grep on the filesystem root is denied for the same reason", () => {
+    // Use the home drive's root so the test works on Windows (where `/`
+    // resolves to the current drive and may not be an ancestor of the
+    // home drive in CI).
+    const fsRoot = parse(HOME).root;
     const result = evaluateCrossAgentGuard(
       "Grep",
-      { pattern: "secret", path: "/" },
+      { pattern: "secret", path: fsRoot },
       "/tmp",
     );
     expect(result).not.toBeNull();

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -504,3 +504,109 @@ describe("checkPermission integration", () => {
     expect(result.decision).toBe("allow");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression tests: known bypass patterns (from real exploit attempts)
+// ---------------------------------------------------------------------------
+
+describe("shell bypass regression tests", () => {
+  test("enumeration: ls ~/.letta/agents is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      { command: "ls ~/.letta/agents" },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.matchedRule).toBe("cross-agent guard");
+  });
+
+  test("enumeration: find over the whole agents tree is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      {
+        command: 'find "${HOME}/.letta/agents" -mindepth 1 -maxdepth 1 -type d',
+      },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("command substitution: assigning a computed target path is denied", () => {
+    // Exploit variant 1 (finds another agent via dynamic path resolution).
+    const command = [
+      'CURRENT="$AGENT_ID"',
+      'BASE="${HOME}/.letta/agents"',
+      'TARGET="$(find "$BASE" -mindepth 1 -maxdepth 1 -type d ! -name "$CURRENT" | sort | head -n 1)"',
+      'cat "$TARGET/memory/system/persona.md"',
+    ].join("\n");
+    const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
+    expect(result).not.toBeNull();
+  });
+
+  test("command substitution variant 2 (find -name memory) is denied", () => {
+    const command = [
+      'CURRENT="$AGENT_ID"',
+      'BASE="${HOME}/.letta/agents"',
+      'TARGET="$(find "$BASE" -mindepth 2 -maxdepth 2 -type d -name memory | grep -v "/$CURRENT/" | sort | head -n 1)"',
+      'cat "$TARGET/system/persona.md"',
+    ].join("\n");
+    const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
+    expect(result).not.toBeNull();
+  });
+
+  test("literal-but-unknown agent ID in quoted assignment is denied", () => {
+    // Exploit variant 3 — the one that actually succeeded previously
+    // because the quote-wrapping on the assignment value broke the
+    // anchored path regex.
+    const command = [
+      'TARGET="${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"',
+      'sed -n "1,80p" "$TARGET/system/persona.md"',
+    ].join("\n");
+    const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
+    expect(result).not.toBeNull();
+    expect(result?.offendingAgentIds).toContain(
+      "agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada",
+    );
+  });
+
+  test("tilde-expansion with unknown agent ID is denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      { command: "cat ~/.letta/agents/agent-victim/memory/system/persona.md" },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+  });
+
+  test("self-targeting references using ${AGENT_ID} pass through", () => {
+    process.env.AGENT_ID = SELF;
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      {
+        command:
+          'cat "${HOME}/.letta/agents/${AGENT_ID}/memory/system/persona.md"',
+      },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("scoped access via LETTA_MEMORY_SCOPE passes through", () => {
+    process.env.LETTA_MEMORY_SCOPE =
+      "agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada";
+    const command =
+      'TARGET="${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"\n' +
+      'cat "$TARGET/system/persona.md"';
+    const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
+    expect(result).toBeNull();
+  });
+
+  test("legitimate bash touching nothing under .letta/agents is not denied", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      { command: "ls /tmp && echo ok" },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -39,7 +39,6 @@ const ENV_KEYS_TO_RESET = [
   "LETTA_MEMORY_SCOPE",
   "MEMORY_DIR",
   "LETTA_MEMORY_DIR",
-  "PARENT_MEMORY_DIR",
 ] as const;
 
 function snapshotEnv(): Partial<

--- a/src/tests/permissions/memoryScope.test.ts
+++ b/src/tests/permissions/memoryScope.test.ts
@@ -11,7 +11,6 @@ afterEach(() => {
   delete process.env.MEMORY_DIR;
   delete process.env.LETTA_MEMORY_DIR;
   delete process.env.LETTA_MEMORY_SCOPE;
-  delete process.env.PARENT_MEMORY_DIR;
   delete process.env.AGENT_ID;
   delete process.env.LETTA_AGENT_ID;
   delete process.env.LETTA_PARENT_AGENT_ID;
@@ -32,8 +31,7 @@ test("explicit env roots are authoritative over fallback inference", () => {
   expect(scope.usedFallback).toBe(false);
   expect(scope.primaryRoot).toBe(normalizeScopedPath("/tmp/explicit-memory"));
   expect(scope.roots).toContain(normalizeScopedPath("/tmp/explicit-memory"));
-  // Parent's memory root is now derived from LETTA_MEMORY_SCOPE agent IDs,
-  // not from a path-based PARENT_MEMORY_DIR.
+  // Parent's memory root is derived from LETTA_MEMORY_SCOPE agent IDs.
   expect(scope.roots).toContain(scopedParentRoot);
   expect(scope.roots).not.toContain(
     normalizeScopedPath(

--- a/src/tests/permissions/memoryScope.test.ts
+++ b/src/tests/permissions/memoryScope.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test } from "bun:test";
 
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { cliPermissions } from "../../permissions/cli";
 import {
   normalizeScopedPath,
   resolveAllowedMemoryRoots,
@@ -9,31 +10,64 @@ import {
 afterEach(() => {
   delete process.env.MEMORY_DIR;
   delete process.env.LETTA_MEMORY_DIR;
+  delete process.env.LETTA_MEMORY_SCOPE;
   delete process.env.PARENT_MEMORY_DIR;
   delete process.env.AGENT_ID;
   delete process.env.LETTA_AGENT_ID;
   delete process.env.LETTA_PARENT_AGENT_ID;
+  cliPermissions.clear();
 });
 
 test("explicit env roots are authoritative over fallback inference", () => {
   process.env.MEMORY_DIR = "/tmp/explicit-memory";
-  process.env.PARENT_MEMORY_DIR = "/tmp/explicit-parent-memory";
+  process.env.LETTA_MEMORY_SCOPE = "agent-parent-in-scope";
   process.env.AGENT_ID = "agent-fallback";
   process.env.LETTA_PARENT_AGENT_ID = "agent-parent-fallback";
 
   const scope = resolveAllowedMemoryRoots({ homeDir: "/Users/test" });
+  const scopedParentRoot = normalizeScopedPath(
+    getMemoryFilesystemRoot("agent-parent-in-scope", "/Users/test"),
+  );
 
   expect(scope.usedFallback).toBe(false);
   expect(scope.primaryRoot).toBe(normalizeScopedPath("/tmp/explicit-memory"));
   expect(scope.roots).toContain(normalizeScopedPath("/tmp/explicit-memory"));
-  expect(scope.roots).toContain(
-    normalizeScopedPath("/tmp/explicit-parent-memory"),
-  );
+  // Parent's memory root is now derived from LETTA_MEMORY_SCOPE agent IDs,
+  // not from a path-based PARENT_MEMORY_DIR.
+  expect(scope.roots).toContain(scopedParentRoot);
   expect(scope.roots).not.toContain(
     normalizeScopedPath(
       getMemoryFilesystemRoot("agent-fallback", "/Users/test"),
     ),
   );
+});
+
+test("LETTA_MEMORY_SCOPE contributes parent roots alongside MEMORY_DIR", () => {
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-self/memory";
+  process.env.LETTA_MEMORY_SCOPE = "agent-alpha,agent-beta";
+
+  const scope = resolveAllowedMemoryRoots({ homeDir: "/Users/test" });
+  const alphaRoot = normalizeScopedPath(
+    getMemoryFilesystemRoot("agent-alpha", "/Users/test"),
+  );
+  const betaRoot = normalizeScopedPath(
+    getMemoryFilesystemRoot("agent-beta", "/Users/test"),
+  );
+
+  expect(scope.roots).toContain(alphaRoot);
+  expect(scope.roots).toContain(betaRoot);
+});
+
+test("--memory-scope CLI flag also contributes roots", () => {
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-self/memory";
+  cliPermissions.setMemoryScope("agent-from-cli");
+
+  const scope = resolveAllowedMemoryRoots({ homeDir: "/Users/test" });
+  const cliRoot = normalizeScopedPath(
+    getMemoryFilesystemRoot("agent-from-cli", "/Users/test"),
+  );
+
+  expect(scope.roots).toContain(cliRoot);
 });
 
 test("falls back to agent-derived roots when no explicit env roots exist", () => {


### PR DESCRIPTION
## Summary

Hard-deny guard that blocks tool calls targeting another agent's memory directory (anything under `~/.letta/agents/<id>/`) unless the caller has opted in via `LETTA_MEMORY_SCOPE` (env) or `--memory-scope` (CLI). Runs before all other permission logic and is **unbypassable** by any permission mode, allow/deny list, or settings rule — closing the previous hole where `bypassPermissions` / `acceptEdits` / `memory+PARENT_MEMORY_DIR` each let agents silently reach sibling memory.

## Architecture

Three layers in `src/permissions/crossAgentGuard.ts`:

**Layer 1 — Allowed agents** (`resolveAllowedAgents`)
Additive union of three sources: `AGENT_ID` (self, always included), `LETTA_MEMORY_SCOPE` (env, inherited across subagent spawn), `--memory-scope` (CLI, per-invocation). Each actor uses the channel that fits them — env for machine-to-machine propagation, CLI for human-to-machine declaration.

**Layer 2 — Target extraction** (`extractTargetAgentPaths`)
Dispatches by tool type:

| Tool class | Extractor |
|---|---|
| Patch (`ApplyPatch`, `apply_patch`, `memory_apply_patch`) | `extractApplyPatchPaths` |
| Shell (`Bash`, `shell`, `run_shell_command`, `shell_command`) | `collectShellAgentTargets` + `scanRawCommandForUnresolvedAgentRefs` (two-pass) |
| `MultiEdit` | `extractMultiEditPaths` |
| Other (`Read`, `Write`, `Edit`, `Grep`, `Glob`, `ListDir`, `NotebookEdit`) | `extractFilePath` (+ `pattern` for recursive tools) |

Every extracted path flows through a shared classifier (`classifyAgentsTreePath`) that returns `outside | agents-root | ancestor | agent(id)`. Roots and ancestors produce a sentinel `<unresolved>` offending ID (never in any allowed set → always denied); `ancestor` only fires for recursive tools (Grep/Glob/ListDir/LS) so `Read` on `$HOME` stays fine.

**Layer 3 — Evaluate** (`evaluateCrossAgentGuard`)
`offending = { id ∈ targets : id ∉ allowed }` plus unresolved refs from the shell raw-scan. Non-empty → DENY with `CrossAgentGuardResult { reason, offendingAgentIds }`; empty → ALLOW (`null`).

## Behavior matrix

| Mode | Own memory | Other agent (not scoped) | Other agent (scoped) |
|---|---|---|---|
| default | prompt | **deny (guard)** | prompt / allow per rules |
| acceptEdits | allow | **deny (guard)** | allow |
| plan | deny (outside plans) | **deny (guard)** | deny (outside plans) |
| memory | allow | **deny (guard)** | allow |
| bypassPermissions | allow | **deny (guard)** | allow |

Middle column is the invariant the guard establishes. Right column is "you explicitly opted in; mode decides normally."

## Notes
- Subagent spawn (`manager.ts`) always appends the parent agent ID to the child's `LETTA_MEMORY_SCOPE`, so scope propagates transitively to grandchildren. `PARENT_MEMORY_DIR` is gone (`ad10374d`).

## Test plan

- [x] `src/tests/permissions/crossAgentGuard.test.ts` — **58 tests** covering the three layers, every extractor, the classifier's four cases, and all bypass patterns documented above (including the reported exploit strings verbatim)
- [x] `src/tests/permissions/memoryScope.test.ts` — `LETTA_MEMORY_SCOPE` and `--memory-scope` both contribute roots; legacy `PARENT_MEMORY_DIR` path removed
- [x] `src/tests/permissions-mode.test.ts` — scope-based parent-memory write test migrated off `PARENT_MEMORY_DIR`
- [x] **160/160 pass** in `src/tests/permissions/`
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean on all touched files
- [x] Manual smoke: spawn a memory-mode subagent and verify writes to parent memory still work; spawn a general-purpose subagent and verify writes to parent memory are hard-denied

👾 Generated with [Letta Code](https://letta.com)