### PR TITLE
perf(listener): process idle input directly

### DIFF
--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -20,6 +20,7 @@ import type {
 import { sharedReminderProviders } from "../../reminders/engine";
 import { queueSkillContent } from "../../tools/impl/skillContentRegistry";
 import { clearTools, loadSpecificTools } from "../../tools/manager";
+import { shouldProcessInboundMessageDirectly } from "../../websocket/listener/queue";
 import { resolveRecoveredApprovalResponse } from "../../websocket/listener/recovery";
 import { injectQueuedSkillContent } from "../../websocket/listener/skill-injection";
 import type { IncomingMessage } from "../../websocket/listener/types";
@@ -817,6 +818,34 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtimeB.queueRuntime.length).toBe(0);
     expect(runtimeA.queuedMessagesByItemId.size).toBe(0);
     expect(runtimeB.queuedMessagesByItemId.size).toBe(0);
+  });
+
+  test("idle inbound user messages bypass the queue runtime", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-idle",
+    );
+    const incoming = makeIncomingMessage("agent-1", "conv-idle", "hello");
+
+    expect(shouldProcessInboundMessageDirectly(runtime, incoming)).toBe(true);
+
+    const queueInput = {
+      kind: "message",
+      source: "user",
+      content: "queued",
+      clientMessageId: "cm-queued",
+      agentId: "agent-1",
+      conversationId: "conv-idle",
+    } satisfies Omit<MessageQueueItem, "id" | "enqueuedAt">;
+    const queuedItem = runtime.queueRuntime.enqueue(queueInput);
+    if (!queuedItem) {
+      throw new Error("Expected queued item to be created");
+    }
+    runtime.queuedMessagesByItemId.set(queuedItem.id, incoming);
+
+    expect(shouldProcessInboundMessageDirectly(runtime, incoming)).toBe(false);
   });
 
   test("channel queue items re-enter the listener loop as normal queued turns", async () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -258,6 +258,7 @@ import {
   normalizeInboundMessages,
   normalizeMessageContentImages,
   scheduleQueuePump,
+  shouldProcessInboundMessageDirectly,
   shouldQueueInboundMessage,
 } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
@@ -4719,9 +4720,75 @@ async function connectWithRetry(
           incoming.conversationId,
         );
 
+        const processIncomingMessageDirectly = (
+          directIncoming: IncomingMessage,
+        ): void => {
+          scopedRuntime.messageQueue = scopedRuntime.messageQueue
+            .then(async () => {
+              if (
+                runtime !== getActiveRuntime() ||
+                runtime.intentionallyClosed
+              ) {
+                return;
+              }
+              emitListenerStatus(
+                runtime,
+                opts.onStatusChange,
+                opts.connectionId,
+              );
+              await handleIncomingMessage(
+                directIncoming,
+                socket,
+                scopedRuntime,
+                opts.onStatusChange,
+                opts.connectionId,
+              );
+              emitListenerStatus(
+                runtime,
+                opts.onStatusChange,
+                opts.connectionId,
+              );
+              if (
+                scopedRuntime.queueRuntime.length > 0 ||
+                scopedRuntime.queuePumpScheduled ||
+                scopedRuntime.queuePumpActive
+              ) {
+                scheduleQueuePump(
+                  scopedRuntime,
+                  socket,
+                  opts,
+                  processQueuedTurn,
+                );
+              }
+            })
+            .catch((error: unknown) => {
+              trackListenerError(
+                "listener_queued_input_failed",
+                error,
+                "listener_message_queue",
+              );
+              if (process.env.DEBUG) {
+                console.error("[Listen] Error handling queued input:", error);
+              }
+              emitListenerStatus(
+                runtime,
+                opts.onStatusChange,
+                opts.connectionId,
+              );
+              scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
+            });
+        };
+
         if (shouldQueueInboundMessage(incoming)) {
-          const queuedIncoming = stampInboundUserMessageOtids(incoming);
-          const firstUserPayload = queuedIncoming.messages.find(
+          const stampedIncoming = stampInboundUserMessageOtids(incoming);
+          if (
+            shouldProcessInboundMessageDirectly(scopedRuntime, stampedIncoming)
+          ) {
+            processIncomingMessageDirectly(stampedIncoming);
+            return;
+          }
+
+          const firstUserPayload = stampedIncoming.messages.find(
             (
               payload,
             ): payload is MessageCreate & { client_message_id?: string } =>
@@ -4741,7 +4808,7 @@ async function connectWithRetry(
             if (enqueuedItem) {
               scopedRuntime.queuedMessagesByItemId.set(
                 enqueuedItem.id,
-                queuedIncoming,
+                stampedIncoming,
               );
             }
           }
@@ -4749,34 +4816,7 @@ async function connectWithRetry(
           return;
         }
 
-        scopedRuntime.messageQueue = scopedRuntime.messageQueue
-          .then(async () => {
-            if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
-              return;
-            }
-            emitListenerStatus(runtime, opts.onStatusChange, opts.connectionId);
-            await handleIncomingMessage(
-              incoming,
-              socket,
-              scopedRuntime,
-              opts.onStatusChange,
-              opts.connectionId,
-            );
-            emitListenerStatus(runtime, opts.onStatusChange, opts.connectionId);
-            scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
-          })
-          .catch((error: unknown) => {
-            trackListenerError(
-              "listener_queued_input_failed",
-              error,
-              "listener_message_queue",
-            );
-            if (process.env.DEBUG) {
-              console.error("[Listen] Error handling queued input:", error);
-            }
-            emitListenerStatus(runtime, opts.onStatusChange, opts.connectionId);
-            scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
-          });
+        processIncomingMessageDirectly(incoming);
         return;
       }
 

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -333,6 +333,54 @@ export function shouldQueueInboundMessage(parsed: IncomingMessage): boolean {
   return parsed.messages.some((payload) => "content" in payload);
 }
 
+export function shouldProcessInboundMessageDirectly(
+  runtime: ConversationRuntime,
+  parsed: IncomingMessage,
+): boolean {
+  if (!shouldQueueInboundMessage(parsed)) {
+    return false;
+  }
+
+  if (
+    runtime.queueRuntime.length > 0 ||
+    runtime.queuePumpActive ||
+    runtime.queuePumpScheduled ||
+    runtime.pendingTurns > 0 ||
+    runtime.queuedMessagesByItemId.size > 0 ||
+    runtime.isProcessing ||
+    runtime.isRecoveringApprovals ||
+    runtime.cancelRequested ||
+    runtime.pendingApprovalResolvers.size > 0 ||
+    runtime.pendingApprovalBatchByToolCallId.size > 0 ||
+    runtime.recoveredApprovalState !== null ||
+    runtime.pendingInterruptedResults !== null ||
+    runtime.pendingInterruptedContext !== null ||
+    runtime.activeExecutingToolCallIds.length > 0 ||
+    (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0 ||
+    runtime.activeRunId !== null ||
+    runtime.activeRunStartedAt !== null ||
+    runtime.activeAbortController !== null
+  ) {
+    return false;
+  }
+
+  const activeScope = resolveRuntimeScope(runtime.listener, {
+    agent_id: runtime.agentId,
+    conversation_id: runtime.conversationId,
+  });
+  return (
+    getListenerBlockedReason({
+      loopStatus: runtime.loopStatus,
+      isProcessing: runtime.isProcessing,
+      pendingApprovalsLen: activeScope
+        ? getPendingControlRequestCount(runtime.listener, activeScope)
+        : 0,
+      cancelRequested: runtime.cancelRequested,
+      isRecoveringApprovals: runtime.isRecoveringApprovals,
+    }) === null
+  );
+}
+
 export function consumeQueuedTurn(runtime: ConversationRuntime): {
   dequeuedBatch: DequeuedBatch;
   queuedTurn: IncomingMessage;


### PR DESCRIPTION
## Summary
- bypass QueueRuntime for idle listener user messages when there is no active processing, approval, recovery, cancel, or queued work
- keep the existing queued path for busy/coalescing cases and continue serializing direct processing through the listener message chain
- add regression coverage for the direct-path predicate and queue fallback

👾 Generated with [Letta Code](https://letta.com)