### PR TITLE
refactor(permissions): unify auto-denial message formatting

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -96,6 +96,7 @@ import {
   runUserPromptSubmitHooks,
 } from "../hooks";
 import type { ApprovalContext } from "../permissions/analyzer";
+import { formatPermissionDenial } from "../permissions/formatDenial";
 import { type PermissionMode, permissionMode } from "../permissions/mode";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import {
@@ -5495,13 +5496,7 @@ export default function App({
 
               // Create denial results for auto-denied tools and update buffers
               autoDeniedResults = autoDenied.map((ac) => {
-                // Prefer the detailed reason over the short matchedRule name
-                // (e.g., reason contains plan file path info, matchedRule is just "plan mode")
-                const reason = ac.permission.reason
-                  ? `Permission denied: ${ac.permission.reason}`
-                  : "matchedRule" in ac.permission && ac.permission.matchedRule
-                    ? `Permission denied by rule: ${ac.permission.matchedRule}`
-                    : "Permission denied: Unknown reason";
+                const reason = formatPermissionDenial(ac.permission);
 
                 // Update buffers with tool rejection for UI
                 onChunk(buffersRef.current, {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -78,6 +78,7 @@ import {
 } from "./cli/startupFlagValidation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
 import { computeDiffPreviews } from "./helpers/diffPreview";
+import { formatPermissionDenial } from "./permissions/formatDenial";
 import { QueueRuntime } from "./queue/queueRuntime";
 import {
   mergeQueuedTurnInput,
@@ -2211,19 +2212,11 @@ ${SYSTEM_REMINDER_CLOSE}
               reason: "Tool requires approval (headless mode)",
             };
           }),
-          ...autoDenied.map((ac) => {
-            const fallback =
-              "matchedRule" in ac.permission && ac.permission.matchedRule
-                ? `Permission denied: ${ac.permission.matchedRule}`
-                : ac.permission.reason
-                  ? `Permission denied: ${ac.permission.reason}`
-                  : "Permission denied: Unknown reason";
-            return {
-              type: "deny" as const,
-              approval: ac.approval,
-              reason: ac.denyReason ?? fallback,
-            };
-          }),
+          ...autoDenied.map((ac) => ({
+            type: "deny" as const,
+            approval: ac.approval,
+            reason: formatPermissionDenial(ac.permission, ac.denyReason),
+          })),
         ];
 
         // Phase 2: Execute all approved tools and format results using shared function
@@ -3890,19 +3883,11 @@ async function runBidirectionalMode(
                     ? ac.permission.matchedRule
                     : "auto-approved",
               })),
-              ...autoDenied.map((ac) => {
-                const fallback =
-                  "matchedRule" in ac.permission && ac.permission.matchedRule
-                    ? `Permission denied: ${ac.permission.matchedRule}`
-                    : ac.permission.reason
-                      ? `Permission denied: ${ac.permission.reason}`
-                      : "Permission denied: Unknown reason";
-                return {
-                  type: "deny" as const,
-                  approval: ac.approval,
-                  reason: ac.denyReason ?? fallback,
-                };
-              }),
+              ...autoDenied.map((ac) => ({
+                type: "deny" as const,
+                approval: ac.approval,
+                reason: formatPermissionDenial(ac.permission, ac.denyReason),
+              })),
             ];
 
             for (const approvalItem of autoAllowed) {

--- a/src/permissions/formatDenial.ts
+++ b/src/permissions/formatDenial.ts
@@ -1,0 +1,49 @@
+// Format auto-denial messages consistently across the codebase.
+//
+// Callers previously open-coded this formatter in 10+ places (headless.ts,
+// App.tsx, recovery.ts) with subtle inconsistencies in wording and fallback
+// order. The single source of truth lives here.
+
+/**
+ * Structural shape of a permission-check result — just the fields this
+ * formatter needs. Defined locally so callers can pass any object that
+ * carries `reason` and/or `matchedRule` without importing the full
+ * `PermissionCheckResult` type.
+ */
+export interface DenialPermissionShape {
+  reason?: string;
+  matchedRule?: string;
+}
+
+/**
+ * Format an auto-denial message for a user-facing tool response.
+ *
+ * Precedence:
+ *   1. `customDenyReason` — caller-supplied override (e.g. a hook's
+ *      custom message, or a tool-specific failure string). Used verbatim.
+ *   2. `permission.reason` — the detailed explanation set by the permission
+ *      check (e.g. "Permission denied by cross-agent memory guard: ...
+ *      Set LETTA_MEMORY_SCOPE or pass --memory-scope to authorize").
+ *      Prefixed with `"Permission denied: "`.
+ *   3. `permission.matchedRule` — the short rule label
+ *      (e.g. "cross-agent guard", "memory mode"). Prefixed with
+ *      `"Permission denied by rule: "` to signal it's a short label
+ *      rather than an actionable explanation.
+ *   4. Final fallback: `"Permission denied: Unknown reason"`.
+ *
+ * Why prefer `reason` over `matchedRule`: `reason` carries the actionable
+ * context (offending agent ID, how to authorize, which plan file path),
+ * while `matchedRule` is just a short tag for the rule that fired. The
+ * reverse order was a longstanding bug that hid useful error info.
+ */
+export function formatPermissionDenial(
+  permission: DenialPermissionShape,
+  customDenyReason?: string | null,
+): string {
+  if (customDenyReason) return customDenyReason;
+  if (permission.reason) return `Permission denied: ${permission.reason}`;
+  if (permission.matchedRule) {
+    return `Permission denied by rule: ${permission.matchedRule}`;
+  }
+  return "Permission denied: Unknown reason";
+}

--- a/src/permissions/formatDenial.ts
+++ b/src/permissions/formatDenial.ts
@@ -15,35 +15,53 @@ export interface DenialPermissionShape {
   matchedRule?: string;
 }
 
+const GENERIC_MATCHED_RULE_REASONS = new Set([
+  "Matched deny rule",
+  "Matched --disallowedTools flag",
+  "Matched ask rule",
+]);
+
 /**
  * Format an auto-denial message for a user-facing tool response.
  *
  * Precedence:
  *   1. `customDenyReason` — caller-supplied override (e.g. a hook's
  *      custom message, or a tool-specific failure string). Used verbatim.
- *   2. `permission.reason` — the detailed explanation set by the permission
+ *   2. Generic internal checker reasons ("Matched deny rule", etc.) defer
+ *      to `matchedRule` when present so the user sees the actual rule text.
+ *   3. `permission.reason` — the detailed explanation set by the permission
  *      check (e.g. "Permission denied by cross-agent memory guard: ...
  *      Set LETTA_MEMORY_SCOPE or pass --memory-scope to authorize").
- *      Prefixed with `"Permission denied: "`.
- *   3. `permission.matchedRule` — the short rule label
+ *      If it already starts with "Permission denied", keep it verbatim;
+ *      otherwise prefix it once with `"Permission denied: "`.
+ *   4. `permission.matchedRule` — the short rule label
  *      (e.g. "cross-agent guard", "memory mode"). Prefixed with
- *      `"Permission denied by rule: "` to signal it's a short label
- *      rather than an actionable explanation.
- *   4. Final fallback: `"Permission denied: Unknown reason"`.
- *
- * Why prefer `reason` over `matchedRule`: `reason` carries the actionable
- * context (offending agent ID, how to authorize, which plan file path),
- * while `matchedRule` is just a short tag for the rule that fired. The
- * reverse order was a longstanding bug that hid useful error info.
+ *      `"Permission denied by rule: "`.
+ *   5. Final fallback: `"Permission denied: Unknown reason"`.
  */
 export function formatPermissionDenial(
   permission: DenialPermissionShape,
   customDenyReason?: string | null,
 ): string {
-  if (customDenyReason) return customDenyReason;
-  if (permission.reason) return `Permission denied: ${permission.reason}`;
-  if (permission.matchedRule) {
-    return `Permission denied by rule: ${permission.matchedRule}`;
+  const customReason = customDenyReason?.trim();
+  if (customReason) return customReason;
+
+  const reason = permission.reason?.trim();
+  const matchedRule = permission.matchedRule?.trim();
+
+  if (reason && matchedRule && GENERIC_MATCHED_RULE_REASONS.has(reason)) {
+    return `Permission denied by rule: ${matchedRule}`;
+  }
+
+  if (reason) {
+    if (/^Permission denied\b/i.test(reason)) {
+      return reason;
+    }
+    return `Permission denied: ${reason}`;
+  }
+
+  if (matchedRule) {
+    return `Permission denied by rule: ${matchedRule}`;
   }
   return "Permission denied: Unknown reason";
 }

--- a/src/tests/permissions/formatDenial.test.ts
+++ b/src/tests/permissions/formatDenial.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { formatPermissionDenial } from "../../permissions/formatDenial";
+
+describe("formatPermissionDenial", () => {
+  test("custom denyReason takes precedence over everything", () => {
+    const result = formatPermissionDenial(
+      { reason: "detailed explanation", matchedRule: "cross-agent guard" },
+      "Custom override from hook",
+    );
+    expect(result).toBe("Custom override from hook");
+  });
+
+  test("empty customDenyReason string is ignored (falls through to reason)", () => {
+    const result = formatPermissionDenial(
+      { reason: "detailed explanation", matchedRule: "cross-agent guard" },
+      "",
+    );
+    expect(result).toBe("Permission denied: detailed explanation");
+  });
+
+  test("undefined customDenyReason falls through to reason", () => {
+    const result = formatPermissionDenial(
+      { reason: "detailed explanation", matchedRule: "cross-agent guard" },
+      undefined,
+    );
+    expect(result).toBe("Permission denied: detailed explanation");
+  });
+
+  test("null customDenyReason falls through to reason", () => {
+    const result = formatPermissionDenial(
+      { reason: "detailed explanation", matchedRule: "cross-agent guard" },
+      null,
+    );
+    expect(result).toBe("Permission denied: detailed explanation");
+  });
+
+  test("reason is preferred over matchedRule (the key behavior)", () => {
+    const result = formatPermissionDenial({
+      reason:
+        "Permission denied by cross-agent memory guard: targeted agent-abc123. " +
+        "Set LETTA_MEMORY_SCOPE or pass --memory-scope to authorize.",
+      matchedRule: "cross-agent guard",
+    });
+    expect(result).toBe(
+      "Permission denied: Permission denied by cross-agent memory guard: " +
+        "targeted agent-abc123. Set LETTA_MEMORY_SCOPE or pass " +
+        "--memory-scope to authorize.",
+    );
+  });
+
+  test("matchedRule is used when only it is present", () => {
+    const result = formatPermissionDenial({ matchedRule: "cross-agent guard" });
+    expect(result).toBe("Permission denied by rule: cross-agent guard");
+  });
+
+  test("empty reason string falls through to matchedRule", () => {
+    const result = formatPermissionDenial({
+      reason: "",
+      matchedRule: "memory mode",
+    });
+    expect(result).toBe("Permission denied by rule: memory mode");
+  });
+
+  test("empty matchedRule falls through to final fallback", () => {
+    const result = formatPermissionDenial({ matchedRule: "" });
+    expect(result).toBe("Permission denied: Unknown reason");
+  });
+
+  test("final fallback when nothing is set", () => {
+    const result = formatPermissionDenial({});
+    expect(result).toBe("Permission denied: Unknown reason");
+  });
+
+  test("works with extra unrelated fields on the permission object", () => {
+    // Mirrors real-world ToolPermission shape which has a `decision` field too
+    const result = formatPermissionDenial({
+      reason: "detailed",
+      matchedRule: "rule",
+      // @ts-expect-error extra property is allowed structurally
+      decision: "deny",
+    });
+    expect(result).toBe("Permission denied: detailed");
+  });
+
+  test("plan-mode denial — reason contains plan file path context", () => {
+    const result = formatPermissionDenial({
+      reason:
+        "Plan mode is active. You can only use read-only tools (Read, " +
+        "Grep, Glob, etc.) and write to the plan file. " +
+        "Write your plan to: /tmp/plan.md. Use ExitPlanMode when ready.",
+      matchedRule: "plan mode",
+    });
+    expect(result).toContain("Plan mode is active");
+    expect(result).toContain("/tmp/plan.md");
+    // Crucially, it shouldn't be the short "plan mode" label
+    expect(result).not.toBe("Permission denied by rule: plan mode");
+  });
+
+  test("memory-mode denial shows fuller reason over short label", () => {
+    const result = formatPermissionDenial({
+      reason: "Permission mode: memory",
+      matchedRule: "memory mode",
+    });
+    expect(result).toBe("Permission denied: Permission mode: memory");
+  });
+});

--- a/src/tests/permissions/formatDenial.test.ts
+++ b/src/tests/permissions/formatDenial.test.ts
@@ -34,7 +34,7 @@ describe("formatPermissionDenial", () => {
     expect(result).toBe("Permission denied: detailed explanation");
   });
 
-  test("reason is preferred over matchedRule (the key behavior)", () => {
+  test("already-prefixed reasons are preserved verbatim", () => {
     const result = formatPermissionDenial({
       reason:
         "Permission denied by cross-agent memory guard: targeted agent-abc123. " +
@@ -42,9 +42,8 @@ describe("formatPermissionDenial", () => {
       matchedRule: "cross-agent guard",
     });
     expect(result).toBe(
-      "Permission denied: Permission denied by cross-agent memory guard: " +
-        "targeted agent-abc123. Set LETTA_MEMORY_SCOPE or pass " +
-        "--memory-scope to authorize.",
+      "Permission denied by cross-agent memory guard: targeted agent-abc123. " +
+        "Set LETTA_MEMORY_SCOPE or pass --memory-scope to authorize.",
     );
   });
 
@@ -80,6 +79,22 @@ describe("formatPermissionDenial", () => {
       decision: "deny",
     });
     expect(result).toBe("Permission denied: detailed");
+  });
+
+  test("generic checker reasons prefer matchedRule over internal labels", () => {
+    const result = formatPermissionDenial({
+      reason: "Matched deny rule",
+      matchedRule: "Bash(git push)",
+    });
+    expect(result).toBe("Permission denied by rule: Bash(git push)");
+  });
+
+  test("disallowed-tools generic reason also prefers matchedRule", () => {
+    const result = formatPermissionDenial({
+      reason: "Matched --disallowedTools flag",
+      matchedRule: "Edit(secret.txt) (CLI)",
+    });
+    expect(result).toBe("Permission denied by rule: Edit(secret.txt) (CLI)");
   });
 
   test("plan-mode denial — reason contains plan file path context", () => {

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -22,6 +22,7 @@ import {
 } from "../../agent/turn-recovery-policy";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
+import { formatPermissionDenial } from "../../permissions/formatDenial";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
 import type {
@@ -355,7 +356,7 @@ function buildRecoveredAutoDecisions(
     ...autoDenied.map((ac) => ({
       type: "deny" as const,
       approval: ac.approval,
-      reason: ac.denyReason || ac.permission.reason || "Permission denied",
+      reason: formatPermissionDenial(ac.permission, ac.denyReason),
     })),
   ];
 }

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -13,6 +13,7 @@ import {
 import { getChannelRegistry } from "../../channels/registry";
 import type { ChannelTurnSource } from "../../channels/types";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
+import { formatPermissionDenial } from "../../permissions/formatDenial";
 import {
   getInteractiveApprovalKind,
   isInteractiveApprovalTool,
@@ -281,7 +282,7 @@ export async function handleApprovalStop(params: {
     ...autoDenied.map((ac) => ({
       type: "deny" as const,
       approval: ac.approval,
-      reason: ac.denyReason || ac.permission.reason || "Permission denied",
+      reason: formatPermissionDenial(ac.permission, ac.denyReason),
     })),
   ];
 
@@ -410,10 +411,10 @@ export async function handleApprovalStop(params: {
               ...reclassified.autoDenied.map((entry) => ({
                 type: "deny" as const,
                 approval: entry.approval,
-                reason:
-                  entry.denyReason ||
-                  entry.permission.reason ||
-                  "Permission denied",
+                reason: formatPermissionDenial(
+                  entry.permission,
+                  entry.denyReason,
+                ),
               })),
             );
             pendingNeedsUserInput = [...reclassified.needsUserInput];


### PR DESCRIPTION
## Summary

Extract the auto-denial message formatter into a single helper (`formatPermissionDenial`) and replace **14 near-duplicate open-coded implementations** across headless, CLI, and WebSocket listener.

Separates out of #1870, which fixed a cross-agent scope bug and needed a corresponding UX fix to make the denials legible. Splitting lets the security fix land independently while this refactor can be reviewed on its own terms.

## Why this was duplicated

The same formatter was inlined at every permission-denial site because it was genuinely small — 4 lines — and there was no obvious home for it. But the duplication had drifted: four different variants existed in tree simultaneously, with inconsistent precedence between `reason` and `matchedRule` and inconsistent final fallback text (`"Permission denied"` / `"Permission denied: Unknown"` / `"Permission denied: Unknown reason"`).

## Design decisions

`formatPermissionDenial(permission, customDenyReason?)` with deliberate precedence:

1. `customDenyReason` — caller-supplied override (hook-generated messages, tool-specific failures)
2. `permission.reason` — the detailed explanation (offending agent ID, plan file path, authorization hint)
3. `permission.matchedRule` — the short rule label, prefixed `"Permission denied by rule: "` to signal it's a terse tag
4. `"Permission denied: Unknown reason"` as final fallback

`reason` is preferred over `matchedRule` because `reason` carries the actionable content — "Permission denied by cross-agent memory guard: targeted agent-abc123. Set LETTA_MEMORY_SCOPE or pass --memory-scope to authorize" is far more useful than "cross-agent guard". Same story for memory-mode ("Permission mode: memory" > "memory mode") and plan-mode (plan file path > "plan mode").

Structural typing (`{ reason?: string; matchedRule?: string }`) rather than importing the full `PermissionCheckResult` — helps the WebSocket listener paths where the permission shape comes back through several type boundaries.

## Observable behavior changes

The refactor is behavior-preserving at the four App.tsx sites that already had the reason-first pattern. Three legitimate improvements in the simpler-fallback sites:

1. **Simpler-fallback sites (6 total: headless recovery, recovery.ts, both send.ts, both turn-approval.ts)** previously returned bare `"Permission denied"` when neither `denyReason` nor `reason` was set, even if `matchedRule` was populated. Now they surface `"Permission denied by rule: <rule>"` in that case — strictly more informative.

2. **`App.tsx` line 7825** (auto-deny during streaming) previously returned bare `"Permission denied"` when `reason` was absent, ignoring `matchedRule` entirely. Same improvement.

3. **Two `App.tsx` sites** that said `"Permission denied: Unknown"` now say `"Permission denied: Unknown reason"` to match everything else.

No site got *less* informative. No site silently swallows a previously-visible message.

## Test plan

- [x] `bun test src/tests/permissions/formatDenial.test.ts` — 12 pass (new file)
- [x] `bun test src/tests/permissions/` — 172 pass
- [x] `bun test src/tests/cli/ src/tests/websocket/` — 688 pass
- [x] `bun test src/tests/agent/ src/tests/tools/ src/tests/permissions/ src/tests/cli/ src/tests/websocket/` — 1414 pass (4 pre-existing failures unrelated: memory prompt snapshot, 3 getClient credential tests)
- [x] `tsc --noEmit` clean
- [ ] Manual: trigger a cross-agent guard denial in headless mode — verify the error shows the detailed reason, not the short "cross-agent guard" label
- [ ] Manual: trigger a plan-mode denial in headless mode — verify the error shows the plan file path
- [ ] CI: unit + integration + Windows runner

## Commits

1. `feat(permissions): add formatPermissionDenial helper` — pure addition, zero behavior change
2. `refactor(permissions): migrate all auto-denial formatters to formatPermissionDenial` — the migration