### PR TITLE
feat(stream-json): emit tool_return_message for locally-executed tools

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,6 +7,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
 import type { ApprovalResult } from "./agent/approval-execution";
 import {
   buildFreshDenialApprovals,
@@ -128,6 +129,7 @@ import type {
   RetryMessage,
   StreamEvent,
   SystemInitMessage,
+  ToolReturnMessageWire,
 } from "./types/protocol";
 import { debugLog, debugWarn, isDebugEnabled } from "./utils/debug";
 import {
@@ -1439,6 +1441,28 @@ export async function handleHeadlessCommand(
     return await flushAndExit(code);
   };
 
+  // Callback that emits a ToolReturnMessageWire for each locally-executed tool.
+  // The server doesn't echo local tool results back on the post-approval stream,
+  // so without this stream-json consumers have no visibility into what the tool
+  // returned, its status, stdout/stderr, etc. Undefined when not in stream-json
+  // mode so executeApprovalBatch is a no-op on emit.
+  const emitToolReturnWire:
+    | ((toolReturn: ToolReturnMessage) => void)
+    | undefined =
+    outputFormat === "stream-json"
+      ? (toolReturn) => {
+          const wire: ToolReturnMessageWire = {
+            ...toolReturn,
+            type: "message",
+            session_id: sessionId,
+            agent_id: agent.id,
+            conversation_id: conversationId,
+            uuid: `tool-return-${toolReturn.tool_call_id}`,
+          };
+          writeWireMessage(wire);
+        }
+      : undefined;
+
   // Output init event for stream-json format
   if (outputFormat === "stream-json") {
     const initEvent: SystemInitMessage = {
@@ -2225,7 +2249,7 @@ ${SYSTEM_REMINDER_CLOSE}
         );
         const executedResults = await executeApprovalBatch(
           decisions,
-          undefined,
+          emitToolReturnWire,
           {
             toolContextId: turnToolContextId ?? undefined,
           },
@@ -2779,6 +2803,20 @@ async function runBidirectionalMode(
     telemetry.trackSessionEnd(undefined, exitReason);
     await telemetry.flush();
     return await flushAndExit(code);
+  };
+
+  // Bidirectional mode is always stream-json; emit tool returns for each
+  // locally-executed tool so SDK consumers can see the result payloads.
+  const emitToolReturnWire = (toolReturn: ToolReturnMessage): void => {
+    const wire: ToolReturnMessageWire = {
+      ...toolReturn,
+      type: "message",
+      session_id: sessionId,
+      agent_id: agent.id,
+      conversation_id: conversationId,
+      uuid: `tool-return-${toolReturn.tool_call_id}`,
+    };
+    writeWireMessage(wire);
   };
 
   // Emit init event
@@ -3963,7 +4001,7 @@ async function runBidirectionalMode(
             );
             const executedResults = await executeApprovalBatch(
               decisions,
-              undefined,
+              emitToolReturnWire,
               { toolContextId: turnToolContextId ?? undefined },
             );
 

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -352,4 +352,75 @@ describe("stream-json format", () => {
     },
     { timeout: 200000 },
   );
+
+  // Prompt that forces a local tool call. The model must Read the file,
+  // which auto-approves and executes locally — giving us a tool_return_message
+  // that would otherwise never reach the wire.
+  const TOOL_PROMPT =
+    "Read the file README.md using the Read tool, then tell me how many lines it has. Do not use any other tools.";
+
+  test(
+    "tool_return_message is emitted on the wire after local tool execution",
+    async () => {
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+
+      const toolReturns = lines
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        .filter(
+          (o) =>
+            o.type === "message" && o.message_type === "tool_return_message",
+        );
+
+      expect(toolReturns.length).toBeGreaterThan(0);
+
+      const first = toolReturns[0] as {
+        tool_call_id: string;
+        tool_return: unknown;
+        status: string;
+        timestamp: string;
+        uuid: string;
+        session_id: string;
+        agent_id: string;
+        conversation_id: string;
+      };
+
+      expect(typeof first.tool_call_id).toBe("string");
+      expect(first.tool_call_id.length).toBeGreaterThan(0);
+      expect(typeof first.tool_return).toBe("string");
+      expect(["success", "error"]).toContain(first.status);
+      expect(first.timestamp).toMatch(ISO_TIMESTAMP_REGEX);
+      expect(first.uuid).toBe(`tool-return-${first.tool_call_id}`);
+      expect(first.session_id).toBe(first.agent_id);
+      expect(first.conversation_id).toBeTruthy();
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "tool_return_message arrives between approval and next assistant_message",
+    async () => {
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+
+      // Extract the sequence of message_type (or top-level type when no message_type).
+      const kinds = lines.map((l) => {
+        const o = JSON.parse(l) as {
+          type: string;
+          message_type?: string;
+        };
+        return o.message_type ?? o.type;
+      });
+
+      const approvalIdx = kinds.findIndex(
+        (k) => k === "approval_request_message" || k === "tool_call_message",
+      );
+      const toolReturnIdx = kinds.indexOf("tool_return_message");
+      // Find the last assistant_message (the model's final summary after the tool).
+      const lastAssistantIdx = kinds.lastIndexOf("assistant_message");
+
+      expect(approvalIdx).toBeGreaterThan(-1);
+      expect(toolReturnIdx).toBeGreaterThan(approvalIdx);
+      expect(lastAssistantIdx).toBeGreaterThan(toolReturnIdx);
+    },
+    { timeout: 200000 },
+  );
 });


### PR DESCRIPTION
## Summary

Headless stream-json consumers currently see approval requests fire, auto-approvals, then an assistant message reply — but the **tool's actual return value is invisible**. The server does not echo local tool results back on the post-approval stream, so the output of `Read`, `Bash`, `Glob`, etc. never reaches the wire.

This PR wires the existing `onChunk` callback on `executeApprovalBatch` into both headless call sites (main mode and bidirectional mode), wrapping each locally-executed tool return in the already-defined `ToolReturnMessageWire` envelope.

- Adds an `emitToolReturnWire` callback near `sessionId` in `handleHeadlessCommand` (gated on `outputFormat === "stream-json"`) and an equivalent in `runBidirectionalMode` (always stream-json).
- Swaps `undefined` → the callback at both `executeApprovalBatch` call sites.
- No new protocol types — `ToolReturnMessageWire` was already defined but unused.
- Zero behavior change for `text` / `json` output or for server-executed tools (web_search, fetch_webpage, etc., which already emit `tool_return_message` via the server stream).
- Deterministic `uuid: tool-return-<tool_call_id>`, matching the existing `auto-approval-<tool_call_id>` convention for idempotency.
- The emitted `tool_return` field is the displayable text variant (multimodal → text) — same as the TUI. The server still receives the full multimodal payload on the approval continuation.
- Success, error, deny, and abort paths all flow through the callback automatically, since `executeSingleDecision` already invokes it on every branch.

## Sample output

Before — step 1 ends, and the next step's assistant message just appears, with no visibility into what `Read` returned:

```json
{"message_type":"approval_request_message","tool_call":{"name":"Read","arguments":"…"},"tool_call_id":"chatcmpl-tool-abc"}
{"type":"auto_approval","tool_call":{"name":"Read","tool_call_id":"chatcmpl-tool-abc",...}}
{"message_type":"stop_reason","stop_reason":"requires_approval"}
{"message_type":"usage_statistics",...}
{"message_type":"assistant_message","content":"README.md is 64 lines total."}
```

After — the tool's return is now visible on the wire:

```json
{"message_type":"approval_request_message","tool_call":{"name":"Read","arguments":"…"},"tool_call_id":"chatcmpl-tool-abc"}
{"type":"auto_approval","tool_call":{"name":"Read","tool_call_id":"chatcmpl-tool-abc",...}}
{"message_type":"stop_reason","stop_reason":"requires_approval"}
{"message_type":"usage_statistics",...}
{"message_type":"tool_return_message","tool_call_id":"chatcmpl-tool-abc","tool_return":" 1→# Letta Code\n 2→\n 3→[![npm](…)]…","status":"success","uuid":"tool-return-chatcmpl-tool-abc"}
{"message_type":"assistant_message","content":"README.md is 64 lines total."}
```

## Test plan

- [x] New integration test: `tool_return_message is emitted on the wire after local tool execution` — verifies shape (tool_call_id, tool_return, status, uuid, envelope fields, ISO timestamp).
- [x] New integration test: `tool_return_message arrives between approval and next assistant_message` — verifies ordering relative to `approval_request_message` and the terminal `assistant_message`.
- [x] Full `headless-stream-json-format.test.ts` suite passes (8/8).
- [x] `stream-json-writer.test.ts` unit tests pass (2/2).
- [x] `src/tests/agent` — 239 pass, same 7 pre-existing failures as `main` (credentials/keychain/integration, unrelated).
- [x] `tsc --noEmit` clean.
- [x] Manual verification: `bun run dev --new-agent -p "summarize the readme" --output-format stream-json` — `tool_return_message` events appear for each local tool call with the expected shape.

## Notes / follow-ups (out of scope for this PR)

- The event's inner `id: "dummy"` is a leftover from `approval-execution.ts` where the TUI consumer didn't need it. Cosmetic; the top-level `uuid` is the real identifier. Cheap cleanup for a later PR.
- `tool_return_message` currently lands **after** the step's `stop_reason`/`usage_statistics`, which is temporally correct (server's step ends before client runs the tool) but logically surprising. Fixable by buffering the step terminators past local execution — planned for the next PR alongside the stream-json format cleanups (coalescing, timestamp normalization).

👾 Generated with [Letta Code](https://letta.com)