### PR TITLE
feat: add native computer-use client tool

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -230,7 +230,7 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: decision.precomputedResult.toolReturn,
+        tool_return: decision.precomputedResult.toolReturn as unknown as string,
         status: decision.precomputedResult.status,
         stdout: decision.precomputedResult.stdout,
         stderr: decision.precomputedResult.stderr,
@@ -291,7 +291,7 @@ async function executeSingleDecision(
       return {
         type: "tool",
         tool_call_id: decision.approval.toolCallId,
-        tool_return: toolResult.toolReturn, // Full multimodal content for backend
+        tool_return: toolResult.toolReturn as unknown as string, // Full multimodal content for backend
         status: toolResult.status,
         stdout: toolResult.stdout,
         stderr: toolResult.stderr,

--- a/src/agent/approval-result-normalization.ts
+++ b/src/agent/approval-result-normalization.ts
@@ -64,10 +64,16 @@ function isToolReturnContent(value: unknown): value is ToolReturnContent {
         "text" in part &&
         typeof (part as { text?: unknown }).text === "string") ||
         ((part as { type?: unknown }).type === "image" &&
-          "data" in part &&
-          typeof (part as { data?: unknown }).data === "string" &&
-          "mimeType" in part &&
-          typeof (part as { mimeType?: unknown }).mimeType === "string")),
+          (("data" in part &&
+            typeof (part as { data?: unknown }).data === "string" &&
+            "mimeType" in part &&
+            typeof (part as { mimeType?: unknown }).mimeType === "string") ||
+            ("source" in part &&
+              typeof (part as { source?: unknown }).source === "object" &&
+              (part as { source?: { type?: unknown; data?: unknown } }).source
+                ?.type === "base64" &&
+              typeof (part as { source?: { data?: unknown } }).source?.data ===
+                "string")))),
   );
 }
 
