### PR TITLE
fix(cli): avoid corrupting commented WezTerm configs

### DIFF
--- a/src/cli/utils/terminalKeybindingInstaller.ts
+++ b/src/cli/utils/terminalKeybindingInstaller.ts
@@ -382,6 +382,41 @@ table.insert(keys, {
 config.keys = keys
 `;
 
+const RETURN_CONFIG_LINE = /^\s*return config\s*$/m;
+
+export function injectWezTermDeleteFix(content: string): string {
+  let nextContent = content;
+
+  // For simple configs that return a table directly, we need to modify them
+  // to use a config variable. Check if it's a simple "return {" style config.
+  if (
+    nextContent.includes("return {") &&
+    !nextContent.includes("local config")
+  ) {
+    nextContent = nextContent.replace(/return\s*\{/, "local config = {");
+    if (!nextContent.includes("return config")) {
+      nextContent = `${nextContent.trimEnd()}\n\nreturn config\n`;
+    }
+  }
+
+  if (!nextContent.trim()) {
+    nextContent = `-- WezTerm configuration
+local config = {}
+
+return config
+`;
+  }
+
+  if (RETURN_CONFIG_LINE.test(nextContent)) {
+    return nextContent.replace(
+      RETURN_CONFIG_LINE,
+      `${WEZTERM_DELETE_FIX}\nreturn config`,
+    );
+  }
+
+  return `${nextContent.trimEnd()}\n${WEZTERM_DELETE_FIX}\n`;
+}
+
 /**
  * Check if WezTerm config already has our Delete key fix
  */
@@ -423,36 +458,7 @@ export function installWezTermDeleteFix(): InstallResult {
       content = readFileSync(configPath, { encoding: "utf-8" });
     }
 
-    // For simple configs that return a table directly, we need to modify them
-    // to use a config variable. Check if it's a simple "return {" style config.
-    if (content.includes("return {") && !content.includes("local config")) {
-      // Convert simple config to use config variable
-      content = content.replace(/return\s*\{/, "local config = {");
-      // Add return config at the end if not present
-      if (!content.includes("return config")) {
-        content = `${content.trimEnd()}\n\nreturn config\n`;
-      }
-    }
-
-    // If config doesn't exist or is empty, create a basic one
-    if (!content.trim()) {
-      content = `-- WezTerm configuration
-local config = {}
-
-return config
-`;
-    }
-
-    // Insert our fix before "return config"
-    if (content.includes("return config")) {
-      content = content.replace(
-        "return config",
-        `${WEZTERM_DELETE_FIX}\nreturn config`,
-      );
-    } else {
-      // Append to end as fallback
-      content = `${content.trimEnd()}\n${WEZTERM_DELETE_FIX}\n`;
-    }
+    content = injectWezTermDeleteFix(content);
 
     // Ensure parent directory exists
     const parentDir = dirname(configPath);

--- a/src/tests/cli/terminal-keybinding-installer.test.ts
+++ b/src/tests/cli/terminal-keybinding-installer.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  injectWezTermDeleteFix,
+  wezTermDeleteFixExists,
+} from "../../cli/utils/terminalKeybindingInstaller";
+
+describe("injectWezTermDeleteFix", () => {
+  test("injects before the real return config line, not a commented one", () => {
+    const input = `---- Pull in the wezterm API
+--local wezterm = require 'wezterm'
+--
+---- This will hold the configuration.
+--local config = wezterm.config_builder()
+--
+--return config
+
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+config.color_scheme = 'Tokyo Night'
+
+return config
+`;
+
+    const output = injectWezTermDeleteFix(input);
+
+    expect(output).toContain("--return config");
+    expect(output).toContain("config.color_scheme = 'Tokyo Night'");
+    expect(output).toContain("key = 'Delete'");
+
+    const markerIdx = output.indexOf("-- Letta Code: Fix Delete key");
+    const liveReturnIdx = output.lastIndexOf("return config");
+    const colorIdx = output.indexOf("config.color_scheme = 'Tokyo Night'");
+
+    expect(markerIdx).toBeGreaterThan(colorIdx);
+    expect(markerIdx).toBeLessThan(liveReturnIdx);
+    expect(output.match(/^\s*return config\s*$/gm)?.length).toBe(1);
+  });
+
+  test("emits a Lua escape sequence for ESC[3~ instead of a literal backslash", () => {
+    const output = injectWezTermDeleteFix(
+      "local config = {}\n\nreturn config\n",
+    );
+
+    expect(output).toContain("SendString '\\x1b[3~'");
+    expect(output).not.toContain("SendString '\\\\x1b[3~'");
+  });
+
+  test("converts simple return-table configs to local config form", () => {
+    const output = injectWezTermDeleteFix(
+      "return {\n  color_scheme = 'Tokyo Night',\n}\n",
+    );
+
+    expect(output).toContain("local config = {");
+    expect(output).toContain("color_scheme = 'Tokyo Night'");
+    expect(output).toContain("key = 'Delete'");
+    expect(output).toContain("return config");
+  });
+});
+
+describe("wezTermDeleteFixExists", () => {
+  test("recognizes the correct escaped Delete binding text", () => {
+    const fs = require("node:fs");
+    const os = require("node:os");
+    const path = require("node:path");
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "wezterm-fix-"));
+    const filePath = path.join(tempDir, "wezterm.lua");
+    fs.writeFileSync(
+      filePath,
+      "local config = {}\nconfig.keys = {{ key = 'Delete', action = wezterm.action.SendString '\\x1b[3~' }}\nreturn config\n",
+      "utf-8",
+    );
+
+    expect(wezTermDeleteFixExists(filePath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The WezTerm Delete-key installer in `terminalKeybindingInstaller.ts` was doing a plain string replacement on `return config`. That also matched commented scaffolding like `--return config` near the top of real configs, so the Letta snippet could get injected into dead code while the live `return config` at the bottom stayed in place.

That produces exactly the failure Cosmo reported: WezTerm reloads the file, hits a top-level `return`, then later sees another `local ...` statement and throws:

```lua
[string "/Users/<username>/.wezterm.lua"]:25: <eof> expected near 'local'
```

## Fix

- factor the rewrite into `injectWezTermDeleteFix(content)`
- only inject before a real standalone `return config` line via a multiline regex, not any substring match inside comments
- keep the existing `return { ... }` → `local config = { ... }` conversion path
- keep empty-file bootstrap behavior
- preserve the intended Lua Delete binding escape sequence (`'\x1b[3~'`)

## Regression coverage

Added `src/tests/cli/terminal-keybinding-installer.test.ts` covering:
- a config shaped like Cosmo's backup, with a commented `--return config` header and a real live `return config` at the bottom
- the emitted Delete binding string, to ensure we write the intended Lua escape sequence
- the existing simple `return { ... }` conversion path
- `wezTermDeleteFixExists()` recognizing the canonical Delete fix text

Written by Cameron ◯ Letta Code

> "String replacement is not a parser. News at eleven."