### PR TITLE
fix(memfs): validate sync endpoint for desktop enable

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -335,13 +335,13 @@ export interface ApplyMemfsFlagsOptions {
  * the /memfs enable command (App.tsx) to avoid duplicating the setup logic.
  *
  * Steps when toggling:
- *   1. Validate Letta Cloud requirement (for explicit enable)
+ *   1. Validate MemFS API endpoint support (for explicit enable)
  *   2. Reconcile system prompt to the target memory mode
  *   3. Persist memfs setting locally
  *   4. Detach old API-based memory tools (when enabling)
  *   5. Add git-memory-enabled tag + clone/pull repo
  *
- * @throws {Error} if Letta Cloud validation fails or git setup fails
+ * @throws {Error} if MemFS endpoint validation fails or git setup fails
  */
 export async function applyMemfsFlags(
   agentId: string,
@@ -351,11 +351,10 @@ export async function applyMemfsFlags(
 ): Promise<ApplyMemfsFlagsResult> {
   const { settingsManager } = await import("../settings-manager");
 
-  // Validate explicit enable on supported backend.
-  if (memfsFlag && !(await isLettaCloud())) {
-    throw new Error(
-      "--memfs is only available on Letta Cloud (api.letta.com).",
-    );
+  // LCD proxies normal API traffic through localhost, while MemFS git sync can
+  // still target api.letta.com through getMemfsServerUrl().
+  if (memfsFlag && !(await isLettaMemfsServer())) {
+    throw new Error(await getMemfsSyncUnavailableMessage());
   }
 
   const hasExplicitToggle = Boolean(memfsFlag || noMemfsFlag);
@@ -469,7 +468,7 @@ export async function applyMemfsFlags(
 }
 
 /**
- * Whether the current server is Letta Cloud (or local memfs testing is enabled).
+ * Whether the current server is the Letta API (or local memfs testing is enabled).
  */
 export async function isLettaCloud(): Promise<boolean> {
   const { getServerUrl } = await import("./client");
@@ -482,8 +481,37 @@ export async function isLettaCloud(): Promise<boolean> {
   );
 }
 
+function getServerHostLabel(serverUrl: string): string {
+  const trimmed = serverUrl.trim();
+  try {
+    return new URL(trimmed).host || trimmed;
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").replace(/\/+$/, "") || trimmed;
+  }
+}
+
 /**
- * Enable memfs for a newly created agent if on Letta Cloud.
+ * Whether the MemFS sync endpoint is backed by the Letta API.
+ */
+export async function isLettaMemfsServer(): Promise<boolean> {
+  const { getMemfsServerUrl } = await import("./client");
+  const memfsServerUrl = getMemfsServerUrl();
+
+  return (
+    memfsServerUrl.includes("api.letta.com") ||
+    process.env.LETTA_MEMFS_LOCAL === "1" ||
+    process.env.LETTA_API_KEY === "local-desktop"
+  );
+}
+
+async function getMemfsSyncUnavailableMessage(): Promise<string> {
+  const { getMemfsServerUrl } = await import("./client");
+  const memfsServerUrl = getMemfsServerUrl();
+  return `MemFS sync failed (expected api.letta.com, got ${getServerHostLabel(memfsServerUrl)})`;
+}
+
+/**
+ * Enable memfs for a newly created agent if on the Letta API.
  * Non-fatal: logs a warning on failure. Skips on self-hosted.
  *
  * Skips the system prompt update since callers are expected to create

--- a/src/tests/agent/memoryFilesystem.test.ts
+++ b/src/tests/agent/memoryFilesystem.test.ts
@@ -10,15 +10,46 @@ import { join } from "node:path";
 import {
   getMemoryFilesystemRoot,
   getMemorySystemDir,
+  isLettaMemfsServer,
   labelFromRelativePath,
   renderMemoryFilesystemTree,
 } from "../../agent/memoryFilesystem";
 import { DIRECTORY_LIMIT_ENV } from "../../utils/directoryLimits";
 
+const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
+const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
+const ORIGINAL_LETTA_MEMFS_LOCAL = process.env.LETTA_MEMFS_LOCAL;
+const ORIGINAL_LETTA_API_KEY = process.env.LETTA_API_KEY;
 const DIRECTORY_LIMIT_ENV_KEYS = Object.values(DIRECTORY_LIMIT_ENV);
 const ORIGINAL_DIRECTORY_ENV = Object.fromEntries(
   DIRECTORY_LIMIT_ENV_KEYS.map((key) => [key, process.env[key]]),
 ) as Record<string, string | undefined>;
+
+function restoreMemfsEnv(): void {
+  if (ORIGINAL_LETTA_BASE_URL === undefined) {
+    delete process.env.LETTA_BASE_URL;
+  } else {
+    process.env.LETTA_BASE_URL = ORIGINAL_LETTA_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_BASE_URL === undefined) {
+    delete process.env.LETTA_MEMFS_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_BASE_URL = ORIGINAL_LETTA_MEMFS_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_LOCAL === undefined) {
+    delete process.env.LETTA_MEMFS_LOCAL;
+  } else {
+    process.env.LETTA_MEMFS_LOCAL = ORIGINAL_LETTA_MEMFS_LOCAL;
+  }
+
+  if (ORIGINAL_LETTA_API_KEY === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = ORIGINAL_LETTA_API_KEY;
+  }
+}
 
 function restoreDirectoryLimitEnv(): void {
   for (const key of DIRECTORY_LIMIT_ENV_KEYS) {
@@ -30,6 +61,10 @@ function restoreDirectoryLimitEnv(): void {
     }
   }
 }
+
+afterEach(() => {
+  restoreMemfsEnv();
+});
 
 // Helper to create a mock client
 function createMockClient(options: {
@@ -127,6 +162,26 @@ describe("labelFromRelativePath", () => {
 
   test("normalizes backslashes to forward slashes", () => {
     expect(labelFromRelativePath("human\\prefs.md")).toBe("human/prefs");
+  });
+});
+
+describe("MemFS endpoint validation", () => {
+  test("allows LCD API proxy when MemFS sync defaults to api.letta.com", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+    delete process.env.LETTA_MEMFS_LOCAL;
+    process.env.LETTA_API_KEY = "desktop-session-token";
+
+    expect(await isLettaMemfsServer()).toBe(true);
+  });
+
+  test("rejects explicit non-Letta MemFS sync endpoints by default", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+    delete process.env.LETTA_MEMFS_LOCAL;
+    process.env.LETTA_API_KEY = "desktop-session-token";
+
+    expect(await isLettaMemfsServer()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

LCD launches Letta Code with `LETTA_BASE_URL` pointed at the desktop localhost proxy, while MemFS git sync uses the separate `getMemfsServerUrl()` path. After #1918, `getMemfsServerUrl()` defaults to `https://api.letta.com` unless `LETTA_MEMFS_BASE_URL` is explicitly set.

The explicit MemFS enable path was still gating on `isLettaCloud()`, which checks `getServerUrl()` / `LETTA_BASE_URL`. That meant LCD could have a valid MemFS sync endpoint and still fail before sync began with the stale `--memfs is only available...` error.

This PR changes explicit MemFS enable to validate the MemFS sync endpoint instead of the normal API endpoint, and replaces the user-facing error with:

`MemFS sync failed (expected api.letta.com, got <host>)`

## Tests

- `bun test src/tests/agent/memoryFilesystem.test.ts`
- `bun run typecheck`
- `bun run lint` exits 0, with pre-existing unrelated warnings in Discord/cross-agent test files