### PR TITLE
fix(permissions): allow git branch filter flags in plan mode read-only check

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -408,6 +408,16 @@ function isReadOnlyGitBranchArgs(args: string[]): boolean {
     "--verbose",
   ]);
 
+  // Filter flags that narrow which branches are listed — purely read-only.
+  // Each optionally accepts a commit/object as the next positional argument.
+  const readOnlyFilterFlags = new Set([
+    "--contains",
+    "--no-contains",
+    "--merged",
+    "--no-merged",
+    "--points-at",
+  ]);
+
   let sawReadOnlyFlag = false;
   let sawListFlag = false;
 
@@ -436,6 +446,16 @@ function isReadOnlyGitBranchArgs(args: string[]): boolean {
 
     if (arg.startsWith("--format=")) {
       sawReadOnlyFlag = true;
+      continue;
+    }
+
+    // Filter flags like --contains, --merged, etc. take an optional commit arg.
+    if (readOnlyFilterFlags.has(arg)) {
+      sawReadOnlyFlag = true;
+      // Consume the optional commit/branch argument if present.
+      if (typeof args[i + 1] === "string" && !args[i + 1]!.startsWith("-")) {
+        i += 1;
+      }
       continue;
     }
 

--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -453,7 +453,7 @@ function isReadOnlyGitBranchArgs(args: string[]): boolean {
     if (readOnlyFilterFlags.has(arg)) {
       sawReadOnlyFlag = true;
       // Consume the optional commit/branch argument if present.
-      if (typeof args[i + 1] === "string" && !args[i + 1]!.startsWith("-")) {
+      if (typeof args[i + 1] === "string" && !args[i + 1]?.startsWith("-")) {
         i += 1;
       }
       continue;

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -248,6 +248,20 @@ describe("isReadOnlyShellCommand", () => {
       expect(isReadOnlyShellCommand("git branch --list 'feature/*'")).toBe(
         true,
       );
+      // Filter flags combined with listing flags
+      expect(
+        isReadOnlyShellCommand("git branch -a --contains 63dd7483"),
+      ).toBe(true);
+      expect(
+        isReadOnlyShellCommand("git branch -r --contains abc123"),
+      ).toBe(true);
+      expect(isReadOnlyShellCommand("git branch --contains HEAD")).toBe(true);
+      expect(isReadOnlyShellCommand("git branch --merged main")).toBe(true);
+      expect(isReadOnlyShellCommand("git branch --no-merged")).toBe(true);
+      expect(isReadOnlyShellCommand("git branch --points-at HEAD")).toBe(true);
+      expect(isReadOnlyShellCommand("git branch -a --no-contains abc")).toBe(
+        true,
+      );
     });
 
     test("blocks unsafe git flags on read-only subcommands", () => {

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -249,12 +249,12 @@ describe("isReadOnlyShellCommand", () => {
         true,
       );
       // Filter flags combined with listing flags
-      expect(
-        isReadOnlyShellCommand("git branch -a --contains 63dd7483"),
-      ).toBe(true);
-      expect(
-        isReadOnlyShellCommand("git branch -r --contains abc123"),
-      ).toBe(true);
+      expect(isReadOnlyShellCommand("git branch -a --contains 63dd7483")).toBe(
+        true,
+      );
+      expect(isReadOnlyShellCommand("git branch -r --contains abc123")).toBe(
+        true,
+      );
       expect(isReadOnlyShellCommand("git branch --contains HEAD")).toBe(true);
       expect(isReadOnlyShellCommand("git branch --merged main")).toBe(true);
       expect(isReadOnlyShellCommand("git branch --no-merged")).toBe(true);


### PR DESCRIPTION
## Summary

- `--contains`, `--no-contains`, `--merged`, `--no-merged`, and `--points-at` are read-only filter flags for `git branch` that narrow which branches are listed
- `isReadOnlyGitBranchArgs` didn't recognise them, so commands like `git branch -a --contains <sha>` were incorrectly denied in plan mode
- Fix adds a `readOnlyFilterFlags` set for these flags and consumes their optional commit/branch argument when present

👾 Generated with [Letta Code](https://letta.com)