### PR TITLE
fix(api): standardize forkConversation on query params (fixes /btw on default conversation)

### DIFF
--- a/src/backend/api/conversations.ts
+++ b/src/backend/api/conversations.ts
@@ -3,14 +3,13 @@ import { apiRequest } from "./request";
 export interface ForkConversationOptions {
   agentId?: string;
   hidden?: boolean;
-  useQuery?: boolean;
 }
 
 export async function forkConversation(
   conversationId: string,
   options: ForkConversationOptions = {},
 ): Promise<{ id: string }> {
-  const payload = {
+  const query = {
     ...(options.agentId ? { agent_id: options.agentId } : {}),
     ...(options.hidden !== undefined ? { hidden: options.hidden } : {}),
   };
@@ -18,7 +17,7 @@ export async function forkConversation(
   return apiRequest<{ id: string }>(
     "POST",
     `/v1/conversations/${encodeURIComponent(conversationId)}/fork`,
-    options.useQuery ? undefined : payload,
-    options.useQuery ? { query: payload } : {},
+    undefined,
+    { query },
   );
 }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9072,7 +9072,6 @@ export default function App({
             const isDefault = conversationIdRef.current === "default";
             const forked = await forkConversation(conversationIdRef.current, {
               ...(isDefault ? { agentId } : {}),
-              useQuery: true,
             });
 
             // If we forked with an explicit summary, update it

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -664,7 +664,6 @@ export async function task(args: TaskArgs): Promise<string> {
       const forkedConv = await forkConversation(parentConvId, {
         ...(parentConvId === "default" ? { agentId: parentAgentId } : {}),
         hidden: true,
-        useQuery: true,
       });
       effectiveAgentId = parentAgentId;
       effectiveConversationId = forkedConv.id;


### PR DESCRIPTION
## The bug

Running \`/btw <question>\` on the default (agent-direct) conversation produced:

\`\`\`
Error: 404 Conversation not found with id='['default']'
\`\`\`

(The \`['default']\` rendering is a cosmetic artifact of the server's error formatter — it's actually looking up a literal \`"default"\` conversation, which doesn't exist.)

## Root cause

The fork endpoint accepts \`agent_id\` only as a query parameter:

\`\`\`python
# apps/core/letta/server/rest_api/routers/v1/conversations.py
async def fork_conversation(
    conversation_id: ConversationIdOrDefault,
    agent_id: Optional[str] = Query(None, ...),  # query string only
    ...
):
    if conversation_id == "default" and agent_id:
        # agent-direct mode
\`\`\`

\`forkConversation\` had a \`useQuery\` option that toggled body-vs-query transport. The \`/btw\` call site was missing \`useQuery: true\` and sent \`agent_id\` in the JSON body, where the server couldn't see it — so the agent-direct branch never fired and the lookup fell through to a literal \`"default"\` conversation ID.

## Why \`useQuery\` existed

The option was added in #2017 (centralizing API calls) to faithfully preserve two pre-existing call sites with disagreeing transports:
- \`/fork\` (and the Task subagent forker) → query (correct, via the SDK originally — #1524)
- \`/btw\` → body (buggy from day one of \`/btw\`'s introduction in #1596 — never noticed because /btw is rarely run on default)

Centralizing made the disagreement configurable instead of resolving it. This PR resolves it.

## Fix

Drop \`useQuery\` entirely. \`forkConversation\` now always uses query params, matching the server contract. Both call sites (\`/fork\`, \`/btw\`, and the Task forker) collapse onto a single transport.

\`\`\`diff
 export interface ForkConversationOptions {
   agentId?: string;
   hidden?: boolean;
-  useQuery?: boolean;
 }
\`\`\`

## Verification

- typecheck ✅ | lint ✅ | tests ✅ (24/24 in fork + btw test suites) | build ✅
- The /btw command on default conversation now correctly hits the agent-direct branch on the server.

## Follow-up flagged

The cosmetic server-side error message (\`id='['default']'\`) lives in \`apps/core/letta/orm/sqlalchemy_base.py\`'s \`_read_multiple_preprocess\` — affects every 404 across the server, not just fork. Worth a separate one-line letta-cloud PR but not blocking.