### PR TITLE
fix(permissions): auto-approve safe git grep commands

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -84,6 +84,7 @@ export const SAFE_GIT_SUBCOMMAND_LIST = [
   "diff",
   "log",
   "show",
+  "grep",
   "branch",
   "tag",
   "remote",
@@ -471,6 +472,64 @@ function isReadOnlyGitBranchArgs(args: string[]): boolean {
   return sawReadOnlyFlag;
 }
 
+function isReadOnlyGitGrepArgs(
+  args: string[],
+  options: ReadOnlyShellOptions,
+): boolean {
+  let inPathspecs = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--") {
+      inPathspecs = true;
+      continue;
+    }
+
+    if (arg === "--no-index") {
+      return false;
+    }
+
+    if (
+      arg === "-O" ||
+      arg.startsWith("-O") ||
+      arg === "--open-files-in-pager" ||
+      arg.startsWith("--open-files-in-pager=") ||
+      arg === "--ext-grep"
+    ) {
+      return false;
+    }
+
+    if (arg === "-f") {
+      const patternFile = args[i + 1];
+      if (!patternFile) {
+        return false;
+      }
+      if (hasDisallowedPathArg(patternFile, options)) {
+        return false;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("-f") && arg.length > 2) {
+      if (hasDisallowedPathArg(arg.slice(2), options)) {
+        return false;
+      }
+      continue;
+    }
+
+    if (inPathspecs && hasDisallowedPathArg(arg, options)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function isSafeEnvInvocation(
   tokens: string[],
   options: ReadOnlyShellOptions,
@@ -696,6 +755,9 @@ function isSafeSegment(
     }
     if (!SAFE_GIT_SUBCOMMANDS.has(subcommand)) {
       return false;
+    }
+    if (subcommand === "grep") {
+      return isReadOnlyGitGrepArgs(tokens.slice(subcommandIndex + 1), options);
     }
     if (subcommand === "branch") {
       return isReadOnlyGitBranchArgs(tokens.slice(subcommandIndex + 1));

--- a/src/tests/permissions-analyzer.test.ts
+++ b/src/tests/permissions-analyzer.test.ts
@@ -64,6 +64,20 @@ test("Git branch --list suggests safe subcommand rule", () => {
   expect(context.safetyLevel).toBe("safe");
 });
 
+test("Git grep pipeline suggests safe subcommand rule", () => {
+  const context = analyzeApprovalContext(
+    "Bash",
+    {
+      command:
+        'git grep -n "stream mode\\|StreamMode\\|conversationMode\\|continuousMode\\|AutoReadIcon\\|ChatInfoIcon" HEAD~1 -- libs/ui-ade-components/src/lib/ade/panels/AgentSimulator/AgentMessenger libs/ui-ade-components/src/translations/en.json | sed -n "1,220p"',
+    },
+    "/Users/test/project",
+  );
+
+  expect(context.recommendedRule).toBe("Bash(git grep:*)");
+  expect(context.safetyLevel).toBe("safe");
+});
+
 test("Git branch mutation suggests moderate safety rule", () => {
   const context = analyzeApprovalContext(
     "Bash",

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -225,6 +225,17 @@ describe("isReadOnlyShellCommand", () => {
       expect(isReadOnlyShellCommand("git count-objects -v")).toBe(true);
       expect(isReadOnlyShellCommand("git verify-commit HEAD")).toBe(true);
       expect(isReadOnlyShellCommand("git verify-tag v1.0")).toBe(true);
+      expect(
+        isReadOnlyShellCommand("git grep -n StreamMode HEAD~1 -- src"),
+      ).toBe(true);
+      expect(
+        isReadOnlyShellCommand(
+          'git grep -n "stream mode\\|StreamMode\\|conversationMode\\|continuousMode\\|AutoReadIcon\\|ChatInfoIcon" HEAD~1 -- libs/ui-ade-components/src/lib/ade/panels/AgentSimulator/AgentMessenger libs/ui-ade-components/src/translations/en.json | sed -n "1,220p"',
+        ),
+      ).toBe(true);
+      expect(isReadOnlyShellCommand("git grep -f patterns.txt -- src")).toBe(
+        true,
+      );
     });
 
     test("allows compound commands with read-only git subcommands", () => {
@@ -276,6 +287,15 @@ describe("isReadOnlyShellCommand", () => {
       expect(
         isReadOnlyShellCommand("git --config-env=core.pager=GIT_PAGER status"),
       ).toBe(false);
+      expect(isReadOnlyShellCommand("git grep --open-files-in-pager foo")).toBe(
+        false,
+      );
+      expect(isReadOnlyShellCommand("git grep -Oless foo")).toBe(false);
+      expect(isReadOnlyShellCommand("git grep --ext-grep foo")).toBe(false);
+      expect(isReadOnlyShellCommand("git grep --no-index foo .")).toBe(false);
+      expect(isReadOnlyShellCommand("git grep -f /tmp/patterns foo")).toBe(
+        false,
+      );
     });
 
     test("blocks bare git", () => {


### PR DESCRIPTION
## Summary
- treat safe `git grep` invocations as read-only so search pipelines like `git grep ... | sed -n ...` auto-approve instead of prompting
- add dedicated `git grep` argument checks so pager launches, external grep execution, `--no-index`, and unsafe pattern-file paths still require approval
- add regression coverage in the readonly-shell and analyzer suites for the reported command shape and for unsafe `git grep` variants

## Test plan
- [x] `bun test src/tests/permissions/readOnlyShell.test.ts src/tests/permissions-analyzer.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/permissions/readOnlyShell.ts src/tests/permissions/readOnlyShell.test.ts src/tests/permissions-analyzer.test.ts`

👾 Generated with [Letta Code](https://letta.com)