### PR TITLE
fix(channels): harden Discord delivery error replies

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -272,6 +272,7 @@ async function notifyDiscordDeliveryError(
     if (typeof message.channel.send !== "function") return;
     const reply = buildDiscordReplyOptions(message.id, message.channelId);
     await message.channel.send({
+      allowedMentions: { parse: [] },
       content: formatDiscordDeliveryError(error),
       ...(reply ?? {}),
     });

--- a/src/channels/discord/errorReply.ts
+++ b/src/channels/discord/errorReply.ts
@@ -25,6 +25,10 @@ function readTrimmedString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function escapeDiscordInlineCode(value: string): string {
+  return value.replace(/`/g, "\\`").replace(/\r?\n/g, " ");
+}
+
 /**
  * Pull the most useful human-readable detail out of an unknown error,
  * falling back through the Letta SDK shape, the standard Error.message,
@@ -75,5 +79,6 @@ export function formatDiscordDeliveryError(error: unknown): string {
   const MAX_DETAIL = 200;
   const truncated =
     detail.length > MAX_DETAIL ? `${detail.slice(0, MAX_DETAIL)}…` : detail;
-  return `Sorry, something went wrong while forwarding your message: \`${truncated}\``;
+  const safeDetail = escapeDiscordInlineCode(truncated);
+  return `Sorry, something went wrong while forwarding your message: \`${safeDetail}\``;
 }

--- a/src/tests/discord-error-reply.test.ts
+++ b/src/tests/discord-error-reply.test.ts
@@ -96,6 +96,12 @@ describe("formatDiscordDeliveryError", () => {
     expect(msg).toContain("`something exploded`");
   });
 
+  test("escapes generic error details for inline code", () => {
+    const msg = formatDiscordDeliveryError(new Error("bad `code`\n@everyone"));
+    expect(msg).toContain("bad \\`code\\` @everyone");
+    expect(msg).not.toContain("\n");
+  });
+
   test("truncates very long detail strings", () => {
     const detail = "x".repeat(500);
     const msg = formatDiscordDeliveryError(new Error(detail));


### PR DESCRIPTION
## Summary
- Disables Discord mention parsing for delivery error notifications.
- Escapes backticks and newlines before rendering generic error details in inline code.
- Adds coverage for escaped generic Discord error details.

"Trust, but verify."

Written by Cameron ◯ Letta Code