### PR TITLE
feat(local): add local compaction

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -82,6 +82,14 @@ export type ConversationMessageListParams = Parameters<
 export type ConversationMessageListBody = ConversationMessageListParams[1];
 export type ConversationMessageListOptions = ConversationMessageListParams[2];
 
+export type ConversationMessageCompactParams = Parameters<
+  APIClient["conversations"]["messages"]["compact"]
+>;
+export type ConversationMessageCompactBody =
+  ConversationMessageCompactParams[1];
+export type ConversationMessageCompactOptions =
+  ConversationMessageCompactParams[2];
+
 export type AgentMessageListParams = Parameters<
   APIClient["agents"]["messages"]["list"]
 >;
@@ -167,6 +175,14 @@ export interface Backend {
     options?: ConversationMessageListOptions,
   ): Promise<
     Awaited<ReturnType<APIClient["conversations"]["messages"]["list"]>>
+  >;
+
+  compactConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageCompactBody,
+    options?: ConversationMessageCompactOptions,
+  ): Promise<
+    Awaited<ReturnType<APIClient["conversations"]["messages"]["compact"]>>
   >;
 
   listAgentMessages(
@@ -328,6 +344,15 @@ export class APIBackend implements Backend {
   ) {
     const client = await this.getClient();
     return client.conversations.messages.list(conversationId, body, options);
+  }
+
+  async compactConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageCompactBody,
+    options?: ConversationMessageCompactOptions,
+  ) {
+    const client = await this.getClient();
+    return client.conversations.messages.compact(conversationId, body, options);
   }
 
   async listAgentMessages(

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -11,14 +11,20 @@ import {
   validateUIMessages,
 } from "ai";
 import type { ClientTool } from "../../tools/manager";
+import type { LocalCompactionStats } from "../local/compaction";
 import type { LocalMessage } from "../local/LocalMessage";
 import { createAISDKModelFactoryFromAgent } from "./AISDKModelFactory";
+import { isContextWindowOverflowError } from "./contextWindowOverflow";
 import type {
   ProviderStreamAdapter,
   ProviderStreamEvent,
   ProviderTurnInput,
 } from "./ProviderTurnExecutor";
-import { providerStreamPart, providerUIMessage } from "./ProviderTurnExecutor";
+import {
+  providerLettaChunk,
+  providerStreamPart,
+  providerUIMessage,
+} from "./ProviderTurnExecutor";
 
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
 type AISDKProviderKind = "anthropic" | "openai" | "unknown";
@@ -53,6 +59,14 @@ export interface AISDKStreamAdapterOptions {
   createModel?: () => LanguageModel;
   abortSignal?: AbortSignal;
   streamText?: AISDKStreamTextFunction;
+  onContextWindowOverflow?: (
+    input: ProviderTurnInput,
+    error: unknown,
+  ) => Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -325,14 +339,18 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
   private readonly createModel?: () => LanguageModel;
   private readonly runStreamText: AISDKStreamTextFunction;
   private readonly abortSignal?: AbortSignal;
+  private readonly onContextWindowOverflow?: AISDKStreamAdapterOptions["onContextWindowOverflow"];
 
   constructor(options: AISDKStreamAdapterOptions) {
     this.createModel = options.createModel;
     this.runStreamText = options.streamText ?? defaultStreamText;
     this.abortSignal = options.abortSignal;
+    this.onContextWindowOverflow = options.onContextWindowOverflow;
   }
 
-  async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
+  private async *streamOnce(
+    input: ProviderTurnInput,
+  ): AsyncIterable<ProviderStreamEvent> {
     const tools = toToolSet(input.clientTools);
     const provider = aiSDKProviderKind(
       input.agent.model,
@@ -367,14 +385,56 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
       },
     );
 
+    let streamError: unknown;
     for await (const part of result.fullStream) {
+      if (part.type === "error" && isContextWindowOverflowError(part.error)) {
+        streamError = part.error;
+        break;
+      }
       yield providerStreamPart(part);
+    }
+
+    if (streamError) {
+      await finalUIMessage.catch(() => undefined);
+      throw streamError;
     }
 
     const message = await finalUIMessage;
     if (uiMessageError) throw uiMessageError;
     if (message) {
       yield providerUIMessage(message);
+    }
+  }
+
+  async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
+    try {
+      yield* this.streamOnce(input);
+    } catch (error) {
+      if (
+        !isContextWindowOverflowError(error) ||
+        !this.onContextWindowOverflow
+      ) {
+        throw error;
+      }
+
+      const compaction = await this.onContextWindowOverflow(input, error);
+      if (!compaction) throw error;
+
+      yield providerLettaChunk({
+        message_type: "event_message",
+        event_type: "compaction",
+        event_data: { trigger: "context_window_overflow" },
+      } as never);
+      yield providerLettaChunk({
+        message_type: "summary_message",
+        summary: compaction.summary,
+        ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
+      } as never);
+
+      yield* this.streamOnce({
+        ...input,
+        uiMessages: compaction.uiMessages,
+      });
     }
   }
 }

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -3,6 +3,7 @@ import {
   convertToModelMessages,
   jsonSchema,
   type LanguageModel,
+  type LanguageModelUsage,
   type ModelMessage,
   streamText,
   type TextStreamPart,
@@ -62,6 +63,14 @@ export interface AISDKStreamAdapterOptions {
   onContextWindowOverflow?: (
     input: ProviderTurnInput,
     error: unknown,
+  ) => Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null>;
+  onContextUsage?: (
+    input: ProviderTurnInput,
+    usage: LanguageModelUsage,
   ) => Promise<{
     uiMessages: LocalMessage[];
     summary: string;
@@ -340,12 +349,34 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
   private readonly runStreamText: AISDKStreamTextFunction;
   private readonly abortSignal?: AbortSignal;
   private readonly onContextWindowOverflow?: AISDKStreamAdapterOptions["onContextWindowOverflow"];
+  private readonly onContextUsage?: AISDKStreamAdapterOptions["onContextUsage"];
 
   constructor(options: AISDKStreamAdapterOptions) {
     this.createModel = options.createModel;
     this.runStreamText = options.streamText ?? defaultStreamText;
     this.abortSignal = options.abortSignal;
     this.onContextWindowOverflow = options.onContextWindowOverflow;
+    this.onContextUsage = options.onContextUsage;
+  }
+
+  private async *emitCompactionChunks(
+    compaction: {
+      summary: string;
+      stats?: LocalCompactionStats;
+    },
+    fallbackTrigger: string,
+  ): AsyncIterable<ProviderStreamEvent> {
+    const trigger = compaction.stats?.trigger ?? fallbackTrigger;
+    yield providerLettaChunk({
+      message_type: "event_message",
+      event_type: "compaction",
+      event_data: { trigger },
+    } as never);
+    yield providerLettaChunk({
+      message_type: "summary_message",
+      summary: compaction.summary,
+      ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
+    } as never);
   }
 
   private async *streamOnce(
@@ -386,10 +417,23 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
     );
 
     let streamError: unknown;
+    let lastUsage: LanguageModelUsage | undefined;
+    let sawToolCall = false;
+    let finishReason: string | undefined;
     for await (const part of result.fullStream) {
       if (part.type === "error" && isContextWindowOverflowError(part.error)) {
         streamError = part.error;
         break;
+      }
+      if (part.type === "tool-call") {
+        sawToolCall = true;
+      }
+      if (part.type === "finish-step") {
+        lastUsage = part.usage;
+      }
+      if (part.type === "finish") {
+        finishReason = part.finishReason;
+        lastUsage ??= part.totalUsage;
       }
       yield providerStreamPart(part);
     }
@@ -403,6 +447,17 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
     if (uiMessageError) throw uiMessageError;
     if (message) {
       yield providerUIMessage(message);
+    }
+    if (
+      lastUsage &&
+      !sawToolCall &&
+      finishReason !== "tool-calls" &&
+      this.onContextUsage
+    ) {
+      const compaction = await this.onContextUsage(input, lastUsage);
+      if (compaction) {
+        yield* this.emitCompactionChunks(compaction, "context_window_limit");
+      }
     }
   }
 
@@ -420,16 +475,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
       const compaction = await this.onContextWindowOverflow(input, error);
       if (!compaction) throw error;
 
-      yield providerLettaChunk({
-        message_type: "event_message",
-        event_type: "compaction",
-        event_data: { trigger: "context_window_overflow" },
-      } as never);
-      yield providerLettaChunk({
-        message_type: "summary_message",
-        summary: compaction.summary,
-        ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
-      } as never);
+      yield* this.emitCompactionChunks(compaction, "context_window_overflow");
 
       yield* this.streamOnce({
         ...input,

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -201,6 +201,12 @@ export class HeadlessBackend implements Backend {
     ) as never;
   }
 
+  async compactConversationMessages(
+    ..._args: Parameters<Backend["compactConversationMessages"]>
+  ): ReturnType<Backend["compactConversationMessages"]> {
+    throw new Error("Compaction is not supported by this backend yet");
+  }
+
   async listAgentMessages(
     ...args: Parameters<Backend["listAgentMessages"]>
   ): ReturnType<Backend["listAgentMessages"]> {

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -29,6 +29,7 @@ export interface ProviderTurnInput {
 export type ProviderStreamEvent =
   | { type: "ai-sdk-part"; part: ProviderStreamPart }
   | { type: "ai-sdk-ui-message"; message: LocalMessage }
+  | { type: "letta-chunk"; chunk: LettaStreamingResponse }
   | { type: "error"; error: unknown };
 
 export function providerStreamPart(
@@ -39,6 +40,12 @@ export function providerStreamPart(
 
 export function providerUIMessage(message: LocalMessage): ProviderStreamEvent {
   return { type: "ai-sdk-ui-message", message };
+}
+
+export function providerLettaChunk(
+  chunk: LettaStreamingResponse,
+): ProviderStreamEvent {
+  return { type: "letta-chunk", chunk };
 }
 
 export interface ProviderStreamAdapter {
@@ -125,6 +132,11 @@ function createProviderLettaStream(
 
           if (event.type === "ai-sdk-ui-message") {
             yield createLocalUIMessageChunk(event.message);
+            continue;
+          }
+
+          if (event.type === "letta-chunk") {
+            yield event.chunk;
             continue;
           }
 

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { LanguageModelUsage } from "ai";
 import type { LocalMessage } from "../local/LocalMessage";
 import type { LocalAgentRecord, StoredMessage } from "../local/LocalStore";
 import {
@@ -105,6 +106,46 @@ function createLocalUIMessageChunk(
   ) as unknown as LettaStreamingResponse;
 }
 
+function createUsageStatisticsChunk(
+  usage: LanguageModelUsage | undefined,
+): LettaStreamingResponse | undefined {
+  if (!usage) return undefined;
+  const promptTokens = usage.inputTokens;
+  const completionTokens = usage.outputTokens;
+  const totalTokens = usage.totalTokens;
+  const cachedInputTokens = usage.inputTokenDetails.cacheReadTokens;
+  const cacheWriteTokens = usage.inputTokenDetails.cacheWriteTokens;
+  const reasoningTokens = usage.outputTokenDetails.reasoningTokens;
+  if (
+    promptTokens === undefined &&
+    completionTokens === undefined &&
+    totalTokens === undefined &&
+    cachedInputTokens === undefined &&
+    cacheWriteTokens === undefined &&
+    reasoningTokens === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    message_type: "usage_statistics",
+    ...(promptTokens !== undefined ? { prompt_tokens: promptTokens } : {}),
+    ...(completionTokens !== undefined
+      ? { completion_tokens: completionTokens }
+      : {}),
+    ...(totalTokens !== undefined ? { total_tokens: totalTokens } : {}),
+    ...(cachedInputTokens !== undefined
+      ? { cached_input_tokens: cachedInputTokens }
+      : {}),
+    ...(cacheWriteTokens !== undefined
+      ? { cache_write_tokens: cacheWriteTokens }
+      : {}),
+    ...(reasoningTokens !== undefined
+      ? { reasoning_tokens: reasoningTokens }
+      : {}),
+    ...(promptTokens !== undefined ? { context_tokens: promptTokens } : {}),
+  } as unknown as LettaStreamingResponse;
+}
+
 function createProviderLettaStream(
   events: AsyncIterable<ProviderStreamEvent>,
 ): Stream<LettaStreamingResponse> {
@@ -114,6 +155,7 @@ function createProviderLettaStream(
     async *[Symbol.asyncIterator]() {
       let sawToolCall = false;
       let pendingStopReason: LettaStreamingResponse | undefined;
+      let sawUsageStatistics = false;
       const assistantOtid = `provider-assistant-${randomUUID()}`;
       const reasoningOtid = `provider-reasoning-${randomUUID()}`;
       try {
@@ -141,6 +183,15 @@ function createProviderLettaStream(
           }
 
           const { part } = event;
+          if (part.type === "finish-step") {
+            const usageChunk = createUsageStatisticsChunk(part.usage);
+            if (usageChunk) {
+              sawUsageStatistics = true;
+              yield usageChunk;
+            }
+            continue;
+          }
+
           if (part.type === "text-delta") {
             yield {
               message_type: "assistant_message",
@@ -173,6 +224,13 @@ function createProviderLettaStream(
           }
 
           if (part.type === "finish") {
+            if (!sawUsageStatistics) {
+              const usageChunk = createUsageStatisticsChunk(part.totalUsage);
+              if (usageChunk) {
+                sawUsageStatistics = true;
+                yield usageChunk;
+              }
+            }
             pendingStopReason = {
               message_type: "stop_reason",
               stop_reason:

--- a/src/backend/dev/contextWindowOverflow.ts
+++ b/src/backend/dev/contextWindowOverflow.ts
@@ -1,0 +1,61 @@
+import { APICallError } from "ai";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function contextOverflowHaystack(error: unknown): string {
+  const pieces: string[] = [];
+  const visit = (value: unknown, depth: number) => {
+    if (value === undefined || value === null || depth > 3) return;
+    if (typeof value === "string") {
+      pieces.push(value);
+      return;
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      pieces.push(String(value));
+      return;
+    }
+    if (value instanceof Error) {
+      pieces.push(value.name, value.message);
+      visit((value as { cause?: unknown }).cause, depth + 1);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, depth + 1);
+      return;
+    }
+    if (isRecord(value)) {
+      for (const [key, item] of Object.entries(value)) {
+        pieces.push(key);
+        visit(item, depth + 1);
+      }
+    }
+  };
+  visit(error, 0);
+  return pieces.join("\n").toLowerCase();
+}
+
+export function isContextWindowOverflowError(error: unknown): boolean {
+  const haystack = contextOverflowHaystack(error);
+  const statusCode = APICallError.isInstance(error)
+    ? error.statusCode
+    : isRecord(error) && typeof error.statusCode === "number"
+      ? error.statusCode
+      : undefined;
+  const hasOverflowMarker = [
+    "context_length_exceeded",
+    "context window",
+    "maximum context length",
+    "max context length",
+    "prompt is too long",
+    "input is too long",
+    "too many tokens",
+    "exceeds the context",
+    "exceeded the context",
+    "reduce the length",
+    "request too large",
+  ].some((marker) => haystack.includes(marker));
+  if (!hasOverflowMarker) return false;
+  return statusCode === undefined || statusCode === 400 || statusCode === 413;
+}

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -1,4 +1,4 @@
-import type { LanguageModel } from "ai";
+import type { LanguageModel, LanguageModelUsage } from "ai";
 import {
   getMemoryHeadRevision,
   type InitializeLocalMemoryRepoFile,
@@ -136,6 +136,14 @@ function createLocalExecutor(
     summary: string;
     stats?: LocalCompactionStats;
   } | null>,
+  onContextUsage?: (
+    input: ProviderTurnInput,
+    usage: LanguageModelUsage,
+  ) => Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null>,
 ): HeadlessTurnExecutor {
   if (options.executor) return options.executor;
   if (options.executionMode === "deterministic") {
@@ -146,6 +154,7 @@ function createLocalExecutor(
       createModel: options.createModel,
       streamText: options.streamText,
       onContextWindowOverflow,
+      onContextUsage,
     }),
   );
 }
@@ -188,6 +197,9 @@ export class LocalBackend extends HeadlessBackend {
         options,
         (input, error) =>
           localBackendRef.current?.compactAfterContextOverflow(input, error) ??
+          Promise.resolve(null),
+        (input, usage) =>
+          localBackendRef.current?.compactAfterContextUsage(input, usage) ??
           Promise.resolve(null),
       ),
       storeOptions,
@@ -343,6 +355,73 @@ export class LocalBackend extends HeadlessBackend {
     };
   }
 
+  private async compactAfterContextUsage(
+    input: ProviderTurnInput,
+    usage: LanguageModelUsage,
+  ): Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null> {
+    const contextTokens = usage.inputTokens;
+    const contextWindow = this.effectiveContextWindow(
+      input.conversationId,
+      input.agentId,
+    );
+    if (
+      contextTokens === undefined ||
+      contextWindow === undefined ||
+      contextTokens <= contextWindow
+    ) {
+      return null;
+    }
+
+    const result = await this.compactLocalConversationAll(
+      input.conversationId,
+      input.agentId,
+      "context_window_limit",
+      {
+        compaction_settings: { mode: "all" },
+      } as ConversationMessageCompactBody,
+    );
+    return {
+      uiMessages: this.store.listLocalMessages(
+        input.conversationId,
+        input.agentId,
+      ),
+      summary: result.summary,
+      stats: result.stats,
+    };
+  }
+
+  private effectiveContextWindow(
+    conversationId: string,
+    agentId: string,
+  ): number | undefined {
+    const conversation = this.store.retrieveConversation(
+      conversationId,
+      agentId,
+    ) as { context_window_limit?: unknown; model_settings?: unknown };
+    if (typeof conversation.context_window_limit === "number") {
+      return conversation.context_window_limit;
+    }
+    const conversationModelSettings = conversation.model_settings;
+    if (
+      conversationModelSettings &&
+      typeof conversationModelSettings === "object" &&
+      !Array.isArray(conversationModelSettings) &&
+      typeof (conversationModelSettings as { context_window_limit?: unknown })
+        .context_window_limit === "number"
+    ) {
+      return (conversationModelSettings as { context_window_limit: number })
+        .context_window_limit;
+    }
+    const agent = this.store.retrieveAgentRecord(agentId);
+    return typeof agent.model_settings.context_window_limit === "number"
+      ? agent.model_settings.context_window_limit
+      : undefined;
+  }
+
   private async compactLocalConversationAll(
     conversationId: string,
     agentId: string,
@@ -384,10 +463,7 @@ export class LocalBackend extends HeadlessBackend {
       trigger,
       context_tokens_before: contextTokensBefore,
       context_tokens_after: Math.ceil(summary.length / 4),
-      context_window:
-        typeof agent.model_settings.context_window_limit === "number"
-          ? agent.model_settings.context_window_limit
-          : undefined,
+      context_window: this.effectiveContextWindow(conversationId, agentId),
       messages_count_before: messages.length,
       messages_count_after: 1,
     };

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -6,8 +6,10 @@ import {
 } from "../../agent/memoryGit";
 import type {
   AgentCreateBody,
+  Backend,
   BackendCapabilities,
   ConversationCreateBody,
+  ConversationMessageCompactBody,
   ConversationMessageCreateBody,
   ConversationMessageListBody,
   ConversationMessageStreamBody,
@@ -22,7 +24,15 @@ import {
   DeterministicPongExecutor,
   type HeadlessTurnExecutor,
 } from "../dev/HeadlessTurnExecutor";
+import type { ProviderTurnInput } from "../dev/ProviderTurnExecutor";
 import { ProviderTurnExecutor } from "../dev/ProviderTurnExecutor";
+import {
+  estimateLocalMessageTokens,
+  type LocalCompactionStats,
+  type LocalGenerateTextFunction,
+  packageLocalSummaryMessage,
+  summarizeLocalMessagesAll,
+} from "./compaction";
 import type { LocalMessage } from "./LocalMessage";
 import { listLocalModels, resolveLocalModelConfig } from "./LocalModelConfig";
 import type {
@@ -47,6 +57,7 @@ export interface LocalBackendOptions {
   executor?: HeadlessTurnExecutor;
   createModel?: () => LanguageModel;
   streamText?: AISDKStreamTextFunction;
+  generateText?: LocalGenerateTextFunction;
   memoryDir?: string;
 }
 
@@ -117,6 +128,14 @@ function initialMemoryFilesFromCreateBody(
 
 function createLocalExecutor(
   options: LocalBackendOptions,
+  onContextWindowOverflow?: (
+    input: ProviderTurnInput,
+    error: unknown,
+  ) => Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null>,
 ): HeadlessTurnExecutor {
   if (options.executor) return options.executor;
   if (options.executionMode === "deterministic") {
@@ -126,6 +145,7 @@ function createLocalExecutor(
     new AISDKStreamAdapter({
       createModel: options.createModel,
       streamText: options.streamText,
+      onContextWindowOverflow,
     }),
   );
 }
@@ -144,8 +164,11 @@ export class LocalBackend extends HeadlessBackend {
 
   private readonly memoryDir?: string;
   private readonly storageDir: string;
+  private readonly createModel?: () => LanguageModel;
+  private readonly generateText?: LocalGenerateTextFunction;
 
   constructor(options: LocalBackendOptions) {
+    const localBackendRef: { current?: LocalBackend } = {};
     const modelConfig = resolveLocalModelConfig();
     const storeOptions: LocalStoreOptions = {
       storageDir: options.storageDir,
@@ -161,7 +184,12 @@ export class LocalBackend extends HeadlessBackend {
     };
     super(
       options.defaultAgentId ?? "agent-local-default",
-      createLocalExecutor(options),
+      createLocalExecutor(
+        options,
+        (input, error) =>
+          localBackendRef.current?.compactAfterContextOverflow(input, error) ??
+          Promise.resolve(null),
+      ),
       storeOptions,
       {
         modelHandle: modelConfig.handle,
@@ -169,8 +197,11 @@ export class LocalBackend extends HeadlessBackend {
         runMetadataBackend: "local",
       },
     );
+    localBackendRef.current = this;
     this.storageDir = options.storageDir;
     this.memoryDir = options.memoryDir;
+    this.createModel = options.createModel;
+    this.generateText = options.generateText;
   }
 
   override async listModels() {
@@ -222,6 +253,28 @@ export class LocalBackend extends HeadlessBackend {
     return compiled.content;
   }
 
+  override async compactConversationMessages(
+    conversationId: string,
+    body?: ConversationMessageCompactBody,
+  ): ReturnType<Backend["compactConversationMessages"]> {
+    const bodyRecord = (body ?? {}) as Record<string, unknown>;
+    const agentId =
+      typeof bodyRecord.agent_id === "string" && bodyRecord.agent_id.length > 0
+        ? bodyRecord.agent_id
+        : this.store.resolveAgentIdForConversation(conversationId);
+    const result = await this.compactLocalConversationAll(
+      conversationId,
+      agentId,
+      "manual",
+      body,
+    );
+    return {
+      num_messages_before: result.numMessagesBefore,
+      num_messages_after: result.numMessagesAfter,
+      summary: result.summary,
+    } as Awaited<ReturnType<Backend["compactConversationMessages"]>>;
+  }
+
   protected override async resolveSystemPromptForTurn(input: {
     conversationId: string;
     agentId: string;
@@ -262,6 +315,95 @@ export class LocalBackend extends HeadlessBackend {
       authorName,
       files,
     });
+  }
+
+  private async compactAfterContextOverflow(
+    input: ProviderTurnInput,
+    _error: unknown,
+  ): Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null> {
+    const result = await this.compactLocalConversationAll(
+      input.conversationId,
+      input.agentId,
+      "context_window_overflow",
+      {
+        compaction_settings: { mode: "all" },
+      } as ConversationMessageCompactBody,
+    );
+    return {
+      uiMessages: this.store.listLocalMessages(
+        input.conversationId,
+        input.agentId,
+      ),
+      summary: result.summary,
+      stats: result.stats,
+    };
+  }
+
+  private async compactLocalConversationAll(
+    conversationId: string,
+    agentId: string,
+    trigger: string,
+    body?: ConversationMessageCompactBody,
+  ): Promise<{
+    numMessagesBefore: number;
+    numMessagesAfter: number;
+    summary: string;
+    stats: LocalCompactionStats;
+  }> {
+    const settings = ((body ?? {}) as Record<string, unknown>)
+      .compaction_settings as Record<string, unknown> | null | undefined;
+    const mode = typeof settings?.mode === "string" ? settings.mode : "all";
+    if (mode !== "all") {
+      throw new Error(
+        `Local backend compaction currently supports only mode "all" (received "${mode}").`,
+      );
+    }
+
+    const agent = this.store.retrieveAgentRecord(agentId);
+    const messages = this.store.listLocalMessages(conversationId, agentId);
+    const contextTokensBefore = estimateLocalMessageTokens(messages);
+    const prompt =
+      typeof settings?.prompt === "string" ? settings.prompt : null;
+    const clipChars =
+      typeof settings?.clip_chars === "number" || settings?.clip_chars === null
+        ? settings.clip_chars
+        : undefined;
+    const summary = await summarizeLocalMessagesAll({
+      agent,
+      messages,
+      createModel: this.createModel,
+      generateText: this.generateText,
+      prompt,
+      clipChars,
+    });
+    const stats: LocalCompactionStats = {
+      trigger,
+      context_tokens_before: contextTokensBefore,
+      context_tokens_after: Math.ceil(summary.length / 4),
+      context_window:
+        typeof agent.model_settings.context_window_limit === "number"
+          ? agent.model_settings.context_window_limit
+          : undefined,
+      messages_count_before: messages.length,
+      messages_count_after: 1,
+    };
+    const storeResult = this.store.compactConversationAll({
+      conversationId,
+      agentId,
+      summary,
+      packedSummary: packageLocalSummaryMessage(summary, stats),
+      stats,
+    });
+    return {
+      numMessagesBefore: storeResult.numMessagesBefore,
+      numMessagesAfter: storeResult.numMessagesAfter,
+      summary,
+      stats,
+    };
   }
 
   private async getOrCompileSystemPrompt(

--- a/src/backend/local/LocalMessage.ts
+++ b/src/backend/local/LocalMessage.ts
@@ -15,6 +15,17 @@ export interface LocalMessageMetadata {
   agent_id?: string;
   conversation_id?: string;
   provider?: LocalMessageProviderMetadata;
+  compaction?: {
+    summary: string;
+    stats?: {
+      trigger?: string;
+      context_tokens_before?: number;
+      context_tokens_after?: number;
+      context_window?: number;
+      messages_count_before?: number;
+      messages_count_after?: number;
+    };
+  };
 }
 
 export type LocalMessage = UIMessage<LocalMessageMetadata>;

--- a/src/backend/local/LocalMessageProjection.ts
+++ b/src/backend/local/LocalMessageProjection.ts
@@ -197,6 +197,22 @@ export function projectLocalMessageToStoredMessages(
   );
   const date = fallbackDate;
 
+  if (message.metadata?.compaction) {
+    return [
+      {
+        id: message.id,
+        date,
+        agent_id: agentId,
+        conversation_id: conversationId,
+        message_type: "summary_message",
+        summary: message.metadata.compaction.summary,
+        ...(message.metadata.compaction.stats
+          ? { compaction_stats: message.metadata.compaction.stats }
+          : {}),
+      } as StoredMessage,
+    ];
+  }
+
   if (message.role === "user" || message.role === "system") {
     return [
       {

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -26,6 +26,7 @@ import type {
   ConversationMessageStreamBody,
   ConversationUpdateBody,
 } from "../backend";
+import type { LocalCompactionStats } from "./compaction";
 import type { LocalMessage } from "./LocalMessage";
 import {
   cloneLocalMessage,
@@ -409,6 +410,12 @@ function toStoredOutputFields(chunk: Record<string, unknown>) {
 export interface StoredTurnInput {
   agentId: string;
   conversationId: string;
+}
+
+export interface LocalCompactionStoreResult {
+  numMessagesBefore: number;
+  numMessagesAfter: number;
+  summaryMessage: LocalMessage;
 }
 
 export interface LocalStoreOptions {
@@ -1052,6 +1059,50 @@ export class LocalStore {
       throw new LocalBackendNotFoundError("Message", messageId);
     }
     return [...messages];
+  }
+
+  compactConversationAll(input: {
+    conversationId: string;
+    agentId: string;
+    summary: string;
+    packedSummary: string;
+    stats?: LocalCompactionStats;
+  }): LocalCompactionStoreResult {
+    const conversation = this.ensureConversation(
+      input.conversationId,
+      input.agentId,
+    );
+    const key = this.conversationKey(conversation.id, input.agentId);
+    const previousMessages = this.localMessagesByConversationKey.get(key) ?? [];
+    const id = this.nextLocalMessageId();
+    const date = this.currentLocalMessageDate();
+    const summaryMessage: LocalMessage = {
+      id,
+      role: "user",
+      metadata: {
+        created_at: date,
+        updated_at: date,
+        agent_id: input.agentId,
+        conversation_id: conversation.id,
+        compaction: {
+          summary: input.summary,
+          ...(input.stats ? { stats: input.stats } : {}),
+        },
+      },
+      parts: [{ type: "text", text: input.packedSummary } as LocalMessagePart],
+    };
+    this.localMessagesByConversationKey.set(key, [summaryMessage]);
+    conversation.in_context_message_ids = [summaryMessage.id];
+    conversation.last_message_at = date;
+    conversation.updated_at = date;
+    this.conversations.set(key, conversation);
+    this.persistConversationState(conversation.id, input.agentId);
+    this.rebuildMessageIndex();
+    return {
+      numMessagesBefore: previousMessages.length,
+      numMessagesAfter: 1,
+      summaryMessage: cloneLocalMessage(summaryMessage),
+    };
   }
 
   private appendUserLocalMessage(

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -1,0 +1,216 @@
+import { generateText, type LanguageModel } from "ai";
+import { createAISDKModelFactoryFromAgent } from "../dev/AISDKModelFactory";
+import { buildAISDKProviderOptions } from "../dev/AISDKStreamAdapter";
+import { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
+import type { LocalMessage } from "./LocalMessage";
+import type { LocalAgentRecord } from "./LocalStore";
+
+const ALL_WORD_LIMIT = 500;
+const SUMMARY_TRUNCATION_SUFFIX = "... [summary truncated to fit]";
+const TOOL_TRANSCRIPT_TRUNCATION_CHARS = 4000;
+const TRANSCRIPT_FALLBACK_MAX_CHARS = 120000;
+
+export const LOCAL_ALL_COMPACTION_PROMPT = `Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
+This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context. Your summary should include the following sections:
+
+1.**High level goals**: What is the high level goal and ongoing task? Capture the user's explicit requests and intent in detail. If there is an existing summary in the transcript, make sure to take it into consideration to continue tracking the higher level goals and long-term progress.
+
+2. **What happened**: The conversations, tasks, and exchanges that took place. What did the user ask for? What did you do? How did things progress? If there is a previous summary being evicted, please extract a concise version of the critical info from it.
+
+3. **Important details**: Enumerate specific files and code sections examined, modified, or created, as well as important plan files, GitHub issues/PR links, and Linear ticket IDs. For each item, include why it matters and any relevant names, data, configs, or facts discussed.
+   - **Preserve identifiers verbatim** (plan filename/path, exact URL, issue/PR number, ticket ID); do not paraphrase or truncate.
+   - **Preserve referenced identifiers unless explicitly resolved**: Keep exact URLs/IDs from the conversation unless there is clear evidence they are no longer relevant.
+   - Do not omit details likely to be referenced later.
+
+4. **Errors and fixes**: List all errors that you ran into, and how you fixed them. Pay special attention to specific user feedback that you received and record verbatim if useful.
+
+5. **Current state**:Describe in detail precisely what is currently being worked on, paying special attention to the most recent messages from both user and assistant. Include file names and code snippets where applicable.
+
+6.**Optional Next Step**: List the next step that you will take that is related to the most recent work you were doing. IMPORTANT: ensure that this step is DIRECTLY in line with the user's most recent explicit requests and the most current task. If your last task was concluded, then only list next steps if they are explicitly in line with the users request. If there is a next step, include direct quotes from the most recent conversation showing exactly what task you were working on and where you left off.
+
+7. **Lookup hints**: For any detailed content (long lists, extensive data, specific conversations) that couldn't fit in the summary, note the topic and key terms that could be used to find it in message history later.
+
+Write in first person as a factual record of what occurred. Be concise but thorough - the goal is to preserve enough context that the recent messages make sense and important information isn't lost to prevent duplicate work or repeated mistakes.
+
+Keep your summary under ${ALL_WORD_LIMIT} words. Only output the summary.`;
+
+export interface LocalCompactionStats {
+  trigger?: string;
+  context_tokens_before?: number;
+  context_tokens_after?: number;
+  context_window?: number;
+  messages_count_before?: number;
+  messages_count_after?: number;
+}
+
+export type LocalGenerateTextFunction = (options: {
+  model: LanguageModel;
+  system?: string;
+  prompt?: string;
+  providerOptions?: Parameters<typeof generateText>[0]["providerOptions"];
+  maxRetries: number;
+  abortSignal?: AbortSignal;
+}) => ReturnType<typeof generateText>;
+
+export interface LocalAllCompactionInput {
+  agent: LocalAgentRecord;
+  messages: LocalMessage[];
+  createModel?: () => LanguageModel;
+  generateText?: LocalGenerateTextFunction;
+  prompt?: string | null;
+  clipChars?: number | null;
+  abortSignal?: AbortSignal;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}… [truncated ${value.length - maxChars} chars]`;
+}
+
+function toolPartSummary(
+  part: Record<string, unknown>,
+  truncationChars?: number,
+) {
+  const toolName = String(part.type).slice("tool-".length);
+  const input = truncate(
+    stringifyUnknown(part.input),
+    truncationChars ?? Number.POSITIVE_INFINITY,
+  );
+  const state = typeof part.state === "string" ? part.state : "unknown";
+  const output =
+    part.output !== undefined || part.errorText !== undefined
+      ? `\noutput: ${truncate(
+          stringifyUnknown(part.output ?? part.errorText),
+          truncationChars ?? Number.POSITIVE_INFINITY,
+        )}`
+      : "";
+  return `[tool ${toolName} state=${state}]\ninput: ${input}${output}`;
+}
+
+function partText(
+  part: LocalMessage["parts"][number],
+  truncationChars?: number,
+) {
+  if (!isRecord(part)) return stringifyUnknown(part);
+  if (
+    (part.type === "text" || part.type === "reasoning") &&
+    typeof part.text === "string"
+  ) {
+    return part.type === "reasoning" ? `[reasoning]\n${part.text}` : part.text;
+  }
+  if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+    return toolPartSummary(part, truncationChars);
+  }
+  return truncate(
+    stringifyUnknown(part),
+    truncationChars ?? Number.POSITIVE_INFINITY,
+  );
+}
+
+export function formatLocalMessagesForSummary(
+  messages: LocalMessage[],
+  options: { truncationChars?: number; maxChars?: number } = {},
+): string {
+  const transcript = messages
+    .map((message, index) => {
+      const compactionSummary = message.metadata?.compaction?.summary;
+      const body =
+        typeof compactionSummary === "string"
+          ? compactionSummary
+          : message.parts
+              .map((part) => partText(part, options.truncationChars))
+              .filter((text) => text.length > 0)
+              .join("\n");
+      return `<message index="${index + 1}" role="${message.role}">\n${body}\n</message>`;
+    })
+    .join("\n\n");
+  if (options.maxChars && transcript.length > options.maxChars) {
+    return `${transcript.slice(
+      transcript.length - options.maxChars,
+    )}\n\n[Earlier transcript content was truncated to fit the summarizer context window.]`;
+  }
+  return transcript;
+}
+
+async function runGenerateText(
+  input: LocalAllCompactionInput,
+  transcript: string,
+) {
+  const run = input.generateText ?? generateText;
+  return run({
+    model:
+      input.createModel?.() ??
+      createAISDKModelFactoryFromAgent(
+        input.agent.model,
+        input.agent.model_settings,
+      )(),
+    system: input.prompt ?? LOCAL_ALL_COMPACTION_PROMPT,
+    prompt: transcript,
+    providerOptions: buildAISDKProviderOptions(
+      input.agent.model,
+      input.agent.model_settings,
+    ),
+    maxRetries: 0,
+    abortSignal: input.abortSignal,
+  });
+}
+
+export async function summarizeLocalMessagesAll(
+  input: LocalAllCompactionInput,
+): Promise<string> {
+  if (input.messages.length === 0) return "No prior conversation messages.";
+  const primaryTranscript = formatLocalMessagesForSummary(input.messages);
+  let result: Awaited<ReturnType<typeof generateText>>;
+  try {
+    result = await runGenerateText(input, primaryTranscript);
+  } catch (error) {
+    if (!isContextWindowOverflowError(error)) throw error;
+    const fallbackTranscript = formatLocalMessagesForSummary(input.messages, {
+      truncationChars: TOOL_TRANSCRIPT_TRUNCATION_CHARS,
+      maxChars: TRANSCRIPT_FALLBACK_MAX_CHARS,
+    });
+    result = await runGenerateText(input, fallbackTranscript);
+  }
+
+  let summary = result.text.trim();
+  const clipChars = input.clipChars === undefined ? 50000 : input.clipChars;
+  if (clipChars !== null && summary.length > clipChars) {
+    summary = `${summary.slice(0, clipChars)}${SUMMARY_TRUNCATION_SUFFIX}`;
+  }
+  return summary;
+}
+
+export function estimateLocalMessageTokens(messages: LocalMessage[]): number {
+  const chars = messages.reduce(
+    (total, message) => total + JSON.stringify(message).length,
+    0,
+  );
+  return Math.ceil(chars / 4);
+}
+
+export function packageLocalSummaryMessage(
+  summary: string,
+  stats?: LocalCompactionStats,
+): string {
+  const message = `Note: prior messages with the user are available in external context. Messages are a record of the conversation history, or "events," containing user or system/automated inputs, reasoning traces, agent outputs, tool calls, and tool responses. As a Letta agent, your conversation history is automatically managed by the system — old messages will be periodically evicted from the conversation history and replaced with a recursive summary ("compaction"), yet all messages are persisted and remain retrievable through active tool calling.\nThe following is an in-context recursive summary of the prior messages: ${summary}`;
+  return JSON.stringify({
+    type: "system_alert",
+    message,
+    time: new Date().toISOString(),
+    ...(stats ? { compaction_stats: stats } : {}),
+  });
+}

--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -1,3 +1,9 @@
+export { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
+export {
+  formatLocalMessagesForSummary,
+  LOCAL_ALL_COMPACTION_PROMPT,
+  type LocalCompactionStats,
+} from "./compaction";
 export { LocalBackend, type LocalBackendOptions } from "./LocalBackend";
 export type {
   LocalMessage,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9300,8 +9300,6 @@ export default function App({
               return { submitted: true };
             }
 
-            const client = await getClient();
-
             // Build compaction settings if mode was specified
             // On server side, if mode changed, summarize function will use corresponding default prompt for new mode
             const compactParams = modeArg
@@ -9323,7 +9321,7 @@ export default function App({
                     ...(compactParams ?? {}),
                   }
                 : compactParams;
-            const result = await client.conversations.messages.compact(
+            const result = await getBackend().compactConversationMessages(
               compactConversationId,
               compactBody,
             );

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -13,6 +13,7 @@ import { dirname, join } from "node:path";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type {
   LanguageModel,
+  LanguageModelUsage,
   ModelMessage,
   TextStreamPart,
   ToolSet,
@@ -176,6 +177,26 @@ function uiMessageStream(
       controller.close();
     },
   });
+}
+
+function modelUsage(
+  inputTokens: number,
+  outputTokens: number,
+): LanguageModelUsage {
+  return {
+    inputTokens,
+    inputTokenDetails: {
+      noCacheTokens: inputTokens,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens,
+    outputTokenDetails: {
+      textTokens: outputTokens,
+      reasoningTokens: undefined,
+    },
+    totalTokens: inputTokens + outputTokens,
+  };
 }
 
 type MockUIMessageStreamOptions = {
@@ -576,6 +597,96 @@ describe("LocalBackend", () => {
       expect(
         page.getPaginatedItems().map((message) => message.message_type),
       ).toEqual(["summary_message", "assistant_message"]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("compacts after local AI SDK usage exceeds the configured context window", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-usage-compact-"),
+    );
+    try {
+      let summaryPrompt: string | undefined;
+      const usage = modelUsage(150, 12);
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryPrompt = options.prompt;
+          return { text: "usage-triggered local summary" } as never;
+        }) as never,
+        streamText: () => {
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: "usage-text",
+                text: "limit response",
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish-step",
+                response: {},
+                usage,
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                providerMetadata: undefined,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                totalUsage: usage,
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: "assistant-usage-limit",
+              role: "assistant",
+              parts: [{ type: "text", text: "limit response" }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Usage Compact Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await backend.updateConversation(conversation.id, {
+        context_window_limit: 100,
+      } as never);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("limit trigger request", agent.id),
+        ),
+      );
+
+      const usageChunk = chunks.find(
+        (chunk) => chunk.message_type === "usage_statistics",
+      ) as { context_tokens?: number; prompt_tokens?: number } | undefined;
+      expect(usageChunk?.context_tokens).toBe(150);
+      expect(usageChunk?.prompt_tokens).toBe(150);
+      expect(summaryPrompt).toContain("limit trigger request");
+      expect(summaryPrompt).toContain("limit response");
+      expect(JSON.stringify(chunks)).toContain("context_window_limit");
+      expect(JSON.stringify(chunks)).toContain("usage-triggered local summary");
+
+      const page = await backend.listConversationMessages(conversation.id, {
+        order: "asc",
+      } as ConversationMessageListBody);
+      const messages = page.getPaginatedItems();
+      expect(messages.map((message) => message.message_type)).toEqual([
+        "summary_message",
+      ]);
+      expect(JSON.stringify(messages[0])).toContain(
+        "usage-triggered local summary",
+      );
+      expect(JSON.stringify(messages[0])).toContain('"context_window":100');
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -18,6 +18,7 @@ import type {
   ToolSet,
   UIMessageChunk,
 } from "ai";
+import { APICallError } from "ai";
 import type {
   AgentCreateBody,
   ConversationCreateBody,
@@ -26,6 +27,7 @@ import type {
   RunMessageStreamBody,
 } from "../../backend";
 import {
+  LOCAL_ALL_COMPACTION_PROMPT,
   LocalBackend,
   listLocalModels,
   resolveLocalModelConfig,
@@ -388,6 +390,192 @@ describe("LocalBackend", () => {
       expect(replayed.map((chunk) => chunk.message_type)).toEqual(
         (chunks as LettaStreamingResponse[]).map((chunk) => chunk.message_type),
       );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("compacts local conversation history with the backend all-compaction prompt", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-compact-"));
+    try {
+      let capturedSystem: string | undefined;
+      let capturedPrompt: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: {
+          system?: string;
+          prompt?: string;
+        }) => {
+          capturedSystem = options.system;
+          capturedPrompt = options.prompt;
+          return { text: "manual local summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "Compact Agent",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("second request", agent.id),
+        ),
+      );
+
+      const result = (await backend.compactConversationMessages(
+        conversation.id,
+        {
+          compaction_settings: { mode: "all" },
+        } as never,
+      )) as {
+        num_messages_before: number;
+        num_messages_after: number;
+        summary: string;
+      };
+
+      expect(result).toEqual({
+        num_messages_before: 4,
+        num_messages_after: 1,
+        summary: "manual local summary",
+      });
+      expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
+      expect(capturedPrompt).toContain("first request");
+      expect(capturedPrompt).toContain("second request");
+
+      const page = await backend.listConversationMessages(conversation.id, {
+        order: "asc",
+      } as ConversationMessageListBody);
+      const messages = page.getPaginatedItems();
+      expect(messages.map((message) => message.message_type)).toEqual([
+        "summary_message",
+      ]);
+      expect(JSON.stringify(messages[0])).toContain("manual local summary");
+
+      const persistedMessages = await readPersistedLocalMessages(storageDir);
+      expect(persistedMessages).toHaveLength(1);
+      expect(JSON.stringify(persistedMessages[0])).toContain("system_alert");
+      expect(JSON.stringify(persistedMessages[0])).toContain(
+        "manual local summary",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("auto-compacts and retries local AI SDK turns on context overflow", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-auto-compact-"),
+    );
+    try {
+      let streamCalls = 0;
+      let summaryPrompt: string | undefined;
+      const modelMessagesByCall: ModelMessage[][] = [];
+      const overflow = new APICallError({
+        message: "context_length_exceeded: maximum context length exceeded",
+        url: "https://example.invalid/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseBody: "maximum context length exceeded",
+        isRetryable: false,
+      });
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryPrompt = options.prompt;
+          return { text: "overflow local summary" } as never;
+        }) as never,
+        streamText: (options) => {
+          streamCalls += 1;
+          modelMessagesByCall.push(options.messages);
+
+          if (streamCalls === 2) {
+            return {
+              fullStream: (async function* () {
+                yield {
+                  type: "error",
+                  error: overflow,
+                } as TextStreamPart<ToolSet>;
+              })(),
+            };
+          }
+
+          const text =
+            streamCalls === 1 ? "first response" : "after compaction";
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: `text-${streamCalls}`,
+                text,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: `assistant-${streamCalls}`,
+              role: "assistant",
+              parts: [{ type: "text", text }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Auto Compact Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("overflowing request", agent.id),
+        ),
+      );
+
+      expect(streamCalls).toBe(3);
+      expect(summaryPrompt).toContain("first request");
+      expect(summaryPrompt).toContain("overflowing request");
+      const chunkTypes = chunks.map((chunk) => chunk.message_type as string);
+      expect(chunkTypes).toContain("event_message");
+      expect(chunkTypes).toContain("summary_message");
+      expect(JSON.stringify(chunks)).toContain("after compaction");
+      expect(JSON.stringify(modelMessagesByCall[2])).toContain(
+        "overflow local summary",
+      );
+      expect(JSON.stringify(modelMessagesByCall[2])).not.toContain(
+        "first request",
+      );
+
+      const page = await backend.listConversationMessages(conversation.id, {
+        order: "asc",
+      } as ConversationMessageListBody);
+      expect(
+        page.getPaginatedItems().map((message) => message.message_type),
+      ).toEqual(["summary_message", "assistant_message"]);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Adds a backend-level compaction method so `/compact` routes through the active backend instead of calling the API client directly.
- Implements local all-message compaction with the backend-style summary prompt, persists the packed summary in the local UIMessage transcript, and projects it as a `summary_message`.
- Detects AI SDK context-window overflow during local turns, emits compaction event/summary chunks, compacts local history, and retries against the compacted transcript.
- Emits AI SDK normalized usage as local `usage_statistics` and post-facto compacts when observed prompt tokens exceed the configured context window limit.

## Test plan
- [x] `bun test src/tests/backend/local-backend.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)