### PR TITLE
perf: cache agent across TUI while-loop iterations

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2179,7 +2179,7 @@ export default function App({
     releaseToolExecutionContext(contextId);
   }, []);
   const prepareScopedToolExecutionContext = useCallback(
-    async (overrideModel?: string | null) => {
+    async (overrideModel?: string | null, cachedAgent?: AgentState | null) => {
       const workingDirectory = getCurrentWorkingDirectory();
       const desiredModel = overrideModel ?? currentModelHandle;
 
@@ -2189,6 +2189,7 @@ export default function App({
           conversationId: conversationIdRef.current,
           overrideModel: desiredModel,
           workingDirectory,
+          cachedAgent,
         });
       }
 
@@ -4352,10 +4353,13 @@ export default function App({
             null;
           let turnToolContextId: string | null = null;
           let preStreamResumeResult: DrainResult | null = null;
+          let prefetchedAgent: AgentState | null = null;
           try {
             const preparedToolContext = await prepareScopedToolExecutionContext(
               tempModelOverrideRef.current ?? undefined,
+              prefetchedAgent,
             );
+            prefetchedAgent = preparedToolContext.agent;
             const nextStream = await sendMessageStream(
               conversationIdRef.current,
               currentInput,
@@ -5447,6 +5451,7 @@ export default function App({
                 (
                   await prepareScopedToolExecutionContext(
                     tempModelOverrideRef.current ?? undefined,
+                    prefetchedAgent,
                   )
                 ).preparedToolContext.contextId;
               autoAllowedResults =

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4306,6 +4306,7 @@ export default function App({
         }
 
         let highestSeqIdSeen: number | null = null;
+        let prefetchedAgent: AgentState | null = null;
 
         while (true) {
           // Capture the signal BEFORE any async operations
@@ -4353,7 +4354,6 @@ export default function App({
             null;
           let turnToolContextId: string | null = null;
           let preStreamResumeResult: DrainResult | null = null;
-          let prefetchedAgent: AgentState | null = null;
           try {
             const preparedToolContext = await prepareScopedToolExecutionContext(
               tempModelOverrideRef.current ?? undefined,


### PR DESCRIPTION
## Problem

In the TUI's `submitUserMessage` while loop, `prepareScopedToolExecutionContext` calls `agents.retrieve` on every iteration. A turn with 3 tool-call rounds makes 3 redundant fetches — the agent state doesn't change mid-turn.

## Fix

Pass `prefetchedAgent` (cached from the first iteration) to subsequent `prepareScopedToolExecutionContext` calls. First iteration fetches fresh (prefetchedAgent is null), subsequent iterations reuse the cache.

Changes:
- Add `let prefetchedAgent: AgentState | null = null;` alongside the other `let` declarations before the try block
- Pass `prefetchedAgent` as the second argument to the main `prepareScopedToolExecutionContext` call inside the try block
- After that call, set `prefetchedAgent = preparedToolContext.agent;` to cache the result
- Update `prepareScopedToolExecutionContext` useCallback to accept `cachedAgent?: AgentState | null` and forward it to `prepareToolExecutionContextForScope`
- Pass `prefetchedAgent` to the auto-approval `prepareScopedToolExecutionContext` call as well

## Result

TUI multi-tool turns reduced from N `agents.retrieve` calls to 1. Verified with `LETTA_COUNT_CALLS=1` instrumentation.

## Note

Does NOT cache across the approval boundary (`sendAllResults`/`handleApproveCurrent` callbacks) — a fresh fetch on approval response is correct behavior since the user may have changed the model while reviewing the prompt.

Depends on #1983 (`caren/cache-agent-in-headless-loop`) which added `cachedAgent` support to `prepareToolExecutionContextForScope`.