### PR TITLE
fix(cli): harden HEIC image handling across shared image tools

### DIFF
--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -85,7 +85,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     lines.splice(
       lines.length - 2,
       0,
-      "If this notification includes attachment local_path values, you can inspect those files with the Read tool.",
+      "If this notification includes attachment local_path values, you can inspect those files with the Read tool. For image attachments, you can also use ViewImage with the local_path.",
     );
   }
 

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -85,7 +85,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     lines.splice(
       lines.length - 2,
       0,
-      "If this notification includes attachment local_path values, you can inspect those files with the Read tool. For image attachments, you can also use ViewImage with the local_path.",
+      "If this notification includes attachment local_path values, you may be able to inspect those files using local file or image tools available in your current toolset (for example Read or ViewImage), using the local_path.",
     );
   }
 

--- a/src/cli/helpers/imageResize.shared.ts
+++ b/src/cli/helpers/imageResize.shared.ts
@@ -15,6 +15,11 @@ export interface ResizeResult {
   resized: boolean;
 }
 
+export function isHeicMediaType(mediaType?: string | null): boolean {
+  const normalized = mediaType?.trim().toLowerCase();
+  return normalized === "image/heic" || normalized === "image/heif";
+}
+
 export function mediaTypeForDecodedImageFormat(
   format?: string | null,
 ): string | null {

--- a/src/cli/helpers/imageResize.sips.ts
+++ b/src/cli/helpers/imageResize.sips.ts
@@ -1,0 +1,43 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function execFileAsync(file: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function convertHeicToJpegWithSips(
+  buffer: Buffer,
+): Promise<Buffer> {
+  const workDir = await mkdtemp(join(tmpdir(), "letta-heic-sips-"));
+  const inputPath = join(workDir, "input.heic");
+  const outputPath = join(workDir, "output.jpg");
+
+  try {
+    await writeFile(inputPath, buffer);
+    await execFileAsync("/usr/bin/sips", [
+      "-s",
+      "format",
+      "jpeg",
+      "-s",
+      "formatOptions",
+      "90",
+      inputPath,
+      "--out",
+      outputPath,
+    ]);
+
+    return Buffer.from(await readFile(outputPath));
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}

--- a/src/cli/helpers/imageResize.ts
+++ b/src/cli/helpers/imageResize.ts
@@ -1,6 +1,8 @@
 // Image resizing utilities for clipboard paste
 // Follows Codex CLI's approach (codex-rs/utils/image/src/lib.rs)
 
+import { isHeicMediaType } from "./imageResize.shared";
+
 export type { ResizeResult } from "./imageResize.shared";
 export {
   isHeicMediaType,
@@ -8,7 +10,6 @@ export {
   MAX_IMAGE_HEIGHT,
   MAX_IMAGE_WIDTH,
 } from "./imageResize.shared";
-import { isHeicMediaType } from "./imageResize.shared";
 
 // Build-time constant for magick variant (set via Bun.build define when USE_MAGICK=1)
 // At dev/test time this is undefined, at build time it's true/false

--- a/src/cli/helpers/imageResize.ts
+++ b/src/cli/helpers/imageResize.ts
@@ -3,10 +3,12 @@
 
 export type { ResizeResult } from "./imageResize.shared";
 export {
+  isHeicMediaType,
   MAX_IMAGE_BYTES,
   MAX_IMAGE_HEIGHT,
   MAX_IMAGE_WIDTH,
 } from "./imageResize.shared";
+import { isHeicMediaType } from "./imageResize.shared";
 
 // Build-time constant for magick variant (set via Bun.build define when USE_MAGICK=1)
 // At dev/test time this is undefined, at build time it's true/false
@@ -17,6 +19,26 @@ declare const __USE_MAGICK__: boolean | undefined;
 const useMagick =
   typeof __USE_MAGICK__ !== "undefined" && __USE_MAGICK__ === true;
 
-export const resizeImageIfNeeded = useMagick
+const backendResizeImageIfNeeded = useMagick
   ? (await import("./imageResize.magick.js")).resizeImageIfNeeded
   : (await import("./imageResize.sharp.js")).resizeImageIfNeeded;
+
+export async function resizeImageIfNeeded(
+  buffer: Buffer,
+  inputMediaType: string,
+) {
+  if (process.platform === "darwin" && isHeicMediaType(inputMediaType)) {
+    try {
+      const { convertHeicToJpegWithSips } = await import(
+        "./imageResize.sips.js"
+      );
+      const convertedBuffer = await convertHeicToJpegWithSips(buffer);
+      return await backendResizeImageIfNeeded(convertedBuffer, "image/jpeg");
+    } catch {
+      // Fall through to the configured backend so non-sips environments still
+      // get the existing behavior.
+    }
+  }
+
+  return await backendResizeImageIfNeeded(buffer, inputMediaType);
+}

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -151,4 +151,30 @@ describe("outbound image normalization", () => {
 
     await expect(normalizeMessageImageParts(rawMessages)).rejects.toThrow();
   });
+
+  test("wraps explicit image normalization failures in a clean error", async () => {
+    const rawMessages: MessageCreate[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/heic",
+              data: TEST_PNG_BASE64,
+            },
+          },
+        ],
+      },
+    ];
+
+    await expect(
+      normalizeMessageImageParts(rawMessages, async () => {
+        throw new Error("codec unavailable");
+      }),
+    ).rejects.toThrow(
+      /Failed to prepare image for model: codec unavailable/,
+    );
+  });
 });

