### PR TITLE
refactor(settings): remove deprecated globalSharedBlockIds from Settings

### DIFF
--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -82,7 +82,6 @@ export interface Settings {
     }
   >;
   conversationSwitchAlertEnabled: boolean; // Send system-reminder when switching conversations/agents
-  globalSharedBlockIds: Record<string, string>; // DEPRECATED: kept for backwards compat
   profiles?: Record<string, string>; // DEPRECATED: old format, kept for migration
   pinnedAgents?: string[]; // DEPRECATED: kept for backwards compat, use pinnedAgentsByServer
   createDefaultAgents?: boolean; // Create Memo/Incognito default agents on startup (default: true)
@@ -154,7 +153,6 @@ const DEFAULT_SETTINGS: Settings = {
   memoryReminderInterval: 25, // DEPRECATED: use reflection* fields
   reflectionTrigger: "step-count",
   reflectionStepCount: 25,
-  globalSharedBlockIds: {},
 };
 
 const DEFAULT_PROJECT_SETTINGS: ProjectSettings = {

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -73,8 +73,6 @@ describe("Settings Manager - Initialization", () => {
     const settings = settingsManager.getSettings();
     expect(settings).toBeDefined();
     expect(typeof settings.tokenStreaming).toBe("boolean");
-    expect(settings.globalSharedBlockIds).toBeDefined();
-    expect(typeof settings.globalSharedBlockIds).toBe("object");
   });
 
   test("Initialize loads existing settings from disk", async () => {
@@ -213,21 +211,6 @@ describe("Settings Manager - Global Settings", () => {
     expect(settings.tokenStreaming).toBe(true);
     expect(settings.lastAgent).toBe("agent-456");
     expect(settings.enableSleeptime).toBe(true);
-  });
-
-  test("Update global shared block IDs", () => {
-    settingsManager.updateSettings({
-      globalSharedBlockIds: {
-        persona: "block-1",
-        human: "block-2",
-      },
-    });
-
-    const settings = settingsManager.getSettings();
-    expect(settings.globalSharedBlockIds).toEqual({
-      persona: "block-1",
-      human: "block-2",
-    });
   });
 
   test("Update env variables", () => {
@@ -929,17 +912,17 @@ describe("Settings Manager - Edge Cases", () => {
     await settingsManager.initialize();
     settingsManager.updateSettings({
       lastAgent: "agent-123",
-      globalSharedBlockIds: {},
+      tokenStreaming: true,
     });
 
     const settings = settingsManager.getSettings();
     settings.lastAgent = "modified-agent";
-    settings.globalSharedBlockIds = { modified: "block" };
+    settings.tokenStreaming = false;
 
     // Internal state should be unchanged
     const actualSettings = settingsManager.getSettings();
     expect(actualSettings.lastAgent).toBe("agent-123");
-    expect(actualSettings.globalSharedBlockIds).toEqual({});
+    expect(actualSettings.tokenStreaming).toBe(true);
   });
 
   test("Partial updates preserve existing values", async () => {


### PR DESCRIPTION
## Summary
Removes the `globalSharedBlockIds` field from the `Settings` interface — explicitly tagged `DEPRECATED: kept for backwards compat` and never read at runtime.

## Verification
- Real reads grep: empty (only definitions, defaults, and test fixtures).
- Serialization-safe: existing on-disk data is preserved via `managedKeys`/`dirtyKeys` passthrough; new files won't include it.
- typecheck ✅ | lint ✅ | tests ✅ | build ✅