### PR TITLE
perf(listener): write protocol telemetry to file

### DIFF
--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -1,3 +1,5 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import { performance } from "node:perf_hooks";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
@@ -76,6 +78,8 @@ type ProtocolPerfBucket = {
 const protocolPerfBuckets = new Map<string, ProtocolPerfBucket>();
 let protocolPerfFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let protocolPerfWindowStartedAt = 0;
+let protocolPerfFileDirEnsured: string | null = null;
+let protocolPerfFileWarningEmitted = false;
 
 function isProtocolPerfTelemetryEnabled(): boolean {
   return PROTOCOL_PERF_ENV_VALUES.has(
@@ -149,20 +153,107 @@ function recordProtocolPerfTelemetry(
   scheduleProtocolPerfFlush();
 }
 
+function writeProtocolPerfFile(
+  record: {
+    ts: string;
+    event: "protocol_emit";
+    window_ms: number;
+    totals: ProtocolPerfBucket;
+    buckets: Record<
+      string,
+      ProtocolPerfBucket & {
+        avg_bytes: number;
+        avg_stringify_ms: number;
+        avg_send_ms: number;
+      }
+    >;
+  },
+  fallbackLine: string,
+): void {
+  const filePath = process.env.LETTA_LISTENER_PERF_FILE?.trim();
+  if (!filePath) {
+    console.error(fallbackLine);
+    return;
+  }
+
+  try {
+    const dir = dirname(filePath);
+    if (protocolPerfFileDirEnsured !== dir) {
+      mkdirSync(dir, { recursive: true });
+      protocolPerfFileDirEnsured = dir;
+    }
+    appendFileSync(filePath, `${JSON.stringify(record)}\n`, {
+      encoding: "utf8",
+    });
+  } catch (error) {
+    if (!protocolPerfFileWarningEmitted) {
+      protocolPerfFileWarningEmitted = true;
+      console.error(
+        `[Listen Perf] Failed to write LETTA_LISTENER_PERF_FILE=${filePath}`,
+        error,
+      );
+    }
+    console.error(fallbackLine);
+  }
+}
+
 function flushProtocolPerfTelemetry(): void {
   if (protocolPerfBuckets.size === 0) {
     protocolPerfWindowStartedAt = 0;
     return;
   }
   const windowMs = Math.max(1, Date.now() - protocolPerfWindowStartedAt);
+  const totals: ProtocolPerfBucket = {
+    count: 0,
+    bytes: 0,
+    stringifyMs: 0,
+    sendMs: 0,
+    maxBufferedBefore: 0,
+    maxBufferedAfter: 0,
+  };
+  const buckets: Record<
+    string,
+    ProtocolPerfBucket & {
+      avg_bytes: number;
+      avg_stringify_ms: number;
+      avg_send_ms: number;
+    }
+  > = {};
   const parts = [...protocolPerfBuckets.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, bucket]) => {
+      totals.count += bucket.count;
+      totals.bytes += bucket.bytes;
+      totals.stringifyMs += bucket.stringifyMs;
+      totals.sendMs += bucket.sendMs;
+      totals.maxBufferedBefore = Math.max(
+        totals.maxBufferedBefore,
+        bucket.maxBufferedBefore,
+      );
+      totals.maxBufferedAfter = Math.max(
+        totals.maxBufferedAfter,
+        bucket.maxBufferedAfter,
+      );
+      buckets[key] = {
+        ...bucket,
+        avg_bytes: bucket.count > 0 ? bucket.bytes / bucket.count : 0,
+        avg_stringify_ms:
+          bucket.count > 0 ? bucket.stringifyMs / bucket.count : 0,
+        avg_send_ms: bucket.count > 0 ? bucket.sendMs / bucket.count : 0,
+      };
+
       const stringifyMs = bucket.stringifyMs.toFixed(2);
       const sendMs = bucket.sendMs.toFixed(2);
       return `${key}{count=${bucket.count},bytes=${bucket.bytes},stringify_ms=${stringifyMs},send_ms=${sendMs},max_buffered_before=${bucket.maxBufferedBefore},max_buffered_after=${bucket.maxBufferedAfter}}`;
     });
-  console.error(
+  writeProtocolPerfFile(
+    {
+      ts: new Date().toISOString(),
+      event: "protocol_emit",
+      window_ms: windowMs,
+      totals,
+      buckets,
+    },
     `[Listen Perf] protocol_emit window_ms=${windowMs} ${parts.join(" ")}`,
   );
   protocolPerfBuckets.clear();

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -65,6 +65,10 @@ const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
 const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
 const PROTOCOL_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
+const PROTOCOL_PERF_ENABLED = PROTOCOL_PERF_ENV_VALUES.has(
+  (process.env.LETTA_LISTENER_PERF ?? "").toLowerCase(),
+);
+const PROTOCOL_PERF_FILE = process.env.LETTA_LISTENER_PERF_FILE?.trim() || null;
 
 type ProtocolPerfBucket = {
   count: number;
@@ -80,12 +84,6 @@ let protocolPerfFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let protocolPerfWindowStartedAt = 0;
 let protocolPerfFileDirEnsured: string | null = null;
 let protocolPerfFileWarningEmitted = false;
-
-function isProtocolPerfTelemetryEnabled(): boolean {
-  return PROTOCOL_PERF_ENV_VALUES.has(
-    (process.env.LETTA_LISTENER_PERF ?? "").toLowerCase(),
-  );
-}
 
 function getProtocolPerfKey(
   message: Omit<
@@ -170,7 +168,7 @@ function writeProtocolPerfFile(
   },
   fallbackLine: string,
 ): void {
-  const filePath = process.env.LETTA_LISTENER_PERF_FILE?.trim();
+  const filePath = PROTOCOL_PERF_FILE;
   if (!filePath) {
     console.error(fallbackLine);
     return;
@@ -605,7 +603,7 @@ export function emitProtocolV2Message(
     emitted_at: new Date().toISOString(),
     idempotency_key: `${message.type}:${eventSeq}:${crypto.randomUUID()}`,
   } as WsProtocolMessage;
-  const perfEnabled = isProtocolPerfTelemetryEnabled();
+  const perfEnabled = PROTOCOL_PERF_ENABLED;
   const stringifyStartedAt = perfEnabled ? performance.now() : 0;
   let payload: string;
   try {


### PR DESCRIPTION
## Summary
- add `LETTA_LISTENER_PERF_FILE` as a JSONL sink for listener protocol telemetry
- keep the existing stderr summary as the fallback when no file path is configured
- include per-window totals and per-message-type averages so LCD runs can be analyzed offline

## Verification
- `bunx @biomejs/biome@2.2.5 check --write src/websocket/listener/protocol-outbound.ts`
- `bun run typecheck`