### PR TITLE
fix: add prepareScopedToolExecutionContext to processConversation dep array

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -6372,6 +6372,7 @@ export default function App({
       closeTrajectorySegment,
       resetTrajectoryBases,
       setUiPermissionMode,
+      prepareScopedToolExecutionContext,
     ],
   );
 


### PR DESCRIPTION
attempting to fix stale toolsets when switching models

whenever the tool context builder `prepareScopedToolExecutionContext` changes (because model or toolset preference changed), `processConversation` will now correctly re-create and capture the updated version.