### PR TITLE
fix(cli): add 'e' keybinding to expand/collapse command preview in approval prompt

### DIFF
--- a/src/cli/components/InlineBashApproval.tsx
+++ b/src/cli/components/InlineBashApproval.tsx
@@ -50,6 +50,7 @@ export const InlineBashApproval = memo(
     defaultScope = "project",
   }: Props) => {
     const [selectedOption, setSelectedOption] = useState(0);
+    const [expanded, setExpanded] = useState(false);
     const {
       text: customReason,
       cursorPos,
@@ -121,6 +122,12 @@ export const InlineBashApproval = memo(
           return;
         }
 
+        // Toggle expanded command preview
+        if (input === "e") {
+          setExpanded((prev) => !prev);
+          return;
+        }
+
         // Number keys for quick selection (only for fixed options, not custom text input)
         if (input === "1") {
           onApprove();
@@ -155,9 +162,9 @@ export const InlineBashApproval = memo(
           <Box paddingLeft={2} flexDirection="column">
             <SyntaxHighlightedCommand
               command={bashInfo.command}
-              maxLines={BASH_PREVIEW_MAX_LINES}
-              maxColumns={Math.max(10, columns - 2)}
-              showTruncationHint
+              maxLines={expanded ? undefined : BASH_PREVIEW_MAX_LINES}
+              maxColumns={expanded ? undefined : Math.max(10, columns - 2)}
+              showTruncationHint={!expanded}
             />
             {bashInfo.description && (
               <Box marginTop={1}>
@@ -167,15 +174,16 @@ export const InlineBashApproval = memo(
           </Box>
         </>
       ),
-      [bashInfo.command, bashInfo.description, solidLine, columns],
+      [bashInfo.command, bashInfo.description, solidLine, columns, expanded],
     );
 
     // Hint text based on state
+    const expandHint = expanded ? "e to collapse" : "e to expand";
     const hintText = isOnCustomOption
       ? customReason
         ? "Enter to submit · Esc to clear"
-        : "Type reason · Esc to cancel"
-      : "Enter to select · Esc to cancel";
+        : `Type reason · Esc to cancel · ${expandHint}`
+      : `Enter to select · Esc to cancel · ${expandHint}`;
 
     const optionsMarginTop = showPreview ? 1 : 0;
 


### PR DESCRIPTION
## Summary

- Adds an `e` keybinding to the bash command approval prompt that toggles between the truncated 3-line preview and the full command
- When expanded, both vertical truncation (`maxLines`) and horizontal column clipping (`maxColumns`) are removed, so the full command is visible with natural terminal wrapping
- Hint bar shows `e to expand` / `e to collapse` to make the keybinding discoverable

## Problem

When the agent requests approval for a shell command, the approval prompt truncates the command both vertically (3 lines max) and horizontally (terminal width), with no way to see the full content before approving. This makes it impossible to make an informed decision on multi-line commands like `git commit` with heredoc messages, piped commands, or anything with long arguments.

Fixes #1584

## Changes

`src/cli/components/InlineBashApproval.tsx`:
- Added `expanded` state toggle
- `e` key toggles expanded/collapsed (only when not typing in the custom denial input)
- `maxLines` and `maxColumns` on `SyntaxHighlightedCommand` are set to `undefined` when expanded
- `showTruncationHint` disabled when expanded
- `expanded` added to `useMemo` deps for the command content block
- Hint text updated to show `e to expand` / `e to collapse`

## Test plan

- [ ] Start a session without `acceptEdits` permission mode
- [ ] Trigger a multi-line command (e.g. `python3 -c "..."` with multiple lines) — should show 3-line preview with `… +N more lines`
- [ ] Press `e` — full command should be visible
- [ ] Press `e` again — should collapse back to 3 lines
- [ ] Trigger a long single-line command (e.g. `curl ... | python3 -c "..."`) — should show clipped with `… output clipped`
- [ ] Press `e` — full command should wrap naturally, no clipping
- [ ] Verify `1`, `2`, arrow keys, Enter, Esc all still work as expected
- [ ] Verify typing in the custom denial input (option 3) still works and `e` types normally there