### PR TITLE
feat(ws): read memory file command

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -752,6 +752,19 @@ export interface MemoryFileAtRefCommand {
   ref: string;
 }
 
+/** Read a file from the agent's MemFS working tree. Use base64 for binary. */
+export interface ReadMemoryFileCommand {
+  type: "read_memory_file";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** The agent whose memory to read. */
+  agent_id: string;
+  /** Relative to the memory root. */
+  path: string;
+  /** Defaults to "utf8". */
+  encoding?: "utf8" | "base64";
+}
+
 /**
  * Write a file into the agent's MemFS and commit + push.
  *
@@ -1536,6 +1549,7 @@ export type WsProtocolCommand =
   | MemoryHistoryCommand
   | MemoryFileAtRefCommand
   | MemoryCommitDiffCommand
+  | ReadMemoryFileCommand
   | WriteMemoryFileCommand
   | EnableMemfsCommand
   | ListModelsCommand

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -218,6 +218,7 @@ import {
   isMemoryFileAtRefCommand,
   isMemoryHistoryCommand,
   isReadFileCommand,
+  isReadMemoryFileCommand,
   isSearchBranchesCommand,
   isSearchFilesCommand,
   isSetExperimentCommand,
@@ -5843,6 +5844,110 @@ async function connectWithRetry(
               },
               "listener_memory_commit_diff_send_failed",
               "listener_memory_commit_diff",
+            );
+          }
+        });
+        return;
+      }
+
+      // ── Read a file from the MemFS working tree ───────────────────────
+      if (isReadMemoryFileCommand(parsed)) {
+        runDetachedListenerTask("read_memory_file", async () => {
+          const encoding = parsed.encoding ?? "utf8";
+          const sendFailure = (error: string): void => {
+            safeSocketSend(
+              socket,
+              {
+                type: "read_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: parsed.path,
+                content: null,
+                encoding,
+                success: false,
+                error,
+              },
+              "listener_read_memory_file_send_failed",
+              "listener_read_memory_file",
+            );
+          };
+
+          try {
+            const {
+              getMemoryFilesystemRoot,
+              ensureLocalMemfsCheckout,
+              isMemfsEnabledOnServer,
+            } = await import("../../agent/memoryFilesystem");
+            const { readFile } = await import("node:fs/promises");
+            const { existsSync } = await import("node:fs");
+            const { isAbsolute, join, normalize, relative, sep } = await import(
+              "node:path"
+            );
+
+            // Reject absolute paths or escapes outside memory root.
+            if (isAbsolute(parsed.path) || parsed.path.length === 0) {
+              sendFailure("path must be a non-empty relative path");
+              return;
+            }
+            const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
+            const absolutePath = normalize(join(memoryRoot, parsed.path));
+            const rel = relative(memoryRoot, absolutePath);
+            if (
+              rel.startsWith("..") ||
+              rel === "" ||
+              isAbsolute(rel) ||
+              rel.split(sep).includes("..")
+            ) {
+              sendFailure("path must resolve inside the memory root");
+              return;
+            }
+
+            // Clone memfs on first read if it isn't local yet.
+            if (!existsSync(join(memoryRoot, ".git"))) {
+              const enabled = await isMemfsEnabledOnServer(parsed.agent_id);
+              if (!enabled) {
+                sendFailure("memfs is not enabled for this agent");
+                return;
+              }
+              await ensureLocalMemfsCheckout(parsed.agent_id);
+              if (!existsSync(join(memoryRoot, ".git"))) {
+                sendFailure("failed to initialize local memory checkout");
+                return;
+              }
+            }
+
+            const buffer = await readFile(absolutePath);
+            const content =
+              encoding === "base64"
+                ? buffer.toString("base64")
+                : buffer.toString("utf-8");
+            const pathspec = rel.split(sep).join("/");
+
+            safeSocketSend(
+              socket,
+              {
+                type: "read_memory_file_response",
+                request_id: parsed.request_id,
+                agent_id: parsed.agent_id,
+                path: pathspec,
+                content,
+                encoding,
+                success: true,
+              },
+              "listener_read_memory_file_send_failed",
+              "listener_read_memory_file",
+            );
+          } catch (err) {
+            trackListenerError(
+              "listener_read_memory_file_failed",
+              err,
+              "listener_memory_read",
+            );
+            console.error(
+              `[Listen] read_memory_file error: ${err instanceof Error ? err.message : "Unknown error"}`,
+            );
+            sendFailure(
+              err instanceof Error ? err.message : "Failed to read memory file",
             );
           }
         });

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -46,6 +46,7 @@ import type {
   MemoryFileAtRefCommand,
   MemoryHistoryCommand,
   ReadFileCommand,
+  ReadMemoryFileCommand,
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
@@ -534,6 +535,28 @@ export function isMemoryFileAtRefCommand(
     typeof c.agent_id === "string" &&
     typeof c.file_path === "string" &&
     typeof c.ref === "string"
+  );
+}
+
+export function isReadMemoryFileCommand(
+  value: unknown,
+): value is ReadMemoryFileCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+    path?: unknown;
+    encoding?: unknown;
+  };
+  return (
+    c.type === "read_memory_file" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string" &&
+    typeof c.path === "string" &&
+    (c.encoding === undefined ||
+      c.encoding === "utf8" ||
+      c.encoding === "base64")
   );
 }
 
@@ -1439,6 +1462,7 @@ export function parseServerMessage(
       isMemoryHistoryCommand(parsed) ||
       isMemoryFileAtRefCommand(parsed) ||
       isMemoryCommitDiffCommand(parsed) ||
+      isReadMemoryFileCommand(parsed) ||
       isWriteMemoryFileCommand(parsed) ||
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||


### PR DESCRIPTION
## Summary
Reads a file from the agent's MemFS working tree, with utf8 or base64 encoding (e.g. rendering profile images).

Different from `memory_file_at_ref`, which is for historical content like specific git commits not what's currently on disk

## Related PRs
https://github.com/letta-ai/letta-code/pull/2030