### PR TITLE
fix(ws): isolate runtime scope for tool execution

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -9,6 +9,7 @@ import type {
 import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { INTERRUPTED_BY_USER } from "../constants";
+import { getCurrentWorkingDirectory } from "../runtime-context";
 import {
   executeTool,
   prepareCurrentToolExecutionContext,
@@ -138,7 +139,7 @@ const GLOBAL_LOCK_TOOLS = new Set([
 export function getResourceKey(
   toolName: string,
   toolArgs: Record<string, unknown>,
-  workingDirectory: string = process.env.USER_CWD || process.cwd(),
+  workingDirectory: string = getCurrentWorkingDirectory(),
 ): string {
   // Global lock tools serialize with everything
   if (GLOBAL_LOCK_TOOLS.has(toolName)) {

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -2,7 +2,7 @@ import { hostname } from "node:os";
 import Letta from "@letta-ai/letta-client";
 import packageJson from "../../package.json";
 import { LETTA_CLOUD_API_URL, refreshAccessToken } from "../auth/oauth";
-import { settingsManager } from "../settings-manager";
+import { type Settings, settingsManager } from "../settings-manager";
 import { trackBoundaryError } from "../telemetry/errorReporting";
 import { isDebugEnabled } from "../utils/debug";
 import { createTimingFetch, isTimingsEnabled } from "../utils/timing";
@@ -111,7 +111,22 @@ export function getServerUrl(): string {
 }
 
 export async function getClient() {
-  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const baseSettings = settingsManager.getSettings();
+  const cachedTokens = settingsManager.getCachedSecureTokens();
+  const cachedSettings: Settings = {
+    ...baseSettings,
+    env: {
+      ...baseSettings.env,
+      ...(cachedTokens.apiKey && { LETTA_API_KEY: cachedTokens.apiKey }),
+    },
+    refreshToken: cachedTokens.refreshToken ?? baseSettings.refreshToken,
+  };
+  const settings =
+    process.env.LETTA_API_KEY ||
+    cachedSettings.env?.LETTA_API_KEY ||
+    cachedSettings.refreshToken
+      ? cachedSettings
+      : await settingsManager.getSettingsWithSecureTokens();
 
   let apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
 

--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import { getSkillSources, getSkillsDirectory } from "./context";
@@ -16,17 +17,21 @@ function getMemorySkillsDirs(agentId?: string): string[] {
   const dirs = new Set<string>();
 
   const scopedMemoryDir = resolveScopedMemoryDir({ agentId });
-  if (scopedMemoryDir && scopedMemoryDir.trim().length > 0) {
+  if (
+    scopedMemoryDir &&
+    scopedMemoryDir.trim().length > 0 &&
+    existsSync(scopedMemoryDir)
+  ) {
     dirs.add(join(scopedMemoryDir.trim(), "skills"));
-  }
-
-  const fallbackMemoryDir = (
-    process.env.LETTA_MEMORY_DIR ||
-    process.env.MEMORY_DIR ||
-    ""
-  ).trim();
-  if (fallbackMemoryDir) {
-    dirs.add(join(fallbackMemoryDir, "skills"));
+  } else {
+    const fallbackMemoryDir = (
+      process.env.LETTA_MEMORY_DIR ||
+      process.env.MEMORY_DIR ||
+      ""
+    ).trim();
+    if (fallbackMemoryDir) {
+      dirs.add(join(fallbackMemoryDir, "skills"));
+    }
   }
 
   return Array.from(dirs);

--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import { getSkillSources, getSkillsDirectory } from "./context";
+import { resolveScopedMemoryDir } from "./memoryFilesystem";
 import {
   compareSkills,
   discoverSkills,
@@ -14,21 +15,18 @@ import {
 function getMemorySkillsDirs(agentId?: string): string[] {
   const dirs = new Set<string>();
 
-  const memoryDir = process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-  if (memoryDir && memoryDir.trim().length > 0) {
-    dirs.add(join(memoryDir.trim(), "skills"));
+  const scopedMemoryDir = resolveScopedMemoryDir({ agentId });
+  if (scopedMemoryDir && scopedMemoryDir.trim().length > 0) {
+    dirs.add(join(scopedMemoryDir.trim(), "skills"));
   }
 
-  if (agentId) {
-    dirs.add(
-      join(
-        process.env.HOME || process.env.USERPROFILE || "~",
-        ".letta/agents",
-        agentId,
-        "memory",
-        "skills",
-      ),
-    );
+  const fallbackMemoryDir = (
+    process.env.LETTA_MEMORY_DIR ||
+    process.env.MEMORY_DIR ||
+    ""
+  ).trim();
+  if (fallbackMemoryDir) {
+    dirs.add(join(fallbackMemoryDir, "skills"));
   }
 
   return Array.from(dirs);

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -65,7 +65,7 @@ export function setAgentContext(
 /**
  * Set the current agent ID in context (simplified version for compatibility)
  */
-export function setCurrentAgentId(agentId: string): void {
+export function setCurrentAgentId(agentId: string | null): void {
   context.agentId = agentId;
   if (getRuntimeContext()) {
     updateRuntimeContext({ agentId });

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -3,6 +3,10 @@
  * This allows tools to access the current agent ID without threading it through params.
  */
 
+import {
+  getRuntimeContext,
+  updateRuntimeContext,
+} from "../runtime-context";
 import { ALL_SKILL_SOURCES } from "./skillSources";
 import type { SkillSource } from "./skills";
 
@@ -51,6 +55,14 @@ export function setAgentContext(
   context.skillsDirectory = skillsDirectory || null;
   context.skillSources =
     skillSources !== undefined ? [...skillSources] : [...ALL_SKILL_SOURCES];
+  if (getRuntimeContext()) {
+    updateRuntimeContext({
+      agentId,
+      skillsDirectory: skillsDirectory || null,
+      skillSources:
+        skillSources !== undefined ? [...skillSources] : [...ALL_SKILL_SOURCES],
+    });
+  }
 }
 
 /**
@@ -58,6 +70,9 @@ export function setAgentContext(
  */
 export function setCurrentAgentId(agentId: string): void {
   context.agentId = agentId;
+  if (getRuntimeContext()) {
+    updateRuntimeContext({ agentId });
+  }
 }
 
 /**
@@ -65,6 +80,13 @@ export function setCurrentAgentId(agentId: string): void {
  * @throws Error if no agent context is set
  */
 export function getCurrentAgentId(): string {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext && "agentId" in runtimeContext) {
+    if (runtimeContext.agentId) {
+      return runtimeContext.agentId;
+    }
+    throw new Error("No agent context set. Agent ID is required.");
+  }
   if (!context.agentId) {
     throw new Error("No agent context set. Agent ID is required.");
   }
@@ -76,6 +98,10 @@ export function getCurrentAgentId(): string {
  * @returns The skills directory path or null if not set
  */
 export function getSkillsDirectory(): string | null {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext && "skillsDirectory" in runtimeContext) {
+    return runtimeContext.skillsDirectory ?? null;
+  }
   return context.skillsDirectory;
 }
 
@@ -83,6 +109,10 @@ export function getSkillsDirectory(): string | null {
  * Get enabled skill sources for discovery/injection.
  */
 export function getSkillSources(): SkillSource[] {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext?.skillSources) {
+    return [...runtimeContext.skillSources];
+  }
   return [...context.skillSources];
 }
 
@@ -99,6 +129,9 @@ export function getNoSkills(): boolean {
  */
 export function setConversationId(conversationId: string | null): void {
   context.conversationId = conversationId;
+  if (getRuntimeContext()) {
+    updateRuntimeContext({ conversationId });
+  }
 }
 
 /**
@@ -106,5 +139,9 @@ export function setConversationId(conversationId: string | null): void {
  * @returns The conversation ID or null if not set
  */
 export function getConversationId(): string | null {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext && "conversationId" in runtimeContext) {
+    return runtimeContext.conversationId ?? null;
+  }
   return context.conversationId;
 }

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -3,10 +3,7 @@
  * This allows tools to access the current agent ID without threading it through params.
  */
 
-import {
-  getRuntimeContext,
-  updateRuntimeContext,
-} from "../runtime-context";
+import { getRuntimeContext, updateRuntimeContext } from "../runtime-context";
 import { ALL_SKILL_SOURCES } from "./skillSources";
 import type { SkillSource } from "./skills";
 

--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -9,11 +9,12 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   DIRECTORY_LIMIT_DEFAULTS,
   getDirectoryLimits,
 } from "../utils/directoryLimits";
+import { getCurrentAgentId } from "./context";
 
 export const MEMORY_FS_ROOT = ".letta";
 export const MEMORY_FS_AGENTS_DIR = "agents";
@@ -50,6 +51,54 @@ export function getMemorySystemDir(
   homeDir: string = homedir(),
 ): string {
   return join(getMemoryFilesystemRoot(agentId, homeDir), MEMORY_SYSTEM_DIR);
+}
+
+export interface ResolveScopedMemoryDirOptions {
+  agentId?: string | null;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}
+
+/**
+ * Resolve the active memory directory for the current execution scope.
+ *
+ * Precedence is intentionally runtime-first:
+ * 1. Explicit agent ID (caller-provided scope)
+ * 2. In-process runtime/agent context
+ * 3. Explicit MEMORY_DIR env fallback
+ * 4. AGENT_ID env fallback
+ */
+export function resolveScopedMemoryDir(
+  options: ResolveScopedMemoryDirOptions = {},
+): string | null {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? env.HOME ?? env.USERPROFILE ?? homedir();
+
+  const explicitAgentId = options.agentId?.trim();
+  if (explicitAgentId) {
+    return getMemoryFilesystemRoot(explicitAgentId, homeDir);
+  }
+
+  try {
+    const scopedAgentId = getCurrentAgentId().trim();
+    if (scopedAgentId) {
+      return getMemoryFilesystemRoot(scopedAgentId, homeDir);
+    }
+  } catch {
+    // No runtime-scoped agent context; fall back below.
+  }
+
+  const directMemoryDir = (env.LETTA_MEMORY_DIR || env.MEMORY_DIR || "").trim();
+  if (directMemoryDir) {
+    return resolve(directMemoryDir);
+  }
+
+  const envAgentId = (env.LETTA_AGENT_ID || env.AGENT_ID || "").trim();
+  if (envAgentId) {
+    return getMemoryFilesystemRoot(envAgentId, homeDir);
+  }
+
+  return null;
 }
 
 export function ensureMemoryFilesystemDirs(

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -8,7 +8,6 @@
  */
 
 import { spawn } from "node:child_process";
-import { createInterface } from "node:readline";
 import { buildChatUrl } from "../../cli/helpers/appUrls";
 import {
   addToolCall,
@@ -782,23 +781,21 @@ async function executeSubagent(
       pendingToolCalls: new Map(),
     };
 
-    // Create readline interface to parse JSON events line by line
-    const rl = createInterface({
-      input: proc.stdout,
-      crlfDelay: Number.POSITIVE_INFINITY,
-    });
+    // Parse child stdout manually instead of using readline. This keeps the
+    // stream handling simple and avoids Bun/runtime-specific instability in
+    // nested child-process line readers.
+    let stdoutBuffer = "";
+    proc.stdout.on("data", (data: Buffer | string) => {
+      const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      stdoutChunks.push(chunk);
+      stdoutBuffer += chunk.toString("utf-8");
 
-    let rlClosed = false;
-    const rlClosedPromise = new Promise<void>((resolve) => {
-      rl.once("close", () => {
-        rlClosed = true;
-        resolve();
-      });
-    });
+      const lines = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = lines.pop() ?? "";
 
-    rl.on("line", (line: string) => {
-      stdoutChunks.push(Buffer.from(`${line}\n`));
-      processStreamEvent(line, state, subagentId);
+      for (const line of lines) {
+        processStreamEvent(line, state, subagentId);
+      }
     });
 
     proc.stderr.on("data", (data: Buffer) => {
@@ -811,12 +808,11 @@ async function executeSubagent(
       proc.on("error", () => resolve(null));
     });
 
-    // Ensure all stdout lines have been processed before completing.
+    // Ensure the trailing partial line is processed before completing.
     // Without this, late tool events can be dropped before Task marks completion.
-    if (!rlClosed) {
-      rl.close();
+    if (stdoutBuffer.length > 0) {
+      processStreamEvent(stdoutBuffer, state, subagentId);
     }
-    await rlClosedPromise;
 
     // Clean up abort listener
     signal?.removeEventListener("abort", abortHandler);

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -26,6 +26,7 @@ import {
   resolveAllowedMemoryRoots,
 } from "../../permissions/memoryScope";
 import { permissionMode } from "../../permissions/mode";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { sessionPermissions } from "../../permissions/session";
 import { settingsManager } from "../../settings-manager";
 import { resolveLettaInvocation } from "../../tools/impl/shellEnv";
@@ -492,7 +493,7 @@ interface SubagentLauncher {
 
 export function resolveSubagentWorkingDirectory(
   env: NodeJS.ProcessEnv = process.env,
-  fallbackCwd: string = process.cwd(),
+  fallbackCwd: string = getCurrentWorkingDirectory(),
 ): string {
   return env.USER_CWD || fallbackCwd;
 }
@@ -721,6 +722,7 @@ async function executeSubagent(
       ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
       ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
       LETTA_CODE_AGENT_ROLE: "subagent",
+      USER_CWD: subagentWorkingDirectory,
       ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
     };
 

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -28,7 +28,10 @@ import { permissionMode } from "../../permissions/mode";
 import { sessionPermissions } from "../../permissions/session";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
-import { resolveLettaInvocation } from "../../tools/impl/shellEnv";
+import {
+  resolveEntryScriptPath,
+  resolveLettaInvocation,
+} from "../../tools/impl/shellEnv";
 import { getErrorMessage } from "../../utils/error";
 import { getAvailableModelHandles } from "../available-models";
 import { getClient } from "../client";
@@ -483,6 +486,7 @@ interface ResolveSubagentLauncherOptions {
   argv?: string[];
   execPath?: string;
   platform?: NodeJS.Platform;
+  cwd?: string;
 }
 
 interface SubagentLauncher {
@@ -505,8 +509,9 @@ export function resolveSubagentLauncher(
   const argv = options.argv ?? process.argv;
   const execPath = options.execPath ?? process.execPath;
   const platform = options.platform ?? process.platform;
+  const cwd = options.cwd ?? process.cwd();
 
-  const invocation = resolveLettaInvocation(env, argv, execPath);
+  const invocation = resolveLettaInvocation(env, argv, execPath, cwd);
   if (invocation) {
     return {
       command: invocation.command,
@@ -515,12 +520,13 @@ export function resolveSubagentLauncher(
   }
 
   const currentScript = argv[1] || "";
+  const resolvedCurrentScript = resolveEntryScriptPath(currentScript, cwd);
 
   // Preserve historical subagent behavior: any .ts entrypoint uses runtime binary.
   if (currentScript.endsWith(".ts")) {
     return {
       command: execPath,
-      args: [currentScript, ...cliArgs],
+      args: [resolvedCurrentScript, ...cliArgs],
     };
   }
 
@@ -528,13 +534,13 @@ export function resolveSubagentLauncher(
   if (currentScript.endsWith(".js") && platform === "win32") {
     return {
       command: execPath,
-      args: [currentScript, ...cliArgs],
+      args: [resolvedCurrentScript, ...cliArgs],
     };
   }
 
   if (currentScript.endsWith(".js")) {
     return {
-      command: currentScript,
+      command: resolvedCurrentScript,
       args: cliArgs,
     };
   }

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -26,8 +26,8 @@ import {
   resolveAllowedMemoryRoots,
 } from "../../permissions/memoryScope";
 import { permissionMode } from "../../permissions/mode";
-import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { sessionPermissions } from "../../permissions/session";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import { resolveLettaInvocation } from "../../tools/impl/shellEnv";
 import { getErrorMessage } from "../../utils/error";

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -115,6 +115,7 @@ import {
   resetSharedReminderState,
   syncReminderStateFromContextTracker,
 } from "../reminders/state";
+import { getCurrentWorkingDirectory } from "../runtime-context";
 import { updateProjectSettings } from "../settings";
 import { settingsManager } from "../settings-manager";
 import { telemetry } from "../telemetry";
@@ -2143,7 +2144,7 @@ export default function App({
   }, []);
   const prepareScopedToolExecutionContext = useCallback(
     async (overrideModel?: string | null) => {
-      const workingDirectory = process.env.USER_CWD || process.cwd();
+      const workingDirectory = getCurrentWorkingDirectory();
       const desiredModel = overrideModel ?? currentModelHandle;
 
       if (desiredModel) {

--- a/src/cli/helpers/approvalClassification.ts
+++ b/src/cli/helpers/approvalClassification.ts
@@ -38,6 +38,7 @@ export type ClassifyApprovalsOptions<TContext = ApprovalContext | null> = {
   missingArgsReason?: (missing: string[]) => string;
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  agentId?: string;
 };
 
 export async function getMissingRequiredArgs(
@@ -86,6 +87,7 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       parsedArgs,
       opts.workingDirectory,
       opts.permissionModeState,
+      opts.agentId,
     );
     const context = opts.getContext
       ? await opts.getContext(toolName, parsedArgs, opts.workingDirectory)

--- a/src/helpers/diffPreview.ts
+++ b/src/helpers/diffPreview.ts
@@ -6,6 +6,7 @@
 
 import path, { basename } from "node:path";
 import type { AdvancedDiffResult, AdvancedHunk } from "../cli/helpers/diff";
+import { getCurrentWorkingDirectory } from "../runtime-context";
 import type { DiffHunk, DiffHunkLine, DiffPreview } from "../types/protocol_v2";
 
 function parseHunkLinePrefix(raw: string): DiffHunkLine | null {
@@ -124,7 +125,7 @@ async function getDiffDeps(): Promise<DiffDeps> {
 export async function computeDiffPreviews(
   toolName: string,
   toolArgs: Record<string, unknown>,
-  workingDirectory: string = process.env.USER_CWD || process.cwd(),
+  workingDirectory: string = getCurrentWorkingDirectory(),
 ): Promise<DiffPreview[]> {
   const {
     computeAdvancedDiff,

--- a/src/hooks/executor.ts
+++ b/src/hooks/executor.ts
@@ -50,9 +50,19 @@ function trySpawnWithLauncher(
   // Extract agent_id if present (available on many hook input types)
   const agentId = "agent_id" in input ? input.agent_id : undefined;
 
-  // Build environment: start with parent env but exclude LETTA_AGENT_ID to prevent inheritance
-  // We only want to pass the agent ID that's explicitly provided in the hook input
-  const { LETTA_AGENT_ID: _, ...parentEnv } = process.env;
+  // Build environment: start with parent env but strip execution-scoped vars so
+  // hooks only inherit the scoped values we set explicitly for this run.
+  const {
+    LETTA_AGENT_ID: _lettaAgentId,
+    AGENT_ID: _agentId,
+    LETTA_CONVERSATION_ID: _lettaConversationId,
+    CONVERSATION_ID: _conversationId,
+    LETTA_MEMORY_DIR: _lettaMemoryDir,
+    MEMORY_DIR: _memoryDir,
+    USER_CWD: _userCwd,
+    LETTA_WORKING_DIR: _lettaWorkingDir,
+    ...parentEnv
+  } = process.env;
 
   return spawn(executable, args, {
     cwd: workingDirectory,
@@ -61,7 +71,11 @@ function trySpawnWithLauncher(
       // Add hook-specific environment variables
       LETTA_HOOK_EVENT: input.event_type,
       LETTA_WORKING_DIR: workingDirectory,
-      ...(agentId && { LETTA_AGENT_ID: agentId }),
+      USER_CWD: workingDirectory,
+      ...(agentId && {
+        LETTA_AGENT_ID: agentId,
+        AGENT_ID: agentId,
+      }),
     },
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -161,6 +161,7 @@ export async function runPermissionRequestHooks(
   permissionType: "allow" | "deny" | "ask",
   scope?: "session" | "project" | "user",
   workingDirectory: string = process.cwd(),
+  agentId?: string,
 ): Promise<HookExecutionResult> {
   const hooks = await getHooksForEvent(
     "PermissionRequest",
@@ -176,6 +177,7 @@ export async function runPermissionRequestHooks(
     working_directory: workingDirectory,
     tool_name: toolName,
     tool_input: toolInput,
+    agent_id: agentId,
     permission: {
       type: permissionType,
       scope,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -302,6 +302,8 @@ export interface PermissionRequestHookInput extends HookInputBase {
   tool_name: string;
   /** Tool input arguments */
   tool_input: Record<string, unknown>;
+  /** Agent ID if available */
+  agent_id?: string;
   /** Permission being requested */
   permission: {
     type: "allow" | "deny" | "ask";

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -139,6 +139,7 @@ export function checkPermission(
   permissions: PermissionRules,
   workingDirectory: string = process.cwd(),
   modeState?: PermissionModeState,
+  agentId?: string,
 ): PermissionCheckResult {
   const engine: PermissionEngine = isPermissionsV2Enabled() ? "v2" : "v1";
   const primary = checkPermissionForEngine(
@@ -148,6 +149,7 @@ export function checkPermission(
     permissions,
     workingDirectory,
     modeState,
+    agentId,
   );
 
   let result: PermissionCheckResult = primary.result;
@@ -178,6 +180,7 @@ export function checkPermission(
       permissions,
       workingDirectory,
       modeState,
+      agentId,
     );
 
     const mismatch =
@@ -253,6 +256,7 @@ function checkPermissionForEngine(
   permissions: PermissionRules,
   workingDirectory: string,
   modeState?: PermissionModeState,
+  agentId?: string,
 ): { result: PermissionCheckResult; trace: PermissionCheckTrace } {
   const canonicalTool = canonicalToolName(toolName);
   const queryTool = engine === "v2" ? canonicalTool : toolName;
@@ -269,6 +273,7 @@ function checkPermissionForEngine(
     toolName,
     toolArgs,
     workingDirectory,
+    { currentAgentId: agentId },
   );
   if (guardResult) {
     traceEvent(trace, "cross-agent-guard", guardResult.reason);
@@ -419,8 +424,8 @@ function checkPermissionForEngine(
     }
     if (shellCommand) {
       try {
-        const agentId = getCurrentAgentId();
-        if (isMemoryDirCommand(shellCommand, agentId)) {
+        const resolvedAgentId = agentId ?? getCurrentAgentId();
+        if (isMemoryDirCommand(shellCommand, resolvedAgentId)) {
           traceEvent(
             trace,
             "memory-dir-auto-allow",
@@ -807,6 +812,7 @@ export async function checkPermissionWithHooks(
   permissions: PermissionRules,
   workingDirectory: string = process.cwd(),
   modeState?: PermissionModeState,
+  agentId?: string,
 ): Promise<PermissionCheckResult> {
   // First, check permission using normal rules
   const result = checkPermission(
@@ -815,6 +821,7 @@ export async function checkPermissionWithHooks(
     permissions,
     workingDirectory,
     modeState,
+    agentId,
   );
 
   // If decision is "ask", run PermissionRequest hooks to see if they auto-allow/deny
@@ -825,6 +832,7 @@ export async function checkPermissionWithHooks(
       "ask",
       undefined,
       workingDirectory,
+      agentId,
     );
 
     // If hook blocked (exit code 2), deny the permission

--- a/src/permissions/memoryScope.ts
+++ b/src/permissions/memoryScope.ts
@@ -146,14 +146,12 @@ export function deriveAgentId(
   const explicit = explicitAgentId?.trim();
   if (explicit) return explicit;
 
-  const envAgentId = (env.AGENT_ID || env.LETTA_AGENT_ID || "").trim();
-  if (envAgentId) return envAgentId;
-
   try {
     const fromContext = getCurrentAgentId().trim();
     return fromContext || null;
   } catch {
-    return null;
+    const envAgentId = (env.AGENT_ID || env.LETTA_AGENT_ID || "").trim();
+    return envAgentId || null;
   }
 }
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { HooksConfig } from "./hooks/types";
 import type { PermissionRules } from "./permissions/types";
+import { getRuntimeContext } from "./runtime-context";
 import { trackBoundaryError } from "./telemetry/errorReporting";
 import { debugWarn } from "./utils/debug.js";
 import { exists, mkdir, readFile, writeFile } from "./utils/fs.js";
@@ -217,6 +218,7 @@ class SettingsManager {
   // Keys explicitly changed by this process. Only these keys are written back,
   // preventing stale in-memory values from clobbering external updates.
   private dirtyKeys = new Set<string>();
+  private secureTokensCache: SecureTokens = {};
 
   // Mark keys as managed AND dirty (i.e. this process owns the value and it
   // should be written back on persist). The only call-site that should add to
@@ -227,6 +229,19 @@ class SettingsManager {
       this.managedKeys.add(key);
       this.dirtyKeys.add(key);
     }
+  }
+
+  private updateSecureTokensCache(tokens: SecureTokens): void {
+    if (tokens.apiKey) {
+      this.secureTokensCache.apiKey = tokens.apiKey;
+    }
+    if (tokens.refreshToken) {
+      this.secureTokensCache.refreshToken = tokens.refreshToken;
+    }
+  }
+
+  private clearSecureTokensCache(): void {
+    this.secureTokensCache = {};
   }
 
   /**
@@ -360,6 +375,7 @@ class SettingsManager {
         if (available) {
           try {
             await setSecureTokens(tokensToMigrate);
+            this.updateSecureTokensCache(tokensToMigrate);
 
             // Remove tokens from settings file
             const updatedSettings = { ...this.settings };
@@ -464,12 +480,19 @@ class SettingsManager {
    */
   async getSettingsWithSecureTokens(): Promise<Settings> {
     const baseSettings = this.getSettings();
-    let secureTokens: SecureTokens = {};
+    let secureTokens: SecureTokens = { ...this.secureTokensCache };
 
-    // Try to get tokens from secrets first
-    const secretsAvailable = await this.isKeychainAvailable();
-    if (secretsAvailable) {
-      secureTokens = await this.getSecureTokens();
+    // Bun 1.3.0 can crash when keychain reads happen while AsyncLocalStorage
+    // runtime scope is active. Reuse cached tokens in that case and let callers
+    // fall back to env/file-backed settings if no cache is available yet.
+    if (!getRuntimeContext()) {
+      const secretsAvailable = await this.isKeychainAvailable();
+      if (secretsAvailable) {
+        secureTokens = {
+          ...secureTokens,
+          ...(await this.getSecureTokens()),
+        };
+      }
     }
 
     // Fallback to tokens in settings file if secrets are not available
@@ -498,6 +521,10 @@ class SettingsManager {
    */
   getSetting<K extends keyof Settings>(key: K): Settings[K] {
     return this.getSettings()[key];
+  }
+
+  getCachedSecureTokens(): SecureTokens {
+    return { ...this.secureTokensCache };
   }
 
   /**
@@ -1749,7 +1776,9 @@ class SettingsManager {
     }
 
     try {
-      return await getSecureTokens();
+      const tokens = await getSecureTokens();
+      this.updateSecureTokensCache(tokens);
+      return tokens;
     } catch (error) {
       trackBoundaryError({
         errorType: "secrets_retrieve_tokens_failed",
@@ -1765,6 +1794,7 @@ class SettingsManager {
    * Store secure tokens in secrets
    */
   async setSecureTokens(tokens: SecureTokens): Promise<void> {
+    this.updateSecureTokensCache(tokens);
     const available = await this.isKeychainAvailable();
     if (!available) {
       debugWarn(
@@ -1794,6 +1824,7 @@ class SettingsManager {
    * Delete secure tokens from secrets
    */
   async deleteSecureTokens(): Promise<void> {
+    this.clearSecureTokensCache();
     const available = await this.isKeychainAvailable();
     if (!available) {
       return;
@@ -1877,6 +1908,7 @@ class SettingsManager {
     this.secretsAvailable = null;
     this.managedKeys.clear();
     this.dirtyKeys.clear();
+    this.clearSecureTokensCache();
   }
 }
 

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -293,6 +293,99 @@ describe("buildClientSkillsPayload", () => {
     }
   });
 
+  test("prefers scoped agent memfs skills over stale MEMORY_DIR env", async () => {
+    const { buildClientSkillsPayload } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const originalMemoryDir = process.env.MEMORY_DIR;
+    const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+    const originalHome = process.env.HOME;
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-client-skills-"));
+
+    try {
+      const staleMemoryDir = join(tempRoot, "stale-memory");
+      const staleSkillDir = join(staleMemoryDir, "skills", "shared-skill");
+      const scopedMemorySkillDir = join(
+        tempRoot,
+        ".letta",
+        "agents",
+        "agent-1",
+        "memory",
+        "skills",
+        "shared-skill",
+      );
+      await mkdir(staleSkillDir, { recursive: true });
+      await mkdir(scopedMemorySkillDir, { recursive: true });
+      await writeFile(
+        join(staleSkillDir, "SKILL.md"),
+        [
+          "---",
+          "id: shared-skill",
+          "name: shared-skill",
+          "description: from stale env",
+          "---",
+          "",
+          "Stale body",
+        ].join("\n"),
+      );
+      await writeFile(
+        join(scopedMemorySkillDir, "SKILL.md"),
+        [
+          "---",
+          "id: shared-skill",
+          "name: shared-skill",
+          "description: from scoped agent",
+          "---",
+          "",
+          "Scoped body",
+        ].join("\n"),
+      );
+
+      process.env.MEMORY_DIR = staleMemoryDir;
+      delete process.env.LETTA_MEMORY_DIR;
+      process.env.HOME = tempRoot;
+
+      const result = await buildClientSkillsPayload({
+        agentId: "agent-1",
+        skillsDirectory: "/tmp/.skills",
+        skillSources: ["global"],
+        discoverSkillsFn: async (): Promise<SkillDiscoveryResult> => ({
+          skills: [],
+          errors: [],
+        }),
+      });
+
+      expect(result.clientSkills).toEqual([
+        {
+          name: "shared-skill",
+          description: "from scoped agent",
+          location: join(scopedMemorySkillDir, "SKILL.md"),
+        },
+      ]);
+      expect(result.skillPathById).toEqual({
+        "shared-skill": join(scopedMemorySkillDir, "SKILL.md"),
+      });
+    } finally {
+      if (originalMemoryDir === undefined) {
+        delete process.env.MEMORY_DIR;
+      } else {
+        process.env.MEMORY_DIR = originalMemoryDir;
+      }
+      if (originalLettaMemoryDir === undefined) {
+        delete process.env.LETTA_MEMORY_DIR;
+      } else {
+        process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("does not let memfs skills override agent or project sources", async () => {
     const { buildClientSkillsPayload } = await import(
       "../../agent/clientSkills"

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -386,6 +386,83 @@ describe("buildClientSkillsPayload", () => {
     }
   });
 
+  test("does not advertise env-only memfs skills when scoped agent memory is present", async () => {
+    const { buildClientSkillsPayload } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const originalMemoryDir = process.env.MEMORY_DIR;
+    const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+    const originalHome = process.env.HOME;
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-client-skills-"));
+
+    try {
+      const staleMemoryDir = join(tempRoot, "stale-memory");
+      const staleSkillDir = join(
+        staleMemoryDir,
+        "skills",
+        "env-only-stale-skill",
+      );
+      const scopedMemorySkillsDir = join(
+        tempRoot,
+        ".letta",
+        "agents",
+        "agent-1",
+        "memory",
+        "skills",
+      );
+
+      await mkdir(staleSkillDir, { recursive: true });
+      await mkdir(scopedMemorySkillsDir, { recursive: true });
+      await writeFile(
+        join(staleSkillDir, "SKILL.md"),
+        [
+          "---",
+          "id: env-only-stale-skill",
+          "name: env-only-stale-skill",
+          "description: from stale env",
+          "---",
+          "",
+          "Stale body",
+        ].join("\n"),
+      );
+
+      process.env.MEMORY_DIR = staleMemoryDir;
+      delete process.env.LETTA_MEMORY_DIR;
+      process.env.HOME = tempRoot;
+
+      const result = await buildClientSkillsPayload({
+        agentId: "agent-1",
+        skillsDirectory: "/tmp/.skills",
+        skillSources: ["global"],
+        discoverSkillsFn: async (): Promise<SkillDiscoveryResult> => ({
+          skills: [],
+          errors: [],
+        }),
+      });
+
+      expect(result.clientSkills).toEqual([]);
+      expect(result.skillPathById).toEqual({});
+    } finally {
+      if (originalMemoryDir === undefined) {
+        delete process.env.MEMORY_DIR;
+      } else {
+        process.env.MEMORY_DIR = originalMemoryDir;
+      }
+      if (originalLettaMemoryDir === undefined) {
+        delete process.env.LETTA_MEMORY_DIR;
+      } else {
+        process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("does not let memfs skills override agent or project sources", async () => {
     const { buildClientSkillsPayload } = await import(
       "../../agent/clientSkills"

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -58,6 +58,32 @@ describe("resolveSubagentLauncher", () => {
     });
   });
 
+  test("resolves relative dev entrypoint against launcher cwd", () => {
+    const launcher = resolveSubagentLauncher(
+      ["--output-format", "stream-json"],
+      {
+        env: {} as NodeJS.ProcessEnv,
+        argv: ["bun", "src/index.ts"],
+        execPath: "/opt/homebrew/bin/bun",
+        platform: "darwin",
+        cwd: "/Users/example/dev/letta-code-prod",
+      },
+    );
+
+    expect(launcher).toEqual({
+      command: "/opt/homebrew/bin/bun",
+      args: [
+        "--loader:.md=text",
+        "--loader:.mdx=text",
+        "--loader:.txt=text",
+        "run",
+        "/Users/example/dev/letta-code-prod/src/index.ts",
+        "--output-format",
+        "stream-json",
+      ],
+    });
+  });
+
   test("uses node runtime for bundled js on win32", () => {
     const launcher = resolveSubagentLauncher(["-p", "prompt"], {
       env: {} as NodeJS.ProcessEnv,

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 import type { SubagentConfig } from "../../agent/subagents";
 import {
   buildSubagentArgs,
@@ -59,25 +60,38 @@ describe("resolveSubagentLauncher", () => {
   });
 
   test("resolves relative dev entrypoint against launcher cwd", () => {
+    const cwd =
+      process.platform === "win32"
+        ? path.win32.join("C:\\", "Users", "example", "dev", "letta-code-prod")
+        : path.posix.join("/", "Users", "example", "dev", "letta-code-prod");
+    const expectedScriptPath =
+      process.platform === "win32"
+        ? path.win32.join(cwd, "src", "index.ts")
+        : path.posix.join(cwd, "src", "index.ts");
+    const execPath =
+      process.platform === "win32"
+        ? "C:\\bun\\bun.exe"
+        : "/opt/homebrew/bin/bun";
+
     const launcher = resolveSubagentLauncher(
       ["--output-format", "stream-json"],
       {
         env: {} as NodeJS.ProcessEnv,
         argv: ["bun", "src/index.ts"],
-        execPath: "/opt/homebrew/bin/bun",
-        platform: "darwin",
-        cwd: "/Users/example/dev/letta-code-prod",
+        execPath,
+        platform: process.platform,
+        cwd,
       },
     );
 
     expect(launcher).toEqual({
-      command: "/opt/homebrew/bin/bun",
+      command: execPath,
       args: [
         "--loader:.md=text",
         "--loader:.mdx=text",
         "--loader:.txt=text",
         "run",
-        "/Users/example/dev/letta-code-prod/src/index.ts",
+        expectedScriptPath,
         "--output-format",
         "stream-json",
       ],

--- a/src/tests/hooks/executor.test.ts
+++ b/src/tests/hooks/executor.test.ts
@@ -179,7 +179,9 @@ describe.skipIf(isWindows)("Hooks Executor", () => {
       const result = await executeHookCommand(hook, input, tempDir);
 
       expect(result.exitCode).toBe(HookExitCode.ALLOW);
-      expect(result.stdout).toBe(`agent-test-12345:agent-test-12345:${tempDir}`);
+      expect(result.stdout).toBe(
+        `agent-test-12345:agent-test-12345:${tempDir}`,
+      );
     });
 
     test("LETTA_AGENT_ID is not set when agent_id is not provided", async () => {

--- a/src/tests/hooks/executor.test.ts
+++ b/src/tests/hooks/executor.test.ts
@@ -162,10 +162,10 @@ describe.skipIf(isWindows)("Hooks Executor", () => {
       expect(result.stdout).toBe("PreToolUse");
     });
 
-    test("receives LETTA_AGENT_ID environment variable when agent_id is provided", async () => {
+    test("receives scoped agent aliases and cwd environment variables when agent_id is provided", async () => {
       const hook: HookCommand = {
         type: "command",
-        command: "echo $LETTA_AGENT_ID",
+        command: 'echo "$LETTA_AGENT_ID:$AGENT_ID:$USER_CWD"',
       };
 
       const input: PreToolUseHookInput = {
@@ -179,7 +179,7 @@ describe.skipIf(isWindows)("Hooks Executor", () => {
       const result = await executeHookCommand(hook, input, tempDir);
 
       expect(result.exitCode).toBe(HookExitCode.ALLOW);
-      expect(result.stdout).toBe("agent-test-12345");
+      expect(result.stdout).toBe(`agent-test-12345:agent-test-12345:${tempDir}`);
     });
 
     test("LETTA_AGENT_ID is not set when agent_id is not provided", async () => {

--- a/src/tests/hooks/integration.test.ts
+++ b/src/tests/hooks/integration.test.ts
@@ -2,7 +2,7 @@
 // Integration tests for all 11 hook types
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -19,6 +19,7 @@ import {
   runSubagentStopHooks,
   runUserPromptSubmitHooks,
 } from "../../hooks";
+import { checkPermissionWithHooks } from "../../permissions/checker";
 import { settingsManager } from "../../settings-manager";
 
 // Skip on Windows - test commands use bash syntax (&&, >&2, etc.)
@@ -483,7 +484,7 @@ describe.skipIf(isWindows)("Hooks Integration Tests", () => {
       expect(result.feedback[0]).toContain("Denied: dangerous command");
     });
 
-    test("receives permission type and scope in input", async () => {
+    test("receives permission type, scope, and agent_id in input", async () => {
       createHooksConfig({
         PermissionRequest: [
           {
@@ -499,11 +500,39 @@ describe.skipIf(isWindows)("Hooks Integration Tests", () => {
         "allow",
         "project",
         tempDir,
+        "agent-permission-input",
       );
 
       const parsed = JSON.parse(result.results[0]?.stdout || "{}");
       expect(parsed.permission?.type).toBe("allow");
       expect(parsed.permission?.scope).toBe("project");
+      expect(parsed.agent_id).toBe("agent-permission-input");
+    });
+
+    test("checkPermissionWithHooks passes agent_id through the permission-request path", async () => {
+      createHooksConfig({
+        PermissionRequest: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "cat > permission-request.json" }],
+          },
+        ],
+      });
+
+      const result = await checkPermissionWithHooks(
+        "Bash",
+        { command: "touch permission-trigger.txt" },
+        { allow: [], deny: [], ask: [] },
+        tempDir,
+        undefined,
+        "agent-checker-path",
+      );
+
+      const parsed = JSON.parse(
+        readFileSync(join(tempDir, "permission-request.json"), "utf8"),
+      );
+      expect(result.decision).toBe("allow");
+      expect(parsed.agent_id).toBe("agent-checker-path");
     });
   });
 

--- a/src/tests/hooks/integration.test.ts
+++ b/src/tests/hooks/integration.test.ts
@@ -514,7 +514,9 @@ describe.skipIf(isWindows)("Hooks Integration Tests", () => {
         PermissionRequest: [
           {
             matcher: "Bash",
-            hooks: [{ type: "command", command: "cat > permission-request.json" }],
+            hooks: [
+              { type: "command", command: "cat > permission-request.json" },
+            ],
           },
         ],
       });

--- a/src/tests/hooks/prompt-executor.test.ts
+++ b/src/tests/hooks/prompt-executor.test.ts
@@ -7,12 +7,12 @@ import {
   mock,
   test,
 } from "bun:test";
-import { executePromptHook } from "../../hooks/prompt-executor";
 import {
   HookExitCode,
   type PreToolUseHookInput,
   type StopHookInput,
 } from "../../hooks/types";
+import { runWithRuntimeContext } from "../../runtime-context";
 
 interface GenerateOpts {
   body: {
@@ -39,16 +39,11 @@ const mockPost = mock(
 );
 const mockGetClient = mock(() => Promise.resolve({ post: mockPost }));
 
-// Mock getCurrentAgentId
-const mockGetCurrentAgentId = mock(() => "agent-test-123");
-
 mock.module("../../agent/client", () => ({
   getClient: mockGetClient,
 }));
 
-mock.module("../../agent/context", () => ({
-  getCurrentAgentId: mockGetCurrentAgentId,
-}));
+const { executePromptHook } = await import("../../hooks/prompt-executor");
 
 /** Helper to get the first call's [path, opts] from mockPost */
 function firstPostCall(): [string, GenerateOpts] {
@@ -62,7 +57,6 @@ describe("Prompt Hook Executor", () => {
   beforeEach(() => {
     mockPost.mockClear();
     mockGetClient.mockClear();
-    mockGetCurrentAgentId.mockClear();
 
     // Default: allow
     mockPost.mockResolvedValue({
@@ -232,8 +226,6 @@ describe("Prompt Hook Executor", () => {
     });
 
     test("falls back to getCurrentAgentId when input has no agent_id", async () => {
-      mockGetCurrentAgentId.mockReturnValue("agent-from-context");
-
       const hook = {
         type: "prompt" as const,
         prompt: "Check this",
@@ -244,16 +236,15 @@ describe("Prompt Hook Executor", () => {
         stop_reason: "end_turn",
       };
 
-      await executePromptHook(hook, input);
+      await runWithRuntimeContext({ agentId: "agent-from-context" }, () =>
+        executePromptHook(hook, input),
+      );
 
       const [path] = firstPostCall();
       expect(path).toBe("/v1/agents/agent-from-context/generate");
     });
 
     test("falls back to LETTA_AGENT_ID env var when context unavailable", async () => {
-      mockGetCurrentAgentId.mockImplementation(() => {
-        throw new Error("No agent context set");
-      });
       process.env.LETTA_AGENT_ID = "agent-from-env";
 
       const hook = {
@@ -266,16 +257,15 @@ describe("Prompt Hook Executor", () => {
         stop_reason: "end_turn",
       };
 
-      await executePromptHook(hook, input);
+      await runWithRuntimeContext({ agentId: null }, () =>
+        executePromptHook(hook, input),
+      );
 
       const [path] = firstPostCall();
       expect(path).toBe("/v1/agents/agent-from-env/generate");
     });
 
     test("returns ERROR when no agent_id available", async () => {
-      mockGetCurrentAgentId.mockImplementation(() => {
-        throw new Error("No agent context set");
-      });
       delete process.env.LETTA_AGENT_ID;
 
       const hook = {
@@ -288,7 +278,9 @@ describe("Prompt Hook Executor", () => {
         stop_reason: "end_turn",
       };
 
-      const result = await executePromptHook(hook, input);
+      const result = await runWithRuntimeContext({ agentId: null }, () =>
+        executePromptHook(hook, input),
+      );
 
       expect(result.exitCode).toBe(HookExitCode.ERROR);
       expect(result.error).toContain("agent_id");

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CommandHookConfig, HookCommand } from "../hooks/types";
+import { runWithRuntimeContext } from "../runtime-context";
 import { settingsManager } from "../settings-manager";
 
 // Type-safe helper to extract command from a hook (tests only use command hooks)
@@ -16,6 +17,7 @@ function asCommand(
 }
 
 import {
+  __setSecretGetOverrideForTests,
   deleteSecureTokens,
   isKeychainAvailable,
   setServiceName,
@@ -264,6 +266,44 @@ describe("Settings Manager - Global Settings", () => {
       expect(typeof settingsWithTokens.tokenExpiresAt).toBe("number");
     },
   );
+
+  test("runtime-scoped lookups reuse cached secure tokens without re-reading secrets", async () => {
+    const originalIsKeychainAvailable =
+      settingsManager.isKeychainAvailable.bind(settingsManager);
+
+    try {
+      settingsManager.isKeychainAvailable = async () => true;
+      __setSecretGetOverrideForTests(async ({ name }) => {
+        if (name === "letta-api-key") {
+          return "sk-runtime-cache";
+        }
+        if (name === "letta-refresh-token") {
+          return "rt-runtime-cache";
+        }
+        return null;
+      });
+
+      const initialSettings =
+        await settingsManager.getSettingsWithSecureTokens();
+      expect(initialSettings.env?.LETTA_API_KEY).toBe("sk-runtime-cache");
+      expect(initialSettings.refreshToken).toBe("rt-runtime-cache");
+
+      __setSecretGetOverrideForTests(async () => {
+        throw new Error("runtime-scoped lookup should reuse cached tokens");
+      });
+
+      const runtimeSettings = await runWithRuntimeContext(
+        { agentId: "agent-runtime-test" },
+        () => settingsManager.getSettingsWithSecureTokens(),
+      );
+
+      expect(runtimeSettings.env?.LETTA_API_KEY).toBe("sk-runtime-cache");
+      expect(runtimeSettings.refreshToken).toBe("rt-runtime-cache");
+    } finally {
+      settingsManager.isKeychainAvailable = originalIsKeychainAvailable;
+      __setSecretGetOverrideForTests(null);
+    }
+  });
 
   test("LETTA_BASE_URL should not be cached in settings", () => {
     // This test verifies that LETTA_BASE_URL is NOT persisted to settings

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -13,15 +13,12 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { runWithRuntimeContext } from "../../runtime-context";
 
 const execFile = promisify(execFileCb);
 
 const TEST_AGENT_ID = "agent-test-memory-apply-patch";
 const TEST_AGENT_NAME = "Bob";
-
-mock.module("../../agent/context", () => ({
-  getCurrentAgentId: () => TEST_AGENT_ID,
-}));
 
 mock.module("../../agent/client", () => ({
   getClient: mock(() =>
@@ -37,6 +34,14 @@ mock.module("../../agent/client", () => ({
 const { memory_apply_patch } = await import(
   "../../tools/impl/MemoryApplyPatch"
 );
+
+function runScopedMemoryApplyPatch(
+  args: Parameters<typeof memory_apply_patch>[0],
+) {
+  return runWithRuntimeContext({ agentId: TEST_AGENT_ID }, () =>
+    memory_apply_patch(args),
+  );
+}
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFile("git", args, { cwd });
@@ -82,6 +87,10 @@ describe("memory_apply_patch tool", () => {
   let memoryDir: string;
   let remoteDir: string;
 
+  // Deliberately avoid mock.module("../../agent/context") here so this suite
+  // doesn't leak agent identity into unrelated tests through Bun's shared
+  // module graph.
+
   const originalMemoryDir = process.env.MEMORY_DIR;
   const originalAgentId = process.env.AGENT_ID;
   const originalAgentName = process.env.AGENT_NAME;
@@ -124,7 +133,7 @@ describe("memory_apply_patch tool", () => {
 
   test("requires reason and input", async () => {
     await expect(
-      memory_apply_patch({
+      runScopedMemoryApplyPatch({
         input: "*** Begin Patch\n*** End Patch",
       } as Parameters<typeof memory_apply_patch>[0]),
     ).rejects.toThrow(/missing required parameter/i);
@@ -141,7 +150,7 @@ describe("memory_apply_patch tool", () => {
       "*** End Patch",
     ].join("\n");
 
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "Create contacts memory via patch",
       input: seedPatch,
     });
@@ -155,7 +164,7 @@ describe("memory_apply_patch tool", () => {
       "*** End Patch",
     ].join("\n");
 
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "Refine contacts memory via patch",
       input: updatePatch,
     });
@@ -185,7 +194,7 @@ describe("memory_apply_patch tool", () => {
     await initTrackedMemoryRepo(staleMemoryDir, scopedRemoteDir);
     process.env.MEMORY_DIR = staleMemoryDir;
 
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "Create scoped memory file via patch",
       input: [
         "*** Begin Patch",
@@ -217,7 +226,7 @@ describe("memory_apply_patch tool", () => {
     ].join("\n");
 
     await expect(
-      memory_apply_patch({
+      runScopedMemoryApplyPatch({
         reason: "should fail",
         input: patch,
       }),
@@ -227,7 +236,7 @@ describe("memory_apply_patch tool", () => {
   test("accepts absolute paths under MEMORY_DIR", async () => {
     const absolutePath = join(memoryDir, "system", "absolute.md");
 
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "add absolute memory path",
       input: [
         "*** Begin Patch",
@@ -262,7 +271,7 @@ describe("memory_apply_patch tool", () => {
     await runGit(memoryDir, ["push", "origin", "main"]);
 
     await expect(
-      memory_apply_patch({
+      runScopedMemoryApplyPatch({
         reason: "attempt edit ro",
         input: [
           "*** Begin Patch",
@@ -277,7 +286,7 @@ describe("memory_apply_patch tool", () => {
   });
 
   test("returns error when push fails but keeps local commit", async () => {
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "seed notes",
       input: [
         "*** Begin Patch",
@@ -296,7 +305,7 @@ describe("memory_apply_patch tool", () => {
 
     const reason = "Update notes with failing push";
     await expect(
-      memory_apply_patch({
+      runScopedMemoryApplyPatch({
         reason,
         input: [
           "*** Begin Patch",
@@ -318,7 +327,7 @@ describe("memory_apply_patch tool", () => {
   });
 
   test("replays patches on top of newer remote memory", async () => {
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "seed replay patch notes",
       input: [
         "*** Begin Patch",
@@ -344,7 +353,7 @@ describe("memory_apply_patch tool", () => {
     await runGit(remoteCloneDir, ["commit", "-m", "Remote patch update"]);
     await runGit(remoteCloneDir, ["push", "origin", "main"]);
 
-    const result = await memory_apply_patch({
+    const result = await runScopedMemoryApplyPatch({
       reason: "Replay patch update",
       input: [
         "*** Begin Patch",
@@ -377,7 +386,7 @@ describe("memory_apply_patch tool", () => {
   });
 
   test("fails closed when replayed patch no longer matches remote", async () => {
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "seed conflicting patch notes",
       input: [
         "*** Begin Patch",
@@ -402,7 +411,7 @@ describe("memory_apply_patch tool", () => {
     await runGit(remoteCloneDir, ["push", "origin", "main"]);
 
     await expect(
-      memory_apply_patch({
+      runScopedMemoryApplyPatch({
         reason: "Attempt conflicting patch replay",
         input: [
           "*** Begin Patch",
@@ -441,7 +450,7 @@ describe("memory_apply_patch tool", () => {
   });
 
   test("updates files that omit frontmatter limit", async () => {
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "seed no-limit memory",
       input: [
         "*** Begin Patch",
@@ -454,7 +463,7 @@ describe("memory_apply_patch tool", () => {
       ].join("\n"),
     });
 
-    await memory_apply_patch({
+    await runScopedMemoryApplyPatch({
       reason: "update no-limit memory",
       input: [
         "*** Begin Patch",

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -52,6 +52,22 @@ async function cloneRemoteRepo(
   await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
 }
 
+async function initTrackedMemoryRepo(
+  repoDir: string,
+  remoteDir: string,
+): Promise<void> {
+  await execFile("git", ["init", "--bare", remoteDir]);
+  await execFile("git", ["init", "-b", "main", repoDir]);
+  await runGit(repoDir, ["config", "user.name", "setup"]);
+  await runGit(repoDir, ["config", "user.email", "setup@example.com"]);
+  await runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+
+  writeFileSync(join(repoDir, ".gitkeep"), "", "utf8");
+  await runGit(repoDir, ["add", ".gitkeep"]);
+  await runGit(repoDir, ["commit", "-m", "initial"]);
+  await runGit(repoDir, ["push", "-u", "origin", "main"]);
+}
+
 async function listRescueRefs(cwd: string): Promise<string[]> {
   const output = await runGit(cwd, [
     "for-each-ref",
@@ -69,23 +85,16 @@ describe("memory_apply_patch tool", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
   const originalAgentId = process.env.AGENT_ID;
   const originalAgentName = process.env.AGENT_NAME;
+  const originalHome = process.env.HOME;
 
   beforeEach(async () => {
     tempRoot = mkdtempSync(join(tmpdir(), "letta-memory-apply-patch-"));
-    memoryDir = join(tempRoot, "memory");
+    memoryDir = join(tempRoot, ".letta", "agents", TEST_AGENT_ID, "memory");
     remoteDir = join(tempRoot, "remote.git");
 
-    await execFile("git", ["init", "--bare", remoteDir]);
-    await execFile("git", ["init", "-b", "main", memoryDir]);
-    await runGit(memoryDir, ["config", "user.name", "setup"]);
-    await runGit(memoryDir, ["config", "user.email", "setup@example.com"]);
-    await runGit(memoryDir, ["remote", "add", "origin", remoteDir]);
+    await initTrackedMemoryRepo(memoryDir, remoteDir);
 
-    writeFileSync(join(memoryDir, ".gitkeep"), "", "utf8");
-    await runGit(memoryDir, ["add", ".gitkeep"]);
-    await runGit(memoryDir, ["commit", "-m", "initial"]);
-    await runGit(memoryDir, ["push", "-u", "origin", "main"]);
-
+    process.env.HOME = tempRoot;
     process.env.MEMORY_DIR = memoryDir;
     process.env.AGENT_ID = TEST_AGENT_ID;
     process.env.AGENT_NAME = TEST_AGENT_NAME;
@@ -100,6 +109,9 @@ describe("memory_apply_patch tool", () => {
 
     if (originalAgentName === undefined) delete process.env.AGENT_NAME;
     else process.env.AGENT_NAME = originalAgentName;
+
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
 
     if (tempRoot) {
       await rm(tempRoot, { recursive: true, force: true });
@@ -163,6 +175,37 @@ describe("memory_apply_patch tool", () => {
     expect(subject).toBe("Refine contacts memory via patch");
     expect(authorName).toBe(TEST_AGENT_NAME);
     expect(authorEmail).toBe(`${TEST_AGENT_ID}@letta.com`);
+  });
+
+  test("prefers scoped agent memory over stale MEMORY_DIR env", async () => {
+    const scopedMemoryDir = memoryDir;
+    const staleMemoryDir = join(tempRoot, "stale-memory");
+    const scopedRemoteDir = join(tempRoot, "scoped-remote.git");
+
+    await initTrackedMemoryRepo(staleMemoryDir, scopedRemoteDir);
+    process.env.MEMORY_DIR = staleMemoryDir;
+
+    await memory_apply_patch({
+      reason: "Create scoped memory file via patch",
+      input: [
+        "*** Begin Patch",
+        "*** Add File: system/scoped.md",
+        "+---",
+        "+description: Scoped file",
+        "+---",
+        "+scoped body",
+        "*** End Patch",
+      ].join("\n"),
+    });
+
+    const scopedContent = await runGit(scopedMemoryDir, [
+      "show",
+      "HEAD:system/scoped.md",
+    ]);
+    expect(scopedContent).toContain("scoped body");
+
+    const staleStatus = await runGit(staleMemoryDir, ["status", "--short"]);
+    expect(staleStatus).not.toContain("scoped.md");
   });
 
   test("rejects absolute paths outside MEMORY_DIR", async () => {

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -13,15 +13,12 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { runWithRuntimeContext } from "../../runtime-context";
 
 const execFile = promisify(execFileCb);
 
 const TEST_AGENT_ID = "agent-test-memory-tool";
 const TEST_AGENT_NAME = "Bob";
-
-mock.module("../../agent/context", () => ({
-  getCurrentAgentId: () => TEST_AGENT_ID,
-}));
 
 mock.module("../../agent/client", () => ({
   getClient: mock(() =>
@@ -35,6 +32,10 @@ mock.module("../../agent/client", () => ({
 }));
 
 const { memory } = await import("../../tools/impl/Memory");
+
+function runScopedMemory(args: Parameters<typeof memory>[0]) {
+  return runWithRuntimeContext({ agentId: TEST_AGENT_ID }, () => memory(args));
+}
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFile("git", args, { cwd });
@@ -80,6 +81,10 @@ describe("memory tool", () => {
   let memoryDir: string;
   let remoteDir: string;
 
+  // Deliberately avoid mock.module("../../agent/context") here so this suite
+  // doesn't leak agent identity into unrelated tests through Bun's shared
+  // module graph.
+
   const originalMemoryDir = process.env.MEMORY_DIR;
   const originalAgentId = process.env.AGENT_ID;
   const originalAgentName = process.env.AGENT_NAME;
@@ -122,7 +127,7 @@ describe("memory tool", () => {
 
   test("requires reason", async () => {
     await expect(
-      memory({
+      runScopedMemory({
         command: "create",
         file_path: "system/test.md",
         description: "test desc",
@@ -133,7 +138,7 @@ describe("memory tool", () => {
   test("uses reason as commit message and agent identity as commit author", async () => {
     const reason = "Create coding preferences block";
 
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason,
       file_path: "system/human/prefs/coding.md",
@@ -168,7 +173,7 @@ describe("memory tool", () => {
     await initTrackedMemoryRepo(staleMemoryDir, scopedRemoteDir);
     process.env.MEMORY_DIR = staleMemoryDir;
 
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Create scoped memory file",
       file_path: "system/scoped.md",
@@ -187,7 +192,7 @@ describe("memory tool", () => {
   });
 
   test("returns error when push fails but keeps local commit", async () => {
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Seed notes",
       file_path: "reference/history/notes.md",
@@ -205,7 +210,7 @@ describe("memory tool", () => {
     const reason = "Update notes after remote failure";
 
     await expect(
-      memory({
+      runScopedMemory({
         command: "str_replace",
         reason,
         file_path: "reference/history/notes.md",
@@ -223,7 +228,7 @@ describe("memory tool", () => {
   });
 
   test("replays str_replace on top of newer remote memory", async () => {
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Seed replay notes",
       file_path: "reference/history/notes.md",
@@ -249,7 +254,7 @@ describe("memory tool", () => {
     await runGit(remoteCloneDir, ["commit", "-m", "Remote update notes"]);
     await runGit(remoteCloneDir, ["push", "origin", "main"]);
 
-    const result = await memory({
+    const result = await runScopedMemory({
       command: "str_replace",
       reason: "Replay local replacement",
       file_path: "reference/history/notes.md",
@@ -278,7 +283,7 @@ describe("memory tool", () => {
   });
 
   test("fails closed when replay cannot be applied safely", async () => {
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Seed conflicting notes",
       file_path: "reference/history/notes.md",
@@ -298,7 +303,7 @@ describe("memory tool", () => {
     await runGit(remoteCloneDir, ["push", "origin", "main"]);
 
     await expect(
-      memory({
+      runScopedMemory({
         command: "str_replace",
         reason: "Attempt conflicting replacement",
         file_path: "reference/history/notes.md",
@@ -337,7 +342,7 @@ describe("memory tool", () => {
     delete process.env.LETTA_AGENT_ID;
 
     const reason = "Create identity via context fallback";
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason,
       file_path: "system/human/identity.md",
@@ -356,7 +361,7 @@ describe("memory tool", () => {
   test("accepts relative file paths like system/contacts.md", async () => {
     const reason = "Create contacts via relative path";
 
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason,
       file_path: "system/contacts.md",
@@ -375,7 +380,7 @@ describe("memory tool", () => {
   test("accepts absolute file paths under MEMORY_DIR", async () => {
     const absolutePath = join(memoryDir, "system", "contacts.md");
 
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Create contacts via absolute path",
       file_path: absolutePath,
@@ -392,7 +397,7 @@ describe("memory tool", () => {
   });
 
   test("updates frontmatter description via update_description command", async () => {
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Create coding prefs",
       file_path: "system/human/prefs/coding.md",
@@ -400,7 +405,7 @@ describe("memory tool", () => {
       file_text: "keep body unchanged",
     });
 
-    await memory({
+    await runScopedMemory({
       command: "update_description",
       reason: "Update coding prefs description",
       file_path: "system/human/prefs/coding.md",
@@ -417,7 +422,7 @@ describe("memory tool", () => {
 
   test("rename requires old_path and new_path", async () => {
     await expect(
-      memory({
+      runScopedMemory({
         command: "rename",
         reason: "should fail",
         file_path: "system/contacts.md",
@@ -427,7 +432,7 @@ describe("memory tool", () => {
   });
 
   test("delete supports recursive directory removal", async () => {
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Create draft note one",
       file_path: "reference/history/draft-one.md",
@@ -435,7 +440,7 @@ describe("memory tool", () => {
       file_text: "one",
     });
 
-    await memory({
+    await runScopedMemory({
       command: "create",
       reason: "Create draft note two",
       file_path: "reference/history/draft-two.md",
@@ -443,7 +448,7 @@ describe("memory tool", () => {
       file_text: "two",
     });
 
-    await memory({
+    await runScopedMemory({
       command: "delete",
       reason: "Delete history directory",
       file_path: "reference/history",
@@ -461,7 +466,7 @@ describe("memory tool", () => {
 
   test("rejects absolute paths outside MEMORY_DIR", async () => {
     await expect(
-      memory({
+      runScopedMemory({
         command: "create",
         reason: "should fail",
         file_path: "/memories/contacts",

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -50,6 +50,22 @@ async function cloneRemoteRepo(
   await runGit(cloneDir, ["config", "user.email", "remote-user@example.com"]);
 }
 
+async function initTrackedMemoryRepo(
+  repoDir: string,
+  remoteDir: string,
+): Promise<void> {
+  await execFile("git", ["init", "--bare", remoteDir]);
+  await execFile("git", ["init", "-b", "main", repoDir]);
+  await runGit(repoDir, ["config", "user.name", "setup"]);
+  await runGit(repoDir, ["config", "user.email", "setup@example.com"]);
+  await runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+
+  writeFileSync(join(repoDir, ".gitkeep"), "", "utf8");
+  await runGit(repoDir, ["add", ".gitkeep"]);
+  await runGit(repoDir, ["commit", "-m", "initial"]);
+  await runGit(repoDir, ["push", "-u", "origin", "main"]);
+}
+
 async function listRescueRefs(cwd: string): Promise<string[]> {
   const output = await runGit(cwd, [
     "for-each-ref",
@@ -67,26 +83,16 @@ describe("memory tool", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
   const originalAgentId = process.env.AGENT_ID;
   const originalAgentName = process.env.AGENT_NAME;
+  const originalHome = process.env.HOME;
 
   beforeEach(async () => {
     tempRoot = mkdtempSync(join(tmpdir(), "letta-memory-tool-"));
-    memoryDir = join(tempRoot, "memory");
+    memoryDir = join(tempRoot, ".letta", "agents", TEST_AGENT_ID, "memory");
     remoteDir = join(tempRoot, "remote.git");
 
-    // Bare remote
-    await execFile("git", ["init", "--bare", remoteDir]);
+    await initTrackedMemoryRepo(memoryDir, remoteDir);
 
-    // Local memory repo
-    await execFile("git", ["init", "-b", "main", memoryDir]);
-    await runGit(memoryDir, ["config", "user.name", "setup"]);
-    await runGit(memoryDir, ["config", "user.email", "setup@example.com"]);
-    await runGit(memoryDir, ["remote", "add", "origin", remoteDir]);
-
-    writeFileSync(join(memoryDir, ".gitkeep"), "", "utf8");
-    await runGit(memoryDir, ["add", ".gitkeep"]);
-    await runGit(memoryDir, ["commit", "-m", "initial"]);
-    await runGit(memoryDir, ["push", "-u", "origin", "main"]);
-
+    process.env.HOME = tempRoot;
     process.env.MEMORY_DIR = memoryDir;
     process.env.AGENT_ID = TEST_AGENT_ID;
     process.env.AGENT_NAME = TEST_AGENT_NAME;
@@ -101,6 +107,9 @@ describe("memory tool", () => {
 
     if (originalAgentName === undefined) delete process.env.AGENT_NAME;
     else process.env.AGENT_NAME = originalAgentName;
+
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
 
     if (tempRoot) {
       await rm(tempRoot, { recursive: true, force: true });
@@ -149,6 +158,32 @@ describe("memory tool", () => {
       {},
     ).then((r) => String(r.stdout ?? "").trim());
     expect(remoteSubject).toBe(reason);
+  });
+
+  test("prefers scoped agent memory over stale MEMORY_DIR env", async () => {
+    const scopedMemoryDir = memoryDir;
+    const staleMemoryDir = join(tempRoot, "stale-memory");
+    const scopedRemoteDir = join(tempRoot, "scoped-remote.git");
+
+    await initTrackedMemoryRepo(staleMemoryDir, scopedRemoteDir);
+    process.env.MEMORY_DIR = staleMemoryDir;
+
+    await memory({
+      command: "create",
+      reason: "Create scoped memory file",
+      file_path: "system/scoped.md",
+      description: "Scoped file",
+      file_text: "scoped body",
+    });
+
+    const scopedContent = await runGit(scopedMemoryDir, [
+      "show",
+      "HEAD:system/scoped.md",
+    ]);
+    expect(scopedContent).toContain("scoped body");
+
+    const staleStatus = await runGit(staleMemoryDir, ["status", "--short"]);
+    expect(staleStatus).not.toContain("scoped.md");
   });
 
   test("returns error when push fails but keeps local commit", async () => {

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { runWithRuntimeContext } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import {
   ensureLettaShimDir,
@@ -190,6 +191,63 @@ test("getShellEnv injects AGENT_ID aliases", () => {
     expect(env.AGENT_ID).toBeTruthy();
     expect(env.LETTA_AGENT_ID).toBe(env.AGENT_ID);
   });
+});
+
+test("getShellEnv prefers runtime-scoped agent, conversation, and cwd", () => {
+  const env = runWithRuntimeContext(
+    {
+      agentId: "agent-runtime-scope",
+      conversationId: "conv-runtime-scope",
+      workingDirectory: "/tmp/runtime-scope-cwd",
+    },
+    () => getShellEnv(),
+  );
+
+  expect(env.AGENT_ID).toBe("agent-runtime-scope");
+  expect(env.LETTA_AGENT_ID).toBe("agent-runtime-scope");
+  expect(env.CONVERSATION_ID).toBe("conv-runtime-scope");
+  expect(env.LETTA_CONVERSATION_ID).toBe("conv-runtime-scope");
+  expect(env.USER_CWD).toBe("/tmp/runtime-scope-cwd");
+});
+
+test("getShellEnv isolates overlapping runtime scopes", async () => {
+  let releaseAgentA!: () => void;
+  const waitForAgentA = new Promise<void>((resolve) => {
+    releaseAgentA = resolve;
+  });
+
+  const taskA = runWithRuntimeContext(
+    {
+      agentId: "agent-a",
+      conversationId: "conv-a",
+      workingDirectory: "/tmp/agent-a",
+    },
+    async () => {
+      await waitForAgentA;
+      return getShellEnv();
+    },
+  );
+
+  const taskB = runWithRuntimeContext(
+    {
+      agentId: "agent-b",
+      conversationId: "conv-b",
+      workingDirectory: "/tmp/agent-b",
+    },
+    async () => {
+      releaseAgentA();
+      return getShellEnv();
+    },
+  );
+
+  const [envA, envB] = await Promise.all([taskA, taskB]);
+
+  expect(envA.AGENT_ID).toBe("agent-a");
+  expect(envA.CONVERSATION_ID).toBe("conv-a");
+  expect(envA.USER_CWD).toBe("/tmp/agent-a");
+  expect(envB.AGENT_ID).toBe("agent-b");
+  expect(envB.CONVERSATION_ID).toBe("conv-b");
+  expect(envB.USER_CWD).toBe("/tmp/agent-b");
 });
 
 test("getShellEnv does not inject MEMORY_DIR aliases when memfs is disabled", () => {

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -86,6 +86,26 @@ describe("shellEnv letta shim", () => {
     });
   });
 
+  test("resolveLettaInvocation resolves relative dev entrypoint against cwd", () => {
+    const invocation = resolveLettaInvocation(
+      {},
+      ["bun", "src/index.ts"],
+      "/opt/homebrew/bin/bun",
+      "/Users/example/dev/letta-code-prod",
+    );
+
+    expect(invocation).toEqual({
+      command: "/opt/homebrew/bin/bun",
+      args: [
+        "--loader:.md=text",
+        "--loader:.mdx=text",
+        "--loader:.txt=text",
+        "run",
+        "/Users/example/dev/letta-code-prod/src/index.ts",
+      ],
+    });
+  });
+
   test("resolveLettaInvocation keeps non-bun dev launcher behavior", () => {
     const invocation = resolveLettaInvocation(
       {},

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -87,21 +87,34 @@ describe("shellEnv letta shim", () => {
   });
 
   test("resolveLettaInvocation resolves relative dev entrypoint against cwd", () => {
+    const cwd =
+      process.platform === "win32"
+        ? path.win32.join("C:\\", "Users", "example", "dev", "letta-code-prod")
+        : path.posix.join("/", "Users", "example", "dev", "letta-code-prod");
+    const expectedScriptPath =
+      process.platform === "win32"
+        ? path.win32.join(cwd, "src", "index.ts")
+        : path.posix.join(cwd, "src", "index.ts");
+    const execPath =
+      process.platform === "win32"
+        ? "C:\\bun\\bun.exe"
+        : "/opt/homebrew/bin/bun";
+
     const invocation = resolveLettaInvocation(
       {},
       ["bun", "src/index.ts"],
-      "/opt/homebrew/bin/bun",
-      "/Users/example/dev/letta-code-prod",
+      execPath,
+      cwd,
     );
 
     expect(invocation).toEqual({
-      command: "/opt/homebrew/bin/bun",
+      command: execPath,
       args: [
         "--loader:.md=text",
         "--loader:.mdx=text",
         "--loader:.txt=text",
         "run",
-        "/Users/example/dev/letta-code-prod/src/index.ts",
+        expectedScriptPath,
       ],
     });
   });

--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -22,6 +22,8 @@ let currentSkillsDirectory: string | null = null;
 
 mock.module("../../agent/context", () => ({
   getCurrentAgentId: () => TEST_AGENT_ID,
+  getConversationId: () => null,
+  getSkillSources: () => [],
   getSkillsDirectory: () => currentSkillsDirectory,
 }));
 
@@ -100,6 +102,49 @@ describe("Skill tool memory filesystem lookup", () => {
     const queued = consumeQueuedSkillContent();
     expect(queued).toHaveLength(1);
     expect(queued[0]?.content).toContain("Loaded from MEMORY_DIR.");
+  });
+
+  test("prefers scoped agent memory skills over stale MEMORY_DIR env", async () => {
+    const skillName = "scoped-over-stale-memory-skill";
+    const staleMemoryDir = join(tempRoot, "stale-memory");
+    const staleSkillDir = join(staleMemoryDir, "skills", skillName);
+    const scopedSkillDir = join(
+      tempRoot,
+      ".letta",
+      "agents",
+      TEST_AGENT_ID,
+      "memory",
+      "skills",
+      skillName,
+    );
+
+    mkdirSync(staleSkillDir, { recursive: true });
+    mkdirSync(scopedSkillDir, { recursive: true });
+    writeFileSync(
+      join(staleSkillDir, "SKILL.md"),
+      "---\nname: scoped-over-stale-memory-skill\ndescription: stale\n---\n\nLoaded from stale MEMORY_DIR.",
+      "utf8",
+    );
+    writeFileSync(
+      join(scopedSkillDir, "SKILL.md"),
+      "---\nname: scoped-over-stale-memory-skill\ndescription: scoped\n---\n\nLoaded from scoped agent memory.",
+      "utf8",
+    );
+
+    process.env.MEMORY_DIR = staleMemoryDir;
+    delete process.env.LETTA_MEMORY_DIR;
+    process.env.HOME = tempRoot;
+
+    const result = await skill({
+      skill: skillName,
+      toolCallId: "tc-scoped-over-stale",
+    });
+    expect(result.message).toBe(`Launching skill: ${skillName}`);
+
+    const queued = consumeQueuedSkillContent();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toContain("Loaded from scoped agent memory.");
+    expect(queued[0]?.content).not.toContain("Loaded from stale MEMORY_DIR.");
   });
 
   test("falls back to ~/.letta/agents/<id>/memory/skills when MEMORY_DIR is unset", async () => {

--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -1,15 +1,8 @@
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runWithRuntimeContext } from "../../runtime-context";
 import { consumeQueuedSkillContent } from "../../tools/impl/skillContentRegistry";
 import {
   clearTools,
@@ -20,14 +13,21 @@ import {
 const TEST_AGENT_ID = "agent-skill-memfs-test";
 let currentSkillsDirectory: string | null = null;
 
-mock.module("../../agent/context", () => ({
-  getCurrentAgentId: () => TEST_AGENT_ID,
-  getConversationId: () => null,
-  getSkillSources: () => [],
-  getSkillsDirectory: () => currentSkillsDirectory,
-}));
-
 const { skill } = await import("../../tools/impl/Skill");
+
+function withSkillContext<T>(fn: () => Promise<T>) {
+  return runWithRuntimeContext(
+    {
+      agentId: TEST_AGENT_ID,
+      skillsDirectory: currentSkillsDirectory,
+    },
+    fn,
+  );
+}
+
+function runScopedSkill(args: Parameters<typeof skill>[0]) {
+  return withSkillContext(() => skill(args));
+}
 
 describe("Skill tool memory filesystem lookup", () => {
   let tempRoot: string;
@@ -74,10 +74,6 @@ describe("Skill tool memory filesystem lookup", () => {
     rmSync(tempRoot, { recursive: true, force: true });
   });
 
-  afterAll(() => {
-    mock.restore();
-  });
-
   test("loads skills from MEMORY_DIR/skills", async () => {
     const skillName = "memfs-only-skill";
     const memoryDir = join(tempRoot, "memory");
@@ -93,7 +89,7 @@ describe("Skill tool memory filesystem lookup", () => {
     process.env.MEMORY_DIR = memoryDir;
     delete process.env.LETTA_MEMORY_DIR;
 
-    const result = await skill({
+    const result = await runScopedSkill({
       skill: skillName,
       toolCallId: "tc-memory-dir",
     });
@@ -135,7 +131,7 @@ describe("Skill tool memory filesystem lookup", () => {
     delete process.env.LETTA_MEMORY_DIR;
     process.env.HOME = tempRoot;
 
-    const result = await skill({
+    const result = await runScopedSkill({
       skill: skillName,
       toolCallId: "tc-scoped-over-stale",
     });
@@ -173,7 +169,7 @@ describe("Skill tool memory filesystem lookup", () => {
     process.env.HOME = tempRoot;
 
     await expect(
-      skill({
+      runScopedSkill({
         skill: skillName,
         toolCallId: "tc-env-only-stale",
       }),
@@ -205,7 +201,7 @@ describe("Skill tool memory filesystem lookup", () => {
     delete process.env.LETTA_MEMORY_DIR;
     process.env.HOME = tempRoot;
 
-    const result = await skill({
+    const result = await runScopedSkill({
       skill: skillName,
       toolCallId: "tc-memory-fallback",
     });
@@ -240,7 +236,7 @@ describe("Skill tool memory filesystem lookup", () => {
     delete process.env.LETTA_MEMORY_DIR;
     process.env.HOME = tempRoot;
 
-    const result = await skill({
+    const result = await runScopedSkill({
       skill: skillName,
       toolCallId: "tc-scoped-agent",
       parentScope: {
@@ -270,7 +266,7 @@ describe("Skill tool memory filesystem lookup", () => {
 
     process.env.USER_CWD = projectRoot;
 
-    const result = await skill({
+    const result = await runScopedSkill({
       skill: skillName,
       toolCallId: "tc-user-cwd",
     });
@@ -310,16 +306,18 @@ describe("Skill tool memory filesystem lookup", () => {
     clearTools();
     await loadSpecificTools(["Skill"]);
 
-    const result = await executeTool(
-      "Skill",
-      { skill: skillName },
-      {
-        toolCallId: "tc-execute-tool-scoped",
-        parentScope: {
-          agentId: injectedAgentId,
-          conversationId: "conversation-execute-tool",
+    const result = await withSkillContext(() =>
+      executeTool(
+        "Skill",
+        { skill: skillName },
+        {
+          toolCallId: "tc-execute-tool-scoped",
+          parentScope: {
+            agentId: injectedAgentId,
+            conversationId: "conversation-execute-tool",
+          },
         },
-      },
+      ),
     );
 
     expect(result.status).toBe("success");

--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -147,6 +147,41 @@ describe("Skill tool memory filesystem lookup", () => {
     expect(queued[0]?.content).not.toContain("Loaded from stale MEMORY_DIR.");
   });
 
+  test("does not load env-only memory skill when scoped agent memory is present", async () => {
+    const skillName = "env-only-stale-skill";
+    const staleMemoryDir = join(tempRoot, "stale-memory");
+    const staleSkillDir = join(staleMemoryDir, "skills", skillName);
+    const scopedMemorySkillsDir = join(
+      tempRoot,
+      ".letta",
+      "agents",
+      TEST_AGENT_ID,
+      "memory",
+      "skills",
+    );
+
+    mkdirSync(staleSkillDir, { recursive: true });
+    mkdirSync(scopedMemorySkillsDir, { recursive: true });
+    writeFileSync(
+      join(staleSkillDir, "SKILL.md"),
+      "---\nname: env-only-stale-skill\ndescription: stale\n---\n\nLoaded from stale MEMORY_DIR only.",
+      "utf8",
+    );
+
+    process.env.MEMORY_DIR = staleMemoryDir;
+    delete process.env.LETTA_MEMORY_DIR;
+    process.env.HOME = tempRoot;
+
+    await expect(
+      skill({
+        skill: skillName,
+        toolCallId: "tc-env-only-stale",
+      }),
+    ).rejects.toThrow(skillName);
+
+    expect(consumeQueuedSkillContent()).toHaveLength(0);
+  });
+
   test("falls back to ~/.letta/agents/<id>/memory/skills when MEMORY_DIR is unset", async () => {
     const skillName = "agent-memory-fallback-skill";
     const skillDir = join(

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -6,9 +6,13 @@ import {
   expect,
   test,
 } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { clearDynamicMessageChannelToolCache } from "../../channels/messageTool";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
 import type { ChannelAdapter } from "../../channels/types";
+import { runWithRuntimeContext } from "../../runtime-context";
 import {
   captureToolExecutionContext,
   clearCapturedToolExecutionContexts,
@@ -168,6 +172,55 @@ describe("tool execution context snapshot", () => {
     ).action;
 
     expect(actionParameter?.enum).toEqual(["send", "react", "upload-file"]);
+  });
+
+  test("captures scoped working directories per execution context", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const tempRoot = mkdtempSync(join(tmpdir(), "tool-context-scope-"));
+    const dirA = join(tempRoot, "agent-a");
+    const dirB = join(tempRoot, "agent-b");
+    const fileName = "scope.txt";
+
+    try {
+      mkdirSync(dirA, { recursive: true });
+      mkdirSync(dirB, { recursive: true });
+      writeFileSync(join(dirA, fileName), "from-agent-a", "utf8");
+      writeFileSync(join(dirB, fileName), "from-agent-b", "utf8");
+
+      const contextA = runWithRuntimeContext(
+        {
+          agentId: "agent-a",
+          conversationId: "conv-a",
+          workingDirectory: dirA,
+        },
+        () => captureToolExecutionContext(),
+      );
+      const contextB = runWithRuntimeContext(
+        {
+          agentId: "agent-b",
+          conversationId: "conv-b",
+          workingDirectory: dirB,
+        },
+        () => captureToolExecutionContext(),
+      );
+
+      const resultA = await executeTool(
+        "Read",
+        { file_path: fileName },
+        { toolContextId: contextA.contextId },
+      );
+      const resultB = await executeTool(
+        "Read",
+        { file_path: fileName },
+        { toolContextId: contextB.contextId },
+      );
+
+      expect(asText(resultA.toolReturn)).toContain("from-agent-a");
+      expect(asText(resultB.toolReturn)).toContain("from-agent-b");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   test("refreshes the loaded MessageChannel schema for synchronous readers", async () => {

--- a/src/tools/impl/ApplyPatch.ts
+++ b/src/tools/impl/ApplyPatch.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
 interface ApplyPatchArgs {
@@ -64,7 +65,7 @@ export async function apply_patch(
     throw new Error("No files were modified.");
   }
 
-  const cwd = process.env.USER_CWD || process.cwd();
+  const cwd = getCurrentWorkingDirectory();
   const affected: AffectedPaths = { added: [], modified: [], deleted: [] };
 
   for (const op of operations) {

--- a/src/tools/impl/Bash.ts
+++ b/src/tools/impl/Bash.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { INTERRUPTED_BY_USER } from "../../constants";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import {
   appendBackgroundProcessOutput,
   appendToOutputFile,
@@ -176,7 +177,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     signal,
     onOutput,
   } = args;
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
 
   // Block worktree creation outside .letta/worktrees/
   const worktreeError = validateWorktreePath(command, userCwd);

--- a/src/tools/impl/BashOutput.ts
+++ b/src/tools/impl/BashOutput.ts
@@ -1,4 +1,5 @@
 import { readFileSync, statSync } from "node:fs";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import {
   backgroundProcesses,
   backgroundTasks,
@@ -276,7 +277,7 @@ async function getProcessOutput(
       .join("\n");
   }
 
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
 
   // Apply character limit to prevent excessive token usage
   const { content: truncatedOutput } = truncateByChars(
@@ -381,7 +382,7 @@ async function getBackgroundTaskOutput(
       .join("\n");
   }
 
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
 
   // Apply character limit to prevent excessive token usage
   const { content: truncatedOutput } = truncateByChars(

--- a/src/tools/impl/Edit.ts
+++ b/src/tools/impl/Edit.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
 interface EditArgs {
@@ -139,7 +140,7 @@ export async function edit(args: EditArgs): Promise<EditResult> {
       "expected_replacements must be a positive integer when provided.",
     );
   }
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);

--- a/src/tools/impl/EnterPlanMode.ts
+++ b/src/tools/impl/EnterPlanMode.ts
@@ -1,6 +1,7 @@
 import { relative } from "node:path";
 import { generatePlanFilePath } from "../../cli/helpers/planName";
 import { permissionMode } from "../../permissions/mode";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { getExecutionContextPermissionModeState } from "../manager";
 
 interface EnterPlanModeArgs {
@@ -47,7 +48,7 @@ export async function enter_plan_mode(
 
   const planFilePath =
     scopedState?.planFilePath ?? permissionMode.getPlanFilePath();
-  const cwd = process.env.USER_CWD || process.cwd();
+  const cwd = getCurrentWorkingDirectory();
   const applyPatchRelativePath = planFilePath
     ? relative(cwd, planFilePath).replace(/\\/g, "/")
     : null;

--- a/src/tools/impl/Glob.ts
+++ b/src/tools/impl/Glob.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { LIMITS, truncateArray } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
@@ -65,7 +66,7 @@ export async function glob(args: GlobArgs): Promise<GlobResult> {
   if (!pattern) {
     throw new Error("Glob tool missing required parameter: pattern");
   }
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
 
   const baseDir = searchPath
     ? path.isAbsolute(searchPath)

--- a/src/tools/impl/Grep.ts
+++ b/src/tools/impl/Grep.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
@@ -73,7 +74,7 @@ export async function grep(args: GrepArgs): Promise<GrepResult> {
     multiline,
   } = args;
 
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const rgArgs: string[] = [];
   if (output_mode === "files_with_matches") rgArgs.push("-l");
   else if (output_mode === "count") rgArgs.push("-c");

--- a/src/tools/impl/ListDirCodex.ts
+++ b/src/tools/impl/ListDirCodex.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { getDirectoryLimits } from "../../utils/directoryLimits.js";
 import { validateRequiredParams } from "./validation.js";
 
@@ -53,7 +54,7 @@ export async function list_dir(
     limit = DEFAULT_LIMIT,
     depth = DEFAULT_DEPTH,
   } = args;
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(dir_path)
     ? dir_path
     : path.resolve(userCwd, dir_path);

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -8,10 +8,10 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
+import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
 import {
   assertMemoryRepoReadyForWrite,
   commitAndSyncMemoryWrite,
@@ -344,24 +344,9 @@ async function applyMemoryCommand(
 }
 
 function resolveMemoryDir(): string {
-  const direct = process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-  if (direct && direct.trim().length > 0) {
-    return resolve(direct);
-  }
-
-  const contextAgentId = (() => {
-    try {
-      return getCurrentAgentId().trim();
-    } catch {
-      return "";
-    }
-  })();
-
-  const agentId =
-    contextAgentId ||
-    (process.env.AGENT_ID || process.env.LETTA_AGENT_ID || "").trim();
-  if (agentId && agentId.trim().length > 0) {
-    return resolve(homedir(), ".letta", "agents", agentId, "memory");
+  const scopedMemoryDir = resolveScopedMemoryDir();
+  if (scopedMemoryDir) {
+    return scopedMemoryDir;
   }
 
   throw new Error(

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -8,10 +8,10 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
+import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
 import {
   assertMemoryRepoReadyForWrite,
   commitAndSyncMemoryWrite,
@@ -485,24 +485,9 @@ function normalizeAddedContent(label: string, rawContent: string): string {
 }
 
 function resolveMemoryDir(): string {
-  const direct = process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-  if (direct && direct.trim().length > 0) {
-    return resolve(direct);
-  }
-
-  const contextAgentId = (() => {
-    try {
-      return getCurrentAgentId().trim();
-    } catch {
-      return "";
-    }
-  })();
-
-  const agentId =
-    contextAgentId ||
-    (process.env.AGENT_ID || process.env.LETTA_AGENT_ID || "").trim();
-  if (agentId && agentId.trim().length > 0) {
-    return resolve(homedir(), ".letta", "agents", agentId, "memory");
+  const scopedMemoryDir = resolveScopedMemoryDir();
+  if (scopedMemoryDir) {
+    return scopedMemoryDir;
   }
 
   throw new Error(

--- a/src/tools/impl/MultiEdit.ts
+++ b/src/tools/impl/MultiEdit.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
 interface Edit {
@@ -27,7 +28,7 @@ export async function multi_edit(
 ): Promise<MultiEditResult> {
   validateRequiredParams(args, ["file_path", "edits"], "MultiEdit");
   const { file_path, edits } = args;
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);

--- a/src/tools/impl/Read.ts
+++ b/src/tools/impl/Read.ts
@@ -6,6 +6,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import { resizeImageIfNeeded } from "../../cli/helpers/imageResize.js";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { debugLog } from "../../utils/debug.js";
 import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
 import { LIMITS } from "./truncation.js";
@@ -196,7 +197,7 @@ function formatWithLineNumbers(
 export async function read(args: ReadArgs): Promise<ReadResult> {
   validateRequiredParams(args, ["file_path"], "Read");
   const { file_path, offset, limit } = args;
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);

--- a/src/tools/impl/ReadLSP.ts
+++ b/src/tools/impl/ReadLSP.ts
@@ -2,6 +2,7 @@
  * LSP-enhanced Read tool - wraps the base Read tool and adds LSP diagnostics
  * This is used when LETTA_ENABLE_LSP is set
  */
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { read as baseRead, type ToolReturnContent } from "./Read.js";
 
 // Format a single diagnostic in opencode style: "ERROR [line:col] message"
@@ -63,7 +64,7 @@ export async function read_lsp(args: ReadLSPArgs): Promise<ReadLSPResult> {
     const path = await import("node:path");
 
     // Resolve the path
-    const userCwd = process.env.USER_CWD || process.cwd();
+    const userCwd = getCurrentWorkingDirectory();
     const resolvedPath = path.default.isAbsolute(args.file_path)
       ? args.file_path
       : path.default.resolve(userCwd, args.file_path);

--- a/src/tools/impl/Shell.ts
+++ b/src/tools/impl/Shell.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { getShellEnv } from "./shellEnv.js";
 import { buildShellLaunchers } from "./shellLaunchers.js";
 import { ShellExecutionError, spawnWithLauncher } from "./shellRunner.js";
@@ -17,7 +18,7 @@ interface ShellArgs {
 }
 
 export function resolveShellWorkdir(workdir?: string): string {
-  const defaultCwd = process.env.USER_CWD || process.cwd();
+  const defaultCwd = getCurrentWorkingDirectory();
   const requestedCwd = workdir
     ? path.isAbsolute(workdir)
       ? workdir

--- a/src/tools/impl/ShellCommand.ts
+++ b/src/tools/impl/ShellCommand.ts
@@ -134,25 +134,16 @@ function getMemoryGitIdentityEnvOverrides(
 }
 
 function getCurrentAgentIdOrEnv(): string {
-  const envAgentId = (
-    process.env.AGENT_ID ||
-    process.env.LETTA_AGENT_ID ||
-    ""
-  ).trim();
-  if (envAgentId) {
-    return envAgentId;
-  }
-
   try {
     const agentId = getCurrentAgentId().trim();
     if (agentId) {
       return agentId;
     }
   } catch {
-    // Fall through to empty string.
+    // Fall through to env fallback below.
   }
 
-  return "";
+  return (process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "").trim();
 }
 
 function containsGitCommitInvocation(command: string): boolean {

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -8,6 +8,7 @@ import {
   getBundledSkills,
   SKILLS_DIR,
 } from "../../agent/skills";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { queueSkillContent } from "./skillContentRegistry";
 import { validateRequiredParams } from "./validation.js";
 
@@ -156,9 +157,7 @@ async function getResolvedSkillsDir(): Promise<string> {
   }
 
   // Fall back to the execution working directory when available.
-  // executeTool() temporarily sets USER_CWD for the duration of the tool call,
-  // which keeps listener/desktop project skill lookup scoped correctly.
-  return join(process.env.USER_CWD || process.cwd(), SKILLS_DIR);
+  return join(getCurrentWorkingDirectory(), SKILLS_DIR);
 }
 
 function getResolvedAgentId(args: SkillArgs): string | undefined {

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getCurrentAgentId, getSkillsDirectory } from "../../agent/context";
@@ -30,17 +30,21 @@ function getMemorySkillsDirs(agentId?: string): string[] {
   const dirs = new Set<string>();
 
   const scopedMemoryDir = resolveScopedMemoryDir({ agentId });
-  if (scopedMemoryDir && scopedMemoryDir.trim().length > 0) {
+  if (
+    scopedMemoryDir &&
+    scopedMemoryDir.trim().length > 0 &&
+    existsSync(scopedMemoryDir)
+  ) {
     dirs.add(join(scopedMemoryDir.trim(), "skills"));
-  }
-
-  const fallbackMemoryDir = (
-    process.env.LETTA_MEMORY_DIR ||
-    process.env.MEMORY_DIR ||
-    ""
-  ).trim();
-  if (fallbackMemoryDir) {
-    dirs.add(join(fallbackMemoryDir, "skills"));
+  } else {
+    const fallbackMemoryDir = (
+      process.env.LETTA_MEMORY_DIR ||
+      process.env.MEMORY_DIR ||
+      ""
+    ).trim();
+    if (fallbackMemoryDir) {
+      dirs.add(join(fallbackMemoryDir, "skills"));
+    }
   }
 
   return Array.from(dirs);

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -2,6 +2,7 @@ import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getCurrentAgentId, getSkillsDirectory } from "../../agent/context";
+import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
 import {
   GLOBAL_SKILLS_DIR,
   getAgentSkillsDir,
@@ -28,21 +29,18 @@ interface SkillResult {
 function getMemorySkillsDirs(agentId?: string): string[] {
   const dirs = new Set<string>();
 
-  const memoryDir = process.env.MEMORY_DIR || process.env.LETTA_MEMORY_DIR;
-  if (memoryDir && memoryDir.trim().length > 0) {
-    dirs.add(join(memoryDir.trim(), "skills"));
+  const scopedMemoryDir = resolveScopedMemoryDir({ agentId });
+  if (scopedMemoryDir && scopedMemoryDir.trim().length > 0) {
+    dirs.add(join(scopedMemoryDir.trim(), "skills"));
   }
 
-  if (agentId) {
-    dirs.add(
-      join(
-        process.env.HOME || process.env.USERPROFILE || "~",
-        ".letta/agents",
-        agentId,
-        "memory",
-        "skills",
-      ),
-    );
+  const fallbackMemoryDir = (
+    process.env.LETTA_MEMORY_DIR ||
+    process.env.MEMORY_DIR ||
+    ""
+  ).trim();
+  if (fallbackMemoryDir) {
+    dirs.add(join(fallbackMemoryDir, "skills"));
   }
 
   return Array.from(dirs);

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -23,6 +23,7 @@ import {
 } from "../../cli/helpers/subagentState.js";
 import { formatTaskNotification } from "../../cli/helpers/taskNotifications.js";
 import { runSubagentStopHooks } from "../../hooks";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import {
   appendToOutputFile,
   assertBackgroundTaskCapacity,
@@ -389,7 +390,7 @@ export function spawnBackgroundSubagentTask(
         const fullResult = result.success
           ? `${header}\n\n${result.report || ""}`
           : `${header}\n\nError: ${result.error || "Subagent execution failed"}`;
-        const userCwd = process.env.USER_CWD || process.cwd();
+        const userCwd = getCurrentWorkingDirectory();
         const { content: truncatedResult } = truncateByChars(
           fullResult,
           LIMITS.TASK_OUTPUT_CHARS,
@@ -738,7 +739,7 @@ export async function task(args: TaskArgs): Promise<string> {
     const fullOutput = `${header}\n\n${result.report}`;
     writeTaskTranscriptResult(outputFile, result, header);
 
-    const userCwd = process.env.USER_CWD || process.cwd();
+    const userCwd = getCurrentWorkingDirectory();
 
     // Apply truncation to prevent excessive token usage (same pattern as Bash tool)
     const { content: truncatedOutput } = truncateByChars(

--- a/src/tools/impl/ViewImage.ts
+++ b/src/tools/impl/ViewImage.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { read, type ToolReturnContent } from "./Read";
 import { validateRequiredParams } from "./validation.js";
 
@@ -25,7 +26,7 @@ export async function view_image(
 ): Promise<{ content: ToolReturnContent }> {
   validateRequiredParams(args, ["path"], "view_image");
 
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(args.path)
     ? args.path
     : path.resolve(userCwd, args.path);

--- a/src/tools/impl/Write.ts
+++ b/src/tools/impl/Write.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
 interface WriteArgs {
@@ -13,7 +14,7 @@ interface WriteResult {
 export async function write(args: WriteArgs): Promise<WriteResult> {
   validateRequiredParams(args, ["file_path", "content"], "Write");
   const { file_path, content } = args;
-  const userCwd = process.env.USER_CWD || process.cwd();
+  const userCwd = getCurrentWorkingDirectory();
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -90,8 +90,25 @@ function parseInvocationArgs(raw: string | undefined): string[] {
   return [];
 }
 
-function isDevLettaEntryScript(scriptPath: string): boolean {
-  const normalized = scriptPath.replaceAll("\\", "/");
+export function resolveEntryScriptPath(
+  scriptPath: string,
+  cwd: string = process.cwd(),
+): string {
+  if (!scriptPath) return scriptPath;
+  if (path.posix.isAbsolute(scriptPath) || path.win32.isAbsolute(scriptPath)) {
+    return scriptPath;
+  }
+  return path.resolve(cwd, scriptPath);
+}
+
+function isDevLettaEntryScript(
+  scriptPath: string,
+  cwd: string = process.cwd(),
+): boolean {
+  const normalized = resolveEntryScriptPath(scriptPath, cwd).replaceAll(
+    "\\",
+    "/",
+  );
   return normalized.endsWith("/src/index.ts");
 }
 
@@ -99,6 +116,7 @@ export function resolveLettaInvocation(
   env: NodeJS.ProcessEnv = process.env,
   argv: string[] = process.argv,
   execPath: string = process.execPath,
+  cwd: string = process.cwd(),
 ): LettaInvocation | null {
   const explicitBin = normalizeInvocationCommand(env.LETTA_CODE_BIN);
   if (explicitBin) {
@@ -109,7 +127,8 @@ export function resolveLettaInvocation(
   }
 
   const scriptPath = argv[1] || "";
-  if (scriptPath && isDevLettaEntryScript(scriptPath)) {
+  if (scriptPath && isDevLettaEntryScript(scriptPath, cwd)) {
+    const resolvedScriptPath = resolveEntryScriptPath(scriptPath, cwd);
     const runtimeName = path.basename(execPath).toLowerCase();
     if (runtimeName.includes("bun")) {
       return {
@@ -119,12 +138,12 @@ export function resolveLettaInvocation(
           "--loader:.mdx=text",
           "--loader:.txt=text",
           "run",
-          scriptPath,
+          resolvedScriptPath,
         ],
       };
     }
 
-    return { command: execPath, args: [scriptPath] };
+    return { command: execPath, args: [resolvedScriptPath] };
   }
 
   return null;

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { getServerUrl } from "../../agent/client";
 import { getConversationId, getCurrentAgentId } from "../../agent/context";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 
 /**
@@ -194,6 +195,8 @@ export function getShellEnv(): NodeJS.ProcessEnv {
       ? `${pathPrefixes.join(path.delimiter)}${path.delimiter}${existingPath}`
       : pathPrefixes.join(path.delimiter);
   }
+
+  env.USER_CWD = getCurrentWorkingDirectory();
 
   // Add Letta context for skill scripts.
   // Prefer explicit agent context, but fall back to inherited env values.

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1,6 +1,12 @@
 import * as nodeFs from "node:fs/promises";
 import * as nodePath from "node:path";
 import { getDisplayableToolReturn } from "../agent/approval-execution";
+import {
+  getConversationId,
+  getCurrentAgentId,
+  getSkillSources,
+  getSkillsDirectory,
+} from "../agent/context";
 import { getModelInfo } from "../agent/model";
 import { getAllSubagentConfigs } from "../agent/subagents";
 import {
@@ -21,6 +27,12 @@ import {
   type PermissionMode,
 } from "../permissions/mode";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
+import {
+  getCurrentWorkingDirectory,
+  getRuntimeContext,
+  runWithRuntimeContext,
+  type RuntimeContextSnapshot,
+} from "../runtime-context";
 import { telemetry } from "../telemetry";
 import { debugLog } from "../utils/debug";
 import {
@@ -401,6 +413,7 @@ type ToolExecutionContextSnapshot = {
   externalTools: Map<string, ExternalToolDefinition>;
   externalExecutor?: ExternalToolExecutor;
   workingDirectory: string;
+  runtimeContext: RuntimeContextSnapshot;
   permissionModeState: PermissionModeState;
 };
 
@@ -436,6 +449,50 @@ function saveExecutionContext(snapshot: ToolExecutionContextSnapshot): string {
   }
 
   return contextId;
+}
+
+function buildExecutionRuntimeContextSnapshot(options?: {
+  workingDirectory?: string;
+  permissionModeState?: PermissionModeState;
+  runtimeContext?: Partial<RuntimeContextSnapshot>;
+}): RuntimeContextSnapshot {
+  const mergedScope: RuntimeContextSnapshot = {
+    ...(getRuntimeContext() ?? {}),
+    ...(options?.runtimeContext ?? {}),
+  };
+
+  if (mergedScope.agentId === undefined) {
+    try {
+      mergedScope.agentId = getCurrentAgentId();
+    } catch {
+      // Leave unset when no scoped or global agent context exists.
+    }
+  }
+
+  if (mergedScope.conversationId === undefined) {
+    mergedScope.conversationId = getConversationId();
+  }
+
+  if (mergedScope.skillsDirectory === undefined) {
+    mergedScope.skillsDirectory = getSkillsDirectory();
+  }
+
+  if (mergedScope.skillSources === undefined) {
+    mergedScope.skillSources = getSkillSources();
+  }
+
+  mergedScope.workingDirectory =
+    options?.workingDirectory ??
+    mergedScope.workingDirectory ??
+    getCurrentWorkingDirectory();
+  mergedScope.permissionMode =
+    options?.permissionModeState?.mode ?? mergedScope.permissionMode;
+  mergedScope.planFilePath =
+    options?.permissionModeState?.planFilePath ?? mergedScope.planFilePath;
+  mergedScope.modeBeforePlan =
+    options?.permissionModeState?.modeBeforePlan ?? mergedScope.modeBeforePlan;
+
+  return mergedScope;
 }
 
 function getExecutionContextById(
@@ -766,14 +823,17 @@ function capturePreparedToolExecutionContext(
   options?: {
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
+    runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): PreparedToolExecutionContext {
+  const runtimeContext = buildExecutionRuntimeContextSnapshot(options);
   const executionSnapshot: ToolExecutionContextSnapshot = {
     toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
     externalTools: new Map(snapshot.externalTools),
     externalExecutor: snapshot.externalExecutor,
     workingDirectory:
-      options?.workingDirectory ?? process.env.USER_CWD ?? process.cwd(),
+      runtimeContext.workingDirectory ?? getCurrentWorkingDirectory(),
+    runtimeContext,
     permissionModeState: getEffectivePermissionModeState(
       options?.permissionModeState,
     ),
@@ -796,7 +856,7 @@ function capturePreparedToolExecutionContext(
  * exact snapshot even if the global registry changes between dispatch and execute.
  */
 export function captureToolExecutionContext(
-  workingDirectory: string = process.env.USER_CWD || process.cwd(),
+  workingDirectory: string = getCurrentWorkingDirectory(),
   permissionModeState?: PermissionModeState,
 ): CapturedToolExecutionContext {
   return capturePreparedToolExecutionContext(
@@ -815,6 +875,7 @@ export function captureToolExecutionContext(
 export async function prepareCurrentToolExecutionContext(options?: {
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  runtimeContext?: Partial<RuntimeContextSnapshot>;
 }): Promise<PreparedToolExecutionContext> {
   await waitForToolsetReady();
   const currentToolNames = maybeAppendChannelTools(
@@ -838,6 +899,7 @@ export async function prepareToolExecutionContextForSpecificTools(
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
+    runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
   const toolRegistrySnapshot = await buildSpecificToolRegistry(
@@ -861,6 +923,7 @@ export async function prepareToolExecutionContextForModel(
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
+    runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
   const toolRegistrySnapshot = await buildRegistryForModel(
@@ -875,27 +938,6 @@ export async function prepareToolExecutionContextForModel(
     },
     options,
   );
-}
-
-async function withExecutionWorkingDirectory<T>(
-  workingDirectory: string | undefined,
-  fn: () => Promise<T>,
-): Promise<T> {
-  if (!workingDirectory) {
-    return fn();
-  }
-
-  const previousUserCwd = process.env.USER_CWD;
-  process.env.USER_CWD = workingDirectory;
-  try {
-    return await fn();
-  } finally {
-    if (previousUserCwd === undefined) {
-      delete process.env.USER_CWD;
-    } else {
-      process.env.USER_CWD = previousUserCwd;
-    }
-  }
 }
 
 /**
@@ -929,6 +971,7 @@ export async function checkToolPermission(
   toolArgs: ToolArgs,
   workingDirectory: string = process.cwd(),
   permissionModeStateArg?: PermissionModeState,
+  agentIdArg?: string,
 ): Promise<{
   decision: "allow" | "deny" | "ask";
   matchedRule?: string;
@@ -938,12 +981,23 @@ export async function checkToolPermission(
   const { loadPermissions } = await import("../permissions/loader");
 
   const permissions = await loadPermissions(workingDirectory);
-  return checkPermissionWithHooks(
-    toolName,
-    toolArgs,
-    permissions,
-    workingDirectory,
-    permissionModeStateArg,
+  return runWithRuntimeContext(
+    {
+      ...(agentIdArg ? { agentId: agentIdArg } : {}),
+      workingDirectory,
+      permissionMode: permissionModeStateArg?.mode,
+      planFilePath: permissionModeStateArg?.planFilePath ?? null,
+      modeBeforePlan: permissionModeStateArg?.modeBeforePlan ?? null,
+    },
+    () =>
+      checkPermissionWithHooks(
+        toolName,
+        toolArgs,
+        permissions,
+        workingDirectory,
+        permissionModeStateArg,
+        agentIdArg,
+      ),
   );
 }
 
@@ -1494,7 +1548,19 @@ export async function executeTool(
     context?.externalTools ?? getExternalToolsRegistry();
   const activeExternalExecutor =
     context?.externalExecutor ?? getExternalToolExecutor();
-  const workingDirectory = context?.workingDirectory;
+  const executionScope = context?.runtimeContext
+    ? buildExecutionRuntimeContextSnapshot({
+        workingDirectory: context.runtimeContext.workingDirectory ?? undefined,
+        permissionModeState: context.permissionModeState,
+        runtimeContext: context.runtimeContext,
+      })
+    : buildExecutionRuntimeContextSnapshot({
+        workingDirectory: context?.workingDirectory,
+        permissionModeState: context?.permissionModeState,
+      });
+  const workingDirectory =
+    executionScope.workingDirectory ?? getCurrentWorkingDirectory();
+  const scopedAgentId = executionScope.agentId ?? undefined;
 
   // Check if this is an external tool (SDK-executed)
   if (activeExternalTools.has(name)) {
@@ -1524,22 +1590,24 @@ export async function executeTool(
 
   const startTime = Date.now();
 
-  // Run PreToolUse hooks - can block tool execution
-  const preHookResult = await runPreToolUseHooks(
-    internalName,
-    args as Record<string, unknown>,
-    options?.toolCallId,
-    workingDirectory,
-  );
-  if (preHookResult.blocked) {
-    const feedback = preHookResult.feedback.join("\n") || "Blocked by hook";
-    return {
-      toolReturn: `Error: Tool execution blocked by hook. ${feedback}`,
-      status: "error",
-    };
-  }
+  const run = async (): Promise<ToolExecutionResult> => {
+    // Run PreToolUse hooks - can block tool execution
+    const preHookResult = await runPreToolUseHooks(
+      internalName,
+      args as Record<string, unknown>,
+      options?.toolCallId,
+      workingDirectory,
+      scopedAgentId,
+    );
+    if (preHookResult.blocked) {
+      const feedback = preHookResult.feedback.join("\n") || "Blocked by hook";
+      return {
+        toolReturn: `Error: Tool execution blocked by hook. ${feedback}`,
+        status: "error",
+      };
+    }
 
-  try {
+    try {
     // Inject options for tools that support them without altering schemas
     let enhancedArgs = args;
 
@@ -1603,9 +1671,7 @@ export async function executeTool(
       };
     }
 
-    const result = await withExecutionWorkingDirectory(workingDirectory, () =>
-      tool.fn(enhancedArgs),
-    );
+    const result = await tool.fn(enhancedArgs);
     const duration = Date.now() - startTime;
 
     // Refresh the file index in the background after every tool execution
@@ -1624,7 +1690,7 @@ export async function executeTool(
         try {
           const resolvedPath = nodePath.isAbsolute(filePath)
             ? filePath
-            : nodePath.resolve(process.env.USER_CWD || process.cwd(), filePath);
+            : nodePath.resolve(workingDirectory, filePath);
           const content = await nodeFs.readFile(resolvedPath, "utf-8");
           options.onFileWrite(resolvedPath, content);
         } catch {
@@ -1702,7 +1768,7 @@ export async function executeTool(
         },
         options?.toolCallId,
         workingDirectory,
-        undefined, // agentId
+        scopedAgentId,
         undefined, // precedingReasoning - not available in tool manager context
         undefined, // precedingAssistantMessage - not available in tool manager context
       );
@@ -1726,7 +1792,7 @@ export async function executeTool(
           "tool_error", // error type for returned errors
           options?.toolCallId,
           workingDirectory,
-          undefined, // agentId
+          scopedAgentId,
           undefined, // precedingReasoning - not available in tool manager context
           undefined, // precedingAssistantMessage - not available in tool manager context
         );
@@ -1809,7 +1875,7 @@ export async function executeTool(
         { status: "error", output: errorMessage },
         options?.toolCallId,
         workingDirectory,
-        undefined, // agentId
+        scopedAgentId,
         undefined, // precedingReasoning - not available in tool manager context
         undefined, // precedingAssistantMessage - not available in tool manager context
       );
@@ -1828,7 +1894,7 @@ export async function executeTool(
         errorType,
         options?.toolCallId,
         workingDirectory,
-        undefined, // agentId
+        scopedAgentId,
         undefined, // precedingReasoning - not available in tool manager context
         undefined, // precedingAssistantMessage - not available in tool manager context
       );
@@ -1854,7 +1920,10 @@ export async function executeTool(
       toolReturn: finalErrorMessage,
       status: "error",
     };
-  }
+    }
+  };
+
+  return runWithRuntimeContext(executionScope, run);
 }
 
 /**

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -30,8 +30,8 @@ import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import {
   getCurrentWorkingDirectory,
   getRuntimeContext,
-  runWithRuntimeContext,
   type RuntimeContextSnapshot,
+  runWithRuntimeContext,
 } from "../runtime-context";
 import { telemetry } from "../telemetry";
 import { debugLog } from "../utils/debug";
@@ -1608,188 +1608,293 @@ export async function executeTool(
     }
 
     try {
-    // Inject options for tools that support them without altering schemas
-    let enhancedArgs = args;
+      // Inject options for tools that support them without altering schemas
+      let enhancedArgs = args;
 
-    if (STREAMING_SHELL_TOOLS.has(internalName)) {
-      if (options?.signal) {
-        enhancedArgs = { ...enhancedArgs, signal: options.signal };
+      if (STREAMING_SHELL_TOOLS.has(internalName)) {
+        if (options?.signal) {
+          enhancedArgs = { ...enhancedArgs, signal: options.signal };
+        }
+        if (options?.onOutput) {
+          enhancedArgs = {
+            ...enhancedArgs,
+            onOutput: (chunk: string, stream: "stdout" | "stderr") => {
+              options.onOutput?.(scrubSecretsFromString(chunk), stream);
+            },
+          };
+        }
+
+        // Substitute $SECRET_NAME patterns with actual secret values
+        enhancedArgs = substituteSecretsInArgs(enhancedArgs);
       }
-      if (options?.onOutput) {
+
+      // Inject toolCallId, abort signal, and parent scope for Task tool
+      if (internalName === "Task") {
+        if (options?.toolCallId) {
+          enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
+        }
+        if (options?.signal) {
+          enhancedArgs = { ...enhancedArgs, signal: options.signal };
+        }
+        if (options?.parentScope) {
+          enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+        }
+      }
+
+      // Inject scoped metadata for Skill tool.
+      // In listener/desktop mode, relying on global agent context is unsafe
+      // because multiple agent/conversation scopes can overlap in one process.
+      if (internalName === "Skill" && options?.toolCallId) {
+        enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
+      }
+      if (internalName === "Skill" && options?.parentScope) {
+        enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+      }
+
+      // Inject parent scope for MessageChannel tool (per-execution, not global singleton)
+      if (internalName === "MessageChannel" && options?.parentScope) {
+        enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+      }
+
+      // Inject the execution context id for plan-mode tools so they can update
+      // the per-conversation PermissionModeState without touching the global singleton.
+      const PLAN_MODE_TOOL_NAMES = new Set([
+        "EnterPlanMode",
+        "enter_plan_mode",
+        "ExitPlanMode",
+        "exit_plan_mode",
+      ]);
+      if (PLAN_MODE_TOOL_NAMES.has(internalName) && options?.toolContextId) {
         enhancedArgs = {
           ...enhancedArgs,
-          onOutput: (chunk: string, stream: "stdout" | "stderr") => {
-            options.onOutput?.(scrubSecretsFromString(chunk), stream);
-          },
+          _executionContextId: options.toolContextId,
         };
       }
 
-      // Substitute $SECRET_NAME patterns with actual secret values
-      enhancedArgs = substituteSecretsInArgs(enhancedArgs);
-    }
+      const result = await tool.fn(enhancedArgs);
+      const duration = Date.now() - startTime;
 
-    // Inject toolCallId, abort signal, and parent scope for Task tool
-    if (internalName === "Task") {
-      if (options?.toolCallId) {
-        enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
-      }
-      if (options?.signal) {
-        enhancedArgs = { ...enhancedArgs, signal: options.signal };
-      }
-      if (options?.parentScope) {
-        enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
-      }
-    }
+      // Refresh the file index in the background after every tool execution
+      // so subsequent @ searches reflect externally created or deleted files.
+      // The incremental rebuild is cheap (metadata-based skip for unchanged
+      // subtrees), so running on every tool adds negligible overhead.
+      void refreshFileIndex();
 
-    // Inject scoped metadata for Skill tool.
-    // In listener/desktop mode, relying on global agent context is unsafe
-    // because multiple agent/conversation scopes can overlap in one process.
-    if (internalName === "Skill" && options?.toolCallId) {
-      enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
-    }
-    if (internalName === "Skill" && options?.parentScope) {
-      enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
-    }
-
-    // Inject parent scope for MessageChannel tool (per-execution, not global singleton)
-    if (internalName === "MessageChannel" && options?.parentScope) {
-      enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
-    }
-
-    // Inject the execution context id for plan-mode tools so they can update
-    // the per-conversation PermissionModeState without touching the global singleton.
-    const PLAN_MODE_TOOL_NAMES = new Set([
-      "EnterPlanMode",
-      "enter_plan_mode",
-      "ExitPlanMode",
-      "exit_plan_mode",
-    ]);
-    if (PLAN_MODE_TOOL_NAMES.has(internalName) && options?.toolContextId) {
-      enhancedArgs = {
-        ...enhancedArgs,
-        _executionContextId: options.toolContextId,
-      };
-    }
-
-    const result = await tool.fn(enhancedArgs);
-    const duration = Date.now() - startTime;
-
-    // Refresh the file index in the background after every tool execution
-    // so subsequent @ searches reflect externally created or deleted files.
-    // The incremental rebuild is cheap (metadata-based skip for unchanged
-    // subtrees), so running on every tool adds negligible overhead.
-    void refreshFileIndex();
-
-    // Broadcast file content after file-mutating tools so web clients update
-    // in real time without waiting for fs.watch → file_changed → re-read.
-    if (options?.onFileWrite && FILE_MUTATING_TOOLS.has(internalName)) {
-      const filePath = (enhancedArgs as Record<string, unknown>).file_path as
-        | string
-        | undefined;
-      if (filePath) {
-        try {
-          const resolvedPath = nodePath.isAbsolute(filePath)
-            ? filePath
-            : nodePath.resolve(workingDirectory, filePath);
-          const content = await nodeFs.readFile(resolvedPath, "utf-8");
-          options.onFileWrite(resolvedPath, content);
-        } catch {
-          // Best-effort — don't fail the tool call if the read fails.
-        }
-      }
-    }
-
-    // Extract stdout/stderr if present (for bash tools)
-    const recordResult = isRecord(result) ? result : undefined;
-    const stdoutValue = recordResult?.stdout;
-    const stderrValue = recordResult?.stderr;
-    const stdout = isStringArray(stdoutValue) ? stdoutValue : undefined;
-    const stderr = isStringArray(stderrValue) ? stderrValue : undefined;
-
-    // Check if tool returned a status (e.g., Bash returns status: "error" on abort)
-    const toolStatus = recordResult?.status === "error" ? "error" : "success";
-
-    // Flatten the response to plain text
-    let flattenedResponse = flattenToolResponse(result);
-
-    // Scrub secret values from tool output so they don't leak into agent context
-    if (STREAMING_SHELL_TOOLS.has(internalName)) {
-      if (typeof flattenedResponse === "string") {
-        flattenedResponse = scrubSecretsFromString(flattenedResponse);
-      } else if (Array.isArray(flattenedResponse)) {
-        flattenedResponse = flattenedResponse.map((block) =>
-          block.type === "text"
-            ? { ...block, text: scrubSecretsFromString(block.text) }
-            : block,
-        );
-      }
-      if (stdout) {
-        for (let i = 0; i < stdout.length; i++) {
-          const line = stdout[i];
-          if (line !== undefined) {
-            stdout[i] = scrubSecretsFromString(line);
+      // Broadcast file content after file-mutating tools so web clients update
+      // in real time without waiting for fs.watch → file_changed → re-read.
+      if (options?.onFileWrite && FILE_MUTATING_TOOLS.has(internalName)) {
+        const filePath = (enhancedArgs as Record<string, unknown>).file_path as
+          | string
+          | undefined;
+        if (filePath) {
+          try {
+            const resolvedPath = nodePath.isAbsolute(filePath)
+              ? filePath
+              : nodePath.resolve(workingDirectory, filePath);
+            const content = await nodeFs.readFile(resolvedPath, "utf-8");
+            options.onFileWrite(resolvedPath, content);
+          } catch {
+            // Best-effort — don't fail the tool call if the read fails.
           }
         }
       }
-      if (stderr) {
-        for (let i = 0; i < stderr.length; i++) {
-          const line = stderr[i];
-          if (line !== undefined) {
-            stderr[i] = scrubSecretsFromString(line);
+
+      // Extract stdout/stderr if present (for bash tools)
+      const recordResult = isRecord(result) ? result : undefined;
+      const stdoutValue = recordResult?.stdout;
+      const stderrValue = recordResult?.stderr;
+      const stdout = isStringArray(stdoutValue) ? stdoutValue : undefined;
+      const stderr = isStringArray(stderrValue) ? stderrValue : undefined;
+
+      // Check if tool returned a status (e.g., Bash returns status: "error" on abort)
+      const toolStatus = recordResult?.status === "error" ? "error" : "success";
+
+      // Flatten the response to plain text
+      let flattenedResponse = flattenToolResponse(result);
+
+      // Scrub secret values from tool output so they don't leak into agent context
+      if (STREAMING_SHELL_TOOLS.has(internalName)) {
+        if (typeof flattenedResponse === "string") {
+          flattenedResponse = scrubSecretsFromString(flattenedResponse);
+        } else if (Array.isArray(flattenedResponse)) {
+          flattenedResponse = flattenedResponse.map((block) =>
+            block.type === "text"
+              ? { ...block, text: scrubSecretsFromString(block.text) }
+              : block,
+          );
+        }
+        if (stdout) {
+          for (let i = 0; i < stdout.length; i++) {
+            const line = stdout[i];
+            if (line !== undefined) {
+              stdout[i] = scrubSecretsFromString(line);
+            }
+          }
+        }
+        if (stderr) {
+          for (let i = 0; i < stderr.length; i++) {
+            const line = stderr[i];
+            if (line !== undefined) {
+              stderr[i] = scrubSecretsFromString(line);
+            }
           }
         }
       }
-    }
 
-    // Track tool usage (calculate size for multimodal content)
-    const responseSize =
-      typeof flattenedResponse === "string"
-        ? flattenedResponse.length
-        : JSON.stringify(flattenedResponse).length;
-    telemetry.trackToolUsage(
-      internalName,
-      toolStatus === "success",
-      duration,
-      responseSize,
-      toolStatus === "error" ? "tool_error" : undefined,
-      stderr ? stderr.join("\n") : undefined,
-    );
-
-    // Run PostToolUse hooks - exit 2 injects stderr into agent context
-    // Note: preceding_reasoning/assistant_message not available here - tracked in accumulator for server tools
-    let postToolUseFeedback: string[] = [];
-    try {
-      const postHookResult = await runPostToolUseHooks(
-        internalName,
-        args as Record<string, unknown>,
-        {
-          status: toolStatus,
-          output: getDisplayableToolReturn(flattenedResponse),
-        },
-        options?.toolCallId,
-        workingDirectory,
-        scopedAgentId,
-        undefined, // precedingReasoning - not available in tool manager context
-        undefined, // precedingAssistantMessage - not available in tool manager context
-      );
-      postToolUseFeedback = postHookResult.feedback;
-    } catch (error) {
-      debugLog("hooks", "PostToolUse hook error (success path)", error);
-    }
-
-    // Run PostToolUseFailure hooks when tool returns error status
-    let postToolUseFailureFeedback: string[] = [];
-    if (toolStatus === "error") {
-      const errorOutput =
+      // Track tool usage (calculate size for multimodal content)
+      const responseSize =
         typeof flattenedResponse === "string"
-          ? flattenedResponse
-          : JSON.stringify(flattenedResponse);
+          ? flattenedResponse.length
+          : JSON.stringify(flattenedResponse).length;
+      telemetry.trackToolUsage(
+        internalName,
+        toolStatus === "success",
+        duration,
+        responseSize,
+        toolStatus === "error" ? "tool_error" : undefined,
+        stderr ? stderr.join("\n") : undefined,
+      );
+
+      // Run PostToolUse hooks - exit 2 injects stderr into agent context
+      // Note: preceding_reasoning/assistant_message not available here - tracked in accumulator for server tools
+      let postToolUseFeedback: string[] = [];
+      try {
+        const postHookResult = await runPostToolUseHooks(
+          internalName,
+          args as Record<string, unknown>,
+          {
+            status: toolStatus,
+            output: getDisplayableToolReturn(flattenedResponse),
+          },
+          options?.toolCallId,
+          workingDirectory,
+          scopedAgentId,
+          undefined, // precedingReasoning - not available in tool manager context
+          undefined, // precedingAssistantMessage - not available in tool manager context
+        );
+        postToolUseFeedback = postHookResult.feedback;
+      } catch (error) {
+        debugLog("hooks", "PostToolUse hook error (success path)", error);
+      }
+
+      // Run PostToolUseFailure hooks when tool returns error status
+      let postToolUseFailureFeedback: string[] = [];
+      if (toolStatus === "error") {
+        const errorOutput =
+          typeof flattenedResponse === "string"
+            ? flattenedResponse
+            : JSON.stringify(flattenedResponse);
+        try {
+          const failureHookResult = await runPostToolUseFailureHooks(
+            internalName,
+            args as Record<string, unknown>,
+            errorOutput,
+            "tool_error", // error type for returned errors
+            options?.toolCallId,
+            workingDirectory,
+            scopedAgentId,
+            undefined, // precedingReasoning - not available in tool manager context
+            undefined, // precedingAssistantMessage - not available in tool manager context
+          );
+          postToolUseFailureFeedback = failureHookResult.feedback;
+        } catch (error) {
+          debugLog(
+            "hooks",
+            "PostToolUseFailure hook error (tool returned error)",
+            error,
+          );
+        }
+      }
+
+      // Combine feedback from both hook types and inject into tool return
+      const allFeedback = [
+        ...postToolUseFeedback,
+        ...postToolUseFailureFeedback,
+      ];
+      if (allFeedback.length > 0) {
+        const feedbackMessage = `\n\n[Hook feedback]:\n${allFeedback.join("\n")}`;
+        let finalToolReturn: ToolReturnContent;
+        if (typeof flattenedResponse === "string") {
+          finalToolReturn = flattenedResponse + feedbackMessage;
+        } else if (Array.isArray(flattenedResponse)) {
+          // Append feedback as a new text content block
+          finalToolReturn = [
+            ...flattenedResponse,
+            { type: "text" as const, text: feedbackMessage },
+          ];
+        } else {
+          finalToolReturn = flattenedResponse;
+        }
+        return {
+          toolReturn: finalToolReturn,
+          status: toolStatus,
+          ...(stdout && { stdout }),
+          ...(stderr && { stderr }),
+        };
+      }
+
+      // Return the full response (truncation happens in UI layer only)
+      return {
+        toolReturn: flattenedResponse,
+        status: toolStatus,
+        ...(stdout && { stdout }),
+        ...(stderr && { stderr }),
+      };
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      const isAbort =
+        error instanceof Error &&
+        (error.name === "AbortError" ||
+          error.message === "The operation was aborted" ||
+          // node:child_process AbortError may include code/message variants
+          ("code" in error && error.code === "ABORT_ERR"));
+      const errorType = isAbort
+        ? "abort"
+        : error instanceof Error
+          ? error.name
+          : "unknown";
+      const errorMessage = isAbort
+        ? INTERRUPTED_BY_USER
+        : error instanceof Error
+          ? error.message
+          : String(error);
+
+      // Track tool usage error
+      telemetry.trackToolUsage(
+        internalName,
+        false,
+        duration,
+        errorMessage.length,
+        errorType,
+        errorMessage,
+      );
+
+      // Run PostToolUse hooks for error case - exit 2 injects stderr
+      let postToolUseFeedback: string[] = [];
+      try {
+        const postHookResult = await runPostToolUseHooks(
+          internalName,
+          args as Record<string, unknown>,
+          { status: "error", output: errorMessage },
+          options?.toolCallId,
+          workingDirectory,
+          scopedAgentId,
+          undefined, // precedingReasoning - not available in tool manager context
+          undefined, // precedingAssistantMessage - not available in tool manager context
+        );
+        postToolUseFeedback = postHookResult.feedback;
+      } catch (error) {
+        debugLog("hooks", "PostToolUse hook error (error path)", error);
+      }
+
+      // Run PostToolUseFailure hooks - exit 2 injects stderr
+      let postToolUseFailureFeedback: string[] = [];
       try {
         const failureHookResult = await runPostToolUseFailureHooks(
           internalName,
           args as Record<string, unknown>,
-          errorOutput,
-          "tool_error", // error type for returned errors
+          errorMessage,
+          errorType,
           options?.toolCallId,
           workingDirectory,
           scopedAgentId,
@@ -1800,126 +1905,27 @@ export async function executeTool(
       } catch (error) {
         debugLog(
           "hooks",
-          "PostToolUseFailure hook error (tool returned error)",
+          "PostToolUseFailure hook error (exception path)",
           error,
         );
       }
-    }
 
-    // Combine feedback from both hook types and inject into tool return
-    const allFeedback = [...postToolUseFeedback, ...postToolUseFailureFeedback];
-    if (allFeedback.length > 0) {
-      const feedbackMessage = `\n\n[Hook feedback]:\n${allFeedback.join("\n")}`;
-      let finalToolReturn: ToolReturnContent;
-      if (typeof flattenedResponse === "string") {
-        finalToolReturn = flattenedResponse + feedbackMessage;
-      } else if (Array.isArray(flattenedResponse)) {
-        // Append feedback as a new text content block
-        finalToolReturn = [
-          ...flattenedResponse,
-          { type: "text" as const, text: feedbackMessage },
-        ];
-      } else {
-        finalToolReturn = flattenedResponse;
-      }
+      // Combine feedback from both hook types
+      const allFeedback = [
+        ...postToolUseFeedback,
+        ...postToolUseFailureFeedback,
+      ];
+      const finalErrorMessage =
+        allFeedback.length > 0
+          ? `${errorMessage}\n\n[Hook feedback]:\n${allFeedback.join("\n")}`
+          : errorMessage;
+
+      // Don't console.error here - it pollutes the TUI
+      // The error message is already returned in toolReturn
       return {
-        toolReturn: finalToolReturn,
-        status: toolStatus,
-        ...(stdout && { stdout }),
-        ...(stderr && { stderr }),
+        toolReturn: finalErrorMessage,
+        status: "error",
       };
-    }
-
-    // Return the full response (truncation happens in UI layer only)
-    return {
-      toolReturn: flattenedResponse,
-      status: toolStatus,
-      ...(stdout && { stdout }),
-      ...(stderr && { stderr }),
-    };
-  } catch (error) {
-    const duration = Date.now() - startTime;
-    const isAbort =
-      error instanceof Error &&
-      (error.name === "AbortError" ||
-        error.message === "The operation was aborted" ||
-        // node:child_process AbortError may include code/message variants
-        ("code" in error && error.code === "ABORT_ERR"));
-    const errorType = isAbort
-      ? "abort"
-      : error instanceof Error
-        ? error.name
-        : "unknown";
-    const errorMessage = isAbort
-      ? INTERRUPTED_BY_USER
-      : error instanceof Error
-        ? error.message
-        : String(error);
-
-    // Track tool usage error
-    telemetry.trackToolUsage(
-      internalName,
-      false,
-      duration,
-      errorMessage.length,
-      errorType,
-      errorMessage,
-    );
-
-    // Run PostToolUse hooks for error case - exit 2 injects stderr
-    let postToolUseFeedback: string[] = [];
-    try {
-      const postHookResult = await runPostToolUseHooks(
-        internalName,
-        args as Record<string, unknown>,
-        { status: "error", output: errorMessage },
-        options?.toolCallId,
-        workingDirectory,
-        scopedAgentId,
-        undefined, // precedingReasoning - not available in tool manager context
-        undefined, // precedingAssistantMessage - not available in tool manager context
-      );
-      postToolUseFeedback = postHookResult.feedback;
-    } catch (error) {
-      debugLog("hooks", "PostToolUse hook error (error path)", error);
-    }
-
-    // Run PostToolUseFailure hooks - exit 2 injects stderr
-    let postToolUseFailureFeedback: string[] = [];
-    try {
-      const failureHookResult = await runPostToolUseFailureHooks(
-        internalName,
-        args as Record<string, unknown>,
-        errorMessage,
-        errorType,
-        options?.toolCallId,
-        workingDirectory,
-        scopedAgentId,
-        undefined, // precedingReasoning - not available in tool manager context
-        undefined, // precedingAssistantMessage - not available in tool manager context
-      );
-      postToolUseFailureFeedback = failureHookResult.feedback;
-    } catch (error) {
-      debugLog(
-        "hooks",
-        "PostToolUseFailure hook error (exception path)",
-        error,
-      );
-    }
-
-    // Combine feedback from both hook types
-    const allFeedback = [...postToolUseFeedback, ...postToolUseFailureFeedback];
-    const finalErrorMessage =
-      allFeedback.length > 0
-        ? `${errorMessage}\n\n[Hook feedback]:\n${allFeedback.join("\n")}`
-        : errorMessage;
-
-    // Don't console.error here - it pollutes the TUI
-    // The error message is already returned in toolReturn
-    return {
-      toolReturn: finalErrorMessage,
-      status: "error",
-    };
     }
   };
 

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -8,6 +8,7 @@ import {
   SUPPORTED_CHANNEL_IDS,
   type SupportedChannelId,
 } from "../channels/types";
+import type { RuntimeContextSnapshot } from "../runtime-context";
 import { settingsManager } from "../settings-manager";
 import { toolFilter } from "./filter";
 import {
@@ -144,6 +145,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
+  runtimeContext?: Partial<RuntimeContextSnapshot>;
 }): Promise<PreparedScopeToolContext> {
   const {
     modelIdentifier,
@@ -152,6 +154,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     workingDirectory,
     permissionModeState,
     channelToolScope,
+    runtimeContext,
   } = params;
   const effectiveModel =
     modelIdentifier && modelIdentifier.length > 0
@@ -166,6 +169,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
         workingDirectory,
         permissionModeState,
         channelToolScope,
+        runtimeContext,
       },
     );
 
@@ -187,6 +191,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       workingDirectory,
       permissionModeState,
       channelToolScope,
+      runtimeContext,
     },
   );
 
@@ -294,6 +299,11 @@ export async function prepareToolExecutionContextForScope(params: {
     exclude,
     workingDirectory,
     permissionModeState,
+    runtimeContext: {
+      agentId,
+      conversationId: conversationId ?? "default",
+      workingDirectory,
+    },
     channelToolScope: resolveConversationChannelToolScope(
       agentId,
       conversationId ?? "default",

--- a/src/utils/secretsStore.ts
+++ b/src/utils/secretsStore.ts
@@ -10,14 +10,43 @@ import { getCurrentAgentId } from "../agent/context";
 /** In-memory cache of secrets (populated on startup from server).
  *  Stored on globalThis via Symbol.for() to survive Bun bundle duplication. */
 const SECRETS_CACHE_KEY = Symbol.for("@letta/secretsCache");
+type SecretsCache = Map<string, Record<string, string>>;
 type GlobalWithSecrets = typeof globalThis & {
-  [key: symbol]: Record<string, string> | null;
+  [key: symbol]: SecretsCache | undefined;
 };
-function getCache(): Record<string, string> | null {
-  return (globalThis as GlobalWithSecrets)[SECRETS_CACHE_KEY] ?? null;
+function getCache(): SecretsCache {
+  const global = globalThis as GlobalWithSecrets;
+  if (!global[SECRETS_CACHE_KEY]) {
+    global[SECRETS_CACHE_KEY] = new Map();
+  }
+  return global[SECRETS_CACHE_KEY];
 }
-function setCache(secrets: Record<string, string> | null): void {
-  (globalThis as GlobalWithSecrets)[SECRETS_CACHE_KEY] = secrets;
+
+function setCache(agentId: string, secrets: Record<string, string>): void {
+  getCache().set(agentId, { ...secrets });
+}
+
+function resolveSecretsAgentId(explicitAgentId?: string): string | null {
+  const trimmedExplicit = explicitAgentId?.trim();
+  if (trimmedExplicit) {
+    return trimmedExplicit;
+  }
+
+  try {
+    const scopedAgentId = getCurrentAgentId().trim();
+    if (scopedAgentId) {
+      return scopedAgentId;
+    }
+  } catch {
+    // Fall through to env fallback below.
+  }
+
+  const envAgentId = (
+    process.env.LETTA_AGENT_ID ||
+    process.env.AGENT_ID ||
+    ""
+  ).trim();
+  return envAgentId || null;
 }
 
 /**
@@ -41,22 +70,26 @@ export async function initSecretsFromServer(agentId: string): Promise<void> {
     }
   }
 
-  setCache(secrets);
+  setCache(agentId, secrets);
 }
 
 /**
  * Load secrets from the in-memory cache.
  * Returns an empty object if secrets have not been initialized yet.
  */
-export function loadSecrets(): Record<string, string> {
-  return getCache() ?? {};
+export function loadSecrets(agentId?: string): Record<string, string> {
+  const resolvedAgentId = resolveSecretsAgentId(agentId);
+  if (!resolvedAgentId) {
+    return {};
+  }
+  return { ...(getCache().get(resolvedAgentId) ?? {}) };
 }
 
 /**
  * List all secret names (not values).
  */
-export function listSecretNames(): string[] {
-  return Object.keys(loadSecrets()).sort();
+export function listSecretNames(agentId?: string): string[] {
+  return Object.keys(loadSecrets(agentId)).sort();
 }
 
 /**
@@ -66,18 +99,22 @@ export function listSecretNames(): string[] {
 export async function setSecretOnServer(
   key: string,
   value: string,
+  agentIdArg?: string,
 ): Promise<void> {
   const client = await getClient();
-  const agentId = getCurrentAgentId();
+  const agentId = resolveSecretsAgentId(agentIdArg);
+  if (!agentId) {
+    throw new Error("No agent context set. Agent ID is required.");
+  }
 
   // Update cache first
-  const secrets = { ...loadSecrets() };
+  const secrets = { ...loadSecrets(agentId) };
   secrets[key] = value;
 
   // PATCH replaces entire map
   await client.agents.update(agentId, { secrets });
 
-  setCache(secrets);
+  setCache(agentId, secrets);
 }
 
 /**
@@ -85,8 +122,15 @@ export async function setSecretOnServer(
  * Rebuilds the map without the key and PATCHes.
  * @returns true if the secret existed and was deleted
  */
-export async function deleteSecretOnServer(key: string): Promise<boolean> {
-  const secrets = { ...loadSecrets() };
+export async function deleteSecretOnServer(
+  key: string,
+  agentIdArg?: string,
+): Promise<boolean> {
+  const agentId = resolveSecretsAgentId(agentIdArg);
+  if (!agentId) {
+    throw new Error("No agent context set. Agent ID is required.");
+  }
+  const secrets = { ...loadSecrets(agentId) };
 
   if (!(key in secrets)) {
     return false;
@@ -95,17 +139,21 @@ export async function deleteSecretOnServer(key: string): Promise<boolean> {
   delete secrets[key];
 
   const client = await getClient();
-  const agentId = getCurrentAgentId();
 
   await client.agents.update(agentId, { secrets });
 
-  setCache(secrets);
+  setCache(agentId, secrets);
   return true;
 }
 
 /**
  * Clear the in-memory cache (useful for testing).
  */
-export function clearSecretsCache(): void {
-  setCache(null);
+export function clearSecretsCache(agentId?: string): void {
+  const resolvedAgentId = resolveSecretsAgentId(agentId);
+  if (resolvedAgentId) {
+    getCache().delete(resolvedAgentId);
+    return;
+  }
+  getCache().clear();
 }

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -63,6 +63,7 @@ import {
   createSharedReminderState,
   resetSharedReminderState,
 } from "../../reminders/state";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
@@ -3950,7 +3951,7 @@ async function handleCwdChange(
 }
 
 function createRuntime(): ListenerRuntime {
-  const bootWorkingDirectory = process.env.USER_CWD || process.cwd();
+  const bootWorkingDirectory = getCurrentWorkingDirectory();
   return {
     socket: null,
     heartbeatInterval: null,

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -440,6 +440,7 @@ export async function recoverApprovalStateForSync(
       missingNameReason: "Tool call incomplete - missing name",
       workingDirectory,
       permissionModeState,
+      agentId: scope.agent_id,
     });
   const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);
 
@@ -561,6 +562,7 @@ export async function resolveRecoveredApprovalResponse(
             recovered.agentId,
             recovered.conversationId,
           ),
+          agentId: recovered.agentId,
         },
       );
 

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -184,6 +184,7 @@ export async function resolveStaleApprovals(
         missingNameReason: "Tool call incomplete - missing name",
         workingDirectory: recoveryWorkingDirectory,
         permissionModeState,
+        agentId: runtime.agentId,
       });
 
     const decisions: ApprovalDecision[] = [
@@ -267,6 +268,7 @@ export async function resolveStaleApprovals(
                   missingNameReason: "Tool call incomplete - missing name",
                   workingDirectory: recoveryWorkingDirectory,
                   permissionModeState,
+                  agentId: runtime.agentId,
                 },
               );
 

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -235,6 +235,7 @@ export async function handleApprovalStop(params: {
       missingNameReason: "Tool call incomplete - missing name",
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
+      agentId,
     });
 
   let pendingNeedsUserInput = [...needsUserInput];
@@ -397,6 +398,7 @@ export async function handleApprovalStop(params: {
                 missingNameReason: "Tool call incomplete - missing name",
                 workingDirectory: turnWorkingDirectory,
                 permissionModeState: turnPermissionModeState,
+                agentId,
               },
             );
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -9,7 +9,12 @@ import type { ApprovalResult } from "../../agent/approval-execution";
 import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
-import { setConversationId, setCurrentAgentId } from "../../agent/context";
+import {
+  getConversationId,
+  getCurrentAgentId,
+  setConversationId,
+  setCurrentAgentId,
+} from "../../agent/context";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import {
   getStreamToolContextId,
@@ -1159,6 +1164,26 @@ export async function handleIncomingMessage(
       agent_id: agentId || null,
       conversation_id: conversationId,
     });
+
+    try {
+      const currentConversationId = getConversationId();
+      let currentAgentId: string | null = null;
+      try {
+        currentAgentId = getCurrentAgentId();
+      } catch {
+        currentAgentId = null;
+      }
+
+      if (
+        currentAgentId === (agentId ?? null) &&
+        currentConversationId === conversationId
+      ) {
+        setCurrentAgentId(null);
+        setConversationId(null);
+      }
+    } catch {
+      // Best-effort cleanup only. Never let teardown obscure the turn result.
+    }
 
     runtime.activeAbortController = null;
     runtime.cancelRequested = false;


### PR DESCRIPTION
## Summary
- capture scoped runtime context for prepared tool execution and run tools inside that context instead of mutating parent-process execution env
- switch agent/conversation/cwd readers and shell env construction to runtime-scoped values, and migrate listener/tool cwd readers off ambient USER_CWD
- isolate agent secrets and thread scoped agent identity through permission-request hooks, with regression coverage for overlapping runtime scopes

## Testing
- bun x tsc --noEmit --pretty false
- bun test src/tests/tools/shell-env.test.ts --bail
- bun test src/tests/tools/tool-execution-context.test.ts --bail
- bun test src/tests/hooks/executor.test.ts --bail
- bun test src/tests/hooks/integration.test.ts --bail
- bun test src/tests/permissions-checker.test.ts --bail
- bun test src/tests/websocket/listen-client-concurrency.test.ts --bail