### PR TITLE
fix(memfs): clear stale origin pushurl during memory remote repair

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -167,18 +167,66 @@ export async function maybeUpdateMemoryRemoteOrigin(
     return;
   }
 
-  const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
+  const expectedOrigin = normalizeRemoteUrl(
+    getGitRemoteUrl(agentId, process.env.LETTA_BASE_URL?.trim() || undefined),
+  );
   const normalizedCurrent = normalizeRemoteUrl(currentOrigin);
 
-  if (normalizedCurrent === expectedOrigin) {
+  if (normalizedCurrent !== expectedOrigin) {
+    await runGit(repoDir, ["remote", "set-url", "origin", expectedOrigin]);
+
+    debugLog(
+      "memfs-git",
+      `Updated origin remote for ${agentId}: ${normalizedCurrent} -> ${expectedOrigin}`,
+    );
+  }
+
+  await clearOriginPushUrl(repoDir, agentId);
+}
+
+/**
+ * Git prefers `remote.origin.pushurl` over `remote.origin.url` for pushes.
+ * Desktop/local proxy sessions can leave an ephemeral localhost pushurl behind,
+ * causing later `git push` calls to fail even after origin.url is repaired.
+ *
+ * For memfs repos, origin should always push to origin.url; mirrors are managed
+ * separately through `letta.memoryRepository.url` and the post-commit hook.
+ */
+async function clearOriginPushUrl(
+  repoDir: string,
+  agentId: string,
+): Promise<void> {
+  let pushUrls: string[] = [];
+  try {
+    const { stdout } = await runGit(repoDir, [
+      "config",
+      "--local",
+      "--get-all",
+      "remote.origin.pushurl",
+    ]);
+    pushUrls = stdout
+      .split("\n")
+      .map((url) => url.trim())
+      .filter(Boolean);
+  } catch {
+    // No pushurl configured — origin.url will be used for pushes.
     return;
   }
 
-  await runGit(repoDir, ["remote", "set-url", "origin", expectedOrigin]);
+  if (pushUrls.length === 0) {
+    return;
+  }
+
+  await runGit(repoDir, [
+    "config",
+    "--local",
+    "--unset-all",
+    "remote.origin.pushurl",
+  ]);
 
   debugLog(
     "memfs-git",
-    `Updated origin remote for ${agentId}: ${normalizedCurrent} -> ${expectedOrigin}`,
+    `Cleared origin pushurl for ${agentId}: ${pushUrls.join(", ")}`,
   );
 }
 

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -1,11 +1,56 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   formatGitCredentialHelperPath,
   getGitRemoteUrl,
   isMemfsRemoteUrlForAgent,
+  maybeUpdateMemoryRemoteOrigin,
   normalizeCredentialBaseUrl,
 } from "../../agent/memoryGit";
+
+const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+
+  if (ORIGINAL_LETTA_BASE_URL === undefined) {
+    delete process.env.LETTA_BASE_URL;
+  } else {
+    process.env.LETTA_BASE_URL = ORIGINAL_LETTA_BASE_URL;
+  }
+});
+
+function makeGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "memory-git-auth-"));
+  tempDirs.push(dir);
+  execSync("git init -b main", { cwd: dir, stdio: "ignore" });
+  return dir;
+}
+
+function git(cwd: string, args: string): string {
+  return execSync(`git ${args}`, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function gitOrEmpty(cwd: string, args: string): string {
+  try {
+    return git(cwd, args);
+  } catch {
+    return "";
+  }
+}
 
 describe("normalizeCredentialBaseUrl", () => {
   test("normalizes Letta Cloud URL to origin", () => {
@@ -84,5 +129,81 @@ describe("formatGitCredentialHelperPath", () => {
     ).toBe(
       "C:/Users/Jane\\ Doe/.letta/agents/agent-1/memory/.git/letta-credential-helper.cmd",
     );
+  });
+});
+
+describe("maybeUpdateMemoryRemoteOrigin", () => {
+  test("updates stale memfs origin URL and clears stale origin pushurl", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const staleOrigin = getGitRemoteUrl(agentId, "http://localhost:50864");
+    const expectedOrigin = getGitRemoteUrl(agentId, "https://api.letta.com");
+
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    git(repo, `remote add origin ${staleOrigin}`);
+    git(repo, `config --local remote.origin.pushurl ${staleOrigin}`);
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(
+      gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
+    ).toBe("");
+  });
+
+  test("clears origin pushurl even when origin URL is already current", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const expectedOrigin = getGitRemoteUrl(agentId, "https://api.letta.com");
+    const stalePushUrl = getGitRemoteUrl(agentId, "http://localhost:50864");
+
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    git(repo, `remote add origin ${expectedOrigin}`);
+    git(repo, `config --local remote.origin.pushurl ${stalePushUrl}`);
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(
+      gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
+    ).toBe("");
+  });
+
+  test("clears non-memfs pushurl when origin is this agent's memfs remote", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const expectedOrigin = getGitRemoteUrl(agentId, "https://api.letta.com");
+
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    git(repo, `remote add origin ${expectedOrigin}`);
+    git(
+      repo,
+      "config --local remote.origin.pushurl git@github.com:example/not-origin.git",
+    );
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(
+      gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
+    ).toBe("");
+  });
+
+  test("leaves non-memfs origins and pushurls untouched", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const origin = "git@github.com:example/memory.git";
+    const pushUrl = "git@github.com:example/memory-push.git";
+
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    git(repo, `remote add origin ${origin}`);
+    git(repo, `config --local remote.origin.pushurl ${pushUrl}`);
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(origin);
+    expect(
+      git(repo, "config --local --get-all remote.origin.pushurl").trim(),
+    ).toBe(pushUrl);
   });
 });


### PR DESCRIPTION
## Summary

- Clear `remote.origin.pushurl` when `origin` is this agent's memfs remote, so `git push` no longer prefers a stale Desktop/local CLI localhost proxy after `origin.url` has been repaired.
- Keep non-memfs origins/pushurls untouched.
- Add focused git-config tests for stale localhost origin/pushurl reconciliation and non-memfs preservation.

## Why

Switching between Desktop, local CLI, and cloud can leave memfs repos with config like:

```ini
[remote "origin"]
  url = https://api.letta.com/v1/git/<agent>/state.git
  pushurl = http://localhost:<old-port>/v1/git/<agent>/state.git
```

Git prefers `pushurl` for pushes, so memory pushes can keep targeting a dead localhost port even after `origin.url` is corrected. Since memfs uses one canonical origin, `pushurl` should not be durable state; mirrors are handled separately via `letta.memoryRepository.url`.

## Test plan

- [x] `bun test src/tests/agent/memoryGit` — 46 pass
- [x] `bun run typecheck` — pass
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/agent/memoryGit.ts src/tests/agent/memoryGit.auth.test.ts` — pass

Note: full `bun run check` on `main` currently reports unrelated lint issues in `reconcileExistingAgentState.ts` and Discord channel files; changed files pass Biome.

👾 Generated with [Letta Code](https://letta.com)