### PR TITLE
fix(cli): harden WezTerm config injection

### DIFF
--- a/src/cli/utils/terminalKeybindingInstaller.ts
+++ b/src/cli/utils/terminalKeybindingInstaller.ts
@@ -382,19 +382,134 @@ table.insert(keys, {
 config.keys = keys
 `;
 
-const RETURN_CONFIG_LINE = /^\s*return config\s*$/m;
+const RETURN_CONFIG_LINE = /^\s*return\s+config\s*$/;
+const RETURN_TABLE_LINE = /^\s*return\s*\{/;
+const LOCAL_CONFIG_LINE = /^\s*local\s+config\b/;
+
+interface LuaCodeLine {
+  start: number;
+  end: number;
+  line: string;
+  lineEnding: string;
+  code: string;
+}
+
+function stripLuaCommentsFromLine(
+  line: string,
+  blockCommentEnd: string | null,
+): { code: string; blockCommentEnd: string | null } {
+  let code = "";
+  let index = 0;
+  let currentBlockCommentEnd = blockCommentEnd;
+
+  while (index < line.length) {
+    if (currentBlockCommentEnd) {
+      const closeIndex = line.indexOf(currentBlockCommentEnd, index);
+      if (closeIndex === -1) {
+        return { code, blockCommentEnd: currentBlockCommentEnd };
+      }
+
+      index = closeIndex + currentBlockCommentEnd.length;
+      currentBlockCommentEnd = null;
+      continue;
+    }
+
+    if (line.startsWith("--", index)) {
+      const longCommentMatch = line.slice(index).match(/^--\[(=*)\[/);
+      if (longCommentMatch) {
+        const equals = longCommentMatch[1] ?? "";
+        currentBlockCommentEnd = `]${equals}]`;
+        index += longCommentMatch[0].length;
+        continue;
+      }
+
+      break;
+    }
+
+    code += line.charAt(index);
+    index += 1;
+  }
+
+  return { code, blockCommentEnd: currentBlockCommentEnd };
+}
+
+function getLuaCodeLines(content: string): LuaCodeLine[] {
+  const lines: LuaCodeLine[] = [];
+  let start = 0;
+  let blockCommentEnd: string | null = null;
+
+  while (start < content.length) {
+    const newlineIndex = content.indexOf("\n", start);
+    const end = newlineIndex === -1 ? content.length : newlineIndex + 1;
+    const rawLine = content.slice(start, end);
+    const lineEnding = rawLine.endsWith("\r\n")
+      ? "\r\n"
+      : rawLine.endsWith("\n")
+        ? "\n"
+        : "";
+    const line = lineEnding
+      ? rawLine.slice(0, rawLine.length - lineEnding.length)
+      : rawLine;
+    const stripped = stripLuaCommentsFromLine(line, blockCommentEnd);
+    blockCommentEnd = stripped.blockCommentEnd;
+
+    lines.push({
+      start,
+      end,
+      line,
+      lineEnding,
+      code: stripped.code,
+    });
+
+    start = end;
+  }
+
+  return lines;
+}
+
+function findLastMatchingLuaLine(
+  content: string,
+  pattern: RegExp,
+): LuaCodeLine | null {
+  let result: LuaCodeLine | null = null;
+
+  for (const line of getLuaCodeLines(content)) {
+    if (pattern.test(line.code)) {
+      result = line;
+    }
+  }
+
+  return result;
+}
+
+function hasMatchingLuaLine(content: string, pattern: RegExp): boolean {
+  return findLastMatchingLuaLine(content, pattern) !== null;
+}
+
+function replaceLuaLine(
+  content: string,
+  line: LuaCodeLine,
+  replacement: string,
+): string {
+  return `${content.slice(0, line.start)}${replacement}${line.lineEnding}${content.slice(line.end)}`;
+}
 
 export function injectWezTermDeleteFix(content: string): string {
   let nextContent = content;
 
   // For simple configs that return a table directly, we need to modify them
   // to use a config variable. Check if it's a simple "return {" style config.
-  if (
-    nextContent.includes("return {") &&
-    !nextContent.includes("local config")
-  ) {
-    nextContent = nextContent.replace(/return\s*\{/, "local config = {");
-    if (!nextContent.includes("return config")) {
+  const returnTableLine = findLastMatchingLuaLine(
+    nextContent,
+    RETURN_TABLE_LINE,
+  );
+  if (returnTableLine && !hasMatchingLuaLine(nextContent, LOCAL_CONFIG_LINE)) {
+    nextContent = replaceLuaLine(
+      nextContent,
+      returnTableLine,
+      returnTableLine.line.replace(/return\s*\{/, "local config = {"),
+    );
+    if (!hasMatchingLuaLine(nextContent, RETURN_CONFIG_LINE)) {
       nextContent = `${nextContent.trimEnd()}\n\nreturn config\n`;
     }
   }
@@ -407,11 +522,12 @@ return config
 `;
   }
 
