### PR TITLE
feat(listener): repair split websocket channels on current main

### DIFF
--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -227,12 +227,13 @@ export async function handleListen(
     }
 
     // Register with cloud
-    const { connectionId, wsUrl } = await registerWithCloud({
-      serverUrl,
-      apiKey,
-      deviceId,
-      connectionName,
-    });
+    const { connectionId, wsUrl, supportsSplitStatusChannels } =
+      await registerWithCloud({
+        serverUrl,
+        apiKey,
+        deviceId,
+        connectionName,
+      });
 
     updateCommandResult(
       ctx.buffersRef,
@@ -257,10 +258,12 @@ export async function handleListen(
     const startClient = async (
       connId: string,
       wsUrlValue: string,
+      nextSupportsSplitStatusChannels: boolean,
     ): Promise<void> => {
       await startListenerClient({
         connectionId: connId,
         wsUrl: wsUrlValue,
+        supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
         deviceId,
         connectionName,
         onStatusChange: (status, id) => {
@@ -349,6 +352,7 @@ export async function handleListen(
             await startClient(
               reregisterResult.connectionId,
               reregisterResult.wsUrl,
+              reregisterResult.supportsSplitStatusChannels,
             );
           } catch (error) {
             updateCommandResult(
@@ -391,7 +395,7 @@ export async function handleListen(
       });
     };
 
-    await startClient(connectionId, wsUrl);
+    await startClient(connectionId, wsUrl, supportsSplitStatusChannels);
   } catch (error) {
     updateCommandResult(
       ctx.buffersRef,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -576,7 +576,8 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       `Registering with ${registerOptions.serverUrl}/v1/environments/register`,
     );
 
-    const { connectionId, wsUrl } = await registerWithCloud(registerOptions);
+    const { connectionId, wsUrl, supportsSplitStatusChannels } =
+      await registerWithCloud(registerOptions);
 
     sessionLog.log(`Registered: connectionId=${connectionId}`);
     sessionLog.log(`wsUrl: ${wsUrl}`);
@@ -600,6 +601,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     const reregister = async (): Promise<{
       connectionId: string;
       wsUrl: string;
+      supportsSplitStatusChannels: boolean;
     }> => {
       sessionLog.log("Re-registering with retry...");
       const nextRegisterOptions = await resolveListenerRegistrationOptions(
@@ -648,10 +650,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       const startDebugClient = async (
         connId: string,
         url: string,
+        nextSupportsSplitStatusChannels: boolean,
       ): Promise<void> => {
         await startListenerClient({
           connectionId: connId,
           wsUrl: url,
+          supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
@@ -680,7 +684,11 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             );
             try {
               const result = await reregister();
-              await startDebugClient(result.connectionId, result.wsUrl);
+              await startDebugClient(
+                result.connectionId,
+                result.wsUrl,
+                result.supportsSplitStatusChannels,
+              );
             } catch (error) {
               const msg =
                 error instanceof Error ? error.message : String(error);
@@ -703,7 +711,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           },
         });
       };
-      await startDebugClient(connectionId, wsUrl);
+      await startDebugClient(connectionId, wsUrl, supportsSplitStatusChannels);
     } else {
       // Normal mode: interactive Ink UI
       console.clear();
@@ -731,10 +739,12 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       const startNormalClient = async (
         connId: string,
         url: string,
+        nextSupportsSplitStatusChannels: boolean,
       ): Promise<void> => {
         await startListenerClient({
           connectionId: connId,
           wsUrl: url,
+          supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
@@ -758,7 +768,11 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             sessionLog.log("Environment expired, re-registering...");
             try {
               const result = await reregister();
-              await startNormalClient(result.connectionId, result.wsUrl);
+              await startNormalClient(
+                result.connectionId,
+                result.wsUrl,
+                result.supportsSplitStatusChannels,
+              );
             } catch (error) {
               const msg =
                 error instanceof Error ? error.message : String(error);
@@ -783,7 +797,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           },
         });
       };
-      await startNormalClient(connectionId, wsUrl);
+      await startNormalClient(connectionId, wsUrl, supportsSplitStatusChannels);
     }
 
     // Keep process alive

--- a/src/tests/websocket/listen-register.test.ts
+++ b/src/tests/websocket/listen-register.test.ts
@@ -33,6 +33,7 @@ describe("registerWithCloud", () => {
     expect(result).toEqual({
       connectionId: "conn-1",
       wsUrl: "wss://example.com",
+      supportsSplitStatusChannels: false,
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
@@ -58,6 +59,26 @@ describe("registerWithCloud", () => {
         nodeVersion: expect.any(String),
       },
     });
+  });
+
+  it("returns advertised split-channel support when present", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          connectionId: "conn-2",
+          wsUrl: "wss://example.com",
+          supportsSplitStatusChannels: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await registerWithCloud(
+      defaultOpts,
+      mockFetch as unknown as typeof fetch,
+    );
+
+    expect(result.supportsSplitStatusChannels).toBe(true);
   });
 
   it("throws with body message on non-OK response with JSON error", async () => {

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -7,6 +7,7 @@ import { getVersion } from "../version.ts";
 export interface RegisterResult {
   connectionId: string;
   wsUrl: string;
+  supportsSplitStatusChannels: boolean;
 }
 
 export interface RegisterOptions {
@@ -117,6 +118,7 @@ export async function registerWithCloud(
   return {
     connectionId: result.connectionId,
     wsUrl: result.wsUrl,
+    supportsSplitStatusChannels: result.supportsSplitStatusChannels === true,
   };
 }
 

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -330,6 +330,46 @@ function getParsedRuntimeScope(
   };
 }
 
+async function waitForStreamSocketOpen(
+  streamSocket: WebSocket,
+  runtime: ListenerRuntime,
+): Promise<ListenerTransport | null> {
+  if (streamSocket.readyState === WebSocket.OPEN) {
+    runtime.streamTransport = streamSocket;
+    return streamSocket;
+  }
+
+  if (
+    streamSocket.readyState === WebSocket.CLOSING ||
+    streamSocket.readyState === WebSocket.CLOSED
+  ) {
+    return null;
+  }
+
+  return await new Promise<ListenerTransport | null>((resolve) => {
+    const handleOpen = () => {
+      cleanup();
+      runtime.streamTransport = streamSocket;
+      resolve(streamSocket);
+    };
+
+    const handleFailure = () => {
+      cleanup();
+      resolve(null);
+    };
+
+    const cleanup = () => {
+      streamSocket.off("open", handleOpen);
+      streamSocket.off("error", handleFailure);
+      streamSocket.off("close", handleFailure);
+    };
+
+    streamSocket.once("open", handleOpen);
+    streamSocket.once("error", handleFailure);
+    streamSocket.once("close", handleFailure);
+  });
+}
+
 /**
  * Wire channel ingress into the listener.
  *
@@ -483,6 +523,8 @@ export function createRuntime(): ListenerRuntime {
   return {
     socket: null,
     transport: null,
+    streamSocket: null,
+    streamTransport: null,
     heartbeatInterval: null,
     reconnectTimeout: null,
     intentionallyClosed: false,
@@ -544,6 +586,15 @@ export function stopRuntime(
   stopAllWorktreeWatchers(runtime);
 
   if (!runtime.socket) {
+    if (
+      runtime.streamSocket &&
+      (runtime.streamSocket.readyState === WebSocket.OPEN ||
+        runtime.streamSocket.readyState === WebSocket.CONNECTING)
+    ) {
+      runtime.streamSocket.close();
+    }
+    runtime.streamSocket = null;
+    runtime.streamTransport = null;
     runtime.transport = null;
     return;
   }
@@ -551,6 +602,9 @@ export function stopRuntime(
   const socket = runtime.socket;
   runtime.socket = null;
   runtime.transport = null;
+  const streamSocket = runtime.streamSocket;
+  runtime.streamSocket = null;
+  runtime.streamTransport = null;
 
   // Stale runtimes being replaced should not emit callbacks/retries.
   if (suppressCallbacks) {
@@ -562,6 +616,14 @@ export function stopRuntime(
     socket.readyState === WebSocket.CONNECTING
   ) {
     socket.close();
+  }
+
+  if (
+    streamSocket &&
+    (streamSocket.readyState === WebSocket.OPEN ||
+      streamSocket.readyState === WebSocket.CONNECTING)
+  ) {
+    streamSocket.close();
   }
 }
 
@@ -576,6 +638,7 @@ export async function startConnectedListenerRuntime(
   options: {
     startHeartbeat?: boolean;
     startCronScheduler?: boolean;
+    streamTransport?: ListenerTransport | null;
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
@@ -593,6 +656,7 @@ export async function startConnectedListenerRuntime(
     options.startCronScheduler !== false && !cronSchedulerDisabledByEnv;
 
   runtime.transport = transport;
+  runtime.streamTransport = options.streamTransport ?? null;
   safeEmitWsEvent("recv", "lifecycle", {
     type:
       getListenerTransportKind(transport) === "websocket"
@@ -893,11 +957,32 @@ async function connectWithRetry(
   url.searchParams.set("deviceId", opts.deviceId);
   url.searchParams.set("connectionName", opts.connectionName);
 
+  const supportsSplitStatusChannels = opts.supportsSplitStatusChannels === true;
+  if (supportsSplitStatusChannels) {
+    url.searchParams.set("channel", "control");
+  }
+
+  let streamUrl: URL | null = null;
+  if (supportsSplitStatusChannels) {
+    streamUrl = new URL(opts.wsUrl);
+    streamUrl.searchParams.set("deviceId", opts.deviceId);
+    streamUrl.searchParams.set("connectionName", opts.connectionName);
+    streamUrl.searchParams.set("channel", "stream");
+  }
+
   const socket = new WebSocket(url.toString(), {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
   });
+
+  const streamSocket = streamUrl
+    ? new WebSocket(streamUrl.toString(), {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      })
+    : null;
 
   const fileCommandSession = createFileCommandSession({
     socket,
@@ -906,6 +991,7 @@ async function connectWithRetry(
   });
 
   runtime.socket = socket;
+  runtime.streamSocket = streamSocket;
   const transport = socket;
   const processQueuedTurn: ProcessQueuedTurn = async (
     queuedTurn: IncomingMessage,
@@ -927,12 +1013,20 @@ async function connectWithRetry(
   };
 
   socket.on("open", async () => {
+    let streamTransport: ListenerTransport | null = null;
+    if (streamSocket) {
+      streamTransport = await waitForStreamSocketOpen(streamSocket, runtime);
+    }
     await startConnectedListenerRuntime(
       runtime,
       transport,
       opts,
       processQueuedTurn,
-      { startHeartbeat: true, startCronScheduler: true },
+      {
+        startHeartbeat: true,
+        startCronScheduler: true,
+        streamTransport,
+      },
     );
   });
 
@@ -1007,7 +1101,18 @@ async function connectWithRetry(
     runtime._unsubscribeSubagentStreamEvents?.();
     runtime._unsubscribeSubagentStreamEvents = undefined;
     clearListenerWarmState(runtime);
+    if (streamSocket) {
+      streamSocket.removeAllListeners();
+      if (
+        streamSocket.readyState === WebSocket.OPEN ||
+        streamSocket.readyState === WebSocket.CONNECTING
+      ) {
+        streamSocket.close();
+      }
+    }
     runtime.socket = null;
+    runtime.streamSocket = null;
+    runtime.streamTransport = null;
     for (const conversationRuntime of runtime.conversationRuntimes.values()) {
       rejectPendingApprovalResolvers(
         conversationRuntime,
@@ -1061,6 +1166,32 @@ async function connectWithRetry(
     }
     // Error triggers close(), which handles retry logic.
   });
+
+  if (streamSocket) {
+    streamSocket.on("error", (error: Error) => {
+      trackListenerError(
+        "listener_stream_socket_error",
+        error,
+        "listener_stream_socket",
+      );
+      if (isDebugEnabled()) {
+        console.error("[Listen] Stream WebSocket error:", error);
+      }
+    });
+
+    streamSocket.on("close", (code: number, reason: Buffer) => {
+      if (isDebugEnabled()) {
+        console.log(
+          `[Listen] Stream WebSocket closed (code: ${code}, reason: ${reason.toString()})`,
+        );
+      }
+
+      if (runtime.streamSocket === streamSocket) {
+        runtime.streamSocket = null;
+        runtime.streamTransport = null;
+      }
+    });
+  }
 }
 
 /**

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -573,6 +573,21 @@ export function setLoopStatus(
   emitLoopStatusIfOpen(runtime, scope);
 }
 
+/** Message types that belong on the stream channel.
+ *  These are high-frequency runtime emissions that should be separated
+ *  from control/command-response traffic on the control channel. */
+const STREAM_CHANNEL_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "stream_delta",
+  "update_device_status",
+  "update_loop_status",
+  "update_queue",
+  "update_subagent_state",
+]);
+
+function isStreamChannelMessage(type: string): boolean {
+  return STREAM_CHANNEL_MESSAGE_TYPES.has(type);
+}
+
 export function emitProtocolV2Message(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
@@ -585,10 +600,20 @@ export function emitProtocolV2Message(
     conversation_id?: string | null;
   },
 ): void {
-  if (!isListenerTransportOpen(socket)) {
+  const listener = getListenerRuntime(runtime);
+
+  // Route stream-type messages to the stream transport when available.
+  // Falls back to the control socket if the stream transport is not open.
+  let targetSocket: ListenerTransport = socket;
+  if (listener?.streamTransport && isStreamChannelMessage(message.type)) {
+    if (isListenerTransportOpen(listener.streamTransport)) {
+      targetSocket = listener.streamTransport;
+    }
+  }
+
+  if (!isListenerTransportOpen(targetSocket)) {
     return;
   }
-  const listener = getListenerRuntime(runtime);
   const runtimeScope = resolveRuntimeScope(
     listener,
     getScopeForRuntime(runtime, scope),
@@ -615,16 +640,16 @@ export function emitProtocolV2Message(
     const stringifyMs = perfEnabled
       ? performance.now() - stringifyStartedAt
       : 0;
-    const bufferedBefore = perfEnabled ? socket.bufferedAmount : 0;
+    const bufferedBefore = perfEnabled ? targetSocket.bufferedAmount : 0;
     const sendStartedAt = perfEnabled ? performance.now() : 0;
-    socket.send(payload);
+    targetSocket.send(payload);
     if (perfEnabled) {
       recordProtocolPerfTelemetry(getProtocolPerfKey(message), {
         bytes: Buffer.byteLength(payload),
         stringifyMs,
         sendMs: performance.now() - sendStartedAt,
         bufferedBefore,
-        bufferedAfter: socket.bufferedAmount,
+        bufferedAfter: targetSocket.bufferedAmount,
       });
     }
   } catch (error) {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -29,6 +29,7 @@ import type { ListenerTransport } from "./transport";
 export interface StartListenerOptions {
   connectionId: string;
   wsUrl: string;
+  supportsSplitStatusChannels?: boolean;
   deviceId: string;
   connectionName: string;
   onConnected: (connectionId: string) => void;
@@ -161,6 +162,8 @@ export type ConversationRuntime = {
 export type ListenerRuntime = {
   socket: WebSocket | null;
   transport?: ListenerTransport | null;
+  streamSocket?: WebSocket | null;
+  streamTransport?: ListenerTransport | null;
   heartbeatInterval: NodeJS.Timeout | null;
   reconnectTimeout: NodeJS.Timeout | null;
   intentionallyClosed: boolean;


### PR DESCRIPTION
Reapply the dual control/stream websocket listener flow on top of the refactored listener architecture so newer servers can split runtime traffic without breaking single-socket fallback on older servers.

👾 Generated with [Letta Code](https://letta.com)