### PR TITLE
fix(permissions): reuse shell analysis for repeated Bash approval rules

### DIFF
--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -9,7 +9,14 @@ import {
   SAFE_GH_COMMANDS,
   SAFE_GIT_SUBCOMMAND_LIST,
 } from "./readOnlyShell";
-import { unwrapShellLauncherCommand } from "./shell-command-normalization";
+import {
+  extractPrimaryShellCommand,
+  unwrapShellLauncherCommand,
+} from "./shell-command-normalization";
+import {
+  splitShellSegmentsAllowCommandSubstitution,
+  tokenizeShellWords,
+} from "./shellAnalysis";
 
 const SAFE_GIT_COMMANDS: readonly string[] = SAFE_GIT_SUBCOMMAND_LIST;
 
@@ -569,12 +576,32 @@ function buildPackageStyleRule(
   };
 }
 
+function containsDangerousFlag(command: string): boolean {
+  const segments = splitShellSegmentsAllowCommandSubstitution(command) ?? [
+    command,
+  ];
+
+  for (const segment of segments) {
+    const tokens = tokenizeShellWords(segment);
+    if (
+      tokens.includes("--force") ||
+      tokens.includes("--hard") ||
+      tokens.includes("-f")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function analyzeBashApproval(
   command: string,
   workingDir: string,
 ): ApprovalContext {
   const normalizedCommand = unwrapShellLauncherCommand(command);
-  const parts = normalizedCommand.trim().split(/\s+/);
+  const analysisCommand = extractPrimaryShellCommand(normalizedCommand);
+  const parts = analysisCommand.trim().split(/\s+/);
   const baseCommand = parts[0] || "";
   const firstArg = parts[1] || "";
   const topLevelGitSubcommand =
@@ -596,11 +623,7 @@ function analyzeBashApproval(
   }
 
   // Check for dangerous flags
-  if (
-    normalizedCommand.includes("--force") ||
-    normalizedCommand.includes("-f") ||
-    normalizedCommand.includes("--hard")
-  ) {
+  if (containsDangerousFlag(normalizedCommand)) {
     return {
       recommendedRule: "",
       ruleDescription: "",
@@ -632,7 +655,7 @@ function analyzeBashApproval(
     if (
       gitSubcommand &&
       SAFE_GIT_COMMANDS.includes(gitSubcommand) &&
-      isReadOnlyShellCommand(normalizedCommand, { allowExternalPaths: true })
+      isReadOnlyShellCommand(analysisCommand, { allowExternalPaths: true })
     ) {
       return {
         recommendedRule: `Bash(git ${gitSubcommand}:*)`,
@@ -708,7 +731,7 @@ function analyzeBashApproval(
   const readOnlyRulePrefix = getReadOnlyRulePrefix(parts);
   if (
     readOnlyRulePrefix &&
-    (isReadOnlyShellCommand(normalizedCommand, {
+    (isReadOnlyShellCommand(analysisCommand, {
       allowExternalPaths: true,
     }) ||
       readOnlyRulePrefix === "curl")
@@ -723,120 +746,14 @@ function analyzeBashApproval(
     };
   }
 
-  // Handle complex piped/chained commands (cd /path && git diff | head)
-  // For pipes (|), the FIRST command is the main one
-  // For && and ;, we skip cd prefixes and use the actual command
-  if (
-    normalizedCommand.includes("&&") ||
-    normalizedCommand.includes("|") ||
-    normalizedCommand.includes(";")
-  ) {
-    // First, strip everything after the first pipe - the piped-to command is secondary
-    // e.g., "curl --version | head -1" -> analyze "curl --version"
-    const beforePipe = (
-      normalizedCommand.split("|")[0] ?? normalizedCommand
-    ).trim();
-
-    // Now split on && and ; to handle cd prefixes
-    const segments = beforePipe.split(/\s*(?:&&|;)\s*/);
-
-    for (const segment of segments) {
-      const segmentParts = segment.trim().split(/\s+/);
-      const segmentBase = segmentParts[0] || "";
-      const segmentArg = segmentParts[1] || "";
-
-      // Skip cd commands - we want the actual command
-      if (segmentBase === "cd") {
-        continue;
-      }
-
-      // Check if this segment is git command
-      if (segmentBase === "git") {
-        const gitSubcommand = extractGitSubcommand(segmentParts);
-        const writeGitCommands = ["push", "pull", "fetch", "commit", "add"];
-        const isReadOnlyGitSegment = isReadOnlyShellCommand(segment, {
-          allowExternalPaths: true,
-        });
-
-        if (
-          gitSubcommand &&
-          ((SAFE_GIT_COMMANDS.includes(gitSubcommand) &&
-            isReadOnlyGitSegment) ||
-            writeGitCommands.includes(gitSubcommand))
-        ) {
-          return {
-            recommendedRule: `Bash(git ${gitSubcommand}:*)`,
-            ruleDescription: `'git ${gitSubcommand}' commands`,
-            approveAlwaysText: `Yes, and don't ask again for 'git ${gitSubcommand}' commands in this project`,
-            defaultScope: "project",
-            allowPersistence: true,
-            safetyLevel: SAFE_GIT_COMMANDS.includes(gitSubcommand)
-              ? "safe"
-              : "moderate",
-          };
-        }
-      }
-
-      // Check if this segment is a gh CLI command
-      if (segmentBase === "gh") {
-        return analyzeGhApproval(segmentArg, segmentParts[2] || "");
-      }
-
-      // Check if this segment is npm/bun/yarn/pnpm
-      if (segmentBase && ["npm", "bun", "yarn", "pnpm"].includes(segmentBase)) {
-        const subcommand = segmentArg;
-        const thirdPart = segmentParts[2];
-
-        if (subcommand === "run" && thirdPart) {
-          const fullCommand = `${segmentBase} ${subcommand} ${thirdPart}`;
-          return buildPackageStyleRule(fullCommand, "safe");
-        }
-
-        if (subcommand) {
-          const fullCommand = `${segmentBase} ${subcommand}`;
-          return buildPackageStyleRule(fullCommand, "safe");
-        }
-      }
-
-      if (segmentBase && ["npx", "bunx"].includes(segmentBase)) {
-        const subcommand = segmentArg;
-        if (subcommand) {
-          return buildPackageStyleRule(
-            `${segmentBase} ${subcommand}`,
-            "moderate",
-          );
-        }
-      }
-
-      // Check if this segment is a safe read-only command
-      const readOnlySegmentPrefix = getReadOnlyRulePrefix(segmentParts);
-      if (
-        readOnlySegmentPrefix &&
-        (isReadOnlyShellCommand(segment.trim(), {
-          allowExternalPaths: true,
-        }) ||
-          readOnlySegmentPrefix === "curl")
-      ) {
-        return {
-          recommendedRule: `Bash(${readOnlySegmentPrefix}:*)`,
-          ruleDescription: `'${readOnlySegmentPrefix}' commands`,
-          approveAlwaysText: `Yes, and don't ask again for '${readOnlySegmentPrefix}' commands in this project`,
-          defaultScope: "project",
-          allowPersistence: true,
-          safetyLevel: "safe",
-        };
-      }
-    }
-  }
-
   // Default: allow this specific command only
   const displayCommand =
-    normalizedCommand.length > 40
-      ? `${normalizedCommand.slice(0, 40)}...`
-      : normalizedCommand;
+    analysisCommand.length > 40
+      ? `${analysisCommand.slice(0, 40)}...`
+      : analysisCommand;
 
   return {
-    recommendedRule: `Bash(${normalizedCommand})`,
+    recommendedRule: `Bash(${analysisCommand})`,
     ruleDescription: `'${displayCommand}'`,
     approveAlwaysText: `Yes, and don't ask again for '${displayCommand}' in this project`,
     defaultScope: "project",

--- a/src/permissions/matcher.ts
+++ b/src/permissions/matcher.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { minimatch } from "minimatch";
 import { canonicalToolName } from "./canonical";
 import {
+  extractPrimaryShellCommand,
   normalizeBashRulePayload,
   unwrapShellLauncherCommand,
 } from "./shell-command-normalization";
@@ -218,30 +219,6 @@ export function matchesFilePattern(
  * @param query - The bash query to check (e.g., "Bash(git diff HEAD)")
  * @param pattern - The permission pattern (e.g., "Bash(git diff:*)")
  */
-/**
- * Extract the "actual" command from a compound command by stripping cd prefixes.
- * e.g., "cd /path && bun run check" → "bun run check"
- */
-function extractActualCommand(command: string): string {
-  // If command contains &&, |, or ;, split and find the actual command (skip cd)
-  if (
-    command.includes("&&") ||
-    command.includes("|") ||
-    command.includes(";")
-  ) {
-    const segments = command.split(/\s*(?:&&|\||;)\s*/);
-    for (const segment of segments) {
-      const trimmed = segment.trim();
-      const firstToken = trimmed.split(/\s+/)[0];
-      // Skip cd commands - we want the actual command
-      if (firstToken !== "cd") {
-        return trimmed;
-      }
-    }
-  }
-  return command;
-}
-
 export function matchesBashPattern(
   query: string,
   pattern: string,
@@ -261,8 +238,7 @@ export function matchesBashPattern(
     return false;
   }
   const rawCommand = queryMatch[2];
-  // Extract actual command by stripping cd prefixes from compound commands
-  const command = extractActualCommand(rawCommand);
+  const command = extractPrimaryShellCommand(rawCommand);
   const normalizedRawCommand = normalizeBashRulePayload(rawCommand);
   const normalizedCommand = normalizeBashRulePayload(command);
   const legacyRawCommand = unwrapShellLauncherCommand(rawCommand).trim();

--- a/src/permissions/shell-command-normalization.ts
+++ b/src/permissions/shell-command-normalization.ts
@@ -1,4 +1,11 @@
+import {
+  splitShellSegmentsAllowCommandSubstitution,
+  tokenizeShellWords,
+} from "./shellAnalysis";
+
 const SHELL_EXECUTORS = new Set(["bash", "sh", "zsh", "dash", "ksh"]);
+
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
 function trimMatchingQuotes(value: string): string {
   const trimmed = value.trim();
@@ -96,6 +103,64 @@ function tokenizeShell(input: string): string[] {
   return tokens;
 }
 
+function extractCommandAfterEnvPrefixes(segment: string): string | null {
+  const trimmed = segment.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed === "cd" || trimmed.startsWith("cd ")) {
+    return null;
+  }
+
+  if (trimmed === "export" || trimmed.startsWith("export ")) {
+    return null;
+  }
+
+  const tokens = tokenizeShellWords(trimmed);
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  let index = 0;
+
+  if (normalizeExecutableToken(tokens[0] ?? "") === "env") {
+    index += 1;
+    while (index < tokens.length) {
+      const token = tokens[index] ?? "";
+      if (!token) {
+        index += 1;
+        continue;
+      }
+
+      if (/^-[A-Za-z]+$/.test(token) || ENV_ASSIGNMENT_PATTERN.test(token)) {
+        index += 1;
+        continue;
+      }
+
+      break;
+    }
+  }
+
+  while (index < tokens.length) {
+    const token = tokens[index] ?? "";
+    if (!token || !ENV_ASSIGNMENT_PATTERN.test(token)) {
+      break;
+    }
+    index += 1;
+  }
+
+  if (index >= tokens.length) {
+    return null;
+  }
+
+  if (index === 0) {
+    return trimmed;
+  }
+
+  return tokens.slice(index).join(" ").trim() || null;
+}
+
 function isDashCFlag(token: string): boolean {
   return token === "-c" || /^-[a-zA-Z]*c[a-zA-Z]*$/.test(token);
 }
@@ -172,6 +237,22 @@ export function unwrapShellLauncherCommand(command: string): string {
     current = inner.trim();
   }
   return current;
+}
+
+export function extractPrimaryShellCommand(command: string): string {
+  const unwrapped = unwrapShellLauncherCommand(command);
+  const segments = splitShellSegmentsAllowCommandSubstitution(unwrapped) ?? [
+    unwrapped,
+  ];
+
+  for (const segment of segments) {
+    const primary = extractCommandAfterEnvPrefixes(segment);
+    if (primary) {
+      return primary;
+    }
+  }
+
+  return unwrapped.trim();
 }
 
 export function normalizeBashRulePayload(payload: string): string {

--- a/src/permissions/shellAnalysis.ts
+++ b/src/permissions/shellAnalysis.ts
@@ -182,6 +182,183 @@ export function splitShellSegments(input: string): string[] | null {
   return segments.map((segment) => segment.trim()).filter(Boolean);
 }
 
+/**
+ * Split a shell command into segments on top-level separators while tolerating
+ * `$(...)` command substitutions. This is useful for approval rule generation
+ * and matching, where we still want to identify the outer command even when a
+ * setup segment contains an inner pipe (e.g. `export FOO=$(grep ... | cut ...)`).
+ *
+ * Unlike `splitShellSegments`, this still rejects unsafe redirects, but it does
+ * not reject `$()` command substitutions.
+ */
+export function splitShellSegmentsAllowCommandSubstitution(
+  input: string,
+): string[] | null {
+  const segments: string[] = [];
+  let current = "";
+  let i = 0;
+  let quote: "single" | "double" | null = null;
+  let commandSubstitutionDepth = 0;
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+
+    if (quote === "single") {
+      current += ch;
+      if (ch === "'") {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (ch === "\\" && i + 1 < input.length) {
+        current += input.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+
+      if (ch === "$" && input.startsWith("$(", i)) {
+        current += "$(";
+        commandSubstitutionDepth += 1;
+        i += 2;
+        continue;
+      }
+
+      current += ch;
+      if (commandSubstitutionDepth > 0 && ch === ")") {
+        commandSubstitutionDepth -= 1;
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (commandSubstitutionDepth > 0) {
+      if (ch === "\\" && i + 1 < input.length) {
+        current += input.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+
+      if (ch === "$" && input.startsWith("$(", i)) {
+        current += "$(";
+        commandSubstitutionDepth += 1;
+        i += 2;
+        continue;
+      }
+
+      current += ch;
+      if (ch === '"') {
+        quote = "double";
+        i += 1;
+        continue;
+      }
+      if (ch === "'") {
+        quote = "single";
+        i += 1;
+        continue;
+      }
+      if (ch === ")") {
+        commandSubstitutionDepth -= 1;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'") {
+      quote = "single";
+      current += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      quote = "double";
+      current += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < input.length) {
+      current += input.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (input.startsWith(">>", i) || ch === ">") {
+      const skipLen = tryConsumeSafeRedirect(input, i);
+      if (skipLen > 0) {
+        i += skipLen;
+        continue;
+      }
+      return null;
+    }
+
+    if (ch === "$" && input.startsWith("$(", i)) {
+      current += "$(";
+      commandSubstitutionDepth += 1;
+      i += 2;
+      continue;
+    }
+
+    if (ch === "`") {
+      return null;
+    }
+
+    if (input.startsWith("&&", i)) {
+      segments.push(current);
+      current = "";
+      i += 2;
+      continue;
+    }
+
+    if (input.startsWith("||", i)) {
+      segments.push(current);
+      current = "";
+      i += 2;
+      continue;
+    }
+
+    if (ch === ";") {
+      segments.push(current);
+      current = "";
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\n" || ch === "\r") {
+      segments.push(current);
+      current = "";
+      i += 1;
+      continue;
+    }
+
+    if (ch === "|") {
+      segments.push(current);
+      current = "";
+      i += 1;
+      continue;
+    }
+
+    current += ch;
+    i += 1;
+  }
+
+  segments.push(current);
+  return segments.map((segment) => segment.trim()).filter(Boolean);
+}
+
 export function isShellExecutor(command: string): boolean {
   return command === "bash" || command === "sh";
 }

--- a/src/tests/permissions-analyzer.test.ts
+++ b/src/tests/permissions-analyzer.test.ts
@@ -200,6 +200,29 @@ test("Command with --hard flag blocks persistence", () => {
   expect(context.safetyLevel).toBe("dangerous");
 });
 
+test("Standalone -f force flag still blocks persistence", () => {
+  const context = analyzeApprovalContext(
+    "Bash",
+    { command: "git push -f origin main" },
+    "/Users/test/project",
+  );
+
+  expect(context.allowPersistence).toBe(false);
+  expect(context.safetyLevel).toBe("dangerous");
+});
+
+test("cut -f2 does not trigger dangerous flag classification", () => {
+  const context = analyzeApprovalContext(
+    "Bash",
+    { command: "cut -d= -f2 .env" },
+    "/Users/test/project",
+  );
+
+  expect(context.allowPersistence).toBe(true);
+  expect(context.safetyLevel).toBe("moderate");
+  expect(context.recommendedRule).toBe("Bash(cut -d= -f2 .env)");
+});
+
 test("npm run commands suggest safe rule", () => {
   const context = analyzeApprovalContext(
     "Bash",
@@ -305,6 +328,22 @@ test("Read-only rg command suggests wildcard rule", () => {
 
   expect(context.recommendedRule).toBe("Bash(rg:*)");
   expect(context.safetyLevel).toBe("safe");
+});
+
+test("Export setup plus curl lookup suggests reusable curl rule", () => {
+  const context = analyzeApprovalContext(
+    "Bash",
+    {
+      command:
+        'export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001" | jq -r "{id, email, name, description}"',
+    },
+    "/Users/test/project",
+  );
+
+  expect(context.allowPersistence).toBe(true);
+  expect(context.safetyLevel).toBe("safe");
+  expect(context.recommendedRule).toBe("Bash(curl:*)");
+  expect(context.approveAlwaysText).toContain("curl");
 });
 
 test("Skill script in bundled skill suggests bundled-scope message", () => {

--- a/src/tests/permissions-matcher.test.ts
+++ b/src/tests/permissions-matcher.test.ts
@@ -290,6 +290,22 @@ test("Bash pattern: wildcard rules match wrapped shell launchers", () => {
   ).toBe(true);
 });
 
+test("Bash pattern: wildcard rules match export setup plus curl lookups", () => {
+  expect(
+    matchesBashPattern(
+      'Bash(export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001" | jq -r "{id, email, name, description}")',
+      "Bash(curl:*)",
+    ),
+  ).toBe(true);
+
+  expect(
+    matchesBashPattern(
+      'Bash(export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0002" | jq -r "{id, email, name, description}")',
+      "Bash(curl:*)",
+    ),
+  ).toBe(true);
+});
+
 // ============================================================================
 // Tool Pattern Matching Tests
 // ============================================================================

--- a/src/tests/permissions-shell-analysis.test.ts
+++ b/src/tests/permissions-shell-analysis.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-
+import { extractPrimaryShellCommand } from "../permissions/shell-command-normalization";
 import {
   parseShellAnalysis,
   splitShellSegments,
+  splitShellSegmentsAllowCommandSubstitution,
 } from "../permissions/shellAnalysis";
 
 describe("shellAnalysis", () => {
@@ -68,5 +69,33 @@ describe("shellAnalysis", () => {
   test("rejects unsafe substitutions and redirects", () => {
     expect(parseShellAnalysis("echo $(rm file)")).toBeNull();
     expect(parseShellAnalysis("sed -n '1,20p' file > out.txt")).toBeNull();
+  });
+
+  test("command-substitution-aware splitter preserves outer separators", () => {
+    const command =
+      'export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001" | jq -r "{id, email, name, description}"';
+
+    expect(splitShellSegmentsAllowCommandSubstitution(command)).toEqual([
+      'export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2)',
+      'curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001"',
+      'jq -r "{id, email, name, description}"',
+    ]);
+  });
+
+  test("command-substitution-aware splitter still rejects unsafe redirects", () => {
+    expect(
+      splitShellSegmentsAllowCommandSubstitution(
+        'export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001" > out.json',
+      ),
+    ).toBeNull();
+  });
+
+  test("extractPrimaryShellCommand skips export setup segments", () => {
+    const command =
+      'export EXAMPLE_API_KEY=$(grep -E "^EXAMPLE_API_KEY=" .env | cut -d= -f2) && curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001" | jq -r "{id, email, name, description}"';
+
+    expect(extractPrimaryShellCommand(command)).toBe(
+      'curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001"',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- fix repeated Bash approvals for setup-plus-command patterns like `export STRIPE_API_KEY=$(...) && curl ... | jq ...` by reusing the shared shell-analysis layer instead of naive string splitting
- stop treating substrings like `cut -f2` as dangerous force flags while still blocking real `-f`, `--force`, and `--hard` flags
- add regression coverage for the reported Stripe lookup shape in analyzer, matcher, and shell-analysis tests so reusable rules like `Bash(curl:*)` are generated and matched correctly

## Test plan
- [x] `bun test src/tests/permissions-analyzer.test.ts src/tests/permissions-matcher.test.ts`
- [x] `bun test src/tests/permissions-shell-analysis.test.ts src/tests/permissions/readOnlyShell.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/permissions/analyzer.ts src/permissions/matcher.ts src/permissions/shell-command-normalization.ts src/permissions/shellAnalysis.ts src/tests/permissions-analyzer.test.ts src/tests/permissions-matcher.test.ts src/tests/permissions-shell-analysis.test.ts`

👾 Generated with [Letta Code](https://letta.com)