### PR TITLE
refactor(tools): tighten TaskOutput/TaskStop schemas to match Claude Code

### DIFF
--- a/src/tests/tools/task-output.test.ts
+++ b/src/tests/tools/task-output.test.ts
@@ -146,21 +146,14 @@ describe.skipIf(isWindows)("TaskOutput and TaskStop", () => {
     expect(backgroundProcesses.has(taskId)).toBe(false);
   });
 
-  test("TaskStop supports deprecated shell_id parameter", async () => {
-    // Start long-running process
-    const startResult = await bash({
-      command: "sleep 10",
-      description: "Process to kill",
-      run_in_background: true,
-    });
-
-    const match = startResult.content[0]?.text.match(/bash_(\d+)/);
-    const shellId = `bash_${match?.[1]}`;
-
-    // Kill using deprecated shell_id
-    const killResult = await task_stop({ shell_id: shellId });
-
-    expect(killResult.killed).toBe(true);
+  test("TaskStop rejects deprecated shell_id-only payloads", async () => {
+    // `shell_id` has been dropped from the TaskStop schema; payloads without
+    // `task_id` must now raise a validation error rather than silently falling
+    // back to the legacy alias.
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally malformed payload
+      task_stop({ shell_id: "bash_nonexistent" } as any),
+    ).rejects.toThrow(/TaskStop tool missing required parameter/);
   });
 
   test("TaskStop handles non-existent task_id", async () => {
@@ -169,25 +162,15 @@ describe.skipIf(isWindows)("TaskOutput and TaskStop", () => {
     expect(result.killed).toBe(false);
   });
 
-  test("TaskOutput defaults to block=true", async () => {
-    // Start a quick background process
-    const startResult = await bash({
-      command: "sleep 0.2 && echo 'default-block-test'",
-      description: "Default block test",
-      run_in_background: true,
-    });
+  test("TaskOutput requires block and timeout", async () => {
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally malformed payload
+      task_output({ task_id: "bash_whatever" } as any),
+    ).rejects.toThrow(/TaskOutput tool missing required parameters/);
 
-    const match = startResult.content[0]?.text.match(/bash_(\d+)/);
-    const taskId = `bash_${match?.[1]}`;
-
-    // Call without specifying block - should default to true
-    const result = await task_output({
-      task_id: taskId,
-      timeout: 5000,
-    });
-
-    // Should have waited and gotten the output
-    expect(result.message).toContain("default-block-test");
-    expect(result.status).toBe("completed");
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally malformed payload
+      task_output({ task_id: "bash_whatever", block: true } as any),
+    ).rejects.toThrow(/TaskOutput tool missing required parameter/);
   });
 });

--- a/src/tools/descriptions/TaskOutput.md
+++ b/src/tools/descriptions/TaskOutput.md
@@ -1,9 +1,9 @@
 # TaskOutput
 
 - Retrieves output from a running or completed task (background shell, agent, or remote session)
-- Takes a task_id parameter identifying the task
+- Required: `task_id` (the task to query), `block` (whether to wait for completion), `timeout` (max wait time in ms; capped at 600000)
 - Returns the task output along with status information
-- Use block=true (default) to wait for task completion
-- Use block=false for non-blocking check of current status
+- Use `block=true` to wait until the task finishes (or `timeout` elapses)
+- Use `block=false` for an immediate, non-blocking check of current status
 - Task IDs can be found using the /tasks command
 - Works with all task types: background shells, async agents, and remote sessions

--- a/src/tools/descriptions/TaskStop.md
+++ b/src/tools/descriptions/TaskStop.md
@@ -1,6 +1,6 @@
 # TaskStop
 
 - Stops a running background task by its ID
-- Takes a task_id parameter identifying the task to stop
-- Returns a success or failure status
+- Required: `task_id` (the task to terminate; the legacy `shell_id` alias has been removed — bash background shells share the same ID space as other tasks)
+- Returns `{ killed: boolean }` indicating whether the task was actively running and got terminated
 - Use this tool when you need to terminate a long-running task

--- a/src/tools/impl/TaskOutput.ts
+++ b/src/tools/impl/TaskOutput.ts
@@ -3,8 +3,8 @@ import { validateRequiredParams } from "./validation.js";
 
 interface TaskOutputArgs {
   task_id: string;
-  block?: boolean;
-  timeout?: number;
+  block: boolean;
+  timeout: number;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
 }
 
@@ -15,13 +15,14 @@ interface TaskOutputResult {
 
 /**
  * TaskOutput - retrieves output from a running or completed background task.
- * Supports blocking (wait for completion) and timeout.
+ * `block` and `timeout` are required by the schema (matches Claude Code's
+ * current tool contract); callers must pass them explicitly.
  */
 export async function task_output(
   args: TaskOutputArgs,
 ): Promise<TaskOutputResult> {
-  validateRequiredParams(args, ["task_id"], "TaskOutput");
-  const { task_id, block = true, timeout = 30000, onOutput } = args;
+  validateRequiredParams(args, ["task_id", "block", "timeout"], "TaskOutput");
+  const { task_id, block, timeout, onOutput } = args;
 
   return getTaskOutput({
     task_id,

--- a/src/tools/impl/TaskStop.ts
+++ b/src/tools/impl/TaskStop.ts
@@ -6,8 +6,7 @@ import {
 import { validateRequiredParams } from "./validation.js";
 
 interface TaskStopArgs {
-  task_id?: string;
-  shell_id?: string; // deprecated, for backwards compatibility
+  task_id: string;
 }
 
 interface TaskStopResult {
@@ -15,27 +14,25 @@ interface TaskStopResult {
 }
 
 export async function task_stop(args: TaskStopArgs): Promise<TaskStopResult> {
-  // Support both task_id and deprecated shell_id
-  let id = args.task_id ?? args.shell_id;
-  if (!id) {
-    validateRequiredParams(args, ["task_id"], "TaskStop");
-    id = ""; // unreachable, validateRequiredParams throws
-  }
+  validateRequiredParams(args, ["task_id"], "TaskStop");
+  const { task_id } = args;
 
   // Check if this is a background Task (subagent)
-  const task = backgroundTasks.get(id);
+  const task = backgroundTasks.get(task_id);
   if (task) {
     if (task.status === "running" && task.abortController) {
       task.abortController.abort();
       task.status = "failed";
       task.error = "Aborted by user";
-      scheduleBackgroundTaskCleanup(id);
+      scheduleBackgroundTaskCleanup(task_id);
       return { killed: true };
     }
     // Task exists but isn't running or doesn't have abort controller
     return { killed: false };
   }
 
-  // Fall back to killing a Bash background process
-  return kill_bash({ shell_id: id });
+  // Fall back to killing a Bash background process.
+  // The KillBash helper still uses `shell_id` internally; task_id is the
+  // unified external contract (bash shells share the same id space).
+  return kill_bash({ shell_id: task_id });
 }

--- a/src/tools/schemas/TaskOutput.json
+++ b/src/tools/schemas/TaskOutput.json
@@ -7,18 +7,16 @@
     },
     "block": {
       "type": "boolean",
-      "default": true,
       "description": "Whether to wait for completion"
     },
     "timeout": {
       "type": "number",
-      "default": 30000,
       "minimum": 0,
       "maximum": 600000,
       "description": "Max wait time in ms"
     }
   },
-  "required": ["task_id"],
+  "required": ["task_id", "block", "timeout"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/src/tools/schemas/TaskStop.json
+++ b/src/tools/schemas/TaskStop.json
@@ -4,10 +4,6 @@
     "task_id": {
       "type": "string",
       "description": "The ID of the background task to stop"
-    },
-    "shell_id": {
-      "type": "string",
-      "description": "Deprecated: use task_id instead"
     }
   },
   "required": ["task_id"],


### PR DESCRIPTION
## Summary
- **TaskStop**: drop the deprecated `shell_id` alias from both the JSON schema and the impl. `task_id` is the unified contract — bash background shells share the same id space as other tasks, so the alias was redundant once the Task family landed.
- **TaskOutput**: make `block` and `timeout` **required** in the schema (and validated in the impl). Defaults inside the tool (`block=true`, `timeout=30000`) were a footgun: the model could omit them and silently get those values, which both hides intent from anyone reading the trace and lets a typo turn an intended non-blocking poll into a 30 s wait.
- Tool description files updated to reflect the new contract.
- Tests:
  - replaced the *"supports deprecated shell_id"* test with one asserting `task_stop({ shell_id })` (no `task_id`) is rejected by `validateRequiredParams`.
  - replaced the *"defaults to block=true"* test with one asserting `task_output` rejects payloads missing `block` and/or `timeout`.

## Why
Aligns these two tool schemas with Claude Code's current contract (see structural comparison in agent memory `project/letta-code/agents.md`). Removing implicit defaults reduces ambiguity in tool traces and forces callers to be explicit about polling vs. waiting semantics.

## Compatibility
- **Breaking for any direct caller** that still passes `shell_id` to `task_stop` or omits `block`/`timeout` on `task_output`. A grep of `src/` (excluding tests) shows no internal callers — these tools are invoked exclusively by the model via JSON tool calls, so the change is contained.
- The legacy `BashOutput` / `KillBash` tools still take `shell_id`; this PR only touches the `Task*` surface.

## Test plan
- [x] `bun test src/tests/tools/task-output.test.ts` — 9 pass
- [x] `bun test src/tests/tools/task-background.test.ts` — 16 pass
- [x] `bunx tsc --noEmit` clean
- [x] Biome check clean on all changed files
- [ ] Smoke: drive a session that uses `Bash run_in_background: true` → `TaskOutput` → `TaskStop` and confirm both work end-to-end with the new required fields.

👾 Generated with [Letta Code](https://letta.com)