### PR TITLE
test(api): make fake headless backend stateful

### DIFF
--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -6,24 +6,31 @@ import type {
   Backend,
   ConversationCreateBody,
   ConversationMessageCreateBody,
+  ConversationMessageStreamBody,
   RunMessageStreamBody,
 } from "../backend";
+import { FakeHeadlessStore } from "./FakeHeadlessStore";
 
-function createEmptyPage<T>() {
+function createPage<T>(items: T[]) {
   return {
-    getPaginatedItems: () => [] as T[],
+    getPaginatedItems: () => items,
   };
 }
 
-function createFakeStream(text: string): Stream<LettaStreamingResponse> {
+function createFakeStream(message: {
+  id: string;
+  date: string;
+  content?: unknown;
+}): Stream<LettaStreamingResponse> {
   const controller = new AbortController();
   return {
     controller,
     async *[Symbol.asyncIterator]() {
       yield {
         message_type: "assistant_message",
-        id: "msg-fake-assistant",
-        content: [{ type: "text", text }],
+        id: message.id,
+        date: message.date,
+        content: message.content ?? [{ type: "text", text: "pong" }],
       } as LettaStreamingResponse;
       yield {
         message_type: "stop_reason",
@@ -34,78 +41,77 @@ function createFakeStream(text: string): Stream<LettaStreamingResponse> {
 }
 
 export class FakeHeadlessBackend implements Backend {
-  private readonly agent: AgentState;
-  private conversationId = "conv-fake-headless";
+  private readonly store: FakeHeadlessStore;
 
   constructor(agentId = "agent-fake-headless") {
-    this.agent = {
-      id: agentId,
-      name: "Fake Headless Agent",
-      tools: [],
-      tags: [],
-      message_ids: [],
-      in_context_message_ids: [],
-      llm_config: {
-        model: "dev/fake-headless",
-        model_endpoint_type: "openai",
-        model_endpoint: "https://example.invalid/v1",
-        context_window: 128000,
-      },
-    } as unknown as AgentState;
+    this.store = new FakeHeadlessStore(agentId);
   }
 
   async retrieveAgent(agentId: string): Promise<AgentState> {
-    return { ...this.agent, id: agentId } as AgentState;
+    return this.store.ensureAgent(agentId);
   }
 
-  async updateAgent(agentId: string): Promise<AgentState> {
-    return { ...this.agent, id: agentId } as AgentState;
+  updateAgent(...args: Parameters<Backend["updateAgent"]>) {
+    const [agentId, body] = args;
+    return Promise.resolve(this.store.updateAgent(agentId, body));
   }
 
   async retrieveConversation(conversationId: string): Promise<Conversation> {
-    return {
-      id: conversationId,
-      agent_id: this.agent.id,
-      in_context_message_ids: [],
-    } as unknown as Conversation;
+    return this.store.retrieveConversation(conversationId);
   }
 
   async createConversation(
     body: ConversationCreateBody,
   ): Promise<Conversation> {
-    this.conversationId = "conv-fake-headless";
-    return {
-      id: this.conversationId,
-      agent_id: body.agent_id ?? this.agent.id,
-      in_context_message_ids: [],
-    } as unknown as Conversation;
+    return this.store.createConversation(body);
   }
 
-  async updateConversation(conversationId: string): Promise<Conversation> {
-    return this.retrieveConversation(conversationId);
+  updateConversation(...args: Parameters<Backend["updateConversation"]>) {
+    const [conversationId, body] = args;
+    return Promise.resolve(this.store.updateConversation(conversationId, body));
   }
 
-  listConversationMessages(): ReturnType<Backend["listConversationMessages"]> {
-    return Promise.resolve(createEmptyPage() as never);
+  listConversationMessages(
+    ...args: Parameters<Backend["listConversationMessages"]>
+  ): ReturnType<Backend["listConversationMessages"]> {
+    const [conversationId, body] = args;
+    return Promise.resolve(
+      createPage(
+        this.store.listConversationMessages(conversationId, body),
+      ) as never,
+    );
   }
 
-  listAgentMessages(): ReturnType<Backend["listAgentMessages"]> {
-    return Promise.resolve(createEmptyPage() as never);
+  listAgentMessages(
+    ...args: Parameters<Backend["listAgentMessages"]>
+  ): ReturnType<Backend["listAgentMessages"]> {
+    const [agentId, body] = args;
+    return Promise.resolve(
+      createPage(this.store.listAgentMessages(agentId, body)) as never,
+    );
   }
 
-  retrieveMessage(): ReturnType<Backend["retrieveMessage"]> {
-    return Promise.resolve([] as never);
+  retrieveMessage(
+    ...args: Parameters<Backend["retrieveMessage"]>
+  ): ReturnType<Backend["retrieveMessage"]> {
+    const [messageId] = args;
+    return Promise.resolve(this.store.retrieveMessage(messageId) as never);
   }
 
   async createConversationMessageStream(
-    _conversationId: string,
-    _body: ConversationMessageCreateBody,
+    conversationId: string,
+    body: ConversationMessageCreateBody,
   ) {
-    return createFakeStream("pong");
+    const assistantMessage = this.store.appendTurn(conversationId, body);
+    return createFakeStream(assistantMessage);
   }
 
-  async streamConversationMessages() {
-    return createFakeStream("pong");
+  async streamConversationMessages(
+    conversationId: string,
+    body: ConversationMessageStreamBody,
+  ) {
+    const assistantMessage = this.store.appendTurn(conversationId, body);
+    return createFakeStream(assistantMessage);
   }
 
   async cancelConversation() {
@@ -117,7 +123,11 @@ export class FakeHeadlessBackend implements Backend {
   }
 
   async streamRunMessages(_runId: string, _body: RunMessageStreamBody) {
-    return createFakeStream("pong");
+    return createFakeStream({
+      id: "msg-fake-headless-run",
+      date: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+      content: [{ type: "text", text: "pong" }],
+    });
   }
 
   async forkConversation(conversationId: string) {

--- a/src/backend/dev/FakeHeadlessStore.ts
+++ b/src/backend/dev/FakeHeadlessStore.ts
@@ -1,0 +1,341 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import type {
+  AgentMessageListBody,
+  AgentUpdateBody,
+  ConversationCreateBody,
+  ConversationMessageCreateBody,
+  ConversationMessageListBody,
+  ConversationMessageStreamBody,
+  ConversationUpdateBody,
+} from "../backend";
+
+type StoredMessage = Message & {
+  id: string;
+  message_type: string;
+  date: string;
+  content?: unknown;
+  agent_id: string;
+  conversation_id: string;
+};
+
+type StoredConversation = Conversation & {
+  id: string;
+  agent_id: string;
+  in_context_message_ids: string[];
+};
+
+function createAgent(agentId: string): AgentState {
+  return {
+    id: agentId,
+    name: "Fake Headless Agent",
+    tools: [],
+    tags: [],
+    message_ids: [],
+    in_context_message_ids: [],
+    llm_config: {
+      model: "dev/fake-headless",
+      model_endpoint_type: "openai",
+      model_endpoint: "https://example.invalid/v1",
+      context_window: 128000,
+    },
+  } as unknown as AgentState;
+}
+
+function textContent(text: string) {
+  return [{ type: "text" as const, text }];
+}
+
+function normalizeContent(content: unknown): unknown {
+  if (typeof content === "string") {
+    return textContent(content);
+  }
+  return content;
+}
+
+function getMessageType(message: Record<string, unknown>): string {
+  if (message.type === "approval") {
+    return "approval_response_message";
+  }
+  if (message.role === "assistant") {
+    return "assistant_message";
+  }
+  return "user_message";
+}
+
+function getListLimit(
+  body?: ConversationMessageListBody | AgentMessageListBody,
+) {
+  const limit = (body as { limit?: unknown } | undefined)?.limit;
+  return typeof limit === "number" && limit > 0 ? limit : undefined;
+}
+
+function getListOrder(
+  body?: ConversationMessageListBody | AgentMessageListBody,
+) {
+  const order = (body as { order?: unknown } | undefined)?.order;
+  return order === "asc" ? "asc" : "desc";
+}
+
+function getCursor(
+  body: ConversationMessageListBody | AgentMessageListBody | undefined,
+  key: "before" | "after",
+): string | undefined {
+  const value = (body as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export class FakeHeadlessStore {
+  private readonly agents = new Map<string, AgentState>();
+  private readonly conversations = new Map<string, StoredConversation>();
+  private readonly messagesByConversationKey = new Map<
+    string,
+    StoredMessage[]
+  >();
+  private readonly messagesById = new Map<string, StoredMessage[]>();
+  private conversationSeq = 0;
+  private messageSeq = 0;
+
+  constructor(private readonly defaultAgentId: string) {
+    this.ensureAgent(this.defaultAgentId);
+  }
+
+  ensureAgent(agentId: string): AgentState {
+    const existing = this.agents.get(agentId);
+    if (existing) return existing;
+    const agent = createAgent(agentId);
+    this.agents.set(agentId, agent);
+    this.ensureConversation("default", agentId);
+    return agent;
+  }
+
+  updateAgent(agentId: string, body: AgentUpdateBody): AgentState {
+    const current = this.ensureAgent(agentId);
+    const updated = { ...current, ...(body as Record<string, unknown>) };
+    this.agents.set(agentId, updated as AgentState);
+    return updated as AgentState;
+  }
+
+  retrieveConversation(conversationId: string, agentId?: string): Conversation {
+    return this.ensureConversation(conversationId, agentId);
+  }
+
+  createConversation(body: ConversationCreateBody): Conversation {
+    const agentId = body.agent_id ?? this.defaultAgentId;
+    this.ensureAgent(agentId);
+    this.conversationSeq += 1;
+    return this.ensureConversation(
+      `conv-fake-headless-${this.conversationSeq}`,
+      agentId,
+    );
+  }
+
+  updateConversation(
+    conversationId: string,
+    body: ConversationUpdateBody,
+  ): Conversation {
+    const current = this.ensureConversation(conversationId);
+    const updated = { ...current, ...(body as Record<string, unknown>) };
+    this.conversations.set(
+      this.conversationKey(conversationId, current.agent_id),
+      updated as StoredConversation,
+    );
+    return updated as Conversation;
+  }
+
+  appendTurn(
+    conversationId: string,
+    body: ConversationMessageCreateBody | ConversationMessageStreamBody,
+  ): StoredMessage {
+    const bodyWithAgent = body as {
+      agent_id?: string;
+      messages?: Array<Record<string, unknown>>;
+    };
+    const agentId =
+      bodyWithAgent.agent_id ?? this.agentIdForConversation(conversationId);
+    this.ensureAgent(agentId);
+    this.ensureConversation(conversationId, agentId);
+
+    for (const message of bodyWithAgent.messages ?? []) {
+      this.appendInputMessage(conversationId, agentId, message);
+    }
+
+    return this.appendAssistantMessage(conversationId, agentId, "pong");
+  }
+
+  listConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageListBody,
+  ): StoredMessage[] {
+    const agentId =
+      (body as { agent_id?: string } | undefined)?.agent_id ??
+      this.agentIdForConversation(conversationId);
+    this.ensureConversation(conversationId, agentId);
+    const messages = [
+      ...(this.messagesByConversationKey.get(
+        this.conversationKey(conversationId, agentId),
+      ) ?? []),
+    ];
+    return this.applyListOptions(messages, body);
+  }
+
+  listAgentMessages(
+    agentId: string,
+    body?: AgentMessageListBody,
+  ): StoredMessage[] {
+    const conversationId =
+      (body as { conversation_id?: string } | undefined)?.conversation_id ??
+      "default";
+    return this.listConversationMessages(conversationId, {
+      ...(body as Record<string, unknown> | undefined),
+      agent_id: agentId,
+    } as ConversationMessageListBody);
+  }
+
+  retrieveMessage(messageId: string): StoredMessage[] {
+    return [...(this.messagesById.get(messageId) ?? [])];
+  }
+
+  private appendInputMessage(
+    conversationId: string,
+    agentId: string,
+    message: Record<string, unknown>,
+  ): StoredMessage {
+    const content =
+      message.type === "approval"
+        ? (message.approvals ?? [])
+        : normalizeContent(message.content);
+    return this.appendMessage(conversationId, agentId, {
+      message_type: getMessageType(message),
+      role: message.role,
+      content,
+      otid: message.otid,
+      approvals: message.approvals,
+    });
+  }
+
+  private appendAssistantMessage(
+    conversationId: string,
+    agentId: string,
+    text: string,
+  ): StoredMessage {
+    return this.appendMessage(conversationId, agentId, {
+      message_type: "assistant_message",
+      role: "assistant",
+      content: textContent(text),
+    });
+  }
+
+  private appendMessage(
+    conversationId: string,
+    agentId: string,
+    fields: Record<string, unknown>,
+  ): StoredMessage {
+    const conversation = this.ensureConversation(conversationId, agentId);
+    this.messageSeq += 1;
+    const id = `msg-fake-headless-${this.messageSeq}`;
+    const message = {
+      id,
+      date: new Date(Date.UTC(2026, 0, 1, 0, 0, this.messageSeq)).toISOString(),
+      agent_id: agentId,
+      conversation_id: conversation.id,
+      ...fields,
+    } as StoredMessage;
+
+    const key = this.conversationKey(conversation.id, agentId);
+    const messages = this.messagesByConversationKey.get(key) ?? [];
+    messages.push(message);
+    this.messagesByConversationKey.set(key, messages);
+    this.messagesById.set(id, [message]);
+
+    conversation.in_context_message_ids = [
+      ...conversation.in_context_message_ids,
+      id,
+    ];
+    this.conversations.set(key, conversation);
+
+    const agent = this.ensureAgent(agentId);
+    const agentWithContext = agent as AgentState & {
+      in_context_message_ids?: string[];
+    };
+    const messageIds = [...(agent.message_ids ?? []), id];
+    const inContextMessageIds = [
+      ...(agentWithContext.in_context_message_ids ?? []),
+      id,
+    ];
+    this.agents.set(agentId, {
+      ...agent,
+      message_ids: messageIds,
+      in_context_message_ids: inContextMessageIds,
+    } as AgentState);
+
+    return message;
+  }
+
+  private applyListOptions(
+    messages: StoredMessage[],
+    body?: ConversationMessageListBody | AgentMessageListBody,
+  ): StoredMessage[] {
+    let items = messages;
+    const before = getCursor(body, "before");
+    if (before) {
+      const beforeIndex = items.findIndex((message) => message.id === before);
+      if (beforeIndex >= 0) {
+        items = items.slice(0, beforeIndex);
+      }
+    }
+
+    const after = getCursor(body, "after");
+    if (after) {
+      const afterIndex = items.findIndex((message) => message.id === after);
+      if (afterIndex >= 0) {
+        items = items.slice(afterIndex + 1);
+      }
+    }
+
+    if (getListOrder(body) === "desc") {
+      items = [...items].reverse();
+    } else {
+      items = [...items];
+    }
+
+    const limit = getListLimit(body);
+    return limit === undefined ? items : items.slice(0, limit);
+  }
+
+  private ensureConversation(
+    conversationId: string,
+    agentId?: string,
+  ): StoredConversation {
+    const resolvedAgentId = agentId ?? this.defaultAgentId;
+    const key = this.conversationKey(conversationId, resolvedAgentId);
+    const existing = this.conversations.get(key);
+    if (existing) return existing;
+
+    const conversation = {
+      id: conversationId,
+      agent_id: resolvedAgentId,
+      in_context_message_ids: [],
+    } as StoredConversation;
+    this.conversations.set(key, conversation);
+    this.messagesByConversationKey.set(key, []);
+    return conversation;
+  }
+
+  private agentIdForConversation(conversationId: string): string {
+    if (conversationId === "default") return this.defaultAgentId;
+    for (const conversation of this.conversations.values()) {
+      if (conversation.id === conversationId) {
+        return conversation.agent_id;
+      }
+    }
+    return this.defaultAgentId;
+  }
+
+  private conversationKey(conversationId: string, agentId: string): string {
+    return conversationId === "default"
+      ? `default:${agentId}`
+      : `conversation:${conversationId}`;
+  }
+}

--- a/src/tests/backend/fake-headless-backend.test.ts
+++ b/src/tests/backend/fake-headless-backend.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  AgentMessageListBody,
+  ConversationMessageCreateBody,
+  ConversationMessageListBody,
+} from "../../backend";
+import { FakeHeadlessBackend } from "../../backend/dev/FakeHeadlessBackend";
+
+async function drainAssistantText(
+  stream: AsyncIterable<LettaStreamingResponse>,
+): Promise<string> {
+  let text = "";
+  for await (const chunk of stream) {
+    if (chunk.message_type !== "assistant_message") continue;
+    const content = chunk.content;
+    if (!Array.isArray(content)) continue;
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        part.type === "text" &&
+        "text" in part &&
+        typeof part.text === "string"
+      ) {
+        text += part.text;
+      }
+    }
+  }
+  return text;
+}
+
+function createBody(
+  text: string,
+  agentId: string,
+): ConversationMessageCreateBody {
+  return {
+    messages: [{ role: "user", content: text }],
+    streaming: true,
+    stream_tokens: true,
+    include_pings: true,
+    background: true,
+    client_tools: [],
+    client_skills: [],
+    agent_id: agentId,
+  } as unknown as ConversationMessageCreateBody;
+}
+
+describe("FakeHeadlessBackend", () => {
+  test("stores user and assistant messages for explicit conversations", async () => {
+    const backend = new FakeHeadlessBackend("agent-test");
+    const conversation = await backend.createConversation({
+      agent_id: "agent-test",
+    });
+
+    const stream = await backend.createConversationMessageStream(
+      conversation.id,
+      createBody("hello", "agent-test"),
+    );
+    await expect(drainAssistantText(stream)).resolves.toBe("pong");
+
+    const page = await backend.listConversationMessages(conversation.id, {
+      order: "asc",
+    } as ConversationMessageListBody);
+    const messages = page.getPaginatedItems();
+
+    expect(messages.map((message) => message.message_type)).toEqual([
+      "user_message",
+      "assistant_message",
+    ]);
+    expect(JSON.stringify(messages[0])).toContain("hello");
+    expect(JSON.stringify(messages[1])).toContain("pong");
+
+    const updatedConversation = (await backend.retrieveConversation(
+      conversation.id,
+    )) as { in_context_message_ids?: string[] };
+    expect(updatedConversation.in_context_message_ids).toHaveLength(2);
+  });
+
+  test("supports default conversation listing through agent messages", async () => {
+    const backend = new FakeHeadlessBackend("agent-default");
+
+    await backend.createConversationMessageStream(
+      "default",
+      createBody("default hello", "agent-default"),
+    );
+
+    const page = await backend.listAgentMessages("agent-default", {
+      conversation_id: "default",
+      order: "asc",
+    } as AgentMessageListBody);
+    const messages = page.getPaginatedItems();
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.message_type)).toEqual([
+      "user_message",
+      "assistant_message",
+    ]);
+    expect(JSON.stringify(messages)).toContain("default hello");
+  });
+
+  test("appends repeated turns and paginates newest-first history", async () => {
+    const backend = new FakeHeadlessBackend("agent-pages");
+    const conversation = await backend.createConversation({
+      agent_id: "agent-pages",
+    });
+
+    await backend.createConversationMessageStream(
+      conversation.id,
+      createBody("first", "agent-pages"),
+    );
+    await backend.createConversationMessageStream(
+      conversation.id,
+      createBody("second", "agent-pages"),
+    );
+
+    const firstPage = await backend.listConversationMessages(conversation.id, {
+      order: "desc",
+      limit: 2,
+    } as ConversationMessageListBody);
+    const firstPageItems = firstPage.getPaginatedItems();
+
+    expect(firstPageItems.map((message) => message.message_type)).toEqual([
+      "assistant_message",
+      "user_message",
+    ]);
+    expect(JSON.stringify(firstPageItems)).toContain("second");
+
+    const secondPage = await backend.listConversationMessages(conversation.id, {
+      order: "desc",
+      limit: 2,
+      before: firstPageItems.at(-1)?.id,
+    } as ConversationMessageListBody);
+    const secondPageItems = secondPage.getPaginatedItems();
+
+    expect(secondPageItems.map((message) => message.message_type)).toEqual([
+      "assistant_message",
+      "user_message",
+    ]);
+    expect(JSON.stringify(secondPageItems)).toContain("first");
+  });
+});

--- a/src/tests/headless/dev-backend-smoke.test.ts
+++ b/src/tests/headless/dev-backend-smoke.test.ts
@@ -100,42 +100,77 @@ async function runStreamJsonCli(): Promise<{
     let stdout = "";
     let stderr = "";
     let buffer = "";
-    let sentInputs = false;
+    let sentInitialInputs = false;
+    let sentListAfterFirstTurn = false;
+    let sentSecondTurn = false;
+    let sentFinalControls = false;
     let closing = false;
+    let resultCount = 0;
+    const controlResponseIds = new Set<string>();
 
     const maybeClose = () => {
-      const controlResponses = objects.filter(
-        (obj) => obj.type === "control_response",
-      ).length;
-      const hasResult = objects.some((obj) => obj.type === "result");
-      if (!closing && controlResponses >= 2 && hasResult) {
+      const hasAllControlResponses = [
+        "bootstrap-initial",
+        "list-after-1",
+        "bootstrap-after-2",
+        "list-after-2",
+      ].every((id) => controlResponseIds.has(id));
+      if (!closing && resultCount >= 2 && hasAllControlResponses) {
         closing = true;
         proc.stdin?.end();
       }
     };
 
-    const sendInputs = () => {
-      if (sentInputs) return;
-      sentInputs = true;
-      const inputs = [
-        {
-          type: "control_request",
-          request_id: "bootstrap-1",
-          request: { subtype: "bootstrap_session_state" },
-        },
-        {
-          type: "control_request",
-          request_id: "list-1",
-          request: { subtype: "list_messages" },
-        },
-        {
-          type: "user",
-          message: { role: "user", content: "ping" },
-        },
-      ];
-      for (const input of inputs) {
-        proc.stdin?.write(`${JSON.stringify(input)}\n`);
-      }
+    const sendInput = (input: Record<string, unknown>) => {
+      proc.stdin?.write(`${JSON.stringify(input)}\n`);
+    };
+
+    const sendInitialInputs = () => {
+      if (sentInitialInputs) return;
+      sentInitialInputs = true;
+      sendInput({
+        type: "control_request",
+        request_id: "bootstrap-initial",
+        request: { subtype: "bootstrap_session_state" },
+      });
+      sendInput({
+        type: "user",
+        message: { role: "user", content: "ping one" },
+      });
+    };
+
+    const sendListAfterFirstTurn = () => {
+      if (sentListAfterFirstTurn) return;
+      sentListAfterFirstTurn = true;
+      sendInput({
+        type: "control_request",
+        request_id: "list-after-1",
+        request: { subtype: "list_messages" },
+      });
+    };
+
+    const sendSecondTurn = () => {
+      if (sentSecondTurn) return;
+      sentSecondTurn = true;
+      sendInput({
+        type: "user",
+        message: { role: "user", content: "ping two" },
+      });
+    };
+
+    const sendFinalControls = () => {
+      if (sentFinalControls) return;
+      sentFinalControls = true;
+      sendInput({
+        type: "control_request",
+        request_id: "bootstrap-after-2",
+        request: { subtype: "bootstrap_session_state" },
+      });
+      sendInput({
+        type: "control_request",
+        request_id: "list-after-2",
+        request: { subtype: "list_messages" },
+      });
     };
 
     const processLine = (line: string) => {
@@ -148,7 +183,26 @@ async function runStreamJsonCli(): Promise<{
       }
       objects.push(parsed);
       if (parsed.type === "system" && parsed.subtype === "init") {
-        sendInputs();
+        sendInitialInputs();
+      }
+      if (parsed.type === "result") {
+        resultCount += 1;
+        if (resultCount === 1) {
+          sendListAfterFirstTurn();
+        } else if (resultCount === 2) {
+          sendFinalControls();
+        }
+      }
+      if (parsed.type === "control_response") {
+        const response = parsed.response as
+          | { request_id?: unknown; subtype?: unknown }
+          | undefined;
+        if (typeof response?.request_id === "string") {
+          controlResponseIds.add(response.request_id);
+          if (response.request_id === "list-after-1") {
+            sendSecondTurn();
+          }
+        }
       }
       maybeClose();
     };
@@ -191,6 +245,29 @@ async function runStreamJsonCli(): Promise<{
   });
 }
 
+function findControlPayload(
+  objects: Array<Record<string, unknown>>,
+  requestId: string,
+): Record<string, unknown> {
+  const control = objects.find((obj) => {
+    if (obj.type !== "control_response") return false;
+    const response = obj.response as { request_id?: unknown } | undefined;
+    return response?.request_id === requestId;
+  });
+  expect(control).toBeDefined();
+
+  const response = control?.response as
+    | { subtype?: unknown; response?: unknown }
+    | undefined;
+  expect(response?.subtype).toBe("success");
+  return response?.response as Record<string, unknown>;
+}
+
+function payloadMessages(payload: Record<string, unknown>) {
+  expect(Array.isArray(payload.messages)).toBe(true);
+  return payload.messages as Array<{ message_type?: string }>;
+}
+
 describe("headless dev backend smoke", () => {
   test("runs one-shot headless without API credentials", async () => {
     const result = await runCli([
@@ -211,7 +288,7 @@ describe("headless dev backend smoke", () => {
     expect(result.stderr).not.toContain("Failed to connect to Letta server");
   });
 
-  test("runs stream-json controls and user turn without API credentials", async () => {
+  test("runs stream-json controls and repeated user turns without API credentials", async () => {
     const result = await runStreamJsonCli();
 
     expect(result.exitCode).toBe(0);
@@ -221,7 +298,7 @@ describe("headless dev backend smoke", () => {
     const controlResponses = result.objects.filter(
       (obj) => obj.type === "control_response",
     );
-    expect(controlResponses).toHaveLength(2);
+    expect(controlResponses).toHaveLength(4);
     expect(
       controlResponses.every(
         (obj) =>
@@ -243,5 +320,31 @@ describe("headless dev backend smoke", () => {
         (obj) => obj.type === "result" && JSON.stringify(obj).includes("pong"),
       ),
     ).toBe(true);
+
+    const listAfterFirst = payloadMessages(
+      findControlPayload(result.objects, "list-after-1"),
+    );
+    expect(listAfterFirst.map((message) => message.message_type)).toEqual([
+      "assistant_message",
+      "user_message",
+    ]);
+    expect(JSON.stringify(listAfterFirst)).toContain("ping one");
+
+    const listAfterSecond = payloadMessages(
+      findControlPayload(result.objects, "list-after-2"),
+    );
+    expect(listAfterSecond.map((message) => message.message_type)).toEqual([
+      "assistant_message",
+      "user_message",
+      "assistant_message",
+      "user_message",
+    ]);
+    expect(JSON.stringify(listAfterSecond)).toContain("ping one");
+    expect(JSON.stringify(listAfterSecond)).toContain("ping two");
+
+    const bootstrapAfterSecond = payloadMessages(
+      findControlPayload(result.objects, "bootstrap-after-2"),
+    );
+    expect(bootstrapAfterSecond).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Summary
- Add an in-memory store behind `FakeHeadlessBackend` for fake agents, conversations, message history, and message lookup.
- Append incoming user/approval payloads plus deterministic assistant responses so fake headless turns are listable through the backend facade.
- Extend dev backend coverage for default/explicit conversations, pagination, bootstrap history, and repeated stream-json turns without API credentials.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/headless src/tests/backend/fake-headless-backend.test.ts src/tests/agent/getResumeData.test.ts src/tests/backend/api-backend.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/cli/args.test.ts src/tests/tools/toolset-client-tool-rule-cleanup.test.ts src/tests/tools/toolset-memfs-detach.test.ts src/tests/websocket/listen-client-concurrency.test.ts`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)