### PR TITLE
fix(channels): fail listener startup on channel errors

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1173,6 +1173,45 @@ export class ChannelRegistry {
 
 // ── Initialization ────────────────────────────────────────────────
 
+export interface ChannelStartupFailure {
+  channelId: string;
+  accountId?: string;
+  error: string;
+}
+
+export class ChannelInitializationError extends Error {
+  constructor(public readonly failures: ChannelStartupFailure[]) {
+    super(formatChannelStartupFailures(failures));
+    this.name = "ChannelInitializationError";
+  }
+}
+
+export function formatChannelStartupFailures(
+  failures: ChannelStartupFailure[],
+): string {
+  const failedChannels = Array.from(
+    new Set(failures.map((failure) => failure.channelId)),
+  );
+  const lines = failures.map((failure) => {
+    const label = failure.accountId
+      ? `${failure.channelId}/${failure.accountId}`
+      : failure.channelId;
+    return `- ${label}: ${failure.error}`;
+  });
+
+  return [
+    "Failed to start requested channel listeners.",
+    ...lines,
+    "",
+    "The listener is not running for these channels.",
+    `Install missing runtimes with: letta server --channels ${failedChannels.join(",")} --install-channel-runtimes`,
+    "Or install them once with:",
+    ...failedChannels.map(
+      (channelId) => `  letta channels install ${channelId}`,
+    ),
+  ].join("\n");
+}
+
 /**
  * Initialize the channel system.
  *
@@ -1186,16 +1225,18 @@ export class ChannelRegistry {
  */
 export async function initializeChannels(
   channelNames: string[],
+  options?: { failOnStartupError?: boolean },
 ): Promise<ChannelRegistry> {
   const registry = ensureChannelRegistry();
+  const failures: ChannelStartupFailure[] = [];
 
   for (const channelId of channelNames) {
     loadChannelAccounts(channelId);
     const accounts = listChannelAccounts(channelId);
     if (accounts.length === 0) {
-      console.error(
-        `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`,
-      );
+      const error = `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`;
+      failures.push({ channelId, error });
+      console.error(error);
       continue;
     }
 
@@ -1207,12 +1248,22 @@ export async function initializeChannels(
       try {
         await registry.startChannelAccount(channelId, account.accountId);
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push({
+          channelId,
+          accountId: account.accountId,
+          error: message,
+        });
         console.error(
           `[Channels] Failed to start ${channelId}/${account.accountId}:`,
-          error instanceof Error ? error.message : error,
+          message,
         );
       }
     }
+  }
+
+  if (failures.length > 0 && options?.failOnStartupError) {
+    throw new ChannelInitializationError(failures);
   }
 
   return registry;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,6 +19,7 @@ import {
   listChannelAccounts,
   loadChannelAccounts,
 } from "./accounts";
+import { getChannelAccountsPath, getChannelsRoot } from "./config";
 import {
   formatChannelControlRequestPrompt,
   parseChannelControlRequestResponse,
@@ -54,6 +55,7 @@ import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
   ChannelRoute,
+  ChannelStartupLogger,
   ChannelTurnLifecycleEvent,
   ChannelTurnSource,
   DiscordChannelAccount,
@@ -612,27 +614,57 @@ export class ChannelRegistry {
   async startChannelAccount(
     channelId: string,
     accountId: string,
+    options?: ChannelStartupOptions,
   ): Promise<boolean> {
+    logChannelStartup(options?.logger, `starting ${channelId}/${accountId}`);
     loadChannelAccounts(channelId);
     const account = getChannelAccount(channelId, accountId);
     if (!account) {
+      logChannelStartup(
+        options?.logger,
+        `account not found: ${channelId}/${accountId}`,
+      );
       return false;
     }
 
+    logChannelStartup(
+      options?.logger,
+      `loading route, pairing, and target stores for ${channelId}/${accountId}`,
+    );
     loadRoutes(channelId);
     loadPairingStore(channelId);
     loadTargetStore(channelId);
 
     const existing = this.getAdapter(channelId, accountId);
     if (existing?.isRunning()) {
+      logChannelStartup(
+        options?.logger,
+        `stopping existing adapter for ${channelId}/${accountId}`,
+      );
       await existing.stop();
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
 
+    logChannelStartup(
+      options?.logger,
+      `loading plugin for ${account.channel}/${accountId}`,
+    );
     const plugin = await loadChannelPlugin(account.channel);
+    logChannelStartup(
+      options?.logger,
+      `creating adapter for ${account.channel}/${accountId}`,
+    );
     const adapter = await plugin.createAdapter(account);
     this.registerAdapter(adapter);
-    await adapter.start();
+    logChannelStartup(
+      options?.logger,
+      `starting adapter for ${account.channel}/${accountId}`,
+    );
+    await adapter.start({ logger: options?.logger });
+    logChannelStartup(
+      options?.logger,
+      `started adapter for ${account.channel}/${accountId}`,
+    );
     return true;
   }
 
@@ -1179,6 +1211,24 @@ export interface ChannelStartupFailure {
   error: string;
 }
 
+type ChannelStartupOptions = {
+  logger?: ChannelStartupLogger;
+};
+
+function logChannelStartup(
+  logger: ChannelStartupLogger | undefined,
+  message: string,
+): void {
+  logger?.(`[Channels] ${message}`);
+}
+
+function formatChannelStartupError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+  return String(error);
+}
+
 export class ChannelInitializationError extends Error {
   constructor(public readonly failures: ChannelStartupFailure[]) {
     super(formatChannelStartupFailures(failures));
@@ -1225,18 +1275,43 @@ export function formatChannelStartupFailures(
  */
 export async function initializeChannels(
   channelNames: string[],
-  options?: { failOnStartupError?: boolean },
+  options?: { failOnStartupError?: boolean; logger?: ChannelStartupLogger },
 ): Promise<ChannelRegistry> {
   const registry = ensureChannelRegistry();
   const failures: ChannelStartupFailure[] = [];
 
+  logChannelStartup(
+    options?.logger,
+    `requested: ${channelNames.length > 0 ? channelNames.join(",") : "none"}`,
+  );
+  logChannelStartup(options?.logger, `root: ${getChannelsRoot()}`);
+
   for (const channelId of channelNames) {
+    logChannelStartup(
+      options?.logger,
+      `loading ${channelId} accounts from ${getChannelAccountsPath(channelId)}`,
+    );
     loadChannelAccounts(channelId);
     const accounts = listChannelAccounts(channelId);
+    const enabledAccountIds = accounts
+      .filter((account) => account.enabled)
+      .map((account) => account.accountId);
+    logChannelStartup(
+      options?.logger,
+      `${channelId}: accounts=${accounts.length}, enabled=${enabledAccountIds.length > 0 ? enabledAccountIds.join(",") : "none"}`,
+    );
     if (accounts.length === 0) {
       const error = `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`;
       failures.push({ channelId, error });
       console.error(error);
+      continue;
+    }
+
+    if (enabledAccountIds.length === 0) {
+      const error = `Channel "${channelId}" has no enabled accounts.`;
+      failures.push({ channelId, error });
+      console.error(error);
+      logChannelStartup(options?.logger, error);
       continue;
     }
 
@@ -1246,7 +1321,9 @@ export async function initializeChannels(
       }
 
       try {
-        await registry.startChannelAccount(channelId, account.accountId);
+        await registry.startChannelAccount(channelId, account.accountId, {
+          logger: options?.logger,
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         failures.push({
@@ -1257,6 +1334,10 @@ export async function initializeChannels(
         console.error(
           `[Channels] Failed to start ${channelId}/${account.accountId}:`,
           message,
+        );
+        logChannelStartup(
+          options?.logger,
+          `failed ${channelId}/${account.accountId}: ${formatChannelStartupError(error)}`,
         );
       }
     }

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,7 +19,6 @@ import {
   listChannelAccounts,
   loadChannelAccounts,
 } from "./accounts";
-import { getChannelAccountsPath, getChannelsRoot } from "./config";
 import {
   formatChannelControlRequestPrompt,
   parseChannelControlRequestResponse,
@@ -55,7 +54,6 @@ import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
   ChannelRoute,
-  ChannelStartupLogger,
   ChannelTurnLifecycleEvent,
   ChannelTurnSource,
   DiscordChannelAccount,
@@ -614,57 +612,27 @@ export class ChannelRegistry {
   async startChannelAccount(
     channelId: string,
     accountId: string,
-    options?: ChannelStartupOptions,
   ): Promise<boolean> {
-    logChannelStartup(options?.logger, `starting ${channelId}/${accountId}`);
     loadChannelAccounts(channelId);
     const account = getChannelAccount(channelId, accountId);
     if (!account) {
-      logChannelStartup(
-        options?.logger,
-        `account not found: ${channelId}/${accountId}`,
-      );
       return false;
     }
 
-    logChannelStartup(
-      options?.logger,
-      `loading route, pairing, and target stores for ${channelId}/${accountId}`,
-    );
     loadRoutes(channelId);
     loadPairingStore(channelId);
     loadTargetStore(channelId);
 
     const existing = this.getAdapter(channelId, accountId);
     if (existing?.isRunning()) {
-      logChannelStartup(
-        options?.logger,
-        `stopping existing adapter for ${channelId}/${accountId}`,
-      );
       await existing.stop();
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
 
-    logChannelStartup(
-      options?.logger,
-      `loading plugin for ${account.channel}/${accountId}`,
-    );
     const plugin = await loadChannelPlugin(account.channel);
-    logChannelStartup(
-      options?.logger,
-      `creating adapter for ${account.channel}/${accountId}`,
-    );
     const adapter = await plugin.createAdapter(account);
     this.registerAdapter(adapter);
-    logChannelStartup(
-      options?.logger,
-      `starting adapter for ${account.channel}/${accountId}`,
-    );
-    await adapter.start({ logger: options?.logger });
-    logChannelStartup(
-      options?.logger,
-      `started adapter for ${account.channel}/${accountId}`,
-    );
+    await adapter.start();
     return true;
   }
 
@@ -1211,24 +1179,6 @@ export interface ChannelStartupFailure {
   error: string;
 }
 
-type ChannelStartupOptions = {
-  logger?: ChannelStartupLogger;
-};
-
-function logChannelStartup(
-  logger: ChannelStartupLogger | undefined,
-  message: string,
-): void {
-  logger?.(`[Channels] ${message}`);
-}
-
-function formatChannelStartupError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack || error.message;
-  }
-  return String(error);
-}
-
 export class ChannelInitializationError extends Error {
   constructor(public readonly failures: ChannelStartupFailure[]) {
     super(formatChannelStartupFailures(failures));
@@ -1275,43 +1225,18 @@ export function formatChannelStartupFailures(
  */
 export async function initializeChannels(
   channelNames: string[],
-  options?: { failOnStartupError?: boolean; logger?: ChannelStartupLogger },
+  options?: { failOnStartupError?: boolean },
 ): Promise<ChannelRegistry> {
   const registry = ensureChannelRegistry();
   const failures: ChannelStartupFailure[] = [];
 
-  logChannelStartup(
-    options?.logger,
-    `requested: ${channelNames.length > 0 ? channelNames.join(",") : "none"}`,
-  );
-  logChannelStartup(options?.logger, `root: ${getChannelsRoot()}`);
-
   for (const channelId of channelNames) {
-    logChannelStartup(
-      options?.logger,
-      `loading ${channelId} accounts from ${getChannelAccountsPath(channelId)}`,
-    );
     loadChannelAccounts(channelId);
     const accounts = listChannelAccounts(channelId);
-    const enabledAccountIds = accounts
-      .filter((account) => account.enabled)
-      .map((account) => account.accountId);
-    logChannelStartup(
-      options?.logger,
-      `${channelId}: accounts=${accounts.length}, enabled=${enabledAccountIds.length > 0 ? enabledAccountIds.join(",") : "none"}`,
-    );
     if (accounts.length === 0) {
       const error = `Channel "${channelId}" not configured. Run: letta channels configure ${channelId}`;
       failures.push({ channelId, error });
       console.error(error);
-      continue;
-    }
-
-    if (enabledAccountIds.length === 0) {
-      const error = `Channel "${channelId}" has no enabled accounts.`;
-      failures.push({ channelId, error });
-      console.error(error);
-      logChannelStartup(options?.logger, error);
       continue;
     }
 
@@ -1321,9 +1246,7 @@ export async function initializeChannels(
       }
 
       try {
-        await registry.startChannelAccount(channelId, account.accountId, {
-          logger: options?.logger,
-        });
+        await registry.startChannelAccount(channelId, account.accountId);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         failures.push({
@@ -1334,10 +1257,6 @@ export async function initializeChannels(
         console.error(
           `[Channels] Failed to start ${channelId}/${account.accountId}:`,
           message,
-        );
-        logChannelStartup(
-          options?.logger,
-          `failed ${channelId}/${account.accountId}: ${formatChannelStartupError(error)}`,
         );
       }
     }

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -34,6 +34,43 @@ type BufferedMediaGroup = {
   messages: TelegramLikeMessage[];
   timer: ReturnType<typeof setTimeout>;
 };
+
+const DEFAULT_TELEGRAM_INIT_TIMEOUT_MS = 15_000;
+const DEFAULT_TELEGRAM_START_TIMEOUT_MS = 20_000;
+const TELEGRAM_FAILED_START_STOP_TIMEOUT_MS = 5_000;
+
+function getStartupTimeoutMs(envName: string, fallbackMs: number): number {
+  const raw = process.env[envName];
+  if (!raw) return fallbackMs;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+}
+
+function withStartupTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+
+    promise.then(
+      (value) => {
+        if (timer) clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (timer) clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 type TelegramReactionType =
   | {
       type?: "emoji";
@@ -414,38 +451,71 @@ export function createTelegramAdapter(
       if (running) return;
       const telegramBot = await ensureBot();
 
-      await telegramBot.init();
+      try {
+        await withStartupTimeout(
+          telegramBot.init(),
+          "Telegram bot init",
+          getStartupTimeoutMs(
+            "LETTA_TELEGRAM_INIT_TIMEOUT_MS",
+            DEFAULT_TELEGRAM_INIT_TIMEOUT_MS,
+          ),
+        );
+      } catch (error) {
+        bot = null;
+        throw error;
+      }
       const info = telegramBot.botInfo;
-      console.log(
-        `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
-      );
+      let startupTimedOut = false;
 
-      await new Promise<void>((resolve, reject) => {
-        let started = false;
+      try {
+        await withStartupTimeout(
+          new Promise<void>((resolve, reject) => {
+            let started = false;
 
-        void telegramBot
-          .start({
-            allowed_updates: ["message", "message_reaction"],
-            onStart: () => {
-              running = true;
-              started = true;
-              resolve();
-            },
-          })
-          .catch((error) => {
-            running = false;
+            void telegramBot
+              .start({
+                allowed_updates: ["message", "message_reaction"],
+                onStart: () => {
+                  if (startupTimedOut) return;
+                  running = true;
+                  started = true;
+                  console.log(
+                    `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
+                  );
+                  resolve();
+                },
+              })
+              .catch((error) => {
+                running = false;
 
-            if (!started) {
-              reject(error);
-              return;
-            }
+                if (!started) {
+                  reject(error);
+                  return;
+                }
 
-            console.error(
-              "[Telegram] Long-polling stopped unexpectedly:",
-              error,
-            );
-          });
-      });
+                console.error(
+                  "[Telegram] Long-polling stopped unexpectedly:",
+                  error,
+                );
+              });
+          }),
+          "Telegram bot polling startup",
+          getStartupTimeoutMs(
+            "LETTA_TELEGRAM_START_TIMEOUT_MS",
+            DEFAULT_TELEGRAM_START_TIMEOUT_MS,
+          ),
+        );
+      } catch (error) {
+        startupTimedOut = true;
+        running = false;
+        bot = null;
+        await withStartupTimeout(
+          telegramBot.stop(),
+          "Telegram bot stop after failed startup",
+          TELEGRAM_FAILED_START_STOP_TIMEOUT_MS,
+        ).catch(() => undefined);
+        throw error;
+      }
     },
 
     async stop(): Promise<void> {

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -9,7 +9,6 @@ import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import { formatChannelControlRequestPrompt } from "../interactive";
 import type {
   ChannelAdapter,
-  ChannelAdapterStartOptions,
   ChannelControlRequestEvent,
   InboundChannelMessage,
   OutboundChannelMessage,
@@ -35,74 +34,6 @@ type BufferedMediaGroup = {
   messages: TelegramLikeMessage[];
   timer: ReturnType<typeof setTimeout>;
 };
-
-const DEFAULT_TELEGRAM_INIT_TIMEOUT_MS = 15_000;
-const DEFAULT_TELEGRAM_START_TIMEOUT_MS = 20_000;
-const TELEGRAM_FAILED_START_STOP_TIMEOUT_MS = 5_000;
-
-function getStartupTimeoutMs(envName: string, fallbackMs: number): number {
-  const raw = process.env[envName];
-  if (!raw) {
-    return fallbackMs;
-  }
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
-}
-
-function withStartupTimeout<T>(
-  promise: Promise<T>,
-  label: string,
-  timeoutMs: number,
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  return new Promise<T>((resolve, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    timer.unref?.();
-
-    promise.then(
-      (value) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        resolve(value);
-      },
-      (error) => {
-        if (timer) {
-          clearTimeout(timer);
-        }
-        reject(error);
-      },
-    );
-  });
-}
-
-function logTelegramStartup(
-  options: ChannelAdapterStartOptions | undefined,
-  message: string,
-): void {
-  options?.logger?.(`[Telegram] ${message}`);
-}
-
-async function stopTelegramBotQuietly(
-  telegramBot: TelegramBot,
-  options: ChannelAdapterStartOptions | undefined,
-): Promise<void> {
-  try {
-    await withStartupTimeout(
-      telegramBot.stop(),
-      "Telegram bot stop after failed startup",
-      TELEGRAM_FAILED_START_STOP_TIMEOUT_MS,
-    );
-  } catch (error) {
-    logTelegramStartup(
-      options,
-      `stop after failed startup failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-}
-
 type TelegramReactionType =
   | {
       type?: "emoji";
@@ -344,21 +275,13 @@ export function createTelegramAdapter(
     }, TELEGRAM_MEDIA_GROUP_FLUSH_MS);
   }
 
-  async function ensureBot(
-    options?: ChannelAdapterStartOptions,
-  ): Promise<TelegramBot> {
+  async function ensureBot(): Promise<TelegramBot> {
     if (bot) {
       return bot;
     }
 
-    logTelegramStartup(options, "loading grammY runtime");
     const grammy = await ensureModule();
-    logTelegramStartup(options, "grammY runtime loaded");
     const Bot = resolveTelegramBotConstructor(grammy);
-    logTelegramStartup(
-      options,
-      `constructing bot for account ${config.accountId}`,
-    );
     const instance = new Bot(config.token);
 
     instance.catch((error) => {
@@ -477,10 +400,6 @@ export function createTelegramAdapter(
       );
     });
 
-    logTelegramStartup(
-      options,
-      `handlers registered for account ${config.accountId}`,
-    );
     bot = instance;
     return instance;
   }
@@ -491,90 +410,42 @@ export function createTelegramAdapter(
     accountId: config.accountId,
     name: "Telegram",
 
-    async start(options?: ChannelAdapterStartOptions): Promise<void> {
+    async start(): Promise<void> {
       if (running) return;
-      logTelegramStartup(
-        options,
-        `start requested for account ${config.accountId}`,
-      );
-      const telegramBot = await ensureBot(options);
+      const telegramBot = await ensureBot();
 
-      logTelegramStartup(options, `init start for account ${config.accountId}`);
-      try {
-        await withStartupTimeout(
-          telegramBot.init(),
-          "Telegram bot init",
-          getStartupTimeoutMs(
-            "LETTA_TELEGRAM_INIT_TIMEOUT_MS",
-            DEFAULT_TELEGRAM_INIT_TIMEOUT_MS,
-          ),
-        );
-      } catch (error) {
-        bot = null;
-        throw error;
-      }
+      await telegramBot.init();
       const info = telegramBot.botInfo;
-      logTelegramStartup(
-        options,
-        `init complete for @${info.username ?? "unknown"} (${config.accountId})`,
+      console.log(
+        `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
       );
 
-      logTelegramStartup(
-        options,
-        `polling start for account ${config.accountId}`,
-      );
-      let startupAborted = false;
-      try {
-        await withStartupTimeout(
-          new Promise<void>((resolve, reject) => {
-            let started = false;
+      await new Promise<void>((resolve, reject) => {
+        let started = false;
 
-            void telegramBot
-              .start({
-                allowed_updates: ["message", "message_reaction"],
-                onStart: () => {
-                  if (startupAborted) {
-                    return;
-                  }
-                  running = true;
-                  started = true;
-                  console.log(
-                    `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
-                  );
-                  logTelegramStartup(
-                    options,
-                    `polling started for @${info.username ?? "unknown"} (${config.accountId})`,
-                  );
-                  resolve();
-                },
-              })
-              .catch((error) => {
-                running = false;
+        void telegramBot
+          .start({
+            allowed_updates: ["message", "message_reaction"],
+            onStart: () => {
+              running = true;
+              started = true;
+              resolve();
+            },
+          })
+          .catch((error) => {
+            running = false;
 
-                if (!started) {
-                  reject(error);
-                  return;
-                }
+            if (!started) {
+              reject(error);
+              return;
+            }
 
-                console.error(
-                  "[Telegram] Long-polling stopped unexpectedly:",
-                  error,
-                );
-              });
-          }),
-          "Telegram bot polling startup",
-          getStartupTimeoutMs(
-            "LETTA_TELEGRAM_START_TIMEOUT_MS",
-            DEFAULT_TELEGRAM_START_TIMEOUT_MS,
-          ),
-        );
-      } catch (error) {
-        startupAborted = true;
-        running = false;
-        bot = null;
-        await stopTelegramBotQuietly(telegramBot, options);
-        throw error;
-      }
+            console.error(
+              "[Telegram] Long-polling stopped unexpectedly:",
+              error,
+            );
+          });
+      });
     },
 
     async stop(): Promise<void> {

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -9,6 +9,7 @@ import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import { formatChannelControlRequestPrompt } from "../interactive";
 import type {
   ChannelAdapter,
+  ChannelAdapterStartOptions,
   ChannelControlRequestEvent,
   InboundChannelMessage,
   OutboundChannelMessage,
@@ -34,6 +35,74 @@ type BufferedMediaGroup = {
   messages: TelegramLikeMessage[];
   timer: ReturnType<typeof setTimeout>;
 };
+
+const DEFAULT_TELEGRAM_INIT_TIMEOUT_MS = 15_000;
+const DEFAULT_TELEGRAM_START_TIMEOUT_MS = 20_000;
+const TELEGRAM_FAILED_START_STOP_TIMEOUT_MS = 5_000;
+
+function getStartupTimeoutMs(envName: string, fallbackMs: number): number {
+  const raw = process.env[envName];
+  if (!raw) {
+    return fallbackMs;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+}
+
+function withStartupTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+
+    promise.then(
+      (value) => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        resolve(value);
+      },
+      (error) => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        reject(error);
+      },
+    );
+  });
+}
+
+function logTelegramStartup(
+  options: ChannelAdapterStartOptions | undefined,
+  message: string,
+): void {
+  options?.logger?.(`[Telegram] ${message}`);
+}
+
+async function stopTelegramBotQuietly(
+  telegramBot: TelegramBot,
+  options: ChannelAdapterStartOptions | undefined,
+): Promise<void> {
+  try {
+    await withStartupTimeout(
+      telegramBot.stop(),
+      "Telegram bot stop after failed startup",
+      TELEGRAM_FAILED_START_STOP_TIMEOUT_MS,
+    );
+  } catch (error) {
+    logTelegramStartup(
+      options,
+      `stop after failed startup failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 type TelegramReactionType =
   | {
       type?: "emoji";
@@ -275,13 +344,21 @@ export function createTelegramAdapter(
     }, TELEGRAM_MEDIA_GROUP_FLUSH_MS);
   }
 
-  async function ensureBot(): Promise<TelegramBot> {
+  async function ensureBot(
+    options?: ChannelAdapterStartOptions,
+  ): Promise<TelegramBot> {
     if (bot) {
       return bot;
     }
 
+    logTelegramStartup(options, "loading grammY runtime");
     const grammy = await ensureModule();
+    logTelegramStartup(options, "grammY runtime loaded");
     const Bot = resolveTelegramBotConstructor(grammy);
+    logTelegramStartup(
+      options,
+      `constructing bot for account ${config.accountId}`,
+    );
     const instance = new Bot(config.token);
 
     instance.catch((error) => {
@@ -400,6 +477,10 @@ export function createTelegramAdapter(
       );
     });
 
+    logTelegramStartup(
+      options,
+      `handlers registered for account ${config.accountId}`,
+    );
     bot = instance;
     return instance;
   }
@@ -410,42 +491,90 @@ export function createTelegramAdapter(
     accountId: config.accountId,
     name: "Telegram",
 
-    async start(): Promise<void> {
+    async start(options?: ChannelAdapterStartOptions): Promise<void> {
       if (running) return;
-      const telegramBot = await ensureBot();
+      logTelegramStartup(
+        options,
+        `start requested for account ${config.accountId}`,
+      );
+      const telegramBot = await ensureBot(options);
 
-      await telegramBot.init();
+      logTelegramStartup(options, `init start for account ${config.accountId}`);
+      try {
+        await withStartupTimeout(
+          telegramBot.init(),
+          "Telegram bot init",
+          getStartupTimeoutMs(
+            "LETTA_TELEGRAM_INIT_TIMEOUT_MS",
+            DEFAULT_TELEGRAM_INIT_TIMEOUT_MS,
+          ),
+        );
+      } catch (error) {
+        bot = null;
+        throw error;
+      }
       const info = telegramBot.botInfo;
-      console.log(
-        `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
+      logTelegramStartup(
+        options,
+        `init complete for @${info.username ?? "unknown"} (${config.accountId})`,
       );
 
-      await new Promise<void>((resolve, reject) => {
-        let started = false;
+      logTelegramStartup(
+        options,
+        `polling start for account ${config.accountId}`,
+      );
+      let startupAborted = false;
+      try {
+        await withStartupTimeout(
+          new Promise<void>((resolve, reject) => {
+            let started = false;
 
-        void telegramBot
-          .start({
-            allowed_updates: ["message", "message_reaction"],
-            onStart: () => {
-              running = true;
-              started = true;
-              resolve();
-            },
-          })
-          .catch((error) => {
-            running = false;
+            void telegramBot
+              .start({
+                allowed_updates: ["message", "message_reaction"],
+                onStart: () => {
+                  if (startupAborted) {
+                    return;
+                  }
+                  running = true;
+                  started = true;
+                  console.log(
+                    `[Telegram] Bot started as @${info.username} (dm_policy: ${config.dmPolicy})`,
+                  );
+                  logTelegramStartup(
+                    options,
+                    `polling started for @${info.username ?? "unknown"} (${config.accountId})`,
+                  );
+                  resolve();
+                },
+              })
+              .catch((error) => {
+                running = false;
 
-            if (!started) {
-              reject(error);
-              return;
-            }
+                if (!started) {
+                  reject(error);
+                  return;
+                }
 
-            console.error(
-              "[Telegram] Long-polling stopped unexpectedly:",
-              error,
-            );
-          });
-      });
+                console.error(
+                  "[Telegram] Long-polling stopped unexpectedly:",
+                  error,
+                );
+              });
+          }),
+          "Telegram bot polling startup",
+          getStartupTimeoutMs(
+            "LETTA_TELEGRAM_START_TIMEOUT_MS",
+            DEFAULT_TELEGRAM_START_TIMEOUT_MS,
+          ),
+        );
+      } catch (error) {
+        startupAborted = true;
+        running = false;
+        bot = null;
+        await stopTelegramBotQuietly(telegramBot, options);
+        throw error;
+      }
     },
 
     async stop(): Promise<void> {

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -56,7 +56,6 @@ function withStartupTimeout<T>(
     timer = setTimeout(() => {
       reject(new Error(`${label} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
-    timer.unref?.();
 
     promise.then(
       (value) => {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -104,12 +104,6 @@ export type ChannelTurnLifecycleEvent =
       error?: string;
     };
 
-export type ChannelStartupLogger = (message: string) => void;
-
-export interface ChannelAdapterStartOptions {
-  logger?: ChannelStartupLogger;
-}
-
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {
@@ -123,7 +117,7 @@ export interface ChannelAdapter {
   readonly name: string;
 
   /** Start receiving messages (e.g. begin long-polling). */
-  start(options?: ChannelAdapterStartOptions): Promise<void>;
+  start(): Promise<void>;
   /** Stop receiving messages gracefully. */
   stop(): Promise<void>;
   /** Whether the adapter is currently running. */

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -104,6 +104,12 @@ export type ChannelTurnLifecycleEvent =
       error?: string;
     };
 
+export type ChannelStartupLogger = (message: string) => void;
+
+export interface ChannelAdapterStartOptions {
+  logger?: ChannelStartupLogger;
+}
+
 // ── Adapter interface ─────────────────────────────────────────────
 
 export interface ChannelAdapter {
@@ -117,7 +123,7 @@ export interface ChannelAdapter {
   readonly name: string;
 
   /** Start receiving messages (e.g. begin long-polling). */
-  start(): Promise<void>;
+  start(options?: ChannelAdapterStartOptions): Promise<void>;
   /** Stop receiving messages gracefully. */
   stop(): Promise<void>;
   /** Whether the adapter is currently running. */

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -385,6 +385,24 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   // Load local project settings to access saved environment name
   await settingsManager.loadLocalProjectSettings();
 
+  // Session log (always written to ~/.letta/logs/remote/). Initialize it
+  // before channel startup so early adapter failures and hangs leave a trail.
+  const sessionLog = new RemoteSessionLog();
+  sessionLog.init();
+  console.log(`Log file: ${sessionLog.path}`);
+
+  const startupLog = (message: string): void => {
+    sessionLog.log(message);
+    if (debugMode) {
+      console.log(`[${formatTimestamp()}] ${message}`);
+    }
+  };
+
+  startupLog(
+    `Process pid=${process.pid} ppid=${process.ppid} cwd=${process.cwd()} HOME=${process.env.HOME ?? "<unset>"} ` +
+      `stdinTTY=${process.stdin.isTTY === true} stdoutTTY=${process.stdout.isTTY === true} stderrTTY=${process.stderr.isTTY === true}`,
+  );
+
   // Initialize channels if explicitly requested, or restore persisted enabled
   // channels when a desktop wrapper opts into boot-time channel restore.
   const channelNames = values.channels
@@ -417,9 +435,18 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     }
 
     const { initializeChannels } = await import("../../channels/registry");
-    await initializeChannels(channelNames, {
-      failOnStartupError: Boolean(values.channels),
-    });
+    try {
+      await initializeChannels(channelNames, {
+        failOnStartupError: Boolean(values.channels),
+        logger: startupLog,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      sessionLog.log(`FATAL: ${msg}`);
+      console.error(`Failed to start listener: ${msg}`);
+      await flushListenerTelemetryEnd("listener_channel_start_failed");
+      return 1;
+    }
   }
 
   // Determine connection name
@@ -457,11 +484,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       settingsManager.setListenerEnvName(connectionName);
     }
   }
-
-  // Session log (always written to ~/.letta/logs/remote/)
-  const sessionLog = new RemoteSessionLog();
-  sessionLog.init();
-  console.log(`Log file: ${sessionLog.path}`);
 
   try {
     // Get device ID

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -417,7 +417,9 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     }
 
     const { initializeChannels } = await import("../../channels/registry");
-    await initializeChannels(channelNames);
+    await initializeChannels(channelNames, {
+      failOnStartupError: Boolean(values.channels),
+    });
   }
 
   // Determine connection name

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -385,6 +385,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   // Load local project settings to access saved environment name
   await settingsManager.loadLocalProjectSettings();
 
+  // Session log (always written to ~/.letta/logs/remote/). Initialize it
+  // before channel startup so early adapter failures leave a trail.
+  const sessionLog = new RemoteSessionLog();
+  sessionLog.init();
+  console.log(`Log file: ${sessionLog.path}`);
+
   // Initialize channels if explicitly requested, or restore persisted enabled
   // channels when a desktop wrapper opts into boot-time channel restore.
   const channelNames = values.channels
@@ -417,9 +423,17 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     }
 
     const { initializeChannels } = await import("../../channels/registry");
-    await initializeChannels(channelNames, {
-      failOnStartupError: Boolean(values.channels),
-    });
+    try {
+      await initializeChannels(channelNames, {
+        failOnStartupError: Boolean(values.channels),
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      sessionLog.log(`FATAL: ${msg}`);
+      console.error(`Failed to start listener: ${msg}`);
+      await flushListenerTelemetryEnd("listener_channel_start_failed");
+      return 1;
+    }
   }
 
   // Determine connection name
@@ -457,11 +471,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       settingsManager.setListenerEnvName(connectionName);
     }
   }
-
-  // Session log (always written to ~/.letta/logs/remote/)
-  const sessionLog = new RemoteSessionLog();
-  sessionLog.init();
-  console.log(`Log file: ${sessionLog.path}`);
 
   try {
     // Get device ID

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -385,24 +385,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   // Load local project settings to access saved environment name
   await settingsManager.loadLocalProjectSettings();
 
-  // Session log (always written to ~/.letta/logs/remote/). Initialize it
-  // before channel startup so early adapter failures and hangs leave a trail.
-  const sessionLog = new RemoteSessionLog();
-  sessionLog.init();
-  console.log(`Log file: ${sessionLog.path}`);
-
-  const startupLog = (message: string): void => {
-    sessionLog.log(message);
-    if (debugMode) {
-      console.log(`[${formatTimestamp()}] ${message}`);
-    }
-  };
-
-  startupLog(
-    `Process pid=${process.pid} ppid=${process.ppid} cwd=${process.cwd()} HOME=${process.env.HOME ?? "<unset>"} ` +
-      `stdinTTY=${process.stdin.isTTY === true} stdoutTTY=${process.stdout.isTTY === true} stderrTTY=${process.stderr.isTTY === true}`,
-  );
-
   // Initialize channels if explicitly requested, or restore persisted enabled
   // channels when a desktop wrapper opts into boot-time channel restore.
   const channelNames = values.channels
@@ -435,18 +417,9 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     }
 
     const { initializeChannels } = await import("../../channels/registry");
-    try {
-      await initializeChannels(channelNames, {
-        failOnStartupError: Boolean(values.channels),
-        logger: startupLog,
-      });
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      sessionLog.log(`FATAL: ${msg}`);
-      console.error(`Failed to start listener: ${msg}`);
-      await flushListenerTelemetryEnd("listener_channel_start_failed");
-      return 1;
-    }
+    await initializeChannels(channelNames, {
+      failOnStartupError: Boolean(values.channels),
+    });
   }
 
   // Determine connection name
@@ -484,6 +457,11 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       settingsManager.setListenerEnvName(connectionName);
     }
   }
+
+  // Session log (always written to ~/.letta/logs/remote/)
+  const sessionLog = new RemoteSessionLog();
+  sessionLog.init();
+  console.log(`Log file: ${sessionLog.path}`);
 
   try {
     // Get device ID

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "../../channels/accounts";
+import { __testOverrideChannelsRoot } from "../../channels/config";
 import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
@@ -18,6 +27,7 @@ import {
   completePairing,
   formatChannelStartupFailures,
   getChannelRegistry,
+  initializeChannels,
 } from "../../channels/registry";
 import {
   __testOverrideLoadRoutes,
@@ -118,6 +128,79 @@ describe("formatChannelStartupFailures", () => {
     );
     expect(message).toContain("letta channels install discord");
     expect(message).toContain("letta channels install slack");
+  });
+});
+
+describe("initializeChannels startup logging", () => {
+  let channelRoot: string;
+
+  beforeEach(() => {
+    channelRoot = mkdtempSync(join(tmpdir(), "letta-channel-startup-"));
+    __testOverrideChannelsRoot(channelRoot);
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+    clearChannelAccountStores();
+  });
+
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideChannelsRoot(null);
+    rmSync(channelRoot, { recursive: true, force: true });
+  });
+
+  test("logs account discovery before fatal startup failures", async () => {
+    const logs: string[] = [];
+
+    await expect(
+      initializeChannels(["telegram"], {
+        failOnStartupError: true,
+        logger: (message) => logs.push(message),
+      }),
+    ).rejects.toThrow('Channel "telegram" not configured');
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        "[Channels] requested: telegram",
+        `[Channels] root: ${channelRoot}`,
+        `[Channels] loading telegram accounts from ${join(channelRoot, "telegram", "accounts.json")}`,
+        "[Channels] telegram: accounts=0, enabled=none",
+      ]),
+    );
+  });
+
+  test("treats explicitly requested channels with no enabled accounts as startup failures", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "telegram",
+        accountId: "acct-disabled",
+        enabled: false,
+        token: "test-token",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        transcribeVoice: false,
+        binding: { agentId: null, conversationId: null },
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    clearChannelAccountStores();
+
+    const logs: string[] = [];
+
+    await expect(
+      initializeChannels(["telegram"], {
+        failOnStartupError: true,
+        logger: (message) => logs.push(message),
+      }),
+    ).rejects.toThrow('Channel "telegram" has no enabled accounts');
+
+    expect(logs).toContain("[Channels] telegram: accounts=1, enabled=none");
   });
 });
 

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,13 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
-  __testOverrideLoadChannelAccounts,
-  __testOverrideSaveChannelAccounts,
-  clearChannelAccountStores,
-} from "../../channels/accounts";
-import { __testOverrideChannelsRoot } from "../../channels/config";
 import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
@@ -27,7 +18,6 @@ import {
   completePairing,
   formatChannelStartupFailures,
   getChannelRegistry,
-  initializeChannels,
 } from "../../channels/registry";
 import {
   __testOverrideLoadRoutes,
@@ -128,79 +118,6 @@ describe("formatChannelStartupFailures", () => {
     );
     expect(message).toContain("letta channels install discord");
     expect(message).toContain("letta channels install slack");
-  });
-});
-
-describe("initializeChannels startup logging", () => {
-  let channelRoot: string;
-
-  beforeEach(() => {
-    channelRoot = mkdtempSync(join(tmpdir(), "letta-channel-startup-"));
-    __testOverrideChannelsRoot(channelRoot);
-    __testOverrideLoadChannelAccounts(() => []);
-    __testOverrideSaveChannelAccounts(() => {});
-    clearChannelAccountStores();
-  });
-
-  afterEach(async () => {
-    const registry = getChannelRegistry();
-    if (registry) {
-      await registry.stopAll();
-    }
-    clearChannelAccountStores();
-    __testOverrideLoadChannelAccounts(null);
-    __testOverrideSaveChannelAccounts(null);
-    __testOverrideChannelsRoot(null);
-    rmSync(channelRoot, { recursive: true, force: true });
-  });
-
-  test("logs account discovery before fatal startup failures", async () => {
-    const logs: string[] = [];
-
-    await expect(
-      initializeChannels(["telegram"], {
-        failOnStartupError: true,
-        logger: (message) => logs.push(message),
-      }),
-    ).rejects.toThrow('Channel "telegram" not configured');
-
-    expect(logs).toEqual(
-      expect.arrayContaining([
-        "[Channels] requested: telegram",
-        `[Channels] root: ${channelRoot}`,
-        `[Channels] loading telegram accounts from ${join(channelRoot, "telegram", "accounts.json")}`,
-        "[Channels] telegram: accounts=0, enabled=none",
-      ]),
-    );
-  });
-
-  test("treats explicitly requested channels with no enabled accounts as startup failures", async () => {
-    __testOverrideLoadChannelAccounts(() => [
-      {
-        channel: "telegram",
-        accountId: "acct-disabled",
-        enabled: false,
-        token: "test-token",
-        dmPolicy: "pairing",
-        allowedUsers: [],
-        transcribeVoice: false,
-        binding: { agentId: null, conversationId: null },
-        createdAt: "2026-01-01T00:00:00.000Z",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-      },
-    ]);
-    clearChannelAccountStores();
-
-    const logs: string[] = [];
-
-    await expect(
-      initializeChannels(["telegram"], {
-        failOnStartupError: true,
-        logger: (message) => logs.push(message),
-      }),
-    ).rejects.toThrow('Channel "telegram" has no enabled accounts');
-
-    expect(logs).toContain("[Channels] telegram: accounts=1, enabled=none");
   });
 });
 

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -16,6 +16,7 @@ import {
   buildSlackConversationSummary,
   ChannelRegistry,
   completePairing,
+  formatChannelStartupFailures,
   getChannelRegistry,
 } from "../../channels/registry";
 import {
@@ -89,6 +90,34 @@ describe("ChannelRegistry", () => {
 
     await registry.stopAll();
     expect(getChannelRegistry()).toBeNull();
+  });
+});
+
+describe("formatChannelStartupFailures", () => {
+  test("shows actionable install commands for missing channel runtimes", () => {
+    const message = formatChannelStartupFailures([
+      {
+        channelId: "discord",
+        accountId: "acct-discord",
+        error:
+          "Discord support is not installed. Run: letta channels install discord or start the listener with --install-channel-runtimes.",
+      },
+      {
+        channelId: "slack",
+        accountId: "acct-slack",
+        error:
+          "Slack support is not installed. Run: letta channels install slack or start the listener with --install-channel-runtimes.",
+      },
+    ]);
+
+    expect(message).toContain("Failed to start requested channel listeners.");
+    expect(message).toContain("discord/acct-discord");
+    expect(message).toContain("slack/acct-slack");
+    expect(message).toContain(
+      "letta server --channels discord,slack --install-channel-runtimes",
+    );
+    expect(message).toContain("letta channels install discord");
+    expect(message).toContain("letta channels install slack");
   });
 });
 

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -45,6 +45,7 @@ class FakeBot {
     async (fileId) => ({
       file_path: `photos/${fileId}.jpg`,
     });
+  static nextInitImpl: () => Promise<void> = async () => {};
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
@@ -83,7 +84,9 @@ class FakeBot {
     return this;
   }
 
-  async init(): Promise<void> {}
+  async init(): Promise<void> {
+    return FakeBot.nextInitImpl();
+  }
 
   start(options?: FakeBotStartOptions): Promise<void> {
     return FakeBot.nextStartImpl(options, this.botInfo);
@@ -137,6 +140,9 @@ const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
 const originalFetch = globalThis.fetch;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+const originalTelegramInitTimeout = process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+const originalTelegramStartTimeout =
+  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 
 beforeEach(() => {
   channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
@@ -153,10 +159,13 @@ beforeEach(() => {
   FakeBot.nextGetFileImpl = async (fileId) => ({
     file_path: `photos/${fileId}.jpg`,
   });
+  FakeBot.nextInitImpl = async () => {};
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
   globalThis.fetch = originalFetch;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+  delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 });
 
 afterEach(() => {
@@ -167,6 +176,16 @@ afterEach(() => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  }
+  if (originalTelegramInitTimeout === undefined) {
+    delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+  } else {
+    process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = originalTelegramInitTimeout;
+  }
+  if (originalTelegramStartTimeout === undefined) {
+    delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
+  } else {
+    process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = originalTelegramStartTimeout;
   }
   rmSync(channelRoot, { recursive: true, force: true });
 });
@@ -229,7 +248,10 @@ test("telegram adapter start waits until polling is live before resolving", asyn
     allowedUsers: [],
   });
 
-  const startPromise = adapter.start();
+  const logs: string[] = [];
+  const startPromise = adapter.start({
+    logger: (message) => logs.push(message),
+  });
   expect(adapter.isRunning()).toBe(false);
 
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -242,6 +264,55 @@ test("telegram adapter start waits until polling is live before resolving", asyn
   await startPromise;
 
   expect(adapter.isRunning()).toBe(true);
+  expect(logs).toEqual(
+    expect.arrayContaining([
+      "[Telegram] start requested for account telegram-test-account",
+      "[Telegram] loading grammY runtime",
+      "[Telegram] grammY runtime loaded",
+      "[Telegram] handlers registered for account telegram-test-account",
+      "[Telegram] polling start for account telegram-test-account",
+      "[Telegram] polling started for @test_bot (telegram-test-account)",
+    ]),
+  );
+  expect(logs.join("\n")).not.toContain("test-token");
+});
+
+test("telegram adapter fails startup when bot init hangs", async () => {
+  process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = "1";
+  FakeBot.nextInitImpl = async () => new Promise<void>(() => {});
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await expect(adapter.start()).rejects.toThrow(
+    "Telegram bot init timed out after 1ms",
+  );
+  expect(adapter.isRunning()).toBe(false);
+});
+
+test("telegram adapter fails startup when polling never reports ready", async () => {
+  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = "1";
+  FakeBot.nextStartImpl = async () => new Promise<void>(() => {});
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await expect(adapter.start()).rejects.toThrow(
+    "Telegram bot polling startup timed out after 1ms",
+  );
+  expect(adapter.isRunning()).toBe(false);
 });
 
 test("telegram adapter logs and clears running state when polling exits unexpectedly", async () => {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -45,7 +45,6 @@ class FakeBot {
     async (fileId) => ({
       file_path: `photos/${fileId}.jpg`,
     });
-  static nextInitImpl: () => Promise<void> = async () => {};
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
@@ -84,9 +83,7 @@ class FakeBot {
     return this;
   }
 
-  async init(): Promise<void> {
-    return FakeBot.nextInitImpl();
-  }
+  async init(): Promise<void> {}
 
   start(options?: FakeBotStartOptions): Promise<void> {
     return FakeBot.nextStartImpl(options, this.botInfo);
@@ -140,9 +137,6 @@ const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
 const originalFetch = globalThis.fetch;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
-const originalTelegramInitTimeout = process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
-const originalTelegramStartTimeout =
-  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 
 beforeEach(() => {
   channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
@@ -159,13 +153,10 @@ beforeEach(() => {
   FakeBot.nextGetFileImpl = async (fileId) => ({
     file_path: `photos/${fileId}.jpg`,
   });
-  FakeBot.nextInitImpl = async () => {};
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
   globalThis.fetch = originalFetch;
   delete process.env.OPENAI_API_KEY;
-  delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
-  delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 });
 
 afterEach(() => {
@@ -176,16 +167,6 @@ afterEach(() => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = originalOpenAiApiKey;
-  }
-  if (originalTelegramInitTimeout === undefined) {
-    delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
-  } else {
-    process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = originalTelegramInitTimeout;
-  }
-  if (originalTelegramStartTimeout === undefined) {
-    delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
-  } else {
-    process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = originalTelegramStartTimeout;
   }
   rmSync(channelRoot, { recursive: true, force: true });
 });
@@ -248,10 +229,7 @@ test("telegram adapter start waits until polling is live before resolving", asyn
     allowedUsers: [],
   });
 
-  const logs: string[] = [];
-  const startPromise = adapter.start({
-    logger: (message) => logs.push(message),
-  });
+  const startPromise = adapter.start();
   expect(adapter.isRunning()).toBe(false);
 
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -264,55 +242,6 @@ test("telegram adapter start waits until polling is live before resolving", asyn
   await startPromise;
 
   expect(adapter.isRunning()).toBe(true);
-  expect(logs).toEqual(
-    expect.arrayContaining([
-      "[Telegram] start requested for account telegram-test-account",
-      "[Telegram] loading grammY runtime",
-      "[Telegram] grammY runtime loaded",
-      "[Telegram] handlers registered for account telegram-test-account",
-      "[Telegram] polling start for account telegram-test-account",
-      "[Telegram] polling started for @test_bot (telegram-test-account)",
-    ]),
-  );
-  expect(logs.join("\n")).not.toContain("test-token");
-});
-
-test("telegram adapter fails startup when bot init hangs", async () => {
-  process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = "1";
-  FakeBot.nextInitImpl = async () => new Promise<void>(() => {});
-
-  const adapter = createTelegramAdapter({
-    ...telegramAccountDefaults,
-    channel: "telegram",
-    enabled: true,
-    token: "test-token",
-    dmPolicy: "pairing",
-    allowedUsers: [],
-  });
-
-  await expect(adapter.start()).rejects.toThrow(
-    "Telegram bot init timed out after 1ms",
-  );
-  expect(adapter.isRunning()).toBe(false);
-});
-
-test("telegram adapter fails startup when polling never reports ready", async () => {
-  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = "1";
-  FakeBot.nextStartImpl = async () => new Promise<void>(() => {});
-
-  const adapter = createTelegramAdapter({
-    ...telegramAccountDefaults,
-    channel: "telegram",
-    enabled: true,
-    token: "test-token",
-    dmPolicy: "pairing",
-    allowedUsers: [],
-  });
-
-  await expect(adapter.start()).rejects.toThrow(
-    "Telegram bot polling startup timed out after 1ms",
-  );
-  expect(adapter.isRunning()).toBe(false);
 });
 
 test("telegram adapter logs and clears running state when polling exits unexpectedly", async () => {

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -45,6 +45,7 @@ class FakeBot {
     async (fileId) => ({
       file_path: `photos/${fileId}.jpg`,
     });
+  static nextInitImpl: () => Promise<void> = async () => {};
 
   readonly token: string;
   botInfo = { username: "test_bot", id: 12345 };
@@ -83,7 +84,9 @@ class FakeBot {
     return this;
   }
 
-  async init(): Promise<void> {}
+  async init(): Promise<void> {
+    return FakeBot.nextInitImpl();
+  }
 
   start(options?: FakeBotStartOptions): Promise<void> {
     return FakeBot.nextStartImpl(options, this.botInfo);
@@ -137,6 +140,9 @@ const consoleErrorSpy = mock(() => {});
 const originalConsoleError = console.error;
 const originalFetch = globalThis.fetch;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+const originalTelegramInitTimeout = process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+const originalTelegramStartTimeout =
+  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 
 beforeEach(() => {
   channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
@@ -153,10 +159,13 @@ beforeEach(() => {
   FakeBot.nextGetFileImpl = async (fileId) => ({
     file_path: `photos/${fileId}.jpg`,
   });
+  FakeBot.nextInitImpl = async () => {};
   consoleErrorSpy.mockClear();
   console.error = consoleErrorSpy as typeof console.error;
   globalThis.fetch = originalFetch;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+  delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
 });
 
 afterEach(() => {
@@ -167,6 +176,16 @@ afterEach(() => {
     delete process.env.OPENAI_API_KEY;
   } else {
     process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  }
+  if (originalTelegramInitTimeout === undefined) {
+    delete process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS;
+  } else {
+    process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = originalTelegramInitTimeout;
+  }
+  if (originalTelegramStartTimeout === undefined) {
+    delete process.env.LETTA_TELEGRAM_START_TIMEOUT_MS;
+  } else {
+    process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = originalTelegramStartTimeout;
   }
   rmSync(channelRoot, { recursive: true, force: true });
 });
@@ -242,6 +261,44 @@ test("telegram adapter start waits until polling is live before resolving", asyn
   await startPromise;
 
   expect(adapter.isRunning()).toBe(true);
+});
+
+test("telegram adapter fails startup when bot init hangs", async () => {
+  process.env.LETTA_TELEGRAM_INIT_TIMEOUT_MS = "1";
+  FakeBot.nextInitImpl = async () => new Promise<void>(() => {});
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await expect(adapter.start()).rejects.toThrow(
+    "Telegram bot init timed out after 1ms",
+  );
+  expect(adapter.isRunning()).toBe(false);
+});
+
+test("telegram adapter fails startup when polling never reports ready", async () => {
+  process.env.LETTA_TELEGRAM_START_TIMEOUT_MS = "1";
+  FakeBot.nextStartImpl = async () => new Promise<void>(() => {});
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await expect(adapter.start()).rejects.toThrow(
+    "Telegram bot polling startup timed out after 1ms",
+  );
+  expect(adapter.isRunning()).toBe(false);
 });
 
 test("telegram adapter logs and clears running state when polling exits unexpectedly", async () => {


### PR DESCRIPTION
## Summary
- Treat explicit `--channels` startup failures as fatal so the listener does not silently continue without requested channels.
- Aggregate channel startup failures with direct install guidance for missing runtimes.
- Create the listener session log before channel startup so early failures are captured.
- Bound Telegram `init()` and polling readiness waits so startup hangs fail loudly.

"Make the failure finite."

Written by Cameron ◯ Letta Code