### PR TITLE
refactor(api): add backend seam for lifecycle calls

### DIFF
--- a/src/agent/available-models.ts
+++ b/src/agent/available-models.ts
@@ -1,4 +1,4 @@
-import { getClient } from "../backend/api/client";
+import { getBackend } from "../backend";
 import { refreshByokProviders } from "../backend/api/providers";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -55,8 +55,7 @@ export function getCachedModelHandles(): Set<string> | null {
 }
 
 async function fetchFromNetwork(): Promise<CacheEntry> {
-  const client = await getClient();
-  const modelsList = await client.models.list();
+  const modelsList = await getBackend().listModels();
   const handles = new Set(
     modelsList.map((m) => m.handle).filter((h): h is string => !!h),
   );
@@ -95,7 +94,8 @@ export async function getAvailableModelHandles(options?: {
 
   // When forceRefresh is true, first refresh BYOK providers to get latest models
   // This matches the behavior in ADE (letta-cloud) where refresh is called before listing models
-  if (forceRefresh) {
+  const backend = getBackend();
+  if (forceRefresh && backend.capabilities.byokProviderRefresh) {
     await refreshByokProviders();
   }
 

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -48,6 +48,7 @@ const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
 const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
   ...RESUME_BACKFILL_MESSAGE_TYPES,
   "approval_request_message",
+  "tool_return_message",
   "approval_response_message",
 ];
 
@@ -88,27 +89,23 @@ export interface GetResumeDataOptions {
   includeMessageHistory?: boolean;
 }
 
-/**
- * Extract approval requests from an approval_request_message.
- * Exported for testing parallel tool call handling.
- */
-export function extractApprovals(messageToCheck: Message): {
-  pendingApproval: ApprovalRequest | null;
-  pendingApprovals: ApprovalRequest[];
-} {
-  // Cast to access tool_calls with proper typing
-  const approvalMsg = messageToCheck as Message & {
-    tool_calls?: Array<{
-      tool_call_id?: string;
-      name?: string;
-      arguments?: string;
-    }>;
-    tool_call?: {
-      tool_call_id?: string;
-      name?: string;
-      arguments?: string;
-    };
+type ApprovalMessage = Message & {
+  tool_calls?: Array<{
+    tool_call_id?: string;
+    name?: string;
+    arguments?: string;
+  }>;
+  tool_call?: {
+    tool_call_id?: string;
+    name?: string;
+    arguments?: string;
   };
+};
+
+function approvalRequestsFromMessage(
+  messageToCheck: Message,
+): ApprovalRequest[] {
+  const approvalMsg = messageToCheck as ApprovalMessage;
 
   // Use tool_calls array (new) or fallback to tool_call (deprecated)
   const toolCalls = Array.isArray(approvalMsg.tool_calls)
@@ -123,7 +120,7 @@ export function extractApprovals(messageToCheck: Message): {
     name?: string;
     arguments?: string;
   };
-  const pendingApprovals = toolCalls
+  return toolCalls
     .filter(
       (tc: ToolCallEntry): tc is ToolCallEntry & { tool_call_id: string } =>
         !!tc && !!tc.tool_call_id,
@@ -133,17 +130,91 @@ export function extractApprovals(messageToCheck: Message): {
       toolName: tc.name || "",
       toolArgs: tc.arguments || "",
     }));
+}
 
-  const pendingApproval = pendingApprovals[0] || null;
-
+function logPendingApprovals(pendingApprovals: ApprovalRequest[]): void {
   if (pendingApprovals.length > 0) {
     debugWarn(
       "check-approval",
       `Found ${pendingApprovals.length} pending approval(s): ${pendingApprovals.map((a) => a.toolName).join(", ")}`,
     );
   }
+}
+
+/**
+ * Extract approval requests from an approval_request_message.
+ * Exported for testing parallel tool call handling.
+ */
+export function extractApprovals(messageToCheck: Message): {
+  pendingApproval: ApprovalRequest | null;
+  pendingApprovals: ApprovalRequest[];
+} {
+  const pendingApprovals = approvalRequestsFromMessage(messageToCheck);
+  const pendingApproval = pendingApprovals[0] || null;
+
+  logPendingApprovals(pendingApprovals);
 
   return { pendingApproval, pendingApprovals };
+}
+
+function completedToolCallIdsFromMessages(messages: Message[]): Set<string> {
+  const completed = new Set<string>();
+  for (const message of messages) {
+    if (message.message_type === "tool_return_message") {
+      const toolReturnMessage = message as Message & {
+        tool_call_id?: unknown;
+        tool_returns?: Array<{ tool_call_id?: unknown }>;
+      };
+      if (typeof toolReturnMessage.tool_call_id === "string") {
+        completed.add(toolReturnMessage.tool_call_id);
+      }
+      for (const toolReturn of toolReturnMessage.tool_returns ?? []) {
+        if (typeof toolReturn.tool_call_id === "string") {
+          completed.add(toolReturn.tool_call_id);
+        }
+      }
+      continue;
+    }
+
+    if (message.message_type === "approval_response_message") {
+      const approvalResponseMessage = message as Message & {
+        approvals?: Array<{ tool_call_id?: unknown }>;
+      };
+      for (const approval of approvalResponseMessage.approvals ?? []) {
+        if (typeof approval.tool_call_id === "string") {
+          completed.add(approval.tool_call_id);
+        }
+      }
+    }
+  }
+  return completed;
+}
+
+function pendingApprovalsFromMessageVariants(messages: Message[]): {
+  messageToCheck: Message | undefined;
+  pendingApproval: ApprovalRequest | null;
+  pendingApprovals: ApprovalRequest[];
+} {
+  const approvalRequest = messages.find(
+    (msg) => msg.message_type === "approval_request_message",
+  );
+  if (!approvalRequest) {
+    return {
+      messageToCheck: messages[0],
+      pendingApproval: null,
+      pendingApprovals: [],
+    };
+  }
+
+  const completedToolCallIds = completedToolCallIdsFromMessages(messages);
+  const pendingApprovals = approvalRequestsFromMessage(approvalRequest).filter(
+    (approval) => !completedToolCallIds.has(approval.toolCallId),
+  );
+  const pendingApproval = pendingApprovals[0] || null;
+
+  logPendingApprovals(pendingApprovals);
+
+  return { messageToCheck: approvalRequest, pendingApproval, pendingApprovals };
 }
 
 /**
@@ -264,6 +335,29 @@ export function prepareMessageHistory(
  * The API doesn't guarantee order, so we must sort explicitly.
  */
 function sortChronological(messages: Message[]): Message[] {
+  const messageTypeRank = (messageType: string | undefined): number => {
+    switch (messageType) {
+      case "user_message":
+        return 0;
+      case "reasoning_message":
+        return 1;
+      case "tool_call_message":
+      case "approval_request_message":
+        return 2;
+      case "tool_return_message":
+      case "approval_response_message":
+        return 3;
+      case "assistant_message":
+        return 4;
+      case "event_message":
+        return 5;
+      case "summary_message":
+        return 6;
+      default:
+        return 7;
+    }
+  };
+
   return [...messages].sort((a, b) => {
     // All message types *should* have 'date', but be defensive.
     const ta = a.date ? new Date(a.date).getTime() : 0;
@@ -271,7 +365,8 @@ function sortChronological(messages: Message[]): Message[] {
     if (!Number.isFinite(ta) && !Number.isFinite(tb)) return 0;
     if (!Number.isFinite(ta)) return -1;
     if (!Number.isFinite(tb)) return 1;
-    return ta - tb;
+    if (ta !== tb) return ta - tb;
+    return messageTypeRank(a.message_type) - messageTypeRank(b.message_type);
   });
 }
 
@@ -427,15 +522,16 @@ export async function getResumeDataFromBackend(
         }
       }
 
-      // Find the approval_request_message variant if it exists
-      // (A single DB message can have multiple content types returned as separate Message objects)
-      const messageToCheck =
-        retrievedMessages.find(
-          (msg) => msg.message_type === "approval_request_message",
-        ) ?? retrievedMessages[0];
+      // Find the approval_request_message variant if it exists, but only treat
+      // it as pending when no matching tool result/approval response has been
+      // projected from the same underlying message.
+      const { messageToCheck, pendingApproval, pendingApprovals } =
+        pendingApprovalsFromMessageVariants(retrievedMessages);
 
       if (messageToCheck) {
-        debugWarn(
+        const logFoundMessage =
+          pendingApprovals.length > 0 ? debugWarn : debugLog;
+        logFoundMessage(
           "check-approval",
           `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
             (retrievedMessages.length > 1
@@ -444,9 +540,7 @@ export async function getResumeDataFromBackend(
         );
 
         // Check for pending approval(s) inline since we already have the message
-        if (messageToCheck.message_type === "approval_request_message") {
-          const { pendingApproval, pendingApprovals } =
-            extractApprovals(messageToCheck);
+        if (pendingApprovals.length > 0) {
           return {
             pendingApproval,
             pendingApprovals,
@@ -510,13 +604,13 @@ export async function getResumeDataFromBackend(
       if (lastInContextId) {
         const retrievedMessages =
           await getBackend().retrieveMessage(lastInContextId);
-        const messageToCheck =
-          retrievedMessages.find(
-            (msg) => msg.message_type === "approval_request_message",
-          ) ?? retrievedMessages[0];
+        const { messageToCheck, pendingApproval, pendingApprovals } =
+          pendingApprovalsFromMessageVariants(retrievedMessages);
 
         if (messageToCheck) {
-          debugWarn(
+          const logFoundMessage =
+            pendingApprovals.length > 0 ? debugWarn : debugLog;
+          logFoundMessage(
             "check-approval",
             `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
               (retrievedMessages.length > 1
@@ -524,9 +618,7 @@ export async function getResumeDataFromBackend(
                 : ""),
           );
 
-          if (messageToCheck.message_type === "approval_request_message") {
-            const { pendingApproval, pendingApprovals } =
-              extractApprovals(messageToCheck);
+          if (pendingApprovals.length > 0) {
             return {
               pendingApproval,
               pendingApprovals,
@@ -576,15 +668,24 @@ export async function getResumeDataFromBackend(
             (msg) => msg.id === latestMessageId,
           )
         : [];
-      const messageToCheck =
-        latestMessageVariants.find(
-          (msg) => msg.message_type === "approval_request_message",
-        ) ??
-        latestMessageVariants[latestMessageVariants.length - 1] ??
-        lastDefaultMessage;
+      const fallbackPendingCheck = pendingApprovalsFromMessageVariants(
+        latestMessageVariants.length > 0
+          ? latestMessageVariants
+          : [lastDefaultMessage].filter((msg): msg is Message => !!msg),
+      );
+      const { messageToCheck, pendingApproval, pendingApprovals } =
+        fallbackPendingCheck.messageToCheck
+          ? fallbackPendingCheck
+          : {
+              messageToCheck: lastDefaultMessage,
+              pendingApproval: null,
+              pendingApprovals: [],
+            };
 
       if (messageToCheck) {
-        debugWarn(
+        const logFoundMessage =
+          pendingApprovals.length > 0 ? debugWarn : debugLog;
+        logFoundMessage(
           "check-approval",
           `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
             (latestMessageVariants.length > 1
@@ -592,9 +693,7 @@ export async function getResumeDataFromBackend(
               : ""),
         );
 
-        if (messageToCheck.message_type === "approval_request_message") {
-          const { pendingApproval, pendingApprovals } =
-            extractApprovals(messageToCheck);
+        if (pendingApprovals.length > 0) {
           return {
             pendingApproval,
             pendingApprovals,

--- a/src/agent/clone.ts
+++ b/src/agent/clone.ts
@@ -4,6 +4,7 @@
 
 import { toFile } from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 
 export interface CloneAgentOptions {
@@ -24,6 +25,9 @@ export interface CloneAgentResult {
 export async function cloneAgent(
   options: CloneAgentOptions,
 ): Promise<CloneAgentResult> {
+  if (!getBackend().capabilities.agentFileImportExport) {
+    throw new Error("Agent clone is not supported by this backend yet");
+  }
   const client = await getClient();
 
   // Step 1: Export the source agent

--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -6,6 +6,7 @@ import type {
   AgentState,
   AgentType,
 } from "@letta-ai/letta-client/resources/agents/agents";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 import { apiRequest, getApiRequestConfig } from "../backend/api/request";
 import { DEFAULT_AGENT_NAME, DEFAULT_SUMMARIZATION_MODEL } from "../constants";
@@ -204,7 +205,7 @@ export async function createAgent(
     modelHandle = getDefaultModel();
   }
 
-  const client = await getClient();
+  const backend = getBackend();
 
   // Only attach server-side tools to the agent.
   // Client-side tools (Read, Write, Bash, etc.) are passed via client_tools at runtime,
@@ -361,7 +362,7 @@ export async function createAgent(
   };
 
   const createWithTools = (tools: string[]) =>
-    client.agents.create({
+    backend.createAgent({
       ...createAgentRequestBase,
       tools,
     });
@@ -386,12 +387,13 @@ export async function createAgent(
   }
 
   // Always retrieve the agent to ensure we get the full state with populated memory blocks
-  const fullAgent = await client.agents.retrieve(agent.id, {
+  const fullAgent = await backend.retrieveAgent(agent.id, {
     include: ["agent.managed_group"],
   });
 
   // Update persona block for sleeptime agent
   if (enableSleeptimeVal && fullAgent.managed_group) {
+    const client = await getClient();
     // Find the sleeptime agent in the managed group by checking agent_type
     for (const groupAgentId of fullAgent.managed_group.agent_ids) {
       try {

--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -5,8 +5,8 @@
  * Incognito: Stateless agent - fresh experience without accumulated memory.
  */
 
-import type { Letta } from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { Backend } from "../backend";
 import { getServerUrl } from "../backend/api/client";
 import { settingsManager } from "../settings-manager";
 import { type CreateAgentOptions, createAgent } from "./create";
@@ -97,7 +97,7 @@ export function selectDefaultAgentModel(params: {
 }
 
 async function resolveDefaultAgentModel(
-  client: Letta,
+  backend: Backend,
   preferredModel?: string,
 ): Promise<string | undefined> {
   if (!isSelfHostedServer()) {
@@ -109,7 +109,7 @@ async function resolveDefaultAgentModel(
 
   try {
     const availableHandles = new Set(
-      (await client.models.list())
+      (await backend.listModels())
         .map((model) => model.handle)
         .filter((handle): handle is string => typeof handle === "string"),
     );
@@ -131,15 +131,15 @@ async function resolveDefaultAgentModel(
  * Add a tag to an existing agent.
  */
 async function addTagToAgent(
-  client: Letta,
+  backend: Backend,
   agentId: string,
   newTag: string,
 ): Promise<void> {
   try {
-    const agent = await client.agents.retrieve(agentId);
+    const agent = await backend.retrieveAgent(agentId);
     const currentTags = agent.tags || [];
     if (!currentTags.includes(newTag)) {
-      await client.agents.update(agentId, {
+      await backend.updateAgent(agentId, {
         tags: [...currentTags, newTag],
       });
     }
@@ -160,7 +160,7 @@ async function addTagToAgent(
  * @returns The Letta Code agent (or null if creation disabled/failed).
  */
 export async function ensureDefaultAgents(
-  client: Letta,
+  backend: Backend,
   options?: {
     preferredModel?: string;
   },
@@ -174,19 +174,22 @@ export async function ensureDefaultAgents(
     const { isLettaCloud, enableMemfsIfCloud } = await import(
       "./memoryFilesystem"
     );
-    const willAutoEnableMemfs = await isLettaCloud();
+    const willAutoEnableMemfs =
+      backend.capabilities.remoteMemfs && (await isLettaCloud());
 
     const { agent } = await createAgent({
       ...DEFAULT_AGENT_CONFIGS.memo,
-      model: await resolveDefaultAgentModel(client, options?.preferredModel),
+      model: await resolveDefaultAgentModel(backend, options?.preferredModel),
       memoryPromptMode: willAutoEnableMemfs ? "memfs" : undefined,
     });
-    await addTagToAgent(client, agent.id, MEMO_TAG);
+    await addTagToAgent(backend, agent.id, MEMO_TAG);
     settingsManager.pinGlobal(agent.id);
 
     // Enable memfs on Letta Cloud (tags, repo clone, tool detach)
     // without blocking startup on the initial clone.
-    void enableMemfsIfCloud(agent.id);
+    if (backend.capabilities.remoteMemfs) {
+      void enableMemfsIfCloud(agent.id, backend);
+    }
 
     return agent;
   } catch (err) {

--- a/src/agent/import.ts
+++ b/src/agent/import.ts
@@ -5,6 +5,7 @@ import { createReadStream } from "node:fs";
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 import { getModelUpdateArgs } from "./model";
 import { updateAgentLLMConfig } from "./modify";
@@ -31,6 +32,9 @@ export interface ImportAgentResult {
 export async function importAgentFromFile(
   options: ImportAgentOptions,
 ): Promise<ImportAgentResult> {
+  if (!getBackend().capabilities.agentFileImportExport) {
+    throw new Error("Agent file import is not supported by this backend yet");
+  }
   const client = await getClient();
   const resolvedPath = resolve(options.filePath);
 

--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -10,6 +10,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import type { Backend } from "../backend";
 import {
   DIRECTORY_LIMIT_DEFAULTS,
   getDirectoryLimits,
@@ -350,6 +351,19 @@ export async function applyMemfsFlags(
   options?: ApplyMemfsFlagsOptions,
 ): Promise<ApplyMemfsFlagsResult> {
   const { settingsManager } = await import("../settings-manager");
+  const { getBackend } = await import("../backend");
+  const backend = getBackend();
+
+  if (!backend.capabilities.remoteMemfs) {
+    if (memfsFlag) {
+      throw new Error("MemFS is not supported by the active backend.");
+    }
+    if (noMemfsFlag) {
+      settingsManager.setMemfsEnabled(agentId, false);
+      return { action: "disabled" };
+    }
+    return { action: "unchanged" };
+  }
 
   // LCD proxies normal API traffic through localhost, while MemFS git sync can
   // still target api.letta.com through getMemfsServerUrl().
@@ -517,7 +531,12 @@ async function getMemfsSyncUnavailableMessage(): Promise<string> {
  * Skips the system prompt update since callers are expected to create
  * the agent with the correct memory mode upfront.
  */
-export async function enableMemfsIfCloud(agentId: string): Promise<void> {
+export async function enableMemfsIfCloud(
+  agentId: string,
+  backend?: Backend,
+): Promise<void> {
+  const resolvedBackend = backend ?? (await import("../backend")).getBackend();
+  if (!resolvedBackend.capabilities.remoteMemfs) return;
   if (!(await isLettaCloud())) return;
 
   try {

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -8,6 +8,7 @@ import type {
   OpenAIModelSettings,
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import { debugLog } from "../utils/debug";
@@ -227,7 +228,7 @@ export async function updateAgentLLMConfig(
   updateArgs?: Record<string, unknown>,
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<AgentState> {
-  const client = await getClient();
+  const backend = getBackend();
 
   const modelSettings = buildModelSettings(modelHandle, updateArgs);
   const explicitContextWindow = updateArgs?.context_window as
@@ -242,7 +243,7 @@ export async function updateAgentLLMConfig(
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
 
-  await client.agents.update(agentId, {
+  await backend.updateAgent(agentId, {
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
     ...(contextWindow && { context_window_limit: contextWindow }),
@@ -252,7 +253,7 @@ export async function updateAgentLLMConfig(
     }),
   });
 
-  const finalAgent = await client.agents.retrieve(agentId);
+  const finalAgent = await backend.retrieveAgent(agentId);
   return finalAgent;
 }
 
@@ -273,7 +274,7 @@ export async function updateConversationLLMConfig(
   updateArgs?: Record<string, unknown>,
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<Conversation> {
-  const client = await getClient();
+  const backend = getBackend();
 
   const modelSettings = buildModelSettings(modelHandle, updateArgs);
   const explicitContextWindow = updateArgs?.context_window as
@@ -290,9 +291,9 @@ export async function updateConversationLLMConfig(
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
     ...(contextWindow && { context_window_limit: contextWindow }),
-  } as unknown as Parameters<typeof client.conversations.update>[1];
+  } as Parameters<typeof backend.updateConversation>[1];
 
-  return client.conversations.update(conversationId, payload);
+  return backend.updateConversation(conversationId, payload);
 }
 
 /**
@@ -321,6 +322,11 @@ export async function recompileAgentSystemPrompt(
     };
   },
 ): Promise<string> {
+  if (!clientOverride && !getBackend().capabilities.promptRecompile) {
+    throw new Error(
+      "Server-side prompt recompile is not supported by this backend yet",
+    );
+  }
   const client = (clientOverride ?? (await getClient())) as Exclude<
     typeof clientOverride,
     undefined
@@ -355,9 +361,7 @@ export async function updateAgentSystemPromptRaw(
   systemPromptContent: string,
 ): Promise<SystemPromptUpdateResult> {
   try {
-    const client = await getClient();
-
-    await client.agents.update(agentId, {
+    await getBackend().updateAgent(agentId, {
       system: systemPromptContent,
     });
 
@@ -400,7 +404,7 @@ export async function updateAgentSystemPrompt(
     );
     const { settingsManager } = await import("../settings-manager");
 
-    const client = await getClient();
+    const backend = getBackend();
     const memoryMode =
       settingsManager.isReady && settingsManager.isMemfsEnabled(agentId)
         ? "memfs"
@@ -435,7 +439,7 @@ export async function updateAgentSystemPrompt(
     }
 
     // Re-fetch agent to get updated state
-    const agent = await client.agents.retrieve(agentId);
+    const agent = await backend.retrieveAgent(agentId);
 
     return {
       success: true,
@@ -480,13 +484,11 @@ export async function updateAgentSystemPromptMemfs(
     if (storedPreset && isKnownPreset(storedPreset)) {
       nextSystemPrompt = buildSystemPrompt(storedPreset, newMode);
     } else {
-      const client = await getClient();
-      const agent = await client.agents.retrieve(agentId);
+      const agent = await getBackend().retrieveAgent(agentId);
       nextSystemPrompt = swapMemoryAddon(agent.system || "", newMode);
     }
 
-    const client = await getClient();
-    await client.agents.update(agentId, {
+    await getBackend().updateAgent(agentId, {
       system: nextSystemPrompt,
     });
 

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -31,14 +31,29 @@ export type RunMessageStreamOptions = RunMessageStreamParams[2];
 export type AgentRetrieveParams = Parameters<APIClient["agents"]["retrieve"]>;
 export type AgentRetrieveOptions = AgentRetrieveParams[1];
 
+export type AgentListParams = Parameters<APIClient["agents"]["list"]>;
+export type AgentListBody = AgentListParams[0];
+
+export type AgentDeleteParams = Parameters<APIClient["agents"]["delete"]>;
+export type AgentDeleteOptions = AgentDeleteParams[1];
+
 export type AgentUpdateParams = Parameters<APIClient["agents"]["update"]>;
 export type AgentUpdateBody = AgentUpdateParams[1];
 export type AgentUpdateOptions = AgentUpdateParams[2];
+
+export type AgentCreateParams = Parameters<APIClient["agents"]["create"]>;
+export type AgentCreateBody = AgentCreateParams[0];
+export type AgentCreateOptions = AgentCreateParams[1];
 
 export type ConversationRetrieveParams = Parameters<
   APIClient["conversations"]["retrieve"]
 >;
 export type ConversationRetrieveOptions = ConversationRetrieveParams[1];
+
+export type ConversationListParams = Parameters<
+  APIClient["conversations"]["list"]
+>;
+export type ConversationListBody = ConversationListParams[0];
 
 export type ConversationCreateParams = Parameters<
   APIClient["conversations"]["create"]
@@ -69,11 +84,35 @@ export type MessageRetrieveParams = Parameters<
 >;
 export type MessageRetrieveOptions = MessageRetrieveParams[1];
 
+export type ModelsListParams = Parameters<APIClient["models"]["list"]>;
+export type ModelsListOptions = ModelsListParams[0];
+
+export interface BackendCapabilities {
+  remoteMemfs: boolean;
+  serverSideToolManagement: boolean;
+  serverSecrets: boolean;
+  agentFileImportExport: boolean;
+  promptRecompile: boolean;
+  byokProviderRefresh: boolean;
+  localModelCatalog: boolean;
+}
+
 export interface Backend {
+  readonly capabilities: BackendCapabilities;
+
   retrieveAgent(
     agentId: string,
     options?: AgentRetrieveOptions,
   ): Promise<Awaited<ReturnType<APIClient["agents"]["retrieve"]>>>;
+
+  listAgents(
+    body?: AgentListBody,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["list"]>>>;
+
+  deleteAgent(
+    agentId: string,
+    options?: AgentDeleteOptions,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["delete"]>>>;
 
   updateAgent(
     agentId: string,
@@ -81,10 +120,19 @@ export interface Backend {
     options?: AgentUpdateOptions,
   ): Promise<Awaited<ReturnType<APIClient["agents"]["update"]>>>;
 
+  createAgent(
+    body: AgentCreateBody,
+    options?: AgentCreateOptions,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["create"]>>>;
+
   retrieveConversation(
     conversationId: string,
     options?: ConversationRetrieveOptions,
   ): Promise<Awaited<ReturnType<APIClient["conversations"]["retrieve"]>>>;
+
+  listConversations(
+    body?: ConversationListBody,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["list"]>>>;
 
   createConversation(
     body: ConversationCreateBody,
@@ -115,6 +163,10 @@ export interface Backend {
     messageId: string,
     options?: MessageRetrieveOptions,
   ): Promise<Awaited<ReturnType<APIClient["messages"]["retrieve"]>>>;
+
+  listModels(
+    options?: ModelsListOptions,
+  ): Promise<Awaited<ReturnType<APIClient["models"]["list"]>>>;
 
   createConversationMessageStream(
     conversationId: string,
@@ -158,6 +210,16 @@ interface APIBackendDeps {
 }
 
 export class APIBackend implements Backend {
+  readonly capabilities: BackendCapabilities = {
+    remoteMemfs: true,
+    serverSideToolManagement: true,
+    serverSecrets: true,
+    agentFileImportExport: true,
+    promptRecompile: true,
+    byokProviderRefresh: true,
+    localModelCatalog: false,
+  };
+
   private readonly getApiClientOverride?: GetAPIClient;
   private readonly forkConversationOverride?: ForkConversation;
 
@@ -179,6 +241,16 @@ export class APIBackend implements Backend {
     return client.agents.retrieve(agentId, options);
   }
 
+  async listAgents(body?: AgentListBody) {
+    const client = await this.getClient();
+    return client.agents.list(body);
+  }
+
+  async deleteAgent(agentId: string, options?: AgentDeleteOptions) {
+    const client = await this.getClient();
+    return client.agents.delete(agentId, options);
+  }
+
   async updateAgent(
     agentId: string,
     body: AgentUpdateBody,
@@ -188,12 +260,22 @@ export class APIBackend implements Backend {
     return client.agents.update(agentId, body, options);
   }
 
+  async createAgent(body: AgentCreateBody, options?: AgentCreateOptions) {
+    const client = await this.getClient();
+    return client.agents.create(body, options);
+  }
+
   async retrieveConversation(
     conversationId: string,
     options?: ConversationRetrieveOptions,
   ) {
     const client = await this.getClient();
     return client.conversations.retrieve(conversationId, options);
+  }
+
+  async listConversations(body?: ConversationListBody) {
+    const client = await this.getClient();
+    return client.conversations.list(body);
   }
 
   async createConversation(
@@ -234,6 +316,11 @@ export class APIBackend implements Backend {
   async retrieveMessage(messageId: string, options?: MessageRetrieveOptions) {
     const client = await this.getClient();
     return client.messages.retrieve(messageId, options);
+  }
+
+  async listModels(options?: ModelsListOptions) {
+    const client = await this.getClient();
+    return client.models.list(options);
   }
 
   async createConversationMessageStream(
@@ -296,6 +383,17 @@ export async function configureDevBackend(name: string): Promise<void> {
     case "fake-headless": {
       const { FakeHeadlessBackend } = await import("./dev/FakeHeadlessBackend");
       backend = new FakeHeadlessBackend();
+      return;
+    }
+    case "fake-headless-tool-call": {
+      const { FakeHeadlessBackend } = await import("./dev/FakeHeadlessBackend");
+      const { DeterministicToolCallExecutor } = await import(
+        "./dev/HeadlessTurnExecutor"
+      );
+      backend = new FakeHeadlessBackend(
+        "agent-fake-headless",
+        new DeterministicToolCallExecutor(),
+      );
       return;
     }
     default:

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -10,6 +10,11 @@ import type {
   RunMessageStreamBody,
 } from "../backend";
 import { FakeHeadlessStore } from "./FakeHeadlessStore";
+import {
+  createAssistantMessageStream,
+  DeterministicPongExecutor,
+  type HeadlessTurnExecutor,
+} from "./HeadlessTurnExecutor";
 
 function createPage<T>(items: T[]) {
   return {
@@ -17,38 +22,41 @@ function createPage<T>(items: T[]) {
   };
 }
 
-function createFakeStream(message: {
-  id: string;
-  date: string;
-  content?: unknown;
-}): Stream<LettaStreamingResponse> {
-  const controller = new AbortController();
-  return {
-    controller,
-    async *[Symbol.asyncIterator]() {
-      yield {
-        message_type: "assistant_message",
-        id: message.id,
-        date: message.date,
-        content: message.content ?? [{ type: "text", text: "pong" }],
-      } as LettaStreamingResponse;
-      yield {
-        message_type: "stop_reason",
-        stop_reason: "end_turn",
-      } as LettaStreamingResponse;
-    },
-  } as unknown as Stream<LettaStreamingResponse>;
-}
-
 export class FakeHeadlessBackend implements Backend {
-  private readonly store: FakeHeadlessStore;
+  readonly capabilities = {
+    remoteMemfs: false,
+    serverSideToolManagement: false,
+    serverSecrets: false,
+    agentFileImportExport: false,
+    promptRecompile: false,
+    byokProviderRefresh: false,
+    localModelCatalog: true,
+  };
 
-  constructor(agentId = "agent-fake-headless") {
+  private readonly store: FakeHeadlessStore;
+  private readonly executor: HeadlessTurnExecutor;
+
+  constructor(
+    agentId = "agent-fake-headless",
+    executor: HeadlessTurnExecutor = new DeterministicPongExecutor(),
+  ) {
     this.store = new FakeHeadlessStore(agentId);
+    this.executor = executor;
   }
 
   async retrieveAgent(agentId: string): Promise<AgentState> {
     return this.store.ensureAgent(agentId);
+  }
+
+  async listAgents(...args: Parameters<Backend["listAgents"]>) {
+    const [body] = args;
+    return this.store.listAgents(body) as never;
+  }
+
+  async deleteAgent(...args: Parameters<Backend["deleteAgent"]>) {
+    const [agentId] = args;
+    this.store.deleteAgent(agentId);
+    return undefined as never;
   }
 
   updateAgent(...args: Parameters<Backend["updateAgent"]>) {
@@ -56,8 +64,18 @@ export class FakeHeadlessBackend implements Backend {
     return Promise.resolve(this.store.updateAgent(agentId, body));
   }
 
+  createAgent(...args: Parameters<Backend["createAgent"]>) {
+    const [body] = args;
+    return Promise.resolve(this.store.createAgent(body));
+  }
+
   async retrieveConversation(conversationId: string): Promise<Conversation> {
     return this.store.retrieveConversation(conversationId);
+  }
+
+  async listConversations(...args: Parameters<Backend["listConversations"]>) {
+    const [body] = args;
+    return this.store.listConversations(body) as never;
   }
 
   async createConversation(
@@ -98,20 +116,48 @@ export class FakeHeadlessBackend implements Backend {
     return Promise.resolve(this.store.retrieveMessage(messageId) as never);
   }
 
+  async listModels(): ReturnType<Backend["listModels"]> {
+    return [
+      {
+        handle: "dev/fake-headless",
+        model: "dev/fake-headless",
+        model_endpoint_type: "openai",
+      },
+    ] as never;
+  }
+
   async createConversationMessageStream(
     conversationId: string,
     body: ConversationMessageCreateBody,
   ) {
-    const assistantMessage = this.store.appendTurn(conversationId, body);
-    return createFakeStream(assistantMessage);
+    const turnInput = this.store.appendTurnInput(conversationId, body);
+    const stream = await this.executor.execute({
+      conversationId,
+      agentId: turnInput.agentId,
+      body,
+    });
+    return this.persistExecutorStream(
+      turnInput.conversationId,
+      turnInput.agentId,
+      stream,
+    );
   }
 
   async streamConversationMessages(
     conversationId: string,
     body: ConversationMessageStreamBody,
   ) {
-    const assistantMessage = this.store.appendTurn(conversationId, body);
-    return createFakeStream(assistantMessage);
+    const turnInput = this.store.appendTurnInput(conversationId, body);
+    const stream = await this.executor.execute({
+      conversationId,
+      agentId: turnInput.agentId,
+      body,
+    });
+    return this.persistExecutorStream(
+      turnInput.conversationId,
+      turnInput.agentId,
+      stream,
+    );
   }
 
   async cancelConversation() {
@@ -123,7 +169,7 @@ export class FakeHeadlessBackend implements Backend {
   }
 
   async streamRunMessages(_runId: string, _body: RunMessageStreamBody) {
-    return createFakeStream({
+    return createAssistantMessageStream({
       id: "msg-fake-headless-run",
       date: new Date(Date.UTC(2026, 0, 1)).toISOString(),
       content: [{ type: "text", text: "pong" }],
@@ -132,5 +178,21 @@ export class FakeHeadlessBackend implements Backend {
 
   async forkConversation(conversationId: string) {
     return { id: conversationId } as never;
+  }
+
+  private persistExecutorStream(
+    conversationId: string,
+    agentId: string,
+    stream: Stream<LettaStreamingResponse>,
+  ): Stream<LettaStreamingResponse> {
+    const store = this.store;
+    return {
+      controller: stream.controller,
+      async *[Symbol.asyncIterator]() {
+        for await (const chunk of stream) {
+          yield store.appendStreamChunk(conversationId, agentId, chunk);
+        }
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
   }
 }

--- a/src/backend/dev/FakeHeadlessStore.ts
+++ b/src/backend/dev/FakeHeadlessStore.ts
@@ -1,17 +1,23 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
-import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  LettaStreamingResponse,
+  Message,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import type {
+  AgentCreateBody,
+  AgentListBody,
   AgentMessageListBody,
   AgentUpdateBody,
   ConversationCreateBody,
+  ConversationListBody,
   ConversationMessageCreateBody,
   ConversationMessageListBody,
   ConversationMessageStreamBody,
   ConversationUpdateBody,
 } from "../backend";
 
-type StoredMessage = Message & {
+export type StoredMessage = Message & {
   id: string;
   message_type: string;
   date: string;
@@ -26,7 +32,7 @@ type StoredConversation = Conversation & {
   in_context_message_ids: string[];
 };
 
-function createAgent(agentId: string): AgentState {
+function createDefaultAgent(agentId: string): AgentState {
   return {
     id: agentId,
     name: "Fake Headless Agent",
@@ -86,6 +92,18 @@ function getCursor(
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+function toStoredOutputFields(chunk: Record<string, unknown>) {
+  const { id: _id, date: _date, agent_id, conversation_id, ...fields } = chunk;
+  void agent_id;
+  void conversation_id;
+  return fields;
+}
+
+export interface StoredTurnInput {
+  agentId: string;
+  conversationId: string;
+}
+
 export class FakeHeadlessStore {
   private readonly agents = new Map<string, AgentState>();
   private readonly conversations = new Map<string, StoredConversation>();
@@ -94,6 +112,7 @@ export class FakeHeadlessStore {
     StoredMessage[]
   >();
   private readonly messagesById = new Map<string, StoredMessage[]>();
+  private agentSeq = 0;
   private conversationSeq = 0;
   private messageSeq = 0;
 
@@ -104,7 +123,7 @@ export class FakeHeadlessStore {
   ensureAgent(agentId: string): AgentState {
     const existing = this.agents.get(agentId);
     if (existing) return existing;
-    const agent = createAgent(agentId);
+    const agent = createDefaultAgent(agentId);
     this.agents.set(agentId, agent);
     this.ensureConversation("default", agentId);
     return agent;
@@ -117,8 +136,91 @@ export class FakeHeadlessStore {
     return updated as AgentState;
   }
 
+  listAgents(body?: AgentListBody): { items: AgentState[] } {
+    const bodyRecord = (body ?? {}) as Record<string, unknown>;
+    const queryText =
+      typeof bodyRecord.query_text === "string"
+        ? bodyRecord.query_text.toLowerCase()
+        : undefined;
+    const tags = Array.isArray(bodyRecord.tags)
+      ? bodyRecord.tags.filter((tag): tag is string => typeof tag === "string")
+      : [];
+    const limit = typeof bodyRecord.limit === "number" ? bodyRecord.limit : 20;
+    let agents = [...this.agents.values()];
+
+    if (tags.length > 0) {
+      agents = agents.filter((agent) =>
+        tags.every((tag) => agent.tags?.includes(tag)),
+      );
+    }
+    if (queryText) {
+      agents = agents.filter((agent) => {
+        const haystack = [agent.name, agent.description, agent.id]
+          .filter((value): value is string => typeof value === "string")
+          .join("\n")
+          .toLowerCase();
+        return haystack.includes(queryText);
+      });
+    }
+    return { items: agents.slice(0, limit) };
+  }
+
+  deleteAgent(agentId: string): void {
+    this.agents.delete(agentId);
+  }
+
+  createAgent(body: AgentCreateBody): AgentState {
+    this.agentSeq += 1;
+    const bodyRecord = body as Record<string, unknown>;
+    const agentId =
+      typeof bodyRecord.id === "string" && bodyRecord.id.length > 0
+        ? bodyRecord.id
+        : `agent-fake-headless-${this.agentSeq}`;
+    const base = createDefaultAgent(agentId);
+    const tools = Array.isArray(bodyRecord.tools)
+      ? bodyRecord.tools.map((name) => ({ name }))
+      : base.tools;
+    const agent = {
+      ...base,
+      ...bodyRecord,
+      id: agentId,
+      tools,
+      tags: Array.isArray(bodyRecord.tags) ? bodyRecord.tags : base.tags,
+      message_ids: [],
+      in_context_message_ids: [],
+      llm_config: {
+        ...base.llm_config,
+        model:
+          typeof bodyRecord.model === "string"
+            ? bodyRecord.model
+            : base.llm_config?.model,
+        context_window:
+          typeof bodyRecord.context_window_limit === "number"
+            ? bodyRecord.context_window_limit
+            : base.llm_config?.context_window,
+      },
+    } as unknown as AgentState;
+    this.agents.set(agentId, agent);
+    this.ensureConversation("default", agentId);
+    return agent;
+  }
+
   retrieveConversation(conversationId: string, agentId?: string): Conversation {
     return this.ensureConversation(conversationId, agentId);
+  }
+
+  listConversations(body?: ConversationListBody): Conversation[] {
+    const bodyRecord = (body ?? {}) as Record<string, unknown>;
+    const agentId =
+      typeof bodyRecord.agent_id === "string" ? bodyRecord.agent_id : undefined;
+    const limit = typeof bodyRecord.limit === "number" ? bodyRecord.limit : 20;
+    return [...this.conversations.values()]
+      .filter(
+        (conversation) =>
+          conversation.id !== "default" &&
+          (!agentId || conversation.agent_id === agentId),
+      )
+      .slice(0, limit);
   }
 
   createConversation(body: ConversationCreateBody): Conversation {
@@ -144,10 +246,10 @@ export class FakeHeadlessStore {
     return updated as Conversation;
   }
 
-  appendTurn(
+  appendTurnInput(
     conversationId: string,
     body: ConversationMessageCreateBody | ConversationMessageStreamBody,
-  ): StoredMessage {
+  ): StoredTurnInput {
     const bodyWithAgent = body as {
       agent_id?: string;
       messages?: Array<Record<string, unknown>>;
@@ -161,7 +263,25 @@ export class FakeHeadlessStore {
       this.appendInputMessage(conversationId, agentId, message);
     }
 
-    return this.appendAssistantMessage(conversationId, agentId, "pong");
+    return { agentId, conversationId };
+  }
+
+  appendStreamChunk(
+    conversationId: string,
+    agentId: string,
+    chunk: LettaStreamingResponse,
+  ): LettaStreamingResponse {
+    const messageType = (chunk as { message_type?: unknown })?.message_type;
+    if (typeof messageType !== "string" || messageType === "stop_reason") {
+      return chunk;
+    }
+
+    const storedMessage = this.appendMessage(
+      conversationId,
+      agentId,
+      toStoredOutputFields(chunk as unknown as Record<string, unknown>),
+    );
+    return storedMessage as unknown as LettaStreamingResponse;
   }
 
   listConversationMessages(
@@ -212,18 +332,6 @@ export class FakeHeadlessStore {
       content,
       otid: message.otid,
       approvals: message.approvals,
-    });
-  }
-
-  private appendAssistantMessage(
-    conversationId: string,
-    agentId: string,
-    text: string,
-  ): StoredMessage {
-    return this.appendMessage(conversationId, agentId, {
-      message_type: "assistant_message",
-      role: "assistant",
-      content: textContent(text),
     });
   }
 

--- a/src/backend/dev/HeadlessTurnExecutor.ts
+++ b/src/backend/dev/HeadlessTurnExecutor.ts
@@ -1,0 +1,121 @@
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  ConversationMessageCreateBody,
+  ConversationMessageStreamBody,
+} from "../backend";
+import type { StoredMessage } from "./FakeHeadlessStore";
+
+export type HeadlessTurnBody =
+  | ConversationMessageCreateBody
+  | ConversationMessageStreamBody;
+
+export interface HeadlessTurnExecutorInput {
+  conversationId: string;
+  agentId: string;
+  body: HeadlessTurnBody;
+}
+
+export interface HeadlessTurnExecutor {
+  execute(
+    input: HeadlessTurnExecutorInput,
+  ): Promise<Stream<LettaStreamingResponse>>;
+}
+
+function createStream(
+  chunks: LettaStreamingResponse[],
+): Stream<LettaStreamingResponse> {
+  const controller = new AbortController();
+  return {
+    controller,
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  } as unknown as Stream<LettaStreamingResponse>;
+}
+
+export function createAssistantMessageStream(
+  message: Partial<Pick<StoredMessage, "id" | "date" | "content">> = {},
+): Stream<LettaStreamingResponse> {
+  return createStream([
+    {
+      message_type: "assistant_message",
+      ...(message.id ? { id: message.id } : {}),
+      ...(message.date ? { date: message.date } : {}),
+      content: message.content ?? [{ type: "text", text: "pong" }],
+    } as LettaStreamingResponse,
+    {
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as LettaStreamingResponse,
+  ]);
+}
+
+function hasApprovalResults(body: HeadlessTurnBody): boolean {
+  const messages = (body as { messages?: Array<Record<string, unknown>> })
+    .messages;
+  return (messages ?? []).some((message) => message.type === "approval");
+}
+
+function summarizeApprovalResults(body: HeadlessTurnBody): string {
+  const messages =
+    (
+      body as {
+        messages?: Array<{ approvals?: Array<Record<string, unknown>> }>;
+      }
+    ).messages ?? [];
+  const approvals = messages.flatMap((message) => message.approvals ?? []);
+  const firstToolResult = approvals.find(
+    (approval) => approval.type === "tool",
+  );
+  const status =
+    typeof firstToolResult?.status === "string"
+      ? firstToolResult.status
+      : "unknown";
+  const toolReturn = firstToolResult?.tool_return;
+  const text =
+    typeof toolReturn === "string"
+      ? toolReturn
+      : JSON.stringify(toolReturn ?? "");
+  return `tool result received (${status}): ${text.slice(0, 240)}`;
+}
+
+export class DeterministicPongExecutor implements HeadlessTurnExecutor {
+  async execute(_input: HeadlessTurnExecutorInput) {
+    return createAssistantMessageStream();
+  }
+}
+
+export class DeterministicToolCallExecutor implements HeadlessTurnExecutor {
+  private toolCallSeq = 0;
+
+  async execute(input: HeadlessTurnExecutorInput) {
+    if (hasApprovalResults(input.body)) {
+      return createAssistantMessageStream({
+        content: [{ type: "text", text: summarizeApprovalResults(input.body) }],
+      });
+    }
+
+    this.toolCallSeq += 1;
+    const toolCallId = `tool-call-fake-shell-${this.toolCallSeq}`;
+    return createStream([
+      {
+        message_type: "approval_request_message",
+        tool_call: {
+          tool_call_id: toolCallId,
+          name: "ShellCommand",
+          arguments: JSON.stringify({
+            command: "echo deterministic-tool-ok",
+            login: false,
+          }),
+        },
+      } as LettaStreamingResponse,
+      {
+        message_type: "stop_reason",
+        stop_reason: "requires_approval",
+      } as LettaStreamingResponse,
+    ]);
+  }
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -3454,13 +3454,12 @@ export default function App({
       const fetchConfig = async () => {
         try {
           // Use pre-loaded agent state if available, otherwise fetch
-          const { getClient } = await import("../backend/api/client");
-          const client = await getClient();
+          const backend = getBackend();
           let agent: AgentState;
           if (initialAgentState && initialAgentState.id === agentId) {
             agent = initialAgentState;
           } else {
-            agent = await client.agents.retrieve(agentId);
+            agent = await backend.retrieveAgent(agentId);
           }
 
           setAgentState(agent);
@@ -3572,28 +3571,31 @@ export default function App({
             setCurrentToolset(persistedToolsetPreference);
           }
 
-          void reconcileExistingAgentState(client, agent)
-            .then((reconcileResult) => {
-              if (!reconcileResult.updated || cancelled) {
-                return;
-              }
-              if (agentIdRef.current !== agent.id) {
-                return;
-              }
+          if (backend.capabilities.serverSideToolManagement) {
+            const client = await getClient();
+            void reconcileExistingAgentState(client, agent)
+              .then((reconcileResult) => {
+                if (!reconcileResult.updated || cancelled) {
+                  return;
+                }
+                if (agentIdRef.current !== agent.id) {
+                  return;
+                }
 
-              setAgentState(reconcileResult.agent);
-              setAgentDescription(reconcileResult.agent.description ?? null);
-            })
-            .catch((reconcileError) => {
-              debugWarn(
-                "agent-config",
-                `Failed to reconcile existing agent settings for ${agentId}: ${
-                  reconcileError instanceof Error
-                    ? reconcileError.message
-                    : String(reconcileError)
-                }`,
-              );
-            });
+                setAgentState(reconcileResult.agent);
+                setAgentDescription(reconcileResult.agent.description ?? null);
+              })
+              .catch((reconcileError) => {
+                debugWarn(
+                  "agent-config",
+                  `Failed to reconcile existing agent settings for ${agentId}: ${
+                    reconcileError instanceof Error
+                      ? reconcileError.message
+                      : String(reconcileError)
+                  }`,
+                );
+              });
+          }
         } catch (error) {
           debugLog("agent-config", "Error fetching agent config: %O", error);
         }
@@ -14508,6 +14510,9 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                       "https://api.letta.com";
                     return !baseURL.includes("api.letta.com");
                   })()}
+                  localModelCatalog={
+                    getBackend().capabilities.localModelCatalog
+                  }
                 />
               ))}
 

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -1,9 +1,8 @@
-import type { Letta } from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getModelDisplayName } from "../../agent/model";
-import { getClient } from "../../backend/api/client";
+import { type Backend, getBackend } from "../../backend";
 import { settingsManager } from "../../settings-manager";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
@@ -122,7 +121,12 @@ export function AgentSelector({
   command = "/agents",
 }: AgentSelectorProps) {
   const terminalWidth = useTerminalWidth();
-  const clientRef = useRef<Letta | null>(null);
+  const backendRef = useRef<Backend | null>(null);
+  const selectorBackend = useCallback(() => {
+    const backend = backendRef.current ?? getBackend();
+    backendRef.current = backend;
+    return backend;
+  }, []);
 
   // Tab state
   const [activeTab, setActiveTab] = useState<TabId>("pinned");
@@ -178,13 +182,12 @@ export function AgentSelector({
         return;
       }
 
-      const client = clientRef.current || (await getClient());
-      clientRef.current = client;
+      const backend = selectorBackend();
 
       const pinnedData = await Promise.all(
         mergedPinned.map(async ({ agentId, isLocal }) => {
           try {
-            const agent = await client.agents.retrieve(agentId, {
+            const agent = await backend.retrieveAgent(agentId, {
               include: ["agent.blocks"],
             });
             return { agentId, agent, error: null, isLocal };
@@ -200,7 +203,7 @@ export function AgentSelector({
     } finally {
       setPinnedLoading(false);
     }
-  }, []);
+  }, [selectorBackend]);
 
   // Fetch agents for list tabs (Letta Code / All)
   const fetchListAgents = useCallback(
@@ -209,10 +212,9 @@ export function AgentSelector({
       afterCursor?: string | null,
       query?: string,
     ) => {
-      const client = clientRef.current || (await getClient());
-      clientRef.current = client;
+      const backend = selectorBackend();
 
-      const agentList = await client.agents.list({
+      const agentList = await backend.listAgents({
         limit: FETCH_PAGE_SIZE,
         ...(filterLettaCode && { tags: ["origin:letta-code"] }),
         include: ["agent.blocks"],
@@ -229,7 +231,7 @@ export function AgentSelector({
 
       return { agents: agentList.items, nextCursor: cursor };
     },
-    [],
+    [selectorBackend],
   );
 
   // Load Letta Code agents
@@ -447,9 +449,8 @@ export function AgentSelector({
 
     setDeleteLoading(true);
     try {
-      const client = clientRef.current || (await getClient());
-      clientRef.current = client;
-      await client.agents.delete(agentId);
+      const backend = selectorBackend();
+      await backend.deleteAgent(agentId);
 
       // Reset state and refresh tabs
       setViewState({ type: "list" });
@@ -463,7 +464,7 @@ export function AgentSelector({
     } finally {
       setDeleteLoading(false);
     }
-  }, [viewState, deleteConfirmInput, loadPinnedAgents]);
+  }, [viewState, deleteConfirmInput, loadPinnedAgents, selectorBackend]);
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -1,4 +1,3 @@
-import type { Letta } from "@letta-ai/letta-client";
 import type {
   Message,
   MessageType,
@@ -6,7 +5,7 @@ import type {
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getClient } from "../../backend/api/client";
+import { type Backend, getBackend } from "../../backend";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
@@ -54,6 +53,10 @@ const RESUME_PREVIEW_MESSAGE_TYPES: MessageType[] = [
   "user_message",
   "assistant_message",
 ];
+
+function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
+  return Array.isArray(value) ? value : value.getPaginatedItems();
+}
 
 /**
  * Format a relative time string from a date
@@ -216,7 +219,12 @@ export function ConversationSelector({
   onNewConversation,
   onCancel,
 }: ConversationSelectorProps) {
-  const clientRef = useRef<Letta | null>(null);
+  const backendRef = useRef<Backend | null>(null);
+  const selectorBackend = useCallback(() => {
+    const backend = backendRef.current ?? getBackend();
+    backendRef.current = backend;
+    return backend;
+  }, []);
 
   // Conversation list state (enriched with message data)
   const [conversations, setConversations] = useState<EnrichedConversation[]>(
@@ -235,16 +243,15 @@ export function ConversationSelector({
 
   // Enrich a single conversation with message data, updating state in-place
   const enrichConversation = useCallback(
-    async (client: Letta, convId: string) => {
+    async (backend: Backend, convId: string) => {
       try {
-        const messages = await client.conversations.messages.list(convId, {
+        const messages = await backend.listConversationMessages(convId, {
           limit: ENRICH_MESSAGE_LIMIT,
           order: "desc",
           include_return_message_types: RESUME_PREVIEW_MESSAGE_TYPES,
-        } as unknown as Parameters<
-          typeof client.conversations.messages.list
-        >[1]);
-        const chronological = [...messages.getPaginatedItems()].reverse();
+          agent_id: agentId,
+        });
+        const chronological = [...paginatedItems(messages)].reverse();
         const stats = getMessageStats(chronological);
         setConversations((prev) =>
           prev.map((c) =>
@@ -272,7 +279,7 @@ export function ConversationSelector({
         return -1;
       }
     },
-    [],
+    [agentId],
   );
 
   // Load conversations — shows list immediately, enriches progressively
@@ -287,11 +294,10 @@ export function ConversationSelector({
       setError(null);
 
       try {
-        const client = clientRef.current || (await getClient());
-        clientRef.current = client;
+        const backend = selectorBackend();
 
         // Phase 1: Fetch conversation list + default messages in parallel
-        const conversationListPromise = client.conversations.list({
+        const conversationListPromise = backend.listConversations({
           agent_id: agentId,
           limit: FETCH_PAGE_SIZE,
           ...(afterCursor && { after: afterCursor }),
@@ -302,17 +308,15 @@ export function ConversationSelector({
         // Fetch default conversation in parallel (not sequentially before)
         const defaultPromise: Promise<EnrichedConversation | null> =
           !afterCursor
-            ? client.agents.messages
-                .list(agentId, {
+            ? backend
+                .listAgentMessages(agentId, {
                   conversation_id: "default",
                   limit: ENRICH_MESSAGE_LIMIT,
                   order: "desc",
                   include_return_message_types: RESUME_PREVIEW_MESSAGE_TYPES,
-                } as unknown as Parameters<
-                  typeof client.agents.messages.list
-                >[1])
+                })
                 .then((msgs) => {
-                  const items = msgs.getPaginatedItems();
+                  const items = paginatedItems(msgs);
                   if (items.length === 0) return null;
                   const stats = getMessageStats([...items].reverse());
                   return {
@@ -382,7 +386,7 @@ export function ConversationSelector({
         // Enrich first page in parallel
         const firstPageResults = await Promise.all(
           firstPageItems.map((c) =>
-            enrichConversation(client, c.conversation.id),
+            enrichConversation(backend, c.conversation.id),
           ),
         );
 
@@ -400,7 +404,7 @@ export function ConversationSelector({
 
         // Enrich remaining conversations one by one in background
         for (const item of restItems) {
-          const count = await enrichConversation(client, item.conversation.id);
+          const count = await enrichConversation(backend, item.conversation.id);
           if (count === 0) {
             setConversations((prev) =>
               prev.filter((c) => c.conversation.id !== item.conversation.id),
@@ -415,7 +419,7 @@ export function ConversationSelector({
         setLoadingMore(false);
       }
     },
-    [agentId, enrichConversation],
+    [agentId, enrichConversation, selectorBackend],
   );
 
   // Initial load
@@ -425,8 +429,8 @@ export function ConversationSelector({
 
   // Re-enrich when page changes (prioritize newly visible unenriched items)
   useEffect(() => {
-    const client = clientRef.current;
-    if (!client || loading) return;
+    const backend = backendRef.current;
+    if (!backend || loading) return;
 
     const visibleItems = conversations.slice(
       page * DISPLAY_PAGE_SIZE,
@@ -436,7 +440,7 @@ export function ConversationSelector({
     if (unenriched.length === 0) return;
 
     for (const item of unenriched) {
-      enrichConversation(client, item.conversation.id);
+      enrichConversation(backend, item.conversation.id);
     }
   }, [page, loading, conversations, enrichConversation]);
 

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -33,14 +33,22 @@ type ModelCategory =
 // Re-export for consumers that import from ModelSelector
 export { buildByokProviderAliases, isByokHandleForSelector };
 
+export function usesBackendModelCatalog(
+  isSelfHosted?: boolean,
+  localModelCatalog?: boolean,
+): boolean {
+  return Boolean(isSelfHosted || localModelCatalog);
+}
+
 // Get tab order for model categories.
 // For self-hosted servers, only show server-specific tabs.
 // For Letta-hosted, keep ordering consistent across billing tiers.
 export function getModelCategories(
   _billingTier?: string,
   isSelfHosted?: boolean,
+  localModelCatalog?: boolean,
 ): ModelCategory[] {
-  if (isSelfHosted) {
+  if (usesBackendModelCatalog(isSelfHosted, localModelCatalog)) {
     return ["server-recommended", "server-all"];
   }
   return ["supported", "all", "byok", "byok-all"];
@@ -90,6 +98,8 @@ interface ModelSelectorProps {
   billingTier?: string;
   /** Whether connected to a self-hosted server (not api.letta.com) */
   isSelfHosted?: boolean;
+  /** Whether the active backend provides a local-only model catalog */
+  localModelCatalog?: boolean;
 }
 
 export function ModelSelector({
@@ -100,15 +110,20 @@ export function ModelSelector({
   forceRefresh: forceRefreshOnMount,
   billingTier,
   isSelfHosted,
+  localModelCatalog,
 }: ModelSelectorProps) {
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
   const typedModels = models as UiModel[];
 
-  // For self-hosted, only show server-specific tabs
+  // For self-hosted and local backends, only show the active backend's model catalog.
   const modelCategories = useMemo(
-    () => getModelCategories(billingTier, isSelfHosted),
-    [billingTier, isSelfHosted],
+    () => getModelCategories(billingTier, isSelfHosted, localModelCatalog),
+    [billingTier, isSelfHosted, localModelCatalog],
+  );
+  const backendModelCatalog = usesBackendModelCatalog(
+    isSelfHosted,
+    localModelCatalog,
   );
   const isFreeTier = billingTier === "free";
   const defaultCategory = modelCategories[0] ?? "supported";
@@ -180,6 +195,10 @@ export function ModelSelector({
   }, [forceRefreshOnMount]);
 
   useEffect(() => {
+    if (localModelCatalog) {
+      setByokProviderAliases(buildByokProviderAliases([]));
+      return;
+    }
     (async () => {
       try {
         const providers = await listProviders();
@@ -190,7 +209,7 @@ export function ModelSelector({
         setByokProviderAliases(buildByokProviderAliases([]));
       }
     })();
-  }, []);
+  }, [localModelCatalog]);
 
   const pickPreferredStaticModel = useCallback(
     (handle: string, contextWindow?: number): UiModel | undefined => {
@@ -405,7 +424,7 @@ export function ModelSelector({
   // Server-recommended models: models.json entries available on the server (for self-hosted)
   // Filter out letta/letta-free legacy model
   const serverRecommendedModels = useMemo(() => {
-    if (!isSelfHosted || availableHandles === undefined) return [];
+    if (!backendModelCatalog || availableHandles === undefined) return [];
     let available = typedModels.filter(
       (m) => availableHandles?.has(m.handle) && m.handle !== "letta/letta-free",
     );
@@ -430,7 +449,7 @@ export function ModelSelector({
     }
     return deduped;
   }, [
-    isSelfHosted,
+    backendModelCatalog,
     typedModels,
     availableHandles,
     searchQuery,
@@ -440,14 +459,14 @@ export function ModelSelector({
   // Server-all models: ALL handles from the server (for self-hosted)
   // Filter out letta/letta-free legacy model
   const serverAllModels = useMemo(() => {
-    if (!isSelfHosted) return [];
+    if (!backendModelCatalog) return [];
     let handles = allApiHandles.filter((h) => h !== "letta/letta-free");
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       handles = handles.filter((h) => h.toLowerCase().includes(query));
     }
     return handles;
-  }, [isSelfHosted, allApiHandles, searchQuery]);
+  }, [backendModelCatalog, allApiHandles, searchQuery]);
 
   // Get the list for current category
   const currentList: UiModel[] = useMemo(() => {

--- a/src/cli/helpers/backfill.ts
+++ b/src/cli/helpers/backfill.ts
@@ -141,6 +141,41 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
   buffers.reasoningCanonicalByOtid.clear();
   // Note: we don't reset tokenCount here (it resets per-turn in onSubmit)
 
+  const pendingToolResults = new Map<
+    string,
+    { resultText: string; resultOk: boolean }
+  >();
+
+  const applyToolResult = (
+    toolCallId: string,
+    result: { resultText: string; resultOk: boolean },
+  ) => {
+    const toolCallLineId = buffers.toolCallIdToLineId.get(toolCallId);
+    if (!toolCallLineId) {
+      pendingToolResults.set(toolCallId, result);
+      return;
+    }
+
+    const existingLine = buffers.byId.get(toolCallLineId);
+    if (!existingLine || existingLine.kind !== "tool_call") {
+      pendingToolResults.set(toolCallId, result);
+      return;
+    }
+
+    pendingToolResults.delete(toolCallId);
+    buffers.byId.set(toolCallLineId, {
+      ...existingLine,
+      ...result,
+      phase: "finished",
+    });
+  };
+
+  const applyPendingToolResult = (toolCallId: string) => {
+    const pending = pendingToolResults.get(toolCallId);
+    if (!pending) return;
+    applyToolResult(toolCallId, pending);
+  };
+
   // Iterate over the history and add the messages to the buffers
   // Want to add user, reasoning, assistant, tool call + tool return
   for (const msg of history) {
@@ -282,6 +317,7 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
 
           // Maintain mapping for tool return to find this line
           buffers.toolCallIdToLineId.set(toolCallId, uniqueLineId);
+          applyPendingToolResult(toolCallId);
         }
         break;
       }
@@ -308,13 +344,6 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
           const toolCallId = toolReturn.tool_call_id;
           if (!toolCallId) continue;
 
-          // Look up the line using the mapping (like streaming does)
-          const toolCallLineId = buffers.toolCallIdToLineId.get(toolCallId);
-          if (!toolCallLineId) continue;
-
-          const existingLine = buffers.byId.get(toolCallLineId);
-          if (!existingLine || existingLine.kind !== "tool_call") continue;
-
           // Update the existing line with the result
           // Handle both func_response (streaming) and tool_return (SDK) properties
           // tool_return can be multimodal (string or array of content parts)
@@ -326,12 +355,46 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
               ? toolReturn.tool_return
               : undefined) ||
             "";
-          const resultText = getDisplayableToolReturn(rawResult);
-          buffers.byId.set(toolCallLineId, {
-            ...existingLine,
-            resultText,
+          applyToolResult(toolCallId, {
+            resultText: getDisplayableToolReturn(rawResult),
             resultOk: toolReturn.status === "success",
-            phase: "finished",
+          });
+        }
+        break;
+      }
+
+      // approval response message - merge into the existing approval/tool call line(s)
+      case "approval_response_message": {
+        const approvals = Array.isArray(msg.approvals) ? msg.approvals : [];
+        for (const approval of approvals) {
+          if (
+            !approval ||
+            typeof approval !== "object" ||
+            !("tool_call_id" in approval) ||
+            typeof approval.tool_call_id !== "string"
+          ) {
+            continue;
+          }
+
+          const isSuccess =
+            "type" in approval && approval.type === "tool"
+              ? true
+              : !("approve" in approval && approval.approve === false);
+          const rawResult =
+            "tool_return" in approval
+              ? approval.tool_return
+              : "reason" in approval
+                ? approval.reason
+                : (msg as { content?: unknown }).content;
+
+          applyToolResult(approval.tool_call_id, {
+            resultText: getDisplayableToolReturn(
+              rawResult as
+                | string
+                | Array<TextContent | ImageContent>
+                | undefined,
+            ),
+            resultOk: isSuccess,
           });
         }
         break;

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -6,7 +6,7 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
 import React, { useCallback, useEffect, useState } from "react";
-import { getClient } from "../backend/api/client";
+import { getBackend } from "../backend";
 import { settingsManager } from "../settings-manager";
 import { colors } from "./components/colors";
 import { Text } from "./components/Text";
@@ -101,7 +101,7 @@ function ProfileSelectionUI({
     setInternalLoading(true);
     try {
       const mergedPinned = settingsManager.getMergedPinnedAgents();
-      const client = await getClient();
+      const backend = getBackend();
 
       const optionsToFetch: ProfileOption[] = [];
       const seenAgentIds = new Set<string>();
@@ -139,7 +139,7 @@ function ProfileSelectionUI({
       const fetchedOptions = await Promise.all(
         optionsToFetch.map(async (opt) => {
           try {
-            const agent = await client.agents.retrieve(opt.agentId, {
+            const agent = await backend.retrieveAgent(opt.agentId, {
               include: ["agent.blocks"],
             });
             return { ...opt, agent };

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -44,7 +44,6 @@ import {
   type ConversationMessageStreamBody,
   getBackend,
 } from "./backend";
-import { getClient } from "./backend/api/client";
 import type { ParsedCliArgs } from "./cli/args";
 import {
   normalizeConversationShorthandFlags,
@@ -611,6 +610,15 @@ export async function handleHeadlessCommand(
     : noMemfsFlag
       ? "standard"
       : undefined;
+  if (memfsFlag && !backend.capabilities.remoteMemfs) {
+    trackHeadlessBoundaryError(
+      "headless_memfs_unsupported_backend",
+      "MemFS requires a backend with remote MemFS support",
+      "headless_startup_memfs_flags",
+    );
+    console.error("Error: --memfs is not supported by this backend yet");
+    process.exit(1);
+  }
   const shouldAutoEnableMemfsForNewAgent = !memfsFlag && !noMemfsFlag;
   const fromAfFile = resolveImportFlagAlias({
     importFlagValue: values.import,
@@ -1014,7 +1022,9 @@ export async function handleHeadlessCommand(
     // Pre-determine memfs mode so the agent is created with the correct prompt.
     const { isLettaCloud } = await import("./agent/memoryFilesystem");
     const willAutoEnableMemfs =
-      shouldAutoEnableMemfsForNewAgent && (await isLettaCloud());
+      backend.capabilities.remoteMemfs &&
+      shouldAutoEnableMemfsForNewAgent &&
+      (await isLettaCloud());
     const effectiveMemoryMode =
       requestedMemoryPromptMode ?? (willAutoEnableMemfs ? "memfs" : undefined);
 
@@ -1070,8 +1080,7 @@ export async function handleHeadlessCommand(
   // Priority 6: Fresh user with no LRU - create default agent
   if (!agent) {
     const { ensureDefaultAgents } = await import("./agent/defaults");
-    const client = await getClient();
-    const defaultAgent = await ensureDefaultAgents(client, {
+    const defaultAgent = await ensureDefaultAgents(backend, {
       preferredModel: model,
     });
     if (defaultAgent) {
@@ -1146,7 +1155,11 @@ export async function handleHeadlessCommand(
   //   "blocking"  (default) – await the pull; exit on conflict.
   //   "background"           – fire pull async; session init proceeds immediately.
   //   "skip"                 – skip the pull this session.
-  if (memfsStartupPolicy === "skip") {
+  if (!backend.capabilities.remoteMemfs) {
+    if (noMemfsFlag) {
+      settingsManager.setMemfsEnabled(agent.id, false);
+    }
+  } else if (memfsStartupPolicy === "skip") {
     // Run enable/disable logic but skip the git pull.
     try {
       const { applyMemfsFlags } = await import("./agent/memoryFilesystem");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
-import { getResumeData, type ResumeData } from "./agent/check-approval";
+import {
+  getResumeDataFromBackend,
+  type ResumeData,
+} from "./agent/check-approval";
 import {
   setAgentContext,
   setConversationId as setContextConversationId,
@@ -18,7 +21,7 @@ import {
 import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import { LETTA_CLOUD_API_URL } from "./auth/oauth";
-import { getClient } from "./backend/api/client";
+import { getBackend } from "./backend";
 import { getBillingTier } from "./backend/api/metadata";
 import {
   type ParsedCliArgs,
@@ -187,12 +190,12 @@ async function printInfo() {
 
   if (allAgentIds.length > 0) {
     try {
-      const client = await getClient();
+      const backend = getBackend();
       // Fetch each agent individually to get accurate names
       await Promise.all(
         allAgentIds.map(async (id) => {
           try {
-            const agent = await client.agents.retrieve(id);
+            const agent = await backend.retrieveAgent(id);
             agentNames[id] = agent.name;
           } catch {
             // Agent not found or error - leave as not found
@@ -285,7 +288,7 @@ function getModelForToolLoading(
 async function resolveAgentByName(
   name: string,
 ): Promise<{ id: string; name: string; agent: AgentState } | null> {
-  const client = await getClient();
+  const backend = getBackend();
 
   // Get all pinned agents (local first, then global, deduplicated)
   const localPinned = settingsManager.getLocalPinnedAgents();
@@ -303,7 +306,7 @@ async function resolveAgentByName(
   await Promise.all(
     allPinned.map(async (id) => {
       try {
-        const agent = await client.agents.retrieve(id);
+        const agent = await backend.retrieveAgent(id);
         if (agent.name?.toLowerCase() === normalizedSearchName) {
           matches.push({ id, name: agent.name, agent });
         }
@@ -335,7 +338,7 @@ async function resolveAgentByName(
  * Get all pinned agent names for error messages
  */
 async function getPinnedAgentNames(): Promise<{ id: string; name: string }[]> {
-  const client = await getClient();
+  const backend = getBackend();
   const localPinned = settingsManager.getLocalPinnedAgents();
   const globalPinned = settingsManager.getGlobalPinnedAgents();
   const allPinned = [...new Set([...localPinned, ...globalPinned])];
@@ -344,7 +347,7 @@ async function getPinnedAgentNames(): Promise<{ id: string; name: string }[]> {
   await Promise.all(
     allPinned.map(async (id) => {
       try {
-        const agent = await client.agents.retrieve(id);
+        const agent = await backend.retrieveAgent(id);
         agents.push({ id, name: agent.name || "(unnamed)" });
       } catch {
         // Agent not found, skip
@@ -1213,7 +1216,7 @@ async function main(): Promise<void> {
         // Load settings
         await settingsManager.loadLocalProjectSettings();
         const localSettings = settingsManager.getLocalProjectSettings();
-        const client = await getClient();
+        const backend = getBackend();
 
         // For self-hosted servers, pre-fetch available models
         // This is needed so ProfileSelectionInline can show model picker
@@ -1233,7 +1236,7 @@ async function main(): Promise<void> {
             const { getDefaultModel } = await import("./agent/model");
             const defaultModel = getDefaultModel();
             setSelfHostedDefaultModel(defaultModel);
-            const modelsList = await client.models.list();
+            const modelsList = await backend.listModels();
             const handles = modelsList
               .map((m) => m.handle)
               .filter((h): h is string => typeof h === "string");
@@ -1273,7 +1276,7 @@ async function main(): Promise<void> {
               "conversations",
               `retrieve(${specifiedConversationId}) [TUI conv→agent lookup]`,
             );
-            const conversation = await client.conversations.retrieve(
+            const conversation = await backend.retrieveConversation(
               specifiedConversationId,
             );
             // Use the agent that owns this conversation
@@ -1308,7 +1311,7 @@ async function main(): Promise<void> {
           // Try local LRU first
           if (localAgentId) {
             try {
-              const agent = await client.agents.retrieve(localAgentId);
+              const agent = await backend.retrieveAgent(localAgentId);
               setResumeAgentId(localAgentId);
               setResumeAgentName(agent.name ?? null);
               setLoadingState("selecting_conversation");
@@ -1328,7 +1331,7 @@ async function main(): Promise<void> {
           const globalAgentId = globalSession?.agentId;
           if (globalAgentId) {
             try {
-              const agent = await client.agents.retrieve(globalAgentId);
+              const agent = await backend.retrieveAgent(globalAgentId);
               setResumeAgentId(globalAgentId);
               setResumeAgentName(agent.name ?? null);
               setLoadingState("selecting_conversation");
@@ -1385,7 +1388,7 @@ async function main(): Promise<void> {
           // Same agent — only need one fetch
           if (localAgentId) {
             try {
-              cachedAgent = await client.agents.retrieve(localAgentId);
+              cachedAgent = await backend.retrieveAgent(localAgentId);
               localAgentExists = true;
             } catch {
               setFailedAgentMessage(
@@ -1398,10 +1401,10 @@ async function main(): Promise<void> {
           // Different agents — fetch in parallel
           const [localResult, globalResult] = await Promise.allSettled([
             localAgentId
-              ? client.agents.retrieve(localAgentId)
+              ? backend.retrieveAgent(localAgentId)
               : Promise.reject(new Error("no local")),
             globalAgentId
-              ? client.agents.retrieve(globalAgentId)
+              ? backend.retrieveAgent(globalAgentId)
               : Promise.reject(new Error("no global")),
           ]);
 
@@ -1456,7 +1459,7 @@ async function main(): Promise<void> {
           case "create": {
             const { ensureDefaultAgents } = await import("./agent/defaults");
             try {
-              const defaultAgent = await ensureDefaultAgents(client, {
+              const defaultAgent = await ensureDefaultAgents(getBackend(), {
                 preferredModel: model,
               });
               if (defaultAgent) {
@@ -1507,7 +1510,7 @@ async function main(): Promise<void> {
       initStartedRef.current = true;
 
       async function init() {
-        const client = await getClient();
+        const backend = getBackend();
 
         // Determine which agent we'll be using (before loading tools)
         let resumingAgentId: string | null = null;
@@ -1522,7 +1525,7 @@ async function main(): Promise<void> {
             resumingAgentId = agentIdArg;
           } else {
             try {
-              const agent = await client.agents.retrieve(agentIdArg, {
+              const agent = await backend.retrieveAgent(agentIdArg, {
                 include: ["agent.secrets", "agent.tools"],
               });
               setValidatedAgent(agent);
@@ -1548,12 +1551,9 @@ async function main(): Promise<void> {
             resumingAgentId = selectedGlobalAgentId;
           } else {
             try {
-              const agent = await client.agents.retrieve(
-                selectedGlobalAgentId,
-                {
-                  include: ["agent.secrets", "agent.tools"],
-                },
-              );
+              const agent = await backend.retrieveAgent(selectedGlobalAgentId, {
+                include: ["agent.secrets", "agent.tools"],
+              });
               setValidatedAgent(agent);
               resolvedAgent = agent;
               resumingAgentId = selectedGlobalAgentId;
@@ -1571,7 +1571,7 @@ async function main(): Promise<void> {
             settingsManager.getLocalProjectSettings();
           if (localProjectSettings?.lastAgent) {
             try {
-              await client.agents.retrieve(localProjectSettings.lastAgent);
+              await backend.retrieveAgent(localProjectSettings.lastAgent);
               resumingAgentId = localProjectSettings.lastAgent;
             } catch {
               // LRU agent doesn't exist (wrong org, deleted, etc.)
@@ -1649,7 +1649,7 @@ async function main(): Promise<void> {
         // Priority 2: Try to use --agent specified ID
         if (!agent && agentIdArg) {
           try {
-            agent = await client.agents.retrieve(agentIdArg);
+            agent = await backend.retrieveAgent(agentIdArg);
           } catch (error) {
             console.error(
               `Agent ${agentIdArg} not found (error: ${JSON.stringify(error)})`,
@@ -1675,7 +1675,11 @@ async function main(): Promise<void> {
           // 2. Use model if --model flag was passed
           // 3. Otherwise, use billing-tier-aware default (free tier gets GLM-5)
           let effectiveModel = selectedServerModel || model;
-          if (!effectiveModel && !selfHostedBaseUrl) {
+          if (
+            !effectiveModel &&
+            !selfHostedBaseUrl &&
+            !backend.capabilities.localModelCatalog
+          ) {
             // On Letta API without explicit model - check billing tier for appropriate default
             const { getDefaultModelForTier } = await import("./agent/model");
             const billingTier = await getBillingTier();
@@ -1716,7 +1720,7 @@ async function main(): Promise<void> {
                 ? resolvedAgent
                 : validatedAgent && validatedAgent.id === resumingAgentId
                   ? validatedAgent
-                  : await client.agents.retrieve(resumingAgentId);
+                  : await backend.retrieveAgent(resumingAgentId);
           } catch (error) {
             // Agent disappeared between validation and now - show selector
             console.error(
@@ -1760,14 +1764,25 @@ async function main(): Promise<void> {
           ? true
           : memfsFlag;
         const shouldBlockOnMemfsStartup = Boolean(memfsFlag || noMemfsFlag);
-        const memfsSyncPromise = import("./agent/memoryFilesystem").then(
-          ({ applyMemfsFlags }) =>
-            applyMemfsFlags(agentId, startupMemfsFlag, noMemfsFlag, {
-              pullOnExistingRepo: true,
-              agentTags,
-              skipPromptUpdate: shouldCreateNew,
-            }),
-        );
+        const memfsSyncPromise = backend.capabilities.remoteMemfs
+          ? import("./agent/memoryFilesystem").then(({ applyMemfsFlags }) =>
+              applyMemfsFlags(agentId, startupMemfsFlag, noMemfsFlag, {
+                pullOnExistingRepo: true,
+                agentTags,
+                skipPromptUpdate: shouldCreateNew,
+              }),
+            )
+          : Promise.resolve().then(() => {
+              if (memfsFlag) {
+                throw new Error(
+                  "MemFS is not supported by the active backend.",
+                );
+              }
+              if (noMemfsFlag) {
+                settingsManager.setMemfsEnabled(agentId, false);
+              }
+              return null;
+            });
         const memfsSyncBackgroundPromise = memfsSyncPromise.catch((error) => {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -1910,8 +1925,7 @@ async function main(): Promise<void> {
           try {
             // Load message history and pending approvals from the conversation
             setLoadingState("checking");
-            const data = await getResumeData(
-              client,
+            const data = await getResumeDataFromBackend(
               agent,
               specifiedConversationId,
             );
@@ -1933,8 +1947,7 @@ async function main(): Promise<void> {
           // Conversation selected from --resume selector or auto-restored from local project settings
           try {
             setLoadingState("checking");
-            const data = await getResumeData(
-              client,
+            const data = await getResumeDataFromBackend(
               agent,
               selectedConversationId,
             );
@@ -1952,7 +1965,7 @@ async function main(): Promise<void> {
               );
               conversationIdToUse = "default";
               setLoadingState("checking");
-              const data = await getResumeData(client, agent, "default");
+              const data = await getResumeDataFromBackend(agent, "default");
               setResumeData(data);
               setResumedExistingConversation(data.messageHistory.length > 0);
             } else {
@@ -1961,7 +1974,7 @@ async function main(): Promise<void> {
           }
         } else if (forceNewConversation) {
           // --new flag: create a new conversation (for concurrent sessions)
-          const conversation = await client.conversations.create({
+          const conversation = await backend.createConversation({
             agent_id: agent.id,
             isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
           });
@@ -1972,7 +1985,7 @@ async function main(): Promise<void> {
 
           // Load message history without waiting on memfs sync.
           setLoadingState("checking");
-          const data = await getResumeData(client, agent, "default");
+          const data = await getResumeDataFromBackend(agent, "default");
           setResumeData(data);
           setResumedExistingConversation(data.messageHistory.length > 0);
         }
@@ -2026,9 +2039,8 @@ async function main(): Promise<void> {
                 : "standard";
               const expected = rebuildPrompt(storedPreset, memoryMode);
               if (agent.system !== expected) {
-                const client = await getClient();
-                await client.agents.update(agent.id, { system: expected });
-                agent = await client.agents.retrieve(agent.id);
+                await backend.updateAgent(agent.id, { system: expected });
+                agent = await backend.retrieveAgent(agent.id);
               }
             } else {
               settingsManager.clearSystemPromptPreset(agent.id);

--- a/src/tests/agent/available-models-backend.test.ts
+++ b/src/tests/agent/available-models-backend.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearAvailableModelsCache,
+  getAvailableModelHandles,
+} from "../../agent/available-models";
+import { __testSetBackend } from "../../backend";
+import { FakeHeadlessBackend } from "../../backend/dev/FakeHeadlessBackend";
+
+describe("available models backend wiring", () => {
+  afterEach(() => {
+    clearAvailableModelsCache();
+    __testSetBackend(null);
+  });
+
+  test("force-refresh uses the active backend model list without provider refresh for local catalogs", async () => {
+    __testSetBackend(new FakeHeadlessBackend());
+
+    const result = await getAvailableModelHandles({ forceRefresh: true });
+
+    expect(result.source).toBe("network");
+    expect(Array.from(result.handles)).toEqual(["dev/fake-headless"]);
+  });
+});

--- a/src/tests/agent/getResumeData.test.ts
+++ b/src/tests/agent/getResumeData.test.ts
@@ -29,6 +29,7 @@ const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
 const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
   ...RESUME_BACKFILL_MESSAGE_TYPES,
   "approval_request_message",
+  "tool_return_message",
   "approval_response_message",
 ];
 
@@ -61,6 +62,20 @@ function makeUserMessage(id = "msg-last"): Message {
     date: new Date().toISOString(),
     message_type: "user_message",
   } as Message;
+}
+
+function datedMessage(
+  id: string,
+  messageType: MessageType,
+  date: string,
+  extras: Record<string, unknown> = {},
+): Message {
+  return {
+    id,
+    date,
+    message_type: messageType,
+    ...extras,
+  } as unknown as Message;
 }
 
 describe("getResumeData", () => {
@@ -220,5 +235,108 @@ describe("getResumeData", () => {
     });
     expect(resume.pendingApprovals).toHaveLength(0);
     expect(resume.messageHistory.length).toBeGreaterThan(0);
+  });
+
+  test("default conversation backfill orders equal-timestamp local tool messages before assistant text", async () => {
+    const sameDate = "2026-01-01T00:00:02.000Z";
+    const listedMessages = [
+      datedMessage("provider-msg-2:assistant", "assistant_message", sameDate),
+      datedMessage(
+        "provider-msg-2:tool:call-1:return",
+        "tool_return_message",
+        sameDate,
+        {
+          tool_call_id: "call-1",
+          status: "success",
+          tool_return: "ok",
+        },
+      ),
+      datedMessage(
+        "provider-msg-2:approval:call-1:request",
+        "approval_request_message",
+        sameDate,
+        {
+          tool_call: {
+            tool_call_id: "call-1",
+            name: "ShellCommand",
+            arguments: '{"command":"pwd"}',
+          },
+        },
+      ),
+      datedMessage(
+        "provider-msg-1",
+        "user_message",
+        "2026-01-01T00:00:01.000Z",
+      ),
+    ];
+    const agentsList = mock(async () => ({
+      getPaginatedItems: () => listedMessages,
+    }));
+    const messagesRetrieve = mock(async () => []);
+
+    installBackend({
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeData(
+      dummyClient,
+      makeAgent({ in_context_message_ids: ["provider-msg-2"] }),
+      "default",
+    );
+
+    expect(
+      resume.messageHistory.map((message) => message.message_type),
+    ).toEqual([
+      "user_message",
+      "approval_request_message",
+      "tool_return_message",
+      "assistant_message",
+    ]);
+  });
+
+  test("completed local approval request variants are not treated as pending", async () => {
+    const messagesRetrieve = mock(async () => [
+      datedMessage(
+        "provider-msg-2:tool:call-1:request",
+        "approval_request_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call: {
+            tool_call_id: "call-1",
+            name: "ShellCommand",
+            arguments: '{"command":"pwd"}',
+          },
+        },
+      ),
+      datedMessage(
+        "provider-msg-2:tool:call-1:return",
+        "tool_return_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call_id: "call-1",
+          status: "success",
+          tool_return: "ok",
+        },
+      ),
+    ]);
+
+    installBackend({
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeData(
+      dummyClient,
+      makeAgent({
+        message_ids: ["provider-msg-2"],
+        in_context_message_ids: ["provider-msg-2"],
+      }),
+      "default",
+      { includeMessageHistory: false },
+    );
+
+    expect(messagesRetrieve).toHaveBeenCalledWith("provider-msg-2");
+    expect(resume.pendingApprovals).toEqual([]);
+    expect(resume.pendingApproval).toBeNull();
   });
 });

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -69,10 +69,10 @@ describe("model preset refresh wiring", () => {
       "buildModelSettings(modelHandle, updateArgs)",
     );
     expect(updateSegment).toContain(
-      "Parameters<typeof client.conversations.update>[1]",
+      "Parameters<typeof backend.updateConversation>[1]",
     );
     expect(updateSegment).toContain(
-      "client.conversations.update(conversationId, payload)",
+      "backend.updateConversation(conversationId, payload)",
     );
     expect(updateSegment).toContain("model: modelHandle");
     expect(updateSegment).toContain("options?: UpdateAgentLLMConfigOptions");

--- a/src/tests/agent/recompile-system-prompt.test.ts
+++ b/src/tests/agent/recompile-system-prompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { recompileAgentSystemPrompt } from "../../agent/modify";
+import { __testSetBackend } from "../../backend";
+import { FakeHeadlessBackend } from "../../backend/dev/FakeHeadlessBackend";
 
 describe("recompileAgentSystemPrompt", () => {
   test("calls the conversation recompile endpoint with mapped params", async () => {
@@ -85,5 +87,19 @@ describe("recompileAgentSystemPrompt", () => {
       recompileAgentSystemPrompt("default", "", undefined, client),
     ).rejects.toThrow("recompileAgentSystemPrompt requires agentId");
     expect(conversationsRecompileMock).not.toHaveBeenCalled();
+  });
+
+  test("throws clearly when backend has no server-side recompile", async () => {
+    try {
+      __testSetBackend(new FakeHeadlessBackend());
+
+      await expect(
+        recompileAgentSystemPrompt("default", "agent-123"),
+      ).rejects.toThrow(
+        "Server-side prompt recompile is not supported by this backend yet",
+      );
+    } finally {
+      __testSetBackend(null);
+    }
   });
 });

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
+  AgentCreateBody,
   AgentMessageListBody,
   AgentUpdateBody,
   APIClient,
@@ -19,6 +20,9 @@ const updateAgentMock = mock(
     id: "agent-1",
   }),
 );
+const createAgentMock = mock(async (_body: unknown, _options?: unknown) => ({
+  id: "agent-created",
+}));
 const retrieveConversationMock = mock(
   async (_conversationId: string, _options?: unknown) => ({ id: "conv-1" }),
 );
@@ -45,6 +49,9 @@ const listAgentMessagesMock = mock(
 const retrieveMessageMock = mock(
   async (_messageId: string, _options?: unknown) => [],
 );
+const listModelsMock = mock(async (_options?: unknown) => [
+  { handle: "model-1" },
+]);
 const createMessageStreamMock = mock(
   async (_conversationId: string, _body: unknown, _options?: unknown) => ({
     kind: "create-stream",
@@ -72,6 +79,7 @@ const forkConversationMock = mock(
 );
 const getClientMock = mock(async () => ({
   agents: {
+    create: createAgentMock,
     retrieve: retrieveAgentMock,
     update: updateAgentMock,
     messages: {
@@ -92,6 +100,9 @@ const getClientMock = mock(async () => ({
   messages: {
     retrieve: retrieveMessageMock,
   },
+  models: {
+    list: listModelsMock,
+  },
   runs: {
     retrieve: retrieveRunMock,
     messages: {
@@ -105,6 +116,7 @@ import { APIBackend } from "../../backend";
 describe("APIBackend", () => {
   beforeEach(() => {
     getClientMock.mockClear();
+    createAgentMock.mockClear();
     retrieveAgentMock.mockClear();
     updateAgentMock.mockClear();
     retrieveConversationMock.mockClear();
@@ -113,6 +125,7 @@ describe("APIBackend", () => {
     listConversationMessagesMock.mockClear();
     listAgentMessagesMock.mockClear();
     retrieveMessageMock.mockClear();
+    listModelsMock.mockClear();
     createMessageStreamMock.mockClear();
     streamConversationMessagesMock.mockClear();
     cancelConversationMock.mockClear();
@@ -126,7 +139,17 @@ describe("APIBackend", () => {
       getClient: getClientMock as unknown as () => Promise<APIClient>,
       forkConversation: forkConversationMock,
     });
+    expect(backend.capabilities).toEqual({
+      remoteMemfs: true,
+      serverSideToolManagement: true,
+      serverSecrets: true,
+      agentFileImportExport: true,
+      promptRecompile: true,
+      byokProviderRefresh: true,
+      localModelCatalog: false,
+    });
     const agentUpdateBody = { system: "system" } as AgentUpdateBody;
+    const agentCreateBody = { name: "new agent" } as AgentCreateBody;
     const conversationCreateBody = {
       agent_id: "agent-1",
     } as ConversationCreateBody;
@@ -156,12 +179,14 @@ describe("APIBackend", () => {
 
     await backend.retrieveAgent("agent-1", { include: ["agent.tools"] });
     await backend.updateAgent("agent-1", agentUpdateBody);
+    await backend.createAgent(agentCreateBody);
     await backend.retrieveConversation("conv-1");
     await backend.createConversation(conversationCreateBody);
     await backend.updateConversation("conv-1", conversationUpdateBody);
     await backend.listConversationMessages("conv-1", conversationListBody);
     await backend.listAgentMessages("agent-1", agentListBody);
     await backend.retrieveMessage("msg-1");
+    await backend.listModels();
     await backend.createConversationMessageStream("conv-1", createBody, {
       maxRetries: 0,
     });
@@ -171,7 +196,7 @@ describe("APIBackend", () => {
     await backend.streamRunMessages("run-1", runStreamBody);
     await backend.forkConversation("conv-1", { agentId: "agent-1" });
 
-    expect(getClientMock).toHaveBeenCalledTimes(13);
+    expect(getClientMock).toHaveBeenCalledTimes(15);
     expect(retrieveAgentMock).toHaveBeenCalledWith("agent-1", {
       include: ["agent.tools"],
     });
@@ -180,6 +205,7 @@ describe("APIBackend", () => {
       agentUpdateBody,
       undefined,
     );
+    expect(createAgentMock).toHaveBeenCalledWith(agentCreateBody, undefined);
     expect(retrieveConversationMock).toHaveBeenCalledWith("conv-1", undefined);
     expect(createConversationMock).toHaveBeenCalledWith(
       conversationCreateBody,
@@ -201,6 +227,7 @@ describe("APIBackend", () => {
       undefined,
     );
     expect(retrieveMessageMock).toHaveBeenCalledWith("msg-1", undefined);
+    expect(listModelsMock).toHaveBeenCalledWith(undefined);
     expect(createMessageStreamMock).toHaveBeenCalledWith("conv-1", createBody, {
       maxRetries: 0,
     });

--- a/src/tests/backend/fake-headless-backend.test.ts
+++ b/src/tests/backend/fake-headless-backend.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type {
+  AgentCreateBody,
   AgentMessageListBody,
   ConversationMessageCreateBody,
   ConversationMessageListBody,
 } from "../../backend";
 import { FakeHeadlessBackend } from "../../backend/dev/FakeHeadlessBackend";
+import { DeterministicToolCallExecutor } from "../../backend/dev/HeadlessTurnExecutor";
+
+async function collectStream(
+  stream: AsyncIterable<LettaStreamingResponse>,
+): Promise<LettaStreamingResponse[]> {
+  const chunks: LettaStreamingResponse[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
 
 async function drainAssistantText(
   stream: AsyncIterable<LettaStreamingResponse>,
@@ -48,6 +60,28 @@ function createBody(
 }
 
 describe("FakeHeadlessBackend", () => {
+  test("creates agents and lists local models through the backend facade", async () => {
+    const backend = new FakeHeadlessBackend("agent-default");
+    expect(backend.capabilities.remoteMemfs).toBe(false);
+
+    const agent = await backend.createAgent({
+      name: "Created Agent",
+      system: "system prompt",
+      model: "dev/fake-headless",
+      tools: ["web_search"],
+      tags: ["origin:test"],
+    } as AgentCreateBody);
+    const retrieved = await backend.retrieveAgent(agent.id);
+    const models = await backend.listModels();
+
+    expect(agent.id).toBe("agent-fake-headless-1");
+    expect(retrieved.name).toBe("Created Agent");
+    expect(retrieved.system).toBe("system prompt");
+    expect(retrieved.tools?.map((tool) => tool.name)).toEqual(["web_search"]);
+    expect(retrieved.tags).toEqual(["origin:test"]);
+    expect(models.map((model) => model.handle)).toEqual(["dev/fake-headless"]);
+  });
+
   test("stores user and assistant messages for explicit conversations", async () => {
     const backend = new FakeHeadlessBackend("agent-test");
     const conversation = await backend.createConversation({
@@ -81,9 +115,11 @@ describe("FakeHeadlessBackend", () => {
   test("supports default conversation listing through agent messages", async () => {
     const backend = new FakeHeadlessBackend("agent-default");
 
-    await backend.createConversationMessageStream(
-      "default",
-      createBody("default hello", "agent-default"),
+    await drainAssistantText(
+      await backend.createConversationMessageStream(
+        "default",
+        createBody("default hello", "agent-default"),
+      ),
     );
 
     const page = await backend.listAgentMessages("agent-default", {
@@ -106,13 +142,17 @@ describe("FakeHeadlessBackend", () => {
       agent_id: "agent-pages",
     });
 
-    await backend.createConversationMessageStream(
-      conversation.id,
-      createBody("first", "agent-pages"),
+    await drainAssistantText(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("first", "agent-pages"),
+      ),
     );
-    await backend.createConversationMessageStream(
-      conversation.id,
-      createBody("second", "agent-pages"),
+    await drainAssistantText(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("second", "agent-pages"),
+      ),
     );
 
     const firstPage = await backend.listConversationMessages(conversation.id, {
@@ -139,5 +179,79 @@ describe("FakeHeadlessBackend", () => {
       "user_message",
     ]);
     expect(JSON.stringify(secondPageItems)).toContain("first");
+  });
+
+  test("persists deterministic tool request and approval-result output", async () => {
+    const backend = new FakeHeadlessBackend(
+      "agent-tool",
+      new DeterministicToolCallExecutor(),
+    );
+    const conversation = await backend.createConversation({
+      agent_id: "agent-tool",
+    });
+
+    const firstChunks = await collectStream(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("use a tool", "agent-tool"),
+      ),
+    );
+    const approvalChunk = firstChunks.find(
+      (chunk) => chunk.message_type === "approval_request_message",
+    ) as
+      | (LettaStreamingResponse & {
+          tool_call?: { tool_call_id?: string; name?: string };
+        })
+      | undefined;
+    expect(approvalChunk?.tool_call?.name).toBe("ShellCommand");
+    expect(
+      firstChunks.some(
+        (chunk) =>
+          chunk.message_type === "stop_reason" &&
+          chunk.stop_reason === "requires_approval",
+      ),
+    ).toBe(true);
+
+    const afterRequest = await backend.listConversationMessages(
+      conversation.id,
+      { order: "asc" } as ConversationMessageListBody,
+    );
+    expect(
+      afterRequest.getPaginatedItems().map((message) => message.message_type),
+    ).toEqual(["user_message", "approval_request_message"]);
+
+    const finalText = await drainAssistantText(
+      await backend.createConversationMessageStream(conversation.id, {
+        ...createBody("", "agent-tool"),
+        messages: [
+          {
+            type: "approval",
+            approvals: [
+              {
+                type: "tool",
+                tool_call_id: approvalChunk?.tool_call?.tool_call_id,
+                tool_return: "deterministic-tool-ok",
+                status: "success",
+              },
+            ],
+          },
+        ],
+      } as unknown as ConversationMessageCreateBody),
+    );
+    expect(finalText).toContain("tool result received (success)");
+    expect(finalText).toContain("deterministic-tool-ok");
+
+    const afterApproval = await backend.listConversationMessages(
+      conversation.id,
+      { order: "asc" } as ConversationMessageListBody,
+    );
+    expect(
+      afterApproval.getPaginatedItems().map((message) => message.message_type),
+    ).toEqual([
+      "user_message",
+      "approval_request_message",
+      "approval_response_message",
+      "assistant_message",
+    ]);
   });
 });

--- a/src/tests/cli/backfill-approval-response.test.ts
+++ b/src/tests/cli/backfill-approval-response.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { createBuffers } from "../../cli/helpers/accumulator";
+import { backfillBuffers } from "../../cli/helpers/backfill";
+
+describe("backfill approval response handling", () => {
+  test("merges local approval requests and tool returns into tool call lines", () => {
+    const buffers = createBuffers();
+    const history = [
+      {
+        id: "approval-request-1",
+        message_type: "approval_request_message",
+        tool_call: {
+          tool_call_id: "call-1",
+          name: "ShellCommand",
+          arguments: JSON.stringify({ command: "pwd" }),
+        },
+      },
+      {
+        id: "tool-return-1",
+        message_type: "tool_return_message",
+        tool_call_id: "call-1",
+        status: "success",
+        tool_return: "/tmp/project",
+      },
+    ] as unknown as Message[];
+
+    backfillBuffers(buffers, history);
+
+    const lineId = buffers.toolCallIdToLineId.get("call-1");
+    expect(lineId).toBe("approval-request-1");
+    const line = lineId ? buffers.byId.get(lineId) : undefined;
+    expect(line).toMatchObject({
+      kind: "tool_call",
+      toolCallId: "call-1",
+      name: "ShellCommand",
+      argsText: JSON.stringify({ command: "pwd" }),
+      resultText: "/tmp/project",
+      resultOk: true,
+      phase: "finished",
+    });
+  });
+
+  test("merges local approval responses into tool call lines", () => {
+    const buffers = createBuffers();
+    const history = [
+      {
+        id: "approval-request-1",
+        message_type: "approval_request_message",
+        tool_call: {
+          tool_call_id: "call-1",
+          name: "ShellCommand",
+          arguments: JSON.stringify({ command: "pwd" }),
+        },
+      },
+      {
+        id: "approval-response-1",
+        message_type: "approval_response_message",
+        approvals: [
+          {
+            type: "tool",
+            tool_call_id: "call-1",
+            status: "success",
+            tool_return: "/tmp/project",
+          },
+        ],
+      },
+    ] as unknown as Message[];
+
+    backfillBuffers(buffers, history);
+
+    const lineId = buffers.toolCallIdToLineId.get("call-1");
+    expect(lineId).toBe("approval-request-1");
+    const line = lineId ? buffers.byId.get(lineId) : undefined;
+    expect(line).toMatchObject({
+      kind: "tool_call",
+      toolCallId: "call-1",
+      name: "ShellCommand",
+      argsText: JSON.stringify({ command: "pwd" }),
+      resultText: "/tmp/project",
+      resultOk: true,
+      phase: "finished",
+    });
+  });
+
+  test("handles approval responses that appear before requests in equal-timestamp backfill", () => {
+    const buffers = createBuffers();
+    const history = [
+      {
+        id: "assistant-1",
+        message_type: "assistant_message",
+        content: [{ type: "text", text: "Done" }],
+      },
+      {
+        id: "approval-response-1",
+        message_type: "approval_response_message",
+        approvals: [
+          {
+            type: "tool",
+            tool_call_id: "call-1",
+            status: "success",
+            tool_return: "moved files",
+          },
+        ],
+      },
+      {
+        id: "approval-request-1",
+        message_type: "approval_request_message",
+        tool_call: {
+          tool_call_id: "call-1",
+          name: "ShellCommand",
+          arguments: JSON.stringify({ command: "mv *.png Screenshots/" }),
+        },
+      },
+    ] as unknown as Message[];
+
+    backfillBuffers(buffers, history);
+
+    const lineId = buffers.toolCallIdToLineId.get("call-1");
+    const line = lineId ? buffers.byId.get(lineId) : undefined;
+    expect(line).toMatchObject({
+      kind: "tool_call",
+      toolCallId: "call-1",
+      resultText: "moved files",
+      resultOk: true,
+      phase: "finished",
+    });
+  });
+});

--- a/src/tests/cli/model-selector-categories.test.ts
+++ b/src/tests/cli/model-selector-categories.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { getModelCategories } from "../../cli/components/ModelSelector";
+import {
+  getModelCategories,
+  usesBackendModelCatalog,
+} from "../../cli/components/ModelSelector";
 
 describe("getModelCategories", () => {
   test("uses the same hosted category order for free and paid tiers", () => {
@@ -24,5 +27,18 @@ describe("getModelCategories", () => {
       "server-recommended",
       "server-all",
     ]);
+  });
+
+  test("uses server-style categories for local backend model catalogs", () => {
+    expect(getModelCategories("pro", false, true)).toEqual([
+      "server-recommended",
+      "server-all",
+    ]);
+  });
+
+  test("treats local backend catalogs as backend model catalogs", () => {
+    expect(usesBackendModelCatalog(false, true)).toBe(true);
+    expect(usesBackendModelCatalog(true, false)).toBe(true);
+    expect(usesBackendModelCatalog(false, false)).toBe(false);
   });
 });

--- a/src/tests/headless/backend-lifecycle-wiring.test.ts
+++ b/src/tests/headless/backend-lifecycle-wiring.test.ts
@@ -44,4 +44,65 @@ describe("headless backend lifecycle wiring", () => {
     expect(source).not.toContain("client.agents.");
     expect(source).not.toContain("client.messages.");
   });
+
+  test("interactive startup routes lifecycle SDK calls through Backend", () => {
+    const source = readSource("../../index.ts");
+
+    expect(source).toContain("const backend = getBackend();");
+    expect(source).toContain("backend.retrieveAgent(");
+    expect(source).toContain("backend.retrieveConversation(");
+    expect(source).toContain("backend.createConversation(");
+    expect(source).toContain("backend.updateAgent(");
+    expect(source).toContain("getResumeDataFromBackend(");
+
+    expect(source).not.toContain("getClient");
+    expect(source).not.toContain("client.agents.");
+    expect(source).not.toContain("client.conversations.");
+    expect(source).not.toContain("client.messages.");
+  });
+
+  test("interactive profile picker resolves agents through Backend", () => {
+    const source = readSource("../../cli/profile-selection.tsx");
+
+    expect(source).toContain('import { getBackend } from "../backend"');
+    expect(source).toContain("backend.retrieveAgent(");
+    expect(source).not.toContain("getClient");
+    expect(source).not.toContain("client.agents.");
+  });
+
+  test("interactive ready-state agent config refresh uses Backend", () => {
+    const source = readSource("../../cli/App.tsx");
+
+    const start = source.indexOf("// Fetch llmConfig when agent is ready");
+    const end = source.indexOf("// Update project settings", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const section = source.slice(start, end);
+    expect(section).toContain("backend.retrieveAgent(agentId)");
+    const capabilityGuardIndex = section.indexOf(
+      "backend.capabilities.serverSideToolManagement",
+    );
+    const getClientIndex = section.indexOf("getClient()");
+    expect(capabilityGuardIndex).toBeGreaterThan(-1);
+    expect(getClientIndex).toBeGreaterThan(capabilityGuardIndex);
+    expect(section.slice(0, capabilityGuardIndex)).not.toContain("getClient");
+    expect(section.slice(0, capabilityGuardIndex)).not.toContain(
+      "client.agents.",
+    );
+  });
+
+  test("memfs flag application skips remote operations for local backends", () => {
+    const source = readSource("../../agent/memoryFilesystem.ts");
+
+    const capabilityGuardIndex = source.indexOf(
+      "!backend.capabilities.remoteMemfs",
+    );
+    const promptUpdateIndex = source.indexOf("updateAgentSystemPromptMemfs");
+    const tagRemovalIndex = source.indexOf("removeGitMemoryTag");
+
+    expect(capabilityGuardIndex).toBeGreaterThan(-1);
+    expect(promptUpdateIndex).toBeGreaterThan(capabilityGuardIndex);
+    expect(tagRemovalIndex).toBeGreaterThan(capabilityGuardIndex);
+  });
 });

--- a/src/tests/headless/dev-backend-smoke.test.ts
+++ b/src/tests/headless/dev-backend-smoke.test.ts
@@ -245,6 +245,141 @@ async function runStreamJsonCli(): Promise<{
   });
 }
 
+async function runStreamJsonToolCli(): Promise<{
+  objects: Array<Record<string, unknown>>;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}> {
+  const env = createIsolatedCliTestEnv({
+    LETTA_DEBUG: "0",
+    DISABLE_AUTOUPDATER: "1",
+  });
+  delete env.LETTA_API_KEY;
+  delete env.LETTA_BASE_URL;
+  delete env.LETTA_API_BASE;
+  delete env.LETTA_AGENT_ID;
+  delete env.LETTA_CONVERSATION_ID;
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      "bun",
+      [
+        "run",
+        "dev",
+        "-p",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--agent",
+        "agent-fake",
+        "--dev-backend",
+        "fake-headless-tool-call",
+        "--permission-mode",
+        "plan",
+        "--no-skills",
+      ],
+      {
+        cwd: projectRoot,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const objects: Array<Record<string, unknown>> = [];
+    let stdout = "";
+    let stderr = "";
+    let buffer = "";
+    let sentUser = false;
+    let sentList = false;
+    let closing = false;
+
+    const sendInput = (input: Record<string, unknown>) => {
+      proc.stdin?.write(`${JSON.stringify(input)}\n`);
+    };
+
+    const maybeClose = () => {
+      const hasResult = objects.some((obj) => obj.type === "result");
+      const hasList = objects.some((obj) => {
+        if (obj.type !== "control_response") return false;
+        const response = obj.response as { request_id?: unknown } | undefined;
+        return response?.request_id === "list-after-tool";
+      });
+      if (!closing && hasResult && hasList) {
+        closing = true;
+        proc.stdin?.end();
+      }
+    };
+
+    const processLine = (line: string) => {
+      if (!line.trim()) return;
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      objects.push(parsed);
+      if (parsed.type === "system" && parsed.subtype === "init" && !sentUser) {
+        sentUser = true;
+        sendInput({
+          type: "user",
+          message: {
+            role: "user",
+            content: "please use the deterministic tool",
+          },
+        });
+      }
+      if (parsed.type === "result" && !sentList) {
+        sentList = true;
+        sendInput({
+          type: "control_request",
+          request_id: "list-after-tool",
+          request: { subtype: "list_messages" },
+        });
+      }
+      maybeClose();
+    };
+
+    proc.stdout?.on("data", (data) => {
+      const chunk = data.toString();
+      stdout += chunk;
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        processLine(line);
+      }
+    });
+
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(
+        new Error(
+          `Timeout waiting for stream-json tool dev backend smoke. stdout: ${stdout}, stderr: ${stderr}`,
+        ),
+      );
+    }, 30000);
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      if (buffer.trim()) {
+        processLine(buffer);
+      }
+      resolve({ objects, stdout, stderr, exitCode: code });
+    });
+    proc.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
 function findControlPayload(
   objects: Array<Record<string, unknown>>,
   requestId: string,
@@ -286,6 +421,49 @@ describe("headless dev backend smoke", () => {
     expect(result.stdout).toContain("pong");
     expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
     expect(result.stderr).not.toContain("Failed to connect to Letta server");
+  });
+
+  test("creates a new headless agent through the dev backend without API credentials", async () => {
+    const result = await runCli([
+      "-p",
+      "ping",
+      "--new-agent",
+      "--dev-backend",
+      "fake-headless",
+      "--permission-mode",
+      "plan",
+      "--no-skills",
+      "--no-memfs",
+      "--memfs-startup",
+      "skip",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("pong");
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Failed to connect to Letta server");
+    expect(result.stderr).not.toContain("Memory flags failed");
+  });
+
+  test("rejects remote MemFS enable on dev backends without API credentials", async () => {
+    const result = await runCli([
+      "-p",
+      "ping",
+      "--agent",
+      "agent-fake",
+      "--dev-backend",
+      "fake-headless",
+      "--permission-mode",
+      "plan",
+      "--no-skills",
+      "--memfs",
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Error: --memfs is not supported by this backend yet",
+    );
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
   });
 
   test("runs stream-json controls and repeated user turns without API credentials", async () => {
@@ -346,5 +524,47 @@ describe("headless dev backend smoke", () => {
       findControlPayload(result.objects, "bootstrap-after-2"),
     );
     expect(bootstrapAfterSecond).toHaveLength(4);
+  });
+
+  test("runs a deterministic tool-call turn without API credentials", async () => {
+    const result = await runStreamJsonToolCli();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Failed to connect to Letta server");
+
+    expect(
+      result.objects.some(
+        (obj) =>
+          obj.type === "message" &&
+          obj.message_type === "approval_request_message" &&
+          JSON.stringify(obj).includes("ShellCommand"),
+      ),
+    ).toBe(true);
+    expect(
+      result.objects.some(
+        (obj) =>
+          obj.type === "auto_approval" &&
+          JSON.stringify(obj).includes("ShellCommand"),
+      ),
+    ).toBe(true);
+    expect(
+      result.objects.some(
+        (obj) =>
+          obj.type === "result" &&
+          JSON.stringify(obj).includes("tool result received (success)"),
+      ),
+    ).toBe(true);
+
+    const messages = payloadMessages(
+      findControlPayload(result.objects, "list-after-tool"),
+    );
+    expect(messages.map((message) => message.message_type)).toEqual([
+      "assistant_message",
+      "approval_response_message",
+      "approval_request_message",
+      "user_message",
+    ]);
+    expect(JSON.stringify(messages)).toContain("deterministic-tool-ok");
   });
 });

--- a/src/tests/tools/toolset-memfs-detach.test.ts
+++ b/src/tests/tools/toolset-memfs-detach.test.ts
@@ -1,6 +1,16 @@
 // Tests for detaching server-side memory tools when enabling memfs
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { __testSetBackend } from "../../backend";
+import { FakeHeadlessBackend } from "../../backend/dev/FakeHeadlessBackend";
 
 // Mock getClient before importing the module under test
 
@@ -49,6 +59,10 @@ describe("detachMemoryTools", () => {
     mockGetClient.mockClear();
   });
 
+  afterEach(() => {
+    __testSetBackend(null);
+  });
+
   afterAll(() => {
     mock.restore();
   });
@@ -77,6 +91,17 @@ describe("detachMemoryTools", () => {
 
     const detached = await detachMemoryTools("agent-123");
     expect(detached).toBe(false);
+    expect(detachMock).not.toHaveBeenCalled();
+  });
+
+  test("returns false without API calls when backend has no server tool management", async () => {
+    __testSetBackend(new FakeHeadlessBackend());
+
+    const detached = await detachMemoryTools("agent-123");
+
+    expect(detached).toBe(false);
+    expect(mockGetClient).not.toHaveBeenCalled();
+    expect(retrieveMock).not.toHaveBeenCalled();
     expect(detachMock).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -349,6 +349,9 @@ export async function ensureCorrectMemoryTool(
 ): Promise<void> {
   void resolveModel(modelIdentifier);
   void useMemoryPatch;
+  if (!getBackend().capabilities.serverSideToolManagement) {
+    return;
+  }
   const client = await getClient();
 
   try {
@@ -424,6 +427,9 @@ export async function ensureCorrectMemoryTool(
  * @returns true if any tools were detached
  */
 export async function detachMemoryTools(agentId: string): Promise<boolean> {
+  if (!getBackend().capabilities.serverSideToolManagement) {
+    return false;
+  }
   const client = await getClient();
 
   try {
@@ -464,6 +470,9 @@ export async function reattachMemoryTool(
   modelIdentifier: string,
 ): Promise<void> {
   void resolveModel(modelIdentifier);
+  if (!getBackend().capabilities.serverSideToolManagement) {
+    return;
+  }
   const client = await getClient();
 
   try {

--- a/src/utils/secretsStore.ts
+++ b/src/utils/secretsStore.ts
@@ -5,6 +5,7 @@
  */
 
 import { getCurrentAgentId } from "../agent/context";
+import { getBackend } from "../backend";
 import { getClient } from "../backend/api/client";
 
 /** In-memory cache of secrets (populated on startup from server).
@@ -58,6 +59,10 @@ export async function initSecretsFromServer(
   agentId: string,
   cachedAgent?: { secrets?: Array<{ key?: string; value?: string }> | null },
 ): Promise<void> {
+  if (!cachedAgent && !getBackend().capabilities.serverSecrets) {
+    setCache(agentId, {});
+    return;
+  }
   const agent =
     cachedAgent ??
     (await (
@@ -158,6 +163,9 @@ export async function setSecretOnServer(
   value: string,
   agentIdArg?: string,
 ): Promise<void> {
+  if (!getBackend().capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
+  }
   const client = await getClient();
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
@@ -183,6 +191,9 @@ export async function deleteSecretOnServer(
   key: string,
   agentIdArg?: string,
 ): Promise<boolean> {
+  if (!getBackend().capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
+  }
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");


### PR DESCRIPTION
## Summary
- Routes agent, conversation, model, and resume/backfill operations through the backend facade instead of raw SDK clients.
- Adds backend capabilities so API-only behavior like remote MemFS, server-managed tools, prompt recompile, import/export, and provider refresh can be gated cleanly.
- Extends the fake headless backend and tests to cover the new seam without adding the local backend implementation.

## Test plan
- [x] `bun test src/tests/backend/api-backend.test.ts src/tests/backend/fake-headless-backend.test.ts src/tests/agent/available-models-backend.test.ts src/tests/agent/getResumeData.test.ts src/tests/cli/backfill-approval-response.test.ts --timeout 60000`
- [x] `bun test src/tests/headless/dev-backend-smoke.test.ts src/tests/headless/backend-lifecycle-wiring.test.ts src/tests/cli/model-selector-categories.test.ts src/tests/tools/toolset-memfs-detach.test.ts --timeout 60000`
- [x] `bun run check && git diff --check`

👾 Generated with [Letta Code](https://letta.com)