### PR TITLE
fix(memfs): route ws git sync through proxy

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -117,9 +117,24 @@ export function getServerUrl(): string {
   );
 }
 
+function isLocalhostUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isDesktopLocalProxyUrl(value: string | undefined): boolean {
+  return process.env.LETTA_DESKTOP_DEBUG_PANEL === "1" && isLocalhostUrl(value);
+}
+
 /**
  * Get the current Letta memfs server URL from environment or settings.
- * Falls back to Letta Cloud when no memfs-specific URL is set.
+ * Falls back to the Desktop localhost proxy in desktop listener sessions,
+ * otherwise falls back to Letta Cloud when no memfs-specific URL is set.
  */
 export function getMemfsServerUrl(): string {
   let settings: Settings | null = null;
@@ -129,11 +144,18 @@ export function getMemfsServerUrl(): string {
     // Settings may be unavailable in isolated tests that only rely on env.
   }
 
-  return (
-    process.env.LETTA_MEMFS_BASE_URL ||
-    settings?.env?.LETTA_MEMFS_BASE_URL ||
-    LETTA_CLOUD_API_URL
-  );
+  const configuredMemfsUrl =
+    process.env.LETTA_MEMFS_BASE_URL || settings?.env?.LETTA_MEMFS_BASE_URL;
+  if (configuredMemfsUrl) {
+    return configuredMemfsUrl;
+  }
+
+  const apiUrl = process.env.LETTA_BASE_URL || settings?.env?.LETTA_BASE_URL;
+  if (apiUrl && isDesktopLocalProxyUrl(apiUrl)) {
+    return apiUrl;
+  }
+
+  return LETTA_CLOUD_API_URL;
 }
 
 export async function getClient() {

--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -494,11 +494,14 @@ function getServerHostLabel(serverUrl: string): string {
  * Whether the MemFS sync endpoint is backed by the Letta API.
  */
 export async function isLettaMemfsServer(): Promise<boolean> {
-  const { getMemfsServerUrl } = await import("./client");
+  const { getMemfsServerUrl, isDesktopLocalProxyUrl } = await import(
+    "./client"
+  );
   const memfsServerUrl = getMemfsServerUrl();
 
   return (
     memfsServerUrl.includes("api.letta.com") ||
+    isDesktopLocalProxyUrl(memfsServerUrl) ||
     process.env.LETTA_MEMFS_LOCAL === "1" ||
     process.env.LETTA_API_KEY === "local-desktop"
   );

--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -335,13 +335,13 @@ export interface ApplyMemfsFlagsOptions {
  * the /memfs enable command (App.tsx) to avoid duplicating the setup logic.
  *
  * Steps when toggling:
- *   1. Validate Letta Cloud requirement (for explicit enable)
+ *   1. Validate MemFS API endpoint support (for explicit enable)
  *   2. Reconcile system prompt to the target memory mode
  *   3. Persist memfs setting locally
  *   4. Detach old API-based memory tools (when enabling)
  *   5. Add git-memory-enabled tag + clone/pull repo
  *
- * @throws {Error} if Letta Cloud validation fails or git setup fails
+ * @throws {Error} if MemFS endpoint validation fails or git setup fails
  */
 export async function applyMemfsFlags(
   agentId: string,
@@ -351,11 +351,10 @@ export async function applyMemfsFlags(
 ): Promise<ApplyMemfsFlagsResult> {
   const { settingsManager } = await import("../settings-manager");
 
-  // Validate explicit enable on supported backend.
-  if (memfsFlag && !(await isLettaCloud())) {
-    throw new Error(
-      "--memfs is only available on Letta Cloud (api.letta.com).",
-    );
+  // LCD proxies normal API traffic through localhost, while MemFS git sync can
+  // still target api.letta.com through getMemfsServerUrl().
+  if (memfsFlag && !(await isLettaMemfsServer())) {
+    throw new Error(await getMemfsSyncUnavailableMessage());
   }
 
   const hasExplicitToggle = Boolean(memfsFlag || noMemfsFlag);
@@ -469,7 +468,7 @@ export async function applyMemfsFlags(
 }
 
 /**
- * Whether the current server is Letta Cloud (or local memfs testing is enabled).
+ * Whether the current server is the Letta API (or local memfs testing is enabled).
  */
 export async function isLettaCloud(): Promise<boolean> {
   const { getServerUrl } = await import("./client");
@@ -482,8 +481,37 @@ export async function isLettaCloud(): Promise<boolean> {
   );
 }
 
+function getServerHostLabel(serverUrl: string): string {
+  const trimmed = serverUrl.trim();
+  try {
+    return new URL(trimmed).host || trimmed;
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").replace(/\/+$/, "") || trimmed;
+  }
+}
+
 /**
- * Enable memfs for a newly created agent if on Letta Cloud.
+ * Whether the MemFS sync endpoint is backed by the Letta API.
+ */
+export async function isLettaMemfsServer(): Promise<boolean> {
+  const { getMemfsServerUrl } = await import("./client");
+  const memfsServerUrl = getMemfsServerUrl();
+
+  return (
+    memfsServerUrl.includes("api.letta.com") ||
+    process.env.LETTA_MEMFS_LOCAL === "1" ||
+    process.env.LETTA_API_KEY === "local-desktop"
+  );
+}
+
+async function getMemfsSyncUnavailableMessage(): Promise<string> {
+  const { getMemfsServerUrl } = await import("./client");
+  const memfsServerUrl = getMemfsServerUrl();
+  return `MemFS sync failed (expected api.letta.com, got ${getServerHostLabel(memfsServerUrl)})`;
+}
+
+/**
+ * Enable memfs for a newly created agent if on the Letta API.
  * Non-fatal: logs a warning on failure. Skips on self-hosted.
  *
  * Skips the system prompt update since callers are expected to create

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -3,7 +3,8 @@
  *
  * When memFS is enabled, the agent's memory is stored in a git repo
  * on the server at $LETTA_MEMFS_BASE_URL/v1/git/$AGENT_ID/state.git
- * (falling back to $LETTA_BASE_URL when unset).
+ * (falling back to the Desktop local proxy in desktop listener sessions, or
+ * api.letta.com otherwise).
  * This module provides the CLI harness helpers: clone on first run,
  * pull on startup, and status check for system reminders.
  *
@@ -246,6 +247,29 @@ async function getAuthToken(): Promise<string> {
   return (client as any)._options?.apiKey ?? "";
 }
 
+export function buildGitAuthArgs(token: string): string[] {
+  return [
+    "-c",
+    "credential.helper=",
+    "-c",
+    "core.askPass=",
+    "-c",
+    `http.extraHeader=Authorization: Basic ${Buffer.from(`letta:${token}`).toString("base64")}`,
+  ];
+}
+
+export function buildNonInteractiveGitEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    GIT_TERMINAL_PROMPT: "0",
+    GCM_INTERACTIVE: "never",
+    GIT_ASKPASS: "",
+    SSH_ASKPASS: "",
+  };
+}
+
 /**
  * Run a git command in the given directory.
  * If a token is provided, passes it as an auth header.
@@ -255,12 +279,7 @@ async function runGit(
   args: string[],
   token?: string,
 ): Promise<{ stdout: string; stderr: string }> {
-  const authArgs = token
-    ? [
-        "-c",
-        `http.extraHeader=Authorization: Basic ${Buffer.from(`letta:${token}`).toString("base64")}`,
-      ]
-    : [];
+  const authArgs = token ? buildGitAuthArgs(token) : [];
   const allArgs = [...authArgs, ...args];
 
   // Redact credential helper values to avoid leaking tokens in debug logs.
@@ -279,6 +298,7 @@ async function runGit(
 
   const result = await execFile("git", allArgs, {
     cwd,
+    env: buildNonInteractiveGitEnv(),
     maxBuffer: 10 * 1024 * 1024, // 10MB
     timeout: 60_000, // 60s
   });

--- a/src/tests/agent/memoryFilesystem.test.ts
+++ b/src/tests/agent/memoryFilesystem.test.ts
@@ -20,6 +20,8 @@ const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
 const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
 const ORIGINAL_LETTA_MEMFS_LOCAL = process.env.LETTA_MEMFS_LOCAL;
 const ORIGINAL_LETTA_API_KEY = process.env.LETTA_API_KEY;
+const ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL =
+  process.env.LETTA_DESKTOP_DEBUG_PANEL;
 const DIRECTORY_LIMIT_ENV_KEYS = Object.values(DIRECTORY_LIMIT_ENV);
 const ORIGINAL_DIRECTORY_ENV = Object.fromEntries(
   DIRECTORY_LIMIT_ENV_KEYS.map((key) => [key, process.env[key]]),
@@ -48,6 +50,12 @@ function restoreMemfsEnv(): void {
     delete process.env.LETTA_API_KEY;
   } else {
     process.env.LETTA_API_KEY = ORIGINAL_LETTA_API_KEY;
+  }
+
+  if (ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL === undefined) {
+    delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
+  } else {
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL;
   }
 }
 
@@ -179,9 +187,20 @@ describe("MemFS endpoint validation", () => {
     process.env.LETTA_BASE_URL = "http://localhost:54085";
     process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
     delete process.env.LETTA_MEMFS_LOCAL;
+    delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
     process.env.LETTA_API_KEY = "desktop-session-token";
 
     expect(await isLettaMemfsServer()).toBe(false);
+  });
+
+  test("allows Desktop local proxy as an explicit MemFS sync endpoint", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_LOCAL;
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+    process.env.LETTA_API_KEY = "desktop-session-token";
+
+    expect(await isLettaMemfsServer()).toBe(true);
   });
 });
 

--- a/src/tests/agent/memoryFilesystem.test.ts
+++ b/src/tests/agent/memoryFilesystem.test.ts
@@ -10,15 +10,46 @@ import { join } from "node:path";
 import {
   getMemoryFilesystemRoot,
   getMemorySystemDir,
+  isLettaMemfsServer,
   labelFromRelativePath,
   renderMemoryFilesystemTree,
 } from "../../agent/memoryFilesystem";
 import { DIRECTORY_LIMIT_ENV } from "../../utils/directoryLimits";
 
+const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
+const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
+const ORIGINAL_LETTA_MEMFS_LOCAL = process.env.LETTA_MEMFS_LOCAL;
+const ORIGINAL_LETTA_API_KEY = process.env.LETTA_API_KEY;
 const DIRECTORY_LIMIT_ENV_KEYS = Object.values(DIRECTORY_LIMIT_ENV);
 const ORIGINAL_DIRECTORY_ENV = Object.fromEntries(
   DIRECTORY_LIMIT_ENV_KEYS.map((key) => [key, process.env[key]]),
 ) as Record<string, string | undefined>;
+
+function restoreMemfsEnv(): void {
+  if (ORIGINAL_LETTA_BASE_URL === undefined) {
+    delete process.env.LETTA_BASE_URL;
+  } else {
+    process.env.LETTA_BASE_URL = ORIGINAL_LETTA_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_BASE_URL === undefined) {
+    delete process.env.LETTA_MEMFS_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_BASE_URL = ORIGINAL_LETTA_MEMFS_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_LOCAL === undefined) {
+    delete process.env.LETTA_MEMFS_LOCAL;
+  } else {
+    process.env.LETTA_MEMFS_LOCAL = ORIGINAL_LETTA_MEMFS_LOCAL;
+  }
+
+  if (ORIGINAL_LETTA_API_KEY === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = ORIGINAL_LETTA_API_KEY;
+  }
+}
 
 function restoreDirectoryLimitEnv(): void {
   for (const key of DIRECTORY_LIMIT_ENV_KEYS) {
@@ -30,6 +61,10 @@ function restoreDirectoryLimitEnv(): void {
     }
   }
 }
+
+afterEach(() => {
+  restoreMemfsEnv();
+});
 
 // Helper to create a mock client
 function createMockClient(options: {
@@ -127,6 +162,26 @@ describe("labelFromRelativePath", () => {
 
   test("normalizes backslashes to forward slashes", () => {
     expect(labelFromRelativePath("human\\prefs.md")).toBe("human/prefs");
+  });
+});
+
+describe("MemFS endpoint validation", () => {
+  test("allows LCD API proxy when MemFS sync defaults to api.letta.com", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+    delete process.env.LETTA_MEMFS_LOCAL;
+    process.env.LETTA_API_KEY = "desktop-session-token";
+
+    expect(await isLettaMemfsServer()).toBe(true);
+  });
+
+  test("rejects explicit non-Letta MemFS sync endpoints by default", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+    delete process.env.LETTA_MEMFS_LOCAL;
+    process.env.LETTA_API_KEY = "desktop-session-token";
+
+    expect(await isLettaMemfsServer()).toBe(false);
   });
 });
 

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -4,7 +4,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { getMemfsServerUrl } from "../../agent/client";
 import {
+  buildGitAuthArgs,
+  buildNonInteractiveGitEnv,
   formatGitCredentialHelperPath,
   getGitRemoteUrl,
   isMemfsRemoteUrlForAgent,
@@ -14,6 +17,8 @@ import {
 
 const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
 const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
+const ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL =
+  process.env.LETTA_DESKTOP_DEBUG_PANEL;
 
 let tempDirs: string[] = [];
 
@@ -33,6 +38,12 @@ afterEach(() => {
     delete process.env.LETTA_MEMFS_BASE_URL;
   } else {
     process.env.LETTA_MEMFS_BASE_URL = ORIGINAL_LETTA_MEMFS_BASE_URL;
+  }
+
+  if (ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL === undefined) {
+    delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
+  } else {
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL;
   }
 });
 
@@ -84,8 +95,20 @@ describe("normalizeCredentialBaseUrl", () => {
     test("defaults to api.letta.com when LETTA_MEMFS_BASE_URL is unset, even if LETTA_BASE_URL is localhost", () => {
       process.env.LETTA_BASE_URL = "http://localhost:51338";
       delete process.env.LETTA_MEMFS_BASE_URL;
+      delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
       expect(getGitRemoteUrl("agent-123")).toBe(
         "https://api.letta.com/v1/git/agent-123/state.git",
+      );
+    });
+
+    test("uses the Desktop localhost proxy for memfs git in desktop listener sessions", () => {
+      process.env.LETTA_BASE_URL = "http://localhost:51338";
+      delete process.env.LETTA_MEMFS_BASE_URL;
+      process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+
+      expect(getMemfsServerUrl()).toBe("http://localhost:51338");
+      expect(getGitRemoteUrl("agent-123")).toBe(
+        "http://localhost:51338/v1/git/agent-123/state.git",
       );
     });
   });
@@ -152,6 +175,26 @@ describe("formatGitCredentialHelperPath", () => {
     ).toBe(
       "C:/Users/Jane\\ Doe/.letta/agents/agent-1/memory/.git/letta-credential-helper.cmd",
     );
+  });
+});
+
+describe("git auth hardening", () => {
+  test("auth args pass Basic auth and suppress inherited credential helpers", () => {
+    const args = buildGitAuthArgs("token-123");
+
+    expect(args.slice(0, 2)).toEqual(["-c", "credential.helper="]);
+    expect(args).toContain("core.askPass=");
+    expect(args.join("\n")).toContain("http.extraHeader=Authorization: Basic");
+  });
+
+  test("git env disables terminal and Git Credential Manager prompts", () => {
+    const env = buildNonInteractiveGitEnv({ PATH: "/usr/bin" });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env.GCM_INTERACTIVE).toBe("never");
+    expect(env.GIT_ASKPASS).toBe("");
+    expect(env.SSH_ASKPASS).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

- Routes MemFS git sync through the ws localhost proxy during ws listener sessions, so the proxy can attach the web API token instead of sending the local session token directly to `api.letta.com`.
- Allows ws localhost proxy URLs as supported MemFS sync endpoints now that #1962 validates the MemFS sync endpoint separately from the normal API endpoint.
- Runs MemFS git subprocesses noninteractively and suppresses inherited credential helpers for token-authenticated commands so Windows Git Credential Manager cannot open a GUI prompt after an auth miss.

## Tests

- `bun test src/tests/agent/memoryGit.auth.test.ts src/tests/agent/memoryFilesystem.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/agent/client.ts src/agent/memoryFilesystem.ts src/agent/memoryGit.ts src/tests/agent/memoryFilesystem.test.ts src/tests/agent/memoryGit.auth.test.ts`
- `bun run check` currently fails on pre-existing unrelated lint diagnostics in Discord/cross-agent files; changed files pass targeted Biome checks.

👾 Generated with [Letta Code](https://letta.com)