### PR TITLE
fix(subagents): make forked subagents stop continuing parent tasks

### DIFF
--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -10,4 +10,4 @@ fork: true
 
 Recall subagent that inherits the parent agent's full conversation history via conversation forking.
 The system prompt body is not used at runtime — the forked conversation retains the parent's system prompt.
-The `searching-messages` skill is pre-loaded and provides instructions for searching conversation history.
+Search instructions are injected inline via the recall fork system reminder (see `src/agent/prompts/recall_subagent.md`).

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -948,8 +948,13 @@ ${SYSTEM_REMINDER_CLOSE}
 function buildForkSystemReminder(subagentType?: string): string {
   if (subagentType === "recall") {
     return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent.
-You CANNOT ask questions mid-execution - all instructions are provided upfront.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its tools.
+
+**Your sole task is now to search previous conversation history and provide a report. Ignore any existing ongoing tasks.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
+
+Your toolset is limited to Bash, Read, and TaskOutput. You cannot edit files, run skills, dispatch further tasks, or take any action beyond searching messages and returning a report.
+
+You CANNOT ask questions mid-execution — all instructions are provided upfront.
 Your final message will be returned to the caller.
 
 ${recallSubagentPrompt}
@@ -959,8 +964,13 @@ ${SYSTEM_REMINDER_CLOSE}
   }
 
   return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent.
-You CANNOT ask questions mid-execution - all instructions are provided upfront.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its full toolset.
+
+**Your sole task is the one described in the user message below. Ignore any existing ongoing tasks from the inherited trajectory.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
+
+You have a scoped toolset that may differ from the primary agent's. Stay within it; don't assume you have the primary's full tool access.
+
+You CANNOT ask questions mid-execution — all instructions are provided upfront.
 Your final message will be returned to the caller.
 ${SYSTEM_REMINDER_CLOSE}
 


### PR DESCRIPTION
## Summary

- Forked subagents (`recall`, `fork`) were treating the inherited conversation trajectory as an ongoing task to continue, instead of as reference context for the new task Bob got called with.
- Rewrote the fork system reminder so it's unambiguous: the fork only exists to carry the parent's trajectory in-context, the subagent is NOT the primary agent, it doesn't share the primary's full toolset, and it should ignore any in-progress work it sees in the inherited history.
- For `recall` specifically, pinned the sole task to \"search history + return a report\" and named the reduced toolset (Bash, Read, TaskOutput) so the subagent doesn't try to run skills, edits, or dispatch further tasks.

### Recall branch — new text

```
You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its tools.

**Your sole task is now to search previous conversation history and provide a report. Ignore any existing ongoing tasks.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.

Your toolset is limited to Bash, Read, and TaskOutput. You cannot edit files, run skills, dispatch further tasks, or take any action beyond searching messages and returning a report.

You CANNOT ask questions mid-execution — all instructions are provided upfront.
Your final message will be returned to the caller.
```

### Generic fork branch — new text

```
You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its full toolset.

**Your sole task is the one described in the user message below. Ignore any existing ongoing tasks from the inherited trajectory.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.

You have a scoped toolset that may differ from the primary agent's. Stay within it; don't assume you have the primary's full tool access.

You CANNOT ask questions mid-execution — all instructions are provided upfront.
Your final message will be returned to the caller.
```

## Test plan

- [x] \`bun run check\` passes (lint + typecheck)
- [x] \`bun test src/tests/agent/subagent-builtins.test.ts src/tests/agent/subagent-model-resolution.test.ts\` passes (35/35)
- [ ] Manual: dispatch a \`recall\` subagent mid-task and confirm it searches + returns a report instead of continuing the parent's work
- [ ] Manual: dispatch a \`fork\` subagent mid-task and confirm it scopes itself to the Task prompt

👾 Generated with [Letta Code](https://letta.com)