### PR TITLE
fix(dream): cap reflection startup context

### DIFF
--- a/src/agent/subagents/contextBudget.ts
+++ b/src/agent/subagents/contextBudget.ts
@@ -1,0 +1,22 @@
+/**
+ * Conservative startup-context budgeting for subagents.
+ *
+ * We intentionally avoid tokenizer dependencies here. The estimate is used only
+ * as a safety guard before sending prompts to the API; using 4 chars/token is
+ * conservative enough for English/Markdown prompts while keeping the codepath
+ * synchronous and dependency-free.
+ */
+
+export const STARTUP_CONTEXT_ESTIMATED_CHARS_PER_TOKEN = 4;
+export const REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT = 16_000;
+export const REFLECTION_STARTUP_CONTEXT_CHAR_LIMIT =
+  REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT *
+  STARTUP_CONTEXT_ESTIMATED_CHARS_PER_TOKEN;
+
+// Leave room for the reflection subagent system prompt and launch boilerplate.
+// The final guard in subagent manager enforces the full system+prompt budget.
+export const REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT = 40_000;
+
+export function estimateStartupContextTokens(text: string): number {
+  return Math.ceil(text.length / STARTUP_CONTEXT_ESTIMATED_CHARS_PER_TOKEN);
+}

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -38,8 +38,12 @@ import { getClient } from "../client";
 import { getCurrentAgentId } from "../context";
 import { getDefaultModelForTier, resolveModel } from "../model";
 import recallSubagentPrompt from "../prompts/recall_subagent.md";
-
 import { getAllSubagentConfigs, type SubagentConfig } from ".";
+import {
+  estimateStartupContextTokens,
+  REFLECTION_STARTUP_CONTEXT_CHAR_LIMIT,
+  REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT,
+} from "./contextBudget";
 
 // ============================================================================
 // Types
@@ -642,6 +646,91 @@ export function composeSubagentChildEnv(
 // Core Functions
 // ============================================================================
 
+function getReflectionStartupNotice(): string {
+  return `[Reflection startup context truncated: system prompt + initial message are capped at ~${REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT.toLocaleString()} estimated tokens. Some parent memory preview content was omitted; read files directly from MEMORY_DIR if needed.]`;
+}
+
+function buildMinimalParentMemorySection(maxChars: number): string {
+  const notice = getReflectionStartupNotice();
+  const section = `<parent_memory>\n${notice}\n</parent_memory>`;
+  if (section.length <= maxChars) {
+    return section;
+  }
+  return section.slice(0, Math.max(0, maxChars));
+}
+
+function shrinkParentMemorySection(section: string, maxChars: number): string {
+  const notice = getReflectionStartupNotice();
+  const treeMatch = section.match(
+    /<memory_filesystem>[\s\S]*?<\/memory_filesystem>/,
+  );
+  const prefix = "<parent_memory>\n";
+  const suffix = "\n</parent_memory>";
+
+  const tree = treeMatch?.[0];
+  if (tree) {
+    const candidate = `${prefix}${tree}\n${notice}${suffix}`;
+    if (candidate.length <= maxChars) {
+      return candidate;
+    }
+  }
+
+  return buildMinimalParentMemorySection(maxChars);
+}
+
+function hardTruncateReflectionPrompt(
+  prompt: string,
+  maxChars: number,
+): string {
+  const notice = `\n${getReflectionStartupNotice()}`;
+  if (maxChars <= notice.length) {
+    return notice.slice(0, Math.max(0, maxChars));
+  }
+  return `${prompt.slice(0, maxChars - notice.length).trimEnd()}${notice}`;
+}
+
+function capReflectionStartupPrompt(
+  type: string,
+  systemPrompt: string,
+  userPrompt: string,
+): string {
+  if (type !== "reflection") {
+    return userPrompt;
+  }
+
+  const estimatedTokens = estimateStartupContextTokens(
+    `${systemPrompt}\n${userPrompt}`,
+  );
+  if (estimatedTokens <= REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT) {
+    return userPrompt;
+  }
+
+  const allowedPromptChars = Math.max(
+    0,
+    REFLECTION_STARTUP_CONTEXT_CHAR_LIMIT - systemPrompt.length - 1,
+  );
+  const parentMemoryMatch = userPrompt.match(
+    /<parent_memory>[\s\S]*?<\/parent_memory>/,
+  );
+
+  if (parentMemoryMatch?.index !== undefined) {
+    const start = parentMemoryMatch.index;
+    const end = start + parentMemoryMatch[0].length;
+    const outsideChars = userPrompt.length - parentMemoryMatch[0].length;
+    const parentMemoryBudget = Math.max(0, allowedPromptChars - outsideChars);
+    const replacement = shrinkParentMemorySection(
+      parentMemoryMatch[0],
+      parentMemoryBudget,
+    );
+    const candidate = `${userPrompt.slice(0, start)}${replacement}${userPrompt.slice(end)}`;
+    if (candidate.length <= allowedPromptChars) {
+      return candidate;
+    }
+  }
+
+  return hardTruncateReflectionPrompt(userPrompt, allowedPromptChars);
+}
+
 /**
  * Build CLI arguments for spawning a subagent
  */
@@ -683,7 +772,12 @@ export function buildSubagentArgs(
     }
   }
 
