### PR TITLE
fix(slack): preserve threaded replies across message subtypes

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -212,15 +212,20 @@ const WRAPPER_SLACK_MESSAGE_SUBTYPES = new Set([
   "message_replied",
 ]);
 
-function shouldIgnoreSlackInboundMessage(
+type SlackProcessableInboundMessage = Record<string, unknown> & {
+  user: string;
+  ts: string;
+};
+
+function isProcessableSlackInboundMessage(
   rawMessage: Record<string, unknown>,
-): boolean {
+): rawMessage is SlackProcessableInboundMessage {
   if (isNonEmptyString(rawMessage.bot_id)) {
-    return true;
+    return false;
   }
 
   if (!isNonEmptyString(rawMessage.user) || !isNonEmptyString(rawMessage.ts)) {
-    return true;
+    return false;
   }
 
   // Slack uses subtypes for both real user-authored messages (for example
@@ -228,21 +233,21 @@ function shouldIgnoreSlackInboundMessage(
   // blanket-drop all subtype messages; instead ignore the known non-user
   // variants and let genuine user messages keep flowing into the routed thread.
   if (rawMessage.hidden === true) {
-    return true;
+    return false;
   }
 
   const subtype = isNonEmptyString(rawMessage.subtype)
     ? rawMessage.subtype
     : null;
   if (!subtype) {
-    return false;
-  }
-
-  if (IGNORED_SLACK_MESSAGE_SUBTYPES.has(subtype)) {
     return true;
   }
 
-  return (
+  if (IGNORED_SLACK_MESSAGE_SUBTYPES.has(subtype)) {
+    return false;
+  }
+
+  return !(
     WRAPPER_SLACK_MESSAGE_SUBTYPES.has(subtype) &&
     asRecord(rawMessage.message) !== null
   );
@@ -699,7 +704,7 @@ export function createSlackAdapter(
         return;
       }
 
-      if (shouldIgnoreSlackInboundMessage(rawMessage)) {
+      if (!isProcessableSlackInboundMessage(rawMessage)) {
         return;
       }
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -178,6 +178,76 @@ function normalizeSlackText(text: string): string {
   return text.replace(/^(?:\s*<@[A-Z0-9]+>\s*)+/, "").trim();
 }
 
+const IGNORED_SLACK_MESSAGE_SUBTYPES = new Set([
+  "assistant_app_thread",
+  "bot_message",
+  "channel_archive",
+  "channel_convert_to_private",
+  "channel_convert_to_public",
+  "channel_join",
+  "channel_leave",
+  "channel_name",
+  "channel_posting_permissions",
+  "channel_purpose",
+  "channel_topic",
+  "channel_unarchive",
+  "document_mention",
+  "ekm_access_denied",
+  "file_comment",
+  "group_archive",
+  "group_join",
+  "group_leave",
+  "group_name",
+  "group_purpose",
+  "group_topic",
+  "group_unarchive",
+  "pinned_item",
+  "reminder_add",
+  "unpinned_item",
+]);
+
+const WRAPPER_SLACK_MESSAGE_SUBTYPES = new Set([
+  "message_changed",
+  "message_deleted",
+  "message_replied",
+]);
+
+function shouldIgnoreSlackInboundMessage(
+  rawMessage: Record<string, unknown>,
+): boolean {
+  if (isNonEmptyString(rawMessage.bot_id)) {
+    return true;
+  }
+
+  if (!isNonEmptyString(rawMessage.user) || !isNonEmptyString(rawMessage.ts)) {
+    return true;
+  }
+
+  // Slack uses subtypes for both real user-authored messages (for example
+  // thread broadcasts and file shares) and bookkeeping/admin wrappers. Don't
+  // blanket-drop all subtype messages; instead ignore the known non-user
+  // variants and let genuine user messages keep flowing into the routed thread.
+  if (rawMessage.hidden === true) {
+    return true;
+  }
+
+  const subtype = isNonEmptyString(rawMessage.subtype)
+    ? rawMessage.subtype
+    : null;
+  if (!subtype) {
+    return false;
+  }
+
+  if (IGNORED_SLACK_MESSAGE_SUBTYPES.has(subtype)) {
+    return true;
+  }
+
+  return (
+    WRAPPER_SLACK_MESSAGE_SUBTYPES.has(subtype) &&
+    asRecord(rawMessage.message) !== null
+  );
+}
+
 function slackTimestampToMillis(timestamp: string): number {
   return Math.round(Number.parseFloat(timestamp) * 1000);
 }
@@ -629,13 +699,7 @@ export function createSlackAdapter(
         return;
       }
 
-      if (
-        (isNonEmptyString(rawMessage.subtype) &&
-          rawMessage.subtype !== "file_share") ||
-        isNonEmptyString(rawMessage.bot_id) ||
-        !isNonEmptyString(rawMessage.user) ||
-        !isNonEmptyString(rawMessage.ts)
-      ) {
+      if (shouldIgnoreSlackInboundMessage(rawMessage)) {
         return;
       }
 

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -12,8 +12,10 @@ type SlackMessageHandler = (args: {
     ts?: string;
     thread_ts?: string;
     subtype?: string;
+    hidden?: boolean;
     bot_id?: string;
     files?: Array<{ id?: string; name?: string }>;
+    message?: Record<string, unknown>;
   };
 }) => Promise<void>;
 
@@ -777,6 +779,94 @@ test("slack adapter allows file_share subtype messages through", async () => {
       ],
     }),
   );
+});
+
+test("slack adapter allows thread_broadcast subtype replies through", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "broadcasting this reply",
+      ts: "1712800000.000101",
+      thread_ts: "1712790000.000050",
+      subtype: "thread_broadcast",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "broadcasting this reply",
+      messageId: "1712800000.000101",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+    }),
+  );
+});
+
+test("slack adapter ignores hidden bookkeeping thread wrapper events", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "C123",
+      ts: "1712800000.000102",
+      hidden: true,
+      subtype: "message_replied",
+      message: {
+        type: "message",
+        user: "U123",
+        text: "Original thread root",
+        thread_ts: "1712790000.000050",
+        ts: "1712790000.000050",
+      },
+    },
+  });
+
+  expect(onMessage).not.toHaveBeenCalled();
 });
 
 test("slack adapter forwards reaction events into the routed Slack thread", async () => {


### PR DESCRIPTION
## Summary
- stop blanket-dropping every Slack `message` subtype in the channel adapter, and instead ignore only known bookkeeping/admin wrappers while allowing real user-authored thread replies through
- preserve thread replies that arrive as `thread_broadcast` / other user-authored subtype variants in the same routed Slack thread
- add regression coverage for subtype passthrough and hidden `message_replied` wrapper events

## Test plan
- [x] `bun test src/tests/channels/slack-adapter.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/channels/slack/adapter.ts src/tests/channels/slack-adapter.test.ts`
- [ ] `bun run check` *(currently fails on pre-existing repo-wide typecheck issues unrelated to this diff, including missing module/type declarations and existing approval typing errors)*

👾 Generated with [Letta Code](https://letta.com)