### PR TITLE
fix(reflection): honor subagent model override

### DIFF
--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -2,7 +2,7 @@
 name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
 tools: Read, Edit, Write, Glob, Grep, Bash, TaskOutput
-model: auto
+model: inherit
 memoryBlocks: none
 mode: stateless
 permissionMode: memory

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -182,6 +182,13 @@ export async function resolveSubagentModel(options: {
   if (userModel) return userModel;
 
   if (options.subagentType === "reflection") {
+    if (recommendedModel && recommendedModel !== "inherit") {
+      const recommendedHandle = resolveModel(recommendedModel);
+      if (recommendedHandle) {
+        return recommendedHandle;
+      }
+    }
+
     return "letta/auto-memory";
   }
 

--- a/src/tests/agent/subagent-builtins.test.ts
+++ b/src/tests/agent/subagent-builtins.test.ts
@@ -40,6 +40,7 @@ describe("built-in subagents", () => {
     const configs = await getAllSubagentConfigs();
     expect(configs.reflection).toBeDefined();
     expect(configs.reflection?.name).toBe("reflection");
+    expect(configs.reflection?.recommendedModel).toBe("inherit");
   });
 
   test("memory-related built-ins use memory permission mode", async () => {

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -276,24 +276,6 @@ describe("buildSubagentArgs", () => {
 });
 
 describe("resolveSubagentModel", () => {
-  async function withAutoMemory<T>(
-    value: string,
-    fn: () => Promise<T>,
-  ): Promise<T> {
-    const original = process.env.AUTO_MEMORY;
-    process.env.AUTO_MEMORY = value;
-
-    try {
-      return await fn();
-    } finally {
-      if (original === undefined) {
-        delete process.env.AUTO_MEMORY;
-      } else {
-        process.env.AUTO_MEMORY = original;
-      }
-    }
-  }
-
   test("prefers BYOK-swapped handle when available", async () => {
     const cases = [
       { parentProvider: "lc-anthropic", baseProvider: "anthropic" },
@@ -438,52 +420,65 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("openai/gpt-5");
   });
 
-  test("uses letta/auto-memory for reflection subagents when AUTO_MEMORY=1", async () => {
-    const result = await withAutoMemory("1", () =>
-      resolveSubagentModel({
-        subagentType: "reflection",
-        recommendedModel: "anthropic/test-model",
-        parentModelHandle: "lc-anthropic/parent-model",
-        availableHandles: new Set(),
-      }),
-    );
+  test("uses letta/auto-memory for reflection subagents by default", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "inherit",
+      parentModelHandle: "lc-anthropic/parent-model",
+      availableHandles: new Set(),
+    });
 
     expect(result).toBe("letta/auto-memory");
   });
 
-  test("accepts AUTO_MEMORY=true for reflection subagents", async () => {
-    const result = await withAutoMemory("true", () =>
-      resolveSubagentModel({
-        subagentType: "reflection",
-        recommendedModel: "anthropic/test-model",
-        availableHandles: new Set(["anthropic/test-model"]),
-      }),
-    );
+  test("uses letta/auto-memory for reflection subagents with no recommended model", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      parentModelHandle: "lc-anthropic/parent-model",
+      availableHandles: new Set(),
+    });
 
     expect(result).toBe("letta/auto-memory");
   });
 
-  test("does not override an explicit user model when AUTO_MEMORY is enabled", async () => {
-    const result = await withAutoMemory("1", () =>
-      resolveSubagentModel({
-        subagentType: "reflection",
-        userModel: "openai/gpt-5",
-        recommendedModel: "anthropic/test-model",
-        availableHandles: new Set(["openai/gpt-5", "letta/auto-memory"]),
-      }),
-    );
+  test("honors reflection subagent model overrides", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "anthropic/test-model",
+      parentModelHandle: "lc-anthropic/parent-model",
+      availableHandles: new Set(),
+    });
+
+    expect(result).toBe("anthropic/test-model");
+  });
+
+  test("resolves reflection subagent model aliases before honoring overrides", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "auto",
+      availableHandles: new Set(["letta/auto"]),
+    });
+
+    expect(result).toBe("letta/auto");
+  });
+
+  test("does not override an explicit user model for reflection subagents", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      userModel: "openai/gpt-5",
+      recommendedModel: "anthropic/test-model",
+      availableHandles: new Set(["openai/gpt-5", "letta/auto-memory"]),
+    });
 
     expect(result).toBe("openai/gpt-5");
   });
 
   test("does not affect non-reflection subagents", async () => {
-    const result = await withAutoMemory("1", () =>
-      resolveSubagentModel({
-        subagentType: "general-purpose",
-        recommendedModel: "anthropic/test-model",
-        availableHandles: new Set(["letta/auto", "anthropic/test-model"]),
-      }),
-    );
+    const result = await resolveSubagentModel({
+      subagentType: "general-purpose",
+      recommendedModel: "anthropic/test-model",
+      availableHandles: new Set(["letta/auto", "anthropic/test-model"]),
+    });
 
     expect(result).toBe("anthropic/test-model");
   });


### PR DESCRIPTION
## Summary

- Closes #2004 by honoring a reflection subagent `model:` frontmatter override before falling back to `letta/auto-memory`.
- Changes the built-in reflection config to `model: inherit` so the hosted auto-memory default remains the fallback while user overrides are reachable.
- Adds regression coverage for default reflection resolution, explicit overrides, alias resolution, explicit Task model precedence, and the built-in reflection config.
- Verified with `bun test src/tests/agent/subagent-model-resolution.test.ts`, `bun test src/tests/agent/subagent-builtins.test.ts`, and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)