--- a/src/tests/agent/send-message-stream-image-normalization.test.ts
+++ b/src/tests/agent/send-message-stream-image-normalization.test.ts
@@ -173,8 +173,6 @@ describe("outbound image normalization", () => {
       normalizeMessageImageParts(rawMessages, async () => {
         throw new Error("codec unavailable");
       }),
-    ).rejects.toThrow(
-      /Failed to prepare image for model: codec unavailable/,
-    );
+    ).rejects.toThrow(/Failed to prepare image for model: codec unavailable/);
   });
 });

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -68,7 +68,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain("Current local time on this device:");
   });
 
-  test("mentions ViewImage for attachment image local_path inspection", () => {
+  test("mentions toolset-dependent local file/image inspection for attachment paths", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",
       chatId: "C123",
@@ -87,8 +87,10 @@ describe("formatChannelNotification", () => {
 
     const reminder = buildChannelReminderText(msg);
 
-    expect(reminder).toContain("Read tool");
+    expect(reminder).toContain("current toolset");
+    expect(reminder).toContain("Read");
     expect(reminder).toContain("ViewImage");
+    expect(reminder).not.toContain("ReadFileGemini");
   });
 
   test("adds Slack thread guidance for channel notifications", () => {

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -68,6 +68,29 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain("Current local time on this device:");
   });
 
+  test("mentions ViewImage for attachment image local_path inspection", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "see image",
+      timestamp: Date.now(),
+      attachments: [
+        {
+          kind: "image",
+          localPath: "/tmp/photo.heic",
+          name: "photo.heic",
+          mimeType: "image/heic",
+        },
+      ],
+    };
+
+    const reminder = buildChannelReminderText(msg);
+
+    expect(reminder).toContain("Read tool");
+    expect(reminder).toContain("ViewImage");
+  });
+
   test("adds Slack thread guidance for channel notifications", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",

--- a/src/tests/cli/imageResize.test.ts
+++ b/src/tests/cli/imageResize.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import sharp from "sharp";
 import {
   MAX_IMAGE_HEIGHT,
@@ -44,5 +48,45 @@ describe("resizeImageIfNeeded", () => {
     const result = await resizeImageIfNeeded(pngBuffer, "image/tiff");
 
     expect(result.mediaType).toBe("image/png");
+  });
+
+  test("converts HEIC inputs on macOS before applying model limits", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-heic-resize-"));
+    try {
+      const pngBuffer = await sharp({
+        create: {
+          width: 128,
+          height: 96,
+          channels: 3,
+          background: { r: 30, g: 140, b: 220 },
+        },
+      })
+        .png()
+        .toBuffer();
+      const pngPath = join(tempRoot, "source.png");
+      const heicPath = join(tempRoot, "source.heic");
+      writeFileSync(pngPath, pngBuffer);
+
+      execFileSync(
+        "/usr/bin/sips",
+        ["-s", "format", "heic", pngPath, "--out", heicPath],
+        { stdio: "ignore" },
+      );
+
+      const heicBuffer = readFileSync(heicPath);
+      const result = await resizeImageIfNeeded(heicBuffer, "image/heic");
+      const resizedBuffer = Buffer.from(result.data, "base64");
+      const metadata = await sharp(resizedBuffer).metadata();
+
+      expect(result.mediaType).toBe("image/jpeg");
+      expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_WIDTH);
+      expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_HEIGHT);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tests/tools/read-heic.test.ts
+++ b/src/tests/tools/read-heic.test.ts
@@ -1,81 +1,103 @@
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import type { ImageContent, TextContent } from "@letta-ai/letta-client/resources/agents/messages";
+import { execFileSync } from "node:child_process";
+import { cpSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import sharp from "sharp";
+import { read } from "../../tools/impl/Read";
 import { TestDirectory } from "../helpers/testFs";
-
-const resizeImageIfNeededMock = mock(async () => ({
-  data: "resized-heic-base64",
-  mediaType: "image/jpeg",
-  width: 640,
-  height: 480,
-  resized: false,
-}));
-
-mock.module("../../cli/helpers/imageResize.js", () => ({
-  resizeImageIfNeeded: resizeImageIfNeededMock,
-}));
-
-const { read } = await import("../../tools/impl/Read");
 
 describe("Read tool HEIC support", () => {
   let testDir: TestDirectory;
 
   afterEach(() => {
     testDir?.cleanup();
-    resizeImageIfNeededMock.mockReset();
-    resizeImageIfNeededMock.mockResolvedValue({
-      data: "resized-heic-base64",
-      mediaType: "image/jpeg",
-      width: 640,
-      height: 480,
-      resized: false,
-    });
   });
 
-  afterAll(() => {
-    mock.restore();
-  });
+  test("reads .heic files as images on macOS", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
 
-  test("routes .heic files through shared image resizing", async () => {
     testDir = new TestDirectory();
-    const file = testDir.createBinaryFile(
-      "photo.heic",
-      Buffer.from([0x01, 0x02, 0x03, 0x04]),
+    const pngPath = testDir.createBinaryFile(
+      "photo.png",
+      await sharp({
+        create: {
+          width: 96,
+          height: 72,
+          channels: 3,
+          background: { r: 35, g: 140, b: 225 },
+        },
+      })
+        .png()
+        .toBuffer(),
+    );
+    const heicPath = testDir.resolve("photo.heic");
+
+    execFileSync(
+      "/usr/bin/sips",
+      ["-s", "format", "heic", pngPath, "--out", heicPath],
+      { stdio: "ignore" },
     );
 
-    const result = await read({ file_path: file });
+    const result = await read({ file_path: heicPath });
 
-    expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
-    const heicCall = resizeImageIfNeededMock.mock.calls[0] as
-      | [Buffer, string]
-      | undefined;
-    expect(heicCall?.[1]).toBe("image/heic");
     expect(Array.isArray(result.content)).toBe(true);
-    const content = result.content as Array<TextContent | ImageContent>;
-    expect(content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
-    expect(content[1]).toEqual({
-      type: "image",
-      source: {
-        type: "base64",
-        media_type: "image/jpeg",
-        data: "resized-heic-base64",
-      },
-    });
+    if (!Array.isArray(result.content)) {
+      throw new Error("Expected image content");
+    }
+
+    expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
+    const imagePart = result.content[1];
+    if (!imagePart || imagePart.type !== "image") {
+      throw new Error("Expected image content part");
+    }
+    expect(imagePart.source.type).toBe("base64");
+    expect(imagePart.source.media_type).toBe("image/jpeg");
   });
 
-  test("routes .heif files through shared image resizing", async () => {
+  test("reads .heif files as images on macOS", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
     testDir = new TestDirectory();
-    const file = testDir.createBinaryFile(
-      "photo.heif",
-      Buffer.from([0x05, 0x06, 0x07, 0x08]),
+    const pngPath = testDir.createBinaryFile(
+      "photo.png",
+      await sharp({
+        create: {
+          width: 96,
+          height: 72,
+          channels: 3,
+          background: { r: 60, g: 120, b: 210 },
+        },
+      })
+        .png()
+        .toBuffer(),
     );
+    const heicPath = testDir.resolve("photo.heic");
+    const heifPath = testDir.resolve("photo.heif");
 
-    await read({ file_path: file });
+    execFileSync(
+      "/usr/bin/sips",
+      ["-s", "format", "heic", pngPath, "--out", heicPath],
+      { stdio: "ignore" },
+    );
+    cpSync(heicPath, heifPath);
 
-    expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
-    const heifCall = resizeImageIfNeededMock.mock.calls[0] as
-      | [Buffer, string]
-      | undefined;
-    expect(heifCall?.[1]).toBe("image/heif");
+    const result = await read({ file_path: heifPath });
+
+    expect(Array.isArray(result.content)).toBe(true);
+    if (!Array.isArray(result.content)) {
+      throw new Error("Expected image content");
+    }
+
+    expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heif]" });
+    const imagePart = result.content[1];
+    if (!imagePart || imagePart.type !== "image") {
+      throw new Error("Expected image content part");
+    }
+    expect(imagePart.source.type).toBe("base64");
+    expect(imagePart.source.media_type).toBe("image/jpeg");
   });
 
   test("surfaces a clean image-read error when HEIC preparation fails", async () => {
@@ -84,12 +106,9 @@ describe("Read tool HEIC support", () => {
       "photo.heic",
       Buffer.from([0x00, 0x0a, 0x0b, 0x0c]),
     );
-    resizeImageIfNeededMock.mockImplementationOnce(async () => {
-      throw new Error("codec unavailable");
-    });
 
     await expect(read({ file_path: file })).rejects.toThrow(
-      /Failed to read image file: .*codec unavailable/,
+      /Failed to read image file:/,
     );
   });
 });

--- a/src/tests/tools/read-heic.test.ts
+++ b/src/tests/tools/read-heic.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import type { ImageContent, TextContent } from "@letta-ai/letta-client/resources/agents/messages";
+import { TestDirectory } from "../helpers/testFs";
+
+const resizeImageIfNeededMock = mock(async () => ({
+  data: "resized-heic-base64",
+  mediaType: "image/jpeg",
+  width: 640,
+  height: 480,
+  resized: false,
+}));
+
+mock.module("../../cli/helpers/imageResize.js", () => ({
+  resizeImageIfNeeded: resizeImageIfNeededMock,
+}));
+
+const { read } = await import("../../tools/impl/Read");
+
+describe("Read tool HEIC support", () => {
+  let testDir: TestDirectory;
+
+  afterEach(() => {
+    testDir?.cleanup();
+    resizeImageIfNeededMock.mockReset();
+    resizeImageIfNeededMock.mockResolvedValue({
+      data: "resized-heic-base64",
+      mediaType: "image/jpeg",
+      width: 640,
+      height: 480,
+      resized: false,
+    });
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("routes .heic files through shared image resizing", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createBinaryFile(
+      "photo.heic",
+      Buffer.from([0x01, 0x02, 0x03, 0x04]),
+    );
+
+    const result = await read({ file_path: file });
+
+    expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(resizeImageIfNeededMock.mock.calls[0]?.[1]).toBe("image/heic");
+    expect(Array.isArray(result.content)).toBe(true);
+    const content = result.content as Array<TextContent | ImageContent>;
+    expect(content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
+    expect(content[1]).toEqual({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: "resized-heic-base64",
+      },
+    });
+  });
+
+  test("routes .heif files through shared image resizing", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createBinaryFile(
+      "photo.heif",
+      Buffer.from([0x05, 0x06, 0x07, 0x08]),
+    );
+
+    await read({ file_path: file });
+
+    expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(resizeImageIfNeededMock.mock.calls[0]?.[1]).toBe("image/heif");
+  });
+
+  test("surfaces a clean image-read error when HEIC preparation fails", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createBinaryFile(
+      "photo.heic",
+      Buffer.from([0x00, 0x0a, 0x0b, 0x0c]),
+    );
+    resizeImageIfNeededMock.mockImplementationOnce(async () => {
+      throw new Error("codec unavailable");
+    });
+
+    await expect(read({ file_path: file })).rejects.toThrow(
+      /Failed to read image file: .*codec unavailable/,
+    );
+  });
+});

--- a/src/tests/tools/read-heic.test.ts
+++ b/src/tests/tools/read-heic.test.ts
@@ -1,6 +1,6 @@
+import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { cpSync } from "node:fs";
-import { afterEach, describe, expect, test } from "bun:test";
 import sharp from "sharp";
 import { read } from "../../tools/impl/Read";
 import { TestDirectory } from "../helpers/testFs";
@@ -46,7 +46,10 @@ describe("Read tool HEIC support", () => {
       throw new Error("Expected image content");
     }
 
-    expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "[Image: photo.heic]",
+    });
     const imagePart = result.content[1];
     if (
       !imagePart ||
@@ -94,7 +97,10 @@ describe("Read tool HEIC support", () => {
       throw new Error("Expected image content");
     }
 
-    expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heif]" });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "[Image: photo.heif]",
+    });
     const imagePart = result.content[1];
     if (
       !imagePart ||

--- a/src/tests/tools/read-heic.test.ts
+++ b/src/tests/tools/read-heic.test.ts
@@ -48,10 +48,13 @@ describe("Read tool HEIC support", () => {
 
     expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
     const imagePart = result.content[1];
-    if (!imagePart || imagePart.type !== "image") {
+    if (
+      !imagePart ||
+      imagePart.type !== "image" ||
+      imagePart.source.type !== "base64"
+    ) {
       throw new Error("Expected image content part");
     }
-    expect(imagePart.source.type).toBe("base64");
     expect(imagePart.source.media_type).toBe("image/jpeg");
   });
 
@@ -93,10 +96,13 @@ describe("Read tool HEIC support", () => {
 
     expect(result.content[0]).toEqual({ type: "text", text: "[Image: photo.heif]" });
     const imagePart = result.content[1];
-    if (!imagePart || imagePart.type !== "image") {
+    if (
+      !imagePart ||
+      imagePart.type !== "image" ||
+      imagePart.source.type !== "base64"
+    ) {
       throw new Error("Expected image content part");
     }
-    expect(imagePart.source.type).toBe("base64");
     expect(imagePart.source.media_type).toBe("image/jpeg");
   });
 

--- a/src/tests/tools/read-heic.test.ts
+++ b/src/tests/tools/read-heic.test.ts
@@ -45,7 +45,10 @@ describe("Read tool HEIC support", () => {
     const result = await read({ file_path: file });
 
     expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
-    expect(resizeImageIfNeededMock.mock.calls[0]?.[1]).toBe("image/heic");
+    const heicCall = resizeImageIfNeededMock.mock.calls[0] as
+      | [Buffer, string]
+      | undefined;
+    expect(heicCall?.[1]).toBe("image/heic");
     expect(Array.isArray(result.content)).toBe(true);
     const content = result.content as Array<TextContent | ImageContent>;
     expect(content[0]).toEqual({ type: "text", text: "[Image: photo.heic]" });
@@ -69,7 +72,10 @@ describe("Read tool HEIC support", () => {
     await read({ file_path: file });
 
     expect(resizeImageIfNeededMock).toHaveBeenCalledTimes(1);
-    expect(resizeImageIfNeededMock.mock.calls[0]?.[1]).toBe("image/heif");
+    const heifCall = resizeImageIfNeededMock.mock.calls[0] as
+      | [Buffer, string]
+      | undefined;
+    expect(heifCall?.[1]).toBe("image/heif");
   });
 
   test("surfaces a clean image-read error when HEIC preparation fails", async () => {

--- a/src/tests/tools/view-image.test.ts
+++ b/src/tests/tools/view-image.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { view_image } from "../../tools/impl/ViewImage";
+import { TestDirectory } from "../helpers/testFs";
+
+describe("ViewImage tool", () => {
+  let testDir: TestDirectory;
+
+  afterEach(() => {
+    testDir?.cleanup();
+  });
+
+  test("accepts .heic paths and delegates to image reading", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createBinaryFile(
+      "photo.heic",
+      Buffer.from([0x00, 0x0a, 0x0b, 0x0c]),
+    );
+
+    await expect(view_image({ path: file })).rejects.toThrow(
+      /Failed to read image file:/,
+    );
+  });
+
+  test("accepts .heif paths and delegates to image reading", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createBinaryFile(
+      "photo.heif",
+      Buffer.from([0x00, 0x0d, 0x0e, 0x0f]),
+    );
+
+    await expect(view_image({ path: file })).rejects.toThrow(
+      /Failed to read image file:/,
+    );
+  });
+});

--- a/src/tests/websocket/listen-client-image-normalization.test.ts
+++ b/src/tests/websocket/listen-client-image-normalization.test.ts
@@ -194,6 +194,7 @@ describe("listen-client inbound image normalization", () => {
       async () => {
         throw new Error("codec unavailable");
       },
+      { imageFailureMode: "drop" },
     );
 
     expect(normalized).toEqual([

--- a/src/tests/websocket/listen-client-image-normalization.test.ts
+++ b/src/tests/websocket/listen-client-image-normalization.test.ts
@@ -169,4 +169,43 @@ describe("listen-client inbound image normalization", () => {
 
     expect(imagePart.source.media_type).toBe("image/png");
   });
+
+  test("drops inbound image parts when best-effort normalization fails", async () => {
+    const normalized = await __listenClientTestUtils.normalizeInboundMessages(
+      [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "text", text: "channel reminder" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/heic",
+                data: "raw-base64-image",
+              },
+            },
+            { type: "text", text: "<channel-notification />" },
+          ],
+          client_message_id: "cm-image-drop-on-failure",
+        },
+      ],
+      async () => {
+        throw new Error("codec unavailable");
+      },
+    );
+
+    expect(normalized).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "text", text: "channel reminder" },
+          { type: "text", text: "<channel-notification />" },
+        ],
+        client_message_id: "cm-image-drop-on-failure",
+      },
+    ]);
+  });
 });

--- a/src/tools/impl/Read.ts
+++ b/src/tools/impl/Read.ts
@@ -33,6 +33,8 @@ const IMAGE_EXTENSIONS = new Set([
   ".gif",
   ".webp",
   ".bmp",
+  ".heic",
+  ".heif",
 ]);
 
 function isImageFile(filePath: string): boolean {
@@ -48,6 +50,8 @@ function getMediaType(ext: string): string {
     ".gif": "image/gif",
     ".webp": "image/webp",
     ".bmp": "image/png", // Convert BMP to PNG
+    ".heic": "image/heic",
+    ".heif": "image/heif",
   };
   return types[ext] || "image/png";
 }
@@ -60,7 +64,13 @@ async function readImageFile(
   const mediaType = getMediaType(ext);
 
   // Use shared image resize utility
-  const result = await resizeImageIfNeeded(buffer, mediaType);
+  let result;
+  try {
+    result = await resizeImageIfNeeded(buffer, mediaType);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read image file: ${filePath} (${detail})`);
+  }
 
   return [
     {

--- a/src/tools/impl/Read.ts
+++ b/src/tools/impl/Read.ts
@@ -64,7 +64,7 @@ async function readImageFile(
   const mediaType = getMediaType(ext);
 
   // Use shared image resize utility
-  let result;
+  let result: Awaited<ReturnType<typeof resizeImageIfNeeded>>;
   try {
     result = await resizeImageIfNeeded(buffer, mediaType);
   } catch (error) {

--- a/src/tools/impl/ViewImage.ts
+++ b/src/tools/impl/ViewImage.ts
@@ -14,6 +14,8 @@ const IMAGE_EXTENSIONS = new Set([
   ".gif",
   ".webp",
   ".bmp",
+  ".heic",
+  ".heif",
 ]);
 
 function isImageFile(filePath: string): boolean {

--- a/src/utils/messageImageNormalization.ts
+++ b/src/utils/messageImageNormalization.ts
@@ -14,6 +14,13 @@ export type Base64ImageContentPart = {
   source: { type: "base64"; media_type: string; data: string };
 };
 
+export type ImageNormalizationFailureMode = "strict" | "drop";
+
+function formatImageNormalizationError(error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`Failed to prepare image for model: ${detail}`);
+}
+
 export function isBase64ImageContentPart(
   part: unknown,
 ): part is Base64ImageContentPart {
@@ -44,6 +51,7 @@ export function isBase64ImageContentPart(
 export async function normalizeMessageContentImages(
   content: MessageCreate["content"],
   resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
+  failureMode: ImageNormalizationFailureMode = "strict",
 ): Promise<MessageCreate["content"]> {
   if (typeof content === "string") {
     return content;
@@ -56,10 +64,19 @@ export async function normalizeMessageContentImages(
         return part;
       }
 
-      const resized = await resize(
-        Buffer.from(part.source.data, "base64"),
-        part.source.media_type,
-      );
+      let resized;
+      try {
+        resized = await resize(
+          Buffer.from(part.source.data, "base64"),
+          part.source.media_type,
+        );
+      } catch (error) {
+        if (failureMode === "drop") {
+          didChange = true;
+          return null;
+        }
+        throw formatImageNormalizationError(error);
+      }
 
       if (
         resized.data !== part.source.data ||
@@ -80,7 +97,12 @@ export async function normalizeMessageContentImages(
     }),
   );
 
-  return didChange ? normalizedParts : content;
+  const filteredParts = normalizedParts.filter(
+    (part): part is Exclude<(typeof normalizedParts)[number], null> =>
+      part !== null,
+  );
+
+  return didChange ? filteredParts : content;
 }
 
 export async function normalizeMessageImageParts<

--- a/src/utils/messageImageNormalization.ts
+++ b/src/utils/messageImageNormalization.ts
@@ -64,7 +64,7 @@ export async function normalizeMessageContentImages(
         return part;
       }
 
-      let resized;
+      let resized: Awaited<ReturnType<typeof resize>>;
       try {
         resized = await resize(
           Buffer.from(part.source.data, "base64"),

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -14,7 +14,10 @@ import type {
 import { isCoalescable } from "../../queue/queueRuntime";
 import { mergeQueuedTurnInput } from "../../queue/turnQueueRuntime";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
-import { normalizeMessageContentImages as normalizeSharedMessageContentImages } from "../../utils/messageImageNormalization";
+import {
+  type ImageNormalizationFailureMode,
+  normalizeMessageContentImages as normalizeSharedMessageContentImages,
+} from "../../utils/messageImageNormalization";
 import { getListenerBlockedReason } from "../helpers/listenerQueueAdapter";
 import { emitDequeuedUserMessage } from "./protocol-outbound";
 import {
@@ -202,13 +205,21 @@ function mapTurnLifecycleOutcome(
 export async function normalizeMessageContentImages(
   content: MessageCreate["content"],
   resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
+  failureMode: ImageNormalizationFailureMode = "strict",
 ): Promise<MessageCreate["content"]> {
-  return await normalizeSharedMessageContentImages(content, resize);
+  return await normalizeSharedMessageContentImages(
+    content,
+    resize,
+    failureMode,
+  );
 }
 
 export async function normalizeInboundMessages(
   messages: InboundMessagePayload[],
   resize: typeof resizeImageIfNeeded = resizeImageIfNeeded,
+  options: {
+    imageFailureMode?: ImageNormalizationFailureMode;
+  } = {},
 ): Promise<InboundMessagePayload[]> {
   let didChange = false;
 
@@ -221,6 +232,7 @@ export async function normalizeInboundMessages(
       const normalizedContent = await normalizeMessageContentImages(
         message.content,
         resize,
+        options.imageFailureMode ?? "strict",
       );
       if (normalizedContent !== message.content) {
         didChange = true;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -442,7 +442,10 @@ export async function handleIncomingMessage(
     }
 
     const { normalizeInboundMessages } = await import("./queue");
-    const normalizedMessages = await normalizeInboundMessages(msg.messages);
+    const normalizedMessages = await normalizeInboundMessages(msg.messages, undefined, {
+      imageFailureMode:
+        (msg.channelTurnSources?.length ?? 0) > 0 ? "drop" : "strict",
+    });
     trackListenerUserInput(normalizedMessages, "unknown");
     const messagesToSend: Array<MessageCreate | ApprovalCreate> = [];
     let turnToolContextId: string | null = null;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -442,10 +442,14 @@ export async function handleIncomingMessage(
     }
 
     const { normalizeInboundMessages } = await import("./queue");
-    const normalizedMessages = await normalizeInboundMessages(msg.messages, undefined, {
-      imageFailureMode:
-        (msg.channelTurnSources?.length ?? 0) > 0 ? "drop" : "strict",
-    });
+    const normalizedMessages = await normalizeInboundMessages(
+      msg.messages,
+      undefined,
+      {
+        imageFailureMode:
+          (msg.channelTurnSources?.length ?? 0) > 0 ? "drop" : "strict",
+      },
+    );
     trackListenerUserInput(normalizedMessages, "unknown");
     const messagesToSend: Array<MessageCreate | ApprovalCreate> = [];
     let turnToolContextId: string | null = null;


### PR DESCRIPTION
## Summary
- contain shared image normalization failures so explicit outbound sends surface a clean error while channel-originated turns drop only the image part that could not be normalized
- add a macOS `sips` HEIC/HEIF conversion path ahead of the existing shared resize backend, with regression coverage for direct sends, listener ingress, and shared resize behavior
- extend local attachment inspection so `Read` and `ViewImage` both handle `.heic`/`.heif` paths, and update channel reminders to mention `ViewImage` for image attachment `local_path`s

👾 Generated with [Letta Code](https://letta.com)