### PR TITLE
fix(channels): scope proactive MessageChannel targets to Slack routes

### DIFF
--- a/src/channels/slack/proactiveAccounts.ts
+++ b/src/channels/slack/proactiveAccounts.ts
@@ -1,5 +1,6 @@
-import { listChannelAccounts } from "../accounts";
+import { getChannelAccount, LEGACY_CHANNEL_ACCOUNT_ID } from "../accounts";
 import { getChannelRegistry } from "../registry";
+import { getRoutesForChannel, loadRoutes } from "../routing";
 import type { ChannelAdapter, SlackChannelAccount } from "../types";
 
 export interface EligibleProactiveSlackAccount {
@@ -7,21 +8,43 @@ export interface EligibleProactiveSlackAccount {
   adapter: ChannelAdapter;
 }
 
-export function listEligibleProactiveSlackAccounts(
-  agentId: string,
-): EligibleProactiveSlackAccount[] {
+export function listEligibleProactiveSlackAccounts(params: {
+  agentId: string;
+  conversationId: string;
+}): EligibleProactiveSlackAccount[] {
   const registry = getChannelRegistry();
   if (!registry) {
     return [];
   }
 
-  const accounts = listChannelAccounts("slack");
+  loadRoutes("slack");
+  const seen = new Set<string>();
 
   const eligible: EligibleProactiveSlackAccount[] = [];
-  for (const account of accounts) {
-    if (account.channel !== "slack" || account.agentId !== agentId) {
+  for (const route of getRoutesForChannel("slack")) {
+    if (
+      route.agentId !== params.agentId ||
+      route.conversationId !== params.conversationId ||
+      !route.enabled
+    ) {
       continue;
     }
+
+    const accountId = route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    if (seen.has(accountId)) {
+      continue;
+    }
+    seen.add(accountId);
+
+    const account = getChannelAccount("slack", accountId);
+    if (
+      !account ||
+      account.channel !== "slack" ||
+      account.agentId !== params.agentId
+    ) {
+      continue;
+    }
+
     const adapter = registry.getAdapter("slack", account.accountId);
     if (!adapter?.isRunning()) {
       continue;
@@ -37,9 +60,13 @@ export function listEligibleProactiveSlackAccounts(
 
 export function resolveEligibleProactiveSlackAccount(params: {
   agentId: string;
+  conversationId: string;
   accountId?: string | null;
 }): EligibleProactiveSlackAccount | string {
-  const eligible = listEligibleProactiveSlackAccounts(params.agentId);
+  const eligible = listEligibleProactiveSlackAccounts({
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+  });
 
   if (params.accountId) {
     const matched = eligible.find(

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -496,6 +496,18 @@ describe("MessageChannel", () => {
       throw new Error("explicit target path should not consult routes");
     });
 
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
     upsertChannelAccount("slack", {
       channel: "slack",
       accountId: "account-1",
@@ -578,6 +590,29 @@ describe("MessageChannel", () => {
     registry.registerAdapter(adapter1);
     registry.registerAdapter(adapter2);
 
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+    setRouteInMemory("slack", {
+      accountId: "account-2",
+      chatId: "C124",
+      chatType: "channel",
+      threadId: "1712790000.000051",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
     upsertChannelAccount("slack", {
       channel: "slack",
       accountId: "account-1",
@@ -647,6 +682,18 @@ describe("MessageChannel", () => {
     };
 
     registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
 
     upsertChannelAccount("slack", {
       channel: "slack",

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../channels/accounts";
 import { clearDynamicMessageChannelToolCache } from "../../channels/messageTool";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
+import { setRouteInMemory } from "../../channels/routing";
 import type { ChannelAdapter } from "../../channels/types";
 import { runWithRuntimeContext } from "../../runtime-context";
 import {
@@ -310,7 +311,7 @@ describe("tool execution context snapshot", () => {
     ).toEqual(["slack"]);
   });
 
-  test("includes MessageChannel in scoped snapshots when the agent has an eligible proactive Slack account even without routes", async () => {
+  test("does not leak MessageChannel into conversations that only share an agent-level Slack account", async () => {
     installChannelAccountTestOverrides();
     await loadSpecificTools(["Read"]);
 
@@ -331,6 +332,53 @@ describe("tool execution context snapshot", () => {
       appToken: "xapp-test-token",
       agentId: "agent-1",
       defaultPermissionMode: "default",
+    });
+
+    const scope = resolveConversationChannelToolScope("agent-1", "default");
+    expect(scope).toEqual({ channels: [] });
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        channelToolScope: scope,
+      },
+    );
+
+    expect(prepared.loadedToolNames).not.toContain("MessageChannel");
+  });
+
+  test("includes MessageChannel in scoped snapshots when the conversation has a Slack route", async () => {
+    installChannelAccountTestOverrides();
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+
+    upsertChannelAccount("slack", {
+      channel: "slack",
+      accountId: "acct-slack",
+      displayName: "DocsBot Slack",
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      mode: "socket",
+      botToken: "xoxb-test-token",
+      appToken: "xapp-test-token",
+      agentId: "agent-1",
+      defaultPermissionMode: "default",
+    });
+    setRouteInMemory("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
     });
 
     const scope = resolveConversationChannelToolScope("agent-1", "default");

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -667,6 +667,7 @@ async function resolveExplicitMessageChannelContext(params: {
 
   const eligibleAccount = resolveEligibleProactiveSlackAccount({
     agentId: params.scope.agentId,
+    conversationId: params.scope.conversationId,
     accountId: params.input.accountId,
   });
   if (typeof eligibleAccount === "string") {

--- a/src/tools/schemas/MessageChannel.json
+++ b/src/tools/schemas/MessageChannel.json
@@ -59,7 +59,5 @@
     }
   },
   "required": ["action", "channel"],
-  "anyOf": [{ "required": ["chat_id"] }, { "required": ["target"] }],
-  "not": { "required": ["chat_id", "target"] },
   "additionalProperties": false
 }

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -4,7 +4,6 @@ import { resolveModel } from "../agent/model";
 import type { MessageChannelToolDiscoveryScope } from "../channels/messageTool";
 import { getChannelRegistry } from "../channels/registry";
 import { getRoutesForChannel, loadRoutes } from "../channels/routing";
-import { listEligibleProactiveSlackAccounts } from "../channels/slack/proactiveAccounts";
 import {
   SUPPORTED_CHANNEL_IDS,
   type SupportedChannelId,
@@ -246,19 +245,6 @@ export function resolveConversationChannelToolScope(
       });
     }
   }
-
-  for (const { account } of listEligibleProactiveSlackAccounts(agentId)) {
-    const key = `slack:${account.accountId}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    channels.push({
-      channelId: "slack",
-      accountId: account.accountId,
-    });
-  }
-
   return { channels };
 }
 


### PR DESCRIPTION
## Summary
- remove the invalid top-level `MessageChannel` schema combinators that caused Anthropic and OpenAI tool validation to fail
- restrict proactive Slack target resolution to conversations that already have a Slack route instead of exposing `MessageChannel` across unrelated conversations on the same agent
- add regression coverage for the schema-safe behavior and the no-leak conversation scoping

## Test plan
- [x] `USER_CWD=/Users/loaner/dev/letta-code-prod bun test src/tests/channels/message-channel.test.ts src/tests/channels/slack-target-resolution.test.ts src/tests/tools/tool-execution-context.test.ts src/tests/channels/message-tool-schema.test.ts`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)