### PR TITLE
fix(channels): correct broken pairing CLI in #2026 + tighten copy

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -72,32 +72,25 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
-function isCommunityChannel(channelId: string): boolean {
-  // First-party channels (telegram, slack, discord) have UI in the desktop
-  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
-  // so the user-facing copy needs to point to CLI commands instead.
-  try {
-    return !isFirstPartyChannelPlugin(channelId);
-  } catch {
-    return false;
-  }
-}
-
 export function buildPairingInstructions(
   channelId: string,
   code: string,
 ): string {
+  // First-party channels (telegram, slack, discord) have UI in the desktop
+  // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
+  // so the user-facing copy needs to point at CLI commands instead.
   const displayName = channelDisplayName(channelId);
-  if (isCommunityChannel(channelId)) {
+  if (!isFirstPartyChannelPlugin(channelId)) {
     return (
       `This chat isn't connected to a Letta agent yet.\n\n` +
       `Pairing code: ${code} (expires in 15 minutes)\n\n` +
-      `Approve this pairing by running this on the machine running your listener:\n\n` +
-      `letta channels pair approve --channel ${channelId} --code ${code}`
+      `On the machine where your listener runs:\n\n` +
+      `letta channels pair --channel ${channelId} --code ${code} --agent <agent-id>\n\n` +
+      `Find your agent id with letta agents list.`
     );
   }
   return (
-    `To connect this chat to a Letta Code agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
+    `To connect this chat to a Letta agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
     `Pairing code: ${code}\n\n` +
     `This code expires in 15 minutes.`
   );
@@ -108,16 +101,16 @@ export function buildUnboundRouteInstructions(
   chatId: string,
 ): string {
   const displayName = channelDisplayName(channelId);
-  if (isCommunityChannel(channelId)) {
+  if (!isFirstPartyChannelPlugin(channelId)) {
     return (
       `This chat isn't connected to a Letta agent yet.\n\n` +
-      `Connect it by running this on the machine running your listener:\n\n` +
+      `On the machine where your listener runs:\n\n` +
       `letta channels route add --channel ${channelId} --chat-id ${chatId} --agent <agent-id>\n\n` +
-      `Find your agent id with \`letta agents list\`.`
+      `Find your agent id with letta agents list.`
     );
   }
   return (
-    `This chat isn't bound to a Letta Code agent yet.\n\n` +
+    `This chat isn't connected to a Letta agent yet.\n\n` +
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +
     `Chat ID: ${chatId}`
   );

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -9,7 +9,7 @@ describe("registry copy: first-party channels", () => {
     expect(text).toContain("open Channels >");
     expect(text).toContain("Telegram");
     expect(text).toContain("Pairing code: ABC123");
-    expect(text).not.toContain("letta channels pair approve");
+    expect(text).not.toContain("letta channels pair");
     expect(text).not.toContain("(community channel)");
   });
 
@@ -27,6 +27,16 @@ describe("registry copy: first-party channels", () => {
     expect(text).toContain("open Channels >");
     expect(text).toContain("Discord");
   });
+
+  test("first-party copy uses 'Letta agent' consistently", () => {
+    expect(buildPairingInstructions("telegram", "X")).toContain("Letta agent");
+    expect(buildUnboundRouteInstructions("slack", "Y")).toContain(
+      "Letta agent",
+    );
+    expect(buildPairingInstructions("telegram", "X")).not.toContain(
+      "Letta Code agent",
+    );
+  });
 });
 
 describe("registry copy: community channels", () => {
@@ -38,12 +48,15 @@ describe("registry copy: community channels", () => {
     const text = buildPairingInstructions("whatsapp", "ABC123");
     expect(text).toContain("isn't connected to a Letta agent yet");
     expect(text).toContain("Pairing code: ABC123 (expires in 15 minutes)");
-    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain("On the machine where your listener runs");
     expect(text).toContain(
-      "letta channels pair approve --channel whatsapp --code ABC123",
+      "letta channels pair --channel whatsapp --code ABC123 --agent <agent-id>",
     );
+    expect(text).toContain("Find your agent id with letta agents list.");
     expect(text).not.toContain("open Channels >");
     expect(text).not.toContain("(community channel)");
+    // Hard-stop against shipping the wrong subcommand again.
+    expect(text).not.toContain("letta channels pair approve");
   });
 
   test("unbound route instructions surface the CLI command for community channels", () => {
@@ -52,11 +65,11 @@ describe("registry copy: community channels", () => {
       "15551234567@s.whatsapp.net",
     );
     expect(text).toContain("isn't connected to a Letta agent yet");
-    expect(text).toContain("on the machine running your listener");
+    expect(text).toContain("On the machine where your listener runs");
     expect(text).toContain(
       "letta channels route add --channel whatsapp --chat-id 15551234567@s.whatsapp.net --agent <agent-id>",
     );
-    expect(text).toContain("`letta agents list`");
+    expect(text).toContain("Find your agent id with letta agents list.");
     expect(text).not.toContain("Open Channels >");
     expect(text).not.toContain("(community channel)");
     expect(text).not.toContain("paste a route");
@@ -67,7 +80,7 @@ describe("registry copy: community channels", () => {
     const text = buildPairingInstructions("imessage", "QQQ");
     expect(text).toContain("isn't connected to a Letta agent yet");
     expect(text).toContain(
-      "letta channels pair approve --channel imessage --code QQQ",
+      "letta channels pair --channel imessage --code QQQ --agent <agent-id>",
     );
   });
 
@@ -76,5 +89,14 @@ describe("registry copy: community channels", () => {
     expect(text).toContain("--channel signal");
     expect(text).toContain("--chat-id +15551234567");
     expect(text).toContain("--agent <agent-id>");
+  });
+
+  test("community pairing copy points at a real subcommand", () => {
+    // The actual handler in src/cli/subcommands/channels.ts is `letta channels
+    // pair` (no `approve` subcommand). If someone introduces an `approve`
+    // subcommand, this test should be updated together with the copy.
+    const text = buildPairingInstructions("whatsapp", "X");
+    expect(text).toMatch(/letta channels pair --channel whatsapp /);
+    expect(text).not.toMatch(/letta channels pair approve/);
   });
 });


### PR DESCRIPTION
Follow-up to #2026 (already merged). Self-review caught real issues that needed fixing:

## What was wrong in #2026

1. **Broken pairing command.** Copy referenced `letta channels pair approve --channel <id> --code <code>`. There is no `approve` subcommand. Verified against `src/cli/subcommands/channels.ts:606`:
   ```
   case "pair":
     return await handlePair(values);
   default:
     console.error(`Unknown channels action: "${action}". Use: install, configure, status, route, bind, pair`);
   ```
   Pasting the command produced `Unknown channels action: "approve"`.

2. **Missing `--agent` in pairing command.** `handlePair` requires `--agent`:
   ```
   if (!agentId) {
     console.error("Error: --agent is required (or set LETTA_AGENT_ID env var).");
     return 1;
   }
   ```
   Even after fixing #1, the command would fail without `--agent`.

3. **Product name drift.** `buildPairingInstructions` first-party branch said "Letta Code agent", `buildSlackAppSetupInstructions` said "Letta agent", new community copy said "Letta agent". Three different names for the same thing.

4. **Dead-code-defensive wrapper.** `isCommunityChannel` wrapped `isFirstPartyChannelPlugin` in `try/catch`, but `isFirstPartyChannelPlugin` is just `Object.hasOwn(...)` — it never throws.

5. **Awkward repetition.** "Approve this pairing by running this on the machine running your listener" — "running... running" in the same sentence.

## What this PR does

- Fix the pairing command to `letta channels pair --channel <id> --code <code> --agent <agent-id>` (real subcommand, all required flags).
- Add `Find your agent id with letta agents list` hint to the pairing copy too (was unbound-only).
- Inline `!isFirstPartyChannelPlugin(channelId)` at the two call sites; drop the wrapper.
- Unify on "Letta agent" everywhere. "Letta Code" stays only where it refers to the desktop app surface ("open Channels > X in Letta Code").
- Reword "running this on the machine running your listener" → "On the machine where your listener runs:".
- Bump tests from 7 to 9, including a regression test that hard-fails if anyone reintroduces `letta channels pair approve`.

## Final rendered copy

**Community pairing:**
```
This chat isn't connected to a Letta agent yet.

Pairing code: ABC123 (expires in 15 minutes)

On the machine where your listener runs:

letta channels pair --channel whatsapp --code ABC123 --agent <agent-id>

Find your agent id with letta agents list.
```

**Community unbound:**
```
This chat isn't connected to a Letta agent yet.

On the machine where your listener runs:

letta channels route add --channel whatsapp --chat-id <id> --agent <agent-id>

Find your agent id with letta agents list.
```

**First-party (telegram pairing) — unchanged structure, name unified:**
```
To connect this chat to a Letta agent, open Channels > Telegram in Letta Code and finish connecting this chat there.

Pairing code: ABC123

This code expires in 15 minutes.
```

## Verification

- `bun test src/tests/channels/registry-community-copy.test.ts` → 9/9 pass.
- `bun run typecheck` → clean.
- `bun run lint` → clean.

"The medium is the message."

Written by Cameron ◯ Letta Code