### PR TITLE
chore: drop unused highlight.js direct dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "dependencies": {
         "@letta-ai/letta-client": "^1.10.2",
         "glob": "^13.0.0",
-        "highlight.js": "^11.11.1",
         "ink-link": "^5.0.0",
         "lowlight": "^3.3.0",
         "node-pty": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@letta-ai/letta-client": "^1.10.2",
     "glob": "^13.0.0",
-    "highlight.js": "^11.11.1",
     "ink-link": "^5.0.0",
     "lowlight": "^3.3.0",
     "node-pty": "^1.1.0",


### PR DESCRIPTION
## Summary
Removes `highlight.js` from direct dependencies in `package.json`. It was added alongside `lowlight` in `bf53c6e3` (Mar 10 2026, "feat: syntax-highlighted bash commands") but never imported directly — only `lowlight` is used. `lowlight` declares `highlight.js` as its own dependency, so it remains installed transitively.

## Verification
- Zero direct imports (`from "highlight.js"`, subpath imports, requires, dynamic imports — all empty).
- `bun pm ls` confirms `highlight.js@11.11.1` still present transitively via lowlight.
- `SyntaxHighlightedCommand.tsx` imports only `lowlight`.
- typecheck ✅ | lint ✅ | tests ✅ | build ✅