### PR TITLE
feat(listener): add dedicated stream websocket channel 

### DIFF
--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -227,12 +227,13 @@ export async function handleListen(
     }
 
     // Register with cloud
-    const { connectionId, wsUrl } = await registerWithCloud({
-      serverUrl,
-      apiKey,
-      deviceId,
-      connectionName,
-    });
+    const { connectionId, wsUrl, supportsSplitStatusChannels } =
+      await registerWithCloud({
+        serverUrl,
+        apiKey,
+        deviceId,
+        connectionName,
+      });
 
     updateCommandResult(
       ctx.buffersRef,
@@ -257,10 +258,12 @@ export async function handleListen(
     const startClient = async (
       connId: string,
       wsUrlValue: string,
+      nextSupportsSplitStatusChannels: boolean,
     ): Promise<void> => {
       await startListenerClient({
         connectionId: connId,
         wsUrl: wsUrlValue,
+        supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
         deviceId,
         connectionName,
         onStatusChange: (status, id) => {
@@ -349,6 +352,7 @@ export async function handleListen(
             await startClient(
               reregisterResult.connectionId,
               reregisterResult.wsUrl,
+              reregisterResult.supportsSplitStatusChannels,
             );
           } catch (error) {
             updateCommandResult(
@@ -391,7 +395,7 @@ export async function handleListen(
       });
     };
 
-    await startClient(connectionId, wsUrl);
+    await startClient(connectionId, wsUrl, supportsSplitStatusChannels);
   } catch (error) {
     updateCommandResult(
       ctx.buffersRef,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -568,7 +568,8 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       `Registering with ${registerOptions.serverUrl}/v1/environments/register`,
     );
 
-    const { connectionId, wsUrl } = await registerWithCloud(registerOptions);
+    const { connectionId, wsUrl, supportsSplitStatusChannels } =
+      await registerWithCloud(registerOptions);
 
     sessionLog.log(`Registered: connectionId=${connectionId}`);
     sessionLog.log(`wsUrl: ${wsUrl}`);
@@ -592,6 +593,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     const reregister = async (): Promise<{
       connectionId: string;
       wsUrl: string;
+      supportsSplitStatusChannels: boolean;
     }> => {
       sessionLog.log("Re-registering with retry...");
       const nextRegisterOptions = await resolveListenerRegistrationOptions(
@@ -640,10 +642,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       const startDebugClient = async (
         connId: string,
         url: string,
+        nextSupportsSplitStatusChannels: boolean,
       ): Promise<void> => {
         await startListenerClient({
           connectionId: connId,
           wsUrl: url,
+          supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
@@ -672,7 +676,11 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             );
             try {
               const result = await reregister();
-              await startDebugClient(result.connectionId, result.wsUrl);
+              await startDebugClient(
+                result.connectionId,
+                result.wsUrl,
+                result.supportsSplitStatusChannels,
+              );
             } catch (error) {
               const msg =
                 error instanceof Error ? error.message : String(error);
@@ -695,7 +703,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           },
         });
       };
-      await startDebugClient(connectionId, wsUrl);
+      await startDebugClient(connectionId, wsUrl, supportsSplitStatusChannels);
     } else {
       // Normal mode: interactive Ink UI
       console.clear();
@@ -723,10 +731,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       const startNormalClient = async (
         connId: string,
         url: string,
+        nextSupportsSplitStatusChannels: boolean,
       ): Promise<void> => {
         await startListenerClient({
           connectionId: connId,
           wsUrl: url,
+          supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
@@ -750,7 +760,11 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             sessionLog.log("Environment expired, re-registering...");
             try {
               const result = await reregister();
-              await startNormalClient(result.connectionId, result.wsUrl);
+              await startNormalClient(
+                result.connectionId,
+                result.wsUrl,
+                result.supportsSplitStatusChannels,
+              );
             } catch (error) {
               const msg =
                 error instanceof Error ? error.message : String(error);
@@ -775,7 +789,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           },
         });
       };
-      await startNormalClient(connectionId, wsUrl);
+      await startNormalClient(connectionId, wsUrl, supportsSplitStatusChannels);
     }
 
     // Keep process alive

--- a/src/tests/websocket/listen-register.test.ts
+++ b/src/tests/websocket/listen-register.test.ts
@@ -33,6 +33,7 @@ describe("registerWithCloud", () => {
     expect(result).toEqual({
       connectionId: "conn-1",
       wsUrl: "wss://example.com",
+      supportsSplitStatusChannels: false,
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
@@ -58,6 +59,26 @@ describe("registerWithCloud", () => {
         nodeVersion: expect.any(String),
       },
     });
+  });
+
+  it("returns advertised split-channel support when present", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          connectionId: "conn-2",
+          wsUrl: "wss://example.com",
+          supportsSplitStatusChannels: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await registerWithCloud(
+      defaultOpts,
+      mockFetch as unknown as typeof fetch,
+    );
+
+    expect(result.supportsSplitStatusChannels).toBe(true);
   });
 
   it("throws with body message on non-OK response with JSON error", async () => {

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -7,6 +7,7 @@ import { getVersion } from "../version.ts";
 export interface RegisterResult {
   connectionId: string;
   wsUrl: string;
+  supportsSplitStatusChannels: boolean;
 }
 
 export interface RegisterOptions {
@@ -117,6 +118,7 @@ export async function registerWithCloud(
   return {
     connectionId: result.connectionId,
     wsUrl: result.wsUrl,
+    supportsSplitStatusChannels: result.supportsSplitStatusChannels === true,
   };
 }
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4056,6 +4056,8 @@ function createRuntime(): ListenerRuntime {
   return {
     socket: null,
     transport: null,
+    streamTransport: null,
+    streamSocket: null,
     heartbeatInterval: null,
     reconnectTimeout: null,
     intentionallyClosed: false,
@@ -4112,6 +4114,22 @@ function stopRuntime(
   runtime.queuedSystemPromptRecompileByConversation.clear();
   stopAllWorktreeWatchers(runtime);
 
+  // Close the stream socket if present.
+  const streamSocket = runtime.streamSocket;
+  runtime.streamSocket = null;
+  runtime.streamTransport = null;
+  if (streamSocket) {
+    if (suppressCallbacks) {
+      streamSocket.removeAllListeners();
+    }
+    if (
+      streamSocket.readyState === WebSocket.OPEN ||
+      streamSocket.readyState === WebSocket.CONNECTING
+    ) {
+      streamSocket.close();
+    }
+  }
+
   if (!runtime.socket) {
     runtime.transport = null;
     return;
@@ -4146,6 +4164,7 @@ async function startConnectedListenerRuntime(
     startHeartbeat?: boolean;
     startCronScheduler?: boolean;
   } = {},
+  streamTransport?: ListenerTransport | null,
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
     return;
@@ -4162,6 +4181,9 @@ async function startConnectedListenerRuntime(
     options.startCronScheduler !== false && !cronSchedulerDisabledByEnv;
 
   runtime.transport = transport;
+  if (streamTransport) {
+    runtime.streamTransport = streamTransport;
+  }
   safeEmitWsEvent("recv", "lifecycle", {
     type:
       getListenerTransportKind(transport) === "websocket"
@@ -4483,6 +4505,62 @@ async function listDirectoryHybrid(
 }
 
 /**
+ * Wait for the stream socket to open, returning it as a ListenerTransport.
+ * Returns null if the stream socket closes or errors before opening, or if
+ * the runtime is shutting down. The caller falls back to the control socket
+ * in that case.
+ */
+function waitForStreamSocketOpen(
+  streamSocket: WebSocket,
+  _runtime: ListenerRuntime,
+): Promise<ListenerTransport | null> {
+  return new Promise((resolve) => {
+    if (streamSocket.readyState === WebSocket.OPEN) {
+      resolve(streamSocket);
+      return;
+    }
+    if (
+      streamSocket.readyState === WebSocket.CLOSING ||
+      streamSocket.readyState === WebSocket.CLOSED
+    ) {
+      resolve(null);
+      return;
+    }
+
+    const onOpen = () => {
+      cleanup();
+      resolve(streamSocket);
+    };
+    const onClose = () => {
+      cleanup();
+      resolve(null);
+    };
+    const onError = () => {
+      cleanup();
+      // Error is followed by close, so resolve null here
+      resolve(null);
+    };
+
+    const cleanup = () => {
+      streamSocket.removeListener("open", onOpen);
+      streamSocket.removeListener("close", onClose);
+      streamSocket.removeListener("error", onError);
+    };
+
+    streamSocket.on("open", onOpen);
+    streamSocket.on("close", onClose);
+    streamSocket.on("error", onError);
+
+    // Safety timeout: if the stream socket doesn't open within 5s, proceed
+    // without it. This prevents the control channel from being blocked.
+    setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, 5000);
+  });
+}
+
+/**
  * Connect to WebSocket with exponential backoff retry.
  */
 async function connectWithRetry(
@@ -4546,12 +4624,30 @@ async function connectWithRetry(
   const url = new URL(opts.wsUrl);
   url.searchParams.set("deviceId", opts.deviceId);
   url.searchParams.set("connectionName", opts.connectionName);
+  url.searchParams.set("channel", "control");
+
+  // Build the stream URL with channel=stream
+  const streamUrl = new URL(opts.wsUrl);
+  streamUrl.searchParams.set("deviceId", opts.deviceId);
+  streamUrl.searchParams.set("connectionName", opts.connectionName);
+  streamUrl.searchParams.set("channel", "stream");
 
   const socket = new WebSocket(url.toString(), {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
   });
+
+  // Open the stream socket alongside the control socket.
+  // The stream socket carries runtime emissions (stream_delta, device/loop
+  // status, queue updates, subagent state) while the control socket handles
+  // command request/response traffic.
+  const streamSocket = new WebSocket(streamUrl.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  runtime.streamSocket = streamSocket;
 
   // ── File watchers (keyed by absolute path) ─────────────────────────────
   // Managed by watch_file / unwatch_file commands from the web client.
@@ -4591,12 +4687,20 @@ async function connectWithRetry(
   };
 
   socket.on("open", async () => {
+    // Wait for the stream socket to also open before starting the runtime.
+    // If the stream socket is not yet open, wait for it; if it fails, we
+    // proceed without it (emissions fall back to the control socket).
+    const streamTransport = await waitForStreamSocketOpen(
+      streamSocket,
+      runtime,
+    );
     await startConnectedListenerRuntime(
       runtime,
       transport,
       opts,
       processQueuedTurn,
       { startHeartbeat: true, startCronScheduler: true },
+      streamTransport,
     );
   });
 
@@ -6562,6 +6666,20 @@ async function connectWithRetry(
     runtime._unsubscribeSubagentState = undefined;
     runtime._unsubscribeSubagentStreamEvents?.();
     runtime._unsubscribeSubagentStreamEvents = undefined;
+    // Close the stream socket when the control socket closes.
+    // The stream socket does not drive reconnection logic — only the control
+    // socket does. Closing the stream socket here prevents orphaned connections.
+    if (streamSocket) {
+      streamSocket.removeAllListeners();
+      if (
+        streamSocket.readyState === WebSocket.OPEN ||
+        streamSocket.readyState === WebSocket.CONNECTING
+      ) {
+        streamSocket.close();
+      }
+    }
+    runtime.streamSocket = null;
+    runtime.streamTransport = null;
     runtime.socket = null;
     for (const conversationRuntime of runtime.conversationRuntimes.values()) {
       rejectPendingApprovalResolvers(
@@ -6616,6 +6734,36 @@ async function connectWithRetry(
     }
     // Error triggers close(), which handles retry logic.
   });
+
+  // Stream socket error/close handlers.
+  // The stream socket is fire-and-forget for emissions — errors here should
+  // not trigger reconnection. If the stream socket drops, emissions fall back
+  // to the control socket via the isListenerTransportOpen check in
+  // emitProtocolV2Message.
+  streamSocket.on("error", (error: Error) => {
+    trackListenerError(
+      "listener_stream_socket_error",
+      error,
+      "listener_stream_socket",
+    );
+    if (isDebugEnabled()) {
+      console.error("[Listen] Stream WebSocket error:", error);
+    }
+  });
+
+  streamSocket.on("close", (code: number, reason: Buffer) => {
+    if (isDebugEnabled()) {
+      console.log(
+        `[Listen] Stream WebSocket closed (code: ${code}, reason: ${reason.toString()})`,
+      );
+    }
+    // Clear the stream transport so emissions fall back to the control socket.
+    // Do NOT trigger reconnection — the control socket owns that lifecycle.
+    if (runtime.streamSocket === streamSocket) {
+      runtime.streamSocket = null;
+      runtime.streamTransport = null;
+    }
+  });
 }
 
 /**
@@ -6649,6 +6797,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   activeAgentId: string | null;
   activeConversationId: string;
   socket: WebSocket | null;
+  streamSocket: WebSocket | null;
   workingDirectoryByConversation: Map<string, string>;
   permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
   reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
@@ -6685,6 +6834,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     activeAgentId: string | null;
     activeConversationId: string;
     socket: WebSocket | null;
+    streamSocket: WebSocket | null;
     workingDirectoryByConversation: Map<string, string>;
     permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
     reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
@@ -6720,6 +6870,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.socket,
       set: (value: WebSocket | null) => {
         listener.socket = value;
+      },
+    },
+    streamSocket: {
+      get: () => listener.streamSocket,
+      set: (value: WebSocket | null) => {
+        listener.streamSocket = value;
       },
     },
     workingDirectoryByConversation: {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4624,13 +4624,19 @@ async function connectWithRetry(
   const url = new URL(opts.wsUrl);
   url.searchParams.set("deviceId", opts.deviceId);
   url.searchParams.set("connectionName", opts.connectionName);
-  url.searchParams.set("channel", "control");
 
-  // Build the stream URL with channel=stream
-  const streamUrl = new URL(opts.wsUrl);
-  streamUrl.searchParams.set("deviceId", opts.deviceId);
-  streamUrl.searchParams.set("connectionName", opts.connectionName);
-  streamUrl.searchParams.set("channel", "stream");
+  const supportsSplitStatusChannels = opts.supportsSplitStatusChannels === true;
+  if (supportsSplitStatusChannels) {
+    url.searchParams.set("channel", "control");
+  }
+
+  let streamUrl: URL | null = null;
+  if (supportsSplitStatusChannels) {
+    streamUrl = new URL(opts.wsUrl);
+    streamUrl.searchParams.set("deviceId", opts.deviceId);
+    streamUrl.searchParams.set("connectionName", opts.connectionName);
+    streamUrl.searchParams.set("channel", "stream");
+  }
 
   const socket = new WebSocket(url.toString(), {
     headers: {
@@ -4642,11 +4648,13 @@ async function connectWithRetry(
   // The stream socket carries runtime emissions (stream_delta, device/loop
   // status, queue updates, subagent state) while the control socket handles
   // command request/response traffic.
-  const streamSocket = new WebSocket(streamUrl.toString(), {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  const streamSocket = streamUrl
+    ? new WebSocket(streamUrl.toString(), {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      })
+    : null;
   runtime.streamSocket = streamSocket;
 
   // ── File watchers (keyed by absolute path) ─────────────────────────────
@@ -4687,13 +4695,13 @@ async function connectWithRetry(
   };
 
   socket.on("open", async () => {
-    // Wait for the stream socket to also open before starting the runtime.
-    // If the stream socket is not yet open, wait for it; if it fails, we
-    // proceed without it (emissions fall back to the control socket).
-    const streamTransport = await waitForStreamSocketOpen(
-      streamSocket,
-      runtime,
-    );
+    let streamTransport: ListenerTransport | null = null;
+    if (streamSocket) {
+      // Wait for the stream socket to also open before starting the runtime.
+      // If the stream socket is not yet open, wait for it; if it fails, we
+      // proceed without it (emissions fall back to the control socket).
+      streamTransport = await waitForStreamSocketOpen(streamSocket, runtime);
+    }
     await startConnectedListenerRuntime(
       runtime,
       transport,
@@ -6740,30 +6748,32 @@ async function connectWithRetry(
   // not trigger reconnection. If the stream socket drops, emissions fall back
   // to the control socket via the isListenerTransportOpen check in
   // emitProtocolV2Message.
-  streamSocket.on("error", (error: Error) => {
-    trackListenerError(
-      "listener_stream_socket_error",
-      error,
-      "listener_stream_socket",
-    );
-    if (isDebugEnabled()) {
-      console.error("[Listen] Stream WebSocket error:", error);
-    }
-  });
-
-  streamSocket.on("close", (code: number, reason: Buffer) => {
-    if (isDebugEnabled()) {
-      console.log(
-        `[Listen] Stream WebSocket closed (code: ${code}, reason: ${reason.toString()})`,
+  if (streamSocket) {
+    streamSocket.on("error", (error: Error) => {
+      trackListenerError(
+        "listener_stream_socket_error",
+        error,
+        "listener_stream_socket",
       );
-    }
-    // Clear the stream transport so emissions fall back to the control socket.
-    // Do NOT trigger reconnection — the control socket owns that lifecycle.
-    if (runtime.streamSocket === streamSocket) {
-      runtime.streamSocket = null;
-      runtime.streamTransport = null;
-    }
-  });
+      if (isDebugEnabled()) {
+        console.error("[Listen] Stream WebSocket error:", error);
+      }
+    });
+
+    streamSocket.on("close", (code: number, reason: Buffer) => {
+      if (isDebugEnabled()) {
+        console.log(
+          `[Listen] Stream WebSocket closed (code: ${code}, reason: ${reason.toString()})`,
+        );
+      }
+      // Clear the stream transport so emissions fall back to the control socket.
+      // Do NOT trigger reconnection — the control socket owns that lifecycle.
+      if (runtime.streamSocket === streamSocket) {
+        runtime.streamSocket = null;
+        runtime.streamTransport = null;
+      }
+    });
+  }
 }
 
 /**

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -573,6 +573,21 @@ export function setLoopStatus(
   emitLoopStatusIfOpen(runtime, scope);
 }
 
+/** Message types that belong on the stream channel.
+ *  These are high-frequency runtime emissions that should be separated
+ *  from control/command-response traffic on the control channel. */
+const STREAM_CHANNEL_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "stream_delta",
+  "update_device_status",
+  "update_loop_status",
+  "update_queue",
+  "update_subagent_state",
+]);
+
+function isStreamChannelMessage(type: string): boolean {
+  return STREAM_CHANNEL_MESSAGE_TYPES.has(type);
+}
+
 export function emitProtocolV2Message(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
@@ -585,10 +600,20 @@ export function emitProtocolV2Message(
     conversation_id?: string | null;
   },
 ): void {
-  if (!isListenerTransportOpen(socket)) {
+  const listener = getListenerRuntime(runtime);
+
+  // Route stream-type messages to the stream transport when available.
+  // Falls back to the control socket if the stream transport is not open.
+  let targetSocket: ListenerTransport = socket;
+  if (listener?.streamTransport && isStreamChannelMessage(message.type)) {
+    if (isListenerTransportOpen(listener.streamTransport)) {
+      targetSocket = listener.streamTransport;
+    }
+  }
+
+  if (!isListenerTransportOpen(targetSocket)) {
     return;
   }
-  const listener = getListenerRuntime(runtime);
   const runtimeScope = resolveRuntimeScope(
     listener,
     getScopeForRuntime(runtime, scope),
@@ -615,16 +640,16 @@ export function emitProtocolV2Message(
     const stringifyMs = perfEnabled
       ? performance.now() - stringifyStartedAt
       : 0;
-    const bufferedBefore = perfEnabled ? socket.bufferedAmount : 0;
+    const bufferedBefore = perfEnabled ? targetSocket.bufferedAmount : 0;
     const sendStartedAt = perfEnabled ? performance.now() : 0;
-    socket.send(payload);
+    targetSocket.send(payload);
     if (perfEnabled) {
       recordProtocolPerfTelemetry(getProtocolPerfKey(message), {
         bytes: Buffer.byteLength(payload),
         stringifyMs,
         sendMs: performance.now() - sendStartedAt,
         bufferedBefore,
-        bufferedAfter: socket.bufferedAmount,
+        bufferedAfter: targetSocket.bufferedAmount,
       });
     }
   } catch (error) {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -156,6 +156,10 @@ export type ConversationRuntime = {
 export type ListenerRuntime = {
   socket: WebSocket | null;
   transport?: ListenerTransport | null;
+  /** Stream transport for runtime emissions (stream_delta, device/loop status, etc.). */
+  streamTransport?: ListenerTransport | null;
+  /** Underlying stream WebSocket (for close/cleanup). */
+  streamSocket: WebSocket | null;
   heartbeatInterval: NodeJS.Timeout | null;
   reconnectTimeout: NodeJS.Timeout | null;
   intentionallyClosed: boolean;

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -29,6 +29,7 @@ import type { ListenerTransport } from "./transport";
 export interface StartListenerOptions {
   connectionId: string;
   wsUrl: string;
+  supportsSplitStatusChannels?: boolean;
   deviceId: string;
   connectionName: string;
   onConnected: (connectionId: string) => void;


### PR DESCRIPTION
### Summary
- add support for a dedicated listener stream websocket alongside the existing control websocket
- route runtime/protocol emissions (`stream_delta`, device/loop status, queue updates, subagent state) over the stream socket
- keep command and request/response handling on the control socket
- fall back to legacy single-socket behavior unless registration advertises `supportsSplitStatusChannels`

### Why
When streamed run output and control/filesystem responses share one socket, heavy streaming can delay or starve latency-sensitive device operations. Splitting those flows improves responsiveness without breaking older servers.

### Main changes
- listener runtime now tracks:
  - `streamSocket`
  - `streamTransport`
- `emitProtocolV2Message()` prefers the stream transport for stream/runtime message types
- listener client opens:
  - `channel=control`
  - `channel=stream`
  only when the server advertises support
- old servers remain single-socket because registration defaults `supportsSplitStatusChannels` to `false`

### Validation
- targeted biome check passed
- `bun test src/tests/websocket/listen-register.test.ts` passed
