### PR TITLE
perf: skip syncAgentState on tool-result continuations in bypass mode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4870,9 +4870,20 @@ export default function App({
             }
           };
 
+          const isAutoApprovalMode =
+            pinnedPermissionMode === "bypassPermissions";
+          const isUserInitiated = currentInput.some(
+            (item) => item.type === "message" && item.role === "user",
+          );
           const handleFirstMessage = () => {
             setNetworkPhase("download");
-            void syncAgentState();
+            // Only sync agent state on user messages or when manual approval
+            // mode is active (user may have changed model while reviewing).
+            // In bypass mode, tool-result continuations happen instantly —
+            // no time for the agent to have changed.
+            if (isUserInitiated || !isAutoApprovalMode) {
+              void syncAgentState();
+            }
           };
 
           const runTokenStart = buffersRef.current.tokenCount;


### PR DESCRIPTION
## Problem

`syncAgentState` fires on every `processConversation` invocation, including tool-result continuations in bypass mode. Each call makes an `agents.retrieve` API call, and the resulting state update triggers a `syncConversationModel` useEffect which adds a `conversations.retrieve`. In a multi-tool turn with 3 tool rounds, this means 3 redundant `agents.retrieve` + 3 redundant `conversations.retrieve` on the continuations.

## Fix

Gate `syncAgentState` on `isUserInitiated || !isAutoApprovalMode`. In bypass mode, tool-result continuations skip the fetch since no user idle time has passed. In manual approval mode, the fetch is preserved since the user may have changed the model while reviewing.

## Result

Multi-tool turns in bypass mode reduced from 2 `agents.retrieve` per continuation to 1. Verified with `LETTA_COUNT_CALLS=1` instrumentation.

👾 Generated with [Letta Code](https://letta.com)