### PR TITLE
fix: verify resized image outputs

### DIFF
--- a/src/cli/helpers/imageResize.magick.ts
+++ b/src/cli/helpers/imageResize.magick.ts
@@ -4,23 +4,15 @@ import { execSync } from "node:child_process";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-// Anthropic limits: 8000x8000 for single images, but 2000x2000 for many-image requests
-// We use 2000 to stay safe when conversation history accumulates multiple images
-export const MAX_IMAGE_WIDTH = 2000;
-export const MAX_IMAGE_HEIGHT = 2000;
-
-// Anthropic's API enforces a 5MB limit on image bytes (not base64 string)
-// We enforce this in the client to avoid API errors
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB = 5,242,880 bytes
-
-export interface ResizeResult {
-  data: string; // base64 encoded
-  mediaType: string;
-  width: number;
-  height: number;
-  resized: boolean;
-}
+import {
+  assertImageHasDimensions,
+  assertImageWithinBounds,
+  buildResizeResult,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+  type ResizeResult,
+} from "./imageResize.shared";
 
 /**
  * Get image dimensions using ImageMagick identify
@@ -45,14 +37,28 @@ async function getImageDimensions(
     if (!width || !height || !format) {
       throw new Error("Failed to get image dimensions");
     }
+    const parsedWidth = parseInt(width, 10);
+    const parsedHeight = parseInt(height, 10);
+    assertImageHasDimensions(parsedWidth, parsedHeight, "decoded image");
     return {
-      width: parseInt(width, 10),
-      height: parseInt(height, 10),
+      width: parsedWidth,
+      height: parsedHeight,
       format: format.toLowerCase(),
     };
   } finally {
     unlinkSync(tempInput);
   }
+}
+
+async function buildVerifiedResizeResult(
+  buffer: Buffer,
+  mediaType: string,
+  resized: boolean,
+  context: string,
+): Promise<ResizeResult> {
+  const { width, height } = await getImageDimensions(buffer);
+  assertImageWithinBounds(width, height, context);
+  return buildResizeResult(buffer, mediaType, width, height, resized);
 }
 
 /**
@@ -90,14 +96,12 @@ async function compressToFitByteLimit(
         });
         const compressed = readFileSync(tempOutput);
         if (compressed.length <= MAX_IMAGE_BYTES) {
-          const { width, height } = await getImageDimensions(compressed);
-          return {
-            data: compressed.toString("base64"),
-            mediaType: "image/jpeg",
-            width,
-            height,
-            resized: true,
-          };
+          return buildVerifiedResizeResult(
+            compressed,
+            "image/jpeg",
+            true,
+            "compressed image output",
+          );
         }
       } finally {
         try {
@@ -124,14 +128,12 @@ async function compressToFitByteLimit(
         );
         const reduced = readFileSync(tempOutput);
         if (reduced.length <= MAX_IMAGE_BYTES) {
-          const { width, height } = await getImageDimensions(reduced);
-          return {
-            data: reduced.toString("base64"),
-            mediaType: "image/jpeg",
-            width,
-            height,
-            resized: true,
-          };
+          return buildVerifiedResizeResult(
+            reduced,
+            "image/jpeg",
+            true,
+            "dimension-reduced image output",
+          );
         }
       } finally {
         try {
@@ -172,13 +174,12 @@ export async function resizeImageIfNeeded(
     if (compressed) {
       return compressed;
     }
-    return {
-      data: buffer.toString("base64"),
-      mediaType: inputMediaType,
-      width,
-      height,
-      resized: false,
-    };
+    return buildVerifiedResizeResult(
+      buffer,
+      inputMediaType,
+      false,
+      "passthrough image output",
+    );
   }
 
   const tempInput = join(
@@ -237,13 +238,12 @@ export async function resizeImageIfNeeded(
         return compressed;
       }
 
-      return {
-        data: outputBuffer.toString("base64"),
-        mediaType: outputMediaType,
-        width: resizedWidth,
-        height: resizedHeight,
-        resized: true,
-      };
+      return buildVerifiedResizeResult(
+        outputBuffer,
+        outputMediaType,
+        true,
+        "resized image output",
+      );
     }
 
     // No resize needed but format needs conversion (e.g., HEIC, TIFF, etc.)
@@ -267,13 +267,12 @@ export async function resizeImageIfNeeded(
       return compressed;
     }
 
-    return {
-      data: outputBuffer.toString("base64"),
-      mediaType: "image/png",
-      width,
-      height,
-      resized: false,
-    };
+    return buildVerifiedResizeResult(
+      outputBuffer,
+      "image/png",
+      false,
+      "converted image output",
+    );
   } finally {
     unlinkSync(tempInput);
   }

--- a/src/cli/helpers/imageResize.shared.ts
+++ b/src/cli/helpers/imageResize.shared.ts
@@ -1,5 +1,10 @@
+// Anthropic limits: 8000x8000 for single images, but 2000x2000 for many-image requests.
+// We use 2000 to stay safe when conversation history accumulates multiple images.
 export const MAX_IMAGE_WIDTH = 2000;
 export const MAX_IMAGE_HEIGHT = 2000;
+
+// Anthropic's API enforces a 5MB limit on image bytes (not the base64 string).
+// We enforce this in the client to avoid provider-side API errors.
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
 export interface ResizeResult {

--- a/src/cli/helpers/imageResize.shared.ts
+++ b/src/cli/helpers/imageResize.shared.ts
@@ -1,0 +1,57 @@
+export const MAX_IMAGE_WIDTH = 2000;
+export const MAX_IMAGE_HEIGHT = 2000;
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export interface ResizeResult {
+  data: string; // base64 encoded
+  mediaType: string;
+  width: number;
+  height: number;
+  resized: boolean;
+}
+
+export function assertImageHasDimensions(
+  width: number,
+  height: number,
+  context: string,
+): void {
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(
+      `${context} has invalid dimensions: ${String(width)}x${String(height)}`,
+    );
+  }
+}
+
+export function assertImageWithinBounds(
+  width: number,
+  height: number,
+  context: string,
+): void {
+  assertImageHasDimensions(width, height, context);
+  if (width > MAX_IMAGE_WIDTH || height > MAX_IMAGE_HEIGHT) {
+    throw new Error(
+      `${context} exceeds ${MAX_IMAGE_WIDTH}x${MAX_IMAGE_HEIGHT}: ${width}x${height}`,
+    );
+  }
+}
+
+export function buildResizeResult(
+  buffer: Buffer,
+  mediaType: string,
+  width: number,
+  height: number,
+  resized: boolean,
+): ResizeResult {
+  return {
+    data: buffer.toString("base64"),
+    mediaType,
+    width,
+    height,
+    resized,
+  };
+}

--- a/src/cli/helpers/imageResize.sharp.ts
+++ b/src/cli/helpers/imageResize.sharp.ts
@@ -1,22 +1,36 @@
 // Image resizing utilities for clipboard paste
 // Follows Codex CLI's approach (codex-rs/utils/image/src/lib.rs)
 import sharp from "sharp";
+import {
+  assertImageHasDimensions,
+  assertImageWithinBounds,
+  buildResizeResult,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+  type ResizeResult,
+} from "./imageResize.shared";
 
-// Anthropic limits: 8000x8000 for single images, but 2000x2000 for many-image requests
-// We use 2000 to stay safe when conversation history accumulates multiple images
-export const MAX_IMAGE_WIDTH = 2000;
-export const MAX_IMAGE_HEIGHT = 2000;
+async function inspectImageBuffer(
+  buffer: Buffer,
+  context: string,
+): Promise<{ width: number; height: number; format?: string }> {
+  const metadata = await sharp(buffer).metadata();
+  const width = metadata.width ?? 0;
+  const height = metadata.height ?? 0;
+  assertImageHasDimensions(width, height, context);
+  return { width, height, format: metadata.format };
+}
 
-// Anthropic's API enforces a 5MB limit on image bytes (not base64 string)
-// We enforce this in the client to avoid API errors
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB = 5,242,880 bytes
-
-export interface ResizeResult {
-  data: string; // base64 encoded
-  mediaType: string;
-  width: number;
-  height: number;
-  resized: boolean;
+async function buildVerifiedResizeResult(
+  buffer: Buffer,
+  mediaType: string,
+  resized: boolean,
+  context: string,
+): Promise<ResizeResult> {
+  const { width, height } = await inspectImageBuffer(buffer, context);
+  assertImageWithinBounds(width, height, context);
+  return buildResizeResult(buffer, mediaType, width, height, resized);
 }
 
 /**
@@ -39,14 +53,12 @@ async function compressToFitByteLimit(
   for (const quality of qualities) {
     const compressed = await sharp(buffer).jpeg({ quality }).toBuffer();
     if (compressed.length <= MAX_IMAGE_BYTES) {
-      const meta = await sharp(compressed).metadata();
-      return {
-        data: compressed.toString("base64"),
-        mediaType: "image/jpeg",
-        width: meta.width ?? currentWidth,
-        height: meta.height ?? currentHeight,
-        resized: true,
-      };
+      return buildVerifiedResizeResult(
+        compressed,
+        "image/jpeg",
+        true,
+        "compressed image output",
+      );
     }
   }
 
@@ -63,14 +75,12 @@ async function compressToFitByteLimit(
       .jpeg({ quality: 70 })
       .toBuffer();
     if (reduced.length <= MAX_IMAGE_BYTES) {
-      const meta = await sharp(reduced).metadata();
-      return {
-        data: reduced.toString("base64"),
-        mediaType: "image/jpeg",
-        width: meta.width ?? scaledWidth,
-        height: meta.height ?? scaledHeight,
-        resized: true,
-      };
+      return buildVerifiedResizeResult(
+        reduced,
+        "image/jpeg",
+        true,
+        "dimension-reduced image output",
+      );
     }
   }
 
@@ -90,10 +100,10 @@ export async function resizeImageIfNeeded(
   inputMediaType: string,
 ): Promise<ResizeResult> {
   const image = sharp(buffer);
-  const metadata = await image.metadata();
-  const width = metadata.width ?? 0;
-  const height = metadata.height ?? 0;
-  const format = metadata.format;
+  const { width, height, format } = await inspectImageBuffer(
+    buffer,
+    "source image",
+  );
 
   const needsResize = width > MAX_IMAGE_WIDTH || height > MAX_IMAGE_HEIGHT;
 
@@ -106,13 +116,12 @@ export async function resizeImageIfNeeded(
     if (compressed) {
       return compressed;
     }
-    return {
-      data: buffer.toString("base64"),
-      mediaType: inputMediaType,
-      width,
-      height,
-      resized: false,
-    };
+    return buildVerifiedResizeResult(
+      buffer,
+      inputMediaType,
+      false,
+      "passthrough image output",
+    );
   }
 
   if (needsResize) {
@@ -137,9 +146,8 @@ export async function resizeImageIfNeeded(
       outputMediaType = "image/png";
     }
 
-    const resizedMeta = await sharp(outputBuffer).metadata();
-    const resizedWidth = resizedMeta.width ?? 0;
-    const resizedHeight = resizedMeta.height ?? 0;
+    const { width: resizedWidth, height: resizedHeight } =
+      await inspectImageBuffer(outputBuffer, "resized image output");
 
     // Check byte limit after dimension resize
     const compressed = await compressToFitByteLimit(
@@ -151,13 +159,12 @@ export async function resizeImageIfNeeded(
       return compressed;
     }
 
-    return {
-      data: outputBuffer.toString("base64"),
-      mediaType: outputMediaType,
-      width: resizedWidth,
-      height: resizedHeight,
-      resized: true,
-    };
+    return buildVerifiedResizeResult(
+      outputBuffer,
+      outputMediaType,
+      true,
+      "resized image output",
+    );
   }
 
   // No resize needed but format needs conversion (e.g., HEIC, TIFF, etc.)
@@ -169,11 +176,10 @@ export async function resizeImageIfNeeded(
     return compressed;
   }
 
-  return {
-    data: outputBuffer.toString("base64"),
-    mediaType: "image/png",
-    width,
-    height,
-    resized: false,
-  };
+  return buildVerifiedResizeResult(
+    outputBuffer,
+    "image/png",
+    false,
+    "converted image output",
+  );
 }

--- a/src/cli/helpers/imageResize.ts
+++ b/src/cli/helpers/imageResize.ts
@@ -1,17 +1,12 @@
 // Image resizing utilities for clipboard paste
 // Follows Codex CLI's approach (codex-rs/utils/image/src/lib.rs)
 
-export const MAX_IMAGE_WIDTH = 2000;
-export const MAX_IMAGE_HEIGHT = 2000;
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
-
-export interface ResizeResult {
-  data: string; // base64 encoded
-  mediaType: string;
-  width: number;
-  height: number;
-  resized: boolean;
-}
+export type { ResizeResult } from "./imageResize.shared";
+export {
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+} from "./imageResize.shared";
 
 // Build-time constant for magick variant (set via Bun.build define when USE_MAGICK=1)
 // At dev/test time this is undefined, at build time it's true/false

--- a/src/tests/cli/imageResize.test.ts
+++ b/src/tests/cli/imageResize.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import sharp from "sharp";
+import {
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+  resizeImageIfNeeded,
+} from "../../cli/helpers/imageResize";
+
+describe("resizeImageIfNeeded", () => {
+  test("returns verified output dimensions for oversized images", async () => {
+    const oversized = await sharp({
+      create: {
+        width: 3400,
+        height: 2200,
+        channels: 3,
+        background: { r: 180, g: 70, b: 40 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const result = await resizeImageIfNeeded(oversized, "image/png");
+    const resizedBuffer = Buffer.from(result.data, "base64");
+    const metadata = await sharp(resizedBuffer).metadata();
+
+    expect(result.width).toBeLessThanOrEqual(MAX_IMAGE_WIDTH);
+    expect(result.height).toBeLessThanOrEqual(MAX_IMAGE_HEIGHT);
+    expect(metadata.width).toBe(result.width);
+    expect(metadata.height).toBe(result.height);
+  });
+});

--- a/src/tests/tools/read.test.ts
+++ b/src/tests/tools/read.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import sharp from "sharp";
+import {
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+} from "../../cli/helpers/imageResize";
 import { SYSTEM_REMINDER_OPEN } from "../../constants";
 import { read } from "../../tools/impl/Read";
 import { TestDirectory } from "../helpers/testFs";
@@ -159,6 +164,55 @@ export default box;
         throw new Error("Expected image content source to be base64");
       }
       expect(imagePart.source.media_type).toBe("image/png");
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  test("clamps oversized image reads to Anthropic many-image limits", async () => {
+    testDir = new TestDirectory();
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    process.env.LETTA_BASE_URL = "http://localhost:58064";
+
+    try {
+      const oversizedBuffer = await sharp({
+        create: {
+          width: 3600,
+          height: 2400,
+          channels: 3,
+          background: { r: 40, g: 130, b: 220 },
+        },
+      })
+        .png()
+        .toBuffer();
+      const imagePath = testDir.createBinaryFile("large.png", oversizedBuffer);
+
+      const result = await read({ file_path: imagePath });
+
+      expect(Array.isArray(result.content)).toBe(true);
+      if (!Array.isArray(result.content)) {
+        throw new Error("Expected image read to return multimodal content");
+      }
+
+      const imagePart = result.content[1];
+      if (!imagePart || imagePart.type !== "image") {
+        throw new Error("Expected second content part to be an image");
+      }
+      if (imagePart.source.type !== "base64") {
+        throw new Error("Expected image content source to be base64");
+      }
+
+      const resizedBuffer = Buffer.from(imagePart.source.data, "base64");
+      const metadata = await sharp(resizedBuffer).metadata();
+
+      expect(metadata.width).toBeDefined();
+      expect(metadata.height).toBeDefined();
+      expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_WIDTH);
+      expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_HEIGHT);
     } finally {
       if (originalBaseUrl === undefined) {
         delete process.env.LETTA_BASE_URL;

--- a/src/tests/websocket/listen-client-image-normalization.test.ts
+++ b/src/tests/websocket/listen-client-image-normalization.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import sharp from "sharp";
+import {
+  MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_WIDTH,
+} from "../../cli/helpers/imageResize";
 import { __listenClientTestUtils } from "../../websocket/listen-client";
 
 describe("listen-client inbound image normalization", () => {
@@ -53,5 +58,63 @@ describe("listen-client inbound image normalization", () => {
         },
       },
     ]);
+  });
+
+  test("clamps oversized base64 image parts to Anthropic many-image limits", async () => {
+    const oversized = await sharp({
+      create: {
+        width: 3200,
+        height: 1800,
+        channels: 3,
+        background: { r: 220, g: 110, b: 30 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const normalized = await __listenClientTestUtils.normalizeInboundMessages([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "text", text: "please inspect these pasted screenshots" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: oversized.toString("base64"),
+            },
+          },
+        ],
+        client_message_id: "cm-image-oversized",
+      },
+    ]);
+
+    const message = normalized[0];
+    if (
+      !message ||
+      !("content" in message) ||
+      typeof message.content === "string"
+    ) {
+      throw new Error("Expected normalized multimodal message");
+    }
+
+    const imagePart = message.content[1];
+    if (
+      !imagePart ||
+      imagePart.type !== "image" ||
+      imagePart.source.type !== "base64"
+    ) {
+      throw new Error("Expected normalized base64 image content");
+    }
+
+    const resizedBuffer = Buffer.from(imagePart.source.data, "base64");
+    const metadata = await sharp(resizedBuffer).metadata();
+
+    expect(metadata.width).toBeDefined();
+    expect(metadata.height).toBeDefined();
+    expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_WIDTH);
+    expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_HEIGHT);
   });
 });


### PR DESCRIPTION
## Summary
- add shared image resize invariants so both sharp and ImageMagick implementations verify final output dimensions before returning base64
- keep the existing 2000x2000 Anthropic-safe cap, but fail closed if a purportedly resized output still exceeds it
- add real oversized-image regressions for the shared helper, websocket listener normalization, and Read tool image path

## Testing
- bun test src/tests/cli/imageResize.test.ts src/tests/websocket/listen-client-image-normalization.test.ts src/tests/tools/read.test.ts