### PR TITLE
fix(backfill): loosen system_alert guard to prevent compaction summary leaking as user message

### DIFF
--- a/src/cli/helpers/backfill.ts
+++ b/src/cli/helpers/backfill.ts
@@ -69,14 +69,10 @@ function removeSystemContextBlocks(text: string): string {
 export function extractCompactionSummary(text: string): string | null {
   try {
     const parsed = JSON.parse(text);
-    if (
-      parsed.type === "system_alert" &&
-      typeof parsed.message === "string" &&
-      parsed.message.includes("prior messages have been hidden")
-    ) {
-      // Extract the summary part after the header
+    if (parsed.type === "system_alert" && typeof parsed.message === "string") {
+      // Extract the summary part after the header (handles both old and new server formats)
       const summaryMatch = parsed.message.match(
-        /The following is a summary of the previous messages:\s*([\s\S]*)/,
+        /The following is an? (?:in-context recursive )?summary(?: of the (?:previous|prior) messages)?:\s*([\s\S]*)/,
       );
       if (summaryMatch?.[1]) {
         return summaryMatch[1].trim();


### PR DESCRIPTION
## Summary

- The `extractCompactionSummary` check matched on the exact phrase `"prior messages have been hidden"`, which broke when the server updated the compaction message prefix in `fb71acbd92` (April 15)
- Any `system_alert` user_message that didn't match fell through to render as a raw `>` user message — both in backfill (session resume) and in live streaming
- Fix: match on `type === "system_alert"` alone — we never want to surface any system_alert as a user message regardless of wording
- Also updated the summary extraction regex to handle both old (`"The following is a summary of the previous messages:"`) and new (`"The following is an in-context recursive summary of the prior messages:"`) server formats

👾 Generated with [Letta Code](https://letta.com)