### PR TITLE
fix(channels): community-channel-aware pairing + unbound copy

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -90,11 +90,10 @@ export function buildPairingInstructions(
   const displayName = channelDisplayName(channelId);
   if (isCommunityChannel(channelId)) {
     return (
-      `This chat isn't bound to a Letta Code agent yet (community channel).\n\n` +
-      `Pairing code: ${code}\n\n` +
-      `Approve this pairing by running:\n` +
-      `letta channels pair approve --channel ${channelId} --code ${code}\n\n` +
-      `This code expires in 15 minutes.`
+      `This chat isn't connected to a Letta agent yet.\n\n` +
+      `Pairing code: ${code} (expires in 15 minutes)\n\n` +
+      `Approve this pairing by running this on the machine running your listener:\n\n` +
+      `letta channels pair approve --channel ${channelId} --code ${code}`
     );
   }
   return (
@@ -111,10 +110,10 @@ export function buildUnboundRouteInstructions(
   const displayName = channelDisplayName(channelId);
   if (isCommunityChannel(channelId)) {
     return (
-      `This chat isn't bound to a Letta Code agent yet (community channel).\n\n` +
-      `Bind it by running:\n` +
+      `This chat isn't connected to a Letta agent yet.\n\n` +
+      `Connect it by running this on the machine running your listener:\n\n` +
       `letta channels route add --channel ${channelId} --chat-id ${chatId} --agent <agent-id>\n\n` +
-      `Or paste a route into ~/.letta/channels/${channelId}/routing.yaml.`
+      `Find your agent id with \`letta agents list\`.`
     );
   }
   return (

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -35,7 +35,11 @@ import {
   removePendingControlRequest as removePersistedPendingControlRequest,
   upsertPendingControlRequest as upsertPersistedPendingControlRequest,
 } from "./pendingControlRequests";
-import { getChannelDisplayName, loadChannelPlugin } from "./pluginRegistry";
+import {
+  getChannelDisplayName,
+  isFirstPartyChannelPlugin,
+  loadChannelPlugin,
+} from "./pluginRegistry";
 import {
   addRoute,
   getRoute as getRouteFromStore,
@@ -68,8 +72,31 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
-function buildPairingInstructions(channelId: string, code: string): string {
+function isCommunityChannel(channelId: string): boolean {
+  // First-party channels (telegram, slack, discord) have UI in the desktop
+  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
+  // so the user-facing copy needs to point to CLI commands instead.
+  try {
+    return !isFirstPartyChannelPlugin(channelId);
+  } catch {
+    return false;
+  }
+}
+
+export function buildPairingInstructions(
+  channelId: string,
+  code: string,
+): string {
   const displayName = channelDisplayName(channelId);
+  if (isCommunityChannel(channelId)) {
+    return (
+      `This chat isn't bound to a Letta Code agent yet (community channel).\n\n` +
+      `Pairing code: ${code}\n\n` +
+      `Approve this pairing by running:\n` +
+      `letta channels pair approve --channel ${channelId} --code ${code}\n\n` +
+      `This code expires in 15 minutes.`
+    );
+  }
   return (
     `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
     `Pairing code: ${code}\n\n` +
@@ -77,11 +104,19 @@ function buildPairingInstructions(channelId: string, code: string): string {
   );
 }
 
-function buildUnboundRouteInstructions(
+export function buildUnboundRouteInstructions(
   channelId: string,
   chatId: string,
 ): string {
   const displayName = channelDisplayName(channelId);
+  if (isCommunityChannel(channelId)) {
+    return (
+      `This chat isn't bound to a Letta Code agent yet (community channel).\n\n` +
+      `Bind it by running:\n` +
+      `letta channels route add --channel ${channelId} --chat-id ${chatId} --agent <agent-id>\n\n` +
+      `Or paste a route into ~/.letta/channels/${channelId}/routing.yaml.`
+    );
+  }
   return (
     `This chat isn't bound to a Letta Code agent yet.\n\n` +
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -36,12 +36,14 @@ describe("registry copy: community channels", () => {
 
   test("pairing instructions surface the CLI command for community channels", () => {
     const text = buildPairingInstructions("whatsapp", "ABC123");
-    expect(text).toContain("(community channel)");
-    expect(text).toContain("Pairing code: ABC123");
+    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain("Pairing code: ABC123 (expires in 15 minutes)");
+    expect(text).toContain("on the machine running your listener");
     expect(text).toContain(
       "letta channels pair approve --channel whatsapp --code ABC123",
     );
     expect(text).not.toContain("open Channels >");
+    expect(text).not.toContain("(community channel)");
   });
 
   test("unbound route instructions surface the CLI command for community channels", () => {
@@ -49,26 +51,30 @@ describe("registry copy: community channels", () => {
       "whatsapp",
       "15551234567@s.whatsapp.net",
     );
-    expect(text).toContain("(community channel)");
+    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain("on the machine running your listener");
     expect(text).toContain(
       "letta channels route add --channel whatsapp --chat-id 15551234567@s.whatsapp.net --agent <agent-id>",
     );
-    expect(text).toContain("~/.letta/channels/whatsapp/routing.yaml");
+    expect(text).toContain("`letta agents list`");
     expect(text).not.toContain("Open Channels >");
+    expect(text).not.toContain("(community channel)");
+    expect(text).not.toContain("paste a route");
+    expect(text).not.toContain("routing.yaml");
   });
 
   test("any non-first-party channel id triggers community copy", () => {
     const text = buildPairingInstructions("imessage", "QQQ");
-    expect(text).toContain("(community channel)");
+    expect(text).toContain("isn't connected to a Letta agent yet");
     expect(text).toContain(
       "letta channels pair approve --channel imessage --code QQQ",
     );
   });
 
-  test("community unbound copy embeds the channel id in both the CLI hint and the path", () => {
+  test("community unbound copy embeds the channel id and chat id in the CLI command", () => {
     const text = buildUnboundRouteInstructions("signal", "+15551234567");
     expect(text).toContain("--channel signal");
     expect(text).toContain("--chat-id +15551234567");
-    expect(text).toContain("~/.letta/channels/signal/routing.yaml");
+    expect(text).toContain("--agent <agent-id>");
   });
 });

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+const { buildPairingInstructions, buildUnboundRouteInstructions } =
+  await import("../../channels/registry");
+
+describe("registry copy: first-party channels", () => {
+  test("pairing instructions point at the desktop UI for telegram", () => {
+    const text = buildPairingInstructions("telegram", "ABC123");
+    expect(text).toContain("open Channels >");
+    expect(text).toContain("Telegram");
+    expect(text).toContain("Pairing code: ABC123");
+    expect(text).not.toContain("letta channels pair approve");
+    expect(text).not.toContain("(community channel)");
+  });
+
+  test("unbound route instructions point at the desktop UI for slack", () => {
+    const text = buildUnboundRouteInstructions("slack", "C123ABC");
+    expect(text).toContain("Open Channels >");
+    expect(text).toContain("Slack");
+    expect(text).toContain("Chat ID: C123ABC");
+    expect(text).not.toContain("letta channels route add");
+    expect(text).not.toContain("(community channel)");
+  });
+
+  test("first-party discord pairing keeps the desktop wording", () => {
+    const text = buildPairingInstructions("discord", "XYZ789");
+    expect(text).toContain("open Channels >");
+    expect(text).toContain("Discord");
+  });
+});
+
+describe("registry copy: community channels", () => {
+  // Any channel id that isn't telegram/slack/discord is a community plugin.
+  // We don't need a real plugin installed — `isFirstPartyChannelPlugin` only
+  // checks the FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS map.
+
+  test("pairing instructions surface the CLI command for community channels", () => {
+    const text = buildPairingInstructions("whatsapp", "ABC123");
+    expect(text).toContain("(community channel)");
+    expect(text).toContain("Pairing code: ABC123");
+    expect(text).toContain(
+      "letta channels pair approve --channel whatsapp --code ABC123",
+    );
+    expect(text).not.toContain("open Channels >");
+  });
+
+  test("unbound route instructions surface the CLI command for community channels", () => {
+    const text = buildUnboundRouteInstructions(
+      "whatsapp",
+      "15551234567@s.whatsapp.net",
+    );
+    expect(text).toContain("(community channel)");
+    expect(text).toContain(
+      "letta channels route add --channel whatsapp --chat-id 15551234567@s.whatsapp.net --agent <agent-id>",
+    );
+    expect(text).toContain("~/.letta/channels/whatsapp/routing.yaml");
+    expect(text).not.toContain("Open Channels >");
+  });
+
+  test("any non-first-party channel id triggers community copy", () => {
+    const text = buildPairingInstructions("imessage", "QQQ");
+    expect(text).toContain("(community channel)");
+    expect(text).toContain(
+      "letta channels pair approve --channel imessage --code QQQ",
+    );
+  });
+
+  test("community unbound copy embeds the channel id in both the CLI hint and the path", () => {
+    const text = buildUnboundRouteInstructions("signal", "+15551234567");
+    expect(text).toContain("--channel signal");
+    expect(text).toContain("--chat-id +15551234567");
+    expect(text).toContain("~/.letta/channels/signal/routing.yaml");
+  });
+});


### PR DESCRIPTION
## Summary

Stacks on top of #2021. The unbound-route and pairing replies in `registry.ts` hardcode "Open Channels > X in Letta Code" for every channel, which is fine for first-party plugins (telegram, slack, discord) but wrong for community plugins installed under `~/.letta/channels/<id>/` — those have no desktop UI panel, so the user gets stuck on copy that points at a screen that doesn't exist.

This branches the copy on `isFirstPartyChannelPlugin(channelId)`:

- **First-party**: keep the existing "Open Channels > X" wording, no behavior change.
- **Community**: emit the actual CLI commands the user can copy/paste:
  - `letta channels pair approve --channel <id> --code <code>`
  - `letta channels route add --channel <id> --chat-id <id> --agent <agent-id>`
  - Plus a fallback to `~/.letta/channels/<id>/routing.yaml`.

Found while testing a WhatsApp community plugin (`letta-ai/letta-channel-whatsapp`) against #2021. The unbound dialog used to send the user to a desktop panel that doesn't exist for community channels.

## Future direction

A cleaner shape would be a plugin-level hook on the channel plugin contract — `plugin.unboundCopy(chatId)` and `plugin.pairingCopy(code)` — so plugins fully own their first-contact UX without `registry.ts` having to special-case anything. Happy to follow up with that if you'd prefer it over the predicate branch.

"The medium is the message."

Written by Cameron ◯ Letta Code