### PR TITLE
perf(tui): write local activity telemetry to file

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -143,6 +143,7 @@ import {
   debugWarn,
   isDebugEnabled,
 } from "../utils/debug";
+import { recordTuiPerf } from "../utils/tuiPerf";
 import { getVersion } from "../version";
 import {
   handleMcpAdd,
@@ -3175,6 +3176,7 @@ export default function App({
     streamingRefreshTimeoutRef.current = setTimeout(() => {
       streamingRefreshTimeoutRef.current = null;
       if (!buffersRef.current.interrupted) {
+        recordTuiPerf("ui_refresh:tool_output");
         refreshDerived();
       }
     }, 100);
@@ -3192,6 +3194,10 @@ export default function App({
   // Helper to update streaming output for bash/shell tools
   const updateStreamingOutput = useCallback(
     (toolCallId: string, chunk: string, isStderr = false) => {
+      recordTuiPerf(`tool_output:${isStderr ? "stderr" : "stdout"}`, {
+        bytes: Buffer.byteLength(chunk),
+      });
+
       const lineId = buffersRef.current.toolCallIdToLineId.get(toolCallId);
       if (!lineId) return;
 
@@ -3233,6 +3239,7 @@ export default function App({
           !buffersRef.current.interrupted &&
           (buffersRef.current.commitGeneration || 0) === capturedGeneration
         ) {
+          recordTuiPerf("ui_refresh:stream");
           refreshDerived();
         }
       }, 16); // ~60fps

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -22,6 +22,7 @@ import {
   createStreamAbortRelay,
 } from "../../utils/streamAbortRelay";
 import { formatDuration, logTiming } from "../../utils/timing";
+import { recordTuiJsonPayload, recordTuiPerf } from "../../utils/tuiPerf";
 
 import {
   type createBuffers,
@@ -265,6 +266,11 @@ export async function drainStream(
 
   try {
     for await (const chunk of stream) {
+      recordTuiJsonPayload(
+        `stream_chunk:${chunk.message_type ?? "unknown"}`,
+        chunk,
+      );
+
       // Check if abort generation changed (handleInterrupt ran while we were waiting)
       // This catches cases where the abort signal might not propagate correctly
       if ((buffers.abortGeneration || 0) !== startAbortGen) {
@@ -350,6 +356,10 @@ export async function drainStream(
       }
 
       if (shouldAccumulate) {
+        recordTuiJsonPayload(
+          `stream_accumulate:${chunk.message_type ?? "unknown"}`,
+          chunk,
+        );
         onChunk(buffers, chunk, contextTracker);
         queueMicrotask(refresh);
       }
@@ -530,6 +540,7 @@ export async function drainStreamWithResume(
   seenSeqIdThreshold?: number | null,
 ): Promise<DrainResult> {
   const overallStartTime = performance.now();
+  recordTuiPerf("stream_lifecycle:start");
   const streamRequestContext = getStreamRequestContext(stream);
   // Use the message OTID stored in the request context (set from messages[0].otid).
   // This is the real UUID OTID — distinct from the tool execution context ID
@@ -864,6 +875,9 @@ export async function drainStreamWithResume(
 
   // Update duration to reflect total time (including resume attempt)
   result.apiDurationMs = performance.now() - overallStartTime;
+  recordTuiPerf(`stream_lifecycle:end:${result.stopReason}`, {
+    ms: result.apiDurationMs,
+  });
 
   return result;
 }

--- a/src/utils/tuiPerf.ts
+++ b/src/utils/tuiPerf.ts
@@ -1,0 +1,176 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const TUI_PERF_FLUSH_INTERVAL_MS = 1_000;
+const TUI_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
+
+type TuiPerfBucket = {
+  count: number;
+  bytes: number;
+  ms: number;
+  maxBytes: number;
+  maxMs: number;
+};
+
+const tuiPerfBuckets = new Map<string, TuiPerfBucket>();
+let tuiPerfFlushTimer: ReturnType<typeof setTimeout> | null = null;
+let tuiPerfWindowStartedAt = 0;
+let tuiPerfFileDirEnsured: string | null = null;
+let tuiPerfWarningEmitted = false;
+let tuiPerfExitHookRegistered = false;
+
+function isTuiPerfEnabled(): boolean {
+  return TUI_PERF_ENV_VALUES.has(
+    (process.env.LETTA_TUI_PERF ?? "").toLowerCase(),
+  );
+}
+
+function getTuiPerfFilePath(): string | null {
+  const filePath = process.env.LETTA_TUI_PERF_FILE?.trim();
+  return filePath && filePath.length > 0 ? filePath : null;
+}
+
+function ensureExitHook(): void {
+  if (tuiPerfExitHookRegistered) {
+    return;
+  }
+  tuiPerfExitHookRegistered = true;
+  process.once("beforeExit", () => {
+    flushTuiPerfTelemetry();
+  });
+}
+
+function scheduleTuiPerfFlush(): void {
+  if (tuiPerfFlushTimer) {
+    return;
+  }
+  tuiPerfFlushTimer = setTimeout(() => {
+    tuiPerfFlushTimer = null;
+    flushTuiPerfTelemetry();
+  }, TUI_PERF_FLUSH_INTERVAL_MS);
+  const timerWithUnref = tuiPerfFlushTimer as ReturnType<typeof setTimeout> & {
+    unref?: () => void;
+  };
+  timerWithUnref.unref?.();
+}
+
+export function recordTuiPerf(
+  key: string,
+  sample?: {
+    bytes?: number;
+    ms?: number;
+  },
+): void {
+  if (!isTuiPerfEnabled() || !getTuiPerfFilePath()) {
+    return;
+  }
+
+  ensureExitHook();
+  if (tuiPerfWindowStartedAt === 0) {
+    tuiPerfWindowStartedAt = Date.now();
+  }
+
+  const bytes = sample?.bytes ?? 0;
+  const ms = sample?.ms ?? 0;
+  const bucket = tuiPerfBuckets.get(key) ?? {
+    count: 0,
+    bytes: 0,
+    ms: 0,
+    maxBytes: 0,
+    maxMs: 0,
+  };
+  bucket.count += 1;
+  bucket.bytes += bytes;
+  bucket.ms += ms;
+  bucket.maxBytes = Math.max(bucket.maxBytes, bytes);
+  bucket.maxMs = Math.max(bucket.maxMs, ms);
+  tuiPerfBuckets.set(key, bucket);
+  scheduleTuiPerfFlush();
+}
+
+export function recordTuiJsonPayload(key: string, value: unknown): void {
+  if (!isTuiPerfEnabled() || !getTuiPerfFilePath()) {
+    return;
+  }
+
+  try {
+    recordTuiPerf(key, { bytes: Buffer.byteLength(JSON.stringify(value)) });
+  } catch {
+    recordTuiPerf(key);
+  }
+}
+
+function flushTuiPerfTelemetry(): void {
+  if (tuiPerfBuckets.size === 0) {
+    tuiPerfWindowStartedAt = 0;
+    return;
+  }
+
+  const filePath = getTuiPerfFilePath();
+  if (!filePath) {
+    tuiPerfBuckets.clear();
+    tuiPerfWindowStartedAt = 0;
+    return;
+  }
+
+  const windowMs = Math.max(1, Date.now() - tuiPerfWindowStartedAt);
+  const totals: TuiPerfBucket = {
+    count: 0,
+    bytes: 0,
+    ms: 0,
+    maxBytes: 0,
+    maxMs: 0,
+  };
+  const buckets: Record<
+    string,
+    TuiPerfBucket & {
+      avg_bytes: number;
+      avg_ms: number;
+    }
+  > = {};
+
+  for (const [key, bucket] of [...tuiPerfBuckets.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    totals.count += bucket.count;
+    totals.bytes += bucket.bytes;
+    totals.ms += bucket.ms;
+    totals.maxBytes = Math.max(totals.maxBytes, bucket.maxBytes);
+    totals.maxMs = Math.max(totals.maxMs, bucket.maxMs);
+    buckets[key] = {
+      ...bucket,
+      avg_bytes: bucket.count > 0 ? bucket.bytes / bucket.count : 0,
+      avg_ms: bucket.count > 0 ? bucket.ms / bucket.count : 0,
+    };
+  }
+
+  try {
+    const dir = dirname(filePath);
+    if (tuiPerfFileDirEnsured !== dir) {
+      mkdirSync(dir, { recursive: true });
+      tuiPerfFileDirEnsured = dir;
+    }
+    appendFileSync(
+      filePath,
+      `${JSON.stringify({
+        ts: new Date().toISOString(),
+        event: "tui_activity",
+        window_ms: windowMs,
+        totals,
+        buckets,
+      })}\n`,
+      { encoding: "utf8" },
+    );
+  } catch (error) {
+    if (!tuiPerfWarningEmitted) {
+      tuiPerfWarningEmitted = true;
+      console.error(
+        `[TUI Perf] Failed to write LETTA_TUI_PERF_FILE=${filePath}`,
+        error,
+      );
+    }
+  } finally {
+    tuiPerfBuckets.clear();
+    tuiPerfWindowStartedAt = 0;
+  }
+}

--- a/src/utils/tuiPerf.ts
+++ b/src/utils/tuiPerf.ts
@@ -3,6 +3,10 @@ import { dirname } from "node:path";
 
 const TUI_PERF_FLUSH_INTERVAL_MS = 1_000;
 const TUI_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
+const TUI_PERF_ENABLED = TUI_PERF_ENV_VALUES.has(
+  (process.env.LETTA_TUI_PERF ?? "").toLowerCase(),
+);
+const TUI_PERF_FILE = process.env.LETTA_TUI_PERF_FILE?.trim() || null;
 
 type TuiPerfBucket = {
   count: number;
@@ -18,17 +22,6 @@ let tuiPerfWindowStartedAt = 0;
 let tuiPerfFileDirEnsured: string | null = null;
 let tuiPerfWarningEmitted = false;
 let tuiPerfExitHookRegistered = false;
-
-function isTuiPerfEnabled(): boolean {
-  return TUI_PERF_ENV_VALUES.has(
-    (process.env.LETTA_TUI_PERF ?? "").toLowerCase(),
-  );
-}
-
-function getTuiPerfFilePath(): string | null {
-  const filePath = process.env.LETTA_TUI_PERF_FILE?.trim();
-  return filePath && filePath.length > 0 ? filePath : null;
-}
 
 function ensureExitHook(): void {
   if (tuiPerfExitHookRegistered) {
@@ -61,7 +54,7 @@ export function recordTuiPerf(
     ms?: number;
   },
 ): void {
-  if (!isTuiPerfEnabled() || !getTuiPerfFilePath()) {
+  if (!TUI_PERF_ENABLED || !TUI_PERF_FILE) {
     return;
   }
 
@@ -89,7 +82,7 @@ export function recordTuiPerf(
 }
 
 export function recordTuiJsonPayload(key: string, value: unknown): void {
-  if (!isTuiPerfEnabled() || !getTuiPerfFilePath()) {
+  if (!TUI_PERF_ENABLED || !TUI_PERF_FILE) {
     return;
   }
 
@@ -106,7 +99,7 @@ function flushTuiPerfTelemetry(): void {
     return;
   }
 
-  const filePath = getTuiPerfFilePath();
+  const filePath = TUI_PERF_FILE;
   if (!filePath) {
     tuiPerfBuckets.clear();
     tuiPerfWindowStartedAt = 0;


### PR DESCRIPTION
## Summary
- add `LETTA_TUI_PERF_FILE` JSONL telemetry for local TUI workload
- aggregate stream chunks, accumulated chunks, streaming tool output, UI refreshes, and stream lifecycle timings
- keep telemetry disabled unless `LETTA_TUI_PERF=1` and a file path are both set

## Verification
- `bunx @biomejs/biome@2.2.5 check --write src/utils/tuiPerf.ts src/cli/helpers/stream.ts src/cli/App.tsx`
- `bun run typecheck`