-  args.push("-p", userPrompt);
+  const boundedUserPrompt = capReflectionStartupPrompt(
+    type,
+    config.systemPrompt,
+    userPrompt,
+  );
+  args.push("-p", boundedUserPrompt);
   args.push("--output-format", "stream-json");
 
   // Use subagent's configured permission mode, or inherit from parent

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -9,6 +9,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { MEMORY_SYSTEM_DIR } from "../../agent/memoryFilesystem";
+import { REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT } from "../../agent/subagents/contextBudget";
 import { getDirectoryLimits } from "../../utils/directoryLimits";
 import { parseFrontmatter } from "../../utils/frontmatter";
 import type { Line } from "./accumulator";
@@ -91,6 +92,11 @@ interface ParentMemoryFile {
   relativePath: string;
   content: string;
   description?: string;
+}
+
+interface ParentMemorySnapshotOptions {
+  /** Maximum characters for the full rendered parent-memory preview. */
+  maxChars?: number;
 }
 
 function isSystemMemoryFile(relativePath: string): boolean {
@@ -293,13 +299,61 @@ function buildParentMemoryTree(files: ParentMemoryFile[]): string {
   return lines.join("\n");
 }
 
+function joinedLength(lines: string[]): number {
+  return lines.join("\n").length;
+}
+
+function canAppendWithinBudget(
+  lines: string[],
+  additions: string[],
+  maxChars: number,
+): boolean {
+  return joinedLength([...lines, ...additions, "</parent_memory>"]) <= maxChars;
+}
+
+function truncateMemoryContentToFit(
+  lines: string[],
+  prefix: string[],
+  content: string,
+  suffix: string[],
+  maxChars: number,
+): string | null {
+  const fixedLength = joinedLength([
+    ...lines,
+    ...prefix,
+    "",
+    ...suffix,
+    "</parent_memory>",
+  ]);
+  const budget = maxChars - fixedLength;
+  if (budget <= 0) {
+    return null;
+  }
+
+  return content.slice(0, budget).trimEnd();
+}
+
+function buildMemoryPreviewNotice(
+  relativePath: string,
+  absolutePath: string,
+  kind: "truncated" | "omitted",
+): string {
+  const action = kind === "truncated" ? "truncated" : "omitted";
+  return `[Memory preview ${action}: startup context is capped at ~16k estimated tokens. Full file available at ${absolutePath}; read it directly if needed. Relative path: ${relativePath}]`;
+}
+
 export async function buildParentMemorySnapshot(
   memoryDir: string,
+  options: ParentMemorySnapshotOptions = {},
 ): Promise<string> {
   const files = await collectParentMemoryFiles(memoryDir);
   const tree = buildParentMemoryTree(files);
   const systemFiles = files.filter((file) =>
     isSystemMemoryFile(file.relativePath),
+  );
+  const maxChars = Math.max(
+    1_000,
+    options.maxChars ?? REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT,
   );
 
   const lines = [
@@ -312,13 +366,63 @@ export async function buildParentMemorySnapshot(
   if (files.length === 0) {
     lines.push("(no memory markdown files found)");
   } else {
+    let omittedSystemFiles = 0;
+
     for (const file of systemFiles) {
       const normalizedPath = file.relativePath.replace(/\\/g, "/");
       const absolutePath = `${memoryDir.replace(/\\/g, "/")}/${normalizedPath}`;
-      lines.push("<memory>");
-      lines.push(`<path>${absolutePath}</path>`);
-      lines.push(file.content);
-      lines.push("</memory>");
+      const prefix = ["<memory>", `<path>${absolutePath}</path>`];
+      const suffix = ["</memory>"];
+      const fullEntry = [...prefix, file.content, ...suffix];
+
+      if (canAppendWithinBudget(lines, fullEntry, maxChars)) {
+        lines.push(...fullEntry);
+        continue;
+      }
+
+      const truncatedNotice = buildMemoryPreviewNotice(
+        normalizedPath,
+        absolutePath,
+        "truncated",
+      );
+      const truncatedContent = truncateMemoryContentToFit(
+        lines,
+        prefix,
+        file.content,
+        [truncatedNotice, ...suffix],
+        maxChars,
+      );
+
+      if (truncatedContent) {
+        const truncatedEntry = [
+          ...prefix,
+          truncatedContent,
+          truncatedNotice,
+          ...suffix,
+        ];
+        if (canAppendWithinBudget(lines, truncatedEntry, maxChars)) {
+          lines.push(...truncatedEntry);
+          continue;
+        }
+      }
+
+      const omittedEntry = [
+        ...prefix,
+        buildMemoryPreviewNotice(normalizedPath, absolutePath, "omitted"),
+        ...suffix,
+      ];
+      if (canAppendWithinBudget(lines, omittedEntry, maxChars)) {
+        lines.push(...omittedEntry);
+      } else {
+        omittedSystemFiles += 1;
+      }
+    }
+
+    if (omittedSystemFiles > 0) {
+      const notice = `[Memory preview omitted ${omittedSystemFiles.toLocaleString()} additional system file(s) because the reflection startup context budget was exhausted. Read files directly from ${memoryDir} if needed.]`;
+      if (canAppendWithinBudget(lines, [notice], maxChars)) {
+        lines.push(notice);
+      }
     }
   }
 

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import type { SubagentConfig } from "../../agent/subagents";
 import {
+  estimateStartupContextTokens,
+  REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT,
+} from "../../agent/subagents/contextBudget";
+import {
   buildSubagentArgs,
   resolveSubagentLauncher,
   resolveSubagentModel,
@@ -232,6 +236,42 @@ describe("buildSubagentArgs", () => {
 
     expect(args).toContain("--permission-mode");
     expect(args).toContain("memory");
+  });
+
+  test("caps reflection system prompt plus initial message to startup budget", () => {
+    const systemPrompt = "system ".repeat(1_000);
+    const memoryPreview = `<parent_memory>\n<memory_filesystem>\n/memory/\n└── system/\n</memory_filesystem>\n${"memory ".repeat(40_000)}\n</parent_memory>`;
+    const userPrompt = `Review transcript at /tmp/payload.json\n\n${memoryPreview}`;
+
+    const args = buildSubagentArgs(
+      "reflection",
+      { ...baseConfig, name: "reflection", systemPrompt },
+      null,
+      userPrompt,
+    );
+    const promptArg = args[args.indexOf("-p") + 1] ?? "";
+
+    expect(
+      estimateStartupContextTokens(`${systemPrompt}\n${promptArg}`),
+    ).toBeLessThanOrEqual(REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT);
+    expect(promptArg).toContain("Review transcript at /tmp/payload.json");
+    expect(promptArg).toContain("<parent_memory>");
+    expect(promptArg).toContain("<memory_filesystem>");
+    expect(promptArg).toContain("Reflection startup context truncated");
+    expect(promptArg.length).toBeLessThan(userPrompt.length);
+  });
+
+  test("does not cap non-reflection initial messages", () => {
+    const longPrompt = "prompt ".repeat(40_000);
+    const args = buildSubagentArgs(
+      "general-purpose",
+      baseConfig,
+      null,
+      longPrompt,
+    );
+    const promptArg = args[args.indexOf("-p") + 1] ?? "";
+
+    expect(promptArg).toBe(longPrompt);
   });
 });
 

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -4,6 +4,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
+  estimateStartupContextTokens,
+  REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT,
+  REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT,
+} from "../../agent/subagents/contextBudget";
+import {
   appendTranscriptDeltaJsonl,
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
@@ -291,6 +296,42 @@ describe("reflectionTranscript helper", () => {
     expect(snapshot).toContain("users/");
     expect(snapshot).toContain("… (7 more entries)");
     expect(snapshot).not.toContain("user_09.md");
+  });
+
+  test("buildParentMemorySnapshot truncates large system memory previews", async () => {
+    const memoryDir = join(testRoot, "memory-large-system");
+    const normalizedMemoryDir = memoryDir.replace(/\\/g, "/");
+    await mkdir(join(memoryDir, "system"), { recursive: true });
+
+    const largeContent = `---\ndescription: Large system memory\n---\nSTART\n${"x".repeat(60_000)}\nEND_SHOULD_BE_TRUNCATED\n`;
+    await writeFile(
+      join(memoryDir, "system", "large.md"),
+      largeContent,
+      "utf-8",
+    );
+    await writeFile(
+      join(memoryDir, "system", "small.md"),
+      "---\ndescription: Small system memory\n---\nsmall content\n",
+      "utf-8",
+    );
+
+    const snapshot = await buildParentMemorySnapshot(memoryDir);
+
+    expect(snapshot.length).toBeLessThanOrEqual(
+      REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT,
+    );
+    expect(estimateStartupContextTokens(snapshot)).toBeLessThanOrEqual(
+      REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT,
+    );
+    expect(snapshot).toContain("<memory_filesystem>");
+    expect(snapshot).toContain("large.md");
+    expect(snapshot).toContain(
+      `<path>${normalizedMemoryDir}/system/large.md</path>`,
+    );
+    expect(snapshot).toContain("START");
+    expect(snapshot).toContain("Memory preview truncated");
+    expect(snapshot).not.toContain("END_SHOULD_BE_TRUNCATED");
+    expect(snapshot).toContain("</parent_memory>");
   });
 
   test("buildReflectionSubagentPrompt uses expanded reflection instructions", () => {


### PR DESCRIPTION
## Summary
- Add a shared reflection startup context budget and conservative token estimator.
- Truncate large parent memory previews while preserving memory tree/path access for reflection agents.
- Add a final reflection-only launch guard so system prompt + initial message stays under the 16k estimated token cap.

## Test plan
- [x] `bun test src/tests/cli/reflection-transcript.test.ts`
- [x] `bun test src/tests/agent/subagent-model-resolution.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/agent/subagents/contextBudget.ts src/agent/subagents/manager.ts src/cli/helpers/reflectionTranscript.ts src/tests/cli/reflection-transcript.test.ts src/tests/agent/subagent-model-resolution.test.ts`
- [ ] `bun run check` — attempted; still fails on existing repo-wide type/dependency issues unrelated to this change (`bun:test`, `ws`, `ink`, Slack/Telegram deps, SDK typing mismatches).

👾 Generated with [Letta Code](https://letta.com)