### PR TITLE
fix(headless): flush terminal stream-json messages

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -94,7 +94,7 @@ import {
 } from "./reminders/state";
 import { getCurrentWorkingDirectory } from "./runtime-context";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
-import { writeWireMessage } from "./streamJsonWriter";
+import { writeWireMessage, writeWireMessageAsync } from "./streamJsonWriter";
 import { telemetry } from "./telemetry";
 import { trackBoundaryError } from "./telemetry/errorReporting";
 import { extractTelemetryInputText } from "./telemetry/input";
@@ -1745,7 +1745,7 @@ ${SYSTEM_REMINDER_CLOSE}
           session_id: sessionId,
           uuid: `error-max-turns-${randomUUID()}`,
         };
-        writeWireMessage(errorMsg);
+        await writeWireMessageAsync(errorMsg);
       } else {
         console.error(
           `Maximum turns limit reached (${buffers.usage.stepCount}/${maxTurns} steps)`,
@@ -2379,7 +2379,7 @@ ${SYSTEM_REMINDER_CLOSE}
               session_id: sessionId,
               uuid: `error-${lastRunId || randomUUID()}`,
             };
-            writeWireMessage(errorMsg);
+            await writeWireMessageAsync(errorMsg);
           } else {
             console.error("Failed to fetch pending approvals for resync");
           }
@@ -2616,7 +2616,7 @@ ${SYSTEM_REMINDER_CLOSE}
           session_id: sessionId,
           uuid: `error-${lastRunId || randomUUID()}`,
         };
-        writeWireMessage(errorMsg);
+        await writeWireMessageAsync(errorMsg);
       } else {
         console.error(`Error: ${errorMessage}`);
       }
@@ -2643,7 +2643,7 @@ ${SYSTEM_REMINDER_CLOSE}
         session_id: sessionId,
         uuid: `error-${lastKnownRunId || randomUUID()}`,
       };
-      writeWireMessage(errorMsg);
+      await writeWireMessageAsync(errorMsg);
     } else {
       console.error(`Error: ${errorDetails}`);
     }
@@ -2749,7 +2749,7 @@ ${SYSTEM_REMINDER_CLOSE}
       usage,
       uuid: resultUuid,
     };
-    writeWireMessage(resultEvent);
+    await writeWireMessageAsync(resultEvent);
   } else {
     // text format (default)
     if (!resultText || resultText === "No assistant response found") {

--- a/src/streamJsonWriter.ts
+++ b/src/streamJsonWriter.ts
@@ -22,10 +22,31 @@
  */
 import type { WireMessage } from "./types/protocol";
 
+function stampWireMessage(msg: WireMessage): WireMessage {
+  return msg.timestamp === undefined
+    ? { ...msg, timestamp: new Date().toISOString() }
+    : msg;
+}
+
 export function writeWireMessage(msg: WireMessage): void {
-  const stamped =
-    msg.timestamp === undefined
-      ? { ...msg, timestamp: new Date().toISOString() }
-      : msg;
-  console.log(JSON.stringify(stamped));
+  console.log(JSON.stringify(stampWireMessage(msg)));
+}
+
+export async function writeWireMessageAsync(msg: WireMessage): Promise<void> {
+  const line = `${JSON.stringify(stampWireMessage(msg))}\n`;
+
+  await new Promise<void>((resolve, reject) => {
+    if (process.stdout.destroyed || process.stdout.writableEnded) {
+      resolve();
+      return;
+    }
+
+    process.stdout.write(line, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
 }

--- a/src/tests/headless/stream-json-writer.test.ts
+++ b/src/tests/headless/stream-json-writer.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { writeWireMessage } from "../../streamJsonWriter";
+import {
+  writeWireMessage,
+  writeWireMessageAsync,
+} from "../../streamJsonWriter";
 import type { ControlRequest, MessageWire } from "../../types/protocol";
 
 const originalConsoleLog = console.log;
+const originalStdoutWrite = process.stdout.write;
 
 afterEach(() => {
   console.log = originalConsoleLog;
+  process.stdout.write = originalStdoutWrite;
 });
 
 describe("writeWireMessage", () => {
@@ -58,5 +63,51 @@ describe("writeWireMessage", () => {
       timestamp?: string;
     };
     expect(payload.timestamp).toBe("2026-04-21T23:59:59.000Z");
+  });
+
+  test("async writer resolves after stdout accepts the stamped line", async () => {
+    let writeCallback: (() => void) | undefined;
+    const stdoutWrite = mock(
+      (
+        chunk: string | Uint8Array,
+        callback?: (error?: Error | null) => void,
+      ) => {
+        expect(typeof chunk).toBe("string");
+        writeCallback = () => callback?.();
+        return true;
+      },
+    );
+    process.stdout.write =
+      stdoutWrite as unknown as typeof process.stdout.write;
+
+    const msg: ControlRequest = {
+      type: "control_request",
+      request_id: "req-async",
+      request: { subtype: "interrupt" },
+    };
+
+    let resolved = false;
+    const pending = writeWireMessageAsync(msg).then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+    expect(stdoutWrite).toHaveBeenCalledTimes(1);
+
+    const firstCall = stdoutWrite.mock.calls[0];
+    const payload = JSON.parse(String(firstCall?.[0]).trim()) as {
+      type: string;
+      timestamp?: string;
+      request_id: string;
+    };
+    expect(payload.type).toBe("control_request");
+    expect(payload.request_id).toBe("req-async");
+    expect(payload.timestamp).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+
+    writeCallback?.();
+    await pending;
+    expect(resolved).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add an awaited stream-json writer for terminal headless messages so large final result lines are accepted by stdout before process exit
- Use the awaited writer for final success results and terminal error paths in one-shot headless mode
- Cover the async writer behavior with a focused unit test

## Validation

- `bun test src/tests/headless/stream-json-writer.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)