### PR TITLE
test: harden flaky channel/auth isolation

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -27,6 +27,26 @@ import { ListenerStatusUI } from "../components/ListenerStatusUI";
 
 const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
 
+type ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL: string;
+  pollForToken: typeof pollForToken;
+  refreshAccessToken: typeof refreshAccessToken;
+  requestDeviceCode: typeof requestDeviceCode;
+};
+
+const defaultListenerOAuthDeps: ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+};
+
+let listenerOAuthDepsOverride: ListenerOAuthDeps | null = null;
+
+function getListenerOAuthDeps(): ListenerOAuthDeps {
+  return listenerOAuthDepsOverride ?? defaultListenerOAuthDeps;
+}
+
 class MissingListenerApiKeyError extends Error {
   constructor() {
     super("LETTA_API_KEY not found");
@@ -78,10 +98,11 @@ async function flushListenerTelemetryEnd(exitReason: string): Promise<void> {
 function getListenerServerUrl(settings: {
   env?: Record<string, string>;
 }): string {
+  const oauthDeps = getListenerOAuthDeps();
   return (
     process.env.LETTA_BASE_URL ||
     settings.env?.LETTA_BASE_URL ||
-    LETTA_CLOUD_API_URL
+    oauthDeps.LETTA_CLOUD_API_URL
   );
 }
 
@@ -92,11 +113,12 @@ async function refreshListenerAccessToken(
   deviceId: string,
   connectionName: string,
 ): Promise<string> {
+  const oauthDeps = getListenerOAuthDeps();
   const now = Date.now();
 
   console.log("Access token expired, refreshing...");
 
-  const tokens = await refreshAccessToken(
+  const tokens = await oauthDeps.refreshAccessToken(
     settings.refreshToken as string,
     deviceId,
     connectionName,
@@ -122,9 +144,10 @@ async function runListenerOAuthLogin(
   deviceId: string,
   connectionName: string,
 ): Promise<string> {
+  const oauthDeps = getListenerOAuthDeps();
   console.log("No API key found. Starting OAuth login...\n");
 
-  const deviceData = await requestDeviceCode();
+  const deviceData = await oauthDeps.requestDeviceCode();
 
   console.log(
     `To authenticate, visit: ${deviceData.verification_uri_complete}`,
@@ -132,7 +155,7 @@ async function runListenerOAuthLogin(
   console.log(`Your code: ${deviceData.user_code}\n`);
   console.log("Waiting for authorization...\n");
 
-  const tokens = await pollForToken(
+  const tokens = await oauthDeps.pollForToken(
     deviceData.device_code,
     deviceData.interval,
     deviceData.expires_in,
@@ -223,6 +246,14 @@ export const __listenSubcommandTestUtils = {
   flushListenerTelemetryEnd,
   getListenerServerUrl,
   resolveListenerRegistrationOptions,
+  setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
+    listenerOAuthDepsOverride = overrides
+      ? {
+          ...defaultListenerOAuthDeps,
+          ...overrides,
+        }
+      : null;
+  },
 };
 
 export async function runListenSubcommand(argv: string[]): Promise<number> {

--- a/src/tests/channels/discord-registry.test.ts
+++ b/src/tests/channels/discord-registry.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import {
   __testOverrideLoadChannelAccounts,
   __testOverrideSaveChannelAccounts,
@@ -107,6 +115,10 @@ describe("discord channel registry", () => {
       await registry.stopAll();
     }
     resetState();
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("does not auto-create a route for non-mentioned traffic in an untracked thread", async () => {

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -81,6 +81,9 @@ describe("channel service", () => {
     __testOverrideSaveRoutes(() => {});
     __testOverrideLoadPairingStore(() => null);
     __testOverrideSavePairingStore(() => {});
+    __testOverrideLoadTargetStore(() => {});
+    __testOverrideSaveTargetStore(() => {});
+    __testOverrideResolveChannelAccountDisplayName(async () => undefined);
   });
 
   afterEach(() => {

--- a/src/tests/channels/slack-adapter-interop.test.ts
+++ b/src/tests/channels/slack-adapter-interop.test.ts
@@ -1,4 +1,4 @@
-import { expect, mock, test } from "bun:test";
+import { afterAll, expect, mock, test } from "bun:test";
 
 class FakeSlackApp {
   readonly client = {
@@ -55,10 +55,19 @@ mock.module("../../channels/slack/runtime", () => ({
       },
     },
   }),
+  loadSlackWebApiModule: async () => ({
+    WebClient: class {},
+    default: {
+      WebClient: class {},
+    },
+  }),
 }));
 
 mock.module("../../channels/slack/media", () => ({
+  resolveSlackChannelHistory: async () => [],
   resolveSlackInboundAttachments: async () => [],
+  resolveSlackThreadStarter: async () => null,
+  resolveSlackThreadHistory: async () => [],
 }));
 
 test("resolveSlackAccountDisplayName supports nested default Slack Bolt exports", async () => {
@@ -74,4 +83,8 @@ test("resolveSlackAccountDisplayName supports nested default Slack Bolt exports"
       "xapp-test-token-1234567890",
     ),
   ).resolves.toBe("Interop Slack Bot");
+});
+
+afterAll(() => {
+  mock.restore();
 });

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -245,6 +245,10 @@ afterEach(() => {
     instance.files.completeUploadExternal.mockClear();
   }
   globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 test("slack adapter start does not re-run bolt init", async () => {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -167,6 +167,10 @@ afterEach(() => {
     process.env.OPENAI_API_KEY = originalOpenAiApiKey;
   }
   rmSync(channelRoot, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 test("telegram adapter logs unhandled grammY errors with update context", async () => {

--- a/src/tests/cli/listen-subcommand-auth.test.ts
+++ b/src/tests/cli/listen-subcommand-auth.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DeviceCodeResponse, TokenResponse } from "../../auth/oauth";
 import { settingsManager } from "../../settings-manager";
 
@@ -19,13 +11,6 @@ const requestDeviceCodeMock = mock(async (): Promise<DeviceCodeResponse> => {
 const pollForTokenMock = mock(async (): Promise<TokenResponse> => {
   throw new Error("pollForToken not mocked");
 });
-
-mock.module("../../auth/oauth", () => ({
-  LETTA_CLOUD_API_URL: "https://api.letta.com",
-  refreshAccessToken: refreshAccessTokenMock,
-  requestDeviceCode: requestDeviceCodeMock,
-  pollForToken: pollForTokenMock,
-}));
 
 const { __listenSubcommandTestUtils } = await import(
   "../../cli/subcommands/listen"
@@ -45,6 +30,12 @@ describe("listen subcommand auth resolution", () => {
     refreshAccessTokenMock.mockReset();
     requestDeviceCodeMock.mockReset();
     pollForTokenMock.mockReset();
+    __listenSubcommandTestUtils.setOAuthDepsForTests({
+      LETTA_CLOUD_API_URL: "https://api.letta.com",
+      refreshAccessToken: refreshAccessTokenMock,
+      requestDeviceCode: requestDeviceCodeMock,
+      pollForToken: pollForTokenMock,
+    });
 
     delete process.env.LETTA_API_KEY;
     delete process.env.LETTA_BASE_URL;
@@ -83,10 +74,7 @@ describe("listen subcommand auth resolution", () => {
     } else {
       process.env.LETTA_BASE_URL = originalBaseUrl;
     }
-  });
-
-  afterAll(() => {
-    mock.restore();
+    __listenSubcommandTestUtils.setOAuthDepsForTests(null);
   });
 
   test("prefers explicit LETTA_API_KEY over saved OAuth credentials", async () => {

--- a/src/tests/cli/listen-subcommand-auth.test.ts
+++ b/src/tests/cli/listen-subcommand-auth.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import type { DeviceCodeResponse, TokenResponse } from "../../auth/oauth";
 import { settingsManager } from "../../settings-manager";
 
@@ -75,6 +83,10 @@ describe("listen subcommand auth resolution", () => {
     } else {
       process.env.LETTA_BASE_URL = originalBaseUrl;
     }
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("prefers explicit LETTA_API_KEY over saved OAuth credentials", async () => {

--- a/src/tests/hooks/prompt-executor.test.ts
+++ b/src/tests/hooks/prompt-executor.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { executePromptHook } from "../../hooks/prompt-executor";
 import {
   HookExitCode,
@@ -71,6 +79,10 @@ describe("Prompt Hook Executor", () => {
   afterEach(() => {
     // Clean up env vars
     delete process.env.LETTA_AGENT_ID;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   describe("executePromptHook", () => {

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { execFile as execFileCb } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
@@ -96,6 +104,10 @@ describe("memory_apply_patch tool", () => {
     if (tempRoot) {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("requires reason and input", async () => {

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { execFile as execFileCb } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
@@ -97,6 +105,10 @@ describe("memory tool", () => {
     if (tempRoot) {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("requires reason", async () => {

--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -62,6 +70,10 @@ describe("Skill tool memory filesystem lookup", () => {
     }
 
     rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("loads skills from MEMORY_DIR/skills", async () => {

--- a/src/tests/tools/toolset-client-tool-rule-cleanup.test.ts
+++ b/src/tests/tools/toolset-client-tool-rule-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const retrieveMock = mock((_agentId: string, _opts?: Record<string, unknown>) =>
   Promise.resolve({
@@ -36,6 +36,10 @@ describe("client tool rule cleanup", () => {
     retrieveMock.mockClear();
     updateMock.mockClear();
     mockGetClient.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("marks Letta Code agents with any persisted tool rules for cleanup", () => {

--- a/src/tests/tools/toolset-memfs-detach.test.ts
+++ b/src/tests/tools/toolset-memfs-detach.test.ts
@@ -1,6 +1,6 @@
 // Tests for detaching server-side memory tools when enabling memfs
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Mock getClient before importing the module under test
 
@@ -45,6 +45,10 @@ describe("detachMemoryTools", () => {
     detachMock.mockClear();
     retrieveMock.mockClear();
     mockGetClient.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("detaches all known memory tool variants", async () => {

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { APIError } from "@letta-ai/letta-client/error";
 import WebSocket from "ws";
 import type { ResumeData } from "../../agent/check-approval";
@@ -327,6 +335,10 @@ describe("listen-client multi-worker concurrency", () => {
     if (registry) {
       await registry.stopAll();
     }
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   test("processes simultaneous turns for two named conversations under one agent", async () => {


### PR DESCRIPTION
## Summary
- restore file-scoped module mocks in tests that used `mock.module(...)` without teardown
- keep `channel service` tests off the real target-store filesystem and off live display-name resolution
- make the Slack interop test declare the full mock surface it needs instead of relying on leaked mocks from other files

## Why
We have been seeing a Linux flake cluster around channel service and OAuth tests. This patch hardens the likely sources of cross-file interference:
- Bun module mocks leaking between test files
- `service.test.ts` falling through to real target-store writes under `~/.letta`
- `slack-adapter-interop.test.ts` only passing when another test had already mocked extra Slack exports

## Verification
- `bunx --bun @biomejs/biome@2.2.5 check src/tests/channels/discord-registry.test.ts src/tests/channels/service.test.ts src/tests/channels/slack-adapter-interop.test.ts src/tests/channels/slack-adapter.test.ts src/tests/channels/telegram-adapter.test.ts src/tests/cli/listen-subcommand-auth.test.ts src/tests/hooks/prompt-executor.test.ts src/tests/tools/memory-apply-patch.test.ts src/tests/tools/memory-tool.test.ts src/tests/tools/skill-tool.test.ts src/tests/tools/toolset-client-tool-rule-cleanup.test.ts src/tests/tools/toolset-memfs-detach.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- `bun test src/tests/channels/service.test.ts src/tests/channels/discord-registry.test.ts src/tests/auth/oauth-network-errors.test.ts src/tests/channels/slack-adapter.test.ts src/tests/channels/telegram-adapter.test.ts`
- repeated that combined flaky cluster twice back-to-back locally
- `bun test src/tests/channels/slack-adapter-interop.test.ts src/tests/channels/discord-registry.test.ts src/tests/cli/listen-subcommand-auth.test.ts`
- `bun test src/tests/channels/discord-registry.test.ts src/tests/channels/service.test.ts src/tests/channels/slack-adapter-interop.test.ts src/tests/channels/slack-adapter.test.ts src/tests/channels/telegram-adapter.test.ts src/tests/cli/listen-subcommand-auth.test.ts src/tests/hooks/prompt-executor.test.ts src/tests/tools/memory-apply-patch.test.ts src/tests/tools/memory-tool.test.ts src/tests/tools/skill-tool.test.ts src/tests/tools/toolset-client-tool-rule-cleanup.test.ts src/tests/tools/toolset-memfs-detach.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
