### PR TITLE
fix(permissions): restore approval flow for targeted cross-agent memfs reads

### DIFF
--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -266,6 +266,9 @@ function checkPermissionForEngine(
   const sessionRules = sessionPermissions.getRules();
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
+  const effectiveMode = modeState?.mode ?? permissionMode.getMode();
+  const effectivePlanFilePath =
+    modeState?.planFilePath ?? permissionMode.getPlanFilePath();
 
   // Cross-agent guard:
   // - hard-denies writes / broad enumeration against another agent memory
@@ -289,6 +292,20 @@ function checkPermissionForEngine(
     };
   }
   if (guardResult?.decision === "ask") {
+    if (effectiveMode === "plan") {
+      const reason =
+        `${guardResult.reason} ` +
+        `Plan mode auto-denies cross-agent memory access to avoid interactive approval prompts.`;
+      traceEvent(trace, "cross-agent-guard-plan-deny", reason);
+      return {
+        result: {
+          decision: "deny",
+          matchedRule: guardResult.matchedRule,
+          reason,
+        },
+        trace,
+      };
+    }
     pendingCrossAgentAsk = true;
     traceEvent(trace, "cross-agent-guard-pending", guardResult.reason);
   }
@@ -340,9 +357,6 @@ function checkPermissionForEngine(
 
   // Use the scoped permission mode state when available (listener/remote mode),
   // otherwise fall back to the global singleton (local/CLI mode).
-  const effectiveMode = modeState?.mode ?? permissionMode.getMode();
-  const effectivePlanFilePath =
-    modeState?.planFilePath ?? permissionMode.getPlanFilePath();
   const modeOverride = permissionMode.checkModeOverride(
     toolName,
     toolArgs,

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -115,9 +115,10 @@ function shouldAttachTrace(result: PermissionCheckResult): boolean {
  * Check permission for a tool execution.
  *
  * Decision logic:
- * 0. Cross-agent guard (unbypassable) → DENY any tool call targeting
- *    another agent's memory dir unless that agent is in allowed_agents
- *    (self ∪ LETTA_MEMORY_SCOPE ∪ --memory-scope)
+ * 0. Cross-agent guard:
+ *    - hard-deny writes / broad enumeration against another agent's memory
+ *    - soft-ask targeted single-agent read-only access unless already
+ *      authorized by normal rules or explicit memory scope
  * 1. Check deny rules from settings (first match wins) → DENY
  * 2. Check CLI disallowedTools (--disallowedTools flag) → DENY
  * 3. Check permission mode (--permission-mode flag) → ALLOW or DENY
@@ -266,25 +267,30 @@ function checkPermissionForEngine(
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
 
-  // Cross-agent guard — denies any tool call targeting another agent's
-  // memory unless that agent is in the allowed set. Unbypassable by any
-  // mode, rule, or flag.
+  // Cross-agent guard:
+  // - hard-denies writes / broad enumeration against another agent memory
+  // - marks targeted single-agent read-only access for a later ask fallback
   const guardResult = evaluateCrossAgentGuard(
     toolName,
     toolArgs,
     workingDirectory,
     { currentAgentId: agentId },
   );
-  if (guardResult) {
+  let pendingCrossAgentAsk = false;
+  if (guardResult?.decision === "deny") {
     traceEvent(trace, "cross-agent-guard", guardResult.reason);
     return {
       result: {
-        decision: "deny",
+        decision: guardResult.decision,
         matchedRule: guardResult.matchedRule,
         reason: guardResult.reason,
       },
       trace,
     };
+  }
+  if (guardResult?.decision === "ask") {
+    pendingCrossAgentAsk = true;
+    traceEvent(trace, "cross-agent-guard-pending", guardResult.reason);
   }
 
   if (permissions.deny) {
@@ -533,6 +539,18 @@ function checkPermissionForEngine(
         };
       }
     }
+  }
+
+  if (pendingCrossAgentAsk && guardResult) {
+    traceEvent(trace, "cross-agent-guard-ask", guardResult.reason);
+    return {
+      result: {
+        decision: "ask",
+        matchedRule: guardResult.matchedRule,
+        reason: guardResult.reason,
+      },
+      trace,
+    };
   }
 
   const defaultDecision = getDefaultDecision(toolName, toolArgs);

--- a/src/permissions/crossAgentGuard.ts
+++ b/src/permissions/crossAgentGuard.ts
@@ -20,6 +20,7 @@ import {
   parseScopeList,
   resolveScopedTargetPath,
 } from "./memoryScope";
+import { isReadOnlyShellCommand } from "./readOnlyShell";
 import { splitShellSegments, tokenizeShellWords } from "./shellAnalysis";
 
 // --------------------------------------------------------------------------
@@ -120,6 +121,14 @@ function normalizePathForCompare(path: string): string {
   return normalized.length === 0 ? "/" : normalized;
 }
 
+function isConcreteAgentPathSegment(segment: string): boolean {
+  if (!segment || segment === "." || segment === "..") {
+    return false;
+  }
+
+  return !/[*?[\]{}$%]/.test(segment);
+}
+
 /**
  * Classification of a path relative to the agents tree:
  *  - `outside`     — path is unrelated to the agents tree.
@@ -157,6 +166,9 @@ export function classifyAgentsTreePath(
     const rest = normalized.slice(root.length + 1);
     const slash = rest.indexOf("/");
     const id = slash === -1 ? rest : rest.slice(0, slash);
+    if (!isConcreteAgentPathSegment(id)) {
+      return { kind: "agents-root" };
+    }
     return { kind: "agent", id };
   }
 
@@ -577,12 +589,13 @@ export function extractTargetAgentPaths(
 // --------------------------------------------------------------------------
 
 export interface CrossAgentGuardResult {
+  decision: "deny" | "ask";
   matchedRule: "cross-agent guard";
   reason: string;
   offendingAgentIds: string[];
 }
 
-function buildReason(
+function buildDenyReason(
   offending: string[],
   allowed: ResolvedAllowedAgents,
 ): string {
@@ -595,6 +608,61 @@ function buildReason(
     `Allowed: ${allowedDesc}. ` +
     `Set LETTA_MEMORY_SCOPE or pass --memory-scope to opt in.`
   );
+}
+
+function buildAskReason(
+  offending: string[],
+  allowed: ResolvedAllowedAgents,
+): string {
+  const offendingDesc = offending.join(", ");
+  const allowedList = [...allowed.ids];
+  const allowedDesc =
+    allowedList.length > 0 ? allowedList.join(", ") : "(none)";
+  return (
+    `Cross-agent memory access requires approval (${offendingDesc}). ` +
+    `Allowed without approval: ${allowedDesc}. ` +
+    `Approve to continue, or set LETTA_MEMORY_SCOPE / --memory-scope to opt in.`
+  );
+}
+
+function isReadOnlyCrossAgentAttempt(
+  toolName: string,
+  toolArgs: ToolArgs,
+): boolean {
+  const canonical = canonicalToolName(toolName);
+  if (
+    canonical === "Read" ||
+    canonical === "Glob" ||
+    canonical === "Grep" ||
+    canonical === "ListDir"
+  ) {
+    return true;
+  }
+
+  if (canonical !== "Bash") {
+    return false;
+  }
+
+  const command = extractShellCommand(toolArgs);
+  return Boolean(
+    command && isReadOnlyShellCommand(command, { allowExternalPaths: true }),
+  );
+}
+
+function shouldAskForCrossAgentAccess(
+  offending: Set<string>,
+  toolName: string,
+  toolArgs: ToolArgs,
+): boolean {
+  if (!isReadOnlyCrossAgentAttempt(toolName, toolArgs)) {
+    return false;
+  }
+
+  if (offending.has(UNRESOLVED_AGENT_ID)) {
+    return false;
+  }
+
+  return offending.size === 1;
 }
 
 /**
@@ -656,9 +724,16 @@ export function evaluateCrossAgentGuard(
   }
 
   const offendingList = [...offending];
+  const decision = shouldAskForCrossAgentAccess(offending, toolName, toolArgs)
+    ? "ask"
+    : "deny";
   return {
+    decision,
     matchedRule: "cross-agent guard",
-    reason: buildReason(offendingList, allowed),
+    reason:
+      decision === "ask"
+        ? buildAskReason(offendingList, allowed)
+        : buildDenyReason(offendingList, allowed),
     offendingAgentIds: offendingList,
   };
 }

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -473,7 +473,7 @@ describe("checkPermission integration", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("single-agent cross-agent reads ask in ordinary modes and allow in elevated read modes", () => {
+  test("single-agent cross-agent reads ask in ordinary modes, deny in plan mode, and allow in elevated read modes", () => {
     const askModes = ["default", "acceptEdits"] as const;
     for (const mode of askModes) {
       permissionMode.setMode(mode);
@@ -494,7 +494,11 @@ describe("checkPermission integration", () => {
       permissions,
       "/tmp",
     );
-    expect(planResult.decision).toBe("allow");
+    expect(planResult.decision).toBe("deny");
+    expect(planResult.matchedRule).toBe("cross-agent guard");
+    expect(planResult.reason).toMatch(
+      /Plan mode auto-denies cross-agent memory access/,
+    );
 
     permissionMode.setMode("memory");
     const memoryResult = checkPermission(

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -10,6 +10,7 @@ import {
   resolveAllowedAgents,
 } from "../../permissions/crossAgentGuard";
 import { permissionMode } from "../../permissions/mode";
+import { sessionPermissions } from "../../permissions/session";
 
 const HOME = homedir();
 const SELF = "agent-self";
@@ -72,12 +73,14 @@ beforeEach(() => {
   process.env.AGENT_ID = SELF;
   cliPermissions.clear();
   permissionMode.reset();
+  sessionPermissions.clear();
 });
 
 afterEach(() => {
   restoreEnv(baselineEnv);
   cliPermissions.clear();
   permissionMode.reset();
+  sessionPermissions.clear();
 });
 
 // ---------------------------------------------------------------------------
@@ -317,9 +320,42 @@ describe("evaluateCrossAgentGuard", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
     expect(result?.matchedRule).toBe("cross-agent guard");
     expect(result?.offendingAgentIds).toEqual([OTHER]);
     expect(result?.reason).toMatch(/cross-agent memory guard/);
+  });
+
+  test("single-agent Read targets downgrade to ask", () => {
+    const result = evaluateCrossAgentGuard(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
+    expect(result?.offendingAgentIds).toEqual([OTHER]);
+    expect(result?.reason).toMatch(/requires approval/);
+  });
+
+  test("single-agent Grep targets downgrade to ask", () => {
+    const result = evaluateCrossAgentGuard(
+      "Grep",
+      { pattern: "agent", path: otherMemory() },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
+  });
+
+  test("single-agent read-only Bash targets downgrade to ask", () => {
+    const result = evaluateCrossAgentGuard(
+      "Bash",
+      { command: `cat ${otherMemory()}/system/a.md` },
+      "/tmp",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
   });
 
   test("passes through when other agent is in LETTA_MEMORY_SCOPE", () => {
@@ -359,22 +395,24 @@ describe("evaluateCrossAgentGuard", () => {
     expect(result?.offendingAgentIds).toEqual([THIRD]);
   });
 
-  test("reads are gated (not just writes)", () => {
+  test("cross-agent writes remain denied", () => {
     const result = evaluateCrossAgentGuard(
-      "Read",
+      "Write",
       { file_path: otherMemory("system/x.md") },
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
-  test("bash read-only against other agent's memory is gated", () => {
+  test("bash broad enumeration stays denied", () => {
     const result = evaluateCrossAgentGuard(
       "Bash",
-      { command: `cat ${otherMemory()}/system/x.md` },
+      { command: "ls ~/.letta/agents" },
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 });
 
@@ -435,15 +473,9 @@ describe("checkPermission integration", () => {
     expect(result.decision).toBe("allow");
   });
 
-  test("reads against another agent's memory are denied across all modes", () => {
-    const modes = [
-      "default",
-      "acceptEdits",
-      "plan",
-      "memory",
-      "bypassPermissions",
-    ] as const;
-    for (const mode of modes) {
+  test("single-agent cross-agent reads ask in ordinary modes and allow in elevated read modes", () => {
+    const askModes = ["default", "acceptEdits"] as const;
+    for (const mode of askModes) {
       permissionMode.setMode(mode);
       const result = checkPermission(
         "Read",
@@ -451,9 +483,36 @@ describe("checkPermission integration", () => {
         permissions,
         "/tmp",
       );
-      expect(result.decision).toBe("deny");
+      expect(result.decision).toBe("ask");
       expect(result.matchedRule).toBe("cross-agent guard");
     }
+
+    permissionMode.setMode("plan");
+    const planResult = checkPermission(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(planResult.decision).toBe("allow");
+
+    permissionMode.setMode("memory");
+    const memoryResult = checkPermission(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(memoryResult.decision).toBe("allow");
+
+    permissionMode.setMode("bypassPermissions");
+    const bypassResult = checkPermission(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(bypassResult.decision).toBe("allow");
   });
 
   test("own-memory access is unaffected by guard in every mode", () => {
@@ -478,11 +537,22 @@ describe("checkPermission integration", () => {
     }
   });
 
-  test("bash against another agent's memory is denied even in bypassPermissions", () => {
+  test("read-only bash against another agent's memory allows once bypassPermissions is enabled", () => {
     permissionMode.setMode("bypassPermissions");
     const result = checkPermission(
       "Bash",
       { command: `git -C ${otherMemory()} log` },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("allow");
+  });
+
+  test("cross-agent write bash remains denied even in bypassPermissions", () => {
+    permissionMode.setMode("bypassPermissions");
+    const result = checkPermission(
+      "Bash",
+      { command: `git -C ${otherMemory()} push` },
       permissions,
       "/tmp",
     );
@@ -502,6 +572,53 @@ describe("checkPermission integration", () => {
     // acceptEdits allows writes, and the guard passes since OTHER is scoped.
     expect(result.decision).toBe("allow");
   });
+
+  test("persisted allow rules can authorize targeted cross-agent reads", () => {
+    const result = checkPermission(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      {
+        allow: [`Read(//${otherMemory("system").replace(/^\/+/, "")}/**)`],
+        deny: [],
+        ask: [],
+      },
+      "/tmp",
+    );
+    expect(result.decision).toBe("allow");
+  });
+
+  test("session allow rules can authorize targeted cross-agent reads", () => {
+    sessionPermissions.addRule(
+      `Read(//${otherMemory("system").replace(/^\/+/, "")}/**)`,
+      "allow",
+    );
+    const result = checkPermission(
+      "Read",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("allow");
+    expect(result.matchedRule).toContain("session");
+  });
+
+  test("specific foreign-agent searches ask instead of denying", () => {
+    const grepResult = checkPermission(
+      "Grep",
+      { pattern: "secret", path: otherMemory() },
+      permissions,
+      "/tmp",
+    );
+    expect(grepResult.decision).toBe("ask");
+
+    const listResult = checkPermission(
+      "ListDir",
+      { path: otherMemory() },
+      permissions,
+      "/tmp",
+    );
+    expect(listResult.decision).toBe("ask");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -520,6 +637,7 @@ describe("shell bypass regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
     expect(result?.matchedRule).toBe("cross-agent guard");
   });
 
@@ -532,6 +650,7 @@ describe("shell bypass regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("command substitution: assigning a computed target path is denied", () => {
@@ -544,6 +663,7 @@ describe("shell bypass regression tests", () => {
     ].join("\n");
     const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("command substitution variant 2 (find -name memory) is denied", () => {
@@ -555,6 +675,7 @@ describe("shell bypass regression tests", () => {
     ].join("\n");
     const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("literal-but-unknown agent ID in quoted assignment is denied", () => {
@@ -567,6 +688,7 @@ describe("shell bypass regression tests", () => {
     ].join("\n");
     const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
     expect(result?.offendingAgentIds).toContain(
       "agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada",
     );
@@ -579,6 +701,7 @@ describe("shell bypass regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
   });
 
   test("self-targeting references using ${AGENT_ID} pass through", () => {
@@ -633,6 +756,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
     expect(result?.matchedRule).toBe("cross-agent guard");
   });
 
@@ -643,6 +767,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("Glob pointed at a specific foreign agent's root (no /memory) is denied", () => {
@@ -652,6 +777,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
     expect(result?.offendingAgentIds).toContain(OTHER);
   });
 
@@ -662,6 +788,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
     expect(result?.offendingAgentIds).toContain(OTHER);
   });
 
@@ -674,6 +801,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("Glob with path=$HOME (ancestor of agents tree) is denied — recursive walk would enter it", () => {
@@ -683,6 +811,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("Grep on the filesystem root is denied for the same reason", () => {
@@ -696,6 +825,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 
   test("Glob on self memory is allowed", () => {
@@ -735,6 +865,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("ask");
     expect(result?.offendingAgentIds).toContain(OTHER);
   });
 
@@ -752,5 +883,6 @@ describe("Grep/Glob ancestor-path regression tests", () => {
       "/tmp",
     );
     expect(result).not.toBeNull();
+    expect(result?.decision).toBe("deny");
   });
 });


### PR DESCRIPTION
## Summary
- downgrade single-agent read-only cross-agent memfs access from an unbypassable deny to the normal approval flow, so explicit debugging reads can be approved or covered by saved rules
- keep writes, broad agents-tree enumeration, ancestor scans, and multi-agent targets hard-denied
- add regression coverage for the new ask-vs-deny split and for persisted/session allow rules authorizing targeted cross-agent reads

## Test plan
- [x] `bun test src/tests/permissions/crossAgentGuard.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)