### PR TITLE
test: enforce mock.module teardown hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lint": "bunx --bun @biomejs/biome@2.2.5 check src",
     "fix": "bunx --bun @biomejs/biome@2.2.5 check --write src",
     "typecheck": "tsc --noEmit",
+    "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check": "bun run scripts/check.js",
     "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts",
     "build": "node scripts/postinstall-patches.js && bun run build.js",

--- a/scripts/check-test-mock-isolation.js
+++ b/scripts/check-test-mock-isolation.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const rootDir = process.cwd();
+const testsDir = join(rootDir, "src", "tests");
+
+function collectTestFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectTestFiles(fullPath));
+      continue;
+    }
+    if (
+      entry.isFile() &&
+      (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx"))
+    ) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const mockModulePattern = /\bmock\.module\s*\(\s*(["'`])([^"'`]+)\1/g;
+const restoreHookPattern =
+  /\bafter(?:All|Each)\s*\(\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>[\s\S]*?\bmock\.restore\s*\(/m;
+const restoreHookFunctionPattern =
+  /\bafter(?:All|Each)\s*\(\s*function\b[\s\S]*?\bmock\.restore\s*\(/m;
+
+const failures = [];
+
+for (const filePath of collectTestFiles(testsDir)) {
+  const sourceText = readFileSync(filePath, "utf8");
+  const mockedModules = Array.from(
+    sourceText.matchAll(mockModulePattern),
+    (match) => match[2] ?? "<dynamic module>",
+  );
+
+  if (mockedModules.length === 0) continue;
+
+  const hasRestoreHook =
+    restoreHookPattern.test(sourceText) ||
+    restoreHookFunctionPattern.test(sourceText);
+  if (hasRestoreHook) continue;
+
+  failures.push({
+    filePath,
+    mockedModules,
+  });
+}
+
+if (failures.length > 0) {
+  console.error(
+    "❌ Found test files that call mock.module() without a top-level afterEach/afterAll hook that calls mock.restore().\n",
+  );
+
+  for (const failure of failures) {
+    const relPath = relative(rootDir, failure.filePath);
+    console.error(`- ${relPath}`);
+    console.error(`  mocked modules: ${failure.mockedModules.join(", ")}`);
+  }
+
+  console.error(
+    "\nWhy this fails: Bun module mocks are process-global and can leak across files in the shared module cache.",
+  );
+  console.error(
+    "Add a top-level afterEach(() => { mock.restore(); }) or afterAll(() => { mock.restore(); }) hook, or remove the module mock in favor of dependency injection.",
+  );
+  process.exit(1);
+}
+
+console.log("✅ No unguarded mock.module() usage found.");

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -7,6 +7,19 @@ console.log("🔍 Running lint and type checks...\n");
 
 let failed = false;
 
+// Run test mock isolation check
+console.log("🧪 Checking Bun module mock isolation...");
+try {
+  await $`bun run check:test-mock-isolation`;
+  console.log("✅ Mock isolation check passed\n");
+} catch (error) {
+  console.error("❌ Mock isolation check failed\n");
+  console.error(
+    "Add a top-level mock.restore() teardown hook to any test file using mock.module(), or remove the module mock.\n",
+  );
+  failed = true;
+}
+
 // Run lint
 console.log("📝 Running Biome linter...");
 try {


### PR DESCRIPTION
Summary:
- add a dedicated check that fails when a test file uses mock.module() without a top-level afterEach/afterAll teardown hook that calls mock.restore()
- wire the new check into bun run check so CI catches unguarded Bun module mocks before lint/typecheck
- keep the first-pass rule intentionally small and dependency-free so it works in fresh worktrees and CI

Why:
Bun module mocks are process-global and have been repeatedly leaking across files when tests forget teardown. This adds a mechanical guardrail so we stop rediscovering that failure mode in review and CI.

Validation:
- bun run check:test-mock-isolation