### PR TITLE
feat(listener): support request-scoped client tool allowlists

### DIFF
--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -168,6 +168,39 @@ describe("tool execution context snapshot", () => {
     expect(prepared.loadedToolNames).not.toContain("RunShellCommand");
   });
 
+  test("filters model-derived client tools by request-scoped allowlist", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["Read", "Grep", "Glob"] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual(["Glob", "Grep", "Read"]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "Glob",
+      "Grep",
+      "Read",
+    ]);
+    expect(prepared.loadedToolNames).not.toContain("Bash");
+
+    const denied = await executeTool(
+      "Bash",
+      { command: "echo no", description: "Print no" },
+      { toolContextId: prepared.contextId },
+    );
+    expect(denied.status).toBe("error");
+    expect(asText(denied.toolReturn)).toContain("Tool not found: Bash");
+  });
+
+  test("empty request-scoped allowlist disables client tools", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: [] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools).toEqual([]);
+  });
+
   test("prepares current tool snapshots with fresh MessageChannel discovery", async () => {
     await loadSpecificTools(["Read"]);
 

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -33,6 +33,7 @@ import {
   prepareToolExecutionContextForModel,
   prepareToolExecutionContextForSpecificTools,
   refreshDynamicChannelToolsInLoadedRegistry,
+  registerExternalTools,
 } from "../../tools/manager";
 import { resolveConversationChannelToolScope } from "../../tools/toolset";
 
@@ -75,6 +76,7 @@ describe("tool execution context snapshot", () => {
     }
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
+    clearExternalTools();
     clearChannelAccountStores();
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
@@ -192,6 +194,60 @@ describe("tool execution context snapshot", () => {
   });
 
   test("empty request-scoped allowlist disables client tools", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: [] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools).toEqual([]);
+  });
+
+  test("request-scoped allowlist accepts server-facing Agent alias", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["Agent"] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual(["Task"]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Agent"]);
+  });
+
+  test("request-scoped allowlist filters external tools by name", async () => {
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "Allowed external tool",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+      {
+        name: "RemoteBar",
+        description: "Filtered external tool",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["Read", "RemoteFoo"] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual(["Read"]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "Read",
+      "RemoteFoo",
+    ]);
+  });
+
+  test("empty request-scoped allowlist disables external tools too", async () => {
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "External tool",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+
     const prepared = await prepareToolExecutionContextForModel(
       "anthropic/claude-sonnet-4",
       { clientToolAllowlist: [] },

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -334,7 +334,11 @@ describe("listen-client parseServerMessage", () => {
         JSON.stringify({
           type: "input",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
-          payload: { kind: "create_message", messages: [] },
+          payload: {
+            kind: "create_message",
+            messages: [],
+            client_tool_allowlist: ["Read", "Grep"],
+          },
         }),
       ),
     );
@@ -348,7 +352,32 @@ describe("listen-client parseServerMessage", () => {
       ),
     );
     expect(msg?.type).toBe("input");
+    if (msg?.type === "input" && msg.payload.kind === "create_message") {
+      expect(msg.payload.client_tool_allowlist).toEqual(["Read", "Grep"]);
+    }
     expect(changeDeviceState?.type).toBe("change_device_state");
+  });
+
+  test("rejects input create_message with invalid client tool allowlist", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [],
+            client_tool_allowlist: ["Read", 42],
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("__invalid_input");
+    if (parsed?.type === "__invalid_input") {
+      expect(parsed.reason).toContain("client_tool_allowlist must be string[]");
+    }
   });
 
   test("parses abort_message as the canonical abort command", () => {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -930,6 +930,7 @@ export async function prepareToolExecutionContextForModel(
   modelIdentifier?: string,
   options?: {
     exclude?: ToolName[];
+    clientToolAllowlist?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -1138,6 +1139,7 @@ async function resolveBaseToolNamesForModel(
   modelIdentifier?: string,
   options?: {
     exclude?: ToolName[];
+    clientToolAllowlist?: string[];
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<ToolName[]> {
@@ -1168,6 +1170,11 @@ async function resolveBaseToolNamesForModel(
     options?.channelToolScope,
   );
 
+  if (options?.clientToolAllowlist !== undefined) {
+    const allowSet = new Set(options.clientToolAllowlist);
+    baseToolNames = baseToolNames.filter((name) => allowSet.has(name));
+  }
+
   return baseToolNames;
 }
 
@@ -1175,6 +1182,7 @@ async function buildRegistryForModel(
   modelIdentifier?: string,
   options?: {
     exclude?: ToolName[];
+    clientToolAllowlist?: string[];
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<ToolRegistry> {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -186,6 +186,55 @@ export function getInternalToolName(serverName: string): string {
   return serverName;
 }
 
+function matchesClientToolAllowlistEntry(
+  allowSet: Set<string> | null,
+  serverToolName: string,
+  internalToolName?: string,
+): boolean {
+  if (!allowSet) {
+    return true;
+  }
+
+  return (
+    allowSet.has(serverToolName) ||
+    (internalToolName !== undefined && allowSet.has(internalToolName))
+  );
+}
+
+export function filterBuiltInToolNamesByClientAllowlist(
+  toolNames: ToolName[],
+  clientToolAllowlist?: string[],
+): ToolName[] {
+  if (clientToolAllowlist === undefined) {
+    return toolNames;
+  }
+
+  const allowSet = new Set(clientToolAllowlist);
+  return toolNames.filter((toolName) =>
+    matchesClientToolAllowlistEntry(
+      allowSet,
+      getServerToolName(toolName),
+      toolName,
+    ),
+  );
+}
+
+function filterExternalToolsByClientAllowlist(
+  externalTools: Map<string, ExternalToolDefinition>,
+  clientToolAllowlist?: string[],
+): Map<string, ExternalToolDefinition> {
+  if (clientToolAllowlist === undefined) {
+    return new Map(externalTools);
+  }
+
+  const allowSet = new Set(clientToolAllowlist);
+  return new Map(
+    Array.from(externalTools.entries()).filter(([internalName, tool]) =>
+      matchesClientToolAllowlistEntry(allowSet, tool.name, internalName),
+    ),
+  );
+}
+
 export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "Bash",
@@ -831,6 +880,7 @@ function capturePreparedToolExecutionContext(
     externalExecutor?: ExternalToolExecutor;
   },
   options?: {
+    clientToolAllowlist?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
@@ -839,7 +889,10 @@ function capturePreparedToolExecutionContext(
   const runtimeContext = buildExecutionRuntimeContextSnapshot(options);
   const executionSnapshot: ToolExecutionContextSnapshot = {
     toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
-    externalTools: new Map(snapshot.externalTools),
+    externalTools: filterExternalToolsByClientAllowlist(
+      snapshot.externalTools,
+      options?.clientToolAllowlist,
+    ),
     externalExecutor: snapshot.externalExecutor,
     workingDirectory:
       runtimeContext.workingDirectory ?? getCurrentWorkingDirectory(),
@@ -906,6 +959,7 @@ export async function prepareCurrentToolExecutionContext(options?: {
 export async function prepareToolExecutionContextForSpecificTools(
   toolNames: string[],
   options?: {
+    clientToolAllowlist?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -1170,10 +1224,10 @@ async function resolveBaseToolNamesForModel(
     options?.channelToolScope,
   );
 
-  if (options?.clientToolAllowlist !== undefined) {
-    const allowSet = new Set(options.clientToolAllowlist);
-    baseToolNames = baseToolNames.filter((name) => allowSet.has(name));
-  }
+  baseToolNames = filterBuiltInToolNamesByClientAllowlist(
+    baseToolNames,
+    options?.clientToolAllowlist,
+  );
 
   return baseToolNames;
 }

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -14,6 +14,7 @@ import { toolFilter } from "./filter";
 import {
   ANTHROPIC_DEFAULT_TOOLS,
   clearToolsWithLock,
+  filterBuiltInToolNamesByClientAllowlist,
   GEMINI_DEFAULT_TOOLS,
   GEMINI_PASCAL_TOOLS,
   getToolNames,
@@ -183,13 +184,15 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     };
   }
 
-  const allowSet =
-    clientToolAllowlist !== undefined ? new Set(clientToolAllowlist) : null;
   const preparedToolContext = await prepareToolExecutionContextForSpecificTools(
-    getToolNamesForToolset(toolsetPreference, channelToolScope)
-      .filter((toolName) => (exclude ? !exclude.includes(toolName) : true))
-      .filter((toolName) => !allowSet || allowSet.has(toolName)),
+    filterBuiltInToolNamesByClientAllowlist(
+      getToolNamesForToolset(toolsetPreference, channelToolScope).filter(
+        (toolName) => (exclude ? !exclude.includes(toolName) : true),
+      ),
+      clientToolAllowlist,
+    ),
     {
+      clientToolAllowlist,
       workingDirectory,
       permissionModeState,
       channelToolScope,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -138,6 +138,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   modelIdentifier?: string | null;
   toolsetPreference: ToolsetPreference;
   exclude?: ToolName[];
+  clientToolAllowlist?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -147,6 +148,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     modelIdentifier,
     toolsetPreference,
     exclude,
+    clientToolAllowlist,
     workingDirectory,
     permissionModeState,
     channelToolScope,
@@ -162,6 +164,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       effectiveModel ?? undefined,
       {
         exclude,
+        clientToolAllowlist,
         workingDirectory,
         permissionModeState,
         channelToolScope,
@@ -180,10 +183,12 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     };
   }
 
+  const allowSet =
+    clientToolAllowlist !== undefined ? new Set(clientToolAllowlist) : null;
   const preparedToolContext = await prepareToolExecutionContextForSpecificTools(
-    getToolNamesForToolset(toolsetPreference, channelToolScope).filter(
-      (toolName) => (exclude ? !exclude.includes(toolName) : true),
-    ),
+    getToolNamesForToolset(toolsetPreference, channelToolScope)
+      .filter((toolName) => (exclude ? !exclude.includes(toolName) : true))
+      .filter((toolName) => !allowSet || allowSet.has(toolName)),
     {
       workingDirectory,
       permissionModeState,
@@ -251,6 +256,7 @@ export async function prepareToolExecutionContextForScope(params: {
   conversationId?: string | null;
   overrideModel?: string | null;
   exclude?: ToolName[];
+  clientToolAllowlist?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   cachedAgent?: AgentState | null;
@@ -260,6 +266,7 @@ export async function prepareToolExecutionContextForScope(params: {
     conversationId,
     overrideModel,
     exclude,
+    clientToolAllowlist,
     workingDirectory,
     permissionModeState,
     cachedAgent,
@@ -297,6 +304,7 @@ export async function prepareToolExecutionContextForScope(params: {
     modelIdentifier: effectiveModel,
     toolsetPreference,
     exclude,
+    clientToolAllowlist,
     workingDirectory,
     permissionModeState,
     runtimeContext: {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -543,6 +543,12 @@ export type ApprovalResponseBody =
 export interface InputCreateMessagePayload {
   kind: "create_message";
   messages: Array<MessageCreate & { client_message_id?: string }>;
+  /**
+   * Optional request-scoped allowlist for locally executed client tools.
+   * Undefined preserves the listener's normal toolset; an empty array means no
+   * client tools for this turn.
+   */
+  client_tool_allowlist?: string[];
 }
 
 export type InputApprovalResponsePayload = {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4726,6 +4726,7 @@ async function connectWithRetry(
           type: "message",
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
+          clientToolAllowlist: inputPayload.client_tool_allowlist,
           messages: inputPayload.messages,
         };
         const hasApprovalPayload = incoming.messages.some(

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -67,6 +67,12 @@ import type {
 import { isValidApprovalResponseBody } from "./approval";
 import type { InvalidInputCommand, ParsedServerMessage } from "./types";
 
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
 function isRuntimeScope(value: unknown): value is RuntimeScope {
   if (!value || typeof value !== "object") {
     return false;
@@ -99,12 +105,17 @@ function isInputCommand(value: unknown): value is InputCommand {
   const payload = candidate.payload as {
     kind?: unknown;
     messages?: unknown;
+    client_tool_allowlist?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
   };
   if (payload.kind === "create_message") {
-    return Array.isArray(payload.messages);
+    return (
+      Array.isArray(payload.messages) &&
+      (payload.client_tool_allowlist === undefined ||
+        isStringArray(payload.client_tool_allowlist))
+    );
   }
   if (payload.kind === "approval_response") {
     return isValidApprovalResponseBody(payload);
@@ -136,6 +147,7 @@ function getInvalidInputReason(value: unknown): {
   const payload = candidate.payload as {
     kind?: unknown;
     messages?: unknown;
+    client_tool_allowlist?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
@@ -146,6 +158,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.kind=create_message requires payload.messages[]",
+      };
+    }
+    if (
+      payload.client_tool_allowlist !== undefined &&
+      !isStringArray(payload.client_tool_allowlist)
+    ) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.payload.client_tool_allowlist must be string[]",
       };
     }
     return null;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -576,6 +576,7 @@ export async function handleIncomingMessage(
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
+      clientToolAllowlist: msg.clientToolAllowlist,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
     });

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -57,6 +57,7 @@ export interface IncomingMessage {
   agentId?: string;
   conversationId?: string;
   channelTurnSources?: ChannelTurnSource[];
+  clientToolAllowlist?: string[];
   messages: Array<
     (MessageCreate & { client_message_id?: string }) | ApprovalCreate
   >;


### PR DESCRIPTION
## Summary
- Adds `client_tool_allowlist` to V2 input payloads and validates it in listener protocol parsing.
- Threads the allowlist into listener turn handling so each request filters its own client tool snapshot before `client_tools` are sent to Core.
- Adds coverage for protocol parsing and filtered tool execution contexts.

"Every program and every user of the system should operate using the least set of privileges necessary to complete the job."

Written by Cameron ◯ Letta Code