### PR TITLE
feat(local): compile MemFS system prompts

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -176,11 +176,13 @@ export async function ensureDefaultAgents(
     );
     const willAutoEnableMemfs =
       backend.capabilities.remoteMemfs && (await isLettaCloud());
+    const shouldUseMemfsPrompt =
+      backend.capabilities.localMemfs || willAutoEnableMemfs;
 
     const { agent } = await createAgent({
       ...DEFAULT_AGENT_CONFIGS.memo,
       model: await resolveDefaultAgentModel(backend, options?.preferredModel),
-      memoryPromptMode: willAutoEnableMemfs ? "memfs" : undefined,
+      memoryPromptMode: shouldUseMemfsPrompt ? "memfs" : undefined,
     });
     await addTagToAgent(backend, agent.id, MEMO_TAG);
     settingsManager.pinGlobal(agent.id);

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -9,7 +9,6 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import { getBackend } from "../backend";
-import { getClient } from "../backend/api/client";
 import { OPENAI_CODEX_PROVIDER_NAME } from "../providers/openai-codex-provider";
 import { debugLog } from "../utils/debug";
 import { getModelContextWindow } from "./available-models";
@@ -322,15 +321,12 @@ export async function recompileAgentSystemPrompt(
     };
   },
 ): Promise<string> {
-  if (!clientOverride && !getBackend().capabilities.promptRecompile) {
+  const backend = getBackend();
+  if (!clientOverride && !backend.capabilities.promptRecompile) {
     throw new Error(
       "Server-side prompt recompile is not supported by this backend yet",
     );
   }
-  const client = (clientOverride ?? (await getClient())) as Exclude<
-    typeof clientOverride,
-    undefined
-  >;
 
   if (!agentId) {
     throw new Error("recompileAgentSystemPrompt requires agentId");
@@ -341,7 +337,11 @@ export async function recompileAgentSystemPrompt(
     agent_id: agentId,
   };
 
-  return client.conversations.recompile(conversationId, params);
+  if (clientOverride) {
+    return clientOverride.conversations.recompile(conversationId, params);
+  }
+
+  return backend.recompileConversation(conversationId, params);
 }
 
 export interface SystemPromptUpdateResult {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -70,6 +70,12 @@ export type ConversationUpdateParams = Parameters<
 export type ConversationUpdateBody = ConversationUpdateParams[1];
 export type ConversationUpdateOptions = ConversationUpdateParams[2];
 
+export type ConversationRecompileParams = Parameters<
+  APIClient["conversations"]["recompile"]
+>;
+export type ConversationRecompileBody = ConversationRecompileParams[1];
+export type ConversationRecompileOptions = ConversationRecompileParams[2];
+
 export type ConversationMessageListParams = Parameters<
   APIClient["conversations"]["messages"]["list"]
 >;
@@ -98,6 +104,7 @@ export interface BackendCapabilities {
   promptRecompile: boolean;
   byokProviderRefresh: boolean;
   localModelCatalog: boolean;
+  localMemfs: boolean;
 }
 
 export interface Backend {
@@ -147,6 +154,12 @@ export interface Backend {
     body: ConversationUpdateBody,
     options?: ConversationUpdateOptions,
   ): Promise<Awaited<ReturnType<APIClient["conversations"]["update"]>>>;
+
+  recompileConversation(
+    conversationId: string,
+    body?: ConversationRecompileBody,
+    options?: ConversationRecompileOptions,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["recompile"]>>>;
 
   listConversationMessages(
     conversationId: string,
@@ -221,6 +234,7 @@ export class APIBackend implements Backend {
     promptRecompile: true,
     byokProviderRefresh: true,
     localModelCatalog: false,
+    localMemfs: false,
   };
 
   private readonly getApiClientOverride?: GetAPIClient;
@@ -296,6 +310,15 @@ export class APIBackend implements Backend {
   ) {
     const client = await this.getClient();
     return client.conversations.update(conversationId, body, options);
+  }
+
+  async recompileConversation(
+    conversationId: string,
+    body?: ConversationRecompileBody,
+    options?: ConversationRecompileOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.recompile(conversationId, body, options);
   }
 
   async listConversationMessages(

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -349,7 +349,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
           input.agent.model,
           input.agent.model_settings,
         )(),
-      system: input.agent.system,
+      system: input.systemPrompt ?? input.agent.system,
       messages: await convertToModelMessages(uiMessages, { tools }),
       tools,
       providerOptions: buildAISDKProviderOptions(

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -104,9 +104,10 @@ export class HeadlessBackend implements Backend {
     promptRecompile: false,
     byokProviderRefresh: false,
     localModelCatalog: true,
+    localMemfs: false,
   };
 
-  private readonly store: LocalStore;
+  protected readonly store: LocalStore;
   private readonly executor: HeadlessTurnExecutor;
   private readonly runs = new Map<string, Run>();
   private readonly activeRunByConversation = new Map<string, string>();
@@ -183,6 +184,12 @@ export class HeadlessBackend implements Backend {
   updateConversation(...args: Parameters<Backend["updateConversation"]>) {
     const [conversationId, body] = args;
     return Promise.resolve(this.store.updateConversation(conversationId, body));
+  }
+
+  async recompileConversation(
+    ..._args: Parameters<Backend["recompileConversation"]>
+  ): ReturnType<Backend["recompileConversation"]> {
+    throw new Error("Prompt recompile is not supported by this backend yet");
   }
 
   async listConversationMessages(
@@ -297,12 +304,21 @@ export class HeadlessBackend implements Backend {
       turnInput.agentId,
     );
     const agent = this.store.retrieveAgentRecord(turnInput.agentId);
+    const systemPrompt = await this.resolveSystemPromptForTurn({
+      conversationId: turnInput.conversationId,
+      agentId: turnInput.agentId,
+      agent,
+      body,
+      history,
+      uiMessages,
+    });
     let stream: Stream<LettaStreamingResponse>;
     try {
       stream = await this.executor.execute({
         conversationId: turnInput.conversationId,
         agentId: turnInput.agentId,
         agent,
+        systemPrompt,
         body,
         history,
         uiMessages,
@@ -318,6 +334,17 @@ export class HeadlessBackend implements Backend {
       stream,
       run.id,
     );
+  }
+
+  protected async resolveSystemPromptForTurn(input: {
+    conversationId: string;
+    agentId: string;
+    agent: ReturnType<LocalStore["retrieveAgentRecord"]>;
+    body: ConversationMessageCreateBody | ConversationMessageStreamBody;
+    history: ReturnType<LocalStore["listConversationMessages"]>;
+    uiMessages: ReturnType<LocalStore["listLocalMessages"]>;
+  }): Promise<string> {
+    return input.agent.system;
   }
 
   private startRun(

--- a/src/backend/dev/HeadlessTurnExecutor.ts
+++ b/src/backend/dev/HeadlessTurnExecutor.ts
@@ -15,6 +15,7 @@ export interface HeadlessTurnExecutorInput {
   conversationId: string;
   agentId: string;
   agent: LocalAgentRecord;
+  systemPrompt?: string;
   body: HeadlessTurnBody;
   history: StoredMessage[];
   uiMessages: LocalMessage[];

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -18,6 +18,7 @@ export interface ProviderTurnInput {
   conversationId: string;
   agentId: string;
   agent: LocalAgentRecord;
+  systemPrompt?: string;
   body: HeadlessTurnBody;
   history: StoredMessage[];
   uiMessages: LocalMessage[];
@@ -71,6 +72,7 @@ export function buildProviderTurnInput(
     conversationId: input.conversationId,
     agentId: input.agentId,
     agent: input.agent,
+    systemPrompt: input.systemPrompt,
     body: input.body,
     history: input.history,
     uiMessages: input.uiMessages,

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -1,4 +1,12 @@
 import type { LanguageModel } from "ai";
+import type {
+  BackendCapabilities,
+  ConversationCreateBody,
+  ConversationMessageCreateBody,
+  ConversationMessageListBody,
+  ConversationMessageStreamBody,
+  ConversationRecompileBody,
+} from "../backend";
 import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
@@ -9,8 +17,19 @@ import {
   type HeadlessTurnExecutor,
 } from "../dev/HeadlessTurnExecutor";
 import { ProviderTurnExecutor } from "../dev/ProviderTurnExecutor";
+import type { LocalMessage } from "./LocalMessage";
 import { listLocalModels, resolveLocalModelConfig } from "./LocalModelConfig";
-import type { LocalStoreOptions } from "./LocalStore";
+import type {
+  LocalAgentRecord,
+  LocalStoreOptions,
+  StoredMessage,
+} from "./LocalStore";
+import {
+  appendAvailableSkillsBlock,
+  compileLocalSystemPrompt,
+  hashRawSystemPrompt,
+  type LocalCompiledSystemPrompt,
+} from "./systemPromptCompilation";
 
 export type LocalBackendExecutionMode = "ai-sdk" | "deterministic";
 
@@ -21,6 +40,7 @@ export interface LocalBackendOptions {
   executor?: HeadlessTurnExecutor;
   createModel?: () => LanguageModel;
   streamText?: AISDKStreamTextFunction;
+  memoryDir?: string;
 }
 
 function createLocalExecutor(
@@ -39,6 +59,19 @@ function createLocalExecutor(
 }
 
 export class LocalBackend extends HeadlessBackend {
+  override readonly capabilities: BackendCapabilities = {
+    remoteMemfs: false,
+    serverSideToolManagement: false,
+    serverSecrets: false,
+    agentFileImportExport: false,
+    promptRecompile: true,
+    byokProviderRefresh: false,
+    localModelCatalog: true,
+    localMemfs: true,
+  };
+
+  private readonly memoryDir?: string;
+
   constructor(options: LocalBackendOptions) {
     const modelConfig = resolveLocalModelConfig();
     const storeOptions: LocalStoreOptions = {
@@ -63,9 +96,118 @@ export class LocalBackend extends HeadlessBackend {
         runMetadataBackend: "local",
       },
     );
+    this.memoryDir = options.memoryDir;
   }
 
   override async listModels() {
     return listLocalModels() as never;
+  }
+
+  override async createAgent(
+    ...args: Parameters<HeadlessBackend["createAgent"]>
+  ) {
+    const agent = await super.createAgent(...args);
+    await this.compileAndMaybePersistSystemPrompt("default", agent.id, {
+      dryRun: false,
+    });
+    return agent;
+  }
+
+  override async createConversation(
+    body: ConversationCreateBody,
+  ): ReturnType<HeadlessBackend["createConversation"]> {
+    const conversation = await super.createConversation(body);
+    await this.compileAndMaybePersistSystemPrompt(
+      conversation.id,
+      conversation.agent_id,
+      { dryRun: false },
+    );
+    return conversation;
+  }
+
+  override async recompileConversation(
+    conversationId: string,
+    body?: ConversationRecompileBody,
+  ) {
+    const bodyRecord = (body ?? {}) as Record<string, unknown>;
+    const agentId =
+      typeof bodyRecord.agent_id === "string" && bodyRecord.agent_id.length > 0
+        ? bodyRecord.agent_id
+        : this.store.resolveAgentIdForConversation(conversationId);
+    const compiled = await this.compileAndMaybePersistSystemPrompt(
+      conversationId,
+      agentId,
+      { dryRun: bodyRecord.dry_run === true },
+    );
+    return compiled.content;
+  }
+
+  protected override async resolveSystemPromptForTurn(input: {
+    conversationId: string;
+    agentId: string;
+    agent: LocalAgentRecord;
+    body: ConversationMessageCreateBody | ConversationMessageStreamBody;
+    history: StoredMessage[];
+    uiMessages: LocalMessage[];
+  }): Promise<string> {
+    const persisted = await this.getOrCompileSystemPrompt(
+      input.conversationId,
+      input.agentId,
+      input.agent,
+      input.history.length,
+    );
+    const clientSkills = Array.isArray(
+      (input.body as Record<string, unknown>).client_skills,
+    )
+      ? ((input.body as Record<string, unknown>).client_skills as unknown[])
+      : [];
+    return appendAvailableSkillsBlock(persisted.content, clientSkills);
+  }
+
+  private memoryDirForAgent(_agentId: string): string | undefined {
+    return this.memoryDir ?? undefined;
+  }
+
+  private async getOrCompileSystemPrompt(
+    conversationId: string,
+    agentId: string,
+    agent = this.store.retrieveAgentRecord(agentId),
+    previousMessageCount = 0,
+  ): Promise<LocalCompiledSystemPrompt> {
+    const existing = this.store.getCompiledSystemPrompt(
+      conversationId,
+      agentId,
+    );
+    if (existing?.rawSystemHash === hashRawSystemPrompt(agent.system)) {
+      return existing;
+    }
+    return this.compileAndMaybePersistSystemPrompt(conversationId, agentId, {
+      dryRun: false,
+      previousMessageCount,
+    });
+  }
+
+  private async compileAndMaybePersistSystemPrompt(
+    conversationId: string,
+    agentId: string,
+    options: { dryRun: boolean; previousMessageCount?: number },
+  ): Promise<LocalCompiledSystemPrompt> {
+    const agent = this.store.retrieveAgentRecord(agentId);
+    const previousMessageCount =
+      options.previousMessageCount ??
+      this.store.listConversationMessages(conversationId, {
+        agent_id: agentId,
+        order: "asc",
+      } as ConversationMessageListBody).length;
+    const compiled = compileLocalSystemPrompt({
+      agent,
+      conversationId,
+      previousMessageCount,
+      memoryDir: this.memoryDirForAgent(agentId),
+    });
+    if (!options.dryRun) {
+      this.store.setCompiledSystemPrompt(conversationId, agentId, compiled);
+    }
+    return compiled;
   }
 }

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -39,6 +39,7 @@ import {
   getAttachedLocalUIMessage,
   isLocalStateChunkOnly,
 } from "./LocalStreamChunks";
+import type { LocalCompiledSystemPrompt } from "./systemPromptCompilation";
 
 export type StoredMessage = Message & {
   id: string;
@@ -504,6 +505,10 @@ export class LocalStore {
     string,
     LocalMessage[]
   >();
+  private readonly compiledSystemPromptByConversationKey = new Map<
+    string,
+    LocalCompiledSystemPrompt
+  >();
   private readonly messagesById = new Map<string, StoredMessage[]>();
   private conversationSeq = 0;
   private messageSeq = 0;
@@ -649,6 +654,10 @@ export class LocalStore {
       this.agents.get(agentId) ??
       this.createDefaultAgentRecord(agentId);
     const bodyRecord = body as Record<string, unknown>;
+    const nextSystem =
+      typeof bodyRecord.system === "string" ? bodyRecord.system : undefined;
+    const systemChanged =
+      nextSystem !== undefined && nextSystem !== existingRecord.system;
     const requestedModel = bodyRecord.model;
     const nextModelSettings = {
       ...existingRecord.model_settings,
@@ -680,6 +689,9 @@ export class LocalStore {
     };
     this.agents.set(agentId, updated);
     this.persistAgent(agentId);
+    if (systemChanged) {
+      this.clearCompiledSystemPromptsForAgent(agentId);
+    }
     return this.projectAgent(updated);
   }
 
@@ -943,6 +955,47 @@ export class LocalStore {
       conversationId,
       resolvedAgentId,
     ).map(cloneLocalMessage);
+  }
+
+  resolveAgentIdForConversation(conversationId: string): string {
+    return this.agentIdForConversation(conversationId);
+  }
+
+  getCompiledSystemPrompt(
+    conversationId: string,
+    agentId: string,
+  ): LocalCompiledSystemPrompt | undefined {
+    const key = this.conversationKey(conversationId, agentId);
+    return this.compiledSystemPromptByConversationKey.get(key);
+  }
+
+  setCompiledSystemPrompt(
+    conversationId: string,
+    agentId: string,
+    prompt: LocalCompiledSystemPrompt,
+  ): void {
+    const conversation = this.ensureConversation(conversationId, agentId);
+    const key = this.conversationKey(conversation.id, agentId);
+    this.compiledSystemPromptByConversationKey.set(key, prompt);
+    this.persistCompiledSystemPrompt(conversation.id, agentId);
+  }
+
+  clearCompiledSystemPromptsForAgent(agentId: string): void {
+    for (const [key, conversation] of this.conversations.entries()) {
+      if (conversation.agent_id !== agentId) continue;
+      this.compiledSystemPromptByConversationKey.delete(key);
+      if (this.storageDir) {
+        rmSync(
+          join(
+            this.storageDir,
+            "conversations",
+            encodePathSegment(key),
+            "system-prompt.json",
+          ),
+          { force: true },
+        );
+      }
+    }
   }
 
   listConversationMessages(
@@ -1575,6 +1628,9 @@ export class LocalStore {
         const localMessages = readJsonlFile<LocalMessage>(
           join(conversationDir, "messages.jsonl"),
         );
+        const compiledSystemPrompt = readJsonFile<LocalCompiledSystemPrompt>(
+          join(conversationDir, "system-prompt.json"),
+        );
         const messages = projectLocalMessagesToStoredMessages(
           localMessages,
           conversation.agent_id,
@@ -1583,6 +1639,12 @@ export class LocalStore {
 
         this.conversations.set(key, conversation);
         this.localMessagesByConversationKey.set(key, localMessages);
+        if (compiledSystemPrompt?.content) {
+          this.compiledSystemPromptByConversationKey.set(
+            key,
+            compiledSystemPrompt,
+          );
+        }
         this.conversationSeq = Math.max(
           this.conversationSeq,
           numericSuffix(conversation.id, this.conversationIdPrefix),
@@ -1657,6 +1719,27 @@ export class LocalStore {
     writeFileSync(
       join(conversationDir, "messages.jsonl"),
       jsonl(this.localMessagesByConversationKey.get(key) ?? []),
+    );
+    this.persistCompiledSystemPrompt(conversationId, agentId);
+  }
+
+  private persistCompiledSystemPrompt(
+    conversationId: string,
+    agentId: string,
+  ): void {
+    if (!this.storageDir) return;
+    const key = this.conversationKey(conversationId, agentId);
+    const prompt = this.compiledSystemPromptByConversationKey.get(key);
+    if (!prompt) return;
+    const conversationDir = join(
+      this.storageDir,
+      "conversations",
+      encodePathSegment(key),
+    );
+    mkdirSync(conversationDir, { recursive: true });
+    writeFileSync(
+      join(conversationDir, "system-prompt.json"),
+      `${JSON.stringify(prompt, null, 2)}\n`,
     );
   }
 

--- a/src/backend/local/systemPromptCompilation.ts
+++ b/src/backend/local/systemPromptCompilation.ts
@@ -1,0 +1,447 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { parseFrontmatter } from "../../utils/frontmatter";
+import type { LocalAgentRecord } from "./LocalStore";
+
+const CORE_MEMORY_VARIABLE = "{CORE_MEMORY}";
+const MEMORY_DIR_PLACEHOLDER = "$" + "{MEMORY_DIR}";
+
+interface LocalMemoryFile {
+  relativePath: string;
+  label: string;
+  value: string;
+  description: string;
+}
+
+export interface LocalCompiledSystemPrompt {
+  content: string;
+  compiledAt: string;
+  rawSystemHash: string;
+  memfsRevision?: string;
+}
+
+export interface CompileLocalSystemPromptOptions {
+  agent: LocalAgentRecord;
+  conversationId: string;
+  memoryDir?: string;
+  now?: Date;
+  previousMessageCount?: number;
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function hashRawSystemPrompt(systemPrompt: string): string {
+  return hashString(systemPrompt);
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function labelFromPath(relativePath: string): string {
+  return normalizePath(relativePath).replace(/\.md$/, "");
+}
+
+function collectMemoryFiles(memoryDir: string): LocalMemoryFile[] {
+  const files: LocalMemoryFile[] = [];
+
+  const walk = (currentDir: string) => {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(currentDir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries.sort((a, b) => a.localeCompare(b))) {
+      if (entry.startsWith(".")) continue;
+      const fullPath = join(currentDir, entry);
+      let stat: ReturnType<typeof statSync>;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!stat.isFile() || !entry.endsWith(".md")) continue;
+
+      try {
+        const raw = readFileSync(fullPath, "utf8");
+        const { frontmatter, body } = parseFrontmatter(raw);
+        const relativePath = normalizePath(relative(memoryDir, fullPath));
+        files.push({
+          relativePath,
+          label: labelFromPath(relativePath),
+          value: body,
+          description:
+            typeof frontmatter.description === "string"
+              ? frontmatter.description.trim()
+              : "",
+        });
+      } catch {
+        // Skip unreadable files. MemFS tooling surfaces read/write errors at
+        // the tool boundary; prompt compilation should stay best-effort.
+      }
+    }
+  };
+
+  if (existsSync(memoryDir)) {
+    walk(memoryDir);
+  }
+  return files.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function computeMemfsRevision(files: LocalMemoryFile[]): string {
+  return hashString(
+    files
+      .map((file) =>
+        [file.relativePath, file.description, file.value].join("\0"),
+      )
+      .join("\0\0"),
+  );
+}
+
+function renderExternalProjection(files: LocalMemoryFile[]): string {
+  interface TreeNode extends Map<string, TreeNode | null> {}
+  const root: TreeNode = new Map();
+
+  for (const file of files) {
+    const parts = file.relativePath.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+    let node = root;
+    for (const part of parts.slice(0, -1)) {
+      const existing = node.get(part);
+      if (existing instanceof Map) {
+        node = existing;
+      } else {
+        const child: TreeNode = new Map();
+        node.set(part, child);
+        node = child;
+      }
+    }
+    const leaf = parts.at(-1);
+    if (leaf) node.set(leaf, null);
+  }
+
+  const lines = ["<external_projection>", `${MEMORY_DIR_PLACEHOLDER}/`];
+  const render = (node: TreeNode, prefix = "") => {
+    const entries = [...node.entries()].sort(
+      ([aName, aNode], [bName, bNode]) => {
+        const aDir = aNode instanceof Map;
+        const bDir = bNode instanceof Map;
+        if (aDir !== bDir) return aDir ? -1 : 1;
+        return aName.localeCompare(bName);
+      },
+    );
+
+    for (const [index, [name, child]] of entries.entries()) {
+      const isLast = index === entries.length - 1;
+      const connector = isLast ? "└── " : "├── ";
+      const isDir = child instanceof Map;
+      lines.push(`${prefix}${connector}${name}${isDir ? "/" : ""}`);
+      if (isDir) {
+        render(child, `${prefix}${isLast ? "    " : "│   "}`);
+      }
+    }
+  };
+  render(root);
+  lines.push("</external_projection>");
+  return lines.join("\n");
+}
+
+function renderSystemTree(files: LocalMemoryFile[]): string {
+  const LEAF_VALUE = "__value__";
+  const LEAF_DESCRIPTION = "__description__";
+  interface TreeNode {
+    [key: string]: TreeNode | string;
+  }
+  const tree: TreeNode = {};
+
+  for (const file of files) {
+    const label = file.label.replace(/^system\//, "");
+    const parts = label.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+    let node = tree;
+    for (const part of parts) {
+      const existing = node[part];
+      if (!existing || typeof existing === "string") {
+        node[part] = {};
+      }
+      node = node[part] as TreeNode;
+    }
+    node[LEAF_VALUE] = file.value;
+    node[LEAF_DESCRIPTION] = file.description;
+  }
+
+  const lines: string[] = [];
+  const render = (node: TreeNode, indent = 0, pathParts: string[] = []) => {
+    const pad = "  ".repeat(indent);
+    const keys = Object.keys(node)
+      .filter((key) => key !== LEAF_VALUE && key !== LEAF_DESCRIPTION)
+      .sort((a, b) => a.localeCompare(b));
+
+    for (const key of keys) {
+      const child = node[key] as TreeNode;
+      const childParts = [...pathParts, key];
+      lines.push(`${pad}<${key}>`);
+      if (Object.hasOwn(child, LEAF_VALUE)) {
+        lines.push(
+          `${pad}  <projection>$MEMORY_DIR/system/${childParts.join("/")}.md</projection>`,
+        );
+        const description = String(child[LEAF_DESCRIPTION] ?? "").trim();
+        if (description) {
+          lines.push(`${pad}  <description>${description}</description>`);
+        }
+        const value = String(child[LEAF_VALUE] ?? "").trimEnd();
+        if (value) {
+          lines.push(`${pad}  ${value}`);
+        }
+      }
+      render(child, indent + 1, childParts);
+      lines.push(`${pad}</${key}>`);
+    }
+  };
+  render(tree);
+  return lines.join("\n");
+}
+
+function renderMemfsProjection(memoryDir: string): {
+  content: string;
+  revision: string;
+} {
+  const files = collectMemoryFiles(memoryDir);
+  const revision = computeMemfsRevision(files);
+  if (files.length === 0) return { content: "", revision };
+
+  const lines = [
+    "Reminder: <projection> contains the local path of the memory file projection.",
+  ];
+
+  const persona = files.find((file) => file.label === "system/persona");
+  if (persona) {
+    lines.push(
+      "",
+      "<self>",
+      "<projection>$MEMORY_DIR/system/persona.md</projection>",
+      persona.value.trimEnd(),
+      "</self>",
+    );
+  }
+
+  const systemFiles = files.filter(
+    (file) =>
+      file.label.startsWith("system/") && file.label !== "system/persona",
+  );
+  const externalFiles = files.filter(
+    (file) =>
+      !file.label.startsWith("system/") && !file.label.startsWith("skills/"),
+  );
+
+  if (systemFiles.length > 0 || externalFiles.length > 0) {
+    lines.push("", "<memory>");
+    const systemTree = renderSystemTree(systemFiles);
+    if (systemTree) lines.push(systemTree);
+    if (externalFiles.length > 0) {
+      lines.push(renderExternalProjection(externalFiles));
+    }
+    lines.push("</memory>");
+  }
+
+  return { content: lines.join("\n"), revision };
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function formatUtcTimestamp(date: Date): string {
+  const hours = date.getUTCHours();
+  const hour12 = hours % 12 || 12;
+  const meridiem = hours < 12 ? "AM" : "PM";
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())} ${pad2(hour12)}:${pad2(date.getUTCMinutes())}:${pad2(date.getUTCSeconds())} ${meridiem} UTC+0000`;
+}
+
+function compileMemoryMetadata(input: {
+  agentId: string;
+  conversationId: string;
+  compiledAt: Date;
+  previousMessageCount: number;
+}): string {
+  return [
+    "<memory_metadata>",
+    `- AGENT_ID: ${input.agentId}`,
+    `- CONVERSATION_ID: ${input.conversationId}`,
+    `- System prompt last recompiled: ${formatUtcTimestamp(input.compiledAt)}`,
+    `- ${input.previousMessageCount} previous messages between you and the user are stored in recall memory`,
+    "</memory_metadata>",
+  ].join("\n");
+}
+
+function injectCoreMemory(rawSystemPrompt: string, coreMemory: string): string {
+  const prompt = rawSystemPrompt.includes(CORE_MEMORY_VARIABLE)
+    ? rawSystemPrompt
+    : `${rawSystemPrompt.trimEnd()}\n\n${CORE_MEMORY_VARIABLE}`;
+  return prompt.replaceAll(CORE_MEMORY_VARIABLE, coreMemory);
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function skillRootAndRelativePath(
+  name: string,
+  location: string,
+): {
+  root: string;
+  relativePath: string;
+} {
+  const normalized = normalizePath(location.trim());
+  if (normalized.endsWith("/SKILL.md")) {
+    const skillDir = dirname(normalized);
+    const root = dirname(skillDir);
+    const relativePath = normalizePath(relative(root, normalized));
+    if (basename(skillDir) === name.split("/").at(-1)) {
+      return { root: normalizePath(root), relativePath };
+    }
+  }
+  return {
+    root: normalizePath(dirname(normalized)),
+    relativePath: basename(normalized),
+  };
+}
+
+export function compileAvailableSkillsBlock(
+  clientSkills: unknown[] = [],
+): string {
+  const seen = new Set<string>();
+  const entries: Array<{
+    root: string;
+    relativePath: string;
+    description: string;
+  }> = [];
+
+  for (const skill of clientSkills) {
+    if (!skill || typeof skill !== "object") continue;
+    const record = skill as Record<string, unknown>;
+    const name = stringField(record.name);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const description =
+      stringField(record.description)?.trim().split("\n")[0] ?? "";
+    const location =
+      stringField(record.location)?.trim() ||
+      `${MEMORY_DIR_PLACEHOLDER}/skills/${name}/SKILL.md`;
+    entries.push({
+      ...skillRootAndRelativePath(name, location),
+      description,
+    });
+  }
+
+  if (entries.length === 0) return "";
+
+  const grouped = new Map<
+    string,
+    Array<{ relativePath: string; description: string }>
+  >();
+  for (const entry of entries) {
+    const group = grouped.get(entry.root) ?? [];
+    group.push({
+      relativePath: entry.relativePath,
+      description: entry.description,
+    });
+    grouped.set(entry.root, group);
+  }
+
+  const lines = ["<available_skills>"];
+  const roots = [...grouped.keys()].sort((a, b) => a.localeCompare(b));
+  for (const [rootIndex, root] of roots.entries()) {
+    lines.push(root);
+    type Tree = Map<string, Tree | string>;
+    const tree: Tree = new Map();
+    for (const entry of (grouped.get(root) ?? []).sort((a, b) =>
+      a.relativePath.localeCompare(b.relativePath),
+    )) {
+      const parts = entry.relativePath.split("/").filter(Boolean);
+      let node = tree;
+      for (const part of parts.slice(0, -1)) {
+        const existing = node.get(part);
+        if (existing instanceof Map) {
+          node = existing;
+        } else {
+          const child: Tree = new Map();
+          node.set(part, child);
+          node = child;
+        }
+      }
+      const leaf = parts.at(-1);
+      if (leaf) node.set(leaf, entry.description);
+    }
+
+    const render = (node: Tree, prefix = "") => {
+      const entries = [...node.entries()].sort(
+        ([aName, aValue], [bName, bValue]) => {
+          const aDir = aValue instanceof Map;
+          const bDir = bValue instanceof Map;
+          if (aDir !== bDir) return aDir ? -1 : 1;
+          return aName.localeCompare(bName);
+        },
+      );
+      for (const [index, [name, value]] of entries.entries()) {
+        const isLast = index === entries.length - 1;
+        const connector = isLast ? "└── " : "├── ";
+        if (value instanceof Map) {
+          lines.push(`${prefix}${connector}${name}/`);
+          render(value, `${prefix}${isLast ? "    " : "│   "}`);
+        } else {
+          const suffix = value.trim() ? ` (${value.trim()})` : "";
+          lines.push(`${prefix}${connector}${name}${suffix}`);
+        }
+      }
+    };
+    render(tree);
+    if (rootIndex !== roots.length - 1) lines.push("");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}
+
+export function appendAvailableSkillsBlock(
+  systemPrompt: string,
+  clientSkills: unknown[] = [],
+): string {
+  const skillsBlock = compileAvailableSkillsBlock(clientSkills);
+  if (!skillsBlock) return systemPrompt;
+  return `${systemPrompt.trimEnd()}\n\n${skillsBlock.trimStart()}`;
+}
+
+export function compileLocalSystemPrompt(
+  options: CompileLocalSystemPromptOptions,
+): LocalCompiledSystemPrompt {
+  const compiledAt = options.now ?? new Date();
+  const memoryDir =
+    options.memoryDir ?? getMemoryFilesystemRoot(options.agent.id);
+  const memfs = renderMemfsProjection(memoryDir);
+  const metadata = compileMemoryMetadata({
+    agentId: options.agent.id,
+    conversationId: options.conversationId,
+    compiledAt,
+    previousMessageCount: options.previousMessageCount ?? 0,
+  });
+  const coreMemory = [memfs.content, metadata]
+    .filter((part) => part.trim().length > 0)
+    .join("\n\n");
+  return {
+    content: injectCoreMemory(options.agent.system, coreMemory),
+    compiledAt: compiledAt.toISOString(),
+    rawSystemHash: hashRawSystemPrompt(options.agent.system),
+    memfsRevision: memfs.revision,
+  };
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8630,20 +8630,13 @@ export default function App({
           setCommandRunning(true);
 
           try {
-            const client = await getClient();
             const currentConversationId = conversationIdRef.current;
-
-            await client.agents.recompile(agentId, {
-              update_timestamp: true,
-            });
-
-            const conversationParams =
-              currentConversationId === "default"
-                ? { agent_id: agentId }
-                : undefined;
-            const compiledSystemPrompt = await client.conversations.recompile(
+            const { recompileAgentSystemPrompt } = await import(
+              "../agent/modify"
+            );
+            const compiledSystemPrompt = await recompileAgentSystemPrompt(
               currentConversationId,
-              conversationParams,
+              agentId,
             );
             setSystemPromptDoctorState(
               agentId,

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -8,6 +8,7 @@ import type {
   ConversationMessageCreateBody,
   ConversationMessageListBody,
   ConversationMessageStreamBody,
+  ConversationRecompileBody,
   ConversationUpdateBody,
   RunMessageStreamBody,
 } from "../../backend";
@@ -35,6 +36,10 @@ const updateConversationMock = mock(
   async (_conversationId: string, _body: unknown, _options?: unknown) => ({
     id: "conv-1",
   }),
+);
+const recompileConversationMock = mock(
+  async (_conversationId: string, _body?: unknown, _options?: unknown) =>
+    "compiled system",
 );
 const listConversationMessagesMock = mock(
   async (_conversationId: string, _body?: unknown, _options?: unknown) => ({
@@ -90,6 +95,7 @@ const getClientMock = mock(async () => ({
     retrieve: retrieveConversationMock,
     create: createConversationMock,
     update: updateConversationMock,
+    recompile: recompileConversationMock,
     messages: {
       list: listConversationMessagesMock,
       create: createMessageStreamMock,
@@ -122,6 +128,7 @@ describe("APIBackend", () => {
     retrieveConversationMock.mockClear();
     createConversationMock.mockClear();
     updateConversationMock.mockClear();
+    recompileConversationMock.mockClear();
     listConversationMessagesMock.mockClear();
     listAgentMessagesMock.mockClear();
     retrieveMessageMock.mockClear();
@@ -147,6 +154,7 @@ describe("APIBackend", () => {
       promptRecompile: true,
       byokProviderRefresh: true,
       localModelCatalog: false,
+      localMemfs: false,
     });
     const agentUpdateBody = { system: "system" } as AgentUpdateBody;
     const agentCreateBody = { name: "new agent" } as AgentCreateBody;
@@ -156,6 +164,10 @@ describe("APIBackend", () => {
     const conversationUpdateBody = {
       summary: "summary",
     } as ConversationUpdateBody;
+    const conversationRecompileBody = {
+      agent_id: "agent-1",
+      dry_run: true,
+    } as ConversationRecompileBody;
     const conversationListBody = {
       limit: 1,
     } as ConversationMessageListBody;
@@ -183,6 +195,7 @@ describe("APIBackend", () => {
     await backend.retrieveConversation("conv-1");
     await backend.createConversation(conversationCreateBody);
     await backend.updateConversation("conv-1", conversationUpdateBody);
+    await backend.recompileConversation("conv-1", conversationRecompileBody);
     await backend.listConversationMessages("conv-1", conversationListBody);
     await backend.listAgentMessages("agent-1", agentListBody);
     await backend.retrieveMessage("msg-1");
@@ -196,7 +209,7 @@ describe("APIBackend", () => {
     await backend.streamRunMessages("run-1", runStreamBody);
     await backend.forkConversation("conv-1", { agentId: "agent-1" });
 
-    expect(getClientMock).toHaveBeenCalledTimes(15);
+    expect(getClientMock).toHaveBeenCalledTimes(16);
     expect(retrieveAgentMock).toHaveBeenCalledWith("agent-1", {
       include: ["agent.tools"],
     });
@@ -214,6 +227,11 @@ describe("APIBackend", () => {
     expect(updateConversationMock).toHaveBeenCalledWith(
       "conv-1",
       conversationUpdateBody,
+      undefined,
+    );
+    expect(recompileConversationMock).toHaveBeenCalledWith(
+      "conv-1",
+      conversationRecompileBody,
       undefined,
     );
     expect(listConversationMessagesMock).toHaveBeenCalledWith(

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type {
   LanguageModel,
@@ -84,6 +91,41 @@ async function readPersistedLocalMessages(storageDir: string) {
     );
   }
   return messages;
+}
+
+async function readPersistedSystemPrompts(storageDir: string) {
+  const conversationDirs = await readdir(join(storageDir, "conversations"));
+  const prompts = [] as Array<{ content?: string; rawSystemHash?: string }>;
+  for (const dir of conversationDirs) {
+    try {
+      prompts.push(
+        JSON.parse(
+          await readFile(
+            join(storageDir, "conversations", dir, "system-prompt.json"),
+            "utf8",
+          ),
+        ) as { content?: string; rawSystemHash?: string },
+      );
+    } catch {
+      // Conversation may not have compiled yet.
+    }
+  }
+  return prompts;
+}
+
+async function writeMemoryFile(
+  memoryDir: string,
+  relativePath: string,
+  description: string,
+  body: string,
+) {
+  const fullPath = join(memoryDir, relativePath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(
+    fullPath,
+    `---\ndescription: ${description}\n---\n${body}\n`,
+    "utf8",
+  );
 }
 
 function createBody(
@@ -200,9 +242,10 @@ describe("LocalBackend", () => {
         serverSideToolManagement: false,
         serverSecrets: false,
         agentFileImportExport: false,
-        promptRecompile: false,
+        promptRecompile: true,
         byokProviderRefresh: false,
         localModelCatalog: true,
+        localMemfs: true,
       });
 
       await expect(backend.retrieveAgent("agent-missing")).rejects.toThrow(
@@ -303,7 +346,10 @@ describe("LocalBackend", () => {
         chunks.push(chunk);
       }
 
-      expect(capturedSystem).toBe("local system");
+      expect(capturedSystem).toContain("local system");
+      expect(capturedSystem).toContain("<memory_metadata>");
+      expect(capturedSystem).toContain(`- AGENT_ID: ${agent.id}`);
+      expect(capturedSystem).toContain(`- CONVERSATION_ID: ${conversation.id}`);
       expect(capturedMessages).toEqual([
         {
           role: "user",
@@ -323,6 +369,157 @@ describe("LocalBackend", () => {
       expect(replayed.map((chunk) => chunk.message_type)).toEqual(
         (chunks as LettaStreamingResponse[]).map((chunk) => chunk.message_type),
       );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("persists compiled system prompt snapshots and reuses them for turns", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-prompt-"));
+    const memoryDir = await mkdtemp(join(tmpdir(), "local-backend-memory-"));
+    try {
+      await writeMemoryFile(
+        memoryDir,
+        "system/project.md",
+        "Project memory",
+        "Use local compiled memory.",
+      );
+      let capturedSystem: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        memoryDir,
+        createModel: () => ({}) as LanguageModel,
+        streamText: (options) => {
+          capturedSystem = options.system;
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Prompt Agent",
+        system: "base {CORE_MEMORY}",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      const promptsAfterCreate = await readPersistedSystemPrompts(storageDir);
+      expect(
+        promptsAfterCreate.some((prompt) =>
+          prompt.content?.includes("Use local compiled memory."),
+        ),
+      ).toBe(true);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("hello compiled prompt", agent.id),
+        ),
+      );
+      expect(capturedSystem).toContain("base Reminder: <projection>");
+      expect(capturedSystem).toContain("Use local compiled memory.");
+      expect(capturedSystem).toContain("<memory_metadata>");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+
+  test("appends client skills per request without persisting them", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-skills-"));
+    try {
+      let capturedSystem: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        streamText: (options) => {
+          capturedSystem = options.system;
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+          };
+        },
+      });
+      const agent = await backend.createAgent({
+        name: "Skills Agent",
+        system: "base {CORE_MEMORY}",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(conversation.id, {
+          ...createBody("hello skills", agent.id),
+          client_skills: [
+            {
+              name: "pdf",
+              description: "Read PDFs",
+              location: "/repo/skills/pdf/SKILL.md",
+            },
+          ],
+        } as unknown as ConversationMessageCreateBody),
+      );
+
+      expect(capturedSystem).toContain("<available_skills>");
+      expect(capturedSystem).toContain("SKILL.md (Read PDFs)");
+      const persistedPrompts = await readPersistedSystemPrompts(storageDir);
+      expect(JSON.stringify(persistedPrompts)).not.toContain(
+        "<available_skills>",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("recompiles local system prompt after raw system changes", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-recompile-"),
+    );
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      const agent = await backend.createAgent({
+        name: "Recompile Agent",
+        system: "first {CORE_MEMORY}",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      const first = await backend.recompileConversation(conversation.id, {
+        agent_id: agent.id,
+        dry_run: true,
+      });
+      expect(first).toContain("first");
+
+      await backend.updateAgent(agent.id, { system: "second {CORE_MEMORY}" });
+      const promptsAfterUpdate = await readPersistedSystemPrompts(storageDir);
+      expect(JSON.stringify(promptsAfterUpdate)).not.toContain("first");
+
+      const second = await backend.recompileConversation(conversation.id, {
+        agent_id: agent.id,
+        dry_run: false,
+      });
+      expect(second).toContain("second");
+      const promptsAfterRecompile =
+        await readPersistedSystemPrompts(storageDir);
+      expect(JSON.stringify(promptsAfterRecompile)).toContain("second");
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/tests/backend/local-system-prompt-compilation.test.ts
+++ b/src/tests/backend/local-system-prompt-compilation.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { LocalAgentRecord } from "../../backend/local/LocalStore";
+import {
+  appendAvailableSkillsBlock,
+  compileAvailableSkillsBlock,
+  compileLocalSystemPrompt,
+  hashRawSystemPrompt,
+} from "../../backend/local/systemPromptCompilation";
+
+function agent(system = "base {CORE_MEMORY}"): LocalAgentRecord {
+  return {
+    id: "agent-local-test",
+    name: "Local Test",
+    description: null,
+    system,
+    tags: [],
+    model: "openai/gpt-test",
+    model_settings: { provider_type: "openai" },
+  };
+}
+
+async function writeMemoryFile(
+  memoryDir: string,
+  relativePath: string,
+  description: string,
+  body: string,
+) {
+  const fullPath = join(memoryDir, relativePath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(
+    fullPath,
+    `---\ndescription: ${description}\n---\n${body}\n`,
+    "utf8",
+  );
+}
+
+describe("local system prompt compilation", () => {
+  test("injects MemFS system files and metadata into CORE_MEMORY", async () => {
+    const memoryDir = await mkdtemp(join(tmpdir(), "local-prompt-memfs-"));
+    try {
+      await writeMemoryFile(
+        memoryDir,
+        "system/persona.md",
+        "Who the agent is",
+        "I am a local agent.",
+      );
+      await writeMemoryFile(
+        memoryDir,
+        "system/project/gotchas.md",
+        "Project gotchas",
+        "Use Bun for tests.",
+      );
+      await writeMemoryFile(
+        memoryDir,
+        "reference/details.md",
+        "Detailed reference",
+        "Only projected as an external file.",
+      );
+
+      const compiled = compileLocalSystemPrompt({
+        agent: agent("hello {CORE_MEMORY}"),
+        conversationId: "local-conv-test",
+        memoryDir,
+        now: new Date("2026-05-04T00:00:00.000Z"),
+        previousMessageCount: 7,
+      });
+
+      expect(compiled.rawSystemHash).toBe(
+        hashRawSystemPrompt("hello {CORE_MEMORY}"),
+      );
+      expect(compiled.content).toContain("hello Reminder: <projection>");
+      expect(compiled.content).toContain("<self>");
+      expect(compiled.content).toContain("I am a local agent.");
+      expect(compiled.content).toContain("<project>");
+      expect(compiled.content).toContain(
+        "<projection>$MEMORY_DIR/system/project/gotchas.md</projection>",
+      );
+      expect(compiled.content).toContain(
+        "<description>Project gotchas</description>",
+      );
+      expect(compiled.content).toContain("Use Bun for tests.");
+      expect(compiled.content).toContain("<external_projection>");
+      expect(compiled.content).toContain("reference/");
+      expect(compiled.content).toContain("details.md");
+      expect(compiled.content).toContain("<memory_metadata>");
+      expect(compiled.content).toContain("- AGENT_ID: agent-local-test");
+      expect(compiled.content).toContain("- CONVERSATION_ID: local-conv-test");
+      expect(compiled.content).toContain(
+        "- System prompt last recompiled: 2026-05-04 12:00:00 AM UTC+0000",
+      );
+      expect(compiled.content).toContain(
+        "- 7 previous messages between you and the user are stored in recall memory",
+      );
+    } finally {
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+
+  test("appends memory metadata when CORE_MEMORY is missing", () => {
+    const compiled = compileLocalSystemPrompt({
+      agent: agent("plain base prompt"),
+      conversationId: "local-conv-test",
+      memoryDir: join(tmpdir(), "missing-local-memory-dir"),
+      now: new Date("2026-05-04T00:00:00.000Z"),
+    });
+
+    expect(compiled.content).toStartWith("plain base prompt");
+    expect(compiled.content).toContain("<memory_metadata>");
+  });
+
+  test("renders available skills as request-scoped prompt content", () => {
+    const skillsBlock = compileAvailableSkillsBlock([
+      {
+        name: "pdf",
+        description: "Read and write PDFs\nLonger details are omitted",
+        location: "/repo/skills/pdf/SKILL.md",
+      },
+      {
+        name: "linear-cli",
+        description: "Manage Linear issues",
+        location: "/home/user/.letta/skills/linear-cli/SKILL.md",
+      },
+    ]);
+
+    expect(skillsBlock).toContain("<available_skills>");
+    expect(skillsBlock).toContain("/home/user/.letta/skills");
+    expect(skillsBlock).toContain(
+      "└── linear-cli/\n    └── SKILL.md (Manage Linear issues)",
+    );
+    expect(skillsBlock).toContain("/repo/skills");
+    expect(skillsBlock).toContain(
+      "└── pdf/\n    └── SKILL.md (Read and write PDFs)",
+    );
+
+    expect(appendAvailableSkillsBlock("compiled", [])).toBe("compiled");
+    expect(
+      appendAvailableSkillsBlock("compiled", [
+        {
+          name: "pdf",
+          description: "Read and write PDFs",
+          location: "/repo/skills/pdf/SKILL.md",
+        },
+      ]),
+    ).toContain("compiled\n\n<available_skills>");
+  });
+});

--- a/src/tests/backend/local-system-prompt-parity.e2e.test.ts
+++ b/src/tests/backend/local-system-prompt-parity.e2e.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from "bun:test";
+
+describe("local/API system prompt parity", () => {
+  test.skip("compares API dry-run recompile with local compiled MemFS prompt", async () => {
+    // TODO(LET-8726 follow-up): enable once local MemFS initialization/sync can
+    // create equivalent API-backed and local-backed agents in CI. The intended
+    // flow is:
+    // 1. create an API-backed MemFS agent and a local-backed agent with the same
+    //    raw system prompt and equivalent MemFS contents;
+    // 2. call API conversations.recompile(..., dry_run: true) and local
+    //    recompileConversation(..., dry_run: true);
+    // 3. normalize dynamic metadata (agent id, conversation id, timestamps, and
+    //    machine-specific memory roots);
+    // 4. assert the persisted compiled prompts match; and
+    // 5. separately assert request-scoped <available_skills> rendering because
+    //    API dry-run recompile intentionally does not persist client_skills.
+  });
+});


### PR DESCRIPTION
## Summary
- Add local MemFS system prompt compilation with per-conversation snapshots and stale detection when the raw system prompt changes.
- Route local AI SDK turns through compiled prompts while keeping `<available_skills>` request-scoped, matching the API backend shape.
- Enable MemFS prompt mode for local default agents and add coverage for local prompt compilation, recompile wiring, request-scoped skills, and a skipped API/local parity scaffold.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/backend --timeout 60000`
- [x] `bun test src/tests/cli/memory-subagent-recompile-wiring.test.ts src/tests/agent/recompile-system-prompt.test.ts --timeout 60000`

👾 Generated with [Letta Code](https://letta.com)