### PR TITLE
feat(stream-json): coalesce chunks, order tool returns, drop redundant date field

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -95,6 +95,7 @@ import {
 } from "./reminders/state";
 import { getCurrentWorkingDirectory } from "./runtime-context";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
+import { StreamJsonAggregator } from "./streamJsonAggregator";
 import { writeWireMessage } from "./streamJsonWriter";
 import { telemetry } from "./telemetry";
 import { trackBoundaryError } from "./telemetry/errorReporting";
@@ -1441,6 +1442,20 @@ export async function handleHeadlessCommand(
     return await flushAndExit(code);
   };
 
+  // Aggregator for stream-json chunk coalescing. Instantiated once per turn
+  // (one handleHeadlessCommand call = one user message). Scoped at function
+  // level so held terminators can survive stream boundaries across approval
+  // continuations. `undefined` outside stream-json mode.
+  const streamJsonAggregator =
+    outputFormat === "stream-json"
+      ? new StreamJsonAggregator({
+          sessionId,
+          agentId: agent.id,
+          conversationId,
+          passthrough: includePartialMessages,
+        })
+      : undefined;
+
   // Callback that emits a ToolReturnMessageWire for each locally-executed tool.
   // The server doesn't echo local tool results back on the post-approval stream,
   // so without this stream-json consumers have no visibility into what the tool
