### PR TITLE
feat(reflection): always use letta/auto-memory for reflection subagents

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -157,12 +157,6 @@ function swapProviderPrefix(
   return `${parentProvider}/${modelPortion}`;
 }
 
-function isEnvFlagEnabled(name: string): boolean {
-  const value = process.env[name]?.trim();
-  if (!value) return false;
-  return value === "1" || value.toLowerCase() === "true";
-}
-
 export async function resolveSubagentModel(options: {
   userModel?: string;
   recommendedModel?: string;
@@ -177,10 +171,7 @@ export async function resolveSubagentModel(options: {
 
   if (userModel) return userModel;
 
-  if (
-    options.subagentType === "reflection" &&
-    isEnvFlagEnabled("AUTO_MEMORY")
-  ) {
+  if (options.subagentType === "reflection") {
     return "letta/auto-memory";
   }
 


### PR DESCRIPTION
## Summary

- Removes the `AUTO_MEMORY` env flag gate from `resolveSubagentModel`
- `letta/auto-memory` is now always used for reflection subagents (no env var required)
- Removes the now-unused `isEnvFlagEnabled` helper

👾 Generated with [Letta Code](https://letta.com)