### PR TITLE
fix(channels): forward Discord delivery errors back to the user

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -8,6 +8,7 @@ import type {
   OutboundChannelMessage,
 } from "../types";
 import { isDiscordGuildChannelAllowed } from "./channelGating";
+import { formatDiscordDeliveryError } from "./errorReply";
 import {
   resolveDiscordInboundAttachments,
   resolveDiscordThreadHistory,
@@ -256,6 +257,30 @@ function buildDiscordReplyOptions(
       messageReference: trimmed,
     },
   };
+}
+
+/**
+ * Best-effort: post a user-facing error reply when forwarding a Discord
+ * message to the agent runtime fails. Swallows any send failure so the
+ * notification path can never crash the listener.
+ */
+async function notifyDiscordDeliveryError(
+  message: DiscordMessageLike,
+  error: unknown,
+): Promise<void> {
+  try {
+    if (typeof message.channel.send !== "function") return;
+    const reply = buildDiscordReplyOptions(message.id, message.channelId);
+    await message.channel.send({
+      content: formatDiscordDeliveryError(error),
+      ...(reply ?? {}),
+    });
+  } catch (sendError) {
+    console.error(
+      "[Discord] Failed to forward delivery error to user:",
+      sendError,
+    );
+  }
 }
 
 export async function resolveDiscordAccountDisplayName(
@@ -602,6 +627,7 @@ export function createDiscordAdapter(
             await adapter.onMessage(inbound);
           } catch (error) {
             console.error("[Discord] Error handling DM:", error);
+            await notifyDiscordDeliveryError(message, error);
           }
           return;
         }
@@ -675,6 +701,7 @@ export function createDiscordAdapter(
           await adapter.onMessage(inbound);
         } catch (error) {
           console.error("[Discord] Error handling guild message:", error);
+          await notifyDiscordDeliveryError(message, error);
         }
       });
 

--- a/src/channels/discord/errorReply.ts
+++ b/src/channels/discord/errorReply.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for surfacing message-handling errors back to the user in Discord
+ * so they aren't silently dropped after the adapter logs them. The adapter
+ * itself wires these into its DM and guild `messageCreate` handlers.
+ */
+
+interface ErrorWithStatus {
+  status?: number;
+  message?: string;
+  error?: { detail?: string };
+}
+
+/**
+ * Pull the most useful human-readable detail out of an unknown error,
+ * falling back through the Letta SDK shape, the standard Error.message,
+ * and finally `String(error)`.
+ */
+export function extractErrorDetail(error: unknown): string {
+  const e = error as ErrorWithStatus | null | undefined;
+  return (
+    e?.error?.detail?.trim() ||
+    e?.message?.trim() ||
+    String(error)
+  );
+}
+
+/**
+ * Format an error encountered while forwarding a Discord message to the
+ * agent runtime into a short, user-facing string.
+ *
+ * Known shapes:
+ *   - 404 + "Agent with ID ... not found": agent binding is stale or wrong.
+ *   - 401/403: API credentials rejected.
+ *
+ * Everything else falls through to a generic message with the (truncated)
+ * detail in a code span so curly braces and quotes render cleanly.
+ */
+export function formatDiscordDeliveryError(error: unknown): string {
+  const status = (error as ErrorWithStatus | null | undefined)?.status;
+  const detail = extractErrorDetail(error);
+
+  if (status === 404 && /Agent with ID .* not found/i.test(detail)) {
+    return (
+      "Sorry, I couldn't deliver your message — the agent I'm bound to " +
+      "wasn't found. The operator needs to rebind this bot with " +
+      "`letta channels bind --channel discord --agent <id>`."
+    );
+  }
+
+  if (status === 401 || status === 403) {
+    return (
+      "Sorry, I couldn't deliver your message — my Letta API credentials " +
+      "were rejected. The operator needs to check the API key."
+    );
+  }
+
+  const MAX_DETAIL = 200;
+  const truncated =
+    detail.length > MAX_DETAIL ? `${detail.slice(0, MAX_DETAIL)}…` : detail;
+  return `Sorry, something went wrong while forwarding your message: \`${truncated}\``;
+}

