### PR TITLE
fix(approval): deny stale restored client approvals

### DIFF
--- a/docs/plans/stale-client-approval-recovery-2026-04-21.md
+++ b/docs/plans/stale-client-approval-recovery-2026-04-21.md
@@ -1,0 +1,41 @@
+## Stale Client Approval Recovery
+
+### Problem
+
+Some client-side approval recovery paths replay auto-allowed tools after the
+backend restores `pendingApprovals`. That is unsafe for replay-sensitive tools
+like `MessageChannel`, because the tool may already have run locally before the
+session was interrupted.
+
+### Canonical policy
+
+1. If we already have a real local approval result, resend or queue that result.
+2. If we do not have the real local result, never auto-rerun replay-unsafe
+   client-side tools from backend-restored pending approvals.
+3. Instead, synthesize denial results for those stale approvals.
+4. For startup / restored-session recovery, queue those synthetic denials and
+   send them with the next user message.
+5. For in-flight stale approval conflicts, synthesize denials immediately and
+   retry the turn.
+
+### Misaligned paths on main
+
+- `src/cli/App.tsx`
+  - `recoverRestoredPendingApprovals(...)`
+  - `checkPendingApprovalsForSlashCommand(...)`
+  - resumed-session eager approval handling inside `onSubmit(...)`
+- `src/headless.ts`
+  - `resolveAllPendingApprovals(...)` recovery branches
+- `src/websocket/listener/send.ts`
+  - `resolveStaleApprovals(...)`
+- `src/websocket/listener/recovery.ts`
+  - restored approval sync recovery
+
+### Intended fix
+
+- Add a shared helper for building queued stale-denial approval results.
+- Replace replay-prone restore/recovery branches with that helper.
+- Keep existing in-memory queued-result resend behavior for same-process
+  interrupted executions.
+- Add tests that prove stale restored approvals become denial payloads instead
+  of rerunning client-side tools.