@@ -2017,6 +2032,9 @@ ${SYSTEM_REMINDER_CLOSE}
           let shouldOutputChunk = shouldOutput;
 
           if (errorInfo && shouldOutput) {
+            // Flush buffered chunks first so their full text lands on the
+            // wire before this error event.
+            streamJsonAggregator?.flushPending();
             const errorEvent: ErrorMessage = {
               type: "error",
               message: errorInfo.message,
@@ -2045,6 +2063,7 @@ ${SYSTEM_REMINDER_CLOSE}
             isApprovalPendingError(errorInfo?.detail) ||
             isApprovalPendingError(errorInfo?.message)
           ) {
+            streamJsonAggregator?.flushPending();
             const recoveryRunId = errorInfo?.run_id;
             const recoveryMsg: RecoveryMessage = {
               type: "recovery",
@@ -2074,6 +2093,11 @@ ${SYSTEM_REMINDER_CLOSE}
             const [approval] = autoAllowed;
             if (approval) {
               const permission = approval.permission;
+              // Ingest the final-args chunk first so the coalesced
+              // approval_request_message is complete, then flush so it
+              // lands on the wire before the auto_approval marker.
+              if (shouldOutputChunk) streamJsonAggregator?.ingest(chunk);
+              streamJsonAggregator?.flushPending();
               shouldOutputChunk = false;
               const autoApprovalMsg: AutoApprovalMessage = {
                 type: "auto_approval",
@@ -2096,29 +2120,7 @@ ${SYSTEM_REMINDER_CLOSE}
           }
 
           if (shouldOutputChunk) {
-            const chunkWithIds = chunk as typeof chunk & {
-              otid?: string;
-              id?: string;
-            };
-            const uuid = chunkWithIds.otid || chunkWithIds.id;
-
-            if (includePartialMessages) {
-              const streamEvent: StreamEvent = {
-                type: "stream_event",
-                event: chunk,
-                session_id: sessionId,
-                uuid: uuid || randomUUID(),
-              };
-              writeWireMessage(streamEvent);
-            } else {
-              const msg: MessageWire = {
-                type: "message",
-                ...chunk,
-                session_id: sessionId,
-                uuid: uuid || randomUUID(),
-              };
-              writeWireMessage(msg);
-            }
+            streamJsonAggregator?.ingest(chunk);
           }
 
           return { shouldOutput: shouldOutputChunk, shouldAccumulate: true };
@@ -2254,6 +2256,11 @@ ${SYSTEM_REMINDER_CLOSE}
             toolContextId: turnToolContextId ?? undefined,
           },
         );
+
+        // Now that tool_return_message events have landed on the wire,
+        // release the step terminators held during the approval step so
+        // stop_reason / usage_statistics come after their tool returns.
+        streamJsonAggregator?.releaseHeldTerminators();
 
         // Send all results in one batch
         const approvalInputWithOtid = {
@@ -2619,6 +2626,9 @@ ${SYSTEM_REMINDER_CLOSE}
         "headless_turn_execution",
       );
       if (outputFormat === "stream-json") {
+        // Flush any buffered chunks so they're visible before the final
+        // error line.
+        streamJsonAggregator?.flushAll();
         // Emit error event
         const errorMsg: ErrorMessage = {
           type: "error",
@@ -2647,6 +2657,7 @@ ${SYSTEM_REMINDER_CLOSE}
     );
 
     if (outputFormat === "stream-json") {
+      streamJsonAggregator?.flushAll();
       const errorMsg: ErrorMessage = {
         type: "error",
         message: errorDetails,
@@ -2731,6 +2742,9 @@ ${SYSTEM_REMINDER_CLOSE}
     };
     console.log(JSON.stringify(output, null, 2));
   } else if (outputFormat === "stream-json") {
+    // Flush any chunks still buffered in the aggregator (and release any
+    // held terminators) so nothing lingers past the result line.
+    streamJsonAggregator?.flushAll();
     // Output final result event
     // Collect all run_ids from buffers
     const allRunIds = new Set<string>();
@@ -3637,6 +3651,15 @@ async function runBidirectionalMode(
       currentAbortController = new AbortController();
 
       turnInProgress = true;
+      // Per-turn aggregator for stream-json coalescing. Declared outside the
+      // try so the catch block below can flush anything still buffered
+      // before emitting the error line.
+      const streamJsonAggregator = new StreamJsonAggregator({
+        sessionId,
+        agentId: agent.id,
+        conversationId,
+        passthrough: includePartialMessages,
+      });
       try {
         const buffers = createBuffers(agent.id);
         const startTime = performance.now();
@@ -3796,6 +3819,9 @@ async function runBidirectionalMode(
             // Handle in-stream errors (emit ErrorMessage with full details)
             if (errorInfo && shouldOutput) {
               sawStreamError = true; // Track that we saw an error (affects result subtype)
+              // Flush buffered chunks so they're on the wire before the
+              // error line.
+              streamJsonAggregator.flushPending();
               const errorEvent: ErrorMessage = {
                 type: "error",
                 message: errorInfo.message,
@@ -3822,29 +3848,7 @@ async function runBidirectionalMode(
               return { shouldAccumulate: true };
             }
 
-            const chunkWithIds = chunk as typeof chunk & {
-              otid?: string;
-              id?: string;
-            };
-            const uuid = chunkWithIds.otid || chunkWithIds.id;
-
-            if (includePartialMessages) {
-              const streamEvent: StreamEvent = {
-                type: "stream_event",
-                event: chunk,
-                session_id: sessionId,
-                uuid: uuid || randomUUID(),
-              };
-              writeWireMessage(streamEvent);
-            } else {
-              const msg: MessageWire = {
-                type: "message",
-                ...chunk,
-                session_id: sessionId,
-                uuid: uuid || randomUUID(),
-              };
-              writeWireMessage(msg);
-            }
+            streamJsonAggregator.ingest(chunk);
 
             return { shouldAccumulate: true };
           };
@@ -4005,6 +4009,11 @@ async function runBidirectionalMode(
               { toolContextId: turnToolContextId ?? undefined },
             );
 
+            // Release the held step terminators now that tool returns have
+            // been emitted — stop_reason / usage_statistics come after their
+            // tool_return_message.
+            streamJsonAggregator.releaseHeldTerminators();
+
             // Send approval results back to continue
             const approvalInputWithOtid = {
               type: "approval" as const,
@@ -4069,6 +4078,9 @@ async function runBidirectionalMode(
             ? "error"
             : "success";
 
+        // Flush any chunks still buffered (and release held terminators)
+        // so nothing lingers past this turn's result line.
+        streamJsonAggregator.flushAll();
         const resultMsg: ResultMessage = {
           type: "result",
           subtype,
@@ -4092,6 +4104,8 @@ async function runBidirectionalMode(
         };
         writeWireMessage(resultMsg);
       } catch (error) {
+        // Flush any buffered chunks so they're on the wire before the error.
+        streamJsonAggregator.flushAll();
         // Use formatErrorDetails for comprehensive error formatting (same as one-shot mode)
         const errorDetails = formatErrorDetails(error, agent.id);
         trackHeadlessBoundaryError(

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2020,14 +2020,10 @@ ${SYSTEM_REMINDER_CLOSE}
       let approvalPendingRecovery = false;
 
       if (outputFormat === "stream-json") {
-        // Track approval requests across streamed chunks
-        const autoApprovalEmitted = new Set<string>();
-
         const streamJsonHook: DrainStreamHook = async ({
           chunk,
           shouldOutput,
           errorInfo,
-          updatedApproval,
         }) => {
           let shouldOutputChunk = shouldOutput;
 
@@ -2079,46 +2075,11 @@ ${SYSTEM_REMINDER_CLOSE}
             return { stopReason: "error", shouldAccumulate: true };
           }
 
-          // Check if this approval will be auto-approved. Dedup per tool_call_id
-          if (
-            updatedApproval &&
-            !autoApprovalEmitted.has(updatedApproval.toolCallId)
-          ) {
-            const { autoAllowed } = await classifyApprovals([updatedApproval], {
-              alwaysRequiresUserInput: isInteractiveApprovalTool,
-              requireArgsForAutoApprove: true,
-              missingNameReason: "Tool call incomplete - missing name",
-            });
-
-            const [approval] = autoAllowed;
-            if (approval) {
-              const permission = approval.permission;
-              // Ingest the final-args chunk first so the coalesced
-              // approval_request_message is complete, then flush so it
-              // lands on the wire before the auto_approval marker.
-              if (shouldOutputChunk) streamJsonAggregator?.ingest(chunk);
-              streamJsonAggregator?.flushPending();
-              shouldOutputChunk = false;
-              const autoApprovalMsg: AutoApprovalMessage = {
-                type: "auto_approval",
-                tool_call: {
-                  name: approval.approval.toolName,
-                  tool_call_id: approval.approval.toolCallId,
-                  arguments: approval.approval.toolArgs || "{}",
-                },
-                reason: permission.reason || "Allowed by permission rule",
-                matched_rule:
-                  "matchedRule" in permission && permission.matchedRule
-                    ? permission.matchedRule
-                    : "auto-approved",
-                session_id: sessionId,
-                uuid: `auto-approval-${approval.approval.toolCallId}`,
-              };
-              writeWireMessage(autoApprovalMsg);
-              autoApprovalEmitted.add(approval.approval.toolCallId);
-            }
-          }
-
+          // Note: `auto_approval` is no longer emitted from inside the hook.
+          // We defer it to the post-drain section so the merged
+          // approval_request_message (with inline stop_reason / usage) lands
+          // on the wire BEFORE the auto_approval marker. Emitting during
+          // drain forced a premature aggregator flush, breaking the merge.
           if (shouldOutputChunk) {
             streamJsonAggregator?.ingest(chunk);
           }
@@ -2217,6 +2178,34 @@ ${SYSTEM_REMINDER_CLOSE}
             missingNameReason: "Tool call incomplete - missing name",
           });
 
+        // Emit `auto_approval` markers for each auto-allowed approval. These
+        // used to fire from inside the streamJsonHook, but doing so forced an
+        // early aggregator flush that broke the merged-terminator emission
+        // for the approval_request_message. Emitting them here ensures the
+        // wire order is: approval_request (merged) → auto_approval →
+        // tool_return_message (from executeApprovalBatch below).
+        if (outputFormat === "stream-json") {
+          for (const approvalItem of autoAllowed) {
+            const permission = approvalItem.permission;
+            const autoApprovalMsg: AutoApprovalMessage = {
+              type: "auto_approval",
+              tool_call: {
+                name: approvalItem.approval.toolName,
+                tool_call_id: approvalItem.approval.toolCallId,
+                arguments: approvalItem.approval.toolArgs || "{}",
+              },
+              reason: permission.reason || "Allowed by permission rule",
+              matched_rule:
+                "matchedRule" in permission && permission.matchedRule
+                  ? permission.matchedRule
+                  : "auto-approved",
+              session_id: sessionId,
+              uuid: `auto-approval-${approvalItem.approval.toolCallId}`,
+            };
+            writeWireMessage(autoApprovalMsg);
+          }
+        }
+
         const decisions: Decision[] = [
           ...autoAllowed.map((ac) => ({
             type: "approve" as const,
@@ -2257,12 +2246,10 @@ ${SYSTEM_REMINDER_CLOSE}
           },
         );
 
-        // Now that tool_return_message events have landed on the wire,
-        // release the step terminators held during the approval step so
-        // stop_reason / usage_statistics come after their tool returns.
-        streamJsonAggregator?.releaseHeldTerminators();
-
-        // Send all results in one batch
+        // Send all results in one batch.
+        // (`stop_reason: requires_approval` and `usage_statistics` are now
+        // merged inline onto the approval_request_message at flush time, so
+        // there's nothing held to release after tool execution.)
         const approvalInputWithOtid = {
           type: "approval" as const,
           approvals: executedResults as ApprovalResult[],
@@ -4009,12 +3996,10 @@ async function runBidirectionalMode(
               { toolContextId: turnToolContextId ?? undefined },
             );
 
-            // Release the held step terminators now that tool returns have
-            // been emitted — stop_reason / usage_statistics come after their
-            // tool_return_message.
-            streamJsonAggregator.releaseHeldTerminators();
-
-            // Send approval results back to continue
+            // Send approval results back to continue.
+            // (`stop_reason: requires_approval` and `usage_statistics` are
+            // merged inline onto the approval_request_message at flush time,
+            // so there's nothing held to release after tool execution.)
             const approvalInputWithOtid = {
               type: "approval" as const,
               approvals: executedResults,

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -423,4 +423,181 @@ describe("stream-json format", () => {
     },
     { timeout: 200000 },
   );
+
+  test(
+    "assistant_message arrives as one complete event per otid in default mode",
+    async () => {
+      // Default (coalesced) mode: each logical message surfaces as exactly
+      // one event. In partial mode (below) the same otid produces many.
+      const lines = await runHeadlessCommand(FAST_PROMPT);
+
+      const assistantLines = lines
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        .filter(
+          (o) => o.type === "message" && o.message_type === "assistant_message",
+        );
+
+      expect(assistantLines.length).toBeGreaterThan(0);
+
+      // Group by otid — each otid should appear exactly once.
+      const perOtid = new Map<string, number>();
+      for (const msg of assistantLines) {
+        const otid = String(msg.otid ?? msg.id ?? "");
+        perOtid.set(otid, (perOtid.get(otid) ?? 0) + 1);
+      }
+      for (const [otid, count] of perOtid) {
+        expect(count, `assistant_message otid "${otid}" fragmented`).toBe(1);
+      }
+
+      // And at least one assistant message should carry non-trivial text.
+      const hasText = assistantLines.some((msg) => {
+        const content = msg.content;
+        if (typeof content === "string") return content.trim().length > 0;
+        if (Array.isArray(content)) {
+          return content.some((part) => {
+            const p = part as { text?: unknown };
+            return typeof p?.text === "string" && p.text.trim().length > 0;
+          });
+        }
+        return false;
+      });
+      expect(hasText).toBe(true);
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "tool_call arguments are complete valid JSON in default mode",
+    async () => {
+      // With coalescing, the approval_request_message on the wire carries a
+      // complete `arguments` string — parseable as JSON, not a fragment.
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+
+      const approvalMessages = lines
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        .filter(
+          (o) =>
+            o.type === "message" &&
+            (o.message_type === "approval_request_message" ||
+              o.message_type === "tool_call_message"),
+        );
+
+      expect(approvalMessages.length).toBeGreaterThan(0);
+
+      // Each approval/tool-call message should appear once per tool_call_id.
+      const perToolCall = new Map<string, number>();
+      for (const msg of approvalMessages) {
+        const toolCall = msg.tool_call as { tool_call_id?: string };
+        const id = toolCall?.tool_call_id;
+        expect(id).toBeTruthy();
+        if (!id) continue;
+        perToolCall.set(id, (perToolCall.get(id) ?? 0) + 1);
+
+        // `arguments` must be a non-empty JSON-parseable string.
+        const args = (toolCall as { arguments?: unknown }).arguments;
+        expect(typeof args).toBe("string");
+        expect(String(args).length).toBeGreaterThan(0);
+        expect(() => JSON.parse(String(args))).not.toThrow();
+      }
+      for (const [id, count] of perToolCall) {
+        expect(count, `tool_call_id "${id}" fragmented`).toBe(1);
+      }
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "tool_return_message lands before stop_reason and usage_statistics of its step",
+    async () => {
+      // Ordering invariant:
+      //   approval_request_message → auto_approval → tool_return_message
+      //   → stop_reason (requires_approval) → usage_statistics → next step.
+      // Before the held-terminator fix, stop_reason and usage_statistics
+      // landed *before* tool_return_message.
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+      const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+
+      const kindFor = (o: Record<string, unknown>): string => {
+        if (o.type === "message") return String(o.message_type ?? "unknown");
+        return String(o.type);
+      };
+
+      // Locate the first tool_return_message and the stop_reason that
+      // follows it. The stop_reason's index must be AFTER the tool_return.
+      const toolReturnIdx = parsed.findIndex(
+        (o) => kindFor(o) === "tool_return_message",
+      );
+      expect(toolReturnIdx).toBeGreaterThan(-1);
+
+      // Find the first stop_reason AT OR AFTER the tool_return_message.
+      // Under the old ordering this would have been before.
+      const stopReasonIdx = parsed.findIndex(
+        (o, i) => i >= toolReturnIdx && kindFor(o) === "stop_reason",
+      );
+      expect(stopReasonIdx).toBeGreaterThan(toolReturnIdx);
+
+      // And the usage_statistics for that step follows stop_reason.
+      const usageIdx = parsed.findIndex(
+        (o, i) => i >= stopReasonIdx && kindFor(o) === "usage_statistics",
+      );
+      expect(usageIdx).toBeGreaterThan(stopReasonIdx);
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "--include-partial-messages yields multiple delta events per otid",
+    async () => {
+      // In passthrough mode the aggregator is bypassed; assistant_message
+      // deltas surface as multiple stream_event lines per otid.
+      const lines = await runHeadlessCommand(FAST_PROMPT, [
+        "--include-partial-messages",
+      ]);
+
+      const assistantEvents = lines
+        .map((l) => JSON.parse(l) as { type: string; event?: unknown })
+        .filter(
+          (o) =>
+            o.type === "stream_event" &&
+            typeof o.event === "object" &&
+            o.event !== null &&
+            (o.event as { message_type?: string }).message_type ===
+              "assistant_message",
+        );
+
+      // Fast prompts sometimes collapse to a single delta. Where we do see
+      // more than one assistant chunk, some otid should have >1 event.
+      if (assistantEvents.length > 1) {
+        const perOtid = new Map<string, number>();
+        for (const ev of assistantEvents) {
+          const event = ev.event as { otid?: string; id?: string };
+          const otid = String(event.otid ?? event.id ?? "");
+          perOtid.set(otid, (perOtid.get(otid) ?? 0) + 1);
+        }
+        const hasFragmented = Array.from(perOtid.values()).some((n) => n > 1);
+        expect(
+          hasFragmented,
+          "passthrough mode should produce multiple deltas per otid",
+        ).toBe(true);
+      }
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "no emitted line carries a `date` field (regression guard for #8)",
+    async () => {
+      // The server includes `date` (second-precision, +00:00 format) on some
+      // messages; `timestamp` (ms, Z) is the canonical time source on the
+      // wire. PR 2 drops `date` from every emission.
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+      expect(lines.length).toBeGreaterThan(0);
+
+      for (const line of lines) {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        expect(obj).not.toHaveProperty("date");
+      }
+    },
+    { timeout: 200000 },
+  );
 });

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -507,77 +507,75 @@ describe("stream-json format", () => {
   );
 
   test(
-    "stop_reason and usage are merged inline onto approval_request_message",
+    "step_end event is emitted for each approval step and for end_turn",
     async () => {
-      // The step that ends in `requires_approval` is now a single coalesced
-      // event: the approval_request_message carries `stop_reason` and
-      // `usage` inline. There should be no standalone `stop_reason` or
-      // `usage_statistics` line for that step.
+      // Each server step terminates with a single `step_end` wire event
+      // carrying `stop_reason`, `step_id`, and `usage`. Content messages
+      // never carry step metadata inline.
       const lines = await runHeadlessCommand(TOOL_PROMPT);
       const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
 
-      const approvalMsgs = parsed.filter(
-        (o) =>
-          o.type === "message" &&
-          (o.message_type === "approval_request_message" ||
-            o.message_type === "tool_call_message"),
-      );
-      expect(approvalMsgs.length).toBeGreaterThan(0);
+      const stepEndEvents = parsed.filter((o) => o.type === "step_end");
+      expect(stepEndEvents.length).toBeGreaterThanOrEqual(2);
 
-      // At least one approval message in the run carries inline terminators.
-      const merged = approvalMsgs.find(
+      // At least one approval step.
+      const approvalStepEnd = stepEndEvents.find(
         (o) => o.stop_reason === "requires_approval",
       );
-      expect(merged).toBeDefined();
-      if (!merged) throw new Error("no merged approval_request_message");
-      expect(merged.usage).toBeDefined();
-      const usage = merged.usage as Record<string, unknown>;
-      expect(typeof usage.total_tokens).toBe("number");
-      expect(typeof usage.completion_tokens).toBe("number");
-      expect(typeof usage.prompt_tokens).toBe("number");
+      expect(approvalStepEnd).toBeDefined();
+      if (!approvalStepEnd) throw new Error("no approval step_end");
+      expect(typeof approvalStepEnd.step_id).toBe("string");
+      expect(approvalStepEnd.usage).toBeDefined();
+      const approvalUsage = approvalStepEnd.usage as Record<string, unknown>;
+      expect(typeof approvalUsage.total_tokens).toBe("number");
+      expect(typeof approvalUsage.prompt_tokens).toBe("number");
+      expect(typeof approvalUsage.completion_tokens).toBe("number");
 
-      // No standalone stop_reason: requires_approval line should remain
-      // (the inline merge replaces it on the wire).
-      const standaloneRequiresApproval = parsed.filter(
-        (o) =>
-          o.type === "message" &&
-          o.message_type === "stop_reason" &&
-          o.stop_reason === "requires_approval",
+      // And exactly one end_turn step at the tail.
+      const endTurnStepEnd = stepEndEvents.find(
+        (o) => o.stop_reason === "end_turn",
       );
-      expect(standaloneRequiresApproval).toHaveLength(0);
+      expect(endTurnStepEnd).toBeDefined();
+      if (!endTurnStepEnd) throw new Error("no end_turn step_end");
+      expect(typeof endTurnStepEnd.step_id).toBe("string");
+      expect(endTurnStepEnd.usage).toBeDefined();
     },
     { timeout: 200000 },
   );
 
   test(
-    "stop_reason: end_turn and usage are merged inline onto the final assistant_message",
+    "content messages never carry stop_reason or usage inline",
     async () => {
-      // The terminating step of the turn ends with `end_turn`; its
-      // assistant_message carries `stop_reason: end_turn` and `usage` inline.
+      // Regression guard: the previous design merged step terminators onto
+      // the last content message in each step. That's gone — content stays
+      // clean, terminators live on the `step_end` event.
       const lines = await runHeadlessCommand(TOOL_PROMPT);
       const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
 
-      const assistantMsgs = parsed.filter(
-        (o) => o.type === "message" && o.message_type === "assistant_message",
-      );
-      expect(assistantMsgs.length).toBeGreaterThan(0);
-
-      // The last assistant_message should carry the inline terminators.
-      const last = assistantMsgs[assistantMsgs.length - 1];
-      if (!last) throw new Error("no assistant_message found");
-      expect(last.stop_reason).toBe("end_turn");
-      expect(last.usage).toBeDefined();
-      const usage = last.usage as Record<string, unknown>;
-      expect(typeof usage.completion_tokens).toBe("number");
-
-      // And no standalone stop_reason: end_turn line for the same step.
-      const standaloneEndTurn = parsed.filter(
+      const contentMsgs = parsed.filter(
         (o) =>
           o.type === "message" &&
-          o.message_type === "stop_reason" &&
-          o.stop_reason === "end_turn",
+          (o.message_type === "assistant_message" ||
+            o.message_type === "reasoning_message" ||
+            o.message_type === "approval_request_message" ||
+            o.message_type === "tool_call_message"),
       );
-      expect(standaloneEndTurn).toHaveLength(0);
+      expect(contentMsgs.length).toBeGreaterThan(0);
+      for (const msg of contentMsgs) {
+        expect(msg.stop_reason).toBeUndefined();
+        expect(msg.usage).toBeUndefined();
+      }
+
+      // And no standalone stop_reason / usage_statistics messages either —
+      // those are subsumed by `step_end`.
+      const standaloneStopReason = parsed.filter(
+        (o) => o.type === "message" && o.message_type === "stop_reason",
+      );
+      const standaloneUsage = parsed.filter(
+        (o) => o.type === "message" && o.message_type === "usage_statistics",
+      );
+      expect(standaloneStopReason).toHaveLength(0);
+      expect(standaloneUsage).toHaveLength(0);
     },
     { timeout: 200000 },
   );

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -507,40 +507,77 @@ describe("stream-json format", () => {
   );
 
   test(
-    "tool_return_message lands before stop_reason and usage_statistics of its step",
+    "stop_reason and usage are merged inline onto approval_request_message",
     async () => {
-      // Ordering invariant:
-      //   approval_request_message → auto_approval → tool_return_message
-      //   → stop_reason (requires_approval) → usage_statistics → next step.
-      // Before the held-terminator fix, stop_reason and usage_statistics
-      // landed *before* tool_return_message.
+      // The step that ends in `requires_approval` is now a single coalesced
+      // event: the approval_request_message carries `stop_reason` and
+      // `usage` inline. There should be no standalone `stop_reason` or
+      // `usage_statistics` line for that step.
       const lines = await runHeadlessCommand(TOOL_PROMPT);
       const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
 
-      const kindFor = (o: Record<string, unknown>): string => {
-        if (o.type === "message") return String(o.message_type ?? "unknown");
-        return String(o.type);
-      };
-
-      // Locate the first tool_return_message and the stop_reason that
-      // follows it. The stop_reason's index must be AFTER the tool_return.
-      const toolReturnIdx = parsed.findIndex(
-        (o) => kindFor(o) === "tool_return_message",
+      const approvalMsgs = parsed.filter(
+        (o) =>
+          o.type === "message" &&
+          (o.message_type === "approval_request_message" ||
+            o.message_type === "tool_call_message"),
       );
-      expect(toolReturnIdx).toBeGreaterThan(-1);
+      expect(approvalMsgs.length).toBeGreaterThan(0);
 
-      // Find the first stop_reason AT OR AFTER the tool_return_message.
-      // Under the old ordering this would have been before.
-      const stopReasonIdx = parsed.findIndex(
-        (o, i) => i >= toolReturnIdx && kindFor(o) === "stop_reason",
+      // At least one approval message in the run carries inline terminators.
+      const merged = approvalMsgs.find(
+        (o) => o.stop_reason === "requires_approval",
       );
-      expect(stopReasonIdx).toBeGreaterThan(toolReturnIdx);
+      expect(merged).toBeDefined();
+      if (!merged) throw new Error("no merged approval_request_message");
+      expect(merged.usage).toBeDefined();
+      const usage = merged.usage as Record<string, unknown>;
+      expect(typeof usage.total_tokens).toBe("number");
+      expect(typeof usage.completion_tokens).toBe("number");
+      expect(typeof usage.prompt_tokens).toBe("number");
 
-      // And the usage_statistics for that step follows stop_reason.
-      const usageIdx = parsed.findIndex(
-        (o, i) => i >= stopReasonIdx && kindFor(o) === "usage_statistics",
+      // No standalone stop_reason: requires_approval line should remain
+      // (the inline merge replaces it on the wire).
+      const standaloneRequiresApproval = parsed.filter(
+        (o) =>
+          o.type === "message" &&
+          o.message_type === "stop_reason" &&
+          o.stop_reason === "requires_approval",
       );
-      expect(usageIdx).toBeGreaterThan(stopReasonIdx);
+      expect(standaloneRequiresApproval).toHaveLength(0);
+    },
+    { timeout: 200000 },
+  );
+
+  test(
+    "stop_reason: end_turn and usage are merged inline onto the final assistant_message",
+    async () => {
+      // The terminating step of the turn ends with `end_turn`; its
+      // assistant_message carries `stop_reason: end_turn` and `usage` inline.
+      const lines = await runHeadlessCommand(TOOL_PROMPT);
+      const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+
+      const assistantMsgs = parsed.filter(
+        (o) => o.type === "message" && o.message_type === "assistant_message",
+      );
+      expect(assistantMsgs.length).toBeGreaterThan(0);
+
+      // The last assistant_message should carry the inline terminators.
+      const last = assistantMsgs[assistantMsgs.length - 1];
+      if (!last) throw new Error("no assistant_message found");
+      expect(last.stop_reason).toBe("end_turn");
+      expect(last.usage).toBeDefined();
+      const usage = last.usage as Record<string, unknown>;
+      expect(typeof usage.completion_tokens).toBe("number");
+
+      // And no standalone stop_reason: end_turn line for the same step.
+      const standaloneEndTurn = parsed.filter(
+        (o) =>
+          o.type === "message" &&
+          o.message_type === "stop_reason" &&
+          o.stop_reason === "end_turn",
+      );
+      expect(standaloneEndTurn).toHaveLength(0);
     },
     { timeout: 200000 },
   );

--- a/src/streamJsonAggregator.ts
+++ b/src/streamJsonAggregator.ts
@@ -16,15 +16,13 @@
  *   `tool_call.tool_call_id` are merged on `arguments` concatenation.
  * - `tool_return_message` is never fragmented by the server; it's emitted
  *   directly, and flushes the matching tool_call accumulator first.
- * - `stop_reason` and the following `usage_statistics` are *merged inline*
- *   onto the step's terminating message rather than emitted as separate
- *   wire events:
- *     - `end_turn` / `max_steps` / `max_tokens` / `stop_sequence` →
- *       attached to the last `assistant_message` (fallback `reasoning_message`)
- *     - `requires_approval` → attached to the `approval_request_message`
- *     - `error` or no clear target → emitted as standalone events (rare)
- *   The merged message carries `stop_reason: "<reason>"` and a nested
- *   `usage: { ... }` block matching the `result` line's usage shape.
+ * - `stop_reason` and the following `usage_statistics` are combined into a
+ *   single `step_end` wire event instead of being emitted as two separate
+ *   server chunks. Content messages are flushed clean (no step metadata
+ *   inline); the `step_end` event carries `stop_reason`, `step_id`, and a
+ *   `usage` block matching the `result` line's usage shape. This keeps
+ *   step-boundary metadata separate from message content and works
+ *   uniformly for single- and multi-message steps.
  * - Unknown or non-accumulable chunks flush pending first, then pass through.
  *
  * When `passthrough: true` (i.e. `--include-partial-messages`), aggregation
@@ -52,17 +50,7 @@ type ChunkWithIds = LettaStreamingResponse & {
 type TextKind = "assistant_message" | "reasoning_message";
 type ToolCallKind = "tool_call_message" | "approval_request_message";
 
-/**
- * Fields shared by every pending entry. The `stopReason` and `usage` slots
- * are populated when the step's terminator events arrive on the stream;
- * they're rendered inline on the merged wire emission at flush time.
- */
-interface PendingTerminators {
-  stopReason?: string;
-  usage?: UsageStatistics;
-}
-
-interface PendingTextEntry extends PendingTerminators {
+interface PendingTextEntry {
   kind: TextKind;
   key: string;
   uuid: string;
@@ -72,18 +60,33 @@ interface PendingTextEntry extends PendingTerminators {
   chunk: LettaStreamingResponse;
   // Concatenated text (for assistant: content; for reasoning: reasoning).
   text: string;
+  // Carries the server-side step_id when present on the content chunk, so
+  // we can stamp the following step_end event with the same step_id.
+  stepId?: string;
 }
 
-interface PendingToolCallEntry extends PendingTerminators {
+interface PendingToolCallEntry {
   kind: ToolCallKind;
   key: string; // tool_call_id
   uuid: string;
   chunk: LettaStreamingResponse;
   toolName: string | undefined;
   args: string; // concatenated arguments JSON text
+  stepId?: string;
 }
 
 type PendingEntry = PendingTextEntry | PendingToolCallEntry;
+
+/**
+ * Buffer the server's `stop_reason` chunk until the matching
+ * `usage_statistics` chunk arrives, so we can emit both as a single
+ * `step_end` event. `stepId` is carried forward from the last content
+ * message flushed in the step.
+ */
+interface BufferedStepEnd {
+  stopReason: string;
+  stepId?: string;
+}
 
 export interface AggregatorOptions {
   sessionId: string;
@@ -102,6 +105,13 @@ export class StreamJsonAggregator {
   // across text and tool-call accumulators — flush emits them in the order
   // they first appeared on the stream.
   private readonly pending = new Map<string, PendingEntry>();
+  // Buffers the server's `stop_reason` chunk until `usage_statistics`
+  // arrives so we can emit a combined `step_end` wire event.
+  private bufferedStepEnd: BufferedStepEnd | undefined;
+  // Tracks the step_id of the most recently flushed content so we can
+  // associate it with the step_end event (the server's stop_reason /
+  // usage_statistics chunks don't carry step_id themselves).
+  private lastFlushedStepId: string | undefined;
 
   constructor(options: AggregatorOptions) {
     this.options = options;
@@ -135,34 +145,31 @@ export class StreamJsonAggregator {
 
       case "stop_reason": {
         const stopReason = (chunk as { stop_reason?: string }).stop_reason;
+        // Flush any content messages first so they land on the wire clean,
+        // before the step_end event that follows.
+        this.flushPending();
         if (!stopReason) {
-          // Malformed chunk — preserve ordering and pass through.
-          this.flushPending();
+          // Malformed chunk — preserve ordering by passing through.
           this.emitMessage(chunk);
           return;
         }
-        const target = this.pickStopReasonTarget(stopReason);
-        if (target) {
-          // Attach inline; do NOT flush yet — we still want to merge the
-          // following `usage_statistics` onto the same message.
-          target.stopReason = stopReason;
-        } else {
-          // No clear target (e.g. error stop with no preceding content):
-          // emit as a standalone event after flushing.
-          this.flushPending();
-          this.emitMessage(chunk);
-        }
+        // Buffer until usage_statistics arrives; the combined event emits
+        // from the usage_statistics branch below.
+        this.bufferedStepEnd = {
+          stopReason,
+          stepId: this.lastFlushedStepId,
+        };
         return;
       }
 
       case "usage_statistics": {
-        const target = this.findTargetWithStopReason();
-        if (target) {
-          target.usage = this.extractUsage(chunk);
-          // `usage_statistics` is the last server event in a step, so it's
-          // safe to flush all pending entries now (the step is closed).
-          this.flushPending();
+        const usage = this.extractUsage(chunk);
+        if (this.bufferedStepEnd) {
+          this.emitStepEnd(this.bufferedStepEnd, usage);
+          this.bufferedStepEnd = undefined;
         } else {
+          // usage_statistics arrived without a preceding stop_reason —
+          // unexpected, but pass it through rather than swallow.
           this.flushPending();
           this.emitMessage(chunk);
         }
@@ -179,10 +186,8 @@ export class StreamJsonAggregator {
 
   /**
    * Emit all buffered text / tool-call accumulators in insertion order, then
-   * clear them.
-   *
-   * Each entry is rendered with its accumulated text/args, and any merged
-   * `stop_reason` / `usage` terminators inline on the wire message.
+   * clear them. Also records the last seen step_id so a subsequent
+   * `step_end` event can be stamped with it.
    *
    * Call this before emitting a non-chunk event (error, recovery,
    * auto_approval) from outside the aggregator, so the buffered chunks
@@ -190,21 +195,28 @@ export class StreamJsonAggregator {
    */
   flushPending(): void {
     if (this.pending.size === 0) return;
+    let lastStepId: string | undefined;
     for (const entry of this.pending.values()) {
-      writeWireMessage(this.buildPendingWire(entry));
+      writeWireMessage(this.buildMessageWire(entry.chunk, entry.uuid));
+      if (entry.stepId) lastStepId = entry.stepId;
     }
+    if (lastStepId) this.lastFlushedStepId = lastStepId;
     this.pending.clear();
   }
 
   /**
-   * Flush all pending buffered events. Safety net for turn-end / abort paths.
-   *
-   * (Kept as a separate method from `flushPending` so callers can express
-   * intent — "I'm done with this turn" vs "I'm interleaving an out-of-band
-   * event" — even though both currently delegate to the same flush.)
+   * Flush all pending content, and release any buffered step_end. Safety net
+   * for turn-end / abort paths where `usage_statistics` may never arrive
+   * (so a buffered `stop_reason` would otherwise leak).
    */
   flushAll(): void {
     this.flushPending();
+    if (this.bufferedStepEnd) {
+      // No usage arrived — emit step_end with usage=null rather than drop
+      // the stop_reason entirely.
+      this.emitStepEnd(this.bufferedStepEnd, null);
+      this.bufferedStepEnd = undefined;
+    }
   }
 
   // ─────────────────────────── internals ───────────────────────────
@@ -244,6 +256,7 @@ export class StreamJsonAggregator {
       uuid,
       chunk: this.mergeTextChunk(kind, undefined, chunk, delta),
       text: delta,
+      stepId: (chunk as { step_id?: string }).step_id,
     };
     this.pending.set(mapKey, entry);
   }
@@ -307,6 +320,7 @@ export class StreamJsonAggregator {
       ),
       toolName: name,
       args: argsDelta,
+      stepId: (chunk as { step_id?: string }).step_id,
     };
     this.pending.set(mapKey, entry);
   }
@@ -317,65 +331,36 @@ export class StreamJsonAggregator {
     for (const k of [approvalKey, toolCallKey]) {
       const entry = this.pending.get(k);
       if (entry) {
-        writeWireMessage(this.buildPendingWire(entry));
+        writeWireMessage(this.buildMessageWire(entry.chunk, entry.uuid));
+        if (entry.stepId) this.lastFlushedStepId = entry.stepId;
         this.pending.delete(k);
       }
     }
   }
 
   /**
-   * Pick the pending entry that a `stop_reason` belongs to, based on the
-   * stop reason value:
-   *   - `requires_approval` → the approval_request_message in the step
-   *     (fallback: tool_call_message)
-   *   - any other natural stop (`end_turn`, `max_steps`, `max_tokens`,
-   *     `stop_sequence`, ...) → the last assistant_message
-   *     (fallback: last reasoning_message)
-   *   - `error` and other unknown reasons → undefined (caller emits standalone)
+   * Emit a combined `step_end` wire event carrying the step's
+   * `stop_reason`, its `step_id` (when known), and the final
+   * `usage_statistics`. Emitted after all content messages for the step
+   * have flushed, so consumers see a clean step boundary.
    */
-  private pickStopReasonTarget(reason: string): PendingEntry | undefined {
-    const entries = Array.from(this.pending.values());
-    if (entries.length === 0) return undefined;
-
-    if (reason === "requires_approval") {
-      // Walk the entries newest-first to pick the most recent matching one.
-      for (let i = entries.length - 1; i >= 0; i--) {
-        const e = entries[i];
-        if (
-          e &&
-          (e.kind === "approval_request_message" ||
-            e.kind === "tool_call_message")
-        ) {
-          return e;
-        }
-      }
-      return undefined;
-    }
-
-    if (reason === "error") {
-      // Errors don't have a clean content target — emit standalone.
-      return undefined;
-    }
-
-    // Default natural-stop behavior: last assistant, fallback last reasoning.
-    let assistant: PendingEntry | undefined;
-    let reasoning: PendingEntry | undefined;
-    for (const e of entries) {
-      if (e.kind === "assistant_message") assistant = e;
-      else if (e.kind === "reasoning_message") reasoning = e;
-    }
-    return assistant ?? reasoning;
-  }
-
-  /**
-   * Locate the pending entry that already has a `stopReason` attached so
-   * we can merge the following `usage_statistics` onto the same message.
-   */
-  private findTargetWithStopReason(): PendingEntry | undefined {
-    for (const e of this.pending.values()) {
-      if (e.stopReason) return e;
-    }
-    return undefined;
+  private emitStepEnd(
+    buffered: BufferedStepEnd,
+    usage: UsageStatistics | null,
+  ): void {
+    const stepId = buffered.stepId ?? this.lastFlushedStepId;
+    const uuid = stepId ? `step-end-${stepId}` : randomUUID();
+    const event = {
+      type: "step_end" as const,
+      stop_reason: buffered.stopReason,
+      ...(stepId ? { step_id: stepId } : {}),
+      usage,
+      session_id: this.options.sessionId,
+      agent_id: this.options.agentId,
+      conversation_id: this.options.conversationId,
+      uuid,
+    };
+    writeWireMessage(event);
   }
 
   private extractUsage(chunk: LettaStreamingResponse): UsageStatistics {
@@ -425,18 +410,6 @@ export class StreamJsonAggregator {
       conversation_id: this.options.conversationId,
       uuid,
     } as MessageWire;
-  }
-
-  /**
-   * Render a pending entry as a wire message, inlining any merged
-   * `stop_reason` / `usage` terminators alongside the accumulated chunk.
-   */
-  private buildPendingWire(entry: PendingEntry): MessageWire {
-    const base = this.buildMessageWire(entry.chunk, entry.uuid) as MessageWire &
-      Record<string, unknown>;
-    if (entry.stopReason) base.stop_reason = entry.stopReason;
-    if (entry.usage) base.usage = entry.usage;
-    return base as MessageWire;
   }
 
   private extractTextDelta(

--- a/src/streamJsonAggregator.ts
+++ b/src/streamJsonAggregator.ts
@@ -286,7 +286,13 @@ export class StreamJsonAggregator {
       return;
     }
 
-    const uuid = chunk.otid ?? chunk.id ?? toolCallId;
+    // Prefer `tool_call_id` as the wire uuid for tool-call entries: the
+    // server often emits multiple parallel tool calls inside a single
+    // message (shared `id` / `otid`), so using the message id would
+    // collide uuids across distinct wire events. `tool_call_id` is unique
+    // per call, which matches the unique-per-event convention the tool_return
+    // and auto_approval wire events already follow.
+    const uuid = toolCallId;
     const entry: PendingToolCallEntry = {
       kind,
       key: toolCallId,

--- a/src/streamJsonAggregator.ts
+++ b/src/streamJsonAggregator.ts
@@ -151,6 +151,25 @@ export class StreamJsonAggregator {
   }
 
   /**
+   * Emit all buffered text / tool-call accumulators in insertion order, then
+   * clear them. Held terminators (stop_reason + usage_statistics from an
+   * approval step) are *not* touched — use {@link releaseHeldTerminators}
+   * for those.
+   *
+   * Call this before emitting a non-chunk event (error, recovery,
+   * auto_approval) from outside the aggregator, so the buffered chunks
+   * appear on the wire before the out-of-band message.
+   */
+  flushPending(): void {
+    if (this.pending.size === 0) return;
+    for (const entry of this.pending.values()) {
+      const wire = this.buildMessageWire(entry.chunk, entry.uuid);
+      writeWireMessage(wire);
+    }
+    this.pending.clear();
+  }
+
+  /**
    * Emit any held `stop_reason` / `usage_statistics` events. Called by the
    * caller after local tool execution (executeApprovalBatch) completes, so
    * that `tool_return_message` events land *before* the step terminators.
@@ -164,8 +183,9 @@ export class StreamJsonAggregator {
   }
 
   /**
-   * Flush all pending buffered events. Safety net for turn-end / abort paths
-   * where `releaseHeldTerminators` may not have been called explicitly.
+   * Flush all pending buffered events and release any held terminators.
+   * Safety net for turn-end / abort paths where `releaseHeldTerminators`
+   * may not have been called explicitly.
    */
   flushAll(): void {
     this.flushPending();
@@ -268,15 +288,6 @@ export class StreamJsonAggregator {
       args: argsDelta,
     };
     this.pending.set(mapKey, entry);
-  }
-
-  private flushPending(): void {
-    if (this.pending.size === 0) return;
-    for (const entry of this.pending.values()) {
-      const wire = this.buildMessageWire(entry.chunk, entry.uuid);
-      writeWireMessage(wire);
-    }
-    this.pending.clear();
   }
 
   private flushToolCall(toolCallId: string): void {

--- a/src/streamJsonAggregator.ts
+++ b/src/streamJsonAggregator.ts
@@ -16,12 +16,15 @@
  *   `tool_call.tool_call_id` are merged on `arguments` concatenation.
  * - `tool_return_message` is never fragmented by the server; it's emitted
  *   directly, and flushes the matching tool_call accumulator first.
- * - `stop_reason: requires_approval` + the following `usage_statistics` are
- *   *held* (buffered) so that `tool_return_message` events can be emitted
- *   before them — matching the logical step boundary. The caller releases
- *   them via `releaseHeldTerminators()` after local tool execution.
- * - `stop_reason` with any other value (e.g. `end_turn`) flushes pending and
- *   emits immediately.
+ * - `stop_reason` and the following `usage_statistics` are *merged inline*
+ *   onto the step's terminating message rather than emitted as separate
+ *   wire events:
+ *     - `end_turn` / `max_steps` / `max_tokens` / `stop_sequence` →
+ *       attached to the last `assistant_message` (fallback `reasoning_message`)
+ *     - `requires_approval` → attached to the `approval_request_message`
+ *     - `error` or no clear target → emitted as standalone events (rare)
+ *   The merged message carries `stop_reason: "<reason>"` and a nested
+ *   `usage: { ... }` block matching the `result` line's usage shape.
  * - Unknown or non-accumulable chunks flush pending first, then pass through.
  *
  * When `passthrough: true` (i.e. `--include-partial-messages`), aggregation
@@ -35,7 +38,11 @@ import type {
   ToolCall,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import { writeWireMessage } from "./streamJsonWriter";
-import type { MessageWire, StreamEvent, WireMessage } from "./types/protocol";
+import type {
+  MessageWire,
+  StreamEvent,
+  UsageStatistics,
+} from "./types/protocol";
 
 type ChunkWithIds = LettaStreamingResponse & {
   id?: string;
@@ -45,7 +52,17 @@ type ChunkWithIds = LettaStreamingResponse & {
 type TextKind = "assistant_message" | "reasoning_message";
 type ToolCallKind = "tool_call_message" | "approval_request_message";
 
-interface PendingTextEntry {
+/**
+ * Fields shared by every pending entry. The `stopReason` and `usage` slots
+ * are populated when the step's terminator events arrive on the stream;
+ * they're rendered inline on the merged wire emission at flush time.
+ */
+interface PendingTerminators {
+  stopReason?: string;
+  usage?: UsageStatistics;
+}
+
+interface PendingTextEntry extends PendingTerminators {
   kind: TextKind;
   key: string;
   uuid: string;
@@ -57,7 +74,7 @@ interface PendingTextEntry {
   text: string;
 }
 
-interface PendingToolCallEntry {
+interface PendingToolCallEntry extends PendingTerminators {
   kind: ToolCallKind;
   key: string; // tool_call_id
   uuid: string;
@@ -85,9 +102,6 @@ export class StreamJsonAggregator {
   // across text and tool-call accumulators — flush emits them in the order
   // they first appeared on the stream.
   private readonly pending = new Map<string, PendingEntry>();
-  // Buffered `stop_reason: requires_approval` + subsequent `usage_statistics`.
-  // Released by `releaseHeldTerminators()` after local tool execution.
-  private readonly heldTerminators: WireMessage[] = [];
 
   constructor(options: AggregatorOptions) {
     this.options = options;
@@ -120,21 +134,34 @@ export class StreamJsonAggregator {
       }
 
       case "stop_reason": {
-        this.flushPending();
         const stopReason = (chunk as { stop_reason?: string }).stop_reason;
-        if (stopReason === "requires_approval") {
-          this.heldTerminators.push(this.buildMessageWire(chunk));
+        if (!stopReason) {
+          // Malformed chunk — preserve ordering and pass through.
+          this.flushPending();
+          this.emitMessage(chunk);
+          return;
+        }
+        const target = this.pickStopReasonTarget(stopReason);
+        if (target) {
+          // Attach inline; do NOT flush yet — we still want to merge the
+          // following `usage_statistics` onto the same message.
+          target.stopReason = stopReason;
         } else {
+          // No clear target (e.g. error stop with no preceding content):
+          // emit as a standalone event after flushing.
+          this.flushPending();
           this.emitMessage(chunk);
         }
         return;
       }
 
       case "usage_statistics": {
-        // If we're holding step terminators (requires_approval path), this
-        // usage_statistics belongs to that step — hold it too.
-        if (this.heldTerminators.length > 0) {
-          this.heldTerminators.push(this.buildMessageWire(chunk));
+        const target = this.findTargetWithStopReason();
+        if (target) {
+          target.usage = this.extractUsage(chunk);
+          // `usage_statistics` is the last server event in a step, so it's
+          // safe to flush all pending entries now (the step is closed).
+          this.flushPending();
         } else {
           this.flushPending();
           this.emitMessage(chunk);
@@ -152,9 +179,10 @@ export class StreamJsonAggregator {
 
   /**
    * Emit all buffered text / tool-call accumulators in insertion order, then
-   * clear them. Held terminators (stop_reason + usage_statistics from an
-   * approval step) are *not* touched — use {@link releaseHeldTerminators}
-   * for those.
+   * clear them.
+   *
+   * Each entry is rendered with its accumulated text/args, and any merged
+   * `stop_reason` / `usage` terminators inline on the wire message.
    *
    * Call this before emitting a non-chunk event (error, recovery,
    * auto_approval) from outside the aggregator, so the buffered chunks
@@ -163,33 +191,20 @@ export class StreamJsonAggregator {
   flushPending(): void {
     if (this.pending.size === 0) return;
     for (const entry of this.pending.values()) {
-      const wire = this.buildMessageWire(entry.chunk, entry.uuid);
-      writeWireMessage(wire);
+      writeWireMessage(this.buildPendingWire(entry));
     }
     this.pending.clear();
   }
 
   /**
-   * Emit any held `stop_reason` / `usage_statistics` events. Called by the
-   * caller after local tool execution (executeApprovalBatch) completes, so
-   * that `tool_return_message` events land *before* the step terminators.
-   */
-  releaseHeldTerminators(): void {
-    if (this.heldTerminators.length === 0) return;
-    for (const msg of this.heldTerminators) {
-      writeWireMessage(msg);
-    }
-    this.heldTerminators.length = 0;
-  }
-
-  /**
-   * Flush all pending buffered events and release any held terminators.
-   * Safety net for turn-end / abort paths where `releaseHeldTerminators`
-   * may not have been called explicitly.
+   * Flush all pending buffered events. Safety net for turn-end / abort paths.
+   *
+   * (Kept as a separate method from `flushPending` so callers can express
+   * intent — "I'm done with this turn" vs "I'm interleaving an out-of-band
+   * event" — even though both currently delegate to the same flush.)
    */
   flushAll(): void {
     this.flushPending();
-    this.releaseHeldTerminators();
   }
 
   // ─────────────────────────── internals ───────────────────────────
@@ -296,10 +311,79 @@ export class StreamJsonAggregator {
     for (const k of [approvalKey, toolCallKey]) {
       const entry = this.pending.get(k);
       if (entry) {
-        writeWireMessage(this.buildMessageWire(entry.chunk, entry.uuid));
+        writeWireMessage(this.buildPendingWire(entry));
         this.pending.delete(k);
       }
     }
+  }
+
+  /**
+   * Pick the pending entry that a `stop_reason` belongs to, based on the
+   * stop reason value:
+   *   - `requires_approval` → the approval_request_message in the step
+   *     (fallback: tool_call_message)
+   *   - any other natural stop (`end_turn`, `max_steps`, `max_tokens`,
+   *     `stop_sequence`, ...) → the last assistant_message
+   *     (fallback: last reasoning_message)
+   *   - `error` and other unknown reasons → undefined (caller emits standalone)
+   */
+  private pickStopReasonTarget(reason: string): PendingEntry | undefined {
+    const entries = Array.from(this.pending.values());
+    if (entries.length === 0) return undefined;
+
+    if (reason === "requires_approval") {
+      // Walk the entries newest-first to pick the most recent matching one.
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const e = entries[i];
+        if (
+          e &&
+          (e.kind === "approval_request_message" ||
+            e.kind === "tool_call_message")
+        ) {
+          return e;
+        }
+      }
+      return undefined;
+    }
+
+    if (reason === "error") {
+      // Errors don't have a clean content target — emit standalone.
+      return undefined;
+    }
+
+    // Default natural-stop behavior: last assistant, fallback last reasoning.
+    let assistant: PendingEntry | undefined;
+    let reasoning: PendingEntry | undefined;
+    for (const e of entries) {
+      if (e.kind === "assistant_message") assistant = e;
+      else if (e.kind === "reasoning_message") reasoning = e;
+    }
+    return assistant ?? reasoning;
+  }
+
+  /**
+   * Locate the pending entry that already has a `stopReason` attached so
+   * we can merge the following `usage_statistics` onto the same message.
+   */
+  private findTargetWithStopReason(): PendingEntry | undefined {
+    for (const e of this.pending.values()) {
+      if (e.stopReason) return e;
+    }
+    return undefined;
+  }
+
+  private extractUsage(chunk: LettaStreamingResponse): UsageStatistics {
+    const c = chunk as Record<string, unknown>;
+    return {
+      prompt_tokens: (c.prompt_tokens as number) ?? 0,
+      completion_tokens: (c.completion_tokens as number) ?? 0,
+      total_tokens: (c.total_tokens as number) ?? 0,
+      step_count: (c.step_count as number) ?? 0,
+      cached_input_tokens: (c.cached_input_tokens as number | null) ?? null,
+      cache_write_tokens: (c.cache_write_tokens as number | null) ?? null,
+      reasoning_tokens: (c.reasoning_tokens as number | null) ?? null,
+      context_tokens: (c.context_tokens as number | null) ?? null,
+    } as UsageStatistics;
   }
 
   private emitMessage(chunk: LettaStreamingResponse): void {
@@ -335,6 +419,18 @@ export class StreamJsonAggregator {
       conversation_id: this.options.conversationId,
       uuid,
     } as MessageWire;
+  }
+
+  /**
+   * Render a pending entry as a wire message, inlining any merged
+   * `stop_reason` / `usage` terminators alongside the accumulated chunk.
+   */
+  private buildPendingWire(entry: PendingEntry): MessageWire {
+    const base = this.buildMessageWire(entry.chunk, entry.uuid) as MessageWire &
+      Record<string, unknown>;
+    if (entry.stopReason) base.stop_reason = entry.stopReason;
+    if (entry.usage) base.usage = entry.usage;
+    return base as MessageWire;
   }
 
   private extractTextDelta(

--- a/src/streamJsonAggregator.ts
+++ b/src/streamJsonAggregator.ts
@@ -1,0 +1,410 @@
+/**
+ * Aggregator for stream-json wire emission.
+ *
+ * The Letta server streams SDK chunks that are fragments of logical messages
+ * — a single assistant_message or approval_request_message typically arrives
+ * as many events with incremental `content` / `arguments` deltas. In
+ * `--output-format stream-json` this used to result in one wire event per
+ * fragment, so consumers saw dozens of tiny `{type:"message", ...}` lines
+ * per turn, many with `arguments: null` or half-JSON strings.
+ *
+ * This module coalesces fragments into one wire event per logical message:
+ *
+ * - `assistant_message` / `reasoning_message` chunks with the same otid (or
+ *   `id` if no otid) are merged on `content` / `reasoning` concatenation.
+ * - `tool_call_message` / `approval_request_message` chunks with the same
+ *   `tool_call.tool_call_id` are merged on `arguments` concatenation.
+ * - `tool_return_message` is never fragmented by the server; it's emitted
+ *   directly, and flushes the matching tool_call accumulator first.
+ * - `stop_reason: requires_approval` + the following `usage_statistics` are
+ *   *held* (buffered) so that `tool_return_message` events can be emitted
+ *   before them — matching the logical step boundary. The caller releases
+ *   them via `releaseHeldTerminators()` after local tool execution.
+ * - `stop_reason` with any other value (e.g. `end_turn`) flushes pending and
+ *   emits immediately.
+ * - Unknown or non-accumulable chunks flush pending first, then pass through.
+ *
+ * When `passthrough: true` (i.e. `--include-partial-messages`), aggregation
+ * is bypassed entirely and chunks are emitted one-to-one as `stream_event`
+ * envelopes, exactly as the pre-aggregator code did.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  LettaStreamingResponse,
+  ToolCall,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import { writeWireMessage } from "./streamJsonWriter";
+import type { MessageWire, StreamEvent, WireMessage } from "./types/protocol";
+
+type ChunkWithIds = LettaStreamingResponse & {
+  id?: string;
+  otid?: string;
+};
+
+type TextKind = "assistant_message" | "reasoning_message";
+type ToolCallKind = "tool_call_message" | "approval_request_message";
+
+interface PendingTextEntry {
+  kind: TextKind;
+  key: string;
+  uuid: string;
+  // The accumulated chunk, with `content` / `reasoning` concatenated.
+  // Stored as a LettaStreamingResponse so we can spread it into a MessageWire
+  // at flush time, preserving all fields (id, otid, model, date, etc.).
+  chunk: LettaStreamingResponse;
+  // Concatenated text (for assistant: content; for reasoning: reasoning).
+  text: string;
+}
+
+interface PendingToolCallEntry {
+  kind: ToolCallKind;
+  key: string; // tool_call_id
+  uuid: string;
+  chunk: LettaStreamingResponse;
+  toolName: string | undefined;
+  args: string; // concatenated arguments JSON text
+}
+
+type PendingEntry = PendingTextEntry | PendingToolCallEntry;
+
+export interface AggregatorOptions {
+  sessionId: string;
+  agentId: string;
+  conversationId: string;
+  /**
+   * When true, bypass aggregation and emit each chunk as a `stream_event`
+   * envelope (matching `--include-partial-messages` behavior).
+   */
+  passthrough: boolean;
+}
+
+export class StreamJsonAggregator {
+  private readonly options: AggregatorOptions;
+  // Single map keyed by `${kind}:${key}` so insertion order is preserved
+  // across text and tool-call accumulators — flush emits them in the order
+  // they first appeared on the stream.
+  private readonly pending = new Map<string, PendingEntry>();
+  // Buffered `stop_reason: requires_approval` + subsequent `usage_statistics`.
+  // Released by `releaseHeldTerminators()` after local tool execution.
+  private readonly heldTerminators: WireMessage[] = [];
+
+  constructor(options: AggregatorOptions) {
+    this.options = options;
+  }
+
+  ingest(chunk: LettaStreamingResponse): void {
+    if (this.options.passthrough) {
+      this.emitStreamEvent(chunk);
+      return;
+    }
+
+    const messageType = (chunk as { message_type?: string }).message_type;
+
+    switch (messageType) {
+      case "assistant_message":
+      case "reasoning_message":
+        this.accumulateText(messageType, chunk as ChunkWithIds);
+        return;
+
+      case "tool_call_message":
+      case "approval_request_message":
+        this.accumulateToolCall(messageType, chunk as ChunkWithIds);
+        return;
+
+      case "tool_return_message": {
+        const toolCallId = (chunk as { tool_call_id?: string }).tool_call_id;
+        if (toolCallId) this.flushToolCall(toolCallId);
+        this.emitMessage(chunk);
+        return;
+      }
+
+      case "stop_reason": {
+        this.flushPending();
+        const stopReason = (chunk as { stop_reason?: string }).stop_reason;
+        if (stopReason === "requires_approval") {
+          this.heldTerminators.push(this.buildMessageWire(chunk));
+        } else {
+          this.emitMessage(chunk);
+        }
+        return;
+      }
+
+      case "usage_statistics": {
+        // If we're holding step terminators (requires_approval path), this
+        // usage_statistics belongs to that step — hold it too.
+        if (this.heldTerminators.length > 0) {
+          this.heldTerminators.push(this.buildMessageWire(chunk));
+        } else {
+          this.flushPending();
+          this.emitMessage(chunk);
+        }
+        return;
+      }
+
+      default:
+        // Unknown or non-accumulable chunk: flush pending so ordering is
+        // preserved, then pass through.
+        this.flushPending();
+        this.emitMessage(chunk);
+    }
+  }
+
+  /**
+   * Emit any held `stop_reason` / `usage_statistics` events. Called by the
+   * caller after local tool execution (executeApprovalBatch) completes, so
+   * that `tool_return_message` events land *before* the step terminators.
+   */
+  releaseHeldTerminators(): void {
+    if (this.heldTerminators.length === 0) return;
+    for (const msg of this.heldTerminators) {
+      writeWireMessage(msg);
+    }
+    this.heldTerminators.length = 0;
+  }
+
+  /**
+   * Flush all pending buffered events. Safety net for turn-end / abort paths
+   * where `releaseHeldTerminators` may not have been called explicitly.
+   */
+  flushAll(): void {
+    this.flushPending();
+    this.releaseHeldTerminators();
+  }
+
+  // ─────────────────────────── internals ───────────────────────────
+
+  private accumulateText(kind: TextKind, chunk: ChunkWithIds): void {
+    const key = chunk.otid ?? chunk.id;
+    if (!key) {
+      // No correlatable key — pass through without merging.
+      this.emitMessage(chunk);
+      return;
+    }
+
+    const mapKey = `${kind}:${key}`;
+    const existing = this.pending.get(mapKey);
+    const delta = this.extractTextDelta(kind, chunk);
+
+    if (existing && existing.kind === kind) {
+      const merged: PendingTextEntry = {
+        ...existing,
+        text: existing.text + delta,
+        chunk: this.mergeTextChunk(
+          kind,
+          existing.chunk,
+          chunk,
+          existing.text + delta,
+        ),
+      };
+      this.pending.set(mapKey, merged);
+      return;
+    }
+
+    // New entry.
+    const uuid = chunk.otid ?? chunk.id ?? randomUUID();
+    const entry: PendingTextEntry = {
+      kind,
+      key,
+      uuid,
+      chunk: this.mergeTextChunk(kind, undefined, chunk, delta),
+      text: delta,
+    };
+    this.pending.set(mapKey, entry);
+  }
+
+  private accumulateToolCall(kind: ToolCallKind, chunk: ChunkWithIds): void {
+    const toolCall = this.extractToolCall(chunk);
+    if (!toolCall?.tool_call_id) {
+      this.emitMessage(chunk);
+      return;
+    }
+
+    const toolCallId = toolCall.tool_call_id;
+    const mapKey = `${kind}:${toolCallId}`;
+    const existing = this.pending.get(mapKey);
+    const argsDelta = toolCall.arguments ?? "";
+    const name = toolCall.name ?? undefined;
+
+    if (existing && existing.kind === kind) {
+      const mergedArgs = existing.args + argsDelta;
+      // Prefer the first non-empty name seen. Backend sometimes streams
+      // the tool's name on a later chunk after the initial args delta.
+      const mergedName =
+        existing.toolName && existing.toolName.length > 0
+          ? existing.toolName
+          : name;
+      const merged: PendingToolCallEntry = {
+        ...existing,
+        toolName: mergedName,
+        args: mergedArgs,
+        chunk: this.mergeToolCallChunk(
+          kind,
+          existing.chunk,
+          chunk,
+          toolCallId,
+          mergedName,
+          mergedArgs,
+        ),
+      };
+      this.pending.set(mapKey, merged);
+      return;
+    }
+
+    const uuid = chunk.otid ?? chunk.id ?? toolCallId;
+    const entry: PendingToolCallEntry = {
+      kind,
+      key: toolCallId,
+      uuid,
+      chunk: this.mergeToolCallChunk(
+        kind,
+        undefined,
+        chunk,
+        toolCallId,
+        name,
+        argsDelta,
+      ),
+      toolName: name,
+      args: argsDelta,
+    };
+    this.pending.set(mapKey, entry);
+  }
+
+  private flushPending(): void {
+    if (this.pending.size === 0) return;
+    for (const entry of this.pending.values()) {
+      const wire = this.buildMessageWire(entry.chunk, entry.uuid);
+      writeWireMessage(wire);
+    }
+    this.pending.clear();
+  }
+
+  private flushToolCall(toolCallId: string): void {
+    const approvalKey = `approval_request_message:${toolCallId}`;
+    const toolCallKey = `tool_call_message:${toolCallId}`;
+    for (const k of [approvalKey, toolCallKey]) {
+      const entry = this.pending.get(k);
+      if (entry) {
+        writeWireMessage(this.buildMessageWire(entry.chunk, entry.uuid));
+        this.pending.delete(k);
+      }
+    }
+  }
+
+  private emitMessage(chunk: LettaStreamingResponse): void {
+    writeWireMessage(this.buildMessageWire(chunk));
+  }
+
+  private emitStreamEvent(chunk: LettaStreamingResponse): void {
+    const chunkWithIds = chunk as ChunkWithIds;
+    const uuid = chunkWithIds.otid ?? chunkWithIds.id ?? randomUUID();
+    const env: StreamEvent = {
+      type: "stream_event",
+      event: chunk,
+      session_id: this.options.sessionId,
+      agent_id: this.options.agentId,
+      conversation_id: this.options.conversationId,
+      uuid,
+    };
+    writeWireMessage(env);
+  }
+
+  private buildMessageWire(
+    chunk: LettaStreamingResponse,
+    explicitUuid?: string,
+  ): MessageWire {
+    const chunkWithIds = chunk as ChunkWithIds;
+    const uuid =
+      explicitUuid ?? chunkWithIds.otid ?? chunkWithIds.id ?? randomUUID();
+    return {
+      type: "message",
+      ...chunk,
+      session_id: this.options.sessionId,
+      agent_id: this.options.agentId,
+      conversation_id: this.options.conversationId,
+      uuid,
+    } as MessageWire;
+  }
+
+  private extractTextDelta(
+    kind: TextKind,
+    chunk: LettaStreamingResponse,
+  ): string {
+    if (kind === "reasoning_message") {
+      const r = (chunk as { reasoning?: string }).reasoning;
+      return typeof r === "string" ? r : "";
+    }
+    // assistant_message: content may be a string (streaming delta) or an
+    // array of content parts; extract text either way.
+    const content = (chunk as { content?: unknown }).content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (part && typeof part === "object" && "text" in part) {
+            const text = (part as { text?: unknown }).text;
+            return typeof text === "string" ? text : "";
+          }
+          return "";
+        })
+        .join("");
+    }
+    return "";
+  }
+
+  private mergeTextChunk(
+    kind: TextKind,
+    prior: LettaStreamingResponse | undefined,
+    incoming: LettaStreamingResponse,
+    mergedText: string,
+  ): LettaStreamingResponse {
+    // Start from the latest chunk to carry its latest metadata (id, otid,
+    // date, etc.), overwriting the content field with the merged text.
+    const base = prior ? { ...prior, ...incoming } : { ...incoming };
+    if (kind === "reasoning_message") {
+      return { ...base, reasoning: mergedText } as LettaStreamingResponse;
+    }
+    return { ...base, content: mergedText } as LettaStreamingResponse;
+  }
+
+  private extractToolCall(chunk: LettaStreamingResponse): ToolCall | undefined {
+    const withToolCall = chunk as {
+      tool_call?: ToolCall;
+      tool_calls?: ToolCall[];
+    };
+    if (withToolCall.tool_call) return withToolCall.tool_call;
+    if (
+      Array.isArray(withToolCall.tool_calls) &&
+      withToolCall.tool_calls.length > 0
+    ) {
+      return withToolCall.tool_calls[0];
+    }
+    return undefined;
+  }
+
+  private mergeToolCallChunk(
+    kind: ToolCallKind,
+    prior: LettaStreamingResponse | undefined,
+    incoming: LettaStreamingResponse,
+    toolCallId: string,
+    toolName: string | undefined,
+    mergedArgs: string,
+  ): LettaStreamingResponse {
+    const base = prior ? { ...prior, ...incoming } : { ...incoming };
+    const mergedToolCall = {
+      tool_call_id: toolCallId,
+      name: toolName ?? "",
+      arguments: mergedArgs,
+    };
+    // Normalize to `tool_call` field; some server paths use `tool_calls[]`.
+    // Consumers of the merged output should find the complete info in either
+    // field. We clear the array form to avoid stale partial entries.
+    void kind;
+    return {
+      ...base,
+      tool_call: mergedToolCall,
+      tool_calls: [mergedToolCall],
+    } as LettaStreamingResponse;
+  }
+}

--- a/src/streamJsonWriter.ts
+++ b/src/streamJsonWriter.ts
@@ -23,9 +23,16 @@
 import type { WireMessage } from "./types/protocol";
 
 export function writeWireMessage(msg: WireMessage): void {
+  // Strip the server-origin `date` field (second precision, +00:00) if
+  // present. `timestamp` (CLI-stamped, ms + Z) is the canonical time source
+  // for stream-json consumers; `date` is a redundant duplicate that diverges
+  // on both field name and format.
+  const { date: _date, ...withoutDate } = msg as typeof msg & {
+    date?: string;
+  };
   const stamped =
-    msg.timestamp === undefined
-      ? { ...msg, timestamp: new Date().toISOString() }
-      : msg;
+    withoutDate.timestamp === undefined
+      ? { ...withoutDate, timestamp: new Date().toISOString() }
+      : withoutDate;
   console.log(JSON.stringify(stamped));
 }

--- a/src/tests/headless/stream-json-aggregator.test.ts
+++ b/src/tests/headless/stream-json-aggregator.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { StreamJsonAggregator } from "../../streamJsonAggregator";
+
+// The aggregator emits via writeWireMessage → console.log(JSON.stringify(...)).
+// We capture console.log to inspect emissions.
+const originalConsoleLog = console.log;
+let consoleLog: ReturnType<typeof mock>;
+
+function getEmissions(): Array<Record<string, unknown>> {
+  return consoleLog.mock.calls.map(
+    (args) => JSON.parse(String(args[0])) as Record<string, unknown>,
+  );
+}
+
+/** Get the Nth emission or fail the test. Keeps call sites clean. */
+function emission(n: number): Record<string, unknown> {
+  const emissions = getEmissions();
+  const e = emissions[n];
+  if (e === undefined) {
+    throw new Error(
+      `expected at least ${n + 1} emissions, got ${emissions.length}`,
+    );
+  }
+  return e;
+}
+
+function aggregator(
+  overrides: Partial<{
+    sessionId: string;
+    agentId: string;
+    conversationId: string;
+    passthrough: boolean;
+  }> = {},
+): StreamJsonAggregator {
+  return new StreamJsonAggregator({
+    sessionId: "session-1",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    passthrough: false,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  consoleLog = mock((..._args: unknown[]) => {});
+  console.log = consoleLog as typeof console.log;
+});
+
+afterEach(() => {
+  console.log = originalConsoleLog;
+});
+
+describe("StreamJsonAggregator", () => {
+  test("coalesces two assistant_message chunks with the same otid", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      id: "msg-1",
+      otid: "otid-a",
+      content: "Hello ",
+    } as never);
+    agg.ingest({
+      message_type: "assistant_message",
+      id: "msg-1",
+      otid: "otid-a",
+      content: "world",
+    } as never);
+    // Nothing emitted yet — waiting for a flush trigger.
+    expect(getEmissions()).toHaveLength(0);
+
+    agg.flushAll();
+    const out = emission(0);
+    expect(out.message_type).toBe("assistant_message");
+    expect(out.content).toBe("Hello world");
+    expect(out.otid).toBe("otid-a");
+    expect(out.uuid).toBe("otid-a");
+    expect(out.session_id).toBe("session-1");
+  });
+
+  test("coalesces two reasoning_message chunks with the same otid", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "reasoning_message",
+      id: "rmsg-1",
+      otid: "otid-r",
+      reasoning: "Let me think ",
+    } as never);
+    agg.ingest({
+      message_type: "reasoning_message",
+      id: "rmsg-1",
+      otid: "otid-r",
+      reasoning: "about this.",
+    } as never);
+    agg.flushAll();
+
+    const out = emission(0);
+    expect(out.message_type).toBe("reasoning_message");
+    expect(out.reasoning).toBe("Let me think about this.");
+  });
+
+  test("coalesces tool_call_message arguments with the same tool_call_id", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "tool_call_message",
+      otid: "otid-tc",
+      tool_call: {
+        tool_call_id: "call-1",
+        name: "Read",
+        arguments: '{"file":"',
+      },
+    } as never);
+    agg.ingest({
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-1",
+        name: "Read",
+        arguments: "/tmp/x.txt",
+      },
+    } as never);
+    agg.ingest({
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-1",
+        name: "Read",
+        arguments: '"}',
+      },
+    } as never);
+    agg.flushAll();
+
+    const out = emission(0);
+    expect(out.message_type).toBe("tool_call_message");
+    const toolCall = out.tool_call as Record<string, string>;
+    expect(toolCall.tool_call_id).toBe("call-1");
+    expect(toolCall.name).toBe("Read");
+    expect(toolCall.arguments).toBe('{"file":"/tmp/x.txt"}');
+    // Parse as valid JSON — the whole point of coalescing.
+    expect(() => JSON.parse(toolCall.arguments as string)).not.toThrow();
+  });
+
+  test("coalesces approval_request_message arguments with the same tool_call_id", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "approval_request_message",
+      otid: "otid-ap",
+      tool_call: {
+        tool_call_id: "call-ap",
+        name: "Bash",
+        arguments: null,
+      },
+    } as never);
+    agg.ingest({
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "call-ap",
+        name: "Bash",
+        arguments: '{"command":"ls"}',
+      },
+    } as never);
+    agg.flushAll();
+
+    const out = emission(0);
+    expect(out.message_type).toBe("approval_request_message");
+    const toolCall = out.tool_call as Record<string, unknown>;
+    expect(toolCall.arguments).toBe('{"command":"ls"}');
+    // Previous `arguments: null` chunk is not visible.
+  });
+
+  test("tool_return_message flushes its matching tool_call first, then passes through", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "call-42",
+        name: "Read",
+        arguments: '{"file":"x"}',
+      },
+    } as never);
+    // No flush yet.
+    expect(getEmissions()).toHaveLength(0);
+
+    agg.ingest({
+      message_type: "tool_return_message",
+      tool_call_id: "call-42",
+      tool_return: "contents",
+      status: "success",
+    } as never);
+
+    // Both emitted: the flushed tool call first, then the tool return.
+    expect(getEmissions()).toHaveLength(2);
+    expect(emission(0).message_type).toBe("approval_request_message");
+    expect(emission(1).message_type).toBe("tool_return_message");
+  });
+
+  test("stop_reason: end_turn flushes pending and emits immediately", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-final",
+      content: "All done.",
+    } as never);
+
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as never);
+
+    expect(getEmissions()).toHaveLength(2);
+    expect(emission(0).message_type).toBe("assistant_message");
+    expect(emission(0).content).toBe("All done.");
+    expect(emission(1).message_type).toBe("stop_reason");
+    expect(emission(1).stop_reason).toBe("end_turn");
+  });
+
+  test("stop_reason: requires_approval flushes pending but holds itself + usage_statistics", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "call-hold",
+        name: "Bash",
+        arguments: '{"command":"ls"}',
+      },
+    } as never);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "requires_approval",
+    } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      completion_tokens: 10,
+      prompt_tokens: 100,
+    } as never);
+
+    // Only the approval_request_message should have been emitted so far.
+    expect(getEmissions()).toHaveLength(1);
+    expect(emission(0).message_type).toBe("approval_request_message");
+
+    // Releasing now emits the held terminators in insertion order.
+    agg.releaseHeldTerminators();
+    expect(getEmissions()).toHaveLength(3);
+    expect(emission(1).message_type).toBe("stop_reason");
+    expect(emission(1).stop_reason).toBe("requires_approval");
+    expect(emission(2).message_type).toBe("usage_statistics");
+  });
+
+  test("releaseHeldTerminators is a no-op when nothing is held", () => {
+    const agg = aggregator();
+    agg.releaseHeldTerminators();
+    expect(getEmissions()).toHaveLength(0);
+  });
+
+  test("flushAll emits pending + held in one sweep (abort/safety-net path)", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-x",
+      content: "partial thought",
+    } as never);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "requires_approval",
+    } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      completion_tokens: 5,
+    } as never);
+
+    agg.flushAll();
+    const emissions = getEmissions();
+    expect(emissions.map((e) => e.message_type)).toEqual([
+      "assistant_message",
+      "stop_reason",
+      "usage_statistics",
+    ]);
+  });
+
+  test("passthrough mode emits each chunk as a stream_event envelope", () => {
+    const agg = aggregator({ passthrough: true });
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-p",
+      content: "Hello ",
+    } as never);
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-p",
+      content: "world",
+    } as never);
+    // No flush required — passthrough is immediate.
+    expect(getEmissions()).toHaveLength(2);
+    expect(emission(0).type).toBe("stream_event");
+    expect(emission(1).type).toBe("stream_event");
+    expect((emission(0) as { event: { content: string } }).event.content).toBe(
+      "Hello ",
+    );
+    expect((emission(1) as { event: { content: string } }).event.content).toBe(
+      "world",
+    );
+  });
+
+  test("unknown chunk types flush pending first, then pass through", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-u",
+      content: "hi",
+    } as never);
+    // Unknown type — should flush the assistant_message then pass through.
+    agg.ingest({
+      message_type: "some_future_type",
+      some_field: "value",
+    } as never);
+
+    expect(getEmissions()).toHaveLength(2);
+    expect(emission(0).message_type).toBe("assistant_message");
+    expect(emission(0).content).toBe("hi");
+    expect(emission(1).message_type).toBe("some_future_type");
+  });
+
+  test("chunks without an otid or id fall back to randomUUID and pass through", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      content: "no correlatable id",
+    } as never);
+
+    // Should emit immediately (can't merge without a key) — flushAll sweeps
+    // nothing since nothing is pending.
+    expect(getEmissions()).toHaveLength(1);
+    expect(emission(0).message_type).toBe("assistant_message");
+    expect(emission(0).content).toBe("no correlatable id");
+    expect(typeof emission(0).uuid).toBe("string");
+  });
+
+  test("preserves first-seen order across kinds on flush", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "reasoning_message",
+      otid: "otid-r",
+      reasoning: "first",
+    } as never);
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-a",
+      content: "second",
+    } as never);
+    agg.ingest({
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "call-3",
+        name: "Read",
+        arguments: "{}",
+      },
+    } as never);
+
+    agg.flushAll();
+    const types = getEmissions().map((e) => e.message_type);
+    expect(types).toEqual([
+      "reasoning_message",
+      "assistant_message",
+      "approval_request_message",
+    ]);
+  });
+
+  test("envelope fields (session_id, agent_id, conversation_id) are stamped on coalesced messages", () => {
+    const agg = aggregator({
+      sessionId: "S",
+      agentId: "A",
+      conversationId: "C",
+    });
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-e",
+      content: "hi",
+    } as never);
+    agg.flushAll();
+
+    const out = emission(0);
+    expect(out.type).toBe("message");
+    expect(out.session_id).toBe("S");
+    expect(out.agent_id).toBe("A");
+    expect(out.conversation_id).toBe("C");
+    expect(out.uuid).toBe("otid-e");
+  });
+
+  test("late name metadata on tool_call chunks is preserved across merge", () => {
+    const agg = aggregator();
+    // First chunk has no name (backend sometimes streams args first).
+    agg.ingest({
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-late",
+        name: "",
+        arguments: '{"a":',
+      },
+    } as never);
+    // Second chunk carries the name.
+    agg.ingest({
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-late",
+        name: "Glob",
+        arguments: '"1"}',
+      },
+    } as never);
+    agg.flushAll();
+
+    const out = emission(0);
+    const toolCall = out.tool_call as Record<string, string>;
+    expect(toolCall.name).toBe("Glob");
+    expect(toolCall.arguments).toBe('{"a":"1"}');
+  });
+});

