### PR TITLE
feat: Wire reflection triggers into headless bidirectional mode

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -215,6 +215,7 @@ import { UserMessage } from "./components/UserMessageRich";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { AnimationProvider } from "./contexts/AnimationContext";
 import {
+  appendOptimisticUserLine,
   appendStreamingOutput,
   type Buffers,
   createBuffers,
@@ -725,27 +726,6 @@ function uid(prefix: string) {
 // server with the real message.id.
 function createClientOtid(): string {
   return randomUUID();
-}
-
-function appendOptimisticUserLine(
-  buffers: Buffers,
-  text: string,
-  otid: string,
-): string | null {
-  if (!text) {
-    return null;
-  }
-
-  const userId = uid("user");
-  buffers.byId.set(userId, {
-    kind: "user",
-    id: userId,
-    text,
-    otid,
-  });
-  buffers.userLineIdByOtid.set(otid, userId);
-  buffers.order.push(userId);
-  return userId;
 }
 
 function buildApprovalBatchKey(approvals: ApprovalRequest[]): string {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -273,6 +273,40 @@ export const CLI_FLAG_CATALOG = {
       description: "Sleeptime step-count interval (positive integer)",
     },
   },
+  "reflection-passive-sweep-enabled": {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<bool>",
+      description: "Enable/disable passive idle-time reflection sweep",
+    },
+  },
+  "reflection-passive-sweep-interval-hours": {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<hours>",
+      description: "Minimum hours between passive sweeps (positive number)",
+    },
+  },
+  "reflection-passive-conversation-min-idle-hours": {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<hours>",
+      description:
+        "Per-conversation: minimum hours of idle time before it qualifies for the passive sweep",
+    },
+  },
+  "reflection-passive-conversation-min-unreflected-turns": {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<n>",
+      description:
+        "Per-conversation: minimum unreflected turns before it qualifies for the passive sweep",
+    },
+  },
   "max-turns": { parser: { type: "string" }, mode: "headless" },
 } as const satisfies Record<string, CliFlagDefinition>;
 

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -326,6 +326,27 @@ function ensure<T extends Line>(b: Buffers, id: string, make: () => T): T {
   return created;
 }
 
