### PR TITLE
fix(shell): alias Letta env vars for PowerShell

### DIFF
--- a/src/tests/tools/shell-launchers.test.ts
+++ b/src/tests/tools/shell-launchers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { buildShellLaunchers } from "../../tools/impl/shellLaunchers";
+import {
+  buildPowerShellCommand,
+  buildShellLaunchers,
+} from "../../tools/impl/shellLaunchers";
 
 describe("Shell Launchers", () => {
   test("builds launchers for a command", () => {
@@ -16,6 +19,26 @@ describe("Shell Launchers", () => {
   test("returns empty array for whitespace-only command", () => {
     const launchers = buildShellLaunchers("   ");
     expect(launchers).toEqual([]);
+  });
+
+  test("PowerShell command aliases common Letta environment variables", () => {
+    const command = buildPowerShellCommand('ls "$MEMORY_DIR/system/human/"');
+
+    expect(command).toContain("$MEMORY_DIR = $env:MEMORY_DIR");
+    expect(command).toContain("$LETTA_MEMORY_DIR = $env:LETTA_MEMORY_DIR");
+    expect(command).toContain("$AGENT_ID = $env:AGENT_ID");
+    expect(command).toContain("$CONVERSATION_ID = $env:CONVERSATION_ID");
+    expect(command.endsWith('ls "$MEMORY_DIR/system/human/"')).toBe(true);
+  });
+
+  test("PowerShell command preserves quoted executable invocation", () => {
+    const command = buildPowerShellCommand(
+      '"C:/Program Files/Git/bin/git.exe" status',
+    );
+
+    expect(
+      command.endsWith('& "C:/Program Files/Git/bin/git.exe" status'),
+    ).toBe(true);
   });
 
   if (process.platform === "win32") {

--- a/src/tools/impl/Bash.ts
+++ b/src/tools/impl/Bash.ts
@@ -42,6 +42,19 @@ function validateWorktreePath(command: string, cwd: string): string | null {
 // Cache the working shell launcher after first successful spawn
 let cachedWorkingLauncher: string[] | null = null;
 
+function rebuildCachedLauncher(command: string): string[] | null {
+  if (!cachedWorkingLauncher) return null;
+  const cachedExecutable = cachedWorkingLauncher[0]?.toLowerCase();
+  if (!cachedExecutable) return null;
+
+  const launchers = buildShellLaunchers(command);
+  return (
+    launchers.find(
+      (launcher) => launcher[0]?.toLowerCase() === cachedExecutable,
+    ) ?? null
+  );
+}
+
 /**
  * Get the first working shell launcher for background processes.
  * Uses cached launcher if available, otherwise returns first launcher from buildShellLaunchers.
@@ -49,12 +62,9 @@ let cachedWorkingLauncher: string[] | null = null;
  * from previous foreground commands or the default launcher order.
  */
 function getBackgroundLauncher(command: string): string[] {
-  if (cachedWorkingLauncher) {
-    const [executable, ...launcherArgs] = cachedWorkingLauncher;
-    if (executable) {
-      return [executable, ...launcherArgs.slice(0, -1), command];
-    }
-  }
+  const cachedLauncher = rebuildCachedLauncher(command);
+  if (cachedLauncher) return cachedLauncher;
+
   const launchers = buildShellLaunchers(command);
   return launchers[0] || [];
 }
@@ -91,9 +101,8 @@ export async function spawnCommand(
 
   // On Windows, use fallback logic to handle PowerShell ENOENT errors (PR #482)
   if (cachedWorkingLauncher) {
-    const [executable, ...launcherArgs] = cachedWorkingLauncher;
-    if (executable) {
-      const newLauncher = [executable, ...launcherArgs.slice(0, -1), command];
+    const newLauncher = rebuildCachedLauncher(command);
+    if (newLauncher) {
       try {
         const result = await spawnWithLauncher(newLauncher, {
           cwd: options.cwd,

--- a/src/tools/impl/shellLaunchers.ts
+++ b/src/tools/impl/shellLaunchers.ts
@@ -3,6 +3,17 @@ type ShellLaunchOptions = {
   login?: boolean;
 };
 
+const POWERSHELL_ENV_ALIASES = [
+  "MEMORY_DIR",
+  "LETTA_MEMORY_DIR",
+  "AGENT_ID",
+  "LETTA_AGENT_ID",
+  "LETTA_PARENT_AGENT_ID",
+  "CONVERSATION_ID",
+  "LETTA_CONVERSATION_ID",
+  "USER_CWD",
+];
+
 function pushUnique(
   list: string[][],
   seen: Set<string>,
@@ -15,19 +26,32 @@ function pushUnique(
   list.push(entry);
 }
 
+function normalizePowerShellCommand(command: string): string {
+  const trimmed = command.trim();
+  if (
+    trimmed.startsWith("&") ||
+    trimmed.startsWith('"') ||
+    trimmed.startsWith("'")
+  ) {
+    return trimmed.startsWith("&") ? trimmed : `& ${trimmed}`;
+  }
+  return trimmed;
+}
+
+export function buildPowerShellCommand(command: string): string {
+  const powerShellCommand = normalizePowerShellCommand(command);
+  const aliasPrelude = POWERSHELL_ENV_ALIASES.map(
+    (name) => `$${name} = $env:${name}`,
+  ).join("; ");
+  return `${aliasPrelude}; ${powerShellCommand}`;
+}
+
 function windowsLaunchers(command: string): string[][] {
   const trimmed = command.trim();
   if (!trimmed) return [];
   const launchers: string[][] = [];
   const seen = new Set<string>();
-  const powerShellCommand =
-    trimmed.startsWith("&") ||
-    trimmed.startsWith('"') ||
-    trimmed.startsWith("'")
-      ? trimmed.startsWith("&")
-        ? trimmed
-        : `& ${trimmed}`
-      : trimmed;
+  const powerShellCommand = buildPowerShellCommand(trimmed);
 
   // Default to PowerShell on Windows (same as Gemini CLI and Codex CLI)
   // This ensures better PATH compatibility since many tools are configured


### PR DESCRIPTION
## Summary

- Defines common Letta environment variables as PowerShell variables before running Windows PowerShell shell-tool commands, so POSIX-style examples like `$MEMORY_DIR/system/...` work when the shell is PowerShell.
- Rebuilds cached Windows shell launchers through the launcher factory instead of replacing the raw command string, preserving the PowerShell compatibility wrapper for cached foreground/background commands.
- Adds shell launcher tests for the PowerShell env alias prelude and quoted executable invocation.

## Tests

- `bun test src/tests/tools/shell-launchers.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/tools/impl/shellLaunchers.ts src/tools/impl/Bash.ts src/tests/tools/shell-launchers.test.ts`
- `bun run check` currently fails on pre-existing unrelated lint diagnostics in Discord/cross-agent files; changed files pass targeted Biome checks.

👾 Generated with [Letta Code](https://letta.com)