--- a/src/tests/headless/stream-json-aggregator.test.ts
+++ b/src/tests/headless/stream-json-aggregator.test.ts
@@ -191,7 +191,7 @@ describe("StreamJsonAggregator", () => {
     expect(emission(1).message_type).toBe("tool_return_message");
   });
 
-  test("stop_reason: end_turn flushes pending and emits immediately", () => {
+  test("stop_reason: end_turn merges inline onto the last assistant_message", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "assistant_message",
@@ -203,20 +203,55 @@ describe("StreamJsonAggregator", () => {
       message_type: "stop_reason",
       stop_reason: "end_turn",
     } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      completion_tokens: 7,
+      prompt_tokens: 11,
+      total_tokens: 18,
+      step_count: 1,
+    } as never);
 
-    expect(getEmissions()).toHaveLength(2);
+    // One coalesced wire event carrying content + stop_reason + usage.
+    expect(getEmissions()).toHaveLength(1);
     expect(emission(0).message_type).toBe("assistant_message");
     expect(emission(0).content).toBe("All done.");
-    expect(emission(1).message_type).toBe("stop_reason");
-    expect(emission(1).stop_reason).toBe("end_turn");
+    expect(emission(0).stop_reason).toBe("end_turn");
+    expect(emission(0).usage).toMatchObject({
+      completion_tokens: 7,
+      prompt_tokens: 11,
+      total_tokens: 18,
+      step_count: 1,
+    });
   });
 
