### PR TITLE
fix(ws): only switch cwd for the conversation that created the worktree

### DIFF
--- a/src/tests/tools/bash.test.ts
+++ b/src/tests/tools/bash.test.ts
@@ -112,4 +112,17 @@ describe("Bash tool", () => {
       "Worktrees must be created under .letta/worktrees/",
     );
   });
+
+  test("blocks env-prefixed git worktree add outside .letta/worktrees/", async () => {
+    const result = await bash({
+      command:
+        "FOO=1 env -i BAR=2 git worktree add -b fix/feature ../my-worktree main",
+      description: "Test env-prefixed worktree path enforcement",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.content[0]?.text).toContain(
+      "Worktrees must be created under .letta/worktrees/",
+    );
+  });
 });

--- a/src/tests/websocket/worktree-ownership.test.ts
+++ b/src/tests/websocket/worktree-ownership.test.ts
@@ -99,4 +99,31 @@ describe("worktree ownership tracking", () => {
       ),
     ).toBe(path.resolve("/repo/packages/app", ".letta/worktrees/fix-bar"));
   });
+
+  test("parses env-prefixed git worktree commands", () => {
+    expect(
+      __worktreeOwnershipTestUtils.resolveGitWorktreeAddTargetPath(
+        "FOO=1 env -i BAR=2 git worktree add -b fix/foo ../outside main",
+        "/repo",
+      ),
+    ).toBe(path.resolve("/repo", "../outside"));
+
+    expect(
+      __worktreeOwnershipTestUtils.resolveGitWorktreeAddTargetPathFromLauncher(
+        [
+          "env",
+          "-i",
+          "FOO=1",
+          "git",
+          "worktree",
+          "add",
+          "-b",
+          "fix/foo",
+          ".letta/worktrees/fix-foo",
+          "main",
+        ],
+        "/repo",
+      ),
+    ).toBe(path.resolve("/repo", ".letta/worktrees/fix-foo"));
+  });
 });

--- a/src/tests/websocket/worktree-ownership.test.ts
+++ b/src/tests/websocket/worktree-ownership.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { runWithRuntimeContext } from "../../runtime-context";
+import { __listenClientTestUtils } from "../../websocket/listen-client";
+import {
+  getConversationRuntime,
+  setActiveRuntime,
+} from "../../websocket/listener/runtime";
+import {
+  __worktreeOwnershipTestUtils,
+  clearExpectedWorktreePath,
+  hasExpectedWorktreePath,
+  noteExpectedWorktreeForLauncher,
+} from "../../websocket/listener/worktree-ownership";
+
+describe("worktree ownership tracking", () => {
+  test("tracks the expected worktree path for the active conversation", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    void __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-1",
+    );
+    setActiveRuntime(listener);
+
+    try {
+      runWithRuntimeContext(
+        {
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          workingDirectory: "/repo",
+        },
+        () => {
+          noteExpectedWorktreeForLauncher(
+            [
+              "/bin/bash",
+              "-lc",
+              'git worktree add -b fix/foo ".letta/worktrees/fix-foo" main',
+            ],
+            "/repo",
+          );
+        },
+      );
+
+      const runtime = getConversationRuntime(listener, "agent-1", "conv-1");
+      expect(runtime?.expectedWorktreePath).toBe(
+        path.resolve("/repo", ".letta/worktrees/fix-foo"),
+      );
+    } finally {
+      setActiveRuntime(null);
+    }
+  });
+
+  test("only accepts the exact expected worktree path and clears it after use", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-1",
+    );
+
+    runtime.expectedWorktreePath = path.resolve(
+      "/repo",
+      ".letta/worktrees/fix-foo",
+    );
+
+    expect(
+      hasExpectedWorktreePath(
+        runtime,
+        path.resolve("/repo", ".letta/worktrees/other"),
+      ),
+    ).toBe(false);
+    expect(
+      hasExpectedWorktreePath(
+        runtime,
+        path.resolve("/repo", ".letta/worktrees/fix-foo"),
+      ),
+    ).toBe(true);
+
+    clearExpectedWorktreePath(runtime);
+    expect(runtime.expectedWorktreePath).toBeNull();
+  });
+
+  test("parses direct git launchers and git -C commands", () => {
+    expect(
+      __worktreeOwnershipTestUtils.resolveGitWorktreeAddTargetPathFromLauncher(
+        [
+          "git",
+          "-C",
+          "packages/app",
+          "worktree",
+          "add",
+          "-b",
+          "fix/bar",
+          ".letta/worktrees/fix-bar",
+          "main",
+        ],
+        "/repo",
+      ),
+    ).toBe(path.resolve("/repo/packages/app", ".letta/worktrees/fix-bar"));
+  });
+});

