### PR TITLE
fix(reflection): fallback to parent model when auto-memory returns empty output

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -28,6 +28,7 @@ import { permissionMode } from "../../permissions/mode";
 import { sessionPermissions } from "../../permissions/session";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
+import { debugWarn } from "../../utils/debug";
 import {
   resolveEntryScriptPath,
   resolveLettaInvocation,
@@ -973,6 +974,31 @@ async function executeSubagent(
 
     // Fallback: parse from stdout
     const stdout = Buffer.concat(stdoutChunks).toString("utf-8");
+
+    // Reflection subagent with auto-memory can return empty output.
+    // Retry once with the parent model before falling through to parseResultFromStdout.
+    if (!stdout.trim() && type === "reflection" && !isRetry) {
+      const fallbackModel = parentModelHandle || "letta/auto";
+      debugWarn(
+        "memory",
+        `Reflection subagent returned empty output, retrying with ${fallbackModel}`,
+      );
+      return executeSubagent(
+        type,
+        config,
+        fallbackModel,
+        userPrompt,
+        baseURL,
+        subagentId,
+        true, // isRetry
+        signal,
+        undefined, // existingAgentId
+        undefined, // existingConversationId
+        maxTurns,
+        parentAgentIdOverride,
+      );
+    }
+
     return parseResultFromStdout(stdout, state.agentId);
   } catch (error) {
     return {


### PR DESCRIPTION
## Problem

The `letta/auto-memory` model (hardcoded for reflection subagents in `resolveSubagentModel()`) can return empty completions — the child process exits 0 with 0 bytes of stdout. This causes `parseResultFromStdout()` to throw `Unexpected end of JSON input`, which surfaces as:

```
Tried to reflect, but got lost in the palace: Failed to parse subagent output: Unexpected end of JSON input
```

This is a silent failure — no stderr, no error code, just empty output. The reflection subagent appears to run successfully but produces nothing.

Fixes #1959

## Fix

When a reflection subagent exits successfully (code 0) but produces no stdout, retry once with the parent agent's model before falling through to `parseResultFromStdout()`. This mirrors the existing `isProviderNotSupportedError` retry pattern already in `executeSubagent()`.

The fallback uses `parentModelHandle` (the model the parent agent is already running on, e.g. `letta/auto`) with a hard fallback to `letta/auto` if the parent handle is unavailable.

**Guards:**
- `type === "reflection"` — only applies to reflection subagents
- `!isRetry` — prevents infinite retry loop (max 1 retry)
- `!stdout.trim()` — only triggers on genuinely empty output

## Testing

- 75 subagent tests pass, 0 fail
- Build succeeds (6069KB)
- Verified on live agent: reflection subagent that previously failed 3/3 times now succeeds with fallback model, produces valid JSON result, and commits memory updates

## Changes

- Added `debugWarn` import from `../../utils/debug`
- Added 25-line fallback block in `executeSubagent()` between stdout collection and `parseResultFromStdout()`

👾 Generated with [Letta Code](https://letta.com)