### PR TITLE
fix: re-root file index when CWD is a git worktree

### DIFF
--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { realpath, stat } from "node:fs/promises";
+import { lstat, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
@@ -282,6 +282,21 @@ type ChannelsServiceModule = typeof import("../../channels/service");
 let channelsServiceLoaderOverride:
   | null
   | (() => Promise<ChannelsServiceModule>) = null;
+
+/**
+ * Detect whether a directory is a git worktree root.
+ * Worktrees have a `.git` **file** (not directory) that points to the main
+ * repo's `.git/worktrees/<name>`.  This distinguishes them from normal repos
+ * where `.git` is a directory.
+ */
+async function isGitWorktreeRoot(dir: string): Promise<boolean> {
+  try {
+    const stats = await lstat(path.join(dir, ".git"));
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+}
 
 async function loadChannelsService(): Promise<ChannelsServiceModule> {
   if (channelsServiceLoaderOverride) {
@@ -3793,12 +3808,16 @@ async function handleCwdChange(
     runtime.reminderState.hasSentSessionContext = false;
     runtime.reminderState.pendingSessionContextReason = "cwd_changed";
 
-    // If the new cwd is outside the current file-index root, re-root the
-    // index so file search covers the new workspace.  setIndexRoot()
-    // triggers a non-blocking rebuild and does NOT mutate process.cwd(),
-    // keeping concurrent conversations safe.
+    // If the new cwd is outside the current file-index root, or is a git
+    // worktree nested under it, re-root the index so file search covers
+    // the new workspace.  setIndexRoot() triggers a non-blocking rebuild
+    // and does NOT mutate process.cwd(), keeping concurrent conversations safe.
     const currentRoot = getIndexRoot();
-    if (!normalizedPath.startsWith(currentRoot)) {
+    const needsReroot =
+      !normalizedPath.startsWith(currentRoot) ||
+      (normalizedPath !== currentRoot &&
+        (await isGitWorktreeRoot(normalizedPath)));
+    if (needsReroot) {
       setIndexRoot(normalizedPath);
     }
 
@@ -4475,10 +4494,12 @@ async function connectWithRetry(
             // the search covers the correct workspace.
             if (parsed.cwd) {
               const currentRoot = getIndexRoot();
-              if (
-                !parsed.cwd.startsWith(currentRoot + path.sep) &&
-                parsed.cwd !== currentRoot
-              ) {
+              const needsReroot =
+                (!parsed.cwd.startsWith(currentRoot + path.sep) &&
+                  parsed.cwd !== currentRoot) ||
+                (parsed.cwd !== currentRoot &&
+                  (await isGitWorktreeRoot(parsed.cwd)));
+              if (needsReroot) {
                 setIndexRoot(parsed.cwd);
               }
             }


### PR DESCRIPTION
When the CWD is a git worktree nested under the main repo (e.g. .letta/worktrees/my-feature), the startsWith guard prevented setIndexRoot() from being called — the worktree path starts with the main repo root. Combined with .letta being in the default .lettaignore, this meant worktree files were never indexed.

Add isGitWorktreeRoot() that detects worktrees by checking if .git is a file (not a directory). Both setIndexRoot guard sites now re-root when the CWD is a different git worktree.

🐾 Generated with [Letta Code](https://letta.com)