--- a/src/channels/discord/errorReply.ts
+++ b/src/channels/discord/errorReply.ts
@@ -6,8 +6,23 @@
 
 interface ErrorWithStatus {
   status?: number;
-  message?: string;
-  error?: { detail?: string };
+  message?: unknown;
+  error?: {
+    detail?: unknown;
+    message?: unknown;
+    error?: {
+      detail?: unknown;
+      message?: unknown;
+    };
+  };
+}
+
+function readTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 /**
@@ -18,8 +33,11 @@ interface ErrorWithStatus {
 export function extractErrorDetail(error: unknown): string {
   const e = error as ErrorWithStatus | null | undefined;
   return (
-    e?.error?.detail?.trim() ||
-    e?.message?.trim() ||
+    readTrimmedString(e?.error?.error?.detail) ||
+    readTrimmedString(e?.error?.error?.message) ||
+    readTrimmedString(e?.error?.detail) ||
+    readTrimmedString(e?.error?.message) ||
+    readTrimmedString(e?.message) ||
     String(error)
   );
 }

--- a/src/tests/discord-error-reply.test.ts
+++ b/src/tests/discord-error-reply.test.ts
@@ -6,6 +6,19 @@ import {
 } from "../channels/discord/errorReply";
 
 describe("extractErrorDetail", () => {
+  test("prefers nested Letta SDK error.error.detail", () => {
+    const err = {
+      status: 404,
+      message: "404 Not Found",
+      error: {
+        error: { detail: "Agent with ID agent-nested not found" },
+      },
+    };
+    expect(extractErrorDetail(err)).toBe(
+      "Agent with ID agent-nested not found",
+    );
+  });
+
   test("prefers Letta SDK error.detail", () => {
     const err = {
       status: 404,
@@ -27,9 +40,26 @@ describe("extractErrorDetail", () => {
     const err = { error: { detail: "  spaced  " } };
     expect(extractErrorDetail(err)).toBe("spaced");
   });
+
+  test("falls back to direct error.message when detail is missing", () => {
+    const err = { error: { message: "operator-visible message" } };
+    expect(extractErrorDetail(err)).toBe("operator-visible message");
+  });
 });
 
 describe("formatDiscordDeliveryError", () => {
+  test("special-cases nested 404 agent-not-found", () => {
+    const err = {
+      status: 404,
+      error: {
+        error: { detail: "Agent with ID agent-nested not found" },
+      },
+    };
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).toContain("agent I'm bound to");
+    expect(msg).toContain("letta channels bind --channel discord");
+  });
+
   test("special-cases 404 agent-not-found", () => {
     const err = {
       status: 404,

--- a/src/tests/discord-error-reply.test.ts
+++ b/src/tests/discord-error-reply.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractErrorDetail,
+  formatDiscordDeliveryError,
+} from "../channels/discord/errorReply";
+
+describe("extractErrorDetail", () => {
+  test("prefers Letta SDK error.detail", () => {
+    const err = {
+      status: 404,
+      message: "404 Not Found",
+      error: { detail: "Agent with ID agent-abc not found" },
+    };
+    expect(extractErrorDetail(err)).toBe("Agent with ID agent-abc not found");
+  });
+
+  test("falls back to error.message", () => {
+    expect(extractErrorDetail(new Error("boom"))).toBe("boom");
+  });
+
+  test("falls back to String(error) for non-Error values", () => {
+    expect(extractErrorDetail("plain string")).toBe("plain string");
+  });
+
+  test("trims whitespace from detail and message", () => {
+    const err = { error: { detail: "  spaced  " } };
+    expect(extractErrorDetail(err)).toBe("spaced");
+  });
+});
+
+describe("formatDiscordDeliveryError", () => {
+  test("special-cases 404 agent-not-found", () => {
+    const err = {
+      status: 404,
+      error: { detail: "Agent with ID agent-33b3 not found" },
+    };
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).toContain("agent I'm bound to");
+    expect(msg).toContain("letta channels bind --channel discord");
+  });
+
+  test("does not match generic 404s as agent-not-found", () => {
+    const err = { status: 404, error: { detail: "Resource missing" } };
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).not.toContain("rebind");
+    expect(msg).toContain("Resource missing");
+  });
+
+  test("special-cases 401", () => {
+    const err = { status: 401, message: "Unauthorized" };
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).toContain("API credentials were rejected");
+  });
+
+  test("special-cases 403", () => {
+    const err = { status: 403, message: "Forbidden" };
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).toContain("API credentials were rejected");
+  });
+
+  test("falls back to generic message for unknown errors", () => {
+    const err = new Error("something exploded");
+    const msg = formatDiscordDeliveryError(err);
+    expect(msg).toContain("something went wrong");
+    expect(msg).toContain("`something exploded`");
+  });
+
+  test("truncates very long detail strings", () => {
+    const detail = "x".repeat(500);
+    const msg = formatDiscordDeliveryError(new Error(detail));
+    expect(msg.length).toBeLessThan(detail.length + 80);
+    expect(msg).toContain("…");
+  });
+});


### PR DESCRIPTION
## Summary

When the Discord adapter fails to forward an inbound message to the agent runtime — for example, when the bot is bound to an agent that has been deleted and the Letta API returns 404 \`Agent with ID ... not found\` — the adapter previously logged the error and dropped the message. The user got no acknowledgement and no clue why the bot went silent.

This change posts a short reply in the same channel/thread, threaded under the user's message:

- **404 agent-not-found** → \`Sorry, I couldn't deliver your message — the agent I'm bound to wasn't found. The operator needs to rebind this bot with \`letta channels bind --channel discord --agent <id>\`.\`
- **401 / 403** → flags rejected API credentials and asks the operator to check the key.
- **anything else** → generic apology + truncated error detail in a code span.

The notification send path is wrapped in its own try/catch, so a failed notification (permissions, rate limit, etc.) can never crash the listener.

## Files

- \`src/channels/discord/errorReply.ts\` (new) — \`extractErrorDetail\` + \`formatDiscordDeliveryError\` pure helpers.
- \`src/channels/discord/adapter.ts\` — \`notifyDiscordDeliveryError\` helper; called from the DM and guild \`messageCreate\` catch blocks.
- \`src/tests/discord-error-reply.test.ts\` (new) — 10 unit tests across both helpers (404 special case, 404 false-positive guard, 401/403, generic fallback, truncation, detail extraction across SDK / Error / string shapes).

## Verification

- \`bun test src/tests/discord-channel-gating.test.ts src/tests/discord-error-reply.test.ts\` → 18/18 pass.
- \`bun run typecheck\` → clean.

"It is the duty of every man to push the little ahead of the lever that controls his life." — Goethe

Written by Cameron ◯ Letta Code