### PR TITLE
refactor(listener): extract model toolset commands

### DIFF
--- a/src/tests/websocket/listen-model-update.test.ts
+++ b/src/tests/websocket/listen-model-update.test.ts
@@ -12,6 +12,16 @@ import { __listenClientTestUtils } from "../../websocket/listen-client";
  * verify wiring that can't be tested without mocking API calls.
  */
 
+function readModelToolsetCommandSource(): string {
+  const commandPath = fileURLToPath(
+    new URL(
+      "../../websocket/listener/commands/model-toolset.ts",
+      import.meta.url,
+    ),
+  );
+  return readFileSync(commandPath, "utf-8");
+}
+
 describe("listen-client model update status message", () => {
   test("emits only model name when toolset did not change", () => {
     const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
@@ -153,10 +163,7 @@ describe("listen-client model update status message", () => {
 
 describe("listen-client applyModelUpdateForRuntime wiring", () => {
   test("uses scoped runtime tool snapshots for change detection and wraps toolset refresh in try/catch", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // Toolset change detection should compare scoped loaded-tool snapshots,
     // not the mutable process-global registry.
@@ -183,10 +190,7 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
   });
 
   test("routes default conversations to agent update and non-default to conversation update", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // Agent-scoped update for default conversation
     expect(source).toContain('conversationId === "default"');
@@ -202,10 +206,7 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
 
 describe("listen-client list_models response wiring", () => {
   test("buildListModelsResponse is async and uses Promise.allSettled for parallel fetches", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // The response builder should use Promise.allSettled for parallel fetches
     expect(source).toContain("Promise.allSettled");
@@ -215,20 +216,14 @@ describe("listen-client list_models response wiring", () => {
   });
 
   test("handler uses async pattern with buildListModelsResponse", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // Handler should be wrapped in void (async () => { ... })() pattern
     expect(source).toContain("buildListModelsResponse(parsed.request_id)");
   });
 
   test("response type includes available_handles and byok_provider_aliases fields", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // The response payload should include the new fields
     expect(source).toContain("available_handles: availableHandles");
@@ -236,10 +231,7 @@ describe("listen-client list_models response wiring", () => {
   });
 
   test("available_handles is null when availability fetch fails (degraded path)", () => {
-    const clientPath = fileURLToPath(
-      new URL("../../websocket/listener/client.ts", import.meta.url),
-    );
-    const source = readFileSync(clientPath, "utf-8");
+    const source = readModelToolsetCommandSource();
 
     // Should handle rejected availability fetch by returning null
     expect(source).toContain('handlesResult.status === "fulfilled"');

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -8,12 +8,7 @@ import path from "node:path";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import WebSocket from "ws";
-import { getAvailableModelHandles } from "../../agent/available-models";
-import { getModelInfo, models, resolveModel } from "../../agent/model";
-import {
-  updateAgentLLMConfig,
-  updateConversationLLMConfig,
-} from "../../agent/modify";
+import { resolveModel } from "../../agent/model";
 import { getBackend } from "../../backend";
 import {
   channelPluginConfigShouldRefreshDisplayName,
@@ -59,10 +54,6 @@ import {
   stopScheduler as stopCronScheduler,
 } from "../../cron/scheduler";
 import { experimentManager } from "../../experiments/manager";
-import {
-  buildByokProviderAliases,
-  listProviders,
-} from "../../providers/byok-providers";
 import { type DequeuedBatch, QueueRuntime } from "../../queue/queueRuntime";
 import { createSharedReminderState } from "../../reminders/state";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
@@ -70,13 +61,6 @@ import { settingsManager } from "../../settings-manager";
 import { telemetry } from "../../telemetry";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
 import { loadTools } from "../../tools/manager";
-import {
-  ensureCorrectMemoryTool,
-  prepareToolExecutionContextForScope,
-  type ToolsetName,
-  type ToolsetPreference,
-} from "../../tools/toolset";
-import { formatToolsetName } from "../../tools/toolset-labels";
 import type {
   AbortMessageCommand,
   ApprovalResponseBody,
@@ -112,8 +96,6 @@ import type {
   GetExperimentsResponseMessage,
   GetReflectionSettingsCommand,
   ListMemoryCommand,
-  ListModelsResponseMessage,
-  ListModelsResponseModelEntry,
   ChannelAccountSnapshot as ProtocolChannelAccountSnapshot,
   ChannelConfigSnapshot as ProtocolChannelConfigSnapshot,
   ReflectionSettingsScope,
@@ -122,8 +104,6 @@ import type {
   SetReflectionSettingsCommand,
   SkillDisableCommand,
   SkillEnableCommand,
-  UpdateModelResponseMessage,
-  UpdateToolsetResponseMessage,
 } from "../../types/protocol_v2";
 import { isDebugEnabled } from "../../utils/debug";
 import {
@@ -143,6 +123,14 @@ import {
 } from "./approval";
 import { handleExecuteCommand } from "./commands";
 import { handleGitBranchCommand } from "./commands/git-branches";
+import {
+  applyModelUpdateForRuntime,
+  buildListModelsEntries,
+  buildListModelsResponse,
+  buildModelUpdateStatusMessage,
+  handleModelToolsetCommand,
+  resolveModelForUpdate,
+} from "./commands/model-toolset";
 import { handleSecretsCommand } from "./commands/secrets";
 import {
   INITIAL_RETRY_DELAY_MS,
@@ -207,7 +195,6 @@ import {
   isGrepInFilesCommand,
   isListInDirectoryCommand,
   isListMemoryCommand,
-  isListModelsCommand,
   isMemoryCommitDiffCommand,
   isMemoryFileAtRefCommand,
   isMemoryHistoryCommand,
@@ -219,8 +206,6 @@ import {
   isSkillDisableCommand,
   isSkillEnableCommand,
   isUnwatchFileCommand,
-  isUpdateModelCommand,
-  isUpdateToolsetCommand,
   isWatchFileCommand,
   isWriteFileCommand,
   isWriteMemoryFileCommand,
@@ -236,7 +221,6 @@ import {
   emitRetryDelta,
   emitRuntimeStateUpdates,
   emitStateSync,
-  emitStatusDelta,
   emitStreamDelta,
   emitSubagentStateIfOpen,
   scheduleQueueEmit,
@@ -662,400 +646,6 @@ type CronCommand =
   | CronGetCommand
   | CronDeleteCommand
   | CronDeleteAllCommand;
-
-type ResolvedModelForUpdate = {
-  id: string;
-  handle: string;
-  label: string;
-  updateArgs?: Record<string, unknown>;
-};
-
-function resolveModelForUpdate(payload: {
-  model_id?: string;
-  model_handle?: string;
-}): ResolvedModelForUpdate | null {
-  if (typeof payload.model_id === "string" && payload.model_id.length > 0) {
-    const byId = getModelInfo(payload.model_id);
-    if (byId) {
-      // When an explicit model_handle is also provided (e.g. BYOK tier
-      // changes), use the model_id entry for updateArgs/label but preserve
-      // the caller-specified handle so the BYOK identity is maintained
-      // end-to-end.
-      const explicitHandle =
-        typeof payload.model_handle === "string" &&
-        payload.model_handle.length > 0
-          ? payload.model_handle
-          : null;
-
-      return {
-        id: byId.id,
-        handle: explicitHandle ?? byId.handle,
-        label: byId.label,
-        updateArgs:
-          byId.updateArgs && typeof byId.updateArgs === "object"
-            ? ({ ...byId.updateArgs } as Record<string, unknown>)
-            : undefined,
-      };
-    }
-  }
-
-  if (
-    typeof payload.model_handle === "string" &&
-    payload.model_handle.length > 0
-  ) {
-    const exactByHandle = models.find((m) => m.handle === payload.model_handle);
-    if (exactByHandle) {
-      return {
-        id: exactByHandle.id,
-        handle: exactByHandle.handle,
-        label: exactByHandle.label,
-        updateArgs:
-          exactByHandle.updateArgs &&
-          typeof exactByHandle.updateArgs === "object"
-            ? ({ ...exactByHandle.updateArgs } as Record<string, unknown>)
-            : undefined,
-      };
-    }
-
-    return {
-      id: payload.model_handle,
-      handle: payload.model_handle,
-      label: payload.model_handle,
-      updateArgs: undefined,
-    };
-  }
-
-  return null;
-}
-
-function formatToolsetStatusMessageForModelUpdate(params: {
-  nextToolset: ToolsetName;
-  toolsetPreference: ToolsetName | "auto";
-}): string {
-  const { nextToolset, toolsetPreference } = params;
-
-  if (toolsetPreference === "auto") {
-    return (
-      "Toolset auto-switched for this model: now using the " +
-      formatToolsetName(nextToolset) +
-      " toolset."
-    );
-  }
-
-  return (
-    "Manual toolset override remains active: " +
-    formatToolsetName(toolsetPreference) +
-    "."
-  );
-}
-
-function formatEffortSuffix(
-  modelLabel: string,
-  updateArgs?: Record<string, unknown>,
-): string {
-  if (!updateArgs) return "";
-  const effort = updateArgs.reasoning_effort;
-  if (typeof effort !== "string" || effort.length === 0) return "";
-  const xhighLabel = modelLabel.includes("Opus 4.7") ? "Extra-High" : "Max";
-  const labels: Record<string, string> = {
-    none: "No Reasoning",
-    low: "Low",
-    medium: "Medium",
-    high: "High",
-    xhigh: xhighLabel,
-    max: "Max",
-  };
-  return ` (${labels[effort] ?? effort})`;
-}
-
-function buildModelUpdateStatusMessage(params: {
-  modelLabel: string;
-  toolsetChanged: boolean;
-  toolsetError: string | null;
-  nextToolset: ToolsetName;
-  toolsetPreference: ToolsetName | "auto";
-  updateArgs?: Record<string, unknown>;
-}): { message: string; level: "info" | "warning" } {
-  const {
-    modelLabel,
-    toolsetChanged,
-    toolsetError,
-    nextToolset,
-    toolsetPreference,
-    updateArgs,
-  } = params;
-  let message = `Model updated to ${modelLabel}${formatEffortSuffix(modelLabel, updateArgs)}.`;
-  if (toolsetError) {
-    message += ` Warning: toolset switch failed (${toolsetError}).`;
-    return { message, level: "warning" };
-  }
-  if (toolsetChanged) {
-    message += ` ${formatToolsetStatusMessageForModelUpdate({
-      nextToolset,
-      toolsetPreference,
-    })}`;
-  }
-  return { message, level: "info" };
-}
-
-async function applyModelUpdateForRuntime(params: {
-  socket: WebSocket;
-  listener: ListenerRuntime;
-  scopedRuntime: ConversationRuntime;
-  requestId: string;
-  model: ResolvedModelForUpdate;
-}): Promise<UpdateModelResponseMessage> {
-  const { socket, listener, scopedRuntime, requestId, model } = params;
-  const agentId = scopedRuntime.agentId;
-  const conversationId = scopedRuntime.conversationId;
-
-  if (!agentId) {
-    return {
-      type: "update_model_response",
-      request_id: requestId,
-      success: false,
-      error: "Missing agent_id in runtime scope",
-    };
-  }
-
-  const isDefaultConversation = conversationId === "default";
-
-  const updateArgs = {
-    ...(model.updateArgs ?? {}),
-    parallel_tool_calls: true,
-  };
-
-  let modelSettings: Record<string, unknown> | null = null;
-  let appliedTo: "agent" | "conversation";
-
-  if (isDefaultConversation) {
-    const updatedAgent = await updateAgentLLMConfig(
-      agentId,
-      model.handle,
-      updateArgs,
-    );
-    modelSettings =
-      (updatedAgent.model_settings as
-        | Record<string, unknown>
-        | null
-        | undefined) ?? null;
-    appliedTo = "agent";
-  } else {
-    const updatedConversation = await updateConversationLLMConfig(
-      conversationId,
-      model.handle,
-      updateArgs,
-      { preserveContextWindow: false },
-    );
-    modelSettings =
-      ((
-        updatedConversation as {
-          model_settings?: Record<string, unknown> | null;
-        }
-      ).model_settings as Record<string, unknown> | null | undefined) ?? null;
-    appliedTo = "conversation";
-  }
-
-  const toolsetPreference = settingsManager.getToolsetPreference(agentId);
-  const previousToolNames = scopedRuntime.currentLoadedTools;
-  let nextToolset: ToolsetName;
-  let nextLoadedTools: string[] = previousToolNames;
-  let toolsetError: string | null = null;
-
-  try {
-    await ensureCorrectMemoryTool(agentId, model.handle);
-    const preparedToolContext = await prepareToolExecutionContextForScope({
-      agentId,
-      conversationId,
-      overrideModel: model.handle,
-    });
-    nextToolset = preparedToolContext.toolset;
-    nextLoadedTools = preparedToolContext.preparedToolContext.loadedToolNames;
-    scopedRuntime.currentToolset = preparedToolContext.toolset;
-    scopedRuntime.currentToolsetPreference =
-      preparedToolContext.toolsetPreference;
-    scopedRuntime.currentLoadedTools = nextLoadedTools;
-  } catch (error) {
-    nextToolset = toolsetPreference === "auto" ? "default" : toolsetPreference;
-    toolsetError =
-      error instanceof Error ? error.message : "Failed to switch toolset";
-  }
-
-  // Only mention toolset in the status message when it actually changed
-  const toolsetChanged =
-    !toolsetError &&
-    JSON.stringify(previousToolNames) !== JSON.stringify(nextLoadedTools);
-  const { message: statusMessage, level: statusLevel } =
-    buildModelUpdateStatusMessage({
-      modelLabel: model.label,
-      toolsetChanged,
-      toolsetError,
-      nextToolset,
-      toolsetPreference,
-      updateArgs: model.updateArgs,
-    });
-
-  emitStatusDelta(socket, scopedRuntime, {
-    message: statusMessage,
-    level: statusLevel,
-    agentId,
-    conversationId,
-  });
-
-  emitRuntimeStateUpdates(listener, {
-    agent_id: agentId,
-    conversation_id: conversationId,
-  });
-
-  return {
-    type: "update_model_response",
-    request_id: requestId,
-    success: true,
-    runtime: {
-      agent_id: agentId,
-      conversation_id: conversationId,
-    },
-    applied_to: appliedTo,
-    model_id: model.id,
-    model_handle: model.handle,
-    model_settings: modelSettings,
-  };
-}
-
-async function applyToolsetUpdateForRuntime(params: {
-  socket: WebSocket;
-  listener: ListenerRuntime;
-  scopedRuntime: ConversationRuntime;
-  requestId: string;
-  toolsetPreference: ToolsetPreference;
-}): Promise<UpdateToolsetResponseMessage> {
-  const { socket, listener, scopedRuntime, requestId, toolsetPreference } =
-    params;
-  const agentId = scopedRuntime.agentId;
-  const conversationId = scopedRuntime.conversationId;
-
-  if (!agentId) {
-    return {
-      type: "update_toolset_response",
-      request_id: requestId,
-      success: false,
-      error: "Missing agent_id in runtime scope",
-    };
-  }
-
-  const previousToolNames = scopedRuntime.currentLoadedTools;
-  let nextToolset: ToolsetName;
-  const previousToolsetPreference = (() => {
-    try {
-      return settingsManager.getToolsetPreference(agentId);
-    } catch {
-      return scopedRuntime.currentToolsetPreference;
-    }
-  })();
-
-  try {
-    settingsManager.setToolsetPreference(agentId, toolsetPreference);
-    const preparedToolContext = await prepareToolExecutionContextForScope({
-      agentId,
-      conversationId,
-    });
-    nextToolset = preparedToolContext.toolset;
-    scopedRuntime.currentToolset = preparedToolContext.toolset;
-    scopedRuntime.currentToolsetPreference =
-      preparedToolContext.toolsetPreference;
-    scopedRuntime.currentLoadedTools =
-      preparedToolContext.preparedToolContext.loadedToolNames;
-  } catch (error) {
-    settingsManager.setToolsetPreference(agentId, previousToolsetPreference);
-    throw error;
-  }
-
-  const toolsChanged =
-    JSON.stringify(previousToolNames) !==
-    JSON.stringify(scopedRuntime.currentLoadedTools);
-
-  const statusMessage =
-    toolsetPreference === "auto"
-      ? `Toolset mode set to auto (currently ${formatToolsetName(nextToolset)}).`
-      : `Switched toolset to ${formatToolsetName(nextToolset)} (manual override).`;
-
-  emitStatusDelta(socket, scopedRuntime, {
-    message: statusMessage,
-    level: toolsChanged ? "info" : "info",
-    agentId,
-    conversationId,
-  });
-
-  emitRuntimeStateUpdates(listener, {
-    agent_id: agentId,
-    conversation_id: conversationId,
-  });
-
-  return {
-    type: "update_toolset_response",
-    request_id: requestId,
-    success: true,
-    runtime: {
-      agent_id: agentId,
-      conversation_id: conversationId,
-    },
-    current_toolset: nextToolset,
-    current_toolset_preference: toolsetPreference,
-  };
-}
-
-function buildListModelsEntries(): ListModelsResponseModelEntry[] {
-  return models.map((model) => ({
-    id: model.id,
-    handle: model.handle,
-    label: model.label,
-    description: model.description,
-    ...(typeof model.isDefault === "boolean"
-      ? { isDefault: model.isDefault }
-      : {}),
-    ...(typeof model.isFeatured === "boolean"
-      ? { isFeatured: model.isFeatured }
-      : {}),
-    ...(typeof model.free === "boolean" ? { free: model.free } : {}),
-    ...(model.updateArgs && typeof model.updateArgs === "object"
-      ? { updateArgs: model.updateArgs as Record<string, unknown> }
-      : {}),
-  }));
-}
-
-/**
- * Build the full list_models_response payload, including availability data.
- * Fetches available handles and BYOK provider aliases in parallel (best-effort).
- */
-async function buildListModelsResponse(
-  requestId: string,
-): Promise<ListModelsResponseMessage> {
-  const entries = buildListModelsEntries();
-
-  const [handlesResult, providersResult] = await Promise.allSettled([
-    getAvailableModelHandles(),
-    listProviders(),
-  ]);
-
-  const availableHandles: string[] | null =
-    handlesResult.status === "fulfilled"
-      ? [...handlesResult.value.handles]
-      : null;
-
-  // listProviders already degrades to [] on failure, but handle rejection too
-  const providers =
-    providersResult.status === "fulfilled" ? providersResult.value : [];
-  const byokProviderAliases = buildByokProviderAliases(providers);
-
-  return {
-    type: "list_models_response",
-    request_id: requestId,
-    success: true,
-    entries,
-    available_handles: availableHandles,
-    byok_provider_aliases: byokProviderAliases,
-  };
-}
 
 type ReflectionSettingsCommand =
   | GetReflectionSettingsCommand
@@ -5581,152 +5171,15 @@ async function connectWithRetry(
         return;
       }
 
-      // ── Model catalog command (no runtime scope required) ───────────────
-      if (isListModelsCommand(parsed)) {
-        runDetachedListenerTask("list_models", async () => {
-          try {
-            const response = await buildListModelsResponse(parsed.request_id);
-            safeSocketSend(
-              socket,
-              response,
-              "listener_list_models_send_failed",
-              "listener_list_models",
-            );
-          } catch (error) {
-            safeSocketSend(
-              socket,
-              {
-                type: "list_models_response",
-                request_id: parsed.request_id,
-                success: false,
-                entries: [],
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Failed to list models",
-              },
-              "listener_list_models_send_failed",
-              "listener_list_models",
-            );
-          }
-        });
-        return;
-      }
-
-      // ── Model update command (runtime scoped) ────────────────────────────
-      if (isUpdateModelCommand(parsed)) {
-        runDetachedListenerTask("update_model", async () => {
-          const scopedRuntime = getOrCreateScopedRuntime(
-            runtime,
-            parsed.runtime.agent_id,
-            parsed.runtime.conversation_id,
-          );
-
-          const resolvedModel = resolveModelForUpdate(parsed.payload);
-          if (!resolvedModel) {
-            const failure: UpdateModelResponseMessage = {
-              type: "update_model_response",
-              request_id: parsed.request_id,
-              success: false,
-              error:
-                "Model not found. Provide a valid model_id from list_models or a model_handle.",
-            };
-            safeSocketSend(
-              socket,
-              failure,
-              "listener_update_model_send_failed",
-              "listener_update_model",
-            );
-            return;
-          }
-
-          try {
-            const response = await applyModelUpdateForRuntime({
-              socket,
-              listener: runtime,
-              scopedRuntime,
-              requestId: parsed.request_id,
-              model: resolvedModel,
-            });
-            safeSocketSend(
-              socket,
-              response,
-              "listener_update_model_send_failed",
-              "listener_update_model",
-            );
-          } catch (error) {
-            const failure: UpdateModelResponseMessage = {
-              type: "update_model_response",
-
-              request_id: parsed.request_id,
-              success: false,
-              runtime: {
-                agent_id: parsed.runtime.agent_id,
-                conversation_id: parsed.runtime.conversation_id,
-              },
-              model_id: resolvedModel.id,
-              model_handle: resolvedModel.handle,
-              error:
-                error instanceof Error
-                  ? error.message
-                  : "Failed to update model",
-            };
-            safeSocketSend(
-              socket,
-              failure,
-              "listener_update_model_send_failed",
-              "listener_update_model",
-            );
-          }
-        });
-        return;
-      }
-
-      // ── Toolset update command (runtime scoped) ──────────────────────
-      if (isUpdateToolsetCommand(parsed)) {
-        runDetachedListenerTask("update_toolset", async () => {
-          const scopedRuntime = getOrCreateScopedRuntime(
-            runtime,
-            parsed.runtime.agent_id,
-            parsed.runtime.conversation_id,
-          );
-
-          try {
-            const response = await applyToolsetUpdateForRuntime({
-              socket,
-              listener: runtime,
-              scopedRuntime,
-              requestId: parsed.request_id,
-              toolsetPreference: parsed.toolset_preference,
-            });
-            safeSocketSend(
-              socket,
-              response,
-              "listener_update_toolset_send_failed",
-              "listener_update_toolset",
-            );
-          } catch (error) {
-            const failure: UpdateToolsetResponseMessage = {
-              type: "update_toolset_response",
-              request_id: parsed.request_id,
-              success: false,
-              runtime: {
-                agent_id: parsed.runtime.agent_id,
-                conversation_id: parsed.runtime.conversation_id,
-              },
-              error:
-                error instanceof Error
-                  ? error.message
-                  : "Failed to update toolset",
-            };
-            safeSocketSend(
-              socket,
-              failure,
-              "listener_update_toolset_send_failed",
-              "listener_update_toolset",
-            );
-          }
-        });
+      if (
+        handleModelToolsetCommand(parsed, {
+          socket,
+          runtime,
+          safeSocketSend,
+          runDetachedListenerTask,
+          getOrCreateScopedRuntime,
+        })
+      ) {
         return;
       }
 

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -1,0 +1,593 @@
+import type WebSocket from "ws";
+import { getAvailableModelHandles } from "../../../agent/available-models";
+import { getModelInfo, models } from "../../../agent/model";
+import {
+  updateAgentLLMConfig,
+  updateConversationLLMConfig,
+} from "../../../agent/modify";
+import {
+  buildByokProviderAliases,
+  listProviders,
+} from "../../../providers/byok-providers";
+import { settingsManager } from "../../../settings-manager";
+import {
+  ensureCorrectMemoryTool,
+  prepareToolExecutionContextForScope,
+  type ToolsetName,
+  type ToolsetPreference,
+} from "../../../tools/toolset";
+import { formatToolsetName } from "../../../tools/toolset-labels";
+import type {
+  ListModelsResponseMessage,
+  ListModelsResponseModelEntry,
+  UpdateModelResponseMessage,
+  UpdateToolsetResponseMessage,
+} from "../../../types/protocol_v2";
+import {
+  isListModelsCommand,
+  isUpdateModelCommand,
+  isUpdateToolsetCommand,
+} from "../protocol-inbound";
+import { emitRuntimeStateUpdates, emitStatusDelta } from "../protocol-outbound";
+import type { ConversationRuntime, ListenerRuntime } from "../types";
+import type {
+  GetOrCreateScopedRuntime,
+  RunDetachedListenerTask,
+  SafeSocketSend,
+} from "./types";
+
+export type ResolvedModelForUpdate = {
+  id: string;
+  handle: string;
+  label: string;
+  updateArgs?: Record<string, unknown>;
+};
+
+type ModelToolsetCommandContext = {
+  socket: WebSocket;
+  runtime: ListenerRuntime;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+  getOrCreateScopedRuntime: GetOrCreateScopedRuntime;
+};
+
+export function resolveModelForUpdate(payload: {
+  model_id?: string;
+  model_handle?: string;
+}): ResolvedModelForUpdate | null {
+  if (typeof payload.model_id === "string" && payload.model_id.length > 0) {
+    const byId = getModelInfo(payload.model_id);
+    if (byId) {
+      // When an explicit model_handle is also provided (e.g. BYOK tier
+      // changes), use the model_id entry for updateArgs/label but preserve
+      // the caller-specified handle so the BYOK identity is maintained
+      // end-to-end.
+      const explicitHandle =
+        typeof payload.model_handle === "string" &&
+        payload.model_handle.length > 0
+          ? payload.model_handle
+          : null;
+
+      return {
+        id: byId.id,
+        handle: explicitHandle ?? byId.handle,
+        label: byId.label,
+        updateArgs:
+          byId.updateArgs && typeof byId.updateArgs === "object"
+            ? ({ ...byId.updateArgs } as Record<string, unknown>)
+            : undefined,
+      };
+    }
+  }
+
+  if (
+    typeof payload.model_handle === "string" &&
+    payload.model_handle.length > 0
+  ) {
+    const exactByHandle = models.find((m) => m.handle === payload.model_handle);
+    if (exactByHandle) {
+      return {
+        id: exactByHandle.id,
+        handle: exactByHandle.handle,
+        label: exactByHandle.label,
+        updateArgs:
+          exactByHandle.updateArgs &&
+          typeof exactByHandle.updateArgs === "object"
+            ? ({ ...exactByHandle.updateArgs } as Record<string, unknown>)
+            : undefined,
+      };
+    }
+
+    return {
+      id: payload.model_handle,
+      handle: payload.model_handle,
+      label: payload.model_handle,
+      updateArgs: undefined,
+    };
+  }
+
+  return null;
+}
+
+function formatToolsetStatusMessageForModelUpdate(params: {
+  nextToolset: ToolsetName;
+  toolsetPreference: ToolsetName | "auto";
+}): string {
+  const { nextToolset, toolsetPreference } = params;
+
+  if (toolsetPreference === "auto") {
+    return (
+      "Toolset auto-switched for this model: now using the " +
+      formatToolsetName(nextToolset) +
+      " toolset."
+    );
+  }
+
+  return (
+    "Manual toolset override remains active: " +
+    formatToolsetName(toolsetPreference) +
+    "."
+  );
+}
+
+function formatEffortSuffix(
+  modelLabel: string,
+  updateArgs?: Record<string, unknown>,
+): string {
+  if (!updateArgs) return "";
+  const effort = updateArgs.reasoning_effort;
+  if (typeof effort !== "string" || effort.length === 0) return "";
+  const xhighLabel = modelLabel.includes("Opus 4.7") ? "Extra-High" : "Max";
+  const labels: Record<string, string> = {
+    none: "No Reasoning",
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    xhigh: xhighLabel,
+    max: "Max",
+  };
+  return ` (${labels[effort] ?? effort})`;
+}
+
+export function buildModelUpdateStatusMessage(params: {
+  modelLabel: string;
+  toolsetChanged: boolean;
+  toolsetError: string | null;
+  nextToolset: ToolsetName;
+  toolsetPreference: ToolsetName | "auto";
+  updateArgs?: Record<string, unknown>;
+}): { message: string; level: "info" | "warning" } {
+  const {
+    modelLabel,
+    toolsetChanged,
+    toolsetError,
+    nextToolset,
+    toolsetPreference,
+    updateArgs,
+  } = params;
+  let message = `Model updated to ${modelLabel}${formatEffortSuffix(modelLabel, updateArgs)}.`;
+  if (toolsetError) {
+    message += ` Warning: toolset switch failed (${toolsetError}).`;
+    return { message, level: "warning" };
+  }
+  if (toolsetChanged) {
+    message += ` ${formatToolsetStatusMessageForModelUpdate({
+      nextToolset,
+      toolsetPreference,
+    })}`;
+  }
+  return { message, level: "info" };
+}
+
+export async function applyModelUpdateForRuntime(params: {
+  socket: WebSocket;
+  listener: ListenerRuntime;
+  scopedRuntime: ConversationRuntime;
+  requestId: string;
+  model: ResolvedModelForUpdate;
+}): Promise<UpdateModelResponseMessage> {
+  const { socket, listener, scopedRuntime, requestId, model } = params;
+  const agentId = scopedRuntime.agentId;
+  const conversationId = scopedRuntime.conversationId;
+
+  if (!agentId) {
+    return {
+      type: "update_model_response",
+      request_id: requestId,
+      success: false,
+      error: "Missing agent_id in runtime scope",
+    };
+  }
+
+  const isDefaultConversation = conversationId === "default";
+
+  const updateArgs = {
+    ...(model.updateArgs ?? {}),
+    parallel_tool_calls: true,
+  };
+
+  let modelSettings: Record<string, unknown> | null = null;
+  let appliedTo: "agent" | "conversation";
+
+  if (isDefaultConversation) {
+    const updatedAgent = await updateAgentLLMConfig(
+      agentId,
+      model.handle,
+      updateArgs,
+    );
+    modelSettings =
+      (updatedAgent.model_settings as
+        | Record<string, unknown>
+        | null
+        | undefined) ?? null;
+    appliedTo = "agent";
+  } else {
+    const updatedConversation = await updateConversationLLMConfig(
+      conversationId,
+      model.handle,
+      updateArgs,
+      { preserveContextWindow: false },
+    );
+    modelSettings =
+      ((
+        updatedConversation as {
+          model_settings?: Record<string, unknown> | null;
+        }
+      ).model_settings as Record<string, unknown> | null | undefined) ?? null;
+    appliedTo = "conversation";
+  }
+
+  const toolsetPreference = settingsManager.getToolsetPreference(agentId);
+  const previousToolNames = scopedRuntime.currentLoadedTools;
+  let nextToolset: ToolsetName;
+  let nextLoadedTools: string[] = previousToolNames;
+  let toolsetError: string | null = null;
+
+  try {
+    await ensureCorrectMemoryTool(agentId, model.handle);
+    const preparedToolContext = await prepareToolExecutionContextForScope({
+      agentId,
+      conversationId,
+      overrideModel: model.handle,
+    });
+    nextToolset = preparedToolContext.toolset;
+    nextLoadedTools = preparedToolContext.preparedToolContext.loadedToolNames;
+    scopedRuntime.currentToolset = preparedToolContext.toolset;
+    scopedRuntime.currentToolsetPreference =
+      preparedToolContext.toolsetPreference;
+    scopedRuntime.currentLoadedTools = nextLoadedTools;
+  } catch (error) {
+    nextToolset = toolsetPreference === "auto" ? "default" : toolsetPreference;
+    toolsetError =
+      error instanceof Error ? error.message : "Failed to switch toolset";
+  }
+
+  const toolsetChanged =
+    !toolsetError &&
+    JSON.stringify(previousToolNames) !== JSON.stringify(nextLoadedTools);
+  const { message: statusMessage, level: statusLevel } =
+    buildModelUpdateStatusMessage({
+      modelLabel: model.label,
+      toolsetChanged,
+      toolsetError,
+      nextToolset,
+      toolsetPreference,
+      updateArgs: model.updateArgs,
+    });
+
+  emitStatusDelta(socket, scopedRuntime, {
+    message: statusMessage,
+    level: statusLevel,
+    agentId,
+    conversationId,
+  });
+
+  emitRuntimeStateUpdates(listener, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
+
+  return {
+    type: "update_model_response",
+    request_id: requestId,
+    success: true,
+    runtime: {
+      agent_id: agentId,
+      conversation_id: conversationId,
+    },
+    applied_to: appliedTo,
+    model_id: model.id,
+    model_handle: model.handle,
+    model_settings: modelSettings,
+  };
+}
+
+export async function applyToolsetUpdateForRuntime(params: {
+  socket: WebSocket;
+  listener: ListenerRuntime;
+  scopedRuntime: ConversationRuntime;
+  requestId: string;
+  toolsetPreference: ToolsetPreference;
+}): Promise<UpdateToolsetResponseMessage> {
+  const { socket, listener, scopedRuntime, requestId, toolsetPreference } =
+    params;
+  const agentId = scopedRuntime.agentId;
+  const conversationId = scopedRuntime.conversationId;
+
+  if (!agentId) {
+    return {
+      type: "update_toolset_response",
+      request_id: requestId,
+      success: false,
+      error: "Missing agent_id in runtime scope",
+    };
+  }
+
+  const previousToolNames = scopedRuntime.currentLoadedTools;
+  let nextToolset: ToolsetName;
+  const previousToolsetPreference = (() => {
+    try {
+      return settingsManager.getToolsetPreference(agentId);
+    } catch {
+      return scopedRuntime.currentToolsetPreference;
+    }
+  })();
+
+  try {
+    settingsManager.setToolsetPreference(agentId, toolsetPreference);
+    const preparedToolContext = await prepareToolExecutionContextForScope({
+      agentId,
+      conversationId,
+    });
+    nextToolset = preparedToolContext.toolset;
+    scopedRuntime.currentToolset = preparedToolContext.toolset;
+    scopedRuntime.currentToolsetPreference =
+      preparedToolContext.toolsetPreference;
+    scopedRuntime.currentLoadedTools =
+      preparedToolContext.preparedToolContext.loadedToolNames;
+  } catch (error) {
+    settingsManager.setToolsetPreference(agentId, previousToolsetPreference);
+    throw error;
+  }
+
+  const toolsChanged =
+    JSON.stringify(previousToolNames) !==
+    JSON.stringify(scopedRuntime.currentLoadedTools);
+
+  const statusMessage =
+    toolsetPreference === "auto"
+      ? `Toolset mode set to auto (currently ${formatToolsetName(nextToolset)}).`
+      : `Switched toolset to ${formatToolsetName(nextToolset)} (manual override).`;
+
+  emitStatusDelta(socket, scopedRuntime, {
+    message: statusMessage,
+    level: toolsChanged ? "info" : "info",
+    agentId,
+    conversationId,
+  });
+
+  emitRuntimeStateUpdates(listener, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
+
+  return {
+    type: "update_toolset_response",
+    request_id: requestId,
+    success: true,
+    runtime: {
+      agent_id: agentId,
+      conversation_id: conversationId,
+    },
+    current_toolset: nextToolset,
+    current_toolset_preference: toolsetPreference,
+  };
+}
+
+export function buildListModelsEntries(): ListModelsResponseModelEntry[] {
+  return models.map((model) => ({
+    id: model.id,
+    handle: model.handle,
+    label: model.label,
+    description: model.description,
+    ...(typeof model.isDefault === "boolean"
+      ? { isDefault: model.isDefault }
+      : {}),
+    ...(typeof model.isFeatured === "boolean"
+      ? { isFeatured: model.isFeatured }
+      : {}),
+    ...(typeof model.free === "boolean" ? { free: model.free } : {}),
+    ...(model.updateArgs && typeof model.updateArgs === "object"
+      ? { updateArgs: model.updateArgs as Record<string, unknown> }
+      : {}),
+  }));
+}
+
+/**
+ * Build the full list_models_response payload, including availability data.
+ * Fetches available handles and BYOK provider aliases in parallel (best-effort).
+ */
+export async function buildListModelsResponse(
+  requestId: string,
+): Promise<ListModelsResponseMessage> {
+  const entries = buildListModelsEntries();
+
+  const [handlesResult, providersResult] = await Promise.allSettled([
+    getAvailableModelHandles(),
+    listProviders(),
+  ]);
+
+  const availableHandles: string[] | null =
+    handlesResult.status === "fulfilled"
+      ? [...handlesResult.value.handles]
+      : null;
+
+  // listProviders already degrades to [] on failure, but handle rejection too
+  const providers =
+    providersResult.status === "fulfilled" ? providersResult.value : [];
+  const byokProviderAliases = buildByokProviderAliases(providers);
+
+  return {
+    type: "list_models_response",
+    request_id: requestId,
+    success: true,
+    entries,
+    available_handles: availableHandles,
+    byok_provider_aliases: byokProviderAliases,
+  };
+}
+
+export function handleModelToolsetCommand(
+  parsed: unknown,
+  context: ModelToolsetCommandContext,
+): boolean {
+  const {
+    socket,
+    runtime,
+    safeSocketSend,
+    runDetachedListenerTask,
+    getOrCreateScopedRuntime,
+  } = context;
+
+  if (isListModelsCommand(parsed)) {
+    runDetachedListenerTask("list_models", async () => {
+      try {
+        const response = await buildListModelsResponse(parsed.request_id);
+        safeSocketSend(
+          socket,
+          response,
+          "listener_list_models_send_failed",
+          "listener_list_models",
+        );
+      } catch (error) {
+        safeSocketSend(
+          socket,
+          {
+            type: "list_models_response",
+            request_id: parsed.request_id,
+            success: false,
+            entries: [],
+            error:
+              error instanceof Error ? error.message : "Failed to list models",
+          },
+          "listener_list_models_send_failed",
+          "listener_list_models",
+        );
+      }
+    });
+    return true;
+  }
+
+  if (isUpdateModelCommand(parsed)) {
+    runDetachedListenerTask("update_model", async () => {
+      const scopedRuntime = getOrCreateScopedRuntime(
+        runtime,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+      );
+
+      const resolvedModel = resolveModelForUpdate(parsed.payload);
+      if (!resolvedModel) {
+        const failure: UpdateModelResponseMessage = {
+          type: "update_model_response",
+          request_id: parsed.request_id,
+          success: false,
+          error:
+            "Model not found. Provide a valid model_id from list_models or a model_handle.",
+        };
+        safeSocketSend(
+          socket,
+          failure,
+          "listener_update_model_send_failed",
+          "listener_update_model",
+        );
+        return;
+      }
+
+      try {
+        const response = await applyModelUpdateForRuntime({
+          socket,
+          listener: runtime,
+          scopedRuntime,
+          requestId: parsed.request_id,
+          model: resolvedModel,
+        });
+        safeSocketSend(
+          socket,
+          response,
+          "listener_update_model_send_failed",
+          "listener_update_model",
+        );
+      } catch (error) {
+        const failure: UpdateModelResponseMessage = {
+          type: "update_model_response",
+
+          request_id: parsed.request_id,
+          success: false,
+          runtime: {
+            agent_id: parsed.runtime.agent_id,
+            conversation_id: parsed.runtime.conversation_id,
+          },
+          model_id: resolvedModel.id,
+          model_handle: resolvedModel.handle,
+          error:
+            error instanceof Error ? error.message : "Failed to update model",
+        };
+        safeSocketSend(
+          socket,
+          failure,
+          "listener_update_model_send_failed",
+          "listener_update_model",
+        );
+      }
+    });
+    return true;
+  }
+
+  if (isUpdateToolsetCommand(parsed)) {
+    runDetachedListenerTask("update_toolset", async () => {
+      const scopedRuntime = getOrCreateScopedRuntime(
+        runtime,
+        parsed.runtime.agent_id,
+        parsed.runtime.conversation_id,
+      );
+
+      try {
+        const response = await applyToolsetUpdateForRuntime({
+          socket,
+          listener: runtime,
+          scopedRuntime,
+          requestId: parsed.request_id,
+          toolsetPreference: parsed.toolset_preference,
+        });
+        safeSocketSend(
+          socket,
+          response,
+          "listener_update_toolset_send_failed",
+          "listener_update_toolset",
+        );
+      } catch (error) {
+        const failure: UpdateToolsetResponseMessage = {
+          type: "update_toolset_response",
+          request_id: parsed.request_id,
+          success: false,
+          runtime: {
+            agent_id: parsed.runtime.agent_id,
+            conversation_id: parsed.runtime.conversation_id,
+          },
+          error:
+            error instanceof Error ? error.message : "Failed to update toolset",
+        };
+        safeSocketSend(
+          socket,
+          failure,
+          "listener_update_toolset_send_failed",
+          "listener_update_toolset",
+        );
+      }
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/websocket/listener/commands/types.ts
+++ b/src/websocket/listener/commands/types.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import type { ConversationRuntime, ListenerRuntime } from "../types";
 
 export type SafeSocketSend = (
   socket: WebSocket,
@@ -11,3 +12,9 @@ export type RunDetachedListenerTask = (
   commandName: string,
   task: () => Promise<void>,
 ) => void;
+
+export type GetOrCreateScopedRuntime = (
+  listener: ListenerRuntime,
+  agentId?: string | null,
+  conversationId?: string | null,
+) => ConversationRuntime;


### PR DESCRIPTION
## Summary
- Extract list_models, update_model, and update_toolset command handling into `commands/model-toolset.ts`
- Move model/toolset helper functions with the command handler while preserving existing test utility exports
- Keep `client.ts` as dispatcher by passing explicit socket/runtime/task/scope helpers into the extracted module

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun test src/tests/websocket`