### PR TITLE
fix(cli): split streamed reasoning blocks on new otid

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -491,6 +491,19 @@ function resolveLineIdForKind(
   return `${kind}:${canonicalId}`;
 }
 
+function hasExistingOtidAlias(
+  aliasMap: Map<string, string>,
+  canonical: string,
+  nextOtid?: string,
+): boolean {
+  for (const [mappedOtid, mappedCanonical] of aliasMap.entries()) {
+    if (mappedCanonical === canonical && mappedOtid !== nextOtid) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function resolveAssistantLineId(
   b: Buffers,
   chunk: LettaStreamingResponse & { id?: string; otid?: string },
@@ -521,11 +534,16 @@ function resolveAssistantLineId(
       "assistant",
     );
     const existingLine = b.byId.get(existingLineId);
+    const hasPriorOtidAlias = hasExistingOtidAlias(
+      b.assistantCanonicalByOtid,
+      canonicalFromMessageId,
+      otid,
+    );
     if (
       existingLine &&
       existingLine.kind === "assistant" &&
       "phase" in existingLine &&
-      existingLine.phase === "finished"
+      (existingLine.phase === "finished" || hasPriorOtidAlias)
     ) {
       canonical = otid;
     }
@@ -597,11 +615,16 @@ function resolveReasoningLineId(
       "reasoning",
     );
     const existingLine = b.byId.get(existingLineId);
+    const hasPriorOtidAlias = hasExistingOtidAlias(
+      b.reasoningCanonicalByOtid,
+      canonicalFromMessageId,
+      otid,
+    );
     if (
       existingLine &&
       existingLine.kind === "reasoning" &&
       "phase" in existingLine &&
-      existingLine.phase === "finished"
+      (existingLine.phase === "finished" || hasPriorOtidAlias)
     ) {
       canonical = otid;
     }

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -46,6 +46,11 @@ type StreamingChunk =
   | CompactionSummaryMessageChunk
   | CompactionEventMessageChunk;
 
+function isAccumulatorChunkDebugEnabled(): boolean {
+  const value = process.env.LETTA_DEBUG_ACCUMULATOR_CHUNKS;
+  return value === "1" || value === "true";
+}
+
 // Constants for streaming output
 const MAX_TAIL_LINES = 5;
 const MAX_BUFFER_SIZE = 100_000; // 100KB
@@ -741,6 +746,15 @@ export function onChunk(
   // that arrive before drainStream exits.
   if (b.interrupted) {
     return;
+  }
+
+  if (isAccumulatorChunkDebugEnabled()) {
+    debugLog(
+      "accumulator",
+      "received chunk (%s): %O",
+      chunk.message_type ?? "unknown",
+      chunk,
+    );
   }
 
   // TODO remove once SDK v1 has proper typing for in-stream errors

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -735,6 +735,13 @@ function trySplitContent(
   return true;
 }
 
+// OpenAI reasoning summaries can start a new `**Section Title**\n\n` block inside the
+// same otid without a leading separator. Insert the missing blank line so markdown
+// renders the title as a new paragraph instead of gluing it to the previous sentence.
+function normalizeReasoningSectionBoundaries(text: string): string {
+  return text.replace(/([^\n])(\*\*[^*\n]+\*\*\n\n)/g, "$1\n\n$2");
+}
+
 // Feed one SDK chunk; mutate buffers in place.
 export function onChunk(
   b: Buffers,
@@ -789,7 +796,7 @@ export function onChunk(
         messageId,
       }));
       if (delta) {
-        const newText = line.text + delta;
+        const newText = normalizeReasoningSectionBoundaries(line.text + delta);
         b.tokenCount += Buffer.byteLength(delta, "utf8");
 
         // Try to split at paragraph boundary (only if streaming enabled)

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -46,11 +46,6 @@ type StreamingChunk =
   | CompactionSummaryMessageChunk
   | CompactionEventMessageChunk;
 
-function isAccumulatorChunkDebugEnabled(): boolean {
-  const value = process.env.LETTA_DEBUG_ACCUMULATOR_CHUNKS;
-  return value === "1" || value === "true";
-}
-
 // Constants for streaming output
 const MAX_TAIL_LINES = 5;
 const MAX_BUFFER_SIZE = 100_000; // 100KB
@@ -753,15 +748,6 @@ export function onChunk(
   // that arrive before drainStream exits.
   if (b.interrupted) {
     return;
-  }
-
-  if (isAccumulatorChunkDebugEnabled()) {
-    debugLog(
-      "accumulator",
-      "received chunk (%s): %O",
-      chunk.message_type ?? "unknown",
-      chunk,
-    );
   }
 
   // TODO remove once SDK v1 has proper typing for in-stream errors

--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -311,6 +311,88 @@ describe("accumulator usage statistics", () => {
     ).toBe("shared-stream-id");
   });
 
+  test("starts a new reasoning line when a new otid arrives for the same message id", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-split",
+      otid: "reasoning-otid-split-1",
+      reasoning: "**Checking user preferences**\n\nFirst section.",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-split",
+      otid: "reasoning-otid-split-2",
+      reasoning: "**Interpreting math notations**\n\nSecond section.",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-split",
+      reasoning: " More detail.",
+    } as unknown as LettaStreamingResponse);
+
+    const firstLine = buffers.byId.get("reasoning-msg-split");
+    const secondLine = buffers.byId.get("reasoning-otid-split-2");
+
+    expect(firstLine?.kind).toBe("reasoning");
+    expect(firstLine && "text" in firstLine ? firstLine.text : "").toBe(
+      "**Checking user preferences**\n\nFirst section.",
+    );
+    expect(
+      firstLine && "phase" in firstLine ? firstLine.phase : undefined,
+    ).toBe("finished");
+    expect(buffers.byId.get("reasoning-otid-split-1")).toBeUndefined();
+
+    expect(secondLine?.kind).toBe("reasoning");
+    expect(secondLine && "text" in secondLine ? secondLine.text : "").toBe(
+      "**Interpreting math notations**\n\nSecond section. More detail.",
+    );
+  });
+
+  test("starts a new assistant line when a new otid arrives for the same message id", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "assistant_message",
+      id: "assistant-msg-split",
+      otid: "assistant-otid-split-1",
+      content: [{ type: "text", text: "First block." }],
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "assistant_message",
+      id: "assistant-msg-split",
+      otid: "assistant-otid-split-2",
+      content: [{ type: "text", text: "Second block." }],
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "assistant_message",
+      id: "assistant-msg-split",
+      content: [{ type: "text", text: " More detail." }],
+    } as unknown as LettaStreamingResponse);
+
+    const firstLine = buffers.byId.get("assistant-msg-split");
+    const secondLine = buffers.byId.get("assistant-otid-split-2");
+
+    expect(firstLine?.kind).toBe("assistant");
+    expect(firstLine && "text" in firstLine ? firstLine.text : "").toBe(
+      "First block.",
+    );
+    expect(
+      firstLine && "phase" in firstLine ? firstLine.phase : undefined,
+    ).toBe("finished");
+    expect(buffers.byId.get("assistant-otid-split-1")).toBeUndefined();
+
+    expect(secondLine?.kind).toBe("assistant");
+    expect(secondLine && "text" in secondLine ? secondLine.text : "").toBe(
+      "Second block. More detail.",
+    );
+  });
+
   test("reconciles optimistic user lines to the backend message id via otid", () => {
     const buffers = createBuffers();
     buffers.byId.set("user-local-1", {

--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -393,6 +393,54 @@ describe("accumulator usage statistics", () => {
     );
   });
 
+  test("inserts a blank line before a streamed reasoning section heading in the same otid", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-heading",
+      otid: "reasoning-otid-heading",
+      reasoning: "**Calculating math problems**\n\nFirst section.",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-heading",
+      otid: "reasoning-otid-heading",
+      reasoning: "**Computing with Python**\n\nSecond section.",
+    } as unknown as LettaStreamingResponse);
+
+    const line = buffers.byId.get("reasoning-msg-heading");
+    expect(line?.kind).toBe("reasoning");
+    expect(line && "text" in line ? line.text : "").toBe(
+      "**Calculating math problems**\n\nFirst section.\n\n**Computing with Python**\n\nSecond section.",
+    );
+  });
+
+  test("retrofits a blank line when a streamed reasoning heading spans multiple chunks", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-split-heading",
+      otid: "reasoning-otid-split-heading",
+      reasoning: "**Calculating math problems**\n\nFirst section.**Computing",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-split-heading",
+      otid: "reasoning-otid-split-heading",
+      reasoning: " with Python**\n\nSecond section.",
+    } as unknown as LettaStreamingResponse);
+
+    const line = buffers.byId.get("reasoning-msg-split-heading");
+    expect(line?.kind).toBe("reasoning");
+    expect(line && "text" in line ? line.text : "").toBe(
+      "**Calculating math problems**\n\nFirst section.\n\n**Computing with Python**\n\nSecond section.",
+    );
+  });
+
   test("reconciles optimistic user lines to the backend message id via otid", () => {
     const buffers = createBuffers();
     buffers.byId.set("user-local-1", {


### PR DESCRIPTION
## Status

This `letta-code` PR contains a client-side defense, but the root cause for the same-`otid` section-break issue turned out to be server-side streaming. The Python core and TS provider paths were dropping the `\n\n` separator between OpenAI reasoning summary parts, so the CLI was appending exactly what it received.

## What This PR Still Does
- split streamed assistant/reasoning blocks when a fresh `otid` arrives for an existing `message.id`
- preserve the existing mixed `id`/`otid` canonicalization behavior for normal continuation cases
- add regressions covering the new-`otid` split case for both reasoning and assistant output

## Why This Is No Longer The Primary Fix
The trace that reproduced `...calculations.Computing with Python` kept the same `otid`; the break was lost before the CLI saw it. Backfill rendered correctly because stored summarized reasoning joins parts with `\n\n`, while live streaming was dropping that separator upstream.

## Upstream Fix
The server-side PR:
- fixes the Python core off-by-one so follow-up summary parts get a leading separator
- updates `codex.ts` to emit separator deltas on `response.reasoning_summary_part.added`
- updates `openai.ts` to handle `response.reasoning_summary_part.added` the same way

## Testing
Client-side tests in this PR:
- `bun test letta-code/src/tests/cli/accumulator-usage.test.ts`
- `bun test src/tests/cli/*.test.ts src/tests/turn-recovery-policy.test.ts`
- pre-commit hook: `tsc --noEmit`

Server-side tests in `letta-cloud` PR #11337:
- `cd /Users/jinjpeng/letta/letta-cloud/apps/core && uv run pytest tests/test_openai_ws_session.py -k separator_for_follow_up_reasoning_summary_part`
- `cd /Users/jinjpeng/letta/letta-cloud && CORE_DATABASE_URL=postgresql://user:pass@localhost:5432/testdb npx jest --runInBand libs/tmp-cloud-api-router/src/lib/core-runtime/llm/providers/codex.test.ts libs/tmp-cloud-api-router/src/lib/core-runtime/llm/providers/openai.test.ts`
