### PR TITLE
fix(tests): wait for memory-repository hook completion

### DIFF
--- a/src/tests/agent/memoryGit.postcommit.test.ts
+++ b/src/tests/agent/memoryGit.postcommit.test.ts
@@ -133,9 +133,16 @@ describe("post-commit memory-repository hook", () => {
     });
     expect(pushed).toBe(true);
 
-    // Log file should have exit=0 for the successful push.
+    // On Windows the remote ref can update before the background hook finishes
+    // appending its trailing exit marker, so wait for the log to show completion.
     const logPath = join(sourceDir, ".git", LOG_FILE);
-    expect(existsSync(logPath)).toBe(true);
+    const loggedSuccess = await waitUntil(() => {
+      if (!existsSync(logPath)) return false;
+      const log = readFileSync(logPath, "utf-8");
+      return log.includes("exit=0");
+    });
+    expect(loggedSuccess).toBe(true);
+
     const log = readFileSync(logPath, "utf-8");
     expect(log).toContain("exit=0");
   });

--- a/src/tests/agent/memoryGit.postcommit.test.ts
+++ b/src/tests/agent/memoryGit.postcommit.test.ts
@@ -184,6 +184,16 @@ describe("post-commit memory-repository hook", () => {
 
     const sha = git(sourceDir, "rev-parse HEAD").trim();
     expect(sha.length).toBe(40);
+
+    // The hook runs in the background. Wait for it to finish logging so
+    // Windows teardown doesn't race a still-open git process and hit EBUSY.
+    const logPath = join(sourceDir, ".git", LOG_FILE);
+    const completed = await waitUntil(() => {
+      if (!existsSync(logPath)) return false;
+      const log = readFileSync(logPath, "utf-8");
+      return /^exit=\d+/m.test(log);
+    });
+    expect(completed).toBe(true);
   });
 
   test("no-ops when HEAD is detached", async () => {


### PR DESCRIPTION
## Summary
- wait for the post-commit memory-repository hook to finish writing its `exit=0` log marker before asserting on the success-path log contents
- keep the production hook behavior unchanged while removing the Windows race where the remote ref updates before the background hook flushes the final log line

## Test plan
- [x] `bun test src/tests/agent/memoryGit.postcommit.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)