### PR TITLE
fix(tools): verify bundled ripgrep binary before using it

### DIFF
--- a/src/tools/impl/glob.ts
+++ b/src/tools/impl/glob.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,8 +15,13 @@ function getRipgrepPath(): string {
     const __filename = fileURLToPath(import.meta.url);
     const require = createRequire(__filename);
     const rgPackage = require("@vscode/ripgrep");
-    return rgPackage.rgPath;
-  } catch (_error) {
+    const bundledPath = rgPackage.rgPath as string;
+    if (bundledPath && existsSync(bundledPath)) {
+      return bundledPath;
+    }
+    return "rg";
+  } catch {
+    // @vscode/ripgrep not installed
     return "rg";
   }
 }

--- a/src/tools/impl/grep.ts
+++ b/src/tools/impl/grep.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,8 +15,13 @@ function getRipgrepPath(): string {
     const __filename = fileURLToPath(import.meta.url);
     const require = createRequire(__filename);
     const rgPackage = require("@vscode/ripgrep");
-    return rgPackage.rgPath;
-  } catch (_error) {
+    const bundledPath = rgPackage.rgPath as string;
+    if (bundledPath && existsSync(bundledPath)) {
+      return bundledPath;
+    }
+    return "rg";
+  } catch {
+    // @vscode/ripgrep not installed
     return "rg";
   }
 }

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -4,7 +4,7 @@
  * including bundled tools like ripgrep in PATH and Letta context for skill scripts.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -29,7 +29,11 @@ function getRipgrepBinDir(): string | undefined {
     const require = createRequire(__filename);
     const rgPackage = require("@vscode/ripgrep");
     // rgPath is the full path to the binary, we want the directory
-    return path.dirname(rgPackage.rgPath);
+    const bundledPath = rgPackage.rgPath as string;
+    if (!bundledPath || !existsSync(bundledPath)) {
+      return undefined;
+    }
+    return path.dirname(bundledPath);
   } catch (_error) {
     return undefined;
   }


### PR DESCRIPTION
just checks if the binary exists before executing. uses rg from path if the binary doesnt exist. this fixes the search tool when npm packages were installed with "--ignore-scripts" which is used in the nix package from https://github.com/numtide/llm-agents.nix