### PR TITLE
feat(channel): support dynamic channel plugins

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -1,0 +1,144 @@
+# Channel plugins
+
+Letta Code channels connect agents to external chat systems. Telegram, Slack,
+and Discord are first-party bundled plugins with custom Desktop UI. User-defined
+plugins are loaded from `~/.letta/channels/<channel-id>/` and run headlessly:
+they can receive inbound messages, participate in pairing/routing, and extend
+the shared `MessageChannel` tool, but they do not get custom Desktop screens.
+
+## Directory layout
+
+```text
+~/.letta/channels/
+  whatsapp/
+    channel.json
+    plugin.mjs
+    accounts.json
+    routing.yaml
+    pairing.yaml
+    runtime/
+      package.json
+      node_modules/
+```
+
+`channel.json` registers the plugin:
+
+```json
+{
+  "id": "whatsapp",
+  "displayName": "WhatsApp",
+  "entry": "./plugin.mjs",
+  "runtimePackages": ["@whiskeysockets/baileys@6.7.18"],
+  "runtimeModules": ["@whiskeysockets/baileys"]
+}
+```
+
+Rules:
+
+- `id` must match the directory name and use lowercase letters, numbers,
+  `_`, or `-`.
+- `entry` is resolved relative to the channel directory.
+- `runtimePackages` are installed into `runtime/` by
+  `letta channels install <id>`.
+- `runtimeModules` are resolved from bundled first-party runtimes first, then
+  from the user channel `runtime/` directory.
+
+## Plugin entry
+
+`plugin.mjs` exports either `channelPlugin` or `default`:
+
+```js
+export const channelPlugin = {
+  metadata: {
+    id: "whatsapp",
+    displayName: "WhatsApp",
+    runtimePackages: ["@whiskeysockets/baileys@6.7.18"],
+    runtimeModules: ["@whiskeysockets/baileys"]
+  },
+
+  async createAdapter(account) {
+    return {
+      id: `whatsapp:${account.accountId}`,
+      channelId: "whatsapp",
+      accountId: account.accountId,
+      name: account.displayName ?? "WhatsApp",
+      async start() {},
+      async stop() {},
+      isRunning() { return false; },
+      async sendMessage(message) { return { messageId: crypto.randomUUID() }; },
+      async sendDirectReply(chatId, text) {},
+      onMessage: undefined
+    };
+  },
+
+  messageActions: {
+    describeMessageTool() {
+      return { actions: ["send"] };
+    },
+    async handleAction({ adapter, request, formatText }) {
+      const formatted = formatText(request.message ?? "");
+      const result = await adapter.sendMessage({
+        channel: request.channel,
+        chatId: request.chatId,
+        text: formatted.text,
+        parseMode: formatted.parseMode,
+        threadId: request.threadId
+      });
+      return `Message sent to ${request.channel} (message_id: ${result.messageId})`;
+    }
+  }
+};
+```
+
+## Account model
+
+All channels share the same persisted account envelope:
+
+```ts
+type ChannelAccount = {
+  channel: string;
+  accountId: string;
+  displayName?: string;
+  enabled: boolean;
+  dmPolicy: "pairing" | "allowlist" | "open";
+  allowedUsers: string[];
+  config: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+The `config` object is plugin-owned and may contain secrets. In the custom
+plugin MVP, Desktop/websocket responses do not echo this object back; they only
+include a generic redacted config summary. First-party bundled plugins can keep
+custom redaction/compatibility adapters because they also have bespoke Desktop
+UI.
+
+First-party bundled plugins may keep compatibility with their older account
+fields internally, but user plugins should only rely on `account.config`.
+
+## Runtime behavior
+
+The MVP runtime path supports custom plugins that fit the generic pairing and
+routing flow:
+
+1. The adapter receives an inbound message and calls `adapter.onMessage(msg)`.
+2. Letta Code enforces `dmPolicy` / `allowedUsers`.
+3. Letta Code resolves a route from `routing.yaml` or creates a pairing code.
+4. The routed message is delivered to the bound agent/conversation.
+5. `MessageChannel` becomes available when the conversation has an active route
+   for at least one running channel adapter.
+
+Plugins that need Slack/Discord-style auto-routing or rich Desktop management
+remain first-party/bundled work for now. Custom plugins can still expose custom
+`MessageChannel` actions and schema fragments via `messageActions`.
+
+## First-party vs user plugins
+
+First-party plugins are bundled in `src/channels/<id>/` and registered by the
+built-in registry. They can have bespoke Desktop UI and compatibility shims.
+
+User plugins are discovered from `~/.letta/channels/<id>/channel.json`. They are
+intentionally headless in this MVP. They should be configured by editing
+`accounts.json` or by sending generic websocket/CLI account updates whose
+plugin-owned fields live under `config` / `plugin_config`.

--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -8,10 +8,11 @@ import type {
 } from "./pluginTypes";
 import { slackAccountConfigAdapter } from "./slack/accountConfig";
 import { telegramAccountConfigAdapter } from "./telegram/accountConfig";
-import type { ChannelAccount, SupportedChannelId } from "./types";
+import type { ChannelAccount } from "./types";
+import { isCustomChannelAccount, isFirstPartyChannelId } from "./types";
 
 const CHANNEL_ACCOUNT_CONFIG_ADAPTERS: Record<
-  SupportedChannelId,
+  string,
   ChannelAccountConfigAdapter<ChannelAccount>
 > = {
   telegram:
@@ -22,14 +23,46 @@ const CHANNEL_ACCOUNT_CONFIG_ADAPTERS: Record<
     discordAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
 };
 
+const customChannelAccountConfigAdapter: ChannelAccountConfigAdapter<ChannelAccount> =
+  {
+    isValidConfig() {
+      return true;
+    },
+    toAccountPatch() {
+      return {};
+    },
+    toAccountConfig(account) {
+      if (!isCustomChannelAccount(account)) {
+        return {};
+      }
+      return {
+        configured: Object.keys(account.config).length > 0,
+      };
+    },
+    toConfigSnapshotConfig(account) {
+      if (!isCustomChannelAccount(account)) {
+        return {};
+      }
+      return {
+        configured: Object.keys(account.config).length > 0,
+      };
+    },
+    shouldRefreshDisplayName() {
+      return false;
+    },
+  };
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 export function getChannelAccountConfigAdapter(
-  channelId: SupportedChannelId,
+  channelId: string,
 ): ChannelAccountConfigAdapter<ChannelAccount> {
-  return CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId];
+  return isFirstPartyChannelId(channelId)
+    ? (CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId] ??
+        customChannelAccountConfigAdapter)
+    : customChannelAccountConfigAdapter;
 }
 
 export function getChannelPluginConfig(
@@ -44,7 +77,7 @@ export function getChannelPluginConfig(
 }
 
 export function isValidChannelPluginConfigPayload(
-  channelId: SupportedChannelId,
+  channelId: string,
   input: Record<string, unknown>,
   key: "config" | "plugin_config" = "config",
 ): boolean {
@@ -56,7 +89,7 @@ export function isValidChannelPluginConfigPayload(
 }
 
 export function normalizeChannelAccountPatch(
-  channelId: SupportedChannelId,
+  channelId: string,
   patch: ChannelAccountPatch,
 ): ChannelAccountPatch {
   const pluginPatch = patch.config
@@ -69,7 +102,7 @@ export function normalizeChannelAccountPatch(
 }
 
 export function normalizeChannelConfigPatch(
-  channelId: SupportedChannelId,
+  channelId: string,
   patch: ChannelConfigPatch,
 ): ChannelConfigPatch {
   const pluginPatch = patch.config
@@ -82,7 +115,7 @@ export function normalizeChannelConfigPatch(
 }
 
 export function channelPluginConfigShouldRefreshDisplayName(
-  channelId: SupportedChannelId,
+  channelId: string,
   patch: Pick<ChannelAccountPatch, keyof ChannelPluginAccountPatch | "config">,
 ): boolean {
   const adapter = getChannelAccountConfigAdapter(channelId);

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -6,11 +6,18 @@ import {
 } from "./config";
 import type {
   ChannelAccount,
+  CustomChannelAccount,
   DiscordChannelAccount,
   SlackChannelAccount,
   SlackDefaultPermissionMode,
   SupportedChannelId,
   TelegramChannelAccount,
+} from "./types";
+import {
+  isDiscordChannelAccount,
+  isFirstPartyChannelId,
+  isSlackChannelAccount,
+  isTelegramChannelAccount,
 } from "./types";
 
 interface ChannelAccountStore {
@@ -34,35 +41,50 @@ function cloneAccount<T extends ChannelAccount>(account: T): T {
     allowedUsers: [...account.allowedUsers],
   } as T;
 
-  if (account.channel === "telegram") {
+  if (isTelegramChannelAccount(account)) {
     (cloned as TelegramChannelAccount).binding = { ...account.binding };
   }
 
-  if (account.channel === "discord" && account.allowedChannels) {
+  if (isDiscordChannelAccount(account) && account.allowedChannels) {
     (cloned as DiscordChannelAccount).allowedChannels = [
       ...account.allowedChannels,
     ];
   }
 
+  if ("config" in account) {
+    (cloned as CustomChannelAccount).config = { ...account.config };
+  }
+
   return cloned;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   const next = cloneAccount(account);
+  if (!isFirstPartyChannelId(next.channel)) {
+    (next as CustomChannelAccount).config = isRecord(
+      (next as Partial<CustomChannelAccount>).config,
+    )
+      ? { ...(next as CustomChannelAccount).config }
+      : {};
+  }
   if (
-    (next.channel === "telegram" &&
+    (isTelegramChannelAccount(next) &&
       (next.displayName === "Telegram bot" ||
         next.displayName === "Migrated Telegram bot")) ||
-    (next.channel === "slack" &&
+    (isSlackChannelAccount(next) &&
       (next.displayName === "Slack app" ||
         next.displayName === "Migrated Slack app")) ||
-    (next.channel === "discord" &&
+    (isDiscordChannelAccount(next) &&
       (next.displayName === "Discord bot" ||
         next.displayName === "Migrated Discord bot"))
   ) {
     next.displayName = undefined;
   }
-  if (next.channel === "slack") {
+  if (isSlackChannelAccount(next)) {
     (next as SlackChannelAccount).defaultPermissionMode = ((
       next as SlackChannelAccount
     ).defaultPermissionMode ?? "default") as SlackDefaultPermissionMode;

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -19,13 +19,14 @@ import type {
 // ── Paths ─────────────────────────────────────────────────────────
 
 const CHANNELS_ROOT = join(homedir(), ".letta", "channels");
+let channelsRootOverride: string | null = null;
 
 export function getChannelsRoot(): string {
-  return CHANNELS_ROOT;
+  return channelsRootOverride ?? CHANNELS_ROOT;
 }
 
 export function getChannelDir(channelId: string): string {
-  return join(CHANNELS_ROOT, channelId);
+  return join(getChannelsRoot(), channelId);
 }
 
 export function getChannelConfigPath(channelId: string): string {
@@ -50,6 +51,10 @@ export function getChannelTargetsPath(channelId: string): string {
 
 export function getPendingChannelControlRequestsPath(): string {
   return join(getChannelsRoot(), "pending-control-requests.json");
+}
+
+export function __testOverrideChannelsRoot(root: string | null): void {
+  channelsRootOverride = root;
 }
 
 // ── YAML helpers ──────────────────────────────────────────────────

--- a/src/channels/discord/plugin.ts
+++ b/src/channels/discord/plugin.ts
@@ -10,6 +10,8 @@ export const discordChannelPlugin: ChannelPlugin = {
     displayName: "Discord",
     runtimePackages: ["discord.js@14.18.0"],
     runtimeModules: ["discord.js"],
+    source: "first-party",
+    firstParty: true,
   },
   createAdapter(account: ChannelAccount) {
     return createDiscordAdapter(account as DiscordChannelAccount);

--- a/src/channels/pluginRegistry.ts
+++ b/src/channels/pluginRegistry.ts
@@ -1,14 +1,27 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+import { getChannelDir, getChannelsRoot } from "./config";
 import type { ChannelPlugin, ChannelPluginMetadata } from "./pluginTypes";
-import type { SupportedChannelId } from "./types";
-import { SUPPORTED_CHANNEL_IDS } from "./types";
+import { FIRST_PARTY_CHANNEL_IDS, type FirstPartyChannelId } from "./types";
 
 type ChannelPluginRegistration = {
   metadata: ChannelPluginMetadata;
   load: () => Promise<ChannelPlugin>;
 };
 
-const CHANNEL_PLUGIN_REGISTRATIONS: Record<
-  SupportedChannelId,
+type ChannelManifest = {
+  id: string;
+  displayName: string;
+  entry: string;
+  runtimePackages: string[];
+  runtimeModules: string[];
+};
+
+const CHANNEL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+const FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS: Record<
+  FirstPartyChannelId,
   ChannelPluginRegistration
 > = {
   telegram: {
@@ -17,6 +30,8 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
       displayName: "Telegram",
       runtimePackages: ["grammy@1.42.0"],
       runtimeModules: ["grammy"],
+      source: "first-party",
+      firstParty: true,
     },
     load: async () => {
       const { telegramChannelPlugin } = await import("./telegram/plugin");
@@ -29,6 +44,8 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
       displayName: "Slack",
       runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
       runtimeModules: ["@slack/bolt", "@slack/web-api"],
+      source: "first-party",
+      firstParty: true,
     },
     load: async () => {
       const { slackChannelPlugin } = await import("./slack/plugin");
@@ -41,6 +58,8 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
       displayName: "Discord",
       runtimePackages: ["discord.js@14.18.0"],
       runtimeModules: ["discord.js"],
+      source: "first-party",
+      firstParty: true,
     },
     load: async () => {
       const { discordChannelPlugin } = await import("./discord/plugin");
@@ -49,28 +68,210 @@ const CHANNEL_PLUGIN_REGISTRATIONS: Record<
   },
 };
 
-export function isSupportedChannelId(
-  value: string,
-): value is SupportedChannelId {
-  return SUPPORTED_CHANNEL_IDS.includes(value as SupportedChannelId);
+const loadedUserPlugins = new Map<string, Promise<ChannelPlugin>>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-export function getSupportedChannelIds(): SupportedChannelId[] {
-  return [...SUPPORTED_CHANNEL_IDS];
+function isValidChannelId(value: string): boolean {
+  return CHANNEL_ID_PATTERN.test(value);
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function readChannelManifest(channelDir: string): ChannelManifest | null {
+  const manifestPath = resolve(channelDir, "channel.json");
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
+    if (!isRecord(parsed)) {
+      return null;
+    }
+
+    const id = typeof parsed.id === "string" ? parsed.id.trim() : "";
+    const displayName =
+      typeof parsed.displayName === "string" ? parsed.displayName.trim() : "";
+    const entry = typeof parsed.entry === "string" ? parsed.entry.trim() : "";
+    if (!id || !displayName || !entry || !isValidChannelId(id)) {
+      return null;
+    }
+
+    return {
+      id,
+      displayName,
+      entry,
+      runtimePackages: readStringArray(parsed.runtimePackages),
+      runtimeModules: readStringArray(parsed.runtimeModules),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function createUserChannelRegistration(
+  manifest: ChannelManifest,
+): ChannelPluginRegistration {
+  const channelDir = getChannelDir(manifest.id);
+  const entryPath = resolve(channelDir, manifest.entry);
+  const resolvedChannelDir = resolve(channelDir);
+  const entryEscapesDir =
+    entryPath !== resolvedChannelDir &&
+    !entryPath.startsWith(`${resolvedChannelDir}${sep}`);
+  const metadata: ChannelPluginMetadata = {
+    id: manifest.id,
+    displayName: manifest.displayName,
+    runtimePackages: manifest.runtimePackages,
+    runtimeModules: manifest.runtimeModules,
+    source: "user",
+    firstParty: false,
+  };
+
+  return {
+    metadata,
+    load: async () => {
+      const cached = loadedUserPlugins.get(manifest.id);
+      if (cached) {
+        return cached;
+      }
+      if (entryEscapesDir) {
+        throw new Error(
+          `Channel plugin "${manifest.id}" entry escapes its directory.`,
+        );
+      }
+
+      const loadPromise = import(pathToFileURL(entryPath).href).then(
+        (loaded): ChannelPlugin => {
+          const exported =
+            (isRecord(loaded) ? loaded.channelPlugin : undefined) ??
+            (isRecord(loaded) ? loaded.default : undefined);
+          if (!isRecord(exported)) {
+            throw new Error(
+              `Channel plugin "${manifest.id}" must export channelPlugin or default.`,
+            );
+          }
+
+          const plugin = exported as unknown as ChannelPlugin;
+          if (typeof plugin.createAdapter !== "function") {
+            throw new Error(
+              `Channel plugin "${manifest.id}" is missing createAdapter().`,
+            );
+          }
+
+          return {
+            ...plugin,
+            metadata: {
+              ...metadata,
+              ...(plugin.metadata ?? {}),
+              id: manifest.id,
+              displayName: plugin.metadata?.displayName ?? metadata.displayName,
+              source: "user",
+              firstParty: false,
+            },
+          };
+        },
+      );
+      loadedUserPlugins.set(manifest.id, loadPromise);
+      return loadPromise;
+    },
+  };
+}
+
+function discoverUserChannelRegistrations(): Map<
+  string,
+  ChannelPluginRegistration
+> {
+  const registrations = new Map<string, ChannelPluginRegistration>();
+  const channelsRoot = getChannelsRoot();
+  if (!existsSync(channelsRoot)) {
+    return registrations;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(channelsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return registrations;
+  }
+
+  for (const entry of entries) {
+    if (!isValidChannelId(entry)) {
+      continue;
+    }
+    if (Object.hasOwn(FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS, entry)) {
+      continue;
+    }
+
+    const manifest = readChannelManifest(getChannelDir(entry));
+    if (!manifest || manifest.id !== entry) {
+      continue;
+    }
+    registrations.set(manifest.id, createUserChannelRegistration(manifest));
+  }
+
+  return registrations;
+}
+
+function getChannelPluginRegistration(
+  channelId: string,
+): ChannelPluginRegistration | null {
+  if (Object.hasOwn(FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS, channelId)) {
+    return FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS[
+      channelId as FirstPartyChannelId
+    ];
+  }
+  return discoverUserChannelRegistrations().get(channelId) ?? null;
+}
+
+export function isSupportedChannelId(value: string): value is string {
+  return getChannelPluginRegistration(value) !== null;
+}
+
+export function getSupportedChannelIds(): string[] {
+  const discovered = discoverUserChannelRegistrations();
+  return [
+    ...FIRST_PARTY_CHANNEL_IDS,
+    ...[...discovered.keys()].sort((left, right) => left.localeCompare(right)),
+  ];
 }
 
 export function getChannelPluginMetadata(
-  channelId: SupportedChannelId,
+  channelId: string,
 ): ChannelPluginMetadata {
-  return CHANNEL_PLUGIN_REGISTRATIONS[channelId].metadata;
+  const registration = getChannelPluginRegistration(channelId);
+  if (!registration) {
+    throw new Error(`Unsupported channel: ${channelId}`);
+  }
+  return registration.metadata;
 }
 
-export function getChannelDisplayName(channelId: SupportedChannelId): string {
+export function getChannelDisplayName(channelId: string): string {
   return getChannelPluginMetadata(channelId).displayName;
 }
 
+export function isFirstPartyChannelPlugin(channelId: string): boolean {
+  return Object.hasOwn(FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS, channelId);
+}
+
 export async function loadChannelPlugin(
-  channelId: SupportedChannelId,
+  channelId: string,
 ): Promise<ChannelPlugin> {
-  return CHANNEL_PLUGIN_REGISTRATIONS[channelId].load();
+  const registration = getChannelPluginRegistration(channelId);
+  if (!registration) {
+    throw new Error(`Unsupported channel: ${channelId}`);
+  }
+  return registration.load();
+}
+
+export function __testClearUserChannelPluginCache(): void {
+  loadedUserPlugins.clear();
 }

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -7,14 +7,15 @@ import type {
   OutboundChannelMessage,
   SlackChannelMode,
   SlackDefaultPermissionMode,
-  SupportedChannelId,
 } from "./types";
 
 export interface ChannelPluginMetadata {
-  id: SupportedChannelId;
+  id: string;
   displayName: string;
   runtimePackages: string[];
   runtimeModules: string[];
+  source?: "first-party" | "user";
+  firstParty?: boolean;
 }
 
 export type ChannelProtocolConfig = Record<string, unknown>;
@@ -65,7 +66,7 @@ export interface ChannelAccountConfigAdapter<TAccount extends ChannelAccount> {
   shouldRefreshDisplayName(patch: ChannelPluginAccountPatch): boolean;
 }
 
-export type ChannelMessageActionName = "send" | "react" | "upload-file";
+export type ChannelMessageActionName = string;
 
 export interface ChannelMessageToolSchemaContribution {
   properties: Record<string, unknown>;
@@ -88,7 +89,7 @@ export interface ChannelMessageToolDiscovery {
 
 export interface ChannelMessageActionRequest {
   action: ChannelMessageActionName;
-  channel: SupportedChannelId;
+  channel: string;
   chatId: string;
   message?: string;
   replyToMessageId?: string;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -35,7 +35,7 @@ import {
   removePendingControlRequest as removePersistedPendingControlRequest,
   upsertPendingControlRequest as upsertPersistedPendingControlRequest,
 } from "./pendingControlRequests";
-import { loadChannelPlugin } from "./pluginRegistry";
+import { getChannelDisplayName, loadChannelPlugin } from "./pluginRegistry";
 import {
   addRoute,
   getRoute as getRouteFromStore,
@@ -57,12 +57,15 @@ import type {
   SlackChannelAccount,
   SlackDefaultPermissionMode,
 } from "./types";
+import { isDiscordChannelAccount, isSlackChannelAccount } from "./types";
 import { formatChannelNotification } from "./xml";
 
 function channelDisplayName(channelId: string): string {
-  if (channelId === "slack") return "Slack";
-  if (channelId === "discord") return "Discord";
-  return "Telegram";
+  try {
+    return getChannelDisplayName(channelId);
+  } catch {
+    return channelId;
+  }
 }
 
 function buildPairingInstructions(channelId: string, code: string): string {
@@ -762,7 +765,7 @@ export class ChannelRegistry {
     const config = getChannelAccount(msg.channel, accountId);
     if (!config) return;
 
-    if (msg.channel === "slack" && config.channel === "slack") {
+    if (msg.channel === "slack" && isSlackChannelAccount(config)) {
       const slackResult = await this.ensureSlackRoute(adapter, msg, config);
       if (!slackResult) {
         return;
@@ -787,7 +790,7 @@ export class ChannelRegistry {
     // standard pairing flow below.
     if (
       msg.channel === "discord" &&
-      config.channel === "discord" &&
+      isDiscordChannelAccount(config) &&
       (msg.chatType === "channel" || config.dmPolicy !== "pairing")
     ) {
       const discordResult = await this.ensureDiscordRoute(adapter, msg, config);

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -35,7 +35,11 @@ import {
   removePendingControlRequest as removePersistedPendingControlRequest,
   upsertPendingControlRequest as upsertPersistedPendingControlRequest,
 } from "./pendingControlRequests";
-import { getChannelDisplayName, loadChannelPlugin } from "./pluginRegistry";
+import {
+  getChannelDisplayName,
+  isFirstPartyChannelPlugin,
+  loadChannelPlugin,
+} from "./pluginRegistry";
 import {
   addRoute,
   getRoute as getRouteFromStore,
@@ -68,8 +72,30 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
-function buildPairingInstructions(channelId: string, code: string): string {
+function isCommunityChannel(channelId: string): boolean {
+  // First-party channels (telegram, slack, discord) have UI in the desktop
+  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
+  // so the user-facing copy needs to point to CLI commands instead.
+  try {
+    return !isFirstPartyChannelPlugin(channelId);
+  } catch {
+    return false;
+  }
+}
+
+export function buildPairingInstructions(
+  channelId: string,
+  code: string,
+): string {
   const displayName = channelDisplayName(channelId);
+  if (isCommunityChannel(channelId)) {
+    return (
+      `This chat isn't connected to a Letta agent yet.\n\n` +
+      `Pairing code: ${code} (expires in 15 minutes)\n\n` +
+      `Approve this pairing by running this on the machine running your listener:\n\n` +
+      `letta channels pair approve --channel ${channelId} --code ${code}`
+    );
+  }
   return (
     `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
     `Pairing code: ${code}\n\n` +
@@ -77,11 +103,19 @@ function buildPairingInstructions(channelId: string, code: string): string {
   );
 }
 
-function buildUnboundRouteInstructions(
+export function buildUnboundRouteInstructions(
   channelId: string,
   chatId: string,
 ): string {
   const displayName = channelDisplayName(channelId);
+  if (isCommunityChannel(channelId)) {
+    return (
+      `This chat isn't connected to a Letta agent yet.\n\n` +
+      `Connect it by running this on the machine running your listener:\n\n` +
+      `letta channels route add --channel ${channelId} --chat-id ${chatId} --agent <agent-id>\n\n` +
+      `Find your agent id with \`letta agents list\`.`
+    );
+  }
   return (
     `This chat isn't bound to a Letta Code agent yet.\n\n` +
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -72,32 +72,25 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
-function isCommunityChannel(channelId: string): boolean {
-  // First-party channels (telegram, slack, discord) have UI in the desktop
-  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
-  // so the user-facing copy needs to point to CLI commands instead.
-  try {
-    return !isFirstPartyChannelPlugin(channelId);
-  } catch {
-    return false;
-  }
-}
-
 export function buildPairingInstructions(
   channelId: string,
   code: string,
 ): string {
+  // First-party channels (telegram, slack, discord) have UI in the desktop
+  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
+  // so the user-facing copy needs to point at CLI commands instead.
   const displayName = channelDisplayName(channelId);
-  if (isCommunityChannel(channelId)) {
+  if (!isFirstPartyChannelPlugin(channelId)) {
     return (
       `This chat isn't connected to a Letta agent yet.\n\n` +
       `Pairing code: ${code} (expires in 15 minutes)\n\n` +
-      `Approve this pairing by running this on the machine running your listener:\n\n` +
-      `letta channels pair approve --channel ${channelId} --code ${code}`
+      `On the machine where your listener runs:\n\n` +
+      `letta channels pair --channel ${channelId} --code ${code} --agent <agent-id>\n\n` +
+      `Find your agent id with letta agents list.`
     );
   }
   return (
-    `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
+    `To connect this chat to a Letta agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
     `Pairing code: ${code}\n\n` +
     `This code expires in 15 minutes.`
   );
@@ -108,16 +101,16 @@ export function buildUnboundRouteInstructions(
   chatId: string,
 ): string {
   const displayName = channelDisplayName(channelId);
-  if (isCommunityChannel(channelId)) {
+  if (!isFirstPartyChannelPlugin(channelId)) {
     return (
       `This chat isn't connected to a Letta agent yet.\n\n` +
-      `Connect it by running this on the machine running your listener:\n\n` +
+      `On the machine where your listener runs:\n\n` +
       `letta channels route add --channel ${channelId} --chat-id ${chatId} --agent <agent-id>\n\n` +
-      `Find your agent id with \`letta agents list\`.`
+      `Find your agent id with letta agents list.`
     );
   }
   return (
-    `This chat isn't bound to a Letta Code agent yet.\n\n` +
+    `This chat isn't connected to a Letta agent yet.\n\n` +
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +
     `Chat ID: ${chatId}`
   );

--- a/src/channels/runtimeDeps.ts
+++ b/src/channels/runtimeDeps.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -23,7 +24,7 @@ type RuntimeResolver = {
 
 let spawnInstallProcess: InstallProcessFactory = spawn;
 let userRuntimeRootOverride: string | null = null;
-let bundledRuntimeRootOverride: string | null = null;
+let bundledRuntimeRootOverride: string | null | undefined;
 let packageManagerOverride: RuntimePackageManager | null = null;
 let platformOverride: NodeJS.Platform | null = null;
 
@@ -49,7 +50,9 @@ export function getBundledChannelRuntimeDir(
   channelId: SupportedChannelId,
 ): string | null {
   const root =
-    bundledRuntimeRootOverride ?? process.env[CHANNEL_RUNTIME_ROOT_ENV] ?? null;
+    bundledRuntimeRootOverride !== undefined
+      ? bundledRuntimeRootOverride
+      : (process.env[CHANNEL_RUNTIME_ROOT_ENV] ?? null);
   if (!root) {
     return null;
   }
@@ -151,6 +154,35 @@ async function writeChannelRuntimeManifest(
   );
 }
 
+async function linkUserPluginNodeModules(
+  channelId: SupportedChannelId,
+): Promise<void> {
+  const spec = getChannelPluginMetadata(channelId);
+  if (spec.firstParty) {
+    return;
+  }
+
+  const runtimeNodeModules = join(
+    getChannelRuntimeDir(channelId),
+    "node_modules",
+  );
+  const channelNodeModules = join(getChannelDir(channelId), "node_modules");
+  if (!existsSync(runtimeNodeModules) || existsSync(channelNodeModules)) {
+    return;
+  }
+
+  try {
+    await mkdir(getChannelDir(channelId), { recursive: true });
+    await symlink(
+      runtimeNodeModules,
+      channelNodeModules,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+  } catch {
+    // Best-effort convenience for ESM package resolution from plugin.mjs.
+  }
+}
+
 function resolveInstallPackageManager(): RuntimePackageManager {
   return packageManagerOverride ?? detectPackageManager();
 }
@@ -226,6 +258,8 @@ export async function installChannelRuntime(
       }
     });
   });
+
+  await linkUserPluginNodeModules(channelId);
 }
 
 export async function ensureChannelRuntimeInstalled(
@@ -277,7 +311,9 @@ export function __testOverrideChannelRuntimeDeps(
   } | null,
 ): void {
   userRuntimeRootOverride = overrides?.runtimeRoot ?? null;
-  bundledRuntimeRootOverride = overrides?.bundledRuntimeRoot ?? null;
+  bundledRuntimeRootOverride = overrides
+    ? (overrides.bundledRuntimeRoot ?? null)
+    : undefined;
   spawnInstallProcess = overrides?.spawnImpl ?? spawn;
   packageManagerOverride = overrides?.packageManager ?? null;
   platformOverride = overrides?.platform ?? null;

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -59,15 +59,21 @@ import type {
   ChannelAccount,
   ChannelBindableTarget,
   ChannelRoute,
+  CustomChannelAccount,
   DmPolicy,
   PendingPairing,
   SlackChannelMode,
   SlackDefaultPermissionMode,
   SupportedChannelId,
 } from "./types";
+import {
+  isDiscordChannelAccount,
+  isSlackChannelAccount,
+  isTelegramChannelAccount,
+} from "./types";
 
 export interface ChannelSummary {
-  channelId: SupportedChannelId;
+  channelId: string;
   displayName: string;
   configured: boolean;
   enabled: boolean;
@@ -78,43 +84,23 @@ export interface ChannelSummary {
   routesCount: number;
 }
 
-export type ChannelConfigSnapshot =
-  | {
-      channelId: "telegram";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      hasToken: boolean;
-    }
-  | {
-      channelId: "slack";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      mode: SlackChannelMode;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      hasBotToken: boolean;
-      hasAppToken: boolean;
-      agentId: string | null;
-      defaultPermissionMode: SlackDefaultPermissionMode;
-    }
-  | {
-      channelId: "discord";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      allowedChannels: string[];
-      hasToken: boolean;
-      agentId: string | null;
-    };
+export interface ChannelConfigSnapshot {
+  [key: string]: unknown;
+  channelId: string;
+  accountId: string;
+  displayName?: string;
+  enabled: boolean;
+  mode?: SlackChannelMode;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+  config: ChannelProtocolConfig;
+  hasToken?: boolean;
+  hasBotToken?: boolean;
+  hasAppToken?: boolean;
+  agentId?: string | null;
+  defaultPermissionMode?: SlackDefaultPermissionMode;
+  allowedChannels?: string[];
+}
 
 export interface PendingPairingSnapshot {
   accountId: string;
@@ -127,7 +113,7 @@ export interface PendingPairingSnapshot {
 }
 
 export interface ChannelRouteSnapshot {
-  channelId: SupportedChannelId;
+  channelId: string;
   accountId: string;
   chatId: string;
   chatType?: "direct" | "channel";
@@ -140,7 +126,7 @@ export interface ChannelRouteSnapshot {
 }
 
 export interface ChannelTargetSnapshot {
-  channelId: SupportedChannelId;
+  channelId: string;
   accountId: string;
   targetId: string;
   targetType: "channel";
@@ -155,60 +141,32 @@ async function refreshLoadedMessageChannelTool(): Promise<void> {
   await refreshDynamicChannelToolsInLoadedRegistry();
 }
 
-export type ChannelAccountSnapshot =
-  | {
-      channelId: "telegram";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      hasToken: boolean;
-      transcribeVoice: boolean;
-      binding: {
-        agentId: string | null;
-        conversationId: string | null;
-      };
-      createdAt: string;
-      updatedAt: string;
-    }
-  | {
-      channelId: "slack";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      mode: SlackChannelMode;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      hasBotToken: boolean;
-      hasAppToken: boolean;
-      agentId: string | null;
-      defaultPermissionMode: SlackDefaultPermissionMode;
-      createdAt: string;
-      updatedAt: string;
-    }
-  | {
-      channelId: "discord";
-      accountId: string;
-      displayName?: string;
-      enabled: boolean;
-      configured: boolean;
-      running: boolean;
-      dmPolicy: DmPolicy;
-      allowedUsers: string[];
-      config: ChannelProtocolConfig;
-      allowedChannels: string[];
-      hasToken: boolean;
-      agentId: string | null;
-      createdAt: string;
-      updatedAt: string;
-    };
+export interface ChannelAccountSnapshot {
+  [key: string]: unknown;
+  channelId: string;
+  accountId: string;
+  displayName?: string;
+  enabled: boolean;
+  configured: boolean;
+  running: boolean;
+  mode?: SlackChannelMode;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+  config: ChannelProtocolConfig;
+  hasToken?: boolean;
+  hasBotToken?: boolean;
+  hasAppToken?: boolean;
+  transcribeVoice?: boolean;
+  binding?: {
+    agentId: string | null;
+    conversationId: string | null;
+  };
+  agentId?: string | null;
+  defaultPermissionMode?: SlackDefaultPermissionMode;
+  allowedChannels?: string[];
+  createdAt: string;
+  updatedAt: string;
+}
 
 export type { ChannelAccountPatch, ChannelConfigPatch } from "./pluginTypes";
 
@@ -245,7 +203,7 @@ async function resolveChannelAccountDisplayName(
   }
 
   try {
-    if (account.channel === "telegram") {
+    if (isTelegramChannelAccount(account)) {
       if (!account.token.trim()) {
         return undefined;
       }
@@ -255,13 +213,17 @@ async function resolveChannelAccountDisplayName(
       );
     }
 
-    if (account.channel === "discord") {
+    if (isDiscordChannelAccount(account)) {
       if (!account.token.trim()) {
         return undefined;
       }
       return normalizeDisplayName(
         await resolveDiscordAccountDisplayName(account.token),
       );
+    }
+
+    if (!isSlackChannelAccount(account)) {
+      return undefined;
     }
 
     if (!account.botToken.trim() || !account.appToken.trim()) {
@@ -277,7 +239,7 @@ async function resolveChannelAccountDisplayName(
 }
 
 function getSelectedChannelAccount(
-  channelId: SupportedChannelId,
+  channelId: string,
   accountId?: string,
 ): ChannelAccount | null {
   const normalizedAccountId = accountId?.trim();
@@ -299,7 +261,7 @@ function getSelectedChannelAccount(
 }
 
 function getSelectedRouteByChatId(
-  channelId: SupportedChannelId,
+  channelId: string,
   chatId: string,
   accountId?: string,
 ): ChannelRoute | null {
@@ -319,7 +281,7 @@ function getSelectedRouteByChatId(
 }
 
 function getSelectedTargetById(
-  channelId: SupportedChannelId,
+  channelId: string,
   targetId: string,
   accountId?: string,
 ): ChannelBindableTarget | null {
@@ -362,7 +324,7 @@ function toPendingPairingSnapshot(
 }
 
 function toRouteSnapshot(
-  channelId: SupportedChannelId,
+  channelId: string,
   route: ChannelRoute,
 ): ChannelRouteSnapshot {
   return {
@@ -380,7 +342,7 @@ function toRouteSnapshot(
 }
 
 function toTargetSnapshot(
-  channelId: SupportedChannelId,
+  channelId: string,
   target: ChannelBindableTarget,
 ): ChannelTargetSnapshot {
   return {
@@ -397,12 +359,16 @@ function toTargetSnapshot(
 }
 
 function isAccountConfigured(account: ChannelAccount): boolean {
-  if (account.channel === "telegram") {
+  if (isTelegramChannelAccount(account)) {
     return account.token.trim().length > 0;
   }
 
-  if (account.channel === "discord") {
+  if (isDiscordChannelAccount(account)) {
     return account.token.trim().length > 0;
+  }
+
+  if (!isSlackChannelAccount(account)) {
+    return Object.keys(account.config).length > 0;
   }
 
   return (
@@ -416,7 +382,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       ?.getAdapter(account.channel, account.accountId)
       ?.isRunning() ?? false;
 
-  if (account.channel === "telegram") {
+  if (isTelegramChannelAccount(account)) {
     loadRoutes(account.channel);
     const fallbackRoute = getRoutesForChannel(
       account.channel,
@@ -457,7 +423,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     };
   }
 
-  if (account.channel === "discord") {
+  if (isDiscordChannelAccount(account)) {
     return {
       channelId: "discord",
       accountId: account.accountId,
@@ -471,6 +437,22 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
       allowedChannels: [...(account.allowedChannels ?? [])],
       hasToken: account.token.trim().length > 0,
       agentId: account.agentId,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+    };
+  }
+
+  if (!isSlackChannelAccount(account)) {
+    return {
+      channelId: account.channel,
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      configured: isAccountConfigured(account),
+      running,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      config: toChannelAccountProtocolConfig(account),
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -538,6 +520,20 @@ function createAccountFromPatch(
     };
   }
 
+  if (channelId !== "slack") {
+    return {
+      channel: channelId,
+      accountId,
+      displayName: normalizeDisplayName(normalizedPatch.displayName),
+      enabled: normalizedPatch.enabled ?? false,
+      dmPolicy: normalizedPatch.dmPolicy ?? "pairing",
+      allowedUsers: normalizedPatch.allowedUsers ?? [],
+      config: { ...(normalizedPatch.config ?? {}) },
+      createdAt: now,
+      updatedAt: now,
+    } satisfies CustomChannelAccount;
+  }
+
   return {
     channel: "slack",
     accountId,
@@ -561,7 +557,7 @@ function mergeAccountPatch(
 ): ChannelAccount {
   const normalizedPatch = normalizeChannelAccountPatch(existing.channel, patch);
   const nextUpdatedAt = new Date().toISOString();
-  if (existing.channel === "telegram") {
+  if (isTelegramChannelAccount(existing)) {
     return {
       ...existing,
       displayName:
@@ -578,7 +574,7 @@ function mergeAccountPatch(
     };
   }
 
-  if (existing.channel === "discord") {
+  if (isDiscordChannelAccount(existing)) {
     return {
       ...existing,
       displayName:
@@ -592,6 +588,24 @@ function mergeAccountPatch(
       allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
       allowedChannels:
         normalizedPatch.allowedChannels ?? existing.allowedChannels,
+      updatedAt: nextUpdatedAt,
+    };
+  }
+
+  if (!isSlackChannelAccount(existing)) {
+    return {
+      ...existing,
+      displayName:
+        normalizedPatch.displayName !== undefined
+          ? normalizeDisplayName(normalizedPatch.displayName)
+          : existing.displayName,
+      enabled: normalizedPatch.enabled ?? existing.enabled,
+      dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
+      config:
+        normalizedPatch.config !== undefined
+          ? { ...normalizedPatch.config }
+          : { ...existing.config },
       updatedAt: nextUpdatedAt,
     };
   }
@@ -668,7 +682,7 @@ export function getChannelConfigSnapshot(
   if (!account) {
     return null;
   }
-  if (account.channel === "telegram") {
+  if (isTelegramChannelAccount(account)) {
     return {
       channelId: "telegram",
       accountId: account.accountId,
@@ -681,7 +695,7 @@ export function getChannelConfigSnapshot(
     };
   }
 
-  if (account.channel === "discord") {
+  if (isDiscordChannelAccount(account)) {
     return {
       channelId: "discord",
       accountId: account.accountId,
@@ -693,6 +707,18 @@ export function getChannelConfigSnapshot(
       allowedChannels: [...(account.allowedChannels ?? [])],
       hasToken: account.token.trim().length > 0,
       agentId: account.agentId,
+    };
+  }
+
+  if (!isSlackChannelAccount(account)) {
+    return {
+      channelId: account.channel,
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      config: toChannelConfigSnapshotProtocolConfig(account),
     };
   }
 
@@ -732,6 +758,7 @@ export async function setChannelConfigLive(
       dmPolicy: normalizedPatch.dmPolicy,
       allowedUsers: normalizedPatch.allowedUsers,
       allowedChannels: normalizedPatch.allowedChannels,
+      config: normalizedPatch.config,
       displayName: existing.displayName,
     });
     shouldRefreshDisplayName = channelPluginConfigShouldRefreshDisplayName(
@@ -751,6 +778,7 @@ export async function setChannelConfigLive(
         allowedUsers: normalizedPatch.allowedUsers,
         allowedChannels: normalizedPatch.allowedChannels,
         transcribeVoice: normalizedPatch.transcribeVoice,
+        config: normalizedPatch.config,
       },
       accountId ? { accountId } : undefined,
     );
@@ -802,14 +830,19 @@ export async function startChannelLive(
     );
   }
   if (!isAccountConfigured(existing)) {
-    if (existing.channel === "telegram") {
+    if (isTelegramChannelAccount(existing)) {
       throw new Error(
         'Channel "telegram" is missing a token. Configure it first.',
       );
     }
-    if (existing.channel === "discord") {
+    if (isDiscordChannelAccount(existing)) {
       throw new Error(
         'Channel "discord" is missing a token. Configure it first.',
+      );
+    }
+    if (!isSlackChannelAccount(existing)) {
+      throw new Error(
+        `Channel "${channelId}" account is not configured. Configure it first.`,
       );
     }
     throw new Error(
@@ -983,17 +1016,25 @@ export function bindChannelAccountLive(
   }
 
   let updated: ChannelAccount;
-  if (existing.channel === "telegram") {
+  if (isTelegramChannelAccount(existing)) {
     updated = upsertChannelAccount(channelId, {
       ...existing,
       binding: { agentId, conversationId },
       updatedAt: new Date().toISOString(),
     });
-  } else {
+  } else if (
+    isSlackChannelAccount(existing) ||
+    isDiscordChannelAccount(existing)
+  ) {
     // Slack and Discord both use a top-level agentId
     updated = upsertChannelAccount(channelId, {
       ...existing,
       agentId,
+      updatedAt: new Date().toISOString(),
+    });
+  } else {
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -1014,17 +1055,25 @@ export function unbindChannelAccountLive(
   }
 
   let updated: ChannelAccount;
-  if (existing.channel === "telegram") {
+  if (isTelegramChannelAccount(existing)) {
     updated = upsertChannelAccount(channelId, {
       ...existing,
       binding: { agentId: null, conversationId: null },
       updatedAt: new Date().toISOString(),
     });
-  } else {
+  } else if (
+    isSlackChannelAccount(existing) ||
+    isDiscordChannelAccount(existing)
+  ) {
     // Slack and Discord both use a top-level agentId
     updated = upsertChannelAccount(channelId, {
       ...existing,
       agentId: null,
+      updatedAt: new Date().toISOString(),
+    });
+  } else {
+    updated = upsertChannelAccount(channelId, {
+      ...existing,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -1044,14 +1093,19 @@ export async function startChannelAccountLive(
     );
   }
   if (!isAccountConfigured(existing)) {
-    if (existing.channel === "telegram") {
+    if (isTelegramChannelAccount(existing)) {
       throw new Error(
         'Channel "telegram" account is missing a token. Configure it first.',
       );
     }
-    if (existing.channel === "discord") {
+    if (isDiscordChannelAccount(existing)) {
       throw new Error(
         'Channel "discord" account is missing a token. Configure it first.',
+      );
+    }
+    if (!isSlackChannelAccount(existing)) {
+      throw new Error(
+        `Channel "${channelId}" account is not configured. Configure it first.`,
       );
     }
     throw new Error(
@@ -1287,7 +1341,7 @@ export function updateChannelRouteLive(
     ? getChannelAccount(channelId, resolvedAccountId)
     : null;
 
-  if (existingAccount?.channel === "telegram") {
+  if (existingAccount && isTelegramChannelAccount(existingAccount)) {
     upsertChannelAccount(channelId, {
       ...existingAccount,
       binding: {
@@ -1316,7 +1370,7 @@ export function updateChannelRouteLive(
     );
     setRouteInMemory(channelId, existingRoute);
 
-    if (existingAccount?.channel === "telegram") {
+    if (existingAccount && isTelegramChannelAccount(existingAccount)) {
       try {
         upsertChannelAccount(channelId, existingAccount);
       } catch (rollbackError) {

--- a/src/channels/slack/plugin.ts
+++ b/src/channels/slack/plugin.ts
@@ -10,6 +10,8 @@ export const slackChannelPlugin: ChannelPlugin = {
     displayName: "Slack",
     runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
     runtimeModules: ["@slack/bolt", "@slack/web-api"],
+    source: "first-party",
+    firstParty: true,
   },
   createAdapter(account: ChannelAccount) {
     return createSlackAdapter(account as SlackChannelAccount);

--- a/src/channels/slack/proactiveAccounts.ts
+++ b/src/channels/slack/proactiveAccounts.ts
@@ -2,6 +2,7 @@ import { getChannelAccount, LEGACY_CHANNEL_ACCOUNT_ID } from "../accounts";
 import { getChannelRegistry } from "../registry";
 import { getRoutesForChannel, loadRoutes } from "../routing";
 import type { ChannelAdapter, SlackChannelAccount } from "../types";
+import { isSlackChannelAccount } from "../types";
 
 export interface EligibleProactiveSlackAccount {
   account: SlackChannelAccount;
@@ -39,7 +40,7 @@ export function listEligibleProactiveSlackAccounts(params: {
     const account = getChannelAccount("slack", accountId);
     if (
       !account ||
-      account.channel !== "slack" ||
+      !isSlackChannelAccount(account) ||
       account.agentId !== params.agentId
     ) {
       continue;

--- a/src/channels/telegram/plugin.ts
+++ b/src/channels/telegram/plugin.ts
@@ -10,6 +10,8 @@ export const telegramChannelPlugin: ChannelPlugin = {
     displayName: "Telegram",
     runtimePackages: ["grammy@1.42.0"],
     runtimeModules: ["grammy"],
+    source: "first-party",
+    firstParty: true,
   },
   createAdapter(account: ChannelAccount) {
     return createTelegramAdapter(account as TelegramChannelAccount);

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,8 +7,18 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
-export const SUPPORTED_CHANNEL_IDS = ["telegram", "slack", "discord"] as const;
-export type SupportedChannelId = (typeof SUPPORTED_CHANNEL_IDS)[number];
+export const FIRST_PARTY_CHANNEL_IDS = [
+  "telegram",
+  "slack",
+  "discord",
+] as const;
+export type FirstPartyChannelId = (typeof FIRST_PARTY_CHANNEL_IDS)[number];
+/**
+ * Built-in channels shipped with Letta Code. Custom channel IDs are discovered
+ * at runtime from ~/.letta/channels/<id>/channel.json.
+ */
+export const SUPPORTED_CHANNEL_IDS = FIRST_PARTY_CHANNEL_IDS;
+export type SupportedChannelId = string;
 export type ChannelChatType = "direct" | "channel";
 export type SlackDefaultPermissionMode =
   | "default"
@@ -48,7 +58,7 @@ export interface ChannelThreadContext {
 }
 
 export interface ChannelTurnSource {
-  channel: SupportedChannelId;
+  channel: string;
   accountId?: string;
   chatId: string;
   chatType?: ChannelChatType;
@@ -100,7 +110,7 @@ export interface ChannelAdapter {
   /** Platform identifier, e.g. "telegram", "slack". */
   readonly id: string;
   /** Channel identifier, e.g. "telegram". */
-  readonly channelId?: SupportedChannelId;
+  readonly channelId?: string;
   /** Account identifier within the channel. */
   readonly accountId?: string;
   /** Human-readable display name, e.g. "Telegram". */
@@ -266,6 +276,12 @@ interface ChannelAccountBase {
   updatedAt: string;
 }
 
+export interface CustomChannelAccount extends ChannelAccountBase {
+  channel: string;
+  /** Plugin-owned persisted account settings. May contain secrets. */
+  config: Record<string, unknown>;
+}
+
 export interface TelegramChannelConfig {
   channel: "telegram";
   enabled: boolean;
@@ -348,7 +364,44 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
 export type ChannelAccount =
   | TelegramChannelAccount
   | SlackChannelAccount
-  | DiscordChannelAccount;
+  | DiscordChannelAccount
+  | CustomChannelAccount;
+
+export function isFirstPartyChannelId(
+  channelId: string,
+): channelId is FirstPartyChannelId {
+  return FIRST_PARTY_CHANNEL_IDS.includes(channelId as FirstPartyChannelId);
+}
+
+export function isTelegramChannelAccount(
+  account: ChannelAccount,
+): account is TelegramChannelAccount {
+  return (
+    account.channel === "telegram" && "token" in account && "binding" in account
+  );
+}
+
+export function isSlackChannelAccount(
+  account: ChannelAccount,
+): account is SlackChannelAccount {
+  return (
+    account.channel === "slack" &&
+    "botToken" in account &&
+    "appToken" in account
+  );
+}
+
+export function isDiscordChannelAccount(
+  account: ChannelAccount,
+): account is DiscordChannelAccount {
+  return account.channel === "discord" && "token" in account;
+}
+
+export function isCustomChannelAccount(
+  account: ChannelAccount,
+): account is CustomChannelAccount {
+  return !isFirstPartyChannelId(account.channel) && "config" in account;
+}
 
 // ── Pairing ───────────────────────────────────────────────────────
 

--- a/src/tests/channels/plugin-registry.test.ts
+++ b/src/tests/channels/plugin-registry.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testOverrideChannelsRoot } from "../../channels/config";
+import {
+  buildDynamicMessageChannelSchema,
+  clearDynamicMessageChannelToolCache,
+} from "../../channels/messageTool";
+import {
+  __testClearUserChannelPluginCache,
+  getChannelDisplayName,
+  getChannelPluginMetadata,
+  getSupportedChannelIds,
+  isSupportedChannelId,
+  loadChannelPlugin,
+} from "../../channels/pluginRegistry";
+
+let channelsRoot: string;
+
+function writeDemoChannel(): void {
+  const channelDir = join(channelsRoot, "demo");
+  mkdirSync(channelDir, { recursive: true });
+  writeFileSync(
+    join(channelDir, "channel.json"),
+    `${JSON.stringify(
+      {
+        id: "demo",
+        displayName: "Demo Chat",
+        entry: "./plugin.mjs",
+        runtimePackages: ["demo-runtime@1.0.0"],
+        runtimeModules: ["demo-runtime"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(channelDir, "plugin.mjs"),
+    `export const channelPlugin = {
+      metadata: {
+        id: "demo",
+        displayName: "Demo Chat",
+        runtimePackages: ["demo-runtime@1.0.0"],
+        runtimeModules: ["demo-runtime"]
+      },
+      createAdapter(account) {
+        return {
+          id: "demo:" + account.accountId,
+          channelId: "demo",
+          accountId: account.accountId,
+          name: "Demo Chat",
+          start: async () => {},
+          stop: async () => {},
+          isRunning: () => true,
+          sendMessage: async () => ({ messageId: "demo-1" }),
+          sendDirectReply: async () => {}
+        };
+      },
+      messageActions: {
+        describeMessageTool() {
+          return {
+            actions: ["wave"],
+            schema: { properties: { intensity: { type: "string" } } }
+          };
+        },
+        handleAction: async () => "ok"
+      }
+    };\n`,
+  );
+}
+
+beforeEach(() => {
+  channelsRoot = mkdtempSync(join(tmpdir(), "letta-channel-plugins-"));
+  __testOverrideChannelsRoot(channelsRoot);
+  __testClearUserChannelPluginCache();
+  clearDynamicMessageChannelToolCache();
+});
+
+afterEach(() => {
+  __testOverrideChannelsRoot(null);
+  __testClearUserChannelPluginCache();
+  clearDynamicMessageChannelToolCache();
+  rmSync(channelsRoot, { recursive: true, force: true });
+});
+
+test("discovers user channel plugins from channel.json manifests", async () => {
+  writeDemoChannel();
+
+  expect(isSupportedChannelId("demo")).toBe(true);
+  expect(getSupportedChannelIds()).toContain("demo");
+  expect(getChannelDisplayName("demo")).toBe("Demo Chat");
+  expect(getChannelPluginMetadata("demo")).toMatchObject({
+    id: "demo",
+    source: "user",
+    firstParty: false,
+  });
+
+  const plugin = await loadChannelPlugin("demo");
+  expect(plugin.metadata).toMatchObject({
+    id: "demo",
+    displayName: "Demo Chat",
+    source: "user",
+    firstParty: false,
+  });
+});
+
+test("user plugins can extend the MessageChannel action schema", async () => {
+  writeDemoChannel();
+
+  const schema = await buildDynamicMessageChannelSchema(
+    {
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        channel: { type: "string" },
+        chat_id: { type: "string" },
+      },
+      required: ["action", "channel", "chat_id"],
+      additionalProperties: false,
+    },
+    { channels: [{ channelId: "demo", accountId: "acct-demo" }] },
+  );
+
+  const properties = schema.properties as Record<
+    string,
+    Record<string, unknown> & { enum?: string[] }
+  >;
+  expect(properties.channel?.enum).toEqual(["demo"]);
+  expect(properties.action?.enum).toEqual(["send", "wave"]);
+  expect(properties.intensity).toEqual({ type: "string" });
+});

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -9,7 +9,7 @@ describe("registry copy: first-party channels", () => {
     expect(text).toContain("open Channels >");
     expect(text).toContain("Telegram");
     expect(text).toContain("Pairing code: ABC123");
-    expect(text).not.toContain("letta channels pair approve");
+    expect(text).not.toContain("letta channels pair");
     expect(text).not.toContain("(community channel)");
   });
 
@@ -27,6 +27,16 @@ describe("registry copy: first-party channels", () => {
     expect(text).toContain("open Channels >");
     expect(text).toContain("Discord");
   });
+
+  test("first-party copy uses 'Letta agent' consistently", () => {
+    expect(buildPairingInstructions("telegram", "X")).toContain("Letta agent");
+    expect(buildUnboundRouteInstructions("slack", "Y")).toContain(
+      "Letta agent",
+    );
+    expect(buildPairingInstructions("telegram", "X")).not.toContain(
+      "Letta Code agent",
+    );
+  });
 });
 
 describe("registry copy: community channels", () => {
@@ -38,12 +48,15 @@ describe("registry copy: community channels", () => {
     const text = buildPairingInstructions("whatsapp", "ABC123");
     expect(text).toContain("isn't connected to a Letta agent yet");
     expect(text).toContain("Pairing code: ABC123 (expires in 15 minutes)");
-    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain("On the machine where your listener runs");
     expect(text).toContain(
-      "letta channels pair approve --channel whatsapp --code ABC123",
+      "letta channels pair --channel whatsapp --code ABC123 --agent <agent-id>",
     );
+    expect(text).toContain("Find your agent id with letta agents list.");
     expect(text).not.toContain("open Channels >");
     expect(text).not.toContain("(community channel)");
+    // Hard-stop against shipping the wrong subcommand again.
+    expect(text).not.toContain("letta channels pair approve");
   });
 
   test("unbound route instructions surface the CLI command for community channels", () => {
@@ -52,11 +65,11 @@ describe("registry copy: community channels", () => {
       "15551234567@s.whatsapp.net",
     );
     expect(text).toContain("isn't connected to a Letta agent yet");
-    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain("On the machine where your listener runs");
     expect(text).toContain(
       "letta channels route add --channel whatsapp --chat-id 15551234567@s.whatsapp.net --agent <agent-id>",
     );
-    expect(text).toContain("`letta agents list`");
+    expect(text).toContain("Find your agent id with letta agents list.");
     expect(text).not.toContain("Open Channels >");
     expect(text).not.toContain("(community channel)");
     expect(text).not.toContain("paste a route");
@@ -67,7 +80,7 @@ describe("registry copy: community channels", () => {
     const text = buildPairingInstructions("imessage", "QQQ");
     expect(text).toContain("isn't connected to a Letta agent yet");
     expect(text).toContain(
-      "letta channels pair approve --channel imessage --code QQQ",
+      "letta channels pair --channel imessage --code QQQ --agent <agent-id>",
     );
   });
 
@@ -76,5 +89,14 @@ describe("registry copy: community channels", () => {
     expect(text).toContain("--channel signal");
     expect(text).toContain("--chat-id +15551234567");
     expect(text).toContain("--agent <agent-id>");
+  });
+
+  test("community pairing copy points at a real subcommand", () => {
+    // The actual handler in src/cli/subcommands/channels.ts is `letta channels
+    // pair` (no `approve` subcommand). If someone introduces an `approve`
+    // subcommand, this test should be updated together with the copy.
+    const text = buildPairingInstructions("whatsapp", "X");
+    expect(text).toMatch(/letta channels pair --channel whatsapp /);
+    expect(text).not.toMatch(/letta channels pair approve/);
   });
 });

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+const { buildPairingInstructions, buildUnboundRouteInstructions } =
+  await import("../../channels/registry");
+
+describe("registry copy: first-party channels", () => {
+  test("pairing instructions point at the desktop UI for telegram", () => {
+    const text = buildPairingInstructions("telegram", "ABC123");
+    expect(text).toContain("open Channels >");
+    expect(text).toContain("Telegram");
+    expect(text).toContain("Pairing code: ABC123");
+    expect(text).not.toContain("letta channels pair approve");
+    expect(text).not.toContain("(community channel)");
+  });
+
+  test("unbound route instructions point at the desktop UI for slack", () => {
+    const text = buildUnboundRouteInstructions("slack", "C123ABC");
+    expect(text).toContain("Open Channels >");
+    expect(text).toContain("Slack");
+    expect(text).toContain("Chat ID: C123ABC");
+    expect(text).not.toContain("letta channels route add");
+    expect(text).not.toContain("(community channel)");
+  });
+
+  test("first-party discord pairing keeps the desktop wording", () => {
+    const text = buildPairingInstructions("discord", "XYZ789");
+    expect(text).toContain("open Channels >");
+    expect(text).toContain("Discord");
+  });
+});
+
+describe("registry copy: community channels", () => {
+  // Any channel id that isn't telegram/slack/discord is a community plugin.
+  // We don't need a real plugin installed — `isFirstPartyChannelPlugin` only
+  // checks the FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS map.
+
+  test("pairing instructions surface the CLI command for community channels", () => {
+    const text = buildPairingInstructions("whatsapp", "ABC123");
+    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain("Pairing code: ABC123 (expires in 15 minutes)");
+    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain(
+      "letta channels pair approve --channel whatsapp --code ABC123",
+    );
+    expect(text).not.toContain("open Channels >");
+    expect(text).not.toContain("(community channel)");
+  });
+
+  test("unbound route instructions surface the CLI command for community channels", () => {
+    const text = buildUnboundRouteInstructions(
+      "whatsapp",
+      "15551234567@s.whatsapp.net",
+    );
+    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain(
+      "letta channels route add --channel whatsapp --chat-id 15551234567@s.whatsapp.net --agent <agent-id>",
+    );
+    expect(text).toContain("`letta agents list`");
+    expect(text).not.toContain("Open Channels >");
+    expect(text).not.toContain("(community channel)");
+    expect(text).not.toContain("paste a route");
+    expect(text).not.toContain("routing.yaml");
+  });
+
+  test("any non-first-party channel id triggers community copy", () => {
+    const text = buildPairingInstructions("imessage", "QQQ");
+    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain(
+      "letta channels pair approve --channel imessage --code QQQ",
+    );
+  });
+
+  test("community unbound copy embeds the channel id and chat id in the CLI command", () => {
+    const text = buildUnboundRouteInstructions("signal", "+15551234567");
+    expect(text).toContain("--channel signal");
+    expect(text).toContain("--chat-id +15551234567");
+    expect(text).toContain("--agent <agent-id>");
+  });
+});

--- a/src/tests/channels/runtimeDeps.test.ts
+++ b/src/tests/channels/runtimeDeps.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -20,6 +21,10 @@ const {
   isChannelRuntimeInstalled,
   loadChannelRuntimeModule,
 } = await import("../../channels/runtimeDeps");
+const { __testOverrideChannelsRoot } = await import("../../channels/config");
+const { __testClearUserChannelPluginCache } = await import(
+  "../../channels/pluginRegistry"
+);
 
 function writeFakeGrammyModule(runtimeDir: string): void {
   const moduleDir = join(runtimeDir, "node_modules", "grammy");
@@ -44,19 +49,26 @@ function writeFakeGrammyModule(runtimeDir: string): void {
 
 let runtimeRoot: string;
 let bundledRuntimeRoot: string;
+let channelsRoot: string;
 
 beforeEach(() => {
   runtimeRoot = mkdtempSync(join(tmpdir(), "letta-channel-runtime-"));
   bundledRuntimeRoot = mkdtempSync(
     join(tmpdir(), "letta-channel-runtime-bundled-"),
   );
+  channelsRoot = mkdtempSync(join(tmpdir(), "letta-channel-root-"));
+  __testOverrideChannelsRoot(channelsRoot);
+  __testClearUserChannelPluginCache();
   __testOverrideChannelRuntimeDeps({ runtimeRoot });
 });
 
 afterEach(() => {
   __testOverrideChannelRuntimeDeps(null);
+  __testOverrideChannelsRoot(null);
+  __testClearUserChannelPluginCache();
   rmSync(runtimeRoot, { recursive: true, force: true });
   rmSync(bundledRuntimeRoot, { recursive: true, force: true });
+  rmSync(channelsRoot, { recursive: true, force: true });
 });
 
 test("loadChannelRuntimeModule throws a friendly install hint when runtime is missing", async () => {
@@ -146,6 +158,46 @@ test("installChannelRuntime writes a manifest and invokes npm in the runtime dir
       cwd: getChannelRuntimeDir("telegram"),
     },
   ]);
+});
+
+test("installChannelRuntime links user plugin node_modules for entry imports", async () => {
+  const channelDir = join(channelsRoot, "demo");
+  mkdirSync(channelDir, { recursive: true });
+  writeFileSync(
+    join(channelDir, "channel.json"),
+    JSON.stringify({
+      id: "demo",
+      displayName: "Demo Chat",
+      entry: "./plugin.mjs",
+      runtimePackages: ["demo-runtime@1.0.0"],
+      runtimeModules: ["demo-runtime"],
+    }),
+  );
+
+  const spawnImpl = mock(
+    (_cmd: string, _args: string[], opts?: { cwd?: string }) => {
+      if (!opts?.cwd) {
+        throw new Error("expected cwd");
+      }
+      mkdirSync(join(opts.cwd, "node_modules"), { recursive: true });
+      const proc = new EventEmitter();
+      queueMicrotask(() => {
+        proc.emit("exit", 0);
+      });
+      return proc as unknown as ReturnType<typeof mock>;
+    },
+  );
+
+  __testOverrideChannelRuntimeDeps({
+    runtimeRoot,
+    spawnImpl: spawnImpl as never,
+    packageManager: "npm",
+    platform: "linux",
+  });
+
+  await installChannelRuntime("demo");
+
+  expect(existsSync(join(channelDir, "node_modules"))).toBe(true);
 });
 
 test("installChannelRuntime uses bun add --no-save for bun installs", async () => {

--- a/src/tests/channels/slack-adapter-interop.test.ts
+++ b/src/tests/channels/slack-adapter-interop.test.ts
@@ -48,6 +48,9 @@ class FakeSlackApp {
 }
 
 mock.module("../../channels/slack/runtime", () => ({
+  ensureSlackRuntimeInstalled: async () => false,
+  installSlackRuntime: async () => {},
+  isSlackRuntimeInstalled: () => true,
   loadSlackBoltModule: async () => ({
     default: {
       default: {

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -165,6 +165,9 @@ const resolveSlackChannelHistoryMock = mock(
 );
 
 mock.module("../../channels/slack/runtime", () => ({
+  ensureSlackRuntimeInstalled: async () => false,
+  installSlackRuntime: async () => {},
+  isSlackRuntimeInstalled: () => true,
   loadSlackBoltModule: async () => ({
     App: FakeSlackApp,
     default: {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { __testOverrideChannelsRoot } from "../../channels/config";
 import type { InboundChannelMessage } from "../../channels/types";
 
 type FakeBotStartOptions = {
@@ -107,10 +108,6 @@ class FakeBot {
   }
 }
 
-mock.module("../../channels/config", () => ({
-  getChannelDir: (channelId: string) => join(channelRoot, channelId),
-}));
-
 mock.module("../../channels/telegram/runtime", () => ({
   loadGrammyModule: async () => ({
     Bot: FakeBot,
@@ -140,6 +137,7 @@ const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 beforeEach(() => {
   channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
+  __testOverrideChannelsRoot(channelRoot);
   FakeBot.instances.length = 0;
   FakeBot.nextStartImpl = async (options, botInfo) => {
     await options?.onStart?.(
@@ -159,6 +157,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  __testOverrideChannelsRoot(null);
   console.error = originalConsoleError;
   globalThis.fetch = originalFetch;
   if (originalOpenAiApiKey === undefined) {

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -554,17 +554,7 @@ function normalizeMessageAction(
   rawAction: string,
 ): ChannelMessageActionName | null {
   const normalized = rawAction.trim().toLowerCase();
-
-  switch (normalized) {
-    case "send":
-      return "send";
-    case "react":
-      return "react";
-    case "upload-file":
-      return "upload-file";
-    default:
-      return null;
-  }
+  return normalized.length > 0 ? normalized : null;
 }
 
 function normalizeMessageChannelInput(

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -2,12 +2,10 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { getClient } from "../agent/client";
 import { resolveModel } from "../agent/model";
 import type { MessageChannelToolDiscoveryScope } from "../channels/messageTool";
+import { getSupportedChannelIds } from "../channels/pluginRegistry";
 import { getChannelRegistry } from "../channels/registry";
 import { getRoutesForChannel, loadRoutes } from "../channels/routing";
-import {
-  SUPPORTED_CHANNEL_IDS,
-  type SupportedChannelId,
-} from "../channels/types";
+import type { SupportedChannelId } from "../channels/types";
 import type { RuntimeContextSnapshot } from "../runtime-context";
 import { settingsManager } from "../settings-manager";
 import { toolFilter } from "./filter";
@@ -216,7 +214,7 @@ export function resolveConversationChannelToolScope(
   }> = [];
   const seen = new Set<string>();
 
-  for (const channelId of SUPPORTED_CHANNEL_IDS) {
+  for (const channelId of getSupportedChannelIds()) {
     loadRoutes(channelId);
     for (const route of getRoutesForChannel(channelId)) {
       if (

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -138,7 +138,7 @@ export interface ReflectionSettingsSnapshot {
   step_count: number;
 }
 
-export type ChannelId = "telegram" | "slack" | "discord";
+export type ChannelId = string;
 
 export type ChannelPluginConfig = Record<string, unknown>;
 

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -1,5 +1,6 @@
 import type WebSocket from "ws";
 import { isValidChannelPluginConfigPayload } from "../../channels/accountConfig";
+import { isSupportedChannelId } from "../../channels/pluginRegistry";
 import type {
   AbortMessageCommand,
   ChangeDeviceStateCommand,
@@ -828,10 +829,8 @@ export function isSetExperimentCommand(
   );
 }
 
-function isChannelId(
-  value: unknown,
-): value is "telegram" | "slack" | "discord" {
-  return value === "telegram" || value === "slack" || value === "discord";
+function isChannelId(value: unknown): value is string {
+  return typeof value === "string" && isSupportedChannelId(value);
 }
 
 function hasValidChannelPolicyFields(config: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary
- Adds `src/channels/README.md` documenting the first-party vs user plugin model, `~/.letta/channels/<id>/channel.json` manifests, plugin entry shape, and headless custom-plugin constraints.
- Makes channel IDs runtime-discovered strings while preserving Telegram/Slack/Discord as bundled first-party plugins with special Desktop treatment.
- Adds generic custom-channel account storage/redacted snapshots, dynamic WS validation, runtime install support for user plugin dependencies, and `MessageChannel` schema/action discovery for custom plugins.
- Validated with `bun run check` plus targeted channel tests for plugin discovery, runtime deps, MessageChannel schema/execution, service, and Discord service paths.

👾 Generated with [Letta Code](https://letta.com)