### PR TITLE
fix(cli): route Gemini models through the default toolset

### DIFF
--- a/src/tests/tools/model-provider-detection.test.ts
+++ b/src/tests/tools/model-provider-detection.test.ts
@@ -38,6 +38,11 @@ describe("deriveToolsetFromModel", () => {
     expect(deriveToolsetFromModel("chatgpt_oauth/gpt-5.3-codex")).toBe("codex");
   });
 
+  test("maps Gemini models to default (anthropic) toolset", () => {
+    expect(deriveToolsetFromModel("google_ai/gemini-2.5-pro")).toBe("default");
+    expect(deriveToolsetFromModel("gemini-pro")).toBe("default");
+  });
+
   test("maps auto models to default (anthropic) toolset", () => {
     expect(deriveToolsetFromModel("auto")).toBe("default");
     expect(deriveToolsetFromModel("letta/auto")).toBe("default");

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -155,6 +155,19 @@ describe("tool execution context snapshot", () => {
     expect(withPreparedContext.status).toBe("success");
   });
 
+  test("Gemini models use the default Claude-style auto toolset", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "google_ai/gemini-2.5-pro",
+    );
+
+    expect(prepared.loadedToolNames).toContain("Read");
+    expect(prepared.loadedToolNames).toContain("Write");
+    expect(prepared.loadedToolNames).toContain("Bash");
+    expect(prepared.loadedToolNames).not.toContain("ReadFileGemini");
+    expect(prepared.loadedToolNames).not.toContain("WriteFileGemini");
+    expect(prepared.loadedToolNames).not.toContain("RunShellCommand");
+  });
+
   test("prepares current tool snapshots with fresh MessageChannel discovery", async () => {
     await loadSpecificTools(["Read"]);
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1142,16 +1142,12 @@ async function resolveBaseToolNamesForModel(
   if (
     !toolFilter.isActive() &&
     modelIdentifier &&
-    isGeminiModel(modelIdentifier)
-  ) {
-    baseToolNames = GEMINI_PASCAL_TOOLS;
-  } else if (
-    !toolFilter.isActive() &&
-    modelIdentifier &&
     isOpenAIModel(modelIdentifier)
   ) {
     baseToolNames = OPENAI_PASCAL_TOOLS;
   } else if (!toolFilter.isActive()) {
+    // Temporary rollback: Gemini models should use the default Claude-style
+    // toolset until we intentionally restore the Gemini-specific toolset.
     baseToolNames = ANTHROPIC_DEFAULT_TOOLS;
   } else {
     baseToolNames = TOOL_NAMES;

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -17,7 +17,6 @@ import {
   GEMINI_DEFAULT_TOOLS,
   GEMINI_PASCAL_TOOLS,
   getToolNames,
-  isGeminiModel,
   isOpenAIModel,
   loadSpecificTools,
   loadTools,
@@ -56,13 +55,9 @@ export type ToolsetPreference = ToolsetName | "auto";
 
 export function deriveToolsetFromModel(
   modelIdentifier: string,
-): "codex" | "gemini" | "default" {
+): "codex" | "default" {
   const resolvedModel = resolveModel(modelIdentifier) ?? modelIdentifier;
-  return isOpenAIModel(resolvedModel)
-    ? "codex"
-    : isGeminiModel(resolvedModel)
-      ? "gemini"
-      : "default";
+  return isOpenAIModel(resolvedModel) ? "codex" : "default";
 }
 
 type ScopeModelCarrier = Pick<AgentState, "model" | "llm_config">;


### PR DESCRIPTION
## Summary
- temporarily make Gemini models resolve to the default Claude-style toolset in auto mode instead of the Gemini-specific toolset
- keep the manual Gemini toolset options intact so this only affects model-based auto-selection
- add regression coverage for both toolset detection and prepared tool snapshots so Gemini models now load Read/Write/Bash instead of the Gemini-specific tools

👾 Generated with [Letta Code](https://letta.com)