### PR TITLE
fix(cli): restore /ade and add /chat slash commands

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -241,7 +241,7 @@ import {
   type ClassifiedApproval,
   classifyApprovals,
 } from "./helpers/approvalClassification";
-import { buildChatUrl } from "./helpers/appUrls";
+import { buildAdeUrl, buildChatUrl } from "./helpers/appUrls";
 import { backfillBuffers } from "./helpers/backfill";
 import { chunkLog } from "./helpers/chunkLog";
 import {
@@ -650,6 +650,7 @@ const INTERACTIVE_SLASH_COMMANDS = new Set([
 // These don't modify agent state, so they should bypass queueing
 const NON_STATE_COMMANDS = new Set([
   "/ade",
+  "/chat",
   "/bg",
   "/btw",
   "/usage",
@@ -7964,9 +7965,9 @@ export default function App({
           return { submitted: true };
         }
 
-        // Special handling for /ade command - open agent in browser
+        // Special handling for /ade command - open ADE in browser
         if (trimmed === "/ade") {
-          const adeUrl = buildChatUrl(agentId, {
+          const adeUrl = buildAdeUrl(agentId, {
             conversationId: conversationIdRef.current,
           });
 
@@ -7981,6 +7982,26 @@ export default function App({
 
           // Always show the URL in case browser doesn't open
           cmd.finish(`Opening ADE...\n→ ${adeUrl}`, true);
+          return { submitted: true };
+        }
+
+        // Special handling for /chat command - open chat UI in browser
+        if (trimmed === "/chat") {
+          const chatUrl = buildChatUrl(agentId, {
+            conversationId: conversationIdRef.current,
+          });
+
+          const cmd = commandRunner.start("/chat", "Opening chat...");
+
+          // Fire-and-forget browser open
+          import("open")
+            .then(({ default: open }) => open(chatUrl, { wait: false }))
+            .catch(() => {
+              // Silently ignore - user can use the URL from the output
+            });
+
+          // Always show the URL in case browser doesn't open
+          cmd.finish(`Opening chat...\n→ ${chatUrl}`, true);
           return { submitted: true };
         }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -270,6 +270,15 @@ export const commands: Record<string, Command> = {
       return "Opening ADE...";
     },
   },
+  "/chat": {
+    desc: "Open agent in chat UI (browser)",
+    order: 28.1,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in App.tsx to access agent ID and open browser
+      return "Opening chat...";
+    },
+  },
 
   // === Page 3: Advanced features (order 30-39) ===
   "/system": {

--- a/src/cli/helpers/appUrls.ts
+++ b/src/cli/helpers/appUrls.ts
@@ -1,17 +1,12 @@
 const APP_BASE = "https://app.letta.com";
 
-/**
- * Build a chat URL for an agent, with optional conversation and extra query params.
- */
-export function buildChatUrl(
-  agentId: string,
-  options?: {
-    conversationId?: string;
-    view?: string;
-    deviceId?: string;
-  },
-): string {
-  const base = `${APP_BASE}/chat/${agentId}`;
+type AgentUrlOptions = {
+  conversationId?: string;
+  view?: string;
+  deviceId?: string;
+};
+
+function buildAgentUrl(base: string, options?: AgentUrlOptions): string {
   const params = new URLSearchParams();
 
   if (options?.view) {
@@ -26,6 +21,26 @@ export function buildChatUrl(
 
   const qs = params.toString();
   return qs ? `${base}?${qs}` : base;
+}
+
+/**
+ * Build the ADE URL for an agent, with optional conversation and extra query params.
+ */
+export function buildAdeUrl(
+  agentId: string,
+  options?: AgentUrlOptions,
+): string {
+  return buildAgentUrl(`${APP_BASE}/agents/${agentId}`, options);
+}
+
+/**
+ * Build a chat URL for an agent, with optional conversation and extra query params.
+ */
+export function buildChatUrl(
+  agentId: string,
+  options?: AgentUrlOptions,
+): string {
+  return buildAgentUrl(`${APP_BASE}/chat/${agentId}`, options);
 }
 
 /**

--- a/src/tests/cli/appUrls.test.ts
+++ b/src/tests/cli/appUrls.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { buildAdeUrl, buildChatUrl } from "../../cli/helpers/appUrls";
+
+describe("appUrls", () => {
+  test("buildAdeUrl points to the ADE agent route", () => {
+    expect(buildAdeUrl("agent-123")).toBe(
+      "https://app.letta.com/agents/agent-123",
+    );
+  });
+
+  test("buildAdeUrl includes a non-default conversation", () => {
+    expect(
+      buildAdeUrl("agent-123", {
+        conversationId: "conv-456",
+      }),
+    ).toBe("https://app.letta.com/agents/agent-123?conversation=conv-456");
+  });
+
+  test("buildChatUrl keeps the chat route and omits default conversation", () => {
+    expect(
+      buildChatUrl("agent-123", {
+        conversationId: "default",
+      }),
+    ).toBe("https://app.letta.com/chat/agent-123");
+  });
+
+  test("buildChatUrl preserves extra chat query params", () => {
+    expect(
+      buildChatUrl("agent-123", {
+        conversationId: "conv-456",
+        view: "tools",
+        deviceId: "device-789",
+      }),
+    ).toBe(
+      "https://app.letta.com/chat/agent-123?view=tools&deviceId=device-789&conversation=conv-456",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Restores `/ade` to open the ADE agent route (`https://app.letta.com/agents/<id>`) instead of the chat route
- Adds a separate `/chat` command that opens the chat UI route (`https://app.letta.com/chat/<id>`)
- Splits `buildChatUrl` and a new `buildAdeUrl` over a shared `buildAgentUrl` helper, with targeted tests

## Background
After #1254 (LET-7798) centralized URL building and pointed `/ade` at the chat route, `/ade` no longer opens the ADE — it opens the chat UI. @kianjones9 originally posted the fix in #1686 (`kian/ade-chat-command`), which was closed Apr 7 without merging. This PR cherry-picks that commit onto current `main` (one trivial conflict in `App.tsx` from the new `/experiments` block, resolved by keeping both) and re-opens the fix.

Authorship is preserved on Kian's commit; I'm just the committer.

Reported in Discord by @vedant_0200.

## Test plan
- [x] `bun test src/tests/cli/appUrls.test.ts` (4/4 pass)
- [x] `bun run typecheck` (clean)
- [ ] Manual: in `letta` interactive session, `/ade` opens `app.letta.com/agents/<id>`; `/chat` opens `app.letta.com/chat/<id>`

cc @cpfiffer for re-review (was closed without comment last time, want to make sure there isn't a reason to keep `/ade` pointing at chat)