### PR TITLE
fix(memfs): refresh memory git origin before write guard

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -1100,6 +1100,43 @@ async function fetchMemoryRemote(
   });
 }
 
+async function getMemoryAheadBehind(
+  memoryDir: string,
+): Promise<{ ahead: number; behind: number } | null> {
+  try {
+    const { stdout } = await runGit(memoryDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "HEAD...@{u}",
+    ]);
+    const [aheadRaw, behindRaw] = stdout.trim().split(/\s+/);
+    return {
+      ahead: Number.parseInt(aheadRaw ?? "0", 10) || 0,
+      behind: Number.parseInt(behindRaw ?? "0", 10) || 0,
+    };
+  } catch {
+    // No upstream configured or unable to inspect divergence.
+    return null;
+  }
+}
+
+async function pushCleanPendingMemoryCommitsForWrite(
+  memoryDir: string,
+  agentId: string,
+  token: string,
+): Promise<void> {
+  await prepareMemoryRepoForGitOps(memoryDir, agentId, token);
+
+  const divergence = await getMemoryAheadBehind(memoryDir);
+
+  if (divergence && divergence.ahead > 0) {
+    await runGitWithRetry(memoryDir, ["push"], token, {
+      operation: "push pending memory commits",
+    });
+  }
+}
+
 async function resetMemoryToUpstream(
   memoryDir: string,
   token: string,
@@ -1221,6 +1258,7 @@ async function recoverMemoryPushConflict(
 
 export async function assertMemoryRepoReadyForWrite(
   memoryDir: string,
+  agentId?: string,
 ): Promise<void> {
   const status = await runGit(memoryDir, ["status", "--porcelain"]);
   if (status.stdout.trim().length > 0) {
@@ -1229,14 +1267,14 @@ export async function assertMemoryRepoReadyForWrite(
     );
   }
 
+  if (agentId) {
+    const token = await getAuthToken();
+    await pushCleanPendingMemoryCommitsForWrite(memoryDir, agentId, token);
+  }
+
   try {
-    const { stdout } = await runGit(memoryDir, [
-      "rev-list",
-      "--count",
-      "@{u}..HEAD",
-    ]);
-    const aheadCount = parseInt(stdout.trim(), 10);
-    if (aheadCount > 0) {
+    const divergence = await getMemoryAheadBehind(memoryDir);
+    if (divergence && divergence.ahead > 0) {
       throw new Error(
         "Memory repo has local commits that are not pushed to remote. Sync the repo before using memory tools.",
       );

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getMemfsServerUrl } from "../../agent/client";
+import { __testOverrideGetClient, getMemfsServerUrl } from "../../agent/client";
 import {
+  assertMemoryRepoReadyForWrite,
   buildGitAuthArgs,
   buildMemfsGitProxyArgs,
   buildNonInteractiveGitEnv,
@@ -23,10 +24,13 @@ const ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL =
   process.env.LETTA_DESKTOP_DEBUG_PANEL;
 const ORIGINAL_LETTA_MEMFS_GIT_PROXY_BASE_URL =
   process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL;
+const ORIGINAL_LETTA_API_KEY = process.env.LETTA_API_KEY;
 
 let tempDirs: string[] = [];
 
 afterEach(() => {
+  __testOverrideGetClient(null);
+
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -56,6 +60,12 @@ afterEach(() => {
     process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL =
       ORIGINAL_LETTA_MEMFS_GIT_PROXY_BASE_URL;
   }
+
+  if (ORIGINAL_LETTA_API_KEY === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = ORIGINAL_LETTA_API_KEY;
+  }
 });
 
 function makeGitRepo(): string {
@@ -63,6 +73,40 @@ function makeGitRepo(): string {
   tempDirs.push(dir);
   execSync("git init -b main", { cwd: dir, stdio: "ignore" });
   return dir;
+}
+
+function makeBareGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "memory-git-remote-"));
+  tempDirs.push(dir);
+  execSync("git init --bare -b main", { cwd: dir, stdio: "ignore" });
+  return dir;
+}
+
+function commitFile(repo: string, fileName: string, content: string): string {
+  writeFileSync(join(repo, fileName), content, "utf-8");
+  git(repo, `add ${fileName}`);
+  git(repo, `commit -m ${fileName}`);
+  return git(repo, "rev-parse HEAD").trim();
+}
+
+function makeSyncedRepo(): { repo: string; remote: string } {
+  const remote = makeBareGitRepo();
+  const repo = makeGitRepo();
+  git(repo, "config user.name Test");
+  git(repo, "config user.email test@example.com");
+  git(repo, `remote add origin ${remote}`);
+  commitFile(repo, "initial.md", "initial");
+  git(repo, "push -u origin main");
+  return { repo, remote };
+}
+
+function cloneRepo(remote: string): string {
+  const repo = mkdtempSync(join(tmpdir(), "memory-git-clone-"));
+  tempDirs.push(repo);
+  execSync(`git clone ${remote} .`, { cwd: repo, stdio: "ignore" });
+  git(repo, "config user.name Test");
+  git(repo, "config user.email test@example.com");
+  return repo;
 }
 
 function git(cwd: string, args: string): string {
@@ -367,5 +411,41 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
+  });
+});
+
+describe("assertMemoryRepoReadyForWrite", () => {
+  test("pushes clean local commits before blocking memory writes", async () => {
+    const { repo, remote } = makeSyncedRepo();
+    const localSha = commitFile(repo, "local.md", "local");
+    process.env.LETTA_API_KEY = "test-token";
+    __testOverrideGetClient(async () => ({
+      _options: { apiKey: "test-token" },
+    }));
+
+    await assertMemoryRepoReadyForWrite(repo, "agent-123");
+
+    expect(git(repo, "rev-list --count @{u}..HEAD").trim()).toBe("0");
+    expect(
+      execSync(`git --git-dir ${remote} rev-parse main`, {
+        encoding: "utf-8",
+      }).trim(),
+    ).toBe(localSha);
+  });
+
+  test("leaves clean behind repos for write-time conflict replay", async () => {
+    const { repo, remote } = makeSyncedRepo();
+    const originalSha = git(repo, "rev-parse HEAD").trim();
+    const other = cloneRepo(remote);
+    commitFile(other, "remote.md", "remote");
+    git(other, "push");
+    process.env.LETTA_API_KEY = "test-token";
+    __testOverrideGetClient(async () => ({
+      _options: { apiKey: "test-token" },
+    }));
+
+    await assertMemoryRepoReadyForWrite(repo, "agent-123");
+
+    expect(git(repo, "rev-parse HEAD").trim()).toBe(originalSha);
   });
 });

--- a/src/tests/tools/memory-apply-patch.test.ts
+++ b/src/tests/tools/memory-apply-patch.test.ts
@@ -20,14 +20,67 @@ const execFile = promisify(execFileCb);
 const TEST_AGENT_ID = "agent-test-memory-apply-patch";
 const TEST_AGENT_NAME = "Bob";
 
+let mockClientOverride: (() => Promise<unknown>) | null = null;
+
+async function getMockClient() {
+  if (mockClientOverride) {
+    return mockClientOverride();
+  }
+
+  return {
+    _options: { apiKey: process.env.LETTA_API_KEY ?? "" },
+    agents: {
+      retrieve: mock(() => Promise.resolve({ name: TEST_AGENT_NAME })),
+    },
+  };
+}
+
+function getMockMemfsServerUrl(): string {
+  return process.env.LETTA_MEMFS_BASE_URL || "https://api.letta.com";
+}
+
+function isMockLocalhostUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function getMockMemfsGitProxyRewriteConfig() {
+  const rawProxyBaseUrl = process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL?.trim();
+  if (!rawProxyBaseUrl || !isMockLocalhostUrl(rawProxyBaseUrl)) {
+    return null;
+  }
+
+  const memfsBaseUrl = getMockMemfsServerUrl().trim().replace(/\/+$/, "");
+  if (!memfsBaseUrl.includes("api.letta.com")) {
+    return null;
+  }
+
+  const proxyBaseUrl = rawProxyBaseUrl.replace(/\/+$/, "");
+  const proxyPrefix = `${proxyBaseUrl}/v1/git/`;
+  const memfsPrefix = `${memfsBaseUrl}/v1/git/`;
+  return {
+    proxyBaseUrl,
+    memfsBaseUrl,
+    proxyPrefix,
+    memfsPrefix,
+    configKey: `url.${proxyPrefix}.insteadOf`,
+    configValue: memfsPrefix,
+  };
+}
+
 mock.module("../../agent/client", () => ({
-  getClient: mock(() =>
-    Promise.resolve({
-      agents: {
-        retrieve: mock(() => Promise.resolve({ name: TEST_AGENT_NAME })),
-      },
-    }),
-  ),
+  __testOverrideGetClient: (factory: (() => Promise<unknown>) | null) => {
+    mockClientOverride = factory;
+  },
+  getClient: mock(getMockClient),
+  LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV: "LETTA_MEMFS_GIT_PROXY_BASE_URL",
+  getMemfsGitProxyRewriteConfig: getMockMemfsGitProxyRewriteConfig,
+  getMemfsServerUrl: getMockMemfsServerUrl,
   getServerUrl: () => "http://localhost:8283",
 }));
 

--- a/src/tests/tools/memory-tool.test.ts
+++ b/src/tests/tools/memory-tool.test.ts
@@ -20,14 +20,67 @@ const execFile = promisify(execFileCb);
 const TEST_AGENT_ID = "agent-test-memory-tool";
 const TEST_AGENT_NAME = "Bob";
 
+let mockClientOverride: (() => Promise<unknown>) | null = null;
+
+async function getMockClient() {
+  if (mockClientOverride) {
+    return mockClientOverride();
+  }
+
+  return {
+    _options: { apiKey: process.env.LETTA_API_KEY ?? "" },
+    agents: {
+      retrieve: mock(() => Promise.resolve({ name: TEST_AGENT_NAME })),
+    },
+  };
+}
+
+function getMockMemfsServerUrl(): string {
+  return process.env.LETTA_MEMFS_BASE_URL || "https://api.letta.com";
+}
+
+function isMockLocalhostUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function getMockMemfsGitProxyRewriteConfig() {
+  const rawProxyBaseUrl = process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL?.trim();
+  if (!rawProxyBaseUrl || !isMockLocalhostUrl(rawProxyBaseUrl)) {
+    return null;
+  }
+
+  const memfsBaseUrl = getMockMemfsServerUrl().trim().replace(/\/+$/, "");
+  if (!memfsBaseUrl.includes("api.letta.com")) {
+    return null;
+  }
+
+  const proxyBaseUrl = rawProxyBaseUrl.replace(/\/+$/, "");
+  const proxyPrefix = `${proxyBaseUrl}/v1/git/`;
+  const memfsPrefix = `${memfsBaseUrl}/v1/git/`;
+  return {
+    proxyBaseUrl,
+    memfsBaseUrl,
+    proxyPrefix,
+    memfsPrefix,
+    configKey: `url.${proxyPrefix}.insteadOf`,
+    configValue: memfsPrefix,
+  };
+}
+
 mock.module("../../agent/client", () => ({
-  getClient: mock(() =>
-    Promise.resolve({
-      agents: {
-        retrieve: mock(() => Promise.resolve({ name: TEST_AGENT_NAME })),
-      },
-    }),
-  ),
+  __testOverrideGetClient: (factory: (() => Promise<unknown>) | null) => {
+    mockClientOverride = factory;
+  },
+  getClient: mock(getMockClient),
+  LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV: "LETTA_MEMFS_GIT_PROXY_BASE_URL",
+  getMemfsGitProxyRewriteConfig: getMockMemfsGitProxyRewriteConfig,
+  getMemfsServerUrl: getMockMemfsServerUrl,
   getServerUrl: () => "http://localhost:8283",
 }));
 

--- a/src/tools/impl/Memory.ts
+++ b/src/tools/impl/Memory.ts
@@ -105,7 +105,8 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
   const memoryDir = resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
-  await assertMemoryRepoReadyForWrite(memoryDir);
+  const { agentId, agentName } = await getAgentIdentity();
+  await assertMemoryRepoReadyForWrite(memoryDir, agentId);
 
   const affectedPaths = await applyMemoryCommand(memoryDir, args);
   if (affectedPaths.length === 0) {
@@ -114,7 +115,6 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
     };
   }
 
-  const { agentId, agentName } = await getAgentIdentity();
   const commitResult = await commitAndSyncMemoryWrite({
     memoryDir,
     pathspecs: affectedPaths,

--- a/src/tools/impl/MemoryApplyPatch.ts
+++ b/src/tools/impl/MemoryApplyPatch.ts
@@ -118,14 +118,14 @@ export async function memory_apply_patch(
   const memoryDir = resolveMemoryDir();
   ensureMemoryRepo(memoryDir);
 
-  await assertMemoryRepoReadyForWrite(memoryDir);
+  const { agentId, agentName } = await getAgentIdentity();
+  await assertMemoryRepoReadyForWrite(memoryDir, agentId);
 
   const pathspecs = await applyMemoryPatch(memoryDir, input);
   if (pathspecs.length === 0) {
     return { message: "memory_apply_patch completed with no changed paths." };
   }
 
-  const { agentId, agentName } = await getAgentIdentity();
   const commitResult = await commitAndSyncMemoryWrite({
     memoryDir,
     pathspecs,


### PR DESCRIPTION
## Summary

- Rebases this write-guard recovery on top of #1969's stable MemFS transport model, where persisted remotes stay canonical and Desktop proxy routing is transient.
- Refreshes memfs git origin/credentials before the memory tool write-readiness guard checks local ahead state.
- Pushes pending clean local memory commits before blocking memory writes, so stale local commits from a previous failed push can self-heal after origin/credential repair.
- Leaves clean behind repos to the existing write-time replay path, preserving `memory` / `memory_apply_patch` conflict replay semantics.
- Passes agent identity into the readiness guard from `memory` and `memory_apply_patch` so the self-healing path can resolve the correct memfs remote.

## Tests

- `bun test src/tests/tools/memory-tool.test.ts`
- `bun test src/tests/tools/memory-apply-patch.test.ts`
- `bun test src/tests/agent/memoryGit.auth.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/agent/memoryGit.ts src/tools/impl/Memory.ts src/tools/impl/MemoryApplyPatch.ts src/tests/agent/memoryGit.auth.test.ts src/tests/tools/memory-tool.test.ts src/tests/tools/memory-apply-patch.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)