### PR TITLE
fix(memfs): replay memory writes on remote conflicts

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -36,6 +36,31 @@ const RETRYABLE_GIT_NETWORK_ERROR_RE =
 const MISSING_CWD_GIT_ERROR_RE =
   /(Unable to read current working directory: No such file or directory|\buv_cwd\b|\bcwd\b.*\bENOENT\b)/i;
 
+const NON_FAST_FORWARD_PUSH_ERROR_RE =
+  /(non-fast-forward|fetch first|failed to push some refs|updates were rejected|remote contains work that you do not have locally|tip of your current branch is behind)/i;
+
+export interface MemoryCommitAuthor {
+  agentId: string;
+  authorName: string;
+  authorEmail: string;
+}
+
+export interface CommitAndSyncMemoryWriteParams {
+  memoryDir: string;
+  pathspecs: string[];
+  reason: string;
+  author: MemoryCommitAuthor;
+  replay?: () => Promise<string[]>;
+}
+
+export interface CommitAndSyncMemoryWriteResult {
+  committed: boolean;
+  sha?: string;
+  replayed?: boolean;
+  replayNoop?: boolean;
+  rescueRef?: string;
+}
+
 /** Get the agent root directory (~/.letta/agents/{id}/) */
 export function getAgentRootDir(agentId: string): string {
   return join(homedir(), ".letta", "agents", agentId);
@@ -498,6 +523,304 @@ function installPreCommitHook(dir: string): void {
   debugLog("memfs-git", "Installed pre-commit hook");
 }
 
+function normalizePathspecs(pathspecs: string[]): string[] {
+  return Array.from(new Set(pathspecs)).filter(
+    (path) => path.trim().length > 0,
+  );
+}
+
+function isNonFastForwardPushError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return NON_FAST_FORWARD_PUSH_ERROR_RE.test(message);
+}
+
+async function prepareMemoryRepoForGitOps(
+  memoryDir: string,
+  agentId: string,
+  token: string,
+): Promise<void> {
+  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
+  await configureLocalCredentialHelper(memoryDir, token);
+  installPreCommitHook(memoryDir);
+}
+
+async function stageMemoryPaths(
+  memoryDir: string,
+  pathspecs: string[],
+): Promise<void> {
+  if (pathspecs.length === 0) {
+    return;
+  }
+  await runGit(memoryDir, ["add", "-A", "--", ...pathspecs]);
+}
+
+async function hasStagedMemoryChanges(
+  memoryDir: string,
+  pathspecs: string[],
+): Promise<boolean> {
+  if (pathspecs.length === 0) {
+    return false;
+  }
+
+  const status = await runGit(memoryDir, [
+    "status",
+    "--porcelain",
+    "--",
+    ...pathspecs,
+  ]);
+  return status.stdout.trim().length > 0;
+}
+
+async function commitMemoryPaths(
+  memoryDir: string,
+  pathspecs: string[],
+  reason: string,
+  author: MemoryCommitAuthor,
+): Promise<{ committed: boolean; sha?: string }> {
+  const normalizedPathspecs = normalizePathspecs(pathspecs);
+  await stageMemoryPaths(memoryDir, normalizedPathspecs);
+
+  if (!(await hasStagedMemoryChanges(memoryDir, normalizedPathspecs))) {
+    return { committed: false };
+  }
+
+  try {
+    await runGit(memoryDir, [
+      "-c",
+      `user.name=${author.authorName.trim() || author.agentId}`,
+      "-c",
+      `user.email=${author.authorEmail}`,
+      "commit",
+      "-m",
+      reason,
+    ]);
+  } catch (error) {
+    await unstageMemoryPaths(memoryDir, normalizedPathspecs);
+    throw error;
+  }
+
+  const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
+  return {
+    committed: true,
+    sha: head.stdout.trim(),
+  };
+}
+
+async function unstageMemoryPaths(
+  memoryDir: string,
+  pathspecs: string[],
+): Promise<void> {
+  if (pathspecs.length === 0) {
+    return;
+  }
+
+  try {
+    await runGit(memoryDir, ["reset", "HEAD", "--", ...pathspecs]);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+async function fetchMemoryRemote(
+  memoryDir: string,
+  token: string,
+): Promise<void> {
+  await runGitWithRetry(memoryDir, ["fetch", "origin"], token, {
+    operation: "fetch origin",
+  });
+}
+
+async function resetMemoryToUpstream(
+  memoryDir: string,
+  token: string,
+): Promise<void> {
+  await runGit(memoryDir, ["reset", "--hard", "@{u}"], token);
+}
+
+function buildMemoryConflictRef(sha: string): string {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[-:TZ.]/g, "")
+    .slice(0, 14);
+  return `refs/letta-conflicts/${timestamp}-${sha.slice(0, 7)}`;
+}
+
+async function preserveMemoryCommit(
+  memoryDir: string,
+  sha: string,
+): Promise<string> {
+  const ref = buildMemoryConflictRef(sha);
+  await runGit(memoryDir, ["update-ref", ref, sha]);
+  return ref;
+}
+
+function formatCommittedButPushFailed(sha: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `Memory changes were committed (${sha.slice(0, 7)}) but push failed: ${message}`;
+}
+
+function formatReplayConflict(
+  sha: string,
+  rescueRef: string,
+  error: unknown,
+): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `Memory changes conflicted with newer remote memory and could not be replayed safely. Preserved local commit ${sha.slice(0, 7)} at ${rescueRef}; local branch was reset to upstream. Replay error: ${message}`;
+}
+
+function formatReplayPushFailure(
+  originalSha: string,
+  originalRef: string,
+  replaySha: string | undefined,
+  replayRef: string | undefined,
+  error: unknown,
+): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const replaySummary =
+    replaySha && replayRef
+      ? ` Replayed commit ${replaySha.slice(0, 7)} was preserved at ${replayRef}.`
+      : "";
+  return `Memory changes conflicted with newer remote memory and the replayed update could not be pushed safely. Original commit ${originalSha.slice(0, 7)} was preserved at ${originalRef}.${replaySummary} Local branch was reset to upstream. Push error: ${message}`;
+}
+
+async function recoverMemoryPushConflict(
+  params: CommitAndSyncMemoryWriteParams,
+  token: string,
+  initialSha: string,
+): Promise<CommitAndSyncMemoryWriteResult> {
+  const rescueRef = await preserveMemoryCommit(params.memoryDir, initialSha);
+
+  await fetchMemoryRemote(params.memoryDir, token);
+  await resetMemoryToUpstream(params.memoryDir, token);
+
+  let replayedPathspecs: string[] = [];
+  try {
+    replayedPathspecs = normalizePathspecs((await params.replay?.()) ?? []);
+  } catch (error) {
+    await resetMemoryToUpstream(params.memoryDir, token);
+    throw new Error(formatReplayConflict(initialSha, rescueRef, error));
+  }
+
+  let replayCommit: { committed: boolean; sha?: string };
+  try {
+    replayCommit = await commitMemoryPaths(
+      params.memoryDir,
+      replayedPathspecs,
+      params.reason,
+      params.author,
+    );
+  } catch (error) {
+    await resetMemoryToUpstream(params.memoryDir, token);
+    throw new Error(formatReplayConflict(initialSha, rescueRef, error));
+  }
+
+  if (!replayCommit.committed) {
+    return {
+      committed: true,
+      replayed: true,
+      replayNoop: true,
+      rescueRef,
+    };
+  }
+
+  try {
+    await runGit(params.memoryDir, ["push"], token);
+  } catch (error) {
+    const replayRef = replayCommit.sha
+      ? await preserveMemoryCommit(params.memoryDir, replayCommit.sha)
+      : undefined;
+    await resetMemoryToUpstream(params.memoryDir, token);
+    throw new Error(
+      formatReplayPushFailure(
+        initialSha,
+        rescueRef,
+        replayCommit.sha,
+        replayRef,
+        error,
+      ),
+    );
+  }
+
+  return {
+    committed: true,
+    sha: replayCommit.sha,
+    replayed: true,
+    rescueRef,
+  };
+}
+
+export async function assertMemoryRepoReadyForWrite(
+  memoryDir: string,
+): Promise<void> {
+  const status = await runGit(memoryDir, ["status", "--porcelain"]);
+  if (status.stdout.trim().length > 0) {
+    throw new Error(
+      "Memory repo has uncommitted changes. Commit, discard, or sync them before using memory tools.",
+    );
+  }
+
+  try {
+    const { stdout } = await runGit(memoryDir, [
+      "rev-list",
+      "--count",
+      "@{u}..HEAD",
+    ]);
+    const aheadCount = parseInt(stdout.trim(), 10);
+    if (aheadCount > 0) {
+      throw new Error(
+        "Memory repo has local commits that are not pushed to remote. Sync the repo before using memory tools.",
+      );
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("not pushed to remote")
+    ) {
+      throw error;
+    }
+  }
+}
+
+export async function commitAndSyncMemoryWrite(
+  params: CommitAndSyncMemoryWriteParams,
+): Promise<CommitAndSyncMemoryWriteResult> {
+  const normalizedPathspecs = normalizePathspecs(params.pathspecs);
+  if (normalizedPathspecs.length === 0) {
+    return { committed: false };
+  }
+
+  const token = await getAuthToken();
+  await prepareMemoryRepoForGitOps(
+    params.memoryDir,
+    params.author.agentId,
+    token,
+  );
+
+  const commitResult = await commitMemoryPaths(
+    params.memoryDir,
+    normalizedPathspecs,
+    params.reason,
+    params.author,
+  );
+  if (!commitResult.committed || !commitResult.sha) {
+    return { committed: false };
+  }
+
+  try {
+    await runGit(params.memoryDir, ["push"], token);
+  } catch (error) {
+    if (!params.replay || !isNonFastForwardPushError(error)) {
+      throw new Error(formatCommittedButPushFailed(commitResult.sha, error));
+    }
+    return recoverMemoryPushConflict(params, token, commitResult.sha);
+  }
+
+  return {
+    committed: true,
+    sha: commitResult.sha,
+  };
+}
+
 /** Check if the memory directory is a git repo */
 export function isGitRepo(agentId: string): boolean {
   return existsSync(join(getMemoryRepoDir(agentId), ".git"));
@@ -610,49 +933,14 @@ export async function pullMemory(
 
 /**
  * Push local memory commits to the server.
- * Handles auth, retries with rebase on conflict, and gracefully
- * handles empty remotes (no branch on server yet).
+ * Keeps remote writes explicit: no automatic pull --rebase.
  */
 export async function pushMemory(agentId: string): Promise<void> {
   const token = await getAuthToken();
   const dir = getMemoryRepoDir(agentId);
 
-  await maybeUpdateMemoryRemoteOrigin(dir, agentId);
-
-  await configureLocalCredentialHelper(dir, token);
-
-  try {
-    await runGit(dir, ["push"], token);
-    return;
-  } catch (pushError) {
-    debugWarn(
-      "memfs-git",
-      `Push failed, attempting pull --rebase: ${pushError instanceof Error ? pushError.message : String(pushError)}`,
-    );
-  }
-
-  // Push failed — try pull --rebase then retry push.
-  // The pull itself may fail (e.g. empty remote with no branch), so catch that.
-  try {
-    await runGit(dir, ["pull", "--rebase"], token);
-  } catch (pullError) {
-    debugWarn(
-      "memfs-git",
-      `Pull --rebase also failed (remote may be empty): ${pullError instanceof Error ? pullError.message : String(pullError)}`,
-    );
-    // If pull fails, the push won't succeed either — surface original push error
-    // but don't crash; the commit is saved locally and can be pushed later.
-    return;
-  }
-
-  try {
-    await runGit(dir, ["push"], token);
-  } catch (retryError) {
-    debugWarn(
-      "memfs-git",
-      `Push failed after rebase: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
-    );
-  }
+  await prepareMemoryRepoForGitOps(dir, agentId, token);
+  await runGit(dir, ["push"], token);
 }
 
 export interface MemoryGitStatus {

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -3,13 +3,14 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { settingsManager } from "../settings-manager";
+import { getClient } from "./client";
 import type { CreateAgentOptions } from "./create";
 import { getDefaultMemoryBlocks, parseMdxFrontmatter } from "./memory";
 import {
+  commitAndSyncMemoryWrite,
   GIT_MEMORY_ENABLED_TAG,
   getMemoryRepoDir,
   pullMemory,
-  pushMemory,
 } from "./memoryGit";
 import { MEMORY_PROMPTS, SYSTEM_PROMPTS } from "./promptAssets";
 
@@ -486,38 +487,69 @@ export function detectPersonalityFromPersonaFile(
   return null;
 }
 
-function isExitCode(error: unknown, expectedCode: number): boolean {
-  if (!error || typeof error !== "object") return false;
-  const code = (error as { code?: unknown }).code;
-  return code === expectedCode;
-}
-
-async function runGit(cwd: string, args: string[]): Promise<string> {
-  const result = await execFile("git", args, {
-    cwd,
-    maxBuffer: 10 * 1024 * 1024,
-    timeout: 60_000,
-  });
-  return result.stdout?.toString() ?? "";
-}
-
-async function hasStagedChanges(
-  cwd: string,
-  relativePaths: string[],
-): Promise<boolean> {
-  if (relativePaths.length === 0) {
-    return false;
-  }
+async function getMemoryCommitAuthor(agentId: string): Promise<{
+  agentId: string;
+  authorName: string;
+  authorEmail: string;
+}> {
+  let authorName = agentId;
 
   try {
-    await runGit(cwd, ["diff", "--cached", "--quiet", "--", ...relativePaths]);
-    return false;
-  } catch (error) {
-    if (isExitCode(error, 1)) {
-      return true;
+    const client = await getClient();
+    const agent = await client.agents.retrieve(agentId);
+    if (agent.name?.trim()) {
+      authorName = agent.name.trim();
     }
-    throw error;
+  } catch {
+    // best-effort fallback to agent id
   }
+
+  return {
+    agentId,
+    authorName,
+    authorEmail: `${agentId}@letta.com`,
+  };
+}
+
+function applyPersonalityFiles(
+  filesToUpdate: Array<{
+    relativePath: string;
+    absolutePath: string;
+    templatePromptAssetName: string;
+    content: string;
+    description?: string;
+  }>,
+): string[] {
+  const changedPaths: string[] = [];
+
+  for (const file of filesToUpdate) {
+    const existingContent = existsSync(file.absolutePath)
+      ? readFileSync(file.absolutePath, "utf-8")
+      : null;
+    const nextContent = existingContent
+      ? replaceBodyPreservingFrontmatter(existingContent, file.content, {
+          description: file.description,
+        })
+      : buildDefaultMemoryFile(
+          file.templatePromptAssetName,
+          file.content,
+          file.description,
+        );
+
+    if (
+      existingContent !== null &&
+      normalizeComparableContent(existingContent) ===
+        normalizeComparableContent(nextContent)
+    ) {
+      continue;
+    }
+
+    mkdirSync(dirname(file.absolutePath), { recursive: true });
+    writeFileSync(file.absolutePath, nextContent, "utf-8");
+    changedPaths.push(file.relativePath);
+  }
+
+  return changedPaths;
 }
 
 export async function applyPersonalityToMemory(
@@ -563,47 +595,9 @@ export async function applyPersonalityToMemory(
     },
   ];
 
-  const changedPaths: string[] = [];
-
-  for (const file of filesToUpdate) {
-    const existingContent = existsSync(file.absolutePath)
-      ? readFileSync(file.absolutePath, "utf-8")
-      : null;
-    const nextContent = existingContent
-      ? replaceBodyPreservingFrontmatter(existingContent, file.content, {
-          description: file.description,
-        })
-      : buildDefaultMemoryFile(
-          file.templatePromptAssetName,
-          file.content,
-          file.description,
-        );
-
-    if (
-      existingContent !== null &&
-      normalizeComparableContent(existingContent) ===
-        normalizeComparableContent(nextContent)
-    ) {
-      continue;
-    }
-
-    mkdirSync(dirname(file.absolutePath), { recursive: true });
-    writeFileSync(file.absolutePath, nextContent, "utf-8");
-    changedPaths.push(file.relativePath);
-  }
+  const changedPaths = applyPersonalityFiles(filesToUpdate);
 
   if (changedPaths.length === 0) {
-    return {
-      changed: false,
-      personality,
-      personaRelativePath,
-      humanRelativePath,
-    };
-  }
-
-  await runGit(repoDir, ["add", "--", ...changedPaths]);
-
-  if (!(await hasStagedChanges(repoDir, changedPaths))) {
     return {
       changed: false,
       personality,
@@ -616,16 +610,23 @@ export async function applyPersonalityToMemory(
     params.commitMessage ??
     `chore(personality): switch to ${personality.label}`;
 
-  await runGit(repoDir, [
-    "commit",
-    "--only",
-    "-m",
-    commitMessage,
-    "--",
-    ...changedPaths,
-  ]);
+  const author = await getMemoryCommitAuthor(params.agentId);
+  const commitResult = await commitAndSyncMemoryWrite({
+    memoryDir: repoDir,
+    pathspecs: changedPaths,
+    reason: commitMessage,
+    author,
+    replay: async () => applyPersonalityFiles(filesToUpdate),
+  });
 
-  await pushMemory(params.agentId);
+  if (!commitResult.committed) {
+    return {
+      changed: false,
+      personality,
+      personaRelativePath,
+      humanRelativePath,
+    };
+  }
 
   return {
     changed: true,

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -39,7 +39,7 @@ async function cloneRemoteRepo(
   remoteDir: string,
   cloneDir: string,
 ): Promise<void> {
-  await execFile("git", ["clone", remoteDir, cloneDir]);
+  await execFile("git", ["clone", "--branch", "main", remoteDir, cloneDir]);
   await runGit(cloneDir, ["config", "user.name", "remote-user"]);
   await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
 }

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { execFile as execFileCb } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -33,6 +33,24 @@ const { memory_apply_patch } = await import(
 async function runGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFile("git", args, { cwd });
   return String(stdout ?? "").trim();
+}
+
+async function cloneRemoteRepo(
+  remoteDir: string,
+  cloneDir: string,
+): Promise<void> {
+  await execFile("git", ["clone", remoteDir, cloneDir]);
+  await runGit(cloneDir, ["config", "user.name", "remote-user"]);
+  await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
+}
+
+async function listRescueRefs(cwd: string): Promise<string[]> {
+  const output = await runGit(cwd, [
+    "for-each-ref",
+    "--format=%(refname)",
+    "refs/letta-conflicts",
+  ]);
+  return output ? output.split("\n").filter(Boolean) : [];
 }
 
 describe("memory_apply_patch tool", () => {
@@ -176,19 +194,17 @@ describe("memory_apply_patch tool", () => {
   });
 
   test("rejects editing read_only memory files", async () => {
-    await memory_apply_patch({
-      reason: "seed read only",
-      input: [
-        "*** Begin Patch",
-        "*** Add File: system/ro.md",
-        "+---",
-        "+description: Read only",
-        "+read_only: true",
-        "+---",
-        "+keep",
-        "*** End Patch",
-      ].join("\n"),
-    });
+    mkdirSync(join(memoryDir, "system"), { recursive: true });
+    writeFileSync(
+      join(memoryDir, "system", "ro.md"),
+      ["---", "description: Read only", "read_only: true", "---", "keep"].join(
+        "\n",
+      ),
+      "utf8",
+    );
+    await runGit(memoryDir, ["add", "system/ro.md"]);
+    await runGit(memoryDir, ["commit", "-m", "seed read only"]);
+    await runGit(memoryDir, ["push", "origin", "main"]);
 
     await expect(
       memory_apply_patch({
@@ -244,6 +260,129 @@ describe("memory_apply_patch tool", () => {
       "--pretty=format:%s",
     ]);
     expect(subject).toBe(reason);
+  });
+
+  test("replays patches on top of newer remote memory", async () => {
+    await memory_apply_patch({
+      reason: "seed replay patch notes",
+      input: [
+        "*** Begin Patch",
+        "*** Add File: reference/history/notes.md",
+        "+---",
+        "+description: Notes block",
+        "+---",
+        "+old",
+        "*** End Patch",
+      ].join("\n"),
+    });
+
+    const remoteCloneDir = join(tempRoot, "remote-patch-clone");
+    await cloneRemoteRepo(remoteDir, remoteCloneDir);
+    writeFileSync(
+      join(remoteCloneDir, "reference", "history", "notes.md"),
+      ["---", "description: Notes block", "---", "old", "remote line"].join(
+        "\n",
+      ),
+      "utf8",
+    );
+    await runGit(remoteCloneDir, ["add", "reference/history/notes.md"]);
+    await runGit(remoteCloneDir, ["commit", "-m", "Remote patch update"]);
+    await runGit(remoteCloneDir, ["push", "origin", "main"]);
+
+    const result = await memory_apply_patch({
+      reason: "Replay patch update",
+      input: [
+        "*** Begin Patch",
+        "*** Update File: reference/history/notes.md",
+        "@@",
+        "-old",
+        "+new",
+        "*** End Patch",
+      ].join("\n"),
+    });
+
+    expect(result.message).toContain(
+      "reapplied on top of newer remote memory and pushed",
+    );
+
+    const content = await runGit(memoryDir, [
+      "show",
+      "HEAD:reference/history/notes.md",
+    ]);
+    expect(content).toContain("new");
+    expect(content).toContain("remote line");
+
+    const divergence = await runGit(memoryDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{u}...HEAD",
+    ]);
+    expect(divergence).toBe("0\t0");
+  });
+
+  test("fails closed when replayed patch no longer matches remote", async () => {
+    await memory_apply_patch({
+      reason: "seed conflicting patch notes",
+      input: [
+        "*** Begin Patch",
+        "*** Add File: reference/history/notes.md",
+        "+---",
+        "+description: Notes block",
+        "+---",
+        "+old",
+        "*** End Patch",
+      ].join("\n"),
+    });
+
+    const remoteCloneDir = join(tempRoot, "remote-patch-conflict-clone");
+    await cloneRemoteRepo(remoteDir, remoteCloneDir);
+    writeFileSync(
+      join(remoteCloneDir, "reference", "history", "notes.md"),
+      ["---", "description: Notes block", "---", "remote"].join("\n"),
+      "utf8",
+    );
+    await runGit(remoteCloneDir, ["add", "reference/history/notes.md"]);
+    await runGit(remoteCloneDir, ["commit", "-m", "Remote conflicting patch"]);
+    await runGit(remoteCloneDir, ["push", "origin", "main"]);
+
+    await expect(
+      memory_apply_patch({
+        reason: "Attempt conflicting patch replay",
+        input: [
+          "*** Begin Patch",
+          "*** Update File: reference/history/notes.md",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+        ].join("\n"),
+      }),
+    ).rejects.toThrow(/could not be replayed safely/i);
+
+    const divergence = await runGit(memoryDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{u}...HEAD",
+    ]);
+    expect(divergence).toBe("0\t0");
+
+    const content = await runGit(memoryDir, [
+      "show",
+      "HEAD:reference/history/notes.md",
+    ]);
+    expect(content).toContain("remote");
+    expect(content).not.toContain("new");
+
+    const rescueRefs = await listRescueRefs(memoryDir);
+    expect(rescueRefs.length).toBeGreaterThan(0);
+
+    const rescuedContent = await runGit(memoryDir, [
+      "show",
+      `${rescueRefs[0]}:reference/history/notes.md`,
+    ]);
+    expect(rescuedContent).toContain("new");
   });
 
   test("updates files that omit frontmatter limit", async () => {

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -33,6 +33,24 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
   return String(stdout ?? "").trim();
 }
 
+async function cloneRemoteRepo(
+  remoteDir: string,
+  cloneDir: string,
+): Promise<void> {
+  await execFile("git", ["clone", remoteDir, cloneDir]);
+  await runGit(cloneDir, ["config", "user.name", "remote-user"]);
+  await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
+}
+
+async function listRescueRefs(cwd: string): Promise<string[]> {
+  const output = await runGit(cwd, [
+    "for-each-ref",
+    "--format=%(refname)",
+    "refs/letta-conflicts",
+  ]);
+  return output ? output.split("\n").filter(Boolean) : [];
+}
+
 describe("memory tool", () => {
   let tempRoot: string;
   let memoryDir: string;
@@ -155,6 +173,116 @@ describe("memory tool", () => {
       "--pretty=format:%s",
     ]);
     expect(subject).toBe(reason);
+  });
+
+  test("replays str_replace on top of newer remote memory", async () => {
+    await memory({
+      command: "create",
+      reason: "Seed replay notes",
+      file_path: "reference/history/notes.md",
+      description: "Notes block",
+      file_text: "old value\nlocal line",
+    });
+
+    const remoteCloneDir = join(tempRoot, "remote-clone");
+    await cloneRemoteRepo(remoteDir, remoteCloneDir);
+    writeFileSync(
+      join(remoteCloneDir, "reference", "history", "notes.md"),
+      [
+        "---",
+        "description: Notes block",
+        "---",
+        "old value",
+        "local line",
+        "remote line",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(remoteCloneDir, ["add", "reference/history/notes.md"]);
+    await runGit(remoteCloneDir, ["commit", "-m", "Remote update notes"]);
+    await runGit(remoteCloneDir, ["push", "origin", "main"]);
+
+    const result = await memory({
+      command: "str_replace",
+      reason: "Replay local replacement",
+      file_path: "reference/history/notes.md",
+      old_string: "old value",
+      new_string: "new value",
+    });
+
+    expect(result.message).toContain(
+      "reapplied on top of newer remote memory and pushed",
+    );
+
+    const content = await runGit(memoryDir, [
+      "show",
+      "HEAD:reference/history/notes.md",
+    ]);
+    expect(content).toContain("new value");
+    expect(content).toContain("remote line");
+
+    const divergence = await runGit(memoryDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{u}...HEAD",
+    ]);
+    expect(divergence).toBe("0\t0");
+  });
+
+  test("fails closed when replay cannot be applied safely", async () => {
+    await memory({
+      command: "create",
+      reason: "Seed conflicting notes",
+      file_path: "reference/history/notes.md",
+      description: "Notes block",
+      file_text: "old value",
+    });
+
+    const remoteCloneDir = join(tempRoot, "remote-conflict-clone");
+    await cloneRemoteRepo(remoteDir, remoteCloneDir);
+    writeFileSync(
+      join(remoteCloneDir, "reference", "history", "notes.md"),
+      ["---", "description: Notes block", "---", "remote value"].join("\n"),
+      "utf8",
+    );
+    await runGit(remoteCloneDir, ["add", "reference/history/notes.md"]);
+    await runGit(remoteCloneDir, ["commit", "-m", "Remote conflicting update"]);
+    await runGit(remoteCloneDir, ["push", "origin", "main"]);
+
+    await expect(
+      memory({
+        command: "str_replace",
+        reason: "Attempt conflicting replacement",
+        file_path: "reference/history/notes.md",
+        old_string: "old value",
+        new_string: "new value",
+      }),
+    ).rejects.toThrow(/could not be replayed safely/i);
+
+    const divergence = await runGit(memoryDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{u}...HEAD",
+    ]);
+    expect(divergence).toBe("0\t0");
+
+    const content = await runGit(memoryDir, [
+      "show",
+      "HEAD:reference/history/notes.md",
+    ]);
+    expect(content).toContain("remote value");
+    expect(content).not.toContain("new value");
+
+    const rescueRefs = await listRescueRefs(memoryDir);
+    expect(rescueRefs.length).toBeGreaterThan(0);
+
+    const rescuedContent = await runGit(memoryDir, [
+      "show",
+      `${rescueRefs[0]}:reference/history/notes.md`,
+    ]);
+    expect(rescuedContent).toContain("new value");
   });
 
   test("falls back to context agent id when AGENT_ID env is missing", async () => {

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -37,7 +37,7 @@ async function cloneRemoteRepo(
   remoteDir: string,
   cloneDir: string,
 ): Promise<void> {
-  await execFile("git", ["clone", remoteDir, cloneDir]);
+  await execFile("git", ["clone", "--branch", "main", remoteDir, cloneDir]);
   await runGit(cloneDir, ["config", "user.name", "remote-user"]);
   await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
 }

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -1,4 +1,3 @@
-import { execFile as execFileCb } from "node:child_process";
 import { existsSync } from "node:fs";
 import {
   mkdir,
@@ -11,13 +10,13 @@ import {
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
-import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
+import {
+  assertMemoryRepoReadyForWrite,
+  commitAndSyncMemoryWrite,
+} from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
-
-const execFile = promisify(execFileCb);
 
 type MemoryCommand =
   | "str_replace"
@@ -91,6 +90,10 @@ interface ParsedMemoryFile {
   body: string;
 }
 
+function normalizeComparableContent(content: string): string {
+  return content.replace(/\r\n/g, "\n").trim();
+}
+
 export async function memory(args: MemoryArgs): Promise<MemoryResult> {
   validateRequiredParams(args, ["command", "reason"], "memory");
 
@@ -102,7 +105,59 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
   const memoryDir = resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
-  let affectedPaths: string[] = [];
+  await assertMemoryRepoReadyForWrite(memoryDir);
+
+  const affectedPaths = await applyMemoryCommand(memoryDir, args);
+  if (affectedPaths.length === 0) {
+    return {
+      message: `Memory ${args.command} completed with no changed paths.`,
+    };
+  }
+
+  const { agentId, agentName } = await getAgentIdentity();
+  const commitResult = await commitAndSyncMemoryWrite({
+    memoryDir,
+    pathspecs: affectedPaths,
+    reason,
+    author: {
+      agentId,
+      authorName: agentName.trim() || agentId,
+      authorEmail: `${agentId}@letta.com`,
+    },
+    replay: async () =>
+      applyMemoryCommand(memoryDir, args, { replaying: true }),
+  });
+  if (!commitResult.committed) {
+    return {
+      message: `Memory ${args.command} made no effective changes; skipped commit and push.`,
+    };
+  }
+
+  // Emit memory_updated push event so web UI auto-refreshes
+  emitMemoryUpdated(affectedPaths);
+
+  if (commitResult.replayed && commitResult.replayNoop) {
+    return {
+      message: `Memory ${args.command} matched newer remote memory; skipped an extra commit.`,
+    };
+  }
+
+  if (commitResult.replayed) {
+    return {
+      message: `Memory ${args.command} reapplied on top of newer remote memory and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
+    };
+  }
+
+  return {
+    message: `Memory ${args.command} applied and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
+  };
+}
+
+async function applyMemoryCommand(
+  memoryDir: string,
+  args: MemoryArgs,
+  options?: { replaying?: boolean },
+): Promise<string[]> {
   const command = args.command;
 
   if (command === "create") {
@@ -115,11 +170,6 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     const label = normalizeMemoryLabel(memoryDir, pathArg, "file_path");
     const filePath = resolveMemoryFilePath(memoryDir, label);
     const relPath = toRepoRelative(memoryDir, filePath);
-
-    if (existsSync(filePath)) {
-      throw new Error(`memory create: block already exists at ${pathArg}`);
-    }
-
     const body = args.file_text ?? "";
     const rendered = renderMemoryFile(
       {
@@ -128,10 +178,28 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
       body,
     );
 
+    if (existsSync(filePath)) {
+      if (!options?.replaying) {
+        throw new Error(`memory create: block already exists at ${pathArg}`);
+      }
+
+      const existingContent = await readFile(filePath, "utf8");
+      if (
+        normalizeComparableContent(existingContent) ===
+        normalizeComparableContent(rendered)
+      ) {
+        return [relPath];
+      }
+
+      throw new Error(`memory create: block already exists at ${pathArg}`);
+    }
+
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, rendered, "utf8");
-    affectedPaths = [relPath];
-  } else if (command === "str_replace") {
+    return [relPath];
+  }
+
+  if (command === "str_replace") {
     const pathArg = requireString(args.file_path, "file_path", "str_replace");
     const oldString = requireString(
       args.old_string,
@@ -159,8 +227,10 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     const nextBody = `${file.body.slice(0, idx)}${newString}${file.body.slice(idx + oldString.length)}`;
     const rendered = renderMemoryFile(file.frontmatter, nextBody);
     await writeFile(filePath, rendered, "utf8");
-    affectedPaths = [relPath];
-  } else if (command === "insert") {
+    return [relPath];
+  }
+
+  if (command === "insert") {
     const pathArg = requireString(args.file_path, "file_path", "insert");
     const insertText = requireString(args.insert_text, "insert_text", "insert");
 
@@ -189,8 +259,16 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
 
     const rendered = renderMemoryFile(file.frontmatter, nextBody);
     await writeFile(filePath, rendered, "utf8");
-    affectedPaths = [relPath];
-  } else if (command === "delete") {
+    return [relPath];
+  }
+
+  if (command === "delete") {
+    if (options?.replaying) {
+      throw new Error(
+        "memory delete could not be replayed safely after remote changes",
+      );
+    }
+
     const pathArg = requireString(args.file_path, "file_path", "delete");
     const label = normalizeMemoryLabel(memoryDir, pathArg, "file_path");
     const targetPath = resolveMemoryPath(memoryDir, label);
@@ -198,16 +276,18 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     if (existsSync(targetPath) && (await stat(targetPath)).isDirectory()) {
       const relPath = toRepoRelative(memoryDir, targetPath);
       await rm(targetPath, { recursive: true, force: false });
-      affectedPaths = [relPath];
-    } else {
-      const filePath = resolveMemoryFilePath(memoryDir, label);
-      const relPath = toRepoRelative(memoryDir, filePath);
-
-      await loadEditableMemoryFile(filePath, pathArg);
-      await unlink(filePath);
-      affectedPaths = [relPath];
+      return [relPath];
     }
-  } else if (command === "rename") {
+
+    const filePath = resolveMemoryFilePath(memoryDir, label);
+    const relPath = toRepoRelative(memoryDir, filePath);
+
+    await loadEditableMemoryFile(filePath, pathArg);
+    await unlink(filePath);
+    return [relPath];
+  }
+
+  if (command === "rename") {
     const oldPathArg = requireString(args.old_path, "old_path", "rename");
     const newPathArg = requireString(args.new_path, "new_path", "rename");
 
@@ -229,8 +309,10 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     await loadEditableMemoryFile(oldFilePath, oldPathArg);
     await mkdir(dirname(newFilePath), { recursive: true });
     await rename(oldFilePath, newFilePath);
-    affectedPaths = [oldRelPath, newRelPath];
-  } else if (command === "update_description") {
+    return [oldRelPath, newRelPath];
+  }
+
+  if (command === "update_description") {
     const pathArg = requireString(
       args.file_path,
       "file_path",
@@ -255,31 +337,10 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
       file.body,
     );
     await writeFile(filePath, rendered, "utf8");
-    affectedPaths = [relPath];
-  } else {
-    throw new Error(`Unsupported memory command: ${command}`);
+    return [relPath];
   }
 
-  affectedPaths = Array.from(new Set(affectedPaths)).filter(
-    (p) => p.length > 0,
-  );
-  if (affectedPaths.length === 0) {
-    return { message: `Memory ${command} completed with no changed paths.` };
-  }
-
-  const commitResult = await commitAndPush(memoryDir, affectedPaths, reason);
-  if (!commitResult.committed) {
-    return {
-      message: `Memory ${command} made no effective changes; skipped commit and push.`,
-    };
-  }
-
-  // Emit memory_updated push event so web UI auto-refreshes
-  emitMemoryUpdated(affectedPaths);
-
-  return {
-    message: `Memory ${command} applied and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
-  };
+  throw new Error(`Unsupported memory command: ${command}`);
 }
 
 function resolveMemoryDir(): string {
@@ -511,117 +572,6 @@ function renderMemoryFile(
 function sanitizeFrontmatterValue(value: string): string {
   return value.replace(/\r?\n/g, " ").trim();
 }
-
-async function runGit(
-  memoryDir: string,
-  args: string[],
-): Promise<{ stdout: string; stderr: string }> {
-  try {
-    const result = await execFile("git", args, {
-      cwd: memoryDir,
-      maxBuffer: 10 * 1024 * 1024,
-      env: {
-        ...process.env,
-        PAGER: "cat",
-        GIT_PAGER: "cat",
-      },
-    });
-
-    return {
-      stdout: result.stdout?.toString() ?? "",
-      stderr: result.stderr?.toString() ?? "",
-    };
-  } catch (error) {
-    const stderr =
-      typeof error === "object" && error !== null && "stderr" in error
-        ? String((error as { stderr?: string }).stderr ?? "")
-        : "";
-    const stdout =
-      typeof error === "object" && error !== null && "stdout" in error
-        ? String((error as { stdout?: string }).stdout ?? "")
-        : "";
-    const message = error instanceof Error ? error.message : String(error);
-
-    throw new Error(
-      `git ${args.join(" ")} failed: ${stderr || stdout || message}`.trim(),
-    );
-  }
-}
-
-async function commitAndPush(
-  memoryDir: string,
-  pathspecs: string[],
-  reason: string,
-): Promise<{ committed: boolean; sha?: string }> {
-  await runGit(memoryDir, ["add", "-A", "--", ...pathspecs]);
-
-  const status = await runGit(memoryDir, [
-    "status",
-    "--porcelain",
-    "--",
-    ...pathspecs,
-  ]);
-  if (!status.stdout.trim()) {
-    return { committed: false };
-  }
-
-  const { agentId, agentName } = await getAgentIdentity();
-  const authorName = agentName.trim() || agentId;
-  const authorEmail = `${agentId}@letta.com`;
-
-  try {
-    await runGit(memoryDir, [
-      "-c",
-      `user.name=${authorName}`,
-      "-c",
-      `user.email=${authorEmail}`,
-      "commit",
-      "-m",
-      reason,
-    ]);
-  } catch (error) {
-    // If commit fails (e.g. pre-commit hook rejects staged changes),
-    // unstage just the paths this memory operation added so future memory
-    // commands do not inherit stale staged entries.
-    await unstagePaths(memoryDir, pathspecs);
-    throw error;
-  }
-
-  const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
-  const sha = head.stdout.trim();
-
-  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
-
-  try {
-    await runGit(memoryDir, ["push"]);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Memory changes were committed (${sha.slice(0, 7)}) but push failed: ${message}`,
-    );
-  }
-
-  return {
-    committed: true,
-    sha,
-  };
-}
-
-async function unstagePaths(
-  memoryDir: string,
-  pathspecs: string[],
-): Promise<void> {
-  if (pathspecs.length === 0) {
-    return;
-  }
-
-  try {
-    await runGit(memoryDir, ["reset", "HEAD", "--", ...pathspecs]);
-  } catch {
-    // Best-effort cleanup only — keep original error from commit path.
-  }
-}
-
 function requireString(
   value: string | undefined,
   field: string,

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -1,4 +1,3 @@
-import { execFile as execFileCb } from "node:child_process";
 import { existsSync } from "node:fs";
 import {
   access,
@@ -11,13 +10,13 @@ import {
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
-import { promisify } from "node:util";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { maybeUpdateMemoryRemoteOrigin } from "../../agent/memoryGit";
+import {
+  assertMemoryRepoReadyForWrite,
+  commitAndSyncMemoryWrite,
+} from "../../agent/memoryGit";
 import { validateRequiredParams } from "./validation";
-
-const execFile = promisify(execFileCb);
 
 type ParsedPatchOp =
   | {
@@ -119,6 +118,54 @@ export async function memory_apply_patch(
   const memoryDir = resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
+  await assertMemoryRepoReadyForWrite(memoryDir);
+
+  const pathspecs = await applyMemoryPatch(memoryDir, input);
+  if (pathspecs.length === 0) {
+    return { message: "memory_apply_patch completed with no changed paths." };
+  }
+
+  const { agentId, agentName } = await getAgentIdentity();
+  const commitResult = await commitAndSyncMemoryWrite({
+    memoryDir,
+    pathspecs,
+    reason,
+    author: {
+      agentId,
+      authorName: agentName.trim() || agentId,
+      authorEmail: `${agentId}@letta.com`,
+    },
+    replay: async () => applyMemoryPatch(memoryDir, input),
+  });
+  if (!commitResult.committed) {
+    return {
+      message:
+        "memory_apply_patch made no effective changes; skipped commit and push.",
+    };
+  }
+
+  if (commitResult.replayed && commitResult.replayNoop) {
+    return {
+      message:
+        "memory_apply_patch matched newer remote memory; skipped an extra commit.",
+    };
+  }
+
+  if (commitResult.replayed) {
+    return {
+      message: `memory_apply_patch reapplied on top of newer remote memory and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
+    };
+  }
+
+  return {
+    message: `memory_apply_patch applied and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
+  };
+}
+
+async function applyMemoryPatch(
+  memoryDir: string,
+  input: string,
+): Promise<string[]> {
   const ops = parsePatchOperations(memoryDir, input);
   if (ops.length === 0) {
     throw new Error("memory_apply_patch: no file operations found in patch");
@@ -242,21 +289,7 @@ export async function memory_apply_patch(
   }
 
   const pathspecs = Array.from(affectedPaths).filter((p) => p.length > 0);
-  if (pathspecs.length === 0) {
-    return { message: "memory_apply_patch completed with no changed paths." };
-  }
-
-  const commitResult = await commitAndPush(memoryDir, pathspecs, reason);
-  if (!commitResult.committed) {
-    return {
-      message:
-        "memory_apply_patch made no effective changes; skipped commit and push.",
-    };
-  }
-
-  return {
-    message: `memory_apply_patch applied and pushed (${commitResult.sha?.slice(0, 7) ?? "unknown"}).`,
-  };
+  return pathspecs;
 }
 
 function parsePatchOperations(
@@ -697,93 +730,6 @@ function renderMemoryFile(
 
 function sanitizeFrontmatterValue(value: string): string {
   return value.replace(/\r?\n/g, " ").trim();
-}
-
-async function runGit(
-  memoryDir: string,
-  args: string[],
-): Promise<{ stdout: string; stderr: string }> {
-  try {
-    const result = await execFile("git", args, {
-      cwd: memoryDir,
-      maxBuffer: 10 * 1024 * 1024,
-      env: {
-        ...process.env,
-        PAGER: "cat",
-        GIT_PAGER: "cat",
-      },
-    });
-
-    return {
-      stdout: result.stdout?.toString() ?? "",
-      stderr: result.stderr?.toString() ?? "",
-    };
-  } catch (error) {
-    const stderr =
-      typeof error === "object" && error !== null && "stderr" in error
-        ? String((error as { stderr?: string }).stderr ?? "")
-        : "";
-    const stdout =
-      typeof error === "object" && error !== null && "stdout" in error
-        ? String((error as { stdout?: string }).stdout ?? "")
-        : "";
-    const message = error instanceof Error ? error.message : String(error);
-
-    throw new Error(
-      `git ${args.join(" ")} failed: ${stderr || stdout || message}`.trim(),
-    );
-  }
-}
-
-async function commitAndPush(
-  memoryDir: string,
-  pathspecs: string[],
-  reason: string,
-): Promise<{ committed: boolean; sha?: string }> {
-  await runGit(memoryDir, ["add", "-A", "--", ...pathspecs]);
-
-  const status = await runGit(memoryDir, [
-    "status",
-    "--porcelain",
-    "--",
-    ...pathspecs,
-  ]);
-  if (!status.stdout.trim()) {
-    return { committed: false };
-  }
-
-  const { agentId, agentName } = await getAgentIdentity();
-  const authorName = agentName.trim() || agentId;
-  const authorEmail = `${agentId}@letta.com`;
-
-  await runGit(memoryDir, [
-    "-c",
-    `user.name=${authorName}`,
-    "-c",
-    `user.email=${authorEmail}`,
-    "commit",
-    "-m",
-    reason,
-  ]);
-
-  const head = await runGit(memoryDir, ["rev-parse", "HEAD"]);
-  const sha = head.stdout.trim();
-
-  await maybeUpdateMemoryRemoteOrigin(memoryDir, agentId);
-
-  try {
-    await runGit(memoryDir, ["push"]);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Memory changes were committed (${sha.slice(0, 7)}) but push failed: ${message}`,
-    );
-  }
-
-  return {
-    committed: true,
-    sha,
-  };
 }
 
 async function isMissing(filePath: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add a shared memory write sync helper that preserves stale local commits, resets to upstream, and replays writes on top of newer remote memory instead of silently rebasing
- migrate `memory`, `memory_apply_patch`, and personality memory writes onto the shared helper and make `pushMemory()` fail closed on plain push errors
- add regression tests for replay success, replay conflicts, and rescue-ref preservation for memory tool writes

## Test plan
- [x] `bun test src/tests/tools/memory-tool.test.ts src/tests/tools/memory-apply-patch.test.ts src/tests/agent/personality.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)