### PR TITLE
fix(listener): parse pong lifecycle frames

### DIFF
--- a/src/tests/websocket/listener-lifecycle-frames.test.ts
+++ b/src/tests/websocket/listener-lifecycle-frames.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type WebSocket from "ws";
+import { __listenClientTestUtils } from "../../websocket/listen-client";
+import { createListenerMessageHandler } from "../../websocket/listener/message-router";
+import { parseServerLifecycleMessage } from "../../websocket/listener/protocol-inbound";
+import type {
+  IncomingMessage,
+  ListenerRuntime,
+  StartListenerOptions,
+} from "../../websocket/listener/types";
+
+function makeListenerOptions(): StartListenerOptions {
+  return {
+    connectionId: "conn-test",
+    wsUrl: "wss://example.test/ws",
+    deviceId: "device-test",
+    connectionName: "listener-test",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+function makeHandler(runtime: ListenerRuntime) {
+  return createListenerMessageHandler({
+    runtime,
+    socket: {} as WebSocket,
+    opts: makeListenerOptions(),
+    processQueuedTurn: async () => {},
+    fileCommandSession: { handle: () => false },
+    getParsedRuntimeScope: () => null,
+    replaySyncStateForRuntime: async () => {},
+    getOrCreateScopedRuntime: () => {
+      throw new Error("unused in lifecycle-frame tests");
+    },
+    handleApprovalResponseInput: async () => false,
+    handleChangeDeviceStateInput: async () => false,
+    handleAbortMessageInput: async () => false,
+    stampInboundUserMessageOtids: (incoming: IncomingMessage) => incoming,
+    safeSocketSend: () => false,
+    runDetachedListenerTask: () => {},
+    trackListenerError: () => {},
+    wireChannelIngress: async () => {},
+  });
+}
+
+describe("listener lifecycle frames", () => {
+  afterEach(() => {
+    __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  test("recognizes app-level pong frames", () => {
+    expect(parseServerLifecycleMessage(Buffer.from('{"type":"pong"}'))).toEqual(
+      { type: "pong" },
+    );
+  });
+
+  test("logs app-level pong frames as lifecycle events", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const events: Array<{
+      direction: "send" | "recv";
+      label: "client" | "protocol" | "control" | "lifecycle";
+      event: unknown;
+    }> = [];
+    runtime.onWsEvent = (direction, label, event) => {
+      events.push({ direction, label, event });
+    };
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime)(Buffer.from('{"type":"pong"}'));
+
+    expect(events).toEqual([
+      { direction: "recv", label: "lifecycle", event: { type: "pong" } },
+    ]);
+  });
+
+  test("still logs malformed frames as unparseable lifecycle events", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const events: Array<{
+      direction: "send" | "recv";
+      label: "client" | "protocol" | "control" | "lifecycle";
+      event: unknown;
+    }> = [];
+    runtime.onWsEvent = (direction, label, event) => {
+      events.push({ direction, label, event });
+    };
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime)(Buffer.from("not-json"));
+
+    expect(events).toEqual([
+      {
+        direction: "recv",
+        label: "lifecycle",
+        event: { type: "_ws_unparseable", raw: "not-json" },
+      },
+    ]);
+  });
+});

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -32,6 +32,7 @@ import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
 import {
   isExecuteCommandCommand,
+  parseServerLifecycleMessage,
   parseServerMessage,
 } from "./protocol-inbound";
 import { emitDeviceStatusUpdate } from "./protocol-outbound";
@@ -184,6 +185,12 @@ export function createListenerMessageHandler(
     let parsedScope: ParsedRuntimeScope = null;
 
     try {
+      const lifecycleMessage = parseServerLifecycleMessage(data);
+      if (lifecycleMessage) {
+        safeEmitWsEvent("recv", "lifecycle", lifecycleMessage);
+        return;
+      }
+
       const parsed = parseServerMessage(data);
       parsedScope = getParsedRuntimeScope(parsed);
       if (parsed) {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -73,6 +73,10 @@ import type {
 import { isValidApprovalResponseBody } from "./approval";
 import type { InvalidInputCommand, ParsedServerMessage } from "./types";
 
+export type ServerLifecycleMessage = {
+  type: "pong";
+};
+
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
@@ -1481,6 +1485,25 @@ export function isExecuteCommandCommand(
     isRuntimeScope(c.runtime) &&
     hasValidArgs
   );
+}
+
+export function parseServerLifecycleMessage(
+  data: WebSocket.RawData,
+): ServerLifecycleMessage | null {
+  try {
+    const raw = typeof data === "string" ? data : data.toString();
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed as { type?: unknown }).type === "pong"
+    ) {
+      return { type: "pong" };
+    }
+  } catch {
+    // Non-JSON frames are handled by the regular unparseable-frame path.
+  }
+  return null;
 }
 
 export function parseServerMessage(


### PR DESCRIPTION
## Summary

- Treat app-level `pong` WebSocket frames as listener lifecycle messages instead of `_ws_unparseable` payloads.
- Preserve the existing malformed-frame `_ws_unparseable` path.
- Add focused listener lifecycle frame coverage.

## Validation

- `bun test src/tests/websocket/listener-lifecycle-frames.test.ts`
- `bun test src/tests/websocket/listen-client-protocol.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`

"The heartbeat is not the bug."

Written by Cameron ◯ Letta Code