### PR TITLE
perf(listener): throttle streaming tool output

### DIFF
--- a/src/websocket/listener/interrupts.ts
+++ b/src/websocket/listener/interrupts.ts
@@ -24,6 +24,24 @@ import type {
 const INTERRUPT_TOOL_RETURN_MAX_CHARS = LIMITS.BASH_OUTPUT_CHARS;
 
 const STREAMING_TOOL_OUTPUT_MAX_CHARS = LIMITS.BASH_OUTPUT_CHARS;
+const STREAMING_TOOL_OUTPUT_EMIT_INTERVAL_MS = 100;
+
+export type ToolExecutionOutputEmitter = ((
+  toolCallId: string,
+  chunk: string,
+  isStderr?: boolean,
+) => void) & {
+  flush: () => void;
+};
+
+type StreamingToolOutputState = {
+  messageId: string;
+  stdout: string;
+  stderr: string;
+  dirty: boolean;
+  lastEmittedAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+};
 
 function truncateInterruptToolReturn(text: string): string {
   const { content } = truncateByChars(
@@ -407,41 +425,19 @@ export function createToolExecutionOutputEmitter(
     agentId?: string;
     conversationId?: string;
   },
-): (toolCallId: string, chunk: string, isStderr?: boolean) => void {
-  const outputByToolCallId = new Map<
-    string,
-    {
-      messageId: string;
-      stdout: string;
-      stderr: string;
-    }
-  >();
+): ToolExecutionOutputEmitter {
+  const outputByToolCallId = new Map<string, StreamingToolOutputState>();
 
-  return (toolCallId: string, chunk: string, isStderr: boolean = false) => {
-    if (!toolCallId || chunk.length === 0) {
+  const emitToolOutput = (
+    toolCallId: string,
+    outputState: StreamingToolOutputState,
+  ) => {
+    if (!outputState.dirty) {
       return;
     }
 
-    const existing = outputByToolCallId.get(toolCallId);
-    const outputState = existing ?? {
-      messageId: `message-tool-return-stream-${toolCallId}`,
-      stdout: "",
-      stderr: "",
-    };
-
-    if (isStderr) {
-      outputState.stderr = appendStreamingOutputWithCap(
-        outputState.stderr,
-        chunk,
-      );
-    } else {
-      outputState.stdout = appendStreamingOutputWithCap(
-        outputState.stdout,
-        chunk,
-      );
-    }
-
-    outputByToolCallId.set(toolCallId, outputState);
+    outputState.dirty = false;
+    outputState.lastEmittedAt = Date.now();
 
     const stdout = normalizeStreamingOutputLines(outputState.stdout);
     const stderr = normalizeStreamingOutputLines(outputState.stderr);
@@ -479,6 +475,74 @@ export function createToolExecutionOutputEmitter(
       },
     );
   };
+
+  const flushToolOutput = (
+    toolCallId: string,
+    outputState: StreamingToolOutputState,
+  ) => {
+    if (outputState.timer) {
+      clearTimeout(outputState.timer);
+      outputState.timer = null;
+    }
+    emitToolOutput(toolCallId, outputState);
+  };
+
+  const emitter = ((
+    toolCallId: string,
+    chunk: string,
+    isStderr: boolean = false,
+  ) => {
+    if (!toolCallId || chunk.length === 0) {
+      return;
+    }
+
+    const existing = outputByToolCallId.get(toolCallId);
+    const outputState = existing ?? {
+      messageId: `message-tool-return-stream-${toolCallId}`,
+      stdout: "",
+      stderr: "",
+      dirty: false,
+      lastEmittedAt: 0,
+      timer: null,
+    };
+
+    if (isStderr) {
+      outputState.stderr = appendStreamingOutputWithCap(
+        outputState.stderr,
+        chunk,
+      );
+    } else {
+      outputState.stdout = appendStreamingOutputWithCap(
+        outputState.stdout,
+        chunk,
+      );
+    }
+
+    outputByToolCallId.set(toolCallId, outputState);
+    outputState.dirty = true;
+
+    const now = Date.now();
+    const elapsed = now - outputState.lastEmittedAt;
+    if (elapsed >= STREAMING_TOOL_OUTPUT_EMIT_INTERVAL_MS) {
+      flushToolOutput(toolCallId, outputState);
+      return;
+    }
+
+    if (!outputState.timer) {
+      outputState.timer = setTimeout(() => {
+        outputState.timer = null;
+        emitToolOutput(toolCallId, outputState);
+      }, STREAMING_TOOL_OUTPUT_EMIT_INTERVAL_MS - elapsed);
+    }
+  }) as ToolExecutionOutputEmitter;
+
+  emitter.flush = () => {
+    for (const [toolCallId, outputState] of outputByToolCallId.entries()) {
+      flushToolOutput(toolCallId, outputState);
+    }
+  };
+
+  return emitter;
 }
 
 export function getInterruptApprovalsForEmission(

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -641,19 +641,24 @@ export async function resolveRecoveredApprovalResponse(
   runtime.currentLoadedTools =
     preparedToolContext.preparedToolContext.loadedToolNames;
   try {
-    const approvalResults = await executeApprovalBatch(decisions, undefined, {
-      abortSignal: recoveryAbortController.signal,
-      onStreamingOutput: emitToolExecutionOutput,
-      toolContextId: preparedToolContext.preparedToolContext.contextId,
-      workingDirectory,
-      parentScope:
-        recovered.agentId && recovered.conversationId
-          ? {
-              agentId: recovered.agentId,
-              conversationId: recovered.conversationId,
-            }
-          : undefined,
-    });
+    let approvalResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
+    try {
+      approvalResults = await executeApprovalBatch(decisions, undefined, {
+        abortSignal: recoveryAbortController.signal,
+        onStreamingOutput: emitToolExecutionOutput,
+        toolContextId: preparedToolContext.preparedToolContext.contextId,
+        workingDirectory,
+        parentScope:
+          recovered.agentId && recovered.conversationId
+            ? {
+                agentId: recovered.agentId,
+                conversationId: recovered.conversationId,
+              }
+            : undefined,
+      });
+    } finally {
+      emitToolExecutionOutput.flush();
+    }
 
     emitToolExecutionFinishedEvents(socket, runtime, {
       approvals: approvalResults,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -497,15 +497,20 @@ export async function handleApprovalStop(params: {
     }
   };
 
-  const executionResults = await executeApprovalBatch(decisions, undefined, {
-    toolContextId: turnToolContextId ?? undefined,
-    abortSignal: abortController.signal,
-    onStreamingOutput: emitToolExecutionOutput,
-    workingDirectory: turnWorkingDirectory,
-    parentScope:
-      agentId && conversationId ? { agentId, conversationId } : undefined,
-    onFileWrite,
-  });
+  let executionResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
+  try {
+    executionResults = await executeApprovalBatch(decisions, undefined, {
+      toolContextId: turnToolContextId ?? undefined,
+      abortSignal: abortController.signal,
+      onStreamingOutput: emitToolExecutionOutput,
+      workingDirectory: turnWorkingDirectory,
+      parentScope:
+        agentId && conversationId ? { agentId, conversationId } : undefined,
+      onFileWrite,
+    });
+  } finally {
+    emitToolExecutionOutput.flush();
+  }
   const persistedExecutionResults = normalizeExecutionResultsForInterruptParity(
     runtime,
     executionResults,


### PR DESCRIPTION
## Summary
- coalesce listener-side streaming stdout/stderr tool output to a 100ms cadence
- keep the first chunk responsive and flush pending output before tool-finished events
- apply the same output emitter behavior to normal approval execution and recovery approval execution

## Verification
- `bunx @biomejs/biome@2.2.5 check --write src/websocket/listener/interrupts.ts src/websocket/listener/recovery.ts src/websocket/listener/turn-approval.ts`
- `bun run typecheck`