### PR TITLE
fix(listener): hydrate secrets for websocket shell tools

### DIFF
--- a/src/tests/tools/secret-substitution.test.ts
+++ b/src/tests/tools/secret-substitution.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  executeTool,
+  prepareToolExecutionContextForSpecificTools,
+  releaseToolExecutionContext,
+} from "../../tools/manager";
+import {
+  scrubSecretsFromString,
+  substituteSecretsInArgs,
+} from "../../tools/secret-substitution";
+import {
+  clearSecretsCache,
+  initSecretsFromServer,
+} from "../../utils/secretsStore";
+import { createTempRuntimeScriptCommand } from "./runtimeScript";
+
+const AGENT_A = "agent-secret-substitution-a";
+const AGENT_B = "agent-secret-substitution-b";
+const SECRET_KEY = "WS_SECRET_TOKEN";
+const SECRET_A = "scopedsecreta";
+const SECRET_B = "scopedsecretb";
+
+function asText(
+  toolReturn: Awaited<ReturnType<typeof executeTool>>["toolReturn"],
+): string {
+  return typeof toolReturn === "string"
+    ? toolReturn
+    : JSON.stringify(toolReturn);
+}
+
+async function seedSecret(agentId: string, value: string): Promise<void> {
+  await initSecretsFromServer(agentId, {
+    secrets: [{ key: SECRET_KEY, value }],
+  });
+}
+
+afterEach(() => {
+  clearSecretsCache(AGENT_A);
+  clearSecretsCache(AGENT_B);
+});
+
+describe("secret substitution", () => {
+  test("uses the explicitly scoped agent id", async () => {
+    await seedSecret(AGENT_A, SECRET_A);
+    await seedSecret(AGENT_B, SECRET_B);
+
+    expect(
+      substituteSecretsInArgs({ command: `echo $${SECRET_KEY}` }, AGENT_A),
+    ).toEqual({ command: `echo ${SECRET_A}` });
+    expect(
+      substituteSecretsInArgs({ command: `echo $${SECRET_KEY}` }, AGENT_B),
+    ).toEqual({ command: `echo ${SECRET_B}` });
+
+    expect(scrubSecretsFromString(SECRET_A, AGENT_A)).toBe(
+      `${SECRET_KEY}=<REDACTED>`,
+    );
+    expect(scrubSecretsFromString(SECRET_B, AGENT_A)).toBe(SECRET_B);
+  });
+
+  test("substitutes strings recursively in arrays and plain objects", async () => {
+    await seedSecret(AGENT_A, SECRET_A);
+
+    expect(
+      substituteSecretsInArgs(
+        {
+          command: [process.execPath, "-e", `console.log('$${SECRET_KEY}')`],
+          env_overrides: {
+            TOKEN: `$${SECRET_KEY}`,
+            nested: [`prefix-$${SECRET_KEY}`],
+          },
+        },
+        AGENT_A,
+      ),
+    ).toEqual({
+      command: [process.execPath, "-e", `console.log('${SECRET_A}')`],
+      env_overrides: {
+        TOKEN: SECRET_A,
+        nested: [`prefix-${SECRET_A}`],
+      },
+    });
+  });
+});
+
+describe("shell tool secret substitution", () => {
+  const stringShellTools: Array<{
+    name: string;
+    toolNames: string[];
+    buildArgs: (command: string) => Record<string, unknown>;
+  }> = [
+    {
+      name: "Bash",
+      toolNames: ["Bash"],
+      buildArgs: (command) => ({ command, timeout: 5000 }),
+    },
+    {
+      name: "shell_command",
+      toolNames: ["shell_command"],
+      buildArgs: (command) => ({ command, login: false, timeout_ms: 5000 }),
+    },
+    {
+      name: "ShellCommand",
+      toolNames: ["ShellCommand"],
+      buildArgs: (command) => ({ command, login: false, timeout_ms: 5000 }),
+    },
+    {
+      name: "run_shell_command",
+      toolNames: ["run_shell_command"],
+      buildArgs: (command) => ({ command, timeout_ms: 5000 }),
+    },
+    {
+      name: "RunShellCommand",
+      toolNames: ["RunShellCommand"],
+      buildArgs: (command) => ({ command, timeout_ms: 5000 }),
+    },
+  ];
+
+  for (const tool of stringShellTools) {
+    test(`${tool.name} substitutes and scrubs scoped secrets`, async () => {
+      await seedSecret(AGENT_A, SECRET_A);
+      const runtimeScript = createTempRuntimeScriptCommand(
+        "process.stdout.write(process.argv[2] ?? '')",
+      );
+      const prepared = await prepareToolExecutionContextForSpecificTools(
+        tool.toolNames,
+        {
+          runtimeContext: {
+            agentId: AGENT_A,
+            workingDirectory: process.cwd(),
+          },
+          workingDirectory: process.cwd(),
+        },
+      );
+
+      try {
+        const result = await executeTool(
+          tool.name,
+          tool.buildArgs(`${runtimeScript.command} $${SECRET_KEY}`),
+          { toolContextId: prepared.contextId },
+        );
+
+        const text = asText(result.toolReturn);
+        expect(result.status).toBe("success");
+        expect(text).toContain(`${SECRET_KEY}=<REDACTED>`);
+        expect(text).not.toContain(SECRET_A);
+      } finally {
+        releaseToolExecutionContext(prepared.contextId);
+        runtimeScript.cleanup();
+      }
+    });
+  }
+
+  for (const toolName of ["shell", "Shell"]) {
+    test(`${toolName} substitutes secrets inside command arrays`, async () => {
+      await seedSecret(AGENT_A, SECRET_A);
+      const prepared = await prepareToolExecutionContextForSpecificTools(
+        [toolName],
+        {
+          runtimeContext: {
+            agentId: AGENT_A,
+            workingDirectory: process.cwd(),
+          },
+          workingDirectory: process.cwd(),
+        },
+      );
+
+      try {
+        const result = await executeTool(
+          toolName,
+          {
+            command: [
+              process.execPath,
+              "-e",
+              "process.stdout.write(process.argv[1] ?? '')",
+              `$${SECRET_KEY}`,
+            ],
+            timeout_ms: 5000,
+          },
+          { toolContextId: prepared.contextId },
+        );
+
+        const text = asText(result.toolReturn);
+        expect(result.status).toBe("success");
+        expect(text).toContain(`${SECRET_KEY}=<REDACTED>`);
+        expect(text).not.toContain(SECRET_A);
+      } finally {
+        releaseToolExecutionContext(prepared.contextId);
+      }
+    });
+  }
+});

