### PR TITLE
fix(channels): dedupe Discord ingress by message id

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -244,10 +244,20 @@ function resolveDiscordReactionEmoji(value: string): string {
   return nameMap[normalized] ?? normalized;
 }
 
-function buildDiscordReplyOptions(
+export function buildDiscordIngressMessageKey(
+  accountId: string | undefined,
+  messageId: string | undefined,
+): string | null {
+  if (!isNonEmptyString(accountId) || !isNonEmptyString(messageId)) {
+    return null;
+  }
+  return `${accountId}:${messageId}`;
+}
+
+export function buildDiscordReplyOptions(
   replyToMessageId: string | undefined,
   channelId: string,
-): { reply: { messageReference: string } } | undefined {
+): { reply: { messageReference: string; failIfNotExists: false } } | undefined {
   const trimmed = replyToMessageId?.trim();
   if (!trimmed || trimmed === channelId) {
     return undefined;
@@ -255,6 +265,7 @@ function buildDiscordReplyOptions(
   return {
     reply: {
       messageReference: trimmed,
+      failIfNotExists: false,
     },
   };
 }
@@ -317,16 +328,6 @@ export function createDiscordAdapter(
   >();
   const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
 
-  function buildIngressMessageKey(
-    channelId: string | undefined,
-    messageId: string | undefined,
-  ): string | null {
-    if (!isNonEmptyString(channelId) || !isNonEmptyString(messageId)) {
-      return null;
-    }
-    return `${channelId}:${messageId}`;
-  }
-
   function pruneSeenIngressMessageKeys(now: number = Date.now()): void {
     for (const [key, expiresAt] of seenIngressMessageKeys) {
       if (expiresAt <= now) {
@@ -348,11 +349,8 @@ export function createDiscordAdapter(
     }
   }
 
-  function markIngressMessageSeen(
-    channelId: string | undefined,
-    messageId: string | undefined,
-  ): boolean {
-    const key = buildIngressMessageKey(channelId, messageId);
+  function markIngressMessageSeen(messageId: string | undefined): boolean {
+    const key = buildDiscordIngressMessageKey(config.accountId, messageId);
     if (!key) return false;
     const now = Date.now();
     pruneSeenIngressMessageKeys(now);
@@ -600,7 +598,7 @@ export function createDiscordAdapter(
 
         // ── DM handling ──────────────────────────────────────────
         if (chatType === "direct") {
-          if (markIngressMessageSeen(message.channelId, message.id)) return;
+          if (markIngressMessageSeen(message.id)) return;
 
           const attachments = await collectAttachments(
             message.attachments,
@@ -653,7 +651,7 @@ export function createDiscordAdapter(
         )
           return;
 
-        if (markIngressMessageSeen(message.channelId, message.id)) return;
+        if (markIngressMessageSeen(message.id)) return;
 
         let effectiveChatId = message.channelId;
         let effectiveThreadId: string | null = isThread

--- a/src/tests/channels/discord-adapter.test.ts
+++ b/src/tests/channels/discord-adapter.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import {
+  buildDiscordIngressMessageKey,
+  buildDiscordReplyOptions,
+} from "../../channels/discord/adapter";
 
 // The Discord adapter's internal helpers are not exported, but we can test
 // the equivalent logic by reimplementing the pure functions here and verifying
@@ -203,5 +207,60 @@ describe("resolveDiscordChatType", () => {
 
   test("non-empty guildId is channel", () => {
     expect(resolveDiscordChatType("guild-123")).toBe("channel");
+  });
+});
+
+// ── buildDiscordIngressMessageKey ────────────────────────────────────────
+
+describe("buildDiscordIngressMessageKey", () => {
+  test("dedupes the same Discord message across parent/thread channel contexts", () => {
+    // Discord message IDs are globally unique. If the same underlying message
+    // is surfaced through both a parent channel and created thread context, the
+    // dedupe key must remain stable.
+    const parentChannelKey = buildDiscordIngressMessageKey(
+      "discord-bot",
+      "msg-1",
+    );
+    const threadChannelKey = buildDiscordIngressMessageKey(
+      "discord-bot",
+      "msg-1",
+    );
+
+    expect(parentChannelKey).toBe(threadChannelKey);
+  });
+
+  test("scopes dedupe by account so multiple bots do not collide", () => {
+    expect(buildDiscordIngressMessageKey("bot-a", "msg-1")).not.toBe(
+      buildDiscordIngressMessageKey("bot-b", "msg-1"),
+    );
+  });
+
+  test("returns null when account or message ID is missing", () => {
+    expect(buildDiscordIngressMessageKey(undefined, "msg-1")).toBeNull();
+    expect(buildDiscordIngressMessageKey("discord-bot", undefined)).toBeNull();
+    expect(buildDiscordIngressMessageKey("", "msg-1")).toBeNull();
+    expect(buildDiscordIngressMessageKey("discord-bot", "")).toBeNull();
+  });
+});
+
+// ── buildDiscordReplyOptions ─────────────────────────────────────────────
+
+describe("buildDiscordReplyOptions", () => {
+  test("omits reply options when no reply target is provided", () => {
+    expect(buildDiscordReplyOptions(undefined, "channel-1")).toBeUndefined();
+    expect(buildDiscordReplyOptions("", "channel-1")).toBeUndefined();
+  });
+
+  test("omits reply options when reply target equals target channel", () => {
+    expect(buildDiscordReplyOptions("channel-1", "channel-1")).toBeUndefined();
+  });
+
+  test("sets failIfNotExists false so stale quote targets do not fail sends", () => {
+    expect(buildDiscordReplyOptions("msg-1", "channel-1")).toEqual({
+      reply: {
+        messageReference: "msg-1",
+        failIfNotExists: false,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Deduplicates Discord channel ingress by account + message ID instead of channel + message ID, preventing the same attachment-bearing Discord message from being queued again if it is surfaced through a different channel context.
- Adds Discord adapter coverage for account-scoped ingress keys and stale reply-reference handling.
- Sets Discord reply references to `failIfNotExists: false` so stale quote targets do not make otherwise-valid sends fail.

Closes #2080.

"The details are not the details. They make the design." — Charles Eames

Written by Cameron ◯ Letta Code