### PR TITLE
feat(ws): hot reload permission settings

### DIFF
--- a/src/permissions/loader.ts
+++ b/src/permissions/loader.ts
@@ -1,7 +1,8 @@
 // src/permissions/loader.ts
 // Load and merge permission settings from hierarchical sources
 
-import { type FSWatcher, statSync, watch } from "node:fs";
+import { createHash } from "node:crypto";
+import { type FSWatcher, readFileSync, statSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { exists, readFile, writeFile } from "../utils/fs.js";
@@ -26,6 +27,7 @@ type FileSignature =
       exists: true;
       mtimeMs: number;
       size: number;
+      hash: string;
     }
   | { exists: false };
 
@@ -75,6 +77,7 @@ function getFileSignature(path: string): FileSignature {
       exists: true,
       mtimeMs: stat.mtimeMs,
       size: stat.size,
+      hash: createHash("sha256").update(readFileSync(path)).digest("hex"),
     };
   } catch {
     return { exists: false };
@@ -95,7 +98,7 @@ function signaturesEqual(
 ): boolean {
   if (!a || !b) return false;
   if (!a.exists || !b.exists) return a.exists === b.exists;
-  return a.mtimeMs === b.mtimeMs && a.size === b.size;
+  return a.mtimeMs === b.mtimeMs && a.size === b.size && a.hash === b.hash;
 }
 
 function cachedEntryMatchesSources(

--- a/src/permissions/loader.ts
+++ b/src/permissions/loader.ts
@@ -1,9 +1,10 @@
-import { exists, readFile, writeFile } from "../utils/fs.js";
 // src/permissions/loader.ts
 // Load and merge permission settings from hierarchical sources
 
+import { type FSWatcher, statSync, watch } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { exists, readFile, writeFile } from "../utils/fs.js";
 import {
   normalizePermissionRule,
   permissionRulesEquivalent,
@@ -19,6 +20,23 @@ type UserSettingsPathsOptions = {
   homeDir?: string;
   xdgConfigHome?: string;
 };
+
+type FileSignature =
+  | {
+      exists: true;
+      mtimeMs: number;
+      size: number;
+    }
+  | { exists: false };
+
+type PermissionCacheEntry = {
+  permissions: PermissionRules;
+  sources: string[];
+  signatures: Map<string, FileSignature>;
+};
+
+const permissionCache = new Map<string, PermissionCacheEntry>();
+const watchers = new Map<string, FSWatcher>();
 
 export function getUserSettingsPaths(options: UserSettingsPathsOptions = {}): {
   canonical: string;
@@ -36,6 +54,136 @@ export function getUserSettingsPaths(options: UserSettingsPathsOptions = {}): {
   };
 }
 
+function getPermissionSourcePaths(workingDirectory: string): string[] {
+  const { canonical: userSettingsPath, legacy: legacyUserSettingsPath } =
+    getUserSettingsPaths();
+  return [
+    legacyUserSettingsPath, // User legacy
+    userSettingsPath, // User (canonical)
+    join(workingDirectory, ".letta", "settings.json"), // Project
+    join(workingDirectory, ".letta", "settings.local.json"), // Local
+  ];
+}
+
+function getFileSignature(path: string): FileSignature {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) {
+      return { exists: false };
+    }
+    return {
+      exists: true,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    };
+  } catch {
+    return { exists: false };
+  }
+}
+
+function getFileSignatures(paths: string[]): Map<string, FileSignature> {
+  const signatures = new Map<string, FileSignature>();
+  for (const path of paths) {
+    signatures.set(path, getFileSignature(path));
+  }
+  return signatures;
+}
+
+function signaturesEqual(
+  a: FileSignature | undefined,
+  b: FileSignature | undefined,
+): boolean {
+  if (!a || !b) return false;
+  if (!a.exists || !b.exists) return a.exists === b.exists;
+  return a.mtimeMs === b.mtimeMs && a.size === b.size;
+}
+
+function cachedEntryMatchesSources(
+  entry: PermissionCacheEntry,
+  sources: string[],
+  signatures: Map<string, FileSignature>,
+): boolean {
+  if (entry.sources.length !== sources.length) {
+    return false;
+  }
+  for (let i = 0; i < sources.length; i += 1) {
+    if (entry.sources[i] !== sources[i]) {
+      return false;
+    }
+  }
+  for (const source of sources) {
+    if (
+      !signaturesEqual(entry.signatures.get(source), signatures.get(source))
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function clonePermissions(permissions: PermissionRules): PermissionRules {
+  return {
+    allow: [...(permissions.allow || [])],
+    deny: [...(permissions.deny || [])],
+    ask: [...(permissions.ask || [])],
+    additionalDirectories: [...(permissions.additionalDirectories || [])],
+  };
+}
+
+function invalidatePermissionSource(sourcePath: string): void {
+  for (const [cacheKey, entry] of permissionCache) {
+    if (entry.sources.includes(sourcePath)) {
+      permissionCache.delete(cacheKey);
+    }
+  }
+}
+
+function invalidatePermissionSourcesInDirectory(directoryPath: string): void {
+  for (const [cacheKey, entry] of permissionCache) {
+    if (entry.sources.some((source) => dirname(source) === directoryPath)) {
+      permissionCache.delete(cacheKey);
+    }
+  }
+}
+
+function watchPath(path: string, onChange: () => void): void {
+  if (watchers.has(path) || !exists(path)) {
+    return;
+  }
+
+  try {
+    const watcher = watch(path, { persistent: false }, onChange);
+    watcher.on("error", () => {
+      watcher.close();
+      watchers.delete(path);
+      onChange();
+    });
+    watchers.set(path, watcher);
+  } catch {
+    // fs.watch can fail on some filesystems; loadPermissions still validates
+    // file signatures on every call, so missed watchers only cost one stat.
+  }
+}
+
+function ensurePermissionWatchers(sources: string[]): void {
+  for (const source of sources) {
+    watchPath(source, () => invalidatePermissionSource(source));
+
+    const directoryPath = dirname(source);
+    watchPath(directoryPath, () =>
+      invalidatePermissionSourcesInDirectory(directoryPath),
+    );
+  }
+}
+
+export function resetPermissionLoaderCacheForTests(): void {
+  permissionCache.clear();
+  for (const watcher of watchers.values()) {
+    watcher.close();
+  }
+  watchers.clear();
+}
+
 /**
  * Load permissions from all settings files and merge them hierarchically.
  *
@@ -50,22 +198,23 @@ export function getUserSettingsPaths(options: UserSettingsPathsOptions = {}): {
 export async function loadPermissions(
   workingDirectory: string = process.cwd(),
 ): Promise<PermissionRules> {
+  const normalizedWorkingDirectory = resolve(workingDirectory);
+  const sources = getPermissionSourcePaths(normalizedWorkingDirectory);
+  const signatures = getFileSignatures(sources);
+  const cacheKey = normalizedWorkingDirectory;
+  const cached = permissionCache.get(cacheKey);
+
+  if (cached && cachedEntryMatchesSources(cached, sources, signatures)) {
+    ensurePermissionWatchers(sources);
+    return clonePermissions(cached.permissions);
+  }
+
   const merged: PermissionRules = {
     allow: [],
     deny: [],
     ask: [],
     additionalDirectories: [],
   };
-
-  // Load in reverse precedence order (lowest to highest)
-  const { canonical: userSettingsPath, legacy: legacyUserSettingsPath } =
-    getUserSettingsPaths();
-  const sources = [
-    legacyUserSettingsPath, // User legacy
-    userSettingsPath, // User (canonical)
-    join(workingDirectory, ".letta", "settings.json"), // Project
-    join(workingDirectory, ".letta", "settings.local.json"), // Local
-  ];
 
   for (const settingsPath of sources) {
     try {
@@ -82,7 +231,14 @@ export async function loadPermissions(
     }
   }
 
-  return merged;
+  permissionCache.set(cacheKey, {
+    permissions: clonePermissions(merged),
+    sources,
+    signatures,
+  });
+  ensurePermissionWatchers(sources);
+
+  return clonePermissions(merged);
 }
 
 /**
@@ -131,6 +287,8 @@ export async function savePermissionRule(
   scope: "project" | "local" | "user",
   workingDirectory: string = process.cwd(),
 ): Promise<void> {
+  const normalizedWorkingDirectory = resolve(workingDirectory);
+
   // Determine settings file path based on scope
   let settingsPath: string;
   switch (scope) {
@@ -138,10 +296,18 @@ export async function savePermissionRule(
       settingsPath = getUserSettingsPaths().canonical;
       break;
     case "project":
-      settingsPath = join(workingDirectory, ".letta", "settings.json");
+      settingsPath = join(
+        normalizedWorkingDirectory,
+        ".letta",
+        "settings.json",
+      );
       break;
     case "local":
-      settingsPath = join(workingDirectory, ".letta", "settings.local.json");
+      settingsPath = join(
+        normalizedWorkingDirectory,
+        ".letta",
+        "settings.local.json",
+      );
       break;
   }
 
@@ -177,10 +343,11 @@ export async function savePermissionRule(
 
   // Save settings
   await writeFile(settingsPath, JSON.stringify(settings, null, 2));
+  invalidatePermissionSource(settingsPath);
 
   // If saving to .letta/settings.local.json, ensure it's gitignored
   if (scope === "local") {
-    await ensureLocalSettingsIgnored(workingDirectory);
+    await ensureLocalSettingsIgnored(normalizedWorkingDirectory);
   }
 }
 

--- a/src/tests/permissions-loader.test.ts
+++ b/src/tests/permissions-loader.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   getUserSettingsPaths,
   loadPermissions,
+  resetPermissionLoaderCacheForTests,
   savePermissionRule,
 } from "../permissions/loader";
 
@@ -16,6 +17,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  resetPermissionLoaderCacheForTests();
   // Clean up test directory
   await rm(testDir, { recursive: true, force: true });
 });
@@ -72,6 +74,71 @@ test("Load permissions from local settings", async () => {
 
   // Should include local rule (may also include user settings from real home dir)
   expect(permissions.allow).toContain("Bash(git push:*)");
+});
+
+test("Load permissions picks up external project settings edits without restart", async () => {
+  const projectDir = join(testDir, "project-hot-reload");
+  const projectSettingsPath = join(projectDir, ".letta", "settings.json");
+
+  await Bun.write(
+    projectSettingsPath,
+    JSON.stringify({
+      permissions: {
+        allow: ["Bash(letta-permission-watch-initial)"],
+      },
+    }),
+  );
+
+  const initial = await loadPermissions(projectDir);
+  expect(initial.allow).toContain("Bash(letta-permission-watch-initial)");
+
+  await Bun.write(
+    projectSettingsPath,
+    JSON.stringify({
+      permissions: {
+        allow: ["Bash(letta-permission-watch-updated)"],
+      },
+    }),
+  );
+
+  const updated = await loadPermissions(projectDir);
+  expect(updated.allow).toContain("Bash(letta-permission-watch-updated)");
+});
+
+test("Load permissions picks up newly-created local settings after cached miss", async () => {
+  const projectDir = join(testDir, "project-create-local");
+
+  const initial = await loadPermissions(projectDir);
+  expect(initial.allow).not.toContain("Bash(letta-permission-watch-created)");
+
+  await Bun.write(
+    join(projectDir, ".letta", "settings.local.json"),
+    JSON.stringify({
+      permissions: {
+        allow: ["Bash(letta-permission-watch-created)"],
+      },
+    }),
+  );
+
+  const updated = await loadPermissions(projectDir);
+  expect(updated.allow).toContain("Bash(letta-permission-watch-created)");
+});
+
+test("Saved permission rules are visible immediately", async () => {
+  const projectDir = join(testDir, "project-save-invalidates");
+
+  const initial = await loadPermissions(projectDir);
+  expect(initial.allow).not.toContain("Bash(letta-permission-watch-saved)");
+
+  await savePermissionRule(
+    "Bash(letta-permission-watch-saved)",
+    "allow",
+    "project",
+    projectDir,
+  );
+
+  const updated = await loadPermissions(projectDir);
+  expect(updated.allow).toContain("Bash(letta-permission-watch-saved)");
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Cache merged permission settings per working directory while validating file signatures on every permission load.
- Add `fs.watch` invalidation for user/project/local settings files and `.letta` directories so external permission edits apply without restarting Letta Code.
- Invalidate the permission cache immediately after persisted permission-rule writes and cover hot-reload paths with loader tests.

Validated with:
- `bun test src/tests/permissions-loader.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)