### PR TITLE
fix(channels): support proactive Slack MessageChannel targets

### DIFF
--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -17,6 +17,7 @@ export type MessageChannelToolDiscoveryScope = {
 
 type ResolvedMessageChannelToolDiscovery = {
   activeChannels: SupportedChannelId[];
+  accountIds: string[];
   actions: string[];
   schemaContributions: ChannelMessageToolSchemaContribution[];
 };
@@ -103,6 +104,10 @@ function buildDynamicMessageChannelSchemaFromDiscovery(
     properties.channel.enum = [...discovery.activeChannels];
   }
 
+  if (properties.accountId && discovery.accountIds.length > 0) {
+    properties.accountId.enum = [...discovery.accountIds];
+  }
+
   if (properties.action) {
     properties.action.enum = [...discovery.actions];
   }
@@ -141,6 +146,13 @@ export async function resolveMessageChannelToolDiscovery(
   const activeChannels = Array.from(
     new Set(discoveryTargets.map(({ channelId }) => channelId)),
   );
+  const accountIds = Array.from(
+    new Set(
+      discoveryTargets
+        .map(({ accountId }) => accountId?.trim())
+        .filter((accountId): accountId is string => Boolean(accountId)),
+    ),
+  );
   const actions = new Set<string>(["send"]);
   const schemaContributions: ChannelMessageToolSchemaContribution[] = [];
 
@@ -162,6 +174,7 @@ export async function resolveMessageChannelToolDiscovery(
 
   return {
     activeChannels,
+    accountIds,
     actions: Array.from(actions),
     schemaContributions,
   };

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelAccount,
   ChannelAdapter,
+  ChannelChatType,
   ChannelRoute,
   OutboundChannelMessage,
   SupportedChannelId,
@@ -49,6 +50,13 @@ export interface ChannelMessageActionRequest {
   title?: string;
 }
 
+export interface ChannelResolvedMessageTarget {
+  chatId: string;
+  chatType?: ChannelChatType;
+  threadId?: string | null;
+  label?: string;
+}
+
 export interface ChannelMessageActionContext {
   request: ChannelMessageActionRequest;
   route: ChannelRoute;
@@ -67,6 +75,10 @@ export interface ChannelMessageActionAdapter {
   describeMessageTool(params: {
     accountId?: string | null;
   }): ChannelMessageToolDiscovery;
+  resolveMessageTarget?(params: {
+    account: ChannelAccount;
+    target: string;
+  }): Promise<ChannelResolvedMessageTarget>;
   handleAction(ctx: ChannelMessageActionContext): Promise<string>;
 }
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -17,7 +17,8 @@ import {
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
 } from "./media";
-import { loadSlackBoltModule, loadSlackWebApiModule } from "./runtime";
+import { loadSlackBoltModule } from "./runtime";
+import { createSlackWebApiClient } from "./webApiClient";
 
 type SlackAppConstructor = typeof import("@slack/bolt").App;
 type SlackBoltModule = typeof import("@slack/bolt") & {
@@ -60,14 +61,6 @@ type SlackWriteClient = {
       thread_ts?: string;
     }) => Promise<{ ok?: boolean; error?: string }>;
   };
-};
-type SlackWriteClientConstructor = new (
-  token: string,
-  options?: Record<string, unknown>,
-) => SlackWriteClient;
-type SlackWebApiModule = {
-  WebClient?: unknown;
-  default?: unknown;
 };
 type SlackReactionEvent = {
   item?: {
@@ -120,44 +113,6 @@ function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
     );
   }
   return App;
-}
-
-function resolveSlackWebClientModule(
-  value: unknown,
-): SlackWriteClientConstructor | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  const webClient = Reflect.get(value, "WebClient");
-  return isConstructorFunction<SlackWriteClientConstructor>(webClient)
-    ? webClient
-    : null;
-}
-
-function resolveSlackWebClientConstructor(
-  mod: SlackWebApiModule,
-): SlackWriteClientConstructor {
-  const defaultExport =
-    mod && typeof mod === "object" ? Reflect.get(mod, "default") : undefined;
-  const nestedDefault =
-    defaultExport && typeof defaultExport === "object"
-      ? Reflect.get(defaultExport, "default")
-      : undefined;
-
-  const WebClient =
-    resolveSlackWebClientModule(mod) ??
-    resolveSlackWebClientModule(defaultExport) ??
-    resolveSlackWebClientModule(nestedDefault) ??
-    (isConstructorFunction<SlackWriteClientConstructor>(defaultExport)
-      ? defaultExport
-      : null);
-
-  if (!WebClient) {
-    throw new Error(
-      'Installed Slack runtime did not export constructor "WebClient".',
-    );
-  }
-  return WebClient;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -912,13 +867,14 @@ export function createSlackAdapter(
       return writeClient;
     }
 
-    const webApi = await loadSlackWebApiModule();
-    const WebClient = resolveSlackWebClientConstructor(webApi);
-    writeClient = new WebClient(config.botToken, {
-      retryConfig: {
-        retries: 0,
+    writeClient = await createSlackWebApiClient<SlackWriteClient>(
+      config.botToken,
+      {
+        retryConfig: {
+          retries: 0,
+        },
       },
-    });
+    );
     return writeClient;
   }
 

--- a/src/channels/slack/messageActions.ts
+++ b/src/channels/slack/messageActions.ts
@@ -2,6 +2,8 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
 } from "../pluginTypes";
