### PR TITLE
feat(file-search): always skip .letta/worktrees in @-mention / quick-…

### DIFF
--- a/src/cli/helpers/fileSearchConfig.ts
+++ b/src/cli/helpers/fileSearchConfig.ts
@@ -10,6 +10,35 @@ interface CwdConfig {
 }
 
 /**
+ * Paths (relative to the index root) that are ALWAYS excluded from the
+ * file index, regardless of the user's `.lettaignore` config. Used for
+ * letta-code-internal directories that would otherwise dwarf real
+ * search results.
+ *
+ * Currently:
+ * - `.letta/worktrees` — parallel git worktrees are full duplicate
+ *   checkouts of the project. They massively pollute @-mention and
+ *   quick-open (cmd+shift+o) results when the user has not (yet)
+ *   added `.letta` to their `.lettaignore`.
+ *
+ * Note: this is matched against the entry's path RELATIVE to the
+ * index root, so `cmd+shift+o` invoked with `cwd` set to a worktree
+ * itself naturally still indexes that worktree's files (the relative
+ * path is never `.letta/worktrees/...` from inside one).
+ */
+const ALWAYS_EXCLUDED_RELATIVE_PATHS: readonly string[] = [".letta/worktrees"];
+
+function isAlwaysExcludedPath(relativePath: string | undefined): boolean {
+  if (!relativePath) return false;
+  for (const p of ALWAYS_EXCLUDED_RELATIVE_PATHS) {
+    if (relativePath === p || relativePath.startsWith(`${p}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Cache of compiled matchers keyed by absolute cwd path.
  * Compiled once per unique cwd for performance, re-built when cwd changes.
  */
@@ -86,6 +115,10 @@ export function shouldExcludeEntry(
   relativePath?: string,
   root?: string,
 ): boolean {
+  // Hard-coded floor: skip letta-code-internal dirs like
+  // .letta/worktrees regardless of user .lettaignore config.
+  if (isAlwaysExcludedPath(relativePath)) return true;
+
   const { nameMatchers, pathMatchers } = getConfig(root);
 
   // Name-based .lettaignore patterns (e.g. *.log, vendor)

--- a/src/tests/cli/fileSearchConfig.test.ts
+++ b/src/tests/cli/fileSearchConfig.test.ts
@@ -76,6 +76,54 @@ describe("shouldExcludeEntry", () => {
       expect(shouldExcludeEntry("package.json")).toBe(false);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Hard-coded floor: .letta/worktrees is always excluded, regardless of
+  // whether the user has anything in .lettaignore. Worktrees are full
+  // duplicate checkouts that would dwarf real search results.
+  // -------------------------------------------------------------------------
+  describe("always-excluded paths (.letta/worktrees)", () => {
+    test("excludes the .letta/worktrees directory itself", () => {
+      expect(shouldExcludeEntry("worktrees", ".letta/worktrees")).toBe(true);
+    });
+
+    test("excludes a worktree subdirectory", () => {
+      expect(shouldExcludeEntry("feat-x", ".letta/worktrees/feat-x")).toBe(
+        true,
+      );
+    });
+
+    test("excludes files deep inside a worktree", () => {
+      expect(
+        shouldExcludeEntry("foo.ts", ".letta/worktrees/feat-x/src/foo.ts"),
+      ).toBe(true);
+    });
+
+    test("does not match a sibling directory with a similar prefix", () => {
+      // Guard against accidental startsWith(".letta/worktrees") matching
+      // ".letta/worktrees-archive/..." — the rule must require a path
+      // separator after the prefix.
+      expect(
+        shouldExcludeEntry("file.ts", ".letta/worktrees-archive/file.ts"),
+      ).toBe(false);
+    });
+
+    test("does not exclude unrelated paths inside .letta/", () => {
+      // The rule is scoped to .letta/worktrees specifically — other
+      // .letta/ subpaths (agents, skills, etc.) are still indexable
+      // unless the user opts them out via .lettaignore.
+      expect(shouldExcludeEntry("some-agent", ".letta/agents/some-agent")).toBe(
+        false,
+      );
+      expect(shouldExcludeEntry("skills", ".letta/skills")).toBe(false);
+    });
+
+    test("does not exclude when no relativePath is provided", () => {
+      // shouldExcludeEntry can be called without a relativePath in some
+      // disk-scan paths; the always-excluded check needs a path to match.
+      expect(shouldExcludeEntry("worktrees")).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
…open

Worktrees inside `.letta/worktrees/` are full duplicate checkouts of the project; they dwarf the actual workspace and pollute every `cmd+shift+o` search with N copies of every file. The default `.lettaignore` template includes `.letta`, but `ensureLettaIgnoreFile` only writes the template when no file exists — users with older `.lettaignore` files (or who intentionally pruned `.letta` from theirs) still see the noise.

Add a hard-coded floor in `shouldExcludeEntry` that skips any path under `.letta/worktrees/` regardless of user config. Scoped via relativePath prefix matching, so `cmd+shift+o` invoked from inside a worktree (where `.letta/worktrees/` doesn't appear under the index root) still indexes that worktree's files normally.

Find-in-files (`cmd+shift+f`) is unaffected — ripgrep already skips hidden directories by default.

👾 Generated with [Letta Code](https://letta.com)