### PR TITLE
fix(channels): Telegram photo MIME type preservation

### DIFF
--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -2,12 +2,12 @@
  * Channel pairing store.
  *
  * Handles the pairing flow for channels with dm_policy: "pairing".
- * When an unknown user messages the bot, they get a pairing code.
+ * When an unknown user messages the channel, they get a pairing code.
  * The user runs `/channels <channel> pair <code>` to approve the connection.
  *
  * Persisted in ~/.letta/channels/<channel>/pairing.yaml.
  *
- * Reference: lettabot src/pairing/store.ts
+ * Reference: earlier pairing-store implementation
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -134,6 +134,11 @@ function isVideoMimeType(mimeType?: string): boolean {
   return normalizeTelegramMimeType(mimeType)?.startsWith("video/") ?? false;
 }
 
+function isGenericTelegramMimeType(mimeType?: string): boolean {
+  const normalized = normalizeTelegramMimeType(mimeType);
+  return !normalized || normalized === "application/octet-stream";
+}
+
 function inferAttachmentKind(params: {
   mimeType?: string;
   fileName?: string;
@@ -549,10 +554,11 @@ async function downloadTelegramAttachment(params: {
     remotePath,
     responseMimeType,
   });
+  const candidateMimeType = normalizeTelegramMimeType(candidate.mimeType);
   const mimeType =
-    responseMimeType ??
-    normalizeTelegramMimeType(candidate.mimeType) ??
-    inferMimeTypeFromName(fileName);
+    (isGenericTelegramMimeType(responseMimeType)
+      ? candidateMimeType
+      : responseMimeType) ?? inferMimeTypeFromName(fileName);
   const kind = inferAttachmentKind({
     mimeType,
     fileName,

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -680,3 +680,66 @@ test("telegram adapter batches media groups and downloads inbound images", async
     channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
   }
 });
+
+test("telegram adapter preserves photo mime type when Telegram download responds with octet-stream", async () => {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(Buffer.from("fake-jpeg"), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+  ) as unknown as typeof fetch;
+
+  FakeBot.nextGetFileImpl = async () => ({
+    file_path: "photos/photo.jpg",
+  });
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  try {
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        date: 1_736_380_800,
+        message_id: 10,
+        photo: [
+          { file_id: "photo1", file_unique_id: "unique-1", file_size: 9 },
+        ],
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const firstCall = onMessage.mock.calls[0] as unknown as
+      | [InboundChannelMessage]
+      | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("Expected inbound Telegram photo to emit a message");
+    }
+
+    const [inbound] = firstCall;
+    expect(inbound.attachments).toHaveLength(1);
+    expect(inbound.attachments?.[0]).toMatchObject({
+      kind: "image",
+      mimeType: "image/jpeg",
+      imageDataBase64: Buffer.from("fake-jpeg").toString("base64"),
+    });
+  } finally {
+    rmSync(channelRoot, { recursive: true, force: true });
+    channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
+  }
+});


### PR DESCRIPTION
## Summary

Preserve Telegram photo MIME type when the file download endpoint returns `application/octet-stream`. Telegram's `getFile` API often responds with a generic MIME type for photos, which caused valid image attachments to be dropped. The fix falls back to the known Telegram photo MIME type instead of trusting the download response's content-type.

Also refactors `pairing.ts` terminology from `bot` to `channel`.

## Test plan

- [x] `bun test src/tests/channels/telegram-adapter.test.ts`