--- a/src/tools/impl/Bash.ts
+++ b/src/tools/impl/Bash.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { INTERRUPTED_BY_USER } from "../../constants";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
+import { resolveGitWorktreeAddTargetPath } from "../../websocket/listener/worktree-ownership";
 import {
   appendBackgroundProcessOutput,
   appendToOutputFile,
@@ -23,19 +24,16 @@ import { validateRequiredParams } from "./validation.js";
  * Returns an error message if the path is invalid, or null if OK.
  */
 function validateWorktreePath(command: string, cwd: string): string | null {
-  // Match `git worktree add` with optional flags before the path
-  const match = command.match(/\bgit\s+worktree\s+add\s+(?:-b\s+\S+\s+)?(\S+)/);
-  if (!match?.[1]) return null;
+  const resolved = resolveGitWorktreeAddTargetPath(command, cwd);
+  if (!resolved) return null;
 
-  const targetPath = match[1];
-  const resolved = resolve(cwd, targetPath);
   const requiredPrefix = resolve(cwd, ".letta/worktrees");
 
   if (!resolved.startsWith(requiredPrefix)) {
     return (
       `Error: Worktrees must be created under .letta/worktrees/. ` +
       `Use: git worktree add -b <branch> .letta/worktrees/<name> main\n` +
-      `Got: ${targetPath}`
+      `Got: ${resolved}`
     );
   }
   return null;

--- a/src/tools/impl/shellRunner.ts
+++ b/src/tools/impl/shellRunner.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { noteExpectedWorktreeForLauncher } from "../../websocket/listener/worktree-ownership";
 
 export class ShellExecutionError extends Error {
   code?: string;
@@ -29,6 +30,8 @@ export function spawnWithLauncher(
       reject(new ShellExecutionError("Executable is required"));
       return;
     }
+
+    noteExpectedWorktreeForLauncher(launcher, options.cwd);
 
     const childProcess = spawn(executable, args, {
       cwd: options.cwd,

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -166,6 +166,8 @@ export function createConversationRuntime(
     lastStopReason: null,
     isProcessing: false,
     activeWorkingDirectory: null,
+    expectedWorktreePath: null,
+    expectedWorktreeExpiresAt: null,
     activeRunId: null,
     activeRunStartedAt: null,
     activeAbortController: null,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -119,6 +119,8 @@ export type ConversationRuntime = {
   lastStopReason: string | null;
   isProcessing: boolean;
   activeWorkingDirectory: string | null;
+  expectedWorktreePath: string | null;
+  expectedWorktreeExpiresAt: number | null;
   activeRunId: string | null;
   activeRunStartedAt: string | null;
   activeAbortController: AbortController | null;

--- a/src/websocket/listener/worktree-ownership.ts
+++ b/src/websocket/listener/worktree-ownership.ts
@@ -9,6 +9,7 @@ import { getActiveRuntime, getConversationRuntime } from "./runtime";
 import type { ConversationRuntime } from "./types";
 
 const EXPECTED_WORKTREE_TTL_MS = 10_000;
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
 const GIT_OPTIONS_WITH_VALUE = new Set([
   "-C",
@@ -26,9 +27,24 @@ const WORKTREE_ADD_OPTIONS_WITH_VALUE = new Set([
   "--reason",
 ]);
 
+const ENV_OPTIONS_WITH_VALUE = new Set([
+  "-u",
+  "--unset",
+  "-C",
+  "--chdir",
+  "-S",
+  "--split-string",
+  "--argv0",
+]);
+
 function isEnvExecutable(command: string): boolean {
   const normalized = command.replace(/\\/g, "/").toLowerCase();
   return normalized === "env" || normalized.endsWith("/env");
+}
+
+function isGitExecutable(command: string): boolean {
+  const normalized = command.replace(/\\/g, "/").toLowerCase();
+  return path.basename(normalized) === "git";
 }
 
 function isShellExecutable(command: string): boolean {
@@ -101,12 +117,13 @@ function resolveGitWorktreePathFromTokens(
   tokens: string[],
   cwd: string,
 ): string | null {
-  if (tokens[0] !== "git") {
+  const gitCommandStart = findGitCommandStartIndex(tokens);
+  if (gitCommandStart === null) {
     return null;
   }
 
   let gitWorkingDirectory = cwd;
-  let index = 1;
+  let index = gitCommandStart + 1;
 
   while (index < tokens.length) {
     const token = tokens[index];
@@ -165,6 +182,77 @@ function resolveGitWorktreePathFromTokens(
   }
 
   return null;
+}
+
+function findGitCommandStartIndex(tokens: string[]): number | null {
+  let index = 0;
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (!token || !ENV_ASSIGNMENT_PATTERN.test(token)) {
+      break;
+    }
+    index += 1;
+  }
+
+  if (index >= tokens.length) {
+    return null;
+  }
+
+  const executable = tokens[index];
+  if (!executable) {
+    return null;
+  }
+
+  if (isEnvExecutable(executable)) {
+    index += 1;
+    while (index < tokens.length) {
+      const token = tokens[index];
+      if (!token) {
+        index += 1;
+        continue;
+      }
+
+      if (token === "--") {
+        index += 1;
+        break;
+      }
+
+      if (token.startsWith("--") && token.includes("=")) {
+        const [flag] = token.split("=", 1);
+        if (flag && ENV_OPTIONS_WITH_VALUE.has(flag)) {
+          index += 1;
+          continue;
+        }
+      }
+
+      if (ENV_OPTIONS_WITH_VALUE.has(token)) {
+        index += 2;
+        continue;
+      }
+
+      if (token.startsWith("-") || ENV_ASSIGNMENT_PATTERN.test(token)) {
+        index += 1;
+        continue;
+      }
+
+      break;
+    }
+  }
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (!token || !ENV_ASSIGNMENT_PATTERN.test(token)) {
+      break;
+    }
+    index += 1;
+  }
+
+  if (index >= tokens.length) {
+    return null;
+  }
+
+  return isGitExecutable(tokens[index] ?? "") ? index : null;
 }
 
 export function resolveGitWorktreeAddTargetPath(

--- a/src/websocket/listener/worktree-ownership.ts
+++ b/src/websocket/listener/worktree-ownership.ts
@@ -1,0 +1,272 @@
+import path from "node:path";
+import {
+  extractDashCArgument,
+  splitShellSegmentsAllowCommandSubstitution,
+  tokenizeShellWords,
+} from "../../permissions/shellAnalysis";
+import { getRuntimeContext } from "../../runtime-context";
+import { getActiveRuntime, getConversationRuntime } from "./runtime";
+import type { ConversationRuntime } from "./types";
+
+const EXPECTED_WORKTREE_TTL_MS = 10_000;
+
+const GIT_OPTIONS_WITH_VALUE = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--namespace",
+  "--super-prefix",
+  "--work-tree",
+]);
+
+const WORKTREE_ADD_OPTIONS_WITH_VALUE = new Set([
+  "-b",
+  "-B",
+  "--branch",
+  "--reason",
+]);
+
+function isEnvExecutable(command: string): boolean {
+  const normalized = command.replace(/\\/g, "/").toLowerCase();
+  return normalized === "env" || normalized.endsWith("/env");
+}
+
+function isShellExecutable(command: string): boolean {
+  const normalized = command.replace(/\\/g, "/").toLowerCase();
+  const basename = path.basename(normalized);
+
+  return (
+    basename === "bash" ||
+    basename === "sh" ||
+    basename === "zsh" ||
+    basename === "ash" ||
+    basename === "cmd.exe" ||
+    basename.includes("powershell") ||
+    basename.includes("pwsh")
+  );
+}
+
+function extractShellCommandArgument(
+  launcher: string[],
+  startIndex: number,
+): string | null {
+  const argIndex = launcher.findIndex((token, index) => {
+    if (index < startIndex) {
+      return false;
+    }
+
+    const normalized = token.toLowerCase();
+    return (
+      normalized === "-command" ||
+      normalized === "/c" ||
+      normalized === "-c" ||
+      normalized === "-lc" ||
+      /^-[a-z]*c$/i.test(token)
+    );
+  });
+
+  if (argIndex >= 0) {
+    return launcher[argIndex + 1] ?? null;
+  }
+
+  return extractDashCArgument(launcher.slice(startIndex)) ?? null;
+}
+
+function resolveShellCommandFromLauncher(launcher: string[]): string | null {
+  const first = launcher[0];
+  if (!first) return null;
+
+  if (isEnvExecutable(first)) {
+    for (let i = 1; i < launcher.length; i += 1) {
+      const token = launcher[i];
+      if (!token) continue;
+      if (token.startsWith("-")) continue;
+      if (/^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token)) continue;
+      if (!isShellExecutable(token)) {
+        return null;
+      }
+      return extractShellCommandArgument(launcher, i + 1);
+    }
+    return null;
+  }
+
+  if (!isShellExecutable(first)) {
+    return null;
+  }
+
+  return extractShellCommandArgument(launcher, 1);
+}
+
+function resolveGitWorktreePathFromTokens(
+  tokens: string[],
+  cwd: string,
+): string | null {
+  if (tokens[0] !== "git") {
+    return null;
+  }
+
+  let gitWorkingDirectory = cwd;
+  let index = 1;
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (!token) break;
+
+    if (token === "worktree" && tokens[index + 1] === "add") {
+      index += 2;
+      break;
+    }
+
+    if (token === "-C") {
+      const candidateCwd = tokens[index + 1];
+      if (!candidateCwd) {
+        return null;
+      }
+      gitWorkingDirectory = path.resolve(cwd, candidateCwd);
+      index += 2;
+      continue;
+    }
+
+    if (GIT_OPTIONS_WITH_VALUE.has(token)) {
+      index += 2;
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      index += 1;
+      continue;
+    }
+
+    return null;
+  }
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (!token) return null;
+
+    if (token === "--") {
+      const explicitPath = tokens[index + 1];
+      return explicitPath
+        ? path.resolve(gitWorkingDirectory, explicitPath)
+        : null;
+    }
+
+    if (WORKTREE_ADD_OPTIONS_WITH_VALUE.has(token)) {
+      index += 2;
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      index += 1;
+      continue;
+    }
+
+    return path.resolve(gitWorkingDirectory, token);
+  }
+
+  return null;
+}
+
+export function resolveGitWorktreeAddTargetPath(
+  command: string,
+  cwd: string,
+): string | null {
+  const segments = splitShellSegmentsAllowCommandSubstitution(command) ?? [
+    command,
+  ];
+
+  for (const segment of segments) {
+    const resolved = resolveGitWorktreePathFromTokens(
+      tokenizeShellWords(segment),
+      cwd,
+    );
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+export function resolveGitWorktreeAddTargetPathFromLauncher(
+  launcher: string[],
+  cwd: string,
+): string | null {
+  const shellCommand = resolveShellCommandFromLauncher(launcher);
+  if (shellCommand) {
+    return resolveGitWorktreeAddTargetPath(shellCommand, cwd);
+  }
+
+  return resolveGitWorktreePathFromTokens(launcher, cwd);
+}
+
+export function noteExpectedWorktreeForLauncher(
+  launcher: string[],
+  cwd: string,
+): void {
+  const expectedWorktreePath = resolveGitWorktreeAddTargetPathFromLauncher(
+    launcher,
+    cwd,
+  );
+  if (!expectedWorktreePath) {
+    return;
+  }
+
+  const runtimeContext = getRuntimeContext();
+  const conversationId = runtimeContext?.conversationId;
+  if (!conversationId) {
+    return;
+  }
+
+  const listener = getActiveRuntime();
+  if (!listener) {
+    return;
+  }
+
+  const conversationRuntime = getConversationRuntime(
+    listener,
+    runtimeContext.agentId ?? null,
+    conversationId,
+  );
+  if (!conversationRuntime) {
+    return;
+  }
+
+  conversationRuntime.expectedWorktreePath = expectedWorktreePath;
+  conversationRuntime.expectedWorktreeExpiresAt =
+    Date.now() + EXPECTED_WORKTREE_TTL_MS;
+}
+
+export function hasExpectedWorktreePath(
+  runtime: ConversationRuntime | null,
+  detectedPath: string,
+): boolean {
+  if (!runtime) {
+    return false;
+  }
+
+  if (
+    runtime.expectedWorktreeExpiresAt !== null &&
+    runtime.expectedWorktreeExpiresAt <= Date.now()
+  ) {
+    clearExpectedWorktreePath(runtime);
+    return false;
+  }
+
+  return runtime.expectedWorktreePath === detectedPath;
+}
+
+export function clearExpectedWorktreePath(
+  runtime: ConversationRuntime | null,
+): void {
+  if (!runtime) {
+    return;
+  }
+  runtime.expectedWorktreePath = null;
+  runtime.expectedWorktreeExpiresAt = null;
+}
+
+export const __worktreeOwnershipTestUtils = {
+  resolveGitWorktreeAddTargetPath,
+  resolveGitWorktreeAddTargetPathFromLauncher,
+};

--- a/src/websocket/listener/worktree-watcher.ts
+++ b/src/websocket/listener/worktree-watcher.ts
@@ -8,6 +8,10 @@ import {
 import { emitDeviceStatusUpdate } from "./protocol-outbound";
 import { getConversationRuntime } from "./runtime";
 import type { ListenerRuntime } from "./types";
+import {
+  clearExpectedWorktreePath,
+  hasExpectedWorktreePath,
+} from "./worktree-ownership";
 
 const WORKTREES_DIR = ".letta/worktrees";
 
@@ -175,18 +179,20 @@ async function handleNewWorktree(params: {
   // Verify it's actually a directory.
   if (!(await directoryExists(newWorktreePath))) return;
 
-  // Only react if THIS conversation is the one actively running a turn.
-  // Multiple conversations in the same project share `.letta/worktrees/`, so
-  // they all receive the same filesystem event when any agent creates a
-  // worktree. Without this guard, every conversation would hijack its CWD
-  // to the new worktree even if it wasn't the one that created it. The
-  // conversation executing `git worktree add` is always `isProcessing`.
+  // Only react if THIS conversation asked git to create this exact worktree
+  // path. Multiple conversations in the same project share
+  // `.letta/worktrees/`, so they all receive the same filesystem event when
+  // any agent creates a worktree. Ownership comes from the tracked expected
+  // path, which stays live briefly after the turn so the debounced watcher can
+  // still attribute the event correctly.
   const conversationRuntime = getConversationRuntime(
     runtime,
     agentId,
     conversationId,
   );
-  if (!conversationRuntime?.isProcessing) return;
+  if (!hasExpectedWorktreePath(conversationRuntime, newWorktreePath)) {
+    return;
+  }
 
   // Check if CWD already points here (stream detection got it first).
   const currentCwd = getConversationWorkingDirectory(
@@ -194,7 +200,12 @@ async function handleNewWorktree(params: {
     agentId,
     conversationId,
   );
-  if (currentCwd === newWorktreePath) return;
+  if (currentCwd === newWorktreePath) {
+    clearExpectedWorktreePath(conversationRuntime);
+    return;
+  }
+
+  clearExpectedWorktreePath(conversationRuntime);
 
   console.log(
     `[WorktreeWatcher] New worktree detected: ${newWorktreePath} — switching CWD`,


### PR DESCRIPTION
## Summary
- track the exact worktree path a conversation asked git to create when shell commands launch
- make the worktree watcher adopt a new cwd only when the detected path matches that conversation's tracked expectation
- handle env-prefixed `git worktree add` commands in both the ownership tracker and the Bash `.letta/worktrees/` validator
- add websocket tests covering worktree ownership tracking and keep the Bash worktree validation aligned with the same parser

## Why
The watcher fallback still inferred ownership from shared filesystem events in `.letta/worktrees/`. When multiple conversations in the same repo were active around the same time, they could both see the same new directory and both decide it was theirs. This PR ties auto-switching to the actual `git worktree add` request so only the owning conversation claims the new cwd.

The follow-up parser fix also closes a bypass where commands like `FOO=1 env -i git worktree add ...` were not recognized as worktree creation, which meant they could skip both the Bash guard and the watcher ownership tracking.

Validated with `bun test src/tests/tools/bash.test.ts src/tests/websocket/worktree-ownership.test.ts` and `bun run typecheck`. `bun run check` still reports unrelated existing lint failures elsewhere in the repo.

👾 Generated with [Letta Code](https://letta.com)