### PR TITLE
refactor(api): route stream-json controls through backend

### DIFF
--- a/src/agent/bootstrapHandler.ts
+++ b/src/agent/bootstrapHandler.ts
@@ -7,11 +7,12 @@
  *  - pending approval flag
  *  - optional wall-clock timings
  *
- * Accepting minimal client/context interfaces keeps the handler fully testable
+ * Accepting minimal backend/context interfaces keeps the handler fully testable
  * without a real network or subprocess.
  */
 
 import { randomUUID } from "node:crypto";
+import type { Backend, ConversationMessageListBody } from "../backend";
 import type {
   BootstrapSessionStatePayload,
   BootstrapSessionStateRequest,
@@ -23,27 +24,7 @@ import { resolveListMessagesRoute } from "./listMessagesRouting";
 // Minimal interfaces — only what the handler needs
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface BootstrapMessagesPage {
-  /** conversations.messages.list() returns a paginated resource */
-  getPaginatedItems(): unknown[];
-}
-
-export interface BootstrapHandlerClient {
-  conversations: {
-    messages: {
-      list(
-        conversationId: string,
-        opts: {
-          limit: number;
-          order: "asc" | "desc";
-          agent_id?: string;
-          before?: string;
-          after?: string;
-        },
-      ): Promise<BootstrapMessagesPage>;
-    };
-  };
-}
+export type BootstrapHandlerBackend = Pick<Backend, "listConversationMessages">;
 
 export interface BootstrapHandlerSessionContext {
   agentId: string;
@@ -58,7 +39,7 @@ export interface HandleBootstrapParams {
   bootstrapReq: BootstrapSessionStateRequest;
   sessionContext: BootstrapHandlerSessionContext;
   requestId: string;
-  client: BootstrapHandlerClient;
+  backend: BootstrapHandlerBackend;
   /** Optional: flag indicating a pending approval is waiting. */
   hasPendingApproval?: boolean;
 }
@@ -80,7 +61,7 @@ export async function handleBootstrapSessionState(
     bootstrapReq,
     sessionContext,
     requestId,
-    client,
+    backend,
     hasPendingApproval,
   } = params;
 
@@ -98,10 +79,11 @@ export async function handleBootstrapSessionState(
     );
 
     const listStart = Date.now();
-    const page = await client.conversations.messages.list(
-      route.conversationId,
-      { limit, order, ...(route.agentId ? { agent_id: route.agentId } : {}) },
-    );
+    const page = await backend.listConversationMessages(route.conversationId, {
+      limit,
+      order,
+      ...(route.agentId ? { agent_id: route.agentId } : {}),
+    } as ConversationMessageListBody);
     const items = page.getPaginatedItems();
     const listEnd = Date.now();
 

--- a/src/agent/listMessagesHandler.ts
+++ b/src/agent/listMessagesHandler.ts
@@ -2,11 +2,12 @@
  * Extracted handler for the list_messages control request.
  *
  * Returns a ControlResponse object (caller does console.log + JSON.stringify).
- * Accepting a minimal client interface makes the handler fully testable with
+ * Accepting a minimal backend interface makes the handler fully testable with
  * mock objects — no real network or process required.
  */
 
 import { randomUUID } from "node:crypto";
+import type { Backend, ConversationMessageListBody } from "../backend";
 import type {
   ControlResponse,
   ListMessagesControlRequest,
@@ -15,29 +16,13 @@ import type {
 import { resolveListMessagesRoute } from "./listMessagesRouting";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Minimal client interface — only what the handler needs
+// Minimal backend interface — only what the handler needs
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface ConversationsMessagesPage {
-  getPaginatedItems(): unknown[];
-}
-
-export interface ListMessagesHandlerClient {
-  conversations: {
-    messages: {
-      list(
-        conversationId: string,
-        opts: {
-          limit: number;
-          order: "asc" | "desc";
-          agent_id?: string;
-          before?: string;
-          after?: string;
-        },
-      ): Promise<ConversationsMessagesPage>;
-    };
-  };
-}
+export type ListMessagesHandlerBackend = Pick<
+  Backend,
+  "listConversationMessages"
+>;
 
 export interface HandleListMessagesParams {
   listReq: ListMessagesControlRequest;
@@ -47,7 +32,7 @@ export interface HandleListMessagesParams {
   sessionAgentId: string;
   sessionId: string;
   requestId: string;
-  client: ListMessagesHandlerClient;
+  backend: ListMessagesHandlerBackend;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -69,7 +54,7 @@ export async function handleListMessages(
     sessionAgentId,
     sessionId,
     requestId,
-    client,
+    backend,
   } = params;
 
   const limit = listReq.limit ?? 50;
@@ -86,15 +71,12 @@ export async function handleListMessages(
       sessionAgentId,
     );
 
-    const page = await client.conversations.messages.list(
-      route.conversationId,
-      {
-        limit,
-        order,
-        ...(route.agentId ? { agent_id: route.agentId } : {}),
-        ...cursorOpts,
-      },
-    );
+    const page = await backend.listConversationMessages(route.conversationId, {
+      limit,
+      order,
+      ...(route.agentId ? { agent_id: route.agentId } : {}),
+      ...cursorOpts,
+    } as ConversationMessageListBody);
     const items = page.getPaginatedItems();
 
     const hasMore = items.length >= limit;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import type { Letta } from "@letta-ai/letta-client";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type {
   AgentState,
@@ -1442,11 +1441,9 @@ export async function handleHeadlessCommand(
 
   // If input-format is stream-json, use bidirectional mode
   if (isBidirectionalMode) {
-    const client = await getClient();
     await runBidirectionalMode(
       agent,
       conversationId,
-      client,
       outputFormat,
       includePartialMessages,
       availableTools,
@@ -2792,7 +2789,6 @@ ${SYSTEM_REMINDER_CLOSE}
 async function runBidirectionalMode(
   agent: AgentState,
   conversationId: string,
-  client: Letta,
   _outputFormat: string,
   includePartialMessages: boolean,
   availableTools: string[],
@@ -3488,7 +3484,7 @@ async function runBidirectionalMode(
             sessionId,
           },
           requestId: requestId ?? "",
-          client,
+          backend,
           hasPendingApproval,
         });
         writeWireMessage(bootstrapResp);
@@ -3500,7 +3496,7 @@ async function runBidirectionalMode(
           sessionAgentId: agent.id,
           sessionId,
           requestId: requestId ?? "",
-          client,
+          backend,
         });
         writeWireMessage(listResp);
       } else if (subtype === "recover_pending_approvals") {

--- a/src/tests/headless/bootstrap-handler.test.ts
+++ b/src/tests/headless/bootstrap-handler.test.ts
@@ -1,20 +1,20 @@
 /**
- * Handler-level tests for bootstrap_session_state using mock Letta clients.
+ * Handler-level tests for bootstrap_session_state using mock backends.
  *
  * Verifies:
- * 1. Correct routing (all paths use conversations.messages.list)
+ * 1. Correct routing (all paths use backend.listConversationMessages)
  * 2. Response payload shape (agent_id, conversation_id, model, tools, messages, etc.)
  * 3. Pagination fields (next_before, has_more)
  * 4. Timing fields presence
- * 5. Error path — client throws → error envelope returned
+ * 5. Error path — backend throws → error envelope returned
  * 6. Default conversation passes conversation_id="default" with agent_id query
- * 7. Explicit conversation uses conversations.messages.list
+ * 7. Explicit conversation uses backend.listConversationMessages
  *
  * No network. No CLI subprocess. No process.stdout.
  */
 import { describe, expect, mock, test } from "bun:test";
 import type {
-  BootstrapHandlerClient,
+  BootstrapHandlerBackend,
   BootstrapHandlerSessionContext,
 } from "../../agent/bootstrapHandler";
 import { handleBootstrapSessionState } from "../../agent/bootstrapHandler";
@@ -23,23 +23,20 @@ import { handleBootstrapSessionState } from "../../agent/bootstrapHandler";
 // Mock factory
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeClient(convMessages: unknown[] = []): {
-  client: BootstrapHandlerClient;
+function makeBackend(convMessages: unknown[] = []): {
+  backend: BootstrapHandlerBackend;
   convListSpy: ReturnType<typeof mock>;
 } {
   const convListSpy = mock(async () => ({
     getPaginatedItems: () => convMessages,
   }));
 
-  const client: BootstrapHandlerClient = {
-    conversations: {
-      messages: {
-        list: convListSpy as unknown as BootstrapHandlerClient["conversations"]["messages"]["list"],
-      },
-    },
+  const backend: BootstrapHandlerBackend = {
+    listConversationMessages:
+      convListSpy as unknown as BootstrapHandlerBackend["listConversationMessages"],
   };
 
-  return { client, convListSpy };
+  return { backend, convListSpy };
 }
 
 const BASE_CTX: BootstrapHandlerSessionContext = {
@@ -56,8 +53,8 @@ const BASE_CTX: BootstrapHandlerSessionContext = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("bootstrap_session_state routing", () => {
-  test("default conversation passes default + agent_id to conversations.messages.list", async () => {
-    const { client, convListSpy } = makeClient([
+  test("default conversation passes default + agent_id to backend.listConversationMessages", async () => {
+    const { backend, convListSpy } = makeBackend([
       { id: "msg-1", type: "user_message" },
     ]);
 
@@ -65,7 +62,7 @@ describe("bootstrap_session_state routing", () => {
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: { ...BASE_CTX, conversationId: "default" },
       requestId: "req-1",
-      client,
+      backend,
     });
 
     expect(convListSpy).toHaveBeenCalledTimes(1);
@@ -77,8 +74,8 @@ describe("bootstrap_session_state routing", () => {
     );
   });
 
-  test("named conversation uses conversations.messages.list", async () => {
-    const { client, convListSpy } = makeClient([
+  test("named conversation uses backend.listConversationMessages", async () => {
+    const { backend, convListSpy } = makeBackend([
       { id: "msg-1", type: "user_message" },
     ]);
 
@@ -86,7 +83,7 @@ describe("bootstrap_session_state routing", () => {
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: { ...BASE_CTX, conversationId: "conv-abc-123" },
       requestId: "req-2",
-      client,
+      backend,
     });
 
     expect(convListSpy).toHaveBeenCalledTimes(1);
@@ -107,13 +104,13 @@ describe("bootstrap_session_state response shape", () => {
       { id: "msg-2", type: "user_message" },
       { id: "msg-1", type: "user_message" },
     ];
-    const { client } = makeClient(messages);
+    const { backend } = makeBackend(messages);
 
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-3",
-      client,
+      backend,
     });
 
     expect(resp.type).toBe("control_response");
@@ -136,12 +133,12 @@ describe("bootstrap_session_state response shape", () => {
   });
 
   test("has_pending_approval defaults to false", async () => {
-    const { client } = makeClient();
+    const { backend } = makeBackend();
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-4",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -149,12 +146,12 @@ describe("bootstrap_session_state response shape", () => {
   });
 
   test("has_pending_approval reflects caller-provided value", async () => {
-    const { client } = makeClient();
+    const { backend } = makeBackend();
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-5",
-      client,
+      backend,
       hasPendingApproval: true,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
@@ -163,12 +160,12 @@ describe("bootstrap_session_state response shape", () => {
   });
 
   test("timings are present and numeric", async () => {
-    const { client } = makeClient();
+    const { backend } = makeBackend();
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-6",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -194,13 +191,13 @@ describe("bootstrap_session_state pagination", () => {
       id: `msg-${i}`,
       type: "user_message",
     }));
-    const { client } = makeClient(messages);
+    const { backend } = makeBackend(messages);
 
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state", limit: 50 },
       sessionContext: BASE_CTX,
       requestId: "req-7",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -212,13 +209,13 @@ describe("bootstrap_session_state pagination", () => {
     const messages = Array.from({ length: limit }, (_, i) => ({
       id: `msg-${i}`,
     }));
-    const { client } = makeClient(messages);
+    const { backend } = makeBackend(messages);
 
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state", limit },
       sessionContext: BASE_CTX,
       requestId: "req-8",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -231,13 +228,13 @@ describe("bootstrap_session_state pagination", () => {
       { id: "msg-middle" },
       { id: "msg-oldest" },
     ];
-    const { client } = makeClient(messages);
+    const { backend } = makeBackend(messages);
 
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-9",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -246,12 +243,12 @@ describe("bootstrap_session_state pagination", () => {
   });
 
   test("next_before is null when no messages", async () => {
-    const { client } = makeClient([]);
+    const { backend } = makeBackend([]);
     const resp = await handleBootstrapSessionState({
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-10",
-      client,
+      backend,
     });
     const payload = (resp.response as { response: Record<string, unknown> })
       .response;
@@ -264,14 +261,10 @@ describe("bootstrap_session_state pagination", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("bootstrap_session_state error handling", () => {
-  test("client error returns error envelope", async () => {
-    const throwingClient: BootstrapHandlerClient = {
-      conversations: {
-        messages: {
-          list: async () => {
-            throw new Error("Network timeout");
-          },
-        },
+  test("backend error returns error envelope", async () => {
+    const throwingBackend: BootstrapHandlerBackend = {
+      listConversationMessages: async () => {
+        throw new Error("Network timeout");
       },
     };
 
@@ -279,7 +272,7 @@ describe("bootstrap_session_state error handling", () => {
       bootstrapReq: { subtype: "bootstrap_session_state" },
       sessionContext: BASE_CTX,
       requestId: "req-err",
-      client: throwingClient,
+      backend: throwingBackend,
     });
 
     expect(resp.type).toBe("control_response");

--- a/src/tests/headless/dev-backend-smoke.test.ts
+++ b/src/tests/headless/dev-backend-smoke.test.ts
@@ -54,6 +54,143 @@ async function runCli(
   });
 }
 
+async function runStreamJsonCli(): Promise<{
+  objects: Array<Record<string, unknown>>;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}> {
+  const env = createIsolatedCliTestEnv({
+    LETTA_DEBUG: "0",
+    DISABLE_AUTOUPDATER: "1",
+  });
+  delete env.LETTA_API_KEY;
+  delete env.LETTA_BASE_URL;
+  delete env.LETTA_API_BASE;
+  delete env.LETTA_AGENT_ID;
+  delete env.LETTA_CONVERSATION_ID;
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      "bun",
+      [
+        "run",
+        "dev",
+        "-p",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--agent",
+        "agent-fake",
+        "--dev-backend",
+        "fake-headless",
+        "--permission-mode",
+        "plan",
+        "--no-skills",
+      ],
+      {
+        cwd: projectRoot,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const objects: Array<Record<string, unknown>> = [];
+    let stdout = "";
+    let stderr = "";
+    let buffer = "";
+    let sentInputs = false;
+    let closing = false;
+
+    const maybeClose = () => {
+      const controlResponses = objects.filter(
+        (obj) => obj.type === "control_response",
+      ).length;
+      const hasResult = objects.some((obj) => obj.type === "result");
+      if (!closing && controlResponses >= 2 && hasResult) {
+        closing = true;
+        proc.stdin?.end();
+      }
+    };
+
+    const sendInputs = () => {
+      if (sentInputs) return;
+      sentInputs = true;
+      const inputs = [
+        {
+          type: "control_request",
+          request_id: "bootstrap-1",
+          request: { subtype: "bootstrap_session_state" },
+        },
+        {
+          type: "control_request",
+          request_id: "list-1",
+          request: { subtype: "list_messages" },
+        },
+        {
+          type: "user",
+          message: { role: "user", content: "ping" },
+        },
+      ];
+      for (const input of inputs) {
+        proc.stdin?.write(`${JSON.stringify(input)}\n`);
+      }
+    };
+
+    const processLine = (line: string) => {
+      if (!line.trim()) return;
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      objects.push(parsed);
+      if (parsed.type === "system" && parsed.subtype === "init") {
+        sendInputs();
+      }
+      maybeClose();
+    };
+
+    proc.stdout?.on("data", (data) => {
+      const chunk = data.toString();
+      stdout += chunk;
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        processLine(line);
+      }
+    });
+
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(
+        new Error(
+          `Timeout waiting for stream-json dev backend smoke. stdout: ${stdout}, stderr: ${stderr}`,
+        ),
+      );
+    }, 30000);
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      if (buffer.trim()) {
+        processLine(buffer);
+      }
+      resolve({ objects, stdout, stderr, exitCode: code });
+    });
+    proc.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
 describe("headless dev backend smoke", () => {
   test("runs one-shot headless without API credentials", async () => {
     const result = await runCli([
@@ -72,5 +209,39 @@ describe("headless dev backend smoke", () => {
     expect(result.stdout).toContain("pong");
     expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
     expect(result.stderr).not.toContain("Failed to connect to Letta server");
+  });
+
+  test("runs stream-json controls and user turn without API credentials", async () => {
+    const result = await runStreamJsonCli();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Failed to connect to Letta server");
+
+    const controlResponses = result.objects.filter(
+      (obj) => obj.type === "control_response",
+    );
+    expect(controlResponses).toHaveLength(2);
+    expect(
+      controlResponses.every(
+        (obj) =>
+          (obj.response as { subtype?: string } | undefined)?.subtype ===
+          "success",
+      ),
+    ).toBe(true);
+
+    expect(
+      result.objects.some(
+        (obj) =>
+          obj.type === "message" &&
+          obj.message_type === "assistant_message" &&
+          JSON.stringify(obj).includes("pong"),
+      ),
+    ).toBe(true);
+    expect(
+      result.objects.some(
+        (obj) => obj.type === "result" && JSON.stringify(obj).includes("pong"),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/tests/headless/list-messages-handler.test.ts
+++ b/src/tests/headless/list-messages-handler.test.ts
@@ -1,42 +1,39 @@
 /**
- * Handler-level tests for list_messages using mock Letta clients.
+ * Handler-level tests for list_messages using mock backends.
  *
  * These tests call handleListMessages() directly with mock implementations
- * of conversations.messages.list.  They verify:
+ * of backend.listConversationMessages.  They verify:
  *
- * 1. Which client method is called for each routing case (explicit conv,
+ * 1. Which backend method is called for each routing case (explicit conv,
  *    omitted+named session conv, omitted+default session conv)
- * 2. The arguments passed to each client method
+ * 2. The arguments passed to each backend method
  * 3. The shape and content of the returned ControlResponse
- * 4. Error path — client throws, handler returns error envelope
+ * 4. Error path — backend throws, handler returns error envelope
  *
  * No network. No CLI subprocess. No process.stdout.
  */
 import { describe, expect, mock, test } from "bun:test";
-import type { ListMessagesHandlerClient } from "../../agent/listMessagesHandler";
+import type { ListMessagesHandlerBackend } from "../../agent/listMessagesHandler";
 import { handleListMessages } from "../../agent/listMessagesHandler";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock factory
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeClient(convMessages: unknown[] = []): {
-  client: ListMessagesHandlerClient;
+function makeBackend(convMessages: unknown[] = []): {
+  backend: ListMessagesHandlerBackend;
   convListSpy: ReturnType<typeof mock>;
 } {
   const convListSpy = mock(async () => ({
     getPaginatedItems: () => convMessages,
   }));
 
-  const client: ListMessagesHandlerClient = {
-    conversations: {
-      messages: {
-        list: convListSpy as unknown as ListMessagesHandlerClient["conversations"]["messages"]["list"],
-      },
-    },
+  const backend: ListMessagesHandlerBackend = {
+    listConversationMessages:
+      convListSpy as unknown as ListMessagesHandlerBackend["listConversationMessages"],
   };
 
-  return { client, convListSpy };
+  return { backend, convListSpy };
 }
 
 const BASE = {
@@ -45,19 +42,19 @@ const BASE = {
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Routing: which client method is called
+// Routing: which backend method is called
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("handleListMessages — routing (which API is called)", () => {
-  test("explicit conversation_id → calls conversations.messages.list with that id", async () => {
-    const { client, convListSpy } = makeClient([{ id: "m1" }]);
+describe("handleListMessages — routing (which backend method is called)", () => {
+  test("explicit conversation_id → calls backend.listConversationMessages with that id", async () => {
+    const { backend, convListSpy } = makeBackend([{ id: "m1" }]);
 
     const resp = await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", conversation_id: "conv-explicit" },
       sessionConversationId: "default",
       sessionAgentId: "agent-session",
-      client,
+      backend,
     });
 
     expect(convListSpy).toHaveBeenCalledTimes(1);
@@ -66,21 +63,21 @@ describe("handleListMessages — routing (which API is called)", () => {
   });
 
   test("explicit conversation_id overrides a non-default session conv", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", conversation_id: "conv-override" },
       sessionConversationId: "conv-session-other",
       sessionAgentId: "agent-session",
-      client,
+      backend,
     });
 
     expect(convListSpy.mock.calls[0]?.[0]).toBe("conv-override");
   });
 
-  test("omitted conversation_id + named session conv → calls conversations.messages.list with session conv", async () => {
-    const { client, convListSpy } = makeClient([
+  test("omitted conversation_id + named session conv → calls backend.listConversationMessages with session conv", async () => {
+    const { backend, convListSpy } = makeBackend([
       { id: "msg-A" },
       { id: "msg-B" },
     ]);
@@ -90,7 +87,7 @@ describe("handleListMessages — routing (which API is called)", () => {
       listReq: { subtype: "list_messages" }, // no conversation_id
       sessionConversationId: "conv-session-xyz",
       sessionAgentId: "agent-session",
-      client,
+      backend,
     });
 
     expect(convListSpy).toHaveBeenCalledTimes(1);
@@ -105,15 +102,15 @@ describe("handleListMessages — routing (which API is called)", () => {
     }
   });
 
-  test("omitted conversation_id + session on default → calls conversations.messages.list with default + agent_id", async () => {
-    const { client, convListSpy } = makeClient([{ id: "msg-default-1" }]);
+  test("omitted conversation_id + session on default → calls backend.listConversationMessages with default + agent_id", async () => {
+    const { backend, convListSpy } = makeBackend([{ id: "msg-default-1" }]);
 
     const resp = await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages" }, // no conversation_id
       sessionConversationId: "default",
       sessionAgentId: "agent-def",
-      client,
+      backend,
     });
 
     expect(convListSpy).toHaveBeenCalledTimes(1);
@@ -124,14 +121,14 @@ describe("handleListMessages — routing (which API is called)", () => {
   });
 
   test("explicit agent_id + session default → conversations path uses request agent_id query", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", agent_id: "agent-override" },
       sessionConversationId: "default",
       sessionAgentId: "agent-session",
-      client,
+      backend,
     });
 
     expect(convListSpy.mock.calls[0]?.[0]).toBe("default");
@@ -144,9 +141,9 @@ describe("handleListMessages — routing (which API is called)", () => {
 // Args forwarding: limit, order, cursor options
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("handleListMessages — API call arguments", () => {
+describe("handleListMessages — backend call arguments", () => {
   test("passes limit and order to conversations path", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
@@ -158,7 +155,7 @@ describe("handleListMessages — API call arguments", () => {
       },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     const opts = convListSpy.mock.calls[0]?.[1] as {
@@ -170,14 +167,14 @@ describe("handleListMessages — API call arguments", () => {
   });
 
   test("defaults to limit=50 and order=desc when not specified", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     expect(convListSpy.mock.calls[0]?.[0]).toBe("default");
@@ -192,7 +189,7 @@ describe("handleListMessages — API call arguments", () => {
   });
 
   test("forwards before cursor to conversations path", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
@@ -203,7 +200,7 @@ describe("handleListMessages — API call arguments", () => {
       },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     const opts = convListSpy.mock.calls[0]?.[1] as { before?: string };
@@ -211,14 +208,14 @@ describe("handleListMessages — API call arguments", () => {
   });
 
   test("forwards before cursor to default conversation path", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", before: "msg-cursor-agents" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     expect(convListSpy.mock.calls[0]?.[0]).toBe("default");
@@ -231,14 +228,14 @@ describe("handleListMessages — API call arguments", () => {
   });
 
   test("does not include before/after when absent", async () => {
-    const { client, convListSpy } = makeClient([]);
+    const { backend, convListSpy } = makeBackend([]);
 
     await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", conversation_id: "conv-1" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     const opts = convListSpy.mock.calls[0]?.[1] as Record<string, unknown>;
@@ -254,14 +251,14 @@ describe("handleListMessages — API call arguments", () => {
 describe("handleListMessages — response shape", () => {
   test("success response has correct envelope", async () => {
     const msgs = [{ id: "m1" }, { id: "m2" }];
-    const { client } = makeClient(msgs);
+    const { backend } = makeBackend(msgs);
 
     const resp = await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", conversation_id: "conv-1" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     expect(resp.type).toBe("control_response");
@@ -282,7 +279,7 @@ describe("handleListMessages — response shape", () => {
 
   test("has_more is true when result length equals limit", async () => {
     const msgs = Array.from({ length: 50 }, (_, i) => ({ id: `m${i}` }));
-    const { client } = makeClient(msgs);
+    const { backend } = makeBackend(msgs);
 
     const resp = await handleListMessages({
       ...BASE,
@@ -293,7 +290,7 @@ describe("handleListMessages — response shape", () => {
       },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     if (resp.response.subtype === "success") {
@@ -303,14 +300,14 @@ describe("handleListMessages — response shape", () => {
   });
 
   test("next_before is null when result is empty", async () => {
-    const { client } = makeClient([]);
+    const { backend } = makeBackend([]);
 
     const resp = await handleListMessages({
       ...BASE,
       listReq: { subtype: "list_messages", conversation_id: "conv-1" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     if (resp.response.subtype === "success") {
@@ -325,16 +322,13 @@ describe("handleListMessages — response shape", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("handleListMessages — error path", () => {
-  test("client Error → error control_response with message", async () => {
+  test("backend Error → error control_response with message", async () => {
     const convListSpy = mock(async () => {
       throw new Error("404 conversation not found");
     });
-    const client: ListMessagesHandlerClient = {
-      conversations: {
-        messages: {
-          list: convListSpy as unknown as ListMessagesHandlerClient["conversations"]["messages"]["list"],
-        },
-      },
+    const backend: ListMessagesHandlerBackend = {
+      listConversationMessages:
+        convListSpy as unknown as ListMessagesHandlerBackend["listConversationMessages"],
     };
 
     const resp = await handleListMessages({
@@ -342,7 +336,7 @@ describe("handleListMessages — error path", () => {
       listReq: { subtype: "list_messages", conversation_id: "conv-bad" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     expect(resp.response.subtype).toBe("error");
@@ -356,12 +350,9 @@ describe("handleListMessages — error path", () => {
     const convListSpy = mock(async () => {
       throw "string error";
     });
-    const client: ListMessagesHandlerClient = {
-      conversations: {
-        messages: {
-          list: convListSpy as unknown as ListMessagesHandlerClient["conversations"]["messages"]["list"],
-        },
-      },
+    const backend: ListMessagesHandlerBackend = {
+      listConversationMessages:
+        convListSpy as unknown as ListMessagesHandlerBackend["listConversationMessages"],
     };
 
     const resp = await handleListMessages({
@@ -369,7 +360,7 @@ describe("handleListMessages — error path", () => {
       listReq: { subtype: "list_messages", conversation_id: "conv-1" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     if (resp.response.subtype === "error") {
@@ -381,12 +372,9 @@ describe("handleListMessages — error path", () => {
     const convListSpy = mock(async () => {
       throw new Error("agent unavailable");
     });
-    const client: ListMessagesHandlerClient = {
-      conversations: {
-        messages: {
-          list: convListSpy as unknown as ListMessagesHandlerClient["conversations"]["messages"]["list"],
-        },
-      },
+    const backend: ListMessagesHandlerBackend = {
+      listConversationMessages:
+        convListSpy as unknown as ListMessagesHandlerBackend["listConversationMessages"],
     };
 
     const resp = await handleListMessages({
@@ -395,7 +383,7 @@ describe("handleListMessages — error path", () => {
       listReq: { subtype: "list_messages" },
       sessionConversationId: "default",
       sessionAgentId: "agent-1",
-      client,
+      backend,
     });
 
     expect(resp.session_id).toBe("my-session");


### PR DESCRIPTION
## Summary
- Route `bootstrap_session_state` and `list_messages` control handling through the `Backend` facade instead of raw SDK clients.
- Remove the bidirectional headless startup `getClient()` dependency so `--input-format stream-json` can use the dev backend path without API credentials.
- Extend the hidden dev backend smoke coverage to exercise stream-json control requests plus a user turn against `fake-headless`.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/headless src/tests/agent/getResumeData.test.ts src/tests/backend/api-backend.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/cli/args.test.ts src/tests/tools/toolset-client-tool-rule-cleanup.test.ts src/tests/tools/toolset-memfs-detach.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)