### PR TITLE
feat: forward approval reason into tool return for agent visibility

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -3,7 +3,6 @@
 import * as path from "node:path";
 import type {
   ApprovalReturn,
-  TextContent,
   ToolReturn,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
@@ -15,32 +14,6 @@ import {
   type ToolExecutionResult,
   type ToolReturnContent,
 } from "../tools/manager";
-
-/**
- * Append a user-provided reason to tool return content so the agent sees it.
- * Used to forward approval messages (e.g. worktree instructions) into the
- * tool return that goes to the LLM context.
- */
-function appendReasonToToolReturn(
-  content: ToolReturnContent,
-  reason: string | undefined,
-): ToolReturnContent {
-  if (!reason || reason.length === 0) return content;
-  const suffix = `\n\n${reason}`;
-  if (typeof content === "string") {
-    return content + suffix;
-  }
-  // Multimodal: append to the last text part or add a new one
-  const lastText = [...content]
-    .reverse()
-    .find((p): p is TextContent => p.type === "text");
-  if (lastText) {
-    return content.map((p) =>
-      p === lastText ? { ...p, text: p.text + suffix } : p,
-    );
-  }
-  return [...content, { type: "text" as const, text: reason }];
-}
 
 /**
  * Extract displayable text from tool return content (for UI display).
@@ -254,10 +227,7 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: appendReasonToToolReturn(
-          decision.precomputedResult.toolReturn,
-          decision.reason,
-        ),
+        tool_return: decision.precomputedResult.toolReturn,
         status: decision.precomputedResult.status,
         stdout: decision.precomputedResult.stdout,
         stderr: decision.precomputedResult.stderr,
@@ -318,10 +288,7 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: appendReasonToToolReturn(
-          toolResult.toolReturn,
-          decision.reason,
-        ),
+        tool_return: toolResult.toolReturn, // Full multimodal content for backend
         status: toolResult.status,
         stdout: toolResult.stdout,
         stderr: toolResult.stderr,

--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -17,6 +17,32 @@ import {
 } from "../tools/manager";
 
 /**
+ * Append a user-provided reason to tool return content so the agent sees it.
+ * Used to forward approval messages (e.g. worktree instructions) into the
+ * tool return that goes to the LLM context.
+ */
+function appendReasonToToolReturn(
+  content: ToolReturnContent,
+  reason: string | undefined,
+): ToolReturnContent {
+  if (!reason || reason.length === 0) return content;
+  const suffix = `\n\n${reason}`;
+  if (typeof content === "string") {
+    return content + suffix;
+  }
+  // Multimodal: append to the last text part or add a new one
+  const lastText = [...content]
+    .reverse()
+    .find((p): p is TextContent => p.type === "text");
+  if (lastText) {
+    return content.map((p) =>
+      p === lastText ? { ...p, text: p.text + suffix } : p,
+    );
+  }
+  return [...content, { type: "text" as const, text: reason }];
+}
+
+/**
  * Extract displayable text from tool return content (for UI display).
  * Multimodal content returns the text parts concatenated.
  */
@@ -228,7 +254,10 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: decision.precomputedResult.toolReturn,
+        tool_return: appendReasonToToolReturn(
+          decision.precomputedResult.toolReturn,
+          decision.reason,
+        ),
         status: decision.precomputedResult.status,
         stdout: decision.precomputedResult.stdout,
         stderr: decision.precomputedResult.stderr,
@@ -289,7 +318,10 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: toolResult.toolReturn, // Full multimodal content for backend
+        tool_return: appendReasonToToolReturn(
+          toolResult.toolReturn,
+          decision.reason,
+        ),
         status: toolResult.status,
         stdout: toolResult.stdout,
         stderr: toolResult.stderr,

--- a/src/tests/agent/message-client-skills.test.ts
+++ b/src/tests/agent/message-client-skills.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ApprovalResult } from "../../agent/approval-execution";
 import { buildConversationMessagesCreateRequestBody } from "../../agent/message";
 
 describe("buildConversationMessagesCreateRequestBody client_skills", () => {
@@ -31,5 +32,47 @@ describe("buildConversationMessagesCreateRequestBody client_skills", () => {
         location: "/tmp/.skills/debugging/SKILL.md",
       },
     ]);
+  });
+
+  test("injects approval comments once when sending approval continuations", () => {
+    const body = buildConversationMessagesCreateRequestBody(
+      "default",
+      [
+        {
+          type: "approval",
+          approvals: [
+            {
+              type: "tool",
+              tool_call_id: "call-1",
+              tool_return: "command output",
+              status: "success",
+              reason: "use worktree",
+            } as ApprovalResult,
+          ],
+        },
+      ],
+      { agentId: "agent-1", streamTokens: true, background: true },
+      [],
+      [],
+    );
+
+    const approvals =
+      body.messages[0]?.type === "approval" ? body.messages[0].approvals : [];
+    expect(approvals).toHaveLength(1);
+    expect(approvals?.[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "call-1",
+      status: "success",
+      tool_return: [
+        {
+          type: "text",
+          text: 'The user approved the tool execution with the following comment: "use worktree"',
+        },
+        {
+          type: "text",
+          text: "command output",
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
When a user approves a tool with a reason/message (e.g. "use worktree" from ExitPlanMode), the reason was stored on the ApprovalResult but never injected into the tool_return text the agent sees. The SDK's ToolReturn type doesn't have a reason field, so the server drops it.

Now appendReasonToToolReturn() appends the approval reason to the tool_return content (string or multimodal) so the agent actually receives the instruction.

🐾 Generated with [Letta Code](https://letta.com)