### PR TITLE
fix(listener): gate post-stop approval recovery

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4936,6 +4936,29 @@ describe("listen-client post-stop approval recovery policy", () => {
     expect(shouldRecover).toBe(true);
   });
 
+  test("extracts streamed approval conflict details from generic error messages", () => {
+    const conflictDetail =
+      "CONFLICT: Cannot send a new message: The agent is waiting for approval on a tool call.";
+
+    expect(
+      __listenClientTestUtils.getApprovalToolCallDesyncErrorText({
+        message: "An unknown error occurred with the LLM streaming request.",
+        detail: conflictDetail,
+      }),
+    ).toBe(conflictDetail);
+
+    const shouldRecover =
+      __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({
+        stopReason: "error",
+        runIdsSeen: 1,
+        retries: 0,
+        runErrorDetail: null,
+        latestErrorText: conflictDetail,
+      });
+
+    expect(shouldRecover).toBe(true);
+  });
+
   test("does not retry on generic no-run errors without an approval conflict", () => {
     const shouldRecover =
       __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4949,6 +4949,21 @@ describe("listen-client post-stop approval recovery policy", () => {
     expect(shouldRecover).toBe(false);
   });
 
+  test("retries on explicit approval conflicts captured as fallback errors", () => {
+    const shouldRecover =
+      __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({
+        stopReason: "error",
+        runIdsSeen: 0,
+        retries: 0,
+        runErrorDetail: null,
+        latestErrorText: null,
+        fallbackError:
+          "CONFLICT: Cannot send a new message: The agent is waiting for approval on a tool call.",
+      });
+
+    expect(shouldRecover).toBe(true);
+  });
+
   test("does not retry when approval response is already stale", () => {
     const shouldRecover =
       __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4936,7 +4936,7 @@ describe("listen-client post-stop approval recovery policy", () => {
     expect(shouldRecover).toBe(true);
   });
 
-  test("retries on generic no-run error heuristic", () => {
+  test("does not retry on generic no-run errors without an approval conflict", () => {
     const shouldRecover =
       __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({
         stopReason: "error",
@@ -4946,7 +4946,20 @@ describe("listen-client post-stop approval recovery policy", () => {
         latestErrorText: null,
       });
 
-    expect(shouldRecover).toBe(true);
+    expect(shouldRecover).toBe(false);
+  });
+
+  test("does not retry when approval response is already stale", () => {
+    const shouldRecover =
+      __listenClientTestUtils.shouldAttemptPostStopApprovalRecovery({
+        stopReason: "error",
+        runIdsSeen: 1,
+        retries: 0,
+        runErrorDetail: "No tool call is currently awaiting approval",
+        latestErrorText: null,
+      });
+
+    expect(shouldRecover).toBe(false);
   });
 
   test("does not retry once retry budget is exhausted", () => {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -84,6 +84,7 @@ import {
 } from "./queue";
 import {
   getApprovalContinuationRecoveryDisposition,
+  getApprovalToolCallDesyncErrorText,
   recoverApprovalStateForSync,
   shouldAttemptPostStopApprovalRecovery,
 } from "./recovery";
@@ -461,6 +462,7 @@ export const __listenClientTestUtils = {
   getInterruptApprovalsForEmission,
   normalizeToolReturnWireMessage,
   normalizeExecutionResultsForInterruptParity,
+  getApprovalToolCallDesyncErrorText,
   shouldAttemptPostStopApprovalRecovery,
   getApprovalContinuationRecoveryDisposition,
   markAwaitingAcceptedApprovalContinuationRunId,

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -9,6 +9,3 @@ export const LLM_API_ERROR_MAX_RETRIES = 3;
 export const EMPTY_RESPONSE_MAX_RETRIES = 2;
 export const MAX_PRE_STREAM_RECOVERY = 2;
 export const MAX_POST_STOP_APPROVAL_RECOVERY = 2;
-
-export const NO_AWAITING_APPROVAL_DETAIL_FRAGMENT =
-  "no tool call is currently awaiting approval";

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -71,6 +71,21 @@ export function isApprovalToolCallDesyncError(detail: unknown): boolean {
   return isInvalidToolCallIdsError(detail) || isApprovalPendingError(detail);
 }
 
+export function getApprovalToolCallDesyncErrorText(errorInfo: {
+  detail?: unknown;
+  message?: unknown;
+}): string | null {
+  const detail = errorInfo.detail;
+  if (typeof detail === "string" && isApprovalToolCallDesyncError(detail)) {
+    return detail;
+  }
+  const message = errorInfo.message;
+  if (typeof message === "string" && isApprovalToolCallDesyncError(message)) {
+    return message;
+  }
+  return null;
+}
+
 export function shouldAttemptPostStopApprovalRecovery(params: {
   stopReason: string | null | undefined;
   runIdsSeen: number;

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -77,10 +77,12 @@ export function shouldAttemptPostStopApprovalRecovery(params: {
   retries: number;
   runErrorDetail: string | null;
   latestErrorText: string | null;
+  fallbackError?: string | null;
 }): boolean {
   const approvalDesyncDetected =
     isApprovalToolCallDesyncError(params.runErrorDetail) ||
-    isApprovalToolCallDesyncError(params.latestErrorText);
+    isApprovalToolCallDesyncError(params.latestErrorText) ||
+    isApprovalToolCallDesyncError(params.fallbackError);
 
   return shouldAttemptApprovalRecovery({
     approvalPendingDetected: approvalDesyncDetected,

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -34,10 +34,7 @@ import {
   applySuggestedPermissionsForApproval,
   classifyApprovalsWithSuggestions,
 } from "./approval-suggestions";
-import {
-  MAX_POST_STOP_APPROVAL_RECOVERY,
-  NO_AWAITING_APPROVAL_DETAIL_FRAGMENT,
-} from "./constants";
+import { MAX_POST_STOP_APPROVAL_RECOVERY } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
   createToolExecutionOutputEmitter,
@@ -71,13 +68,7 @@ import type {
 } from "./types";
 
 export function isApprovalToolCallDesyncError(detail: unknown): boolean {
-  if (isInvalidToolCallIdsError(detail) || isApprovalPendingError(detail)) {
-    return true;
-  }
-  return (
-    typeof detail === "string" &&
-    detail.toLowerCase().includes(NO_AWAITING_APPROVAL_DETAIL_FRAGMENT)
-  );
+  return isInvalidToolCallIdsError(detail) || isApprovalPendingError(detail);
 }
 
 export function shouldAttemptPostStopApprovalRecovery(params: {
@@ -91,11 +82,8 @@ export function shouldAttemptPostStopApprovalRecovery(params: {
     isApprovalToolCallDesyncError(params.runErrorDetail) ||
     isApprovalToolCallDesyncError(params.latestErrorText);
 
-  const genericNoRunError =
-    params.stopReason === "error" && params.runIdsSeen === 0;
-
   return shouldAttemptApprovalRecovery({
-    approvalPendingDetected: approvalDesyncDetected || genericNoRunError,
+    approvalPendingDetected: approvalDesyncDetected,
     retries: params.retries,
     maxRetries: MAX_POST_STOP_APPROVAL_RECOVERY,
   });

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -91,6 +91,7 @@ import {
   emitRecoverableStatusNotice,
 } from "./recoverable-notices";
 import {
+  getApprovalToolCallDesyncErrorText,
   isRetriablePostStopError,
   shouldAttemptPostStopApprovalRecovery,
 } from "./recovery";
@@ -684,18 +685,32 @@ export async function handleIncomingMessage(
           }
 
           if (errorInfo) {
-            latestErrorText = errorInfo.message || latestErrorText;
-            emitLoopErrorNotice(socket, runtime, {
-              message: errorInfo.message || "Stream error",
-              stopReason: (errorInfo.error_type as StopReasonType) || "error",
-              isTerminal: false,
-              runId: runId || errorInfo.run_id,
-              agentId,
-              conversationId,
-              errorInfo,
-              cancelRequested: runtime.cancelRequested,
-              abortSignal: turnAbortSignal,
-            });
+            const recoverableApprovalErrorText =
+              getApprovalToolCallDesyncErrorText(errorInfo);
+            latestErrorText =
+              recoverableApprovalErrorText ||
+              errorInfo.detail ||
+              errorInfo.message ||
+              latestErrorText;
+            if (!recoverableApprovalErrorText) {
+              emitLoopErrorNotice(socket, runtime, {
+                message: errorInfo.message || "Stream error",
+                stopReason: (errorInfo.error_type as StopReasonType) || "error",
+                isTerminal: false,
+                runId: runId || errorInfo.run_id,
+                agentId,
+                conversationId,
+                errorInfo,
+                cancelRequested: runtime.cancelRequested,
+                abortSignal: turnAbortSignal,
+              });
+            } else {
+              debugLog(
+                "recovery",
+                "Suppressing streamed approval conflict while post-stop recovery runs: %s",
+                recoverableApprovalErrorText,
+              );
+            }
           }
 
           if (shouldOutput) {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -725,6 +725,7 @@ export async function handleIncomingMessage(
 
       const stopReason = result.stopReason;
       const approvals = result.approvals || [];
+      const fallbackError = result.fallbackError ?? null;
       lastApprovalContinuationAccepted = false;
 
       if (stopReason === "end_turn" && runtime.cancelRequested) {
@@ -789,6 +790,7 @@ export async function handleIncomingMessage(
           latestErrorText ||
           runErrorInfo?.detail ||
           runErrorInfo?.message ||
+          fallbackError ||
           null;
 
         if (
@@ -798,6 +800,7 @@ export async function handleIncomingMessage(
             retries: postStopApprovalRecoveryRetries,
             runErrorDetail: errorDetail,
             latestErrorText,
+            fallbackError,
           })
         ) {
           postStopApprovalRecoveryRetries += 1;


### PR DESCRIPTION
## Summary

- Restricts listener post-stop approval recovery to explicit approval conflicts only.
- Stops generic no-run stream errors from triggering stale approval denial/retry logic.
- Treats `No tool call is currently awaiting approval` as already-stale, not recoverable.

This should prevent channel approval prompts, including Slack DM `Task`/recall approvals, from being clobbered by listener recovery after benign stream errors.

"The first principle is that you must not fool yourself." — Richard Feynman

Written by Cameron ◯ Letta Code