+import type { SlackChannelAccount } from "../types";
+import { resolveSlackMessageTarget } from "./targetResolution";
 
 async function sendSlackMessage(
   ctx: ChannelMessageActionContext,
@@ -65,6 +67,13 @@ export const slackMessageActions: ChannelMessageActionAdapter = {
     return {
       actions: ["send", "react", "upload-file"],
     };
+  },
+
+  async resolveMessageTarget(params) {
+    return await resolveSlackMessageTarget({
+      account: params.account as SlackChannelAccount,
+      target: params.target,
+    });
   },
 
   async handleAction(ctx) {

--- a/src/channels/slack/proactiveAccounts.ts
+++ b/src/channels/slack/proactiveAccounts.ts
@@ -1,0 +1,63 @@
+import { listChannelAccounts } from "../accounts";
+import { getChannelRegistry } from "../registry";
+import type { ChannelAdapter, SlackChannelAccount } from "../types";
+
+export interface EligibleProactiveSlackAccount {
+  account: SlackChannelAccount;
+  adapter: ChannelAdapter;
+}
+
+export function listEligibleProactiveSlackAccounts(
+  agentId: string,
+): EligibleProactiveSlackAccount[] {
+  const registry = getChannelRegistry();
+  if (!registry) {
+    return [];
+  }
+
+  const accounts = listChannelAccounts("slack");
+
+  const eligible: EligibleProactiveSlackAccount[] = [];
+  for (const account of accounts) {
+    if (account.channel !== "slack" || account.agentId !== agentId) {
+      continue;
+    }
+    const adapter = registry.getAdapter("slack", account.accountId);
+    if (!adapter?.isRunning()) {
+      continue;
+    }
+    eligible.push({
+      account,
+      adapter,
+    });
+  }
+
+  return eligible;
+}
+
+export function resolveEligibleProactiveSlackAccount(params: {
+  agentId: string;
+  accountId?: string | null;
+}): EligibleProactiveSlackAccount | string {
+  const eligible = listEligibleProactiveSlackAccounts(params.agentId);
+
+  if (params.accountId) {
+    const matched = eligible.find(
+      ({ account }) => account.accountId === params.accountId,
+    );
+    if (!matched) {
+      return `Error: Slack account "${params.accountId}" is not available for proactive sends in this agent scope.`;
+    }
+    return matched;
+  }
+
+  if (eligible.length === 0) {
+    return "Error: No proactive Slack accounts are available for this agent.";
+  }
+
+  if (eligible.length > 1) {
+    return "Error: Multiple proactive Slack accounts are available for this agent. Pass accountId.";
+  }
+
+  return eligible[0] as EligibleProactiveSlackAccount;
+}

--- a/src/channels/slack/targetResolution.ts
+++ b/src/channels/slack/targetResolution.ts
@@ -1,0 +1,292 @@
+import type { ChannelResolvedMessageTarget } from "../pluginTypes";
+import {
+  listChannelTargets,
+  loadTargetStore,
+  upsertChannelTarget,
+} from "../targets";
+import type { SlackChannelAccount } from "../types";
+import { createSlackWebApiClient } from "./webApiClient";
+
+const SLACK_CHANNEL_ID_PATTERN = /^[CG][A-Z0-9]+$/;
+const SLACK_CHANNEL_TYPES = "public_channel,private_channel";
+const SLACK_LIST_LIMIT = 200;
+
+export type SlackConversationRecord = {
+  id: string;
+  name?: string;
+};
+
+type SlackReadClient = {
+  conversations: {
+    list: (args: {
+      exclude_archived?: boolean;
+      limit?: number;
+      types?: string;
+      cursor?: string;
+    }) => Promise<{
+      ok?: boolean;
+      error?: string;
+      channels?: Array<{
+        id?: string;
+        name?: string;
+        is_archived?: boolean;
+      }>;
+      response_metadata?: {
+        next_cursor?: string;
+      };
+    }>;
+  };
+};
+
+type NormalizedSlackTarget =
+  | {
+      kind: "id";
+      raw: string;
+      chatId: string;
+    }
+  | {
+      kind: "name";
+      raw: string;
+      name: string;
+    };
+
+function normalizeSlackChannelName(value: string): string {
+  return value.trim().replace(/^#/, "").trim().toLowerCase();
+}
+
+function buildSlackChannelLabel(record: {
+  name?: string;
+  chatId: string;
+}): string {
+  const normalizedName =
+    typeof record.name === "string"
+      ? normalizeSlackChannelName(record.name)
+      : "";
+  return normalizedName ? `#${normalizedName}` : `#${record.chatId}`;
+}
+
+function normalizeSlackTarget(
+  rawTarget: string,
+): NormalizedSlackTarget | string {
+  const trimmed = rawTarget.trim();
+  if (!trimmed) {
+    return "Error: MessageChannel target cannot be empty.";
+  }
+
+  const prefixed = trimmed.match(/^([a-z_-]+):(.*)$/i);
+  if (prefixed) {
+    const prefix = prefixed[1]?.toLowerCase();
+    const value = prefixed[2]?.trim() ?? "";
+    if (!value) {
+      return "Error: MessageChannel target cannot be empty.";
+    }
+    if (prefix === "channel") {
+      return normalizeSlackTarget(value);
+    }
+    if (prefix === "user") {
+      return 'Error: Slack proactive MessageChannel currently supports channel targets only. Use a channel target like "#general" or "channel:C123".';
+    }
+    return `Error: Unsupported Slack MessageChannel target prefix "${prefix}".`;
+  }
+
+  if (SLACK_CHANNEL_ID_PATTERN.test(trimmed)) {
+    return {
+      kind: "id",
+      raw: trimmed,
+      chatId: trimmed,
+    };
+  }
+
+  const normalizedName = normalizeSlackChannelName(trimmed);
+  if (!normalizedName) {
+    return "Error: MessageChannel target cannot be empty.";
+  }
+
+  return {
+    kind: "name",
+    raw: trimmed,
+    name: normalizedName,
+  };
+}
+
+function findCachedSlackTarget(params: {
+  accountId: string;
+  normalizedTarget: NormalizedSlackTarget;
+}): SlackConversationRecord | string | null {
+  loadTargetStore("slack");
+  const targets = listChannelTargets("slack", params.accountId);
+
+  const matches = targets.filter((target) => {
+    const normalizedTarget = params.normalizedTarget;
+    if (normalizedTarget.kind === "id") {
+      return (
+        target.targetId === normalizedTarget.chatId ||
+        target.chatId === normalizedTarget.chatId
+      );
+    }
+    return normalizeSlackChannelName(target.label) === normalizedTarget.name;
+  });
+
+  if (matches.length > 1) {
+    return `Error: Slack MessageChannel target "${params.normalizedTarget.raw}" is ambiguous for account "${params.accountId}".`;
+  }
+
+  const match = matches[0];
+  if (!match) {
+    return null;
+  }
+
+  return {
+    id: match.chatId,
+    name: normalizeSlackChannelName(match.label) || undefined,
+  };
+}
+
+export async function listSlackChannels(
+  account: SlackChannelAccount,
+  existingClient?: SlackReadClient,
+): Promise<SlackConversationRecord[]> {
+  const client =
+    existingClient ??
+    (await createSlackWebApiClient<SlackReadClient>(account.botToken, {
+      retryConfig: {
+        retries: 0,
+      },
+    }));
+
+  const channels: SlackConversationRecord[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await client.conversations.list({
+      exclude_archived: true,
+      limit: SLACK_LIST_LIMIT,
+      types: SLACK_CHANNEL_TYPES,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to list Slack channels: ${response.error ?? "unknown error"}`,
+      );
+    }
+
+    for (const channel of response.channels ?? []) {
+      if (!channel?.id || channel.is_archived) {
+        continue;
+      }
+      channels.push({
+        id: channel.id,
+        name: channel.name,
+      });
+    }
+
+    const nextCursor = response.response_metadata?.next_cursor?.trim();
+    cursor = nextCursor ? nextCursor : undefined;
+  } while (cursor);
+
+  return channels;
+}
+
+function findSlackChannelByTarget(params: {
+  channels: SlackConversationRecord[];
+  normalizedTarget: NormalizedSlackTarget;
+}): SlackConversationRecord | string | null {
+  const normalizedTarget = params.normalizedTarget;
+  if (normalizedTarget.kind === "id") {
+    return (
+      params.channels.find(
+        (channel) => channel.id === normalizedTarget.chatId,
+      ) ?? null
+    );
+  }
+
+  const matches = params.channels.filter(
+    (channel) =>
+      normalizeSlackChannelName(channel.name ?? "") === normalizedTarget.name,
+  );
+  if (matches.length > 1) {
+    return `Error: Slack MessageChannel target "${normalizedTarget.raw}" matched multiple channels.`;
+  }
+  return matches[0] ?? null;
+}
+
+function cacheSlackChannelTarget(params: {
+  accountId: string;
+  channel: SlackConversationRecord;
+}): void {
+  const now = new Date().toISOString();
+  upsertChannelTarget("slack", {
+    accountId: params.accountId,
+    targetId: params.channel.id,
+    targetType: "channel",
+    chatId: params.channel.id,
+    label: buildSlackChannelLabel({
+      name: params.channel.name,
+      chatId: params.channel.id,
+    }),
+    discoveredAt: now,
+    lastSeenAt: now,
+  });
+}
+
+export async function resolveSlackMessageTarget(params: {
+  account: SlackChannelAccount;
+  target: string;
+  lookupChannels?: (
+    account: SlackChannelAccount,
+  ) => Promise<SlackConversationRecord[]>;
+}): Promise<ChannelResolvedMessageTarget> {
+  const normalizedTarget = normalizeSlackTarget(params.target);
+  if (typeof normalizedTarget === "string") {
+    throw new Error(normalizedTarget);
+  }
+
+  const cachedTarget = findCachedSlackTarget({
+    accountId: params.account.accountId,
+    normalizedTarget,
+  });
+  if (typeof cachedTarget === "string") {
+    throw new Error(cachedTarget);
+  }
+  if (cachedTarget) {
+    return {
+      chatId: cachedTarget.id,
+      chatType: "channel",
+      label: buildSlackChannelLabel({
+        name: cachedTarget.name,
+        chatId: cachedTarget.id,
+      }),
+    };
+  }
+
+  const channels = await (params.lookupChannels ?? listSlackChannels)(
+    params.account,
+  );
+  const matchedChannel = findSlackChannelByTarget({
+    channels,
+    normalizedTarget,
+  });
+  if (typeof matchedChannel === "string") {
+    throw new Error(matchedChannel);
+  }
+  if (!matchedChannel) {
+    throw new Error(
+      `Unknown Slack MessageChannel target "${normalizedTarget.raw}" for account "${params.account.accountId}".`,
+    );
+  }
+
+  cacheSlackChannelTarget({
+    accountId: params.account.accountId,
+    channel: matchedChannel,
+  });
+
+  return {
+    chatId: matchedChannel.id,
+    chatType: "channel",
+    label: buildSlackChannelLabel({
+      name: matchedChannel.name,
+      chatId: matchedChannel.id,
+    }),
+  };
+}

--- a/src/channels/slack/webApiClient.ts
+++ b/src/channels/slack/webApiClient.ts
@@ -1,0 +1,66 @@
+import { loadSlackWebApiModule } from "./runtime";
+
+type SlackWebClientConstructor = new (
+  token: string,
+  options?: Record<string, unknown>,
+) => unknown;
+
+type SlackWebApiModule = {
+  WebClient?: unknown;
+  default?: unknown;
+};
+
+type Constructor = abstract new (...args: never[]) => unknown;
+
+function isConstructorFunction<T extends Constructor>(
+  value: unknown,
+): value is T {
+  return typeof value === "function";
+}
+
+function resolveSlackWebClientModule(
+  value: unknown,
+): SlackWebClientConstructor | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const webClient = Reflect.get(value, "WebClient");
+  return isConstructorFunction<SlackWebClientConstructor>(webClient)
+    ? webClient
+    : null;
+}
+
+function resolveSlackWebClientConstructor(
+  mod: SlackWebApiModule,
+): SlackWebClientConstructor {
+  const defaultExport =
+    mod && typeof mod === "object" ? Reflect.get(mod, "default") : undefined;
+  const nestedDefault =
+    defaultExport && typeof defaultExport === "object"
+      ? Reflect.get(defaultExport, "default")
+      : undefined;
+
+  const WebClient =
+    resolveSlackWebClientModule(mod) ??
+    resolveSlackWebClientModule(defaultExport) ??
+    resolveSlackWebClientModule(nestedDefault) ??
+    (isConstructorFunction<SlackWebClientConstructor>(defaultExport)
+      ? defaultExport
+      : null);
+
+  if (!WebClient) {
+    throw new Error(
+      'Installed Slack runtime did not export constructor "WebClient".',
+    );
+  }
+  return WebClient;
+}
+
+export async function createSlackWebApiClient<TClient = unknown>(
+  token: string,
+  options?: Record<string, unknown>,
+): Promise<TClient> {
+  const webApi = await loadSlackWebApiModule();
+  const WebClient = resolveSlackWebClientConstructor(webApi);
+  return new WebClient(token, options) as TClient;
+}

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -51,6 +51,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     `This message originated from an external ${escapedChannel} channel.`,
     `If you want to ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
     `Use action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}" when calling MessageChannel, and put your reply text in message.`,
+    "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",
     "Only pass replyTo if you intentionally want the platform's quote/reply UI.",
     `Current local time on this device: ${localTime}`,
     SYSTEM_REMINDER_CLOSE,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2181,19 +2181,19 @@ export default function App({
       const workingDirectory = getCurrentWorkingDirectory();
       const desiredModel = overrideModel ?? currentModelHandle;
 
-      if (desiredModel) {
-        return prepareToolExecutionContextForResolvedTarget({
-          modelIdentifier: desiredModel,
-          toolsetPreference: currentToolsetPreference,
-          workingDirectory,
-        });
-      }
-
       if (agentIdRef.current) {
         return prepareToolExecutionContextForScope({
           agentId: agentIdRef.current,
           conversationId: conversationIdRef.current,
-          overrideModel,
+          overrideModel: desiredModel,
+          workingDirectory,
+        });
+      }
+
+      if (desiredModel) {
+        return prepareToolExecutionContextForResolvedTarget({
+          modelIdentifier: desiredModel,
+          toolsetPreference: currentToolsetPreference,
           workingDirectory,
         });
       }

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -1,7 +1,19 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  upsertChannelAccount,
+} from "../../channels/accounts";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
 import { clearAllRoutes, setRouteInMemory } from "../../channels/routing";
+import {
+  __testOverrideLoadTargetStore,
+  __testOverrideSaveTargetStore,
+  clearTargetStores,
+  upsertChannelTarget,
+} from "../../channels/targets";
 import type { ChannelAdapter } from "../../channels/types";
 import { message_channel } from "../../tools/impl/MessageChannel";
 
@@ -12,7 +24,20 @@ describe("MessageChannel", () => {
       await registry.stopAll();
     }
     clearAllRoutes();
+    clearChannelAccountStores();
+    clearTargetStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideLoadTargetStore(null);
+    __testOverrideSaveTargetStore(null);
   });
+
+  function installChannelStateTestOverrides(): void {
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+    __testOverrideLoadTargetStore(() => {});
+    __testOverrideSaveTargetStore(() => {});
+  }
 
   test("uses the routed account adapter for multi-account channels", async () => {
     const registry = new ChannelRegistry();
@@ -443,6 +468,254 @@ describe("MessageChannel", () => {
     });
 
     expect(result).toBe("Error: Slack send requires message or media.");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test("supports proactive Slack sends to explicit cached targets without consulting routes", async () => {
+    installChannelStateTestOverrides();
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({
+      messageId: "slack-msg-proactive-1",
+    }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+    registry.getRouteForScope = mock(() => {
+      throw new Error("explicit target path should not consult routes");
+    });
+
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "account-1",
+      displayName: "DocsBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token",
+      appToken: "xapp-test-token",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+    upsertChannelTarget("slack", {
+      accountId: "account-1",
+      targetId: "C999",
+      targetType: "channel",
+      chatId: "C999",
+      label: "#eng",
+      discoveredAt: "2026-04-11T00:00:00.000Z",
+      lastSeenAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      target: "#eng",
+      message: "hello proactive slack",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "C999",
+      text: "hello proactive slack",
+      replyToMessageId: undefined,
+      threadId: null,
+      parseMode: undefined,
+    });
+  });
+
+  test("requires accountId when multiple proactive Slack accounts are eligible", async () => {
+    installChannelStateTestOverrides();
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({
+      messageId: "slack-msg-proactive-2",
+    }));
+
+    const adapter1: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+    const adapter2: ChannelAdapter = {
+      id: "slack:account-2",
+      channelId: "slack",
+      accountId: "account-2",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter1);
+    registry.registerAdapter(adapter2);
+
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "account-1",
+      displayName: "DocsBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token-1",
+      appToken: "xapp-test-token-1",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "account-2",
+      displayName: "SupportBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token-2",
+      appToken: "xapp-test-token-2",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      target: "#eng",
+      message: "hello proactive slack",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toBe(
+      "Error: Multiple proactive Slack accounts are available for this agent. Pass accountId.",
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test("rejects proactive Slack sends for accounts outside the agent scope", async () => {
+    installChannelStateTestOverrides();
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({
+      messageId: "slack-msg-proactive-3",
+    }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "account-1",
+      displayName: "DocsBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token",
+      appToken: "xapp-test-token",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      target: "#eng",
+      accountId: "other-account",
+      message: "hello proactive slack",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toBe(
+      'Error: Slack account "other-account" is not available for proactive sends in this agent scope.',
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test("requires exactly one of chat_id or target", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-msg-4" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "D123",
+      target: "#eng",
+      message: "hello",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toBe(
+      "Error: MessageChannel requires exactly one of chat_id or target.",
+    );
     expect(sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/channels/slack-target-resolution.test.ts
+++ b/src/tests/channels/slack-target-resolution.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  listSlackChannels,
+  resolveSlackMessageTarget,
+} from "../../channels/slack/targetResolution";
+import {
+  __testOverrideLoadTargetStore,
+  __testOverrideSaveTargetStore,
+  clearTargetStores,
+  listChannelTargets,
+  upsertChannelTarget,
+} from "../../channels/targets";
+import type { SlackChannelAccount } from "../../channels/types";
+
+function makeSlackAccount(accountId: string): SlackChannelAccount {
+  return {
+    channel: "slack",
+    accountId,
+    displayName: `Slack ${accountId}`,
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    createdAt: "2026-04-11T00:00:00.000Z",
+    updatedAt: "2026-04-11T00:00:00.000Z",
+    mode: "socket",
+    botToken: `xoxb-${accountId}`,
+    appToken: `xapp-${accountId}`,
+    agentId: "agent-1",
+    defaultPermissionMode: "default",
+  };
+}
+
+describe("Slack MessageChannel target resolution", () => {
+  afterEach(() => {
+    clearTargetStores();
+    __testOverrideLoadTargetStore(null);
+    __testOverrideSaveTargetStore(null);
+  });
+
+  test("keeps cached target matching scoped to the selected account", async () => {
+    __testOverrideLoadTargetStore(() => {});
+    __testOverrideSaveTargetStore(() => {});
+
+    upsertChannelTarget("slack", {
+      accountId: "docsbot",
+      targetId: "C111",
+      targetType: "channel",
+      chatId: "C111",
+      label: "#eng",
+      discoveredAt: "2026-04-11T00:00:00.000Z",
+      lastSeenAt: "2026-04-11T00:00:00.000Z",
+    });
+    upsertChannelTarget("slack", {
+      accountId: "supportbot",
+      targetId: "C222",
+      targetType: "channel",
+      chatId: "C222",
+      label: "#eng",
+      discoveredAt: "2026-04-11T00:00:00.000Z",
+      lastSeenAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const resolved = await resolveSlackMessageTarget({
+      account: makeSlackAccount("supportbot"),
+      target: "#eng",
+    });
+
+    expect(resolved).toEqual({
+      chatId: "C222",
+      chatType: "channel",
+      label: "#eng",
+    });
+  });
+
+  test("resolves live lookup matches by raw Slack channel id and warms the cache", async () => {
+    __testOverrideLoadTargetStore(() => {});
+    __testOverrideSaveTargetStore(() => {});
+
+    const lookupChannels = mock(async () => [
+      { id: "C777", name: "eng" },
+      { id: "C888", name: "sales" },
+    ]);
+
+    const resolved = await resolveSlackMessageTarget({
+      account: makeSlackAccount("docsbot"),
+      target: "channel:C777",
+      lookupChannels,
+    });
+
+    expect(resolved).toEqual({
+      chatId: "C777",
+      chatType: "channel",
+      label: "#eng",
+    });
+    expect(lookupChannels).toHaveBeenCalledTimes(1);
+    expect(listChannelTargets("slack", "docsbot")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: "docsbot",
+          targetId: "C777",
+          chatId: "C777",
+          label: "#eng",
+        }),
+      ]),
+    );
+  });
+
+  test("paginates Slack channel listing until exhaustion", async () => {
+    const list = mock()
+      .mockResolvedValueOnce({
+        ok: true,
+        channels: [{ id: "C100", name: "general" }],
+        response_metadata: { next_cursor: "cursor-2" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        channels: [{ id: "C200", name: "eng" }],
+        response_metadata: { next_cursor: "" },
+      });
+
+    const channels = await listSlackChannels(makeSlackAccount("docsbot"), {
+      conversations: {
+        list,
+      },
+    });
+
+    expect(channels).toEqual([
+      { id: "C100", name: "general" },
+      { id: "C200", name: "eng" },
+    ]);
+    expect(list).toHaveBeenNthCalledWith(1, {
+      exclude_archived: true,
+      limit: 200,
+      types: "public_channel,private_channel",
+    });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      exclude_archived: true,
+      limit: 200,
+      types: "public_channel,private_channel",
+      cursor: "cursor-2",
+    });
+  });
+
+  test("rejects unsupported Slack user targets in proactive mode", async () => {
+    await expect(
+      resolveSlackMessageTarget({
+        account: makeSlackAccount("docsbot"),
+        target: "user:U12345678",
+      }),
+    ).rejects.toThrow(
+      'Error: Slack proactive MessageChannel currently supports channel targets only. Use a channel target like "#general" or "channel:C123".',
+    );
+  });
+});

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -9,6 +9,12 @@ import {
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  upsertChannelAccount,
+} from "../../channels/accounts";
 import { clearDynamicMessageChannelToolCache } from "../../channels/messageTool";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
 import type { ChannelAdapter } from "../../channels/types";
@@ -27,6 +33,7 @@ import {
   prepareToolExecutionContextForSpecificTools,
   refreshDynamicChannelToolsInLoadedRegistry,
 } from "../../tools/manager";
+import { resolveConversationChannelToolScope } from "../../tools/toolset";
 
 function asText(
   toolReturn: Awaited<ReturnType<typeof executeTool>>["toolReturn"],
@@ -67,7 +74,15 @@ describe("tool execution context snapshot", () => {
     }
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
   });
+
+  function installChannelAccountTestOverrides(): void {
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+  }
 
   afterAll(async () => {
     clearExternalTools();
@@ -293,5 +308,79 @@ describe("tool execution context snapshot", () => {
         >
       ).channel?.enum,
     ).toEqual(["slack"]);
+  });
+
+  test("includes MessageChannel in scoped snapshots when the agent has an eligible proactive Slack account even without routes", async () => {
+    installChannelAccountTestOverrides();
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "acct-slack",
+      displayName: "DocsBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token",
+      appToken: "xapp-test-token",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+
+    const scope = resolveConversationChannelToolScope("agent-1", "default");
+    expect(scope).toEqual({
+      channels: [{ channelId: "slack", accountId: "acct-slack" }],
+    });
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        channelToolScope: scope,
+      },
+    );
+
+    expect(prepared.loadedToolNames).toContain("MessageChannel");
+  });
+
+  test("does not grant proactive MessageChannel scope for Telegram-only accounts", async () => {
+    installChannelAccountTestOverrides();
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    upsertChannelAccount("telegram", {
+      channel: "telegram",
+      accountId: "acct-telegram",
+      displayName: "Telegram Bot",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      token: "telegram-token",
+      binding: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    const scope = resolveConversationChannelToolScope("agent-1", "default");
+    expect(scope).toEqual({ channels: [] });
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        channelToolScope: scope,
+      },
+    );
+
+    expect(prepared.loadedToolNames).not.toContain("MessageChannel");
   });
 });

--- a/src/tools/descriptions/MessageChannel.md
+++ b/src/tools/descriptions/MessageChannel.md
@@ -1,28 +1,35 @@
 # MessageChannel
 
-Send a message or channel action to an external channel in response to a channel notification.
+Send a message or channel action to an external channel.
 
 When you receive a `<channel-notification>`, use this tool to reply directly to the user on the same external channel. A normal assistant response is not delivered back to the external channel automatically.
 
-Preferred pattern:
+There are two supported send modes:
+- Reply mode: use `channel` + `chat_id` from the notification to respond in the current routed chat.
+- Proactive mode: use `channel` + `target` on supported channels to send to an explicit outbound destination.
+
+Preferred reply pattern:
 - `action="send"` to send a normal reply
 - `channel` + `chat_id` from the notification attributes
 - `message` for the text body
 
 Parameters:
 - `action`: The action to perform. The exact available actions depend on the active channel plugins and are reflected in the JSON schema.
-- `channel`: The platform to send to (matches the `source` attribute)
-- `chat_id`: The chat ID to send to (matches the `chat_id` attribute)
-- `message`: The text to send for `action="send"`
-- `replyTo`: (Optional) Reply to a specific message ID. Omit this unless you intentionally want the platform's quote/reply UI.
-- `messageId`: (Optional) Target message id for message-scoped actions like reactions.
-- `emoji`: (Optional) Reaction payload for channels that support reactions.
-- `remove`: (Optional) Set to `true` to remove the reaction instead of adding it
-- `media`: (Optional) Absolute local file path for file/media uploads on channels that support uploads.
-- `filename`: (Optional) Override the uploaded filename when supported by the channel.
-- `title`: (Optional) Override the uploaded attachment title when supported by the channel.
+- `channel`: The platform to send to.
+- `chat_id`: Reply target for the current routed chat. Use this when responding to a channel notification.
+- `target`: Explicit outbound target for proactive sends on supported channels.
+- `accountId`: Optional channel account selector when multiple eligible accounts are available.
+- `message`: Text body for `action="send"`.
+- `replyTo`: Optional message ID to reply to. Omit this unless you intentionally want the platform's quote/reply UI.
+- `messageId`: Optional target message id for message-scoped actions like reactions.
+- `emoji`: Optional reaction payload for channels that support reactions.
+- `remove`: Optional boolean to remove a reaction instead of adding it.
+- `media`: Optional absolute local file path for file/media uploads on channels that support uploads.
+- `filename`: Optional uploaded filename override when supported by the channel.
+- `title`: Optional uploaded attachment title when supported by the channel.
 
 Rules:
 - Always pass `action` explicitly, even for a normal reply.
+- Pass exactly one of `chat_id` or `target`.
 - `react` should be its own call.
 - `upload-file` can include both `media` and `message` so the uploaded file has a caption/comment when the channel supports it.

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -19,9 +19,12 @@ import type {
   ChannelMessageActionRequest,
 } from "../../channels/pluginTypes";
 import { getChannelRegistry } from "../../channels/registry";
+import { resolveEligibleProactiveSlackAccount } from "../../channels/slack/proactiveAccounts";
 import type {
+  ChannelAdapter,
   ChannelRoute,
   OutboundChannelMessage,
+  SupportedChannelId,
 } from "../../channels/types";
 
 const TELEGRAM_CHANNEL_ID = "telegram";
@@ -467,7 +470,9 @@ export function formatOutboundChannelMessage(
 interface MessageChannelArgs {
   channel: string;
   action: string;
-  chat_id: string;
+  chat_id?: string;
+  target?: string;
+  accountId?: string;
   message?: string;
   replyTo?: string;
   threadId?: string;
@@ -479,6 +484,30 @@ interface MessageChannelArgs {
   title?: string;
   /** Injected by executeTool() — NOT read from global context. */
   parentScope?: { agentId: string; conversationId: string };
+}
+
+interface NormalizedMessageChannelInput {
+  channel: SupportedChannelId;
+  action: ChannelMessageActionName;
+  chatId?: string;
+  target?: string;
+  accountId?: string;
+  message?: string;
+  replyToMessageId?: string;
+  threadId?: string | null;
+  messageId?: string;
+  emoji?: string;
+  remove?: boolean;
+  mediaPath?: string;
+  filename?: string;
+  title?: string;
+}
+
+interface ResolvedMessageChannelExecutionContext {
+  request: ChannelMessageActionRequest;
+  route: ChannelRoute;
+  adapter: ChannelAdapter;
+  plugin: Awaited<ReturnType<typeof loadChannelPlugin>>;
 }
 
 function firstNonEmptyString(...values: unknown[]): string | undefined {
@@ -538,9 +567,9 @@ function normalizeMessageAction(
   }
 }
 
-function normalizeMessageChannelRequest(
+function normalizeMessageChannelInput(
   args: MessageChannelArgs,
-): ChannelMessageActionRequest | string {
+): NormalizedMessageChannelInput | string {
   const channel = firstNonEmptyString(args.channel)?.toLowerCase();
   if (!channel) {
     return "Error: MessageChannel requires channel.";
@@ -560,14 +589,20 @@ function normalizeMessageChannelRequest(
   }
 
   const rawChatId = firstNonEmptyString(args.chat_id);
-  if (!rawChatId) {
-    return "Error: MessageChannel requires chat_id.";
+  const rawTarget = firstNonEmptyString(args.target);
+  if (!rawChatId && !rawTarget) {
+    return "Error: MessageChannel requires exactly one of chat_id or target.";
+  }
+  if (rawChatId && rawTarget) {
+    return "Error: MessageChannel requires exactly one of chat_id or target.";
   }
 
   return {
     action,
     channel,
-    chatId: normalizeChatTarget(rawChatId),
+    ...(rawChatId ? { chatId: normalizeChatTarget(rawChatId) } : {}),
+    ...(rawTarget ? { target: rawTarget } : {}),
+    accountId: firstNonEmptyString(args.accountId),
     message: firstNonEmptyString(args.message),
     replyToMessageId: firstNonEmptyString(args.replyTo),
     threadId: firstNonEmptyString(args.threadId) ?? null,
@@ -577,6 +612,93 @@ function normalizeMessageChannelRequest(
     mediaPath: firstNonEmptyString(args.media),
     filename: firstNonEmptyString(args.filename),
     title: firstNonEmptyString(args.title),
+  };
+}
+
+function buildMessageChannelRequest(
+  input: NormalizedMessageChannelInput,
+  chatId: string,
+  threadId?: string | null,
+): ChannelMessageActionRequest {
+  return {
+    action: input.action,
+    channel: input.channel,
+    chatId,
+    message: input.message,
+    replyToMessageId: input.replyToMessageId,
+    threadId: threadId ?? input.threadId ?? null,
+    messageId: input.messageId,
+    emoji: input.emoji,
+    remove: input.remove,
+    mediaPath: input.mediaPath,
+    filename: input.filename,
+    title: input.title,
+  };
+}
+
+function buildSyntheticChannelRoute(params: {
+  scope: { agentId: string; conversationId: string };
+  accountId: string;
+  chatId: string;
+  chatType?: ChannelRoute["chatType"];
+  threadId?: string | null;
+}): ChannelRoute {
+  const now = new Date().toISOString();
+  return {
+    accountId: params.accountId,
+    chatId: params.chatId,
+    chatType: params.chatType,
+    threadId: params.threadId ?? null,
+    agentId: params.scope.agentId,
+    conversationId: params.scope.conversationId,
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function resolveExplicitMessageChannelContext(params: {
+  input: NormalizedMessageChannelInput;
+  scope: { agentId: string; conversationId: string };
+}): Promise<ResolvedMessageChannelExecutionContext | string> {
+  if (params.input.channel !== "slack") {
+    return `Error: Explicit MessageChannel targets are not supported on ${params.input.channel}.`;
+  }
+
+  const eligibleAccount = resolveEligibleProactiveSlackAccount({
+    agentId: params.scope.agentId,
+    accountId: params.input.accountId,
+  });
+  if (typeof eligibleAccount === "string") {
+    return eligibleAccount;
+  }
+
+  const plugin = await loadChannelPlugin("slack");
+  const resolver = plugin.messageActions?.resolveMessageTarget;
+  if (!resolver) {
+    return "Error: Explicit MessageChannel targets are not supported on slack.";
+  }
+
+  const resolvedTarget = await resolver({
+    account: eligibleAccount.account,
+    target: params.input.target ?? "",
+  });
+
+  return {
+    request: buildMessageChannelRequest(
+      params.input,
+      resolvedTarget.chatId,
+      resolvedTarget.threadId,
+    ),
+    route: buildSyntheticChannelRoute({
+      scope: params.scope,
+      accountId: eligibleAccount.account.accountId,
+      chatId: resolvedTarget.chatId,
+      chatType: resolvedTarget.chatType,
+      threadId: resolvedTarget.threadId,
+    }),
+    adapter: eligibleAccount.adapter,
+    plugin,
   };
 }
 
@@ -596,32 +718,56 @@ export async function message_channel(
     return "Error: MessageChannel requires execution scope (agentId + conversationId).";
   }
 
-  const request = normalizeMessageChannelRequest(args);
-  if (typeof request === "string") {
-    return request;
-  }
-
-  const route: ChannelRoute | null = registry.getRouteForScope(
-    request.channel,
-    request.chatId,
-    scope.agentId,
-    scope.conversationId,
-  );
-  if (!route) {
-    return `Error: No route for chat_id "${request.chatId}" on "${request.channel}" for this agent/conversation.`;
-  }
-
-  const adapter = registry.getAdapter(request.channel, route.accountId);
-  if (!adapter) {
-    return `Error: Channel "${request.channel}" is not configured or not running.`;
-  }
-
-  if (!adapter.isRunning()) {
-    return `Error: Channel "${request.channel}" is not currently running.`;
+  const input = normalizeMessageChannelInput(args);
+  if (typeof input === "string") {
+    return input;
   }
 
   try {
-    const plugin = await loadChannelPlugin(request.channel);
+    let executionContext: ResolvedMessageChannelExecutionContext | string;
+    if (input.chatId) {
+      const route: ChannelRoute | null = registry.getRouteForScope(
+        input.channel,
+        input.chatId,
+        scope.agentId,
+        scope.conversationId,
+      );
+      if (!route) {
+        return `Error: No route for chat_id "${input.chatId}" on "${input.channel}" for this agent/conversation.`;
+      }
+
+      const adapter = registry.getAdapter(input.channel, route.accountId);
+      if (!adapter) {
+        return `Error: Channel "${input.channel}" is not configured or not running.`;
+      }
+
+      if (!adapter.isRunning()) {
+        return `Error: Channel "${input.channel}" is not currently running.`;
+      }
+
+      const plugin = await loadChannelPlugin(input.channel);
+      executionContext = {
+        request: buildMessageChannelRequest(
+          input,
+          input.chatId,
+          input.threadId,
+        ),
+        route,
+        adapter,
+        plugin,
+      };
+    } else {
+      executionContext = await resolveExplicitMessageChannelContext({
+        input,
+        scope,
+      });
+    }
+
+    if (typeof executionContext === "string") {
+      return executionContext;
+    }
+
+    const { request, route, adapter, plugin } = executionContext;
     if (!plugin.messageActions) {
       return `Error: Channel "${request.channel}" does not expose MessageChannel actions.`;
     }
@@ -645,6 +791,6 @@ export async function message_channel(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "unknown error";
-    return `Error sending message to ${request.channel}: ${msg}`;
+    return `Error sending message to ${input.channel}: ${msg}`;
   }
 }

--- a/src/tools/schemas/MessageChannel.json
+++ b/src/tools/schemas/MessageChannel.json
@@ -11,7 +11,15 @@
     },
     "chat_id": {
       "type": "string",
-      "description": "The chat/conversation ID to send to (from the channel-notification attributes)."
+      "description": "The chat/conversation ID to reply to (usually from the channel-notification attributes). Use this for replies in the current routed chat."
+    },
+    "target": {
+      "type": "string",
+      "description": "Explicit outbound target for proactive sends on supported channels (for example, a Slack channel like '#general' or 'channel:C12345678')."
+    },
+    "accountId": {
+      "type": "string",
+      "description": "Optional channel account identifier when multiple eligible channel accounts are available for proactive sends."
     },
     "message": {
       "type": "string",
@@ -50,6 +58,8 @@
       "description": "Optional uploaded title override for media attachments"
     }
   },
-  "required": ["action", "channel", "chat_id"],
+  "required": ["action", "channel"],
+  "anyOf": [{ "required": ["chat_id"] }, { "required": ["target"] }],
+  "not": { "required": ["chat_id", "target"] },
   "additionalProperties": false
 }

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -4,6 +4,7 @@ import { resolveModel } from "../agent/model";
 import type { MessageChannelToolDiscoveryScope } from "../channels/messageTool";
 import { getChannelRegistry } from "../channels/registry";
 import { getRoutesForChannel, loadRoutes } from "../channels/routing";
+import { listEligibleProactiveSlackAccounts } from "../channels/slack/proactiveAccounts";
 import {
   SUPPORTED_CHANNEL_IDS,
   type SupportedChannelId,
@@ -203,7 +204,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   };
 }
 
-function resolveConversationChannelToolScope(
+export function resolveConversationChannelToolScope(
   agentId: string,
   conversationId: string,
 ): MessageChannelToolDiscoveryScope {
@@ -244,6 +245,18 @@ function resolveConversationChannelToolScope(
         accountId: route.accountId ?? null,
       });
     }
+  }
+
+  for (const { account } of listEligibleProactiveSlackAccounts(agentId)) {
+    const key = `slack:${account.accountId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    channels.push({
+      channelId: "slack",
+      accountId: account.accountId,
+    });
   }
 
   return { channels };


### PR DESCRIPTION
## Summary
- add an explicit Slack target path to `MessageChannel` while preserving the existing scoped `chat_id` reply flow
- scope proactive `MessageChannel` availability to eligible Slack-bound agent accounts and align the interactive tool-prep path with listener/headless scoping
- add Slack target resolution helpers and coverage for cached target lookup, paginated channel discovery, scoped tool exposure, and proactive send behavior

## Test plan
- [x] `bun test src/tests/channels/message-channel.test.ts src/tests/channels/slack-target-resolution.test.ts src/tests/tools/tool-execution-context.test.ts`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)