### PR TITLE
perf(listener): preserve bootstrap reminders on reconnect

### DIFF
--- a/src/tests/reminders/listen-session-context.test.ts
+++ b/src/tests/reminders/listen-session-context.test.ts
@@ -124,7 +124,7 @@ describe("listen-mode session context", () => {
   );
 
   test(
-    "WS reconnect (state reset) re-arms session-context on next turn",
+    "manual state reset re-arms session-context on next turn",
     withStubbedProviders(async () => {
       const state = createSharedReminderState();
       const ctx = listenContext(state);
@@ -133,11 +133,11 @@ describe("listen-mode session context", () => {
       await buildSharedReminderParts(ctx);
       expect(state.hasSentSessionContext).toBe(true);
 
-      // Simulate WS reconnect: reset state (open handler)
+      // Simulate a manual reset of bootstrap reminder state.
       resetSharedReminderState(state);
       expect(state.hasSentSessionContext).toBe(false);
 
-      // Next turn after reconnect — should fire again
+      // Next turn after reset — should fire again
       const result = await buildSharedReminderParts(ctx);
       expect(result.appliedReminderIds).toContain("session-context");
       expect(result.appliedReminderIds).toContain("agent-info");

--- a/src/tests/websocket/listener-reconnect-reminders.test.ts
+++ b/src/tests/websocket/listener-reconnect-reminders.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { __listenClientTestUtils } from "../../websocket/listen-client";
+
+const { setActiveRuntime, stopRuntime } = __listenClientTestUtils;
+
+describe("listen reconnect reminders", () => {
+  afterEach(() => {
+    setActiveRuntime(null);
+  });
+
+  test("transport reconnect preserves existing bootstrap reminder and context state", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    setActiveRuntime(runtime);
+
+    const conversationRuntime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      runtime,
+      "agent-1",
+      "conv-1",
+    );
+
+    conversationRuntime.reminderState.hasSentAgentInfo = true;
+    conversationRuntime.reminderState.hasSentSessionContext = true;
+    conversationRuntime.reminderState.turnCount = 7;
+    conversationRuntime.reminderState.pendingReflectionTrigger = true;
+    conversationRuntime.contextTracker.currentTurnId = 9;
+    conversationRuntime.contextTracker.pendingReflectionTrigger = true;
+    conversationRuntime.contextTracker.pendingCompaction = true;
+
+    const transport = {
+      kind: "local" as const,
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send: () => {},
+    };
+
+    try {
+      await __listenClientTestUtils.startConnectedListenerRuntime(
+        runtime,
+        transport,
+        {
+          connectionId: "connection-1",
+          onConnected: () => {},
+          onStatusChange: () => {},
+          onWsEvent: () => {},
+        },
+        async () => {},
+        { startHeartbeat: false, startCronScheduler: false },
+      );
+
+      expect(conversationRuntime.reminderState.hasSentAgentInfo).toBe(true);
+      expect(conversationRuntime.reminderState.hasSentSessionContext).toBe(true);
+      expect(conversationRuntime.reminderState.turnCount).toBe(7);
+      expect(conversationRuntime.reminderState.pendingReflectionTrigger).toBe(
+        true,
+      );
+      expect(conversationRuntime.contextTracker.currentTurnId).toBe(9);
+      expect(conversationRuntime.contextTracker.pendingReflectionTrigger).toBe(
+        true,
+      );
+      expect(conversationRuntime.contextTracker.pendingCompaction).toBe(true);
+    } finally {
+      stopRuntime(runtime, true);
+      setActiveRuntime(null);
+    }
+  });
+});

--- a/src/tests/websocket/listener-reconnect-reminders.test.ts
+++ b/src/tests/websocket/listener-reconnect-reminders.test.ts
@@ -12,11 +12,12 @@ describe("listen reconnect reminders", () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     setActiveRuntime(runtime);
 
-    const conversationRuntime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      runtime,
-      "agent-1",
-      "conv-1",
-    );
+    const conversationRuntime =
+      __listenClientTestUtils.getOrCreateConversationRuntime(
+        runtime,
+        "agent-1",
+        "conv-1",
+      );
 
     conversationRuntime.reminderState.hasSentAgentInfo = true;
     conversationRuntime.reminderState.hasSentSessionContext = true;
@@ -48,7 +49,9 @@ describe("listen reconnect reminders", () => {
       );
 
       expect(conversationRuntime.reminderState.hasSentAgentInfo).toBe(true);
-      expect(conversationRuntime.reminderState.hasSentSessionContext).toBe(true);
+      expect(conversationRuntime.reminderState.hasSentSessionContext).toBe(
+        true,
+      );
       expect(conversationRuntime.reminderState.turnCount).toBe(7);
       expect(conversationRuntime.reminderState.pendingReflectionTrigger).toBe(
         true,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -26,7 +26,6 @@ import {
   getChannelRegistry,
 } from "../../channels/registry";
 import type { ChannelTurnSource } from "../../channels/types";
-import { resetContextHistory } from "../../cli/helpers/contextTracker";
 import {
   ensureFileIndex,
   getIndexRoot,
@@ -68,10 +67,7 @@ import {
   listProviders,
 } from "../../providers/byok-providers";
 import { type DequeuedBatch, QueueRuntime } from "../../queue/queueRuntime";
-import {
-  createSharedReminderState,
-  resetSharedReminderState,
-} from "../../reminders/state";
+import { createSharedReminderState } from "../../reminders/state";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
@@ -4180,17 +4176,8 @@ async function startConnectedListenerRuntime(
     // runtime and emit a properly-scoped device_status at that point.
     emitLoopStatusUpdate(transport, runtime);
   } else {
-    for (const reminderState of runtime.reminderStateByConversation.values()) {
-      // Reset bootstrap reminder state on (re)connect so session-context
-      // and agent-info fire on the first turn of the new connection.
-      // This is intentionally in the open handler, NOT the sync handler,
-      // because the Desktop UMI controller sends sync every ~5 s and
-      // resetting there would re-arm reminders on every periodic sync.
-      resetSharedReminderState(reminderState);
-    }
-    for (const contextTracker of runtime.contextTrackerByConversation.values()) {
-      resetContextHistory(contextTracker);
-    }
+    // Preserve existing per-conversation reminder and context state across
+    // pure transport reconnects; only refresh the live status snapshots here.
     for (const conversationRuntime of runtime.conversationRuntimes.values()) {
       const scope = {
         agent_id: conversationRuntime.agentId,
@@ -6926,6 +6913,7 @@ export const __listenClientTestUtils = {
   },
   createRuntime: createLegacyTestRuntime,
   createListenerRuntime: createRuntime,
+  startConnectedListenerRuntime: startConnectedListenerRuntime,
   handleModeChange,
   getOrCreateScopedRuntime,
   buildListModelsEntries,


### PR DESCRIPTION
## Summary
- Preserve existing bootstrap reminder and context state across pure transport reconnects in listen mode.
- Continue emitting device, loop, queue, and subagent status snapshots on reconnect, and add a focused regression test for the reconnect path.

👾 Generated with [Letta Code](https://letta.com)