### PR TITLE
fix(memfs): run interactive startup sync in background

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import {
   DIRECTORY_LIMIT_DEFAULTS,
   getDirectoryLimits,
@@ -59,6 +59,63 @@ export interface ResolveScopedMemoryDirOptions {
   homeDir?: string;
 }
 
+const localMemfsCheckoutPromises = new Map<string, Promise<void>>();
+
+export function resolveScopedAgentId(
+  options: ResolveScopedMemoryDirOptions = {},
+): string | null {
+  const env = options.env ?? process.env;
+
+  const explicitAgentId = options.agentId?.trim();
+  if (explicitAgentId) {
+    return explicitAgentId;
+  }
+
+  try {
+    const scopedAgentId = getCurrentAgentId().trim();
+    if (scopedAgentId) {
+      return scopedAgentId;
+    }
+  } catch {
+    // No runtime-scoped agent context; fall back below.
+  }
+
+  const envAgentId = (env.LETTA_AGENT_ID || env.AGENT_ID || "").trim();
+  if (envAgentId) {
+    return envAgentId;
+  }
+
+  return null;
+}
+
+function isPathWithinDirectory(
+  pathToCheck: string,
+  directory: string,
+): boolean {
+  const rel = relative(resolve(directory), resolve(pathToCheck));
+  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function isMemfsEnabledLocally(agentId: string): Promise<boolean> {
+  try {
+    const { settingsManager } = await import("../settings-manager");
+    return settingsManager.isMemfsEnabled(agentId);
+  } catch {
+    return false;
+  }
+}
+
+export function isPathInsideMemoryDirForAgent(
+  pathToCheck: string,
+  agentId: string,
+  homeDir: string = homedir(),
+): boolean {
+  return isPathWithinDirectory(
+    pathToCheck,
+    getMemoryFilesystemRoot(agentId, homeDir),
+  );
+}
+
 /**
  * Resolve the active memory directory for the current execution scope.
  *
@@ -99,6 +156,82 @@ export function resolveScopedMemoryDir(
   }
 
   return null;
+}
+
+export async function ensureScopedMemoryDirReady(
+  options: ResolveScopedMemoryDirOptions = {},
+): Promise<string | null> {
+  const memoryDir = resolveScopedMemoryDir(options);
+  if (!memoryDir) {
+    return null;
+  }
+
+  const agentId = resolveScopedAgentId(options);
+  if (!agentId) {
+    return memoryDir;
+  }
+
+  const homeDir = options.homeDir ?? homedir();
+  const defaultMemoryDir = getMemoryFilesystemRoot(agentId, homeDir);
+  if (resolve(memoryDir) === resolve(defaultMemoryDir)) {
+    await ensureLocalMemfsCheckout(agentId);
+  }
+
+  return memoryDir;
+}
+
+export async function ensureMemfsCheckoutForPath(
+  pathToCheck: string,
+  options: ResolveScopedMemoryDirOptions = {},
+): Promise<void> {
+  const agentId = resolveScopedAgentId(options);
+  if (!agentId) {
+    return;
+  }
+  if (!(await isMemfsEnabledLocally(agentId))) {
+    return;
+  }
+
+  const homeDir = options.homeDir ?? homedir();
+  if (!isPathInsideMemoryDirForAgent(pathToCheck, agentId, homeDir)) {
+    return;
+  }
+
+  await ensureLocalMemfsCheckout(agentId);
+}
+
+export async function ensureMemfsCheckoutForShellCommand(
+  command: string,
+  workdir?: string,
+  options: ResolveScopedMemoryDirOptions = {},
+): Promise<void> {
+  const agentId = resolveScopedAgentId(options);
+  if (!agentId) {
+    return;
+  }
+  if (!(await isMemfsEnabledLocally(agentId))) {
+    return;
+  }
+
+  const homeDir = options.homeDir ?? homedir();
+  const memoryDir = getMemoryFilesystemRoot(agentId, homeDir);
+  const referencesMemoryEnv =
+    command.includes("$MEMORY_DIR") ||
+    command.includes("$" + "{MEMORY_DIR}") ||
+    command.includes("%MEMORY_DIR%") ||
+    command.includes("$LETTA_MEMORY_DIR") ||
+    command.includes("$" + "{LETTA_MEMORY_DIR}") ||
+    command.includes("%LETTA_MEMORY_DIR%");
+  const referencesMemoryPath = command.includes(memoryDir);
+  const workdirIsMemoryPath = workdir
+    ? isPathWithinDirectory(resolve(workdir), memoryDir)
+    : false;
+
+  if (!referencesMemoryEnv && !referencesMemoryPath && !workdirIsMemoryPath) {
+    return;
+  }
+
+  await ensureLocalMemfsCheckout(agentId);
 }
 
 export function ensureMemoryFilesystemDirs(
@@ -150,7 +283,23 @@ export async function ensureLocalMemfsCheckout(agentId: string): Promise<void> {
   if (isGitRepo(agentId)) {
     return;
   }
-  await cloneMemoryRepo(agentId);
+
+  const existing = localMemfsCheckoutPromises.get(agentId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const checkoutPromise = (async () => {
+    if (!isGitRepo(agentId)) {
+      await cloneMemoryRepo(agentId);
+    }
+  })().finally(() => {
+    localMemfsCheckoutPromises.delete(agentId);
+  });
+
+  localMemfsCheckoutPromises.set(agentId, checkoutPromise);
+  await checkoutPromise;
 }
 
 // ----- Path helpers -----
@@ -326,6 +475,12 @@ export interface ApplyMemfsFlagsOptions {
   agentTags?: string[];
   /** Skip the system prompt update (when the agent was created with the correct mode). */
   skipPromptUpdate?: boolean;
+  /**
+   * Local memfs setting captured before any startup pre-seeding. Used by
+   * interactive startup so tools can see memfs immediately without suppressing
+   * the normal auto-enable-from-server-tag reconciliation path.
+   */
+  initialLocalMemfsEnabled?: boolean;
 }
 
 /**
@@ -359,7 +514,9 @@ export async function applyMemfsFlags(
   }
 
   const hasExplicitToggle = Boolean(memfsFlag || noMemfsFlag);
-  const localMemfsEnabled = settingsManager.isMemfsEnabled(agentId);
+  const localMemfsEnabled =
+    options?.initialLocalMemfsEnabled ??
+    settingsManager.isMemfsEnabled(agentId);
   const { GIT_MEMORY_ENABLED_TAG } = await import("./memoryGit");
   const shouldAutoEnableFromTag =
     !hasExplicitToggle &&
@@ -433,14 +590,15 @@ export async function applyMemfsFlags(
   // 4. Add git tag + clone/pull repo.
   let pullSummary: string | undefined;
   if (isEnabled) {
-    const { addGitMemoryTag, isGitRepo, cloneMemoryRepo, pullMemory } =
-      await import("./memoryGit");
+    const { addGitMemoryTag, isGitRepo, pullMemory } = await import(
+      "./memoryGit"
+    );
     await addGitMemoryTag(
       agentId,
       options?.agentTags ? { tags: options.agentTags } : undefined,
     );
     if (!isGitRepo(agentId)) {
-      await cloneMemoryRepo(agentId);
+      await ensureLocalMemfsCheckout(agentId);
     } else if (options?.pullOnExistingRepo) {
       const result = await pullMemory(agentId);
       pullSummary = result.summary;

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7458,8 +7458,12 @@ export default function App({
 
         // Use spawnCommand for actual execution
         const { spawnCommand } = await import("../tools/impl/Bash.js");
+        const { ensureMemfsCheckoutForShellCommand } = await import(
+          "../agent/memoryFilesystem"
+        );
         const { getShellEnv } = await import("../tools/impl/shellEnv.js");
 
+        await ensureMemfsCheckoutForShellCommand(finalCommand, process.cwd());
         const result = await spawnCommand(finalCommand, {
           cwd: process.cwd(),
           env: getShellEnv(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { markMilestone } from "./utils/timing";
 // anti-pattern of creating new [] on every render which triggers useEffect re-runs
 const EMPTY_APPROVAL_ARRAY: ApprovalRequest[] = [];
 const EMPTY_MESSAGE_ARRAY: Message[] = [];
+const GIT_MEMORY_ENABLED_TAG = "git-memory-enabled";
 
 function trackCliBoundaryError(
   errorType: string,
@@ -1722,19 +1723,38 @@ async function main(): Promise<void> {
         // Set agent context for tools that need it (e.g., Skill tool)
         setAgentContext(agent.id, skillsDirectory, resolvedSkillSources);
 
-        // Start memfs sync early — awaited in parallel with getResumeData below
+        // Start memfs setup early, but do not block interactive startup on it.
+        // Memory tools and direct memory-path file tools lazily ensure the local
+        // checkout exists before touching $MEMORY_DIR.
         const agentId = agent.id;
         const agentTags = agent.tags ?? undefined;
         const startupMemfsFlag = autoEnableMemfsForFreshAgent
           ? true
           : memfsFlag;
+        const initialLocalMemfsEnabled =
+          settingsManager.isMemfsEnabled(agentId);
+        if (noMemfsFlag) {
+          settingsManager.setMemfsEnabled(agentId, false);
+        } else if (
+          startupMemfsFlag ||
+          agentTags?.includes(GIT_MEMORY_ENABLED_TAG)
+        ) {
+          settingsManager.setMemfsEnabled(agentId, true);
+        }
         const memfsSyncPromise = import("./agent/memoryFilesystem").then(
           ({ applyMemfsFlags }) =>
             applyMemfsFlags(agentId, startupMemfsFlag, noMemfsFlag, {
               agentTags,
               skipPromptUpdate: shouldCreateNew,
+              initialLocalMemfsEnabled,
             }),
         );
+        void memfsSyncPromise.catch((error) => {
+          debugWarn(
+            "memfs-git",
+            `Background startup sync failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
 
         // Init secrets cache — runs in parallel with memfs sync below.
         const secretsInitPromise = import("./utils/secretsStore").then(
@@ -1923,27 +1943,25 @@ async function main(): Promise<void> {
           // Default (including --new-agent): use the agent's "default" conversation
           conversationIdToUse = "default";
 
-          // Load message history and memfs sync in parallel — they're independent
+          // Load message history without blocking on memfs. Memfs setup continues
+          // in the background and is awaited lazily by memory access paths.
           setLoadingState("checking");
-          const [data] = await Promise.all([
-            getResumeData(client, agent, "default"),
-            memfsSyncPromise.catch((error) => {
-              console.error(
-                error instanceof Error ? error.message : String(error),
-              );
-              process.exit(1);
-            }),
-          ]);
+          const data = await getResumeData(client, agent, "default");
           setResumeData(data);
           setResumedExistingConversation(data.messageHistory.length > 0);
         }
 
-        // Ensure memfs sync completed (already resolved for default path via Promise.all above)
-        try {
-          await memfsSyncPromise;
-        } catch (error) {
-          console.error(error instanceof Error ? error.message : String(error));
-          process.exit(1);
+        // Explicit memfs mode changes should still be settled before the session
+        // starts; ordinary resume/new-agent startup leaves setup in the background.
+        if (memfsFlag || noMemfsFlag) {
+          try {
+            await memfsSyncPromise;
+          } catch (error) {
+            console.error(
+              error instanceof Error ? error.message : String(error),
+            );
+            process.exit(1);
+          }
         }
 
         // Ensure secrets cache is populated (non-fatal).
@@ -1959,7 +1977,8 @@ async function main(): Promise<void> {
         }
 
         // Auto-heal system prompt drift (rebuild from stored recipe).
-        // Runs after memfs sync so isMemfsEnabled() reflects the final state.
+        // Memfs mode is pre-seeded from the startup flags/server tag above so
+        // this does not need to wait for background local checkout setup.
         if (resuming && !systemPromptPreset) {
           let storedPreset = settingsManager.getSystemPromptPreset(agent.id);
 

--- a/src/tests/cli/interactive-memfs-wiring.test.ts
+++ b/src/tests/cli/interactive-memfs-wiring.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("interactive memfs startup wiring", () => {
+  const indexPath = fileURLToPath(new URL("../../index.ts", import.meta.url));
+  const source = readFileSync(indexPath, "utf-8");
+
+  test("starts memfs setup in the background", () => {
+    expect(source).toContain("const memfsSyncPromise = import(");
+    expect(source).toContain("void memfsSyncPromise.catch");
+    expect(source).toContain("Background startup sync failed");
+    expect(source).toContain("initialLocalMemfsEnabled");
+  });
+
+  test("default conversation resume does not wait for memfs setup", () => {
+    const start = source.indexOf(
+      "// Load message history without blocking on memfs.",
+    );
+    expect(start).toBeGreaterThan(-1);
+
+    const end = source.indexOf("setResumeData(data);", start);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain('getResumeData(client, agent, "default")');
+    expect(segment).not.toContain("Promise.all");
+    expect(segment).not.toContain("memfsSyncPromise");
+  });
+
+  test("explicit memfs mode changes still settle before ready", () => {
+    const start = source.indexOf("if (memfsFlag || noMemfsFlag) {");
+    expect(start).toBeGreaterThan(-1);
+
+    const end = source.indexOf("// Ensure secrets cache is populated", start);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("await memfsSyncPromise");
+  });
+});

--- a/src/tests/tools/memfs-lazy-checkout-wiring.test.ts
+++ b/src/tests/tools/memfs-lazy-checkout-wiring.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function source(relativePath: string): string {
+  const path = fileURLToPath(
+    new URL(`../../tools/impl/${relativePath}`, import.meta.url),
+  );
+  return readFileSync(path, "utf-8");
+}
+
+function appSource(): string {
+  const path = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+  return readFileSync(path, "utf-8");
+}
+
+describe("lazy memfs checkout wiring", () => {
+  test("memory tools ensure local checkout before resolving the repo", () => {
+    expect(source("Memory.ts")).toContain("ensureScopedMemoryDirReady");
+    expect(source("Memory.ts")).toContain("await resolveMemoryDir()");
+
+    expect(source("MemoryApplyPatch.ts")).toContain(
+      "ensureScopedMemoryDirReady",
+    );
+    expect(source("MemoryApplyPatch.ts")).toContain("await resolveMemoryDir()");
+  });
+
+  test("file tools ensure checkout before touching memory paths", () => {
+    const files = [
+      "ApplyPatch.ts",
+      "Edit.ts",
+      "Glob.ts",
+      "Grep.ts",
+      "ListDirCodex.ts",
+      "LS.ts",
+      "ReadFileCodex.ts",
+      "Read.ts",
+      "Write.ts",
+    ];
+
+    for (const file of files) {
+      expect(source(file)).toContain("ensureMemfsCheckoutForPath");
+    }
+  });
+
+  test("shell tools ensure checkout before commands that reference memory", () => {
+    expect(source("Bash.ts")).toContain("ensureMemfsCheckoutForShellCommand");
+    expect(source("ShellCommand.ts")).toContain(
+      "ensureMemfsCheckoutForShellCommand",
+    );
+    expect(source("Shell.ts")).toContain("ensureMemfsCheckoutForShellCommand");
+    expect(appSource()).toContain("ensureMemfsCheckoutForShellCommand");
+  });
+});

--- a/src/tools/impl/ApplyPatch.ts
+++ b/src/tools/impl/ApplyPatch.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
@@ -71,6 +72,7 @@ export async function apply_patch(
   for (const op of operations) {
     if (op.kind === "add") {
       const targetPath = resolvePatchPath(cwd, op.path);
+      await ensureMemfsCheckoutForPath(targetPath);
       const parent = path.dirname(targetPath);
       if (parent) {
         await fs.mkdir(parent, { recursive: true });
@@ -84,6 +86,7 @@ export async function apply_patch(
 
     if (op.kind === "delete") {
       const targetPath = resolvePatchPath(cwd, op.path);
+      await ensureMemfsCheckoutForPath(targetPath);
       try {
         await fs.unlink(targetPath);
       } catch {
@@ -94,6 +97,7 @@ export async function apply_patch(
     }
 
     const sourcePath = resolvePatchPath(cwd, op.fromPath);
+    await ensureMemfsCheckoutForPath(sourcePath);
     const newContents = await deriveNewContentsFromChunks(
       sourcePath,
       op.fromPath,
@@ -102,6 +106,7 @@ export async function apply_patch(
 
     if (op.toPath && op.toPath !== op.fromPath) {
       const destinationPath = resolvePatchPath(cwd, op.toPath);
+      await ensureMemfsCheckoutForPath(destinationPath);
       const parent = path.dirname(destinationPath);
       if (parent) {
         await fs.mkdir(parent, { recursive: true });

--- a/src/tools/impl/Bash.ts
+++ b/src/tools/impl/Bash.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
+import { ensureMemfsCheckoutForShellCommand } from "../../agent/memoryFilesystem";
 import { INTERRUPTED_BY_USER } from "../../constants";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import {
@@ -178,6 +179,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     onOutput,
   } = args;
   const userCwd = getCurrentWorkingDirectory();
+  await ensureMemfsCheckoutForShellCommand(command, userCwd);
 
   // Block worktree creation outside .letta/worktrees/
   const worktreeError = validateWorktreePath(command, userCwd);

--- a/src/tools/impl/Edit.ts
+++ b/src/tools/impl/Edit.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
@@ -144,6 +145,7 @@ export async function edit(args: EditArgs): Promise<EditResult> {
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);
+  await ensureMemfsCheckoutForPath(resolvedPath);
   if (old_string === new_string)
     throw new Error(
       "No changes to make: old_string and new_string are exactly the same.",

--- a/src/tools/impl/Glob.ts
+++ b/src/tools/impl/Glob.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { LIMITS, truncateArray } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
@@ -73,6 +74,7 @@ export async function glob(args: GlobArgs): Promise<GlobResult> {
       ? searchPath
       : path.resolve(userCwd, searchPath)
     : userCwd;
+  await ensureMemfsCheckoutForPath(baseDir);
 
   // Build ripgrep args for file listing
   // --files: list files instead of searching content

--- a/src/tools/impl/Grep.ts
+++ b/src/tools/impl/Grep.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
@@ -91,13 +92,14 @@ export async function grep(args: GrepArgs): Promise<GrepResult> {
   if (glob) rgArgs.push("--glob", glob);
   if (multiline) rgArgs.push("-U", "--multiline-dotall");
   rgArgs.push(pattern);
-  if (searchPath)
-    rgArgs.push(
-      path.isAbsolute(searchPath)
-        ? searchPath
-        : path.resolve(userCwd, searchPath),
-    );
-  else rgArgs.push(userCwd);
+  let searchRoot = userCwd;
+  if (searchPath) {
+    searchRoot = path.isAbsolute(searchPath)
+      ? searchPath
+      : path.resolve(userCwd, searchPath);
+  }
+  rgArgs.push(searchRoot);
+  await ensureMemfsCheckoutForPath(searchRoot);
 
   try {
     const { stdout } = await execFileAsync(rgPath, rgArgs, {

--- a/src/tools/impl/LS.ts
+++ b/src/tools/impl/LS.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import picomatch from "picomatch";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import LSSchema from "../schemas/LS.json";
 import { LIMITS } from "./truncation.js";
 import { validateParamTypes, validateRequiredParams } from "./validation.js";
@@ -26,6 +27,7 @@ export async function ls(
   );
   const { path: inputPath, ignore = [] } = args;
   const dirPath = resolve(inputPath);
+  await ensureMemfsCheckoutForPath(dirPath);
   try {
     const items = await readdir(dirPath);
     const filteredItems = items.filter(

--- a/src/tools/impl/ListDirCodex.ts
+++ b/src/tools/impl/ListDirCodex.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { getDirectoryLimits } from "../../utils/directoryLimits.js";
 import { validateRequiredParams } from "./validation.js";
@@ -58,6 +59,7 @@ export async function list_dir(
   const resolvedPath = path.isAbsolute(dir_path)
     ? dir_path
     : path.resolve(userCwd, dir_path);
+  await ensureMemfsCheckoutForPath(resolvedPath);
 
   if (!Number.isInteger(offset) || offset < 1) {
     throw new Error("offset must be a positive integer (1-indexed)");

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -11,7 +11,7 @@ import {
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
+import { ensureScopedMemoryDirReady } from "../../agent/memoryFilesystem";
 import {
   assertMemoryRepoReadyForWrite,
   commitAndSyncMemoryWrite,
@@ -102,7 +102,7 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     throw new Error("memory: 'reason' must be a non-empty string");
   }
 
-  const memoryDir = resolveMemoryDir();
+  const memoryDir = await resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
   await assertMemoryRepoReadyForWrite(memoryDir);
@@ -343,8 +343,8 @@ async function applyMemoryCommand(
   throw new Error(`Unsupported memory command: ${command}`);
 }
 
-function resolveMemoryDir(): string {
-  const scopedMemoryDir = resolveScopedMemoryDir();
+async function resolveMemoryDir(): Promise<string> {
+  const scopedMemoryDir = await ensureScopedMemoryDirReady();
   if (scopedMemoryDir) {
     return scopedMemoryDir;
   }

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -11,7 +11,7 @@ import {
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getClient } from "../../agent/client";
 import { getCurrentAgentId } from "../../agent/context";
-import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
+import { ensureScopedMemoryDirReady } from "../../agent/memoryFilesystem";
 import {
   assertMemoryRepoReadyForWrite,
   commitAndSyncMemoryWrite,
@@ -115,7 +115,7 @@ export async function memory_apply_patch(
     throw new Error("memory_apply_patch: 'input' must be a non-empty string");
   }
 
-  const memoryDir = resolveMemoryDir();
+  const memoryDir = await resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
   await assertMemoryRepoReadyForWrite(memoryDir);
@@ -484,8 +484,8 @@ function normalizeAddedContent(label: string, rawContent: string): string {
   }
 }
 
-function resolveMemoryDir(): string {
-  const scopedMemoryDir = resolveScopedMemoryDir();
+async function resolveMemoryDir(): Promise<string> {
+  const scopedMemoryDir = await ensureScopedMemoryDirReady();
   if (scopedMemoryDir) {
     return scopedMemoryDir;
   }

--- a/src/tools/impl/Read.ts
+++ b/src/tools/impl/Read.ts
@@ -4,6 +4,7 @@ import type {
   ImageContent,
   TextContent,
 } from "@letta-ai/letta-client/resources/agents/messages";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { resizeImageIfNeeded } from "../../cli/helpers/imageResize.js";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
@@ -201,6 +202,7 @@ export async function read(args: ReadArgs): Promise<ReadResult> {
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);
+  await ensureMemfsCheckoutForPath(resolvedPath);
   try {
     const stats = await fs.stat(resolvedPath);
     if (stats.isDirectory())

--- a/src/tools/impl/ReadFileCodex.ts
+++ b/src/tools/impl/ReadFileCodex.ts
@@ -1,4 +1,7 @@
 import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
+import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
 const MAX_LINE_LENGTH = 500;
@@ -48,6 +51,11 @@ export async function read_file(
     mode = "slice",
     indentation,
   } = args;
+  const userCwd = getCurrentWorkingDirectory();
+  const resolvedPath = path.isAbsolute(file_path)
+    ? file_path
+    : path.resolve(userCwd, file_path);
+  await ensureMemfsCheckoutForPath(resolvedPath);
 
   if (offset < 1) {
     throw new Error("offset must be a 1-indexed line number");
@@ -61,13 +69,13 @@ export async function read_file(
 
   if (mode === "indentation") {
     lines = await readIndentationMode(
-      file_path,
+      resolvedPath,
       offset,
       limit,
       indentation ?? {},
     );
   } else {
-    lines = await readSliceMode(file_path, offset, limit);
+    lines = await readSliceMode(resolvedPath, offset, limit);
   }
 
   return { content: lines.join("\n") };

--- a/src/tools/impl/Shell.ts
+++ b/src/tools/impl/Shell.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import * as path from "node:path";
+import { ensureMemfsCheckoutForShellCommand } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { getShellEnv } from "./shellEnv.js";
 import { buildShellLaunchers } from "./shellLaunchers.js";
@@ -92,6 +93,7 @@ export async function shell(args: ShellArgs): Promise<ShellResult> {
 
   const timeout = timeout_ms ?? DEFAULT_TIMEOUT;
   const cwd = resolveShellWorkdir(workdir);
+  await ensureMemfsCheckoutForShellCommand(command.join(" "), cwd);
 
   const context: SpawnContext = {
     command,

--- a/src/tools/impl/ShellCommand.ts
+++ b/src/tools/impl/ShellCommand.ts
@@ -1,4 +1,5 @@
 import { getCurrentAgentId } from "../../agent/context";
+import { ensureMemfsCheckoutForShellCommand } from "../../agent/memoryFilesystem";
 import { isMemoryDirCommand } from "../../permissions/readOnlyShell";
 import { resolveShellWorkdir, type ShellResult, shell } from "./Shell.js";
 import { buildShellLaunchers } from "./shellLaunchers.js";
@@ -64,6 +65,7 @@ export async function shell_command(
   } = args;
   const envOverrides = getMemoryGitIdentityEnvOverrides(command, workdir);
   const resolvedWorkdir = resolveShellWorkdir(workdir);
+  await ensureMemfsCheckoutForShellCommand(command, resolvedWorkdir);
   const launchers = buildShellLaunchers(command, { login });
   if (launchers.length === 0) {
     throw new Error("Command must be a non-empty string");

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -2,7 +2,10 @@ import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getCurrentAgentId, getSkillsDirectory } from "../../agent/context";
-import { resolveScopedMemoryDir } from "../../agent/memoryFilesystem";
+import {
+  ensureLocalMemfsCheckout,
+  resolveScopedMemoryDir,
+} from "../../agent/memoryFilesystem";
 import {
   GLOBAL_SKILLS_DIR,
   getAgentSkillsDir,
@@ -10,6 +13,7 @@ import {
   SKILLS_DIR,
 } from "../../agent/skills";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
+import { settingsManager } from "../../settings-manager";
 import { queueSkillContent } from "./skillContentRegistry";
 import { validateRequiredParams } from "./validation.js";
 
@@ -104,6 +108,13 @@ async function readSkillContent(
   }
 
   // 3. Try agent memory skills directories
+  if (agentId && settingsManager.isMemfsEnabled(agentId)) {
+    try {
+      await ensureLocalMemfsCheckout(agentId);
+    } catch {
+      // Keep skill lookup best-effort; global/bundled skills may still match.
+    }
+  }
   for (const memorySkillsDir of getMemorySkillsDirs(agentId)) {
     const memorySkillPath = join(memorySkillsDir, skillId, "SKILL.md");
     try {

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -67,6 +67,14 @@ function hasAdditionalFiles(skillMdPath: string): boolean {
   }
 }
 
+function isMemfsEnabledForSkillLookup(agentId: string): boolean {
+  try {
+    return settingsManager.isMemfsEnabled(agentId);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Read skill content from file or bundled source
  * Returns both content and the path to the SKILL.md file
@@ -108,7 +116,7 @@ async function readSkillContent(
   }
 
   // 3. Try agent memory skills directories
-  if (agentId && settingsManager.isMemfsEnabled(agentId)) {
+  if (agentId && isMemfsEnabledForSkillLookup(agentId)) {
     try {
       await ensureLocalMemfsCheckout(agentId);
     } catch {

--- a/src/tools/impl/Write.ts
+++ b/src/tools/impl/Write.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { ensureMemfsCheckoutForPath } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { validateRequiredParams } from "./validation.js";
 
@@ -18,6 +19,7 @@ export async function write(args: WriteArgs): Promise<WriteResult> {
   const resolvedPath = path.isAbsolute(file_path)
     ? file_path
     : path.resolve(userCwd, file_path);
+  await ensureMemfsCheckoutForPath(resolvedPath);
   try {
     const dir = path.dirname(resolvedPath);
     await fs.mkdir(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- Move ordinary interactive memfs startup sync off the resume critical path so `letta --conv` can become ready after conversation data loads.
- Add lazy local-checkout guards across memory/file/shell/skill access paths before touching `$MEMORY_DIR`.
- Preserve blocking behavior for explicit `--memfs` / `--no-memfs` changes and first-use checkout safety.

## Test plan
- [x] `bun run lint` (passes with existing repo warnings)
- [x] `bunx --bun @biomejs/biome@2.2.5 check <changed files>`
- [x] `bun test src/tests/cli/interactive-memfs-wiring.test.ts src/tests/tools/memfs-lazy-checkout-wiring.test.ts src/tests/tools/memory-tool.test.ts src/tests/tools/memory-apply-patch.test.ts src/tests/agent/memoryFilesystem.test.ts src/tests/tools/ls.test.ts src/tests/tools/glob.test.ts src/tests/tools/grep.test.ts src/tests/tools/shell-command.test.ts src/tests/tools/run-shell-command.test.ts`
- [ ] `bun run typecheck` (currently fails on existing repo-wide missing deps/types and SDK drift, unrelated to this PR)

👾 Generated with [Letta Code](https://letta.com)