### PR TITLE
fix: desktop listener registers with local env server when channels a…

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -132,6 +132,14 @@ async function resolveListenerStartupMode(
     return { kind: "remote", serverUrl };
   }
 
+  // When running under the desktop app (which sets LETTA_DESKTOP_DEBUG_PANEL),
+  // the local proxy has a full environment server that expects device
+  // registration. Treat it as "remote" so the listener registers and connects
+  // via WebSocket, even when channels are active.
+  if (process.env.LETTA_DESKTOP_DEBUG_PANEL === "1") {
+    return { kind: "remote", serverUrl };
+  }
+
   if (channelNames.length > 0) {
     return { kind: "local-channels", serverUrl };
   }


### PR DESCRIPTION
…ctive

When channels (Slack, Telegram, Discord) are enabled in the desktop app, the listener entered `local-channels` mode which skips environment registration. This caused the UI to permanently show "Connecting" because the local environment server never received a device WebSocket.

The desktop proxy's local environment server has a full registration endpoint, so detect the desktop context via LETTA_DESKTOP_DEBUG_PANEL and use "remote" mode to ensure the listener registers and connects.

🐾 Generated with [Letta Code](https://letta.com)