### PR TITLE
feat: runtime experiment toggles for node

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -211,6 +211,20 @@ export function getMemfsServerUrl(): string {
   return LETTA_CLOUD_API_URL;
 }
 
+export function getClientDefaultHeaders(): Record<string, string> {
+  const nodeExperiment = experimentManager.getSnapshot("node");
+
+  return {
+    "X-Letta-Source": "letta-code",
+    "User-Agent": `letta-code/${packageJson.version}`,
+    ...(nodeExperiment.source === "override"
+      ? { "x-letta-node": nodeExperiment.enabled ? "1" : "0" }
+      : nodeExperiment.enabled
+        ? { "x-letta-node": "1" }
+        : {}),
+  };
+}
+
 export async function getClient() {
   if (_testClientOverride) {
     return (await _testClientOverride()) as Letta;
@@ -318,22 +332,12 @@ export async function getClient() {
 
   // Note: ChatGPT OAuth token refresh is handled by the Letta backend
   // when using the chatgpt_oauth provider type
-  const nodeExperiment = experimentManager.getSnapshot("node");
-
   return new Letta({
     apiKey,
     baseURL,
     logger: sdkLogger,
     timeout: Number(process.env.LETTA_REQUEST_TIMEOUT_MS) || 10 * 60 * 1000, // default 10 min; override via env for slow local inference
-    defaultHeaders: {
-      "X-Letta-Source": "letta-code",
-      "User-Agent": `letta-code/${packageJson.version}`,
-      ...(nodeExperiment.source === "override"
-        ? { "x-letta-node": nodeExperiment.enabled ? "1" : "0" }
-        : nodeExperiment.enabled
-          ? { "x-letta-node": "1" }
-          : {}),
-    },
+    defaultHeaders: getClientDefaultHeaders(),
     // Use instrumented fetch for timing logs when LETTA_DEBUG_TIMINGS is enabled
     ...(isTimingsEnabled() && { fetch: createTimingFetch(fetch) }),
   });

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -2,6 +2,7 @@ import { hostname } from "node:os";
 import Letta from "@letta-ai/letta-client";
 import packageJson from "../../package.json";
 import { LETTA_CLOUD_API_URL, refreshAccessToken } from "../auth/oauth";
+import { experimentManager } from "../experiments/manager";
 import { type Settings, settingsManager } from "../settings-manager";
 import { trackBoundaryError } from "../telemetry/errorReporting";
 import { isDebugEnabled } from "../utils/debug";
@@ -317,6 +318,7 @@ export async function getClient() {
 
   // Note: ChatGPT OAuth token refresh is handled by the Letta backend
   // when using the chatgpt_oauth provider type
+  const nodeExperiment = experimentManager.getSnapshot("node");
 
   return new Letta({
     apiKey,
@@ -326,9 +328,11 @@ export async function getClient() {
     defaultHeaders: {
       "X-Letta-Source": "letta-code",
       "User-Agent": `letta-code/${packageJson.version}`,
-      ...(process.env.LETTA_NODE === "1" && {
-        "x-letta-node": "1",
-      }),
+      ...(nodeExperiment.source === "override"
+        ? { "x-letta-node": nodeExperiment.enabled ? "1" : "0" }
+        : nodeExperiment.enabled
+          ? { "x-letta-node": "1" }
+          : {}),
     },
     // Use instrumented fetch for timing logs when LETTA_DEBUG_TIMINGS is enabled
     ...(isTimingsEnabled() && { fetch: createTimingFetch(fetch) }),

--- a/src/agent/reconcileExistingAgentState.ts
+++ b/src/agent/reconcileExistingAgentState.ts
@@ -28,23 +28,6 @@ export interface ReconcileAgentStateResult {
   skippedTweaks: string[];
 }
 
-function areToolSetsEqual(
-  currentToolIds: string[],
-  desiredToolIds: string[],
-): boolean {
-  if (currentToolIds.length !== desiredToolIds.length) {
-    return false;
-  }
-
-  const currentSet = new Set(currentToolIds);
-  for (const toolId of desiredToolIds) {
-    if (!currentSet.has(toolId)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function getToolName(tool: Tool): string {
   if (typeof tool.name !== "string") {
     return "";

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -6,7 +6,6 @@ import {
 } from "./config";
 import type {
   ChannelAccount,
-  DiscordChannelAccount,
   SlackChannelAccount,
   SlackDefaultPermissionMode,
   SupportedChannelId,

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -138,7 +138,6 @@ interface DiscordClient {
 
 type DiscordMessage = DiscordMessageLike;
 
-const DISCORD_MAX_LENGTH = 2000;
 const DISCORD_SPLIT_THRESHOLD = 1900;
 const INGRESS_DEDUPE_TTL_MS = 60_000;
 const INGRESS_DEDUPE_MAX = 2_000;

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -86,6 +86,8 @@ import {
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from "../constants";
+import { experimentManager } from "../experiments/manager";
+import type { ExperimentId } from "../experiments/types";
 import {
   runNotificationHooks,
   runPreCompactHooks,
@@ -94,8 +96,6 @@ import {
   runStopHooks,
   runUserPromptSubmitHooks,
 } from "../hooks";
-import { experimentManager } from "../experiments/manager";
-import type { ExperimentId } from "../experiments/types";
 import type { ApprovalContext } from "../permissions/analyzer";
 import { formatPermissionDenial } from "../permissions/formatDenial";
 import { type PermissionMode, permissionMode } from "../permissions/mode";
@@ -181,8 +181,8 @@ import { ConversationSelector } from "./components/ConversationSelector";
 import { colors } from "./components/colors";
 // EnterPlanModeDialog removed - now using InlineEnterPlanModeApproval
 import { ErrorMessage } from "./components/ErrorMessageRich";
-import { ExperimentSelector } from "./components/ExperimentSelector";
 import { EventMessage } from "./components/EventMessage";
+import { ExperimentSelector } from "./components/ExperimentSelector";
 import { FeedbackDialog } from "./components/FeedbackDialog";
 import { HelpDialog } from "./components/HelpDialog";
 import { HooksManager } from "./components/HooksManager";

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -94,6 +94,8 @@ import {
   runStopHooks,
   runUserPromptSubmitHooks,
 } from "../hooks";
+import { experimentManager } from "../experiments/manager";
+import type { ExperimentId } from "../experiments/types";
 import type { ApprovalContext } from "../permissions/analyzer";
 import { formatPermissionDenial } from "../permissions/formatDenial";
 import { type PermissionMode, permissionMode } from "../permissions/mode";
@@ -179,6 +181,7 @@ import { ConversationSelector } from "./components/ConversationSelector";
 import { colors } from "./components/colors";
 // EnterPlanModeDialog removed - now using InlineEnterPlanModeApproval
 import { ErrorMessage } from "./components/ErrorMessageRich";
+import { ExperimentSelector } from "./components/ExperimentSelector";
 import { EventMessage } from "./components/EventMessage";
 import { FeedbackDialog } from "./components/FeedbackDialog";
 import { HelpDialog } from "./components/HelpDialog";
@@ -614,6 +617,7 @@ function extractErrorMeta(e: unknown) {
 // Any changes made in the overlay will be queued until end_turn
 const INTERACTIVE_SLASH_COMMANDS = new Set([
   "/model",
+  "/experiment",
   "/toolset",
   "/system",
   "/personality",
@@ -1581,6 +1585,7 @@ export default function App({
   // Overlay/selector state - only one can be open at a time
   type ActiveOverlay =
     | "model"
+    | "experiment"
     | "sleeptime"
     | "compaction"
     | "toolset"
@@ -1649,6 +1654,12 @@ export default function App({
   type QueuedOverlayAction =
     | { type: "switch_agent"; agentId: string; commandId?: string }
     | { type: "switch_model"; modelId: string; commandId?: string }
+    | {
+        type: "set_experiment";
+        experimentId: ExperimentId;
+        enabled: boolean;
+        commandId?: string;
+      }
     | {
         type: "set_sleeptime";
         settings: ReflectionSettings;
@@ -7942,6 +7953,17 @@ export default function App({
           return { submitted: true };
         }
 
+        if (trimmed === "/experiment") {
+          startOverlayCommand(
+            "experiment",
+            "/experiment",
+            "Opening experiment selector...",
+            "Experiment dialog dismissed",
+          );
+          setActiveOverlay("experiment");
+          return { submitted: true };
+        }
+
         // Special handling for /ade command - open agent in browser
         if (trimmed === "/ade") {
           const adeUrl = buildChatUrl(agentId, {
@@ -12763,6 +12785,72 @@ ${SYSTEM_REMINDER_CLOSE}
     ],
   );
 
+  const handleExperimentSelect = useCallback(
+    async (
+      selection: { experimentId: ExperimentId; enabled: boolean },
+      commandId?: string | null,
+    ) => {
+      const overlayCommand = commandId
+        ? commandRunner.getHandle(commandId, "/experiment")
+        : consumeOverlayCommand("experiment");
+
+      if (isAgentBusy()) {
+        setActiveOverlay(null);
+        const cmd =
+          overlayCommand ??
+          commandRunner.start(
+            "/experiment",
+            "Experiment toggle queued – will update after current task completes",
+          );
+        cmd.update({
+          output:
+            "Experiment toggle queued – will update after current task completes",
+          phase: "running",
+        });
+        setQueuedOverlayAction({
+          type: "set_experiment",
+          experimentId: selection.experimentId,
+          enabled: selection.enabled,
+          commandId: cmd.id,
+        });
+        return;
+      }
+
+      await withCommandLock(async () => {
+        const cmd =
+          overlayCommand ??
+          commandRunner.start("/experiment", "Updating experiment...");
+        cmd.update({
+          output: "Updating experiment...",
+          phase: "running",
+        });
+
+        try {
+          const snapshot = experimentManager.set(
+            selection.experimentId,
+            selection.enabled,
+          );
+          cmd.finish(
+            `Experiment "${snapshot.label}" ${snapshot.enabled ? "enabled" : "disabled"} (${snapshot.source})`,
+            true,
+          );
+        } catch (error) {
+          const errorDetails = formatErrorDetails(error, agentId);
+          cmd.fail(`Failed to update experiment: ${errorDetails}`);
+        } finally {
+          setActiveOverlay(null);
+        }
+      });
+    },
+    [
+      agentId,
+      commandRunner,
+      consumeOverlayCommand,
+      isAgentBusy,
+      withCommandLock,
+    ],
+  );
+
   // Process queued overlay actions when streaming ends
   // These are actions from interactive commands (like /agents, /model) that were
   // used while the agent was busy. The change is applied after end_turn.
@@ -12854,6 +12942,14 @@ ${SYSTEM_REMINDER_CLOSE}
         })();
       } else if (action.type === "switch_toolset") {
         handleToolsetSelect(action.toolsetId, action.commandId);
+      } else if (action.type === "set_experiment") {
+        handleExperimentSelect(
+          {
+            experimentId: action.experimentId,
+            enabled: action.enabled,
+          },
+          action.commandId,
+        );
       } else if (action.type === "switch_system") {
         handleSystemPromptSelect(action.promptId, action.commandId);
       } else if (action.type === "switch_personality") {
@@ -12871,6 +12967,7 @@ ${SYSTEM_REMINDER_CLOSE}
     handleSleeptimeModeSelect,
     handleCompactionModeSelect,
     handleToolsetSelect,
+    handleExperimentSelect,
     handleSystemPromptSelect,
     handlePersonalitySelect,
     agentId,
@@ -14598,6 +14695,15 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                     setActiveConnectCommandId(null);
                   }
                 }}
+              />
+            )}
+
+            {/* Experiment Selector - conditionally mounted as overlay */}
+            {activeOverlay === "experiment" && (
+              <ExperimentSelector
+                experiments={experimentManager.list()}
+                onSelect={handleExperimentSelect}
+                onCancel={closeOverlay}
               />
             )}
 

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -617,7 +617,7 @@ function extractErrorMeta(e: unknown) {
 // Any changes made in the overlay will be queued until end_turn
 const INTERACTIVE_SLASH_COMMANDS = new Set([
   "/model",
-  "/experiment",
+  "/experiments",
   "/toolset",
   "/system",
   "/personality",
@@ -7953,12 +7953,12 @@ export default function App({
           return { submitted: true };
         }
 
-        if (trimmed === "/experiment") {
+        if (trimmed === "/experiments") {
           startOverlayCommand(
             "experiment",
-            "/experiment",
-            "Opening experiment selector...",
-            "Experiment dialog dismissed",
+            "/experiments",
+            "Opening experiments selector...",
+            "Experiments dialog dismissed",
           );
           setActiveOverlay("experiment");
           return { submitted: true };
@@ -12791,7 +12791,7 @@ ${SYSTEM_REMINDER_CLOSE}
       commandId?: string | null,
     ) => {
       const overlayCommand = commandId
-        ? commandRunner.getHandle(commandId, "/experiment")
+        ? commandRunner.getHandle(commandId, "/experiments")
         : consumeOverlayCommand("experiment");
 
       if (isAgentBusy()) {
@@ -12799,7 +12799,7 @@ ${SYSTEM_REMINDER_CLOSE}
         const cmd =
           overlayCommand ??
           commandRunner.start(
-            "/experiment",
+            "/experiments",
             "Experiment toggle queued – will update after current task completes",
           );
         cmd.update({
@@ -12819,7 +12819,7 @@ ${SYSTEM_REMINDER_CLOSE}
       await withCommandLock(async () => {
         const cmd =
           overlayCommand ??
-          commandRunner.start("/experiment", "Updating experiment...");
+          commandRunner.start("/experiments", "Updating experiment...");
         cmd.update({
           output: "Updating experiment...",
           phase: "running",
@@ -12831,7 +12831,7 @@ ${SYSTEM_REMINDER_CLOSE}
             selection.enabled,
           );
           cmd.finish(
-            `Experiment "${snapshot.label}" ${snapshot.enabled ? "enabled" : "disabled"} (${snapshot.source})`,
+            `Experiment "${snapshot.label}" ${snapshot.enabled ? "enabled" : "disabled"}`,
             true,
           );
         } catch (error) {

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -252,6 +252,15 @@ export const commands: Record<string, Command> = {
       return "Opening toolset selector...";
     },
   },
+  "/experiment": {
+    desc: "Toggle runtime experiments",
+    order: 27.1,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx to open experiment selector
+      return "Opening experiment selector...";
+    },
+  },
   "/ade": {
     desc: "Open agent in ADE (browser)",
     order: 28,

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -252,13 +252,13 @@ export const commands: Record<string, Command> = {
       return "Opening toolset selector...";
     },
   },
-  "/experiment": {
-    desc: "Toggle runtime experiments",
+  "/experiments": {
+    desc: "Toggle experiments",
     order: 27.1,
     noArgs: true,
     handler: () => {
-      // Handled specially in App.tsx to open experiment selector
-      return "Opening experiment selector...";
+      // Handled specially in App.tsx to open experiments selector
+      return "Opening experiments selector...";
     },
   },
   "/ade": {

--- a/src/cli/components/ExperimentSelector.tsx
+++ b/src/cli/components/ExperimentSelector.tsx
@@ -16,7 +16,7 @@ interface ExperimentSelectorProps {
 function formatExperimentState(experiment: ExperimentSnapshot): string {
   const state = experiment.enabled ? "on" : "off";
   if (experiment.source === "override") {
-    return `${state} · in-app override`;
+    return state;
   }
   if (experiment.source === "env") {
     return `${state} · env`;
@@ -73,7 +73,7 @@ export function ExperimentSelector({
 
   return (
     <Box flexDirection="column">
-      <Text dimColor>{"> /experiment"}</Text>
+      <Text dimColor>{"> /experiments"}</Text>
       <Text dimColor>{solidLine}</Text>
 
       <Box height={1} />

--- a/src/cli/components/ExperimentSelector.tsx
+++ b/src/cli/components/ExperimentSelector.tsx
@@ -9,7 +9,10 @@ const SOLID_LINE = "─";
 
 interface ExperimentSelectorProps {
   experiments: ExperimentSnapshot[];
-  onSelect: (selection: { experimentId: ExperimentId; enabled: boolean }) => void;
+  onSelect: (selection: {
+    experimentId: ExperimentId;
+    enabled: boolean;
+  }) => void;
   onCancel: () => void;
 }
 
@@ -109,7 +112,7 @@ export function ExperimentSelector({
       </Box>
 
       <Box marginTop={1}>
-        <Text dimColor>  Enter toggle · ↑↓ navigate · Esc cancel</Text>
+        <Text dimColor> Enter toggle · ↑↓ navigate · Esc cancel</Text>
       </Box>
     </Box>
   );

--- a/src/cli/components/ExperimentSelector.tsx
+++ b/src/cli/components/ExperimentSelector.tsx
@@ -1,0 +1,116 @@
+import { Box, useInput } from "ink";
+import { useEffect, useState } from "react";
+import type { ExperimentId, ExperimentSnapshot } from "../../experiments/types";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+import { colors } from "./colors";
+import { Text } from "./Text";
+
+const SOLID_LINE = "─";
+
+interface ExperimentSelectorProps {
+  experiments: ExperimentSnapshot[];
+  onSelect: (selection: { experimentId: ExperimentId; enabled: boolean }) => void;
+  onCancel: () => void;
+}
+
+function formatExperimentState(experiment: ExperimentSnapshot): string {
+  const state = experiment.enabled ? "on" : "off";
+  if (experiment.source === "override") {
+    return `${state} · in-app override`;
+  }
+  if (experiment.source === "env") {
+    return `${state} · env`;
+  }
+  return `${state} · default`;
+}
+
+export function ExperimentSelector({
+  experiments,
+  onSelect,
+  onCancel,
+}: ExperimentSelectorProps) {
+  const terminalWidth = useTerminalWidth();
+  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (selectedIndex >= experiments.length) {
+      setSelectedIndex(Math.max(0, experiments.length - 1));
+    }
+  }, [experiments.length, selectedIndex]);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") {
+      onCancel();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((prev) => Math.min(experiments.length - 1, prev + 1));
+      return;
+    }
+
+    if (key.return) {
+      const experiment = experiments[selectedIndex];
+      if (experiment) {
+        onSelect({
+          experimentId: experiment.id,
+          enabled: !experiment.enabled,
+        });
+      }
+      return;
+    }
+
+    if (key.escape) {
+      onCancel();
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{"> /experiment"}</Text>
+      <Text dimColor>{solidLine}</Text>
+
+      <Box height={1} />
+
+      <Box marginBottom={1}>
+        <Text bold color={colors.selector.title}>
+          Toggle experiments
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        {experiments.map((experiment, index) => {
+          const isSelected = index === selectedIndex;
+
+          return (
+            <Box key={experiment.id} flexDirection="row">
+              <Text
+                color={isSelected ? colors.selector.itemHighlighted : undefined}
+              >
+                {isSelected ? "> " : "  "}
+              </Text>
+              <Text
+                bold={isSelected}
+                color={isSelected ? colors.selector.itemHighlighted : undefined}
+              >
+                {experiment.label}
+              </Text>
+              <Text dimColor>{` · ${formatExperimentState(experiment)}`}</Text>
+              <Text dimColor>{` · ${experiment.description}`}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>  Enter toggle · ↑↓ navigate · Esc cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -1,0 +1,95 @@
+import { settingsManager } from "../settings-manager";
+import type {
+  ExperimentDefinition,
+  ExperimentId,
+  ExperimentSnapshot,
+} from "./types";
+
+const ENABLED_TOGGLE_VALUES = new Set(["1", "true", "yes"]);
+
+const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
+  {
+    id: "node",
+    label: "node",
+    description: "Route API requests through the Letta Node / TS core path.",
+    envVar: "LETTA_NODE",
+  },
+] as const;
+
+function isEnabledToggle(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  return ENABLED_TOGGLE_VALUES.has(value.trim().toLowerCase());
+}
+
+function getExperimentDefinition(id: ExperimentId): ExperimentDefinition {
+  const definition = EXPERIMENT_DEFINITIONS.find((entry) => entry.id === id);
+  if (!definition) {
+    throw new Error(`Unknown experiment: ${id}`);
+  }
+  return definition;
+}
+
+class ExperimentManager {
+  private getStoredOverrides(): Partial<Record<ExperimentId, boolean>> {
+    try {
+      return settingsManager.getSettings().experiments ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  list(): ExperimentSnapshot[] {
+    return EXPERIMENT_DEFINITIONS.map((definition) =>
+      this.getSnapshot(definition.id),
+    );
+  }
+
+  getSnapshot(id: ExperimentId): ExperimentSnapshot {
+    const definition = getExperimentDefinition(id);
+    const override = this.getStoredOverrides()[id];
+
+    if (typeof override === "boolean") {
+      return {
+        ...definition,
+        enabled: override,
+        source: "override",
+        override,
+      };
+    }
+
+    const envEnabled = definition.envVar
+      ? isEnabledToggle(process.env[definition.envVar])
+      : false;
+
+    return {
+      ...definition,
+      enabled: envEnabled,
+      source: envEnabled ? "env" : "default",
+      override: null,
+    };
+  }
+
+  isEnabled(id: ExperimentId): boolean {
+    return this.getSnapshot(id).enabled;
+  }
+
+  set(id: ExperimentId, enabled: boolean): ExperimentSnapshot {
+    const settings = settingsManager.getSettings();
+    settingsManager.updateSettings({
+      experiments: {
+        ...(settings.experiments ?? {}),
+        [id]: enabled,
+      },
+    });
+    return this.getSnapshot(id);
+  }
+
+  toggle(id: ExperimentId): ExperimentSnapshot {
+    const snapshot = this.getSnapshot(id);
+    return this.set(id, !snapshot.enabled);
+  }
+}
+
+export const experimentManager = new ExperimentManager();

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -1,0 +1,16 @@
+export type ExperimentId = "node";
+
+export type ExperimentSource = "override" | "env" | "default";
+
+export interface ExperimentDefinition {
+  id: ExperimentId;
+  label: string;
+  description: string;
+  envVar?: string;
+}
+
+export interface ExperimentSnapshot extends ExperimentDefinition {
+  enabled: boolean;
+  source: ExperimentSource;
+  override: boolean | null;
+}

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import type { ExperimentId } from "./experiments/types";
 import type { HooksConfig } from "./hooks/types";
 import type { PermissionRules } from "./permissions/types";
 import { getRuntimeContext } from "./runtime-context";
@@ -89,6 +90,7 @@ export interface Settings {
   hooks?: HooksConfig; // Hook commands that run at various lifecycle points (includes disabled flag)
   statusLine?: StatusLineConfig; // Configurable status line command
   env?: Record<string, string>;
+  experiments?: Partial<Record<ExperimentId, boolean>>;
   // Server-indexed settings (agent IDs are server-specific)
   sessionsByServer?: Record<string, SessionRef>; // key = normalized base URL (e.g., "api.letta.com", "localhost:8283")
   pinnedAgentsByServer?: Record<string, string[]>; // DEPRECATED: use agents array

--- a/src/tests/agent/client-experiments.test.ts
+++ b/src/tests/agent/client-experiments.test.ts
@@ -56,7 +56,7 @@ function getDefaultHeaders(client: unknown): Record<string, string> {
 }
 
 describe("getClient experiment headers", () => {
-  test("uses LETTA_NODE when no in-app override exists", async () => {
+  test("uses LETTA_NODE when no explicit experiment override exists", async () => {
     process.env.LETTA_NODE = "1";
 
     const client = await getClient();

--- a/src/tests/agent/client-experiments.test.ts
+++ b/src/tests/agent/client-experiments.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getClient } from "../../agent/client";
+import { experimentManager } from "../../experiments/manager";
+import { settingsManager } from "../../settings-manager";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalApiKey = process.env.LETTA_API_KEY;
+const originalNodeFlag = process.env.LETTA_NODE;
+
+let testHomeDir = "";
+
+beforeEach(async () => {
+  await settingsManager.reset();
+  testHomeDir = await mkdtemp(join(tmpdir(), "letta-client-exp-home-"));
+  process.env.HOME = testHomeDir;
+  process.env.USERPROFILE = testHomeDir;
+  process.env.LETTA_API_KEY = "test-api-key";
+  delete process.env.LETTA_NODE;
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  await settingsManager.reset();
+  if (testHomeDir) {
+    await rm(testHomeDir, { recursive: true, force: true });
+    testHomeDir = "";
+  }
+
+  process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = originalUserProfile;
+  }
+
+  if (originalApiKey === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = originalApiKey;
+  }
+
+  if (originalNodeFlag === undefined) {
+    delete process.env.LETTA_NODE;
+  } else {
+    process.env.LETTA_NODE = originalNodeFlag;
+  }
+});
+
+function getDefaultHeaders(client: unknown): Record<string, string> {
+  return ((client as { _options?: { defaultHeaders?: Record<string, string> } })
+    ._options?.defaultHeaders ?? {}) as Record<string, string>;
+}
+
+describe("getClient experiment headers", () => {
+  test("uses LETTA_NODE when no in-app override exists", async () => {
+    process.env.LETTA_NODE = "1";
+
+    const client = await getClient();
+
+    expect(getDefaultHeaders(client)["x-letta-node"]).toBe("1");
+  });
+
+  test("sends an explicit off header when the override disables node", async () => {
+    process.env.LETTA_NODE = "1";
+    experimentManager.set("node", false);
+
+    const client = await getClient();
+
+    expect(getDefaultHeaders(client)["x-letta-node"]).toBe("0");
+  });
+
+  test("omits the node header when the experiment is default-off", async () => {
+    const client = await getClient();
+
+    expect(getDefaultHeaders(client)["x-letta-node"]).toBeUndefined();
+  });
+});

--- a/src/tests/agent/client-experiments.test.ts
+++ b/src/tests/agent/client-experiments.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getClient } from "../../agent/client";
+import { getClientDefaultHeaders } from "../../agent/client";
 import { experimentManager } from "../../experiments/manager";
 import { settingsManager } from "../../settings-manager";
 
@@ -50,32 +50,21 @@ afterEach(async () => {
   }
 });
 
-function getDefaultHeaders(client: unknown): Record<string, string> {
-  return ((client as { _options?: { defaultHeaders?: Record<string, string> } })
-    ._options?.defaultHeaders ?? {}) as Record<string, string>;
-}
-
 describe("getClient experiment headers", () => {
   test("uses LETTA_NODE when no explicit experiment override exists", async () => {
     process.env.LETTA_NODE = "1";
 
-    const client = await getClient();
-
-    expect(getDefaultHeaders(client)["x-letta-node"]).toBe("1");
+    expect(getClientDefaultHeaders()["x-letta-node"]).toBe("1");
   });
 
   test("sends an explicit off header when the override disables node", async () => {
     process.env.LETTA_NODE = "1";
     experimentManager.set("node", false);
 
-    const client = await getClient();
-
-    expect(getDefaultHeaders(client)["x-letta-node"]).toBe("0");
+    expect(getClientDefaultHeaders()["x-letta-node"]).toBe("0");
   });
 
   test("omits the node header when the experiment is default-off", async () => {
-    const client = await getClient();
-
-    expect(getDefaultHeaders(client)["x-letta-node"]).toBeUndefined();
+    expect(getClientDefaultHeaders()["x-letta-node"]).toBeUndefined();
   });
 });

--- a/src/tests/channels/discord-adapter.test.ts
+++ b/src/tests/channels/discord-adapter.test.ts
@@ -46,7 +46,7 @@ describe("splitMessageText", () => {
     const chunks = splitMessageText(text, 1900);
     expect(chunks.length).toBeGreaterThan(1);
     // First chunk should split at the newline (position 900), not mid-content
-    expect(chunks[0]!.length).toBeLessThanOrEqual(1900);
+    expect(chunks[0]?.length).toBeLessThanOrEqual(1900);
     // The split should happen at a \n boundary, so first chunk should be
     // exactly 900+1 chars (the first line plus the newline)
     expect(chunks[0]).toBe(`${line}\n${line}`);
@@ -65,9 +65,9 @@ describe("splitMessageText", () => {
     const solid = "x".repeat(5000);
     const chunks = splitMessageText(solid, 1900);
     expect(chunks.length).toBe(3); // 1900 + 1900 + 1200
-    expect(chunks[0]!.length).toBe(1900);
-    expect(chunks[1]!.length).toBe(1900);
-    expect(chunks[2]!.length).toBe(1200);
+    expect(chunks[0]?.length).toBe(1900);
+    expect(chunks[1]?.length).toBe(1900);
+    expect(chunks[2]?.length).toBe(1200);
   });
 
   test("reconstructed text matches original content", () => {

--- a/src/tests/channels/discord-message-channel.test.ts
+++ b/src/tests/channels/discord-message-channel.test.ts
@@ -104,7 +104,7 @@ describe("message_channel (discord)", () => {
 
     expect(result).toContain("discord");
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+    const call = (sendMessage.mock.calls as unknown[][])[0]?.[0] as Record<
       string,
       unknown
     >;
@@ -153,7 +153,7 @@ describe("message_channel (discord)", () => {
 
     expect(result).toContain("discord");
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+    const call = (sendMessage.mock.calls as unknown[][])[0]?.[0] as Record<
       string,
       unknown
     >;
@@ -200,7 +200,7 @@ describe("message_channel (discord)", () => {
     });
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    const call = (sendMessage.mock.calls as unknown[][])[0]![0] as Record<
+    const call = (sendMessage.mock.calls as unknown[][])[0]?.[0] as Record<
       string,
       unknown
     >;

--- a/src/tests/channels/discord-xml.test.ts
+++ b/src/tests/channels/discord-xml.test.ts
@@ -3,7 +3,6 @@ import type { InboundChannelMessage } from "../../channels/types";
 import {
   buildChannelNotificationXml,
   buildChannelReminderText,
-  formatChannelNotification,
 } from "../../channels/xml";
 
 describe("discord xml", () => {

--- a/src/tests/channels/runtimeDeps.test.ts
+++ b/src/tests/channels/runtimeDeps.test.ts
@@ -45,15 +45,6 @@ function writeFakeGrammyModule(runtimeDir: string): void {
 let runtimeRoot: string;
 let bundledRuntimeRoot: string;
 
-function expectedPackageManagerCommand(
-  packageManager: "bun" | "npm" | "pnpm",
-  platform: NodeJS.Platform = process.platform,
-): string {
-  return platform === "win32" && packageManager !== "bun"
-    ? `${packageManager}.cmd`
-    : packageManager;
-}
-
 beforeEach(() => {
   runtimeRoot = mkdtempSync(join(tmpdir(), "letta-channel-runtime-"));
   bundledRuntimeRoot = mkdtempSync(

--- a/src/tests/cli/queue-ordering-wiring.test.ts
+++ b/src/tests/cli/queue-ordering-wiring.test.ts
@@ -95,6 +95,8 @@ describe("queue ordering wiring", () => {
     expect(segment).toContain("handleModelSelect(action.modelId");
     expect(segment).toContain('action.type === "switch_toolset"');
     expect(segment).toContain("handleToolsetSelect(action.toolsetId");
+    expect(segment).toContain('action.type === "set_experiment"');
+    expect(segment).toContain("handleExperimentSelect(");
   });
 
   test("busy model/toolset handlers enqueue overlay actions", () => {
@@ -123,5 +125,17 @@ describe("queue ordering wiring", () => {
     expect(toolsetWindow).toContain("if (isAgentBusy())");
     expect(toolsetWindow).toContain("setQueuedOverlayAction({");
     expect(toolsetWindow).toContain('type: "switch_toolset"');
+
+    const experimentAnchor = source.indexOf(
+      "Experiment toggle queued – will update after current task completes",
+    );
+    expect(experimentAnchor).toBeGreaterThan(-1);
+    const experimentWindow = source.slice(
+      Math.max(0, experimentAnchor - 700),
+      experimentAnchor + 700,
+    );
+    expect(experimentWindow).toContain("if (isAgentBusy())");
+    expect(experimentWindow).toContain("setQueuedOverlayAction({");
+    expect(experimentWindow).toContain('type: "set_experiment"');
   });
 });

--- a/src/tests/experiments/manager.test.ts
+++ b/src/tests/experiments/manager.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { experimentManager } from "../../experiments/manager";
+import { settingsManager } from "../../settings-manager";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalNodeFlag = process.env.LETTA_NODE;
+
+let testHomeDir = "";
+
+beforeEach(async () => {
+  await settingsManager.reset();
+  testHomeDir = await mkdtemp(join(tmpdir(), "letta-experiments-home-"));
+  process.env.HOME = testHomeDir;
+  process.env.USERPROFILE = testHomeDir;
+  delete process.env.LETTA_NODE;
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  await settingsManager.reset();
+  if (testHomeDir) {
+    await rm(testHomeDir, { recursive: true, force: true });
+    testHomeDir = "";
+  }
+
+  process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = originalUserProfile;
+  }
+
+  if (originalNodeFlag === undefined) {
+    delete process.env.LETTA_NODE;
+  } else {
+    process.env.LETTA_NODE = originalNodeFlag;
+  }
+});
+
+describe("experimentManager", () => {
+  test("falls back to LETTA_NODE when no override is stored", () => {
+    process.env.LETTA_NODE = "1";
+
+    expect(experimentManager.getSnapshot("node")).toMatchObject({
+      id: "node",
+      enabled: true,
+      source: "env",
+      override: null,
+    });
+  });
+
+  test("persists explicit overrides and lets them beat the env flag", async () => {
+    process.env.LETTA_NODE = "1";
+
+    expect(experimentManager.set("node", false)).toMatchObject({
+      id: "node",
+      enabled: false,
+      source: "override",
+      override: false,
+    });
+    await settingsManager.flush();
+
+    await settingsManager.reset();
+    await settingsManager.initialize();
+
+    expect(experimentManager.getSnapshot("node")).toMatchObject({
+      id: "node",
+      enabled: false,
+      source: "override",
+      override: false,
+    });
+  });
+});

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -527,7 +527,7 @@ describe("shell bypass regression tests", () => {
     const result = evaluateCrossAgentGuard(
       "Bash",
       {
-        command: 'find "${HOME}/.letta/agents" -mindepth 1 -maxdepth 1 -type d',
+        command: `find "\${HOME}/.letta/agents" -mindepth 1 -maxdepth 1 -type d`,
       },
       "/tmp",
     );
@@ -538,7 +538,7 @@ describe("shell bypass regression tests", () => {
     // Exploit variant 1 (finds another agent via dynamic path resolution).
     const command = [
       'CURRENT="$AGENT_ID"',
-      'BASE="${HOME}/.letta/agents"',
+      `BASE="\${HOME}/.letta/agents"`,
       'TARGET="$(find "$BASE" -mindepth 1 -maxdepth 1 -type d ! -name "$CURRENT" | sort | head -n 1)"',
       'cat "$TARGET/memory/system/persona.md"',
     ].join("\n");
@@ -549,7 +549,7 @@ describe("shell bypass regression tests", () => {
   test("command substitution variant 2 (find -name memory) is denied", () => {
     const command = [
       'CURRENT="$AGENT_ID"',
-      'BASE="${HOME}/.letta/agents"',
+      `BASE="\${HOME}/.letta/agents"`,
       'TARGET="$(find "$BASE" -mindepth 2 -maxdepth 2 -type d -name memory | grep -v "/$CURRENT/" | sort | head -n 1)"',
       'cat "$TARGET/system/persona.md"',
     ].join("\n");
@@ -562,7 +562,7 @@ describe("shell bypass regression tests", () => {
     // because the quote-wrapping on the assignment value broke the
     // anchored path regex.
     const command = [
-      'TARGET="${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"',
+      `TARGET="\${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"`,
       'sed -n "1,80p" "$TARGET/system/persona.md"',
     ].join("\n");
     const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
@@ -581,13 +581,12 @@ describe("shell bypass regression tests", () => {
     expect(result).not.toBeNull();
   });
 
-  test("self-targeting references using ${AGENT_ID} pass through", () => {
+  test(`self-targeting references using \${AGENT_ID} pass through`, () => {
     process.env.AGENT_ID = SELF;
     const result = evaluateCrossAgentGuard(
       "Bash",
       {
-        command:
-          'cat "${HOME}/.letta/agents/${AGENT_ID}/memory/system/persona.md"',
+        command: `cat "\${HOME}/.letta/agents/\${AGENT_ID}/memory/system/persona.md"`,
       },
       "/tmp",
     );
@@ -597,9 +596,8 @@ describe("shell bypass regression tests", () => {
   test("scoped access via LETTA_MEMORY_SCOPE passes through", () => {
     process.env.LETTA_MEMORY_SCOPE =
       "agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada";
-    const command =
-      'TARGET="${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"\n' +
-      'cat "$TARGET/system/persona.md"';
+    const command = `TARGET="\${HOME}/.letta/agents/agent-0037d3d9-389b-4c02-82ae-d77aa29d1ada/memory"
+cat "$TARGET/system/persona.md"`;
     const result = evaluateCrossAgentGuard("Bash", { command }, "/tmp");
     expect(result).toBeNull();
   });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -872,6 +872,30 @@ describe("listen-client parseServerMessage", () => {
     expect(setSettings?.type).toBe("set_reflection_settings");
   });
 
+  test("parses experiment commands", () => {
+    const getExperiments = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "get_experiments",
+          request_id: "experiments-get-1",
+        }),
+      ),
+    );
+    const setExperiment = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "set_experiment",
+          request_id: "experiment-set-1",
+          experiment_id: "node",
+          enabled: true,
+        }),
+      ),
+    );
+
+    expect(getExperiments?.type).toBe("get_experiments");
+    expect(setExperiment?.type).toBe("set_experiment");
+  });
+
   test("rejects legacy cancel_run in hard-cut v2 protocol", () => {
     const legacyCancel = parseServerMessage(
       Buffer.from(
@@ -2050,6 +2074,110 @@ describe("listen-client reflection settings command handling", () => {
   });
 });
 
+describe("listen-client experiment command handling", () => {
+  test("wraps typed experiment reads and writes over WS", async () => {
+    const originalGetSettings = settingsManager.getSettings;
+    const originalUpdateSettings = settingsManager.updateSettings;
+    const originalNodeFlag = process.env.LETTA_NODE;
+    const globalSettings = {} as Settings;
+
+    try {
+      delete process.env.LETTA_NODE;
+      (settingsManager as typeof settingsManager).getSettings = (() =>
+        globalSettings) as typeof settingsManager.getSettings;
+      (settingsManager as typeof settingsManager).updateSettings = ((
+        updates: Record<string, unknown>,
+      ) => {
+        Object.assign(
+          globalSettings as unknown as Record<string, unknown>,
+          updates,
+        );
+      }) as typeof settingsManager.updateSettings;
+
+      const socket = new MockSocket(WebSocket.OPEN);
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        "agent-1",
+        "default",
+      );
+
+      await __listenClientTestUtils.handleExperimentCommand(
+        {
+          type: "get_experiments",
+          request_id: "experiments-get-1",
+        },
+        socket as unknown as WebSocket,
+        listener,
+      );
+
+      const getResponse = JSON.parse(socket.sentPayloads[0] as string);
+      expect(getResponse).toMatchObject({
+        type: "get_experiments_response",
+        request_id: "experiments-get-1",
+        success: true,
+        experiments: [
+          expect.objectContaining({
+            id: "node",
+            enabled: false,
+            source: "default",
+          }),
+        ],
+      });
+
+      socket.sentPayloads.length = 0;
+
+      await __listenClientTestUtils.handleExperimentCommand(
+        {
+          type: "set_experiment",
+          request_id: "experiment-set-1",
+          experiment_id: "node",
+          enabled: true,
+        },
+        socket as unknown as WebSocket,
+        listener,
+      );
+
+      const setResponse = JSON.parse(socket.sentPayloads[0] as string);
+      const deviceStatusUpdate = JSON.parse(socket.sentPayloads[1] as string);
+      expect(setResponse).toMatchObject({
+        type: "set_experiment_response",
+        request_id: "experiment-set-1",
+        success: true,
+        experiments: [
+          expect.objectContaining({
+            id: "node",
+            enabled: true,
+            source: "override",
+          }),
+        ],
+      });
+      expect(deviceStatusUpdate).toMatchObject({
+        type: "update_device_status",
+        device_status: {
+          experiments: [
+            expect.objectContaining({
+              id: "node",
+              enabled: true,
+              source: "override",
+            }),
+          ],
+        },
+      });
+    } finally {
+      if (originalNodeFlag === undefined) {
+        delete process.env.LETTA_NODE;
+      } else {
+        process.env.LETTA_NODE = originalNodeFlag;
+      }
+      (settingsManager as typeof settingsManager).getSettings =
+        originalGetSettings;
+      (settingsManager as typeof settingsManager).updateSettings =
+        originalUpdateSettings;
+    }
+  });
+});
+
 describe("listen-client permission mode scope keys", () => {
   test("falls back from legacy default key and migrates to agent-scoped key", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
@@ -2492,13 +2620,29 @@ describe("listen-client v2 status builders", () => {
   });
 
   test("buildDeviceStatus includes the effective working directory", () => {
+    const originalNodeFlag = process.env.LETTA_NODE;
+    delete process.env.LETTA_NODE;
     const runtime = __listenClientTestUtils.createRuntime();
-    const deviceStatus = __listenClientTestUtils.buildDeviceStatus(runtime);
-    expect(typeof deviceStatus.current_working_directory).toBe("string");
-    expect(
-      (deviceStatus.current_working_directory ?? "").length,
-    ).toBeGreaterThan(0);
-    expect(deviceStatus.current_toolset_preference).toBe("auto");
+    try {
+      const deviceStatus = __listenClientTestUtils.buildDeviceStatus(runtime);
+      expect(typeof deviceStatus.current_working_directory).toBe("string");
+      expect(
+        (deviceStatus.current_working_directory ?? "").length,
+      ).toBeGreaterThan(0);
+      expect(deviceStatus.current_toolset_preference).toBe("auto");
+      expect(deviceStatus.experiments).toEqual([
+        expect.objectContaining({
+          id: "node",
+          source: "default",
+        }),
+      ]);
+    } finally {
+      if (originalNodeFlag === undefined) {
+        delete process.env.LETTA_NODE;
+      } else {
+        process.env.LETTA_NODE = originalNodeFlag;
+      }
+    }
   });
 
   test("buildDeviceStatus includes should_doctor state when available", () => {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -15,6 +15,7 @@ import type {
   SlackDefaultPermissionMode,
 } from "../channels/types";
 import type { CronTask } from "../cron";
+import type { ExperimentId, ExperimentSnapshot } from "../experiments/types";
 
 /**
  * Runtime identity for all state and delta events.
@@ -300,6 +301,7 @@ export interface DeviceStatus {
   current_available_skills: AvailableSkillSummary[];
   background_processes: BackgroundProcessSummary[];
   pending_control_requests: PendingControlRequest[];
+  experiments: ExperimentSnapshot[];
   memory_directory: string | null;
   should_doctor?: boolean;
   reflection_settings: ReflectionSettingsSnapshot | null;
@@ -990,6 +992,18 @@ export interface SetReflectionSettingsCommand {
   scope?: ReflectionSettingsScope;
 }
 
+export interface GetExperimentsCommand {
+  type: "get_experiments";
+  request_id: string;
+}
+
+export interface SetExperimentCommand {
+  type: "set_experiment";
+  request_id: string;
+  experiment_id: ExperimentId;
+  enabled: boolean;
+}
+
 export interface ChannelsListCommand {
   type: "channels_list";
   request_id: string;
@@ -1265,6 +1279,22 @@ export interface SetReflectionSettingsResponseMessage {
   success: boolean;
   reflection_settings: ReflectionSettingsSnapshot | null;
   scope: ReflectionSettingsScope;
+  error?: string;
+}
+
+export interface GetExperimentsResponseMessage {
+  type: "get_experiments_response";
+  request_id: string;
+  success: boolean;
+  experiments: ExperimentSnapshot[];
+  error?: string;
+}
+
+export interface SetExperimentResponseMessage {
+  type: "set_experiment_response";
+  request_id: string;
+  success: boolean;
+  experiments: ExperimentSnapshot[];
   error?: string;
 }
 
@@ -1587,6 +1617,8 @@ export type WsProtocolCommand =
   | CreateAgentCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
+  | GetExperimentsCommand
+  | SetExperimentCommand
   | ChannelsListCommand
   | ChannelAccountsListCommand
   | ChannelAccountCreateCommand
@@ -1620,6 +1652,8 @@ export type WsProtocolMessage =
   | ListModelsResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
+  | GetExperimentsResponseMessage
+  | SetExperimentResponseMessage
   | ChannelsListResponseMessage
   | ChannelAccountsListResponseMessage
   | ChannelAccountCreateResponseMessage

--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -38,6 +38,13 @@ const PER_DIFF_CAP = 100_000; // 100KB per diff
 const TOTAL_PAYLOAD_CAP = 5_000_000; // 5MB total
 const RECORD_SEP = "\x1e";
 
+type ConversationListItem = {
+  id?: string | null;
+  created_at?: string | null;
+  last_run_completion?: string | null;
+  label?: string | null;
+};
+
 export interface GenerateResult {
   filePath: string;
   opened: boolean;
@@ -433,13 +440,20 @@ async function collectMemoryData(
       order: "desc",
       order_by: "last_run_completion",
     });
-    const convItems = convPage;
-    conversations = convItems.map((c: any) => ({
-      id: c.id,
-      created_at: c.created_at,
-      last_run_completion: c.last_run_completion ?? null,
-      label: c.label ?? null,
-    }));
+    const convItems = convPage as ConversationListItem[];
+    conversations = convItems.flatMap((c) => {
+      if (!c.id || !c.created_at) {
+        return [];
+      }
+      return [
+        {
+          id: c.id,
+          created_at: c.created_at,
+          last_run_completion: c.last_run_completion ?? null,
+          label: c.label ?? null,
+        },
+      ];
+    });
   } catch {
     // Conversation fetch failed - continue without it
   }

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -37,6 +37,7 @@ import {
 } from "../../cli/helpers/memoryReminder";
 import { setMessageQueueAdder } from "../../cli/helpers/messageQueueBridge";
 import { generatePlanFilePath } from "../../cli/helpers/planName";
+import { experimentManager } from "../../experiments/manager";
 import {
   getSubagents,
   subscribe as subscribeToSubagentState,
@@ -110,11 +111,15 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
+  GetExperimentsCommand,
+  GetExperimentsResponseMessage,
   GetReflectionSettingsCommand,
   ListMemoryCommand,
   ListModelsResponseMessage,
   ListModelsResponseModelEntry,
   ReflectionSettingsScope,
+  SetExperimentCommand,
+  SetExperimentResponseMessage,
   SetReflectionSettingsCommand,
   SkillDisableCommand,
   SkillEnableCommand,
@@ -196,6 +201,7 @@ import {
   isEnableMemfsCommand,
   isExecuteCommandCommand,
   isFileOpsCommand,
+  isGetExperimentsCommand,
   isGetReflectionSettingsCommand,
   isGetTreeCommand,
   isGrepInFilesCommand,
@@ -208,6 +214,7 @@ import {
   isReadFileCommand,
   isSearchBranchesCommand,
   isSearchFilesCommand,
+  isSetExperimentCommand,
   isSetReflectionSettingsCommand,
   isSkillDisableCommand,
   isSkillEnableCommand,
@@ -1009,6 +1016,8 @@ async function buildListModelsResponse(
 type ReflectionSettingsCommand =
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand;
+
+type ExperimentCommand = GetExperimentsCommand | SetExperimentCommand;
 
 type ChannelsCommand =
   | ChannelsListCommand
@@ -3104,6 +3113,63 @@ function resolveReflectionSettingsScope(
     persistGlobal: true,
     normalizedScope: "both",
   };
+}
+
+async function handleExperimentCommand(
+  parsed: ExperimentCommand,
+  socket: WebSocket,
+  listener: ListenerRuntime,
+): Promise<boolean> {
+  if (parsed.type === "get_experiments") {
+    const response: GetExperimentsResponseMessage = {
+      type: "get_experiments_response",
+      request_id: parsed.request_id,
+      success: true,
+      experiments: experimentManager.list(),
+    };
+    safeSocketSend(
+      socket,
+      response,
+      "listener_experiments_send_failed",
+      "listener_experiments",
+    );
+    return true;
+  }
+
+  try {
+    experimentManager.set(parsed.experiment_id, parsed.enabled);
+    const response: SetExperimentResponseMessage = {
+      type: "set_experiment_response",
+      request_id: parsed.request_id,
+      success: true,
+      experiments: experimentManager.list(),
+    };
+    safeSocketSend(
+      socket,
+      response,
+      "listener_experiments_send_failed",
+      "listener_experiments",
+    );
+
+    emitDeviceStatusUpdate(socket, listener);
+  } catch (err) {
+    const response: SetExperimentResponseMessage = {
+      type: "set_experiment_response",
+      request_id: parsed.request_id,
+      success: false,
+      experiments: experimentManager.list(),
+      error:
+        err instanceof Error ? err.message : "Failed to update experiment",
+    };
+    safeSocketSend(
+      socket,
+      response,
+      "listener_experiments_send_failed",
+      "listener_experiments",
+    );
+  }
+
+  return true;
 }
 
 async function handleReflectionSettingsCommand(
@@ -5704,6 +5770,13 @@ async function connectWithRetry(
         return;
       }
 
+      if (isGetExperimentsCommand(parsed) || isSetExperimentCommand(parsed)) {
+        runDetachedListenerTask("experiment_command", async () => {
+          await handleExperimentCommand(parsed, socket, runtime);
+        });
+        return;
+      }
+
       if (
         isGetReflectionSettingsCommand(parsed) ||
         isSetReflectionSettingsCommand(parsed)
@@ -6395,6 +6468,7 @@ export const __listenClientTestUtils = {
   handleChannelRegistryEvent,
   handleSkillCommand,
   handleCreateAgentCommand,
+  handleExperimentCommand,
   handleReflectionSettingsCommand,
   enqueueChannelTurn,
   scheduleQueuePump,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -37,7 +37,6 @@ import {
 } from "../../cli/helpers/memoryReminder";
 import { setMessageQueueAdder } from "../../cli/helpers/messageQueueBridge";
 import { generatePlanFilePath } from "../../cli/helpers/planName";
-import { experimentManager } from "../../experiments/manager";
 import {
   getSubagents,
   subscribe as subscribeToSubagentState,
@@ -59,6 +58,7 @@ import {
   startScheduler as startCronScheduler,
   stopScheduler as stopCronScheduler,
 } from "../../cron/scheduler";
+import { experimentManager } from "../../experiments/manager";
 import {
   buildByokProviderAliases,
   listProviders,
@@ -3158,8 +3158,7 @@ async function handleExperimentCommand(
       request_id: parsed.request_id,
       success: false,
       experiments: experimentManager.list(),
-      error:
-        err instanceof Error ? err.message : "Failed to update experiment",
+      error: err instanceof Error ? err.message : "Failed to update experiment",
     };
     safeSocketSend(
       socket,

--- a/src/websocket/listener/grepInFiles.ts
+++ b/src/websocket/listener/grepInFiles.ts
@@ -137,7 +137,7 @@ export async function runGrepInFiles(
   if (contextLines > 0) {
     rgArgs.push("-C", contextLines.toString());
   }
-  if (glob && glob.trim()) {
+  if (glob?.trim()) {
     rgArgs.push("--glob", glob.trim());
   }
   // Respect .gitignore + skip hidden files/dirs by default. These are

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -806,9 +806,7 @@ export function isGetExperimentsCommand(
     type?: unknown;
     request_id?: unknown;
   };
-  return (
-    c.type === "get_experiments" && typeof c.request_id === "string"
-  );
+  return c.type === "get_experiments" && typeof c.request_id === "string";
 }
 
 export function isSetExperimentCommand(

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -33,6 +33,7 @@ import type {
   EnableMemfsCommand,
   ExecuteCommandCommand,
   FileOpsCommand,
+  GetExperimentsCommand,
   GetReflectionSettingsCommand,
   GetTreeCommand,
   GrepInFilesCommand,
@@ -47,6 +48,7 @@ import type {
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
+  SetExperimentCommand,
   SetReflectionSettingsCommand,
   SkillDisableCommand,
   SkillEnableCommand,
@@ -796,6 +798,37 @@ export function isSetReflectionSettingsCommand(
   );
 }
 
+export function isGetExperimentsCommand(
+  value: unknown,
+): value is GetExperimentsCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+  };
+  return (
+    c.type === "get_experiments" && typeof c.request_id === "string"
+  );
+}
+
+export function isSetExperimentCommand(
+  value: unknown,
+): value is SetExperimentCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    experiment_id?: unknown;
+    enabled?: unknown;
+  };
+  return (
+    c.type === "set_experiment" &&
+    typeof c.request_id === "string" &&
+    c.experiment_id === "node" &&
+    typeof c.enabled === "boolean"
+  );
+}
+
 function isChannelId(
   value: unknown,
 ): value is "telegram" | "slack" | "discord" {
@@ -1383,6 +1416,8 @@ export function parseServerMessage(
       isSkillEnableCommand(parsed) ||
       isSkillDisableCommand(parsed) ||
       isCreateAgentCommand(parsed) ||
+      isGetExperimentsCommand(parsed) ||
+      isSetExperimentCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||
       isSetReflectionSettingsCommand(parsed) ||
       isChannelsListCommand(parsed) ||

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -9,6 +9,7 @@ import { getGitContext } from "../../cli/helpers/gitContext";
 import { getReflectionSettings } from "../../cli/helpers/memoryReminder";
 import { getSubagents } from "../../cli/helpers/subagentState";
 import { getSystemPromptDoctorState } from "../../cli/helpers/systemPromptWarning";
+import { experimentManager } from "../../experiments/manager";
 import { permissionMode } from "../../permissions/mode";
 import type { DequeuedBatch } from "../../queue/queueRuntime";
 import { settingsManager } from "../../settings-manager";
@@ -387,6 +388,7 @@ export function buildDeviceStatus(
       current_available_skills: [],
       background_processes: buildBackgroundProcessSnapshot(),
       pending_control_requests: [],
+      experiments: experimentManager.list(),
       memory_directory: null,
       should_doctor: false,
       reflection_settings: null,
@@ -456,6 +458,7 @@ export function buildDeviceStatus(
     pending_control_requests: interruptedCacheActive
       ? []
       : getPendingControlRequests(listener, scope),
+    experiments: experimentManager.list(),
     memory_directory: scopedAgentId
       ? getMemoryFilesystemRoot(scopedAgentId)
       : null,


### PR DESCRIPTION
## Summary
- add a runtime experiment manager backed by persisted settings, starting with the `node` experiment
- add a new `/experiment` CLI overlay that toggles experiments immediately or queues the change until the current turn finishes
- expose experiment snapshots through device status plus detached `get_experiments` / `set_experiment` listener commands for future desktop integration
- route `x-letta-node` through the experiment manager so in-app overrides take precedence over the local env flag inside `letta-code`

settings will override process var, so to go back to env vars being the primary gate you should manually remove the settings boolean override

## Testing
- `bun test src/tests/experiments/manager.test.ts`
- `bun test src/tests/agent/client-experiments.test.ts`
- `bun test src/tests/websocket/listen-client-protocol.test.ts -t "experiment"`
- `bun test src/tests/cli/queue-ordering-wiring.test.ts`

## Notes
- full repo `tsc` is currently noisy in this checkout because optional channel deps and existing non-experiment type issues are missing/broken locally
- broad `listen-client-protocol.test.ts` also still has a pre-existing memfs sandbox failure in `buildDeviceStatus does not cold-refresh should_doctor from stray memfs`, so I ran the experiment-specific slice directly