-  test("stop_reason: requires_approval flushes pending but holds itself + usage_statistics", () => {
+  test("stop_reason: end_turn falls back to last reasoning_message when no assistant present", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "reasoning_message",
+      otid: "reason-1",
+      reasoning: "thinking...",
+    } as never);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      completion_tokens: 1,
+    } as never);
+
+    expect(getEmissions()).toHaveLength(1);
+    expect(emission(0).message_type).toBe("reasoning_message");
+    expect(emission(0).stop_reason).toBe("end_turn");
+    expect(emission(0).usage).toMatchObject({ completion_tokens: 1 });
+  });
+
+  test("stop_reason: requires_approval merges inline onto the approval_request_message", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "approval_request_message",
       tool_call: {
-        tool_call_id: "call-hold",
+        tool_call_id: "call-merge",
         name: "Bash",
         arguments: '{"command":"ls"}',
       },
@@ -229,49 +264,55 @@ describe("StreamJsonAggregator", () => {
       message_type: "usage_statistics",
       completion_tokens: 10,
       prompt_tokens: 100,
+      step_count: 1,
     } as never);
 
-    // Only the approval_request_message should have been emitted so far.
+    // Single wire event carrying tool_call + stop_reason + usage inline.
     expect(getEmissions()).toHaveLength(1);
     expect(emission(0).message_type).toBe("approval_request_message");
-
-    // Releasing now emits the held terminators in insertion order.
-    agg.releaseHeldTerminators();
-    expect(getEmissions()).toHaveLength(3);
-    expect(emission(1).message_type).toBe("stop_reason");
-    expect(emission(1).stop_reason).toBe("requires_approval");
-    expect(emission(2).message_type).toBe("usage_statistics");
+    expect(emission(0).stop_reason).toBe("requires_approval");
+    expect(emission(0).usage).toMatchObject({
+      completion_tokens: 10,
+      prompt_tokens: 100,
+      step_count: 1,
+    });
   });
 
