### PR TITLE
perf(listener): cache secrets hydration

### DIFF
--- a/src/tests/websocket/listener-secrets-sync.test.ts
+++ b/src/tests/websocket/listener-secrets-sync.test.ts
@@ -133,6 +133,48 @@ describe("listener secrets sync", () => {
     });
   });
 
+  test("invalidation during in-flight refresh forces a follow-up fetch", async () => {
+    let resolveFirst:
+      | ((value: { secrets: Array<{ key: string; value: string }> }) => void)
+      | undefined;
+    retrieveMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "updated" }],
+      });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    const first = ensureSecretsHydratedForAgent(
+      listener,
+      "agent-listener-secret",
+    );
+    for (let i = 0; i < 10 && !resolveFirst; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(resolveFirst).toBeDefined();
+
+    invalidateSecretsCacheForAgent(listener, "agent-listener-secret");
+    const second = ensureSecretsHydratedForAgent(
+      listener,
+      "agent-listener-secret",
+    );
+
+    resolveFirst?.({
+      secrets: [{ key: "WS_SECRET_TOKEN", value: "stale" }],
+    });
+    await Promise.all([first, second]);
+
+    expect(retrieveMock).toHaveBeenCalledTimes(2);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "updated",
+    });
+  });
+
   test("invalidation forces re-fetch even within the freshness window", async () => {
     retrieveMock
       .mockResolvedValueOnce({

--- a/src/tests/websocket/listener-secrets-sync.test.ts
+++ b/src/tests/websocket/listener-secrets-sync.test.ts
@@ -7,7 +7,9 @@ import {
 import { __listenClientTestUtils } from "../../websocket/listen-client";
 import {
   __testOverrideRefreshSecretsForAgent,
+  __testSetFreshnessMs,
   ensureSecretsHydratedForAgent,
+  invalidateSecretsCacheForAgent,
 } from "../../websocket/listener/secrets-sync";
 
 const retrieveMock = mock((_agentId: string, _opts?: Record<string, unknown>) =>
@@ -23,11 +25,14 @@ describe("listener secrets sync", () => {
       });
       await initSecretsFromServer(agentId, agent);
     });
+    // Use a short freshness window for deterministic tests.
+    __testSetFreshnessMs(500);
     clearSecretsCache("agent-listener-secret");
   });
 
   afterEach(() => {
     __testOverrideRefreshSecretsForAgent(null);
+    __testSetFreshnessMs(null);
     clearSecretsCache("agent-listener-secret");
   });
 
@@ -47,7 +52,7 @@ describe("listener secrets sync", () => {
     });
   });
 
-  test("does not memoize completed refreshes so GUI updates are visible", async () => {
+  test("returns cached secrets within the freshness window (cache hit)", async () => {
     retrieveMock
       .mockResolvedValueOnce({
         secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
@@ -58,6 +63,32 @@ describe("listener secrets sync", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
 
     await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    // Second call within the freshness window should be a cache hit.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+
+    // Only one server fetch — the second call hit the cache.
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "first",
+    });
+  });
+
+  test("re-fetches after the freshness window expires", async () => {
+    // Use a very short freshness window so it expires immediately.
+    __testSetFreshnessMs(1);
+
+    retrieveMock
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
+      })
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "second" }],
+      });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    // Wait for the freshness window to expire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
 
     expect(retrieveMock).toHaveBeenCalledTimes(2);
@@ -100,5 +131,76 @@ describe("listener secrets sync", () => {
     expect(loadSecrets("agent-listener-secret")).toEqual({
       WS_SECRET_TOKEN: "coalesced",
     });
+  });
+
+  test("invalidation forces re-fetch even within the freshness window", async () => {
+    retrieveMock
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
+      })
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "updated" }],
+      });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+
+    // Simulate a GUI secret mutation invalidating the cache.
+    invalidateSecretsCacheForAgent(listener, "agent-listener-secret");
+
+    // Next call should re-fetch even though the freshness window hasn't expired.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    expect(retrieveMock).toHaveBeenCalledTimes(2);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "updated",
+    });
+  });
+
+  test("approval reuse: same-turn call after preflight hits cache", async () => {
+    retrieveMock.mockResolvedValueOnce({
+      secrets: [{ key: "WS_SECRET_TOKEN", value: "preflight" }],
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    // Simulate the turn preflight hydration.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+
+    // Simulate the approval execution path calling again in the same turn.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+
+    // Only one server fetch — the approval path reused the cached hydration.
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+    expect(loadSecrets("agent-listener-secret")).toEqual({
+      WS_SECRET_TOKEN: "preflight",
+    });
+  });
+
+  test("invalidation clears dirty flag after successful re-fetch", async () => {
+    retrieveMock
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
+      })
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "second" }],
+      })
+      .mockResolvedValueOnce({
+        secrets: [{ key: "WS_SECRET_TOKEN", value: "third" }],
+      });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    // First hydration.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+
+    // Invalidate and re-fetch.
+    invalidateSecretsCacheForAgent(listener, "agent-listener-secret");
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    expect(retrieveMock).toHaveBeenCalledTimes(2);
+
+    // After re-fetch, the dirty flag is cleared and the cache is fresh again.
+    // A third call within the freshness window should be a cache hit.
+    await ensureSecretsHydratedForAgent(listener, "agent-listener-secret");
+    expect(retrieveMock).toHaveBeenCalledTimes(2); // no new fetch
   });
 });

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -4082,6 +4082,8 @@ function createRuntime(): ListenerRuntime {
     approvalRuntimeKeyByRequestId: new Map(),
     memfsSyncedAgents: new Map(),
     secretsHydrationByAgent: new Map(),
+    secretsHydrationFreshnessByAgent: new Map(),
+    secretsDirtyAgents: new Set(),
     lastEmittedStatus: null,
   };
 }