-  if (RETURN_CONFIG_LINE.test(nextContent)) {
-    return nextContent.replace(
-      RETURN_CONFIG_LINE,
-      `${WEZTERM_DELETE_FIX}\nreturn config`,
-    );
+  const returnConfigLine = findLastMatchingLuaLine(
+    nextContent,
+    RETURN_CONFIG_LINE,
+  );
+  if (returnConfigLine) {
+    return `${nextContent.slice(0, returnConfigLine.start)}${WEZTERM_DELETE_FIX}\n${nextContent.slice(returnConfigLine.start)}`;
   }
 
   return `${nextContent.trimEnd()}\n${WEZTERM_DELETE_FIX}\n`;

--- a/src/tests/cli/terminal-keybinding-installer.test.ts
+++ b/src/tests/cli/terminal-keybinding-installer.test.ts
@@ -57,6 +57,82 @@ return config
     expect(output).toContain("key = 'Delete'");
     expect(output).toContain("return config");
   });
+
+  test("injects before the final return config when helpers return config earlier", () => {
+    const input = `local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+local function get_config()
+  return config
+end
+
+config.color_scheme = 'Tokyo Night'
+
+return config
+`;
+
+    const output = injectWezTermDeleteFix(input);
+    const markerIdx = output.indexOf("-- Letta Code: Fix Delete key");
+    const colorIdx = output.indexOf("config.color_scheme = 'Tokyo Night'");
+    const finalReturnIdx = output.lastIndexOf("return config");
+
+    expect(markerIdx).toBeGreaterThan(colorIdx);
+    expect(markerIdx).toBeLessThan(finalReturnIdx);
+    expect(output).toContain(
+      "local function get_config()\n  return config\nend",
+    );
+  });
+
+  test("ignores return config inside Lua block comments", () => {
+    const input = `local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+--[[
+return config
+]]
+
+config.color_scheme = 'Tokyo Night'
+
+return config
+`;
+
+    const output = injectWezTermDeleteFix(input);
+    const markerIdx = output.indexOf("-- Letta Code: Fix Delete key");
+    const colorIdx = output.indexOf("config.color_scheme = 'Tokyo Night'");
+    const finalReturnIdx = output.lastIndexOf("return config");
+
+    expect(markerIdx).toBeGreaterThan(colorIdx);
+    expect(markerIdx).toBeLessThan(finalReturnIdx);
+  });
+
+  test("adds a live return config when converting return-table configs with commented return config text", () => {
+    const output = injectWezTermDeleteFix(`-- return config
+return {
+  color_scheme = 'Tokyo Night',
+}
+`);
+
+    expect(output).toContain("-- return config");
+    expect(output).toContain("local config = {");
+    expect(output).toContain("color_scheme = 'Tokyo Night'");
+    expect(output.match(/^\s*return config\s*$/gm)?.length).toBe(1);
+
+    const markerIdx = output.indexOf("-- Letta Code: Fix Delete key");
+    const liveReturnIdx = output.lastIndexOf("return config");
+    expect(markerIdx).toBeLessThan(liveReturnIdx);
+  });
+
+  test("ignores commented local config text when converting return-table configs", () => {
+    const output = injectWezTermDeleteFix(`-- local config = {}
+return {
+  color_scheme = 'Tokyo Night',
+}
+`);
+
+    expect(output).toContain("-- local config = {}");
+    expect(output).toContain("local config = {");
+    expect(output).toContain("return config");
+  });
 });
 
 describe("wezTermDeleteFixExists", () => {


### PR DESCRIPTION
## Summary
- Harden the WezTerm Delete-key installer so it finds live Lua config lines instead of using raw substring checks.
- Inject before the final live `return config`, ignoring commented scaffolding, block comments, and earlier helper returns.
- Add regression coverage for helper returns and commented `return config` / `local config` text in simple return-table configs.

## Tests
- `bun test src/tests/cli/terminal-keybinding-installer.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)