### PR TITLE
refactor(settings): remove unused localSharedBlockIds from ProjectSettings

### DIFF
--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -113,7 +113,6 @@ export interface Settings {
 }
 
 export interface ProjectSettings {
-  localSharedBlockIds: Record<string, string>;
   hooks?: HooksConfig; // Project-specific hook commands (checked in)
   statusLine?: StatusLineConfig; // Project-specific status line command
 }
@@ -157,9 +156,7 @@ const DEFAULT_SETTINGS: Settings = {
   globalSharedBlockIds: {},
 };
 
-const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {
-  localSharedBlockIds: {},
-};
+const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {};
 
 const DEFAULT_LOCAL_PROJECT_SETTINGS: LocalProjectSettings = {
   lastAgent: null,
@@ -707,8 +704,6 @@ class SettingsManager {
       const rawSettings = JSON.parse(content) as Record<string, unknown>;
 
       const projectSettings: ProjectSettings = {
-        localSharedBlockIds:
-          (rawSettings.localSharedBlockIds as Record<string, string>) ?? {},
         hooks: rawSettings.hooks as HooksConfig | undefined,
         statusLine: rawSettings.statusLine as StatusLineConfig | undefined,
       };

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -351,7 +351,8 @@ describe("Settings Manager - Project Settings", () => {
     const projectSettings =
       await settingsManager.loadProjectSettings(testProjectDir);
 
-    expect(projectSettings.localSharedBlockIds).toEqual({});
+    expect(projectSettings.hooks).toBeUndefined();
+    expect(projectSettings.statusLine).toBeUndefined();
   });
 
   test("Get project settings returns cached value", async () => {
@@ -369,19 +370,13 @@ describe("Settings Manager - Project Settings", () => {
 
     settingsManager.updateProjectSettings(
       {
-        localSharedBlockIds: {
-          style: "block-style-1",
-          project: "block-project-1",
-        },
+        statusLine: { command: "echo test" },
       },
       testProjectDir,
     );
 
     const settings = settingsManager.getProjectSettings(testProjectDir);
-    expect(settings.localSharedBlockIds).toEqual({
-      style: "block-style-1",
-      project: "block-project-1",
-    });
+    expect(settings.statusLine?.command).toBe("echo test");
   });
 
   test("Project settings persist to disk", async () => {
@@ -389,9 +384,7 @@ describe("Settings Manager - Project Settings", () => {
 
     settingsManager.updateProjectSettings(
       {
-        localSharedBlockIds: {
-          test: "block-test-1",
-        },
+        statusLine: { command: "echo persist-test" },
       },
       testProjectDir,
     );
@@ -404,9 +397,7 @@ describe("Settings Manager - Project Settings", () => {
     await settingsManager.initialize();
     const reloaded = await settingsManager.loadProjectSettings(testProjectDir);
 
-    expect(reloaded.localSharedBlockIds).toEqual({
-      test: "block-test-1",
-    });
+    expect(reloaded.statusLine?.command).toBe("echo persist-test");
   });
 
   test("Throw error if accessing project settings before loading", async () => {
@@ -426,7 +417,7 @@ describe("Settings Manager - Project Settings", () => {
 
     const projectSettings =
       await settingsManager.loadProjectSettings(testHomeDir);
-    expect(projectSettings.localSharedBlockIds).toEqual({});
+    expect(projectSettings.hooks).toBeUndefined();
     expect(projectSettings.statusLine).toBeUndefined();
   });
 
@@ -628,19 +619,19 @@ describe("Settings Manager - Multiple Projects", () => {
     await settingsManager.loadProjectSettings(testProjectDir2);
 
     settingsManager.updateProjectSettings(
-      { localSharedBlockIds: { test: "block-1" } },
+      { statusLine: { command: "echo project-1" } },
       testProjectDir,
     );
     settingsManager.updateProjectSettings(
-      { localSharedBlockIds: { test: "block-2" } },
+      { statusLine: { command: "echo project-2" } },
       testProjectDir2,
     );
 
     const settings1 = settingsManager.getProjectSettings(testProjectDir);
     const settings2 = settingsManager.getProjectSettings(testProjectDir2);
 
-    expect(settings1.localSharedBlockIds.test).toBe("block-1");
-    expect(settings2.localSharedBlockIds.test).toBe("block-2");
+    expect(settings1.statusLine?.command).toBe("echo project-1");
+    expect(settings2.statusLine?.command).toBe("echo project-2");
   });
 });
 


### PR DESCRIPTION
## Summary
Removes the `localSharedBlockIds` field from the `ProjectSettings` interface in `settings-manager.ts`. The field is defined, defaulted, and deserialized but **never read at runtime** — no code branches on its value, no callers consume it.

## Verification
- Real reads grep: empty (only definitions, defaults, and test fixtures).
- typecheck ✅ | lint ✅ | tests ✅ | build ✅

## Note
The same field also existed in the now-deleted `src/project-settings.ts` (PR #2112). This is the parallel cleanup in the active settings module.