--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -24,6 +24,7 @@ export type {
 } from "./turn-recovery-policy";
 // ── Re-export pure policy helpers (single source of truth) ──────────
 export {
+  buildFreshDenialApprovals,
   classifyPreStreamConflict,
   extractConflictDetail,
   getPreStreamErrorAction,
@@ -39,6 +40,7 @@ export {
   isRetryableProviderErrorDetail,
   parseRetryAfterHeaderMs,
   rebuildInputWithFreshDenials,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
   shouldRetryPreStreamTransientError,
   shouldRetryRunMetadataError,

--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -368,6 +368,21 @@ export interface PendingApprovalInfo {
   toolArgs: string;
 }
 
+export const STALE_APPROVAL_RECOVERY_DENIAL_REASON =
+  "Auto-denied: stale approval from interrupted session";
+
+export function buildFreshDenialApprovals(
+  serverApprovals: PendingApprovalInfo[],
+  denialReason: string,
+): NonNullable<ApprovalCreate["approvals"]> {
+  return serverApprovals.map((approval) => ({
+    type: "approval" as const,
+    tool_call_id: approval.toolCallId,
+    approve: false,
+    reason: denialReason,
+  }));
+}
+
 /**
  * Strip stale approval payloads from the message input array and optionally
  * prepend fresh denial results for the actual pending approvals from the server.
@@ -385,12 +400,7 @@ export function rebuildInputWithFreshDenials(
   if (serverApprovals.length > 0) {
     const denials: ApprovalCreate = {
       type: "approval",
-      approvals: serverApprovals.map((a) => ({
-        type: "approval" as const,
-        tool_call_id: a.toolCallId,
-        approve: false,
-        reason: denialReason,
-      })),
+      approvals: buildFreshDenialApprovals(serverApprovals, denialReason),
       otid: randomUUID(),
     };
     return [denials, ...stripped];

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1388,6 +1388,7 @@ export default function App({
   const [queuedApprovalResults, setQueuedApprovalResults] = useState<
     ApprovalResult[] | null
   >(null);
+  const queuedApprovalResultsRef = useRef<ApprovalResult[] | null>(null);
   const toolAbortControllerRef = useRef<AbortController | null>(null);
 
   // Bash mode state - track running commands for input locking and ESC cancellation
@@ -1442,6 +1443,7 @@ export default function App({
       results: ApprovalResult[] | null,
       metadata?: { conversationId: string; generation: number },
     ) => {
+      queuedApprovalResultsRef.current = results;
       setQueuedApprovalResults(results);
       if (results) {
         queuedApprovalMetadataRef.current = metadata ?? {
@@ -6469,8 +6471,8 @@ export default function App({
 
       const queuedMetadata = queuedApprovalMetadataRef.current;
       const hasQueuedRealResults =
-        queuedApprovalResults !== null &&
-        queuedApprovalResults.length > 0 &&
+        queuedApprovalResultsRef.current !== null &&
+        queuedApprovalResultsRef.current.length > 0 &&
         queuedMetadata?.conversationId === conversationIdRef.current &&
         queuedMetadata.generation === generationAtStart;
 
@@ -6534,7 +6536,7 @@ export default function App({
         };
       }
     },
-    [queueApprovalResults, queuedApprovalResults, restorePendingApprovalUi],
+    [queueApprovalResults, restorePendingApprovalUi],
   );
 
   useEffect(() => {
@@ -7615,8 +7617,8 @@ export default function App({
 
     const queuedMetadata = queuedApprovalMetadataRef.current;
     const hasQueuedRealResults =
-      queuedApprovalResults !== null &&
-      queuedApprovalResults.length > 0 &&
+      queuedApprovalResultsRef.current !== null &&
+      queuedApprovalResultsRef.current.length > 0 &&
       queuedMetadata?.conversationId === conversationIdRef.current &&
       queuedMetadata.generation === conversationGenerationRef.current;
     if (hasQueuedRealResults) {
@@ -7655,12 +7657,55 @@ export default function App({
       // If check fails, proceed anyway (don't block user)
       return { blocked: false };
     }
-  }, [
-    agentId,
-    needsEagerApprovalCheck,
-    queuedApprovalResults,
-    queueApprovalResults,
-  ]);
+  }, [agentId, needsEagerApprovalCheck, queueApprovalResults]);
+
+  const consumeQueuedApprovalInputForCurrentConversation = useCallback(
+    (otid: string = createClientOtid()): ApprovalCreate | null => {
+      const queuedResults = queuedApprovalResultsRef.current;
+      if (!queuedResults || queuedResults.length === 0) {
+        return null;
+      }
+
+      const queuedMetadata = queuedApprovalMetadataRef.current;
+      const isQueuedValid =
+        queuedMetadata &&
+        queuedMetadata.conversationId === conversationIdRef.current &&
+        queuedMetadata.generation === conversationGenerationRef.current;
+
+      queueApprovalResults(null);
+      interruptQueuedRef.current = false;
+
+      if (!isQueuedValid) {
+        debugWarn(
+          "queue",
+          "Dropping stale queued approval results for mismatched conversation or generation",
+        );
+        return null;
+      }
+
+      return {
+        type: "approval",
+        approvals: queuedResults,
+        otid,
+      };
+    },
+    [queueApprovalResults],
+  );
+
+  const processConversationWithQueuedApprovals = useCallback(
+    async (
+      input: Array<MessageCreate | ApprovalCreate>,
+      options?: Parameters<typeof processConversation>[1],
+    ): Promise<void> => {
+      const queuedApprovalInput =
+        consumeQueuedApprovalInputForCurrentConversation();
+      const nextInput = queuedApprovalInput
+        ? [queuedApprovalInput, ...input]
+        : input;
+      await processConversation(nextInput, options);
+    },
+    [consumeQueuedApprovalInputForCurrentConversation, processConversation],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: blanket suppression — same caveat as processConversation above. Omitted deps are mostly refs and stable callbacks, but this hides any genuinely missing reactive deps too.
   const onSubmit = useCallback(
@@ -8772,7 +8817,7 @@ export default function App({
 
             // Send the prompt with ralph reminder prepended
             const systemMsg = buildRalphFirstTurnReminder(ralphState);
-            processConversation([
+            processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10220,7 +10265,7 @@ export default function App({
             );
 
             // Process conversation with the skill-creation prompt
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10284,7 +10329,7 @@ export default function App({
             );
 
             // Process conversation with the remember prompt
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10473,7 +10518,7 @@ export default function App({
               memoryDir,
             });
 
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10519,7 +10564,7 @@ export default function App({
               memoryDir,
             });
 
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10619,7 +10664,7 @@ export default function App({
               "Direct, a little playful. Don't overthink it.",
             ].join("\n");
 
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -10675,7 +10720,7 @@ export default function App({
             // Send prompt to agent
             // NOTE: Unlike /remember, we DON'T append args separately because
             // they're already substituted into the prompt via $ARGUMENTS
-            await processConversation([
+            await processConversationWithQueuedApprovals([
               {
                 type: "message",
                 role: "user",
@@ -11079,27 +11124,10 @@ ${SYSTEM_REMINDER_CLOSE}
         });
       }
 
-      if (queuedApprovalResults) {
-        const queuedMetadata = queuedApprovalMetadataRef.current;
-        const isQueuedValid =
-          queuedMetadata &&
-          queuedMetadata.conversationId === conversationIdRef.current &&
-          queuedMetadata.generation === conversationGenerationRef.current;
-
-        if (isQueuedValid) {
-          initialInput.push({
-            type: "approval",
-            approvals: queuedApprovalResults,
-            otid: createClientOtid(),
-          });
-        } else {
-          debugWarn(
-            "queue",
-            "Dropping stale queued approval results for mismatched conversation or generation",
-          );
-        }
-        queueApprovalResults(null);
-        interruptQueuedRef.current = false;
+      const queuedApprovalInput =
+        consumeQueuedApprovalInputForCurrentConversation();
+      if (queuedApprovalInput) {
+        initialInput.push(queuedApprovalInput);
       }
 
       initialInput.push({
@@ -11133,7 +11161,7 @@ ${SYSTEM_REMINDER_CLOSE}
       handleExit,
       isExecutingTool,
       queuedApprovalResults,
-      queueApprovalResults,
+      consumeQueuedApprovalInputForCurrentConversation,
       pendingApprovals,
       profileConfirmPending,
       handleAgentSelect,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -30,6 +30,7 @@ import {
   getDisplayableToolReturn,
 } from "../agent/approval-execution";
 import {
+  buildFreshDenialApprovals,
   extractConflictDetail,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
@@ -40,6 +41,7 @@ import {
   isQuotaLimitErrorDetail,
   parseRetryAfterHeaderMs,
   rebuildInputWithFreshDenials,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
   shouldRetryRunMetadataError,
 } from "../agent/approval-recovery";
@@ -754,7 +756,7 @@ function buildApprovalBatchKey(approvals: ApprovalRequest[]): string {
     .join("|");
 }
 
-function precomputeDiffsForApprovalBatch(
+function _precomputeDiffsForApprovalBatch(
   approvals: Array<Pick<ClassifiedApproval, "approval" | "parsedArgs">>,
   precomputedDiffs: Map<string, AdvancedDiffSuccess>,
 ): void {
@@ -6442,7 +6444,7 @@ export default function App({
   const recoverRestoredPendingApprovals = useCallback(
     async (
       approvals: ApprovalRequest[],
-      options: { notifyOnManualApproval?: boolean } = {},
+      _options: { notifyOnManualApproval?: boolean } = {},
     ): Promise<void> => {
       if (approvals.length === 0) {
         return;
@@ -6465,27 +6467,20 @@ export default function App({
         status: "running",
       };
 
+      const queuedMetadata = queuedApprovalMetadataRef.current;
+      const hasQueuedRealResults =
+        queuedApprovalResults !== null &&
+        queuedApprovalResults.length > 0 &&
+        queuedMetadata?.conversationId === conversationIdRef.current &&
+        queuedMetadata.generation === generationAtStart;
+
       setApprovalResults([]);
       setAutoHandledResults([]);
       setAutoDeniedApprovals([]);
       setApprovalContexts([]);
       setPendingApprovals([]);
-      queueApprovalResults(null);
 
       try {
-        const desiredMode = uiPermissionModeRef.current;
-        if (permissionMode.getMode() !== desiredMode) {
-          permissionMode.setMode(desiredMode);
-        }
-
-        const { needsUserInput, autoAllowed, autoDenied } =
-          await classifyApprovals(approvals, {
-            getContext: analyzeToolApproval,
-            alwaysRequiresUserInput,
-            missingNameReason:
-              "Tool call incomplete - missing name or arguments",
-          });
-
         if (conversationGenerationRef.current !== generationAtStart) {
           restoredApprovalRecoveryRef.current = {
             batchKey,
@@ -6495,158 +6490,26 @@ export default function App({
           return;
         }
 
-        precomputeDiffsForApprovalBatch(
-          [...autoAllowed, ...needsUserInput],
-          precomputedDiffsRef.current,
-        );
+        if (hasQueuedRealResults) {
+          setNeedsEagerApprovalCheck(false);
+          restoredApprovalRecoveryRef.current = {
+            batchKey,
+            generation: generationAtStart,
+            status: "completed",
+          };
+          return;
+        }
 
-        const autoAllowedToolCallIds = autoAllowed.map(
-          (ac) => ac.approval.toolCallId,
-        );
-        const autoAllowedAbortController =
-          abortControllerRef.current ?? new AbortController();
-        const shouldTrackAutoAllowed = autoAllowedToolCallIds.length > 0;
-        let autoAllowedResults: Array<{
-          toolCallId: string;
-          result: ToolExecutionResult;
-        }> = [];
-        let autoDeniedResults: Array<{
-          approval: ApprovalRequest;
-          reason: string;
-        }> = [];
-
-        if (shouldTrackAutoAllowed) {
-          setIsExecutingTool(true);
-          executingToolCallIdsRef.current = autoAllowedToolCallIds;
-          toolAbortControllerRef.current = autoAllowedAbortController;
-          autoAllowedExecutionRef.current = {
-            toolCallIds: autoAllowedToolCallIds,
-            results: null,
+        const staleDenials = buildFreshDenialApprovals(
+          approvals,
+          STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+        ) as ApprovalResult[];
+        if (staleDenials.length > 0) {
+          queueApprovalResults(staleDenials, {
             conversationId: conversationIdRef.current,
             generation: generationAtStart,
-          };
-        }
-
-        try {
-          if (autoAllowedToolCallIds.length > 0) {
-            setToolCallsRunning(buffersRef.current, autoAllowedToolCallIds);
-            refreshDerived();
-          }
-
-          const approvalToolContextId =
-            approvalToolContextIdRef.current ??
-            (
-              await prepareScopedToolExecutionContext(
-                tempModelOverrideRef.current ?? undefined,
-              )
-            ).preparedToolContext.contextId;
-          autoAllowedResults =
-            autoAllowed.length > 0
-              ? await executeAutoAllowedTools(
-                  autoAllowed,
-                  (chunk) => onChunk(buffersRef.current, chunk),
-                  {
-                    abortSignal: autoAllowedAbortController.signal,
-                    onStreamingOutput: updateStreamingOutput,
-                    toolContextId: approvalToolContextId,
-                  },
-                )
-              : [];
-
-          autoDeniedResults = autoDenied.map((ac) => {
-            const reason = ac.permission.reason
-              ? `Permission denied: ${ac.permission.reason}`
-              : "matchedRule" in ac.permission && ac.permission.matchedRule
-                ? `Permission denied by rule: ${ac.permission.matchedRule}`
-                : "Permission denied: Unknown reason";
-
-            onChunk(buffersRef.current, {
-              message_type: "tool_return_message",
-              id: "dummy",
-              date: new Date().toISOString(),
-              tool_call_id: ac.approval.toolCallId,
-              tool_return: `Error: request to call tool denied. User reason: ${reason}`,
-              status: "error",
-              stdout: null,
-              stderr: null,
-            });
-
-            return {
-              approval: ac.approval,
-              reason,
-            };
           });
-        } finally {
-          if (shouldTrackAutoAllowed) {
-            setIsExecutingTool(false);
-            toolAbortControllerRef.current = null;
-            executingToolCallIdsRef.current = [];
-            autoAllowedExecutionRef.current = null;
-            toolResultsInFlightRef.current = false;
-          }
-        }
-
-        if (conversationGenerationRef.current !== generationAtStart) {
-          restoredApprovalRecoveryRef.current = {
-            batchKey,
-            generation: generationAtStart,
-            status: "completed",
-          };
-          return;
-        }
-
-        if (needsUserInput.length > 0) {
-          await restorePendingApprovalUi(
-            needsUserInput.map((ac) => ac.approval),
-            needsUserInput
-              .map((ac) => ac.context)
-              .filter((ctx): ctx is ApprovalContext => ctx !== null),
-          );
-          setAutoHandledResults(autoAllowedResults);
-          setAutoDeniedApprovals(autoDeniedResults);
-          if (options.notifyOnManualApproval !== false) {
-            sendDesktopNotification("Approval needed");
-          }
-          restoredApprovalRecoveryRef.current = {
-            batchKey,
-            generation: generationAtStart,
-            status: "completed",
-          };
-          return;
-        }
-
-        const allResults = [
-          ...autoAllowedResults.map((ar) => ({
-            type: "tool" as const,
-            tool_call_id: ar.toolCallId,
-            tool_return: ar.result.toolReturn,
-            status: ar.result.status,
-            stdout: ar.result.stdout,
-            stderr: ar.result.stderr,
-          })),
-          ...autoDeniedResults.map((ad) => ({
-            type: "approval" as const,
-            tool_call_id: ad.approval.toolCallId,
-            approve: false,
-            reason: ad.reason,
-          })),
-        ];
-
-        if (allResults.length > 0) {
-          setThinkingMessage(getRandomThinkingVerb());
-          refreshDerived();
-          toolResultsInFlightRef.current = true;
-          await processConversation(
-            [
-              {
-                type: "approval",
-                approvals: allResults,
-                otid: randomUUID(),
-              },
-            ],
-            { allowReentry: true },
-          );
-          toolResultsInFlightRef.current = false;
+          setNeedsEagerApprovalCheck(false);
         }
 
         restoredApprovalRecoveryRef.current = {
@@ -6671,14 +6534,7 @@ export default function App({
         };
       }
     },
-    [
-      processConversation,
-      queueApprovalResults,
-      refreshDerived,
-      restorePendingApprovalUi,
-      prepareScopedToolExecutionContext,
-      updateStreamingOutput,
-    ],
+    [queueApprovalResults, queuedApprovalResults, restorePendingApprovalUi],
   );
 
   useEffect(() => {
@@ -7757,6 +7613,17 @@ export default function App({
       return { blocked: false };
     }
 
+    const queuedMetadata = queuedApprovalMetadataRef.current;
+    const hasQueuedRealResults =
+      queuedApprovalResults !== null &&
+      queuedApprovalResults.length > 0 &&
+      queuedMetadata?.conversationId === conversationIdRef.current &&
+      queuedMetadata.generation === conversationGenerationRef.current;
+    if (hasQueuedRealResults) {
+      setNeedsEagerApprovalCheck(false);
+      return { blocked: false };
+    }
+
     try {
       const client = await getClient();
       const agent = await client.agents.retrieve(agentId);
@@ -7767,158 +7634,20 @@ export default function App({
       );
 
       if (!existingApprovals || existingApprovals.length === 0) {
+        setNeedsEagerApprovalCheck(false);
         return { blocked: false };
       }
 
-      // There are pending approvals - check permissions (respects yolo mode)
-      const desiredMode = uiPermissionModeRef.current;
-      if (permissionMode.getMode() !== desiredMode) {
-        permissionMode.setMode(desiredMode);
-      }
-
-      const { needsUserInput, autoAllowed, autoDenied } =
-        await classifyApprovals(existingApprovals, {
-          getContext: analyzeToolApproval,
-          alwaysRequiresUserInput,
-          missingNameReason: "Tool call incomplete - missing name",
-        });
-
-      // If any approvals need user input, show dialog
-      if (needsUserInput.length > 0) {
-        setPendingApprovals(needsUserInput.map((ac) => ac.approval));
-        setApprovalContexts(
-          needsUserInput
-            .map((ac) => ac.context)
-            .filter((ctx): ctx is ApprovalContext => ctx !== null),
-        );
-        return { blocked: true };
-      }
-
-      // All approvals can be auto-handled - execute them before proceeding
-      const allResults: ApprovalResult[] = [];
-
-      const autoAllowedToolCallIds = autoAllowed.map(
-        (ac) => ac.approval.toolCallId,
-      );
-      const autoAllowedAbortController =
-        abortControllerRef.current ?? new AbortController();
-      const shouldTrackAutoAllowed = autoAllowedToolCallIds.length > 0;
-      let autoAllowedResults: Array<{
-        toolCallId: string;
-        result: ToolExecutionResult;
-      }> = [];
-
-      if (shouldTrackAutoAllowed) {
-        setIsExecutingTool(true);
-        executingToolCallIdsRef.current = autoAllowedToolCallIds;
-        toolAbortControllerRef.current = autoAllowedAbortController;
-        autoAllowedExecutionRef.current = {
-          toolCallIds: autoAllowedToolCallIds,
-          results: null,
+      const staleDenials = buildFreshDenialApprovals(
+        existingApprovals,
+        STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+      ) as ApprovalResult[];
+      if (staleDenials.length > 0) {
+        queueApprovalResults(staleDenials, {
           conversationId: conversationIdRef.current,
           generation: conversationGenerationRef.current,
-        };
-      }
-
-      try {
-        // Execute auto-allowed tools
-        if (autoAllowed.length > 0) {
-          // Set phase to "running" for auto-allowed tools
-          setToolCallsRunning(buffersRef.current, autoAllowedToolCallIds);
-          refreshDerived();
-
-          const approvalToolContextId =
-            approvalToolContextIdRef.current ??
-            (
-              await prepareScopedToolExecutionContext(
-                tempModelOverrideRef.current ?? undefined,
-              )
-            ).preparedToolContext.contextId;
-          autoAllowedResults = await executeAutoAllowedTools(
-            autoAllowed,
-            (chunk) => onChunk(buffersRef.current, chunk),
-            {
-              abortSignal: autoAllowedAbortController.signal,
-              onStreamingOutput: updateStreamingOutput,
-              toolContextId: approvalToolContextId,
-            },
-          );
-          // Map to ApprovalResult format (ToolReturn)
-          allResults.push(
-            ...autoAllowedResults.map((ar) => ({
-              type: "tool" as const,
-              tool_call_id: ar.toolCallId,
-              tool_return: ar.result.toolReturn,
-              status: ar.result.status,
-              stdout: ar.result.stdout,
-              stderr: ar.result.stderr,
-            })),
-          );
-        }
-
-        // Create denial results for auto-denied
-        for (const ac of autoDenied) {
-          const reason = ac.permission.reason || "Permission denied";
-          // Update UI with denial
-          onChunk(buffersRef.current, {
-            message_type: "tool_return_message",
-            id: "dummy",
-            date: new Date().toISOString(),
-            tool_call_id: ac.approval.toolCallId,
-            tool_return: `Error: request to call tool denied. User reason: ${reason}`,
-            status: "error",
-            stdout: null,
-            stderr: null,
-          });
-          // Map to ApprovalResult format (ApprovalReturn)
-          allResults.push({
-            type: "approval" as const,
-            tool_call_id: ac.approval.toolCallId,
-            approve: false,
-            reason,
-          });
-        }
-
-        if (autoAllowedExecutionRef.current) {
-          autoAllowedExecutionRef.current.results = allResults;
-        }
-        const autoAllowedMetadata = autoAllowedExecutionRef.current
-          ? {
-              conversationId: autoAllowedExecutionRef.current.conversationId,
-              generation: conversationGenerationRef.current,
-            }
-          : undefined;
-
-        if (
-          userCancelledRef.current ||
-          autoAllowedAbortController.signal.aborted ||
-          interruptQueuedRef.current
-        ) {
-          if (allResults.length > 0) {
-            queueApprovalResults(allResults, autoAllowedMetadata);
-          }
-          return { blocked: false };
-        }
-
-        // Send all results to server if any
-        if (allResults.length > 0) {
-          toolResultsInFlightRef.current = true;
-          await processConversation([
-            { type: "approval", approvals: allResults, otid: randomUUID() },
-          ]);
-          toolResultsInFlightRef.current = false;
-
-          // Clear any stale queued results from previous interrupts.
-          queueApprovalResults(null);
-        }
-      } finally {
-        if (shouldTrackAutoAllowed) {
-          setIsExecutingTool(false);
-          toolAbortControllerRef.current = null;
-          executingToolCallIdsRef.current = [];
-          autoAllowedExecutionRef.current = null;
-          toolResultsInFlightRef.current = false;
-        }
+        });
+        setNeedsEagerApprovalCheck(false);
       }
 
       return { blocked: false };
@@ -7928,11 +7657,8 @@ export default function App({
     }
   }, [
     agentId,
-    processConversation,
-    refreshDerived,
-    updateStreamingOutput,
     needsEagerApprovalCheck,
-    prepareScopedToolExecutionContext,
+    queuedApprovalResults,
     queueApprovalResults,
   ]);
 
@@ -11280,6 +11006,7 @@ ${SYSTEM_REMINDER_CLOSE}
       // Check for pending approvals before sending message (skip if we already have
       // a queued approval response to send first).
       // Only do eager check when resuming a session (LET-7101) - otherwise lazy recovery handles it
+      let eagerRecoveryDenials: ApprovalResult[] | null = null;
       if (needsEagerApprovalCheck && !queuedApprovalResults) {
         // Log for debugging
         const eagerStatusId = uid("status");
@@ -11329,516 +11056,12 @@ ${SYSTEM_REMINDER_CLOSE}
           }
 
           if (existingApprovals && existingApprovals.length > 0) {
-            // There are pending approvals - check permissions first (respects yolo mode)
-            const desiredMode = uiPermissionModeRef.current;
-            if (permissionMode.getMode() !== desiredMode) {
-              permissionMode.setMode(desiredMode);
-            }
-
-            const { needsUserInput, autoAllowed, autoDenied } =
-              await classifyApprovals(existingApprovals, {
-                getContext: analyzeToolApproval,
-                alwaysRequiresUserInput,
-                missingNameReason: "Tool call incomplete - missing name",
-              });
-
-            // Check if user cancelled during permission check
-            if (
-              userCancelledRef.current ||
-              abortControllerRef.current?.signal.aborted
-            ) {
-              if (optimisticUserLineId) {
-                buffersRef.current.byId.delete(optimisticUserLineId);
-                const orderIndex =
-                  buffersRef.current.order.indexOf(optimisticUserLineId);
-                if (orderIndex !== -1) {
-                  buffersRef.current.order.splice(orderIndex, 1);
-                }
-              }
-              setStreaming(false);
-              refreshDerived();
-              return { submitted: false };
-            }
-
-            // If all approvals can be auto-handled (yolo mode), process them immediately
-            if (needsUserInput.length === 0) {
-              // Precompute diffs for file edit tools before execution (both auto-allowed and needs-user-input)
-              for (const ac of [...autoAllowed, ...needsUserInput]) {
-                const toolName = ac.approval.toolName;
-                const toolCallId = ac.approval.toolCallId;
-                try {
-                  const args = JSON.parse(ac.approval.toolArgs || "{}");
-
-                  if (isFileWriteTool(toolName)) {
-                    const filePath = args.file_path as string | undefined;
-                    if (filePath) {
-                      const result = computeAdvancedDiff({
-                        kind: "write",
-                        filePath,
-                        content: (args.content as string) || "",
-                      });
-                      if (result.mode === "advanced") {
-                        precomputedDiffsRef.current.set(toolCallId, result);
-                      }
-                    }
-                  } else if (isFileEditTool(toolName)) {
-                    const filePath = args.file_path as string | undefined;
-                    if (filePath) {
-                      // Check if it's a multi-edit (has edits array) or single edit
-                      if (args.edits && Array.isArray(args.edits)) {
-                        const result = computeAdvancedDiff({
-                          kind: "multi_edit",
-                          filePath,
-                          edits: args.edits as Array<{
-                            old_string: string;
-                            new_string: string;
-                            replace_all?: boolean;
-                          }>,
-                        });
-                        if (result.mode === "advanced") {
-                          precomputedDiffsRef.current.set(toolCallId, result);
-                        }
-                      } else {
-                        const result = computeAdvancedDiff({
-                          kind: "edit",
-                          filePath,
-                          oldString: (args.old_string as string) || "",
-                          newString: (args.new_string as string) || "",
-                          replaceAll: args.replace_all as boolean | undefined,
-                        });
-                        if (result.mode === "advanced") {
-                          precomputedDiffsRef.current.set(toolCallId, result);
-                        }
-                      }
-                    }
-                  } else if (isPatchTool(toolName) && args.input) {
-                    // Patch tools - parse hunks directly (patches ARE diffs)
-                    const operations = parsePatchOperations(
-                      args.input as string,
-                    );
-                    for (const op of operations) {
-                      const key = `${toolCallId}:${op.path}`;
-                      if (op.kind === "add" || op.kind === "update") {
-                        const result = parsePatchToAdvancedDiff(
-                          op.patchLines,
-                          op.path,
-                        );
-                        if (result) {
-                          precomputedDiffsRef.current.set(key, result);
-                        }
-                      }
-                      // Delete operations don't need diffs
-                    }
-                  }
-                } catch {
-                  // Ignore errors in diff computation for auto-allowed tools
-                }
-              }
-
-              const autoAllowedToolCallIds = autoAllowed.map(
-                (ac) => ac.approval.toolCallId,
-              );
-              const autoAllowedAbortController =
-                abortControllerRef.current ?? new AbortController();
-              const shouldTrackAutoAllowed = autoAllowedToolCallIds.length > 0;
-              let autoAllowedResults: Array<{
-                toolCallId: string;
-                result: ToolExecutionResult;
-              }> = [];
-              let autoDeniedResults: ApprovalResult[] = [];
-
-              if (shouldTrackAutoAllowed) {
-                setIsExecutingTool(true);
-                executingToolCallIdsRef.current = autoAllowedToolCallIds;
-                toolAbortControllerRef.current = autoAllowedAbortController;
-                autoAllowedExecutionRef.current = {
-                  toolCallIds: autoAllowedToolCallIds,
-                  results: null,
-                  conversationId: conversationIdRef.current,
-                  generation: conversationGenerationRef.current,
-                };
-              }
-
-              try {
-                if (autoAllowedToolCallIds.length > 0) {
-                  // Set phase to "running" for auto-allowed tools
-                  setToolCallsRunning(
-                    buffersRef.current,
-                    autoAllowedToolCallIds,
-                  );
-                  refreshDerived();
-                }
-
-                // Execute auto-allowed tools (sequential for writes, parallel for reads)
-                const approvalToolContextId =
-                  approvalToolContextIdRef.current ??
-                  (
-                    await prepareScopedToolExecutionContext(
-                      tempModelOverrideRef.current ?? undefined,
-                    )
-                  ).preparedToolContext.contextId;
-                autoAllowedResults =
-                  autoAllowed.length > 0
-                    ? await executeAutoAllowedTools(
-                        autoAllowed,
-                        (chunk) => onChunk(buffersRef.current, chunk),
-                        {
-                          abortSignal: autoAllowedAbortController.signal,
-                          onStreamingOutput: updateStreamingOutput,
-                          toolContextId: approvalToolContextId,
-                        },
-                      )
-                    : [];
-
-                // Create denial results for auto-denied and update UI
-                autoDeniedResults = autoDenied.map((ac) => {
-                  // Prefer the detailed reason over the short matchedRule name
-                  const reason = ac.permission.reason
-                    ? `Permission denied: ${ac.permission.reason}`
-                    : "matchedRule" in ac.permission &&
-                        ac.permission.matchedRule
-                      ? `Permission denied by rule: ${ac.permission.matchedRule}`
-                      : "Permission denied: Unknown";
-
-                  // Update buffers with denial for UI
-                  onChunk(buffersRef.current, {
-                    message_type: "tool_return_message",
-                    id: "dummy",
-                    date: new Date().toISOString(),
-                    tool_call_id: ac.approval.toolCallId,
-                    tool_return: `Error: request to call tool denied. User reason: ${reason}`,
-                    status: "error",
-                    stdout: null,
-                    stderr: null,
-                  });
-
-                  return {
-                    type: "approval" as const,
-                    tool_call_id: ac.approval.toolCallId,
-                    approve: false,
-                    reason,
-                  };
-                });
-
-                const queuedResults: ApprovalResult[] = [
-                  ...autoAllowedResults.map((ar) => ({
-                    type: "tool" as const,
-                    tool_call_id: ar.toolCallId,
-                    tool_return: ar.result.toolReturn,
-                    status: ar.result.status,
-                    stdout: ar.result.stdout,
-                    stderr: ar.result.stderr,
-                  })),
-                  ...autoDeniedResults,
-                ];
-
-                if (autoAllowedExecutionRef.current) {
-                  autoAllowedExecutionRef.current.results = queuedResults;
-                }
-                const autoAllowedMetadata = autoAllowedExecutionRef.current
-                  ? {
-                      conversationId:
-                        autoAllowedExecutionRef.current.conversationId,
-                      generation: conversationGenerationRef.current,
-                    }
-                  : undefined;
-
-                if (
-                  userCancelledRef.current ||
-                  autoAllowedAbortController.signal.aborted ||
-                  interruptQueuedRef.current
-                ) {
-                  if (queuedResults.length > 0) {
-                    queueApprovalResults(queuedResults, autoAllowedMetadata);
-                  }
-                  setStreaming(false);
-                  markIncompleteToolsAsCancelled(
-                    buffersRef.current,
-                    true,
-                    "user_interrupt",
-                  );
-                  refreshDerived();
-                  return { submitted: false };
-                }
-
-                refreshDerived();
-
-                // Combine results and send directly with the user's message
-                // (can't use state here as it won't be available until next render)
-                const recoveryApprovalResults = [
-                  ...autoAllowedResults.map((ar) => ({
-                    type: "tool" as const,
-                    tool_call_id: ar.toolCallId,
-                    tool_return: ar.result.toolReturn,
-                    status: ar.result.status,
-                    stdout: ar.result.stdout,
-                    stderr: ar.result.stderr,
-                  })),
-                  ...autoDeniedResults,
-                ];
-
-                // Build and send initialInput directly
-                const initialInput: Array<MessageCreate | ApprovalCreate> = [
-                  {
-                    type: "approval",
-                    approvals: recoveryApprovalResults,
-                    otid: randomUUID(),
-                  },
-                  {
-                    type: "message",
-                    role: "user",
-                    content:
-                      messageContent as unknown as MessageCreate["content"],
-                    otid: randomUUID(),
-                  },
-                ];
-
-                toolResultsInFlightRef.current = true;
-                await processConversation(initialInput);
-                toolResultsInFlightRef.current = false;
-                clearPlaceholdersInText(msg);
-                return { submitted: true };
-              } finally {
-                if (shouldTrackAutoAllowed) {
-                  setIsExecutingTool(false);
-                  toolAbortControllerRef.current = null;
-                  executingToolCallIdsRef.current = [];
-                  autoAllowedExecutionRef.current = null;
-                  toolResultsInFlightRef.current = false;
-                }
-              }
-            } else {
-              // Some approvals need user input - show dialog
-              // Remove the optimistic user message from transcript
-              if (optimisticUserLineId) {
-                buffersRef.current.byId.delete(optimisticUserLineId);
-                const orderIndex =
-                  buffersRef.current.order.indexOf(optimisticUserLineId);
-                if (orderIndex !== -1) {
-                  buffersRef.current.order.splice(orderIndex, 1);
-                }
-              }
-
-              setStreaming(false);
-              setPendingApprovals(needsUserInput.map((ac) => ac.approval));
-              setApprovalContexts(
-                needsUserInput
-                  .map((ac) => ac.context)
-                  .filter(Boolean) as ApprovalContext[],
-              );
-
-              // Precompute diffs for file edit tools before execution (both auto-allowed and needs-user-input)
-              for (const ac of [...autoAllowed, ...needsUserInput]) {
-                const toolName = ac.approval.toolName;
-                const toolCallId = ac.approval.toolCallId;
-                try {
-                  const args = JSON.parse(ac.approval.toolArgs || "{}");
-
-                  if (isFileWriteTool(toolName)) {
-                    const filePath = args.file_path as string | undefined;
-                    if (filePath) {
-                      const result = computeAdvancedDiff({
-                        kind: "write",
-                        filePath,
-                        content: (args.content as string) || "",
-                      });
-                      if (result.mode === "advanced") {
-                        precomputedDiffsRef.current.set(toolCallId, result);
-                      }
-                    }
-                  } else if (isFileEditTool(toolName)) {
-                    const filePath = args.file_path as string | undefined;
-                    if (filePath) {
-                      // Check if it's a multi-edit (has edits array) or single edit
-                      if (args.edits && Array.isArray(args.edits)) {
-                        const result = computeAdvancedDiff({
-                          kind: "multi_edit",
-                          filePath,
-                          edits: args.edits as Array<{
-                            old_string: string;
-                            new_string: string;
-                            replace_all?: boolean;
-                          }>,
-                        });
-                        if (result.mode === "advanced") {
-                          precomputedDiffsRef.current.set(toolCallId, result);
-                        }
-                      } else {
-                        const result = computeAdvancedDiff({
-                          kind: "edit",
-                          filePath,
-                          oldString: (args.old_string as string) || "",
-                          newString: (args.new_string as string) || "",
-                          replaceAll: args.replace_all as boolean | undefined,
-                        });
-                        if (result.mode === "advanced") {
-                          precomputedDiffsRef.current.set(toolCallId, result);
-                        }
-                      }
-                    }
-                  } else if (isPatchTool(toolName) && args.input) {
-                    // Patch tools - parse hunks directly (patches ARE diffs)
-                    const operations = parsePatchOperations(
-                      args.input as string,
-                    );
-                    for (const op of operations) {
-                      const key = `${toolCallId}:${op.path}`;
-                      if (op.kind === "add" || op.kind === "update") {
-                        const result = parsePatchToAdvancedDiff(
-                          op.patchLines,
-                          op.path,
-                        );
-                        if (result) {
-                          precomputedDiffsRef.current.set(key, result);
-                        }
-                      }
-                      // Delete operations don't need diffs
-                    }
-                  }
-                } catch {
-                  // Ignore errors in diff computation for auto-allowed tools
-                }
-              }
-
-              const autoAllowedToolCallIds = autoAllowed.map(
-                (ac) => ac.approval.toolCallId,
-              );
-              const autoAllowedAbortController =
-                abortControllerRef.current ?? new AbortController();
-              const shouldTrackAutoAllowed = autoAllowedToolCallIds.length > 0;
-              let autoAllowedWithResults: Array<{
-                toolCallId: string;
-                result: ToolExecutionResult;
-              }> = [];
-              let autoDeniedWithReasons: Array<{
-                approval: ApprovalRequest;
-                reason: string;
-              }> = [];
-
-              if (shouldTrackAutoAllowed) {
-                setIsExecutingTool(true);
-                executingToolCallIdsRef.current = autoAllowedToolCallIds;
-                toolAbortControllerRef.current = autoAllowedAbortController;
-                autoAllowedExecutionRef.current = {
-                  toolCallIds: autoAllowedToolCallIds,
-                  results: null,
-                  conversationId: conversationIdRef.current,
-                  generation: conversationGenerationRef.current,
-                };
-              }
-
-              try {
-                // Execute auto-allowed tools (sequential for writes, parallel for reads)
-                const approvalToolContextId =
-                  approvalToolContextIdRef.current ??
-                  (
-                    await prepareScopedToolExecutionContext(
-                      tempModelOverrideRef.current ?? undefined,
-                    )
-                  ).preparedToolContext.contextId;
-                autoAllowedWithResults =
-                  autoAllowed.length > 0
-                    ? await executeAutoAllowedTools(
-                        autoAllowed,
-                        (chunk) => onChunk(buffersRef.current, chunk),
-                        {
-                          abortSignal: autoAllowedAbortController.signal,
-                          onStreamingOutput: updateStreamingOutput,
-                          toolContextId: approvalToolContextId,
-                        },
-                      )
-                    : [];
-
-                // Create denial reasons for auto-denied and update UI
-                autoDeniedWithReasons = autoDenied.map((ac) => {
-                  // Prefer the detailed reason over the short matchedRule name
-                  const reason = ac.permission.reason
-                    ? `Permission denied: ${ac.permission.reason}`
-                    : "matchedRule" in ac.permission &&
-                        ac.permission.matchedRule
-                      ? `Permission denied by rule: ${ac.permission.matchedRule}`
-                      : "Permission denied: Unknown";
-
-                  // Update buffers with denial for UI
-                  onChunk(buffersRef.current, {
-                    message_type: "tool_return_message",
-                    id: "dummy",
-                    date: new Date().toISOString(),
-                    tool_call_id: ac.approval.toolCallId,
-                    tool_return: `Error: request to call tool denied. User reason: ${reason}`,
-                    status: "error",
-                    stdout: null,
-                    stderr: null,
-                  });
-
-                  return {
-                    approval: ac.approval,
-                    reason,
-                  };
-                });
-
-                const queuedResults: ApprovalResult[] = [
-                  ...autoAllowedWithResults.map((ar) => ({
-                    type: "tool" as const,
-                    tool_call_id: ar.toolCallId,
-                    tool_return: ar.result.toolReturn,
-                    status: ar.result.status,
-                    stdout: ar.result.stdout,
-                    stderr: ar.result.stderr,
-                  })),
-                  ...autoDeniedWithReasons.map((ad) => ({
-                    type: "approval" as const,
-                    tool_call_id: ad.approval.toolCallId,
-                    approve: false,
-                    reason: ad.reason,
-                  })),
-                ];
-
-                if (autoAllowedExecutionRef.current) {
-                  autoAllowedExecutionRef.current.results = queuedResults;
-                }
-                const autoAllowedMetadata = autoAllowedExecutionRef.current
-                  ? {
-                      conversationId:
-                        autoAllowedExecutionRef.current.conversationId,
-                      generation: conversationGenerationRef.current,
-                    }
-                  : undefined;
-
-                if (
-                  userCancelledRef.current ||
-                  autoAllowedAbortController.signal.aborted ||
-                  interruptQueuedRef.current
-                ) {
-                  if (queuedResults.length > 0) {
-                    queueApprovalResults(queuedResults, autoAllowedMetadata);
-                  }
-                  setStreaming(false);
-                  markIncompleteToolsAsCancelled(
-                    buffersRef.current,
-                    true,
-                    "user_interrupt",
-                  );
-                  refreshDerived();
-                  return { submitted: false };
-                }
-
-                // Store auto-handled results to send along with user decisions
-                setAutoHandledResults(autoAllowedWithResults);
-                setAutoDeniedApprovals(autoDeniedWithReasons);
-
-                refreshDerived();
-                return { submitted: false };
-              } finally {
-                if (shouldTrackAutoAllowed) {
-                  setIsExecutingTool(false);
-                  toolAbortControllerRef.current = null;
-                  executingToolCallIdsRef.current = [];
-                  autoAllowedExecutionRef.current = null;
-                }
-              }
-            }
+            eagerRecoveryDenials = buildFreshDenialApprovals(
+              existingApprovals,
+              STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+            ) as ApprovalResult[];
           }
+          setNeedsEagerApprovalCheck(false);
         } catch (_error) {
           // If check fails, proceed anyway (don't block user)
         }
@@ -11847,6 +11070,14 @@ ${SYSTEM_REMINDER_CLOSE}
       // Start the conversation loop. If we have queued approval results from an interrupted
       // client-side execution, send them first before the new user message.
       const initialInput: Array<MessageCreate | ApprovalCreate> = [];
+
+      if (eagerRecoveryDenials && eagerRecoveryDenials.length > 0) {
+        initialInput.push({
+          type: "approval",
+          approvals: eagerRecoveryDenials,
+          otid: randomUUID(),
+        });
+      }
 
       if (queuedApprovalResults) {
         const queuedMetadata = queuedApprovalMetadataRef.current;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,11 +7,9 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import type {
-  ApprovalDecision,
-  ApprovalResult,
-} from "./agent/approval-execution";
+import type { ApprovalResult } from "./agent/approval-execution";
 import {
+  buildFreshDenialApprovals,
   extractConflictDetail,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
@@ -20,6 +18,7 @@ import {
   isEmptyResponseRetryable,
   isInvalidToolCallIdsError,
   parseRetryAfterHeaderMs,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldRetryRunMetadataError,
 } from "./agent/approval-recovery";
 import { handleBootstrapSessionState } from "./agent/bootstrapHandler";
@@ -1444,9 +1443,12 @@ export async function handleHeadlessCommand(
 
   const reminderContextTracker = createContextTracker();
   const sharedReminderState = createSharedReminderState();
+  let queuedRecoveredApprovalResults: ApprovalResult[] | null = null;
 
   // Helper to resolve any pending approvals before sending user input
-  const resolveAllPendingApprovals = async () => {
+  const resolveAllPendingApprovals = async (
+    mode: "queue_for_next_turn" | "send_immediately" = "send_immediately",
+  ) => {
     const { getResumeData } = await import("./agent/check-approval");
     while (true) {
       // Re-fetch agent to get latest in-context messages (source of truth for backend)
@@ -1470,104 +1472,23 @@ export async function handleHeadlessCommand(
       const pendingApprovals = resume.pendingApprovals || [];
       if (pendingApprovals.length === 0) break;
 
-      // Phase 1: Collect decisions for all approvals
-      type Decision =
-        | {
-            type: "approve";
-            approval: {
-              toolCallId: string;
-              toolName: string;
-              toolArgs: string;
-            };
-            reason: string;
-            matchedRule: string;
-          }
-        | {
-            type: "deny";
-            approval: {
-              toolCallId: string;
-              toolName: string;
-              toolArgs: string;
-            };
-            reason: string;
-          };
-
-      const { autoAllowed, autoDenied } = await classifyApprovals(
+      const denialResults = buildFreshDenialApprovals(
         pendingApprovals,
-        {
-          alwaysRequiresUserInput: isInteractiveApprovalTool,
-          treatAskAsDeny: true,
-          denyReasonForAsk: "Tool requires approval (headless mode)",
-          requireArgsForAutoApprove: true,
-          missingNameReason: "Tool call incomplete - missing name",
-        },
-      );
-
-      const decisions: Decision[] = [
-        ...autoAllowed.map((ac) => ({
-          type: "approve" as const,
-          approval: ac.approval,
-          reason: ac.permission.reason || "Allowed by permission rule",
-          matchedRule:
-            "matchedRule" in ac.permission && ac.permission.matchedRule
-              ? ac.permission.matchedRule
-              : "auto-approved",
-        })),
-        ...autoDenied.map((ac) => {
-          const fallback =
-            "matchedRule" in ac.permission && ac.permission.matchedRule
-              ? `Permission denied: ${ac.permission.matchedRule}`
-              : ac.permission.reason
-                ? `Permission denied: ${ac.permission.reason}`
-                : "Permission denied: Unknown reason";
-          return {
-            type: "deny" as const,
-            approval: ac.approval,
-            reason: ac.denyReason ?? fallback,
-          };
-        }),
-      ];
-
-      // Phase 2: Execute approved tools and format results using shared function
-      const { executeApprovalBatch } = await import(
-        "./agent/approval-execution"
-      );
-
-      // Emit auto_approval events for stream-json format
-      if (outputFormat === "stream-json") {
-        for (const decision of decisions) {
-          if (decision.type === "approve") {
-            const autoApprovalMsg: AutoApprovalMessage = {
-              type: "auto_approval",
-              tool_call: {
-                name: decision.approval.toolName,
-                tool_call_id: decision.approval.toolCallId,
-                arguments: decision.approval.toolArgs,
-              },
-              reason: decision.reason,
-              matched_rule: decision.matchedRule,
-              session_id: sessionId,
-              uuid: `auto-approval-${decision.approval.toolCallId}`,
-            };
-            writeWireMessage(autoApprovalMsg);
-          }
-        }
+        STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+      ) as ApprovalResult[];
+      if (denialResults.length === 0) {
+        break;
       }
 
-      const recoveryToolContext = await prepareHeadlessToolExecutionContext({
-        agentId: agent.id,
-        conversationId,
-      });
-      availableTools = recoveryToolContext.availableTools;
-      const executedResults = await executeApprovalBatch(decisions, undefined, {
-        toolContextId:
-          recoveryToolContext.preparedToolContext.preparedToolContext.contextId,
-      });
+      if (mode === "queue_for_next_turn") {
+        queuedRecoveredApprovalResults = denialResults;
+        break;
+      }
 
       // Send all results in one batch
       const approvalInput: ApprovalCreate = {
         type: "approval",
-        approvals: executedResults as ApprovalResult[],
+        approvals: denialResults,
         otid: randomUUID(),
       };
 
@@ -1629,7 +1550,7 @@ export async function handleHeadlessCommand(
   // For new agents/conversations, lazy recovery handles any edge cases
   if (isResumingAgent) {
     try {
-      await resolveAllPendingApprovals();
+      await resolveAllPendingApprovals("queue_for_next_turn");
     } catch (approvalError) {
       // Don't crash on pre-loop approval resolution (e.g., 409 from server-side
       // sleeptime run holding the conversation lock). The main loop's own
@@ -1752,6 +1673,20 @@ ${SYSTEM_REMINDER_CLOSE}
       otid: randomUUID(),
     },
   ];
+  if (
+    queuedRecoveredApprovalResults &&
+    queuedRecoveredApprovalResults.length > 0
+  ) {
+    currentInput = [
+      {
+        type: "approval",
+        approvals: queuedRecoveredApprovalResults,
+        otid: randomUUID(),
+      },
+      ...currentInput,
+    ];
+    queuedRecoveredApprovalResults = null;
+  }
   const refreshCurrentInputOtids = () => {
     // Terminal stop-reason retries are NEW requests and must not reuse OTIDs.
     currentInput = currentInput.map((item) => ({
@@ -2889,78 +2824,17 @@ async function runBidirectionalMode(
       const pendingApprovals = resume.pendingApprovals || [];
       if (pendingApprovals.length === 0) break;
 
-      type Decision =
-        | {
-            type: "approve";
-            approval: {
-              toolCallId: string;
-              toolName: string;
-              toolArgs: string;
-            };
-            reason: string;
-            matchedRule: string;
-          }
-        | {
-            type: "deny";
-            approval: {
-              toolCallId: string;
-              toolName: string;
-              toolArgs: string;
-            };
-            reason: string;
-          };
-
-      const { autoAllowed, autoDenied } = await classifyApprovals(
+      const denialResults = buildFreshDenialApprovals(
         pendingApprovals,
-        {
-          treatAskAsDeny: true,
-          denyReasonForAsk: "Tool requires approval (headless mode)",
-          requireArgsForAutoApprove: true,
-          missingNameReason: "Tool call incomplete - missing name",
-        },
-      );
-
-      const decisions: Decision[] = [
-        ...autoAllowed.map((ac) => ({
-          type: "approve" as const,
-          approval: ac.approval,
-          reason: ac.permission.reason || "Allowed by permission rule",
-          matchedRule:
-            "matchedRule" in ac.permission && ac.permission.matchedRule
-              ? ac.permission.matchedRule
-              : "auto-approved",
-        })),
-        ...autoDenied.map((ac) => {
-          const fallback =
-            "matchedRule" in ac.permission && ac.permission.matchedRule
-              ? `Permission denied: ${ac.permission.matchedRule}`
-              : ac.permission.reason
-                ? `Permission denied: ${ac.permission.reason}`
-                : "Permission denied: Unknown reason";
-          return {
-            type: "deny" as const,
-            approval: ac.approval,
-            reason: ac.denyReason ?? fallback,
-          };
-        }),
-      ];
-
-      const { executeApprovalBatch } = await import(
-        "./agent/approval-execution"
-      );
-      const recoveryToolContext = await prepareHeadlessToolExecutionContext({
-        agentId: agent.id,
-        conversationId,
-      });
-      availableTools = recoveryToolContext.availableTools;
-      const executedResults = await executeApprovalBatch(decisions, undefined, {
-        toolContextId:
-          recoveryToolContext.preparedToolContext.preparedToolContext.contextId,
-      });
+        STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+      ) as ApprovalResult[];
+      if (denialResults.length === 0) {
+        break;
+      }
 
       const approvalInput: ApprovalCreate = {
         type: "approval",
-        approvals: executedResults as ApprovalResult[],
+        approvals: denialResults,
         otid: randomUUID(),
       };
 
@@ -3312,7 +3186,6 @@ async function runBidirectionalMode(
     }
 
     const { getResumeData } = await import("./agent/check-approval");
-    const { executeApprovalBatch } = await import("./agent/approval-execution");
 
     let approvalsProcessed = 0;
     const MAX_RECOVERY_PASSES = 8;
@@ -3348,60 +3221,22 @@ async function runBidirectionalMode(
         };
       }
 
-      const { autoAllowed, autoDenied, needsUserInput } =
-        await classifyApprovals(pendingApprovals, {
-          alwaysRequiresUserInput: isInteractiveApprovalTool,
-          requireArgsForAutoApprove: true,
-          missingNameReason: "Tool call incomplete - missing name",
-        });
-
-      const decisions: ApprovalDecision[] = [
-        ...autoAllowed.map((ac) => ({
-          type: "approve" as const,
-          approval: ac.approval,
-        })),
-        ...autoDenied.map((ac) => ({
-          type: "deny" as const,
-          approval: ac.approval,
-          reason: ac.denyReason || ac.permission.reason || "Permission denied",
-        })),
-      ];
-
-      // In headless recovery mode, auto-deny approvals that would require user
-      // input. Calling requestPermission() here would block waiting for a
-      // response that will never come, causing a timeout.
-      for (const ac of needsUserInput) {
-        decisions.push({
-          type: "deny",
-          approval: ac.approval,
-          reason:
-            ac.denyReason ||
-            "Auto-denied during recovery - tool requires interactive approval",
-        });
-      }
-
-      if (decisions.length === 0) {
+      const denialResults = buildFreshDenialApprovals(
+        pendingApprovals,
+        STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+      ) as ApprovalResult[];
+      if (denialResults.length === 0) {
         return {
           recovered: false,
           pending_approval: true,
           approvals_processed: approvalsProcessed,
         };
       }
-
-      const recoveryToolContext = await prepareHeadlessToolExecutionContext({
-        agentId: agent.id,
-        conversationId: targetConversationId,
-      });
-      availableTools = recoveryToolContext.availableTools;
-      const executedResults = await executeApprovalBatch(decisions, undefined, {
-        toolContextId:
-          recoveryToolContext.preparedToolContext.preparedToolContext.contextId,
-      });
-      approvalsProcessed += executedResults.length;
+      approvalsProcessed += denialResults.length;
 
       const approvalInput: ApprovalCreate = {
         type: "approval",
-        approvals: executedResults as ApprovalResult[],
+        approvals: denialResults,
         otid: randomUUID(),
       };
       const approvalStream = await sendMessageStream(
@@ -3409,8 +3244,6 @@ async function runBidirectionalMode(
         [approvalInput],
         {
           agentId: agent.id,
-          preparedToolContext:
-            recoveryToolContext.preparedToolContext.preparedToolContext,
         },
       );
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1445,6 +1445,22 @@ export async function handleHeadlessCommand(
   const sharedReminderState = createSharedReminderState();
   let queuedRecoveredApprovalResults: ApprovalResult[] | null = null;
 
+  const sendScopedApprovalMessages = async (
+    targetConversationId: string,
+    approvalMessages: Array<MessageCreate | ApprovalCreate>,
+  ) => {
+    const approvalToolContext = await prepareHeadlessToolExecutionContext({
+      agentId: agent.id,
+      conversationId: targetConversationId,
+    });
+
+    return await sendMessageStream(targetConversationId, approvalMessages, {
+      agentId: agent.id,
+      preparedToolContext:
+        approvalToolContext.preparedToolContext.preparedToolContext,
+    });
+  };
+
   // Helper to resolve any pending approvals before sending user input
   const resolveAllPendingApprovals = async (
     mode: "queue_for_next_turn" | "send_immediately" = "send_immediately",
@@ -1515,12 +1531,9 @@ export async function handleHeadlessCommand(
       }
 
       // Send the approval to clear the pending state; drain the stream without output
-      const approvalStream = await sendMessageStream(
+      const approvalStream = await sendScopedApprovalMessages(
         conversationId,
         approvalMessages,
-        {
-          agentId: agent.id,
-        },
       );
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -2857,12 +2870,9 @@ async function runBidirectionalMode(
         }
       }
 
-      const approvalStream = await sendMessageStream(
+      const approvalStream = await sendScopedApprovalMessages(
         conversationId,
         approvalMessages,
-        {
-          agentId: agent.id,
-        },
       );
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -3234,12 +3244,9 @@ async function runBidirectionalMode(
         approvals: denialResults,
         otid: randomUUID(),
       };
-      const approvalStream = await sendMessageStream(
+      const approvalStream = await sendScopedApprovalMessages(
         targetConversationId,
         [approvalInput],
-        {
-          agentId: agent.id,
-        },
       );
 
       const drainResult = await drainStreamWithResume(

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1520,8 +1520,6 @@ export async function handleHeadlessCommand(
         approvalMessages,
         {
           agentId: agent.id,
-          preparedToolContext:
-            recoveryToolContext.preparedToolContext.preparedToolContext,
         },
       );
       const drainResult = await drainStreamWithResume(
@@ -1673,14 +1671,13 @@ ${SYSTEM_REMINDER_CLOSE}
       otid: randomUUID(),
     },
   ];
-  if (
-    queuedRecoveredApprovalResults &&
-    queuedRecoveredApprovalResults.length > 0
-  ) {
+  const recoveredApprovalResults: ApprovalResult[] =
+    queuedRecoveredApprovalResults ?? [];
+  if (recoveredApprovalResults.length > 0) {
     currentInput = [
       {
         type: "approval",
-        approvals: queuedRecoveredApprovalResults,
+        approvals: recoveredApprovalResults,
         otid: randomUUID(),
       },
       ...currentInput,
@@ -2865,8 +2862,6 @@ async function runBidirectionalMode(
         approvalMessages,
         {
           agentId: agent.id,
-          preparedToolContext:
-            recoveryToolContext.preparedToolContext.preparedToolContext,
         },
       );
       const drainResult = await drainStreamWithResume(

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -386,6 +386,27 @@ async function prepareHeadlessToolExecutionContext(params: {
   };
 }
 
+async function sendScopedApprovalMessages(params: {
+  agentId: string;
+  conversationId: string;
+  approvalMessages: Array<MessageCreate | ApprovalCreate>;
+}): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
+  const approvalToolContext = await prepareHeadlessToolExecutionContext({
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+  });
+
+  return await sendMessageStream(
+    params.conversationId,
+    params.approvalMessages,
+    {
+      agentId: params.agentId,
+      preparedToolContext:
+        approvalToolContext.preparedToolContext.preparedToolContext,
+    },
+  );
+}
+
 async function flushAndExit(code: number): Promise<never> {
   const flushWritable = (stream: NodeJS.WriteStream): Promise<void> =>
     new Promise((resolve) => {
@@ -1445,22 +1466,6 @@ export async function handleHeadlessCommand(
   const sharedReminderState = createSharedReminderState();
   let queuedRecoveredApprovalResults: ApprovalResult[] | null = null;
 
-  const sendScopedApprovalMessages = async (
-    targetConversationId: string,
-    approvalMessages: Array<MessageCreate | ApprovalCreate>,
-  ) => {
-    const approvalToolContext = await prepareHeadlessToolExecutionContext({
-      agentId: agent.id,
-      conversationId: targetConversationId,
-    });
-
-    return await sendMessageStream(targetConversationId, approvalMessages, {
-      agentId: agent.id,
-      preparedToolContext:
-        approvalToolContext.preparedToolContext.preparedToolContext,
-    });
-  };
-
   // Helper to resolve any pending approvals before sending user input
   const resolveAllPendingApprovals = async (
     mode: "queue_for_next_turn" | "send_immediately" = "send_immediately",
@@ -1531,10 +1536,11 @@ export async function handleHeadlessCommand(
       }
 
       // Send the approval to clear the pending state; drain the stream without output
-      const approvalStream = await sendScopedApprovalMessages(
+      const approvalStream = await sendScopedApprovalMessages({
+        agentId: agent.id,
         conversationId,
         approvalMessages,
-      );
+      });
       const drainResult = await drainStreamWithResume(
         approvalStream,
         createBuffers(agent.id),
@@ -2870,10 +2876,11 @@ async function runBidirectionalMode(
         }
       }
 
-      const approvalStream = await sendScopedApprovalMessages(
+      const approvalStream = await sendScopedApprovalMessages({
+        agentId: agent.id,
         conversationId,
         approvalMessages,
-      );
+      });
       const drainResult = await drainStreamWithResume(
         approvalStream,
         createBuffers(agent.id),
@@ -3244,10 +3251,11 @@ async function runBidirectionalMode(
         approvals: denialResults,
         otid: randomUUID(),
       };
-      const approvalStream = await sendScopedApprovalMessages(
-        targetConversationId,
-        [approvalInput],
-      );
+      const approvalStream = await sendScopedApprovalMessages({
+        agentId: agent.id,
+        conversationId: targetConversationId,
+        approvalMessages: [approvalInput],
+      });
 
       const drainResult = await drainStreamWithResume(
         approvalStream,

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -113,4 +113,37 @@ describe("approval recovery wiring", () => {
       "await recoverRestoredPendingApprovals(",
     );
   });
+
+  test("slash command recovery consumes queued stale denials on the slash send", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    expect(source).toContain(
+      "const processConversationWithQueuedApprovals = useCallback(",
+    );
+    expect(source).toContain(
+      "consumeQueuedApprovalInputForCurrentConversation();",
+    );
+
+    const slashHandlers = [
+      'if (\n          trimmed === "/skill-creator"',
+      'if (trimmed.startsWith("/remember")) {',
+      'if (trimmed === "/init") {',
+      'if (trimmed === "/doctor") {',
+      'if (trimmed.startsWith("/empanada")) {',
+      "if (matchedCustom) {",
+    ];
+
+    for (const startNeedle of slashHandlers) {
+      const start = source.indexOf(startNeedle);
+      expect(start).toBeGreaterThan(-1);
+
+      const segment = source.slice(start, start + 7000);
+      expect(segment).toContain("checkPendingApprovalsForSlashCommand()");
+      expect(segment).toContain("processConversationWithQueuedApprovals([");
+      expect(segment).not.toContain("await processConversation([");
+    }
+  });
 });

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -71,9 +71,6 @@ describe("approval recovery wiring", () => {
     expect(source).toContain(
       "const recoverRestoredPendingApprovals = useCallback(",
     );
-    expect(source).toContain("await classifyApprovals(approvals, {");
-    expect(source).toContain("await executeAutoAllowedTools(");
-    expect(source).toContain("await processConversation(");
     expect(source).toContain(
       "void recoverRestoredPendingApprovals(approvals);",
     );
@@ -81,6 +78,23 @@ describe("approval recovery wiring", () => {
     expect(source).not.toContain(
       "setPendingApprovals(resumeData.pendingApprovals);",
     );
+
+    const recoverStart = source.indexOf(
+      "const recoverRestoredPendingApprovals = useCallback(",
+    );
+    const recoverEnd = source.indexOf("useEffect(() => {", recoverStart);
+    expect(recoverStart).toBeGreaterThan(-1);
+    expect(recoverEnd).toBeGreaterThan(recoverStart);
+
+    const recoverSegment = source.slice(recoverStart, recoverEnd);
+    expect(recoverSegment).toContain("const hasQueuedRealResults =");
+    expect(recoverSegment).toContain("buildFreshDenialApprovals(");
+    expect(recoverSegment).toContain("queueApprovalResults(staleDenials");
+    expect(recoverSegment).not.toContain("queueApprovalResults(null)");
+    expect(recoverSegment).not.toContain(
+      "await classifyApprovals(approvals, {",
+    );
+    expect(recoverSegment).not.toContain("await executeAutoAllowedTools(");
 
     const queuedSwitchStart = source.indexOf(
       'if (action.type === "switch_conversation")',

--- a/src/tests/headless/approval-recovery-wiring.test.ts
+++ b/src/tests/headless/approval-recovery-wiring.test.ts
@@ -85,6 +85,7 @@ describe("headless approval recovery wiring", () => {
     expect(segment).toContain(
       "queuedRecoveredApprovalResults = denialResults;",
     );
+    expect(segment).toContain("sendScopedApprovalMessages(");
     expect(segment).not.toContain("executeApprovalBatch(");
   });
 
@@ -100,6 +101,27 @@ describe("headless approval recovery wiring", () => {
     const segment = source.slice(start, end);
     expect(segment).toContain("buildFreshDenialApprovals(");
     expect(segment).toContain("approvalsProcessed += denialResults.length;");
+    expect(segment).toContain("sendScopedApprovalMessages(");
     expect(segment).not.toContain("executeApprovalBatch(");
+  });
+
+  test("approval-only recovery sends use scoped prepared tool context", () => {
+    expect(source).toContain("const sendScopedApprovalMessages = async (");
+
+    const helperStart = source.indexOf(
+      "const sendScopedApprovalMessages = async (",
+    );
+    const helperEnd = source.indexOf(
+      "// Helper to resolve any pending approvals before sending user input",
+      helperStart,
+    );
+
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helperEnd).toBeGreaterThan(helperStart);
+
+    const helperSegment = source.slice(helperStart, helperEnd);
+    expect(helperSegment).toContain("prepareHeadlessToolExecutionContext({");
+    expect(helperSegment).toContain("conversationId: targetConversationId,");
+    expect(helperSegment).toContain("preparedToolContext:");
   });
 });

--- a/src/tests/headless/approval-recovery-wiring.test.ts
+++ b/src/tests/headless/approval-recovery-wiring.test.ts
@@ -66,4 +66,40 @@ describe("headless approval recovery wiring", () => {
     const importBlock = source.slice(0, source.indexOf("export "));
     expect(importBlock).toContain("extractConflictDetail");
   });
+
+  test("resume approval recovery queues stale denials instead of replaying tools", () => {
+    const start = source.indexOf("let queuedRecoveredApprovalResults");
+    const end = source.indexOf(
+      "// Clear any pending approvals before starting a new turn",
+      start,
+    );
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain(
+      'mode: "queue_for_next_turn" | "send_immediately" = "send_immediately"',
+    );
+    expect(segment).toContain("buildFreshDenialApprovals(");
+    expect(segment).toContain(
+      "queuedRecoveredApprovalResults = denialResults;",
+    );
+    expect(segment).not.toContain("executeApprovalBatch(");
+  });
+
+  test("recover_pending_approvals sends synthetic denials instead of rerunning approvals", () => {
+    const start = source.indexOf(
+      "async function recoverPendingApprovalsFromControlRequest(",
+    );
+    const end = source.indexOf("// Main processing loop", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("buildFreshDenialApprovals(");
+    expect(segment).toContain("approvalsProcessed += denialResults.length;");
+    expect(segment).not.toContain("executeApprovalBatch(");
+  });
 });

--- a/src/tests/headless/approval-recovery-wiring.test.ts
+++ b/src/tests/headless/approval-recovery-wiring.test.ts
@@ -106,13 +106,13 @@ describe("headless approval recovery wiring", () => {
   });
 
   test("approval-only recovery sends use scoped prepared tool context", () => {
-    expect(source).toContain("const sendScopedApprovalMessages = async (");
+    expect(source).toContain("async function sendScopedApprovalMessages(");
 
     const helperStart = source.indexOf(
-      "const sendScopedApprovalMessages = async (",
+      "async function sendScopedApprovalMessages(",
     );
     const helperEnd = source.indexOf(
-      "// Helper to resolve any pending approvals before sending user input",
+      "async function flushAndExit(",
       helperStart,
     );
 
@@ -121,7 +121,7 @@ describe("headless approval recovery wiring", () => {
 
     const helperSegment = source.slice(helperStart, helperEnd);
     expect(helperSegment).toContain("prepareHeadlessToolExecutionContext({");
-    expect(helperSegment).toContain("conversationId: targetConversationId,");
+    expect(helperSegment).toContain("conversationId: params.conversationId,");
     expect(helperSegment).toContain("preparedToolContext:");
   });
 });

--- a/src/tests/headless/reminder-wiring.test.ts
+++ b/src/tests/headless/reminder-wiring.test.ts
@@ -73,7 +73,9 @@ describe("headless shared reminder wiring", () => {
     );
     const source = readFileSync(headlessPath, "utf-8");
 
-    expect(source).toContain("const approvalStream = await sendMessageStream(");
+    expect(source).toContain(
+      "const approvalStream = await sendScopedApprovalMessages(",
+    );
     expect(source).toContain("await drainStreamWithResume(");
     expect(source).not.toContain("for await (const _ of approvalStream)");
   });

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -1126,7 +1126,7 @@ describe("listen-client multi-worker concurrency", () => {
     ]);
   });
 
-  test("resolveStaleApprovals injects queued turns and marks recovery drain as processing", async () => {
+  test("resolveStaleApprovals injects stale denials and queued turns without replaying tools", async () => {
     const runtime = __listenClientTestUtils.createRuntime();
     runtime.agentId = "agent-1";
     runtime.conversationId = "conv-1";
@@ -1141,30 +1141,11 @@ describe("listen-client multi-worker concurrency", () => {
       toolName: "Write",
       toolArgs: '{"file_path":"foo.ts"}',
     };
-    const approvalResult = {
-      type: "tool",
-      tool_call_id: "tool-call-1",
-      tool_return: "ok",
-      status: "success",
-    };
-
     getResumeDataMock.mockResolvedValueOnce({
       pendingApproval: approval,
       pendingApprovals: [approval],
       messageHistory: [],
     });
-    // biome-ignore lint/suspicious/noExplicitAny: mock method access
-    (classifyApprovalsMock as any).mockResolvedValueOnce({
-      autoAllowed: [
-        {
-          approval,
-          parsedArgs: { file_path: "foo.ts" },
-        },
-      ],
-      autoDenied: [],
-      needsUserInput: [],
-    } as never);
-    executeApprovalBatchMock.mockResolvedValueOnce([approvalResult] as never);
 
     const queuedMessageInput = {
       kind: "message",
@@ -1218,7 +1199,14 @@ describe("listen-client multi-worker concurrency", () => {
     expect(continuationMessages?.[0]).toEqual(
       expect.objectContaining({
         type: "approval",
-        approvals: [approvalResult],
+        approvals: [
+          {
+            type: "approval",
+            tool_call_id: "tool-call-1",
+            approve: false,
+            reason: "Auto-denied: stale approval from interrupted session",
+          },
+        ],
         otid: expect.any(String),
       }),
     );
@@ -1254,6 +1242,8 @@ describe("listen-client multi-worker concurrency", () => {
         payload.includes("<task-notification>done</task-notification>"),
       ),
     ).toBe(true);
+    expect(classifyApprovalsMock).not.toHaveBeenCalled();
+    expect(executeApprovalBatchMock).not.toHaveBeenCalled();
 
     drain.resolve({
       stopReason: "end_turn",
@@ -1385,6 +1375,7 @@ describe("listen-client multi-worker concurrency", () => {
       "tool-call-recovered-1",
       "<searching-messages>recovered skill content</searching-messages>",
     );
+    executeApprovalBatchMock.mockResolvedValueOnce([] as never);
 
     await resolveRecoveredApprovalResponse(
       runtime,
@@ -1419,7 +1410,7 @@ describe("listen-client multi-worker concurrency", () => {
     });
   });
 
-  test("sync replay preserves hidden auto decisions while only surfacing manual recovered approvals", async () => {
+  test("sync replay queues stale denials instead of restoring approval UI", async () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     __listenClientTestUtils.setActiveRuntime(listener);
     const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
@@ -1472,86 +1463,43 @@ describe("listen-client multi-worker concurrency", () => {
         ],
       },
     ]);
-    // biome-ignore lint/suspicious/noExplicitAny: mock method access
-    (classifyApprovalsMock as any).mockResolvedValueOnce({
-      autoAllowed: [
-        {
-          approval: autoAllowedApproval,
-          parsedArgs: { file_path: "foo.ts" },
-          permission: { decision: "allow", reason: "auto" },
-        },
-      ],
-      autoDenied: [
-        {
-          approval: autoDeniedApproval,
-          parsedArgs: { file_path: "denied.ts", content: "nope" },
-          permission: { decision: "deny", reason: "blocked" },
-          denyReason: "blocked by policy",
-        },
-      ],
-      needsUserInput: [
-        {
-          approval: manualApproval,
-          parsedArgs: { command: "rm -rf tmp" },
-          permission: { decision: "ask", reason: "needs approval" },
-          context: {
-            recommendedRule: "Bash(rm:*)",
-            ruleDescription: "rm commands",
-            approveAlwaysText:
-              "Yes, and don't ask again for 'rm' commands in this project",
-            defaultScope: "project",
-            allowPersistence: true,
-            safetyLevel: "moderate",
-          },
-        },
-      ],
-    } as never);
-
     await __listenClientTestUtils.recoverApprovalStateForSync(runtime, {
       agent_id: "agent-1",
       conversation_id: "conv-mixed-sync",
     });
 
-    expect(runtime.recoveredApprovalState?.pendingRequestIds).toEqual(
-      new Set(["perm-tool-manual"]),
-    );
-    expect(runtime.recoveredApprovalState?.autoDecisions).toEqual([
+    expect(runtime.recoveredApprovalState).toBeNull();
+    expect(runtime.pendingInterruptedResults).toEqual([
       {
-        type: "approve",
-        approval: autoAllowedApproval,
+        type: "approval",
+        tool_call_id: autoAllowedApproval.toolCallId,
+        approve: false,
+        reason: "Auto-denied: stale approval from interrupted session",
       },
       {
-        type: "deny",
-        approval: autoDeniedApproval,
-        reason: "blocked by policy",
+        type: "approval",
+        tool_call_id: manualApproval.toolCallId,
+        approve: false,
+        reason: "Auto-denied: stale approval from interrupted session",
+      },
+      {
+        type: "approval",
+        tool_call_id: autoDeniedApproval.toolCallId,
+        approve: false,
+        reason: "Auto-denied: stale approval from interrupted session",
       },
     ]);
-    expect(runtime.recoveredApprovalState?.allApprovals).toEqual([
-      autoAllowedApproval,
-      manualApproval,
-      autoDeniedApproval,
-    ]);
+    expect(runtime.pendingInterruptedContext).toEqual({
+      agentId: "agent-1",
+      conversationId: "conv-mixed-sync",
+      continuationEpoch: runtime.continuationEpoch,
+    });
 
     const deviceStatus = __listenClientTestUtils.buildDeviceStatus(listener, {
       agent_id: "agent-1",
       conversation_id: "conv-mixed-sync",
     });
-    expect(deviceStatus.pending_control_requests).toEqual([
-      {
-        request_id: "perm-tool-manual",
-        request: expect.objectContaining({
-          subtype: "can_use_tool",
-          tool_name: "Bash",
-          tool_call_id: "tool-manual",
-          permission_suggestions: [
-            {
-              id: "save-default",
-              text: "Yes, and don't ask again for 'rm' commands in this project",
-            },
-          ],
-        }),
-      },
-    ]);
+    expect(deviceStatus.pending_control_requests).toEqual([]);
   });
 
   test("recovered approval continuation executes hidden auto decisions together with manual responses", async () => {

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -2887,22 +2887,24 @@ describe("listen-client v2 status builders", () => {
     });
   });
 
-  test("sync wiring only surfaces recovered approvals that still need user input", () => {
+  test("sync wiring converts recovered stale approvals into queued denials", () => {
     const recoveryPath = fileURLToPath(
       new URL("../../websocket/listener/recovery.ts", import.meta.url),
     );
     const source = readFileSync(recoveryPath, "utf-8");
+    const recoverySection =
+      source
+        .split("export async function recoverApprovalStateForSync")[1]
+        ?.split("export async function resolveRecoveredApprovalResponse")[0] ??
+      "";
 
-    expect(source).toContain(
-      "const { needsUserInput, autoAllowed, autoDenied } =",
+    expect(recoverySection).toContain(
+      "runtime.pendingInterruptedResults = buildFreshDenialApprovals(",
     );
-    expect(source).toContain("classifyApprovalsWithSuggestions(");
-    expect(source).toContain(
-      "const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);",
-    );
-    expect(source).toContain("if (needsUserInput.length === 0) {");
-    expect(source).toContain("needsUserInput.map(async (approvalEntry) => {");
-    expect(source).not.toContain("pendingApprovals.map(async (approval) => {");
+    expect(recoverySection).toContain("STALE_APPROVAL_RECOVERY_DENIAL_REASON");
+    expect(recoverySection).toContain("clearRecoveredApprovalState(runtime);");
+    expect(recoverySection).not.toContain("classifyApprovalsWithSuggestions(");
+    expect(recoverySection).not.toContain("buildRecoveredAutoDecisions(");
   });
 
   test("sync ignores backend recovered approvals while a live turn is already processing", async () => {

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -13,14 +13,15 @@ import {
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
 import {
+  buildFreshDenialApprovals,
   isApprovalPendingError,
   isInvalidToolCallIdsError,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
   shouldRetryRunMetadataError,
 } from "../../agent/turn-recovery-policy";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
-import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
 import type {
@@ -30,7 +31,6 @@ import type {
 } from "../../types/protocol_v2";
 import {
   applySuggestedPermissionsForApproval,
-  buildApprovalSuggestionPayload,
   classifyApprovalsWithSuggestions,
 } from "./approval-suggestions";
 import {
@@ -423,75 +423,17 @@ export async function recoverApprovalStateForSync(
     return;
   }
 
-  const workingDirectory = getConversationWorkingDirectory(
-    runtime.listener,
-    scope.agent_id,
-    scope.conversation_id,
+  runtime.pendingInterruptedResults = buildFreshDenialApprovals(
+    pendingApprovals,
+    STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   );
-  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
-    runtime.listener,
-    scope.agent_id,
-    scope.conversation_id,
-  );
-  const { needsUserInput, autoAllowed, autoDenied } =
-    await classifyApprovalsWithSuggestions(pendingApprovals, {
-      alwaysRequiresUserInput: isInteractiveApprovalTool,
-      requireArgsForAutoApprove: true,
-      missingNameReason: "Tool call incomplete - missing name",
-      workingDirectory,
-      permissionModeState,
-      agentId: scope.agent_id,
-    });
-  const autoDecisions = buildRecoveredAutoDecisions(autoAllowed, autoDenied);
-
-  if (needsUserInput.length === 0) {
-    clearRecoveredApprovalState(runtime);
-    return;
-  }
-
-  const approvalsByRequestId = new Map<string, RecoveredPendingApproval>();
-  await Promise.all(
-    needsUserInput.map(async (approvalEntry) => {
-      const approval = approvalEntry.approval;
-      const requestId = `perm-${approval.toolCallId}`;
-      const input = approvalEntry.parsedArgs;
-      const diffs = await computeDiffPreviews(
-        approval.toolName,
-        input,
-        workingDirectory,
-      );
-
-      approvalsByRequestId.set(requestId, {
-        approval,
-        approvalContext: approvalEntry.context,
-        controlRequest: {
-          type: "control_request",
-          request_id: requestId,
-          request: {
-            subtype: "can_use_tool",
-            tool_name: approval.toolName,
-            input,
-            tool_call_id: approval.toolCallId,
-            ...buildApprovalSuggestionPayload(approvalEntry.context),
-            blocked_path: null,
-            ...(diffs.length > 0 ? { diffs } : {}),
-          },
-          agent_id: scope.agent_id,
-          conversation_id: scope.conversation_id,
-        },
-      });
-    }),
-  );
-
-  runtime.recoveredApprovalState = {
+  runtime.pendingInterruptedContext = {
     agentId: scope.agent_id,
     conversationId: scope.conversation_id,
-    approvalsByRequestId,
-    pendingRequestIds: new Set(approvalsByRequestId.keys()),
-    responsesByRequestId: new Map(),
-    autoDecisions,
-    allApprovals: pendingApprovals,
+    continuationEpoch: runtime.continuationEpoch,
   };
+  runtime.pendingInterruptedToolCallIds = null;
+  clearRecoveredApprovalState(runtime);
 }
 
 export async function resolveRecoveredApprovalResponse(
@@ -523,7 +465,7 @@ export async function resolveRecoveredApprovalResponse(
   }
 
   const recovered = runtime.recoveredApprovalState;
-  if (!recovered || !recovered.approvalsByRequestId.has(requestId)) {
+  if (!recovered?.approvalsByRequestId.has(requestId)) {
     return false;
   }
 

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -6,53 +6,34 @@ import type {
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
-import {
-  type ApprovalDecision,
-  executeApprovalBatch,
-} from "../../agent/approval-execution";
 import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
 import { sendMessageStream } from "../../agent/message";
 import {
+  buildFreshDenialApprovals,
   extractConflictDetail,
   getPreStreamErrorAction,
   getRetryDelayMs,
   parseRetryAfterHeaderMs,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
 } from "../../agent/turn-recovery-policy";
 import { getRetryStatusMessage } from "../../cli/helpers/errorFormatter";
-
-import { computeDiffPreviews } from "../../helpers/diffPreview";
-import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
-import type { ControlRequest } from "../../types/protocol_v2";
 import { createStreamAbortRelay } from "../../utils/streamAbortRelay";
 import {
   rememberPendingApprovalBatchIds,
-  requestApprovalOverWS,
   resolveRecoveryBatchId,
 } from "./approval";
-import {
-  applySuggestedPermissionsForApproval,
-  buildApprovalSuggestionPayload,
-  classifyApprovalsWithSuggestions,
-} from "./approval-suggestions";
 import {
   LLM_API_ERROR_MAX_RETRIES,
   MAX_PRE_STREAM_RECOVERY,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
-import {
-  createToolExecutionOutputEmitter,
-  emitInterruptToolReturnMessage,
-  emitToolExecutionFinishedEvents,
-  emitToolExecutionStartedEvents,
-} from "./interrupts";
 import { getOrCreateConversationPermissionModeStateRef } from "./permissionMode";
 import {
   emitDequeuedUserMessage,
   emitRetryDelta,
-  emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
 import { consumeQueuedTurn } from "./queue";
@@ -172,199 +153,15 @@ export async function resolveStaleApprovals(
     }
     rememberPendingApprovalBatchIds(runtime, pendingApprovals, recoveryBatchId);
 
-    const permissionModeState = getOrCreateConversationPermissionModeStateRef(
-      runtime.listener,
-      runtime.agentId,
-      runtime.conversationId,
+    const approvalResults = buildFreshDenialApprovals(
+      pendingApprovals,
+      STALE_APPROVAL_RECOVERY_DENIAL_REASON,
     );
-    const { autoAllowed, autoDenied, needsUserInput } =
-      await classifyApprovalsWithSuggestions(pendingApprovals, {
-        alwaysRequiresUserInput: isInteractiveApprovalTool,
-        requireArgsForAutoApprove: true,
-        missingNameReason: "Tool call incomplete - missing name",
-        workingDirectory: recoveryWorkingDirectory,
-        permissionModeState,
-        agentId: runtime.agentId,
-      });
-
-    const decisions: ApprovalDecision[] = [
-      ...autoAllowed.map((ac) => ({
-        type: "approve" as const,
-        approval: ac.approval,
-      })),
-      ...autoDenied.map((ac) => ({
-        type: "deny" as const,
-        approval: ac.approval,
-        reason: ac.denyReason || ac.permission.reason || "Permission denied",
-      })),
-    ];
-
-    let pendingNeedsUserInput = [...needsUserInput];
-    if (pendingNeedsUserInput.length > 0) {
-      while (pendingNeedsUserInput.length > 0) {
-        const ac = pendingNeedsUserInput.shift();
-        if (!ac) {
-          break;
-        }
-
-        if (abortSignal.aborted) throw new Error("Cancelled");
-
-        const requestId = `perm-${ac.approval.toolCallId}`;
-        const diffs = await computeDiffPreviews(
-          ac.approval.toolName,
-          ac.parsedArgs,
-          recoveryWorkingDirectory,
-        );
-        const controlRequest: ControlRequest = {
-          type: "control_request",
-          request_id: requestId,
-          request: {
-            subtype: "can_use_tool",
-            tool_name: ac.approval.toolName,
-            input: ac.parsedArgs,
-            tool_call_id: ac.approval.toolCallId,
-            ...buildApprovalSuggestionPayload(ac.context),
-            blocked_path: null,
-            ...(diffs.length > 0 ? { diffs } : {}),
-          },
-          agent_id: runtime.agentId,
-          conversation_id: recoveryConversationId,
-        };
-
-        const responseBody = await requestApprovalOverWS(
-          runtime,
-          socket,
-          requestId,
-          controlRequest,
-        );
-
-        if ("decision" in responseBody) {
-          const response = responseBody.decision;
-          if (response.behavior === "allow") {
-            const savedSuggestions = await applySuggestedPermissionsForApproval(
-              {
-                decision: response,
-                context: ac.context,
-                workingDirectory: recoveryWorkingDirectory,
-              },
-            );
-            decisions.push({
-              type: "approve",
-              approval: response.updated_input
-                ? {
-                    ...ac.approval,
-                    toolArgs: JSON.stringify(response.updated_input),
-                  }
-                : ac.approval,
-              reason: response.message,
-            });
-
-            if (savedSuggestions && pendingNeedsUserInput.length > 0) {
-              const reclassified = await classifyApprovalsWithSuggestions(
-                pendingNeedsUserInput.map((entry) => entry.approval),
-                {
-                  alwaysRequiresUserInput: isInteractiveApprovalTool,
-                  requireArgsForAutoApprove: true,
-                  missingNameReason: "Tool call incomplete - missing name",
-                  workingDirectory: recoveryWorkingDirectory,
-                  permissionModeState,
-                  agentId: runtime.agentId,
-                },
-              );
-
-              decisions.push(
-                ...reclassified.autoAllowed.map((entry) => ({
-                  type: "approve" as const,
-                  approval: entry.approval,
-                })),
-                ...reclassified.autoDenied.map((entry) => ({
-                  type: "deny" as const,
-                  approval: entry.approval,
-                  reason:
-                    entry.denyReason ||
-                    entry.permission.reason ||
-                    "Permission denied",
-                })),
-              );
-              pendingNeedsUserInput = [...reclassified.needsUserInput];
-            }
-          } else {
-            decisions.push({
-              type: "deny",
-              approval: ac.approval,
-              reason: response.message || "Denied via WebSocket",
-            });
-          }
-        } else {
-          decisions.push({
-            type: "deny",
-            approval: ac.approval,
-            reason: responseBody.error,
-          });
-        }
-      }
-    }
-
-    if (decisions.length === 0) {
+    if (approvalResults.length === 0) {
       return null;
     }
 
-    const approvedToolCallIds = decisions
-      .filter(
-        (
-          decision,
-        ): decision is Extract<ApprovalDecision, { type: "approve" }> =>
-          decision.type === "approve",
-      )
-      .map((decision) => decision.approval.toolCallId);
-
-    runtime.activeExecutingToolCallIds = [...approvedToolCallIds];
-    setLoopStatus(runtime, "EXECUTING_CLIENT_SIDE_TOOL", scope);
-    emitRuntimeStateUpdates(runtime, scope);
-    emitToolExecutionStartedEvents(socket, runtime, {
-      toolCallIds: approvedToolCallIds,
-      runId: runtime.activeRunId ?? undefined,
-      agentId: runtime.agentId ?? undefined,
-      conversationId: recoveryConversationId,
-    });
-    const emitToolExecutionOutput = createToolExecutionOutputEmitter(
-      socket,
-      runtime,
-      {
-        runId: runtime.activeRunId ?? undefined,
-        agentId: runtime.agentId ?? undefined,
-        conversationId: recoveryConversationId,
-      },
-    );
-
     try {
-      const approvalResults = await executeApprovalBatch(decisions, undefined, {
-        abortSignal,
-        onStreamingOutput: emitToolExecutionOutput,
-        toolContextId: preparedToolContext.preparedToolContext.contextId,
-        workingDirectory: recoveryWorkingDirectory,
-        parentScope:
-          runtime.agentId && runtime.conversationId
-            ? {
-                agentId: runtime.agentId,
-                conversationId: runtime.conversationId,
-              }
-            : undefined,
-      });
-      emitToolExecutionFinishedEvents(socket, runtime, {
-        approvals: approvalResults,
-        runId: runtime.activeRunId ?? undefined,
-        agentId: runtime.agentId ?? undefined,
-        conversationId: recoveryConversationId,
-      });
-      emitInterruptToolReturnMessage(
-        socket,
-        runtime,
-        approvalResults,
-        runtime.activeRunId ?? undefined,
-        "tool-return",
-      );
-
       const continuationMessages: Array<MessageCreate | ApprovalCreate> = [
         {
           type: "approval",


### PR DESCRIPTION
## Summary
- stop replaying restored client-side approvals from stale backend pending approvals
- synthesize stale denials instead, while preserving already-queued real local approval results
- align TUI, listener, and headless recovery behavior to the same safer policy

## Root cause
We were treating restored `pendingApprovals` from the backend as safe to auto-execute in some recovery paths. That is unsafe for replay-prone client-side tools because backend pending state cannot tell us whether the local side effect already happened. `MessageChannel`/Slack duplicate sends were the clearest symptom, but the bug class was broader than Slack.

## New policy
- if we already have a real local approval result, resend or queue that result
- if we do not have the real local result, never auto-rerun restored client-side approvals
- instead synthesize denial results for stale approvals
- queue those denials for the next user turn on restore/startup; send immediately for active stale-conflict recovery

## Scope
- TUI restore/startup + eager approval recovery in `src/cli/App.tsx`
- listener stale/sync recovery in `src/websocket/listener/send.ts` and `src/websocket/listener/recovery.ts`
- headless recovery in `src/headless.ts`
- shared stale-denial helper in `src/agent/turn-recovery-policy.ts`
- diagnosis/implementation notes in `docs/plans/stale-client-approval-recovery-2026-04-21.md`

## Verification
- `bunx --bun @biomejs/biome check src/agent/turn-recovery-policy.ts src/agent/approval-recovery.ts src/cli/App.tsx src/headless.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts src/tests/websocket/listen-client-concurrency.test.ts src/websocket/listener/recovery.ts src/websocket/listener/send.ts`
- `bun test src/tests/websocket/listen-client-concurrency.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts src/tests/headless/bootstrap-pending-approval-wiring.test.ts src/tests/turn-recovery-policy.test.ts src/tests/approval-recovery.test.ts`