### PR TITLE
fix(memfs): Support separate memfs base URL via LETTA_MEMFS_BASE_URL

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -117,6 +117,27 @@ export function getServerUrl(): string {
   );
 }
 
+/**
+ * Get the current Letta memfs server URL from environment or settings.
+ * Falls back to the primary API server URL when no memfs-specific URL is set.
+ */
+export function getMemfsServerUrl(): string {
+  let settings: Settings | null = null;
+  try {
+    settings = settingsManager.getSettings();
+  } catch {
+    // Settings may be unavailable in isolated tests that only rely on env.
+  }
+
+  return (
+    process.env.LETTA_MEMFS_BASE_URL ||
+    settings?.env?.LETTA_MEMFS_BASE_URL ||
+    process.env.LETTA_BASE_URL ||
+    settings?.env?.LETTA_BASE_URL ||
+    LETTA_CLOUD_API_URL
+  );
+}
+
 export async function getClient() {
   if (_testClientOverride) {
     return (await _testClientOverride()) as Letta;

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -119,7 +119,7 @@ export function getServerUrl(): string {
 
 /**
  * Get the current Letta memfs server URL from environment or settings.
- * Falls back to the primary API server URL when no memfs-specific URL is set.
+ * Falls back to Letta Cloud when no memfs-specific URL is set.
  */
 export function getMemfsServerUrl(): string {
   let settings: Settings | null = null;
@@ -132,8 +132,6 @@ export function getMemfsServerUrl(): string {
   return (
     process.env.LETTA_MEMFS_BASE_URL ||
     settings?.env?.LETTA_MEMFS_BASE_URL ||
-    process.env.LETTA_BASE_URL ||
-    settings?.env?.LETTA_BASE_URL ||
     LETTA_CLOUD_API_URL
   );
 }

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -168,9 +168,7 @@ export async function maybeUpdateMemoryRemoteOrigin(
     return;
   }
 
-  const expectedOrigin = normalizeRemoteUrl(
-    getGitRemoteUrl(agentId),
-  );
+  const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
   const normalizedCurrent = normalizeRemoteUrl(currentOrigin);
 
   if (normalizedCurrent !== expectedOrigin) {

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -2,7 +2,8 @@
  * Git operations for git-backed agent memory.
  *
  * When memFS is enabled, the agent's memory is stored in a git repo
- * on the server at $LETTA_BASE_URL/v1/git/$AGENT_ID/state.git.
+ * on the server at $LETTA_MEMFS_BASE_URL/v1/git/$AGENT_ID/state.git
+ * (falling back to $LETTA_BASE_URL when unset).
  * This module provides the CLI harness helpers: clone on first run,
  * pull on startup, and status check for system reminders.
  *
@@ -23,7 +24,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { debugLog, debugWarn } from "../utils/debug";
-import { getClient, getServerUrl } from "./client";
+import { getClient, getMemfsServerUrl } from "./client";
 
 const execFile = promisify(execFileCb);
 
@@ -79,8 +80,8 @@ export function getMemoryRepoDir(agentId: string): string {
  *
  * Git credential config lookup is sensitive to URL key shape. We normalize to
  * origin form (scheme + host + optional port) and remove trailing slashes so
- * pull/push flows remain resilient when LETTA_BASE_URL has path/trailing-slash
- * variations.
+ * pull/push flows remain resilient when LETTA_MEMFS_BASE_URL /
+ * LETTA_BASE_URL has path/trailing-slash variations.
  */
 export function normalizeCredentialBaseUrl(serverUrl: string): string {
   const trimmed = serverUrl.trim().replace(/\/+$/, "");
@@ -134,7 +135,7 @@ export function isMemfsRemoteUrlForAgent(
 
 /** Git remote URL for the agent's state repo */
 export function getGitRemoteUrl(agentId: string, baseUrl?: string): string {
-  const resolvedBaseUrl = (baseUrl ?? getServerUrl())
+  const resolvedBaseUrl = (baseUrl ?? getMemfsServerUrl())
     .trim()
     .replace(/\/+$/, "");
   return `${resolvedBaseUrl}/v1/git/${agentId}/state.git`;
@@ -168,7 +169,7 @@ export async function maybeUpdateMemoryRemoteOrigin(
   }
 
   const expectedOrigin = normalizeRemoteUrl(
-    getGitRemoteUrl(agentId, process.env.LETTA_BASE_URL?.trim() || undefined),
+    getGitRemoteUrl(agentId),
   );
   const normalizedCurrent = normalizeRemoteUrl(currentOrigin);
 
@@ -377,7 +378,7 @@ async function configureLocalCredentialHelper(
   dir: string,
   token: string,
 ): Promise<void> {
-  const rawBaseUrl = getServerUrl();
+  const rawBaseUrl = getMemfsServerUrl();
   const normalizedBaseUrl = normalizeCredentialBaseUrl(rawBaseUrl);
 
   let helper: string;

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -204,6 +204,22 @@ function getCurrentServerKey(settings?: Settings | null): string {
   return normalizeBaseUrl(baseUrl);
 }
 
+/**
+ * Get the current memfs server key for memfs-related agent settings.
+ * Uses LETTA_MEMFS_BASE_URL first, then falls back to LETTA_BASE_URL.
+ * @param settings - Optional settings object to check for env overrides
+ * @returns Normalized server key (e.g., "api.letta.com", "localhost:8283")
+ */
+function getCurrentMemfsServerKey(settings?: Settings | null): string {
+  const baseUrl =
+    process.env.LETTA_MEMFS_BASE_URL ||
+    settings?.env?.LETTA_MEMFS_BASE_URL ||
+    process.env.LETTA_BASE_URL ||
+    settings?.env?.LETTA_BASE_URL ||
+    DEFAULT_LETTA_API_URL;
+  return normalizeBaseUrl(baseUrl);
+}
+
 class SettingsManager {
   private settings: Settings | null = null;
   private projectSettings: Map<string, ProjectSettings> = new Map();
@@ -1550,9 +1566,12 @@ class SettingsManager {
    * Get settings for a specific agent on the current server.
    * Returns undefined if agent not found in settings.
    */
-  private getAgentSettings(agentId: string): AgentSettings | undefined {
+  private getAgentSettings(
+    agentId: string,
+    serverKeyOverride?: string,
+  ): AgentSettings | undefined {
     const settings = this.getSettings();
-    const serverKey = getCurrentServerKey(settings);
+    const serverKey = serverKeyOverride ?? getCurrentServerKey(settings);
     const normalizedBaseUrl =
       serverKey === "api.letta.com" ? undefined : serverKey;
 
@@ -1568,9 +1587,10 @@ class SettingsManager {
   private upsertAgentSettings(
     agentId: string,
     updates: Partial<Omit<AgentSettings, "agentId" | "baseUrl">>,
+    serverKeyOverride?: string,
   ): void {
     const settings = this.getSettings();
-    const serverKey = getCurrentServerKey(settings);
+    const serverKey = serverKeyOverride ?? getCurrentServerKey(settings);
     const normalizedBaseUrl =
       serverKey === "api.letta.com" ? undefined : serverKey;
 
@@ -1631,14 +1651,18 @@ class SettingsManager {
    * Check if memory filesystem is enabled for an agent on the current server.
    */
   isMemfsEnabled(agentId: string): boolean {
-    return this.getAgentSettings(agentId)?.memfs === true;
+    const settings = this.getSettings();
+    const memfsServerKey = getCurrentMemfsServerKey(settings);
+    return this.getAgentSettings(agentId, memfsServerKey)?.memfs === true;
   }
 
   /**
    * Enable or disable memory filesystem for an agent on the current server.
    */
   setMemfsEnabled(agentId: string, enabled: boolean): void {
-    this.upsertAgentSettings(agentId, { memfs: enabled });
+    const settings = this.getSettings();
+    const memfsServerKey = getCurrentMemfsServerKey(settings);
+    this.upsertAgentSettings(agentId, { memfs: enabled }, memfsServerKey);
   }
 
   /**

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -206,7 +206,7 @@ function getCurrentServerKey(settings?: Settings | null): string {
 
 /**
  * Get the current memfs server key for memfs-related agent settings.
- * Uses LETTA_MEMFS_BASE_URL first, then falls back to LETTA_BASE_URL.
+ * Uses LETTA_MEMFS_BASE_URL and falls back to api.letta.com.
  * @param settings - Optional settings object to check for env overrides
  * @returns Normalized server key (e.g., "api.letta.com", "localhost:8283")
  */
@@ -214,8 +214,6 @@ function getCurrentMemfsServerKey(settings?: Settings | null): string {
   const baseUrl =
     process.env.LETTA_MEMFS_BASE_URL ||
     settings?.env?.LETTA_MEMFS_BASE_URL ||
-    process.env.LETTA_BASE_URL ||
-    settings?.env?.LETTA_BASE_URL ||
     DEFAULT_LETTA_API_URL;
   return normalizeBaseUrl(baseUrl);
 }

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -80,6 +80,14 @@ describe("normalizeCredentialBaseUrl", () => {
         "https://selfhost.example.com/v1/git/agent-123/state.git",
       );
     });
+
+    test("defaults to api.letta.com when LETTA_MEMFS_BASE_URL is unset, even if LETTA_BASE_URL is localhost", () => {
+      process.env.LETTA_BASE_URL = "http://localhost:51338";
+      delete process.env.LETTA_MEMFS_BASE_URL;
+      expect(getGitRemoteUrl("agent-123")).toBe(
+        "https://api.letta.com/v1/git/agent-123/state.git",
+      );
+    });
   });
 
   describe("isMemfsRemoteUrlForAgent", () => {

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../agent/memoryGit";
 
 const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
+const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
 
 let tempDirs: string[] = [];
 
@@ -26,6 +27,12 @@ afterEach(() => {
     delete process.env.LETTA_BASE_URL;
   } else {
     process.env.LETTA_BASE_URL = ORIGINAL_LETTA_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_BASE_URL === undefined) {
+    delete process.env.LETTA_MEMFS_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_BASE_URL = ORIGINAL_LETTA_MEMFS_BASE_URL;
   }
 });
 
@@ -63,6 +70,14 @@ describe("normalizeCredentialBaseUrl", () => {
     test("builds remote URL from provided base URL", () => {
       expect(getGitRemoteUrl("agent-123", "http://localhost:51338/")).toBe(
         "http://localhost:51338/v1/git/agent-123/state.git",
+      );
+    });
+
+    test("prefers LETTA_MEMFS_BASE_URL over LETTA_BASE_URL when base URL is omitted", () => {
+      process.env.LETTA_BASE_URL = "http://localhost:51338";
+      process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+      expect(getGitRemoteUrl("agent-123")).toBe(
+        "https://selfhost.example.com/v1/git/agent-123/state.git",
       );
     });
   });
@@ -205,5 +220,27 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
     expect(
       git(repo, "config --local --get-all remote.origin.pushurl").trim(),
     ).toBe(pushUrl);
+  });
+
+  test("updates stale memfs origin to LETTA_MEMFS_BASE_URL when proxy LETTA_BASE_URL differs", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const staleOrigin = getGitRemoteUrl(agentId, "http://localhost:50864");
+    const expectedOrigin = getGitRemoteUrl(
+      agentId,
+      "https://selfhost.example.com",
+    );
+
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+    git(repo, `remote add origin ${staleOrigin}`);
+    git(repo, `config --local remote.origin.pushurl ${staleOrigin}`);
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(
+      gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
+    ).toBe("");
   });
 });

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -1179,6 +1179,38 @@ describe("Settings Manager - Agents Array Migration", () => {
     }
   });
 
+  test("isMemfsEnabled ignores LETTA_BASE_URL when LETTA_MEMFS_BASE_URL is unset", async () => {
+    await settingsManager.initialize();
+
+    settingsManager.updateSettings({
+      agents: [
+        { agentId: "agent-cloud-memfs", memfs: true },
+        { agentId: "agent-local-memfs", baseUrl: "localhost:54085", memfs: true },
+      ],
+    });
+
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+
+    try {
+      expect(settingsManager.isMemfsEnabled("agent-cloud-memfs")).toBe(true);
+      expect(settingsManager.isMemfsEnabled("agent-local-memfs")).toBe(false);
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+      if (originalMemfsBaseUrl === undefined) {
+        delete process.env.LETTA_MEMFS_BASE_URL;
+      } else {
+        process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
+      }
+    }
+  });
+
   test("setMemfsEnabled stores agent settings under LETTA_MEMFS_BASE_URL server key", async () => {
     await settingsManager.initialize();
 
@@ -1200,6 +1232,43 @@ describe("Settings Manager - Agents Array Migration", () => {
         settings.agents?.some(
           (agent) =>
             agent.agentId === "agent-memfs-write" &&
+            agent.baseUrl === "localhost:54085",
+        ),
+      ).toBe(false);
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+      if (originalMemfsBaseUrl === undefined) {
+        delete process.env.LETTA_MEMFS_BASE_URL;
+      } else {
+        process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
+      }
+    }
+  });
+
+  test("setMemfsEnabled defaults to api.letta.com key when LETTA_MEMFS_BASE_URL is unset", async () => {
+    await settingsManager.initialize();
+
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+
+    try {
+      settingsManager.setMemfsEnabled("agent-memfs-default-cloud", true);
+
+      const settings = settingsManager.getSettings();
+      expect(settings.agents).toContainEqual({
+        agentId: "agent-memfs-default-cloud",
+        memfs: true,
+      });
+      expect(
+        settings.agents?.some(
+          (agent) =>
+            agent.agentId === "agent-memfs-default-cloud" &&
             agent.baseUrl === "localhost:54085",
         ),
       ).toBe(false);

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -1145,6 +1145,78 @@ describe("Settings Manager - Agents Array Migration", () => {
     expect(settingsManager.isMemfsEnabled("agent-test")).toBe(false);
   });
 
+  test("isMemfsEnabled uses LETTA_MEMFS_BASE_URL before LETTA_BASE_URL", async () => {
+    await settingsManager.initialize();
+
+    settingsManager.updateSettings({
+      agents: [
+        {
+          agentId: "agent-memfs-url",
+          baseUrl: "selfhost.example.com",
+          memfs: true,
+        },
+      ],
+    });
+
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+
+    try {
+      expect(settingsManager.isMemfsEnabled("agent-memfs-url")).toBe(true);
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+      if (originalMemfsBaseUrl === undefined) {
+        delete process.env.LETTA_MEMFS_BASE_URL;
+      } else {
+        process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
+      }
+    }
+  });
+
+  test("setMemfsEnabled stores agent settings under LETTA_MEMFS_BASE_URL server key", async () => {
+    await settingsManager.initialize();
+
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+
+    try {
+      settingsManager.setMemfsEnabled("agent-memfs-write", true);
+
+      const settings = settingsManager.getSettings();
+      expect(settings.agents).toContainEqual({
+        agentId: "agent-memfs-write",
+        baseUrl: "selfhost.example.com",
+        memfs: true,
+      });
+      expect(
+        settings.agents?.some(
+          (agent) =>
+            agent.agentId === "agent-memfs-write" &&
+            agent.baseUrl === "localhost:54085",
+        ),
+      ).toBe(false);
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+      if (originalMemfsBaseUrl === undefined) {
+        delete process.env.LETTA_MEMFS_BASE_URL;
+      } else {
+        process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
+      }
+    }
+  });
+
   test("setMemfsEnabled persists to disk", async () => {
     await settingsManager.initialize();
 

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -1185,7 +1185,11 @@ describe("Settings Manager - Agents Array Migration", () => {
     settingsManager.updateSettings({
       agents: [
         { agentId: "agent-cloud-memfs", memfs: true },
-        { agentId: "agent-local-memfs", baseUrl: "localhost:54085", memfs: true },
+        {
+          agentId: "agent-local-memfs",
+          baseUrl: "localhost:54085",
+          memfs: true,
+        },
       ],
     });
 


### PR DESCRIPTION
## Summary
This PR fully decouples memfs git routing from `LETTA_BASE_URL`.

- Adds a dedicated memfs base URL path via `LETTA_MEMFS_BASE_URL`
- Uses that memfs URL for memfs git remote + credential helper logic
- Keys memfs-enabled agent settings by memfs server key (not API/proxy server key)
- Defaults memfs to cloud (`https://api.letta.com`) when `LETTA_MEMFS_BASE_URL` is unset

## Problem
Desktop can set `LETTA_BASE_URL` to a random localhost proxy port each launch.
That caused two issues:
- memfs settings lookups missed (because settings were keyed by a different host:port)
- memfs git remotes/credentials drifted to stale localhost origins

## Behavior Change (Intentional)
Memfs URL resolution is now:
1. `process.env.LETTA_MEMFS_BASE_URL`
2. `settings.env.LETTA_MEMFS_BASE_URL`
3. `https://api.letta.com`

`LETTA_BASE_URL` is intentionally ignored for memfs URL resolution.

## Self-Host Note
If you self-host Letta and want memfs to target your self-hosted backend,
set `LETTA_MEMFS_BASE_URL` explicitly.

## Code Changes
- `src/agent/client.ts`
  - Added `getMemfsServerUrl()` with strict memfs-only resolution + cloud default.
- `src/agent/memoryGit.ts`
  - memfs git remote URL generation uses `getMemfsServerUrl()`
  - origin self-heal target uses memfs URL
  - credential helper URL key uses memfs URL
- `src/settings-manager.ts`
  - Added memfs server key resolver (`getCurrentMemfsServerKey()`)
  - `isMemfsEnabled` and `setMemfsEnabled` now use memfs server key

## Tests
Added regression coverage for:
- memfs URL defaults to cloud when `LETTA_MEMFS_BASE_URL` is unset even if `LETTA_BASE_URL` is localhost
- memfs settings lookup ignores `LETTA_BASE_URL` when memfs URL is unset
- memfs settings writes default to cloud key when memfs URL is unset

Ran:
- `bun test src/tests/agent/memoryGit.auth.test.ts src/tests/settings-manager.test.ts src/tests/tools/shell-env.test.ts`
