### PR TITLE
fix: refresh OTIDs for post-stop listener retries

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -40,6 +40,7 @@ export {
   isRetryableProviderErrorDetail,
   parseRetryAfterHeaderMs,
   rebuildInputWithFreshDenials,
+  refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
   shouldRetryPreStreamTransientError,

--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -384,6 +384,18 @@ export function buildFreshDenialApprovals(
 }
 
 /**
+ * Post-stop retries create a new request/run and must not reuse OTIDs.
+ */
+export function refreshInputOtidsForNewRequest<
+  T extends MessageCreate | ApprovalCreate,
+>(currentInput: T[]): T[] {
+  return currentInput.map((item) => ({
+    ...item,
+    otid: randomUUID(),
+  })) as T[];
+}
+
+/**
  * Strip stale approval payloads from the message input array and optionally
  * prepend fresh denial results for the actual pending approvals from the server.
  */
@@ -392,10 +404,9 @@ export function rebuildInputWithFreshDenials(
   serverApprovals: PendingApprovalInfo[],
   denialReason: string,
 ): Array<MessageCreate | ApprovalCreate> {
-  // Refresh OTIDs on all stripped messages — this is a new request, not a retry
-  const stripped = currentInput
-    .filter((item) => item?.type !== "approval")
-    .map((item) => ({ ...item, otid: randomUUID() }));
+  const stripped = refreshInputOtidsForNewRequest(
+    currentInput.filter((item) => item?.type !== "approval"),
+  );
 
   if (serverApprovals.length > 0) {
     const denials: ApprovalCreate = {

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -41,6 +41,7 @@ import {
   isQuotaLimitErrorDetail,
   parseRetryAfterHeaderMs,
   rebuildInputWithFreshDenials,
+  refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
   shouldRetryRunMetadataError,
@@ -4173,13 +4174,6 @@ export default function App({
 
       // Copy so we can safely mutate for retry recovery flows
       let currentInput = [...initialInput];
-      const refreshCurrentInputOtids = () => {
-        // Terminal stop-reason retries are NEW requests and must not reuse OTIDs.
-        currentInput = currentInput.map((item) => ({
-          ...item,
-          otid: randomUUID(),
-        }));
-      };
       const allowReentry = options?.allowReentry ?? false;
       const hasApprovalInput = initialInput.some(
         (item) => item.type === "approval",
@@ -5995,7 +5989,7 @@ export default function App({
             refreshDerived();
 
             // Empty-response retry starts a new request/run, so refresh OTIDs.
-            refreshCurrentInputOtids();
+            currentInput = refreshInputOtidsForNewRequest(currentInput);
             buffersRef.current.interrupted = false;
             continue;
           }
@@ -6040,7 +6034,7 @@ export default function App({
                 buffersRef.current.order.push(statusId);
                 refreshDerived();
 
-                refreshCurrentInputOtids();
+                currentInput = refreshInputOtidsForNewRequest(currentInput);
                 highestSeqIdSeen = null;
                 buffersRef.current.interrupted = false;
                 continue;
@@ -6113,7 +6107,7 @@ export default function App({
 
             if (!cancelled) {
               // Post-stream retry is a new request/run, so refresh OTIDs.
-              refreshCurrentInputOtids();
+              currentInput = refreshInputOtidsForNewRequest(currentInput);
               // Reset seq_id threshold — new run starts from seq_id 1, not a resume.
               highestSeqIdSeen = null;
               // Reset interrupted flag so retry stream chunks are processed

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -18,6 +18,7 @@ import {
   isEmptyResponseRetryable,
   isInvalidToolCallIdsError,
   parseRetryAfterHeaderMs,
+  refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldRetryRunMetadataError,
 } from "./agent/approval-recovery";
@@ -1732,13 +1733,6 @@ ${SYSTEM_REMINDER_CLOSE}
     ];
     queuedRecoveredApprovalResults = null;
   }
-  const refreshCurrentInputOtids = () => {
-    // Terminal stop-reason retries are NEW requests and must not reuse OTIDs.
-    currentInput = currentInput.map((item) => ({
-      ...item,
-      otid: randomUUID(),
-    }));
-  };
 
   // Track lastRunId outside the while loop so it's available in catch block
   let lastKnownRunId: string | null = null;
@@ -2317,7 +2311,7 @@ ${SYSTEM_REMINDER_CLOSE}
                   "Anthropic API error; falling back to Bedrock...",
                 );
               }
-              refreshCurrentInputOtids();
+              currentInput = refreshInputOtidsForNewRequest(currentInput);
               continue;
             }
           }
@@ -2351,7 +2345,7 @@ ${SYSTEM_REMINDER_CLOSE}
           await new Promise((resolve) => setTimeout(resolve, delayMs));
 
           // Post-stream retry creates a new run/request.
-          refreshCurrentInputOtids();
+          currentInput = refreshInputOtidsForNewRequest(currentInput);
           continue;
         }
       }
@@ -2493,7 +2487,7 @@ ${SYSTEM_REMINDER_CLOSE}
 
             await new Promise((resolve) => setTimeout(resolve, delayMs));
             // Empty-response retry creates a new run/request.
-            refreshCurrentInputOtids();
+            currentInput = refreshInputOtidsForNewRequest(currentInput);
             continue;
           }
 
@@ -2528,7 +2522,7 @@ ${SYSTEM_REMINDER_CLOSE}
 
             await new Promise((resolve) => setTimeout(resolve, delayMs));
             // Post-stream retry creates a new run/request.
-            refreshCurrentInputOtids();
+            currentInput = refreshInputOtidsForNewRequest(currentInput);
             continue;
           }
         } catch (_e) {
@@ -2569,7 +2563,7 @@ ${SYSTEM_REMINDER_CLOSE}
 
             await new Promise((resolve) => setTimeout(resolve, delayMs));
             // Post-stream retry creates a new run/request.
-            refreshCurrentInputOtids();
+            currentInput = refreshInputOtidsForNewRequest(currentInput);
             continue;
           }
 

--- a/src/tests/turn-recovery-policy.test.ts
+++ b/src/tests/turn-recovery-policy.test.ts
@@ -14,6 +14,7 @@ import {
   isRetryableProviderErrorDetail,
   parseRetryAfterHeaderMs,
   rebuildInputWithFreshDenials,
+  refreshInputOtidsForNewRequest,
   shouldAttemptApprovalRecovery,
   shouldRetryPreStreamTransientError,
   shouldRetryRunMetadataError,
@@ -476,6 +477,31 @@ describe("rebuildInputWithFreshDenials", () => {
     role: "user" as const,
     content: "hello",
   };
+
+  test("refreshInputOtidsForNewRequest replaces OTIDs for every item", () => {
+    const input = [
+      {
+        type: "approval" as const,
+        approvals: [] as never[],
+        otid: "approval-old",
+      },
+      {
+        ...userMsg,
+        otid: "message-old",
+      },
+    ];
+
+    const result = refreshInputOtidsForNewRequest(input);
+
+    expect(result).toHaveLength(2);
+    expect(result).not.toBe(input);
+    expect(result[0]).not.toBe(input[0]);
+    expect(result[1]).not.toBe(input[1]);
+    expect(result[0]?.type).toBe("approval");
+    expect(result[1]?.type).toBe("message");
+    expect(result[0]?.otid).not.toBe("approval-old");
+    expect(result[1]?.otid).not.toBe("message-old");
+  });
 
   test("strips stale + prepends fresh denials", () => {
     const input = [

--- a/src/tests/websocket/listen-retry-wiring.test.ts
+++ b/src/tests/websocket/listen-retry-wiring.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("listen retry wiring", () => {
+  test("post-stop retries refresh OTIDs before resending", () => {
+    const turnPath = fileURLToPath(
+      new URL("../../websocket/listener/turn.ts", import.meta.url),
+    );
+    const source = readFileSync(turnPath, "utf-8");
+
+    expect(source).toContain("refreshInputOtidsForNewRequest");
+
+    const emptyResponseStart = source.indexOf(
+      "if (\n          isEmptyResponseRetryable(",
+    );
+    const transientRetryStart = source.indexOf(
+      "const retriable = await isRetriablePostStopError(",
+    );
+    const terminalHandlingStart = source.indexOf(
+      "const effectiveStopReason: StopReasonType =",
+    );
+
+    expect(emptyResponseStart).toBeGreaterThan(-1);
+    expect(transientRetryStart).toBeGreaterThan(emptyResponseStart);
+    expect(terminalHandlingStart).toBeGreaterThan(transientRetryStart);
+
+    const emptyResponseSegment = source.slice(
+      emptyResponseStart,
+      transientRetryStart,
+    );
+    const transientRetrySegment = source.slice(
+      transientRetryStart,
+      terminalHandlingStart,
+    );
+
+    expect(emptyResponseSegment).toContain(
+      "currentInput = refreshInputOtidsForNewRequest(currentInput);",
+    );
+    expect(transientRetrySegment).toContain(
+      "currentInput = refreshInputOtidsForNewRequest(currentInput);",
+    );
+  });
+});

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -23,6 +23,7 @@ import {
   getRetryDelayMs,
   isEmptyResponseRetryable,
   rebuildInputWithFreshDenials,
+  refreshInputOtidsForNewRequest,
 } from "../../agent/turn-recovery-policy";
 import { createBuffers, toLines } from "../../cli/helpers/accumulator";
 import { getRetryStatusMessage } from "../../cli/helpers/errorFormatter";
@@ -902,6 +903,7 @@ export async function handleIncomingMessage(
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
+          currentInput = refreshInputOtidsForNewRequest(currentInput);
 
           setLoopStatus(runtime, "SENDING_API_REQUEST", {
             agent_id: agentId,
@@ -976,6 +978,7 @@ export async function handleIncomingMessage(
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
+          currentInput = refreshInputOtidsForNewRequest(currentInput);
 
           setLoopStatus(runtime, "SENDING_API_REQUEST", {
             agent_id: agentId,


### PR DESCRIPTION
## Summary
- refresh OTIDs for websocket listener post-stop retries before resending the request
- move OTID refresh into the shared turn recovery policy helper and reuse it from listener, headless, and TUI
- add coverage for the shared helper and listener retry wiring

## Why
The websocket listener was resending `currentInput` with the same OTIDs after terminal `llm_api_error` / empty-response retries. Core hashes those OTIDs into the duplicate request token, so those retries could be interpreted as duplicates of the old run instead of a new request.

This PR fixes the client-side semantics only. The companion core hardening in `letta-cloud` is intentionally not included here.

## Testing
- bun test src/tests/turn-recovery-policy.test.ts src/tests/websocket/listen-retry-wiring.test.ts
- bun test src/tests/cli/approval-recovery-wiring.test.ts
- bun run check