### PR TITLE
fix: support self-hosted channel listeners

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -1,6 +1,7 @@
 /**
  * CLI subcommand: letta server --name \"george\"
- * Register letta-code as a listener to receive messages from Letta Cloud
+ * Register letta-code as a Cloud listener, or run local channel adapters for
+ * self-hosted servers.
  */
 
 import { hostname } from "node:os";
@@ -54,6 +55,11 @@ class MissingListenerApiKeyError extends Error {
   }
 }
 
+type ListenerStartupMode =
+  | { kind: "remote"; serverUrl: string }
+  | { kind: "local-channels"; serverUrl: string }
+  | { kind: "unsupported-self-hosted"; serverUrl: string };
+
 /**
  * Interactive prompt for environment name
  */
@@ -104,6 +110,34 @@ function getListenerServerUrl(settings: {
     settings.env?.LETTA_BASE_URL ||
     oauthDeps.LETTA_CLOUD_API_URL
   );
+}
+
+function normalizeListenerBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function isCloudListenerServerUrl(serverUrl: string): boolean {
+  return (
+    normalizeListenerBaseUrl(serverUrl) ===
+    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
+  );
+}
+
+async function resolveListenerStartupMode(
+  channelNames: string[],
+): Promise<ListenerStartupMode> {
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const serverUrl = getListenerServerUrl(settings);
+
+  if (isCloudListenerServerUrl(serverUrl)) {
+    return { kind: "remote", serverUrl };
+  }
+
+  if (channelNames.length > 0) {
+    return { kind: "local-channels", serverUrl };
+  }
+
+  return { kind: "unsupported-self-hosted", serverUrl };
 }
 
 async function refreshListenerAccessToken(
@@ -245,7 +279,9 @@ async function resolveListenerRegistrationOptions(
 export const __listenSubcommandTestUtils = {
   flushListenerTelemetryEnd,
   getListenerServerUrl,
+  isCloudListenerServerUrl,
   resolveListenerRegistrationOptions,
+  resolveListenerStartupMode,
   setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
     listenerOAuthDepsOverride = overrides
       ? {
@@ -278,7 +314,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       "Usage: letta server [--env-name <name>] [--channels <list>] [--debug]\n",
     );
     console.log(
-      "Register this letta-code instance to receive messages from Letta Cloud.\n",
+      "Register this letta-code instance for Letta Cloud remote control, or run local channels for self-hosted servers.\n",
     );
     console.log("Options:");
     console.log(
@@ -312,7 +348,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       "  letta server --debug                       # Log all WS events\n",
     );
     console.log(
-      "Once connected, this instance will listen for incoming messages from cloud agents.",
+      "Once connected, this instance will listen for incoming messages from cloud agents or local channel adapters.",
     );
     console.log(
       "Messages will be executed locally using your letta-code environment.",
@@ -430,6 +466,73 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   try {
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
+    const startupMode = await resolveListenerStartupMode(channelNames);
+
+    if (startupMode.kind === "unsupported-self-hosted") {
+      console.error(
+        `Self-hosted listener registration is not supported for ${startupMode.serverUrl}.`,
+      );
+      console.error(
+        "Start with --channels to run a local channel listener, or unset LETTA_BASE_URL to use Letta Cloud remote environments.",
+      );
+      await flushListenerTelemetryEnd("listener_self_hosted_no_channels");
+      return 1;
+    }
+
+    sessionLog.log(`Session started (debug=${debugMode})`);
+    sessionLog.log(`deviceId: ${deviceId}`);
+    sessionLog.log(`connectionName: ${connectionName}`);
+
+    if (startupMode.kind === "local-channels") {
+      const connectionId = `local-${deviceId}`;
+      sessionLog.log(
+        `Starting local channel listener for ${startupMode.serverUrl}`,
+      );
+      sessionLog.log("Skipping environment registration");
+      console.log(
+        `Starting local channel listener for self-hosted server ${startupMode.serverUrl}`,
+      );
+      console.log("Skipping environment registration. Press Ctrl+C to stop.\n");
+
+      const { startLocalChannelListener } = await import(
+        "../../websocket/listen-client"
+      );
+
+      await startLocalChannelListener({
+        connectionId,
+        deviceId,
+        connectionName,
+        onWsEvent:
+          process.env.LETTA_LOG_WS_EVENTS === "1"
+            ? (direction, label, event) => {
+                sessionLog.wsEvent(direction, label, event);
+              }
+            : undefined,
+        onStatusChange: (status) => {
+          sessionLog.log(`status: ${status}`);
+          if (debugMode) {
+            console.log(`[${formatTimestamp()}] status: ${status}`);
+          }
+        },
+        onConnected: () => {
+          sessionLog.log("Local channel listener ready.");
+          if (debugMode) {
+            console.log(`[${formatTimestamp()}] Local channel listener ready.`);
+            console.log("");
+          }
+        },
+        onError: (error: Error) => {
+          sessionLog.log(`Error: ${error.message}`);
+          console.error(`[${formatTimestamp()}] Error: ${error.message}`);
+          void exitWithTelemetry(1, "listener_error");
+        },
+      });
+
+      return new Promise<number>(() => {
+        // Never resolves - runs until Ctrl+C
+      });
+    }
+
     let registerOptions: RegisterOptions;
 
     try {
@@ -452,10 +555,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       await flushListenerTelemetryEnd("listener_oauth_failed");
       return 1;
     }
-
-    sessionLog.log(`Session started (debug=${debugMode})`);
-    sessionLog.log(`deviceId: ${deviceId}`);
-    sessionLog.log(`connectionName: ${connectionName}`);
 
     if (debugMode) {
       console.log(

--- a/src/tests/cli/listen-subcommand-auth.test.ts
+++ b/src/tests/cli/listen-subcommand-auth.test.ts
@@ -232,4 +232,57 @@ describe("listen subcommand auth resolution", () => {
     expect(requestDeviceCodeMock).not.toHaveBeenCalled();
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
+
+  test("uses local channel mode for self-hosted listeners with channels", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:8283";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      ["telegram"],
+    );
+
+    expect(result).toEqual({
+      kind: "local-channels",
+      serverUrl: "http://localhost:8283",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects self-hosted listener startup without channels", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:8283";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      [],
+    );
+
+    expect(result).toEqual({
+      kind: "unsupported-self-hosted",
+      serverUrl: "http://localhost:8283",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("uses remote registration mode for Cloud listeners with channels", async () => {
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      ["telegram"],
+    );
+
+    expect(result).toEqual({
+      kind: "remote",
+      serverUrl: "https://api.letta.com",
+    });
+  });
 });

--- a/src/tests/cli/listen-subcommand-telemetry.test.ts
+++ b/src/tests/cli/listen-subcommand-telemetry.test.ts
@@ -56,7 +56,7 @@ describe("listen subcommand telemetry", () => {
     telemetry.flush = originalFlush;
   });
 
-  test("tracks and flushes session end on missing API key", async () => {
+  test("tracks and flushes session end on self-hosted listener without channels", async () => {
     const trackSessionEndMock = mock(() => {});
     const flushMock = mock(async () => {});
     telemetry.trackSessionEnd =
@@ -69,7 +69,7 @@ describe("listen subcommand telemetry", () => {
     expect(exitCode).toBe(1);
     expect(trackSessionEndMock).toHaveBeenCalledWith(
       undefined,
-      "listener_missing_api_key",
+      "listener_self_hosted_no_channels",
     );
     expect(flushMock).toHaveBeenCalledTimes(1);
   });

--- a/src/tests/websocket/listen-local-channel-listener.test.ts
+++ b/src/tests/websocket/listen-local-channel-listener.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { telemetry } from "../../telemetry";
+import {
+  isListenerActive,
+  startLocalChannelListener,
+  stopListenerClient,
+} from "../../websocket/listen-client";
+
+describe("local channel listener", () => {
+  const originalTelemetryInit = telemetry.init;
+
+  beforeEach(() => {
+    telemetry.init = mock(() => {}) as typeof telemetry.init;
+  });
+
+  afterEach(() => {
+    stopListenerClient();
+    telemetry.init = originalTelemetryInit;
+  });
+
+  test("starts an active listener runtime without a remote WebSocket", async () => {
+    const connectedConnectionIds: string[] = [];
+
+    await startLocalChannelListener({
+      connectionId: "local-test-device",
+      deviceId: "test-device",
+      connectionName: "self-hosted-test",
+      startCronScheduler: false,
+      onConnected: (connectionId) => {
+        connectedConnectionIds.push(connectionId);
+      },
+      onStatusChange: () => {},
+      onError: (error) => {
+        throw error;
+      },
+    });
+
+    expect(connectedConnectionIds).toEqual(["local-test-device"]);
+    expect(isListenerActive()).toBe(true);
+
+    stopListenerClient();
+    expect(isListenerActive()).toBe(false);
+  });
+});

--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -4,6 +4,7 @@
  * Implementation lives under `src/websocket/listener/`.
  */
 
+export type { StartLocalChannelListenerOptions } from "./listener/client";
 export {
   __listenClientTestUtils,
   emitInterruptedStatusDelta,
@@ -13,5 +14,6 @@ export {
   requestApprovalOverWS,
   resolvePendingApprovalResolver,
   startListenerClient,
+  startLocalChannelListener,
   stopListenerClient,
 } from "./listener/client";

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -3468,6 +3468,210 @@ type ProcessQueuedTurn = (
   dequeuedBatch: DequeuedBatch,
 ) => Promise<void>;
 
+export type StartLocalChannelListenerOptions = Omit<
+  StartListenerOptions,
+  "wsUrl" | "onDisconnected" | "onNeedsReregister" | "onRetrying"
+> & {
+  startCronScheduler?: boolean;
+};
+
+function createLocalNoopSocket(): WebSocket {
+  const socket: {
+    readyState: number;
+    bufferedAmount: number;
+    send: () => void;
+    close: () => void;
+    removeAllListeners: () => unknown;
+  } = {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: 0,
+    send: () => {},
+    close() {
+      this.readyState = WebSocket.CLOSED;
+    },
+    removeAllListeners() {
+      return this;
+    },
+  };
+  return socket as unknown as WebSocket;
+}
+
+function buildProcessQueuedTurn(
+  runtime: ListenerRuntime,
+  socket: WebSocket,
+  opts: Pick<StartListenerOptions, "onStatusChange" | "connectionId">,
+): ProcessQueuedTurn {
+  return async (
+    queuedTurn: IncomingMessage,
+    dequeuedBatch: DequeuedBatch,
+  ): Promise<void> => {
+    const scopedRuntime = getOrCreateScopedRuntime(
+      runtime,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      socket,
+      scopedRuntime,
+      opts.onStatusChange,
+      opts.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+}
+
+async function initializeConnectedListenerRuntime(
+  runtime: ListenerRuntime,
+  socket: WebSocket,
+  opts: StartListenerOptions,
+  processQueuedTurn: ProcessQueuedTurn,
+  options: { startHeartbeat: boolean; startCronScheduler: boolean },
+): Promise<void> {
+  if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+    return;
+  }
+
+  safeEmitWsEvent("recv", "lifecycle", { type: "_ws_open" });
+  runtime.hasSuccessfulConnection = true;
+  runtime.everConnected = true;
+  opts.onConnected(opts.connectionId);
+
+  if (runtime.conversationRuntimes.size === 0) {
+    // Don't emit device_status before the lookup store exists.
+    // Without a conversation runtime, the scope resolves to
+    // agent:__unknown__ which misses persisted CWD and permission
+    // mode entries. The web's sync command will create a scoped
+    // runtime and emit a properly-scoped device_status at that point.
+    emitLoopStatusUpdate(socket, runtime);
+  } else {
+    for (const reminderState of runtime.reminderStateByConversation.values()) {
+      // Reset bootstrap reminder state on (re)connect so session-context
+      // and agent-info fire on the first turn of the new connection.
+      // This is intentionally in the open handler, NOT the sync handler,
+      // because the Desktop UMI controller sends sync every ~5 s and
+      // resetting there would re-arm reminders on every periodic sync.
+      resetSharedReminderState(reminderState);
+    }
+    for (const contextTracker of runtime.contextTrackerByConversation.values()) {
+      resetContextHistory(contextTracker);
+    }
+    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+      const scope = {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      };
+      emitDeviceStatusUpdate(socket, conversationRuntime, scope);
+      emitLoopStatusUpdate(socket, conversationRuntime, scope);
+    }
+  }
+
+  // Subscribe to subagent state changes and emit snapshots over WS.
+  // Store the unsubscribe function on the runtime for cleanup on close.
+  runtime._unsubscribeSubagentState?.();
+  runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
+    if (runtime.conversationRuntimes.size === 0) {
+      emitSubagentStateIfOpen(runtime);
+      return;
+    }
+
+    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+      emitSubagentStateIfOpen(runtime, {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      });
+    }
+  });
+
+  // Subscribe to subagent stream events and forward as tagged stream_delta.
+  // Events are raw JSON lines from the subagent's stdout (headless format):
+  //   { type: "message", message_type, ...LettaStreamingResponse fields }
+  // These are already MessageDelta-shaped (type:"message" + LettaStreamingResponse).
+  runtime._unsubscribeSubagentStreamEvents?.();
+  runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
+    (subagentId, event) => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+
+      const subagent = getSubagents().find((entry) => entry.id === subagentId);
+      if (subagent?.silent === true) {
+        // Reflection/background "silent" subagents should not stream their
+        // internal transcript into the parent conversation.
+        return;
+      }
+
+      // The event has { type: "message", message_type, ...LettaStreamingResponse }
+      // plus extra headless fields (session_id, uuid) that pass through harmlessly.
+      emitStreamDelta(
+        socket,
+        runtime,
+        event as unknown as import("../../types/protocol_v2").StreamDelta,
+        subagent?.parentAgentId
+          ? {
+              agent_id: subagent.parentAgentId,
+              conversation_id: subagent.parentConversationId ?? "default",
+            }
+          : undefined,
+        subagentId,
+      );
+    },
+  );
+
+  // Register the message queue bridge to route task notifications into the
+  // correct per-conversation QueueRuntime. This enables background Task
+  // completions to reach the agent in listen mode.
+  setMessageQueueAdder((queuedMessage) => {
+    const targetRuntime =
+      queuedMessage.agentId && queuedMessage.conversationId
+        ? getOrCreateScopedRuntime(
+            runtime,
+            queuedMessage.agentId,
+            queuedMessage.conversationId,
+          )
+        : findFallbackRuntime(runtime);
+
+    if (!targetRuntime?.queueRuntime) {
+      return; // No target — notification dropped
+    }
+
+    targetRuntime.queueRuntime.enqueue({
+      kind: "task_notification",
+      source: "task_notification",
+      text: queuedMessage.text,
+      agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
+      conversationId:
+        queuedMessage.conversationId ?? targetRuntime.conversationId,
+    } as Omit<
+      import("../../queue/queueRuntime").TaskNotificationQueueItem,
+      "id" | "enqueuedAt"
+    >);
+
+    // Kick the queue pump so the notification can trigger a standalone turn
+    // (see consumeQueuedTurn notification-aware path in queue.ts).
+    scheduleQueuePump(targetRuntime, socket, opts, processQueuedTurn);
+  });
+
+  if (options.startHeartbeat) {
+    runtime.heartbeatInterval = setInterval(() => {
+      if (socket.readyState === WebSocket.OPEN) {
+        safeSocketSend(
+          socket,
+          { type: "ping" },
+          "listener_ping_send_failed",
+          "listener_heartbeat",
+        );
+      }
+    }, 30000);
+  }
+
+  if (options.startCronScheduler) {
+    // Start cron scheduler if tasks exist
+    startCronScheduler(socket, opts, processQueuedTurn);
+  }
+
+  // Wire channel ingress (if channels are active)
+  await wireChannelIngress(runtime, socket, opts, processQueuedTurn);
+}
+
 async function handleApprovalResponseInput(
   listener: ListenerRuntime,
   params: {
@@ -4078,6 +4282,51 @@ export async function startListenerClient(
   await connectWithRetry(runtime, opts);
 }
 
+export async function startLocalChannelListener(
+  opts: StartLocalChannelListenerOptions,
+): Promise<void> {
+  // Replace any existing runtime without stale callback leakage.
+  const existingRuntime = getActiveRuntime();
+  if (existingRuntime) {
+    stopRuntime(existingRuntime, true);
+  }
+
+  const runtime = createRuntime();
+  runtime.onWsEvent = opts.onWsEvent;
+  runtime.connectionId = opts.connectionId;
+  runtime.connectionName = opts.connectionName;
+  setActiveRuntime(runtime);
+  telemetry.setSurface("websocket");
+  telemetry.init();
+
+  await loadTools();
+
+  const socket = createLocalNoopSocket();
+  runtime.socket = socket;
+
+  const listenerOpts: StartListenerOptions = {
+    ...opts,
+    wsUrl: "local://channels",
+    onDisconnected: () => {},
+  };
+  const processQueuedTurn = buildProcessQueuedTurn(
+    runtime,
+    socket,
+    listenerOpts,
+  );
+
+  await initializeConnectedListenerRuntime(
+    runtime,
+    socket,
+    listenerOpts,
+    processQueuedTurn,
+    {
+      startHeartbeat: false,
+      startCronScheduler: opts.startCronScheduler !== false,
+    },
+  );
+}
+
 /** File/directory names filtered from directory listings (OS/VCS noise). */
 const DIR_LISTING_IGNORED_NAMES = new Set([".DS_Store", ".git", "Thumbs.db"]);
 
@@ -4242,165 +4491,18 @@ async function connectWithRetry(
   const cancelledWatches = new Set<string>();
 
   runtime.socket = socket;
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn: IncomingMessage,
-    dequeuedBatch: DequeuedBatch,
-  ): Promise<void> => {
-    const scopedRuntime = getOrCreateScopedRuntime(
+  const processQueuedTurn = buildProcessQueuedTurn(runtime, socket, opts);
+
+  socket.on("open", () => {
+    initializeConnectedListenerRuntime(
       runtime,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
       socket,
-      scopedRuntime,
-      opts.onStatusChange,
-      opts.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
-
-  socket.on("open", async () => {
-    if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
-      return;
-    }
-
-    safeEmitWsEvent("recv", "lifecycle", { type: "_ws_open" });
-    runtime.hasSuccessfulConnection = true;
-    runtime.everConnected = true;
-    opts.onConnected(opts.connectionId);
-
-    if (runtime.conversationRuntimes.size === 0) {
-      // Don't emit device_status before the lookup store exists.
-      // Without a conversation runtime, the scope resolves to
-      // agent:__unknown__ which misses persisted CWD and permission
-      // mode entries. The web's sync command will create a scoped
-      // runtime and emit a properly-scoped device_status at that point.
-      emitLoopStatusUpdate(socket, runtime);
-    } else {
-      for (const reminderState of runtime.reminderStateByConversation.values()) {
-        // Reset bootstrap reminder state on (re)connect so session-context
-        // and agent-info fire on the first turn of the new connection.
-        // This is intentionally in the open handler, NOT the sync handler,
-        // because the Desktop UMI controller sends sync every ~5 s and
-        // resetting there would re-arm reminders on every periodic sync.
-        resetSharedReminderState(reminderState);
-      }
-      for (const contextTracker of runtime.contextTrackerByConversation.values()) {
-        resetContextHistory(contextTracker);
-      }
-      for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-        const scope = {
-          agent_id: conversationRuntime.agentId,
-          conversation_id: conversationRuntime.conversationId,
-        };
-        emitDeviceStatusUpdate(socket, conversationRuntime, scope);
-        emitLoopStatusUpdate(socket, conversationRuntime, scope);
-      }
-    }
-
-    // Subscribe to subagent state changes and emit snapshots over WS.
-    // Store the unsubscribe function on the runtime for cleanup on close.
-    runtime._unsubscribeSubagentState?.();
-    runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
-      if (runtime.conversationRuntimes.size === 0) {
-        emitSubagentStateIfOpen(runtime);
-        return;
-      }
-
-      for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-        emitSubagentStateIfOpen(runtime, {
-          agent_id: conversationRuntime.agentId,
-          conversation_id: conversationRuntime.conversationId,
-        });
-      }
+      opts,
+      processQueuedTurn,
+      { startHeartbeat: true, startCronScheduler: true },
+    ).catch((error: unknown) => {
+      opts.onError(error instanceof Error ? error : new Error(String(error)));
     });
-
-    // Subscribe to subagent stream events and forward as tagged stream_delta.
-    // Events are raw JSON lines from the subagent's stdout (headless format):
-    //   { type: "message", message_type: "tool_call_message", ...LettaStreamingResponse fields }
-    // These are already MessageDelta-shaped (type:"message" + LettaStreamingResponse).
-    runtime._unsubscribeSubagentStreamEvents?.();
-    runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
-      (subagentId, event) => {
-        if (socket.readyState !== WebSocket.OPEN) return;
-
-        const subagent = getSubagents().find(
-          (entry) => entry.id === subagentId,
-        );
-        if (subagent?.silent === true) {
-          // Reflection/background "silent" subagents should not stream their
-          // internal transcript into the parent conversation.
-          return;
-        }
-
-        // The event has { type: "message", message_type, ...LettaStreamingResponse }
-        // plus extra headless fields (session_id, uuid) that pass through harmlessly.
-        emitStreamDelta(
-          socket,
-          runtime,
-          event as unknown as import("../../types/protocol_v2").StreamDelta,
-          subagent?.parentAgentId
-            ? {
-                agent_id: subagent.parentAgentId,
-                conversation_id: subagent.parentConversationId ?? "default",
-              }
-            : undefined,
-          subagentId,
-        );
-      },
-    );
-
-    // Register the message queue bridge to route task notifications into the
-    // correct per-conversation QueueRuntime. This enables background Task
-    // completions to reach the agent in listen mode.
-    setMessageQueueAdder((queuedMessage) => {
-      const targetRuntime =
-        queuedMessage.agentId && queuedMessage.conversationId
-          ? getOrCreateScopedRuntime(
-              runtime,
-              queuedMessage.agentId,
-              queuedMessage.conversationId,
-            )
-          : findFallbackRuntime(runtime);
-
-      if (!targetRuntime?.queueRuntime) {
-        return; // No target — notification dropped
-      }
-
-      targetRuntime.queueRuntime.enqueue({
-        kind: "task_notification",
-        source: "task_notification",
-        text: queuedMessage.text,
-        agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
-        conversationId:
-          queuedMessage.conversationId ?? targetRuntime.conversationId,
-      } as Omit<
-        import("../../queue/queueRuntime").TaskNotificationQueueItem,
-        "id" | "enqueuedAt"
-      >);
-
-      // Kick the queue pump so the notification can trigger a standalone turn
-      // (see consumeQueuedTurn notification-aware path in queue.ts).
-      scheduleQueuePump(targetRuntime, socket, opts, processQueuedTurn);
-    });
-    runtime.heartbeatInterval = setInterval(() => {
-      if (socket.readyState === WebSocket.OPEN) {
-        safeSocketSend(
-          socket,
-          { type: "ping" },
-          "listener_ping_send_failed",
-          "listener_heartbeat",
-        );
-      }
-    }, 30000);
-
-    // Start cron scheduler if tasks exist
-    startCronScheduler(socket, opts, processQueuedTurn);
-
-    // Wire channel ingress (if channels are active)
-    await wireChannelIngress(runtime, socket, opts, processQueuedTurn);
   });
 
   socket.on("message", async (data: WebSocket.RawData) => {


### PR DESCRIPTION
## Summary
- Adds a local channel listener path for non-Cloud `LETTA_BASE_URL` when channels are enabled.
- Skips Cloud environment registration while reusing the existing listener queue, approvals, and `MessageChannel` pipeline.
- Keeps Cloud listener registration behavior unchanged and improves the self-hosted no-channel error.

"Small bridges should not require a control tower."

Written by Cameron ◯ Letta Code