+/**
+ * Append a user line into buffers before sending — gives the transcript a
+ * row to count even when the server doesn't echo `user_message` back. The
+ * caller passes its own otid so a later server echo can reconcile via
+ * `userLineIdByOtid`.
+ */
+export function appendOptimisticUserLine(
+  buffers: Buffers,
+  text: string,
+  otid: string,
+): string | null {
+  if (!text) return null;
+  const userId = `user-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  buffers.byId.set(userId, { kind: "user", id: userId, text, otid });
+  buffers.userLineIdByOtid.set(otid, userId);
+  buffers.order.push(userId);
+  return userId;
+}
+
 // Mark a line as finished if it has a phase (immutable update)
 function markAsFinished(b: Buffers, id: string) {
   const line = b.byId.get(id);

--- a/src/cli/helpers/autoReflection.ts
+++ b/src/cli/helpers/autoReflection.ts
@@ -404,7 +404,10 @@ async function runReflectionLaunch(
     endMessageId: autoPayload.endMessageId,
   });
 
-  debugLog("memory", `Auto-launched reflection subagent (${triggerSource})`);
+  debugLog(
+    "memory",
+    `Auto-launched reflection subagent (${triggerSource}) reflectionAgentId=${reflectionAgentId ?? "unknown"}`,
+  );
   return await completionPromise;
 }
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -49,14 +49,21 @@ import {
   resolveImportFlagAlias,
 } from "./cli/flagUtils";
 import {
+  appendOptimisticUserLine,
   createBuffers,
+  extractTextPart,
   type Line,
   markIncompleteToolsAsCancelled,
   toLines,
 } from "./cli/helpers/accumulator";
 import { classifyApprovals } from "./cli/helpers/approvalClassification";
+import {
+  launchReflectionSubagent,
+  type ReflectionRecompileContext,
+} from "./cli/helpers/autoReflection";
 import { createContextTracker } from "./cli/helpers/contextTracker";
 import { formatErrorDetails } from "./cli/helpers/errorFormatter";
+import { maybeStartIdleReflectionSweep } from "./cli/helpers/idleReflectionSweep";
 import {
   getReflectionSettings,
   mergeReflectionSettingsPatch,
@@ -68,6 +75,7 @@ import {
   type QueuedMessage,
   setMessageQueueAdder,
 } from "./cli/helpers/messageQueueBridge";
+import { appendTranscriptDeltaJsonl } from "./cli/helpers/reflectionTranscript";
 import {
   type DrainStreamHook,
   drainStreamWithResume,
@@ -136,6 +144,58 @@ import {
   measureSinceMilestone,
   reportAllMilestones,
 } from "./utils/timing";
+
+// Process-shared recompile context for reflection completions. Headless has
+// no persistent system-prompt recompile loop, so a single Map+Set per process
+// is enough to dedupe overlapping recompiles without leaking across runs.
+const headlessReflectionRecompileContext: ReflectionRecompileContext = {
+  recompileByConversation: new Map<string, Promise<void>>(),
+  recompileQueuedByConversation: new Set<string>(),
+  logRecompileFailure: (message) => debugWarn("memory", message),
+};
+
+function buildHeadlessReflectionCallbacks(input: {
+  agentId: string;
+  conversationId: string;
+  workingDirectory: string;
+  reflectionSettings: ReflectionSettings;
+}): {
+  maybeLaunchReflectionSubagent: (
+    triggerSource: "step-count" | "compaction-event",
+  ) => Promise<boolean>;
+  maybeStartIdleReflectionSweep: () => void;
+} {
+  const emitCompletionNotification = (message: string) => {
+    debugLog("memory", `Reflection completion: ${message}`);
+  };
+  const maybeLaunch = async (
+    triggerSource: "step-count" | "compaction-event",
+  ) => {
+    const result = await launchReflectionSubagent({
+      agentId: input.agentId,
+      conversationId: input.conversationId,
+      workingDirectory: input.workingDirectory,
+      triggerSource,
+      waitUntil: "queued",
+      recompileContext: headlessReflectionRecompileContext,
+      emitCompletionNotification,
+    });
+    return result.status !== "skipped" && result.status !== "failed";
+  };
+  const maybeStartSweep = () => {
+    maybeStartIdleReflectionSweep({
+      agentId: input.agentId,
+      workingDirectory: input.workingDirectory,
+      reflectionSettings: input.reflectionSettings,
+      recompileContext: headlessReflectionRecompileContext,
+      emitCompletionNotification,
+    });
+  };
+  return {
+    maybeLaunchReflectionSubagent: maybeLaunch,
+    maybeStartIdleReflectionSweep: maybeStartSweep,
+  };
+}
 
 // Maximum number of times to retry a turn when the backend
 // reports an `llm_api_error` stop reason. This helps smooth
@@ -263,7 +323,29 @@ type ReflectionOverrides = {
   trigger?: ReflectionTrigger;
   deprecatedBehaviorRaw?: string;
   stepCount?: number;
+  passiveSweepEnabled?: boolean;
+  passiveSweepIntervalHours?: number;
+  passiveConversationMinIdleHours?: number;
+  passiveConversationMinUnreflectedTurns?: number;
 };
+
+function parsePositiveNumberFlag(rawValue: string, flagName: string): number {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      `Invalid --${flagName} "${rawValue}". Expected a positive number.`,
+    );
+  }
+  return parsed;
+}
+
+function parseBooleanFlag(rawValue: string, flagName: string): boolean {
+  if (rawValue === "true" || rawValue === "1") return true;
+  if (rawValue === "false" || rawValue === "0") return false;
+  throw new Error(
+    `Invalid --${flagName} "${rawValue}". Expected true|false|1|0.`,
+  );
+}
 
 function parseReflectionOverrides(
   values: ParsedCliArgs["values"],
@@ -271,8 +353,22 @@ function parseReflectionOverrides(
   const triggerRaw = values["reflection-trigger"];
   const behaviorRaw = values["reflection-behavior"];
   const stepCountRaw = values["reflection-step-count"];
+  const passiveEnabledRaw = values["reflection-passive-sweep-enabled"];
+  const passiveIntervalRaw = values["reflection-passive-sweep-interval-hours"];
+  const passiveConvIdleRaw =
+    values["reflection-passive-conversation-min-idle-hours"];
+  const passiveConvTurnsRaw =
+    values["reflection-passive-conversation-min-unreflected-turns"];
 
-  if (!triggerRaw && !behaviorRaw && !stepCountRaw) {
+  if (
+    !triggerRaw &&
+    !behaviorRaw &&
+    !stepCountRaw &&
+    !passiveEnabledRaw &&
+    !passiveIntervalRaw &&
+    !passiveConvIdleRaw &&
+    !passiveConvTurnsRaw
+  ) {
     return {};
   }
 
@@ -313,6 +409,31 @@ function parseReflectionOverrides(
     }
   }
 
+  if (passiveEnabledRaw !== undefined) {
+    overrides.passiveSweepEnabled = parseBooleanFlag(
+      passiveEnabledRaw,
+      "reflection-passive-sweep-enabled",
+    );
+  }
+  if (passiveIntervalRaw !== undefined) {
+    overrides.passiveSweepIntervalHours = parsePositiveNumberFlag(
+      passiveIntervalRaw,
+      "reflection-passive-sweep-interval-hours",
+    );
+  }
+  if (passiveConvIdleRaw !== undefined) {
+    overrides.passiveConversationMinIdleHours = parsePositiveNumberFlag(
+      passiveConvIdleRaw,
+      "reflection-passive-conversation-min-idle-hours",
+    );
+  }
+  if (passiveConvTurnsRaw !== undefined) {
+    overrides.passiveConversationMinUnreflectedTurns = parsePositiveIntFlag({
+      rawValue: passiveConvTurnsRaw,
+      flagName: "reflection-passive-conversation-min-unreflected-turns",
+    });
+  }
+
   return overrides;
 }
 
@@ -320,7 +441,11 @@ function hasReflectionOverrides(overrides: ReflectionOverrides): boolean {
   return (
     overrides.trigger !== undefined ||
     overrides.deprecatedBehaviorRaw !== undefined ||
-    overrides.stepCount !== undefined
+    overrides.stepCount !== undefined ||
+    overrides.passiveSweepEnabled !== undefined ||
+    overrides.passiveSweepIntervalHours !== undefined ||
+    overrides.passiveConversationMinIdleHours !== undefined ||
+    overrides.passiveConversationMinUnreflectedTurns !== undefined
   );
 }
 
@@ -332,6 +457,16 @@ async function applyReflectionOverrides(
   const merged: ReflectionSettings = mergeReflectionSettingsPatch(current, {
     trigger: overrides.trigger ?? current.trigger,
     stepCount: overrides.stepCount ?? current.stepCount,
+    passiveSweepEnabled:
+      overrides.passiveSweepEnabled ?? current.passiveSweepEnabled,
+    passiveSweepIntervalHours:
+      overrides.passiveSweepIntervalHours ?? current.passiveSweepIntervalHours,
+    passiveConversationMinIdleHours:
+      overrides.passiveConversationMinIdleHours ??
+      current.passiveConversationMinIdleHours,
+    passiveConversationMinUnreflectedTurns:
+      overrides.passiveConversationMinUnreflectedTurns ??
+      current.passiveConversationMinUnreflectedTurns,
   });
 
   if (!hasReflectionOverrides(overrides)) {
@@ -3614,6 +3749,14 @@ async function runBidirectionalMode(
         );
         const lastRunAt = (agent as { last_run_completion?: string })
           .last_run_completion;
+        const reflectionCallbacks = isSubagent
+          ? null
+          : buildHeadlessReflectionCallbacks({
+              agentId: agent.id,
+              conversationId,
+              workingDirectory: getCurrentWorkingDirectory(),
+              reflectionSettings,
+            });
         const { parts: sharedReminderParts } = await buildSharedReminderParts({
           mode: isSubagent ? "subagent" : "headless-bidirectional",
           agent: {
@@ -3632,15 +3775,34 @@ async function runBidirectionalMode(
             const { PLAN_MODE_REMINDER } = await import("./agent/promptAssets");
             return PLAN_MODE_REMINDER;
           },
+          maybeLaunchReflectionSubagent:
+            reflectionCallbacks?.maybeLaunchReflectionSubagent,
+          maybeStartIdleReflectionSweep:
+            reflectionCallbacks?.maybeStartIdleReflectionSweep,
         });
         const enrichedContent = prependReminderPartsToContent(
           userContent,
           sharedReminderParts,
         );
 
+        // Inject an optimistic user row so the transcript captures user turns
+        // even when the server does not echo `user_message`. Without this the
+        // step-count cadence (which derives from `total_completed_turns -
+        // reflected_completed_turns`) would never advance in headless. The
+        // same otid is attached to the outgoing message so a later echo can
+        // reconcile via `userLineIdByOtid`.
+        const userOtid = randomUUID();
+        if (!isSubagent) {
+          appendOptimisticUserLine(
+            buffers,
+            extractTextPart(userContent),
+            userOtid,
+          );
+        }
+
         // Initial input is the user message
         let currentInput: MessageCreate[] = [
-          { role: "user", content: enrichedContent },
+          { role: "user", content: enrichedContent, otid: userOtid },
         ];
 
         // Approval handling loop - continue until end_turn or error
@@ -3827,6 +3989,27 @@ async function runBidirectionalMode(
 
           // Case 1: Turn ended normally - break out of loop
           if (stopReason === "end_turn") {
+            if (!isSubagent) {
+              try {
+                const transcriptLines = toLines(buffers);
+                if (transcriptLines.length > 0) {
+                  await appendTranscriptDeltaJsonl(
+                    agent.id,
+                    conversationId,
+                    transcriptLines,
+                  );
+                }
+              } catch (transcriptError) {
+                debugWarn(
+                  "memory",
+                  `Failed to append transcript delta: ${
+                    transcriptError instanceof Error
+                      ? transcriptError.message
+                      : String(transcriptError)
+                  }`,
+                );
+              }
+            }
             break;
           }
 

--- a/src/reminders/catalog.ts
+++ b/src/reminders/catalog.ts
@@ -77,22 +77,12 @@ export const SHARED_REMINDER_CATALOG: ReadonlyArray<SharedReminderDefinition> =
     {
       id: "reflection-step-count",
       description: "Step-count reflection trigger handling",
-      modes: [
-        "interactive",
-        "headless-one-shot",
-        "headless-bidirectional",
-        "listen",
-      ],
+      modes: ["interactive", "headless-bidirectional", "listen"],
     },
     {
       id: "reflection-compaction",
       description: "Compaction-triggered reflection trigger handling",
-      modes: [
-        "interactive",
-        "headless-one-shot",
-        "headless-bidirectional",
-        "listen",
-      ],
+      modes: ["interactive", "headless-bidirectional", "listen"],
     },
     {
       id: "command-io",


### PR DESCRIPTION
Stacked on #1951. Once that merges, this branch can rebase onto main without conflicts.

## Summary

Headless was the only entry point that did not invoke the reflection launcher. The shared reminder catalog claimed both `reflection-step-count` and `reflection-compaction` were valid in headless modes, but `headless.ts` neither passed `maybeLaunchReflectionSubagent` / `maybeStartIdleReflectionSweep` into `buildSharedReminderParts` nor called `appendTranscriptDeltaJsonl` after `end_turn` — so the on-disk transcript counter never advanced and no trigger ever fired.

Changes:

- **Drop `headless-one-shot` from the reflection reminder catalog** — a single user turn cannot satisfy any reflection cadence, so the entry was misleading.
- **Wire bidirectional mode**: append an optimistic user row to buffers with a matching otid before sending, append transcript delta after `end_turn`, and pass both `maybeLaunchReflectionSubagent` and `maybeStartIdleReflectionSweep` into `buildSharedReminderParts`. `isSubagent` honored throughout so reflection subagents don't recursively trigger reflection.
- **Add CLI flags** for passive sweep thresholds — `--reflection-passive-sweep-enabled`, `--reflection-passive-sweep-interval-hours`, `--reflection-passive-conversation-min-idle-hours`, `--reflection-passive-conversation-min-unreflected-turns`. Useful for testability and for users who want different defaults.
- **Extract `appendOptimisticUserLine`** from a local helper in `App.tsx` into an exported helper in `cli/helpers/accumulator.ts` so headless can reuse it without duplicating the line id + otid plumbing.
- **Log resolved reflection agent id at auto-launch** so the parent's debug log can be correlated with the spawned subagent's `agent.id` server-side.

## Tests

- [x] `bun run typecheck`
- [x] `bun test src/tests/cli src/tests/websocket`
- Live verification against api.letta.com agents:
  - **Step-count**: `--reflection-step-count=2` + 3 user turns → `Auto-launched reflection subagent (step-count)` at start of turn 3.
  - **Idle-time**: build transcript on conv-X, open conv-Y on the same agent with low passive thresholds → `Auto-launched reflection subagent (idle-time)` for conv-X. Cursor advances to `reflected_completed_turns = 3`, `last_reflection_source = idle-time` after subagent completion.
  - **Multi-conversation idle sweep**: two eligible conversations → sweep finds 2 candidate(s), reflections run sequentially through the per-agent queue (~2s gap between #1 success and #2 start), with one aggregate notification.