### PR TITLE
Add DeepSeek V4 Pro model

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1402,6 +1402,17 @@
       }
     },
     {
+      "id": "deepseek-v4-pro",
+      "handle": "openrouter/deepseek/deepseek-v4-pro",
+      "label": "DeepSeek V4 Pro",
+      "description": "DeepSeek's V4 Pro model",
+      "updateArgs": {
+        "context_window": 1048576,
+        "max_output_tokens": 384000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "glm-5.1",
       "handle": "zai/glm-5.1",
       "label": "GLM-5.1",


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 Pro to the Letta Code model registry using the hosted OpenRouter handle.
- Position it above GLM-5.1 in the model selector ordering.

## Verification
- `bun test src/tests/tools/model-provider-detection.test.ts src/tests/agent/default-model-for-tier.test.ts`
- `bun run check`
- `bun -e 'import { models } from "./src/agent/model.ts"; const ids=models.map((m)=>m.id); console.log(ids.indexOf("deepseek-v4-pro"), ids.indexOf("glm-5.1"));'`

👾 Generated with [Letta Code](https://letta.com)