### PR TITLE
refactor(cli): rename memfs subcommand to memory

### DIFF
--- a/src/cli/subcommands/memory.ts
+++ b/src/cli/subcommands/memory.ts
@@ -9,20 +9,20 @@ import {
   isGitRepo,
   pullMemory,
 } from "../../agent/memoryGit";
-import { runMemfsTokensAction } from "./memfsTokens";
+import { runMemoryTokensAction } from "./memoryTokens";
 
 function printUsage(): void {
   console.log(
     `
 Usage:
-  letta memfs status [--agent <id>]
-  letta memfs diff [--agent <id>]
-  letta memfs backup [--agent <id>]
-  letta memfs backups [--agent <id>]
-  letta memfs restore --from <backup> --force [--agent <id>]
-  letta memfs export --agent <id> --out <dir>
-  letta memfs pull [--agent <id>]
-  letta memfs tokens [--memory-dir <path>] [--agent <id>] [--top <N>]
+  letta memory status [--agent <id>]
+  letta memory diff [--agent <id>]
+  letta memory backup [--agent <id>]
+  letta memory backups [--agent <id>]
+  letta memory restore --from <backup> --force [--agent <id>]
+  letta memory export --agent <id> --out <dir>
+  letta memory pull [--agent <id>]
+  letta memory tokens [--memory-dir <path>] [--agent <id>] [--top <N>]
                      [--format text|json] [--quiet]
 
 Notes:
@@ -33,12 +33,12 @@ Notes:
   - Memory is git-backed. Use git commands for commit/push.
 
 Examples:
-  LETTA_AGENT_ID=agent-123 letta memfs status
-  letta memfs pull --agent agent-123
-  letta memfs backup --agent agent-123
-  letta memfs export --agent agent-123 --out /tmp/letta-memfs-agent-123
-  letta memfs tokens
-  letta memfs tokens --memory-dir ~/.letta/agents/agent-123/memory --format json
+  LETTA_AGENT_ID=agent-123 letta memory status
+  letta memory pull --agent agent-123
+  letta memory backup --agent agent-123
+  letta memory export --agent agent-123 --out /tmp/letta-memory-agent-123
+  letta memory tokens
+  letta memory tokens --memory-dir ~/.letta/agents/agent-123/memory --format json
 `.trim(),
   );
 }
@@ -47,7 +47,7 @@ function getAgentId(agentFromArgs?: string, agentIdFromArgs?: string): string {
   return agentFromArgs || agentIdFromArgs || process.env.LETTA_AGENT_ID || "";
 }
 
