### PR TITLE
feat(cli): add set-max-context command

### DIFF
--- a/src/agent/maxContext.ts
+++ b/src/agent/maxContext.ts
@@ -1,0 +1,328 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getBackend } from "../backend";
+import { getModelInfo, models } from "./model";
+
+export const MIN_CONTEXT_WINDOW_TOKENS = 30_000;
+
+type ModelConfigSnapshot = {
+  model?: string | null;
+  model_endpoint_type?: string | null;
+  reasoning_effort?: string | null;
+  enable_reasoner?: boolean | null;
+  context_window?: number | null;
+};
+
+export type SetMaxContextArgs = {
+  value: number | null;
+  override: boolean;
+};
+
+export type SetMaxContextResult = {
+  contextWindow: number;
+  reset: boolean;
+  override: boolean;
+  appliedTo: "agent" | "conversation";
+  defaultContextWindow?: number;
+  modelLabel?: string;
+  updatedAgent?: AgentState;
+};
+
+type ModelContextDefault = {
+  contextWindow?: number;
+  modelLabel?: string;
+};
+
+function buildModelHandleFromConfig(
+  config: ModelConfigSnapshot | null | undefined,
+): string | null {
+  if (!config) return null;
+  if (config.model_endpoint_type && config.model) {
+    return `${config.model_endpoint_type}/${config.model}`;
+  }
+  return config.model ?? null;
+}
+
+function numericUpdateArg(
+  updateArgs: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = updateArgs?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function getUpdateArgs(model: (typeof models)[number] | null | undefined) {
+  return model?.updateArgs && typeof model.updateArgs === "object"
+    ? (model.updateArgs as Record<string, unknown>)
+    : undefined;
+}
+
+export function formatContextWindowTokens(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+export function parseContextWindowValue(raw: string): number | null {
+  const trimmed = raw.trim().replace(/_/g, "").replace(/,/g, "");
+  const match = trimmed.match(/^(\d+)([kKmM]?)$/);
+  if (!match) return null;
+  const base = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isSafeInteger(base)) return null;
+  const suffix = match[2]?.toLowerCase();
+  const multiplier = suffix === "m" ? 1_000_000 : suffix === "k" ? 1_000 : 1;
+  const value = base * multiplier;
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+export function parseSetMaxContextArgs(
+  args: string | undefined,
+): SetMaxContextArgs {
+  const tokens = (args ?? "").trim().split(/\s+/).filter(Boolean);
+  let override = false;
+  const values: string[] = [];
+
+  for (const token of tokens) {
+    if (token === "--override") {
+      override = true;
+    } else if (token.startsWith("--")) {
+      throw new Error(`Unknown option: ${token}`);
+    } else {
+      values.push(token);
+    }
+  }
+
+  if (values.length > 1) {
+    throw new Error("Usage: /set-max-context [tokens] [--override]");
+  }
+
+  if (values.length === 0) {
+    return { value: null, override };
+  }
+
+  const value = parseContextWindowValue(values[0] ?? "");
+  if (value === null || value <= 0) {
+    throw new Error(
+      `Invalid context window "${values[0]}". Provide a positive token count, e.g. 200000 or 200k.`,
+    );
+  }
+
+  return { value, override };
+}
+
+export function resolveModelJsonContextWindow(input: {
+  modelId?: string | null;
+  modelHandle?: string | null;
+  llmConfig?: ModelConfigSnapshot | null;
+  currentContextWindow?: number | null;
+}): ModelContextDefault {
+  const byId = input.modelId ? getModelInfo(input.modelId) : null;
+  const byIdContextWindow = numericUpdateArg(
+    getUpdateArgs(byId),
+    "context_window",
+  );
+  if (byIdContextWindow !== undefined) {
+    return { contextWindow: byIdContextWindow, modelLabel: byId?.label };
+  }
+
+  const modelHandle =
+    input.modelHandle ?? buildModelHandleFromConfig(input.llmConfig);
+  if (!modelHandle) return {};
+
+  let candidates = models.filter((model) => model.handle === modelHandle);
+  if (candidates.length === 0) return {};
+
+  const currentContextWindow = input.currentContextWindow;
+  if (typeof currentContextWindow === "number") {
+    const exactContextWindowMatch = candidates.find(
+      (model) =>
+        numericUpdateArg(getUpdateArgs(model), "context_window") ===
+        currentContextWindow,
+    );
+    if (exactContextWindowMatch) {
+      return {
+        contextWindow: currentContextWindow,
+        modelLabel: exactContextWindowMatch.label,
+      };
+    }
+  }
+
+  const effort = input.llmConfig?.reasoning_effort;
+  if (effort) {
+    const effortMatches = candidates.filter(
+      (model) => getUpdateArgs(model)?.reasoning_effort === effort,
+    );
+    if (effortMatches.length > 0) {
+      candidates = effortMatches;
+    }
+  }
+
+  const enableReasoner = input.llmConfig?.enable_reasoner;
+  if (typeof enableReasoner === "boolean") {
+    const reasonerMatches = candidates.filter(
+      (model) => getUpdateArgs(model)?.enable_reasoner === enableReasoner,
+    );
+    if (reasonerMatches.length > 0) {
+      candidates = reasonerMatches;
+    }
+  }
+
+  const candidatesWithContext = candidates
+    .map((model) => ({
+      model,
+      contextWindow: numericUpdateArg(getUpdateArgs(model), "context_window"),
+    }))
+    .filter(
+      (
+        entry,
+      ): entry is { model: (typeof models)[number]; contextWindow: number } =>
+        entry.contextWindow !== undefined,
+    );
+
+  if (candidatesWithContext.length === 0) return {};
+
+  const selected =
+    typeof currentContextWindow === "number"
+      ? (candidatesWithContext
+          .filter((entry) => entry.contextWindow >= currentContextWindow)
+          .sort((a, b) => a.contextWindow - b.contextWindow)[0] ??
+        candidatesWithContext.sort(
+          (a, b) => b.contextWindow - a.contextWindow,
+        )[0])
+      : candidatesWithContext[0];
+
+  return {
+    contextWindow: selected?.contextWindow,
+    modelLabel: selected?.model.label,
+  };
+}
+
+function validateRequestedContextWindow(params: {
+  value: number;
+  defaultContextWindow?: number;
+  override: boolean;
+}): void {
+  const { value, defaultContextWindow, override } = params;
+  if (!override && value < MIN_CONTEXT_WINDOW_TOKENS) {
+    throw new Error(
+      `Context window must be at least ${formatContextWindowTokens(MIN_CONTEXT_WINDOW_TOKENS)} tokens. Use --override to apply a smaller value.`,
+    );
+  }
+
+  if (
+    !override &&
+    defaultContextWindow !== undefined &&
+    value > defaultContextWindow
+  ) {
+    throw new Error(
+      `Context window cannot exceed the model.json default of ${formatContextWindowTokens(defaultContextWindow)} tokens. Use --override to apply a larger value.`,
+    );
+  }
+}
+
+export async function applySetMaxContext(params: {
+  agentId: string;
+  conversationId: string;
+  args?: string;
+  currentModelId?: string | null;
+  currentModelHandle?: string | null;
+  currentLlmConfig?: ModelConfigSnapshot | null;
+  currentContextWindow?: number | null;
+}): Promise<SetMaxContextResult> {
+  const parsed = parseSetMaxContextArgs(params.args);
+  const backend = getBackend();
+  const agent = await backend.retrieveAgent(params.agentId);
+  const isDefaultConversation = params.conversationId === "default";
+  const conversation = isDefaultConversation
+    ? null
+    : await backend.retrieveConversation(params.conversationId);
+
+  const conversationRecord = (conversation ?? {}) as Record<string, unknown>;
+  const agentRecord = agent as unknown as Record<string, unknown>;
+  const conversationContextWindow =
+    typeof conversationRecord.context_window_limit === "number"
+      ? conversationRecord.context_window_limit
+      : undefined;
+  const agentContextWindow =
+    typeof agentRecord.context_window_limit === "number"
+      ? agentRecord.context_window_limit
+      : undefined;
+  const effectiveContextWindow =
+    params.currentContextWindow ??
+    conversationContextWindow ??
+    agentContextWindow ??
+    null;
+  const effectiveModelHandle =
+    params.currentModelHandle ??
+    (typeof conversationRecord.model === "string"
+      ? conversationRecord.model
+      : null) ??
+    (typeof agent.model === "string" && agent.model.length > 0
+      ? agent.model
+      : null) ??
+    buildModelHandleFromConfig(agent.llm_config as ModelConfigSnapshot | null);
+  const effectiveLlmConfig =
+    params.currentLlmConfig ??
+    ((agent.llm_config ?? null) as ModelConfigSnapshot | null);
+  const modelDefault = resolveModelJsonContextWindow({
+    modelId: params.currentModelId,
+    modelHandle: effectiveModelHandle,
+    llmConfig: effectiveLlmConfig,
+    currentContextWindow: effectiveContextWindow,
+  });
+
+  const reset = parsed.value === null;
+  const contextWindow = reset ? modelDefault.contextWindow : parsed.value;
+  if (contextWindow === undefined || contextWindow === null) {
+    throw new Error(
+      "No default value for max context window found in model.json",
+    );
+  }
+
+  if (!reset) {
+    validateRequestedContextWindow({
+      value: contextWindow,
+      defaultContextWindow: modelDefault.contextWindow,
+      override: parsed.override,
+    });
+  }
+
+  if (isDefaultConversation) {
+    const updatedAgent = await backend.updateAgent(params.agentId, {
+      context_window_limit: contextWindow,
+    } as Parameters<typeof backend.updateAgent>[1]);
+    return {
+      contextWindow,
+      reset,
+      override: parsed.override,
+      appliedTo: "agent",
+      defaultContextWindow: modelDefault.contextWindow,
+      modelLabel: modelDefault.modelLabel,
+      updatedAgent,
+    };
+  }
+
+  await backend.updateConversation(params.conversationId, {
+    context_window_limit: contextWindow,
+  } as Parameters<typeof backend.updateConversation>[1]);
+  return {
+    contextWindow,
+    reset,
+    override: parsed.override,
+    appliedTo: "conversation",
+    defaultContextWindow: modelDefault.contextWindow,
+    modelLabel: modelDefault.modelLabel,
+  };
+}
+
+export function formatSetMaxContextResult(result: SetMaxContextResult): string {
+  const target =
+    result.appliedTo === "agent" ? "Agent" : "Current conversation";
+  const value = formatContextWindowTokens(result.contextWindow);
+  const modelSuffix = result.modelLabel ? ` for ${result.modelLabel}` : "";
+  if (result.reset) {
+    return `${target} max context reset to ${value} tokens${modelSuffix}.`;
+  }
+  return `${target} max context set to ${value} tokens${
+    result.override ? " with override" : ""
+  }.`;
+}

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -193,6 +193,9 @@ function createLocalConversationRecord(
       ? { model: bodyRecord.model }
       : {}),
     ...(modelSettings !== undefined ? { model_settings: modelSettings } : {}),
+    ...(typeof bodyRecord.context_window_limit === "number"
+      ? { context_window_limit: bodyRecord.context_window_limit }
+      : {}),
   } as StoredConversation;
 }
 