-  test("releaseHeldTerminators is a no-op when nothing is held", () => {
+  test("stop_reason: error with no content target emits standalone", () => {
     const agg = aggregator();
-    agg.releaseHeldTerminators();
-    expect(getEmissions()).toHaveLength(0);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "error",
+    } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      completion_tokens: 0,
+    } as never);
+
+    // No content message to attach to → both emit as separate events.
+    const emissions = getEmissions();
+    expect(emissions.map((e) => e.message_type)).toEqual([
+      "stop_reason",
+      "usage_statistics",
+    ]);
+    expect(emission(0).stop_reason).toBe("error");
   });
 
-  test("flushAll emits pending + held in one sweep (abort/safety-net path)", () => {
+  test("flushAll emits pending entries even when terminators never arrive (abort path)", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "assistant_message",
       otid: "otid-x",
       content: "partial thought",
     } as never);
-    agg.ingest({
-      message_type: "stop_reason",
-      stop_reason: "requires_approval",
-    } as never);
-    agg.ingest({
-      message_type: "usage_statistics",
-      completion_tokens: 5,
-    } as never);
 
+    // No stop_reason / usage_statistics ever arrive (abort mid-stream).
     agg.flushAll();
     const emissions = getEmissions();
-    expect(emissions.map((e) => e.message_type)).toEqual([
-      "assistant_message",
-      "stop_reason",
-      "usage_statistics",
-    ]);
+    expect(emissions.map((e) => e.message_type)).toEqual(["assistant_message"]);
+    // No stop_reason / usage on the message since none arrived.
+    expect(emission(0).stop_reason).toBeUndefined();
+    expect(emission(0).usage).toBeUndefined();
   });
 
   test("passthrough mode emits each chunk as a stream_event envelope", () => {

--- a/src/tests/headless/stream-json-aggregator.test.ts
+++ b/src/tests/headless/stream-json-aggregator.test.ts
@@ -163,6 +163,57 @@ describe("StreamJsonAggregator", () => {
     const toolCall = out.tool_call as Record<string, unknown>;
     expect(toolCall.arguments).toBe('{"command":"ls"}');
     // Previous `arguments: null` chunk is not visible.
+    // Wire uuid is derived from tool_call_id, not the shared otid.
+    expect(out.uuid).toBe("call-ap");
+  });
+
+  test("parallel tool calls in the same server message get distinct wire uuids", () => {
+    // Server often emits multiple tool calls in a single message (shared
+    // otid/id). Each emission must end up with a distinct uuid derived from
+    // its tool_call_id — otherwise consumers can't tell the events apart.
+    const agg = aggregator();
+    const sharedOtid = "message-parallel";
+    agg.ingest({
+      message_type: "approval_request_message",
+      id: sharedOtid,
+      otid: sharedOtid,
+      tool_call: {
+        tool_call_id: "call-a",
+        name: "Read",
+        arguments: '{"file":"a"}',
+      },
+    } as never);
+    agg.ingest({
+      message_type: "approval_request_message",
+      id: sharedOtid,
+      otid: sharedOtid,
+      tool_call: {
+        tool_call_id: "call-b",
+        name: "Read",
+        arguments: '{"file":"b"}',
+      },
+    } as never);
+    agg.ingest({
+      message_type: "approval_request_message",
+      id: sharedOtid,
+      otid: sharedOtid,
+      tool_call: {
+        tool_call_id: "call-c",
+        name: "Read",
+        arguments: '{"file":"c"}',
+      },
+    } as never);
+    agg.flushAll();
+
+    const emissions = getEmissions();
+    expect(emissions).toHaveLength(3);
+    const uuids = emissions.map((e) => e.uuid);
+    expect(uuids).toEqual(["call-a", "call-b", "call-c"]);
+    // Each emission's uuid matches its own tool_call_id.
+    for (const e of emissions) {
+      const tc = e.tool_call as Record<string, unknown>;
+      expect(e.uuid).toBe(tc.tool_call_id);
+    }
   });
 
   test("tool_return_message flushes its matching tool_call first, then passes through", () => {

--- a/src/tests/headless/stream-json-aggregator.test.ts
+++ b/src/tests/headless/stream-json-aggregator.test.ts
@@ -242,11 +242,12 @@ describe("StreamJsonAggregator", () => {
     expect(emission(1).message_type).toBe("tool_return_message");
   });
 
-  test("stop_reason: end_turn merges inline onto the last assistant_message", () => {
+  test("emits step_end after assistant_message when stop_reason is end_turn", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "assistant_message",
       otid: "otid-final",
+      step_id: "step-123",
       content: "All done.",
     } as never);
 
@@ -262,12 +263,19 @@ describe("StreamJsonAggregator", () => {
       step_count: 1,
     } as never);
 
-    // One coalesced wire event carrying content + stop_reason + usage.
-    expect(getEmissions()).toHaveLength(1);
+    // Content message first (clean, no terminators inline), then step_end.
+    const emissions = getEmissions();
+    expect(emissions).toHaveLength(2);
+
     expect(emission(0).message_type).toBe("assistant_message");
     expect(emission(0).content).toBe("All done.");
-    expect(emission(0).stop_reason).toBe("end_turn");
-    expect(emission(0).usage).toMatchObject({
+    expect(emission(0).stop_reason).toBeUndefined();
+    expect(emission(0).usage).toBeUndefined();
+
+    expect(emission(1).type).toBe("step_end");
+    expect(emission(1).stop_reason).toBe("end_turn");
+    expect(emission(1).step_id).toBe("step-123");
+    expect(emission(1).usage).toMatchObject({
       completion_tokens: 7,
       prompt_tokens: 11,
       total_tokens: 18,
@@ -275,34 +283,13 @@ describe("StreamJsonAggregator", () => {
     });
   });
 
-  test("stop_reason: end_turn falls back to last reasoning_message when no assistant present", () => {
-    const agg = aggregator();
-    agg.ingest({
-      message_type: "reasoning_message",
-      otid: "reason-1",
-      reasoning: "thinking...",
-    } as never);
-    agg.ingest({
-      message_type: "stop_reason",
-      stop_reason: "end_turn",
-    } as never);
-    agg.ingest({
-      message_type: "usage_statistics",
-      completion_tokens: 1,
-    } as never);
-
-    expect(getEmissions()).toHaveLength(1);
-    expect(emission(0).message_type).toBe("reasoning_message");
-    expect(emission(0).stop_reason).toBe("end_turn");
-    expect(emission(0).usage).toMatchObject({ completion_tokens: 1 });
-  });
-
-  test("stop_reason: requires_approval merges inline onto the approval_request_message", () => {
+  test("emits step_end after approval_request_message when stop_reason is requires_approval", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "approval_request_message",
+      step_id: "step-appr",
       tool_call: {
-        tool_call_id: "call-merge",
+        tool_call_id: "call-approve",
         name: "Bash",
         arguments: '{"command":"ls"}',
       },
@@ -318,38 +305,112 @@ describe("StreamJsonAggregator", () => {
       step_count: 1,
     } as never);
 
-    // Single wire event carrying tool_call + stop_reason + usage inline.
-    expect(getEmissions()).toHaveLength(1);
+    const emissions = getEmissions();
+    expect(emissions).toHaveLength(2);
+
     expect(emission(0).message_type).toBe("approval_request_message");
-    expect(emission(0).stop_reason).toBe("requires_approval");
-    expect(emission(0).usage).toMatchObject({
+    expect(emission(0).stop_reason).toBeUndefined();
+    expect(emission(0).usage).toBeUndefined();
+
+    expect(emission(1).type).toBe("step_end");
+    expect(emission(1).stop_reason).toBe("requires_approval");
+    expect(emission(1).step_id).toBe("step-appr");
+    expect(emission(1).usage).toMatchObject({
       completion_tokens: 10,
       prompt_tokens: 100,
       step_count: 1,
     });
   });
 
-  test("stop_reason: error with no content target emits standalone", () => {
+  test("step_end is uniform across multi-message steps (parallel tool calls)", () => {
+    // Server emits three parallel approval_request_messages in one step;
+    // step_end should fire once after all three content messages, carrying
+    // the step's stop_reason and usage.
     const agg = aggregator();
+    for (const toolCallId of ["call-a", "call-b", "call-c"]) {
+      agg.ingest({
+        message_type: "approval_request_message",
+        step_id: "step-parallel",
+        tool_call: {
+          tool_call_id: toolCallId,
+          name: "Read",
+          arguments: `{"file":"${toolCallId}"}`,
+        },
+      } as never);
+    }
     agg.ingest({
       message_type: "stop_reason",
-      stop_reason: "error",
+      stop_reason: "requires_approval",
     } as never);
     agg.ingest({
       message_type: "usage_statistics",
-      completion_tokens: 0,
+      total_tokens: 42,
     } as never);
 
-    // No content message to attach to → both emit as separate events.
     const emissions = getEmissions();
-    expect(emissions.map((e) => e.message_type)).toEqual([
-      "stop_reason",
-      "usage_statistics",
+    expect(emissions).toHaveLength(4);
+    expect(emissions.slice(0, 3).map((e) => e.message_type)).toEqual([
+      "approval_request_message",
+      "approval_request_message",
+      "approval_request_message",
     ]);
-    expect(emission(0).stop_reason).toBe("error");
+    // None of the content messages carry inline terminators.
+    for (let i = 0; i < 3; i++) {
+      expect(emission(i).stop_reason).toBeUndefined();
+      expect(emission(i).usage).toBeUndefined();
+    }
+    expect(emission(3).type).toBe("step_end");
+    expect(emission(3).stop_reason).toBe("requires_approval");
+    expect(emission(3).step_id).toBe("step-parallel");
+    expect(emission(3).usage).toMatchObject({ total_tokens: 42 });
   });
 
-  test("flushAll emits pending entries even when terminators never arrive (abort path)", () => {
+  test("stop_reason without step_id on content omits step_id from step_end", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-no-step",
+      content: "hi",
+    } as never);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as never);
+    agg.ingest({
+      message_type: "usage_statistics",
+      total_tokens: 5,
+    } as never);
+
+    expect(emission(1).type).toBe("step_end");
+    expect(emission(1).step_id).toBeUndefined();
+    expect(emission(1).stop_reason).toBe("end_turn");
+  });
+
+  test("flushAll emits step_end with usage=null when usage_statistics never arrives", () => {
+    const agg = aggregator();
+    agg.ingest({
+      message_type: "assistant_message",
+      otid: "otid-abort",
+      step_id: "step-abort",
+      content: "partial",
+    } as never);
+    agg.ingest({
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as never);
+    // usage_statistics never arrives (abort path).
+    agg.flushAll();
+
+    const emissions = getEmissions();
+    expect(emissions.map((e) => e.message_type ?? e.type)).toEqual([
+      "assistant_message",
+      "step_end",
+    ]);
+    expect(emission(1).stop_reason).toBe("end_turn");
+    expect(emission(1).usage).toBeNull();
+  });
+
+  test("flushAll emits pending content even when no terminators arrive", () => {
     const agg = aggregator();
     agg.ingest({
       message_type: "assistant_message",
@@ -357,13 +418,12 @@ describe("StreamJsonAggregator", () => {
       content: "partial thought",
     } as never);
 
-    // No stop_reason / usage_statistics ever arrive (abort mid-stream).
+    // No stop_reason / usage_statistics ever arrive (abort mid-stream before
+    // the server emitted any step terminator at all).
     agg.flushAll();
     const emissions = getEmissions();
-    expect(emissions.map((e) => e.message_type)).toEqual(["assistant_message"]);
-    // No stop_reason / usage on the message since none arrived.
-    expect(emission(0).stop_reason).toBeUndefined();
-    expect(emission(0).usage).toBeUndefined();
+    expect(emissions).toHaveLength(1);
+    expect(emission(0).message_type).toBe("assistant_message");
   });
 
   test("passthrough mode emits each chunk as a stream_event envelope", () => {

--- a/src/tests/headless/stream-json-writer.test.ts
+++ b/src/tests/headless/stream-json-writer.test.ts
@@ -59,4 +59,63 @@ describe("writeWireMessage", () => {
     };
     expect(payload.timestamp).toBe("2026-04-21T23:59:59.000Z");
   });
+
+  test("strips the server-origin `date` field from emitted payloads", () => {
+    const consoleLog = mock((..._args: unknown[]) => {});
+    console.log = consoleLog as typeof console.log;
+
+    const msg: MessageWire = {
+      type: "message",
+      session_id: "session-1",
+      uuid: "uuid-1",
+      message_type: "assistant_message",
+      id: "msg-1",
+      date: "2026-04-22T00:00:00+00:00",
+      content: [{ type: "text", text: "hi" }],
+    };
+
+    writeWireMessage(msg);
+
+    const firstCall = consoleLog.mock.calls[0];
+    const payload = JSON.parse(String(firstCall?.[0])) as Record<
+      string,
+      unknown
+    >;
+
+    expect(payload).not.toHaveProperty("date");
+    expect(payload.timestamp).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+    // Other fields unaffected.
+    expect(payload.message_type).toBe("assistant_message");
+    expect(payload.id).toBe("msg-1");
+    expect(payload.session_id).toBe("session-1");
+  });
+
+  test("leaves messages without `date` unaffected", () => {
+    const consoleLog = mock((..._args: unknown[]) => {});
+    console.log = consoleLog as typeof console.log;
+
+    const msg: MessageWire = {
+      type: "message",
+      session_id: "session-1",
+      uuid: "uuid-1",
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    };
+
+    writeWireMessage(msg);
+
+    const firstCall = consoleLog.mock.calls[0];
+    const payload = JSON.parse(String(firstCall?.[0])) as Record<
+      string,
+      unknown
+    >;
+
+    expect(payload).not.toHaveProperty("date");
+    expect(payload.stop_reason).toBe("end_turn");
+    expect(payload.timestamp).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+  });
 });

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -303,6 +303,26 @@ export interface CancelAckMessage extends MessageEnvelope {
   reason?: string;
 }
 
+/**
+ * Marks the end of a server-side step. Combines the server's `stop_reason`
+ * and `usage_statistics` chunks into a single wire event so consumers can
+ * observe a clean step boundary without hunting for two separate messages.
+ *
+ * Emitted after all content messages (`assistant_message`,
+ * `reasoning_message`, `tool_call_message`, `approval_request_message`) for
+ * the step have been flushed, and before any client-side markers
+ * (`auto_approval`, `tool_return_message`) for tools invoked in that step.
+ */
+export interface StepEndMessage extends MessageEnvelope {
+  type: "step_end";
+  /** Why the step ended — e.g. `end_turn`, `requires_approval`, `max_steps`. */
+  stop_reason: string;
+  /** Server step identifier for the step that just ended, if available. */
+  step_id?: string;
+  /** Usage statistics for the step. May be null for error paths. */
+  usage: UsageStatistics | null;
+}
+
 // ═══════════════════════════════════════════════════════════════
 // RESULT
 // ═══════════════════════════════════════════════════════════════
@@ -886,6 +906,7 @@ export type WireMessage =
   | ErrorMessage
   | RetryMessage
   | RecoveryMessage
+  | StepEndMessage
   | ResultMessage
   | ControlResponse
   | ControlRequest // CLI → SDK control requests (e.g., can_use_tool)


### PR DESCRIPTION
Stacked on #1914. Addresses the remaining items from the stream-json SDK review: coalesce fragmented chunks (#2, #3), enforce `tool_return_message` ordering, add a `step_end` wire event, and drop the redundant `date` field (#8). Our `message_type` taxonomy is preserved — no envelope reshape.

## Four logical changes

### 1. Drop redundant `date` field (#8)
Every stream-json line already carries `timestamp` (CLI-stamped, ms + `Z`) as the canonical time source. The server's `date` field (seconds + `+00:00`) was being relayed alongside, giving every line two timestamps in different formats. `writeWireMessage` now strips `date` before emitting.

### 2. Coalesce fragmented chunks (#2, #3)
New `StreamJsonAggregator` module buffers server chunks and emits one wire event per logical message:

- `assistant_message` / `reasoning_message` chunks with the same `otid` (fallback `id`) merge into a single event with concatenated text.
- `tool_call_message` / `approval_request_message` chunks with the same `tool_call.tool_call_id` merge into a single event with concatenated `arguments` — the result is a complete, JSON-parseable args string.
- `tool_return_message` flushes its matching tool_call accumulator first, then passes through (never fragmented).

Both `streamJsonHook` sites in `headless.ts` (one-shot + bidirectional) route chunks through the aggregator. Bypass emissions (error, recovery, auto_approval) call `flushPending()` first so ordering is preserved. `flushAll()` runs at every result/error boundary so nothing leaks past a turn.

`--include-partial-messages` passthrough mode bypasses aggregation entirely and emits each chunk as a `stream_event` envelope, preserving delta-level granularity for consumers who want it.

### 3. Unique wire uuids for parallel tool calls
The server emits multiple parallel tool calls as distinct `tool_calls` within a single logical message (shared `id` / `otid`). Previously all parallel `approval_request_message` events ended up with the same `uuid`, so consumers couldn't tell them apart. Now the wire uuid for tool-call entries is derived from `tool_call_id`, mirroring the existing pattern for related events:

| Event | UUID format |
|---|---|
| `approval_request_message` / `tool_call_message` | `<tool_call_id>` |
| `auto_approval` | `auto-approval-<tool_call_id>` |
| `tool_return_message` | `tool-return-<tool_call_id>` |

Consumers can group all events for a single tool call by matching the `tool_call_id` suffix, or use the existing `tool_call_id` field that's already present on each event.

### 4. New `step_end` wire event
Server-side step terminators (`stop_reason` + `usage_statistics`) are coalesced into a single `step_end` event emitted at the end of each step. Step metadata stays separate from message content:

```json
{
  "type": "step_end",
  "stop_reason": "end_turn" | "requires_approval" | "max_steps" | ...,
  "step_id": "step-abc",
  "usage": { "prompt_tokens": ..., "completion_tokens": ..., "total_tokens": ..., ... } | null,
  "session_id": "...", "agent_id": "...", "conversation_id": "...",
  "uuid": "step-end-<step_id>",
  "timestamp": "..."
}
```

Emitted **after** all content messages for the step have flushed, and **before** any client-side markers (`auto_approval`, `tool_return_message`) for tools invoked in that step. Works uniformly whether the step has one content message (end_turn) or many (parallel tool calls).

## Wire-order example (verified manually with 3 parallel `Read` calls)

```
system/init
message/reasoning_message
message/approval_request_message   tcid=toolu_01LBe...
message/approval_request_message   tcid=toolu_01BWm...
message/approval_request_message   tcid=toolu_01979...
step_end                            stop=requires_approval  step_id=step-2f21...  tot=19271
auto_approval × 3
message/tool_return_message × 3
message/approval_request_message × 2  (follow-up Reads)
step_end                            stop=requires_approval  step_id=step-549a...  tot=20802
auto_approval × 2
message/tool_return_message × 2
message/assistant_message          (635-char summary)
step_end                            stop=end_turn           step_id=step-1553...  tot=23031
result                                                                             tot=63104
```

Before this PR: ~20 events per turn with fragmented text/args and separate `stop_reason` + `usage_statistics` messages per step. After: ~10 events per turn with complete messages, one `step_end` per step, uniform handling of parallel tool calls, and no redundant `date` fields.

## Breaking wire-format changes

Consumers that parse the stream-json output should be aware:

- `date` field is gone — use `timestamp` instead.
- `assistant_message` / `reasoning_message` arrive as single coalesced events (not chunked) in default mode. Pass `--include-partial-messages` to get the original delta behavior.
- `tool_call_message` / `approval_request_message` `arguments` are complete JSON strings in default mode (not fragmented).
- `stop_reason` and `usage_statistics` messages are gone; consumers read from `step_end` events instead.
- Parallel tool calls in one server message now emit distinct wire uuids (previously collided on the outer message id).

## Test plan

- [x] `bun test src/tests/headless/stream-json-aggregator.test.ts` — 18 pass (coalescing, step_end emission, parallel-uuid distinctness, abort path, passthrough, edge cases).
- [x] `bun test src/tests/headless/stream-json-writer.test.ts` — 4 pass (date-strip + timestamp preservation).
- [x] `bun test src/tests/headless` — 108 pass (all headless unit tests green).
- [x] `bun test src/integration-tests/headless-stream-json-format.test.ts` — 14 pass, including step_end emission test and regression guard that content messages never carry `stop_reason` / `usage` inline.
- [x] Manual verification with parallel tool-call prompt: single `step_end` per step, clean content messages, distinct uuids on parallel tool calls, no `date` field anywhere, correct `content → step_end → auto_approval → tool_return` ordering. `--include-partial-messages` preserves original fragmented-delta behavior end-to-end.
- [x] `bun run tsc --noEmit` clean.

👾 Generated with [Letta Code](https://letta.com)