-const MEMFS_OPTIONS = {
+const MEMORY_OPTIONS = {
   help: { type: "boolean", short: "h" },
   agent: { type: "string" },
   "agent-id": { type: "string" },
@@ -60,10 +60,10 @@ const MEMFS_OPTIONS = {
   quiet: { type: "boolean" },
 } as const;
 
-function parseMemfsArgs(argv: string[]) {
+function parseMemoryArgs(argv: string[]) {
   return parseArgs({
     args: argv,
-    options: MEMFS_OPTIONS,
+    options: MEMORY_OPTIONS,
     strict: true,
     allowPositionals: true,
   });
@@ -125,10 +125,10 @@ function resolveBackupPath(agentId: string, from: string): string {
   return join(getAgentRoot(agentId), from);
 }
 
-export async function runMemfsSubcommand(argv: string[]): Promise<number> {
-  let parsed: ReturnType<typeof parseMemfsArgs>;
+export async function runMemorySubcommand(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseMemoryArgs>;
   try {
-    parsed = parseMemfsArgs(argv);
+    parsed = parseMemoryArgs(argv);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Error: ${message}`);
@@ -148,7 +148,7 @@ export async function runMemfsSubcommand(argv: string[]): Promise<number> {
   // `tokens` has its own input resolution (--memory-dir / $MEMORY_DIR first,
   // then falls back to agent id). Short-circuit before the agent-id hard check.
   if (action === "tokens") {
-    return runMemfsTokensAction({
+    return runMemoryTokensAction({
       memoryDir: parsed.values["memory-dir"],
       agentMemoryDir: agentId ? getMemoryRoot(agentId) : undefined,
       top: parsed.values.top,

--- a/src/cli/subcommands/memoryTokens.ts
+++ b/src/cli/subcommands/memoryTokens.ts
@@ -8,7 +8,7 @@ const DEFAULT_TOP = 20;
 const USAGE_EXIT = 64;
 const IO_EXIT = 65;
 
-export interface MemfsTokensOptions {
+export interface MemoryTokensOptions {
   memoryDir: string | undefined;
   agentMemoryDir: string | undefined;
   top: string | undefined;
@@ -66,15 +66,15 @@ function printJson(total: number, files: FileEstimate[]): void {
   );
 }
 
-function resolveMemoryDir(options: MemfsTokensOptions): string | null {
+function resolveMemoryDir(options: MemoryTokensOptions): string | null {
   if (options.memoryDir) return options.memoryDir;
   if (process.env.MEMORY_DIR) return process.env.MEMORY_DIR;
   if (options.agentMemoryDir) return options.agentMemoryDir;
   return null;
 }
 
-export async function runMemfsTokensAction(
-  options: MemfsTokensOptions,
+export async function runMemoryTokensAction(
+  options: MemoryTokensOptions,
 ): Promise<number> {
   const format = options.format ?? "text";
   if (format !== "text" && format !== "json") {

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -4,7 +4,7 @@ import { runChannelsSubcommand } from "./channels";
 import { runConnectSubcommand } from "./connect";
 import { runCronSubcommand } from "./cron";
 import { runListenSubcommand } from "./listen.tsx";
-import { runMemfsSubcommand } from "./memfs";
+import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
 
 export async function runSubcommand(argv: string[]): Promise<number | null> {
@@ -15,8 +15,9 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
   }
 
   switch (command) {
-    case "memfs":
-      return runMemfsSubcommand(rest);
+    case "memory":
+    case "memfs": // legacy alias
+      return runMemorySubcommand(rest);
     case "agents":
       return runAgentsSubcommand(rest);
     case "messages":

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ USAGE
 
   # maintenance
   letta update          Manually check for updates and install if available
-  letta memfs ...       Memory filesystem subcommands (JSON-only)
+  letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
   letta blocks ...      Blocks subcommands (JSON-only)
@@ -100,14 +100,16 @@ USAGE
 OPTIONS
 ${renderCliOptionsHelp()}
 
-SUBCOMMANDS (JSON-only)
-  letta memfs status --agent <id>
-  letta memfs diff --agent <id>
-  letta memfs resolve --agent <id> --resolutions '<JSON>'
-  letta memfs backup --agent <id>
-  letta memfs backups --agent <id>
-  letta memfs restore --agent <id> --from <backup> --force
-  letta memfs export --agent <id> --out <dir>
+SUBCOMMANDS
+  letta memory status --agent <id>
+  letta memory diff --agent <id>
+  letta memory resolve --agent <id> --resolutions '<JSON>'
+  letta memory backup --agent <id>
+  letta memory backups --agent <id>
+  letta memory restore --agent <id> --from <backup> --force
+  letta memory export --agent <id> --out <dir>
+  letta memory pull --agent <id>
+  letta memory tokens [--memory-dir <path>] [--agent <id>] [--format text|json]
   letta agents list [--query <text> | --name <name> | --tags <tags>]
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
@@ -355,7 +357,7 @@ async function getPinnedAgentNames(): Promise<{ id: string; name: string }[]> {
 async function main(): Promise<void> {
   markMilestone("CLI_START");
 
-  // Early exit for CLI subcommands (e.g., `letta server`, `letta memfs`).
+  // Early exit for CLI subcommands (e.g., `letta server`, `letta memory`).
   // Subcommands handle their own setup and don't need TUI init, theme
   // detection, or base tool bootstrapping.
   const subcommandResult = await runSubcommand(process.argv.slice(2));

--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -169,6 +169,8 @@ const SAFE_MEMORY_COMMANDS = new Set([
 
 // letta CLI read-only subcommands: group -> allowed actions
 const SAFE_LETTA_COMMANDS: Record<string, Set<string>> = {
+  memory: new Set(["status", "help", "backups", "export", "tokens"]),
+  // Legacy alias for `letta memory ...`.
   memfs: new Set(["status", "help", "backups", "export", "tokens"]),
   agents: new Set(["list", "help"]),
   messages: new Set(["search", "list", "help"]),

--- a/src/skills/builtin/migrating-memory/SKILL.md
+++ b/src/skills/builtin/migrating-memory/SKILL.md
@@ -30,7 +30,7 @@ This is the recommended flow:
 
 1. **Export the source agent's memfs to a temp directory**
    ```bash
-   letta memfs export --agent <source-agent-id> --out /tmp/letta-memfs-<source-agent-id>
+   letta memory export --agent <source-agent-id> --out /tmp/letta-memory-<source-agent-id>
    ```
 
 2. **Copy the files you want into your own memfs**
@@ -39,13 +39,16 @@ This is the recommended flow:
 
    Example:
    ```bash
-   cp -r /tmp/letta-memfs-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
-   cp /tmp/letta-memfs-agent-abc123/notes.md ~/.letta/agents/$LETTA_AGENT_ID/memory/
+   cp -r /tmp/letta-memory-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
+   cp /tmp/letta-memory-agent-abc123/notes.md ~/.letta/agents/$LETTA_AGENT_ID/memory/
    ```
 
-3. **Sync to API**
+3. **Commit and push the memory repo**
    ```bash
-   letta memfs sync --agent $LETTA_AGENT_ID
+   cd ~/.letta/agents/$LETTA_AGENT_ID/memory
+   git add system/project notes.md
+   git commit -m "Import memory from source agent"
+   git push
    ```
 
 This gives you full control over what you bring across and keeps everything consistent with memfs.
@@ -107,15 +110,18 @@ Scenario: You're a new agent and want to inherit memory from an existing agent "
 
 2. **Export their memfs:**
    ```bash
-   letta memfs export --agent agent-abc123 --out /tmp/letta-memfs-agent-abc123
+   letta memory export --agent agent-abc123 --out /tmp/letta-memory-agent-abc123
    ```
 
 3. **Copy the relevant files into your memfs:**
    ```bash
-   cp -r /tmp/letta-memfs-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
+   cp -r /tmp/letta-memory-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
    ```
 
-4. **Sync:**
+4. **Commit and push:**
    ```bash
-   letta memfs sync --agent $LETTA_AGENT_ID
+   cd ~/.letta/agents/$LETTA_AGENT_ID/memory
+   git add system/project
+   git commit -m "Import project memory"
+   git push
    ```

--- a/src/tests/cli/memory-tokens.test.ts
+++ b/src/tests/cli/memory-tokens.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runMemfsSubcommand } from "../../cli/subcommands/memfs";
+import { runMemorySubcommand } from "../../cli/subcommands/memory";
 
 interface Capture {
   stdout: string[];
@@ -32,13 +32,13 @@ function captureConsole(): { capture: Capture; restore: () => void } {
   };
 }
 
-describe("letta memfs tokens", () => {
+describe("letta memory tokens", () => {
   let tmpRoot: string;
   let priorMemoryDir: string | undefined;
   let priorAgentId: string | undefined;
 
   beforeEach(() => {
-    tmpRoot = mkdtempSync(join(tmpdir(), "memfs-tokens-"));
+    tmpRoot = mkdtempSync(join(tmpdir(), "memory-tokens-"));
     priorMemoryDir = process.env.MEMORY_DIR;
     priorAgentId = process.env.LETTA_AGENT_ID;
     delete process.env.MEMORY_DIR;
@@ -68,7 +68,7 @@ describe("letta memfs tokens", () => {
   test("returns 64 when no memory dir source is available", async () => {
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand(["tokens"]);
+      const code = await runMemorySubcommand(["tokens"]);
       expect(code).toBe(64);
       expect(capture.stderr.join("\n")).toContain("Missing memory dir");
     } finally {
@@ -80,7 +80,7 @@ describe("letta memfs tokens", () => {
     mkdirSync(join(tmpRoot, "system"), { recursive: true });
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -97,7 +97,7 @@ describe("letta memfs tokens", () => {
     process.env.MEMORY_DIR = tmpRoot;
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand(["tokens", "--quiet"]);
+      const code = await runMemorySubcommand(["tokens", "--quiet"]);
       expect(code).toBe(0);
       expect(capture.stdout.join("\n")).toContain("Total: 1 tokens");
     } finally {
@@ -112,7 +112,7 @@ describe("letta memfs tokens", () => {
     process.env.MEMORY_DIR = "/nonexistent/does-not-exist";
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -129,7 +129,7 @@ describe("letta memfs tokens", () => {
     writeSystemFile("persona.md", "a".repeat(4 * 50000));
     const { restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -145,7 +145,7 @@ describe("letta memfs tokens", () => {
     mkdirSync(join(tmpRoot, "system"), { recursive: true });
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -163,7 +163,7 @@ describe("letta memfs tokens", () => {
     mkdirSync(join(tmpRoot, "system"), { recursive: true });
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -181,7 +181,7 @@ describe("letta memfs tokens", () => {
     writeSystemFile("persona.md", "abcd");
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -206,7 +206,7 @@ describe("letta memfs tokens", () => {
     writeSystemFile("large.md", "a".repeat(40)); // 10 tokens
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -227,7 +227,7 @@ describe("letta memfs tokens", () => {
     writeSystemFile("persona.md", "abcd");
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([
+      const code = await runMemorySubcommand([
         "tokens",
         "--memory-dir",
         tmpRoot,
@@ -246,9 +246,9 @@ describe("letta memfs tokens", () => {
   test("help usage mentions tokens", async () => {
     const { capture, restore } = captureConsole();
     try {
-      const code = await runMemfsSubcommand([]);
+      const code = await runMemorySubcommand([]);
       expect(code).toBe(0);
-      expect(capture.stdout.join("\n")).toContain("letta memfs tokens");
+      expect(capture.stdout.join("\n")).toContain("letta memory tokens");
     } finally {
       restore();
     }

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -446,45 +446,48 @@ describe("isReadOnlyShellCommand", () => {
   });
 
   describe("letta CLI commands", () => {
-    test("allows letta memfs tokens", () => {
-      expect(isReadOnlyShellCommand("letta memfs tokens")).toBe(true);
+    test("allows letta memory tokens", () => {
+      expect(isReadOnlyShellCommand("letta memory tokens")).toBe(true);
     });
 
-    test("allows letta memfs tokens with flags", () => {
+    test("allows letta memory tokens with flags", () => {
       expect(
-        isReadOnlyShellCommand("letta memfs tokens --quiet --format json"),
+        isReadOnlyShellCommand("letta memory tokens --quiet --format json"),
       ).toBe(true);
       expect(
         isReadOnlyShellCommand(
-          "letta memfs tokens --memory-dir /tmp/mem --top 10",
+          "letta memory tokens --memory-dir /tmp/mem --top 10",
         ),
       ).toBe(true);
     });
 
-    test("allows letta memfs help", () => {
-      expect(isReadOnlyShellCommand("letta memfs help")).toBe(true);
+    test("allows letta memory help", () => {
+      expect(isReadOnlyShellCommand("letta memory help")).toBe(true);
     });
 
-    test("blocks unknown letta memfs action", () => {
+    test("blocks unknown letta memory action", () => {
       // restore/backup/pull/diff mutate state — not in read-only allowlist
-      expect(isReadOnlyShellCommand("letta memfs restore")).toBe(false);
-      expect(isReadOnlyShellCommand("letta memfs pull")).toBe(false);
-      expect(isReadOnlyShellCommand("letta memfs delete")).toBe(false);
+      expect(isReadOnlyShellCommand("letta memory restore")).toBe(false);
+      expect(isReadOnlyShellCommand("letta memory pull")).toBe(false);
+      expect(isReadOnlyShellCommand("letta memory delete")).toBe(false);
     });
 
-    test("blocks letta memfs with no action", () => {
-      expect(isReadOnlyShellCommand("letta memfs")).toBe(false);
+    test("blocks letta memory with no action", () => {
+      expect(isReadOnlyShellCommand("letta memory")).toBe(false);
     });
 
     test("blocks unknown letta group", () => {
-      expect(isReadOnlyShellCommand("letta memory tokens")).toBe(false);
       expect(isReadOnlyShellCommand("letta install plugin")).toBe(false);
       expect(isReadOnlyShellCommand("letta doctor")).toBe(false);
     });
 
-    test("allows letta memfs tokens piped to a safe command", () => {
+    test("allows legacy letta memfs alias", () => {
+      expect(isReadOnlyShellCommand("letta memfs tokens")).toBe(true);
+    });
+
+    test("allows letta memory tokens piped to a safe command", () => {
       expect(
-        isReadOnlyShellCommand("letta memfs tokens --format json | head -5"),
+        isReadOnlyShellCommand("letta memory tokens --format json | head -5"),
       ).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Renames the memory filesystem CLI namespace from `letta memfs ...` to `letta memory ...`.
- Keeps `letta memfs ...` as a hidden legacy alias in the router and read-only shell allowlist.
- Updates help text, token tests, permission tests, and migrating-memory skill docs.

## Notes

`letta memory tokens` is now the primary command. Existing scripts using `letta memfs tokens` still work through the alias, but it no longer appears in help text.

I also fixed stale migrating-memory examples that referenced nonexistent `letta memfs sync`; those now use the actual git commit/push flow.

## Test plan

- [x] `bun run check`
- [x] `bun test src/tests/utils/systemPromptSize.test.ts src/tests/cli/memory-tokens.test.ts src/tests/permissions/readOnlyShell.test.ts`
- [x] Smoke: `MEMORY_DIR=$HOME/.letta/agents/$AGENT_ID/memory bun run src/index.ts memory tokens --top 3`
- [x] Smoke: `MEMORY_DIR=$HOME/.letta/agents/$AGENT_ID/memory bun run src/index.ts memfs tokens --quiet`

👾 Generated with [Letta Code](https://letta.com)