### PR TITLE
perf(listener): make sync approval recovery explicit

### DIFF
--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -92,6 +92,89 @@ type RunsListClient = {
 
 const FALLBACK_RUN_DISCOVERY_TIMEOUT_MS = 5000;
 
+function summarizeStreamForDebug(stream: unknown): string {
+  if (!stream || typeof stream !== "object") {
+    return `type=${typeof stream}`;
+  }
+  const record = stream as Record<PropertyKey, unknown>;
+  const ctor = (stream as { constructor?: { name?: string } }).constructor
+    ?.name;
+  const controller =
+    record.controller && typeof record.controller === "object"
+      ? (record.controller as Record<string, unknown>)
+      : null;
+  const keys = Object.keys(record).slice(0, 8);
+  return [
+    `ctor=${ctor ?? "unknown"}`,
+    `asyncIterator=${typeof record[Symbol.asyncIterator]}`,
+    `controller=${typeof record.controller}`,
+    `controllerAbort=${typeof controller?.abort}`,
+    `controllerSignal=${typeof controller?.signal}`,
+    keys.length > 0 ? `keys=${keys.join(",")}` : "keys=(none)",
+  ].join(" ");
+}
+
+function summarizeChunkForDebug(chunk: LettaStreamingResponse | null): string {
+  if (!chunk) {
+    return "none";
+  }
+  const record = chunk as unknown as Record<string, unknown>;
+  const parts = [`message_type=${chunk.message_type ?? "unknown"}`];
+  for (const key of ["run_id", "seq_id", "id", "otid", "tool_call_id"]) {
+    const value = record[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      parts.push(`${key}=${value}`);
+    }
+  }
+  if (chunk.message_type === "stop_reason") {
+    parts.push(`stop_reason=${String(record.stop_reason ?? "unknown")}`);
+  }
+  const toolCalls = record.tool_calls;
+  if (Array.isArray(toolCalls)) {
+    parts.push(`tool_calls=${toolCalls.length}`);
+  }
+  return parts.join(" ");
+}
+
+function abortStreamController(
+  stream: Stream<LettaStreamingResponse>,
+  reason: string,
+): void {
+  const controller = (stream as unknown as { controller?: unknown }).controller;
+  if (!controller || typeof controller !== "object") {
+    debugWarn(
+      "drainStream",
+      "stream.controller is unavailable during %s - cannot abort HTTP request (%s)",
+      reason,
+      summarizeStreamForDebug(stream),
+    );
+    return;
+  }
+
+  const controllerRecord = controller as {
+    abort?: () => void;
+    signal?: { aborted?: boolean };
+  };
+  if (controllerRecord.signal?.aborted) {
+    return;
+  }
+  if (typeof controllerRecord.abort !== "function") {
+    debugWarn(
+      "drainStream",
+      "stream.controller.abort is unavailable during %s - cannot abort HTTP request (%s)",
+      reason,
+      summarizeStreamForDebug(stream),
+    );
+    return;
+  }
+
+  controllerRecord.abort();
+}
+
 function hasPaginatedItems(
   response: RunsListResponse,
 ): response is { getPaginatedItems: () => Run[] } {
@@ -230,6 +313,7 @@ export async function drainStream(
   let stopReason: StopReasonType | null = null;
   let hasCalledFirstMessage = false;
   let fallbackError: string | null = null;
+  let lastChunkDebugSummary = "none";
 
   // Track if we triggered abort via our listener (for eager cancellation)
   let abortedViaListener = false;
@@ -241,17 +325,7 @@ export async function drainStream(
   // This immediately cancels the HTTP request instead of waiting for next chunk
   const abortHandler = () => {
     abortedViaListener = true;
-    // Abort the SDK's stream controller to cancel the underlying HTTP request
-    if (!stream.controller) {
-      debugWarn(
-        "drainStream",
-        "stream.controller is undefined - cannot abort HTTP request",
-      );
-      return;
-    }
-    if (!stream.controller.signal.aborted) {
-      stream.controller.abort();
-    }
+    abortStreamController(stream, "abort_signal");
   };
 
   if (abortSignal && !abortSignal.aborted) {
@@ -259,13 +333,21 @@ export async function drainStream(
   } else if (abortSignal?.aborted) {
     // Already aborted before we started
     abortedViaListener = true;
-    if (stream.controller && !stream.controller.signal.aborted) {
-      stream.controller.abort();
-    }
+    abortStreamController(stream, "pre_aborted_signal");
   }
 
   try {
+    const asyncIterator = (stream as unknown as Record<PropertyKey, unknown>)[
+      Symbol.asyncIterator
+    ];
+    if (typeof asyncIterator !== "function") {
+      throw new TypeError(
+        `Stream is not async iterable (${summarizeStreamForDebug(stream)})`,
+      );
+    }
+
     for await (const chunk of stream) {
+      lastChunkDebugSummary = summarizeChunkForDebug(chunk);
       recordTuiJsonPayload(
         `stream_chunk:${chunk.message_type ?? "unknown"}`,
         chunk,
@@ -376,7 +458,16 @@ export async function drainStream(
     const errorMessageWithDiagnostic = sdkDiagnostic
       ? `${errorMessage} [${sdkDiagnostic}]`
       : errorMessage;
-    debugWarn("drainStream", "Stream error caught:", errorMessage);
+    debugWarn(
+      "drainStream",
+      "Stream error caught: %s last_chunk=%s stream=%s",
+      errorMessageWithDiagnostic,
+      lastChunkDebugSummary,
+      summarizeStreamForDebug(stream),
+    );
+    if (e instanceof Error && e.stack) {
+      debugWarn("drainStream", "Stream error stack: %s", e.stack);
+    }
 
     // Try to extract run_id from APIError if we don't have one yet
     if (!streamProcessor.lastRunId && e instanceof APIError && e.error) {

--- a/src/tests/cli/stream-stop-reason-wiring.test.ts
+++ b/src/tests/cli/stream-stop-reason-wiring.test.ts
@@ -134,4 +134,28 @@ describe("drainStream stop reason wiring", () => {
     expect(result.stopReason).toBe("end_turn");
     expect(getEventListeners(parent.signal, "abort")).toHaveLength(0);
   });
+
+  test("drainStream tolerates stream controllers without abort()", async () => {
+    const parent = new AbortController();
+    parent.abort();
+
+    const fakeStream = {
+      controller: { signal: { aborted: false } },
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const result = await drainStream(
+      fakeStream,
+      createBuffers("agent-test"),
+      () => {},
+      parent.signal,
+    );
+
+    expect(result.stopReason).toBe("cancelled");
+  });
 });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -371,10 +371,15 @@ describe("listen-client parseServerMessage", () => {
         JSON.stringify({
           type: "sync",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
+          recover_approvals: false,
         }),
       ),
     );
     expect(sync?.type).toBe("sync");
+    if (sync?.type !== "sync") {
+      throw new Error("expected sync command");
+    }
+    expect(sync.recover_approvals).toBe(false);
   });
 
   test("parses cron CRUD commands", () => {
@@ -2762,6 +2767,41 @@ describe("listen-client v2 status builders", () => {
           message.delta?.message_type === "loop_error",
       ),
     ).toBe(false);
+  });
+
+  test("sync replay can skip backend approval recovery for lightweight state sync", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+    const recoverApprovalStateForSync = mock(async () => {});
+
+    await __listenClientTestUtils.replaySyncStateForRuntime(
+      listener,
+      socket as unknown as WebSocket,
+      {
+        agent_id: "agent-1",
+        conversation_id: "default",
+      },
+      {
+        recoverApprovals: false,
+        recoverApprovalStateForSync,
+      },
+    );
+
+    expect(recoverApprovalStateForSync).not.toHaveBeenCalled();
+    const outbound = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload as string),
+    );
+    expect(outbound.map((message) => message.type)).toEqual([
+      "update_device_status",
+      "update_loop_status",
+      "update_queue",
+      "update_subagent_state",
+    ]);
   });
 
   test("sync includes silent background reflection subagents in update_subagent_state", () => {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -578,6 +578,12 @@ export interface AbortMessageCommand {
 export interface SyncCommand {
   type: "sync";
   runtime: RuntimeScope;
+  /**
+   * Whether the device should probe backend state for stale pending approvals.
+   * Defaults to true for older clients. Lightweight status/recovery syncs should
+   * set this false and only replay in-memory listener state.
+   */
+  recover_approvals?: boolean;
 }
 
 export interface TerminalSpawnCommand {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -361,6 +361,7 @@ async function replaySyncStateForRuntime(
   socket: WebSocket,
   scope: { agent_id: string; conversation_id: string },
   opts?: {
+    recoverApprovals?: boolean;
     recoverApprovalStateForSync?: (
       runtime: ConversationRuntime,
       scope: { agent_id: string; conversation_id: string },
@@ -375,16 +376,18 @@ async function replaySyncStateForRuntime(
   const recoverFn =
     opts?.recoverApprovalStateForSync ?? recoverApprovalStateForSync;
 
-  try {
-    await recoverFn(syncScopedRuntime, scope);
-  } catch (error) {
-    trackListenerError(
-      "listener_sync_recovery_failed",
-      error,
-      "listener_sync_recovery",
-    );
-    if (isDebugEnabled()) {
-      console.warn("[Listen] Sync approval recovery failed:", error);
+  if (opts?.recoverApprovals ?? true) {
+    try {
+      await recoverFn(syncScopedRuntime, scope);
+    } catch (error) {
+      trackListenerError(
+        "listener_sync_recovery_failed",
+        error,
+        "listener_sync_recovery",
+      );
+      if (isDebugEnabled()) {
+        console.warn("[Listen] Sync approval recovery failed:", error);
+      }
     }
   }
 
@@ -4426,7 +4429,9 @@ async function connectWithRetry(
           console.log(`[Listen V2] Dropping sync: runtime mismatch or closed`);
           return;
         }
-        await replaySyncStateForRuntime(runtime, socket, parsed.runtime);
+        await replaySyncStateForRuntime(runtime, socket, parsed.runtime, {
+          recoverApprovals: parsed.recover_approvals !== false,
+        });
         return;
       }
 

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -237,8 +237,14 @@ function isSyncCommand(value: unknown): value is SyncCommand {
   const candidate = value as {
     type?: unknown;
     runtime?: unknown;
+    recover_approvals?: unknown;
   };
-  return candidate.type === "sync" && isRuntimeScope(candidate.runtime);
+  return (
+    candidate.type === "sync" &&
+    isRuntimeScope(candidate.runtime) &&
+    (candidate.recover_approvals === undefined ||
+      typeof candidate.recover_approvals === "boolean")
+  );
 }
 
 function isTerminalSpawnCommand(value: unknown): value is TerminalSpawnCommand {


### PR DESCRIPTION
## Summary
- add `recover_approvals` to the listener `sync` command so clients can request lightweight state replay without backend approval recovery
- keep legacy/default behavior as `recover_approvals !== false`, preserving existing approval recovery semantics for older clients and explicit recovery syncs
- add diagnostics for opaque stream drain errors, including stream shape, last chunk summary, and controller abort-shape handling

## Why
WS clients sends routine status/recovery syncs during active turns. Those syncs should replay in-memory listener state, not repeatedly perform the `getResumeData` last-in-context approval probe that the TUI only uses at resume/recovery boundaries.

## Tests
- `bun test src/tests/websocket/listen-client-protocol.test.ts src/tests/cli/stream-stop-reason-wiring.test.ts src/tests/websocket/listen-client-concurrency.test.ts src/tests/websocket/listen-recovery.test.ts src/tests/agent/getResumeData.test.ts`
- `bun run typecheck`
