### PR TITLE
feat(permissions): instructive memory-mode denial reasons

### DIFF
--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -345,8 +345,12 @@ function checkPermissionForEngine(
     effectivePlanFilePath,
   );
   if (modeOverride) {
-    let reason = `Permission mode: ${effectiveMode}`;
-    if (effectiveMode === "plan" && modeOverride === "deny") {
+    let reason = modeOverride.reason ?? `Permission mode: ${effectiveMode}`;
+    if (
+      effectiveMode === "plan" &&
+      modeOverride.decision === "deny" &&
+      !modeOverride.reason
+    ) {
       const applyPatchRelativePath = effectivePlanFilePath
         ? relative(workingDirectory, effectivePlanFilePath).replace(/\\/g, "/")
         : null;
@@ -361,7 +365,7 @@ function checkPermissionForEngine(
     traceEvent(trace, "mode-override", reason);
     return {
       result: {
-        decision: modeOverride,
+        decision: modeOverride.decision,
         matchedRule: `${effectiveMode} mode`,
         reason,
       },

--- a/src/permissions/memoryDenialReason.ts
+++ b/src/permissions/memoryDenialReason.ts
@@ -1,0 +1,502 @@
+// Classify why a Bash command was denied under permission_mode=memory and
+// produce a human-readable reason string the agent can use to recover.
+//
+// This is a heuristic labeller, not a permission check — it runs only after
+// the actual `isScopedMemoryShellCommand` validator has already returned
+// false, and its job is to tell the agent WHY (cmdsub vs. unsafe binary vs.
+// redirect outside roots, etc.) and WHAT to do instead. False positives are
+// acceptable: a slightly-off hint is still better than the previous bare
+// "Permission mode: memory" message.
+
+const ALLOWED_BINARIES =
+  "cat, echo, printf, mkdir, rm, mv, cp, ls, find, sort, head, tail, wc, split, cd, sleep, git";
+
+// Binaries that the rollout-style "Bash-only" prompt advertises but that the
+// memory-mode allowlist does not include. Listing them explicitly lets us
+// produce a targeted hint ("don't use python3, use cat heredoc") instead of a
+// generic one.
+const TEMPTING_UNSAFE_BINARIES = new Set([
+  "python",
+  "python3",
+  "node",
+  "ruby",
+  "perl",
+  "bash",
+  "sh",
+  "zsh",
+  "fish",
+  "ksh",
+  "dash",
+  "eval",
+  "exec",
+  "source",
+  ".",
+  "sed",
+  "awk",
+  "tee",
+  "curl",
+  "wget",
+  "ssh",
+  "scp",
+  "rsync",
+  "nc",
+  "netcat",
+  "ftp",
+  "telnet",
+  "make",
+  "cmake",
+  "docker",
+  "kubectl",
+  "npm",
+  "yarn",
+  "pnpm",
+  "pip",
+  "pip3",
+  "uv",
+  "poetry",
+  "cargo",
+  "go",
+  "java",
+  "javac",
+  "mvn",
+  "gradle",
+  "gcc",
+  "g++",
+  "clang",
+  "rustc",
+]);
+
+export type MemoryBashDenialCategory =
+  | "cmdsub"
+  | "unsafe-cmd"
+  | "redirect-outside-roots"
+  | "path-outside-roots"
+  | "other";
+
+export interface MemoryBashDenialClassification {
+  category: MemoryBashDenialCategory;
+  reason: string;
+}
+
+export interface ClassifyOptions {
+  workingDirectory?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Inspect a Bash command and label the most likely reason it was denied
+ * under memory mode. Returns a category + a reason string that names the
+ * recommended alternative idiom.
+ */
+export function classifyMemoryBashDenial(
+  command: string | string[],
+  allowedRoots: string[],
+  options: ClassifyOptions = {},
+): MemoryBashDenialClassification {
+  const text = Array.isArray(command) ? command.join(" ") : command;
+  const env = options.env ?? process.env;
+
+  // Order matters: cmdsub is the most actionable signal (fix is to use $VAR
+  // directly) and is reliably detectable. Unsafe-cmd is next because the
+  // remediation is concrete (use heredoc instead). Redirect/path checks come
+  // after because they require path resolution and can false-positive.
+
+  const cmdsubMatch = findUnquotedCommandSubstitution(text);
+  if (cmdsubMatch) {
+    const example = cmdsubMatch === "`" ? "`cmd`" : "$(cmd)";
+    return {
+      category: "cmdsub",
+      reason:
+        `Memory mode does not allow command substitution (\`${example}\`) ` +
+        `or arbitrary code execution. Use variables directly: ` +
+        `\`$LETTA_AGENT_ID\`, not \`$(echo $LETTA_AGENT_ID)\`. If you need ` +
+        `to embed dynamic values in strings, set them as variables first ` +
+        `(\`agent_id=$LETTA_AGENT_ID\`) and reference \`$agent_id\` inline.`,
+    };
+  }
+
+  const unsafeBinary = findUnsafeBinary(text);
+  if (unsafeBinary) {
+    return {
+      category: "unsafe-cmd",
+      reason:
+        `Memory mode does not allow \`${unsafeBinary}\`. To write files, use ` +
+        `a heredoc: \`cat > "$MEMORY_DIR/path/to/file" << 'EOF' ... EOF\`. ` +
+        `For multi-file writes, issue separate Bash calls. Allowed binaries: ` +
+        `${ALLOWED_BINARIES}.`,
+    };
+  }
+
+  const redirect = findOutsideRedirectTarget(text, allowedRoots, env);
+  if (redirect) {
+    return {
+      category: "redirect-outside-roots",
+      reason:
+        `Memory mode allows shell redirects only to paths under ` +
+        `\`$MEMORY_DIR\`. Got target: \`${redirect}\`. Use a path under ` +
+        `\`$MEMORY_DIR\`, e.g. \`> "$MEMORY_DIR/system/foo.md"\`.`,
+    };
+  }
+
+  if (hasPathOutsideRoots(text, allowedRoots, env)) {
+    return {
+      category: "path-outside-roots",
+      reason:
+        `Memory mode requires shell commands to operate on paths under ` +
+        `\`$MEMORY_DIR\`. Prefix with \`cd "$MEMORY_DIR"\` or use absolute ` +
+        `paths under it.`,
+    };
+  }
+
+  return {
+    category: "other",
+    reason:
+      `Memory mode denied this Bash command. Allowed shapes: read-only ` +
+      `shell commands, or commands that operate inside \`$MEMORY_DIR\` ` +
+      `(${ALLOWED_BINARIES}). For writes, use heredocs: ` +
+      `\`cat > "$MEMORY_DIR/path" << 'EOF' ... EOF\`.`,
+  };
+}
+
+/**
+ * Scan for `$(` or backtick command substitution that is NOT inside a
+ * single-quoted region. Heredoc bodies are not stripped — substitutions
+ * inside heredoc bodies still count, since bash expands them at runtime.
+ * (Single quotes around heredoc delimiters do prevent expansion, but for
+ * the classifier we err on the side of flagging it.)
+ *
+ * Returns the matched literal (`$(` or `` ` ``) for use in the reason text,
+ * or null if no unquoted substitution is found.
+ */
+function findUnquotedCommandSubstitution(input: string): string | null {
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < input.length) {
+    const ch = input[i];
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < input.length && !inSingle) {
+      i += 2;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      i += 1;
+      continue;
+    }
+
+    // $(...) is expanded inside double quotes too, only single quotes inhibit.
+    if (!inSingle && ch === "$" && input.startsWith("$(", i)) {
+      return "$(";
+    }
+    if (!inSingle && ch === "`") {
+      return "`";
+    }
+
+    i += 1;
+  }
+  return null;
+}
+
+/**
+ * Find the first segment whose leading verb is in the
+ * `TEMPTING_UNSAFE_BINARIES` set. Segments are split on `;`, `&&`, `||`, `|`,
+ * and newlines, respecting single/double quotes. Heredoc bodies are skipped
+ * so the classifier doesn't pick up command names that appear in file
+ * contents.
+ */
+function findUnsafeBinary(input: string): string | null {
+  for (const segment of splitSegmentsForClassifier(input)) {
+    const trimmed = segment.trimStart();
+    if (!trimmed) continue;
+
+    // Skip leading env-var assignments: `FOO=bar BAZ=qux command ...`
+    let rest = trimmed;
+    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(rest)) {
+      const spaceIdx = rest.search(/\s/);
+      if (spaceIdx === -1) break;
+      rest = rest.slice(spaceIdx).trimStart();
+    }
+    if (!rest) continue;
+
+    const verbMatch = rest.match(/^([^\s;|&<>()]+)/);
+    if (!verbMatch) continue;
+    const verb = verbMatch[1];
+    if (!verb) continue;
+    // Strip absolute path prefix: /usr/bin/python3 -> python3
+    const baseVerb = verb.includes("/") ? (verb.split("/").pop() ?? "") : verb;
+    if (TEMPTING_UNSAFE_BINARIES.has(baseVerb)) {
+      return baseVerb;
+    }
+  }
+  return null;
+}
+
+/**
+ * Look for `>` or `>>` redirect operators (outside single quotes and outside
+ * heredoc bodies) and check whether the redirect target resolves outside the
+ * allowed roots. Returns the offending target string for the reason text, or
+ * null if every redirect target is inside roots (or there are no redirects,
+ * or the targets cannot be resolved without execution).
+ */
+function findOutsideRedirectTarget(
+  input: string,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+): string | null {
+  const stripped = stripHeredocBodies(input);
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < stripped.length) {
+    const ch = stripped[i];
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < stripped.length && !inSingle) {
+      i += 2;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      i += 1;
+      continue;
+    }
+
+    if (
+      !inSingle &&
+      !inDouble &&
+      (ch === ">" || stripped.startsWith(">>", i))
+    ) {
+      const op = stripped.startsWith(">>", i) ? ">>" : ">";
+      let cursor = i + op.length;
+      // Skip & for fd-dup like `>&2` — not a path target.
+      if (stripped[cursor] === "&") {
+        i = cursor + 1;
+        continue;
+      }
+      while (cursor < stripped.length && /\s/.test(stripped[cursor] ?? "")) {
+        cursor += 1;
+      }
+      const targetStart = cursor;
+      const target = readToken(stripped, cursor);
+      if (!target) {
+        i = cursor + 1;
+        continue;
+      }
+      const expanded = expandSimpleEnv(target.value, env);
+      if (expanded === "/dev/null" || /^&\d+$/.test(expanded)) {
+        i = target.end;
+        continue;
+      }
+      if (!isPathInsideRoots(expanded, allowedRoots)) {
+        return stripped.slice(targetStart, target.end);
+      }
+      i = target.end;
+      continue;
+    }
+
+    i += 1;
+  }
+  return null;
+}
+
+/**
+ * Look for path-shaped tokens (absolute paths or `~/...`) that resolve
+ * outside the allowed roots. Used as a last-resort label when there's no
+ * cmdsub, no unsafe binary, and no out-of-roots redirect, but the command
+ * still got denied — usually because it's reading/writing somewhere we
+ * don't accept (e.g., bare `git push` outside memory dir).
+ */
+function hasPathOutsideRoots(
+  input: string,
+  allowedRoots: string[],
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (allowedRoots.length === 0) return false;
+  const stripped = stripHeredocBodies(input);
+  // Look for absolute-path-shaped tokens in the command outside quotes.
+  // This is a heuristic — we only flag when at least one absolute path
+  // appears that is not inside roots and there's no relative-only
+  // alternative reading.
+  const tokens = stripped.match(/(?:[^\s"'`]+|"[^"]*"|'[^']*')+/g) ?? [];
+  let sawOutside = false;
+  let sawAny = false;
+  for (const raw of tokens) {
+    const unquoted = stripQuotes(raw);
+    if (!unquoted.startsWith("/") && !unquoted.startsWith("~")) continue;
+    // Skip standard non-filesystem targets like /dev/null and /dev/std*.
+    if (unquoted === "/dev/null" || unquoted.startsWith("/dev/std")) continue;
+    sawAny = true;
+    const expanded = expandSimpleEnv(unquoted, env);
+    if (!isPathInsideRoots(expanded, allowedRoots)) {
+      sawOutside = true;
+    }
+  }
+  return sawAny && sawOutside;
+}
+
+function readToken(
+  input: string,
+  start: number,
+): { value: string; end: number } | null {
+  if (start >= input.length) return null;
+  const first = input[start];
+  if (first === '"' || first === "'") {
+    const close = input.indexOf(first, start + 1);
+    if (close === -1) return null;
+    return { value: input.slice(start + 1, close), end: close + 1 };
+  }
+  let end = start;
+  while (end < input.length && !/[\s;|&><()`]/.test(input[end] ?? "")) {
+    end += 1;
+  }
+  if (end === start) return null;
+  return { value: input.slice(start, end), end };
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Expand only `$VAR`, `${VAR}`, and `~` against `env`. Anything else is left
+ * literal. Sufficient for the classifier — false negatives just downgrade
+ * to the generic reason.
+ */
+function expandSimpleEnv(value: string, env: NodeJS.ProcessEnv): string {
+  let result = value;
+  if (result.startsWith("~")) {
+    const home = env.HOME ?? "";
+    if (home) {
+      result = home + result.slice(1);
+    }
+  }
+  result = result.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, name) =>
+    typeof env[name] === "string" ? (env[name] as string) : "",
+  );
+  result = result.replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, name) =>
+    typeof env[name] === "string" ? (env[name] as string) : "",
+  );
+  return result;
+}
+
+function isPathInsideRoots(path: string, roots: string[]): boolean {
+  if (!path.startsWith("/")) return true; // unresolvable; don't flag
+  for (const root of roots) {
+    if (path === root) return true;
+    if (path.startsWith(root.endsWith("/") ? root : `${root}/`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove heredoc bodies from a command string so subsequent scanners don't
+ * scan file contents (which legitimately contain `$()`, paths, etc.).
+ * Approximate: matches `<<` or `<<-` followed by an optional quote,
+ * delimiter, and a body terminated by the delimiter on its own line.
+ */
+function stripHeredocBodies(input: string): string {
+  const lines = input.split(/\n/);
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    out.push(line);
+    const heredocMatch = line.match(/<<-?\s*("[^"]+"|'[^']+'|[A-Za-z_]\w*)/);
+    if (heredocMatch?.[1]) {
+      const delim = stripQuotes(heredocMatch[1]);
+      i += 1;
+      while (i < lines.length && (lines[i] ?? "").trim() !== delim) {
+        i += 1;
+      }
+      if (i < lines.length) {
+        out.push(lines[i] ?? "");
+        i += 1;
+      }
+      continue;
+    }
+    i += 1;
+  }
+  return out.join("\n");
+}
+
+/**
+ * Split a command into segments on `;`, `&&`, `||`, `|`, and newlines,
+ * respecting quote regions and heredoc bodies. Used by `findUnsafeBinary`
+ * to identify the leading verb of each segment.
+ */
+function splitSegmentsForClassifier(input: string): string[] {
+  const stripped = stripHeredocBodies(input);
+  const segments: string[] = [];
+  let current = "";
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < stripped.length) {
+    const ch = stripped[i];
+    if (!ch) {
+      i += 1;
+      continue;
+    }
+    if (ch === "\\" && i + 1 < stripped.length && !inSingle) {
+      current += stripped.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      i += 1;
+      continue;
+    }
+    if (!inSingle && !inDouble) {
+      if (stripped.startsWith("&&", i) || stripped.startsWith("||", i)) {
+        segments.push(current);
+        current = "";
+        i += 2;
+        continue;
+      }
+      if (ch === ";" || ch === "|" || ch === "\n" || ch === "\r") {
+        segments.push(current);
+        current = "";
+        i += 1;
+        continue;
+      }
+    }
+    current += ch;
+    i += 1;
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter(Boolean);
+}

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -5,6 +5,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
 import { canonicalToolName } from "./canonical";
 import { extractApplyPatchPaths } from "./crossAgentGuard";
+import { classifyMemoryBashDenial } from "./memoryDenialReason";
 import {
   isPathWithinRoots,
   resolveAllowedMemoryRoots,
@@ -57,6 +58,37 @@ function everyResolvedTargetIsWithinRoots(
       const resolvedPath = resolveScopedTargetPath(path, workingDirectory);
       return resolvedPath ? isPathWithinRoots(resolvedPath, roots) : false;
     })
+  );
+}
+
+/**
+ * Build a denial reason for write/edit tools whose target is outside the
+ * allowed memory roots (or where the tool was invoked without any target
+ * path at all). Names the offending path and the allowed roots so the
+ * agent can correct course.
+ */
+function buildWriteOutsideRootsReason(
+  candidatePaths: string[],
+  allowedRoots: string[],
+): string {
+  if (allowedRoots.length === 0) {
+    return (
+      "Memory mode requires $MEMORY_DIR (or LETTA_MEMORY_SCOPE / " +
+      "--memory-scope) to be set so write targets can be resolved against " +
+      "an allowed memory root."
+    );
+  }
+  const rootsList = allowedRoots.join(", ");
+  if (candidatePaths.length === 0) {
+    return (
+      `Memory mode requires Write/Edit targets to be inside $MEMORY_DIR ` +
+      `(${rootsList}). The tool was invoked without a resolvable target path.`
+    );
+  }
+  const targetList = candidatePaths.join(", ");
+  return (
+    `Memory mode requires Write/Edit targets to be inside $MEMORY_DIR. ` +
+    `Got: ${targetList}. Allowed roots: ${rootsList}.`
   );
 }
 
@@ -544,8 +576,15 @@ class PermissionModeManager {
         }
 
         if (toolName === "memory_apply_patch") {
+          if (allowedMemoryRoots.length > 0) {
+            return { decision: "allow" };
+          }
           return {
-            decision: allowedMemoryRoots.length > 0 ? "allow" : "deny",
+            decision: "deny",
+            reason:
+              "Memory mode requires $MEMORY_DIR (or LETTA_MEMORY_SCOPE / " +
+              "--memory-scope) to be set so the apply-patch target can be " +
+              "resolved.",
           };
         }
 
@@ -574,7 +613,13 @@ class PermissionModeManager {
             return { decision: "allow" };
           }
 
-          return { decision: "deny" };
+          return {
+            decision: "deny",
+            reason: buildWriteOutsideRootsReason(
+              candidatePaths,
+              allowedMemoryRoots,
+            ),
+          };
         }
 
         if (shellTools.includes(toolName)) {
@@ -596,10 +641,30 @@ class PermissionModeManager {
             return { decision: "allow" };
           }
 
-          return { decision: "deny" };
+          if (!command) {
+            return {
+              decision: "deny",
+              reason:
+                "Memory mode requires the Bash tool to be invoked with a " +
+                "`command` argument.",
+            };
+          }
+
+          const { reason } = classifyMemoryBashDenial(
+            command,
+            allowedMemoryRoots,
+            { workingDirectory },
+          );
+          return { decision: "deny", reason };
         }
 
-        return { decision: "deny" };
+        return {
+          decision: "deny",
+          reason:
+            `Memory mode only permits read-only tools, Edit/Write to paths ` +
+            `under $MEMORY_DIR, and scoped Bash. Tool '${toolName}' is not ` +
+            `available.`,
+        };
       }
 
       case "default":

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -23,6 +23,17 @@ export type PermissionMode =
   | "memory"
   | "bypassPermissions";
 
+/**
+ * Result of a permission-mode check. Includes a decision and an optional
+ * `reason` string the caller can surface to the agent (e.g. denial guidance
+ * like "use heredoc instead of $()"). When `reason` is omitted the caller
+ * falls back to a generic `"Permission mode: {mode}"` message.
+ */
+export interface ModeOverrideResult {
+  decision: "allow" | "deny";
+  reason?: string;
+}
+
 // Use globalThis to ensure singleton across bundle
 // This prevents Bun's bundler from creating duplicate instances of the mode manager
 const MODE_KEY = Symbol.for("@letta/permissionMode");
@@ -249,6 +260,11 @@ class PermissionModeManager {
    * scoped PermissionModeState (listener/remote mode) can bypass the global
    * singleton without requiring a temporary mutation of global state.
    * Returns null if mode doesn't apply to this tool.
+   *
+   * When returning a deny decision, the result may include a `reason` string
+   * to help the agent recover (e.g. "use heredoc instead of $()"). If
+   * `reason` is omitted callers fall back to a generic
+   * `"Permission mode: {mode}"` message.
    */
   checkModeOverride(
     toolName: string,
@@ -256,7 +272,7 @@ class PermissionModeManager {
     workingDirectory: string = process.cwd(),
     modeOverride?: PermissionMode,
     planFilePathOverride?: string | null,
-  ): "allow" | "deny" | null {
+  ): ModeOverrideResult | null {
     const effectiveMode = modeOverride ?? this.currentMode;
     const _effectivePlanFilePath =
       planFilePathOverride !== undefined
@@ -269,7 +285,7 @@ class PermissionModeManager {
           return null;
         }
         // Auto-allow everything else (except explicit deny rules checked earlier)
-        return "allow";
+        return { decision: "allow" };
 
       case "acceptEdits":
         // Auto-allow edit/write tools across Anthropic, Codex, and Gemini
@@ -293,7 +309,7 @@ class PermissionModeManager {
             "WriteFileGemini",
           ].includes(toolName)
         ) {
-          return "allow";
+          return { decision: "allow" };
         }
         return null;
 
@@ -358,7 +374,7 @@ class PermissionModeManager {
         ];
 
         if (allowedInPlan.includes(toolName)) {
-          return "allow";
+          return { decision: "allow" };
         }
 
         // Special case: allow writes to any plan file in ~/.letta/plans/
@@ -397,7 +413,7 @@ class PermissionModeManager {
                 : false;
             })
           ) {
-            return "allow";
+            return { decision: "allow" };
           }
         }
 
@@ -412,13 +428,13 @@ class PermissionModeManager {
         if (canonicalToolName(toolName) === "Task") {
           const subagentType = toolArgs?.subagent_type as string | undefined;
           if (subagentType && readOnlySubagentTypes.has(subagentType)) {
-            return "allow";
+            return { decision: "allow" };
           }
         }
 
         // Allow Skill tool — skills are read-only (load instructions, not modify files)
         if (toolName === "Skill" || toolName === "skill") {
-          return "allow";
+          return { decision: "allow" };
         }
 
         // Allow read-only shell commands (ls, git status, git log, etc.)
@@ -439,7 +455,7 @@ class PermissionModeManager {
             command &&
             isReadOnlyShellCommand(command, { allowExternalPaths: true })
           ) {
-            return "allow";
+            return { decision: "allow" };
           }
 
           // Special case: allow shell heredoc writes when they ONLY target
@@ -454,13 +470,13 @@ class PermissionModeManager {
             );
 
             if (resolvedPath && isPathInPlansDir(resolvedPath, plansDir)) {
-              return "allow";
+              return { decision: "allow" };
             }
           }
         }
 
         // Everything else denied in plan mode
-        return "deny";
+        return { decision: "deny" };
       }
 
       case "memory": {
@@ -524,11 +540,13 @@ class PermissionModeManager {
         ];
 
         if (allowedReadOnlyTools.includes(toolName)) {
-          return "allow";
+          return { decision: "allow" };
         }
 
         if (toolName === "memory_apply_patch") {
-          return allowedMemoryRoots.length > 0 ? "allow" : "deny";
+          return {
+            decision: allowedMemoryRoots.length > 0 ? "allow" : "deny",
+          };
         }
 
         if (writeTools.includes(toolName)) {
@@ -553,10 +571,10 @@ class PermissionModeManager {
               workingDirectory,
             )
           ) {
-            return "allow";
+            return { decision: "allow" };
           }
 
-          return "deny";
+          return { decision: "deny" };
         }
 
         if (shellTools.includes(toolName)) {
@@ -565,7 +583,7 @@ class PermissionModeManager {
             command &&
             isReadOnlyShellCommand(command, { allowExternalPaths: true })
           ) {
-            return "allow";
+            return { decision: "allow" };
           }
 
           if (
@@ -575,13 +593,13 @@ class PermissionModeManager {
               workingDirectory,
             })
           ) {
-            return "allow";
+            return { decision: "allow" };
           }
 
-          return "deny";
+          return { decision: "deny" };
         }
 
-        return "deny";
+        return { decision: "deny" };
       }
 
       case "default":

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -920,6 +920,152 @@ test("memory mode - denies git rebase exec hooks inside scoped shell commands", 
   }
 });
 
+// ============================================================================
+// Permission Mode: memory — instructive denial reasons
+// ============================================================================
+// The bare "Permission mode: memory" reason gives the agent no signal for
+// how to recover. These tests assert that each deny path produces a
+// category-specific reason that names the offending construct and a
+// concrete remediation idiom.
+
+test("memory mode reason - tool not allowed names the tool", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "WebSearch",
+      { query: "letta" },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("Memory mode");
+    expect(result.reason).toContain("WebSearch");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode reason - Write outside roots names target and roots", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Write",
+      { file_path: "/Users/test/project/README.md" },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/project",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("/Users/test/project/README.md");
+    expect(result.reason).toContain("/Users/test/.letta/agents/agent-1/memory");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode reason - Bash with $() points at variable usage", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      {
+        command:
+          'cd "$MEMORY_DIR" && CHILD=$(echo $LETTA_AGENT_ID) && echo $CHILD',
+      },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("command substitution");
+    expect(result.reason).toContain("$LETTA_AGENT_ID");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode reason - Bash with python3 points at heredoc", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      {
+        command: `cd "$MEMORY_DIR" && python3 -c "open('x.md','w').write('hi')"`,
+      },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("python3");
+    expect(result.reason).toContain("heredoc");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode reason - Bash redirect outside roots names target", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      { command: 'echo "hi" > /tmp/outside.txt' },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("redirects only to paths under");
+    expect(result.reason).toContain("/tmp/outside.txt");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode reason - existing scoped denials get instructive reason too", () => {
+  // Regression: the existing "denies command substitution" test (line 879)
+  // only asserted decision=deny. With the new wiring it should also surface
+  // the cmdsub category reason, not the generic "Permission mode: memory".
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "Bash",
+      {
+        command:
+          'cd /Users/test/.letta/agents/agent-1/memory && git commit -m "$(touch /tmp/pwn)"',
+      },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("command substitution");
+    // Must NOT be the bare default — that was the bug we're fixing.
+    expect(result.reason).not.toBe("Permission mode: memory");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
 test("plan mode deny reason includes exact apply_patch relative path hint", () => {
   permissionMode.setMode("plan");
   const workingDirectory = join(homedir(), "dev", "repo");

--- a/src/tests/permissions/memoryDenialReason.test.ts
+++ b/src/tests/permissions/memoryDenialReason.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "bun:test";
+import { classifyMemoryBashDenial } from "../../permissions/memoryDenialReason";
+
+const memDir = "/Users/test/.letta/agents/agent-1/memory";
+const roots = [memDir];
+const env = {
+  MEMORY_DIR: memDir,
+  LETTA_AGENT_ID: "agent-1",
+  HOME: "/Users/test",
+} as NodeJS.ProcessEnv;
+const opts = { workingDirectory: memDir, env };
+
+describe("classifyMemoryBashDenial", () => {
+  describe("cmdsub category", () => {
+    test("flags `$()` substitution outside quotes", () => {
+      const result = classifyMemoryBashDenial(
+        "CHILD=$(echo $LETTA_AGENT_ID) && echo $CHILD",
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("cmdsub");
+      expect(result.reason).toContain("command substitution");
+      expect(result.reason).toContain("$LETTA_AGENT_ID");
+    });
+
+    test("flags `$()` substitution inside double quotes", () => {
+      const result = classifyMemoryBashDenial(
+        'git commit -m "...$(echo $LETTA_AGENT_ID)..."',
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("cmdsub");
+    });
+
+    test("flags backtick substitution", () => {
+      const result = classifyMemoryBashDenial(
+        'echo "rev=`git rev-parse HEAD`"',
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("cmdsub");
+      expect(result.reason).toContain("`cmd`");
+    });
+
+    test("does NOT flag `$()` literal inside single quotes", () => {
+      const result = classifyMemoryBashDenial(
+        "echo '$(this is just text)'",
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("cmdsub");
+    });
+
+    test("does NOT flag backtick literal inside single quotes", () => {
+      const result = classifyMemoryBashDenial(
+        "echo '`literal backticks`'",
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("cmdsub");
+    });
+  });
+
+  describe("unsafe-cmd category", () => {
+    test("flags python3 invocation", () => {
+      const result = classifyMemoryBashDenial(
+        'python3 -c "print(1)"',
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+      expect(result.reason).toContain("python3");
+      expect(result.reason).toContain("heredoc");
+      expect(result.reason).toContain('cat > "$MEMORY_DIR/');
+    });
+
+    test("flags python3 with leading env var", () => {
+      const result = classifyMemoryBashDenial(
+        'PYTHONPATH=/foo python3 -c "print(1)"',
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+      expect(result.reason).toContain("python3");
+    });
+
+    test("flags sed -i", () => {
+      const result = classifyMemoryBashDenial(
+        `sed -i s/old/new/ "$MEMORY_DIR/x.md"`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+      expect(result.reason).toContain("sed");
+    });
+
+    test("flags curl, tee, awk", () => {
+      for (const verb of ["curl", "tee", "awk", "perl", "node"]) {
+        const result = classifyMemoryBashDenial(`${verb} foo`, roots, opts);
+        expect(result.category).toBe("unsafe-cmd");
+        expect(result.reason).toContain(verb);
+      }
+    });
+
+    test("flags absolute-path python3", () => {
+      const result = classifyMemoryBashDenial(
+        `/usr/bin/python3 -c "print(1)"`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+      expect(result.reason).toContain("python3");
+    });
+
+    test("does NOT flag unsafe verb appearing inside heredoc body", () => {
+      const result = classifyMemoryBashDenial(
+        [
+          `cat > "$MEMORY_DIR/x.md" << 'EOF'`,
+          "import python  # this should not trigger unsafe-cmd",
+          "sed_example: yes",
+          "EOF",
+        ].join("\n"),
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("unsafe-cmd");
+    });
+
+    test("does NOT flag safe binaries (cat, git, printf)", () => {
+      for (const cmd of [
+        "cat foo.txt",
+        "git status",
+        `printf "hi" > "$MEMORY_DIR/x.md"`,
+      ]) {
+        const result = classifyMemoryBashDenial(cmd, roots, opts);
+        expect(result.category).not.toBe("unsafe-cmd");
+      }
+    });
+  });
+
+  describe("redirect-outside-roots category", () => {
+    test("flags redirect to /tmp", () => {
+      const result = classifyMemoryBashDenial(
+        `echo hi > /tmp/x.md`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("redirect-outside-roots");
+      expect(result.reason).toContain("/tmp/x.md");
+      expect(result.reason).toContain("$MEMORY_DIR");
+    });
+
+    test("flags append-redirect outside roots", () => {
+      const result = classifyMemoryBashDenial(
+        `echo hi >> /tmp/x.md`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("redirect-outside-roots");
+    });
+
+    test("does NOT flag redirect to /dev/null", () => {
+      const result = classifyMemoryBashDenial(
+        `echo hi > /dev/null 2>&1`,
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("redirect-outside-roots");
+    });
+
+    test("does NOT flag redirect to fd dup (>&2)", () => {
+      const result = classifyMemoryBashDenial(`echo hi >&2`, roots, opts);
+      expect(result.category).not.toBe("redirect-outside-roots");
+    });
+
+    test("does NOT flag redirect inside MEMORY_DIR", () => {
+      const result = classifyMemoryBashDenial(
+        `echo hi > "$MEMORY_DIR/x.md"`,
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("redirect-outside-roots");
+    });
+
+    test("does NOT flag redirect-shaped chars inside heredoc body", () => {
+      const result = classifyMemoryBashDenial(
+        [
+          `cat > "$MEMORY_DIR/x.md" << 'EOF'`,
+          "code: foo > /tmp/bar # not a real redirect",
+          "EOF",
+        ].join("\n"),
+        roots,
+        opts,
+      );
+      expect(result.category).not.toBe("redirect-outside-roots");
+    });
+  });
+
+  describe("path-outside-roots category", () => {
+    test("flags absolute path outside roots in non-redirect context", () => {
+      const result = classifyMemoryBashDenial(`cd /tmp && ls`, roots, opts);
+      expect(result.category).toBe("path-outside-roots");
+      expect(result.reason).toContain("$MEMORY_DIR");
+    });
+
+    test("falls through to other for bare-relative commands", () => {
+      // No absolute paths, no redirect, no unsafe verb, no cmdsub.
+      const result = classifyMemoryBashDenial(
+        `git push origin main`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("other");
+    });
+  });
+
+  describe("other category (final fallback)", () => {
+    test("uses generic guidance when no specific signal is found", () => {
+      const result = classifyMemoryBashDenial(
+        `someweirdcommand --foo bar`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("other");
+      expect(result.reason).toContain("Allowed shapes");
+      expect(result.reason).toContain("$MEMORY_DIR");
+    });
+  });
+
+  describe("ordering / precedence", () => {
+    test("cmdsub takes precedence over unsafe-cmd", () => {
+      const result = classifyMemoryBashDenial(
+        `python3 -c "print($(date +%s))"`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("cmdsub");
+    });
+
+    test("unsafe-cmd takes precedence over redirect", () => {
+      const result = classifyMemoryBashDenial(
+        `python3 -c "print(1)" > /tmp/x.md`,
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+    });
+  });
+
+  describe("array command input", () => {
+    test("accepts a string[] command and joins it", () => {
+      const result = classifyMemoryBashDenial(
+        ["python3", "-c", "print(1)"],
+        roots,
+        opts,
+      );
+      expect(result.category).toBe("unsafe-cmd");
+      expect(result.reason).toContain("python3");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the bare `"Permission mode: memory"` reason with category-specific guidance that names the offending construct **and** the idiom to use instead. Designed for small models that loop on forbidden patterns when given no recovery signal.
- Add `classifyMemoryBashDenial` (heuristic labeller) covering five categories: `cmdsub`, `unsafe-cmd`, `redirect-outside-roots`, `path-outside-roots`, and `other`.
- Wire reasons into every memory-mode deny site: tool-not-allowed, Write/Edit outside roots, Bash deny, and `memory_apply_patch` deny.
- Refactor `checkModeOverride` return type to `ModeOverrideResult | null` (carries optional `reason`) so any mode can supply a custom denial reason. No behavior change in the refactor commit.

## Motivation
Stacked on top of #2089 (Kevin's memory-mode redirect/heredoc fix). That PR opens up the dominant `cat+heredoc` and `echo>$MEMORY_DIR/...` denials. Other denials are:
- `$()` / backticks for unwrapping env vars (e.g. `CHILD=$(echo $LETTA_AGENT_ID)`) — kept denied for security.
- `python3 -c "..."`, `sed -i`, `tee`, `curl`, etc. — kept denied for security.
- Redirects to paths outside roots.

The agent gets no signal which of these it tripped, or what to do instead, so it retries the same shape for many turns. Plan mode already ships a multi-sentence reason that names the allowed write target — this PR applies the same treatment to memory mode.

## Examples (denial reasons before/after)

**Before** — every memory-mode deny:
> Permission mode: memory

**After** — `CHILD=$(echo $LETTA_AGENT_ID)`:
> Memory mode does not allow command substitution (`$(cmd)`) or arbitrary code execution. Use variables directly: `$LETTA_AGENT_ID`, not `$(echo $LETTA_AGENT_ID)`. If you need to embed dynamic values in strings, set them as variables first (`agent_id=$LETTA_AGENT_ID`) and reference `$agent_id` inline.

**After** — `python3 -c "open(...).write(...)"`:
> Memory mode does not allow `python3`. To write files, use a heredoc: `` cat > "$MEMORY_DIR/path/to/file" << 'EOF' ... EOF ``. For multi-file writes, issue separate Bash calls. Allowed binaries: cat, echo, printf, mkdir, rm, mv, cp, ls, find, sort, head, tail, wc, split, cd, sleep, git.

**After** — `echo hi > /tmp/x.md`:
> Memory mode allows shell redirects only to paths under `$MEMORY_DIR`. Got target: `/tmp/x.md`. Use a path under `$MEMORY_DIR`, e.g. `> "$MEMORY_DIR/system/foo.md"`.

## Test plan
- [x] 24 unit tests for `classifyMemoryBashDenial` covering each category, precedence (cmdsub > unsafe-cmd > redirect), and quote/heredoc-region edge cases.
- [x] 6 integration tests in `permissions-mode.test.ts` asserting reason strings for tool-not-allowed, Write outside roots, `$()`, `python3`, redirect outside roots, and a regression that the existing scoped-cmdsub test now surfaces an instructive reason instead of the bare default.
- [x] `bun test src/tests/permissions/ src/tests/permissions-mode.test.ts` — 275 pass, 0 fail.
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/permissions/ src/tests/permissions/ src/tests/permissions-mode.test.ts` — clean.
- [x] `bunx tsc --noEmit` — clean.
- [x] Manual spot check against rollout-derived denial commands.

## Notes
- The classifier is heuristic-only. It runs **after** the real validator (`isScopedMemoryShellCommand`) has already returned false, and its only job is to label why. False positives just downgrade to the generic reason — they cannot affect the deny/allow decision.
- No security policy changes. `$()`, backticks, `python3`, `sed`, `tee`, `curl`, etc. are still denied.
- Stacked on #2089. Will auto-retarget to `main` when that merges.

👾 Generated with [Letta Code](https://letta.com)