### PR TITLE
fix(cli): normalize outgoing base64 image media types

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -21,6 +21,13 @@ let lastSDKDiagnostic: SDKDiagnostic | null = null;
 // whenever the OAuth refresh obtains a new token. Used as a fallback so
 // transient keychain failures don't crash the process mid-session.
 let _cachedApiKey: string | undefined;
+let _testClientOverride: (() => Promise<unknown>) | null = null;
+
+export function __testOverrideGetClient(
+  factory: (() => Promise<unknown>) | null,
+): void {
+  _testClientOverride = factory;
+}
 
 function safeDiagnosticString(value: unknown): string {
   if (value === null || value === undefined) {
@@ -111,6 +118,10 @@ export function getServerUrl(): string {
 }
 
 export async function getClient() {
+  if (_testClientOverride) {
+    return (await _testClientOverride()) as Letta;
+  }
+
   const baseSettings = settingsManager.getSettings();
   const cachedTokens = settingsManager.getCachedSecureTokens();
   const cachedSettings: Settings = {

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -17,6 +17,10 @@ import {
   waitForToolsetReady,
 } from "../tools/manager";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
+import {
+  assertSupportedBase64ImageMediaTypes,
+  normalizeMessageImageParts,
+} from "../utils/messageImageNormalization";
 import { createStreamAbortRelay } from "../utils/streamAbortRelay";
 import { isTimingsEnabled } from "../utils/timing";
 import {
@@ -133,6 +137,8 @@ export async function sendMessageStream(
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;
   const requestStartedAtMs = Date.now();
   const client = await getClient();
+  const normalizedMessages = await normalizeMessageImageParts(messages);
+  assertSupportedBase64ImageMediaTypes(normalizedMessages);
 
   const preparedToolContext = opts.preparedToolContext
     ? opts.preparedToolContext
@@ -155,7 +161,7 @@ export async function sendMessageStream(
   const resolvedConversationId = conversationId;
   const requestBody = buildConversationMessagesCreateRequestBody(
     conversationId,
-    messages,
+    normalizedMessages,
     opts,
     clientTools,
     clientSkills,
@@ -196,7 +202,7 @@ export async function sendMessageStream(
     extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
   }
 
-  const messageSummary = messages
+  const messageSummary = normalizedMessages
     .map((item) => {
       if (item.type === "approval") {
         return `approval:${item.approvals?.length ?? 0}`;
@@ -212,7 +218,8 @@ export async function sendMessageStream(
     })
     .join(",");
 
-  const firstOtid = (messages[0] as unknown as { otid?: string })?.otid;
+  const firstOtid = (normalizedMessages[0] as unknown as { otid?: string })
+    ?.otid;
   debugLog(
     "send-message-stream",
     "request_start conversation_id=%s agent_id=%s messages=%s otid=%s stream_tokens=%s background=%s max_retries=%s",

--- a/src/cli/helpers/imageResize.magick.ts
+++ b/src/cli/helpers/imageResize.magick.ts
@@ -8,6 +8,7 @@ import {
   assertImageHasDimensions,
   assertImageWithinBounds,
   buildResizeResult,
+  canonicalizeOutputMediaType,
   MAX_IMAGE_BYTES,
   MAX_IMAGE_HEIGHT,
   MAX_IMAGE_WIDTH,
@@ -56,9 +57,15 @@ async function buildVerifiedResizeResult(
   resized: boolean,
   context: string,
 ): Promise<ResizeResult> {
-  const { width, height } = await getImageDimensions(buffer);
+  const { width, height, format } = await getImageDimensions(buffer);
   assertImageWithinBounds(width, height, context);
-  return buildResizeResult(buffer, mediaType, width, height, resized);
+  return buildResizeResult(
+    buffer,
+    canonicalizeOutputMediaType(format, mediaType),
+    width,
+    height,
+    resized,
+  );
 }
 
 /**

--- a/src/cli/helpers/imageResize.shared.ts
+++ b/src/cli/helpers/imageResize.shared.ts
@@ -15,6 +15,32 @@ export interface ResizeResult {
   resized: boolean;
 }
 
+export function mediaTypeForDecodedImageFormat(
+  format?: string | null,
+): string | null {
+  const normalized = format?.trim().toLowerCase();
+  switch (normalized) {
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    default:
+      return null;
+  }
+}
+
+export function canonicalizeOutputMediaType(
+  decodedFormat: string | null | undefined,
+  fallbackMediaType: string,
+): string {
+  return mediaTypeForDecodedImageFormat(decodedFormat) ?? fallbackMediaType;
+}
+
 export function assertImageHasDimensions(
   width: number,
   height: number,

--- a/src/cli/helpers/imageResize.sharp.ts
+++ b/src/cli/helpers/imageResize.sharp.ts
@@ -5,6 +5,7 @@ import {
   assertImageHasDimensions,
   assertImageWithinBounds,
   buildResizeResult,
+  canonicalizeOutputMediaType,
   MAX_IMAGE_BYTES,
   MAX_IMAGE_HEIGHT,
   MAX_IMAGE_WIDTH,
@@ -28,9 +29,15 @@ async function buildVerifiedResizeResult(
   resized: boolean,
   context: string,
 ): Promise<ResizeResult> {
-  const { width, height } = await inspectImageBuffer(buffer, context);
+  const { width, height, format } = await inspectImageBuffer(buffer, context);
   assertImageWithinBounds(width, height, context);
-  return buildResizeResult(buffer, mediaType, width, height, resized);
+  return buildResizeResult(
+    buffer,
+    canonicalizeOutputMediaType(format, mediaType),
+    width,
+    height,
+    resized,
+  );
 }
 
 /**

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -133,4 +133,79 @@ describe("sendMessageStream image normalization", () => {
       ALLOWED_ANTHROPIC_MEDIA_TYPES.has(imagePart?.source?.media_type ?? ""),
     ).toBe(true);
   });
+
+  test("normalizes direct shared-send image payloads before the API request", async () => {
+    await sendMessageStream(
+      "conv-test",
+      [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/heic",
+                data: TEST_PNG_BASE64,
+              },
+            },
+          ],
+        },
+      ],
+      {
+        preparedToolContext: {
+          contextId: "ctx-test-direct",
+          clientTools: [],
+          loadedToolNames: [],
+        },
+      },
+    );
+
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    const requestMessages = (capturedRequestBody as { messages?: unknown[] })
+      .messages;
+    const firstMessage = requestMessages?.[0] as {
+      content?: Array<{
+        type: string;
+        source?: { type: string; media_type: string; data: string };
+      }>;
+    };
+    const imagePart = firstMessage.content?.find(
+      (part) => part.type === "image",
+    );
+
+    expect(imagePart?.source?.media_type).toBe("image/png");
+  });
+
+  test("fails closed before the API request when base64 image bytes are invalid", async () => {
+    await expect(
+      sendMessageStream(
+        "conv-test",
+        [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/tiff",
+                  data: Buffer.from("not-an-image", "utf8").toString("base64"),
+                },
+              },
+            ],
+          },
+        ],
+        {
+          preparedToolContext: {
+            contextId: "ctx-test-invalid",
+            clientTools: [],
+            loadedToolNames: [],
+          },
+        },
+      ),
+    ).rejects.toThrow();
+
+    expect(createMessage).not.toHaveBeenCalled();
+  });
 });

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -1,22 +1,17 @@
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { __testOverrideGetClient } from "../../agent/client";
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { translatePasteForImages } from "../../cli/helpers/clipboard";
 import {
   buildMessageContentFromDisplay,
   clearPlaceholdersInText,
 } from "../../cli/helpers/pasteRegistry";
-import { runWithRuntimeContext } from "../../runtime-context";
+import {
+  assertSupportedBase64ImageMediaTypes,
+  normalizeMessageImageParts,
+} from "../../utils/messageImageNormalization";
 
 const TEST_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=";
@@ -27,33 +22,31 @@ const ALLOWED_ANTHROPIC_MEDIA_TYPES = new Set([
   "image/webp",
 ]);
 
-let capturedRequestBody: Record<string, unknown> | null = null;
+function getFirstImageMediaType(message: MessageCreate): string | null {
+  if (typeof message.content === "string") {
+    return null;
+  }
 
-const createMessage = mock(async (_conversationId: string, body: unknown) => {
-  capturedRequestBody = body as Record<string, unknown>;
-  return {
-    [Symbol.asyncIterator]: async function* () {
-      // No-op stream for request-boundary assertions.
-    },
-  } as AsyncIterable<unknown>;
-});
+  const imagePart = message.content.find(
+    (
+      part,
+    ): part is {
+      type: "image";
+      source: { type: "base64"; media_type: string; data: string };
+    } =>
+      part.type === "image" &&
+      part.source.type === "base64" &&
+      typeof part.source.media_type === "string",
+  );
 
-const { sendMessageStream } = await import("../../agent/message");
+  return imagePart?.source.media_type ?? null;
+}
 
-describe("sendMessageStream image normalization", () => {
+describe("outbound image normalization", () => {
   let tempRoot = "";
   let displayText = "";
 
   beforeEach(() => {
-    capturedRequestBody = null;
-    createMessage.mockClear();
-    __testOverrideGetClient(async () => ({
-      conversations: {
-        messages: {
-          create: createMessage,
-        },
-      },
-    }));
     tempRoot = mkdtempSync(join(tmpdir(), "letta-image-send-"));
     displayText = "";
   });
@@ -65,11 +58,6 @@ describe("sendMessageStream image normalization", () => {
     if (tempRoot) {
       rmSync(tempRoot, { recursive: true, force: true });
     }
-    __testOverrideGetClient(null);
-  });
-
-  afterAll(() => {
-    mock.restore();
   });
 
   test("normalizes TUI file-path pasted images to Anthropic-supported media types before sending", async () => {
@@ -79,118 +67,88 @@ describe("sendMessageStream image normalization", () => {
     displayText = translatePasteForImages(imagePath);
     expect(displayText).toMatch(/^\[Image #\d+\]$/);
 
-    const content = buildMessageContentFromDisplay(displayText);
+    const rawMessages: MessageCreate[] = [
+      {
+        role: "user",
+        content: buildMessageContentFromDisplay(displayText),
+      },
+    ];
+    const rawMessage = rawMessages[0];
+    if (!rawMessage) {
+      throw new Error("Expected raw TUI message");
+    }
 
-    await runWithRuntimeContext({ skillSources: [] }, () =>
-      sendMessageStream("conv-test", [{ role: "user", content }], {
-        preparedToolContext: {
-          contextId: "ctx-test",
-          clientTools: [],
-          loadedToolNames: [],
-        },
-      }),
+    expect(getFirstImageMediaType(rawMessage)).toBe("image/tiff");
+    expect(() => assertSupportedBase64ImageMediaTypes(rawMessages)).toThrow(
+      /Unsupported base64 image media type/,
     );
 
-    expect(createMessage).toHaveBeenCalledTimes(1);
-    expect(capturedRequestBody).not.toBeNull();
+    const normalizedMessages = await normalizeMessageImageParts(rawMessages);
+    const normalizedMessage = normalizedMessages[0];
+    if (!normalizedMessage) {
+      throw new Error("Expected normalized TUI message");
+    }
 
-    const requestMessages = (capturedRequestBody as { messages?: unknown[] })
-      .messages;
-    expect(Array.isArray(requestMessages)).toBe(true);
-    const firstMessage = requestMessages?.[0] as {
-      content?: Array<{
-        type: string;
-        source?: { type: string; media_type: string; data: string };
-      }>;
-    };
-    const imagePart = firstMessage.content?.find(
-      (part) => part.type === "image",
-    );
-
-    expect(imagePart?.source?.type).toBe("base64");
+    expect(() =>
+      assertSupportedBase64ImageMediaTypes(normalizedMessages),
+    ).not.toThrow();
     expect(
-      ALLOWED_ANTHROPIC_MEDIA_TYPES.has(imagePart?.source?.media_type ?? ""),
+      ALLOWED_ANTHROPIC_MEDIA_TYPES.has(
+        getFirstImageMediaType(normalizedMessage) ?? "",
+      ),
     ).toBe(true);
   });
 
   test("normalizes direct shared-send image payloads before the API request", async () => {
-    await runWithRuntimeContext({ skillSources: [] }, () =>
-      sendMessageStream(
-        "conv-test",
-        [
+    const rawMessages: MessageCreate[] = [
+      {
+        role: "user",
+        content: [
           {
-            role: "user",
-            content: [
-              {
-                type: "image",
-                source: {
-                  type: "base64",
-                  media_type: "image/heic",
-                  data: TEST_PNG_BASE64,
-                },
-              },
-            ],
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/heic",
+              data: TEST_PNG_BASE64,
+            },
           },
         ],
-        {
-          preparedToolContext: {
-            contextId: "ctx-test-direct",
-            clientTools: [],
-            loadedToolNames: [],
-          },
-        },
-      ),
+      },
+    ];
+
+    expect(() => assertSupportedBase64ImageMediaTypes(rawMessages)).toThrow(
+      /Unsupported base64 image media type/,
     );
 
-    expect(createMessage).toHaveBeenCalledTimes(1);
-    const requestMessages = (capturedRequestBody as { messages?: unknown[] })
-      .messages;
-    const firstMessage = requestMessages?.[0] as {
-      content?: Array<{
-        type: string;
-        source?: { type: string; media_type: string; data: string };
-      }>;
-    };
-    const imagePart = firstMessage.content?.find(
-      (part) => part.type === "image",
-    );
+    const normalizedMessages = await normalizeMessageImageParts(rawMessages);
+    const normalizedMessage = normalizedMessages[0];
+    if (!normalizedMessage) {
+      throw new Error("Expected normalized direct-send message");
+    }
 
-    expect(imagePart?.source?.media_type).toBe("image/png");
+    expect(() =>
+      assertSupportedBase64ImageMediaTypes(normalizedMessages),
+    ).not.toThrow();
+    expect(getFirstImageMediaType(normalizedMessage)).toBe("image/png");
   });
 
   test("fails closed before the API request when base64 image bytes are invalid", async () => {
-    await expect(
-      runWithRuntimeContext({ skillSources: [] }, () =>
-        sendMessageStream(
-          "conv-test",
-          [
-            {
-              role: "user",
-              content: [
-                {
-                  type: "image",
-                  source: {
-                    type: "base64",
-                    media_type: "image/tiff",
-                    data: Buffer.from("not-an-image", "utf8").toString(
-                      "base64",
-                    ),
-                  },
-                },
-              ],
-            },
-          ],
+    const rawMessages: MessageCreate[] = [
+      {
+        role: "user",
+        content: [
           {
-            preparedToolContext: {
-              contextId: "ctx-test-invalid",
-              clientTools: [],
-              loadedToolNames: [],
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/tiff",
+              data: Buffer.from("not-an-image", "utf8").toString("base64"),
             },
           },
-        ),
-      ),
-    ).rejects.toThrow();
+        ],
+      },
+    ];
 
-    expect(createMessage).not.toHaveBeenCalled();
+    await expect(normalizeMessageImageParts(rawMessages)).rejects.toThrow();
   });
 });

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -1,0 +1,136 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { translatePasteForImages } from "../../cli/helpers/clipboard";
+import {
+  buildMessageContentFromDisplay,
+  clearPlaceholdersInText,
+} from "../../cli/helpers/pasteRegistry";
+
+const TEST_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=";
+const ALLOWED_ANTHROPIC_MEDIA_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+let capturedRequestBody: Record<string, unknown> | null = null;
+
+const createMessage = mock(async (_conversationId: string, body: unknown) => {
+  capturedRequestBody = body as Record<string, unknown>;
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      // No-op stream for request-boundary assertions.
+    },
+  } as AsyncIterable<unknown>;
+});
+
+mock.module("../../agent/client", () => ({
+  getClient: async () => ({
+    conversations: {
+      messages: {
+        create: createMessage,
+      },
+    },
+  }),
+  getServerUrl: () => "http://localhost:8283",
+  consumeLastSDKDiagnostic: () => null,
+  clearLastSDKDiagnostic: () => {},
+}));
+
+mock.module("../../agent/clientSkills", () => ({
+  buildClientSkillsPayload: async () => ({
+    clientSkills: [],
+    errors: [],
+  }),
+}));
+
+mock.module("../../tools/manager", () => ({
+  waitForToolsetReady: async () => {},
+  prepareCurrentToolExecutionContext: async () => {
+    throw new Error(
+      "prepareCurrentToolExecutionContext should not run in this test",
+    );
+  },
+}));
+
+mock.module("../../agent/context", () => ({
+  getSkillSources: () => [],
+}));
+
+const { sendMessageStream } = await import("../../agent/message");
+
+describe("sendMessageStream image normalization", () => {
+  let tempRoot = "";
+  let displayText = "";
+
+  beforeEach(() => {
+    capturedRequestBody = null;
+    createMessage.mockClear();
+    tempRoot = mkdtempSync(join(tmpdir(), "letta-image-send-"));
+    displayText = "";
+  });
+
+  afterEach(() => {
+    if (displayText) {
+      clearPlaceholdersInText(displayText);
+    }
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("normalizes TUI file-path pasted images to Anthropic-supported media types before sending", async () => {
+    const imagePath = join(tempRoot, "clipboard-screenshot.tiff");
+    writeFileSync(imagePath, Buffer.from(TEST_PNG_BASE64, "base64"));
+
+    displayText = translatePasteForImages(imagePath);
+    expect(displayText).toMatch(/^\[Image #\d+\]$/);
+
+    const content = buildMessageContentFromDisplay(displayText);
+
+    await sendMessageStream("conv-test", [{ role: "user", content }], {
+      preparedToolContext: {
+        contextId: "ctx-test",
+        clientTools: [],
+        loadedToolNames: [],
+      },
+    });
+
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    expect(capturedRequestBody).not.toBeNull();
+
+    const requestMessages = (capturedRequestBody as { messages?: unknown[] })
+      .messages;
+    expect(Array.isArray(requestMessages)).toBe(true);
+    const firstMessage = requestMessages?.[0] as {
+      content?: Array<{
+        type: string;
+        source?: { type: string; media_type: string; data: string };
+      }>;
+    };
+    const imagePart = firstMessage.content?.find(
+      (part) => part.type === "image",
+    );
+
+    expect(imagePart?.source?.type).toBe("base64");
+    expect(
+      ALLOWED_ANTHROPIC_MEDIA_TYPES.has(imagePart?.source?.media_type ?? ""),
+    ).toBe(true);
+  });
+});

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -15,6 +15,7 @@ import {
   buildMessageContentFromDisplay,
   clearPlaceholdersInText,
 } from "../../cli/helpers/pasteRegistry";
+import { runWithRuntimeContext } from "../../runtime-context";
 
 const TEST_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=";
@@ -47,26 +48,6 @@ mock.module("../../agent/client", () => ({
   getServerUrl: () => "http://localhost:8283",
   consumeLastSDKDiagnostic: () => null,
   clearLastSDKDiagnostic: () => {},
-}));
-
-mock.module("../../agent/clientSkills", () => ({
-  buildClientSkillsPayload: async () => ({
-    clientSkills: [],
-    errors: [],
-  }),
-}));
-
-mock.module("../../tools/manager", () => ({
-  waitForToolsetReady: async () => {},
-  prepareCurrentToolExecutionContext: async () => {
-    throw new Error(
-      "prepareCurrentToolExecutionContext should not run in this test",
-    );
-  },
-}));
-
-mock.module("../../agent/context", () => ({
-  getSkillSources: () => [],
 }));
 
 const { sendMessageStream } = await import("../../agent/message");
@@ -104,13 +85,15 @@ describe("sendMessageStream image normalization", () => {
 
     const content = buildMessageContentFromDisplay(displayText);
 
-    await sendMessageStream("conv-test", [{ role: "user", content }], {
-      preparedToolContext: {
-        contextId: "ctx-test",
-        clientTools: [],
-        loadedToolNames: [],
-      },
-    });
+    await runWithRuntimeContext({ skillSources: [] }, () =>
+      sendMessageStream("conv-test", [{ role: "user", content }], {
+        preparedToolContext: {
+          contextId: "ctx-test",
+          clientTools: [],
+          loadedToolNames: [],
+        },
+      }),
+    );
 
     expect(createMessage).toHaveBeenCalledTimes(1);
     expect(capturedRequestBody).not.toBeNull();
@@ -135,30 +118,32 @@ describe("sendMessageStream image normalization", () => {
   });
 
   test("normalizes direct shared-send image payloads before the API request", async () => {
-    await sendMessageStream(
-      "conv-test",
-      [
-        {
-          role: "user",
-          content: [
-            {
-              type: "image",
-              source: {
-                type: "base64",
-                media_type: "image/heic",
-                data: TEST_PNG_BASE64,
+    await runWithRuntimeContext({ skillSources: [] }, () =>
+      sendMessageStream(
+        "conv-test",
+        [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/heic",
+                  data: TEST_PNG_BASE64,
+                },
               },
-            },
-          ],
+            ],
+          },
+        ],
+        {
+          preparedToolContext: {
+            contextId: "ctx-test-direct",
+            clientTools: [],
+            loadedToolNames: [],
+          },
         },
-      ],
-      {
-        preparedToolContext: {
-          contextId: "ctx-test-direct",
-          clientTools: [],
-          loadedToolNames: [],
-        },
-      },
+      ),
     );
 
     expect(createMessage).toHaveBeenCalledTimes(1);
@@ -179,30 +164,34 @@ describe("sendMessageStream image normalization", () => {
 
   test("fails closed before the API request when base64 image bytes are invalid", async () => {
     await expect(
-      sendMessageStream(
-        "conv-test",
-        [
-          {
-            role: "user",
-            content: [
-              {
-                type: "image",
-                source: {
-                  type: "base64",
-                  media_type: "image/tiff",
-                  data: Buffer.from("not-an-image", "utf8").toString("base64"),
+      runWithRuntimeContext({ skillSources: [] }, () =>
+        sendMessageStream(
+          "conv-test",
+          [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/tiff",
+                    data: Buffer.from("not-an-image", "utf8").toString(
+                      "base64",
+                    ),
+                  },
                 },
-              },
-            ],
+              ],
+            },
+          ],
+          {
+            preparedToolContext: {
+              contextId: "ctx-test-invalid",
+              clientTools: [],
+              loadedToolNames: [],
+            },
           },
-        ],
-        {
-          preparedToolContext: {
-            contextId: "ctx-test-invalid",
-            clientTools: [],
-            loadedToolNames: [],
-          },
-        },
+        ),
       ),
     ).rejects.toThrow();
 

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -10,6 +10,7 @@ import {
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { __testOverrideGetClient } from "../../agent/client";
 import { translatePasteForImages } from "../../cli/helpers/clipboard";
 import {
   buildMessageContentFromDisplay,
@@ -37,19 +38,6 @@ const createMessage = mock(async (_conversationId: string, body: unknown) => {
   } as AsyncIterable<unknown>;
 });
 
-mock.module("../../agent/client", () => ({
-  getClient: async () => ({
-    conversations: {
-      messages: {
-        create: createMessage,
-      },
-    },
-  }),
-  getServerUrl: () => "http://localhost:8283",
-  consumeLastSDKDiagnostic: () => null,
-  clearLastSDKDiagnostic: () => {},
-}));
-
 const { sendMessageStream } = await import("../../agent/message");
 
 describe("sendMessageStream image normalization", () => {
@@ -59,6 +47,13 @@ describe("sendMessageStream image normalization", () => {
   beforeEach(() => {
     capturedRequestBody = null;
     createMessage.mockClear();
+    __testOverrideGetClient(async () => ({
+      conversations: {
+        messages: {
+          create: createMessage,
+        },
+      },
+    }));
     tempRoot = mkdtempSync(join(tmpdir(), "letta-image-send-"));
     displayText = "";
   });
@@ -70,6 +65,7 @@ describe("sendMessageStream image normalization", () => {
     if (tempRoot) {
       rmSync(tempRoot, { recursive: true, force: true });
     }
+    __testOverrideGetClient(null);
   });
 
   afterAll(() => {

--- a/src/tests/cli/imageResize.test.ts
+++ b/src/tests/cli/imageResize.test.ts
@@ -28,4 +28,21 @@ describe("resizeImageIfNeeded", () => {
     expect(metadata.width).toBe(result.width);
     expect(metadata.height).toBe(result.height);
   });
+
+  test("canonicalizes passthrough media types from decoded image bytes", async () => {
+    const pngBuffer = await sharp({
+      create: {
+        width: 32,
+        height: 32,
+        channels: 3,
+        background: { r: 90, g: 40, b: 180 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const result = await resizeImageIfNeeded(pngBuffer, "image/tiff");
+
+    expect(result.mediaType).toBe("image/png");
+  });
 });

--- a/src/tests/websocket/listen-client-image-normalization.test.ts
+++ b/src/tests/websocket/listen-client-image-normalization.test.ts
@@ -117,4 +117,56 @@ describe("listen-client inbound image normalization", () => {
     expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_WIDTH);
     expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_HEIGHT);
   });
+
+  test("canonicalizes unsupported declared media types from decoded image bytes", async () => {
+    const pngBuffer = await sharp({
+      create: {
+        width: 64,
+        height: 48,
+        channels: 3,
+        background: { r: 20, g: 80, b: 200 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const normalized = await __listenClientTestUtils.normalizeInboundMessages([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "text", text: "check this screenshot" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/tiff",
+              data: pngBuffer.toString("base64"),
+            },
+          },
+        ],
+        client_message_id: "cm-image-tiff-label",
+      },
+    ]);
+
+    const message = normalized[0];
+    if (
+      !message ||
+      !("content" in message) ||
+      typeof message.content === "string"
+    ) {
+      throw new Error("Expected normalized multimodal message");
+    }
+
+    const imagePart = message.content[1];
+    if (
+      !imagePart ||
+      imagePart.type !== "image" ||
+      imagePart.source.type !== "base64"
+    ) {
+      throw new Error("Expected normalized base64 image content");
+    }
+
+    expect(imagePart.source.media_type).toBe("image/png");
+  });
 });

--- a/src/utils/messageImageNormalization.ts
+++ b/src/utils/messageImageNormalization.ts
@@ -1,0 +1,138 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import { resizeImageIfNeeded } from "../cli/helpers/imageResize";
+
+export const SUPPORTED_BASE64_IMAGE_MEDIA_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+export type Base64ImageContentPart = {
+  type: "image";
+  source: { type: "base64"; media_type: string; data: string };
+};
+
+export function isBase64ImageContentPart(
+  part: unknown,
+): part is Base64ImageContentPart {
+  if (!part || typeof part !== "object") {
+    return false;
+  }
+
+  const candidate = part as {
+    type?: unknown;
+    source?: {
+      type?: unknown;
+      media_type?: unknown;
+      data?: unknown;
+    };
+  };
+
+  return (
+    candidate.type === "image" &&
+    !!candidate.source &&
+    candidate.source.type === "base64" &&
+    typeof candidate.source.media_type === "string" &&
+    candidate.source.media_type.length > 0 &&
+    typeof candidate.source.data === "string" &&
+    candidate.source.data.length > 0
+  );
+}
+
+export async function normalizeMessageContentImages(
+  content: MessageCreate["content"],
+  resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
+): Promise<MessageCreate["content"]> {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  let didChange = false;
+  const normalizedParts = await Promise.all(
+    content.map(async (part) => {
+      if (!isBase64ImageContentPart(part)) {
+        return part;
+      }
+
+      const resized = await resize(
+        Buffer.from(part.source.data, "base64"),
+        part.source.media_type,
+      );
+
+      if (
+        resized.data !== part.source.data ||
+        resized.mediaType !== part.source.media_type
+      ) {
+        didChange = true;
+      }
+
+      return {
+        ...part,
+        source: {
+          ...part.source,
+          type: "base64" as const,
+          data: resized.data,
+          media_type: resized.mediaType,
+        },
+      };
+    }),
+  );
+
+  return didChange ? normalizedParts : content;
+}
+
+export async function normalizeMessageImageParts<
+  T extends ApprovalCreate | MessageCreate,
+>(
+  messages: T[],
+  resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
+): Promise<T[]> {
+  let didChange = false;
+
+  const normalizedMessages = await Promise.all(
+    messages.map(async (message) => {
+      if (!("content" in message)) {
+        return message;
+      }
+
+      const normalizedContent = await normalizeMessageContentImages(
+        message.content,
+        resize,
+      );
+      if (normalizedContent !== message.content) {
+        didChange = true;
+        return {
+          ...message,
+          content: normalizedContent,
+        };
+      }
+      return message;
+    }),
+  );
+
+  return didChange ? normalizedMessages : messages;
+}
+
+export function assertSupportedBase64ImageMediaTypes(
+  messages: Array<ApprovalCreate | MessageCreate>,
+): void {
+  for (const message of messages) {
+    if (!("content" in message) || typeof message.content === "string") {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!isBase64ImageContentPart(part)) {
+        continue;
+      }
+
+      if (!SUPPORTED_BASE64_IMAGE_MEDIA_TYPES.has(part.source.media_type)) {
+        throw new Error(
+          `Unsupported base64 image media type after normalization: ${part.source.media_type}`,
+        );
+      }
+    }
+  }
+}

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -14,6 +14,7 @@ import type {
 import { isCoalescable } from "../../queue/queueRuntime";
 import { mergeQueuedTurnInput } from "../../queue/turnQueueRuntime";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
+import { normalizeMessageContentImages as normalizeSharedMessageContentImages } from "../../utils/messageImageNormalization";
 import { getListenerBlockedReason } from "../helpers/listenerQueueAdapter";
 import { emitDequeuedUserMessage } from "./protocol-outbound";
 import {
@@ -198,73 +199,11 @@ function mapTurnLifecycleOutcome(
   return "completed";
 }
 
-function isBase64ImageContentPart(part: unknown): part is {
-  type: "image";
-  source: { type: "base64"; media_type: string; data: string };
-} {
-  if (!part || typeof part !== "object") {
-    return false;
-  }
-
-  const candidate = part as {
-    type?: unknown;
-    source?: {
-      type?: unknown;
-      media_type?: unknown;
-      data?: unknown;
-    };
-  };
-
-  return (
-    candidate.type === "image" &&
-    !!candidate.source &&
-    candidate.source.type === "base64" &&
-    typeof candidate.source.media_type === "string" &&
-    candidate.source.media_type.length > 0 &&
-    typeof candidate.source.data === "string" &&
-    candidate.source.data.length > 0
-  );
-}
-
 export async function normalizeMessageContentImages(
   content: MessageCreate["content"],
   resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
 ): Promise<MessageCreate["content"]> {
-  if (typeof content === "string") {
-    return content;
-  }
-
-  let didChange = false;
-  const normalizedParts = await Promise.all(
-    content.map(async (part) => {
-      if (!isBase64ImageContentPart(part)) {
-        return part;
-      }
-
-      const resized = await resize(
-        Buffer.from(part.source.data, "base64"),
-        part.source.media_type,
-      );
-      if (
-        resized.data !== part.source.data ||
-        resized.mediaType !== part.source.media_type
-      ) {
-        didChange = true;
-      }
-
-      return {
-        ...part,
-        source: {
-          ...part.source,
-          type: "base64" as const,
-          data: resized.data,
-          media_type: resized.mediaType,
-        },
-      };
-    }),
-  );
-
-  return didChange ? normalizedParts : content;
+  return await normalizeSharedMessageContentImages(content, resize);
 }
 
 export async function normalizeInboundMessages(


### PR DESCRIPTION
## Summary
- add a regression test that reproduces the TUI file-path paste bug by showing `sendMessageStream` still forwarding an unsupported base64 image `media_type` at the request boundary
- add a shared outbound image normalization guard in `sendMessageStream` so TUI, headless, and listener-originated sends all canonicalize base64 image parts before the API request
- derive final image media types from decoded output bytes instead of trusting incoming labels, and expand the regression suite to cover TUI placeholders, direct shared-send payloads, listener normalization, and fail-closed invalid image bytes

## Test plan
- [x] `bun test src/tests/agent/send-message-stream-image-normalization.test.ts src/tests/cli/imageResize.test.ts src/tests/websocket/listen-client-image-normalization.test.ts src/tests/tools/read.test.ts`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)