### PR TITLE
fix(memfs): route desktop git transport transiently

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -127,14 +127,71 @@ function isLocalhostUrl(value: string | undefined): boolean {
   }
 }
 
-export function isDesktopLocalProxyUrl(value: string | undefined): boolean {
-  return process.env.LETTA_DESKTOP_DEBUG_PANEL === "1" && isLocalhostUrl(value);
+export const LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV =
+  "LETTA_MEMFS_GIT_PROXY_BASE_URL";
+
+export interface MemfsGitProxyRewriteConfig {
+  /** Ephemeral proxy base URL used only for git transport. */
+  proxyBaseUrl: string;
+  /** Canonical memfs base URL that remains persisted in git config/settings. */
+  memfsBaseUrl: string;
+  /** Git URL prefix for the ephemeral transport. */
+  proxyPrefix: string;
+  /** Git URL prefix for the canonical remote. */
+  memfsPrefix: string;
+  /** Git config key for url.<proxyPrefix>.insteadOf. */
+  configKey: string;
+  /** Git config value for url.<proxyPrefix>.insteadOf. */
+  configValue: string;
+}
+
+function trimBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+/**
+ * Resolve Desktop's transient MemFS git proxy rewrite, if configured.
+ *
+ * LETTA_MEMFS_GIT_PROXY_BASE_URL is intentionally transport-only: it should
+ * never be used for settings keys, persisted remotes, or credential helper
+ * config. It lets Desktop route git network traffic through its localhost
+ * proxy while keeping the local repo's origin canonical and stable.
+ */
+export function getMemfsGitProxyRewriteConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): MemfsGitProxyRewriteConfig | null {
+  const rawProxyBaseUrl = env[LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV]?.trim();
+  if (!rawProxyBaseUrl || !isLocalhostUrl(rawProxyBaseUrl)) {
+    return null;
+  }
+
+  const memfsBaseUrl = trimBaseUrl(getMemfsServerUrl());
+  if (!memfsBaseUrl.includes("api.letta.com")) {
+    return null;
+  }
+
+  const proxyBaseUrl = trimBaseUrl(rawProxyBaseUrl);
+  const proxyPrefix = `${proxyBaseUrl}/v1/git/`;
+  const memfsPrefix = `${memfsBaseUrl}/v1/git/`;
+
+  return {
+    proxyBaseUrl,
+    memfsBaseUrl,
+    proxyPrefix,
+    memfsPrefix,
+    configKey: `url.${proxyPrefix}.insteadOf`,
+    configValue: memfsPrefix,
+  };
 }
 
 /**
  * Get the current Letta memfs server URL from environment or settings.
- * Falls back to the Desktop localhost proxy in desktop listener sessions,
- * otherwise falls back to Letta Cloud when no memfs-specific URL is set.
+ * Falls back to Letta Cloud when no memfs-specific URL is set.
+ *
+ * Intentionally ignores LETTA_BASE_URL: Desktop sets LETTA_BASE_URL to an
+ * ephemeral localhost proxy port, but MemFS git config/settings must stay
+ * keyed by a stable canonical URL. Desktop's transient git transport proxy is
+ * handled separately by LETTA_MEMFS_GIT_PROXY_BASE_URL.
  */
 export function getMemfsServerUrl(): string {
   let settings: Settings | null = null;
@@ -148,11 +205,6 @@ export function getMemfsServerUrl(): string {
     process.env.LETTA_MEMFS_BASE_URL || settings?.env?.LETTA_MEMFS_BASE_URL;
   if (configuredMemfsUrl) {
     return configuredMemfsUrl;
-  }
-
-  const apiUrl = process.env.LETTA_BASE_URL || settings?.env?.LETTA_BASE_URL;
-  if (apiUrl && isDesktopLocalProxyUrl(apiUrl)) {
-    return apiUrl;
   }
 
   return LETTA_CLOUD_API_URL;

--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -494,14 +494,11 @@ function getServerHostLabel(serverUrl: string): string {
  * Whether the MemFS sync endpoint is backed by the Letta API.
  */
 export async function isLettaMemfsServer(): Promise<boolean> {
-  const { getMemfsServerUrl, isDesktopLocalProxyUrl } = await import(
-    "./client"
-  );
+  const { getMemfsServerUrl } = await import("./client");
   const memfsServerUrl = getMemfsServerUrl();
 
   return (
     memfsServerUrl.includes("api.letta.com") ||
-    isDesktopLocalProxyUrl(memfsServerUrl) ||
     process.env.LETTA_MEMFS_LOCAL === "1" ||
     process.env.LETTA_API_KEY === "local-desktop"
   );

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -3,8 +3,9 @@
  *
  * When memFS is enabled, the agent's memory is stored in a git repo
  * on the server at $LETTA_MEMFS_BASE_URL/v1/git/$AGENT_ID/state.git
- * (falling back to the Desktop local proxy in desktop listener sessions, or
- * api.letta.com otherwise).
+ * (falling back to api.letta.com when unset). Desktop may route git transport
+ * through a localhost proxy transiently, but that URL must not be persisted in
+ * the repo's git config.
  * This module provides the CLI harness helpers: clone on first run,
  * pull on startup, and status check for system reminders.
  *
@@ -25,7 +26,11 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { debugLog, debugWarn } from "../utils/debug";
-import { getClient, getMemfsServerUrl } from "./client";
+import {
+  getClient,
+  getMemfsGitProxyRewriteConfig,
+  getMemfsServerUrl,
+} from "./client";
 
 const execFile = promisify(execFileCb);
 
@@ -258,6 +263,32 @@ export function buildGitAuthArgs(token: string): string[] {
   ];
 }
 
+export function isMemfsGitNetworkCommand(args: string[]): boolean {
+  return ["clone", "fetch", "pull", "push"].includes(args[0] ?? "");
+}
+
+export function buildMemfsGitProxyArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (!isMemfsGitNetworkCommand(args)) {
+    return [];
+  }
+
+  const rewrite = getMemfsGitProxyRewriteConfig(env);
+  if (!rewrite) {
+    return [];
+  }
+
+  return ["-c", `${rewrite.configKey}=${rewrite.configValue}`];
+}
+
+export function shouldConfigurePersistentMemfsCredentialHelper(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return getMemfsGitProxyRewriteConfig(env) === null;
+}
+
 export function buildNonInteractiveGitEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
@@ -280,7 +311,7 @@ async function runGit(
   token?: string,
 ): Promise<{ stdout: string; stderr: string }> {
   const authArgs = token ? buildGitAuthArgs(token) : [];
-  const allArgs = [...authArgs, ...args];
+  const allArgs = [...buildMemfsGitProxyArgs(args), ...authArgs, ...args];
 
   // Redact credential helper values to avoid leaking tokens in debug logs.
   let loggableArgs = args;
@@ -388,6 +419,9 @@ async function runGitWithRetry(
 /**
  * Configure a local credential helper in the repo's .git/config
  * so plain `git push` / `git pull` work without auth prefixes.
+ * Skipped in Desktop proxy transport mode because the listener only has a
+ * local session token; persisting that token under api.letta.com would break
+ * normal CLI/TUI sessions that share the same memory repo.
  *
  * On Windows, we write a batch script because the bash-style inline
  * helper (`!f() { ... }; f`) doesn't work in PowerShell/cmd.
@@ -398,6 +432,15 @@ async function configureLocalCredentialHelper(
 ): Promise<void> {
   const rawBaseUrl = getMemfsServerUrl();
   const normalizedBaseUrl = normalizeCredentialBaseUrl(rawBaseUrl);
+
+  if (!shouldConfigurePersistentMemfsCredentialHelper()) {
+    await clearLocalCredentialHelper(dir, rawBaseUrl, normalizedBaseUrl);
+    debugLog(
+      "memfs-git",
+      `Skipped persistent credential helper for ${normalizedBaseUrl}; using transient MemFS git proxy transport`,
+    );
+    return;
+  }
 
   let helper: string;
 
@@ -433,6 +476,25 @@ echo password=${token}
     "memfs-git",
     `Configured local credential helper for ${normalizedBaseUrl}${rawBaseUrl !== normalizedBaseUrl ? ` (and raw ${rawBaseUrl})` : ""}`,
   );
+}
+
+async function clearLocalCredentialHelper(
+  dir: string,
+  rawBaseUrl: string,
+  normalizedBaseUrl: string,
+): Promise<void> {
+  const keys = new Set([
+    `credential.${normalizedBaseUrl}.helper`,
+    `credential.${rawBaseUrl}.helper`,
+  ]);
+
+  for (const key of keys) {
+    try {
+      await runGit(dir, ["config", "--local", "--unset-all", key]);
+    } catch {
+      // Already unset — ignore.
+    }
+  }
 }
 
 /**

--- a/src/tests/agent/memoryFilesystem.test.ts
+++ b/src/tests/agent/memoryFilesystem.test.ts
@@ -193,14 +193,14 @@ describe("MemFS endpoint validation", () => {
     expect(await isLettaMemfsServer()).toBe(false);
   });
 
-  test("allows Desktop local proxy as an explicit MemFS sync endpoint", async () => {
+  test("rejects Desktop local proxy as a canonical MemFS sync endpoint", async () => {
     process.env.LETTA_BASE_URL = "http://localhost:54085";
     process.env.LETTA_MEMFS_BASE_URL = "http://localhost:54085";
     delete process.env.LETTA_MEMFS_LOCAL;
     process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
     process.env.LETTA_API_KEY = "desktop-session-token";
 
-    expect(await isLettaMemfsServer()).toBe(true);
+    expect(await isLettaMemfsServer()).toBe(false);
   });
 });
 

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -7,18 +7,22 @@ import { join } from "node:path";
 import { getMemfsServerUrl } from "../../agent/client";
 import {
   buildGitAuthArgs,
+  buildMemfsGitProxyArgs,
   buildNonInteractiveGitEnv,
   formatGitCredentialHelperPath,
   getGitRemoteUrl,
   isMemfsRemoteUrlForAgent,
   maybeUpdateMemoryRemoteOrigin,
   normalizeCredentialBaseUrl,
+  shouldConfigurePersistentMemfsCredentialHelper,
 } from "../../agent/memoryGit";
 
 const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
 const ORIGINAL_LETTA_MEMFS_BASE_URL = process.env.LETTA_MEMFS_BASE_URL;
 const ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL =
   process.env.LETTA_DESKTOP_DEBUG_PANEL;
+const ORIGINAL_LETTA_MEMFS_GIT_PROXY_BASE_URL =
+  process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL;
 
 let tempDirs: string[] = [];
 
@@ -44,6 +48,13 @@ afterEach(() => {
     delete process.env.LETTA_DESKTOP_DEBUG_PANEL;
   } else {
     process.env.LETTA_DESKTOP_DEBUG_PANEL = ORIGINAL_LETTA_DESKTOP_DEBUG_PANEL;
+  }
+
+  if (ORIGINAL_LETTA_MEMFS_GIT_PROXY_BASE_URL === undefined) {
+    delete process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL =
+      ORIGINAL_LETTA_MEMFS_GIT_PROXY_BASE_URL;
   }
 });
 
@@ -101,15 +112,61 @@ describe("normalizeCredentialBaseUrl", () => {
       );
     });
 
-    test("uses the Desktop localhost proxy for memfs git in desktop listener sessions", () => {
+    test("keeps canonical memfs URL stable in desktop proxy transport sessions", () => {
       process.env.LETTA_BASE_URL = "http://localhost:51338";
       delete process.env.LETTA_MEMFS_BASE_URL;
       process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
 
-      expect(getMemfsServerUrl()).toBe("http://localhost:51338");
+      expect(getMemfsServerUrl()).toBe("https://api.letta.com");
       expect(getGitRemoteUrl("agent-123")).toBe(
-        "http://localhost:51338/v1/git/agent-123/state.git",
+        "https://api.letta.com/v1/git/agent-123/state.git",
       );
+    });
+
+    test("uses desktop proxy as a transient git transport rewrite for network commands", () => {
+      process.env.LETTA_BASE_URL = "http://localhost:51338";
+      delete process.env.LETTA_MEMFS_BASE_URL;
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
+
+      expect(buildMemfsGitProxyArgs(["push"])).toEqual([
+        "-c",
+        "url.http://localhost:51338/v1/git/.insteadOf=https://api.letta.com/v1/git/",
+      ]);
+      expect(buildMemfsGitProxyArgs(["pull", "--ff-only"])).toEqual([
+        "-c",
+        "url.http://localhost:51338/v1/git/.insteadOf=https://api.letta.com/v1/git/",
+      ]);
+    });
+
+    test("does not apply desktop proxy rewrite to local git config reads", () => {
+      delete process.env.LETTA_MEMFS_BASE_URL;
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
+
+      expect(buildMemfsGitProxyArgs(["remote", "get-url", "origin"])).toEqual(
+        [],
+      );
+      expect(buildMemfsGitProxyArgs(["config", "--local", "--list"])).toEqual(
+        [],
+      );
+      expect(buildMemfsGitProxyArgs(["status", "--porcelain"])).toEqual([]);
+    });
+
+    test("does not proxy explicit self-hosted memfs URLs", () => {
+      process.env.LETTA_MEMFS_BASE_URL = "https://selfhost.example.com";
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
+
+      expect(buildMemfsGitProxyArgs(["push"])).toEqual([]);
+      expect(getGitRemoteUrl("agent-123")).toBe(
+        "https://selfhost.example.com/v1/git/agent-123/state.git",
+      );
+    });
+
+    test("does not persist credential helpers when desktop proxy transport is active", () => {
+      delete process.env.LETTA_MEMFS_BASE_URL;
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
+
+      expect(shouldConfigurePersistentMemfsCredentialHelper()).toBe(false);
     });
   });
 
@@ -215,6 +272,23 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
+  });
+
+  test("repairs stale desktop proxy origin back to canonical cloud while proxy transport is active", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+    const staleOrigin = getGitRemoteUrl(agentId, "http://localhost:50864");
+
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+    git(repo, `remote add origin ${staleOrigin}`);
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "remote get-url origin").trim()).toBe(
+      "https://api.letta.com/v1/git/agent-123/state.git",
+    );
   });
 
   test("clears origin pushurl even when origin URL is already current", async () => {

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -34,6 +34,35 @@ function withTemporaryAgentEnv<T>(agentId: string, fn: () => T): T {
   }
 }
 
+function withTemporaryEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const original = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  ) as Record<string, string | undefined>;
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe("shellEnv letta shim", () => {
   test("resolveLettaInvocation prefers explicit launcher env", () => {
     const invocation = resolveLettaInvocation(
@@ -343,4 +372,51 @@ test("getShellEnv injects MEMORY_DIR aliases when memfs is enabled", () => {
       ).isMemfsEnabled = original;
     }
   });
+});
+
+test("getShellEnv injects transient MemFS git proxy config for Desktop Bash commands", () => {
+  const env = withTemporaryEnv(
+    {
+      LETTA_BASE_URL: "http://localhost:57294",
+      LETTA_MEMFS_BASE_URL: undefined,
+      LETTA_MEMFS_GIT_PROXY_BASE_URL: "http://localhost:57294",
+      GIT_CONFIG_COUNT: undefined,
+      GIT_CONFIG_KEY_0: undefined,
+      GIT_CONFIG_VALUE_0: undefined,
+    },
+    () => getShellEnv(),
+  );
+
+  expect(env.GIT_CONFIG_COUNT).toBe("1");
+  expect(env.GIT_CONFIG_KEY_0).toBe(
+    "url.http://localhost:57294/v1/git/.insteadOf",
+  );
+  expect(env.GIT_CONFIG_VALUE_0).toBe("https://api.letta.com/v1/git/");
+  expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+  expect(env.GCM_INTERACTIVE).toBe("never");
+  expect(env.GIT_ASKPASS).toBe("");
+  expect(env.SSH_ASKPASS).toBe("");
+});
+
+test("getShellEnv appends MemFS git proxy config without clobbering existing git config env", () => {
+  const env = withTemporaryEnv(
+    {
+      LETTA_MEMFS_BASE_URL: undefined,
+      LETTA_MEMFS_GIT_PROXY_BASE_URL: "http://localhost:57294",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "safe.directory",
+      GIT_CONFIG_VALUE_0: "*",
+      GIT_CONFIG_KEY_1: undefined,
+      GIT_CONFIG_VALUE_1: undefined,
+    },
+    () => getShellEnv(),
+  );
+
+  expect(env.GIT_CONFIG_COUNT).toBe("2");
+  expect(env.GIT_CONFIG_KEY_0).toBe("safe.directory");
+  expect(env.GIT_CONFIG_VALUE_0).toBe("*");
+  expect(env.GIT_CONFIG_KEY_1).toBe(
+    "url.http://localhost:57294/v1/git/.insteadOf",
+  );
+  expect(env.GIT_CONFIG_VALUE_1).toBe("https://api.letta.com/v1/git/");
 });

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -9,7 +9,10 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getServerUrl } from "../../agent/client";
+import {
+  getMemfsGitProxyRewriteConfig,
+  getServerUrl,
+} from "../../agent/client";
 import { getConversationId, getCurrentAgentId } from "../../agent/context";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
@@ -182,6 +185,31 @@ export function ensureLettaShimDir(invocation: LettaInvocation): string | null {
   return shimDir;
 }
 
+function appendGitConfigEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  value: string,
+): void {
+  const rawCount = env.GIT_CONFIG_COUNT;
+  const count = rawCount && /^\d+$/.test(rawCount) ? Number(rawCount) : 0;
+  env[`GIT_CONFIG_KEY_${count}`] = key;
+  env[`GIT_CONFIG_VALUE_${count}`] = value;
+  env.GIT_CONFIG_COUNT = String(count + 1);
+}
+
+function applyMemfsGitProxyEnv(env: NodeJS.ProcessEnv): void {
+  const rewrite = getMemfsGitProxyRewriteConfig(env);
+  if (!rewrite) {
+    return;
+  }
+
+  appendGitConfigEnv(env, rewrite.configKey, rewrite.configValue);
+  env.GIT_TERMINAL_PROMPT = "0";
+  env.GCM_INTERACTIVE = "never";
+  env.GIT_ASKPASS = "";
+  env.SSH_ASKPASS = "";
+}
+
 /**
  * Get enhanced environment variables for shell execution.
  * Includes bundled tools (like ripgrep) in PATH and Letta context for skill scripts.
@@ -307,6 +335,12 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   if (!env.TERM) {
     env.TERM = "xterm-256color";
   }
+
+  // Desktop's local listener only has a localhost session token; the proxy owns
+  // the real Cloud token. Apply a process-local git URL rewrite so agent-run
+  // `git push`/`pull` inside $MEMORY_DIR uses the proxy without persisting the
+  // ephemeral localhost URL into the memory repo's git config.
+  applyMemfsGitProxyEnv(env);
 
   return env;
 }


### PR DESCRIPTION
## Summary

- Restores stable MemFS URL semantics so Desktop listener sessions keep persisted remotes/settings canonical instead of writing ephemeral localhost proxy URLs.
- Adds `LETTA_MEMFS_GIT_PROXY_BASE_URL` as a transport-only git rewrite for Desktop MemFS network operations, covering both app-owned git commands and Bash-spawned `git push`/`pull`.
- Skips and clears persistent MemFS credential helpers in Desktop proxy transport mode so local session tokens are not saved under `api.letta.com`.

## Tests

- `bun test src/tests/agent/memoryGit.auth.test.ts src/tests/agent/memoryFilesystem.test.ts src/tests/tools/shell-env.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/agent/client.ts src/agent/memoryFilesystem.ts src/agent/memoryGit.ts src/tools/impl/shellEnv.ts src/tests/agent/memoryGit.auth.test.ts src/tests/agent/memoryFilesystem.test.ts src/tests/tools/shell-env.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)