### PR TITLE
docs(tools): clarify Edit path expansion

### DIFF
--- a/src/tools/descriptions/Edit.md
+++ b/src/tools/descriptions/Edit.md
@@ -4,6 +4,7 @@ Performs exact string replacements in files.
 
 Usage:
 - You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. Exception: files under `$MEMORY_DIR/system/` do not require a Read call first, since their contents are already provided in your system prompt.
+- `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.

--- a/src/tools/descriptions/Write.md
+++ b/src/tools/descriptions/Write.md
@@ -5,6 +5,7 @@ Writes a file to the local filesystem.
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first. Exception: files under `$MEMORY_DIR/system/` do not require a Read call first, since their contents are already provided in your system prompt.
+- `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.


### PR DESCRIPTION
## Summary
- Clarify that `Edit.file_path` and `Write.file_path` are interpreted literally and do not expand `$VAR`, `$MEMORY_DIR`, `~`, etc.

## Test plan
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)