### PR TITLE
Add DeepSeek V4 Flash model

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1413,6 +1413,17 @@
       }
     },
     {
+      "id": "deepseek-v4-flash",
+      "handle": "openrouter/deepseek/deepseek-v4-flash",
+      "label": "DeepSeek V4 Flash",
+      "description": "DeepSeek's V4 Flash model",
+      "updateArgs": {
+        "context_window": 1048576,
+        "max_output_tokens": 384000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "glm-5.1",
       "handle": "zai/glm-5.1",
       "label": "GLM-5.1",


### PR DESCRIPTION
## Summary
- Add the DeepSeek V4 Flash model preset backed by OpenRouter.
- Configure the preset with 1M context, 384k max output, and parallel tool calls.

## Test plan
- `python3 -m json.tool src/models.json`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)