### PR TITLE
fix(reflection): use .json extension for reflection payload files

### DIFF
--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -553,7 +553,7 @@ async function readTranscriptLines(
 
 function buildPayloadPath(kind: "auto" | "remember"): string {
   const nonce = Math.random().toString(36).slice(2, 8);
-  return join(tmpdir(), `letta-${kind}-${nonce}.txt`);
+  return join(tmpdir(), `letta-${kind}-${nonce}.json`);
 }
 
 export function getReflectionTranscriptPaths(

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -64,6 +64,8 @@ describe("reflectionTranscript helper", () => {
     expect(payload.startMessageId).toBe("u1");
     expect(payload.endMessageId).toBe("a1");
 
+    expect(payload.payloadPath.endsWith(".json")).toBe(true);
+
     const payloadText = await readFile(payload.payloadPath, "utf-8");
     const messages = JSON.parse(payloadText);
     expect(messages).toBeArray();
@@ -291,7 +293,7 @@ describe("reflectionTranscript helper", () => {
 
   test("buildReflectionSubagentPrompt uses expanded reflection instructions", () => {
     const prompt = buildReflectionSubagentPrompt({
-      transcriptPath: "/tmp/transcript.txt",
+      transcriptPath: "/tmp/transcript.json",
       memoryDir: "/tmp/memory",
       cwd: "/tmp/work",
       parentMemory: "<parent_memory>snapshot</parent_memory>",


### PR DESCRIPTION
## Summary
- The auto/remember reflection payload written to `/tmp` is JSON (a ChatML message array from `JSON.stringify(...)`), but `buildPayloadPath` gave it a `.txt` extension. Rename to `.json` so the file extension matches its content.
- Updated the fixture path in `reflection-transcript.test.ts` for consistency, and added an assertion that `payloadPath` ends with `.json`.

The persistent per-conversation transcript at `~/.letta/transcripts/<agent>/<conv>/transcript.jsonl` is unchanged — it was already correctly named.

## Test plan
- [x] `bun test src/tests/cli/reflection-transcript.test.ts` — 13/13 pass
- [x] `bun run check` — biome + tsc pass

👾 Generated with [Letta Code](https://letta.com)