### PR TITLE
fix(reflection): store payload snapshots under the transcript root

### DIFF
--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -6,7 +6,7 @@ import {
   readFile,
   writeFile,
 } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { MEMORY_SYSTEM_DIR } from "../../agent/memoryFilesystem";
 import { getDirectoryLimits } from "../../utils/directoryLimits";
@@ -551,9 +551,9 @@ async function readTranscriptLines(
   }
 }
 
-function buildPayloadPath(kind: "auto" | "remember"): string {
+function buildPayloadPath(rootDir: string, kind: "auto" | "remember"): string {
   const nonce = Math.random().toString(36).slice(2, 8);
-  return join(tmpdir(), `letta-${kind}-${nonce}.json`);
+  return join(rootDir, `payload-${kind}-${nonce}.json`);
 }
 
 export function getReflectionTranscriptPaths(
@@ -674,7 +674,7 @@ export async function buildAutoReflectionPayload(
     return null;
   }
 
-  const payloadPath = buildPayloadPath("auto");
+  const payloadPath = buildPayloadPath(paths.rootDir, "auto");
   await writeFile(payloadPath, transcript, "utf-8");
 
   state.last_auto_reflection_started_at = new Date().toISOString();

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   appendTranscriptDeltaJsonl,
   buildAutoReflectionPayload,
@@ -65,6 +65,9 @@ describe("reflectionTranscript helper", () => {
     expect(payload.endMessageId).toBe("a1");
 
     expect(payload.payloadPath.endsWith(".json")).toBe(true);
+    const paths = getReflectionTranscriptPaths(agentId, conversationId);
+    expect(payload.payloadPath.startsWith(paths.rootDir)).toBe(true);
+    expect(dirname(payload.payloadPath)).toBe(paths.rootDir);
 
     const payloadText = await readFile(payload.payloadPath, "utf-8");
     const messages = JSON.parse(payloadText);
@@ -82,7 +85,6 @@ describe("reflectionTranscript helper", () => {
 
     expect(existsSync(payload.payloadPath)).toBe(true);
 
-    const paths = getReflectionTranscriptPaths(agentId, conversationId);
     const stateRaw = await readFile(paths.statePath, "utf-8");
     const state = JSON.parse(stateRaw) as { auto_cursor_line: number };
     expect(state.auto_cursor_line).toBe(payload.endSnapshotLine);


### PR DESCRIPTION
## Summary
- write generated reflection payload snapshots into each conversation's durable transcript directory instead of `os.tmpdir()`
- keep the existing filtered reflection payload format and existing handoff wiring unchanged by returning the new durable path from `buildAutoReflectionPayload()`
- extend the reflection transcript helper test to assert the payload file lives under the per-conversation transcript root

👾 Generated with [Letta Code](https://letta.com)