### PR TITLE
fix(secrets): clarify reminder text and redaction placeholder

### DIFF
--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -100,7 +100,7 @@ async function buildSecretsInfoReminder(
     }
 
     const list = names.map((n) => `- \`$${n}\``).join("\n");
-    return `${SYSTEM_REMINDER_OPEN}Use \`$SECRET_NAME\` syntax in shell commands to reference these secrets:\n\n${list}\n\nThe actual secret value will be automatically substituted before the command runs, and scrubbed from the output. You never see the real value — just use \`$SECRET_NAME\` directly (e.g. \`curl -H "Authorization: Bearer $MY_API_KEY" ...\`).\n${SYSTEM_REMINDER_CLOSE}`;
+    return `${SYSTEM_REMINDER_OPEN}\nThe following secrets are set on your agent and available for use.\nReference them with \`$SECRET_NAME\` in shell commands — substitution happens automatically at exec time:\n${list}\n\nYou cannot read the raw values. If a value would appear in tool output, you will see \`NAME=<REDACTED>\` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using \`$NAME\`; it will resolve correctly.\n${SYSTEM_REMINDER_CLOSE}`;
   } catch (error) {
     debugLog(
       "secrets",

--- a/src/tools/secret-substitution.ts
+++ b/src/tools/secret-substitution.ts
@@ -45,7 +45,8 @@ export function substituteSecretsInArgs(
 }
 
 /**
- * Scrub secret values from a string, replacing them with $SECRET_NAME.
+ * Scrub secret values from a string, replacing them with an explicit
+ * placeholder that makes it unambiguous to the LLM that the value is hidden.
  * Used to prevent secret values from leaking into agent context via tool output.
  */
 export function scrubSecretsFromString(input: string): string {
@@ -57,7 +58,7 @@ export function scrubSecretsFromString(input: string): string {
   );
   for (const [name, value] of entries) {
     if (value.length > 0) {
-      result = result.replaceAll(value, `$${name}`);
+      result = result.replaceAll(value, `${name}=<REDACTED>`);
     }
   }
   return result;


### PR DESCRIPTION
## Summary

Agents were reading scrubbed tool output as "secret not set" rather than "secret set but hidden." Two small fixes close the gap.

### Reminder text (`src/reminders/engine.ts`)

**Before:**
```
<system-reminder>Use `$SECRET_NAME` syntax in shell commands to reference these secrets:

- `$FOO`

The actual secret value will be automatically substituted before the command runs, and scrubbed from the output. You never see the real value — just use `$SECRET_NAME` directly (e.g. `curl -H "Authorization: Bearer $MY_API_KEY" ...`).
</system-reminder>
```

**After:**
```
<system-reminder>
The following secrets are set on your agent and available for use.
Reference them with `$SECRET_NAME` in shell commands — substitution happens automatically at exec time:
- `$FOO`

You cannot read the raw values. If a value would appear in tool output, you will see `NAME=<REDACTED>` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using `$NAME`; it will resolve correctly.
</system-reminder>
```

Key changes:
- Leads with **"are set on your agent and available"** — kills the "unset/broken" hypothesis upfront.
- Calls out the exact placeholder form (`NAME=<REDACTED>`) the agent will see in scrubbed output, so it recognizes it.
- Explicit reassurance that `$NAME` still resolves.

### Scrub placeholder (`src/tools/secret-substitution.ts`)

- **Before:** `$SECRET_NAME` — identical to the substitution token, ambiguous between "reference me" and "I was redacted."
- **After:** `NAME=<REDACTED>` — mirrors `env(1)` / dotenv printout format. Piggybacks on the strong training-data prior for `<REDACTED>` (FOIA docs, legal filings, security writeups, `git-secrets` output) that reads as "value existed, was removed" rather than "value missing."

## Test plan

- [ ] Spot-check that `buildSecretsInfoReminder` still only fires once per session and still skips when no secrets are set.
- [ ] Exercise `scrubSecretsFromString` against a tool output that contains a secret value; confirm the output shows `NAME=<REDACTED>` and that longer-value-first ordering still works when one secret value is a substring of another.
- [ ] Run with a secret set and confirm the agent sees the new reminder and correctly uses `$NAME` substitution after seeing a scrubbed echo.

👾 Generated with [Letta Code](https://letta.com)