### PR TITLE
refactor(api): add API backend facade

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -6,7 +6,7 @@
  * helper (`fetchRunErrorDetail`) that requires network access.
  */
 
-import { getClient } from "../backend/api/client";
+import { getBackend } from "../backend";
 
 export interface RunErrorInfo {
   error_type?: string;
@@ -72,8 +72,7 @@ export async function fetchRunErrorInfo(
 ): Promise<RunErrorInfo | null> {
   if (!runId) return null;
   try {
-    const client = await getClient();
-    const run = await client.runs.retrieve(runId);
+    const run = await getBackend().retrieveRun(runId);
     const metaError = run.metadata?.error as RunErrorMetadata;
     const nestedError = metaError?.error;
     const errorInfo: RunErrorInfo = {

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -9,7 +9,7 @@ import type {
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
-import { getClient } from "../backend/api/client";
+import { getBackend } from "../backend";
 import {
   type ClientTool,
   type PermissionModeState,
@@ -136,7 +136,7 @@ export async function sendMessageStream(
 ): Promise<Stream<LettaStreamingResponse>> {
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;
   const requestStartedAtMs = Date.now();
-  const client = await getClient();
+  const backend = getBackend();
   const normalizedMessages = await normalizeMessageImageParts(messages);
   assertSupportedBase64ImageMediaTypes(normalizedMessages);
 
@@ -235,7 +235,7 @@ export async function sendMessageStream(
   let stream: Stream<LettaStreamingResponse>;
   const abortRelay = createStreamAbortRelay(requestOptions.signal);
   try {
-    stream = await client.conversations.messages.create(
+    stream = await backend.createConversationMessageStream(
       resolvedConversationId,
       requestBody,
       {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,0 +1,122 @@
+import type { getClient } from "./api/client";
+import { getClient as getApiClient } from "./api/client";
+import {
+  type ForkConversationOptions,
+  forkConversation as forkConversationRequest,
+} from "./api/conversations";
+
+export type APIClient = Awaited<ReturnType<typeof getClient>>;
+
+export type ConversationMessageCreateParams = Parameters<
+  APIClient["conversations"]["messages"]["create"]
+>;
+export type ConversationMessageCreateBody = ConversationMessageCreateParams[1];
+export type ConversationMessageCreateOptions =
+  ConversationMessageCreateParams[2];
+
+export type ConversationMessageStreamParams = Parameters<
+  APIClient["conversations"]["messages"]["stream"]
+>;
+export type ConversationMessageStreamBody = ConversationMessageStreamParams[1];
+export type ConversationMessageStreamOptions =
+  ConversationMessageStreamParams[2];
+
+export type RunMessageStreamParams = Parameters<
+  APIClient["runs"]["messages"]["stream"]
+>;
+export type RunMessageStreamBody = RunMessageStreamParams[1];
+export type RunMessageStreamOptions = RunMessageStreamParams[2];
+
+export interface Backend {
+  createConversationMessageStream(
+    conversationId: string,
+    body: ConversationMessageCreateBody,
+    options?: ConversationMessageCreateOptions,
+  ): Promise<
+    Awaited<ReturnType<APIClient["conversations"]["messages"]["create"]>>
+  >;
+
+  streamConversationMessages(
+    conversationId: string,
+    body: ConversationMessageStreamBody,
+    options?: ConversationMessageStreamOptions,
+  ): Promise<
+    Awaited<ReturnType<APIClient["conversations"]["messages"]["stream"]>>
+  >;
+
+  cancelConversation(
+    conversationIdOrAgentId: string,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["cancel"]>>>;
+
+  retrieveRun(
+    runId: string,
+  ): Promise<Awaited<ReturnType<APIClient["runs"]["retrieve"]>>>;
+
+  streamRunMessages(
+    runId: string,
+    body: RunMessageStreamBody,
+    options?: RunMessageStreamOptions,
+  ): Promise<Awaited<ReturnType<APIClient["runs"]["messages"]["stream"]>>>;
+
+  forkConversation(
+    conversationId: string,
+    options?: ForkConversationOptions,
+  ): ReturnType<typeof forkConversationRequest>;
+}
+
+export class APIBackend implements Backend {
+  private async getClient(): Promise<APIClient> {
+    return getApiClient();
+  }
+
+  async createConversationMessageStream(
+    conversationId: string,
+    body: ConversationMessageCreateBody,
+    options?: ConversationMessageCreateOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.messages.create(conversationId, body, options);
+  }
+
+  async streamConversationMessages(
+    conversationId: string,
+    body: ConversationMessageStreamBody,
+    options?: ConversationMessageStreamOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.messages.stream(conversationId, body, options);
+  }
+
+  async cancelConversation(conversationIdOrAgentId: string) {
+    const client = await this.getClient();
+    return client.conversations.cancel(conversationIdOrAgentId);
+  }
+
+  async retrieveRun(runId: string) {
+    const client = await this.getClient();
+    return client.runs.retrieve(runId);
+  }
+
+  async streamRunMessages(
+    runId: string,
+    body: RunMessageStreamBody,
+    options?: RunMessageStreamOptions,
+  ) {
+    const client = await this.getClient();
+    return client.runs.messages.stream(runId, body, options);
+  }
+
+  forkConversation(conversationId: string, options?: ForkConversationOptions) {
+    return forkConversationRequest(conversationId, options);
+  }
+}
+
+let backend: Backend = new APIBackend();
+
+export function getBackend(): Backend {
+  return backend;
+}
+
+export function __testSetBackend(nextBackend: Backend | null): void {
+  backend = nextBackend ?? new APIBackend();
+}

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,11 +1,12 @@
 import type { getClient } from "./api/client";
-import { getClient as getApiClient } from "./api/client";
-import {
-  type ForkConversationOptions,
+import type {
+  ForkConversationOptions,
   forkConversation as forkConversationRequest,
 } from "./api/conversations";
 
 export type APIClient = Awaited<ReturnType<typeof getClient>>;
+type GetAPIClient = typeof getClient;
+type ForkConversation = typeof forkConversationRequest;
 
 export type ConversationMessageCreateParams = Parameters<
   APIClient["conversations"]["messages"]["create"]
@@ -64,9 +65,26 @@ export interface Backend {
   ): ReturnType<typeof forkConversationRequest>;
 }
 
+interface APIBackendDeps {
+  getClient?: GetAPIClient;
+  forkConversation?: ForkConversation;
+}
+
 export class APIBackend implements Backend {
+  private readonly getApiClientOverride?: GetAPIClient;
+  private readonly forkConversationOverride?: ForkConversation;
+
+  constructor(deps: APIBackendDeps = {}) {
+    this.getApiClientOverride = deps.getClient;
+    this.forkConversationOverride = deps.forkConversation;
+  }
+
   private async getClient(): Promise<APIClient> {
-    return getApiClient();
+    if (this.getApiClientOverride) {
+      return this.getApiClientOverride();
+    }
+    const { getClient: resolveClient } = await import("./api/client");
+    return resolveClient();
   }
 
   async createConversationMessageStream(
@@ -106,8 +124,15 @@ export class APIBackend implements Backend {
     return client.runs.messages.stream(runId, body, options);
   }
 
-  forkConversation(conversationId: string, options?: ForkConversationOptions) {
-    return forkConversationRequest(conversationId, options);
+  async forkConversation(
+    conversationId: string,
+    options?: ForkConversationOptions,
+  ) {
+    if (this.forkConversationOverride) {
+      return this.forkConversationOverride(conversationId, options);
+    }
+    const { forkConversation } = await import("./api/conversations");
+    return forkConversation(conversationId, options);
   }
 }
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,0 +1,1 @@
+export * from "./backend";

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -77,6 +77,7 @@ import {
 import { reconcileExistingAgentState } from "../agent/reconcileExistingAgentState";
 import { recordSessionEnd } from "../agent/sessionHistory";
 import { SessionStats } from "../agent/stats";
+import { type ConversationMessageStreamBody, getBackend } from "../backend";
 import { getAgentContextOverview } from "../backend/api/agents";
 import { getClient, getServerUrl } from "../backend/api/client";
 import { forkConversation } from "../backend/api/conversations";
@@ -885,8 +886,7 @@ async function isRetriableError(
   // underlying cause is a transient LLM/network issue that should be retried
   if (lastRunId) {
     try {
-      const client = await getClient();
-      const run = await client.runs.retrieve(lastRunId);
+      const run = await getBackend().retrieveRun(lastRunId);
       const metaError = run.metadata?.error as
         | {
             error_type?: string;
@@ -4465,7 +4465,7 @@ export default function App({
               // Attempt to resume the in-flight run via the conversation stream endpoint.
               // Server resolves: (1) otid lookup, (2) active run fallback.
               try {
-                const client = await getClient();
+                const backend = getBackend();
                 const messageOtid = currentInput
                   .map((item) => (item as Record<string, unknown>).otid)
                   .find((v): v is string => typeof v === "string");
@@ -4485,7 +4485,7 @@ export default function App({
                 }
 
                 const conversationId = conversationIdRef.current ?? "default";
-                const resumeStream = await client.conversations.messages.stream(
+                const resumeStream = await backend.streamConversationMessages(
                   conversationId,
                   // Cast needed until SDK MessageStreamParams includes otid field
                   {
@@ -4496,9 +4496,7 @@ export default function App({
                     otid: messageOtid ?? undefined,
                     starting_after: 0,
                     batch_size: 1000,
-                  } as unknown as Parameters<
-                    typeof client.conversations.messages.stream
-                  >[1],
+                  } as unknown as ConversationMessageStreamBody,
                 );
 
                 // Only reset buffer state after confirming stream is available
@@ -6166,8 +6164,7 @@ export default function App({
           // Fetch error details from the run if available (server-side errors)
           if (lastRunId) {
             try {
-              const client = await getClient();
-              const run = await client.runs.retrieve(lastRunId);
+              const run = await getBackend().retrieveRun(lastRunId);
 
               // Check if run has error information in metadata
               if (run.metadata?.error) {
@@ -6695,8 +6692,8 @@ export default function App({
       // Send cancel request to backend (fire-and-forget).
       // Without this, the backend stays in requires_approval state after tool interrupt,
       // causing CONFLICT on the next user message.
-      getClient()
-        .then((client) => {
+      Promise.resolve()
+        .then(() => {
           const cancelConversationId =
             conversationIdRef.current === "default"
               ? agentIdRef.current
@@ -6704,7 +6701,7 @@ export default function App({
           if (!cancelConversationId || cancelConversationId === "loading") {
             return;
           }
-          return client.conversations.cancel(cancelConversationId);
+          return getBackend().cancelConversation(cancelConversationId);
         })
         .catch(() => {
           // Silently ignore - cancellation already happened client-side
@@ -6817,8 +6814,8 @@ export default function App({
 
       // Send cancel request to backend asynchronously (fire-and-forget)
       // Don't wait for it or show errors since user already got feedback
-      getClient()
-        .then((client) => {
+      Promise.resolve()
+        .then(() => {
           const cancelConversationId =
             conversationIdRef.current === "default"
               ? agentIdRef.current
@@ -6826,7 +6823,7 @@ export default function App({
           if (!cancelConversationId || cancelConversationId === "loading") {
             return;
           }
-          return client.conversations.cancel(cancelConversationId);
+          return getBackend().cancelConversation(cancelConversationId);
         })
         .catch(() => {
           // Silently ignore - cancellation already happened client-side
@@ -6845,7 +6842,6 @@ export default function App({
     } else {
       setInterruptRequested(true);
       try {
-        const client = await getClient();
         const cancelConversationId =
           conversationIdRef.current === "default"
             ? agentIdRef.current
@@ -6853,7 +6849,7 @@ export default function App({
         if (!cancelConversationId || cancelConversationId === "loading") {
           return;
         }
-        await client.conversations.cancel(cancelConversationId);
+        await getBackend().cancelConversation(cancelConversationId);
 
         if (abortControllerRef.current) {
           abortControllerRef.current.abort();
@@ -6935,7 +6931,6 @@ export default function App({
       setBtwState({ status: "forking", question });
 
       try {
-        const client = await getClient();
         const isDefault = conversationIdRef.current === "default";
 
         // Fork the conversation
@@ -6951,10 +6946,13 @@ export default function App({
         }));
 
         // Send the question to the forked conversation
-        const stream = await client.conversations.messages.create(forked.id, {
-          messages: [{ role: "user", content: question }],
-          stream_tokens: true,
-        });
+        const stream = await getBackend().createConversationMessageStream(
+          forked.id,
+          {
+            messages: [{ role: "user", content: question }],
+            stream_tokens: true,
+          },
+        );
 
         let responseText = "";
         for await (const chunk of stream) {

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -11,6 +11,11 @@ import {
   type StreamRequestContext,
 } from "../../agent/message";
 import {
+  type ConversationMessageStreamBody,
+  getBackend,
+  type RunMessageStreamBody,
+} from "../../backend";
+import {
   clearLastSDKDiagnostic,
   consumeLastSDKDiagnostic,
   getClient,
@@ -775,7 +780,7 @@ export async function drainStreamWithResume(
     );
 
     try {
-      const client = await lazyClient();
+      const backend = getBackend();
 
       // Reset interrupted flag so resumed chunks can be processed by onChunk.
       // Without this, tool_return_message for server-side tools (web_search, fetch_webpage)
@@ -793,7 +798,7 @@ export async function drainStreamWithResume(
       try {
         resumeStream =
           runIdSource === "otid" && streamOtid && streamRequestContext
-            ? await client.conversations.messages.stream(
+            ? await backend.streamConversationMessages(
                 streamRequestContext.resolvedConversationId,
                 {
                   agent_id:
@@ -803,21 +808,19 @@ export async function drainStreamWithResume(
                   otid: streamOtid,
                   starting_after: result.lastSeqId ?? 0,
                   batch_size: 1000,
-                } as unknown as Parameters<
-                  typeof client.conversations.messages.stream
-                >[1],
+                } as unknown as ConversationMessageStreamBody,
                 resumeAbortRelay
                   ? { signal: resumeAbortRelay.signal }
                   : undefined,
               )
-            : await client.runs.messages.stream(
+            : await backend.streamRunMessages(
                 runIdToResume as string,
                 {
                   // If lastSeqId is null the stream failed before any seq_id-bearing
                   // chunk arrived; use 0 to replay the run from the beginning.
                   starting_after: result.lastSeqId ?? 0,
                   batch_size: 1000,
-                },
+                } as unknown as RunMessageStreamBody,
                 resumeAbortRelay
                   ? { signal: resumeAbortRelay.signal }
                   : undefined,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -40,6 +40,7 @@ import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import type { SkillSource } from "./agent/skills";
 import { SessionStats } from "./agent/stats";
+import { type ConversationMessageStreamBody, getBackend } from "./backend";
 import { getClient } from "./backend/api/client";
 import type { ParsedCliArgs } from "./cli/args";
 import {
@@ -1870,8 +1871,7 @@ ${SYSTEM_REMINDER_CLOSE}
             .find((v): v is string => typeof v === "string");
 
           try {
-            const client = await getClient();
-            stream = (await client.conversations.messages.stream(
+            stream = (await getBackend().streamConversationMessages(
               conversationId,
               // Cast needed until SDK MessageStreamParams includes otid field
               {
@@ -1882,9 +1882,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 otid: messageOtid ?? undefined,
                 starting_after: 0,
                 batch_size: 1000,
-              } as unknown as Parameters<
-                typeof client.conversations.messages.stream
-              >[1],
+              } as unknown as ConversationMessageStreamBody,
             )) as Awaited<ReturnType<typeof sendMessageStream>>;
             conversationBusyRetries = 0;
             // Fall through to drain
@@ -2422,7 +2420,7 @@ ${SYSTEM_REMINDER_CLOSE}
           let detail = detailFromRun ?? latestErrorText ?? "";
 
           if (lastRunId) {
-            const run = await client.runs.retrieve(lastRunId);
+            const run = await getBackend().retrieveRun(lastRunId);
             const metaError = run.metadata?.error as
               | {
                   error_type?: string;
@@ -2590,7 +2588,7 @@ ${SYSTEM_REMINDER_CLOSE}
       // Fetch detailed error from run metadata if available (same as TUI mode)
       if (lastRunId && errorMessages.length === 0) {
         try {
-          const run = await client.runs.retrieve(lastRunId);
+          const run = await getBackend().retrieveRun(lastRunId);
           if (run.metadata?.error) {
             const errorData = run.metadata.error as {
               type?: string;

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
+  APIClient,
   ConversationMessageCreateBody,
   ConversationMessageStreamBody,
   RunMessageStreamBody,
@@ -46,15 +47,7 @@ const getClientMock = mock(async () => ({
   },
 }));
 
-mock.module("../../backend/api/client", () => ({
-  getClient: getClientMock,
-}));
-
-mock.module("../../backend/api/conversations", () => ({
-  forkConversation: forkConversationMock,
-}));
-
-const { APIBackend } = await import("../../backend");
+import { APIBackend } from "../../backend";
 
 describe("APIBackend", () => {
   beforeEach(() => {
@@ -67,12 +60,11 @@ describe("APIBackend", () => {
     forkConversationMock.mockClear();
   });
 
-  afterAll(() => {
-    mock.restore();
-  });
-
   test("delegates core conversation and run operations to the Letta API", async () => {
-    const backend = new APIBackend();
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
     const createBody = {
       messages: [{ role: "user", content: "hello" }],
       streaming: true,

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  ConversationMessageCreateBody,
+  ConversationMessageStreamBody,
+  RunMessageStreamBody,
+} from "../../backend";
+
+const createMessageStreamMock = mock(
+  async (_conversationId: string, _body: unknown, _options?: unknown) => ({
+    kind: "create-stream",
+  }),
+);
+const streamConversationMessagesMock = mock(
+  async (_conversationId: string, _body: unknown, _options?: unknown) => ({
+    kind: "resume-stream",
+  }),
+);
+const cancelConversationMock = mock(async (_conversationId: string) => ({
+  status: "cancelled",
+}));
+const retrieveRunMock = mock(async (_runId: string) => ({
+  id: "run-1",
+  metadata: {},
+}));
+const streamRunMessagesMock = mock(
+  async (_runId: string, _body: unknown, _options?: unknown) => ({
+    kind: "run-stream",
+  }),
+);
+const forkConversationMock = mock(
+  async (_conversationId: string, _options?: unknown) => ({ id: "conv-fork" }),
+);
+const getClientMock = mock(async () => ({
+  conversations: {
+    messages: {
+      create: createMessageStreamMock,
+      stream: streamConversationMessagesMock,
+    },
+    cancel: cancelConversationMock,
+  },
+  runs: {
+    retrieve: retrieveRunMock,
+    messages: {
+      stream: streamRunMessagesMock,
+    },
+  },
+}));
+
+mock.module("../../backend/api/client", () => ({
+  getClient: getClientMock,
+}));
+
+mock.module("../../backend/api/conversations", () => ({
+  forkConversation: forkConversationMock,
+}));
+
+const { APIBackend } = await import("../../backend");
+
+describe("APIBackend", () => {
+  beforeEach(() => {
+    getClientMock.mockClear();
+    createMessageStreamMock.mockClear();
+    streamConversationMessagesMock.mockClear();
+    cancelConversationMock.mockClear();
+    retrieveRunMock.mockClear();
+    streamRunMessagesMock.mockClear();
+    forkConversationMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("delegates core conversation and run operations to the Letta API", async () => {
+    const backend = new APIBackend();
+    const createBody = {
+      messages: [{ role: "user", content: "hello" }],
+      streaming: true,
+    } as unknown as ConversationMessageCreateBody;
+    const streamBody = {
+      otid: "otid-1",
+      starting_after: 0,
+      batch_size: 1000,
+    } as unknown as ConversationMessageStreamBody;
+    const runStreamBody = {
+      starting_after: 10,
+      batch_size: 1000,
+    } as unknown as RunMessageStreamBody;
+
+    await backend.createConversationMessageStream("conv-1", createBody, {
+      maxRetries: 0,
+    });
+    await backend.streamConversationMessages("conv-1", streamBody);
+    await backend.cancelConversation("conv-1");
+    await backend.retrieveRun("run-1");
+    await backend.streamRunMessages("run-1", runStreamBody);
+    await backend.forkConversation("conv-1", { agentId: "agent-1" });
+
+    expect(getClientMock).toHaveBeenCalledTimes(5);
+    expect(createMessageStreamMock).toHaveBeenCalledWith("conv-1", createBody, {
+      maxRetries: 0,
+    });
+    expect(streamConversationMessagesMock).toHaveBeenCalledWith(
+      "conv-1",
+      streamBody,
+      undefined,
+    );
+    expect(cancelConversationMock).toHaveBeenCalledWith("conv-1");
+    expect(retrieveRunMock).toHaveBeenCalledWith("run-1");
+    expect(streamRunMessagesMock).toHaveBeenCalledWith(
+      "run-1",
+      runStreamBody,
+      undefined,
+    );
+    expect(forkConversationMock).toHaveBeenCalledWith("conv-1", {
+      agentId: "agent-1",
+    });
+  });
+});

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -58,8 +58,7 @@ describe("approval recovery wiring", () => {
 
     const segment = source.slice(start, end);
 
-    expect(segment).toContain("getClient()");
-    expect(segment).toContain("client.conversations.cancel");
+    expect(segment).toContain("getBackend().cancelConversation");
   });
 
   test("startup and resume approval restores route through shared recovery helper", () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -16,7 +16,7 @@ import {
   updateAgentLLMConfig,
   updateConversationLLMConfig,
 } from "../../agent/modify";
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
 import {
   channelPluginConfigShouldRefreshDisplayName,
   getChannelPluginConfig,
@@ -3797,12 +3797,11 @@ async function handleAbortMessageInput(
     emitInterruptedStatusDelta,
     scheduleQueuePump,
     cancelConversation: async (agentId: string, conversationId: string) => {
-      const client = await getClient();
       const cancelId =
         conversationId === "default" || !conversationId
           ? agentId
           : conversationId;
-      await client.conversations.cancel(cancelId);
+      await getBackend().cancelConversation(cancelId);
     },
     ...deps,
   };

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -18,6 +18,7 @@ import {
   shouldAttemptApprovalRecovery,
   shouldRetryRunMetadataError,
 } from "../../agent/turn-recovery-policy";
+import { getBackend } from "../../backend";
 import { getClient } from "../../backend/api/client";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
@@ -128,8 +129,7 @@ export async function isRetriablePostStopError(
   }
 
   try {
-    const client = await getClient();
-    const run = await client.runs.retrieve(lastRunId);
+    const run = await getBackend().retrieveRun(lastRunId);
     const metaError = run.metadata?.error as
       | {
           error_type?: string;

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -16,6 +16,7 @@ import {
   parseRetryAfterHeaderMs,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
 } from "../../agent/turn-recovery-policy";
+import { type ConversationMessageStreamBody, getBackend } from "../../backend";
 import { getClient } from "../../backend/api/client";
 import { getRetryStatusMessage } from "../../cli/helpers/errorFormatter";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
@@ -368,7 +369,7 @@ export async function sendMessageStreamWithRetry(
           conversation_id: conversationId,
         });
         try {
-          const client = await getClient();
+          const backend = getBackend();
           const messageOtid = messages
             .map((item) => (item as Record<string, unknown>).otid)
             .find((value): value is string => typeof value === "string");
@@ -379,7 +380,7 @@ export async function sendMessageStreamWithRetry(
           }
 
           try {
-            const resumeStream = await client.conversations.messages.stream(
+            const resumeStream = await backend.streamConversationMessages(
               conversationId,
               {
                 agent_id:
@@ -389,9 +390,7 @@ export async function sendMessageStreamWithRetry(
                 otid: messageOtid ?? undefined,
                 starting_after: 0,
                 batch_size: 1000,
-              } as unknown as Parameters<
-                typeof client.conversations.messages.stream
-              >[1],
+              } as unknown as ConversationMessageStreamBody,
               resumeAbortRelay
                 ? { signal: resumeAbortRelay.signal }
                 : undefined,
@@ -600,7 +599,7 @@ export async function sendApprovalContinuationWithRetry(
         });
 
         try {
-          const client = await getClient();
+          const backend = getBackend();
           const messageOtid = messages
             .map((item) => (item as Record<string, unknown>).otid)
             .find((value): value is string => typeof value === "string");
@@ -611,7 +610,7 @@ export async function sendApprovalContinuationWithRetry(
           }
 
           try {
-            const resumeStream = await client.conversations.messages.stream(
+            const resumeStream = await backend.streamConversationMessages(
               conversationId,
               {
                 agent_id:
@@ -621,9 +620,7 @@ export async function sendApprovalContinuationWithRetry(
                 otid: messageOtid ?? undefined,
                 starting_after: 0,
                 batch_size: 1000,
-              } as unknown as Parameters<
-                typeof client.conversations.messages.stream
-              >[1],
+              } as unknown as ConversationMessageStreamBody,
               resumeAbortRelay
                 ? { signal: resumeAbortRelay.signal }
                 : undefined,


### PR DESCRIPTION
## Summary
- Add a `Backend` interface with an `APIBackend` implementation for core conversation streaming, resume, cancellation, run lookup, and conversation fork operations.
- Route TUI, headless, websocket listener, and shared stream recovery hot paths through `getBackend()` instead of directly calling those SDK endpoints outside the backend layer.
- Add APIBackend delegation coverage and update the approval recovery wiring assertion for backend-mediated cancellation.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/backend/api-backend.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/headless/approval-recovery-wiring.test.ts src/tests/websocket/listen-client-concurrency.test.ts`

👾 Generated with [Letta Code](https://letta.com)