### PR TITLE
refactor(channel): move WS account config into plugin payloads

### DIFF
--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -32,39 +32,27 @@ export function getChannelAccountConfigAdapter(
   return CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId];
 }
 
-function getNestedConfig(
+export function getChannelPluginConfig(
   input: Record<string, unknown>,
+  key: "config" | "plugin_config" = "config",
 ): ChannelProtocolConfig | null {
-  if (!("config" in input) || input.config === undefined) {
+  const value = input[key];
+  if (value === undefined) {
     return {};
   }
-  return isRecord(input.config) ? input.config : null;
-}
-
-export function getMergedChannelPluginConfig(
-  channelId: SupportedChannelId,
-  input: Record<string, unknown>,
-): ChannelProtocolConfig | null {
-  const nestedConfig = getNestedConfig(input);
-  if (!nestedConfig) {
-    return null;
-  }
-  const adapter = getChannelAccountConfigAdapter(channelId);
-  return {
-    ...adapter.extractLegacyConfig(input),
-    ...nestedConfig,
-  };
+  return isRecord(value) ? value : null;
 }
 
 export function isValidChannelPluginConfigPayload(
   channelId: SupportedChannelId,
   input: Record<string, unknown>,
+  key: "config" | "plugin_config" = "config",
 ): boolean {
-  const mergedConfig = getMergedChannelPluginConfig(channelId, input);
-  if (!mergedConfig) {
+  const config = getChannelPluginConfig(input, key);
+  if (!config) {
     return false;
   }
-  return getChannelAccountConfigAdapter(channelId).isValidConfig(mergedConfig);
+  return getChannelAccountConfigAdapter(channelId).isValidConfig(config);
 }
 
 export function normalizeChannelAccountPatch(

--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -1,0 +1,121 @@
+import { discordAccountConfigAdapter } from "./discord/accountConfig";
+import type {
+  ChannelAccountConfigAdapter,
+  ChannelAccountPatch,
+  ChannelConfigPatch,
+  ChannelPluginAccountPatch,
+  ChannelProtocolConfig,
+} from "./pluginTypes";
+import { slackAccountConfigAdapter } from "./slack/accountConfig";
+import { telegramAccountConfigAdapter } from "./telegram/accountConfig";
+import type { ChannelAccount, SupportedChannelId } from "./types";
+
+const CHANNEL_ACCOUNT_CONFIG_ADAPTERS: Record<
+  SupportedChannelId,
+  ChannelAccountConfigAdapter<ChannelAccount>
+> = {
+  telegram:
+    telegramAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
+  slack:
+    slackAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
+  discord:
+    discordAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function getChannelAccountConfigAdapter(
+  channelId: SupportedChannelId,
+): ChannelAccountConfigAdapter<ChannelAccount> {
+  return CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId];
+}
+
+function getNestedConfig(
+  input: Record<string, unknown>,
+): ChannelProtocolConfig | null {
+  if (!("config" in input) || input.config === undefined) {
+    return {};
+  }
+  return isRecord(input.config) ? input.config : null;
+}
+
+export function getMergedChannelPluginConfig(
+  channelId: SupportedChannelId,
+  input: Record<string, unknown>,
+): ChannelProtocolConfig | null {
+  const nestedConfig = getNestedConfig(input);
+  if (!nestedConfig) {
+    return null;
+  }
+  const adapter = getChannelAccountConfigAdapter(channelId);
+  return {
+    ...adapter.extractLegacyConfig(input),
+    ...nestedConfig,
+  };
+}
+
+export function isValidChannelPluginConfigPayload(
+  channelId: SupportedChannelId,
+  input: Record<string, unknown>,
+): boolean {
+  const mergedConfig = getMergedChannelPluginConfig(channelId, input);
+  if (!mergedConfig) {
+    return false;
+  }
+  return getChannelAccountConfigAdapter(channelId).isValidConfig(mergedConfig);
+}
+
+export function normalizeChannelAccountPatch(
+  channelId: SupportedChannelId,
+  patch: ChannelAccountPatch,
+): ChannelAccountPatch {
+  const pluginPatch = patch.config
+    ? getChannelAccountConfigAdapter(channelId).toAccountPatch(patch.config)
+    : {};
+  return {
+    ...patch,
+    ...pluginPatch,
+  };
+}
+
+export function normalizeChannelConfigPatch(
+  channelId: SupportedChannelId,
+  patch: ChannelConfigPatch,
+): ChannelConfigPatch {
+  const pluginPatch = patch.config
+    ? getChannelAccountConfigAdapter(channelId).toAccountPatch(patch.config)
+    : {};
+  return {
+    ...patch,
+    ...pluginPatch,
+  };
+}
+
+export function channelPluginConfigShouldRefreshDisplayName(
+  channelId: SupportedChannelId,
+  patch: Pick<ChannelAccountPatch, keyof ChannelPluginAccountPatch | "config">,
+): boolean {
+  const adapter = getChannelAccountConfigAdapter(channelId);
+  const pluginPatch = patch.config
+    ? adapter.toAccountPatch(patch.config)
+    : patch;
+  return adapter.shouldRefreshDisplayName(pluginPatch);
+}
+
+export function toChannelAccountProtocolConfig(
+  account: ChannelAccount,
+): ChannelProtocolConfig {
+  return getChannelAccountConfigAdapter(account.channel).toAccountConfig(
+    account,
+  );
+}
+
+export function toChannelConfigSnapshotProtocolConfig(
+  account: ChannelAccount,
+): ChannelProtocolConfig {
+  return getChannelAccountConfigAdapter(account.channel).toConfigSnapshotConfig(
+    account,
+  );
+}

--- a/src/channels/discord/accountConfig.ts
+++ b/src/channels/discord/accountConfig.ts
@@ -1,0 +1,81 @@
+import type { ChannelAccountConfigAdapter } from "../pluginTypes";
+import type { DiscordChannelAccount } from "../types";
+
+const DISCORD_CONFIG_KEYS = new Set(["token", "agent_id", "allowed_channels"]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
+
+export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordChannelAccount> =
+  {
+    extractLegacyConfig(input) {
+      const config: Record<string, unknown> = {};
+      if ("token" in input) {
+        config.token = input.token;
+      }
+      if ("agent_id" in input) {
+        config.agent_id = input.agent_id;
+      }
+      if ("allowed_channels" in input) {
+        config.allowed_channels = input.allowed_channels;
+      }
+      return config;
+    },
+
+    isValidConfig(config) {
+      for (const key of Object.keys(config)) {
+        if (!DISCORD_CONFIG_KEYS.has(key)) {
+          return false;
+        }
+      }
+      return (
+        (config.token === undefined || isString(config.token)) &&
+        (config.agent_id === undefined || isNullableString(config.agent_id)) &&
+        (config.allowed_channels === undefined ||
+          isStringArray(config.allowed_channels))
+      );
+    },
+
+    toAccountPatch(config) {
+      return {
+        token: isString(config.token) ? config.token : undefined,
+        agentId: isNullableString(config.agent_id)
+          ? config.agent_id
+          : undefined,
+        allowedChannels: isStringArray(config.allowed_channels)
+          ? [...config.allowed_channels]
+          : undefined,
+      };
+    },
+
+    toAccountConfig(account) {
+      return {
+        has_token: account.token.trim().length > 0,
+        agent_id: account.agentId,
+        allowed_channels: [...(account.allowedChannels ?? [])],
+      };
+    },
+
+    toConfigSnapshotConfig(account) {
+      return {
+        has_token: account.token.trim().length > 0,
+        agent_id: account.agentId,
+        allowed_channels: [...(account.allowedChannels ?? [])],
+      };
+    },
+
+    shouldRefreshDisplayName(patch) {
+      return patch.token !== undefined;
+    },
+  };

--- a/src/channels/discord/accountConfig.ts
+++ b/src/channels/discord/accountConfig.ts
@@ -19,20 +19,6 @@ function isStringArray(value: unknown): value is string[] {
 
 export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordChannelAccount> =
   {
-    extractLegacyConfig(input) {
-      const config: Record<string, unknown> = {};
-      if ("token" in input) {
-        config.token = input.token;
-      }
-      if ("agent_id" in input) {
-        config.agent_id = input.agent_id;
-      }
-      if ("allowed_channels" in input) {
-        config.allowed_channels = input.allowed_channels;
-      }
-      return config;
-    },
-
     isValidConfig(config) {
       for (const key of Object.keys(config)) {
         if (!DISCORD_CONFIG_KEYS.has(key)) {

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -3,7 +3,10 @@ import type {
   ChannelAdapter,
   ChannelChatType,
   ChannelRoute,
+  DmPolicy,
   OutboundChannelMessage,
+  SlackChannelMode,
+  SlackDefaultPermissionMode,
   SupportedChannelId,
 } from "./types";
 
@@ -12,6 +15,56 @@ export interface ChannelPluginMetadata {
   displayName: string;
   runtimePackages: string[];
   runtimeModules: string[];
+}
+
+export type ChannelProtocolConfig = Record<string, unknown>;
+
+export interface ChannelCommonAccountPatch {
+  displayName?: string;
+  enabled?: boolean;
+  dmPolicy?: DmPolicy;
+  allowedUsers?: string[];
+}
+
+export interface ChannelPluginAccountPatch {
+  token?: string;
+  botToken?: string;
+  appToken?: string;
+  mode?: SlackChannelMode;
+  agentId?: string | null;
+  defaultPermissionMode?: SlackDefaultPermissionMode;
+  allowedChannels?: string[];
+  transcribeVoice?: boolean;
+}
+
+export type ChannelAccountPatch = ChannelCommonAccountPatch &
+  ChannelPluginAccountPatch & {
+    /** Plugin-owned snake_case config accepted from the websocket protocol. */
+    config?: ChannelProtocolConfig;
+  };
+
+export type ChannelConfigPatch = Pick<
+  ChannelCommonAccountPatch,
+  "dmPolicy" | "allowedUsers"
+> &
+  ChannelPluginAccountPatch & {
+    /** Plugin-owned snake_case config accepted from the websocket protocol. */
+    config?: ChannelProtocolConfig;
+  };
+
+export interface ChannelAccountConfigAdapter<TAccount extends ChannelAccount> {
+  /** Extract deprecated top-level websocket fields for backwards compatibility. */
+  extractLegacyConfig(input: Record<string, unknown>): ChannelProtocolConfig;
+  /** Validate plugin-owned config payloads after legacy + nested config merging. */
+  isValidConfig(config: ChannelProtocolConfig): boolean;
+  /** Convert protocol snake_case config into the internal account patch shape. */
+  toAccountPatch(config: ChannelProtocolConfig): ChannelPluginAccountPatch;
+  /** Redacted/safe plugin config included in account list/get responses. */
+  toAccountConfig(account: TAccount): ChannelProtocolConfig;
+  /** Redacted/safe plugin config included in channel_get_config responses. */
+  toConfigSnapshotConfig(account: TAccount): ChannelProtocolConfig;
+  /** Whether this plugin config patch changes credentials/display identity. */
+  shouldRefreshDisplayName(patch: ChannelPluginAccountPatch): boolean;
 }
 
 export type ChannelMessageActionName = "send" | "react" | "upload-file";

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -53,9 +53,7 @@ export type ChannelConfigPatch = Pick<
   };
 
 export interface ChannelAccountConfigAdapter<TAccount extends ChannelAccount> {
-  /** Extract deprecated top-level websocket fields for backwards compatibility. */
-  extractLegacyConfig(input: Record<string, unknown>): ChannelProtocolConfig;
-  /** Validate plugin-owned config payloads after legacy + nested config merging. */
+  /** Validate plugin-owned config payloads. */
   isValidConfig(config: ChannelProtocolConfig): boolean;
   /** Convert protocol snake_case config into the internal account patch shape. */
   toAccountPatch(config: ChannelProtocolConfig): ChannelPluginAccountPatch;

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { refreshDynamicChannelToolsInLoadedRegistry } from "../tools/manager";
 import {
+  channelPluginConfigShouldRefreshDisplayName,
+  normalizeChannelAccountPatch,
+  normalizeChannelConfigPatch,
+  toChannelAccountProtocolConfig,
+  toChannelConfigSnapshotProtocolConfig,
+} from "./accountConfig";
+import {
   getChannelAccount,
   LEGACY_CHANNEL_ACCOUNT_ID,
   listChannelAccounts,
@@ -19,6 +26,11 @@ import {
   getSupportedChannelIds,
   isSupportedChannelId,
 } from "./pluginRegistry";
+import type {
+  ChannelAccountPatch,
+  ChannelConfigPatch,
+  ChannelProtocolConfig,
+} from "./pluginTypes";
 import {
   completePairing,
   ensureChannelRegistry,
@@ -74,6 +86,7 @@ export type ChannelConfigSnapshot =
       enabled: boolean;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       hasToken: boolean;
     }
   | {
@@ -84,8 +97,11 @@ export type ChannelConfigSnapshot =
       mode: SlackChannelMode;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       hasBotToken: boolean;
       hasAppToken: boolean;
+      agentId: string | null;
+      defaultPermissionMode: SlackDefaultPermissionMode;
     }
   | {
       channelId: "discord";
@@ -94,8 +110,10 @@ export type ChannelConfigSnapshot =
       enabled: boolean;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       allowedChannels: string[];
       hasToken: boolean;
+      agentId: string | null;
     };
 
 export interface PendingPairingSnapshot {
@@ -147,6 +165,7 @@ export type ChannelAccountSnapshot =
       running: boolean;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       hasToken: boolean;
       transcribeVoice: boolean;
       binding: {
@@ -166,6 +185,7 @@ export type ChannelAccountSnapshot =
       mode: SlackChannelMode;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       hasBotToken: boolean;
       hasAppToken: boolean;
       agentId: string | null;
@@ -182,6 +202,7 @@ export type ChannelAccountSnapshot =
       running: boolean;
       dmPolicy: DmPolicy;
       allowedUsers: string[];
+      config: ChannelProtocolConfig;
       allowedChannels: string[];
       hasToken: boolean;
       agentId: string | null;
@@ -189,32 +210,7 @@ export type ChannelAccountSnapshot =
       updatedAt: string;
     };
 
-export interface ChannelConfigPatch {
-  token?: string;
-  botToken?: string;
-  appToken?: string;
-  mode?: SlackChannelMode;
-  dmPolicy?: DmPolicy;
-  allowedUsers?: string[];
-  /** Discord-only: allowlist of guild channel IDs (parent channel for threads). */
-  allowedChannels?: string[];
-}
-
-export interface ChannelAccountPatch {
-  displayName?: string;
-  enabled?: boolean;
-  token?: string;
-  botToken?: string;
-  appToken?: string;
-  mode?: SlackChannelMode;
-  agentId?: string | null;
-  defaultPermissionMode?: SlackDefaultPermissionMode;
-  dmPolicy?: DmPolicy;
-  allowedUsers?: string[];
-  /** Discord-only: allowlist of guild channel IDs (parent channel for threads). */
-  allowedChannels?: string[];
-  transcribeVoice?: boolean;
-}
+export type { ChannelAccountPatch, ChannelConfigPatch } from "./pluginTypes";
 
 let resolveChannelAccountDisplayNameOverride:
   | ((
@@ -435,6 +431,13 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
               conversationId: fallbackRoute.conversationId,
             }
           : { ...account.binding };
+    const config = {
+      ...toChannelAccountProtocolConfig(account),
+      binding: {
+        agent_id: binding.agentId,
+        conversation_id: binding.conversationId,
+      },
+    };
 
     return {
       channelId: "telegram",
@@ -445,6 +448,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       running,
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
+      config,
       hasToken: account.token.trim().length > 0,
       transcribeVoice: account.transcribeVoice === true,
       binding,
@@ -463,6 +467,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       running,
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
+      config: toChannelAccountProtocolConfig(account),
       allowedChannels: [...(account.allowedChannels ?? [])],
       hasToken: account.token.trim().length > 0,
       agentId: account.agentId,
@@ -481,6 +486,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     mode: account.mode,
     dmPolicy: account.dmPolicy,
     allowedUsers: [...account.allowedUsers],
+    config: toChannelAccountProtocolConfig(account),
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
@@ -495,17 +501,18 @@ function createAccountFromPatch(
   accountId: string,
   patch: ChannelAccountPatch,
 ): ChannelAccount {
+  const normalizedPatch = normalizeChannelAccountPatch(channelId, patch);
   const now = new Date().toISOString();
   if (channelId === "telegram") {
     return {
       channel: "telegram",
       accountId,
-      displayName: normalizeDisplayName(patch.displayName),
-      enabled: patch.enabled ?? false,
-      token: patch.token ?? "",
-      dmPolicy: patch.dmPolicy ?? "pairing",
-      allowedUsers: patch.allowedUsers ?? [],
-      transcribeVoice: patch.transcribeVoice === true,
+      displayName: normalizeDisplayName(normalizedPatch.displayName),
+      enabled: normalizedPatch.enabled ?? false,
+      token: normalizedPatch.token ?? "",
+      dmPolicy: normalizedPatch.dmPolicy ?? "pairing",
+      allowedUsers: normalizedPatch.allowedUsers ?? [],
+      transcribeVoice: normalizedPatch.transcribeVoice === true,
       binding: {
         agentId: null,
         conversationId: null,
@@ -519,13 +526,13 @@ function createAccountFromPatch(
     return {
       channel: "discord",
       accountId,
-      displayName: normalizeDisplayName(patch.displayName),
-      enabled: patch.enabled ?? false,
-      token: patch.token ?? "",
-      agentId: patch.agentId ?? null,
-      dmPolicy: patch.dmPolicy ?? "pairing",
-      allowedUsers: patch.allowedUsers ?? [],
-      allowedChannels: patch.allowedChannels ?? [],
+      displayName: normalizeDisplayName(normalizedPatch.displayName),
+      enabled: normalizedPatch.enabled ?? false,
+      token: normalizedPatch.token ?? "",
+      agentId: normalizedPatch.agentId ?? null,
+      dmPolicy: normalizedPatch.dmPolicy ?? "pairing",
+      allowedUsers: normalizedPatch.allowedUsers ?? [],
+      allowedChannels: normalizedPatch.allowedChannels ?? [],
       createdAt: now,
       updatedAt: now,
     };
@@ -534,15 +541,15 @@ function createAccountFromPatch(
   return {
     channel: "slack",
     accountId,
-    displayName: normalizeDisplayName(patch.displayName),
-    enabled: patch.enabled ?? false,
-    mode: patch.mode ?? "socket",
-    botToken: patch.botToken ?? "",
-    appToken: patch.appToken ?? "",
-    agentId: patch.agentId ?? null,
-    defaultPermissionMode: patch.defaultPermissionMode ?? "default",
-    dmPolicy: patch.dmPolicy ?? "open",
-    allowedUsers: patch.allowedUsers ?? [],
+    displayName: normalizeDisplayName(normalizedPatch.displayName),
+    enabled: normalizedPatch.enabled ?? false,
+    mode: normalizedPatch.mode ?? "socket",
+    botToken: normalizedPatch.botToken ?? "",
+    appToken: normalizedPatch.appToken ?? "",
+    agentId: normalizedPatch.agentId ?? null,
+    defaultPermissionMode: normalizedPatch.defaultPermissionMode ?? "default",
+    dmPolicy: normalizedPatch.dmPolicy ?? "open",
+    allowedUsers: normalizedPatch.allowedUsers ?? [],
     createdAt: now,
     updatedAt: now,
   };
@@ -552,20 +559,21 @@ function mergeAccountPatch(
   existing: ChannelAccount,
   patch: ChannelAccountPatch,
 ): ChannelAccount {
+  const normalizedPatch = normalizeChannelAccountPatch(existing.channel, patch);
   const nextUpdatedAt = new Date().toISOString();
   if (existing.channel === "telegram") {
     return {
       ...existing,
       displayName:
-        patch.displayName !== undefined
-          ? normalizeDisplayName(patch.displayName)
+        normalizedPatch.displayName !== undefined
+          ? normalizeDisplayName(normalizedPatch.displayName)
           : existing.displayName,
-      enabled: patch.enabled ?? existing.enabled,
-      token: patch.token ?? existing.token,
-      dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
-      allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+      enabled: normalizedPatch.enabled ?? existing.enabled,
+      token: normalizedPatch.token ?? existing.token,
+      dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
       transcribeVoice:
-        patch.transcribeVoice ?? existing.transcribeVoice ?? false,
+        normalizedPatch.transcribeVoice ?? existing.transcribeVoice ?? false,
       updatedAt: nextUpdatedAt,
     };
   }
@@ -574,15 +582,16 @@ function mergeAccountPatch(
     return {
       ...existing,
       displayName:
-        patch.displayName !== undefined
-          ? normalizeDisplayName(patch.displayName)
+        normalizedPatch.displayName !== undefined
+          ? normalizeDisplayName(normalizedPatch.displayName)
           : existing.displayName,
-      enabled: patch.enabled ?? existing.enabled,
-      token: patch.token ?? existing.token,
-      agentId: patch.agentId ?? existing.agentId,
-      dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
-      allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
-      allowedChannels: patch.allowedChannels ?? existing.allowedChannels,
+      enabled: normalizedPatch.enabled ?? existing.enabled,
+      token: normalizedPatch.token ?? existing.token,
+      agentId: normalizedPatch.agentId ?? existing.agentId,
+      dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
+      allowedChannels:
+        normalizedPatch.allowedChannels ?? existing.allowedChannels,
       updatedAt: nextUpdatedAt,
     };
   }
@@ -590,20 +599,20 @@ function mergeAccountPatch(
   return {
     ...existing,
     displayName:
-      patch.displayName !== undefined
-        ? normalizeDisplayName(patch.displayName)
+      normalizedPatch.displayName !== undefined
+        ? normalizeDisplayName(normalizedPatch.displayName)
         : existing.displayName,
-    enabled: patch.enabled ?? existing.enabled,
-    mode: patch.mode ?? existing.mode,
-    botToken: patch.botToken ?? existing.botToken,
-    appToken: patch.appToken ?? existing.appToken,
-    agentId: patch.agentId ?? existing.agentId,
+    enabled: normalizedPatch.enabled ?? existing.enabled,
+    mode: normalizedPatch.mode ?? existing.mode,
+    botToken: normalizedPatch.botToken ?? existing.botToken,
+    appToken: normalizedPatch.appToken ?? existing.appToken,
+    agentId: normalizedPatch.agentId ?? existing.agentId,
     defaultPermissionMode:
-      patch.defaultPermissionMode ??
+      normalizedPatch.defaultPermissionMode ??
       existing.defaultPermissionMode ??
       "default",
-    dmPolicy: patch.dmPolicy ?? existing.dmPolicy,
-    allowedUsers: patch.allowedUsers ?? existing.allowedUsers,
+    dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
+    allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
     updatedAt: nextUpdatedAt,
   };
 }
@@ -667,6 +676,7 @@ export function getChannelConfigSnapshot(
       enabled: account.enabled,
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
+      config: toChannelConfigSnapshotProtocolConfig(account),
       hasToken: account.token.trim().length > 0,
     };
   }
@@ -679,8 +689,10 @@ export function getChannelConfigSnapshot(
       enabled: account.enabled,
       dmPolicy: account.dmPolicy,
       allowedUsers: [...account.allowedUsers],
+      config: toChannelConfigSnapshotProtocolConfig(account),
       allowedChannels: [...(account.allowedChannels ?? [])],
       hasToken: account.token.trim().length > 0,
+      agentId: account.agentId,
     };
   }
 
@@ -692,8 +704,11 @@ export function getChannelConfigSnapshot(
     mode: account.mode,
     dmPolicy: account.dmPolicy,
     allowedUsers: [...account.allowedUsers],
+    config: toChannelConfigSnapshotProtocolConfig(account),
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
+    agentId: account.agentId,
+    defaultPermissionMode: account.defaultPermissionMode ?? "default",
   };
 }
 
@@ -703,37 +718,39 @@ export async function setChannelConfigLive(
   accountId?: string,
 ): Promise<ChannelConfigSnapshot> {
   assertSupportedChannelId(channelId);
+  const normalizedPatch = normalizeChannelConfigPatch(channelId, patch);
   const existing = getSelectedChannelAccount(channelId, accountId);
   let targetAccountId = existing?.accountId;
   let shouldRefreshDisplayName = false;
   if (existing) {
     updateChannelAccountLive(channelId, existing.accountId, {
       enabled: existing.enabled,
-      token: patch.token,
-      botToken: patch.botToken,
-      appToken: patch.appToken,
-      mode: patch.mode,
-      dmPolicy: patch.dmPolicy,
-      allowedUsers: patch.allowedUsers,
-      allowedChannels: patch.allowedChannels,
+      token: normalizedPatch.token,
+      botToken: normalizedPatch.botToken,
+      appToken: normalizedPatch.appToken,
+      mode: normalizedPatch.mode,
+      dmPolicy: normalizedPatch.dmPolicy,
+      allowedUsers: normalizedPatch.allowedUsers,
+      allowedChannels: normalizedPatch.allowedChannels,
       displayName: existing.displayName,
     });
-    shouldRefreshDisplayName =
-      channelId === "telegram" || channelId === "discord"
-        ? patch.token !== undefined
-        : patch.botToken !== undefined || patch.appToken !== undefined;
+    shouldRefreshDisplayName = channelPluginConfigShouldRefreshDisplayName(
+      channelId,
+      normalizedPatch,
+    );
   } else {
     const created = createChannelAccountLive(
       channelId,
       {
         enabled: false,
-        token: patch.token,
-        botToken: patch.botToken,
-        appToken: patch.appToken,
-        mode: patch.mode,
-        dmPolicy: patch.dmPolicy,
-        allowedUsers: patch.allowedUsers,
-        allowedChannels: patch.allowedChannels,
+        token: normalizedPatch.token,
+        botToken: normalizedPatch.botToken,
+        appToken: normalizedPatch.appToken,
+        mode: normalizedPatch.mode,
+        dmPolicy: normalizedPatch.dmPolicy,
+        allowedUsers: normalizedPatch.allowedUsers,
+        allowedChannels: normalizedPatch.allowedChannels,
+        transcribeVoice: normalizedPatch.transcribeVoice,
       },
       accountId ? { accountId } : undefined,
     );

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -1,0 +1,107 @@
+import type { ChannelAccountConfigAdapter } from "../pluginTypes";
+import type { SlackChannelAccount, SlackDefaultPermissionMode } from "../types";
+
+const SLACK_CONFIG_KEYS = new Set([
+  "bot_token",
+  "app_token",
+  "mode",
+  "agent_id",
+  "default_permission_mode",
+]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isDefaultPermissionMode(
+  value: unknown,
+): value is SlackDefaultPermissionMode {
+  return (
+    value === "default" ||
+    value === "acceptEdits" ||
+    value === "bypassPermissions"
+  );
+}
+
+export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannelAccount> =
+  {
+    extractLegacyConfig(input) {
+      const config: Record<string, unknown> = {};
+      if ("bot_token" in input) {
+        config.bot_token = input.bot_token;
+      }
+      if ("app_token" in input) {
+        config.app_token = input.app_token;
+      }
+      if ("mode" in input) {
+        config.mode = input.mode;
+      }
+      if ("agent_id" in input) {
+        config.agent_id = input.agent_id;
+      }
+      if ("default_permission_mode" in input) {
+        config.default_permission_mode = input.default_permission_mode;
+      }
+      return config;
+    },
+
+    isValidConfig(config) {
+      for (const key of Object.keys(config)) {
+        if (!SLACK_CONFIG_KEYS.has(key)) {
+          return false;
+        }
+      }
+      return (
+        (config.bot_token === undefined || isString(config.bot_token)) &&
+        (config.app_token === undefined || isString(config.app_token)) &&
+        (config.mode === undefined || config.mode === "socket") &&
+        (config.agent_id === undefined || isNullableString(config.agent_id)) &&
+        (config.default_permission_mode === undefined ||
+          isDefaultPermissionMode(config.default_permission_mode))
+      );
+    },
+
+    toAccountPatch(config) {
+      return {
+        botToken: isString(config.bot_token) ? config.bot_token : undefined,
+        appToken: isString(config.app_token) ? config.app_token : undefined,
+        mode: config.mode === "socket" ? "socket" : undefined,
+        agentId: isNullableString(config.agent_id)
+          ? config.agent_id
+          : undefined,
+        defaultPermissionMode: isDefaultPermissionMode(
+          config.default_permission_mode,
+        )
+          ? config.default_permission_mode
+          : undefined,
+      };
+    },
+
+    toAccountConfig(account) {
+      return {
+        mode: account.mode,
+        has_bot_token: account.botToken.trim().length > 0,
+        has_app_token: account.appToken.trim().length > 0,
+        agent_id: account.agentId,
+        default_permission_mode: account.defaultPermissionMode ?? "default",
+      };
+    },
+
+    toConfigSnapshotConfig(account) {
+      return {
+        mode: account.mode,
+        has_bot_token: account.botToken.trim().length > 0,
+        has_app_token: account.appToken.trim().length > 0,
+        agent_id: account.agentId,
+        default_permission_mode: account.defaultPermissionMode ?? "default",
+      };
+    },
+
+    shouldRefreshDisplayName(patch) {
+      return patch.botToken !== undefined || patch.appToken !== undefined;
+    },
+  };

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -29,26 +29,6 @@ function isDefaultPermissionMode(
 
 export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannelAccount> =
   {
-    extractLegacyConfig(input) {
-      const config: Record<string, unknown> = {};
-      if ("bot_token" in input) {
-        config.bot_token = input.bot_token;
-      }
-      if ("app_token" in input) {
-        config.app_token = input.app_token;
-      }
-      if ("mode" in input) {
-        config.mode = input.mode;
-      }
-      if ("agent_id" in input) {
-        config.agent_id = input.agent_id;
-      }
-      if ("default_permission_mode" in input) {
-        config.default_permission_mode = input.default_permission_mode;
-      }
-      return config;
-    },
-
     isValidConfig(config) {
       for (const key of Object.keys(config)) {
         if (!SLACK_CONFIG_KEYS.has(key)) {

--- a/src/channels/telegram/accountConfig.ts
+++ b/src/channels/telegram/accountConfig.ts
@@ -1,0 +1,74 @@
+import type { ChannelAccountConfigAdapter } from "../pluginTypes";
+import type { TelegramChannelAccount } from "../types";
+
+const TELEGRAM_CONFIG_KEYS = new Set(["token", "transcribe_voice"]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+export const telegramAccountConfigAdapter: ChannelAccountConfigAdapter<TelegramChannelAccount> =
+  {
+    extractLegacyConfig(input) {
+      const config: Record<string, unknown> = {};
+      if ("token" in input) {
+        config.token = input.token;
+      }
+      if ("transcribe_voice" in input) {
+        config.transcribe_voice = input.transcribe_voice;
+      }
+      return config;
+    },
+
+    isValidConfig(config) {
+      for (const key of Object.keys(config)) {
+        if (!TELEGRAM_CONFIG_KEYS.has(key)) {
+          return false;
+        }
+      }
+      return (
+        (config.token === undefined || isString(config.token)) &&
+        (config.transcribe_voice === undefined ||
+          isBoolean(config.transcribe_voice))
+      );
+    },
+
+    toAccountPatch(config) {
+      return {
+        token: isString(config.token) ? config.token : undefined,
+        transcribeVoice: isBoolean(config.transcribe_voice)
+          ? config.transcribe_voice
+          : undefined,
+      };
+    },
+
+    toAccountConfig(account) {
+      return {
+        has_token: account.token.trim().length > 0,
+        transcribe_voice: account.transcribeVoice === true,
+        binding: {
+          agent_id: account.binding.agentId,
+          conversation_id: account.binding.conversationId,
+        },
+      };
+    },
+
+    toConfigSnapshotConfig(account) {
+      return {
+        has_token: account.token.trim().length > 0,
+        transcribe_voice: account.transcribeVoice === true,
+        binding: {
+          agent_id: account.binding.agentId,
+          conversation_id: account.binding.conversationId,
+        },
+      };
+    },
+
+    shouldRefreshDisplayName(patch) {
+      return patch.token !== undefined;
+    },
+  };

--- a/src/channels/telegram/accountConfig.ts
+++ b/src/channels/telegram/accountConfig.ts
@@ -13,17 +13,6 @@ function isBoolean(value: unknown): value is boolean {
 
 export const telegramAccountConfigAdapter: ChannelAccountConfigAdapter<TelegramChannelAccount> =
   {
-    extractLegacyConfig(input) {
-      const config: Record<string, unknown> = {};
-      if ("token" in input) {
-        config.token = input.token;
-      }
-      if ("transcribe_voice" in input) {
-        config.transcribe_voice = input.transcribe_voice;
-      }
-      return config;
-    },
-
     isValidConfig(config) {
       for (const key of Object.keys(config)) {
         if (!TELEGRAM_CONFIG_KEYS.has(key)) {

--- a/src/tests/channels/discord-protocol.test.ts
+++ b/src/tests/channels/discord-protocol.test.ts
@@ -11,7 +11,7 @@ describe("discord protocol-inbound validators", () => {
       type: "channel_account_create",
       channel_id: "discord",
       request_id: "r1",
-      account: { token: "test-token" },
+      account: { config: { token: "test-token" } },
     };
     expect(isChannelAccountCreateCommand(msg)).toBe(true);
   });
@@ -22,9 +22,11 @@ describe("discord protocol-inbound validators", () => {
       channel_id: "discord",
       request_id: "r1",
       account: {
-        token: "test-token",
-        agent_id: "a-1",
-        allowed_channels: ["channel-1"],
+        config: {
+          token: "test-token",
+          agent_id: "a-1",
+          allowed_channels: ["channel-1"],
+        },
       },
     };
     expect(isChannelAccountCreateCommand(msg)).toBe(true);
@@ -51,7 +53,9 @@ describe("discord protocol-inbound validators", () => {
       type: "channel_account_create",
       channel_id: "discord",
       request_id: "r1",
-      account: { token: "test-token", allowed_channels: ["channel-1", 42] },
+      account: {
+        config: { token: "test-token", allowed_channels: ["channel-1", 42] },
+      },
     };
     expect(isChannelAccountCreateCommand(msg)).toBe(false);
   });
@@ -66,16 +70,14 @@ describe("discord protocol-inbound validators", () => {
     expect(isChannelAccountCreateCommand(msg)).toBe(false);
   });
 
-  test("discord account create without discord fields still passes (validator only checks discord-specific fields)", () => {
+  test("discord account create rejects legacy top-level plugin fields", () => {
     const msg = {
       type: "channel_account_create",
       channel_id: "discord",
       request_id: "r1",
-      account: { bot_token: "xoxb-test" },
+      account: { token: "test-token" },
     };
-    // validator only rejects discord-specific-field violations; Slack-style
-    // extra fields should not cause rejection by the discord validator.
-    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+    expect(isChannelAccountCreateCommand(msg)).toBe(false);
   });
 
   test("valid discord account update passes", () => {
@@ -84,7 +86,7 @@ describe("discord protocol-inbound validators", () => {
       channel_id: "discord",
       account_id: "acc-1",
       request_id: "r1",
-      patch: { token: "new-token" },
+      patch: { config: { token: "new-token" } },
     };
     expect(isChannelAccountUpdateCommand(msg)).toBe(true);
   });
@@ -94,7 +96,9 @@ describe("discord protocol-inbound validators", () => {
       type: "channel_set_config",
       channel_id: "discord",
       request_id: "r1",
-      config: { token: "new-token", allowed_channels: ["channel-1"] },
+      config: {
+        plugin_config: { token: "new-token", allowed_channels: ["channel-1"] },
+      },
     };
     expect(isChannelSetConfigCommand(msg)).toBe(true);
   });
@@ -105,7 +109,7 @@ describe("discord protocol-inbound validators", () => {
       channel_id: "discord",
       request_id: "r1",
       config: {
-        config: { token: "new-token", allowed_channels: ["channel-1"] },
+        plugin_config: { token: "new-token", allowed_channels: ["channel-1"] },
       },
     };
     expect(isChannelSetConfigCommand(msg)).toBe(true);
@@ -116,7 +120,7 @@ describe("discord protocol-inbound validators", () => {
       type: "channel_account_create",
       channel_id: "discord",
       request_id: "r1",
-      account: { token: "t" },
+      account: { config: { token: "t" } },
     };
     expect(isChannelAccountCreateCommand(msg)).toBe(true);
   });

--- a/src/tests/channels/discord-protocol.test.ts
+++ b/src/tests/channels/discord-protocol.test.ts
@@ -30,12 +30,38 @@ describe("discord protocol-inbound validators", () => {
     expect(isChannelAccountCreateCommand(msg)).toBe(true);
   });
 
+  test("valid discord account create with generic config passes", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: {
+        config: {
+          token: "test-token",
+          agent_id: "a-1",
+          allowed_channels: ["channel-1"],
+        },
+      },
+    };
+    expect(isChannelAccountCreateCommand(msg)).toBe(true);
+  });
+
   test("discord account create rejects non-string allowed_channels", () => {
     const msg = {
       type: "channel_account_create",
       channel_id: "discord",
       request_id: "r1",
       account: { token: "test-token", allowed_channels: ["channel-1", 42] },
+    };
+    expect(isChannelAccountCreateCommand(msg)).toBe(false);
+  });
+
+  test("discord account create rejects unknown nested plugin config fields", () => {
+    const msg = {
+      type: "channel_account_create",
+      channel_id: "discord",
+      request_id: "r1",
+      account: { config: { bot_token: "xoxb-test" } },
     };
     expect(isChannelAccountCreateCommand(msg)).toBe(false);
   });
@@ -69,6 +95,18 @@ describe("discord protocol-inbound validators", () => {
       channel_id: "discord",
       request_id: "r1",
       config: { token: "new-token", allowed_channels: ["channel-1"] },
+    };
+    expect(isChannelSetConfigCommand(msg)).toBe(true);
+  });
+
+  test("valid discord config set with nested generic config passes", () => {
+    const msg = {
+      type: "channel_set_config",
+      channel_id: "discord",
+      request_id: "r1",
+      config: {
+        config: { token: "new-token", allowed_channels: ["channel-1"] },
+      },
     };
     expect(isChannelSetConfigCommand(msg)).toBe(true);
   });

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -461,6 +461,12 @@ describe("channel service", () => {
           agentId: "agent-telegram",
           conversationId: "conv-telegram",
         },
+        config: expect.objectContaining({
+          binding: {
+            agent_id: "agent-telegram",
+            conversation_id: "conv-telegram",
+          },
+        }),
       }),
     );
   });

--- a/src/tests/websocket/listen-client-channel-accounts.test.ts
+++ b/src/tests/websocket/listen-client-channel-accounts.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import WebSocket from "ws";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "../../channels/accounts";
 import { __listenClientTestUtils } from "../../websocket/listener/client";
 
 class MockSocket {
@@ -16,6 +21,9 @@ const actualChannelsService = await import("../../channels/service");
 
 afterEach(() => {
   __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
+  clearChannelAccountStores();
+  __testOverrideLoadChannelAccounts(null);
+  __testOverrideSaveChannelAccounts(null);
 });
 
 describe("channel account list responses", () => {
@@ -37,6 +45,13 @@ describe("channel account list responses", () => {
           mode: "socket" as const,
           dmPolicy: "pairing" as const,
           allowedUsers: [],
+          config: {
+            mode: "socket",
+            has_bot_token: true,
+            has_app_token: true,
+            agent_id: "agent-1",
+            default_permission_mode: "acceptEdits",
+          },
           hasBotToken: true,
           hasAppToken: true,
           agentId: "agent-1",
@@ -58,6 +73,13 @@ describe("channel account list responses", () => {
               mode: "socket" as const,
               dmPolicy: "pairing" as const,
               allowedUsers: [],
+              config: {
+                mode: "socket",
+                has_bot_token: true,
+                has_app_token: true,
+                agent_id: "agent-1",
+                default_permission_mode: "acceptEdits",
+              },
               hasBotToken: true,
               hasAppToken: true,
               agentId: "agent-1",
@@ -99,6 +121,13 @@ describe("channel account list responses", () => {
             mode: "socket",
             dm_policy: "pairing",
             allowed_users: [],
+            config: {
+              mode: "socket",
+              has_bot_token: true,
+              has_app_token: true,
+              agent_id: "agent-1",
+              default_permission_mode: "acceptEdits",
+            },
             has_bot_token: true,
             has_app_token: true,
             agent_id: "agent-1",
@@ -110,6 +139,153 @@ describe("channel account list responses", () => {
       });
     } finally {
       releaseRefresh();
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
+  test("round-trips plugin config through create, update, list, and get", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_create",
+          request_id: "discord-create-generic-config",
+          channel_id: "discord",
+          account: {
+            account_id: "discord-bot",
+            display_name: "Discord Bot",
+            enabled: false,
+            dm_policy: "pairing",
+            config: {
+              token: "discord-token",
+              agent_id: "agent-1",
+              allowed_channels: ["channel-1"],
+            },
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_update",
+          request_id: "discord-update-generic-config",
+          channel_id: "discord",
+          account_id: "discord-bot",
+          patch: {
+            config: {
+              agent_id: "agent-2",
+              allowed_channels: ["channel-2"],
+            },
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_accounts_list",
+          request_id: "discord-list-generic-config",
+          channel_id: "discord",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_get_config",
+          request_id: "discord-get-generic-config",
+          channel_id: "discord",
+          account_id: "discord-bot",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_create_response",
+        success: true,
+        account: {
+          account_id: "discord-bot",
+          config: {
+            has_token: true,
+            agent_id: "agent-1",
+            allowed_channels: ["channel-1"],
+          },
+        },
+      });
+      expect(messages[3]).toMatchObject({
+        type: "channel_account_update_response",
+        success: true,
+        account: {
+          account_id: "discord-bot",
+          config: {
+            has_token: true,
+            agent_id: "agent-2",
+            allowed_channels: ["channel-2"],
+          },
+        },
+      });
+      expect(messages[6]).toMatchObject({
+        type: "channel_accounts_list_response",
+        success: true,
+        accounts: [
+          {
+            account_id: "discord-bot",
+            config: {
+              has_token: true,
+              agent_id: "agent-2",
+              allowed_channels: ["channel-2"],
+            },
+          },
+        ],
+      });
+      expect(messages[7]).toMatchObject({
+        type: "channel_get_config_response",
+        success: true,
+        config: {
+          account_id: "discord-bot",
+          config: {
+            has_token: true,
+            agent_id: "agent-2",
+            allowed_channels: ["channel-2"],
+          },
+        },
+      });
+    } finally {
       __listenClientTestUtils.stopRuntime(runtime, true);
     }
   });

--- a/src/tests/websocket/listen-client-channel-accounts.test.ts
+++ b/src/tests/websocket/listen-client-channel-accounts.test.ts
@@ -118,7 +118,6 @@ describe("channel account list responses", () => {
             enabled: true,
             configured: true,
             running: false,
-            mode: "socket",
             dm_policy: "pairing",
             allowed_users: [],
             config: {
@@ -128,10 +127,6 @@ describe("channel account list responses", () => {
               agent_id: "agent-1",
               default_permission_mode: "acceptEdits",
             },
-            has_bot_token: true,
-            has_app_token: true,
-            agent_id: "agent-1",
-            default_permission_mode: "acceptEdits",
             created_at: "2026-04-13T00:00:00.000Z",
             updated_at: "2026-04-13T00:00:00.000Z",
           },

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -109,10 +109,12 @@ describe("listen-client channel command dispatch", () => {
         channel_id: "slack",
         account: {
           display_name: "DocsBot Slack",
-          bot_token: "xoxb-test",
-          app_token: "xapp-test",
-          mode: "socket",
           dm_policy: "pairing",
+          config: {
+            bot_token: "xoxb-test",
+            app_token: "xapp-test",
+            mode: "socket",
+          },
         },
       }),
     ).toBe(true);
@@ -477,11 +479,13 @@ describe("listen-client parseServerMessage", () => {
           channel_id: "slack",
           account: {
             display_name: "DocsBot Slack",
-            bot_token: "xoxb-test",
-            app_token: "xapp-test",
-            mode: "socket",
             dm_policy: "pairing",
             allowed_users: ["user-1"],
+            config: {
+              bot_token: "xoxb-test",
+              app_token: "xapp-test",
+              mode: "socket",
+            },
           },
         }),
       ),
@@ -495,8 +499,10 @@ describe("listen-client parseServerMessage", () => {
           account_id: "bot-1",
           patch: {
             display_name: "@docsbot",
-            token: "telegram-token",
             dm_policy: "open",
+            config: {
+              token: "telegram-token",
+            },
           },
         }),
       ),
@@ -559,11 +565,13 @@ describe("listen-client parseServerMessage", () => {
           request_id: "channel-set-config-1",
           channel_id: "slack",
           config: {
-            bot_token: "xoxb-test",
-            app_token: "xapp-test",
-            mode: "socket",
             dm_policy: "pairing",
             allowed_users: ["user-1"],
+            plugin_config: {
+              bot_token: "xoxb-test",
+              app_token: "xapp-test",
+              mode: "socket",
+            },
           },
         }),
       ),
@@ -1355,10 +1363,12 @@ describe("listen-client channels command handling", () => {
             configured: true,
             running: true,
             dm_policy: "pairing",
-            has_token: true,
-            binding: {
-              agent_id: "agent-1",
-              conversation_id: "default",
+            config: {
+              has_token: true,
+              binding: {
+                agent_id: "agent-1",
+                conversation_id: "default",
+              },
             },
             created_at: "2026-04-11T00:00:00.000Z",
             updated_at: "2026-04-11T01:00:00.000Z",
@@ -1699,8 +1709,10 @@ describe("listen-client channels command handling", () => {
         channel_id: "slack",
         account: {
           account_id: "acct-1",
-          agent_id: "agent-1",
-          default_permission_mode: "acceptEdits",
+          config: {
+            agent_id: "agent-1",
+            default_permission_mode: "acceptEdits",
+          },
         },
       });
       expect(messages[1]).toMatchObject({
@@ -1741,8 +1753,10 @@ describe("listen-client channels command handling", () => {
         channel_id: "slack",
         account: {
           account_id: "acct-1",
-          agent_id: null,
-          default_permission_mode: "acceptEdits",
+          config: {
+            agent_id: null,
+            default_permission_mode: "acceptEdits",
+          },
         },
       });
       expect(messages[1]).toMatchObject({
@@ -1828,8 +1842,10 @@ describe("listen-client channels command handling", () => {
           channel_id: "telegram",
           account: {
             display_name: "@docsbot",
-            token: "telegram-token",
             dm_policy: "pairing",
+            config: {
+              token: "telegram-token",
+            },
           },
         },
         socket as unknown as WebSocket,
@@ -1852,7 +1868,9 @@ describe("listen-client channels command handling", () => {
         account: {
           account_id: "bot-1",
           display_name: "@docsbot",
-          has_token: true,
+          config: {
+            has_token: true,
+          },
         },
       });
       expect(messages[1]).toMatchObject({

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1305,6 +1305,14 @@ describe("listen-client channels command handling", () => {
           running: true,
           dmPolicy: "pairing" as const,
           allowedUsers: [],
+          config: {
+            has_token: true,
+            transcribe_voice: false,
+            binding: {
+              agent_id: "agent-1",
+              conversation_id: "default",
+            },
+          },
           hasToken: true,
           transcribeVoice: false,
           binding: {
@@ -1620,6 +1628,13 @@ describe("listen-client channels command handling", () => {
         mode: "socket" as const,
         dmPolicy: "pairing" as const,
         allowedUsers: [],
+        config: {
+          mode: "socket",
+          has_bot_token: true,
+          has_app_token: true,
+          agent_id: "agent-1",
+          default_permission_mode: "acceptEdits",
+        },
         hasBotToken: true,
         hasAppToken: true,
         agentId: "agent-1",
@@ -1637,6 +1652,13 @@ describe("listen-client channels command handling", () => {
         mode: "socket" as const,
         dmPolicy: "pairing" as const,
         allowedUsers: [],
+        config: {
+          mode: "socket",
+          has_bot_token: true,
+          has_app_token: true,
+          agent_id: null,
+          default_permission_mode: "acceptEdits",
+        },
         hasBotToken: true,
         hasAppToken: true,
         agentId: null,
@@ -1752,6 +1774,14 @@ describe("listen-client channels command handling", () => {
         running: false,
         dmPolicy: "pairing" as const,
         allowedUsers: [],
+        config: {
+          has_token: true,
+          transcribe_voice: false,
+          binding: {
+            agent_id: null,
+            conversation_id: null,
+          },
+        },
         hasToken: true,
         transcribeVoice: false,
         binding: {
@@ -1770,6 +1800,14 @@ describe("listen-client channels command handling", () => {
         running: true,
         dmPolicy: "pairing" as const,
         allowedUsers: [],
+        config: {
+          has_token: true,
+          transcribe_voice: false,
+          binding: {
+            agent_id: null,
+            conversation_id: null,
+          },
+        },
         hasToken: true,
         transcribeVoice: false,
         binding: {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -144,6 +144,8 @@ export interface ReflectionSettingsSnapshot {
 
 export type ChannelId = "telegram" | "slack" | "discord";
 
+export type ChannelPluginConfig = Record<string, unknown>;
+
 export interface ChannelSummary {
   channel_id: ChannelId;
   display_name: string;
@@ -156,88 +158,66 @@ export interface ChannelSummary {
   routes_count: number;
 }
 
-export type ChannelConfigSnapshot =
-  | {
-      channel_id: "telegram";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      has_token: boolean;
-    }
-  | {
-      channel_id: "slack";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      mode: SlackChannelMode;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      has_bot_token: boolean;
-      has_app_token: boolean;
-    }
-  | {
-      channel_id: "discord";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      allowed_channels: string[];
-      has_token: boolean;
-    };
+export interface ChannelConfigSnapshot {
+  channel_id: ChannelId;
+  account_id: string;
+  display_name?: string;
+  enabled: boolean;
+  dm_policy: DmPolicy;
+  allowed_users: string[];
+  /** Plugin-owned redacted config/settings payload. */
+  config: ChannelPluginConfig;
+  /** @deprecated Use config.has_token. */
+  has_token?: boolean;
+  /** @deprecated Use config.mode. */
+  mode?: SlackChannelMode;
+  /** @deprecated Use config.has_bot_token. */
+  has_bot_token?: boolean;
+  /** @deprecated Use config.has_app_token. */
+  has_app_token?: boolean;
+  /** @deprecated Use config.agent_id. */
+  agent_id?: string | null;
+  /** @deprecated Use config.default_permission_mode. */
+  default_permission_mode?: SlackDefaultPermissionMode;
+  /** @deprecated Use config.allowed_channels. */
+  allowed_channels?: string[];
+}
 
-export type ChannelAccountSnapshot =
-  | {
-      channel_id: "telegram";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      has_token: boolean;
-      binding: {
-        agent_id: string | null;
-        conversation_id: string | null;
-      };
-      created_at: string;
-      updated_at: string;
-    }
-  | {
-      channel_id: "slack";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      mode: SlackChannelMode;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      has_bot_token: boolean;
-      has_app_token: boolean;
-      agent_id: string | null;
-      default_permission_mode: SlackDefaultPermissionMode;
-      created_at: string;
-      updated_at: string;
-    }
-  | {
-      channel_id: "discord";
-      account_id: string;
-      display_name?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      dm_policy: DmPolicy;
-      allowed_users: string[];
-      allowed_channels: string[];
-      has_token: boolean;
-      agent_id: string | null;
-      created_at: string;
-      updated_at: string;
-    };
+export interface ChannelAccountSnapshot {
+  channel_id: ChannelId;
+  account_id: string;
+  display_name?: string;
+  enabled: boolean;
+  configured: boolean;
+  running: boolean;
+  dm_policy: DmPolicy;
+  allowed_users: string[];
+  /** Plugin-owned redacted config/settings payload. */
+  config: ChannelPluginConfig;
+  /** @deprecated Use config.has_token. */
+  has_token?: boolean;
+  /** @deprecated Use config.transcribe_voice. */
+  transcribe_voice?: boolean;
+  /** @deprecated Use config.binding. */
+  binding?: {
+    agent_id: string | null;
+    conversation_id: string | null;
+  };
+  /** @deprecated Use config.mode. */
+  mode?: SlackChannelMode;
+  /** @deprecated Use config.has_bot_token. */
+  has_bot_token?: boolean;
+  /** @deprecated Use config.has_app_token. */
+  has_app_token?: boolean;
+  /** @deprecated Use config.agent_id. */
+  agent_id?: string | null;
+  /** @deprecated Use config.default_permission_mode. */
+  default_permission_mode?: SlackDefaultPermissionMode;
+  /** @deprecated Use config.allowed_channels. */
+  allowed_channels?: string[];
+  created_at: string;
+  updated_at: string;
+}
 
 export interface ChannelPendingPairing {
   account_id: string;
@@ -1017,37 +997,31 @@ export interface ChannelAccountsListCommand {
   channel_id: ChannelId;
 }
 
-export type ChannelAccountCreatePayload =
-  | {
-      account_id?: string;
-      display_name?: string;
-      enabled?: boolean;
-      token?: string;
-      dm_policy?: DmPolicy;
-      allowed_users?: string[];
-    }
-  | {
-      account_id?: string;
-      display_name?: string;
-      enabled?: boolean;
-      bot_token?: string;
-      app_token?: string;
-      mode?: SlackChannelMode;
-      agent_id?: string | null;
-      default_permission_mode?: SlackDefaultPermissionMode;
-      dm_policy?: DmPolicy;
-      allowed_users?: string[];
-    }
-  | {
-      account_id?: string;
-      display_name?: string;
-      enabled?: boolean;
-      token?: string;
-      agent_id?: string | null;
-      dm_policy?: DmPolicy;
-      allowed_users?: string[];
-      allowed_channels?: string[];
-    };
+export interface ChannelAccountCreatePayload {
+  account_id?: string;
+  display_name?: string;
+  enabled?: boolean;
+  dm_policy?: DmPolicy;
+  allowed_users?: string[];
+  /** Plugin-owned account config. New fields should be added here, not centrally. */
+  config?: ChannelPluginConfig;
+  /** @deprecated Use config.token. */
+  token?: string;
+  /** @deprecated Use config.transcribe_voice. */
+  transcribe_voice?: boolean;
+  /** @deprecated Use config.bot_token. */
+  bot_token?: string;
+  /** @deprecated Use config.app_token. */
+  app_token?: string;
+  /** @deprecated Use config.mode. */
+  mode?: SlackChannelMode;
+  /** @deprecated Use config.agent_id. */
+  agent_id?: string | null;
+  /** @deprecated Use config.default_permission_mode. */
+  default_permission_mode?: SlackDefaultPermissionMode;
+  /** @deprecated Use config.allowed_channels. */
+  allowed_channels?: string[];
+}
 
 export interface ChannelAccountCreateCommand {
   type: "channel_account_create";
@@ -1061,34 +1035,7 @@ export interface ChannelAccountUpdateCommand {
   request_id: string;
   channel_id: ChannelId;
   account_id: string;
-  patch:
-    | {
-        display_name?: string;
-        enabled?: boolean;
-        token?: string;
-        dm_policy?: DmPolicy;
-        allowed_users?: string[];
-      }
-    | {
-        display_name?: string;
-        enabled?: boolean;
-        bot_token?: string;
-        app_token?: string;
-        mode?: SlackChannelMode;
-        agent_id?: string | null;
-        default_permission_mode?: SlackDefaultPermissionMode;
-        dm_policy?: DmPolicy;
-        allowed_users?: string[];
-      }
-    | {
-        display_name?: string;
-        enabled?: boolean;
-        token?: string;
-        agent_id?: string | null;
-        dm_policy?: DmPolicy;
-        allowed_users?: string[];
-        allowed_channels?: string[];
-      };
+  patch: Omit<ChannelAccountCreatePayload, "account_id">;
 }
 
 export interface ChannelAccountBindCommand {
@@ -1139,20 +1086,28 @@ export interface ChannelSetConfigCommand {
   request_id: string;
   channel_id: ChannelId;
   account_id?: string;
-  config:
-    | {
-        token?: string;
-        dm_policy?: DmPolicy;
-        allowed_users?: string[];
-        allowed_channels?: string[];
-      }
-    | {
-        bot_token?: string;
-        app_token?: string;
-        mode?: SlackChannelMode;
-        dm_policy?: DmPolicy;
-        allowed_users?: string[];
-      };
+  config: {
+    dm_policy?: DmPolicy;
+    allowed_users?: string[];
+    /** Optional nested plugin config. Direct plugin fields are still accepted. */
+    config?: ChannelPluginConfig;
+    /** @deprecated Use config.token. */
+    token?: string;
+    /** @deprecated Use config.transcribe_voice. */
+    transcribe_voice?: boolean;
+    /** @deprecated Use config.bot_token. */
+    bot_token?: string;
+    /** @deprecated Use config.app_token. */
+    app_token?: string;
+    /** @deprecated Use config.mode. */
+    mode?: SlackChannelMode;
+    /** @deprecated Use config.agent_id. */
+    agent_id?: string | null;
+    /** @deprecated Use config.default_permission_mode. */
+    default_permission_mode?: SlackDefaultPermissionMode;
+    /** @deprecated Use config.allowed_channels. */
+    allowed_channels?: string[];
+  };
 }
 
 export interface ChannelStartCommand {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -9,11 +9,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import type {
-  DmPolicy,
-  SlackChannelMode,
-  SlackDefaultPermissionMode,
-} from "../channels/types";
+import type { DmPolicy } from "../channels/types";
 import type { CronTask } from "../cron";
 import type { ExperimentId, ExperimentSnapshot } from "../experiments/types";
 
@@ -167,20 +163,6 @@ export interface ChannelConfigSnapshot {
   allowed_users: string[];
   /** Plugin-owned redacted config/settings payload. */
   config: ChannelPluginConfig;
-  /** @deprecated Use config.has_token. */
-  has_token?: boolean;
-  /** @deprecated Use config.mode. */
-  mode?: SlackChannelMode;
-  /** @deprecated Use config.has_bot_token. */
-  has_bot_token?: boolean;
-  /** @deprecated Use config.has_app_token. */
-  has_app_token?: boolean;
-  /** @deprecated Use config.agent_id. */
-  agent_id?: string | null;
-  /** @deprecated Use config.default_permission_mode. */
-  default_permission_mode?: SlackDefaultPermissionMode;
-  /** @deprecated Use config.allowed_channels. */
-  allowed_channels?: string[];
 }
 
 export interface ChannelAccountSnapshot {
@@ -194,27 +176,6 @@ export interface ChannelAccountSnapshot {
   allowed_users: string[];
   /** Plugin-owned redacted config/settings payload. */
   config: ChannelPluginConfig;
-  /** @deprecated Use config.has_token. */
-  has_token?: boolean;
-  /** @deprecated Use config.transcribe_voice. */
-  transcribe_voice?: boolean;
-  /** @deprecated Use config.binding. */
-  binding?: {
-    agent_id: string | null;
-    conversation_id: string | null;
-  };
-  /** @deprecated Use config.mode. */
-  mode?: SlackChannelMode;
-  /** @deprecated Use config.has_bot_token. */
-  has_bot_token?: boolean;
-  /** @deprecated Use config.has_app_token. */
-  has_app_token?: boolean;
-  /** @deprecated Use config.agent_id. */
-  agent_id?: string | null;
-  /** @deprecated Use config.default_permission_mode. */
-  default_permission_mode?: SlackDefaultPermissionMode;
-  /** @deprecated Use config.allowed_channels. */
-  allowed_channels?: string[];
   created_at: string;
   updated_at: string;
 }
@@ -1005,22 +966,6 @@ export interface ChannelAccountCreatePayload {
   allowed_users?: string[];
   /** Plugin-owned account config. New fields should be added here, not centrally. */
   config?: ChannelPluginConfig;
-  /** @deprecated Use config.token. */
-  token?: string;
-  /** @deprecated Use config.transcribe_voice. */
-  transcribe_voice?: boolean;
-  /** @deprecated Use config.bot_token. */
-  bot_token?: string;
-  /** @deprecated Use config.app_token. */
-  app_token?: string;
-  /** @deprecated Use config.mode. */
-  mode?: SlackChannelMode;
-  /** @deprecated Use config.agent_id. */
-  agent_id?: string | null;
-  /** @deprecated Use config.default_permission_mode. */
-  default_permission_mode?: SlackDefaultPermissionMode;
-  /** @deprecated Use config.allowed_channels. */
-  allowed_channels?: string[];
 }
 
 export interface ChannelAccountCreateCommand {
@@ -1089,24 +1034,7 @@ export interface ChannelSetConfigCommand {
   config: {
     dm_policy?: DmPolicy;
     allowed_users?: string[];
-    /** Optional nested plugin config. Direct plugin fields are still accepted. */
-    config?: ChannelPluginConfig;
-    /** @deprecated Use config.token. */
-    token?: string;
-    /** @deprecated Use config.transcribe_voice. */
-    transcribe_voice?: boolean;
-    /** @deprecated Use config.bot_token. */
-    bot_token?: string;
-    /** @deprecated Use config.app_token. */
-    app_token?: string;
-    /** @deprecated Use config.mode. */
-    mode?: SlackChannelMode;
-    /** @deprecated Use config.agent_id. */
-    agent_id?: string | null;
-    /** @deprecated Use config.default_permission_mode. */
-    default_permission_mode?: SlackDefaultPermissionMode;
-    /** @deprecated Use config.allowed_channels. */
-    allowed_channels?: string[];
+    plugin_config?: ChannelPluginConfig;
   };
 }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -18,6 +18,10 @@ import {
   updateConversationLLMConfig,
 } from "../../agent/modify";
 import {
+  channelPluginConfigShouldRefreshDisplayName,
+  getMergedChannelPluginConfig,
+} from "../../channels/accountConfig";
+import {
   type ChannelRegistryEvent,
   getChannelRegistry,
 } from "../../channels/registry";
@@ -1722,6 +1726,7 @@ async function handleChannelsProtocolCommand(
         enabled: snapshot.enabled,
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
+        config: snapshot.config ?? {},
         has_token: snapshot.hasToken,
       };
     }
@@ -1733,8 +1738,10 @@ async function handleChannelsProtocolCommand(
         enabled: snapshot.enabled,
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
+        config: snapshot.config ?? {},
         allowed_channels: snapshot.allowedChannels,
         has_token: snapshot.hasToken,
+        agent_id: snapshot.agentId,
       };
     }
     return {
@@ -1745,8 +1752,11 @@ async function handleChannelsProtocolCommand(
       mode: snapshot.mode,
       dm_policy: snapshot.dmPolicy,
       allowed_users: snapshot.allowedUsers,
+      config: snapshot.config ?? {},
       has_bot_token: snapshot.hasBotToken,
       has_app_token: snapshot.hasAppToken,
+      agent_id: snapshot.agentId,
+      default_permission_mode: snapshot.defaultPermissionMode,
     };
   };
 
@@ -1763,7 +1773,9 @@ async function handleChannelsProtocolCommand(
         running: snapshot.running,
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
+        config: snapshot.config ?? {},
         has_token: snapshot.hasToken,
+        transcribe_voice: snapshot.transcribeVoice,
         binding: {
           agent_id: snapshot.binding.agentId,
           conversation_id: snapshot.binding.conversationId,
@@ -1783,6 +1795,7 @@ async function handleChannelsProtocolCommand(
         running: snapshot.running,
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
+        config: snapshot.config ?? {},
         allowed_channels: snapshot.allowedChannels,
         has_token: snapshot.hasToken,
         agent_id: snapshot.agentId,
@@ -1801,6 +1814,7 @@ async function handleChannelsProtocolCommand(
       mode: snapshot.mode,
       dm_policy: snapshot.dmPolicy,
       allowed_users: snapshot.allowedUsers,
+      config: snapshot.config ?? {},
       has_bot_token: snapshot.hasBotToken,
       has_app_token: snapshot.hasAppToken,
       agent_id: snapshot.agentId,
@@ -1944,6 +1958,11 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_account_create") {
     try {
+      const pluginConfig =
+        getMergedChannelPluginConfig(
+          parsed.channel_id,
+          parsed.account as Record<string, unknown>,
+        ) ?? {};
       const created = createChannelAccountLive(
         parsed.channel_id,
         {
@@ -1953,28 +1972,9 @@ async function handleChannelsProtocolCommand(
               : undefined,
           enabled:
             "enabled" in parsed.account ? parsed.account.enabled : undefined,
-          token: "token" in parsed.account ? parsed.account.token : undefined,
-          botToken:
-            "bot_token" in parsed.account
-              ? parsed.account.bot_token
-              : undefined,
-          appToken:
-            "app_token" in parsed.account
-              ? parsed.account.app_token
-              : undefined,
-          mode: "mode" in parsed.account ? parsed.account.mode : undefined,
-          agentId:
-            "agent_id" in parsed.account ? parsed.account.agent_id : undefined,
-          defaultPermissionMode:
-            "default_permission_mode" in parsed.account
-              ? parsed.account.default_permission_mode
-              : undefined,
           dmPolicy: parsed.account.dm_policy,
           allowedUsers: parsed.account.allowed_users,
-          allowedChannels:
-            "allowed_channels" in parsed.account
-              ? parsed.account.allowed_channels
-              : undefined,
+          config: pluginConfig,
         },
         {
           accountId:
@@ -2032,6 +2032,11 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_account_update") {
     try {
+      const pluginConfig =
+        getMergedChannelPluginConfig(
+          parsed.channel_id,
+          parsed.patch as Record<string, unknown>,
+        ) ?? {};
       const updated = updateChannelAccountLive(
         parsed.channel_id,
         parsed.account_id,
@@ -2041,31 +2046,16 @@ async function handleChannelsProtocolCommand(
               ? parsed.patch.display_name
               : undefined,
           enabled: "enabled" in parsed.patch ? parsed.patch.enabled : undefined,
-          token: "token" in parsed.patch ? parsed.patch.token : undefined,
-          botToken:
-            "bot_token" in parsed.patch ? parsed.patch.bot_token : undefined,
-          appToken:
-            "app_token" in parsed.patch ? parsed.patch.app_token : undefined,
-          mode: "mode" in parsed.patch ? parsed.patch.mode : undefined,
-          agentId:
-            "agent_id" in parsed.patch ? parsed.patch.agent_id : undefined,
-          defaultPermissionMode:
-            "default_permission_mode" in parsed.patch
-              ? parsed.patch.default_permission_mode
-              : undefined,
           dmPolicy: parsed.patch.dm_policy,
           allowedUsers: parsed.patch.allowed_users,
-          allowedChannels:
-            "allowed_channels" in parsed.patch
-              ? parsed.patch.allowed_channels
-              : undefined,
+          config: pluginConfig,
         },
       );
       const shouldRefreshDisplayName =
         !("display_name" in parsed.patch) &&
-        (parsed.channel_id === "telegram"
-          ? "token" in parsed.patch
-          : "bot_token" in parsed.patch || "app_token" in parsed.patch);
+        channelPluginConfigShouldRefreshDisplayName(parsed.channel_id, {
+          config: pluginConfig,
+        });
       const account = shouldRefreshDisplayName
         ? await refreshChannelAccountDisplayNameLive(
             parsed.channel_id,
@@ -2389,21 +2379,17 @@ async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_set_config") {
     try {
+      const pluginConfig =
+        getMergedChannelPluginConfig(
+          parsed.channel_id,
+          parsed.config as Record<string, unknown>,
+        ) ?? {};
       const snapshot = await setChannelConfigLive(
         parsed.channel_id,
         {
-          token: "token" in parsed.config ? parsed.config.token : undefined,
-          botToken:
-            "bot_token" in parsed.config ? parsed.config.bot_token : undefined,
-          appToken:
-            "app_token" in parsed.config ? parsed.config.app_token : undefined,
-          mode: "mode" in parsed.config ? parsed.config.mode : undefined,
           dmPolicy: parsed.config.dm_policy,
           allowedUsers: parsed.config.allowed_users,
-          allowedChannels:
-            "allowed_channels" in parsed.config
-              ? parsed.config.allowed_channels
-              : undefined,
+          config: pluginConfig,
         },
         parsed.account_id,
       );

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -19,7 +19,7 @@ import {
 } from "../../agent/modify";
 import {
   channelPluginConfigShouldRefreshDisplayName,
-  getMergedChannelPluginConfig,
+  getChannelPluginConfig,
 } from "../../channels/accountConfig";
 import {
   type ChannelRegistryEvent,
@@ -1727,7 +1727,6 @@ async function handleChannelsProtocolCommand(
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
         config: snapshot.config ?? {},
-        has_token: snapshot.hasToken,
       };
     }
     if (snapshot.channelId === "discord") {
@@ -1739,9 +1738,6 @@ async function handleChannelsProtocolCommand(
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
         config: snapshot.config ?? {},
-        allowed_channels: snapshot.allowedChannels,
-        has_token: snapshot.hasToken,
-        agent_id: snapshot.agentId,
       };
     }
     return {
@@ -1749,14 +1745,9 @@ async function handleChannelsProtocolCommand(
       account_id: snapshot.accountId,
       display_name: snapshot.displayName,
       enabled: snapshot.enabled,
-      mode: snapshot.mode,
       dm_policy: snapshot.dmPolicy,
       allowed_users: snapshot.allowedUsers,
       config: snapshot.config ?? {},
-      has_bot_token: snapshot.hasBotToken,
-      has_app_token: snapshot.hasAppToken,
-      agent_id: snapshot.agentId,
-      default_permission_mode: snapshot.defaultPermissionMode,
     };
   };
 
@@ -1774,12 +1765,6 @@ async function handleChannelsProtocolCommand(
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
         config: snapshot.config ?? {},
-        has_token: snapshot.hasToken,
-        transcribe_voice: snapshot.transcribeVoice,
-        binding: {
-          agent_id: snapshot.binding.agentId,
-          conversation_id: snapshot.binding.conversationId,
-        },
         created_at: snapshot.createdAt,
         updated_at: snapshot.updatedAt,
       };
@@ -1796,9 +1781,6 @@ async function handleChannelsProtocolCommand(
         dm_policy: snapshot.dmPolicy,
         allowed_users: snapshot.allowedUsers,
         config: snapshot.config ?? {},
-        allowed_channels: snapshot.allowedChannels,
-        has_token: snapshot.hasToken,
-        agent_id: snapshot.agentId,
         created_at: snapshot.createdAt,
         updated_at: snapshot.updatedAt,
       };
@@ -1811,14 +1793,9 @@ async function handleChannelsProtocolCommand(
       enabled: snapshot.enabled,
       configured: snapshot.configured,
       running: snapshot.running,
-      mode: snapshot.mode,
       dm_policy: snapshot.dmPolicy,
       allowed_users: snapshot.allowedUsers,
       config: snapshot.config ?? {},
-      has_bot_token: snapshot.hasBotToken,
-      has_app_token: snapshot.hasAppToken,
-      agent_id: snapshot.agentId,
-      default_permission_mode: snapshot.defaultPermissionMode,
       created_at: snapshot.createdAt,
       updated_at: snapshot.updatedAt,
     };
@@ -1959,10 +1936,7 @@ async function handleChannelsProtocolCommand(
   if (parsed.type === "channel_account_create") {
     try {
       const pluginConfig =
-        getMergedChannelPluginConfig(
-          parsed.channel_id,
-          parsed.account as Record<string, unknown>,
-        ) ?? {};
+        getChannelPluginConfig(parsed.account as Record<string, unknown>) ?? {};
       const created = createChannelAccountLive(
         parsed.channel_id,
         {
@@ -2033,10 +2007,7 @@ async function handleChannelsProtocolCommand(
   if (parsed.type === "channel_account_update") {
     try {
       const pluginConfig =
-        getMergedChannelPluginConfig(
-          parsed.channel_id,
-          parsed.patch as Record<string, unknown>,
-        ) ?? {};
+        getChannelPluginConfig(parsed.patch as Record<string, unknown>) ?? {};
       const updated = updateChannelAccountLive(
         parsed.channel_id,
         parsed.account_id,
@@ -2380,9 +2351,9 @@ async function handleChannelsProtocolCommand(
   if (parsed.type === "channel_set_config") {
     try {
       const pluginConfig =
-        getMergedChannelPluginConfig(
-          parsed.channel_id,
+        getChannelPluginConfig(
           parsed.config as Record<string, unknown>,
+          "plugin_config",
         ) ?? {};
       const snapshot = await setChannelConfigLive(
         parsed.channel_id,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import { isValidChannelPluginConfigPayload } from "../../channels/accountConfig";
 import type {
   AbortMessageCommand,
   ChangeDeviceStateCommand,
@@ -843,10 +844,6 @@ function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {
     config.allowed_users === undefined ||
     (Array.isArray(config.allowed_users) &&
       config.allowed_users.every((entry) => typeof entry === "string"));
-  const hasValidAllowedChannels =
-    config.allowed_channels === undefined ||
-    (Array.isArray(config.allowed_channels) &&
-      config.allowed_channels.every((entry) => typeof entry === "string"));
   const hasValidDisplayName =
     config.display_name === undefined ||
     typeof config.display_name === "string";
@@ -856,7 +853,6 @@ function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {
   return (
     hasValidDmPolicy &&
     hasValidAllowedUsers &&
-    hasValidAllowedChannels &&
     hasValidDisplayName &&
     hasValidEnabled
   );
@@ -915,29 +911,7 @@ export function isChannelAccountCreateCommand(
     return false;
   }
 
-  if (c.channel_id === "telegram") {
-    return account.token === undefined || typeof account.token === "string";
-  }
-
-  if (c.channel_id === "discord") {
-    return (
-      (account.token === undefined || typeof account.token === "string") &&
-      (account.agent_id === undefined ||
-        account.agent_id === null ||
-        typeof account.agent_id === "string")
-    );
-  }
-
-  return (
-    (account.bot_token === undefined ||
-      typeof account.bot_token === "string") &&
-    (account.app_token === undefined ||
-      typeof account.app_token === "string") &&
-    (account.mode === undefined || account.mode === "socket") &&
-    (account.agent_id === undefined ||
-      account.agent_id === null ||
-      typeof account.agent_id === "string")
-  );
+  return isValidChannelPluginConfigPayload(c.channel_id, account);
 }
 
 export function isChannelAccountUpdateCommand(
@@ -967,27 +941,7 @@ export function isChannelAccountUpdateCommand(
     return false;
   }
 
-  if (c.channel_id === "telegram") {
-    return patch.token === undefined || typeof patch.token === "string";
-  }
-
-  if (c.channel_id === "discord") {
-    return (
-      (patch.token === undefined || typeof patch.token === "string") &&
-      (patch.agent_id === undefined ||
-        patch.agent_id === null ||
-        typeof patch.agent_id === "string")
-    );
-  }
-
-  return (
-    (patch.bot_token === undefined || typeof patch.bot_token === "string") &&
-    (patch.app_token === undefined || typeof patch.app_token === "string") &&
-    (patch.mode === undefined || patch.mode === "socket") &&
-    (patch.agent_id === undefined ||
-      patch.agent_id === null ||
-      typeof patch.agent_id === "string")
-  );
+  return isValidChannelPluginConfigPayload(c.channel_id, patch);
 }
 
 export function isChannelAccountBindCommand(
@@ -1126,19 +1080,7 @@ export function isChannelSetConfigCommand(
     return false;
   }
 
-  if (c.channel_id === "telegram") {
-    return config.token === undefined || typeof config.token === "string";
-  }
-
-  if (c.channel_id === "discord") {
-    return config.token === undefined || typeof config.token === "string";
-  }
-
-  return (
-    (config.bot_token === undefined || typeof config.bot_token === "string") &&
-    (config.app_token === undefined || typeof config.app_token === "string") &&
-    (config.mode === undefined || config.mode === "socket")
-  );
+  return isValidChannelPluginConfigPayload(c.channel_id, config);
 }
 
 export function isChannelStartCommand(

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -858,6 +858,36 @@ function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {
   );
 }
 
+function hasOnlyFields(
+  value: Record<string, unknown>,
+  allowedFields: ReadonlySet<string>,
+): boolean {
+  return Object.keys(value).every((field) => allowedFields.has(field));
+}
+
+const CHANNEL_ACCOUNT_CREATE_FIELDS = new Set([
+  "account_id",
+  "display_name",
+  "enabled",
+  "dm_policy",
+  "allowed_users",
+  "config",
+]);
+
+const CHANNEL_ACCOUNT_UPDATE_FIELDS = new Set([
+  "display_name",
+  "enabled",
+  "dm_policy",
+  "allowed_users",
+  "config",
+]);
+
+const CHANNEL_SET_CONFIG_FIELDS = new Set([
+  "dm_policy",
+  "allowed_users",
+  "plugin_config",
+]);
+
 export function isChannelsListCommand(
   value: unknown,
 ): value is ChannelsListCommand {
@@ -906,7 +936,8 @@ export function isChannelAccountCreateCommand(
   if (
     (account.account_id !== undefined &&
       typeof account.account_id !== "string") ||
-    !hasValidChannelPolicyFields(account)
+    !hasValidChannelPolicyFields(account) ||
+    !hasOnlyFields(account, CHANNEL_ACCOUNT_CREATE_FIELDS)
   ) {
     return false;
   }
@@ -937,7 +968,10 @@ export function isChannelAccountUpdateCommand(
   }
 
   const patch = c.patch as Record<string, unknown>;
-  if (!hasValidChannelPolicyFields(patch)) {
+  if (
+    !hasValidChannelPolicyFields(patch) ||
+    !hasOnlyFields(patch, CHANNEL_ACCOUNT_UPDATE_FIELDS)
+  ) {
     return false;
   }
 
@@ -1076,11 +1110,18 @@ export function isChannelSetConfigCommand(
     return false;
   }
   const config = c.config as Record<string, unknown>;
-  if (!hasValidChannelPolicyFields(config)) {
+  if (
+    !hasValidChannelPolicyFields(config) ||
+    !hasOnlyFields(config, CHANNEL_SET_CONFIG_FIELDS)
+  ) {
     return false;
   }
 
-  return isValidChannelPluginConfigPayload(c.channel_id, config);
+  return isValidChannelPluginConfigPayload(
+    c.channel_id,
+    config,
+    "plugin_config",
+  );
 }
 
 export function isChannelStartCommand(


### PR DESCRIPTION
## Summary
- Move channel-specific websocket account/config fields into generic plugin-owned `config` payloads while keeping common account fields typed centrally.
- Add per-channel config adapters for Telegram, Slack, and Discord to validate, normalize, redact, and round-trip plugin settings.
- Hard-cut the protocol by removing the old top-level channel-specific fields; Code Desktop is updated in the paired PR.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/channels/discord-protocol.test.ts src/tests/websocket/listen-client-channel-accounts.test.ts src/tests/websocket/listen-client-protocol.test.ts src/tests/channels/service.test.ts src/tests/channels/discord-service.test.ts`

Paired Code Desktop PR: https://github.com/letta-ai/letta-cloud/pull/11252

👾 Generated with [Letta Code](https://letta.com)