--- a/src/tests/tools/shell-secrets.test.ts
+++ b/src/tests/tools/shell-secrets.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { bash } from "../../tools/impl/Bash";
 import { run_shell_command } from "../../tools/impl/RunShellCommandGemini";
 import { shell_command } from "../../tools/impl/ShellCommand.js";
@@ -6,34 +6,45 @@ import { buildPowerShellCommand } from "../../tools/impl/shellLaunchers";
 import {
   executeTool,
   prepareToolExecutionContextForSpecificTools,
+  releaseToolExecutionContext,
   type ToolReturnContent,
 } from "../../tools/manager";
 import {
   extractSecretEnvFromCommand,
   scrubSecretsFromString,
 } from "../../tools/secret-substitution";
+import {
+  clearSecretsCache,
+  initSecretsFromServer,
+} from "../../utils/secretsStore";
 
-const mockSecrets: Record<string, string> = {
+const TEST_AGENT_ID = "agent-shell-secrets";
+
+const seededSecrets = {
   API_KEY: "sk-12345",
   PASSWORD: "he$$o",
   TOKEN: "$foo$bar",
-  EMPTY: "",
   BACKTICK: "`whoami`",
-};
+} as const;
 
-mock.module("../../utils/secretsStore", () => ({
-  loadSecrets: () => mockSecrets,
-}));
-
-afterAll(() => {
-  mock.restore();
+afterEach(() => {
+  clearSecretsCache(TEST_AGENT_ID);
 });
 
 const secretEnv = {
-  PASSWORD: "he$$o",
-  BACKTICK: "`whoami`",
-  TOKEN: "$foo$bar",
+  PASSWORD: seededSecrets.PASSWORD,
+  BACKTICK: seededSecrets.BACKTICK,
+  TOKEN: seededSecrets.TOKEN,
 };
+
+async function seedSecrets(): Promise<void> {
+  await initSecretsFromServer(TEST_AGENT_ID, {
+    secrets: Object.entries(seededSecrets).map(([key, value]) => ({
+      key,
+      value,
+    })),
+  });
+}
 
 function literalSecretCommand(): string {
   return process.platform === "win32"
@@ -56,38 +67,49 @@ function toolReturnText(toolReturn: ToolReturnContent): string {
 }
 
 describe("shell secret env extraction", () => {
-  test("extracts only referenced known secrets", () => {
+  test("extracts only referenced known secrets", async () => {
+    await seedSecrets();
     expect(
-      extractSecretEnvFromCommand("$API_KEY:$PASSWORD:$UNKNOWN:$EMPTY"),
+      extractSecretEnvFromCommand("$API_KEY:$PASSWORD:$UNKNOWN", TEST_AGENT_ID),
     ).toEqual({
-      API_KEY: "sk-12345",
-      PASSWORD: "he$$o",
-      EMPTY: "",
+      API_KEY: seededSecrets.API_KEY,
+      PASSWORD: seededSecrets.PASSWORD,
     });
   });
 
-  test("deduplicates repeated references", () => {
-    expect(extractSecretEnvFromCommand("$API_KEY and $API_KEY")).toEqual({
-      API_KEY: "sk-12345",
+  test("deduplicates repeated references", async () => {
+    await seedSecrets();
+    expect(
+      extractSecretEnvFromCommand("$API_KEY and $API_KEY", TEST_AGENT_ID),
+    ).toEqual({
+      API_KEY: seededSecrets.API_KEY,
     });
   });
 
-  test("returns empty object when no secrets are referenced", () => {
-    expect(extractSecretEnvFromCommand("echo hello")).toEqual({});
+  test("returns empty object when no secrets are referenced", async () => {
+    await seedSecrets();
+    expect(extractSecretEnvFromCommand("echo hello", TEST_AGENT_ID)).toEqual(
+      {},
+    );
   });
 });
 
 describe("shell secret scrubbing", () => {
-  test("replaces secret values with NAME=<REDACTED>", () => {
-    expect(scrubSecretsFromString("key=sk-12345")).toBe(
-      "key=API_KEY=<REDACTED>",
-    );
+  test("replaces secret values with NAME=<REDACTED>", async () => {
+    await seedSecrets();
+    expect(
+      scrubSecretsFromString(`key=${seededSecrets.API_KEY}`, TEST_AGENT_ID),
+    ).toBe("key=API_KEY=<REDACTED>");
   });
 
-  test("scrubs shell-sensitive secret values literally", () => {
-    expect(scrubSecretsFromString("pw=he$$o x=`whoami`")).toBe(
-      "pw=PASSWORD=<REDACTED> x=BACKTICK=<REDACTED>",
-    );
+  test("scrubs shell-sensitive secret values literally", async () => {
+    await seedSecrets();
+    expect(
+      scrubSecretsFromString(
+        `pw=${seededSecrets.PASSWORD} x=${seededSecrets.BACKTICK}`,
+        TEST_AGENT_ID,
+      ),
+    ).toBe("pw=PASSWORD=<REDACTED> x=BACKTICK=<REDACTED>");
   });
 });
 
@@ -133,33 +155,43 @@ describe("shell secret execution", () => {
   });
 
   test("executeTool injects and scrubs referenced shell secrets", async () => {
+    await seedSecrets();
     const command = literalSecretCommand();
-    const context = await prepareToolExecutionContextForSpecificTools([
-      "Bash",
-      "shell_command",
-      "ShellCommand",
-      "run_shell_command",
-    ]);
-    const calls = [
-      ["Bash", { command, description: "Test shell secrets" }],
-      ["shell_command", { command }],
-      ["ShellCommand", { command }],
-      ["run_shell_command", { command }],
-    ] as const;
+    const context = await prepareToolExecutionContextForSpecificTools(
+      ["Bash", "shell_command", "ShellCommand", "run_shell_command"],
+      {
+        runtimeContext: {
+          agentId: TEST_AGENT_ID,
+          workingDirectory: process.cwd(),
+        },
+        workingDirectory: process.cwd(),
+      },
+    );
 
-    for (const [toolName, args] of calls) {
-      const result = await executeTool(toolName, args, {
-        toolContextId: context.contextId,
-      });
-      const output = toolReturnText(result.toolReturn);
+    try {
+      const calls = [
+        ["Bash", { command, description: "Test shell secrets" }],
+        ["shell_command", { command }],
+        ["ShellCommand", { command }],
+        ["run_shell_command", { command }],
+      ] as const;
 
-      expect(result.status).toBe("success");
-      expect(output).toContain("PASSWORD=<REDACTED>");
-      expect(output).toContain("BACKTICK=<REDACTED>");
-      expect(output).toContain("TOKEN=<REDACTED>");
-      expect(output).not.toContain("he$$o");
-      expect(output).not.toContain("`whoami`");
-      expect(output).not.toContain("$foo$bar");
+      for (const [toolName, args] of calls) {
+        const result = await executeTool(toolName, args, {
+          toolContextId: context.contextId,
+        });
+        const output = toolReturnText(result.toolReturn);
+
+        expect(result.status).toBe("success");
+        expect(output).toContain("PASSWORD=<REDACTED>");
+        expect(output).toContain("BACKTICK=<REDACTED>");
+        expect(output).toContain("TOKEN=<REDACTED>");
+        expect(output).not.toContain(seededSecrets.PASSWORD);
+        expect(output).not.toContain(seededSecrets.BACKTICK);
+        expect(output).not.toContain(seededSecrets.TOKEN);
+      }
+    } finally {
+      releaseToolExecutionContext(context.contextId);
     }
   });
 });

--- a/src/tests/websocket/listener-secrets-sync.test.ts
+++ b/src/tests/websocket/listener-secrets-sync.test.ts
@@ -1,49 +1,34 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  clearSecretsCache,
+  initSecretsFromServer,
+  loadSecrets,
+} from "../../utils/secretsStore";
+import { __listenClientTestUtils } from "../../websocket/listen-client";
+import {
+  __testOverrideRefreshSecretsForAgent,
+  ensureSecretsHydratedForAgent,
+} from "../../websocket/listener/secrets-sync";
 
 const retrieveMock = mock((_agentId: string, _opts?: Record<string, unknown>) =>
   Promise.resolve({ secrets: [] as Array<{ key: string; value: string }> }),
 );
 
-const getClientMock = mock(() =>
-  Promise.resolve({
-    agents: {
-      retrieve: retrieveMock,
-    },
-  }),
-);
-
-mock.module("../../agent/client", () => ({
-  __testOverrideGetClient: () => {},
-  clearLastSDKDiagnostic: () => {},
-  consumeLastSDKDiagnostic: () => null,
-  getClient: getClientMock,
-  getClientDefaultHeaders: () => ({}),
-  getMemfsGitProxyRewriteConfig: () => null,
-  getMemfsServerUrl: () => "https://example.test",
-  getServerUrl: () => "https://example.test",
-  LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV: "LETTA_MEMFS_GIT_PROXY_BASE_URL",
-}));
-
-const { __listenClientTestUtils } = await import(
-  "../../websocket/listen-client"
-);
-const { ensureSecretsHydratedForAgent } = await import(
-  "../../websocket/listener/secrets-sync"
-);
-const { clearSecretsCache, loadSecrets } = await import(
-  "../../utils/secretsStore"
-);
-
 describe("listener secrets sync", () => {
   beforeEach(() => {
     retrieveMock.mockReset();
-    getClientMock.mockClear();
+    __testOverrideRefreshSecretsForAgent(async (agentId) => {
+      const agent = await retrieveMock(agentId, {
+        include: ["agent.secrets"],
+      });
+      await initSecretsFromServer(agentId, agent);
+    });
     clearSecretsCache("agent-listener-secret");
   });
 
-  afterAll(() => {
+  afterEach(() => {
+    __testOverrideRefreshSecretsForAgent(null);
     clearSecretsCache("agent-listener-secret");
-    mock.restore();
   });
 
   test("hydrates the agent-scoped secrets cache from the server", async () => {

--- a/src/tests/websocket/listener-secrets-sync.test.ts
+++ b/src/tests/websocket/listener-secrets-sync.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const retrieveMock = mock((_agentId: string, _opts?: Record<string, unknown>) =>
+  Promise.resolve({ secrets: [] as Array<{ key: string; value: string }> }),
+);
+
+const getClientMock = mock(() =>
+  Promise.resolve({
+    agents: {
+      retrieve: retrieveMock,
+    },
+  }),
+);
+
+mock.module("../../agent/client", () => ({
+  __testOverrideGetClient: () => {},
+  clearLastSDKDiagnostic: () => {},
+  consumeLastSDKDiagnostic: () => null,
+  getClient: getClientMock,
+  getClientDefaultHeaders: () => ({}),
+  getMemfsGitProxyRewriteConfig: () => null,
+  getMemfsServerUrl: () => "https://example.test",
+  getServerUrl: () => "https://example.test",
+  LETTA_MEMFS_GIT_PROXY_BASE_URL_ENV: "LETTA_MEMFS_GIT_PROXY_BASE_URL",
+}));
+
+const { __listenClientTestUtils } = await import(
+  "../../websocket/listen-client"
+);
+const { ensureSecretsHydratedForAgent } = await import(
+  "../../websocket/listener/secrets-sync"
+);
+const { clearSecretsCache, loadSecrets } = await import(
+  "../../utils/secretsStore"
+);
+
+describe("listener secrets sync", () => {
+  beforeEach(() => {
+    retrieveMock.mockReset();
+    getClientMock.mockClear();
+    clearSecretsCache("agent-listener-secret");
+  });
+
+  afterAll(() => {
+    clearSecretsCache("agent-listener-secret");
+    mock.restore();
+  });
+
+  test("hydrates the agent-scoped secrets cache from the server", async () => {
+    retrieveMock.mockResolvedValueOnce({
+      secrets: [{ key: "WS_SECRET_TOKEN", value: "listenersecret" }],
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+
+    expect(retrieveMock).toHaveBeenCalledWith("agent-listener-secret", {
+      include: ["agent.secrets"],
+    });
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "listenersecret",
+    });
+  });
+
+  test("does not memoize completed refreshes so GUI updates are visible", async () => {
+    retrieveMock
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
+      })
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "second" }],
+      });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+
+    expect(retrieveMock).toHaveBeenCalledTimes(2);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "second",
+    });
+  });
+
+  test("coalesces concurrent refreshes for the same agent", async () => {
+    let resolveRetrieve:
+      | ((value: { secrets: Array<{ key: string; value: string }> }) => void)
+      | undefined;
+    retrieveMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRetrieve = resolve;
+        }),
+    );
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    const first = ensureSecretsHydratedForAgent(
+      listener,
+      "agent-listener-secret",
+    );
+    const second = ensureSecretsHydratedForAgent(
+      listener,
+      "agent-listener-secret",
+    );
+
+    for (let i = 0; i < 10 && !resolveRetrieve; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(resolveRetrieve).toBeDefined();
+    resolveRetrieve?.({
+      secrets: [{ key: "WS_SECRET_TOKEN", value: "coalesced" }],
+    });
+    await Promise.all([first, second]);
+
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "coalesced",
+    });
+  });
+});

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1625,13 +1625,16 @@ export async function executeTool(
           enhancedArgs = {
             ...enhancedArgs,
             onOutput: (chunk: string, stream: "stdout" | "stderr") => {
-              options.onOutput?.(scrubSecretsFromString(chunk), stream);
+              options.onOutput?.(
+                scrubSecretsFromString(chunk, scopedAgentId),
+                stream,
+              );
             },
           };
         }
 
         // Substitute $SECRET_NAME patterns with actual secret values
-        enhancedArgs = substituteSecretsInArgs(enhancedArgs);
+        enhancedArgs = substituteSecretsInArgs(enhancedArgs, scopedAgentId);
       }
 
       // Inject toolCallId, abort signal, and parent scope for Task tool
@@ -1721,11 +1724,17 @@ export async function executeTool(
       // Scrub secret values from tool output so they don't leak into agent context
       if (STREAMING_SHELL_TOOLS.has(internalName)) {
         if (typeof flattenedResponse === "string") {
-          flattenedResponse = scrubSecretsFromString(flattenedResponse);
+          flattenedResponse = scrubSecretsFromString(
+            flattenedResponse,
+            scopedAgentId,
+          );
         } else if (Array.isArray(flattenedResponse)) {
           flattenedResponse = flattenedResponse.map((block) =>
             block.type === "text"
-              ? { ...block, text: scrubSecretsFromString(block.text) }
+              ? {
+                  ...block,
+                  text: scrubSecretsFromString(block.text, scopedAgentId),
+                }
               : block,
           );
         }
@@ -1733,7 +1742,7 @@ export async function executeTool(
           for (let i = 0; i < stdout.length; i++) {
             const line = stdout[i];
             if (line !== undefined) {
-              stdout[i] = scrubSecretsFromString(line);
+              stdout[i] = scrubSecretsFromString(line, scopedAgentId);
             }
           }
         }
@@ -1741,7 +1750,7 @@ export async function executeTool(
           for (let i = 0; i < stderr.length; i++) {
             const line = stderr[i];
             if (line !== undefined) {
-              stderr[i] = scrubSecretsFromString(line);
+              stderr[i] = scrubSecretsFromString(line, scopedAgentId);
             }
           }
         }

--- a/src/tools/secret-substitution.ts
+++ b/src/tools/secret-substitution.ts
@@ -11,34 +11,63 @@ import { loadSecrets } from "../utils/secretsStore";
  */
 const SECRET_PATTERN = /\$([A-Z_][A-Z0-9_]*)/g;
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 /**
  * Substitute $SECRET_NAME patterns in a string with actual secret values.
  * If a secret is not found, the pattern is left unchanged.
  */
-export function substituteSecretsInString(input: string): string {
-  const secrets = loadSecrets();
+export function substituteSecretsInString(
+  input: string,
+  agentId?: string,
+): string {
+  const secrets = loadSecrets(agentId);
   return input.replace(SECRET_PATTERN, (match, name) => {
     const value = secrets[name];
     return value !== undefined ? value : match;
   });
 }
 
+function substituteSecretsInValue(value: unknown, agentId?: string): unknown {
+  if (typeof value === "string") {
+    return substituteSecretsInString(value, agentId);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => substituteSecretsInValue(item, agentId));
+  }
+
+  if (isPlainRecord(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      result[key] = substituteSecretsInValue(nestedValue, agentId);
+    }
+    return result;
+  }
+
+  return value;
+}
+
 /**
  * Substitute secrets in tool arguments.
- * Only processes string values; other types are passed through unchanged.
+ * Processes strings recursively in arrays and plain objects; other values are
+ * passed through unchanged.
  * Only applies to shell tools (checked by caller in manager.ts).
  */
 export function substituteSecretsInArgs(
   args: Record<string, unknown>,
+  agentId?: string,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(args)) {
-    if (typeof value === "string") {
-      result[key] = substituteSecretsInString(value);
-    } else {
-      result[key] = value;
-    }
+    result[key] = substituteSecretsInValue(value, agentId);
   }
 
   return result;
@@ -49,8 +78,11 @@ export function substituteSecretsInArgs(
  * placeholder that makes it unambiguous to the LLM that the value is hidden.
  * Used to prevent secret values from leaking into agent context via tool output.
  */
-export function scrubSecretsFromString(input: string): string {
-  const secrets = loadSecrets();
+export function scrubSecretsFromString(
+  input: string,
+  agentId?: string,
+): string {
+  const secrets = loadSecrets(agentId);
   let result = input;
   // Replace longer values first to avoid partial matches
   const entries = Object.entries(secrets).sort(

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4121,6 +4121,7 @@ function createRuntime(): ListenerRuntime {
     conversationRuntimes: new Map(),
     approvalRuntimeKeyByRequestId: new Map(),
     memfsSyncedAgents: new Map(),
+    secretsHydrationByAgent: new Map(),
     lastEmittedStatus: null,
   };
 }
@@ -6333,6 +6334,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   conversationRuntimes: ListenerRuntime["conversationRuntimes"];
   approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
   memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
+  secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
   worktreeWatcherByConversation: ListenerRuntime["worktreeWatcherByConversation"];
   lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
 } {
@@ -6368,6 +6370,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     conversationRuntimes: ListenerRuntime["conversationRuntimes"];
     approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
     memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
+    secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
     worktreeWatcherByConversation: ListenerRuntime["worktreeWatcherByConversation"];
     lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
   };
@@ -6523,6 +6526,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.memfsSyncedAgents,
       set: (value: ListenerRuntime["memfsSyncedAgents"]) => {
         listener.memfsSyncedAgents = value;
+      },
+    },
+    secretsHydrationByAgent: {
+      get: () => listener.secretsHydrationByAgent,
+      set: (value: ListenerRuntime["secretsHydrationByAgent"]) => {
+        listener.secretsHydrationByAgent = value;
       },
     },
     worktreeWatcherByConversation: {

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -61,6 +61,7 @@ import {
   clearRecoveredApprovalState,
   hasInterruptedCacheForScope,
 } from "./runtime";
+import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import type { ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
@@ -626,6 +627,7 @@ export async function resolveRecoveredApprovalResponse(
   );
   const recoveryAbortController = new AbortController();
   runtime.activeAbortController = recoveryAbortController;
+  await ensureSecretsHydratedForAgent(runtime.listener, recovered.agentId);
   const preparedToolContext = await prepareToolExecutionContextForScope({
     agentId: recovered.agentId,
     conversationId: recovered.conversationId,

--- a/src/websocket/listener/secrets-sync.ts
+++ b/src/websocket/listener/secrets-sync.ts
@@ -1,0 +1,55 @@
+/**
+ * Server-backed secrets hydration for listen mode.
+ *
+ * Desktop and other WebSocket clients can update agent secrets directly through
+ * the API. The listener process still needs a fresh local cache before it
+ * builds reminders or executes shell tools that use $SECRET_NAME references.
+ */
+
+import { debugLog, debugWarn } from "../../utils/debug";
+import type { ListenerRuntime } from "./types";
+
+async function refreshSecretsForAgent(agentId: string): Promise<void> {
+  const { initSecretsFromServer } = await import("../../utils/secretsStore");
+  await initSecretsFromServer(agentId);
+  debugLog("secrets-sync", `Refreshed secrets for agent ${agentId}`);
+}
+
+/**
+ * Refresh the in-memory secrets cache for an agent.
+ *
+ * Concurrent callers for the same agent coalesce onto a single in-flight
+ * request, but completed refreshes are not memoized. That keeps desktop GUI
+ * updates visible on the next turn / tool execution without requiring a
+ * listener restart.
+ *
+ * Non-fatal: logs a warning on failure but doesn't throw.
+ */
+export async function ensureSecretsHydratedForAgent(
+  listener: ListenerRuntime,
+  agentId: string,
+): Promise<void> {
+  const existing = listener.secretsHydrationByAgent.get(agentId);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const promise = refreshSecretsForAgent(agentId)
+    .catch((err) => {
+      // Non-fatal — agent can still process messages, just without local
+      // secret substitution for this turn/tool execution.
+      debugWarn(
+        "secrets-sync",
+        `Failed to refresh secrets for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    })
+    .finally(() => {
+      if (listener.secretsHydrationByAgent.get(agentId) === promise) {
+        listener.secretsHydrationByAgent.delete(agentId);
+      }
+    });
+
+  listener.secretsHydrationByAgent.set(agentId, promise);
+  await promise;
+}

--- a/src/websocket/listener/secrets-sync.ts
+++ b/src/websocket/listener/secrets-sync.ts
@@ -9,7 +9,23 @@
 import { debugLog, debugWarn } from "../../utils/debug";
 import type { ListenerRuntime } from "./types";
 
+let _testRefreshSecretsForAgentOverride:
+  | ((agentId: string) => Promise<void>)
+  | null = null;
+
+export function __testOverrideRefreshSecretsForAgent(
+  factory: ((agentId: string) => Promise<void>) | null,
+): void {
+  _testRefreshSecretsForAgentOverride = factory;
+}
+
 async function refreshSecretsForAgent(agentId: string): Promise<void> {
+  if (_testRefreshSecretsForAgentOverride) {
+    await _testRefreshSecretsForAgentOverride(agentId);
+    debugLog("secrets-sync", `Refreshed secrets for agent ${agentId}`);
+    return;
+  }
+
   const { initSecretsFromServer } = await import("../../utils/secretsStore");
   await initSecretsFromServer(agentId);
   debugLog("secrets-sync", `Refreshed secrets for agent ${agentId}`);

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -51,6 +51,7 @@ import {
 import { consumeQueuedTurn } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import { debugLogApprovalResumeState } from "./recovery";
+import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import {
   markAwaitingAcceptedApprovalContinuationRunId,
   sendApprovalContinuationWithRetry,
@@ -499,6 +500,9 @@ export async function handleApprovalStop(params: {
 
   let executionResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
   try {
+    if (agentId) {
+      await ensureSecretsHydratedForAgent(runtime.listener, agentId);
+    }
     executionResults = await executeApprovalBatch(decisions, undefined, {
       toolContextId: turnToolContextId ?? undefined,
       abortSignal: abortController.signal,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -423,9 +423,15 @@ export async function handleIncomingMessage(
       return;
     }
 
-    // Ensure memfs repo is cloned/pulled for this agent (lazy, once per session).
-    const { ensureMemfsSyncedForAgent } = await import("./memfs-sync");
-    await ensureMemfsSyncedForAgent(runtime.listener, agentId);
+    // Ensure local per-agent state is ready before reminders and tool execution.
+    const [{ ensureMemfsSyncedForAgent }, { ensureSecretsHydratedForAgent }] =
+      await Promise.all([import("./memfs-sync"), import("./secrets-sync")]);
+    await Promise.all([
+      // Memfs is lazy and memoized once per session.
+      ensureMemfsSyncedForAgent(runtime.listener, agentId),
+      // Secrets refresh every turn so desktop GUI updates are picked up.
+      ensureSecretsHydratedForAgent(runtime.listener, agentId),
+    ]);
 
     // Set agent context for tools that need it (e.g., Skill tool)
     setCurrentAgentId(agentId);

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -196,6 +196,8 @@ export type ListenerRuntime = {
   >;
   /** Agent IDs whose memfs repo has been cloned/pulled this session. Concurrent callers coalesce on the same promise. */
   memfsSyncedAgents: Map<string, Promise<void>>;
+  /** Agent IDs with an in-flight secrets refresh. Completed refreshes are not memoized so GUI updates are picked up. */
+  secretsHydrationByAgent: Map<string, Promise<void>>;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;
   /** Unsubscribe from subagent state store (set on socket open, cleared on close). */
   _unsubscribeSubagentState?: (() => void) | undefined;


### PR DESCRIPTION
## Summary
- Hydrates server-backed agent secrets in WebSocket listener mode before turns and approval execution, without adding `/secret` command support to the WS protocol.
- Threads the scoped agent id through centralized shell substitution/scrubbing so Desktop-managed secrets work across Bash, Codex, and Gemini shell toolsets.
- Adds regression coverage for listener hydration/coalescing and shell secret substitution/redaction.

Fixes #1999

👾 Generated with [Letta Code](https://letta.com)