### PR TITLE
fix(permissions): unblock memory-mode subagents on commit flows

### DIFF
--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -132,9 +132,11 @@ const UNSAFE_GIT_FLAGS = new Set([
 const SAFE_MEMORY_GIT_SUBCOMMANDS = new Set([
   "add",
   "commit",
+  "config",
   "push",
   "pull",
   "rebase",
+  "reset",
   "status",
   "diff",
   "log",

--- a/src/permissions/readOnlyShell.ts
+++ b/src/permissions/readOnlyShell.ts
@@ -1096,6 +1096,28 @@ function hasUnsafeRebaseOption(tokens: string[], startIndex: number): boolean {
   return false;
 }
 
+// `git config --global` writes to ~/.gitconfig and `git config --system`
+// writes to /etc/gitconfig — both outside the memory dir. These tokens
+// don't look like paths, so validateScopedTokens can't catch them.
+// Reject both the read and write forms uniformly: agents operating on
+// memory should only touch the local repo config (the implicit default
+// or an explicit --local / --worktree).
+function hasUnsafeConfigOption(tokens: string[], startIndex: number): boolean {
+  for (let i = startIndex; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!token) {
+      continue;
+    }
+    const lower = token.toLowerCase();
+
+    if (lower === "--global" || lower === "--system") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function parseScopedGitInvocation(
   tokens: string[],
   cwd: string | null,
@@ -1206,6 +1228,15 @@ function parseScopedGitInvocation(
     }
 
     if (subcommand === "rebase" && hasUnsafeRebaseOption(tokens, index + 1)) {
+      return {
+        subcommand,
+        worktreeSubcommand,
+        resolvedCwd,
+        isSafe: false,
+      };
+    }
+
+    if (subcommand === "config" && hasUnsafeConfigOption(tokens, index + 1)) {
       return {
         subcommand,
         worktreeSubcommand,

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -133,6 +133,45 @@ describe("isReadOnlyShellCommand", () => {
           ),
         ).toBe(true);
       });
+
+      test("denies git config --global / --system in memory-scoped commands", () => {
+        // --global writes to ~/.gitconfig, --system writes to /etc/gitconfig.
+        // Neither flag looks like a path token, so validateScopedTokens
+        // can't catch them — must be rejected explicitly.
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git config --global user.email evil@example.com",
+            roots,
+          ),
+        ).toBe(false);
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git config --system core.editor 'rm -rf /'",
+            roots,
+          ),
+        ).toBe(false);
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git config --get --global user.email",
+            roots,
+          ),
+        ).toBe(false);
+      });
+
+      test("allows git config without --global / --system in memory-scoped commands", () => {
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git config --get remote.origin.url",
+            roots,
+          ),
+        ).toBe(true);
+        expect(
+          isScopedMemoryShellCommand(
+            "cd /Users/test/.letta/agents/agent-1/memory && git config --local user.email reflection@letta.com",
+            roots,
+          ),
+        ).toBe(true);
+      });
     });
 
     test("allows grep", () => {

--- a/src/tests/permissions/readOnlyShell.test.ts
+++ b/src/tests/permissions/readOnlyShell.test.ts
@@ -769,6 +769,30 @@ describe("isMemoryDirCommand", () => {
       );
     });
 
+    test("allows git reset", () => {
+      expect(
+        isMemoryDirCommand(`cd ${memDir} && git reset HEAD`, AGENT_ID),
+      ).toBe(true);
+      expect(
+        isMemoryDirCommand(`cd ${memDir} && git reset --soft HEAD~1`, AGENT_ID),
+      ).toBe(true);
+    });
+
+    test("allows git config", () => {
+      expect(
+        isMemoryDirCommand(
+          `cd ${memDir} && git config --get remote.origin.url`,
+          AGENT_ID,
+        ),
+      ).toBe(true);
+      expect(
+        isMemoryDirCommand(
+          `cd ${memDir} && git config --local user.email reflection@letta.com`,
+          AGENT_ID,
+        ),
+      ).toBe(true);
+    });
+
     test("allows git rm", () => {
       expect(
         isMemoryDirCommand(`cd ${memDir} && git rm file.md`, AGENT_ID),

--- a/src/tools/descriptions/Bash.md
+++ b/src/tools/descriptions/Bash.md
@@ -86,17 +86,16 @@ Important notes:
 - IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
 - IMPORTANT: Do not use --no-edit with git rebase commands, as the --no-edit flag is not a valid option for git rebase.
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
+- In order to ensure good formatting, ALWAYS pass the commit message as a single-quoted string with embedded newlines, a la this example:
 <example>
-git commit -m "$(cat <<'EOF'
-   Commit message here.
+git commit -m 'Commit message here.
 
-   👾 Generated with [Letta Code](https://letta.com)
+👾 Generated with [Letta Code](https://letta.com)
 
-   Co-Authored-By: Letta Code <noreply@letta.com>
-   EOF
-   )"
+Co-Authored-By: Letta Code <noreply@letta.com>'
 </example>
+
+Use single quotes (not double quotes) and do NOT wrap the message in `$(...)` or backticks — single-quoting preserves the message verbatim (including `$VAR`, backticks, and other special characters) without needing escapes.
 
 # Creating pull requests
 Use the gh command via the Bash tool for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.
@@ -112,18 +111,15 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
 3. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following commands in parallel:
    - Create new branch if needed
    - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+   - Create PR using gh pr create with the format below. Pass the body as a single-quoted string with embedded newlines (do NOT wrap it in `$(...)` or backticks).
 <example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
-## Summary
+gh pr create --title "the pr title" --body '## Summary
 <1-3 bullet points>
 
 ## Test plan
 [Bulleted markdown checklist of TODOs for testing the pull request...]
 
-👾 Generated with [Letta Code](https://letta.com)
-EOF
-)"
+👾 Generated with [Letta Code](https://letta.com)'
 </example>
 
 Important:

--- a/src/tools/descriptions/RunShellCommandGemini.md
+++ b/src/tools/descriptions/RunShellCommandGemini.md
@@ -50,17 +50,16 @@ Important notes:
 - IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
 - IMPORTANT: Do not use --no-edit with git rebase commands, as the --no-edit flag is not a valid option for git rebase.
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
+- In order to ensure good formatting, ALWAYS pass the commit message as a single-quoted string with embedded newlines, a la this example:
 <example>
-git commit -m "$(cat <<'EOF'
-   Commit message here.
+git commit -m 'Commit message here.
 
-   👾 Generated with [Letta Code](https://letta.com)
+👾 Generated with [Letta Code](https://letta.com)
 
-   Co-Authored-By: Letta Code <noreply@letta.com>
-   EOF
-   )"
+Co-Authored-By: Letta Code <noreply@letta.com>'
 </example>
+
+Use single quotes (not double quotes) and do NOT wrap the message in `$(...)` or backticks — single-quoting preserves the message verbatim (including `$VAR`, backticks, and other special characters) without needing escapes.
 
 # Creating pull requests
 Use the gh command for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.
@@ -76,18 +75,15 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
 3. Run the following commands in parallel:
    - Create new branch if needed
    - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+   - Create PR using gh pr create with the format below. Pass the body as a single-quoted string with embedded newlines (do NOT wrap it in `$(...)` or backticks).
 <example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
-## Summary
+gh pr create --title "the pr title" --body '## Summary
 <1-3 bullet points>
 
 ## Test plan
 [Bulleted markdown checklist of TODOs for testing the pull request...]
 
-👾 Generated with [Letta Code](https://letta.com)
-EOF
-)"
+👾 Generated with [Letta Code](https://letta.com)'
 </example>
 
 Important:

--- a/src/tools/descriptions/Shell.md
+++ b/src/tools/descriptions/Shell.md
@@ -40,17 +40,16 @@ Important notes:
 - IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
 - IMPORTANT: Do not use --no-edit with git rebase commands, as the --no-edit flag is not a valid option for git rebase.
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
+- In order to ensure good formatting, ALWAYS pass the commit message as a single-quoted string with embedded newlines, a la this example:
 <example>
-git commit -m "$(cat <<'EOF'
-   Commit message here.
+git commit -m 'Commit message here.
 
-   👾 Generated with [Letta Code](https://letta.com)
+👾 Generated with [Letta Code](https://letta.com)
 
-   Co-Authored-By: Letta Code <noreply@letta.com>
-   EOF
-   )"
+Co-Authored-By: Letta Code <noreply@letta.com>'
 </example>
+
+Use single quotes (not double quotes) and do NOT wrap the message in `$(...)` or backticks — single-quoting preserves the message verbatim (including `$VAR`, backticks, and other special characters) without needing escapes.
 
 # Creating pull requests
 Use the gh command for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.
@@ -66,18 +65,15 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
 3. Run the following commands in parallel:
    - Create new branch if needed
    - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+   - Create PR using gh pr create with the format below. Pass the body as a single-quoted string with embedded newlines (do NOT wrap it in `$(...)` or backticks).
 <example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
-## Summary
+gh pr create --title "the pr title" --body '## Summary
 <1-3 bullet points>
 
 ## Test plan
 [Bulleted markdown checklist of TODOs for testing the pull request...]
 
-👾 Generated with [Letta Code](https://letta.com)
-EOF
-)"
+👾 Generated with [Letta Code](https://letta.com)'
 </example>
 
 Important:

--- a/src/tools/descriptions/ShellCommand.md
+++ b/src/tools/descriptions/ShellCommand.md
@@ -39,17 +39,16 @@ Important notes:
 - IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
 - IMPORTANT: Do not use --no-edit with git rebase commands, as the --no-edit flag is not a valid option for git rebase.
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
+- In order to ensure good formatting, ALWAYS pass the commit message as a single-quoted string with embedded newlines, a la this example:
 <example>
-git commit -m "$(cat <<'EOF'
-   Commit message here.
+git commit -m 'Commit message here.
 
-   👾 Generated with [Letta Code](https://letta.com)
+👾 Generated with [Letta Code](https://letta.com)
 
-   Co-Authored-By: Letta Code <noreply@letta.com>
-   EOF
-   )"
+Co-Authored-By: Letta Code <noreply@letta.com>'
 </example>
+
+Use single quotes (not double quotes) and do NOT wrap the message in `$(...)` or backticks — single-quoting preserves the message verbatim (including `$VAR`, backticks, and other special characters) without needing escapes.
 
 # Creating pull requests
 Use the gh command for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.
@@ -65,18 +64,15 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
 3. Run the following commands in parallel:
    - Create new branch if needed
    - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+   - Create PR using gh pr create with the format below. Pass the body as a single-quoted string with embedded newlines (do NOT wrap it in `$(...)` or backticks).
 <example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
-## Summary
+gh pr create --title "the pr title" --body '## Summary
 <1-3 bullet points>
 
 ## Test plan
 [Bulleted markdown checklist of TODOs for testing the pull request...]
 
-👾 Generated with [Letta Code](https://letta.com)
-EOF
-)"
+👾 Generated with [Letta Code](https://letta.com)'
 </example>
 
 Important:


### PR DESCRIPTION
## Summary

Memory-mode agents ran into Bash denials because of two contradicting policies:

1. The Bash/Shell tool descriptions instructed models to format commit messages and PR bodies via `git commit -m \"\$(cat <<'EOF' ... EOF )\"` heredocs.
2. `splitShellSegments` rejects any command containing `\$(...)` or backticks (intentional defense against `-m \"\$(touch /tmp/pwn)\"` injection — see `tests/permissions/readOnlyShell.test.ts:92`).

So every commit attempt by a memory-mode subagent was correctly identified as containing `\$(...)` and rejected.

In addition, `SAFE_MEMORY_GIT_SUBCOMMANDS` was missing `reset` and `config`, two subcommands that show up routinely in commit/push flows (e.g., `git reset HEAD`, `git config --get remote.origin.url`).

## Changes

**Commit 1 — unblock the hot path:** Fix at the source by teaching models a sandbox-compatible commit pattern instead of widening the parser. Replace heredoc-via-`\$()` examples in all 4 shell tool descriptions (Bash, Shell, ShellCommand, RunShellCommandGemini) with single-quoted multi-line strings, which preserve message contents verbatim (no shell expansion) without triggering the injection guard. Add `reset` and `config` to `SAFE_MEMORY_GIT_SUBCOMMANDS`.

**Commit 2 — plug the hole opened by allowing `config`:** `git config --global` writes to `~/.gitconfig` and `git config --system` writes to `/etc/gitconfig`. Neither flag is a path-shaped token, so `validateScopedTokens` can't catch them. Add `hasUnsafeConfigOption` (mirrors the existing `hasUnsafeRebaseOption` for `git rebase --exec`) and reject both flags uniformly.

## What was NOT changed (and why)

- `splitShellSegments` is left strict on `\$(...)` and backticks. That protection exists for a reason; the prompt fix is the right lever.
- The other shell tool descriptions still mention heredocs in passing for non-commit use cases (e.g., piping configs to scripts) — runtime support for heredocs is unchanged.
- `reflection.md` / `history-analyzer.md` already use plain `-m` patterns, no change needed.

## Follow-up (not in this PR)

The current model is an allowlist: `SAFE_MEMORY_GIT_SUBCOMMANDS` enumerates approved git subcommands. This requires extension every time an agent legitimately needs a new git op. A separate, larger PR could flip to a denylist (allow everything by default, deny known escape vectors) — better long-term maintenance, but requires careful security review of git's flag space.

👾 Generated with [Letta Code](https://letta.com)