### PR TITLE
fix(channels): prevent MessageChannel from leaking into unrouted conversations

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -94,8 +94,14 @@ async function maybeResolveDynamicChannelTool(
 function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
   const nextRegistry = new Map(registry);
   const existing = nextRegistry.get("MessageChannel");
+
+  // Only update an existing entry — never inject MessageChannel into a registry
+  // that deliberately excluded it (e.g. a conversation with no channel routes).
+  if (!existing) {
+    return nextRegistry;
+  }
+
   if (
-    existing &&
     existing.schema.description !== TOOL_DEFINITIONS.MessageChannel.description
   ) {
     return nextRegistry;


### PR DESCRIPTION
## Summary

- `withDynamicMessageChannelCache` was meant to update the `MessageChannel` tool description/schema when channels are active, but had no guard against *injecting* it into registries where the tool was deliberately absent
- When a new conversation has no Slack routes, `prepareToolExecutionContextForScope` correctly builds a registry without `MessageChannel` — but `capturePreparedToolExecutionContext` then re-applied `withDynamicMessageChannelCache`, which re-injected `MessageChannel` from the global cache whenever any channel adapter was running
- Fix: return early when `MessageChannel` is not already present in the registry, so the function only updates existing entries and never promotes the tool into a scope that excluded it

👾 Generated with [Letta Code](https://letta.com)