### PR TITLE
feat(cron): add LETTA_DISABLE_CRON_SCHEDULER opt-out + quiet failed-c…

### DIFF
--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -268,8 +268,13 @@ export function startScheduler(
   try {
     token = claimSchedulerLease();
   } catch (err) {
-    // Another process holds the lease — that's OK, don't start scheduler here
-    console.error("[Cron] Could not claim scheduler lease:", err);
+    // Another process holds the lease — that's the expected outcome when
+    // multiple letta-code instances run against the same dir. Log at debug
+    // level so we don't spam the user's terminal on every reconnect; set
+    // LETTA_DISABLE_CRON_SCHEDULER=1 in the env to skip the claim entirely.
+    if (process.env.LETTA_DEBUG === "1") {
+      console.debug("[Cron] Could not claim scheduler lease:", err);
+    }
     return;
   }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4149,7 +4149,14 @@ async function startConnectedListenerRuntime(
   }
 
   const shouldStartHeartbeat = options.startHeartbeat !== false;
-  const shouldStartCronScheduler = options.startCronScheduler !== false;
+  // LETTA_DISABLE_CRON_SCHEDULER=1 lets users opt out entirely. Useful when
+  // running multiple letta-code instances against the same agent dir, since
+  // only one process can hold the lease and the others would otherwise log
+  // "scheduler lease held by PID …" on every connect.
+  const cronSchedulerDisabledByEnv =
+    process.env.LETTA_DISABLE_CRON_SCHEDULER === "1";
+  const shouldStartCronScheduler =
+    options.startCronScheduler !== false && !cronSchedulerDisabledByEnv;
 
   runtime.transport = transport;
   safeEmitWsEvent("recv", "lifecycle", {


### PR DESCRIPTION
…laim log

When multiple letta-code instances run against the same agent directory (common during dev), only one process can hold the scheduler lease and the others print a noisy "scheduler lease held by PID …" error on every reconnect even though there's nothing wrong.

- Add LETTA_DISABLE_CRON_SCHEDULER=1 env opt-out — folds into the existing shouldStartCronScheduler gate so secondary instances can skip the claim entirely.
- Downgrade the failed-claim log from console.error to a gated console.debug (LETTA_DEBUG=1). The lease being held by another process is the expected outcome, not an error.

👾 Generated with [Letta Code](https://letta.com)