### PR TITLE
perf: cache messages.retrieve to reduce redundant API calls

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -337,7 +337,7 @@ export async function getClient() {
 
   // Note: ChatGPT OAuth token refresh is handled by the Letta backend
   // when using the chatgpt_oauth provider type
-  return new Letta({
+  const client = new Letta({
     apiKey,
     baseURL,
     logger: sdkLogger,
@@ -346,4 +346,36 @@ export async function getClient() {
     // Use instrumented fetch for timing logs when LETTA_DEBUG_TIMINGS is enabled
     ...(isTimingsEnabled() && { fetch: createTimingFetch(fetch) }),
   });
+
+  // ── Immutable-resource cache ──
+  // messages.retrieve returns immutable data (messages don't change after
+  // creation), so we cache results to avoid redundant round-trips.
+  // Capped at 32 entries with LRU eviction.
+  const MESSAGE_CACHE_MAX = 32;
+  const messageCache = new Map<string, Promise<unknown>>();
+  const origRetrieveMessage = client.messages.retrieve.bind(client.messages);
+  client.messages.retrieve = ((
+    ...args: Parameters<typeof client.messages.retrieve>
+  ) => {
+    const messageId = args[0] as string;
+    const cached = messageCache.get(messageId);
+    if (cached) {
+      // Move to end (most recent) for LRU ordering.
+      messageCache.delete(messageId);
+      messageCache.set(messageId, cached);
+      return cached;
+    }
+    const promise = origRetrieveMessage(...args);
+    messageCache.set(messageId, promise);
+    // Evict oldest entry when over capacity.
+    if (messageCache.size > MESSAGE_CACHE_MAX) {
+      const oldest = messageCache.keys().next().value;
+      if (oldest !== undefined) messageCache.delete(oldest);
+    }
+    // Evict on failure so transient errors don't stick.
+    promise.catch(() => messageCache.delete(messageId));
+    return promise;
+  }) as typeof client.messages.retrieve;
+
+  return client;
 }


### PR DESCRIPTION
## Summary

- Add an in-process LRU cache (32 entries) for `client.messages.retrieve()` in `getClient()`
- Messages are immutable after creation, so cached results never go stale
- Failed requests are evicted from cache so transient errors don't persist

## Context

Production profiling of the LC pod showed `retrieve_message` (`GET /v1/messages/{message_id}`) consuming 32.6% of route CPU time (18.36s) and 8.9% of MainThread. Combined with `retrieve_conversation` (39.8%) and `list_messages` (20.4%), these three polling endpoints account for **93% of all route CPU** on the pod.

Key finding: during the profiling window there were **165K calls** to `messages.retrieve` but only **479 unique message IDs** across ~500 active agents. That's a **99.7% redundancy rate** — the same immutable messages fetched ~330 times each.

The source is `getResumeData()` in `check-approval.ts`, which calls both `conversations.retrieve` and `messages.retrieve` on every session resume, error recovery, approval check, and conversation switch. There are 27 callsites across `App.tsx`, `headless.ts`, `index.ts`, and the websocket listener.

## Implementation

LRU cache using `Map` insertion order (no dependencies):
- Cache key: message ID string
- Cache value: the `Promise` (deduplicates concurrent in-flight requests for the same ID)
- On cache hit: delete + re-insert to promote to most-recent (LRU)
- On eviction: oldest entry removed when size exceeds 32
- On rejection: entry evicted so next call retries

## Expected impact

Eliminates ~99.7% of `messages.retrieve` HTTP calls (165K → ~479 unique fetches). This directly reduces CPU pressure on the LC pod's MainThread, which should improve `send_conversation_message` latency for all users on the pod.

## Test plan

- [ ] Verified cache logic (hit, miss, LRU eviction, LRU promotion, error eviction) passes with isolated unit test
- [ ] Typecheck passes (no new errors)
- [ ] Existing `getResumeData` tests still pass
- [ ] Monitor `retrieve_message` call volume on LC pod after deploy

🐻 Generated with [Letta Code](https://letta.com)