### PR TITLE
fix(channels): post Slack lifecycle errors in-thread

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -269,6 +269,7 @@ const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
 const SLACK_INGRESS_DEDUPE_MAX = 2_000;
 const SLACK_LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_LIFECYCLE_STATE_MAX = 2_000;
+const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
 
 type SlackLifecycleState = "queued" | "completed" | "error" | "cancelled";
 
@@ -493,6 +494,27 @@ export function createSlackAdapter(
     return `${source.chatId}:${source.messageId}`;
   }
 
+  function getLifecycleReplyKey(source: ChannelTurnSource): string | null {
+    if (source.channel !== "slack" || !isNonEmptyString(source.chatId)) {
+      return null;
+    }
+    const replyToMessageId = source.threadId ?? source.messageId;
+    if (!isNonEmptyString(replyToMessageId)) {
+      return null;
+    }
+    return `${source.chatId}:${replyToMessageId}`;
+  }
+
+  function formatSlackLifecycleErrorMessage(errorText: string): string {
+    const normalized = errorText.trim();
+    const truncated =
+      normalized.length > SLACK_LIFECYCLE_ERROR_TEXT_MAX
+        ? `${normalized.slice(0, SLACK_LIFECYCLE_ERROR_TEXT_MAX - 1).trimEnd()}…`
+        : normalized;
+    const escaped = truncated.replace(/```/g, "``\u200b`");
+    return `Turn failed:\n\`\`\`\n${escaped}\n\`\`\``;
+  }
+
   function pruneLifecycleState(now: number = Date.now()): void {
     for (const [key, entry] of lifecycleStateByMessageKey) {
       if (entry.updatedAt + SLACK_LIFECYCLE_STATE_TTL_MS <= now) {
@@ -540,6 +562,25 @@ export function createSlackAdapter(
       timestamp: source.messageId,
       name: emoji,
     });
+  }
+
+  async function sendLifecycleErrorReply(
+    source: ChannelTurnSource,
+    errorText: string,
+  ): Promise<void> {
+    const replyToMessageId = source.threadId ?? source.messageId;
+    if (!isNonEmptyString(replyToMessageId)) {
+      return;
+    }
+
+    await ensureApp();
+    const slackClient = await ensureWriteClient();
+    const response = await slackClient.chat.postMessage({
+      channel: source.chatId,
+      text: formatSlackLifecycleErrorMessage(errorText),
+      thread_ts: replyToMessageId,
+    });
+    rememberMessageThread(response.ts, replyToMessageId);
   }
 
   function scheduleLifecycleTransition(
@@ -990,6 +1031,33 @@ export function createSlackAdapter(
         event.sources.map((source) =>
           scheduleLifecycleTransition(source, nextState),
         ),
+      );
+
+      const errorText = event.outcome === "error" ? event.error?.trim() : null;
+      if (!errorText) {
+        return;
+      }
+
+      const uniqueReplySources = new Map<string, ChannelTurnSource>();
+      for (const source of event.sources) {
+        const key = getLifecycleReplyKey(source);
+        if (!key || uniqueReplySources.has(key)) {
+          continue;
+        }
+        uniqueReplySources.set(key, source);
+      }
+
+      await Promise.all(
+        Array.from(uniqueReplySources.values()).map(async (source) => {
+          try {
+            await sendLifecycleErrorReply(source, errorText);
+          } catch (error) {
+            console.warn(
+              `[Slack] Failed to post lifecycle error for ${source.chatId}:`,
+              error instanceof Error ? error.message : error,
+            );
+          }
+        }),
       );
     },
 

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -1088,6 +1088,184 @@ test("slack adapter swaps queued turns to x when the turn fails", async () => {
     timestamp: "1712800000.000200",
     name: "x",
   });
+  expect(writeClient?.chat.postMessage).not.toHaveBeenCalled();
+});
+
+test("slack adapter posts the lifecycle error back into the same thread as a code block", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatType: "channel",
+      messageId: "1712800000.000300",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-3",
+    outcome: "error",
+    error: "Boom: something went wrong\nsecond line",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000300",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.add).toHaveBeenNthCalledWith(2, {
+    channel: "C123",
+    timestamp: "1712800000.000300",
+    name: "x",
+  });
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "Turn failed:\n```\nBoom: something went wrong\nsecond line\n```",
+    thread_ts: "1712790000.000050",
+  });
+});
+
+test("slack adapter dedupes lifecycle error posts by reply destination", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatType: "channel",
+      messageId: "1712800000.000401",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatType: "channel",
+      messageId: "1712800000.000402",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-4",
+    outcome: "error",
+    error: "Debounced batch failure",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000401",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000402",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledTimes(1);
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "Turn failed:\n```\nDebounced batch failure\n```",
+    thread_ts: "1712790000.000050",
+  });
+});
+
+test("slack adapter does not post an extra lifecycle message for cancelled turns", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-5",
+    outcome: "cancelled",
+    error: "Should not be posted",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000500",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.postMessage).not.toHaveBeenCalled();
 });
 
 test("slack adapter uploads local files through Slack's external upload flow", async () => {


### PR DESCRIPTION
## Summary
- keep the existing Slack lifecycle x reaction on failed turns, but also post the actual error text back into the originating Slack thread as a fenced code block
- dedupe lifecycle error replies by Slack reply destination so batched failures only post once per thread or DM
- add focused Slack adapter coverage for in-thread error posts, dedupe behavior, and cancelled-turn no-op behavior

## Test plan
- [x] `bun test src/tests/channels/slack-adapter.test.ts`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)