### PR TITLE
feat(ws): write + sync memory file command

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -752,6 +752,34 @@ export interface MemoryFileAtRefCommand {
   ref: string;
 }
 
+/**
+ * Write a file into the agent's MemFS (memory git repo) and commit + push.
+ *
+ * Use for durable agent memory writes (e.g. profile images, blocks). Path is
+ * relative to the memory root and is rejected if it escapes the root.
+ *
+ * Differs from generic `write_file`:
+ *  - resolves path against `getMemoryFilesystemRoot(agent_id)` (no absolute paths)
+ *  - bypasses Edit/Write tools so binary bytes aren't CRLF-mangled
+ *  - performs `git add` + commit + push via `commitAndSyncMemoryWrite`
+ *  - emits `memory_updated` so the UI auto-refreshes
+ */
+export interface WriteMemoryFileCommand {
+  type: "write_memory_file";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** The agent whose memory to write to. */
+  agent_id: string;
+  /** Relative path within the memory directory (e.g. "profile.png"). */
+  path: string;
+  /** Content to write — utf8 string or base64-encoded bytes. */
+  content: string;
+  /** Encoding of `content`. Defaults to "utf8". */
+  encoding?: "utf8" | "base64";
+  /** Optional commit message; defaults to a sensible fallback. */
+  commit_message?: string;
+}
+
 export interface MemoryCommitDiffCommand {
   type: "memory_commit_diff";
   /** Echoed back in the response for request correlation. */
@@ -1514,6 +1542,7 @@ export type WsProtocolCommand =
   | MemoryHistoryCommand
   | MemoryFileAtRefCommand
   | MemoryCommitDiffCommand
+  | WriteMemoryFileCommand
   | EnableMemfsCommand
   | ListModelsCommand
   | UpdateModelCommand

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -753,16 +753,10 @@ export interface MemoryFileAtRefCommand {
 }
 
 /**
- * Write a file into the agent's MemFS (memory git repo) and commit + push.
+ * Write a file into the agent's MemFS and commit + push.
  *
- * Use for durable agent memory writes (e.g. profile images, blocks). Path is
+ * Use for agent memory writes (e.g. profile images). Path is
  * relative to the memory root and is rejected if it escapes the root.
- *
- * Differs from generic `write_file`:
- *  - resolves path against `getMemoryFilesystemRoot(agent_id)` (no absolute paths)
- *  - bypasses Edit/Write tools so binary bytes aren't CRLF-mangled
- *  - performs `git add` + commit + push via `commitAndSyncMemoryWrite`
- *  - emits `memory_updated` so the UI auto-refreshes
  */
 export interface WriteMemoryFileCommand {
   type: "write_memory_file";

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -752,6 +752,19 @@ export interface MemoryFileAtRefCommand {
   ref: string;
 }
 
+/** Read a file from the agent's MemFS working tree. Use base64 for binary. */
+export interface ReadMemoryFileCommand {
+  type: "read_memory_file";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** The agent whose memory to read. */
+  agent_id: string;
+  /** Relative to the memory root. */
+  path: string;
+  /** Defaults to "utf8". */
+  encoding?: "utf8" | "base64";
+}
+
 /**
  * Write a file into the agent's MemFS and commit + push.
  *
@@ -1536,6 +1549,7 @@ export type WsProtocolCommand =
   | MemoryHistoryCommand
   | MemoryFileAtRefCommand
   | MemoryCommitDiffCommand
+  | ReadMemoryFileCommand
   | WriteMemoryFileCommand
   | EnableMemfsCommand
   | ListModelsCommand

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -229,6 +229,7 @@ import {
   isUpdateToolsetCommand,
   isWatchFileCommand,
   isWriteFileCommand,
+  isWriteMemoryFileCommand,
   parseServerMessage,
 } from "./protocol-inbound";
 import {
@@ -5842,6 +5843,171 @@ async function connectWithRetry(
               },
               "listener_memory_commit_diff_send_failed",
               "listener_memory_commit_diff",
+            );
+          }
+        });
+        return;
+      }
+
+      // ── Write a file into MemFS (durable agent memory write + commit + push) ─
+      if (isWriteMemoryFileCommand(parsed)) {
+        runDetachedListenerTask("write_memory_file", async () => {
+          const encoding = parsed.encoding ?? "utf8";
+          const sendFailure = (error: string): void => {
+            safeSocketSend(
+              socket,
+              {
+                type: "write_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: parsed.path,
+                success: false,
+                error,
+              },
+              "listener_write_memory_file_send_failed",
+              "listener_write_memory_file",
+            );
+          };
+
+          try {
+            const {
+              getMemoryFilesystemRoot,
+              ensureLocalMemfsCheckout,
+              isMemfsEnabledOnServer,
+            } = await import("../../agent/memoryFilesystem");
+            const { commitAndSyncMemoryWrite } = await import(
+              "../../agent/memoryGit"
+            );
+            const { writeFile, mkdir } = await import("node:fs/promises");
+            const { existsSync } = await import("node:fs");
+            const { dirname, isAbsolute, join, normalize, relative, sep } =
+              await import("node:path");
+
+            // ── Validate relative path ─────────────────────────────────────
+            if (isAbsolute(parsed.path) || parsed.path.length === 0) {
+              sendFailure(
+                "write_memory_file: path must be a non-empty relative path",
+              );
+              return;
+            }
+            const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
+            const absolutePath = normalize(join(memoryRoot, parsed.path));
+            const rel = relative(memoryRoot, absolutePath);
+            if (
+              rel.startsWith("..") ||
+              rel === "" ||
+              isAbsolute(rel) ||
+              rel.split(sep).includes("..")
+            ) {
+              sendFailure(
+                "write_memory_file: path must resolve inside the memory root",
+              );
+              return;
+            }
+
+            // ── Ensure MemFS is enabled and checked out ───────────────────
+            if (!existsSync(join(memoryRoot, ".git"))) {
+              const enabled = await isMemfsEnabledOnServer(parsed.agent_id);
+              if (!enabled) {
+                sendFailure(
+                  "write_memory_file: memfs is not enabled for this agent",
+                );
+                return;
+              }
+              await ensureLocalMemfsCheckout(parsed.agent_id);
+              if (!existsSync(join(memoryRoot, ".git"))) {
+                sendFailure(
+                  "write_memory_file: failed to initialize local memory checkout",
+                );
+                return;
+              }
+            }
+
+            // ── Decode + write bytes (binary-safe for base64) ──────────────
+            const buffer =
+              encoding === "base64"
+                ? Buffer.from(parsed.content, "base64")
+                : Buffer.from(parsed.content, "utf-8");
+            await mkdir(dirname(absolutePath), { recursive: true });
+            await writeFile(absolutePath, buffer);
+
+            // ── Resolve agent identity for the commit author ───────────────
+            let agentName = parsed.agent_id;
+            try {
+              const { getClient } = await import("../../backend/api/client");
+              const client = await getClient();
+              const agent = await client.agents.retrieve(parsed.agent_id);
+              if (agent.name && agent.name.trim().length > 0) {
+                agentName = agent.name.trim();
+              }
+            } catch {
+              // Best-effort — fall back to agent id as the author name.
+            }
+
+            // ── Commit + push (with replay-on-conflict from helper) ────────
+            // Use posix separators in the pathspec — git expects forward slashes
+            // even on Windows.
+            const pathspec = rel.split(sep).join("/");
+            const reason =
+              parsed.commit_message?.trim() || `Update memory file ${pathspec}`;
+            const commitResult = await commitAndSyncMemoryWrite({
+              memoryDir: memoryRoot,
+              pathspecs: [pathspec],
+              reason,
+              author: {
+                agentId: parsed.agent_id,
+                authorName: agentName,
+                authorEmail: `${parsed.agent_id}@letta.com`,
+              },
+              replay: async () => {
+                // Re-write the same bytes on top of the latest remote state.
+                await mkdir(dirname(absolutePath), { recursive: true });
+                await writeFile(absolutePath, buffer);
+                return [pathspec];
+              },
+            });
+
+            // ── Notify UI so the memory view auto-refreshes ────────────────
+            if (commitResult.committed) {
+              safeSocketSend(
+                socket,
+                {
+                  type: "memory_updated",
+                  affected_paths: [pathspec],
+                  timestamp: Date.now(),
+                },
+                "listener_write_memory_file_send_failed",
+                "listener_write_memory_file",
+              );
+            }
+
+            safeSocketSend(
+              socket,
+              {
+                type: "write_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: pathspec,
+                success: true,
+                committed: commitResult.committed,
+                ...(commitResult.sha ? { commit_sha: commitResult.sha } : {}),
+              },
+              "listener_write_memory_file_send_failed",
+              "listener_write_memory_file",
+            );
+          } catch (err) {
+            trackListenerError(
+              "listener_write_memory_file_failed",
+              err,
+              "listener_memory_write",
+            );
+            console.error(
+              `[Listen] write_memory_file error: ${err instanceof Error ? err.message : "Unknown error"}`,
+            );
+            sendFailure(
+              err instanceof Error
+                ? err.message
+                : "Failed to write memory file",
             );
           }
         });

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -218,6 +218,7 @@ import {
   isMemoryFileAtRefCommand,
   isMemoryHistoryCommand,
   isReadFileCommand,
+  isReadMemoryFileCommand,
   isSearchBranchesCommand,
   isSearchFilesCommand,
   isSetExperimentCommand,
@@ -5843,6 +5844,110 @@ async function connectWithRetry(
               },
               "listener_memory_commit_diff_send_failed",
               "listener_memory_commit_diff",
+            );
+          }
+        });
+        return;
+      }
+
+      // ── Read a file from the MemFS working tree ───────────────────────
+      if (isReadMemoryFileCommand(parsed)) {
+        runDetachedListenerTask("read_memory_file", async () => {
+          const encoding = parsed.encoding ?? "utf8";
+          const sendFailure = (error: string): void => {
+            safeSocketSend(
+              socket,
+              {
+                type: "read_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: parsed.path,
+                content: null,
+                encoding,
+                success: false,
+                error,
+              },
+              "listener_read_memory_file_send_failed",
+              "listener_read_memory_file",
+            );
+          };
+
+          try {
+            const {
+              getMemoryFilesystemRoot,
+              ensureLocalMemfsCheckout,
+              isMemfsEnabledOnServer,
+            } = await import("../../agent/memoryFilesystem");
+            const { readFile } = await import("node:fs/promises");
+            const { existsSync } = await import("node:fs");
+            const { isAbsolute, join, normalize, relative, sep } = await import(
+              "node:path"
+            );
+
+            // Reject absolute paths or escapes outside memory root.
+            if (isAbsolute(parsed.path) || parsed.path.length === 0) {
+              sendFailure("path must be a non-empty relative path");
+              return;
+            }
+            const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
+            const absolutePath = normalize(join(memoryRoot, parsed.path));
+            const rel = relative(memoryRoot, absolutePath);
+            if (
+              rel.startsWith("..") ||
+              rel === "" ||
+              isAbsolute(rel) ||
+              rel.split(sep).includes("..")
+            ) {
+              sendFailure("path must resolve inside the memory root");
+              return;
+            }
+
+            // Clone memfs on first read if it isn't local yet.
+            if (!existsSync(join(memoryRoot, ".git"))) {
+              const enabled = await isMemfsEnabledOnServer(parsed.agent_id);
+              if (!enabled) {
+                sendFailure("memfs is not enabled for this agent");
+                return;
+              }
+              await ensureLocalMemfsCheckout(parsed.agent_id);
+              if (!existsSync(join(memoryRoot, ".git"))) {
+                sendFailure("failed to initialize local memory checkout");
+                return;
+              }
+            }
+
+            const buffer = await readFile(absolutePath);
+            const content =
+              encoding === "base64"
+                ? buffer.toString("base64")
+                : buffer.toString("utf-8");
+            const pathspec = rel.split(sep).join("/");
+
+            safeSocketSend(
+              socket,
+              {
+                type: "read_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: pathspec,
+                content,
+                encoding,
+                success: true,
+              },
+              "listener_read_memory_file_send_failed",
+              "listener_read_memory_file",
+            );
+          } catch (err) {
+            trackListenerError(
+              "listener_read_memory_file_failed",
+              err,
+              "listener_memory_read",
+            );
+            console.error(
+              `[Listen] read_memory_file error: ${err instanceof Error ? err.message : "Unknown error"}`,
+            );
+            sendFailure(
+              err instanceof Error ? err.message : "Failed to read memory file",
             );
           }
         });

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -63,6 +63,7 @@ import type {
   UpdateToolsetCommand,
   WatchFileCommand,
   WriteFileCommand,
+  WriteMemoryFileCommand,
   WsProtocolCommand,
 } from "../../types/protocol_v2";
 import { isValidApprovalResponseBody } from "./approval";
@@ -533,6 +534,32 @@ export function isMemoryFileAtRefCommand(
     typeof c.agent_id === "string" &&
     typeof c.file_path === "string" &&
     typeof c.ref === "string"
+  );
+}
+
+export function isWriteMemoryFileCommand(
+  value: unknown,
+): value is WriteMemoryFileCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+    path?: unknown;
+    content?: unknown;
+    encoding?: unknown;
+    commit_message?: unknown;
+  };
+  return (
+    c.type === "write_memory_file" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string" &&
+    typeof c.path === "string" &&
+    typeof c.content === "string" &&
+    (c.encoding === undefined ||
+      c.encoding === "utf8" ||
+      c.encoding === "base64") &&
+    (c.commit_message === undefined || typeof c.commit_message === "string")
   );
 }
 
@@ -1412,6 +1439,7 @@ export function parseServerMessage(
       isMemoryHistoryCommand(parsed) ||
       isMemoryFileAtRefCommand(parsed) ||
       isMemoryCommitDiffCommand(parsed) ||
+      isWriteMemoryFileCommand(parsed) ||
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||
       isUpdateModelCommand(parsed) ||

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -46,6 +46,7 @@ import type {
   MemoryFileAtRefCommand,
   MemoryHistoryCommand,
   ReadFileCommand,
+  ReadMemoryFileCommand,
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
@@ -534,6 +535,28 @@ export function isMemoryFileAtRefCommand(
     typeof c.agent_id === "string" &&
     typeof c.file_path === "string" &&
     typeof c.ref === "string"
+  );
+}
+
+export function isReadMemoryFileCommand(
+  value: unknown,
+): value is ReadMemoryFileCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+    path?: unknown;
+    encoding?: unknown;
+  };
+  return (
+    c.type === "read_memory_file" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string" &&
+    typeof c.path === "string" &&
+    (c.encoding === undefined ||
+      c.encoding === "utf8" ||
+      c.encoding === "base64")
   );
 }
 
@@ -1439,6 +1462,7 @@ export function parseServerMessage(
       isMemoryHistoryCommand(parsed) ||
       isMemoryFileAtRefCommand(parsed) ||
       isMemoryCommitDiffCommand(parsed) ||
+      isReadMemoryFileCommand(parsed) ||
       isWriteMemoryFileCommand(parsed) ||
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||


### PR DESCRIPTION
## Summary

Adds a new device WS command that lets the UI write a file into an agent's MemFS (write and commit + push). 

This is specifically introduced for profile image upload — but works for any binary or text file the UI needs to persist into agent memory.