@@ -6421,6 +6423,14 @@ async function connectWithRetry(
               { set: parsed.set, unset: parsed.unset },
               parsed.agent_id,
             );
+            // Invalidate the listener's secrets freshness cache so the
+            // next tool execution re-fetches from the server.
+            const { invalidateSecretsCacheForAgent } = await import(
+              "./secrets-sync"
+            );
+            if (parsed.agent_id) {
+              invalidateSecretsCacheForAgent(runtime, parsed.agent_id);
+            }
             safeSocketSend(
               socket,
               {
@@ -6676,6 +6686,8 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
   memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
   secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
+  secretsHydrationFreshnessByAgent: ListenerRuntime["secretsHydrationFreshnessByAgent"];
+  secretsDirtyAgents: ListenerRuntime["secretsDirtyAgents"];
   worktreeWatcherByConversation: ListenerRuntime["worktreeWatcherByConversation"];
   lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
 } {
@@ -6712,6 +6724,8 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
     memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
     secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
+    secretsHydrationFreshnessByAgent: ListenerRuntime["secretsHydrationFreshnessByAgent"];
+    secretsDirtyAgents: ListenerRuntime["secretsDirtyAgents"];
     worktreeWatcherByConversation: ListenerRuntime["worktreeWatcherByConversation"];
     lastEmittedStatus: ListenerRuntime["lastEmittedStatus"];
   };
@@ -6873,6 +6887,18 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.secretsHydrationByAgent,
       set: (value: ListenerRuntime["secretsHydrationByAgent"]) => {
         listener.secretsHydrationByAgent = value;
+      },
+    },
+    secretsHydrationFreshnessByAgent: {
+      get: () => listener.secretsHydrationFreshnessByAgent,
+      set: (value: ListenerRuntime["secretsHydrationFreshnessByAgent"]) => {
+        listener.secretsHydrationFreshnessByAgent = value;
+      },
+    },
+    secretsDirtyAgents: {
+      get: () => listener.secretsDirtyAgents,
+      set: (value: ListenerRuntime["secretsDirtyAgents"]) => {
+        listener.secretsDirtyAgents = value;
       },
     },
     worktreeWatcherByConversation: {

--- a/src/websocket/listener/secrets-sync.ts
+++ b/src/websocket/listener/secrets-sync.ts
@@ -1,13 +1,37 @@
 /**
  * Server-backed secrets hydration for listen mode.
  *
- * Desktop and other WebSocket clients can update agent secrets directly through
- * the API. The listener process still needs a fresh local cache before it
- * builds reminders or executes shell tools that use $SECRET_NAME references.
+ * Listen-mode clients can update agent secrets directly through the API. The
+ * listener process still needs a fresh local cache before it builds reminders
+ * or executes shell tools that use $SECRET_NAME references.
+ *
+ * Caching strategy:
+ * - Completed refreshes are cached for a configurable freshness window
+ *   (default 60 s) so that the same-turn approval path and rapid sequential
+ *   turns don't re-fetch.
+ * - Mutation paths (secret_apply, setSecretOnServer, deleteSecretOnServer)
+ *   mark the agent's cache dirty so the next hydration call re-fetches.
+ * - Concurrent callers for the same agent still coalesce onto a single
+ *   in-flight request.
  */
 
 import { debugLog, debugWarn } from "../../utils/debug";
 import type { ListenerRuntime } from "./types";
+
+/** Default freshness window in milliseconds. */
+const DEFAULT_FRESHNESS_MS = 60_000;
+
+/** Test-only override for the freshness window. */
+let _testFreshnessMsOverride: number | null = null;
+
+/** @internal */
+export function __testSetFreshnessMs(ms: number | null): void {
+  _testFreshnessMsOverride = ms;
+}
+
+function getFreshnessMs(): number {
+  return _testFreshnessMsOverride ?? DEFAULT_FRESHNESS_MS;
+}
 
 let _testRefreshSecretsForAgentOverride:
   | ((agentId: string) => Promise<void>)
@@ -32,12 +56,53 @@ async function refreshSecretsForAgent(agentId: string): Promise<void> {
 }
 
 /**
+ * Mark an agent's cached secrets as stale so the next hydration call
+ * re-fetches from the server.
+ *
+ * Call this from mutation paths (secret_apply, setSecretOnServer,
+ * deleteSecretOnServer) so that subsequent tool executions see the
+ * updated values without waiting for the freshness window to expire.
+ */
+export function invalidateSecretsCacheForAgent(
+  listener: ListenerRuntime,
+  agentId: string,
+): void {
+  listener.secretsDirtyAgents.add(agentId);
+  debugLog("secrets-sync", `Marked secrets cache dirty for agent ${agentId}`);
+}
+
+/**
+ * Check whether an agent's cached secrets are still fresh.
+ *
+ * Returns true when:
+ *  - the agent has been hydrated before, AND
+ *  - the last hydration time is within the freshness window, AND
+ *  - the agent is not marked dirty.
+ */
+function isSecretsCacheFresh(
+  listener: ListenerRuntime,
+  agentId: string,
+): boolean {
+  if (listener.secretsDirtyAgents.has(agentId)) {
+    return false;
+  }
+  const lastHydrated = listener.secretsHydrationFreshnessByAgent.get(agentId);
+  if (lastHydrated === undefined) {
+    return false;
+  }
+  return Date.now() - lastHydrated < getFreshnessMs();
+}
+
+/**
  * Refresh the in-memory secrets cache for an agent.
  *
  * Concurrent callers for the same agent coalesce onto a single in-flight
- * request, but completed refreshes are not memoized. That keeps desktop GUI
- * updates visible on the next turn / tool execution without requiring a
- * listener restart.
+ * request. Completed refreshes are cached for a freshness window so that
+ * rapid sequential calls (e.g. turn preflight + approval execution) reuse
+ * the same hydration without a duplicate server round-trip.
+ *
+ * Mutation paths invalidate the cache via `invalidateSecretsCacheForAgent`
+ * so the next call always re-fetches after a GUI secret update.
  *
  * Non-fatal: logs a warning on failure but doesn't throw.
  */
@@ -45,13 +110,31 @@ export async function ensureSecretsHydratedForAgent(
   listener: ListenerRuntime,
   agentId: string,
 ): Promise<void> {
+  // Fast path: cache is still fresh and not dirty.
+  if (isSecretsCacheFresh(listener, agentId)) {
+    debugLog(
+      "secrets-sync",
+      `Secrets cache hit for agent ${agentId} (age ${Date.now() - (listener.secretsHydrationFreshnessByAgent.get(agentId) ?? 0)}ms)`,
+    );
+    return;
+  }
+
+  // Coalesce concurrent callers onto the same in-flight request.
   const existing = listener.secretsHydrationByAgent.get(agentId);
   if (existing) {
     await existing;
     return;
   }
 
+  // Clear dirty flag before fetching so the fresh result is not
+  // immediately considered stale.
+  listener.secretsDirtyAgents.delete(agentId);
+
   const promise = refreshSecretsForAgent(agentId)
+    .then(() => {
+      // Record freshness timestamp on successful hydration.
+      listener.secretsHydrationFreshnessByAgent.set(agentId, Date.now());
+    })
     .catch((err) => {
       // Non-fatal — agent can still process messages, just without local
       // secret substitution for this turn/tool execution.

--- a/src/websocket/listener/secrets-sync.ts
+++ b/src/websocket/listener/secrets-sync.ts
@@ -110,45 +110,58 @@ export async function ensureSecretsHydratedForAgent(
   listener: ListenerRuntime,
   agentId: string,
 ): Promise<void> {
-  // Fast path: cache is still fresh and not dirty.
-  if (isSecretsCacheFresh(listener, agentId)) {
-    debugLog(
-      "secrets-sync",
-      `Secrets cache hit for agent ${agentId} (age ${Date.now() - (listener.secretsHydrationFreshnessByAgent.get(agentId) ?? 0)}ms)`,
-    );
-    return;
-  }
-
-  // Coalesce concurrent callers onto the same in-flight request.
-  const existing = listener.secretsHydrationByAgent.get(agentId);
-  if (existing) {
-    await existing;
-    return;
-  }
-
-  // Clear dirty flag before fetching so the fresh result is not
-  // immediately considered stale.
-  listener.secretsDirtyAgents.delete(agentId);
-
-  const promise = refreshSecretsForAgent(agentId)
-    .then(() => {
-      // Record freshness timestamp on successful hydration.
-      listener.secretsHydrationFreshnessByAgent.set(agentId, Date.now());
-    })
-    .catch((err) => {
-      // Non-fatal — agent can still process messages, just without local
-      // secret substitution for this turn/tool execution.
-      debugWarn(
+  while (true) {
+    // Fast path: cache is still fresh and not dirty.
+    if (isSecretsCacheFresh(listener, agentId)) {
+      debugLog(
         "secrets-sync",
-        `Failed to refresh secrets for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        `Secrets cache hit for agent ${agentId} (age ${Date.now() - (listener.secretsHydrationFreshnessByAgent.get(agentId) ?? 0)}ms)`,
       );
-    })
-    .finally(() => {
-      if (listener.secretsHydrationByAgent.get(agentId) === promise) {
-        listener.secretsHydrationByAgent.delete(agentId);
-      }
-    });
+      return;
+    }
 
-  listener.secretsHydrationByAgent.set(agentId, promise);
-  await promise;
+    // Coalesce concurrent callers onto the same in-flight request. If a
+    // mutation marks the agent dirty while that request is in flight, loop back
+    // after it settles so the post-mutation caller forces a fresh hydration
+    // instead of satisfying itself from the stale promise.
+    const existing = listener.secretsHydrationByAgent.get(agentId);
+    if (existing) {
+      await existing;
+      if (listener.secretsDirtyAgents.has(agentId)) {
+        continue;
+      }
+      return;
+    }
+
+    // Clear dirty flag before fetching so the fresh result is not immediately
+    // considered stale. A mutation during the fetch will set it again and the
+    // loop will run another hydration before returning to that caller.
+    listener.secretsDirtyAgents.delete(agentId);
+
+    const promise = refreshSecretsForAgent(agentId)
+      .then(() => {
+        // Record freshness timestamp on successful hydration.
+        listener.secretsHydrationFreshnessByAgent.set(agentId, Date.now());
+      })
+      .catch((err) => {
+        // Non-fatal — agent can still process messages, just without local
+        // secret substitution for this turn/tool execution.
+        debugWarn(
+          "secrets-sync",
+          `Failed to refresh secrets for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      })
+      .finally(() => {
+        if (listener.secretsHydrationByAgent.get(agentId) === promise) {
+          listener.secretsHydrationByAgent.delete(agentId);
+        }
+      });
+
+    listener.secretsHydrationByAgent.set(agentId, promise);
+    await promise;
+    if (listener.secretsDirtyAgents.has(agentId)) {
+      continue;
+    }
+    return;
+  }
 }

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -430,7 +430,8 @@ export async function handleIncomingMessage(
     await Promise.all([
       // Memfs is lazy and memoized once per session.
       ensureMemfsSyncedForAgent(runtime.listener, agentId),
-      // Secrets refresh every turn so desktop GUI updates are picked up.
+      // Secrets are cached with a freshness window; mutation paths
+      // invalidate the cache so the next hydration re-fetches.
       ensureSecretsHydratedForAgent(runtime.listener, agentId),
     ]);
 

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -197,8 +197,12 @@ export type ListenerRuntime = {
   >;
   /** Agent IDs whose memfs repo has been cloned/pulled this session. Concurrent callers coalesce on the same promise. */
   memfsSyncedAgents: Map<string, Promise<void>>;
-  /** Agent IDs with an in-flight secrets refresh. Completed refreshes are not memoized so GUI updates are picked up. */
+  /** Agent IDs with an in-flight secrets refresh. Concurrent callers coalesce on the same promise. */
   secretsHydrationByAgent: Map<string, Promise<void>>;
+  /** Per-agent timestamp of the last successful secrets hydration. Used for freshness-based caching. */
+  secretsHydrationFreshnessByAgent: Map<string, number>;
+  /** Agent IDs whose cached secrets are stale and must re-fetch on the next hydration call. */
+  secretsDirtyAgents: Set<string>;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;
   /** Unsubscribe from subagent state store (set on socket open, cleared on close). */
   _unsubscribeSubagentState?: (() => void) | undefined;


### PR DESCRIPTION
## Summary
- Add freshness-based caching (60 s window) to `ensureSecretsHydratedForAgent` so that the same-turn approval execution and rapid sequential turns reuse a recent hydration instead of unconditionally fetching from the server every turn
- Add `invalidateSecretsCacheForAgent` for mutation paths; wired into the `secret_apply` WS handler so the next tool execution always re-fetches after a listen-mode client secret update
- Turn-approval path now reuses the same-turn preflight hydration automatically via the freshness cache (eliminates the duplicate fetch between turn preflight and approval execution)
- New tests: cache hit, freshness expiry, invalidation, approval reuse, dirty-flag clearing after re-fetch

👾 Generated with [Letta Code](https://letta.com)