### PR TITLE
fix(permissions): allow memory-scoped bash redirects

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -728,22 +728,107 @@ function rewriteScopedMemoryRedirects(
   return rewritten;
 }
 
-function extractScopedHeredocWritePath(command: string): string | null {
-  const lines = command.split(/\r?\n/);
-  const firstLine = lines[0]?.trim() ?? "";
-  if (!firstLine) {
-    return null;
+function splitShellSegmentsAllowUnsafeRedirects(
+  input: string,
+): string[] | null {
+  const segments: string[] = [];
+  let current = "";
+  let i = 0;
+  let quote: "single" | "double" | null = null;
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+
+    if (quote === "single") {
+      current += ch;
+      if (ch === "'") {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (ch === "\\" && i + 1 < input.length) {
+        current += input.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+      if (ch === "`" || input.startsWith("$(", i)) {
+        return null;
+      }
+      current += ch;
+      if (ch === '"') {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'") {
+      quote = "single";
+      current += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      quote = "double";
+      current += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < input.length) {
+      current += input.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (ch === "`" || input.startsWith("$(", i)) {
+      return null;
+    }
+
+    if (input.startsWith("&&", i) || input.startsWith("||", i)) {
+      segments.push(current);
+      current = "";
+      i += 2;
+      continue;
+    }
+
+    if (ch === ";" || ch === "|" || ch === "\n" || ch === "\r") {
+      segments.push(current);
+      current = "";
+      i += 1;
+      continue;
+    }
+
+    current += ch;
+    i += 1;
   }
 
-  const firstLineMatch = firstLine.match(
-    /^cat\s+(?:>\s*(?<path1>"[^"]+"|'[^']+'|\S+)\s+<<-?\s*(?<delim1>"[^"]+"|'[^']+'|\S+)|<<-?\s*(?<delim2>"[^"]+"|'[^']+'|\S+)\s+>\s*(?<path2>"[^"]+"|'[^']+'|\S+))\s*$/,
+  segments.push(current);
+  return segments.map((segment) => segment.trim()).filter(Boolean);
+}
+
+function extractHeredocWrite(segment: string): {
+  path: string;
+  delimiter: string;
+} | null {
+  const match = segment.match(
+    /^cat\s+(?:(?:>|>>)\s*(?<path1>"[^"]+"|'[^']+'|\S+)\s+<<-?\s*(?<delim1>"[^"]+"|'[^']+'|\S+)|<<-?\s*(?<delim2>"[^"]+"|'[^']+'|\S+)\s+(?:>|>>)\s*(?<path2>"[^"]+"|'[^']+'|\S+))\s*$/,
   );
-  if (!firstLineMatch?.groups) {
+  if (!match?.groups) {
     return null;
   }
 
-  const rawPath = firstLineMatch.groups.path1 || firstLineMatch.groups.path2;
-  const rawDelim = firstLineMatch.groups.delim1 || firstLineMatch.groups.delim2;
+  const rawPath = match.groups.path1 || match.groups.path2;
+  const rawDelim = match.groups.delim1 || match.groups.delim2;
   if (!rawPath || !rawDelim) {
     return null;
   }
@@ -753,24 +838,133 @@ function extractScopedHeredocWritePath(command: string): string | null {
     return null;
   }
 
+  return { path: stripShellQuotes(rawPath), delimiter };
+}
+
+function validateScopedSegments(
+  command: string,
+  cwd: string | null,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+  shellVars: ScopedShellVars,
+): { safe: boolean; cwd: string | null } {
+  const scopedCommand = rewriteScopedMemoryRedirects(
+    command,
+    cwd,
+    allowedRoots,
+    env,
+    shellVars,
+  );
+  if (!scopedCommand) {
+    return { safe: false, cwd };
+  }
+
+  const segments = splitShellSegments(scopedCommand);
+  if (!segments || segments.length === 0) {
+    return { safe: false, cwd };
+  }
+
+  let nextCwd: string | null = cwd;
+  for (const segment of segments) {
+    const result = isAllowedMemorySegment(
+      segment,
+      nextCwd,
+      allowedRoots,
+      env,
+      shellVars,
+    );
+    if (!result.safe) {
+      return { safe: false, cwd: nextCwd };
+    }
+    nextCwd = result.nextCwd;
+  }
+
+  return { safe: true, cwd: nextCwd };
+}
+
+function isScopedHeredocMemoryCommand(
+  command: string,
+  initialCwd: string | null,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+  shellVars: ScopedShellVars,
+): boolean | null {
+  const lines = command.split(/\r?\n/);
+  const firstLine = lines[0]?.trim() ?? "";
+  if (!firstLine) {
+    return null;
+  }
+
+  const firstLineSegments = splitShellSegmentsAllowUnsafeRedirects(firstLine);
+  if (!firstLineSegments) {
+    return false;
+  }
+
+  const heredocIndex = firstLineSegments.findIndex((segment) =>
+    Boolean(extractHeredocWrite(segment)),
+  );
+  if (heredocIndex === -1) {
+    return null;
+  }
+
+  if (firstLineSegments.slice(heredocIndex + 1).length > 0) {
+    return false;
+  }
+
+  let cwd: string | null = initialCwd;
+  if (heredocIndex > 0) {
+    const prefixResult = validateScopedSegments(
+      firstLineSegments.slice(0, heredocIndex).join(" && "),
+      cwd,
+      allowedRoots,
+      env,
+      shellVars,
+    );
+    if (!prefixResult.safe) {
+      return false;
+    }
+    cwd = prefixResult.cwd;
+  }
+
+  const heredoc = extractHeredocWrite(firstLineSegments[heredocIndex] ?? "");
+  if (!heredoc) {
+    return false;
+  }
+
+  const resolved = normalizeScopePath(heredoc.path, cwd, env, shellVars);
+  if (!resolved || !isPathWithinRoots(resolved, allowedRoots)) {
+    return false;
+  }
+
   let terminatorLine = -1;
   for (let i = 1; i < lines.length; i += 1) {
-    if ((lines[i] ?? "") === delimiter) {
+    if ((lines[i] ?? "") === heredoc.delimiter) {
       terminatorLine = i;
       break;
     }
   }
   if (terminatorLine === -1) {
-    return null;
+    return false;
   }
 
-  for (let i = terminatorLine + 1; i < lines.length; i += 1) {
-    if ((lines[i] ?? "").trim().length > 0) {
-      return null;
+  const trailingCommand = lines
+    .slice(terminatorLine + 1)
+    .join("\n")
+    .trim();
+  if (trailingCommand) {
+    const trailingResult = validateScopedSegments(
+      trailingCommand,
+      cwd,
+      allowedRoots,
+      env,
+      shellVars,
+    );
+    if (!trailingResult.safe) {
+      return false;
     }
   }
 
-  return stripShellQuotes(rawPath);
+  return true;
 }
 
 function isReadOnlyGhApiInvocation(args: string[]): boolean {
@@ -1582,52 +1776,26 @@ export function isScopedMemoryShellCommand(
     ? normalizeScopePath(options.workingDirectory, null, env, shellVars)
     : null;
 
-  const heredocWritePath = extractScopedHeredocWritePath(trimmed);
-  if (heredocWritePath) {
-    const resolved = normalizeScopePath(
-      heredocWritePath,
+  if (trimmed.includes("<<")) {
+    const heredocResult = isScopedHeredocMemoryCommand(
+      trimmed,
       initialCwd,
+      allowedRoots,
       env,
       shellVars,
     );
-    return resolved ? isPathWithinRoots(resolved, allowedRoots) : false;
+    if (heredocResult !== null) {
+      return heredocResult;
+    }
   }
 
-  const scopedCommand = rewriteScopedMemoryRedirects(
+  return validateScopedSegments(
     trimmed,
     initialCwd,
     allowedRoots,
     env,
     shellVars,
-  );
-  if (!scopedCommand) {
-    return false;
-  }
-
-  const segments = splitShellSegments(scopedCommand);
-  if (!segments) {
-    return false;
-  }
-  if (segments.length === 0) {
-    return false;
-  }
-
-  let cwd: string | null = initialCwd;
-  for (const segment of segments) {
-    const result = isAllowedMemorySegment(
-      segment,
-      cwd,
-      allowedRoots,
-      env,
-      shellVars,
-    );
-    if (!result.safe) {
-      return false;
-    }
-    cwd = result.nextCwd;
-  }
-
-  return true;
+  ).safe;
 }
 
 /**

--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -161,6 +161,7 @@ const SAFE_MEMORY_COMMANDS = new Set([
   "find",
   "sort",
   "echo",
+  "printf",
   "wc",
   "split",
   "cd",
@@ -581,6 +582,195 @@ function isSafeEnvInvocation(
   }
 
   return true;
+}
+
+function readRedirectTarget(
+  input: string,
+  pos: number,
+): { token: string; end: number } | null {
+  let cursor = pos;
+  while (cursor < input.length && /\s/.test(input[cursor] ?? "")) {
+    cursor += 1;
+  }
+  if (cursor >= input.length) {
+    return null;
+  }
+
+  const quote = input[cursor];
+  if (quote === "'" || quote === '"') {
+    let end = cursor + 1;
+    while (end < input.length) {
+      const ch = input[end];
+      if (quote === '"' && ch === "\\" && end + 1 < input.length) {
+        end += 2;
+        continue;
+      }
+      if (ch === quote) {
+        return { token: input.slice(cursor, end + 1), end: end + 1 };
+      }
+      end += 1;
+    }
+    return null;
+  }
+
+  let end = cursor;
+  while (end < input.length && !/[\s;|&><()`]/.test(input[end] ?? "")) {
+    end += 1;
+  }
+  if (end === cursor) {
+    return null;
+  }
+  return { token: input.slice(cursor, end), end };
+}
+
+function isScopedRedirectTarget(
+  token: string,
+  cwd: string | null,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+  shellVars: ScopedShellVars,
+): boolean {
+  const stripped = stripShellQuotes(token);
+  if (stripped === "/dev/null" || /^&\d+$/.test(stripped)) {
+    return true;
+  }
+  const resolved = normalizeScopePath(stripped, cwd, env, shellVars);
+  return resolved ? isPathWithinRoots(resolved, allowedRoots) : false;
+}
+
+function rewriteScopedMemoryRedirects(
+  input: string,
+  cwd: string | null,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+  shellVars: ScopedShellVars,
+): string | null {
+  let rewritten = "";
+  let i = 0;
+  let quote: "single" | "double" | null = null;
+
+  while (i < input.length) {
+    const ch = input[i];
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+
+    if (quote === "single") {
+      rewritten += ch;
+      if (ch === "'") quote = null;
+      i += 1;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (ch === "\\" && i + 1 < input.length) {
+        rewritten += input.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+      if (ch === "`" || input.startsWith("$(", i)) {
+        return null;
+      }
+      rewritten += ch;
+      if (ch === '"') quote = null;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "'") {
+      quote = "single";
+      rewritten += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      quote = "double";
+      rewritten += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < input.length) {
+      rewritten += input.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (ch === "`" || input.startsWith("$(", i)) {
+      return null;
+    }
+
+    if (input.startsWith(">>", i) || ch === ">") {
+      const op = input.startsWith(">>", i) ? ">>" : ">";
+      const target = readRedirectTarget(input, i + op.length);
+      if (!target) {
+        return null;
+      }
+      if (
+        !isScopedRedirectTarget(target.token, cwd, allowedRoots, env, shellVars)
+      ) {
+        return null;
+      }
+      // Preserve shell shape but replace the target with /dev/null so the
+      // read-only shell splitter can continue to reject unsafe commands while
+      // tolerating this already-validated scoped write redirection.
+      rewritten += `${op} /dev/null`;
+      i = target.end;
+      continue;
+    }
+
+    rewritten += ch;
+    i += 1;
+  }
+
+  return rewritten;
+}
+
+function extractScopedHeredocWritePath(command: string): string | null {
+  const lines = command.split(/\r?\n/);
+  const firstLine = lines[0]?.trim() ?? "";
+  if (!firstLine) {
+    return null;
+  }
+
+  const firstLineMatch = firstLine.match(
+    /^cat\s+(?:>\s*(?<path1>"[^"]+"|'[^']+'|\S+)\s+<<-?\s*(?<delim1>"[^"]+"|'[^']+'|\S+)|<<-?\s*(?<delim2>"[^"]+"|'[^']+'|\S+)\s+>\s*(?<path2>"[^"]+"|'[^']+'|\S+))\s*$/,
+  );
+  if (!firstLineMatch?.groups) {
+    return null;
+  }
+
+  const rawPath = firstLineMatch.groups.path1 || firstLineMatch.groups.path2;
+  const rawDelim = firstLineMatch.groups.delim1 || firstLineMatch.groups.delim2;
+  if (!rawPath || !rawDelim) {
+    return null;
+  }
+
+  const delimiter = stripShellQuotes(rawDelim);
+  if (!delimiter) {
+    return null;
+  }
+
+  let terminatorLine = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    if ((lines[i] ?? "") === delimiter) {
+      terminatorLine = i;
+      break;
+    }
+  }
+  if (terminatorLine === -1) {
+    return null;
+  }
+
+  for (let i = terminatorLine + 1; i < lines.length; i += 1) {
+    if ((lines[i] ?? "").trim().length > 0) {
+      return null;
+    }
+  }
+
+  return stripShellQuotes(rawPath);
 }
 
 function isReadOnlyGhApiInvocation(args: string[]): boolean {
@@ -1386,7 +1576,35 @@ export function isScopedMemoryShellCommand(
     return false;
   }
 
-  const segments = splitShellSegments(trimmed);
+  const env = options.env ?? process.env;
+  const shellVars: ScopedShellVars = {};
+  const initialCwd = options.workingDirectory
+    ? normalizeScopePath(options.workingDirectory, null, env, shellVars)
+    : null;
+
+  const heredocWritePath = extractScopedHeredocWritePath(trimmed);
+  if (heredocWritePath) {
+    const resolved = normalizeScopePath(
+      heredocWritePath,
+      initialCwd,
+      env,
+      shellVars,
+    );
+    return resolved ? isPathWithinRoots(resolved, allowedRoots) : false;
+  }
+
+  const scopedCommand = rewriteScopedMemoryRedirects(
+    trimmed,
+    initialCwd,
+    allowedRoots,
+    env,
+    shellVars,
+  );
+  if (!scopedCommand) {
+    return false;
+  }
+
+  const segments = splitShellSegments(scopedCommand);
   if (!segments) {
     return false;
   }
@@ -1394,11 +1612,6 @@ export function isScopedMemoryShellCommand(
     return false;
   }
 
-  const env = options.env ?? process.env;
-  const shellVars: ScopedShellVars = {};
-  const initialCwd = options.workingDirectory
-    ? normalizeScopePath(options.workingDirectory, null, env, shellVars)
-    : null;
   let cwd: string | null = initialCwd;
   for (const segment of segments) {
     const result = isAllowedMemorySegment(

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -638,6 +638,51 @@ test("memory mode - allows Write inside MEMORY_DIR", () => {
   }
 });
 
+test("memory mode - allows Bash redirection inside MEMORY_DIR", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      {
+        command:
+          'echo "test content" > "$MEMORY_DIR/skills/example/SKILL.md" && ls -la "$MEMORY_DIR/skills/example/"',
+      },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+
+    expect(result.decision).toBe("allow");
+    expect(result.matchedRule).toBe("memory mode");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode - denies Bash redirection outside MEMORY_DIR", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      { command: 'echo "test content" > /tmp/outside-memory.txt' },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+
+    expect(result.decision).toBe("deny");
+    expect(result.matchedRule).toBe("memory mode");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
 test("memory mode - denies Write outside memory roots", () => {
   permissionMode.setMode("memory");
   const originalMemoryDir = process.env.MEMORY_DIR;

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -128,6 +128,161 @@ describe("isReadOnlyShellCommand", () => {
         ).toBe(true);
       });
 
+      test("allows rollout-style absolute heredoc overwrite", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cat > \"$MEMORY_DIR/system/preferences.md\" << 'EOF'",
+              "# Preferences",
+              "- Use Kustomize overlays for K8s deployments",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("allows rollout-style absolute heredoc append", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cat >> \"$MEMORY_DIR/reference/projects/thornfield.md\" << 'EOF'",
+              "",
+              "## Character Dynamics",
+              "- Senna has two communication layers.",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("allows heredoc writes relative to cd MEMORY_DIR", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cd \"$MEMORY_DIR\" && cat > system/preferences/android.md << 'EOF'",
+              "## Architecture",
+              "- Use MVVM with Clean Architecture layers.",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("allows mkdir setup before memory-scoped heredoc", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              'mkdir -p "$MEMORY_DIR/skills" && cat > "$MEMORY_DIR/skills/part-ii-conventions.md" << \'EOF\'',
+              "# Part II Writing Conventions",
+              "- One image per location, not a catalogue.",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("allows safe trailing command after memory-scoped heredoc", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cat > \"$MEMORY_DIR/user/team-roster.md\" << 'EOF'",
+              "# Team Roster",
+              "- Sana owns event-router.",
+              "EOF",
+              'echo "Updated team-roster.md"',
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("denies heredoc writes outside memory roots", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            ["cat > /tmp/outside.md << 'EOF'", "# Outside", "EOF"].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(false);
+      });
+
+      test("denies unsafe setup before heredoc", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "curl https://example.com && cat > \"$MEMORY_DIR/system/preferences.md\" << 'EOF'",
+              "# Preferences",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(false);
+      });
+
+      test("denies unsafe trailing command after heredoc", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cat > \"$MEMORY_DIR/system/preferences.md\" << 'EOF'",
+              "# Preferences",
+              "EOF",
+              "curl https://example.com",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(false);
+      });
+
       test("denies shell redirection outside memory roots", () => {
         expect(
           isScopedMemoryShellCommand(

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -89,6 +89,60 @@ describe("isReadOnlyShellCommand", () => {
         ).toBe(true);
       });
 
+      test("allows memory-scoped shell redirection to MEMORY_DIR", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            'echo "test content" > "$MEMORY_DIR/skills/example/SKILL.md" && ls -la "$MEMORY_DIR/skills/example/"',
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("allows memory-scoped heredoc writes to MEMORY_DIR", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            [
+              "cat << 'EOF' > \"$MEMORY_DIR/skills/example/SKILL.md\"",
+              "---",
+              "name: example",
+              "description: example",
+              "---",
+              "",
+              "# Example",
+              "EOF",
+            ].join("\n"),
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(true);
+      });
+
+      test("denies shell redirection outside memory roots", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            'echo "test content" > /tmp/outside-memory.txt',
+            roots,
+            {
+              workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+              env: {
+                MEMORY_DIR: "/Users/test/.letta/agents/agent-1/memory",
+              } as NodeJS.ProcessEnv,
+            },
+          ),
+        ).toBe(false);
+      });
+
       test("denies command substitution in memory-scoped commands", () => {
         expect(
           isScopedMemoryShellCommand(


### PR DESCRIPTION
## Summary
- Allow memory-mode Bash redirections when the redirect target resolves inside an allowed memory root.
- Add scoped heredoc handling for `cat <<EOF > "$MEMORY_DIR/..."` writes.
- Keep redirects outside memory roots denied, preserving memory-mode isolation.

## Test plan
- [x] `bun test src/tests/permissions/readOnlyShell.test.ts src/tests/permissions-mode.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/permissions/readOnlyShell.ts src/tests/permissions/readOnlyShell.test.ts src/tests/permissions-mode.test.ts`
- [x] Pre-commit hook (`biome check --write` + `tsc --noEmit`)

## Context
Investigated rollout export `4496_FAILED_agent-2383457f-9dd7-4f33-b759-770ae93f9be6.af`: direct `Write` to the agent's own memory succeeded, but `echo ... > "$MEMORY_DIR/..."` and heredoc writes through Bash were denied by memory mode. The shell parser was rejecting redirections before checking that the target was under `$MEMORY_DIR`.

👾 Generated with [Letta Code](https://letta.com)