### PR TITLE
fix(cli): harden shared image resize handling

### DIFF
--- a/src/cli/helpers/imageResize.shared.ts
+++ b/src/cli/helpers/imageResize.shared.ts
@@ -7,6 +7,10 @@ export const MAX_IMAGE_HEIGHT = 2000;
 // We enforce this in the client to avoid provider-side API errors.
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
+// Match OpenClaw's decompression-bomb guard to fail closed on pathological
+// images before the shared resize path spends significant work decoding them.
+export const MAX_IMAGE_INPUT_PIXELS = 25_000_000;
+
 export interface ResizeResult {
   data: string; // base64 encoded
   mediaType: string;

--- a/src/cli/helpers/imageResize.sharp.ts
+++ b/src/cli/helpers/imageResize.sharp.ts
@@ -15,7 +15,7 @@ import {
 
 function createSharpInstance(buffer: Buffer) {
   return sharp(buffer, {
-    failOnError: false,
+    failOn: "warning",
     limitInputPixels: MAX_IMAGE_INPUT_PIXELS,
   });
 }

--- a/src/cli/helpers/imageResize.sharp.ts
+++ b/src/cli/helpers/imageResize.sharp.ts
@@ -8,9 +8,30 @@ import {
   canonicalizeOutputMediaType,
   MAX_IMAGE_BYTES,
   MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_INPUT_PIXELS,
   MAX_IMAGE_WIDTH,
   type ResizeResult,
 } from "./imageResize.shared";
+
+function createSharpInstance(buffer: Buffer) {
+  return sharp(buffer, {
+    failOnError: false,
+    limitInputPixels: MAX_IMAGE_INPUT_PIXELS,
+  });
+}
+
+function wrapSharpImageError(error: unknown): Error {
+  if (
+    error instanceof Error &&
+    error.message.toLowerCase().includes("pixel limit")
+  ) {
+    return new Error(
+      `Image exceeds the ${MAX_IMAGE_INPUT_PIXELS.toLocaleString()} pixel input limit`,
+    );
+  }
+
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 async function inspectImageBuffer(
   buffer: Buffer,
@@ -21,7 +42,11 @@ async function inspectImageBuffer(
   format?: string;
   orientation?: number;
 }> {
-  const metadata = await sharp(buffer).metadata();
+  const metadata = await createSharpInstance(buffer)
+    .metadata()
+    .catch((error) => {
+      throw wrapSharpImageError(error);
+    });
   const width = metadata.width ?? 0;
   const height = metadata.height ?? 0;
   assertImageHasDimensions(width, height, context);
@@ -68,7 +93,9 @@ async function compressToFitByteLimit(
   // Try progressive JPEG quality reduction
   const qualities = [85, 70, 55, 40];
   for (const quality of qualities) {
-    const compressed = await sharp(buffer).jpeg({ quality }).toBuffer();
+    const compressed = await createSharpInstance(buffer)
+      .jpeg({ quality })
+      .toBuffer();
     if (compressed.length <= MAX_IMAGE_BYTES) {
       return buildVerifiedResizeResult(
         compressed,
@@ -84,7 +111,7 @@ async function compressToFitByteLimit(
   for (const scale of scales) {
     const scaledWidth = Math.floor(currentWidth * scale);
     const scaledHeight = Math.floor(currentHeight * scale);
-    const reduced = await sharp(buffer)
+    const reduced = await createSharpInstance(buffer)
       .resize(scaledWidth, scaledHeight, {
         fit: "inside",
         withoutEnlargement: true,
@@ -119,9 +146,9 @@ export async function resizeImageIfNeeded(
   const sourceMetadata = await inspectImageBuffer(buffer, "source image");
   const normalizedBuffer =
     sourceMetadata.orientation && sourceMetadata.orientation !== 1
-      ? await sharp(buffer).rotate().toBuffer()
+      ? await createSharpInstance(buffer).rotate().toBuffer()
       : buffer;
-  const image = sharp(normalizedBuffer);
+  const image = createSharpInstance(normalizedBuffer);
   const { width, height, format } = await inspectImageBuffer(
     normalizedBuffer,
     "normalized source image",

--- a/src/cli/helpers/imageResize.sharp.ts
+++ b/src/cli/helpers/imageResize.sharp.ts
@@ -15,12 +15,22 @@ import {
 async function inspectImageBuffer(
   buffer: Buffer,
   context: string,
-): Promise<{ width: number; height: number; format?: string }> {
+): Promise<{
+  width: number;
+  height: number;
+  format?: string;
+  orientation?: number;
+}> {
   const metadata = await sharp(buffer).metadata();
   const width = metadata.width ?? 0;
   const height = metadata.height ?? 0;
   assertImageHasDimensions(width, height, context);
-  return { width, height, format: metadata.format };
+  return {
+    width,
+    height,
+    format: metadata.format,
+    orientation: metadata.orientation,
+  };
 }
 
 async function buildVerifiedResizeResult(
@@ -106,10 +116,15 @@ export async function resizeImageIfNeeded(
   buffer: Buffer,
   inputMediaType: string,
 ): Promise<ResizeResult> {
-  const image = sharp(buffer);
+  const sourceMetadata = await inspectImageBuffer(buffer, "source image");
+  const normalizedBuffer =
+    sourceMetadata.orientation && sourceMetadata.orientation !== 1
+      ? await sharp(buffer).rotate().toBuffer()
+      : buffer;
+  const image = sharp(normalizedBuffer);
   const { width, height, format } = await inspectImageBuffer(
-    buffer,
-    "source image",
+    normalizedBuffer,
+    "normalized source image",
   );
 
   const needsResize = width > MAX_IMAGE_WIDTH || height > MAX_IMAGE_HEIGHT;
@@ -119,12 +134,16 @@ export async function resizeImageIfNeeded(
 
   if (!needsResize && isPassthroughFormat) {
     // No resize needed and format is supported - but check byte limit
-    const compressed = await compressToFitByteLimit(buffer, width, height);
+    const compressed = await compressToFitByteLimit(
+      normalizedBuffer,
+      width,
+      height,
+    );
     if (compressed) {
       return compressed;
     }
     return buildVerifiedResizeResult(
-      buffer,
+      normalizedBuffer,
       inputMediaType,
       false,
       "passthrough image output",

--- a/src/cli/helpers/imageResize.ts
+++ b/src/cli/helpers/imageResize.ts
@@ -8,6 +8,7 @@ export {
   isHeicMediaType,
   MAX_IMAGE_BYTES,
   MAX_IMAGE_HEIGHT,
+  MAX_IMAGE_INPUT_PIXELS,
   MAX_IMAGE_WIDTH,
 } from "./imageResize.shared";
 

--- a/src/tests/cli/imageResize.test.ts
+++ b/src/tests/cli/imageResize.test.ts
@@ -75,6 +75,23 @@ describe("resizeImageIfNeeded", () => {
     expect(metadata.orientation).toBeUndefined();
   });
 
+  test("rejects images whose input pixel count exceeds the safety limit", async () => {
+    const oversizedByPixels = await sharp({
+      create: {
+        width: 5000,
+        height: 5001,
+        channels: 3,
+        background: { r: 40, g: 120, b: 200 },
+      },
+    })
+      .jpeg({ quality: 80 })
+      .toBuffer();
+
+    await expect(
+      resizeImageIfNeeded(oversizedByPixels, "image/jpeg"),
+    ).rejects.toThrow(/pixel input limit/);
+  });
+
   test("converts HEIC inputs on macOS before applying model limits", async () => {
     if (process.platform !== "darwin") {
       return;

--- a/src/tests/cli/imageResize.test.ts
+++ b/src/tests/cli/imageResize.test.ts
@@ -50,6 +50,31 @@ describe("resizeImageIfNeeded", () => {
     expect(result.mediaType).toBe("image/png");
   });
 
+  test("normalizes EXIF-oriented JPEG inputs before returning them", async () => {
+    const orientedJpeg = await sharp({
+      create: {
+        width: 200,
+        height: 120,
+        channels: 3,
+        background: { r: 220, g: 60, b: 40 },
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer();
+
+    const result = await resizeImageIfNeeded(orientedJpeg, "image/jpeg");
+    const normalizedBuffer = Buffer.from(result.data, "base64");
+    const metadata = await sharp(normalizedBuffer).metadata();
+
+    expect(result.mediaType).toBe("image/jpeg");
+    expect(result.width).toBe(120);
+    expect(result.height).toBe(200);
+    expect(metadata.width).toBe(120);
+    expect(metadata.height).toBe(200);
+    expect(metadata.orientation).toBeUndefined();
+  });
+
   test("converts HEIC inputs on macOS before applying model limits", async () => {
     if (process.platform !== "darwin") {
       return;


### PR DESCRIPTION
## Summary
- normalize EXIF-oriented JPEGs before the shared resize pipeline inspects or re-encodes them, so image reads and sends don't come back sideways after metadata gets stripped
- reject decoded images above a 25,000,000 pixel safety ceiling early in the shared sharp backend instead of silently processing pathological inputs
- add regression coverage for both the EXIF normalization path and the oversized-image guard

👾 Generated with [Letta Code](https://letta.com)