### PR TITLE
fix(memfs-git): skip checkout when remote has no HEAD

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -1368,8 +1368,25 @@ export async function cloneMemoryRepo(agentId: string): Promise<void> {
       // Move .git into the existing memory directory
       renameSync(join(tmpDir, ".git"), join(dir, ".git"));
 
-      // Reset to match remote state
-      await runGit(dir, ["checkout", "--", "."], token);
+      // Reset to match remote state. Skip when the remote has no HEAD
+      // yet (empty repo, e.g. a freshly-allocated training agent) —
+      // `git checkout -- .` fails with "pathspec '.' did not match any
+      // file(s) known to git" in that case, which is fatal here. When
+      // there's nothing on the remote there's nothing to restore, so
+      // leaving the existing local files in place is the right move.
+      try {
+        await runGit(dir, ["rev-parse", "--verify", "HEAD"], token);
+        await runGit(dir, ["checkout", "--", "."], token);
+      } catch (checkoutErr) {
+        const msg =
+          checkoutErr instanceof Error
+            ? checkoutErr.message
+            : String(checkoutErr);
+        debugLog(
+          "memfs-git",
+          `Skipping checkout (likely empty remote, no HEAD yet): ${msg}`,
+        );
+      }
 
       debugLog("memfs-git", "Migrated existing memory directory to git repo");
     } finally {


### PR DESCRIPTION
## Summary

`cloneMemoryRepo()` has a migration path that moves an existing memory directory into a fresh git checkout: clone remote into a temp dir, rename the temp `.git/` over the target, then run `git checkout -- .` to restore working-tree state from the freshly cloned index.

That last step assumes HEAD points at a real commit. When the remote is empty (a newly-allocated training agent, or any first-time memfs repo) HEAD doesn't exist yet and checkout fails fatally with:

```
fatal: pathspec '.' did not match any file(s) known to git
```

This propagates as `Memory git sync failed` and aborts the CLI with `exit 1` before the agent can do any work. We hit this during letta-train rollouts where 192/192 agents failed with this identical error.

## Fix

Wrap the checkout in `git rev-parse --verify HEAD`. If HEAD doesn't exist (empty remote), skip the checkout with a `debugLog` instead of a fatal error — there's nothing to restore from an empty repo, so leaving the existing local files in place is the right behavior. The subsequent push will populate the remote on first commit.

## Test plan

- [x] Local: confirmed against a fresh empty memfs repo — clone succeeds, debug log shows the skip
- [ ] In training rollout: agents successfully bootstrap empty repos and produce output

👾 Generated with [Letta Code](https://letta.com)