### PR TITLE
fix(channels): Discord direct-message routing

### DIFF
--- a/src/channels/discord/setup.ts
+++ b/src/channels/discord/setup.ts
@@ -64,8 +64,8 @@ export async function runDiscordSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
-    // Agent binding — required for guild @mention routing to work.
-    // Without this, the bot won't know which agent to create threads for.
+    // Agent binding — required for account-bound DMs and guild @mentions.
+    // Without this, the bot won't know which agent to create conversations for.
     const envAgentId = process.env.LETTA_AGENT_ID || "";
     let agentId: string | null = null;
 
@@ -80,14 +80,14 @@ export async function runDiscordSetup(): Promise<boolean> {
 
     if (!agentId) {
       const agentInput = await rl.question(
-        "\nAgent ID to bind this bot to (required for @mention routing): ",
+        "\nAgent ID to bind this bot to (required for DM and @mention routing): ",
       );
       agentId = agentInput.trim() || null;
     }
 
     if (!agentId) {
       console.log(
-        "\nWarning: No agent bound. DM pairing will still work, but guild @mentions won't route until you bind an agent.",
+        "\nWarning: No agent bound. DM pairing will still work, but open/allowlist DMs and guild @mentions won't route until you bind an agent.",
       );
       console.log(
         "  You can bind later: letta channels bind --channel discord --agent <id>",

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -128,6 +128,27 @@ export function buildSlackConversationSummary(
   return `[Slack] Thread${channelLabel || ` ${msg.chatId}`}`;
 }
 
+function buildDiscordConversationSummary(
+  msg: Pick<
+    InboundChannelMessage,
+    "chatId" | "chatLabel" | "chatType" | "senderId" | "senderName" | "text"
+  >,
+): string {
+  if (msg.chatType === "direct") {
+    return `[Discord] DM with ${msg.senderName?.trim() || msg.senderId}`;
+  }
+
+  const preview = truncateChannelSummaryPreview(msg.text);
+  const channelLabel =
+    msg.chatLabel && msg.chatLabel !== msg.chatId ? ` in ${msg.chatLabel}` : "";
+
+  if (preview) {
+    return `[Discord] Thread${channelLabel}: ${preview}`;
+  }
+
+  return `[Discord] Thread${channelLabel || ` ${msg.chatId}`}`;
+}
+
 function buildChannelTurnSource(
   route: ChannelRoute,
   msg: Pick<
@@ -761,12 +782,13 @@ export class ChannelRegistry {
       return;
     }
 
-    // Discord guild messages use auto-routing (like Slack).
-    // DMs fall through to the standard pairing flow below.
+    // Discord guild messages and account-bound DMs use auto-routing (like
+    // Slack). DMs configured with explicit pairing fall through to the
+    // standard pairing flow below.
     if (
       msg.channel === "discord" &&
       config.channel === "discord" &&
-      msg.chatType === "channel"
+      (msg.chatType === "channel" || config.dmPolicy !== "pairing")
     ) {
       const discordResult = await this.ensureDiscordRoute(adapter, msg, config);
       if (!discordResult) {
@@ -1016,7 +1038,7 @@ export class ChannelRegistry {
 
     const conversationId = await this.createConversationForAgent(
       config.agentId,
-      `[Discord] Thread ${msg.chatLabel ?? msg.chatId}`,
+      buildDiscordConversationSummary(msg),
     );
     const now = new Date().toISOString();
     const route: ChannelRoute = {
@@ -1052,6 +1074,18 @@ export class ChannelRegistry {
       return null;
     }
 
+    if (
+      msg.chatType === "direct" &&
+      config.dmPolicy === "allowlist" &&
+      !config.allowedUsers.includes(msg.senderId)
+    ) {
+      await adapter.sendDirectReply(
+        msg.chatId,
+        "You are not on the allowed users list for this Discord bot.",
+      );
+      return null;
+    }
+
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     const routeThreadId = msg.threadId ?? null;
     let route = getRouteFromStore(
@@ -1074,9 +1108,9 @@ export class ChannelRegistry {
       return { route, isFirstRouteTurn: false };
     }
 
-    // Only create routes from explicit mentions.
+    // In guild channels, only create routes from explicit mentions.
     // Existing routed threads continue above via the route lookup path.
-    if (!msg.isMention) {
+    if (msg.chatType === "channel" && !msg.isMention) {
       return null;
     }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -327,7 +327,7 @@ export interface SlackChannelAccount extends ChannelAccountBase {
 export interface DiscordChannelAccount extends ChannelAccountBase {
   channel: "discord";
   token: string;
-  /** Agent ID used for guild auto-routing (like Slack's agentId). */
+  /** Agent ID used for account-bound DM and guild auto-routing. */
   agentId: string | null;
 }
 

--- a/src/tests/channels/discord-registry.test.ts
+++ b/src/tests/channels/discord-registry.test.ts
@@ -72,7 +72,9 @@ describe("discord channel registry", () => {
     };
   }
 
-  function createAdapter(): ChannelAdapter {
+  function createAdapter(
+    replies: Array<{ chatId: string; text: string }> = [],
+  ): ChannelAdapter {
     return {
       id: "discord:discord-bot",
       channelId: "discord",
@@ -82,7 +84,9 @@ describe("discord channel registry", () => {
       stop: async () => {},
       isRunning: () => true,
       sendMessage: async () => ({ messageId: "outbound-1" }),
-      sendDirectReply: async () => {},
+      sendDirectReply: async (chatId, text) => {
+        replies.push({ chatId, text });
+      },
     };
   }
 
@@ -166,5 +170,138 @@ describe("discord channel registry", () => {
       null,
     );
     expect(deliveries).toHaveLength(1);
+  });
+
+  test("auto-creates a direct-message route for bound open Discord accounts", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        enabled: true,
+        token: "discord-token",
+        agentId: "agent-1",
+        dmPolicy: "open",
+        allowedUsers: [],
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const { ChannelRegistry } = await import("../../channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        chatId: "dm-1",
+        threadId: null,
+        chatType: "direct",
+        isMention: false,
+        messageId: "dm-msg-1",
+      }),
+    );
+
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(createConversation).toHaveBeenCalledWith({
+      agent_id: "agent-1",
+      isolated_block_labels: expect.any(Array),
+      summary: "[Discord] DM with Cameron",
+    });
+    expect(getRoute("discord", "dm-1", "discord-bot")).toMatchObject({
+      accountId: "discord-bot",
+      chatId: "dm-1",
+      chatType: "direct",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-discord",
+    });
+    expect(deliveries).toHaveLength(1);
+  });
+
+  test("rejects direct messages from users outside a Discord allowlist", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        enabled: true,
+        token: "discord-token",
+        agentId: "agent-1",
+        dmPolicy: "allowlist",
+        allowedUsers: ["user-2"],
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const { ChannelRegistry } = await import("../../channels/registry");
+    const registry = new ChannelRegistry();
+    const replies: Array<{ chatId: string; text: string }> = [];
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        chatId: "dm-1",
+        threadId: null,
+        chatType: "direct",
+        isMention: false,
+        messageId: "dm-msg-1",
+      }),
+    );
+
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(getRoute("discord", "dm-1", "discord-bot")).toBe(null);
+    expect(deliveries).toHaveLength(0);
+    expect(replies).toEqual([
+      {
+        chatId: "dm-1",
+        text: "You are not on the allowed users list for this Discord bot.",
+      },
+    ]);
+  });
+
+  test("keeps explicit Discord pairing DMs on the pairing flow", async () => {
+    const { ChannelRegistry } = await import("../../channels/registry");
+    const registry = new ChannelRegistry();
+    const replies: Array<{ chatId: string; text: string }> = [];
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        chatId: "dm-1",
+        threadId: null,
+        chatType: "direct",
+        isMention: false,
+        messageId: "dm-msg-1",
+      }),
+    );
+
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(getRoute("discord", "dm-1", "discord-bot")).toBe(null);
+    expect(deliveries).toHaveLength(0);
+    expect(replies).toHaveLength(1);
+    expect(replies[0]?.text).toContain("Pairing code:");
   });
 });


### PR DESCRIPTION
## Summary
- Auto-route Discord DMs for bound accounts when `dm_policy` is `open` or `allowlist`, creating one Letta conversation per DM like Slack.
- Keep explicit Discord `pairing` DMs on the existing pairing flow.
- Enforce Discord DM allowlists before route creation and update setup copy to mention DM auto-routing.

## Tests
- `bun test src/tests/channels/discord-registry.test.ts`
- `bun test src/tests/channels/registry.test.ts`
- `bun test src/tests/channels/discord-service.test.ts src/tests/channels/discord-message-channel.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bunx --bun @biomejs/biome@2.2.5 check src/channels/registry.ts src/channels/types.ts src/channels/discord/setup.ts src/tests/channels/discord-registry.test.ts`
- `git diff --check`