### PR TITLE
fix(listener): support local channel listeners for self-hosted servers

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -106,6 +106,39 @@ function getListenerServerUrl(settings: {
   );
 }
 
+type ListenerStartupMode =
+  | { kind: "remote"; serverUrl: string }
+  | { kind: "local-channels"; serverUrl: string }
+  | { kind: "unsupported-self-hosted"; serverUrl: string };
+
+function normalizeListenerBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function isCloudListenerServerUrl(serverUrl: string): boolean {
+  return (
+    normalizeListenerBaseUrl(serverUrl) ===
+    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
+  );
+}
+
+async function resolveListenerStartupMode(
+  channelNames: string[],
+): Promise<ListenerStartupMode> {
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const serverUrl = getListenerServerUrl(settings);
+
+  if (isCloudListenerServerUrl(serverUrl)) {
+    return { kind: "remote", serverUrl };
+  }
+
+  if (channelNames.length > 0) {
+    return { kind: "local-channels", serverUrl };
+  }
+
+  return { kind: "unsupported-self-hosted", serverUrl };
+}
+
 async function refreshListenerAccessToken(
   settings: Awaited<
     ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
@@ -198,7 +231,7 @@ async function resolveListenerRegistrationOptions(
 
   let apiKey = settings.env?.LETTA_API_KEY;
 
-  if (serverUrl === LETTA_CLOUD_API_URL) {
+  if (isCloudListenerServerUrl(serverUrl)) {
     const expiresAt = settings.tokenExpiresAt;
     if (settings.refreshToken && expiresAt) {
       const now = Date.now();
@@ -245,6 +278,7 @@ async function resolveListenerRegistrationOptions(
 export const __listenSubcommandTestUtils = {
   flushListenerTelemetryEnd,
   getListenerServerUrl,
+  resolveListenerStartupMode,
   resolveListenerRegistrationOptions,
   setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
     listenerOAuthDepsOverride = overrides
@@ -430,6 +464,73 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   try {
     // Get device ID
     const deviceId = settingsManager.getOrCreateDeviceId();
+    const startupMode = await resolveListenerStartupMode(channelNames);
+
+    if (startupMode.kind === "unsupported-self-hosted") {
+      console.error(
+        `Self-hosted listener registration is not available for ${startupMode.serverUrl}.`,
+      );
+      console.error(
+        "Start with --channels to run local channel adapters, or unset LETTA_BASE_URL to use Letta API remote environments.",
+      );
+      await flushListenerTelemetryEnd("listener_self_hosted_no_channels");
+      return 1;
+    }
+
+    sessionLog.log(`Session started (debug=${debugMode})`);
+    sessionLog.log(`deviceId: ${deviceId}`);
+    sessionLog.log(`connectionName: ${connectionName}`);
+
+    if (startupMode.kind === "local-channels") {
+      const connectionId = `local-${deviceId}`;
+      sessionLog.log(
+        `Starting local channel listener for ${startupMode.serverUrl}`,
+      );
+      sessionLog.log("Skipping environment registration");
+      console.log(
+        `Starting local channel listener for self-hosted server ${startupMode.serverUrl}`,
+      );
+      console.log("Skipping environment registration. Press Ctrl+C to stop.\n");
+
+      const { startLocalChannelListener } = await import(
+        "../../websocket/listen-client"
+      );
+
+      await startLocalChannelListener({
+        connectionId,
+        deviceId,
+        connectionName,
+        onWsEvent:
+          process.env.LETTA_LOG_WS_EVENTS === "1"
+            ? (direction, label, event) => {
+                sessionLog.wsEvent(direction, label, event);
+              }
+            : undefined,
+        onStatusChange: (status) => {
+          sessionLog.log(`status: ${status}`);
+          if (debugMode) {
+            console.log(`[${formatTimestamp()}] status: ${status}`);
+          }
+        },
+        onConnected: () => {
+          sessionLog.log("Local channel listener ready.");
+          if (debugMode) {
+            console.log(`[${formatTimestamp()}] Local channel listener ready.`);
+            console.log("");
+          }
+        },
+        onError: (error: Error) => {
+          sessionLog.log(`Error: ${error.message}`);
+          console.error(`[${formatTimestamp()}] Error: ${error.message}`);
+          void exitWithTelemetry(1, "listener_error");
+        },
+      });
+
+      return new Promise<number>(() => {
+        // Never resolves - runs until Ctrl+C
+      });
+    }
+
     let registerOptions: RegisterOptions;
 
     try {
@@ -452,10 +553,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       await flushListenerTelemetryEnd("listener_oauth_failed");
       return 1;
     }
-
-    sessionLog.log(`Session started (debug=${debugMode})`);
-    sessionLog.log(`deviceId: ${deviceId}`);
-    sessionLog.log(`connectionName: ${connectionName}`);
 
     if (debugMode) {
       console.log(

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -12,7 +12,6 @@
  * On stop: clears interval, releases lease.
  */
 
-import type WebSocket from "ws";
 import type { CronPromptQueueItem, DequeuedBatch } from "../queue/queueRuntime";
 import { ensureConversationQueueRuntime } from "../websocket/listener/client";
 import { scheduleQueuePump } from "../websocket/listener/queue";
@@ -20,6 +19,7 @@ import {
   getActiveRuntime,
   getOrCreateConversationRuntime,
 } from "../websocket/listener/runtime";
+import type { ListenerTransport } from "../websocket/listener/transport";
 import type {
   IncomingMessage,
   StartListenerOptions,
@@ -114,7 +114,7 @@ function shouldFireTask(task: CronTask, now: Date): boolean {
 function fireCronTask(
   task: CronTask,
   now: Date,
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
 ): void {
@@ -185,7 +185,7 @@ function handleMissedOneShot(task: CronTask, now: Date): boolean {
 
 function tick(
   state: SchedulerState,
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
 ): void {
@@ -258,7 +258,7 @@ function tick(
  * No-ops if already running.
  */
 export function startScheduler(
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
 ): void {

--- a/src/tests/cli/listen-subcommand-auth.test.ts
+++ b/src/tests/cli/listen-subcommand-auth.test.ts
@@ -232,4 +232,57 @@ describe("listen subcommand auth resolution", () => {
     expect(requestDeviceCodeMock).not.toHaveBeenCalled();
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
+
+  test("uses local channel mode for self-hosted listeners with channels", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:8283";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      ["telegram"],
+    );
+
+    expect(result).toEqual({
+      kind: "local-channels",
+      serverUrl: "http://localhost:8283",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects self-hosted listener startup without channels", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:8283";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      [],
+    );
+
+    expect(result).toEqual({
+      kind: "unsupported-self-hosted",
+      serverUrl: "http://localhost:8283",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("uses remote registration mode for Cloud listeners with channels", async () => {
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      ["telegram"],
+    );
+
+    expect(result).toEqual({
+      kind: "remote",
+      serverUrl: "https://api.letta.com",
+    });
+  });
 });

--- a/src/tests/cli/listen-subcommand-telemetry.test.ts
+++ b/src/tests/cli/listen-subcommand-telemetry.test.ts
@@ -56,7 +56,7 @@ describe("listen subcommand telemetry", () => {
     telemetry.flush = originalFlush;
   });
 
-  test("tracks and flushes session end on missing API key", async () => {
+  test("tracks and flushes session end for unsupported self-hosted listener startup", async () => {
     const trackSessionEndMock = mock(() => {});
     const flushMock = mock(async () => {});
     telemetry.trackSessionEnd =
@@ -69,7 +69,7 @@ describe("listen subcommand telemetry", () => {
     expect(exitCode).toBe(1);
     expect(trackSessionEndMock).toHaveBeenCalledWith(
       undefined,
-      "listener_missing_api_key",
+      "listener_self_hosted_no_channels",
     );
     expect(flushMock).toHaveBeenCalledTimes(1);
   });

--- a/src/websocket/listen-client.ts
+++ b/src/websocket/listen-client.ts
@@ -13,5 +13,6 @@ export {
   requestApprovalOverWS,
   resolvePendingApprovalResolver,
   startListenerClient,
+  startLocalChannelListener,
   stopListenerClient,
 } from "./listener/client";

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -1,4 +1,3 @@
-import WebSocket from "ws";
 import type { ApprovalResult } from "../../agent/approval-execution";
 import type {
   ApprovalResponseBody,
@@ -10,6 +9,7 @@ import {
   setLoopStatus,
 } from "./protocol-outbound";
 import { evictConversationRuntimeIfIdle } from "./runtime";
+import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type { ConversationRuntime } from "./types";
 
 export function rememberPendingApprovalBatchIds(
@@ -240,11 +240,11 @@ export function rejectPendingApprovalResolvers(
 
 export function requestApprovalOverWS(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   requestId: string,
   controlRequest: ControlRequest,
 ): Promise<ApprovalResponseBody> {
-  if (socket.readyState !== WebSocket.OPEN) {
+  if (!isListenerTransportOpen(socket)) {
     return Promise.reject(new Error("WebSocket not open"));
   }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -282,6 +282,12 @@ import {
   markAwaitingAcceptedApprovalContinuationRunId,
   resolveStaleApprovals,
 } from "./send";
+import {
+  getListenerTransportKind,
+  isListenerTransportOpen,
+  type ListenerTransport,
+  LocalListenerTransport,
+} from "./transport";
 import { handleIncomingMessage } from "./turn";
 import type {
   ChangeCwdMessage,
@@ -352,6 +358,30 @@ function safeSocketSend(
     const serialized =
       typeof payload === "string" ? payload : JSON.stringify(payload);
     socket.send(serialized);
+    return true;
+  } catch (error) {
+    trackListenerError(errorType, error, context);
+    if (isDebugEnabled()) {
+      console.error(`[Listen] ${context} send failed:`, error);
+    }
+    return false;
+  }
+}
+
+function safeTransportSend(
+  transport: ListenerTransport,
+  payload: unknown,
+  errorType: string,
+  context: string,
+): boolean {
+  if (!isListenerTransportOpen(transport)) {
+    return false;
+  }
+
+  try {
+    const serialized =
+      typeof payload === "string" ? payload : JSON.stringify(payload);
+    transport.send(serialized);
     return true;
   } catch (error) {
     trackListenerError(errorType, error, context);
@@ -3284,7 +3314,7 @@ async function handleReflectionSettingsCommand(
  */
 async function wireChannelIngress(
   listener: ListenerRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
 ): Promise<void> {
@@ -3346,18 +3376,22 @@ async function wireChannelIngress(
 
 function handleChannelRegistryEvent(
   event: ChannelRegistryEvent,
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ListenerRuntime,
 ): void {
   if (event.type === "pairings_updated") {
-    emitChannelPairingsUpdated(socket, event.channelId as ChannelId);
-    emitChannelsUpdated(socket, event.channelId as ChannelId);
+    if (socket instanceof WebSocket) {
+      emitChannelPairingsUpdated(socket, event.channelId as ChannelId);
+      emitChannelsUpdated(socket, event.channelId as ChannelId);
+    }
     return;
   }
 
   if (event.type === "targets_updated") {
-    emitChannelTargetsUpdated(socket, event.channelId as ChannelId);
-    emitChannelsUpdated(socket, event.channelId as ChannelId);
+    if (socket instanceof WebSocket) {
+      emitChannelTargetsUpdated(socket, event.channelId as ChannelId);
+      emitChannelsUpdated(socket, event.channelId as ChannelId);
+    }
     return;
   }
 
@@ -3541,7 +3575,7 @@ async function handleApprovalResponseInput(
       conversation_id?: string | null;
     };
     response: ApprovalResponseBody;
-    socket: WebSocket;
+    socket: ListenerTransport;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];
       connectionId?: string;
@@ -3564,7 +3598,7 @@ async function handleApprovalResponseInput(
     ) => ConversationRuntime;
     resolveRecoveredApprovalResponse: (
       runtime: ConversationRuntime,
-      socket: WebSocket,
+      socket: ListenerTransport,
       response: ApprovalResponseBody,
       processTurn: typeof handleIncomingMessage,
       opts?: {
@@ -3574,7 +3608,7 @@ async function handleApprovalResponseInput(
     ) => Promise<boolean>;
     scheduleQueuePump: (
       runtime: ConversationRuntime,
-      socket: WebSocket,
+      socket: ListenerTransport,
       opts: StartListenerOptions,
       processQueuedTurn: ProcessQueuedTurn,
     ) => void;
@@ -4045,6 +4079,7 @@ function createRuntime(): ListenerRuntime {
   const bootWorkingDirectory = getCurrentWorkingDirectory();
   return {
     socket: null,
+    transport: null,
     heartbeatInterval: null,
     reconnectTimeout: null,
     intentionallyClosed: false,
@@ -4101,11 +4136,13 @@ function stopRuntime(
   stopAllWorktreeWatchers(runtime);
 
   if (!runtime.socket) {
+    runtime.transport = null;
     return;
   }
 
   const socket = runtime.socket;
   runtime.socket = null;
+  runtime.transport = null;
 
   // Stale runtimes being replaced should not emit callbacks/retries.
   if (suppressCallbacks) {
@@ -4118,6 +4155,180 @@ function stopRuntime(
   ) {
     socket.close();
   }
+}
+
+async function startConnectedListenerRuntime(
+  runtime: ListenerRuntime,
+  transport: ListenerTransport,
+  opts: Pick<
+    StartListenerOptions,
+    "connectionId" | "onConnected" | "onStatusChange" | "onWsEvent"
+  >,
+  processQueuedTurn: ProcessQueuedTurn,
+  options: {
+    startHeartbeat?: boolean;
+    startCronScheduler?: boolean;
+  } = {},
+): Promise<void> {
+  if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+    return;
+  }
+
+  const shouldStartHeartbeat = options.startHeartbeat !== false;
+  const shouldStartCronScheduler = options.startCronScheduler !== false;
+
+  runtime.transport = transport;
+  safeEmitWsEvent("recv", "lifecycle", {
+    type:
+      getListenerTransportKind(transport) === "websocket"
+        ? "_ws_open"
+        : "_local_open",
+  });
+  runtime.hasSuccessfulConnection = true;
+  runtime.everConnected = true;
+  opts.onConnected(opts.connectionId);
+
+  if (runtime.conversationRuntimes.size === 0) {
+    // Don't emit device_status before the lookup store exists.
+    // Without a conversation runtime, the scope resolves to
+    // agent:__unknown__ which misses persisted CWD and permission
+    // mode entries. The web's sync command will create a scoped
+    // runtime and emit a properly-scoped device_status at that point.
+    emitLoopStatusUpdate(transport, runtime);
+  } else {
+    for (const reminderState of runtime.reminderStateByConversation.values()) {
+      // Reset bootstrap reminder state on (re)connect so session-context
+      // and agent-info fire on the first turn of the new connection.
+      // This is intentionally in the open handler, NOT the sync handler,
+      // because the Desktop UMI controller sends sync every ~5 s and
+      // resetting there would re-arm reminders on every periodic sync.
+      resetSharedReminderState(reminderState);
+    }
+    for (const contextTracker of runtime.contextTrackerByConversation.values()) {
+      resetContextHistory(contextTracker);
+    }
+    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+      const scope = {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      };
+      emitDeviceStatusUpdate(transport, conversationRuntime, scope);
+      emitLoopStatusUpdate(transport, conversationRuntime, scope);
+    }
+  }
+
+  // Subscribe to subagent state changes and emit snapshots over the listener
+  // transport. Local channel mode intentionally discards these frames.
+  runtime._unsubscribeSubagentState?.();
+  runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
+    if (runtime.conversationRuntimes.size === 0) {
+      emitSubagentStateIfOpen(runtime);
+      return;
+    }
+
+    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+      emitSubagentStateIfOpen(runtime, {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      });
+    }
+  });
+
+  // Subscribe to subagent stream events and forward as tagged stream_delta.
+  runtime._unsubscribeSubagentStreamEvents?.();
+  runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
+    (subagentId, event) => {
+      if (!isListenerTransportOpen(transport)) return;
+
+      const subagent = getSubagents().find((entry) => entry.id === subagentId);
+      if (subagent?.silent === true) {
+        // Reflection/background "silent" subagents should not stream their
+        // internal transcript into the parent conversation.
+        return;
+      }
+
+      // The event has { type: "message", message_type, ...LettaStreamingResponse }
+      // plus extra headless fields (session_id, uuid) that pass through harmlessly.
+      emitStreamDelta(
+        transport,
+        runtime,
+        event as unknown as import("../../types/protocol_v2").StreamDelta,
+        subagent?.parentAgentId
+          ? {
+              agent_id: subagent.parentAgentId,
+              conversation_id: subagent.parentConversationId ?? "default",
+            }
+          : undefined,
+        subagentId,
+      );
+    },
+  );
+
+  // Register the message queue bridge to route task notifications into the
+  // correct per-conversation QueueRuntime. This enables background Task
+  // completions to reach the agent in listen mode.
+  setMessageQueueAdder((queuedMessage) => {
+    const targetRuntime =
+      queuedMessage.agentId && queuedMessage.conversationId
+        ? getOrCreateScopedRuntime(
+            runtime,
+            queuedMessage.agentId,
+            queuedMessage.conversationId,
+          )
+        : findFallbackRuntime(runtime);
+
+    if (!targetRuntime?.queueRuntime) {
+      return; // No target — notification dropped
+    }
+
+    targetRuntime.queueRuntime.enqueue({
+      kind: "task_notification",
+      source: "task_notification",
+      text: queuedMessage.text,
+      agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
+      conversationId:
+        queuedMessage.conversationId ?? targetRuntime.conversationId,
+    } as Omit<
+      import("../../queue/queueRuntime").TaskNotificationQueueItem,
+      "id" | "enqueuedAt"
+    >);
+
+    // Kick the queue pump so the notification can trigger a standalone turn
+    // (see consumeQueuedTurn notification-aware path in queue.ts).
+    scheduleQueuePump(
+      targetRuntime,
+      transport,
+      opts as StartListenerOptions,
+      processQueuedTurn,
+    );
+  });
+
+  if (shouldStartHeartbeat) {
+    runtime.heartbeatInterval = setInterval(() => {
+      safeTransportSend(
+        transport,
+        { type: "ping" },
+        "listener_ping_send_failed",
+        "listener_heartbeat",
+      );
+    }, 30000);
+  }
+
+  if (shouldStartCronScheduler) {
+    startCronScheduler(
+      transport,
+      opts as StartListenerOptions,
+      processQueuedTurn,
+    );
+  }
+
+  // Wire channel ingress (if channels are active).
+  await wireChannelIngress(
+    runtime,
+    transport,
+    opts as StartListenerOptions,
+    processQueuedTurn,
+  );
 }
 
 /**
@@ -4141,6 +4352,74 @@ export async function startListenerClient(
   telemetry.init();
 
   await connectWithRetry(runtime, opts);
+}
+
+export interface StartLocalChannelListenerOptions {
+  connectionId: string;
+  deviceId: string;
+  connectionName: string;
+  onConnected: (connectionId: string) => void;
+  onError: (error: Error) => void;
+  onStatusChange?: StartListenerOptions["onStatusChange"];
+  onWsEvent?: StartListenerOptions["onWsEvent"];
+}
+
+/**
+ * Start a listener runtime for local channel adapters without environment
+ * registration or a remote WebSocket server.
+ */
+export async function startLocalChannelListener(
+  opts: StartLocalChannelListenerOptions,
+): Promise<void> {
+  const existingRuntime = getActiveRuntime();
+  if (existingRuntime) {
+    stopRuntime(existingRuntime, true);
+  }
+
+  const runtime = createRuntime();
+  runtime.onWsEvent = opts.onWsEvent;
+  runtime.connectionId = opts.connectionId;
+  runtime.connectionName = opts.connectionName;
+  setActiveRuntime(runtime);
+  telemetry.setSurface("websocket");
+  telemetry.init();
+
+  try {
+    await loadTools();
+    const transport = new LocalListenerTransport();
+    const processQueuedTurn: ProcessQueuedTurn = async (
+      queuedTurn: IncomingMessage,
+      dequeuedBatch: DequeuedBatch,
+    ): Promise<void> => {
+      const scopedRuntime = getOrCreateScopedRuntime(
+        runtime,
+        queuedTurn.agentId,
+        queuedTurn.conversationId,
+      );
+      await handleIncomingMessage(
+        queuedTurn,
+        transport,
+        scopedRuntime,
+        opts.onStatusChange,
+        opts.connectionId,
+        dequeuedBatch.batchId,
+      );
+    };
+
+    await startConnectedListenerRuntime(
+      runtime,
+      transport,
+      opts,
+      processQueuedTurn,
+      { startHeartbeat: false, startCronScheduler: true },
+    );
+  } catch (error) {
+    stopRuntime(runtime, true);
+    if (getActiveRuntime() === runtime) {
+      setActiveRuntime(null);
+    }
+    opts.onError(error instanceof Error ? error : new Error(String(error)));
+  }
 }
 
 /** File/directory names filtered from directory listings (OS/VCS noise). */
@@ -4307,6 +4586,7 @@ async function connectWithRetry(
   const cancelledWatches = new Set<string>();
 
   runtime.socket = socket;
+  const transport = socket;
   const processQueuedTurn: ProcessQueuedTurn = async (
     queuedTurn: IncomingMessage,
     dequeuedBatch: DequeuedBatch,
@@ -4318,7 +4598,7 @@ async function connectWithRetry(
     );
     await handleIncomingMessage(
       queuedTurn,
-      socket,
+      transport,
       scopedRuntime,
       opts.onStatusChange,
       opts.connectionId,
@@ -4327,145 +4607,13 @@ async function connectWithRetry(
   };
 
   socket.on("open", async () => {
-    if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
-      return;
-    }
-
-    safeEmitWsEvent("recv", "lifecycle", { type: "_ws_open" });
-    runtime.hasSuccessfulConnection = true;
-    runtime.everConnected = true;
-    opts.onConnected(opts.connectionId);
-
-    if (runtime.conversationRuntimes.size === 0) {
-      // Don't emit device_status before the lookup store exists.
-      // Without a conversation runtime, the scope resolves to
-      // agent:__unknown__ which misses persisted CWD and permission
-      // mode entries. The web's sync command will create a scoped
-      // runtime and emit a properly-scoped device_status at that point.
-      emitLoopStatusUpdate(socket, runtime);
-    } else {
-      for (const reminderState of runtime.reminderStateByConversation.values()) {
-        // Reset bootstrap reminder state on (re)connect so session-context
-        // and agent-info fire on the first turn of the new connection.
-        // This is intentionally in the open handler, NOT the sync handler,
-        // because the Desktop UMI controller sends sync every ~5 s and
-        // resetting there would re-arm reminders on every periodic sync.
-        resetSharedReminderState(reminderState);
-      }
-      for (const contextTracker of runtime.contextTrackerByConversation.values()) {
-        resetContextHistory(contextTracker);
-      }
-      for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-        const scope = {
-          agent_id: conversationRuntime.agentId,
-          conversation_id: conversationRuntime.conversationId,
-        };
-        emitDeviceStatusUpdate(socket, conversationRuntime, scope);
-        emitLoopStatusUpdate(socket, conversationRuntime, scope);
-      }
-    }
-
-    // Subscribe to subagent state changes and emit snapshots over WS.
-    // Store the unsubscribe function on the runtime for cleanup on close.
-    runtime._unsubscribeSubagentState?.();
-    runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
-      if (runtime.conversationRuntimes.size === 0) {
-        emitSubagentStateIfOpen(runtime);
-        return;
-      }
-
-      for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-        emitSubagentStateIfOpen(runtime, {
-          agent_id: conversationRuntime.agentId,
-          conversation_id: conversationRuntime.conversationId,
-        });
-      }
-    });
-
-    // Subscribe to subagent stream events and forward as tagged stream_delta.
-    // Events are raw JSON lines from the subagent's stdout (headless format):
-    //   { type: "message", message_type: "tool_call_message", ...LettaStreamingResponse fields }
-    // These are already MessageDelta-shaped (type:"message" + LettaStreamingResponse).
-    runtime._unsubscribeSubagentStreamEvents?.();
-    runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
-      (subagentId, event) => {
-        if (socket.readyState !== WebSocket.OPEN) return;
-
-        const subagent = getSubagents().find(
-          (entry) => entry.id === subagentId,
-        );
-        if (subagent?.silent === true) {
-          // Reflection/background "silent" subagents should not stream their
-          // internal transcript into the parent conversation.
-          return;
-        }
-
-        // The event has { type: "message", message_type, ...LettaStreamingResponse }
-        // plus extra headless fields (session_id, uuid) that pass through harmlessly.
-        emitStreamDelta(
-          socket,
-          runtime,
-          event as unknown as import("../../types/protocol_v2").StreamDelta,
-          subagent?.parentAgentId
-            ? {
-                agent_id: subagent.parentAgentId,
-                conversation_id: subagent.parentConversationId ?? "default",
-              }
-            : undefined,
-          subagentId,
-        );
-      },
+    await startConnectedListenerRuntime(
+      runtime,
+      transport,
+      opts,
+      processQueuedTurn,
+      { startHeartbeat: true, startCronScheduler: true },
     );
-
-    // Register the message queue bridge to route task notifications into the
-    // correct per-conversation QueueRuntime. This enables background Task
-    // completions to reach the agent in listen mode.
-    setMessageQueueAdder((queuedMessage) => {
-      const targetRuntime =
-        queuedMessage.agentId && queuedMessage.conversationId
-          ? getOrCreateScopedRuntime(
-              runtime,
-              queuedMessage.agentId,
-              queuedMessage.conversationId,
-            )
-          : findFallbackRuntime(runtime);
-
-      if (!targetRuntime?.queueRuntime) {
-        return; // No target — notification dropped
-      }
-
-      targetRuntime.queueRuntime.enqueue({
-        kind: "task_notification",
-        source: "task_notification",
-        text: queuedMessage.text,
-        agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
-        conversationId:
-          queuedMessage.conversationId ?? targetRuntime.conversationId,
-      } as Omit<
-        import("../../queue/queueRuntime").TaskNotificationQueueItem,
-        "id" | "enqueuedAt"
-      >);
-
-      // Kick the queue pump so the notification can trigger a standalone turn
-      // (see consumeQueuedTurn notification-aware path in queue.ts).
-      scheduleQueuePump(targetRuntime, socket, opts, processQueuedTurn);
-    });
-    runtime.heartbeatInterval = setInterval(() => {
-      if (socket.readyState === WebSocket.OPEN) {
-        safeSocketSend(
-          socket,
-          { type: "ping" },
-          "listener_ping_send_failed",
-          "listener_heartbeat",
-        );
-      }
-    }, 30000);
-
-    // Start cron scheduler if tasks exist
-    startCronScheduler(socket, opts, processQueuedTurn);
-
-    // Wire channel ingress (if channels are active)
-    await wireChannelIngress(runtime, socket, opts, processQueuedTurn);
   });
 
   socket.on("message", async (data: WebSocket.RawData) => {
@@ -6117,7 +6265,7 @@ async function connectWithRetry(
  */
 export function isListenerActive(): boolean {
   const runtime = getActiveRuntime();
-  return runtime !== null && runtime.socket !== null;
+  return runtime !== null && runtime.transport !== null;
 }
 
 /**

--- a/src/websocket/listener/interrupts.ts
+++ b/src/websocket/listener/interrupts.ts
@@ -1,4 +1,3 @@
-import type WebSocket from "ws";
 import type { ApprovalResult } from "../../agent/approval-execution";
 import { normalizeApprovalResultsForPersistence } from "../../agent/approval-result-normalization";
 import { INTERRUPTED_BY_USER } from "../../constants";
@@ -14,6 +13,7 @@ import {
   emitCanonicalMessageDelta,
 } from "./protocol-outbound";
 import { clearRecoveredApprovalState } from "./runtime";
+import type { ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
   InterruptPopulateInput,
@@ -328,7 +328,7 @@ export function extractInterruptToolReturns(
 }
 
 export function emitInterruptToolReturnMessage(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   approvals: ApprovalResult[] | null,
   runId?: string | null,
@@ -372,7 +372,7 @@ export function emitInterruptToolReturnMessage(
 }
 
 export function emitToolExecutionStartedEvents(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   params: {
     toolCallIds: string[];
@@ -394,7 +394,7 @@ export function emitToolExecutionStartedEvents(
 }
 
 export function emitToolExecutionFinishedEvents(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   params: {
     approvals: ApprovalResult[] | null;
@@ -418,7 +418,7 @@ export function emitToolExecutionFinishedEvents(
 }
 
 export function createToolExecutionOutputEmitter(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   params: {
     runId?: string | null;

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -3,7 +3,6 @@ import { dirname } from "node:path";
 import { performance } from "node:perf_hooks";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
-import WebSocket from "ws";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { getGitContext } from "../../cli/helpers/gitContext";
 import { getReflectionSettings } from "../../cli/helpers/memoryReminder";
@@ -54,6 +53,7 @@ import {
   resolveScopedAgentId,
   resolveScopedConversationId,
 } from "./scope";
+import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -438,10 +438,11 @@ export function buildDeviceStatus(
   const systemPromptDoctorState = scopedAgentId
     ? getSystemPromptDoctorState(scopedAgentId)
     : null;
+  const transport = listener.transport ?? listener.socket;
   return {
     current_connection_id: listener.connectionId,
     connection_name: listener.connectionName,
-    is_online: listener.socket?.readyState === WebSocket.OPEN,
+    is_online: transport ? isListenerTransportOpen(transport) : false,
     is_processing: !!conversationRuntime?.isProcessing,
     current_permission_mode: conversationPermissionModeState.mode,
     current_working_directory: resolvedCwd,
@@ -573,7 +574,7 @@ export function setLoopStatus(
 }
 
 export function emitProtocolV2Message(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   message: Omit<
     WsProtocolMessage,
@@ -584,7 +585,7 @@ export function emitProtocolV2Message(
     conversation_id?: string | null;
   },
 ): void {
-  if (socket.readyState !== WebSocket.OPEN) {
+  if (!isListenerTransportOpen(socket)) {
     return;
   }
   const listener = getListenerRuntime(runtime);
@@ -646,7 +647,7 @@ export function emitProtocolV2Message(
 }
 
 export function emitDeviceStatusUpdate(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope?: {
     agent_id?: string | null;
@@ -664,7 +665,7 @@ export function emitDeviceStatusUpdate(
 }
 
 export function emitLoopStatusUpdate(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope?: {
     agent_id?: string | null;
@@ -689,8 +690,9 @@ export function emitLoopStatusIfOpen(
   },
 ): void {
   const listener = getListenerRuntime(runtime);
-  if (listener?.socket?.readyState === WebSocket.OPEN) {
-    emitLoopStatusUpdate(listener.socket, runtime, scope);
+  const transport = listener?.transport ?? listener?.socket;
+  if (transport && isListenerTransportOpen(transport)) {
+    emitLoopStatusUpdate(transport, runtime, scope);
   }
 }
 
@@ -702,13 +704,14 @@ export function emitDeviceStatusIfOpen(
   },
 ): void {
   const listener = getListenerRuntime(runtime);
-  if (listener?.socket?.readyState === WebSocket.OPEN) {
-    emitDeviceStatusUpdate(listener.socket, runtime, scope);
+  const transport = listener?.transport ?? listener?.socket;
+  if (transport && isListenerTransportOpen(transport)) {
+    emitDeviceStatusUpdate(transport, runtime, scope);
   }
 }
 
 export function emitQueueUpdate(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope?: {
     agent_id?: string | null;
@@ -749,7 +752,7 @@ export function isSystemReminderPart(part: unknown): boolean {
 }
 
 export function emitDequeuedUserMessage(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   incoming: IncomingMessage,
   batch: DequeuedBatch,
@@ -808,13 +811,14 @@ export function emitQueueUpdateIfOpen(
   },
 ): void {
   const listener = getListenerRuntime(runtime);
-  if (listener?.socket?.readyState === WebSocket.OPEN) {
-    emitQueueUpdate(listener.socket, runtime, scope);
+  const transport = listener?.transport ?? listener?.socket;
+  if (transport && isListenerTransportOpen(transport)) {
+    emitQueueUpdate(transport, runtime, scope);
   }
 }
 
 export function emitStateSync(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope: RuntimeScope,
 ): void {
@@ -891,7 +895,7 @@ export function buildSubagentSnapshot(
 }
 
 export function emitSubagentStateUpdate(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope?: {
     agent_id?: string | null;
@@ -916,8 +920,9 @@ export function emitSubagentStateIfOpen(
   },
 ): void {
   const listener = getListenerRuntime(runtime);
-  if (listener?.socket?.readyState === WebSocket.OPEN) {
-    emitSubagentStateUpdate(listener.socket, runtime, scope);
+  const transport = listener?.transport ?? listener?.socket;
+  if (transport && isListenerTransportOpen(transport)) {
+    emitSubagentStateUpdate(transport, runtime, scope);
   }
 }
 
@@ -959,7 +964,7 @@ export function createLifecycleMessageBase<TMessageType extends string>(
 }
 
 export function emitCanonicalMessageDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   delta: StreamDelta,
   scope?: {
@@ -971,7 +976,7 @@ export function emitCanonicalMessageDelta(
 }
 
 export function emitLoopErrorDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   params: {
     message: string;
@@ -1001,7 +1006,7 @@ export function emitLoopErrorDelta(
 }
 
 export function emitRetryDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   params: {
     message: string;
@@ -1029,7 +1034,7 @@ export function emitRetryDelta(
 }
 
 export function emitStatusDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   params: {
     message: string;
@@ -1051,7 +1056,7 @@ export function emitStatusDelta(
 }
 
 export function emitInterruptedStatusDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   params: {
     runId?: string | null;
@@ -1069,7 +1074,7 @@ export function emitInterruptedStatusDelta(
 }
 
 export function emitStreamDelta(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: RuntimeCarrier,
   delta: StreamDelta,
   scope?: {

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -1,5 +1,4 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import type WebSocket from "ws";
 import { getChannelRegistry } from "../../channels/registry";
 import type {
   ChannelTurnOutcome,
@@ -28,6 +27,7 @@ import {
   getPendingControlRequestCount,
 } from "./runtime";
 import { resolveRuntimeScope } from "./scope";
+import type { ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
   InboundMessagePayload,
@@ -410,7 +410,7 @@ function computeListenerQueueBlockedReason(
 
 async function drainQueuedMessages(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: (
     queuedTurn: IncomingMessage,
@@ -502,7 +502,7 @@ async function drainQueuedMessages(
 
 export function scheduleQueuePump(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: (
     queuedTurn: IncomingMessage,

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -1,6 +1,5 @@
 import { APIError, APIUserAbortError } from "@letta-ai/letta-client/core/error";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
-import type WebSocket from "ws";
 import type { RunErrorInfo } from "../../agent/approval-recovery";
 import { extractConflictDetail } from "../../agent/turn-recovery-policy";
 import {
@@ -15,6 +14,7 @@ import {
   emitRetryDelta,
   emitStatusDelta,
 } from "./protocol-outbound";
+import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
 export type RecoverableStatusNoticeKind = "stale_approval_conflict_recovery";
@@ -244,7 +244,7 @@ export function getLoopErrorNoticeDecision(params: {
 }
 
 export function emitLoopErrorNotice(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ListenerRuntime | ConversationRuntime,
   params: {
     message: string;
@@ -284,7 +284,7 @@ export function emitLoopErrorNotice(
 }
 
 export function emitRecoverableStatusNotice(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ListenerRuntime | ConversationRuntime,
   params: {
     kind: RecoverableStatusNoticeKind;
@@ -316,7 +316,7 @@ export function emitRecoverableStatusNotice(
 }
 
 export function emitRecoverableRetryNotice(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ListenerRuntime | ConversationRuntime,
   params: Parameters<typeof emitRetryDelta>[2] & {
     kind: RecoverableRetryNoticeKind;

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -5,7 +5,6 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import type WebSocket from "ws";
 import {
   type ApprovalDecision,
   executeApprovalBatch,
@@ -62,6 +61,7 @@ import {
   clearRecoveredApprovalState,
   hasInterruptedCacheForScope,
 } from "./runtime";
+import type { ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -147,7 +147,7 @@ export async function isRetriablePostStopError(
 
 export async function drainRecoveryStreamWithEmission(
   recoveryStream: Stream<LettaStreamingResponse>,
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   params: {
     agentId?: string | null;
@@ -218,7 +218,7 @@ export async function drainRecoveryStreamWithEmission(
 
 export function finalizeHandledRecoveryTurn(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   params: {
     drainResult: Awaited<ReturnType<typeof drainStreamWithResume>>;
     agentId?: string | null;
@@ -439,11 +439,11 @@ export async function recoverApprovalStateForSync(
 
 export async function resolveRecoveredApprovalResponse(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   response: ApprovalResponseBody,
   processTurn: (
     msg: IncomingMessage,
-    socket: WebSocket,
+    socket: ListenerTransport,
     runtime: ConversationRuntime,
     onStatusChange?: (
       status: "idle" | "receiving" | "processing",

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -5,7 +5,6 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import type WebSocket from "ws";
 import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
 import { getClient } from "../../agent/client";
@@ -44,6 +43,7 @@ import {
   isApprovalToolCallDesyncError,
 } from "./recovery";
 import { injectQueuedSkillContent } from "./skill-injection";
+import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime } from "./types";
 
 export function isApprovalOnlyInput(
@@ -73,7 +73,7 @@ export function markAwaitingAcceptedApprovalContinuationRunId(
  */
 export async function resolveStaleApprovals(
   runtime: ConversationRuntime,
-  socket: WebSocket,
+  socket: ListenerTransport,
   abortSignal: AbortSignal,
   deps: {
     getResumeData?: typeof getResumeData;
@@ -235,7 +235,7 @@ export async function sendMessageStreamWithRetry(
   conversationId: string,
   messages: Parameters<typeof sendMessageStream>[1],
   opts: Parameters<typeof sendMessageStream>[2],
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   abortSignal?: AbortSignal,
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
@@ -449,7 +449,7 @@ export async function sendApprovalContinuationWithRetry(
   conversationId: string,
   messages: Parameters<typeof sendMessageStream>[1],
   opts: Parameters<typeof sendMessageStream>[2],
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   abortSignal?: AbortSignal,
   retryOptions: {

--- a/src/websocket/listener/transport.ts
+++ b/src/websocket/listener/transport.ts
@@ -1,0 +1,44 @@
+import WebSocket from "ws";
+
+/**
+ * Outbound side of a listener connection.
+ *
+ * Remote environment listeners write protocol frames to a real WebSocket.
+ * Local channel listeners have no remote peer, but still run the same turn
+ * processor; their outbound protocol frames are intentionally discarded.
+ */
+export interface LocalTransport {
+  readonly kind: "local";
+  readonly bufferedAmount: number;
+  isOpen(): boolean;
+  send(data: string): void;
+}
+
+export type ListenerTransport = WebSocket | LocalTransport;
+
+export class LocalListenerTransport implements LocalTransport {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+
+  isOpen(): boolean {
+    return true;
+  }
+
+  send(_data: string): void {
+    // Local channel mode has no remote status subscriber. The agent turn still
+    // executes locally; protocol/status frames are not sent anywhere.
+  }
+}
+
+export function isListenerTransportOpen(transport: ListenerTransport): boolean {
+  if ("isOpen" in transport && typeof transport.isOpen === "function") {
+    return transport.isOpen();
+  }
+  return (transport as WebSocket).readyState === WebSocket.OPEN;
+}
+
+export function getListenerTransportKind(
+  transport: ListenerTransport,
+): "websocket" | "local" {
+  return "kind" in transport ? transport.kind : "websocket";
+}

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -5,7 +5,6 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import WebSocket from "ws";
 import {
   type ApprovalResult,
   executeApprovalBatch,
@@ -57,6 +56,7 @@ import {
   sendApprovalContinuationWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
+import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type { ConversationRuntime } from "./types";
 
 type Decision =
@@ -152,7 +152,7 @@ export async function handleApprovalStop(params: {
     toolArgs: string;
   }>;
   runtime: ConversationRuntime;
-  socket: WebSocket;
+  socket: ListenerTransport;
   agentId: string;
   conversationId: string;
   turnWorkingDirectory: string;
@@ -483,7 +483,7 @@ export async function handleApprovalStop(params: {
   // Broadcast new file content to web clients when a file-mutating tool
   // (Edit, Write, MultiEdit) writes to disk, so all windows update immediately.
   const onFileWrite = (filePath: string, content: string) => {
-    if (socket.readyState === WebSocket.OPEN) {
+    if (isListenerTransportOpen(socket)) {
       socket.send(
         JSON.stringify({
           type: "file_ops",

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -4,7 +4,6 @@ import type {
   ApprovalCreate,
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import type WebSocket from "ws";
 import type { ApprovalResult } from "../../agent/approval-execution";
 import { fetchRunErrorInfo } from "../../agent/approval-recovery";
 import { getResumeData } from "../../agent/check-approval";
@@ -104,6 +103,7 @@ import {
   sendMessageStreamWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
+import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import type {
   ConversationRuntime,
@@ -165,7 +165,7 @@ function escapeTaskNotificationSummary(summary: string): string {
 
 function buildMaybeLaunchReflectionSubagent(params: {
   runtime: ConversationRuntime;
-  socket: WebSocket;
+  socket: ListenerTransport;
   agentId: string;
   conversationId: string;
   workingDirectory: string;
@@ -311,7 +311,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
 }
 
 function finalizeInterruptedTurn(
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   params: {
     runId?: string | null;
@@ -347,7 +347,7 @@ function finalizeInterruptedTurn(
 
 export async function handleIncomingMessage(
   msg: IncomingMessage,
-  socket: WebSocket,
+  socket: ListenerTransport,
   runtime: ConversationRuntime,
   onStatusChange?: (
     status: "idle" | "receiving" | "processing",

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -24,6 +24,7 @@ import type {
   RuntimeScope,
   WsProtocolCommand,
 } from "../../types/protocol_v2";
+import type { ListenerTransport } from "./transport";
 
 export interface StartListenerOptions {
   connectionId: string;
@@ -153,6 +154,7 @@ export type ConversationRuntime = {
 
 export type ListenerRuntime = {
   socket: WebSocket | null;
+  transport?: ListenerTransport | null;
   heartbeatInterval: NodeJS.Timeout | null;
   reconnectTimeout: NodeJS.Timeout | null;
   intentionallyClosed: boolean;


### PR DESCRIPTION
## Summary
- Routes non-Cloud `LETTA_BASE_URL` listener startup with `--channels` into a local channel listener instead of attempting environment registration.
- Introduces a listener transport abstraction so the existing turn/queue/recovery path can run without a remote WebSocket or fake socket object.
- Keeps default Letta API remote environment registration unchanged and returns a clearer error for self-hosted listener startup without channels.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/cli/listen-subcommand-auth.test.ts src/tests/websocket/listen-client-concurrency.test.ts src/tests/websocket/listen-client-protocol.test.ts src/tests/websocket/listen-interrupt-queue.test.ts`

👾 Generated with [Letta Code](https://letta.com)