@@ -228,6 +231,10 @@ function updateLocalConversationRecord(
   const modelSettings = conversationModelSettings(bodyRecord.model_settings);
   if (modelSettings !== undefined) {
     next.model_settings = modelSettings as StoredConversation["model_settings"];
+  }
+  if (typeof bodyRecord.context_window_limit === "number") {
+    (next as unknown as Record<string, unknown>).context_window_limit =
+      bodyRecord.context_window_limit;
   }
   if (typeof bodyRecord.summary === "string" || bodyRecord.summary === null) {
     next.summary = bodyRecord.summary;

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -51,6 +51,10 @@ import { getResumeData } from "../agent/check-approval";
 import { getCurrentAgentId, setCurrentAgentId } from "../agent/context";
 import { type AgentProvenance, createAgent } from "../agent/create";
 import { selectDefaultAgentModel } from "../agent/defaults";
+import {
+  applySetMaxContext,
+  formatSetMaxContextResult,
+} from "../agent/maxContext";
 import { ISOLATED_BLOCK_LABELS } from "../agent/memory";
 import {
   ensureMemoryFilesystemDirs,
@@ -3687,7 +3691,10 @@ export default function App({
           conversationModel !== undefined && conversationModel !== null
             ? true
             : conversationModelSettings !== undefined &&
-              conversationModelSettings !== null;
+                conversationModelSettings !== null
+              ? true
+              : conversationContextWindowLimit !== undefined &&
+                conversationContextWindowLimit !== null;
 
         if (!hasOverride) {
           applyAgentModelLocally();
@@ -8620,6 +8627,55 @@ export default function App({
           return { submitted: true };
         }
 
+        // Hidden command for setting/resetting the active scope's max context window.
+        if (
+          trimmed === "/set-max-context" ||
+          trimmed.startsWith("/set-max-context ")
+        ) {
+          const args = trimmed.slice("/set-max-context".length).trim();
+          const cmd = commandRunner.start(
+            trimmed,
+            "Setting max context window...",
+          );
+          setCommandRunning(true);
+
+          try {
+            const result = await applySetMaxContext({
+              agentId: agentIdRef.current,
+              conversationId: conversationIdRef.current,
+              args,
+              currentModelId,
+              currentModelHandle,
+              currentLlmConfig: llmConfigRef.current,
+              currentContextWindow: effectiveContextWindowSize ?? null,
+            });
+
+            if (result.updatedAgent) {
+              setAgentState(result.updatedAgent);
+              setHasConversationModelOverride(false);
+              setConversationOverrideModelSettings(null);
+              setConversationOverrideContextWindowLimit(null);
+            } else {
+              setHasConversationModelOverride(true);
+              setConversationOverrideContextWindowLimit(result.contextWindow);
+            }
+
+            setLlmConfig({
+              ...(llmConfigRef.current ?? ({} as LlmConfig)),
+              context_window: result.contextWindow,
+            } as LlmConfig);
+            resetContextHistory(contextTrackerRef.current);
+            cmd.finish(formatSetMaxContextResult(result), true);
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to set max context: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+
         // Special handling for /recompile command - recompile agent + current conversation
         if (trimmed === "/recompile") {
           const cmd = commandRunner.start(
@@ -11125,6 +11181,9 @@ ${SYSTEM_REMINDER_CLOSE}
       agentDescription,
       agentLastRunAt,
       conversationId,
+      currentModelHandle,
+      currentModelId,
+      effectiveContextWindowSize,
       commandRunner,
       handleExit,
       isExecutingTool,

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -554,6 +554,15 @@ export const commands: Record<string, Command> = {
       return "Compacting conversation...";
     },
   },
+  "/set-max-context": {
+    desc: "Set or reset the max context window",
+    args: "[tokens] [--override]",
+    hidden: true,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Setting max context window...";
+    },
+  },
   "/link": {
     desc: "Attach all Letta Code tools to agent (deprecated, use /toolset instead)",
     hidden: true,

--- a/src/tests/agent/max-context.test.ts
+++ b/src/tests/agent/max-context.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applySetMaxContext,
+  MIN_CONTEXT_WINDOW_TOKENS,
+  parseContextWindowValue,
+  parseSetMaxContextArgs,
+  resolveModelJsonContextWindow,
+} from "../../agent/maxContext";
+import {
+  __testSetBackend,
+  type AgentCreateBody,
+  type ConversationCreateBody,
+} from "../../backend";
+import { LocalBackend } from "../../backend/local";
+
+afterEach(() => {
+  __testSetBackend(null);
+});
+
+describe("max context command helpers", () => {
+  test("parses token counts and override flag", () => {
+    expect(parseContextWindowValue("30000")).toBe(30_000);
+    expect(parseContextWindowValue("30k")).toBe(30_000);
+    expect(parseContextWindowValue("1m")).toBe(1_000_000);
+    expect(parseSetMaxContextArgs("10000 --override")).toEqual({
+      value: 10_000,
+      override: true,
+    });
+    expect(parseSetMaxContextArgs("")).toEqual({
+      value: null,
+      override: false,
+    });
+    expect(() => parseSetMaxContextArgs("10000 --force")).toThrow(
+      "Unknown option: --force",
+    );
+  });
+
+  test("resolves model.json default context windows", () => {
+    expect(
+      resolveModelJsonContextWindow({ modelId: "sonnet" }).contextWindow,
+    ).toBe(200_000);
+    expect(
+      resolveModelJsonContextWindow({
+        modelHandle: "anthropic/claude-sonnet-4-6",
+        llmConfig: { reasoning_effort: "low", enable_reasoner: true },
+      }).contextWindow,
+    ).toBe(200_000);
+    expect(
+      resolveModelJsonContextWindow({ modelHandle: "custom/model" })
+        .contextWindow,
+    ).toBeUndefined();
+  });
+
+  test("applies min/max validation with override escape hatch", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "max-context-local-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Max Context Agent",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+
+      await expect(
+        applySetMaxContext({
+          agentId: agent.id,
+          conversationId: "default",
+          args: `${MIN_CONTEXT_WINDOW_TOKENS - 1}`,
+          currentModelId: "sonnet",
+        }),
+      ).rejects.toThrow("at least 30,000 tokens");
+
+      await expect(
+        applySetMaxContext({
+          agentId: agent.id,
+          conversationId: "default",
+          args: "250000",
+          currentModelId: "sonnet",
+        }),
+      ).rejects.toThrow("model.json default of 200,000 tokens");
+
+      const overrideResult = await applySetMaxContext({
+        agentId: agent.id,
+        conversationId: "default",
+        args: "10000 --override",
+        currentModelId: "sonnet",
+      });
+      expect(overrideResult.contextWindow).toBe(10_000);
+      expect(overrideResult.appliedTo).toBe("agent");
+      expect(
+        (
+          (await backend.retrieveAgent(agent.id)) as {
+            llm_config?: { context_window?: number };
+          }
+        ).llm_config?.context_window,
+      ).toBe(10_000);
+
+      const resetResult = await applySetMaxContext({
+        agentId: agent.id,
+        conversationId: "default",
+        args: "",
+        currentModelId: "sonnet",
+      });
+      expect(resetResult.contextWindow).toBe(200_000);
+      expect(resetResult.reset).toBe(true);
+
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      const conversationResult = await applySetMaxContext({
+        agentId: agent.id,
+        conversationId: conversation.id,
+        args: "50000",
+        currentModelId: "sonnet",
+      });
+      expect(conversationResult.appliedTo).toBe("conversation");
+      expect(
+        (
+          (await backend.retrieveConversation(conversation.id)) as {
+            context_window_limit?: number;
+          }
+        ).context_window_limit,
+      ).toBe(50_000);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails reset when no model.json default exists", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "max-context-custom-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Custom Model Agent",
+        model: "custom/model",
+      } as AgentCreateBody);
+
+      await expect(
+        applySetMaxContext({
+          agentId: agent.id,
+          conversationId: "default",
+          args: "",
+          currentModelHandle: "custom/model",
+        }),
+      ).rejects.toThrow(
+        "No default value for max context window found in model.json",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -14,6 +14,8 @@ import {
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   getPersonalityOption,
 } from "../../agent/personality";
+import { __testSetBackend, type AgentCreateBody } from "../../backend";
+import { LocalBackend } from "../../backend/local";
 import { formatErrorDetails } from "../../cli/helpers/errorFormatter";
 import {
   ensureFileIndex,
@@ -47,6 +49,10 @@ import {
   requestApprovalOverWS,
   resolvePendingApprovalResolver,
 } from "../../websocket/listen-client";
+import {
+  handleExecuteCommand,
+  SUPPORTED_REMOTE_COMMANDS,
+} from "../../websocket/listener/commands";
 import { isEditFileCommand } from "../../websocket/listener/protocol-inbound";
 import {
   DESKTOP_DEBUG_PANEL_INFO_PREFIX,
@@ -88,6 +94,7 @@ class MockSocket {
 const actualChannelsService = await import("../../channels/service");
 
 afterEach(() => {
+  __testSetBackend(null);
   __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
   mock.restore();
 });
@@ -931,6 +938,76 @@ describe("listen-client parseServerMessage", () => {
 
     expect(getExperiments?.type).toBe("get_experiments");
     expect(setExperiment?.type).toBe("set_experiment");
+  });
+
+  test("advertises and parses remote set-max-context execute_command", () => {
+    expect(SUPPORTED_REMOTE_COMMANDS).toContain("set-max-context");
+
+    const command = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "execute_command",
+          command_id: "set-max-context",
+          request_id: "set-max-context-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          args: "10000 --override",
+        }),
+      ),
+    );
+
+    expect(command).toMatchObject({
+      type: "execute_command",
+      command_id: "set-max-context",
+      args: "10000 --override",
+    });
+  });
+
+  test("runs remote set-max-context execute_command", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "ws-max-context-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "WS Max Context Agent",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        agent.id,
+        "default",
+      );
+      const socket = new MockSocket(WebSocket.OPEN);
+
+      await handleExecuteCommand(
+        {
+          type: "execute_command",
+          command_id: "set-max-context",
+          request_id: "set-max-context-run-1",
+          runtime: { agent_id: agent.id, conversation_id: "default" },
+          args: "10000 --override",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {},
+      );
+
+      expect(
+        (
+          (await backend.retrieveAgent(agent.id)) as {
+            llm_config?: { context_window?: number };
+          }
+        ).llm_config?.context_window,
+      ).toBe(10_000);
+      expect(socket.sentPayloads.join("\n")).toContain(
+        "Agent max context set to 10,000 tokens with override.",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("rejects legacy cancel_run in hard-cut v2 protocol", () => {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,4 +1,8 @@
 import type WebSocket from "ws";
+import {
+  applySetMaxContext,
+  formatSetMaxContextResult,
+} from "../../agent/maxContext";
 import { ISOLATED_BLOCK_LABELS } from "../../agent/memory";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { REMEMBER_PROMPT } from "../../agent/promptAssets";
@@ -37,6 +41,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "doctor",
   "init",
   "remember",
+  "set-max-context",
   "channels",
   "toolset",
   // /secret opens the EditSecretsDialog and routes reads/writes through the
@@ -106,6 +111,13 @@ export async function handleExecuteCommand(
           conversationRuntime,
           trimmedArgs,
           opts,
+        );
+        break;
+
+      case "set-max-context":
+        output = await handleSetMaxContextCommand(
+          conversationRuntime,
+          trimmedArgs,
         );
         break;
 
@@ -382,6 +394,24 @@ async function handleRememberCommand(
   );
 
   return "Memory request submitted";
+}
+
+/** /set-max-context — Set or reset the active scope's max context window. */
+async function handleSetMaxContextCommand(
+  conversationRuntime: ConversationRuntime,
+  args: string | undefined,
+): Promise<string> {
+  const agentId = conversationRuntime.agentId;
+  if (!agentId) {
+    throw new Error("No agent ID available for /set-max-context command");
+  }
+
+  const result = await applySetMaxContext({
+    agentId,
+    conversationId: conversationRuntime.conversationId,
+    args,
+  });
+  return formatSetMaxContextResult(result);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add hidden `/set-max-context [tokens] [--override]` support to set or reset the active agent/conversation context window.
- Validate requested values against the 30k minimum and the model.json default unless `--override` is provided.
- Expose the command through websocket `execute_command` for desktop clients and cover local/backend + WS paths in tests.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/agent/max-context.test.ts src/tests/websocket/listen-client-protocol.test.ts src/tests/backend/local-backend.test.ts --timeout 60000`

👾 Generated with [Letta Code](https://letta.com)