### PR TITLE
refactor(api): route headless lifecycle through backend

### DIFF
--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -8,6 +8,11 @@ import type {
   Message,
   MessageType,
 } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  type AgentMessageListBody,
+  type ConversationMessageListBody,
+  getBackend,
+} from "../backend";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
 
@@ -271,7 +276,6 @@ function sortChronological(messages: Message[]): Message[] {
 }
 
 async function fetchConversationBackfillMessages(
-  client: Letta,
   conversationId: string,
 ): Promise<Message[]> {
   const collected: Message[] = [];
@@ -285,12 +289,12 @@ async function fetchConversationBackfillMessages(
   let anchorCount = 0;
 
   for (let pageIndex = 0; pageIndex < BACKFILL_MAX_PAGES; pageIndex += 1) {
-    const page = await client.conversations.messages.list(conversationId, {
+    const page = await getBackend().listConversationMessages(conversationId, {
       limit: BACKFILL_PAGE_LIMIT,
       order: "desc",
       include_return_message_types: RESUME_BACKFILL_MESSAGE_TYPES,
       ...(cursorBefore ? { before: cursorBefore } : {}),
-    } as unknown as Parameters<typeof client.conversations.messages.list>[1]);
+    } as unknown as ConversationMessageListBody);
     const items = page.getPaginatedItems();
     if (items.length === 0) break;
 
@@ -344,13 +348,11 @@ async function fetchConversationBackfillMessages(
  * The source of truth for pending approvals is `conversation.in_context_message_ids`.
  * We anchor our message fetch to that, not arbitrary recent cursor messages.
  *
- * @param client - The Letta client
  * @param agent - The agent state
  * @param conversationId - Optional conversation ID (uses conversations API)
  * @returns Pending approval (if any) and recent message history
  */
-export async function getResumeData(
-  client: Letta,
+export async function getResumeDataFromBackend(
   agent: AgentState,
   conversationId?: string,
   options: GetResumeDataOptions = {},
@@ -369,7 +371,8 @@ export async function getResumeData(
 
     if (useConversationsApi) {
       // Get conversation to access in_context_message_ids (source of truth)
-      const conversation = await client.conversations.retrieve(conversationId);
+      const conversation =
+        await getBackend().retrieveConversation(conversationId);
       inContextMessageIds = conversation.in_context_message_ids;
 
       if (!inContextMessageIds || inContextMessageIds.length === 0) {
@@ -379,10 +382,8 @@ export async function getResumeData(
         );
         if (includeMessageHistory && isBackfillEnabled()) {
           try {
-            const backfill = await fetchConversationBackfillMessages(
-              client,
-              conversationId,
-            );
+            const backfill =
+              await fetchConversationBackfillMessages(conversationId);
             return {
               pendingApproval: null,
               pendingApprovals: [],
@@ -410,16 +411,14 @@ export async function getResumeData(
       if (!lastInContextId) {
         throw new Error("Expected at least one in-context message");
       }
-      const retrievedMessages = await client.messages.retrieve(lastInContextId);
+      const retrievedMessages =
+        await getBackend().retrieveMessage(lastInContextId);
 
       // Fetch message history separately for backfill (desc then reverse for last N chronological)
       // Wrapped in try/catch so backfill failures don't crash the CLI
       if (includeMessageHistory && isBackfillEnabled()) {
         try {
-          messages = await fetchConversationBackfillMessages(
-            client,
-            conversationId,
-          );
+          messages = await fetchConversationBackfillMessages(conversationId);
         } catch (backfillError) {
           debugWarn(
             "check-approval",
@@ -480,12 +479,12 @@ export async function getResumeData(
             ? BACKFILL_PAGE_LIMIT
             : 1;
         try {
-          const messagesPage = await client.agents.messages.list(agent.id, {
+          const messagesPage = await getBackend().listAgentMessages(agent.id, {
             conversation_id: "default",
             limit: listLimit,
             order: "desc",
             include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
-          } as unknown as Parameters<typeof client.agents.messages.list>[1]);
+          } as unknown as AgentMessageListBody);
           defaultConversationMessages = sortChronological(
             messagesPage.getPaginatedItems(),
           );
@@ -510,7 +509,7 @@ export async function getResumeData(
 
       if (lastInContextId) {
         const retrievedMessages =
-          await client.messages.retrieve(lastInContextId);
+          await getBackend().retrieveMessage(lastInContextId);
         const messageToCheck =
           retrievedMessages.find(
             (msg) => msg.message_type === "approval_request_message",
@@ -627,4 +626,16 @@ export async function getResumeData(
     console.error("Error getting resume data:", error);
     return { pendingApproval: null, pendingApprovals: [], messageHistory: [] };
   }
+}
+
+/**
+ * @deprecated Pass through for older call sites. Resume data is loaded through getBackend().
+ */
+export async function getResumeData(
+  _client: Letta,
+  agent: AgentState,
+  conversationId?: string,
+  options: GetResumeDataOptions = {},
+): Promise<ResumeData> {
+  return getResumeDataFromBackend(agent, conversationId, options);
 }

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -28,7 +28,94 @@ export type RunMessageStreamParams = Parameters<
 export type RunMessageStreamBody = RunMessageStreamParams[1];
 export type RunMessageStreamOptions = RunMessageStreamParams[2];
 
+export type AgentRetrieveParams = Parameters<APIClient["agents"]["retrieve"]>;
+export type AgentRetrieveOptions = AgentRetrieveParams[1];
+
+export type AgentUpdateParams = Parameters<APIClient["agents"]["update"]>;
+export type AgentUpdateBody = AgentUpdateParams[1];
+export type AgentUpdateOptions = AgentUpdateParams[2];
+
+export type ConversationRetrieveParams = Parameters<
+  APIClient["conversations"]["retrieve"]
+>;
+export type ConversationRetrieveOptions = ConversationRetrieveParams[1];
+
+export type ConversationCreateParams = Parameters<
+  APIClient["conversations"]["create"]
+>;
+export type ConversationCreateBody = ConversationCreateParams[0];
+export type ConversationCreateOptions = ConversationCreateParams[1];
+
+export type ConversationUpdateParams = Parameters<
+  APIClient["conversations"]["update"]
+>;
+export type ConversationUpdateBody = ConversationUpdateParams[1];
+export type ConversationUpdateOptions = ConversationUpdateParams[2];
+
+export type ConversationMessageListParams = Parameters<
+  APIClient["conversations"]["messages"]["list"]
+>;
+export type ConversationMessageListBody = ConversationMessageListParams[1];
+export type ConversationMessageListOptions = ConversationMessageListParams[2];
+
+export type AgentMessageListParams = Parameters<
+  APIClient["agents"]["messages"]["list"]
+>;
+export type AgentMessageListBody = AgentMessageListParams[1];
+export type AgentMessageListOptions = AgentMessageListParams[2];
+
+export type MessageRetrieveParams = Parameters<
+  APIClient["messages"]["retrieve"]
+>;
+export type MessageRetrieveOptions = MessageRetrieveParams[1];
+
 export interface Backend {
+  retrieveAgent(
+    agentId: string,
+    options?: AgentRetrieveOptions,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["retrieve"]>>>;
+
+  updateAgent(
+    agentId: string,
+    body: AgentUpdateBody,
+    options?: AgentUpdateOptions,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["update"]>>>;
+
+  retrieveConversation(
+    conversationId: string,
+    options?: ConversationRetrieveOptions,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["retrieve"]>>>;
+
+  createConversation(
+    body: ConversationCreateBody,
+    options?: ConversationCreateOptions,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["create"]>>>;
+
+  updateConversation(
+    conversationId: string,
+    body: ConversationUpdateBody,
+    options?: ConversationUpdateOptions,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["update"]>>>;
+
+  listConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageListBody,
+    options?: ConversationMessageListOptions,
+  ): Promise<
+    Awaited<ReturnType<APIClient["conversations"]["messages"]["list"]>>
+  >;
+
+  listAgentMessages(
+    agentId: string,
+    body?: AgentMessageListBody,
+    options?: AgentMessageListOptions,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["messages"]["list"]>>>;
+
+  retrieveMessage(
+    messageId: string,
+    options?: MessageRetrieveOptions,
+  ): Promise<Awaited<ReturnType<APIClient["messages"]["retrieve"]>>>;
+
   createConversationMessageStream(
     conversationId: string,
     body: ConversationMessageCreateBody,
@@ -85,6 +172,68 @@ export class APIBackend implements Backend {
     }
     const { getClient: resolveClient } = await import("./api/client");
     return resolveClient();
+  }
+
+  async retrieveAgent(agentId: string, options?: AgentRetrieveOptions) {
+    const client = await this.getClient();
+    return client.agents.retrieve(agentId, options);
+  }
+
+  async updateAgent(
+    agentId: string,
+    body: AgentUpdateBody,
+    options?: AgentUpdateOptions,
+  ) {
+    const client = await this.getClient();
+    return client.agents.update(agentId, body, options);
+  }
+
+  async retrieveConversation(
+    conversationId: string,
+    options?: ConversationRetrieveOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.retrieve(conversationId, options);
+  }
+
+  async createConversation(
+    body: ConversationCreateBody,
+    options?: ConversationCreateOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.create(body, options);
+  }
+
+  async updateConversation(
+    conversationId: string,
+    body: ConversationUpdateBody,
+    options?: ConversationUpdateOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.update(conversationId, body, options);
+  }
+
+  async listConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageListBody,
+    options?: ConversationMessageListOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.messages.list(conversationId, body, options);
+  }
+
+  async listAgentMessages(
+    agentId: string,
+    body?: AgentMessageListBody,
+    options?: AgentMessageListOptions,
+  ) {
+    const client = await this.getClient();
+    return client.agents.messages.list(agentId, body, options);
+  }
+
+  async retrieveMessage(messageId: string, options?: MessageRetrieveOptions) {
+    const client = await this.getClient();
+    return client.messages.retrieve(messageId, options);
   }
 
   async createConversationMessageStream(

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -291,6 +291,18 @@ export function getBackend(): Backend {
   return backend;
 }
 
+export async function configureDevBackend(name: string): Promise<void> {
+  switch (name) {
+    case "fake-headless": {
+      const { FakeHeadlessBackend } = await import("./dev/FakeHeadlessBackend");
+      backend = new FakeHeadlessBackend();
+      return;
+    }
+    default:
+      throw new Error(`Unknown --dev-backend value "${name}"`);
+  }
+}
+
 export function __testSetBackend(nextBackend: Backend | null): void {
   backend = nextBackend ?? new APIBackend();
 }

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -1,0 +1,126 @@
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import type {
+  Backend,
+  ConversationCreateBody,
+  ConversationMessageCreateBody,
+  RunMessageStreamBody,
+} from "../backend";
+
+function createEmptyPage<T>() {
+  return {
+    getPaginatedItems: () => [] as T[],
+  };
+}
+
+function createFakeStream(text: string): Stream<LettaStreamingResponse> {
+  const controller = new AbortController();
+  return {
+    controller,
+    async *[Symbol.asyncIterator]() {
+      yield {
+        message_type: "assistant_message",
+        id: "msg-fake-assistant",
+        content: [{ type: "text", text }],
+      } as LettaStreamingResponse;
+      yield {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+      } as LettaStreamingResponse;
+    },
+  } as unknown as Stream<LettaStreamingResponse>;
+}
+
+export class FakeHeadlessBackend implements Backend {
+  private readonly agent: AgentState;
+  private conversationId = "conv-fake-headless";
+
+  constructor(agentId = "agent-fake-headless") {
+    this.agent = {
+      id: agentId,
+      name: "Fake Headless Agent",
+      tools: [],
+      tags: [],
+      message_ids: [],
+      in_context_message_ids: [],
+      llm_config: {
+        model: "dev/fake-headless",
+        model_endpoint_type: "openai",
+        model_endpoint: "https://example.invalid/v1",
+        context_window: 128000,
+      },
+    } as unknown as AgentState;
+  }
+
+  async retrieveAgent(agentId: string): Promise<AgentState> {
+    return { ...this.agent, id: agentId } as AgentState;
+  }
+
+  async updateAgent(agentId: string): Promise<AgentState> {
+    return { ...this.agent, id: agentId } as AgentState;
+  }
+
+  async retrieveConversation(conversationId: string): Promise<Conversation> {
+    return {
+      id: conversationId,
+      agent_id: this.agent.id,
+      in_context_message_ids: [],
+    } as unknown as Conversation;
+  }
+
+  async createConversation(
+    body: ConversationCreateBody,
+  ): Promise<Conversation> {
+    this.conversationId = "conv-fake-headless";
+    return {
+      id: this.conversationId,
+      agent_id: body.agent_id ?? this.agent.id,
+      in_context_message_ids: [],
+    } as unknown as Conversation;
+  }
+
+  async updateConversation(conversationId: string): Promise<Conversation> {
+    return this.retrieveConversation(conversationId);
+  }
+
+  listConversationMessages(): ReturnType<Backend["listConversationMessages"]> {
+    return Promise.resolve(createEmptyPage() as never);
+  }
+
+  listAgentMessages(): ReturnType<Backend["listAgentMessages"]> {
+    return Promise.resolve(createEmptyPage() as never);
+  }
+
+  retrieveMessage(): ReturnType<Backend["retrieveMessage"]> {
+    return Promise.resolve([] as never);
+  }
+
+  async createConversationMessageStream(
+    _conversationId: string,
+    _body: ConversationMessageCreateBody,
+  ) {
+    return createFakeStream("pong");
+  }
+
+  async streamConversationMessages() {
+    return createFakeStream("pong");
+  }
+
+  async cancelConversation() {
+    return { status: "cancelled" } as never;
+  }
+
+  async retrieveRun(runId: string) {
+    return { id: runId, status: "completed", metadata: {} } as never;
+  }
+
+  async streamRunMessages(_runId: string, _body: RunMessageStreamBody) {
+    return createFakeStream("pong");
+  }
+
+  async forkConversation(conversationId: string) {
+    return { id: conversationId } as never;
+  }
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -125,6 +125,7 @@ export const CLI_FLAG_CATALOG = {
   // Advanced/internal flags intentionally hidden from --help output.
   // They remain in the shared catalog for strict parsing parity.
   run: { parser: { type: "boolean" }, mode: "headless" },
+  "dev-backend": { parser: { type: "string" }, mode: "headless" },
   tools: { parser: { type: "string" }, mode: "both" },
   allowedTools: { parser: { type: "string" }, mode: "both" },
   disallowedTools: { parser: { type: "string" }, mode: "both" },

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -40,7 +40,11 @@ import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import type { SkillSource } from "./agent/skills";
 import { SessionStats } from "./agent/stats";
-import { type ConversationMessageStreamBody, getBackend } from "./backend";
+import {
+  type ConversationCreateBody,
+  type ConversationMessageStreamBody,
+  getBackend,
+} from "./backend";
 import { getClient } from "./backend/api/client";
 import type { ParsedCliArgs } from "./cli/args";
 import {
@@ -547,7 +551,7 @@ export async function handleHeadlessCommand(
     process.exit(1);
   }
 
-  const client = await getClient();
+  const backend = getBackend();
   markMilestone("HEADLESS_CLIENT_READY");
 
   // Check for --resume flag (interactive only)
@@ -931,10 +935,10 @@ export async function handleHeadlessCommand(
         "conversations",
         `retrieve(${specifiedConversationId}) [headless conv→agent lookup]`,
       );
-      const conversation = await client.conversations.retrieve(
+      const conversation = await backend.retrieveConversation(
         specifiedConversationId,
       );
-      agent = await client.agents.retrieve(conversation.agent_id);
+      agent = await backend.retrieveAgent(conversation.agent_id);
     } catch (error) {
       trackHeadlessBoundaryError(
         "headless_conversation_lookup_failed",
@@ -991,7 +995,7 @@ export async function handleHeadlessCommand(
   // Priority 2: Try to use --agent specified ID
   if (!agent && specifiedAgentId) {
     try {
-      agent = await client.agents.retrieve(specifiedAgentId, {
+      agent = await backend.retrieveAgent(specifiedAgentId, {
         include: ["agent.secrets", "agent.tools"],
       });
     } catch (_error) {
@@ -1038,7 +1042,7 @@ export async function handleHeadlessCommand(
     );
     if (localAgentId) {
       try {
-        agent = await client.agents.retrieve(localAgentId);
+        agent = await backend.retrieveAgent(localAgentId);
       } catch (_error) {
         // Local LRU agent doesn't exist - log and continue
         console.error(`Unable to locate agent ${localAgentId} in .letta/`);
@@ -1052,7 +1056,7 @@ export async function handleHeadlessCommand(
     const globalAgentId = settingsManager.getGlobalLastAgentId();
     if (globalAgentId) {
       try {
-        agent = await client.agents.retrieve(globalAgentId);
+        agent = await backend.retrieveAgent(globalAgentId);
       } catch (_error) {
         // Global LRU agent doesn't exist
       }
@@ -1062,6 +1066,7 @@ export async function handleHeadlessCommand(
   // Priority 6: Fresh user with no LRU - create default agent
   if (!agent) {
     const { ensureDefaultAgents } = await import("./agent/defaults");
+    const client = await getClient();
     const defaultAgent = await ensureDefaultAgents(client, {
       preferredModel: model,
     });
@@ -1270,9 +1275,8 @@ export async function handleHeadlessCommand(
           : "standard";
         const expected = rebuildPrompt(storedPreset, memoryMode);
         if (agent.system !== expected) {
-          const client = await getClient();
-          await client.agents.update(agent.id, { system: expected });
-          agent = await client.agents.retrieve(agent.id);
+          await backend.updateAgent(agent.id, { system: expected });
+          agent = await backend.retrieveAgent(agent.id);
         }
       } else {
         settingsManager.clearSystemPromptPreset(agent.id);
@@ -1337,7 +1341,7 @@ export async function handleHeadlessCommand(
           "conversations",
           `retrieve(${specifiedConversationId}) [headless --conv validate]`,
         );
-        await client.conversations.retrieve(specifiedConversationId);
+        await backend.retrieveConversation(specifiedConversationId);
         conversationId = specifiedConversationId;
       } catch {
         console.error(
@@ -1354,14 +1358,14 @@ export async function handleHeadlessCommand(
     // missing from @letta-ai/letta-client@1.10.1 types, but the core
     // endpoint accepts it and the SDK's create impl forwards unknown
     // body fields unchanged — remove the cast once the SDK is bumped.
-    const createParams: Parameters<typeof client.conversations.create>[0] = {
+    const createParams: ConversationCreateBody = {
       agent_id: agent.id,
       isolated_block_labels: isolatedBlockLabels,
     };
     if (fromAgentId) {
       (createParams as { hidden?: boolean }).hidden = true;
     }
-    const conversation = await client.conversations.create(createParams);
+    const conversation = await backend.createConversation(createParams);
     conversationId = conversation.id;
   } else if (isSubagent) {
     // Freshly created subagents have no concurrency risk — use the default
@@ -1372,7 +1376,7 @@ export async function handleHeadlessCommand(
     // 409 "conversation busy" races (e.g., parent agent calling letta -p).
     // Use --conv default to explicitly target the agent's
     // primary conversation.
-    const conversation = await client.conversations.create({
+    const conversation = await backend.createConversation({
       agent_id: agent.id,
       isolated_block_labels: isolatedBlockLabels,
     });
@@ -1433,6 +1437,7 @@ export async function handleHeadlessCommand(
 
   // If input-format is stream-json, use bidirectional mode
   if (isBidirectionalMode) {
+    const client = await getClient();
     await runBidirectionalMode(
       agent,
       conversationId,
@@ -1501,14 +1506,14 @@ export async function handleHeadlessCommand(
   const resolveAllPendingApprovals = async (
     mode: "queue_for_next_turn" | "send_immediately" = "send_immediately",
   ) => {
-    const { getResumeData } = await import("./agent/check-approval");
+    const { getResumeDataFromBackend } = await import("./agent/check-approval");
     while (true) {
       // Re-fetch agent to get latest in-context messages (source of truth for backend)
-      const freshAgent = await client.agents.retrieve(agent.id);
+      const freshAgent = await backend.retrieveAgent(agent.id);
 
-      let resume: Awaited<ReturnType<typeof getResumeData>>;
+      let resume: Awaited<ReturnType<typeof getResumeDataFromBackend>>;
       try {
-        resume = await getResumeData(client, freshAgent, conversationId);
+        resume = await getResumeDataFromBackend(freshAgent, conversationId);
       } catch (error) {
         // Treat 404/422 as "no approvals" - stale message/conversation state
         if (
@@ -1630,7 +1635,7 @@ export async function handleHeadlessCommand(
 
   if (fromAgentId) {
     const senderAgentId = fromAgentId;
-    const senderAgent = await client.agents.retrieve(senderAgentId);
+    const senderAgent = await backend.retrieveAgent(senderAgentId);
     const systemReminder = `${SYSTEM_REMINDER_OPEN}
 This message is from "${senderAgent.name}" (agent ID: ${senderAgentId}), an agent currently running inside the Letta Code CLI (docs.letta.com/letta-code).
 The sender will only see the final message you generate (not tool calls or reasoning).
@@ -2791,6 +2796,7 @@ async function runBidirectionalMode(
   reflectionSettings: ReflectionSettings,
 ): Promise<void> {
   const sessionId = agent.id;
+  const backend = getBackend();
   const telemetryModelId = agent.llm_config?.model ?? "unknown";
   const readline = await import("node:readline");
   const exitBidirectional = async (
@@ -2832,14 +2838,14 @@ async function runBidirectionalMode(
 
   // Resolve pending approvals for this conversation before retrying user input.
   const resolveAllPendingApprovals = async () => {
-    const { getResumeData } = await import("./agent/check-approval");
+    const { getResumeDataFromBackend } = await import("./agent/check-approval");
     while (true) {
       // Re-fetch agent to get latest in-context messages (source of truth for backend)
-      const freshAgent = await client.agents.retrieve(agent.id);
+      const freshAgent = await backend.retrieveAgent(agent.id);
 
-      let resume: Awaited<ReturnType<typeof getResumeData>>;
+      let resume: Awaited<ReturnType<typeof getResumeDataFromBackend>>;
       try {
-        resume = await getResumeData(client, freshAgent, conversationId);
+        resume = await getResumeDataFromBackend(freshAgent, conversationId);
       } catch (error) {
         // Treat 404/422 as "no approvals" - stale message/conversation state
         if (
@@ -3211,19 +3217,23 @@ async function runBidirectionalMode(
       );
     }
 
-    const { getResumeData } = await import("./agent/check-approval");
+    const { getResumeDataFromBackend } = await import("./agent/check-approval");
 
     let approvalsProcessed = 0;
     const MAX_RECOVERY_PASSES = 8;
 
     for (let pass = 0; pass < MAX_RECOVERY_PASSES; pass += 1) {
-      const freshAgent = await client.agents.retrieve(agent.id);
+      const freshAgent = await backend.retrieveAgent(agent.id);
 
-      let resume: Awaited<ReturnType<typeof getResumeData>>;
+      let resume: Awaited<ReturnType<typeof getResumeDataFromBackend>>;
       try {
-        resume = await getResumeData(client, freshAgent, targetConversationId, {
-          includeMessageHistory: false,
-        });
+        resume = await getResumeDataFromBackend(
+          freshAgent,
+          targetConversationId,
+          {
+            includeMessageHistory: false,
+          },
+        );
       } catch (error) {
         if (
           error instanceof APIError &&
@@ -3434,14 +3444,15 @@ async function runBidirectionalMode(
         writeWireMessage(registerResponse);
       } else if (subtype === "bootstrap_session_state") {
         const bootstrapReq = message.request as BootstrapSessionStateRequest;
-        const { getResumeData } = await import("./agent/check-approval");
+        const { getResumeDataFromBackend } = await import(
+          "./agent/check-approval"
+        );
         let hasPendingApproval = false;
 
         try {
           // Re-fetch for parity with approval checks elsewhere in headless mode.
-          const freshAgent = await client.agents.retrieve(agent.id);
-          const resume = await getResumeData(
-            client,
+          const freshAgent = await backend.retrieveAgent(agent.id);
+          const resume = await getResumeDataFromBackend(
             freshAgent,
             conversationId,
             {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -551,6 +551,11 @@ export async function handleHeadlessCommand(
     process.exit(1);
   }
 
+  const devBackend = values["dev-backend"];
+  if (typeof devBackend === "string" && devBackend.length > 0) {
+    const { configureDevBackend } = await import("./backend");
+    await configureDevBackend(devBackend);
+  }
   const backend = getBackend();
   markMilestone("HEADLESS_CLIENT_READY");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,95 +800,104 @@ async function main(): Promise<void> {
     settings.env?.LETTA_BASE_URL ||
     LETTA_CLOUD_API_URL;
 
-  // Headless mode against Letta API requires an explicit LETTA_API_KEY env var.
-  // Stored OAuth credentials (interactive session tokens) are not accepted for
-  // automated/headless use — get an API key at https://app.letta.com/api-keys
-  if (
+  const isUsingDevBackend =
     isHeadless &&
-    baseURL === LETTA_CLOUD_API_URL &&
-    !process.env.LETTA_API_KEY
-  ) {
-    console.error("Missing LETTA_API_KEY");
-    console.error(
-      "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
-    );
-    console.error("Get an API key at https://app.letta.com/api-keys");
-    process.exit(1);
-  }
+    typeof values["dev-backend"] === "string" &&
+    values["dev-backend"].length > 0;
 
-  // Check if refresh token is missing for Letta Cloud (only when not using env var)
-  // Skip this check if we already have an API key from env
-  if (
-    !isHeadless &&
-    baseURL === LETTA_CLOUD_API_URL &&
-    !settings.refreshToken &&
-    !apiKey
-  ) {
-    // For interactive mode, show setup flow
-    const { runSetup } = await import("./auth/setup");
-    await runSetup();
-    // After setup, restart main flow
-    return main().catch((err: unknown) => {
-      // Handle top-level errors gracefully without raw stack traces
-      trackCliBoundaryError("setup_restart_failed", err, "tui_setup_restart");
-      const message =
-        err instanceof Error ? err.message : "An unexpected error occurred";
-      console.error(`\nError: ${message}`);
-      if (isDebugEnabled()) {
-        console.error(err);
-      }
-      process.exit(1);
-    });
-  }
-
-  if (!apiKey && baseURL === LETTA_CLOUD_API_URL) {
-    // For interactive mode, show setup flow
-    console.log("No credentials found. Let's get you set up!\n");
-    const { runSetup } = await import("./auth/setup");
-    await runSetup();
-    // After setup, restart main flow
-    return main();
-  }
-
-  // Validate credentials by checking health endpoint
-  const { validateCredentials } = await import("./auth/oauth");
-  const isValid = await validateCredentials(baseURL, apiKey ?? "");
-  markMilestone("CREDENTIALS_VALIDATED");
-
-  // Ensure base tools exist on the server (first-run-per-machine, non-blocking).
-  // Must run after credentials are validated so OAuth tokens are available.
-  if (isValid) {
-    const { bootstrapBaseToolsIfNeeded } = await import(
-      "./agent/bootstrap-tools"
-    );
-    await bootstrapBaseToolsIfNeeded();
-  }
-
-  if (!isValid) {
-    // For headless mode, error out with helpful message
-    if (isHeadless) {
-      console.error("Failed to connect to Letta server");
-      console.error(`Base URL: ${baseURL}`);
+  if (!isUsingDevBackend) {
+    // Headless mode against Letta API requires an explicit LETTA_API_KEY env var.
+    // Stored OAuth credentials (interactive session tokens) are not accepted for
+    // automated/headless use — get an API key at https://app.letta.com/api-keys
+    if (
+      isHeadless &&
+      baseURL === LETTA_CLOUD_API_URL &&
+      !process.env.LETTA_API_KEY
+    ) {
+      console.error("Missing LETTA_API_KEY");
       console.error(
-        "Your credentials may be invalid or the server may be unreachable.",
+        "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
       );
-      console.error(
-        "Delete ~/.letta/settings.json then run 'letta' to re-authenticate",
-      );
+      console.error("Get an API key at https://app.letta.com/api-keys");
       process.exit(1);
     }
 
-    // For interactive mode, show setup flow
-    console.log("Failed to connect to Letta server.");
-    console.log(`Base URL: ${baseURL}\n`);
-    console.log(
-      "Your credentials may be invalid or the server may be unreachable.",
-    );
-    console.log("Let's reconfigure your setup.\n");
-    const { runSetup } = await import("./auth/setup");
-    await runSetup();
-    // After setup, restart main flow
-    return main();
+    // Check if refresh token is missing for Letta Cloud (only when not using env var)
+    // Skip this check if we already have an API key from env
+    if (
+      !isHeadless &&
+      baseURL === LETTA_CLOUD_API_URL &&
+      !settings.refreshToken &&
+      !apiKey
+    ) {
+      // For interactive mode, show setup flow
+      const { runSetup } = await import("./auth/setup");
+      await runSetup();
+      // After setup, restart main flow
+      return main().catch((err: unknown) => {
+        // Handle top-level errors gracefully without raw stack traces
+        trackCliBoundaryError("setup_restart_failed", err, "tui_setup_restart");
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred";
+        console.error(`\nError: ${message}`);
+        if (isDebugEnabled()) {
+          console.error(err);
+        }
+        process.exit(1);
+      });
+    }
+
+    if (!apiKey && baseURL === LETTA_CLOUD_API_URL) {
+      // For interactive mode, show setup flow
+      console.log("No credentials found. Let's get you set up!\n");
+      const { runSetup } = await import("./auth/setup");
+      await runSetup();
+      // After setup, restart main flow
+      return main();
+    }
+
+    // Validate credentials by checking health endpoint
+    const { validateCredentials } = await import("./auth/oauth");
+    const isValid = await validateCredentials(baseURL, apiKey ?? "");
+    markMilestone("CREDENTIALS_VALIDATED");
+
+    // Ensure base tools exist on the server (first-run-per-machine, non-blocking).
+    // Must run after credentials are validated so OAuth tokens are available.
+    if (isValid) {
+      const { bootstrapBaseToolsIfNeeded } = await import(
+        "./agent/bootstrap-tools"
+      );
+      await bootstrapBaseToolsIfNeeded();
+    }
+
+    if (!isValid) {
+      // For headless mode, error out with helpful message
+      if (isHeadless) {
+        console.error("Failed to connect to Letta server");
+        console.error(`Base URL: ${baseURL}`);
+        console.error(
+          "Your credentials may be invalid or the server may be unreachable.",
+        );
+        console.error(
+          "Delete ~/.letta/settings.json then run 'letta' to re-authenticate",
+        );
+        process.exit(1);
+      }
+
+      // For interactive mode, show setup flow
+      console.log("Failed to connect to Letta server.");
+      console.log(`Base URL: ${baseURL}\n`);
+      console.log(
+        "Your credentials may be invalid or the server may be unreachable.",
+      );
+      console.log("Let's reconfigure your setup.\n");
+      const { runSetup } = await import("./auth/setup");
+      await runSetup();
+      // After setup, restart main flow
+      return main();
+    }
+  } else {
+    markMilestone("CREDENTIALS_VALIDATED");
   }
 
   // Resolve --name to agent ID if provided

--- a/src/tests/agent/getResumeData.test.ts
+++ b/src/tests/agent/getResumeData.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import type Letta from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
@@ -6,10 +6,17 @@ import type {
   MessageType,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import { getResumeData } from "../../agent/check-approval";
+import { __testSetBackend, type Backend } from "../../backend";
 
 type ResumeAgentState = AgentState & {
   in_context_message_ids?: string[] | null;
 };
+
+const dummyClient = {} as Letta;
+
+function installBackend(overrides: Record<string, unknown>): void {
+  __testSetBackend(overrides as unknown as Backend);
+}
 
 const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
   "user_message",
@@ -57,6 +64,10 @@ function makeUserMessage(id = "msg-last"): Message {
 }
 
 describe("getResumeData", () => {
+  afterEach(() => {
+    __testSetBackend(null);
+  });
+
   test("includeMessageHistory=false still computes pending approvals without backfill (conversation path)", async () => {
     const conversationsRetrieve = mock(async () => ({
       in_context_message_ids: ["msg-last"],
@@ -67,16 +78,14 @@ describe("getResumeData", () => {
     const agentsList = mock(async () => ({ items: [] }));
     const messagesRetrieve = mock(async () => [makeApprovalMessage()]);
 
-    const client = {
-      conversations: {
-        retrieve: conversationsRetrieve,
-        messages: { list: conversationsList },
-      },
-      agents: { messages: { list: agentsList } },
-      messages: { retrieve: messagesRetrieve },
-    } as unknown as Letta;
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
 
-    const resume = await getResumeData(client, makeAgent(), "conv-abc", {
+    const resume = await getResumeData(dummyClient, makeAgent(), "conv-abc", {
       includeMessageHistory: false,
     });
 
@@ -100,17 +109,15 @@ describe("getResumeData", () => {
     }));
     const messagesRetrieve = mock(async () => [makeApprovalMessage()]);
 
-    const client = {
-      conversations: {
-        retrieve: conversationsRetrieve,
-        messages: { list: conversationsList },
-      },
-      agents: { messages: { list: agentsList } },
-      messages: { retrieve: messagesRetrieve },
-    } as unknown as Letta;
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
 
     const resume = await getResumeData(
-      client,
+      dummyClient,
       makeAgent({
         message_ids: ["msg-last"],
         in_context_message_ids: ["msg-last"],
@@ -133,13 +140,13 @@ describe("getResumeData", () => {
       makeApprovalMessage("msg-live"),
     ]);
 
-    const client = {
-      agents: { messages: { list: agentsList } },
-      messages: { retrieve: messagesRetrieve },
-    } as unknown as Letta;
+    installBackend({
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
 
     const resume = await getResumeData(
-      client,
+      dummyClient,
       makeAgent({
         message_ids: ["msg-stale"],
         in_context_message_ids: ["msg-live"],
@@ -161,13 +168,13 @@ describe("getResumeData", () => {
     }));
     const messagesRetrieve = mock(async () => [makeUserMessage("msg-stale")]);
 
-    const client = {
-      agents: { messages: { list: agentsList } },
-      messages: { retrieve: messagesRetrieve },
-    } as unknown as Letta;
+    installBackend({
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
 
     const resume = await getResumeData(
-      client,
+      dummyClient,
       makeAgent({ in_context_message_ids: [] }),
       "default",
       { includeMessageHistory: false },
@@ -191,16 +198,14 @@ describe("getResumeData", () => {
     }));
     const messagesRetrieve = mock(async () => [makeUserMessage()]);
 
-    const client = {
-      conversations: {
-        retrieve: conversationsRetrieve,
-      },
-      agents: { messages: { list: agentsList } },
-      messages: { retrieve: messagesRetrieve },
-    } as unknown as Letta;
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
 
     const resume = await getResumeData(
-      client,
+      dummyClient,
       makeAgent({ in_context_message_ids: ["msg-last"] }),
       "default",
     );

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -1,11 +1,50 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
+  AgentMessageListBody,
+  AgentUpdateBody,
   APIClient,
+  ConversationCreateBody,
   ConversationMessageCreateBody,
+  ConversationMessageListBody,
   ConversationMessageStreamBody,
+  ConversationUpdateBody,
   RunMessageStreamBody,
 } from "../../backend";
 
+const retrieveAgentMock = mock(
+  async (_agentId: string, _options?: unknown) => ({ id: "agent-1" }),
+);
+const updateAgentMock = mock(
+  async (_agentId: string, _body: unknown, _options?: unknown) => ({
+    id: "agent-1",
+  }),
+);
+const retrieveConversationMock = mock(
+  async (_conversationId: string, _options?: unknown) => ({ id: "conv-1" }),
+);
+const createConversationMock = mock(
+  async (_body: unknown, _options?: unknown) => ({
+    id: "conv-1",
+  }),
+);
+const updateConversationMock = mock(
+  async (_conversationId: string, _body: unknown, _options?: unknown) => ({
+    id: "conv-1",
+  }),
+);
+const listConversationMessagesMock = mock(
+  async (_conversationId: string, _body?: unknown, _options?: unknown) => ({
+    getPaginatedItems: () => [],
+  }),
+);
+const listAgentMessagesMock = mock(
+  async (_agentId: string, _body?: unknown, _options?: unknown) => ({
+    getPaginatedItems: () => [],
+  }),
+);
+const retrieveMessageMock = mock(
+  async (_messageId: string, _options?: unknown) => [],
+);
 const createMessageStreamMock = mock(
   async (_conversationId: string, _body: unknown, _options?: unknown) => ({
     kind: "create-stream",
@@ -32,12 +71,26 @@ const forkConversationMock = mock(
   async (_conversationId: string, _options?: unknown) => ({ id: "conv-fork" }),
 );
 const getClientMock = mock(async () => ({
-  conversations: {
+  agents: {
+    retrieve: retrieveAgentMock,
+    update: updateAgentMock,
     messages: {
+      list: listAgentMessagesMock,
+    },
+  },
+  conversations: {
+    retrieve: retrieveConversationMock,
+    create: createConversationMock,
+    update: updateConversationMock,
+    messages: {
+      list: listConversationMessagesMock,
       create: createMessageStreamMock,
       stream: streamConversationMessagesMock,
     },
     cancel: cancelConversationMock,
+  },
+  messages: {
+    retrieve: retrieveMessageMock,
   },
   runs: {
     retrieve: retrieveRunMock,
@@ -52,6 +105,14 @@ import { APIBackend } from "../../backend";
 describe("APIBackend", () => {
   beforeEach(() => {
     getClientMock.mockClear();
+    retrieveAgentMock.mockClear();
+    updateAgentMock.mockClear();
+    retrieveConversationMock.mockClear();
+    createConversationMock.mockClear();
+    updateConversationMock.mockClear();
+    listConversationMessagesMock.mockClear();
+    listAgentMessagesMock.mockClear();
+    retrieveMessageMock.mockClear();
     createMessageStreamMock.mockClear();
     streamConversationMessagesMock.mockClear();
     cancelConversationMock.mockClear();
@@ -65,6 +126,20 @@ describe("APIBackend", () => {
       getClient: getClientMock as unknown as () => Promise<APIClient>,
       forkConversation: forkConversationMock,
     });
+    const agentUpdateBody = { system: "system" } as AgentUpdateBody;
+    const conversationCreateBody = {
+      agent_id: "agent-1",
+    } as ConversationCreateBody;
+    const conversationUpdateBody = {
+      summary: "summary",
+    } as ConversationUpdateBody;
+    const conversationListBody = {
+      limit: 1,
+    } as ConversationMessageListBody;
+    const agentListBody = {
+      conversation_id: "default",
+      limit: 1,
+    } as AgentMessageListBody;
     const createBody = {
       messages: [{ role: "user", content: "hello" }],
       streaming: true,
@@ -79,6 +154,14 @@ describe("APIBackend", () => {
       batch_size: 1000,
     } as unknown as RunMessageStreamBody;
 
+    await backend.retrieveAgent("agent-1", { include: ["agent.tools"] });
+    await backend.updateAgent("agent-1", agentUpdateBody);
+    await backend.retrieveConversation("conv-1");
+    await backend.createConversation(conversationCreateBody);
+    await backend.updateConversation("conv-1", conversationUpdateBody);
+    await backend.listConversationMessages("conv-1", conversationListBody);
+    await backend.listAgentMessages("agent-1", agentListBody);
+    await backend.retrieveMessage("msg-1");
     await backend.createConversationMessageStream("conv-1", createBody, {
       maxRetries: 0,
     });
@@ -88,7 +171,36 @@ describe("APIBackend", () => {
     await backend.streamRunMessages("run-1", runStreamBody);
     await backend.forkConversation("conv-1", { agentId: "agent-1" });
 
-    expect(getClientMock).toHaveBeenCalledTimes(5);
+    expect(getClientMock).toHaveBeenCalledTimes(13);
+    expect(retrieveAgentMock).toHaveBeenCalledWith("agent-1", {
+      include: ["agent.tools"],
+    });
+    expect(updateAgentMock).toHaveBeenCalledWith(
+      "agent-1",
+      agentUpdateBody,
+      undefined,
+    );
+    expect(retrieveConversationMock).toHaveBeenCalledWith("conv-1", undefined);
+    expect(createConversationMock).toHaveBeenCalledWith(
+      conversationCreateBody,
+      undefined,
+    );
+    expect(updateConversationMock).toHaveBeenCalledWith(
+      "conv-1",
+      conversationUpdateBody,
+      undefined,
+    );
+    expect(listConversationMessagesMock).toHaveBeenCalledWith(
+      "conv-1",
+      conversationListBody,
+      undefined,
+    );
+    expect(listAgentMessagesMock).toHaveBeenCalledWith(
+      "agent-1",
+      agentListBody,
+      undefined,
+    );
+    expect(retrieveMessageMock).toHaveBeenCalledWith("msg-1", undefined);
     expect(createMessageStreamMock).toHaveBeenCalledWith("conv-1", createBody, {
       maxRetries: 0,
     });

--- a/src/tests/cli/args.test.ts
+++ b/src/tests/cli/args.test.ts
@@ -55,6 +55,7 @@ describe("shared CLI arg schema", () => {
     expect(help).toContain("--memfs-startup <m>");
     expect(help).toContain("Default: text");
     expect(help).not.toContain("--run");
+    expect(help).not.toContain("--dev-backend");
 
     for (const [flagName, definition] of Object.entries(
       CLI_FLAG_CATALOG,
@@ -95,6 +96,8 @@ describe("shared CLI arg schema", () => {
         "3",
         "--block-value",
         "persona=hello",
+        "--dev-backend",
+        "fake-headless",
       ]),
       true,
     );
@@ -102,6 +105,7 @@ describe("shared CLI arg schema", () => {
     expect(parsed.values["pre-load-skills"]).toBe("skill-a,skill-b");
     expect(parsed.values["max-turns"]).toBe("3");
     expect(parsed.values["block-value"]).toEqual(["persona=hello"]);
+    expect(parsed.values["dev-backend"]).toBe("fake-headless");
   });
 
   test("rejects removed system-append flag in strict mode", () => {

--- a/src/tests/headless/backend-lifecycle-wiring.test.ts
+++ b/src/tests/headless/backend-lifecycle-wiring.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function readSource(relativePath: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(relativePath, import.meta.url)),
+    "utf-8",
+  );
+}
+
+describe("headless backend lifecycle wiring", () => {
+  test("headless startup and approval recovery route lifecycle SDK calls through Backend", () => {
+    const source = readSource("../../headless.ts");
+
+    expect(source).toContain("const backend = getBackend();");
+    const backendReadyIndex = source.indexOf("const backend = getBackend();");
+    const agentLookupIndex = source.indexOf("// Priority 0: --conversation");
+    expect(backendReadyIndex).toBeGreaterThan(-1);
+    expect(agentLookupIndex).toBeGreaterThan(backendReadyIndex);
+    expect(source.slice(backendReadyIndex, agentLookupIndex)).not.toContain(
+      "getClient()",
+    );
+
+    expect(source).toContain("backend.retrieveAgent(");
+    expect(source).toContain("backend.retrieveConversation(");
+    expect(source).toContain("backend.createConversation(");
+    expect(source).toContain("backend.updateAgent(");
+
+    expect(source).not.toContain("client.agents.");
+    expect(source).not.toContain("client.conversations.");
+    expect(source).not.toContain("client.messages.");
+  });
+
+  test("resume data probes use Backend instead of raw SDK clients", () => {
+    const source = readSource("../../agent/check-approval.ts");
+
+    expect(source).toContain("getBackend().retrieveConversation");
+    expect(source).toContain("getBackend().listConversationMessages");
+    expect(source).toContain("getBackend().listAgentMessages");
+    expect(source).toContain("getBackend().retrieveMessage");
+
+    expect(source).not.toContain("client.conversations.");
+    expect(source).not.toContain("client.agents.");
+    expect(source).not.toContain("client.messages.");
+  });
+});

--- a/src/tests/headless/bootstrap-pending-approval-wiring.test.ts
+++ b/src/tests/headless/bootstrap-pending-approval-wiring.test.ts
@@ -10,7 +10,7 @@ describe("bootstrap pending-approval wiring", () => {
     const source = readFileSync(headlessPath, "utf-8");
 
     expect(source).toContain(
-      'const { getResumeData } = await import("./agent/check-approval");',
+      "const { getResumeDataFromBackend } = await import(",
     );
     expect(source).toContain("includeMessageHistory: false");
     expect(source).toContain(

--- a/src/tests/headless/dev-backend-smoke.test.ts
+++ b/src/tests/headless/dev-backend-smoke.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { createIsolatedCliTestEnv } from "../testProcessEnv";
+
+const projectRoot = process.cwd();
+
+async function runCli(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  const env = createIsolatedCliTestEnv({
+    LETTA_DEBUG: "0",
+    DISABLE_AUTOUPDATER: "1",
+  });
+  delete env.LETTA_API_KEY;
+  delete env.LETTA_BASE_URL;
+  delete env.LETTA_API_BASE;
+  delete env.LETTA_AGENT_ID;
+  delete env.LETTA_CONVERSATION_ID;
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn("bun", ["run", "dev", ...args], {
+      cwd: projectRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(
+        new Error(
+          `Timeout waiting for dev backend smoke. stdout: ${stdout}, stderr: ${stderr}`,
+        ),
+      );
+    }, 30000);
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ stdout, stderr, exitCode: code });
+    });
+    proc.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+describe("headless dev backend smoke", () => {
+  test("runs one-shot headless without API credentials", async () => {
+    const result = await runCli([
+      "-p",
+      "ping",
+      "--agent",
+      "agent-fake",
+      "--dev-backend",
+      "fake-headless",
+      "--permission-mode",
+      "plan",
+      "--no-skills",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("pong");
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Failed to connect to Letta server");
+  });
+});

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -1,5 +1,6 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { resolveModel } from "../agent/model";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 import type { MessageChannelToolDiscoveryScope } from "../channels/messageTool";
 import { getSupportedChannelIds } from "../channels/pluginRegistry";
@@ -273,16 +274,16 @@ export async function prepareToolExecutionContextForScope(params: {
     cachedAgent,
   } = params;
 
-  const client = await getClient();
+  const backend = getBackend();
   const agent = (cachedAgent ??
-    (await client.agents.retrieve(agentId))) as ScopeModelCarrier;
+    (await backend.retrieveAgent(agentId))) as ScopeModelCarrier;
   let effectiveModel =
     overrideModel && overrideModel.length > 0
       ? (resolveModel(overrideModel) ?? overrideModel)
       : null;
 
   if (!effectiveModel && conversationId && conversationId !== "default") {
-    const conversation = await client.conversations.retrieve(conversationId);
+    const conversation = await backend.retrieveConversation(conversationId);
     const conversationModel = (conversation as { model?: string | null }).model;
     if (typeof conversationModel === "string" && conversationModel.length > 0) {
       effectiveModel = conversationModel;
@@ -507,11 +508,11 @@ export async function clearPersistedClientToolRules(
   agentId: string,
   cachedAgent?: AgentState | null,
 ): Promise<{ removedToolNames: string[] } | null> {
-  const client = await getClient();
+  const backend = getBackend();
 
   try {
     const agentWithTools = (cachedAgent ??
-      (await client.agents.retrieve(agentId, {
+      (await backend.retrieveAgent(agentId, {
         include: ["agent.tools"],
       }))) as AgentWithToolsAndRules;
     if (!shouldClearPersistedToolRules(agentWithTools)) {
@@ -519,7 +520,7 @@ export async function clearPersistedClientToolRules(
     }
     const existingRules = agentWithTools.tool_rules || [];
 
-    await client.agents.update(agentId, {
+    await backend.updateAgent(agentId, {
       tool_rules: [],
     });
 


### PR DESCRIPTION
## Summary
- Extend `Backend` / `APIBackend` with headless lifecycle operations for agent retrieval/update, conversation retrieval/create/update, message listing, and message retrieval.
- Route headless startup, conversation selection/creation, approval recovery refreshes, tool-context prep, and `getResumeData` backfill probes through `getBackend()` instead of raw SDK lifecycle calls.
- Add a hidden `--dev-backend fake-headless` path plus a one-shot headless smoke test that runs without API credentials.
- Add wiring coverage to keep headless startup/resume on the backend facade and update resume-data/APIBackend tests to mock the facade boundary.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/headless src/tests/agent/getResumeData.test.ts src/tests/backend/api-backend.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/cli/args.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- [x] `bun test src/tests/tools/toolset-client-tool-rule-cleanup.test.ts src/tests/tools/toolset-memfs-detach.test.ts`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)