### PR TITLE
fix(reflection): record real agent and message ids in telemetry

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -290,7 +290,7 @@ function handleInitEvent(
     const agentURL = buildChatUrl(event.agent_id, {
       conversationId: event.conversation_id,
     });
-    updateSubagent(subagentId, { agentURL });
+    updateSubagent(subagentId, { agentId: event.agent_id, agentURL });
   }
   if (event.conversation_id) {
     state.conversationId = event.conversation_id;

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5548,13 +5548,19 @@ export default function App({
                   ? buildQueuedUserText(queuedItemsToAppend)
                   : "";
 
+                const queuedUserOtid = randomUUID();
                 if (queuedUserText) {
                   const userId = uid("user");
                   buffersRef.current.byId.set(userId, {
                     kind: "user",
                     id: userId,
                     text: queuedUserText,
+                    otid: queuedUserOtid,
                   });
+                  buffersRef.current.userLineIdByOtid.set(
+                    queuedUserOtid,
+                    userId,
+                  );
                   buffersRef.current.order.push(userId);
                 }
 
@@ -5575,7 +5581,7 @@ export default function App({
                         type: "message",
                         role: "user",
                         content: queuedContentParts,
-                        otid: randomUUID(),
+                        otid: queuedUserOtid,
                       },
                     ],
                     { allowReentry: true },
@@ -10599,17 +10605,22 @@ export default function App({
               parentMemory,
             });
 
-            const { spawnBackgroundSubagentTask } = await import(
-              "../tools/impl/Task"
-            );
+            const {
+              spawnBackgroundSubagentTask,
+              waitForBackgroundSubagentAgentId,
+            } = await import("../tools/impl/Task");
             const { subagentId } = spawnBackgroundSubagentTask({
               subagentType: "reflection",
               prompt: reflectionPrompt,
               description: "Reflecting on conversation",
               silentCompletion: true,
-              onComplete: async ({ success, error }) => {
+              onComplete: async ({
+                success,
+                error,
+                agentId: reflectionAgentId,
+              }) => {
                 telemetry.trackReflectionEnd("manual", success, {
-                  subagentId,
+                  subagentId: reflectionAgentId ?? undefined,
                   conversationId: reflectionConversationId,
                   error,
                 });
@@ -10641,8 +10652,12 @@ export default function App({
                 appendTaskNotificationEvents([msg]);
               },
             });
-            telemetry.trackReflectionStart("manual", {
+            const reflectionAgentId = await waitForBackgroundSubagentAgentId(
               subagentId,
+              1000,
+            );
+            telemetry.trackReflectionStart("manual", {
+              subagentId: reflectionAgentId ?? undefined,
               conversationId: reflectionConversationId,
               startMessageId: autoPayload.startMessageId,
               endMessageId: autoPayload.endMessageId,
@@ -11085,17 +11100,22 @@ ${SYSTEM_REMINDER_CLOSE}
             parentMemory,
           });
 
-          const { spawnBackgroundSubagentTask } = await import(
-            "../tools/impl/Task"
-          );
+          const {
+            spawnBackgroundSubagentTask,
+            waitForBackgroundSubagentAgentId,
+          } = await import("../tools/impl/Task");
           const { subagentId } = spawnBackgroundSubagentTask({
             subagentType: "reflection",
             prompt: reflectionPrompt,
             description: AUTO_REFLECTION_DESCRIPTION,
             silentCompletion: true,
-            onComplete: async ({ success, error }) => {
+            onComplete: async ({
+              success,
+              error,
+              agentId: reflectionAgentId,
+            }) => {
               telemetry.trackReflectionEnd(triggerSource, success, {
-                subagentId,
+                subagentId: reflectionAgentId ?? undefined,
                 conversationId: reflectionConversationId,
                 error,
               });
@@ -11127,8 +11147,12 @@ ${SYSTEM_REMINDER_CLOSE}
               appendTaskNotificationEvents([msg]);
             },
           });
-          telemetry.trackReflectionStart(triggerSource, {
+          const reflectionAgentId = await waitForBackgroundSubagentAgentId(
             subagentId,
+            1000,
+          );
+          telemetry.trackReflectionStart(triggerSource, {
+            subagentId: reflectionAgentId ?? undefined,
             conversationId: reflectionConversationId,
             startMessageId: autoPayload.startMessageId,
             endMessageId: autoPayload.endMessageId,
@@ -11203,12 +11227,15 @@ ${SYSTEM_REMINDER_CLOSE}
 
       // Append the user message to transcript IMMEDIATELY (optimistic update)
       const userId = uid("user");
+      const userOtid = randomUUID();
       if (userTextForInput) {
         buffersRef.current.byId.set(userId, {
           kind: "user",
           id: userId,
           text: userTextForInput,
+          otid: userOtid,
         });
+        buffersRef.current.userLineIdByOtid.set(userOtid, userId);
         buffersRef.current.order.push(userId);
       }
       const transcriptStartLineIndex = userTextForInput
@@ -11821,7 +11848,7 @@ ${SYSTEM_REMINDER_CLOSE}
         type: "message",
         role: "user",
         content: messageContent as unknown as MessageCreate["content"],
-        otid: randomUUID(),
+        otid: userOtid,
       });
 
       await processConversation(initialInput, {
@@ -12180,20 +12207,23 @@ ${SYSTEM_REMINDER_CLOSE}
           ];
           if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
             const queuedUserText = buildQueuedUserText(queuedItemsToAppend);
+            const queuedUserOtid = randomUUID();
             if (queuedUserText) {
               const userId = uid("user");
               buffersRef.current.byId.set(userId, {
                 kind: "user",
                 id: userId,
                 text: queuedUserText,
+                otid: queuedUserOtid,
               });
+              buffersRef.current.userLineIdByOtid.set(queuedUserOtid, userId);
               buffersRef.current.order.push(userId);
             }
             input.push({
               type: "message",
               role: "user",
               content: buildQueuedContentParts(queuedItemsToAppend),
-              otid: randomUUID(),
+              otid: queuedUserOtid,
             });
             refreshDerived();
           } else if (hadNotifications) {

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -716,6 +716,35 @@ function uid(prefix: string) {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// OTIDs are client-generated correlation ids, not canonical backend message ids.
+// We use them to stitch together an optimistic local transcript row, the outbound
+// request payload, and the echoed user_message chunk that later arrives from the
+// server with the real message.id.
+function createClientOtid(): string {
+  return randomUUID();
+}
+
+function appendOptimisticUserLine(
+  buffers: Buffers,
+  text: string,
+  otid: string,
+): string | null {
+  if (!text) {
+    return null;
+  }
+
+  const userId = uid("user");
+  buffers.byId.set(userId, {
+    kind: "user",
+    id: userId,
+    text,
+    otid,
+  });
+  buffers.userLineIdByOtid.set(otid, userId);
+  buffers.order.push(userId);
+  return userId;
+}
+
 function buildApprovalBatchKey(approvals: ApprovalRequest[]): string {
   return approvals
     .map((approval) => approval.toolCallId)
@@ -5548,21 +5577,12 @@ export default function App({
                   ? buildQueuedUserText(queuedItemsToAppend)
                   : "";
 
-                const queuedUserOtid = randomUUID();
-                if (queuedUserText) {
-                  const userId = uid("user");
-                  buffersRef.current.byId.set(userId, {
-                    kind: "user",
-                    id: userId,
-                    text: queuedUserText,
-                    otid: queuedUserOtid,
-                  });
-                  buffersRef.current.userLineIdByOtid.set(
-                    queuedUserOtid,
-                    userId,
-                  );
-                  buffersRef.current.order.push(userId);
-                }
+                const queuedUserOtid = createClientOtid();
+                appendOptimisticUserLine(
+                  buffersRef.current,
+                  queuedUserText,
+                  queuedUserOtid,
+                );
 
                 if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
                   const queuedContentParts =
@@ -5575,7 +5595,7 @@ export default function App({
                       {
                         type: "approval",
                         approvals: allResults,
-                        otid: randomUUID(),
+                        otid: createClientOtid(),
                       },
                       {
                         type: "message",
@@ -11225,19 +11245,14 @@ ${SYSTEM_REMINDER_CLOSE}
       // Append task notifications (if any) as event lines before the user message
       appendTaskNotificationEvents(taskNotifications);
 
-      // Append the user message to transcript IMMEDIATELY (optimistic update)
-      const userId = uid("user");
-      const userOtid = randomUUID();
-      if (userTextForInput) {
-        buffersRef.current.byId.set(userId, {
-          kind: "user",
-          id: userId,
-          text: userTextForInput,
-          otid: userOtid,
-        });
-        buffersRef.current.userLineIdByOtid.set(userOtid, userId);
-        buffersRef.current.order.push(userId);
-      }
+      // Append an optimistic user row now, then reconcile it with the echoed
+      // user_message chunk once the server returns the canonical message.id.
+      const userOtid = createClientOtid();
+      const optimisticUserLineId = appendOptimisticUserLine(
+        buffersRef.current,
+        userTextForInput,
+        userOtid,
+      );
       const transcriptStartLineIndex = userTextForInput
         ? Math.max(0, toLines(buffersRef.current).length - 1)
         : null;
@@ -11297,10 +11312,13 @@ ${SYSTEM_REMINDER_CLOSE}
             abortControllerRef.current?.signal.aborted
           ) {
             // User hit ESC during the check - abort and clean up
-            buffersRef.current.byId.delete(userId);
-            const orderIndex = buffersRef.current.order.indexOf(userId);
-            if (orderIndex !== -1) {
-              buffersRef.current.order.splice(orderIndex, 1);
+            if (optimisticUserLineId) {
+              buffersRef.current.byId.delete(optimisticUserLineId);
+              const orderIndex =
+                buffersRef.current.order.indexOf(optimisticUserLineId);
+              if (orderIndex !== -1) {
+                buffersRef.current.order.splice(orderIndex, 1);
+              }
             }
             setStreaming(false);
             refreshDerived();
@@ -11326,10 +11344,13 @@ ${SYSTEM_REMINDER_CLOSE}
               userCancelledRef.current ||
               abortControllerRef.current?.signal.aborted
             ) {
-              buffersRef.current.byId.delete(userId);
-              const orderIndex = buffersRef.current.order.indexOf(userId);
-              if (orderIndex !== -1) {
-                buffersRef.current.order.splice(orderIndex, 1);
+              if (optimisticUserLineId) {
+                buffersRef.current.byId.delete(optimisticUserLineId);
+                const orderIndex =
+                  buffersRef.current.order.indexOf(optimisticUserLineId);
+                if (orderIndex !== -1) {
+                  buffersRef.current.order.splice(orderIndex, 1);
+                }
               }
               setStreaming(false);
               refreshDerived();
@@ -11586,10 +11607,13 @@ ${SYSTEM_REMINDER_CLOSE}
             } else {
               // Some approvals need user input - show dialog
               // Remove the optimistic user message from transcript
-              buffersRef.current.byId.delete(userId);
-              const orderIndex = buffersRef.current.order.indexOf(userId);
-              if (orderIndex !== -1) {
-                buffersRef.current.order.splice(orderIndex, 1);
+              if (optimisticUserLineId) {
+                buffersRef.current.byId.delete(optimisticUserLineId);
+                const orderIndex =
+                  buffersRef.current.order.indexOf(optimisticUserLineId);
+                if (orderIndex !== -1) {
+                  buffersRef.current.order.splice(orderIndex, 1);
+                }
               }
 
               setStreaming(false);
@@ -11832,7 +11856,7 @@ ${SYSTEM_REMINDER_CLOSE}
           initialInput.push({
             type: "approval",
             approvals: queuedApprovalResults,
-            otid: randomUUID(),
+            otid: createClientOtid(),
           });
         } else {
           debugWarn(
@@ -12202,23 +12226,17 @@ ${SYSTEM_REMINDER_CLOSE}
             {
               type: "approval",
               approvals: allResults as ApprovalResult[],
-              otid: randomUUID(),
+              otid: createClientOtid(),
             },
           ];
           if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
             const queuedUserText = buildQueuedUserText(queuedItemsToAppend);
-            const queuedUserOtid = randomUUID();
-            if (queuedUserText) {
-              const userId = uid("user");
-              buffersRef.current.byId.set(userId, {
-                kind: "user",
-                id: userId,
-                text: queuedUserText,
-                otid: queuedUserOtid,
-              });
-              buffersRef.current.userLineIdByOtid.set(queuedUserOtid, userId);
-              buffersRef.current.order.push(userId);
-            }
+            const queuedUserOtid = createClientOtid();
+            appendOptimisticUserLine(
+              buffersRef.current,
+              queuedUserText,
+              queuedUserOtid,
+            );
             input.push({
               type: "message",
               role: "user",

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -140,8 +140,8 @@ export type Line =
       kind: "user";
       id: string;
       text: string;
-      messageId?: string;
-      otid?: string;
+      messageId?: string; // canonical backend message.id when known
+      otid?: string; // client-generated correlation id echoed back by the server
     }
   | {
       kind: "reasoning";
@@ -149,7 +149,7 @@ export type Line =
       text: string;
       phase: "streaming" | "finished";
       isContinuation?: boolean; // true for split continuation lines (no header)
-      messageId?: string;
+      messageId?: string; // canonical backend message.id when known
     }
   | {
       kind: "assistant";
@@ -157,7 +157,7 @@ export type Line =
       text: string;
       phase: "streaming" | "finished";
       isContinuation?: boolean; // true for split continuation lines (no bullet)
-      messageId?: string;
+      messageId?: string; // canonical backend message.id when known
     }
   | {
       kind: "tool_call";
@@ -245,6 +245,8 @@ export type Buffers = {
   byId: Map<string, Line>;
   pendingToolByRun: Map<string, string>; // temporary id per run until real id
   toolCallIdToLineId: Map<string, string>;
+  // Maps a client-generated user OTID to the optimistic local transcript line id
+  // so the later echoed user_message chunk can backfill the canonical message.id.
   userLineIdByOtid: Map<string, string>;
   lastOtid: string | null; // Track the last otid to detect transitions
   // Alias maps to keep assistant deltas on one line when streams mix id/otid.
@@ -821,11 +823,14 @@ export function onChunk(
       const otid =
         typeof chunkWithIds.otid === "string" ? chunkWithIds.otid : undefined;
       const mappedLineId = otid ? b.userLineIdByOtid.get(otid) : undefined;
-      const id = mappedLineId || otid || messageId;
-      if (!id) break;
+      // Prefer the optimistic local line id when we can resolve it from the echoed
+      // OTID. That lets us preserve the already-rendered row and attach the real
+      // backend message.id once the server sends it back.
+      const lineId = mappedLineId || otid || messageId;
+      if (!lineId) break;
 
       // Handle otid transition (mark previous line as finished)
-      handleOtidTransition(b, id);
+      handleOtidTransition(b, lineId);
 
       // Extract text content from the user message
       const rawText = extractTextPart(chunk.content);
@@ -835,9 +840,9 @@ export function onChunk(
       const compactionSummary = extractCompactionSummary(rawText);
       if (compactionSummary) {
         // Render as a finished compaction event
-        ensure(b, id, () => ({
+        ensure(b, lineId, () => ({
           kind: "event",
-          id,
+          id: lineId,
           eventType: "compaction",
           eventData: {},
           phase: "finished",
@@ -849,15 +854,15 @@ export function onChunk(
         break;
       }
 
-      const line = ensure(b, id, () => ({
+      const line = ensure(b, lineId, () => ({
         kind: "user",
-        id,
+        id: lineId,
         text: rawText,
         messageId,
         otid,
       }));
       if (line.kind === "user") {
-        b.byId.set(id, {
+        b.byId.set(lineId, {
           ...line,
           text: line.text || rawText,
           messageId: messageId ?? line.messageId,
@@ -865,7 +870,7 @@ export function onChunk(
         });
       }
       if (otid) {
-        b.userLineIdByOtid.set(otid, id);
+        b.userLineIdByOtid.set(otid, lineId);
       }
       break;
     }

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -136,13 +136,20 @@ export function appendStreamingOutput(
 // One line per transcript row. Tool calls evolve in-place.
 // For tool call returns, merge into the tool call matching the toolCallId
 export type Line =
-  | { kind: "user"; id: string; text: string }
+  | {
+      kind: "user";
+      id: string;
+      text: string;
+      messageId?: string;
+      otid?: string;
+    }
   | {
       kind: "reasoning";
       id: string;
       text: string;
       phase: "streaming" | "finished";
       isContinuation?: boolean; // true for split continuation lines (no header)
+      messageId?: string;
     }
   | {
       kind: "assistant";
@@ -150,6 +157,7 @@ export type Line =
       text: string;
       phase: "streaming" | "finished";
       isContinuation?: boolean; // true for split continuation lines (no bullet)
+      messageId?: string;
     }
   | {
       kind: "tool_call";
@@ -237,6 +245,7 @@ export type Buffers = {
   byId: Map<string, Line>;
   pendingToolByRun: Map<string, string>; // temporary id per run until real id
   toolCallIdToLineId: Map<string, string>;
+  userLineIdByOtid: Map<string, string>;
   lastOtid: string | null; // Track the last otid to detect transitions
   // Alias maps to keep assistant deltas on one line when streams mix id/otid.
   assistantCanonicalByMessageId: Map<string, string>;
@@ -278,6 +287,7 @@ export function createBuffers(agentId?: string): Buffers {
     byId: new Map(),
     pendingToolByRun: new Map(),
     toolCallIdToLineId: new Map(),
+    userLineIdByOtid: new Map(),
     lastOtid: null,
     assistantCanonicalByMessageId: new Map(),
     assistantCanonicalByOtid: new Map(),
@@ -659,12 +669,18 @@ function trySplitContent(
   // Create committed line for "before" content
   // Only the first split (counter=0) shows the bullet/header; subsequent splits are continuations
   const commitId = `${id}-split-${counter}`;
+  const originalLine = b.byId.get(id);
   const committedLine = {
     kind,
     id: commitId,
     text: beforeText,
     phase: "finished" as const,
     isContinuation: counter > 0, // First split shows bullet, subsequent don't
+    messageId:
+      originalLine &&
+      (originalLine.kind === "assistant" || originalLine.kind === "reasoning")
+        ? originalLine.messageId
+        : undefined,
   };
   b.byId.set(commitId, committedLine);
 
@@ -679,7 +695,6 @@ function trySplitContent(
 
   // Update original line with just the "after" content (keep streaming)
   // Mark it as a continuation so it doesn't show bullet/header
-  const originalLine = b.byId.get(id);
   if (
     originalLine &&
     (originalLine.kind === "assistant" || originalLine.kind === "reasoning")
@@ -725,11 +740,14 @@ export function onChunk(
       handleOtidTransition(b, id);
 
       const delta = chunk.reasoning;
+      const messageId =
+        typeof chunkWithIds.id === "string" ? chunkWithIds.id : undefined;
       const line = ensure(b, id, () => ({
         kind: "reasoning",
         id,
         text: "",
         phase: "streaming",
+        messageId,
       }));
       if (delta) {
         const newText = line.text + delta;
@@ -738,10 +756,16 @@ export function onChunk(
         // Try to split at paragraph boundary (only if streaming enabled)
         if (!trySplitContent(b, id, "reasoning", newText)) {
           // No split - normal accumulation
-          b.byId.set(id, { ...line, text: newText });
+          b.byId.set(id, {
+            ...line,
+            text: newText,
+            messageId: messageId ?? line.messageId,
+          });
         }
-        // console.log(`[REASONING] Updated ${id}, textLen=${newText.length}`);
+      } else if (messageId && line.messageId !== messageId) {
+        b.byId.set(id, { ...line, messageId });
       }
+      // console.log(`[REASONING] Updated ${id}, textLen=${newText.length}`);
       break;
     }
 
@@ -759,11 +783,14 @@ export function onChunk(
       handleOtidTransition(b, id);
 
       const delta = extractTextPart(chunk.content); // NOTE: may be list of parts
+      const messageId =
+        typeof chunkWithIds.id === "string" ? chunkWithIds.id : undefined;
       const line = ensure(b, id, () => ({
         kind: "assistant",
         id,
         text: "",
         phase: "streaming",
+        messageId,
       }));
       if (delta) {
         const newText = line.text + delta;
@@ -772,16 +799,29 @@ export function onChunk(
         // Try to split at paragraph boundary (only if streaming enabled)
         if (!trySplitContent(b, id, "assistant", newText)) {
           // No split - normal accumulation
-          b.byId.set(id, { ...line, text: newText });
+          b.byId.set(id, {
+            ...line,
+            text: newText,
+            messageId: messageId ?? line.messageId,
+          });
         }
+      } else if (messageId && line.messageId !== messageId) {
+        b.byId.set(id, { ...line, messageId });
       }
       break;
     }
 
     case "user_message": {
-      // Use otid if available, fall back to id (server sends otid: null for summary messages)
-      const chunkWithId = chunk as LettaStreamingResponse & { id?: string };
-      const id = chunk.otid || chunkWithId.id;
+      const chunkWithIds = chunk as LettaStreamingResponse & {
+        id?: string;
+        otid?: string;
+      };
+      const messageId =
+        typeof chunkWithIds.id === "string" ? chunkWithIds.id : undefined;
+      const otid =
+        typeof chunkWithIds.otid === "string" ? chunkWithIds.otid : undefined;
+      const mappedLineId = otid ? b.userLineIdByOtid.get(otid) : undefined;
+      const id = mappedLineId || otid || messageId;
       if (!id) break;
 
       // Handle otid transition (mark previous line as finished)
@@ -806,8 +846,27 @@ export function onChunk(
         // Legacy servers may emit compaction completion as a user_message
         // system alert instead of summary_message.
         markCompactionCompleted(ctx);
+        break;
       }
-      // If not a summary, ignore it (user messages aren't rendered during streaming)
+
+      const line = ensure(b, id, () => ({
+        kind: "user",
+        id,
+        text: rawText,
+        messageId,
+        otid,
+      }));
+      if (line.kind === "user") {
+        b.byId.set(id, {
+          ...line,
+          text: line.text || rawText,
+          messageId: messageId ?? line.messageId,
+          otid: otid ?? line.otid,
+        });
+      }
+      if (otid) {
+        b.userLineIdByOtid.set(otid, id);
+      }
       break;
     }
 

--- a/src/cli/helpers/backfill.ts
+++ b/src/cli/helpers/backfill.ts
@@ -137,6 +137,7 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
   buffers.byId.clear();
   buffers.toolCallIdToLineId.clear();
   buffers.pendingToolByRun.clear();
+  buffers.userLineIdByOtid.clear();
   buffers.lastOtid = null;
   buffers.assistantCanonicalByMessageId.clear();
   buffers.assistantCanonicalByOtid.clear();
@@ -193,11 +194,17 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
 
         if (cleanedText) {
           const exists = buffers.byId.has(lineId);
+          const otid = "otid" in msg ? msg.otid || undefined : undefined;
           buffers.byId.set(lineId, {
             kind: "user",
             id: lineId,
             text: cleanedText,
+            messageId: msg.id,
+            otid,
           });
+          if (otid) {
+            buffers.userLineIdByOtid.set(otid, lineId);
+          }
           if (!exists) buffers.order.push(lineId);
         }
         break;
@@ -211,6 +218,7 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
           id: lineId,
           text: msg.reasoning,
           phase: "finished",
+          messageId: msg.id,
         });
         if (!exists) buffers.order.push(lineId);
         break;
@@ -224,6 +232,7 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
           id: lineId,
           text: renderAssistantContentParts(msg.content),
           phase: "finished",
+          messageId: msg.id,
         });
         if (!exists) buffers.order.push(lineId);
         break;

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -28,6 +28,7 @@ type TranscriptEntry =
       text: string;
       captured_at: string;
       source_line_id?: string;
+      source_message_id?: string;
     }
   | {
       kind: "tool_call";
@@ -37,6 +38,7 @@ type TranscriptEntry =
       resultOk?: boolean;
       captured_at: string;
       source_line_id?: string;
+      source_message_id?: string;
     };
 
 export interface ReflectionTranscriptPaths {
@@ -447,6 +449,7 @@ function lineToTranscriptEntry(
         text: line.text,
         captured_at: capturedAt,
         source_line_id: line.id,
+        source_message_id: line.messageId,
       };
     case "assistant":
       return {
@@ -454,6 +457,7 @@ function lineToTranscriptEntry(
         text: line.text,
         captured_at: capturedAt,
         source_line_id: line.id,
+        source_message_id: line.messageId,
       };
     case "reasoning":
       return {
@@ -461,6 +465,7 @@ function lineToTranscriptEntry(
         text: line.text,
         captured_at: capturedAt,
         source_line_id: line.id,
+        source_message_id: line.messageId,
       };
     case "error":
       return {
@@ -652,7 +657,8 @@ export async function buildAutoReflectionPayload(
     .map((line) => parseJsonLine<TranscriptEntry>(line))
     .filter((entry): entry is TranscriptEntry => entry !== null);
   const messageIds = entries
-    .map((entry) => entry.source_line_id)
+    .filter((entry) => entry.kind === "user" || entry.kind === "assistant")
+    .map((entry) => entry.source_message_id)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
   const startMessageId = messageIds[0];
   const endMessageId = messageIds[messageIds.length - 1];

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -27,8 +27,8 @@ type TranscriptEntry =
       kind: "user" | "assistant" | "reasoning" | "error";
       text: string;
       captured_at: string;
-      source_line_id?: string;
-      source_message_id?: string;
+      source_line_id?: string; // local transcript row id; may be synthetic
+      source_message_id?: string; // canonical backend message.id when known
     }
   | {
       kind: "tool_call";
@@ -37,8 +37,8 @@ type TranscriptEntry =
       resultText?: string;
       resultOk?: boolean;
       captured_at: string;
-      source_line_id?: string;
-      source_message_id?: string;
+      source_line_id?: string; // local transcript row id; may be synthetic
+      source_message_id?: string; // canonical backend message.id when known
     };
 
 export interface ReflectionTranscriptPaths {
@@ -656,6 +656,10 @@ export async function buildAutoReflectionPayload(
   const entries = snapshotLines
     .map((line) => parseJsonLine<TranscriptEntry>(line))
     .filter((entry): entry is TranscriptEntry => entry !== null);
+  // Reflection telemetry boundaries must use canonical backend message ids from
+  // user/assistant entries only. Tool rows use local transcript ids, and
+  // reasoning rows can share an assistant message id while still being a
+  // separate transcript row.
   const messageIds = entries
     .filter((entry) => entry.kind === "user" || entry.kind === "assistant")
     .map((entry) => entry.source_message_id)

--- a/src/cli/helpers/subagentState.ts
+++ b/src/cli/helpers/subagentState.ts
@@ -21,6 +21,7 @@ export interface SubagentState {
   type: string; // "Explore", "Plan", "code-reviewer", etc.
   description: string;
   status: "pending" | "running" | "completed" | "error";
+  agentId?: string | null;
   agentURL: string | null;
   toolCalls: ToolCall[];
   // Monotonic counter to avoid transient regressions in rendered tool usage.
@@ -179,6 +180,7 @@ export function registerSubagent(
     type: displayType,
     description,
     status: "pending",
+    agentId: null,
     agentURL: null,
     toolCalls: [],
     maxToolCallsSeen: 0,

--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -288,4 +288,52 @@ describe("accumulator usage statistics", () => {
       "Final answer",
     );
   });
+
+  test("stores the actual assistant message id even when the line id is synthetic", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "shared-stream-id",
+      reasoning: "Thinking... ",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "assistant_message",
+      id: "shared-stream-id",
+      content: [{ type: "text", text: "Final answer" }],
+    } as unknown as LettaStreamingResponse);
+
+    const assistant = buffers.byId.get("assistant:shared-stream-id");
+    expect(assistant?.kind).toBe("assistant");
+    expect(
+      assistant && "messageId" in assistant ? assistant.messageId : undefined,
+    ).toBe("shared-stream-id");
+  });
+
+  test("reconciles optimistic user lines to the backend message id via otid", () => {
+    const buffers = createBuffers();
+    buffers.byId.set("user-local-1", {
+      kind: "user",
+      id: "user-local-1",
+      text: "hello",
+      otid: "user-otid-1",
+    });
+    buffers.userLineIdByOtid.set("user-otid-1", "user-local-1");
+    buffers.order.push("user-local-1");
+
+    onChunk(buffers, {
+      message_type: "user_message",
+      id: "message-user-1",
+      otid: "user-otid-1",
+      content: "hello",
+    } as unknown as LettaStreamingResponse);
+
+    const userLine = buffers.byId.get("user-local-1");
+    expect(userLine?.kind).toBe("user");
+    expect(
+      userLine && "messageId" in userLine ? userLine.messageId : undefined,
+    ).toBe("message-user-1");
+    expect(buffers.byId.get("message-user-1")).toBeUndefined();
+  });
 });

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -48,12 +48,13 @@ describe("reflectionTranscript helper", () => {
 
   test("auto payload advances cursor on success", async () => {
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: "hello" },
+      { kind: "user", id: "u1", text: "hello", messageId: "u1" },
       {
         kind: "assistant",
         id: "a1",
         text: "hi there",
         phase: "finished",
+        messageId: "a1",
       },
     ]);
 
@@ -93,7 +94,7 @@ describe("reflectionTranscript helper", () => {
 
   test("auto payload keeps cursor on failure", async () => {
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: "remember this" },
+      { kind: "user", id: "u1", text: "remember this", messageId: "u1" },
     ]);
 
     const payload = await buildAutoReflectionPayload(agentId, conversationId);
@@ -121,7 +122,7 @@ describe("reflectionTranscript helper", () => {
 
   test("auto payload clamps out-of-range cursor and resumes on new transcript lines", async () => {
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: "first" },
+      { kind: "user", id: "u1", text: "first", messageId: "u1" },
     ]);
 
     const paths = getReflectionTranscriptPaths(agentId, conversationId);
@@ -142,7 +143,13 @@ describe("reflectionTranscript helper", () => {
     expect(clamped.auto_cursor_line).toBe(1);
 
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "assistant", id: "a2", text: "second", phase: "finished" },
+      {
+        kind: "assistant",
+        id: "a2",
+        text: "second",
+        phase: "finished",
+        messageId: "a2",
+      },
     ]);
 
     const secondAttempt = await buildAutoReflectionPayload(
@@ -157,6 +164,49 @@ describe("reflectionTranscript helper", () => {
     const payloadText = await readFile(secondAttempt.payloadPath, "utf-8");
     const messages = JSON.parse(payloadText);
     expect(messages).toContainEqual({ role: "assistant", content: "second" });
+  });
+
+  test("auto payload uses actual message ids instead of transcript line ids", async () => {
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      {
+        kind: "user",
+        id: "user-local-1",
+        text: "hello",
+        messageId: "message-user-1",
+        otid: "otid-user-1",
+      },
+      {
+        kind: "reasoning",
+        id: "reasoning:message-assistant-1",
+        text: "thinking",
+        phase: "finished",
+        messageId: "message-assistant-1",
+      },
+      {
+        kind: "tool_call",
+        id: "tool-call-1",
+        toolCallId: "tool-call-1",
+        name: "Read",
+        argsText: "{}",
+        resultText: "done",
+        resultOk: true,
+        phase: "finished",
+      },
+      {
+        kind: "assistant",
+        id: "assistant:message-assistant-1",
+        text: "answer",
+        phase: "finished",
+        messageId: "message-assistant-1",
+      },
+    ]);
+
+    const payload = await buildAutoReflectionPayload(agentId, conversationId);
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    expect(payload.startMessageId).toBe("message-user-1");
+    expect(payload.endMessageId).toBe("message-assistant-1");
   });
 
   test("buildParentMemorySnapshot renders tree descriptions and system <memory> blocks", async () => {
@@ -264,7 +314,7 @@ describe("reflectionTranscript helper", () => {
   test("reflection payload drops tool call results and truncates args", async () => {
     const longArgs = "a".repeat(500);
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: "run a search" },
+      { kind: "user", id: "u1", text: "run a search", messageId: "u1" },
       {
         kind: "tool_call",
         id: "tc1",
@@ -280,6 +330,7 @@ describe("reflectionTranscript helper", () => {
         id: "a1",
         text: "Found results",
         phase: "finished",
+        messageId: "a1",
       },
     ]);
 
@@ -312,7 +363,7 @@ describe("reflectionTranscript helper", () => {
     const userTextWithImage =
       "Check this: ![screenshot](data:image/png;base64,iVBORw0KGgoAAAANS) and tell me what you see";
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: userTextWithImage },
+      { kind: "user", id: "u1", text: userTextWithImage, messageId: "u1" },
     ]);
 
     const payload = await buildAutoReflectionPayload(agentId, conversationId);
@@ -330,7 +381,7 @@ describe("reflectionTranscript helper", () => {
 
   test("reflection payload prepends filtered system prompt when provided", async () => {
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
-      { kind: "user", id: "u1", text: "hello" },
+      { kind: "user", id: "u1", text: "hello", messageId: "u1" },
     ]);
 
     const systemPrompt = [

--- a/src/tests/telemetry/reflection-events-wiring.test.ts
+++ b/src/tests/telemetry/reflection-events-wiring.test.ts
@@ -27,6 +27,7 @@ describe("reflection telemetry wiring", () => {
     expect(appSource).toContain('telemetry.trackReflectionEnd("manual"');
     expect(appSource).toContain("telemetry.trackReflectionStart(triggerSource");
     expect(appSource).toContain("telemetry.trackReflectionEnd(triggerSource");
+    expect(appSource).toContain("waitForBackgroundSubagentAgentId");
     expect(appSource).toContain("startMessageId: autoPayload.startMessageId");
     expect(appSource).toContain("endMessageId: autoPayload.endMessageId");
   });
@@ -41,6 +42,7 @@ describe("reflection telemetry wiring", () => {
       "telemetry.trackReflectionStart(triggerSource",
     );
     expect(turnSource).toContain("telemetry.trackReflectionEnd(triggerSource");
+    expect(turnSource).toContain("waitForBackgroundSubagentAgentId");
     expect(turnSource).toContain("startMessageId: autoPayload.startMessageId");
     expect(turnSource).toContain("endMessageId: autoPayload.endMessageId");
   });

--- a/src/tests/tools/task-background-helper.test.ts
+++ b/src/tests/tools/task-background-helper.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../tools/impl/process_manager";
 import {
   spawnBackgroundSubagentTask,
+  waitForBackgroundSubagentAgentId,
   waitForBackgroundSubagentLink,
 } from "../../tools/impl/Task";
 
@@ -499,5 +500,34 @@ describe("waitForBackgroundSubagentLink", () => {
     const elapsed = Date.now() - start;
 
     expect(elapsed).toBeGreaterThanOrEqual(50);
+  });
+
+  test("returns the Letta agent id after the subagent publishes it", async () => {
+    registerSubagent("subagent-link-3", "reflection", "Reflect", "tc-3", true);
+
+    setTimeout(() => {
+      updateSubagent("subagent-link-3", {
+        agentId: "agent-123",
+        agentURL: "https://app.letta.com/chat/agent-123",
+      });
+    }, 20);
+
+    const agentId = await waitForBackgroundSubagentAgentId(
+      "subagent-link-3",
+      300,
+    );
+
+    expect(agentId).toBe("agent-123");
+  });
+
+  test("returns null when the Letta agent id is unavailable", async () => {
+    registerSubagent("subagent-link-4", "reflection", "Reflect", "tc-4", true);
+
+    const agentId = await waitForBackgroundSubagentAgentId(
+      "subagent-link-4",
+      70,
+    );
+
+    expect(agentId).toBeNull();
   });
 });

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -106,6 +106,8 @@ export interface SpawnBackgroundSubagentTaskArgs {
   onComplete?: (result: {
     success: boolean;
     error?: string;
+    agentId?: string;
+    conversationId?: string;
   }) => void | Promise<void>;
   /**
    * Optional dependency overrides for tests.
@@ -261,6 +263,37 @@ export async function waitForBackgroundSubagentLink(
   }
 }
 
+export async function waitForBackgroundSubagentAgentId(
+  subagentId: string,
+  timeoutMs: number | null = null,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const deadline =
+    timeoutMs !== null && timeoutMs > 0 ? Date.now() + timeoutMs : null;
+
+  while (true) {
+    if (signal?.aborted) {
+      return null;
+    }
+
+    const agent = getSubagentSnapshot().agents.find((a) => a.id === subagentId);
+    if (!agent) {
+      return null;
+    }
+    if (agent.agentId) {
+      return agent.agentId;
+    }
+    if (agent.status === "error" || agent.status === "completed") {
+      return agent.agentId ?? null;
+    }
+    if (deadline !== null && Date.now() >= deadline) {
+      return agent.agentId ?? null;
+    }
+
+    await sleep(BACKGROUND_STARTUP_POLL_MS);
+  }
+}
+
 /**
  * Spawn a background subagent task and return task metadata immediately.
  * Notification/hook behavior is identical to Task's background path.
@@ -372,7 +405,12 @@ export function spawnBackgroundSubagentTask(
       });
 
       try {
-        await onComplete?.({ success: result.success, error: result.error });
+        await onComplete?.({
+          success: result.success,
+          error: result.error,
+          agentId: result.agentId,
+          conversationId: result.conversationId,
+        });
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -448,7 +486,12 @@ export function spawnBackgroundSubagentTask(
       completeSubagentFn(subagentId, { success: false, error: errorMessage });
 
       try {
-        await onComplete?.({ success: false, error: errorMessage });
+        await onComplete?.({
+          success: false,
+          error: errorMessage,
+          agentId: existingAgentId,
+          conversationId: existingConversationId,
+        });
       } catch (onCompleteError) {
         const callbackMessage =
           onCompleteError instanceof Error
@@ -654,7 +697,7 @@ export async function task(args: TaskArgs): Promise<string> {
     const linkedAgent = getSubagentSnapshot().agents.find(
       (a) => a.id === subagentId,
     );
-    const agentId = linkedAgent?.agentURL?.split("/agents/")[1] ?? null;
+    const agentId = linkedAgent?.agentId ?? null;
     const agentIdLine = agentId ? `\nAgent ID: ${agentId}` : "";
 
     return `Task running in background with task ID: ${taskId}${agentIdLine}\nOutput file: ${outputFile}\n\nYou will be notified automatically when this task completes — a <task-notification> message will be delivered with the result. No need to poll, sleep-wait, or check the output file. Just continue with your current work.`;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -219,18 +219,17 @@ function buildMaybeLaunchReflectionSubagent(params: {
         parentMemory,
       });
 
-      const { spawnBackgroundSubagentTask } = await import(
-        "../../tools/impl/Task"
-      );
+      const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
+        await import("../../tools/impl/Task");
       const { subagentId } = spawnBackgroundSubagentTask({
         subagentType: "reflection",
         prompt: reflectionPrompt,
         description: AUTO_REFLECTION_DESCRIPTION,
         silentCompletion: true,
         parentScope: { agentId, conversationId },
-        onComplete: async ({ success, error }) => {
+        onComplete: async ({ success, error, agentId: reflectionAgentId }) => {
           telemetry.trackReflectionEnd(triggerSource, success, {
-            subagentId,
+            subagentId: reflectionAgentId ?? undefined,
             conversationId,
             error,
           });
@@ -278,8 +277,12 @@ function buildMaybeLaunchReflectionSubagent(params: {
           );
         },
       });
-      telemetry.trackReflectionStart(triggerSource, {
+      const reflectionAgentId = await waitForBackgroundSubagentAgentId(
         subagentId,
+        1000,
+      );
+      telemetry.trackReflectionStart(triggerSource, {
+        subagentId: reflectionAgentId ?? undefined,
         conversationId,
         startMessageId: autoPayload.startMessageId,
         endMessageId: autoPayload.endMessageId,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -458,6 +458,9 @@ export async function handleIncomingMessage(
         "content" in m && !m.otid
           ? {
               ...m,
+              // Ensure every client-originated message carries an OTID so the
+              // echoed user_message can reconcile optimistic local transcript
+              // rows with the later canonical backend message.id.
               otid:
                 "client_message_id" in m &&
                 typeof m.client_message_id === "string"


### PR DESCRIPTION
## Summary
- record the spawned reflection subagent's core `agent-...` id in telemetry while keeping `conversation_id` tied to the parent conversation
- preserve canonical backend message ids alongside local transcript line ids and reconcile optimistic user rows by `otid`
- derive reflection start/end boundaries from actual user/assistant message ids instead of synthetic line ids, reasoning entries, or tool call ids

## Test plan
- [x] `bun test --cwd "/Users/sarahwooders/repos/letta-code" src/tests/cli/reflection-transcript.test.ts src/tests/cli/accumulator-usage.test.ts src/tests/telemetry/reflection-events-wiring.test.ts src/tests/tools/task-background-helper.test.ts`
- [x] `bun run --cwd "/Users/sarahwooders/repos/letta-code" check`

👾 Generated with [Letta Code](https://letta.com)