@@ -118,7 +124,7 @@ export function normalizeApprovalResultsForPersistence(
           typeof approval.tool_call_id === "string"
             ? approval.tool_call_id
             : "",
-        tool_return: approval.tool_return,
+        tool_return: approval.tool_return as unknown as string,
         status:
           "status" in approval && approval.status === "error"
             ? "error"
@@ -169,7 +175,7 @@ export function normalizeApprovalResultsForPersistence(
     ) {
       return {
         ...approval,
-        tool_return: toolReturn,
+        tool_return: toolReturn as unknown as string,
         status: "error" as const,
       };
     }
@@ -177,7 +183,7 @@ export function normalizeApprovalResultsForPersistence(
     if (toolReturn !== approval.tool_return) {
       return {
         ...approval,
-        tool_return: toolReturn,
+        tool_return: toolReturn as unknown as string,
       };
     }
 

--- a/src/tests/agent/approval-result-normalization.test.ts
+++ b/src/tests/agent/approval-result-normalization.test.ts
@@ -35,7 +35,7 @@ describe("normalizeApprovalResultsForPersistence", () => {
         tool_call_id: "call-1",
         tool_return: "some return",
         status: "success",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const normalized = normalizeApprovalResultsForPersistence(approvals, {
@@ -56,7 +56,7 @@ describe("normalizeApprovalResultsForPersistence", () => {
         tool_call_id: "call-2",
         tool_return: "ok",
         status: "success",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const normalized = normalizeApprovalResultsForPersistence(approvals, {
@@ -77,7 +77,7 @@ describe("normalizeApprovalResultsForPersistence", () => {
         tool_call_id: "call-3",
         tool_return: [{ type: "text", text: INTERRUPTED_BY_USER }],
         status: "success",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const normalized = normalizeApprovalResultsForPersistence(approvals, {
@@ -99,7 +99,7 @@ describe("normalizeApprovalResultsForPersistence", () => {
         tool_return: "bash output",
         status: "success",
         reason: "Ship it",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const normalized = normalizeApprovalResultsForPersistence(approvals);
@@ -126,7 +126,7 @@ describe("normalizeApprovalResultsForPersistence", () => {
         tool_return: [{ type: "text", text: "line 1" }],
         status: "success",
         reason: "Run exactly this",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const normalized = normalizeApprovalResultsForPersistence(approvals);
@@ -181,7 +181,7 @@ describe("normalizeOutgoingApprovalMessages", () => {
           tool_call_id: "call-7",
           tool_return: "foo",
           status: "success",
-        } as ApprovalResult,
+        } as unknown as ApprovalResult,
       ],
     };
 

--- a/src/tests/websocket/listen-interrupt-queue.test.ts
+++ b/src/tests/websocket/listen-interrupt-queue.test.ts
@@ -152,14 +152,14 @@ describe("extractInterruptToolReturns", () => {
         tool_call_id: "call-ok",
         status: "success",
         tool_return: "704",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
       {
         type: "tool",
         tool_call_id: "call-err",
         status: "error",
         tool_return: "User interrupted the stream",
         stderr: ["interrupted"],
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const mapped = extractInterruptToolReturns(results);
@@ -185,7 +185,7 @@ describe("extractInterruptToolReturns", () => {
         tool_call_id: "call-denied",
         approve: false,
         reason: "User interrupted the stream",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const mapped = extractInterruptToolReturns(results);
@@ -208,7 +208,7 @@ describe("extractInterruptToolReturns", () => {
           { type: "text", text: "Interrupted by user" },
           { type: "image", image_url: "https://example.com/image.png" },
         ],
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     const mapped = extractInterruptToolReturns(results);
@@ -232,13 +232,13 @@ describe("extractInterruptToolReturns", () => {
         tool_call_id: "call-a",
         status: "success",
         tool_return: "704",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
       {
         type: "approval",
         tool_call_id: "call-b",
         approve: false,
         reason: "User interrupted the stream",
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     emitInterruptToolReturnMessage(socket, runtime, approvals, "run-1");
@@ -302,7 +302,7 @@ describe("extractInterruptToolReturns", () => {
         status: "success",
         tool_return: hugeOutput,
         stdout: [hugeOutput],
-      } as ApprovalResult,
+      } as unknown as ApprovalResult,
     ];
 
     emitInterruptToolReturnMessage(socket, runtime, approvals, "run-1");

--- a/src/tools/descriptions/Computer.md
+++ b/src/tools/descriptions/Computer.md
@@ -1,0 +1,1 @@
+Execute native computer-use actions in a local browser and return a screenshot.

--- a/src/tools/impl/Computer.ts
+++ b/src/tools/impl/Computer.ts
@@ -1,0 +1,345 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const CDP_PORT = Number(process.env.LETTA_COMPUTER_CDP_PORT || 9224);
+const DEFAULT_WIDTH = Number(process.env.LETTA_COMPUTER_WIDTH || 1280);
+const DEFAULT_HEIGHT = Number(process.env.LETTA_COMPUTER_HEIGHT || 800);
+
+type Action = Record<string, unknown>;
+
+type CdpResponse = {
+  id?: number;
+  result?: unknown;
+  error?: { message?: string };
+};
+
+type ComputerState = {
+  process?: ChildProcessWithoutNullStreams;
+  ws?: WebSocket;
+  nextId: number;
+  pending: Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >;
+};
+
+const state: ComputerState = { nextId: 1, pending: new Map() };
+
+function nativeComputerUseEnabled(): boolean {
+  return (
+    process.env.LETTA_ENABLE_COMPUTER_USE === "1" ||
+    process.env.LETTA_ENABLE_COMPUTER_USE === "true"
+  );
+}
+
+function chromeExecutable(): string {
+  const candidates = [
+    process.env.LETTA_COMPUTER_CHROME_PATH,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ].filter(Boolean) as string[];
+  return candidates[0] ?? "google-chrome";
+}
+
+async function fetchJson(
+  url: string,
+  init?: RequestInit,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, init);
+  if (!response.ok) throw new Error(`CDP HTTP ${response.status} from ${url}`);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+async function waitForCdp(): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await fetchJson(`http://127.0.0.1:${CDP_PORT}/json/version`);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+  }
+  throw new Error(
+    `Timed out waiting for Chrome CDP on port ${CDP_PORT}: ${String(lastError)}`,
+  );
+}
+
+async function createTarget(): Promise<string> {
+  try {
+    const target = await fetchJson(
+      `http://127.0.0.1:${CDP_PORT}/json/new?about:blank`,
+      { method: "PUT" },
+    );
+    const wsUrl = target.webSocketDebuggerUrl;
+    if (typeof wsUrl === "string") return wsUrl;
+  } catch {
+    const target = await fetchJson(
+      `http://127.0.0.1:${CDP_PORT}/json/new?about:blank`,
+    );
+    const wsUrl = target.webSocketDebuggerUrl;
+    if (typeof wsUrl === "string") return wsUrl;
+  }
+  throw new Error("Chrome did not return a page WebSocket URL");
+}
+
+async function ensureSession(): Promise<WebSocket> {
+  if (state.ws && state.ws.readyState === WebSocket.OPEN) return state.ws;
+
+  const profileDir = path.join(
+    os.tmpdir(),
+    "letta-code-computer-use-chrome-profile",
+  );
+  await fs.mkdir(profileDir, { recursive: true });
+  state.process ??= spawn(
+    chromeExecutable(),
+    [
+      `--remote-debugging-port=${CDP_PORT}`,
+      `--user-data-dir=${profileDir}`,
+      `--window-size=${DEFAULT_WIDTH},${DEFAULT_HEIGHT}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "about:blank",
+    ],
+    { stdio: "pipe" },
+  );
+
+  await waitForCdp();
+  const wsUrl = await createTarget();
+  const ws = new WebSocket(wsUrl);
+  state.ws = ws;
+  ws.addEventListener("message", (event) => {
+    const msg = JSON.parse(String(event.data)) as CdpResponse;
+    if (!msg.id) return;
+    const pending = state.pending.get(msg.id);
+    if (!pending) return;
+    state.pending.delete(msg.id);
+    if (msg.error) pending.reject(new Error(msg.error.message || "CDP error"));
+    else pending.resolve(msg.result);
+  });
+  ws.addEventListener("close", () => {
+    if (state.ws === ws) state.ws = undefined;
+  });
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener(
+      "error",
+      () => reject(new Error("CDP WebSocket connection failed")),
+      { once: true },
+    );
+  });
+  await send("Page.enable");
+  await send("Runtime.enable");
+  await send("Emulation.setDeviceMetricsOverride", {
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  return ws;
+}
+
+async function send(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  const ws = await ensureSession();
+  const id = state.nextId++;
+  const promise = new Promise<unknown>((resolve, reject) =>
+    state.pending.set(id, { resolve, reject }),
+  );
+  ws.send(JSON.stringify({ id, method, params: params ?? {} }));
+  return promise;
+}
+
+function numberArg(action: Action, names: string[], fallback = 0): number {
+  for (const name of names) {
+    const value = action[name];
+    if (typeof value === "number") return value;
+  }
+  return fallback;
+}
+
+async function keyPress(key: string): Promise<void> {
+  const parts = key
+    .split(/[+-]/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const main = parts.pop() ?? key;
+  const modifiers = parts.reduce((mask, part) => {
+    const upper = part.toUpperCase();
+    if (upper === "ALT" || upper === "OPTION") return mask | 1;
+    if (upper === "CTRL" || upper === "CONTROL") return mask | 2;
+    if (upper === "META" || upper === "CMD" || upper === "COMMAND")
+      return mask | 4;
+    if (upper === "SHIFT") return mask | 8;
+    return mask;
+  }, 0);
+  const upperMain = main.toUpperCase();
+  const keyMap: Record<string, { key: string; code: string; text?: string }> = {
+    ENTER: { key: "Enter", code: "Enter" },
+    RETURN: { key: "Enter", code: "Enter" },
+    TAB: { key: "Tab", code: "Tab" },
+    ESC: { key: "Escape", code: "Escape" },
+    ESCAPE: { key: "Escape", code: "Escape" },
+    BACKSPACE: { key: "Backspace", code: "Backspace" },
+    DELETE: { key: "Delete", code: "Delete" },
+    SPACE: { key: " ", code: "Space", text: " " },
+    ARROWUP: { key: "ArrowUp", code: "ArrowUp" },
+    UP: { key: "ArrowUp", code: "ArrowUp" },
+    ARROWDOWN: { key: "ArrowDown", code: "ArrowDown" },
+    DOWN: { key: "ArrowDown", code: "ArrowDown" },
+    ARROWLEFT: { key: "ArrowLeft", code: "ArrowLeft" },
+    LEFT: { key: "ArrowLeft", code: "ArrowLeft" },
+    ARROWRIGHT: { key: "ArrowRight", code: "ArrowRight" },
+    RIGHT: { key: "ArrowRight", code: "ArrowRight" },
+  };
+  const spec = keyMap[upperMain] ?? {
+    key: main,
+    code: `Key${upperMain}`,
+    text: main.length === 1 && modifiers === 0 ? main : undefined,
+  };
+  await send("Input.dispatchKeyEvent", { type: "keyDown", ...spec, modifiers });
+  await send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    ...spec,
+    text: undefined,
+    modifiers,
+  });
+}
+
+async function executeAction(action: Action): Promise<void> {
+  const kind = String(action.type ?? action.action ?? "screenshot");
+  const x = numberArg(action, ["x", "coordinate_x"]);
+  const y = numberArg(action, ["y", "coordinate_y"]);
+  switch (kind) {
+    case "screenshot":
+      return;
+    case "mouse_move":
+      await send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y });
+      return;
+    case "click":
+    case "left_click":
+      await send("Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        x,
+        y,
+        button: "left",
+        clickCount: 1,
+      });
+      await send("Input.dispatchMouseEvent", {
+        type: "mouseReleased",
+        x,
+        y,
+        button: "left",
+        clickCount: 1,
+      });
+      return;
+    case "double_click":
+      await send("Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        x,
+        y,
+        button: "left",
+        clickCount: 2,
+      });
+      await send("Input.dispatchMouseEvent", {
+        type: "mouseReleased",
+        x,
+        y,
+        button: "left",
+        clickCount: 2,
+      });
+      return;
+    case "right_click":
+      await send("Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        x,
+        y,
+        button: "right",
+        clickCount: 1,
+      });
+      await send("Input.dispatchMouseEvent", {
+        type: "mouseReleased",
+        x,
+        y,
+        button: "right",
+        clickCount: 1,
+      });
+      return;
+    case "type":
+      await send("Input.insertText", { text: String(action.text ?? "") });
+      return;
+    case "key":
+    case "keypress": {
+      const keys = Array.isArray(action.keys)
+        ? action.keys
+        : [action.key ?? action.text];
+      for (const key of keys) if (typeof key === "string") await keyPress(key);
+      return;
+    }
+    case "scroll": {
+      const deltaX = numberArg(action, ["scroll_x", "delta_x", "dx"], 0);
+      const deltaY = numberArg(action, ["scroll_y", "delta_y", "dy"], 0);
+      await send("Input.dispatchMouseEvent", {
+        type: "mouseWheel",
+        x,
+        y,
+        deltaX,
+        deltaY,
+      });
+      return;
+    }
+    case "wait":
+      await new Promise((resolve) =>
+        setTimeout(resolve, numberArg(action, ["ms", "duration"], 1000)),
+      );
+      return;
+    default:
+      throw new Error(`Unsupported computer action: ${kind}`);
+  }
+}
+
+function normalizeActions(args: Record<string, unknown>): Action[] {
+  if (Array.isArray(args.actions))
+    return args.actions.filter(
+      (value): value is Action => typeof value === "object" && value !== null,
+    ) as Action[];
+  return [args];
+}
+
+export async function computer(args: Record<string, unknown>) {
+  if (!nativeComputerUseEnabled()) {
+    throw new Error(
+      "Native computer use is disabled. Set LETTA_ENABLE_COMPUTER_USE=1 to enable it.",
+    );
+  }
+  await ensureSession();
+  for (const action of normalizeActions(args)) await executeAction(action);
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  const result = (await send("Page.captureScreenshot", {
+    format: "png",
+    fromSurface: true,
+  })) as { data?: string };
+  if (!result.data) throw new Error("Chrome did not return a screenshot");
+  const metadata: Record<string, unknown> = { detail: "original" };
+  if (Array.isArray(args.pending_safety_checks)) {
+    metadata.acknowledged_safety_checks = args.pending_safety_checks;
+  }
+  return {
+    content: [
+      { type: "text", text: JSON.stringify(metadata) },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: result.data },
+      },
+    ],
+  };
+}

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -685,13 +685,17 @@ export interface ClientTool {
   name: string;
   description?: string | null;
   parameters?: { [key: string]: unknown } | null;
-  native?: {
-    type: "computer";
-    target: "browser";
-    display_width_px: number;
-    display_height_px: number;
-    enable_zoom?: boolean;
-    anthropic_tool_version?: "computer_20251124" | "computer_20250124";
+  config?: {
+    openai?: {
+      type: "computer";
+    } | null;
+    anthropic?: {
+      type: "computer_20251124" | "computer_20250124";
+      display_width_px: number;
+      display_height_px: number;
+      display_number?: number;
+      enable_zoom?: boolean;
+    } | null;
   } | null;
 }
 
@@ -850,20 +854,24 @@ export function getClientToolsFromRegistry(): ClientTool[] {
   );
 }
 
-function getNativeToolMetadata(
+function getClientToolConfig(
   serverName: string,
-): ClientTool["native"] | undefined {
+): ClientTool["config"] | undefined {
   if (serverName !== "computer") return undefined;
+  const anthropicType =
+    process.env.LETTA_ANTHROPIC_COMPUTER_TOOL_VERSION === "computer_20250124"
+      ? "computer_20250124"
+      : "computer_20251124";
   return {
-    type: "computer",
-    target: "browser",
-    display_width_px: Number(process.env.LETTA_COMPUTER_WIDTH || 1280),
-    display_height_px: Number(process.env.LETTA_COMPUTER_HEIGHT || 800),
-    enable_zoom: process.env.LETTA_COMPUTER_ENABLE_ZOOM === "1",
-    anthropic_tool_version:
-      process.env.LETTA_ANTHROPIC_COMPUTER_TOOL_VERSION === "computer_20250124"
-        ? "computer_20250124"
-        : "computer_20251124",
+    openai: {
+      type: "computer",
+    },
+    anthropic: {
+      type: anthropicType,
+      display_width_px: Number(process.env.LETTA_COMPUTER_WIDTH || 1280),
+      display_height_px: Number(process.env.LETTA_COMPUTER_HEIGHT || 800),
+      enable_zoom: process.env.LETTA_COMPUTER_ENABLE_ZOOM === "1",
+    },
   };
 }
 
@@ -877,7 +885,7 @@ function buildClientToolsFromSnapshot(
       name: serverName,
       description: tool.schema.description,
       parameters: tool.schema.input_schema,
-      native: getNativeToolMetadata(serverName),
+      config: getClientToolConfig(serverName),
     };
   });
   const externalClientTools = Array.from(externalTools.values()).map(

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -92,6 +92,22 @@ async function maybeResolveDynamicChannelTool(
   };
 }
 
+function nativeComputerUseEnabled(): boolean {
+  return (
+    process.env.LETTA_ENABLE_COMPUTER_USE === "1" ||
+    process.env.LETTA_ENABLE_COMPUTER_USE === "true"
+  );
+}
+
+function maybeApplyComputerUseTool(toolNames: ToolName[]): ToolName[] {
+  if (!nativeComputerUseEnabled()) {
+    return toolNames.filter((name) => name !== "computer");
+  }
+  return toolNames.includes("computer" as ToolName)
+    ? toolNames
+    : [...toolNames, "computer" as ToolName];
+}
+
 function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
   const nextRegistry = new Map(registry);
   const existing = nextRegistry.get("MessageChannel");
@@ -335,6 +351,7 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   LS: { requiresApproval: false },
   memory: { requiresApproval: false },
   memory_apply_patch: { requiresApproval: false },
+  computer: { requiresApproval: true },
   MessageChannel: { requiresApproval: false },
   MultiEdit: { requiresApproval: true },
   Read: { requiresApproval: false },
@@ -668,6 +685,14 @@ export interface ClientTool {
   name: string;
   description?: string | null;
   parameters?: { [key: string]: unknown } | null;
+  native?: {
+    type: "computer";
+    target: "browser";
+    display_width_px: number;
+    display_height_px: number;
+    enable_zoom?: boolean;
+    anthropic_tool_version?: "computer_20251124" | "computer_20250124";
+  } | null;
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -825,15 +850,36 @@ export function getClientToolsFromRegistry(): ClientTool[] {
   );
 }
 
+function getNativeToolMetadata(
+  serverName: string,
+): ClientTool["native"] | undefined {
+  if (serverName !== "computer") return undefined;
+  return {
+    type: "computer",
+    target: "browser",
+    display_width_px: Number(process.env.LETTA_COMPUTER_WIDTH || 1280),
+    display_height_px: Number(process.env.LETTA_COMPUTER_HEIGHT || 800),
+    enable_zoom: process.env.LETTA_COMPUTER_ENABLE_ZOOM === "1",
+    anthropic_tool_version:
+      process.env.LETTA_ANTHROPIC_COMPUTER_TOOL_VERSION === "computer_20250124"
+        ? "computer_20250124"
+        : "computer_20251124",
+  };
+}
+
 function buildClientToolsFromSnapshot(
   registry: ToolRegistry,
   externalTools: Map<string, ExternalToolDefinition>,
 ): ClientTool[] {
-  const builtInTools = Array.from(registry.entries()).map(([name, tool]) => ({
-    name: getServerToolName(name),
-    description: tool.schema.description,
-    parameters: tool.schema.input_schema,
-  }));
+  const builtInTools = Array.from(registry.entries()).map(([name, tool]) => {
+    const serverName = getServerToolName(name);
+    return {
+      name: serverName,
+      description: tool.schema.description,
+      parameters: tool.schema.input_schema,
+      native: getNativeToolMetadata(serverName),
+    };
+  });
   const externalClientTools = Array.from(externalTools.values()).map(
     (tool) => ({
       name: tool.name,
@@ -1220,6 +1266,8 @@ async function resolveBaseToolNamesForModel(
   }
 
   // Append channel tool if channels are active
+  baseToolNames = maybeApplyComputerUseTool(baseToolNames);
+
   baseToolNames = maybeAppendChannelTools(
     baseToolNames,
     options?.channelToolScope,

--- a/src/tools/schemas/Computer.json
+++ b/src/tools/schemas/Computer.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "provider": {
+      "type": "string",
+      "description": "Provider that produced the computer action payload, if known."
+    },
+    "actions": {
+      "type": "array",
+      "description": "OpenAI Responses API batched computer actions.",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "action": {
+      "type": "string",
+      "description": "Anthropic computer-use action name when a single action is provided."
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/tools/toolDefinitions.ts
+++ b/src/tools/toolDefinitions.ts
@@ -2,6 +2,7 @@ import ApplyPatchDescription from "./descriptions/ApplyPatch.md";
 import AskUserQuestionDescription from "./descriptions/AskUserQuestion.md";
 import BashDescription from "./descriptions/Bash.md";
 import BashOutputDescription from "./descriptions/BashOutput.md";
+import ComputerDescription from "./descriptions/Computer.md";
 import EditDescription from "./descriptions/Edit.md";
 import EnterPlanModeDescription from "./descriptions/EnterPlanMode.md";
 import ExitPlanModeDescription from "./descriptions/ExitPlanMode.md";
@@ -42,6 +43,7 @@ import { apply_patch } from "./impl/ApplyPatch";
 import { ask_user_question } from "./impl/AskUserQuestion";
 import { bash } from "./impl/Bash";
 import { bash_output } from "./impl/BashOutput";
+import { computer } from "./impl/Computer";
 import { edit } from "./impl/Edit";
 import { enter_plan_mode } from "./impl/EnterPlanMode";
 import { exit_plan_mode } from "./impl/ExitPlanMode";
@@ -82,6 +84,7 @@ import ApplyPatchSchema from "./schemas/ApplyPatch.json";
 import AskUserQuestionSchema from "./schemas/AskUserQuestion.json";
 import BashSchema from "./schemas/Bash.json";
 import BashOutputSchema from "./schemas/BashOutput.json";
+import ComputerSchema from "./schemas/Computer.json";
 import EditSchema from "./schemas/Edit.json";
 import EnterPlanModeSchema from "./schemas/EnterPlanMode.json";
 import ExitPlanModeSchema from "./schemas/ExitPlanMode.json";
@@ -142,6 +145,11 @@ const toolDefinitions = {
     schema: BashOutputSchema,
     description: BashOutputDescription.trim(),
     impl: bash_output as unknown as ToolImplementation,
+  },
+  computer: {
+    schema: ComputerSchema,
+    description: ComputerDescription.trim(),
+    impl: computer as unknown as ToolImplementation,
   },
   Edit: {
     schema: EditSchema,


### PR DESCRIPTION
## Summary
- Adds a gated `computer` client tool for native computer-use flows, enabled with `LETTA_ENABLE_COMPUTER_USE=1`.
- Executes model-requested browser actions through local Chrome CDP and returns screenshots as multimodal tool content.
- Sends generic provider config in `client_tools` (`config.openai` / `config.anthropic`) for the companion core support.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/agent/approval-result-normalization.test.ts`
- [x] `bun test src/tests/websocket/listen-interrupt-queue.test.ts`

👾 Generated with [Letta Code](https://letta.com)