### PR TITLE
feat: add GPT-5.5 ChatGPT BYOK models

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -510,6 +510,137 @@
       }
     },
     {
+      "id": "gpt-5.5-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.5",
+      "label": "GPT-5.5 (ChatGPT)",
+      "description": "GPT-5.5 (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.5",
+      "label": "GPT-5.5 (ChatGPT)",
+      "description": "GPT-5.5 (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.5",
+      "label": "GPT-5.5 (ChatGPT)",
+      "description": "GPT-5.5 (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.5",
+      "label": "GPT-5.5 (ChatGPT)",
+      "description": "OpenAI's most capable model (high reasoning) via ChatGPT Plus/Pro",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.5",
+      "label": "GPT-5.5 (ChatGPT)",
+      "description": "GPT-5.5 (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-fast-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.5-fast",
+      "label": "GPT-5.5 Fast (ChatGPT)",
+      "description": "GPT-5.5 Fast (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-fast-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.5-fast",
+      "label": "GPT-5.5 Fast (ChatGPT)",
+      "description": "GPT-5.5 Fast (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-fast-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.5-fast",
+      "label": "GPT-5.5 Fast (ChatGPT)",
+      "description": "GPT-5.5 Fast (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-fast-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.5-fast",
+      "label": "GPT-5.5 Fast (ChatGPT)",
+      "description": "GPT-5.5 Fast (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.5-fast-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.5-fast",
+      "label": "GPT-5.5 Fast (ChatGPT)",
+      "description": "GPT-5.5 Fast (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5.4-plus-pro-none",
       "handle": "chatgpt-plus-pro/gpt-5.4",
       "label": "GPT-5.4 (ChatGPT)",

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -123,6 +123,46 @@ describe("getReasoningTierOptionsForHandle", () => {
     ]);
   });
 
+  test("returns byok reasoning options for chatgpt-plus-pro gpt-5.5", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "chatgpt-plus-pro/gpt-5.5",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "gpt-5.5-plus-pro-none",
+      "gpt-5.5-plus-pro-low",
+      "gpt-5.5-plus-pro-medium",
+      "gpt-5.5-plus-pro-high",
+      "gpt-5.5-plus-pro-xhigh",
+    ]);
+  });
+
+  test("returns byok reasoning options for chatgpt-plus-pro gpt-5.5-fast", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "chatgpt-plus-pro/gpt-5.5-fast",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "gpt-5.5-fast-plus-pro-none",
+      "gpt-5.5-fast-plus-pro-low",
+      "gpt-5.5-fast-plus-pro-medium",
+      "gpt-5.5-fast-plus-pro-high",
+      "gpt-5.5-fast-plus-pro-xhigh",
+    ]);
+  });
+
   test("returns reasoning options for anthropic sonnet 4.6", () => {
     const options = getReasoningTierOptionsForHandle(
       "anthropic/claude-sonnet-4-6",


### PR DESCRIPTION
## Summary
- Adds GPT-5.5 and GPT-5.5 Fast ChatGPT OAuth/BYOK entries to `src/models.json`.
- Includes none/low/medium/high/xhigh reasoning tiers so the handles show in the curated BYOK tab, not only BYOK (all).
- Adds model-tier tests for both new ChatGPT BYOK handles.

## Test plan
- [x] `bun test src/tests/model-tier-selection.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)