### PR TITLE
feat(cli): client-side conversation titles + opt-in AI title generation

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9391,8 +9391,7 @@ export default function App({
               "",
               "USAGE",
               "  /rename agent <name>      — rename the agent",
-              "  /rename convo <title>     — set a manual conversation title",
-              "  /rename convo auto        — generate a conversation title",
+              "  /rename convo [title]     — set a title, or auto-generate when omitted",
               "  /rename help              — show this help",
             ].join("\n");
             cmd.finish(output, true);
@@ -9403,24 +9402,20 @@ export default function App({
             !subcommand ||
             (subcommand !== "agent" && subcommand !== "convo")
           ) {
-            cmd.fail(
-              "Usage: /rename agent <name> or /rename convo <title|auto>",
-            );
+            cmd.fail("Usage: /rename agent <name> or /rename convo [title]");
             return { submitted: true };
           }
 
           const newValue = parts.slice(2).join(" ");
-          if (!newValue) {
-            cmd.fail(
-              subcommand === "convo"
-                ? "Please provide a title or use /rename convo auto"
-                : "Please provide a name: /rename agent <name>",
-            );
+          if (subcommand === "agent" && !newValue) {
+            cmd.fail("Please provide a name: /rename agent <name>");
             return { submitted: true };
           }
 
           if (subcommand === "convo") {
-            const shouldAutoGenerate = newValue.trim().toLowerCase() === "auto";
+            const shouldAutoGenerate =
+              newValue.trim().length === 0 ||
+              newValue.trim().toLowerCase() === "auto";
             cmd.update({
               output: shouldAutoGenerate
                 ? "Generating conversation title..."

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -257,6 +257,10 @@ import {
   resetContextHistory,
 } from "./helpers/contextTracker";
 import {
+  generateConversationTitleFromFork,
+  normalizeConversationTitle,
+} from "./helpers/conversationTitle";
+import {
   type AdvancedDiffSuccess,
   computeAdvancedDiff,
   parsePatchToAdvancedDiff,
@@ -2049,14 +2053,6 @@ export default function App({
     [],
   );
   const deriveAutoConversationTitle = useCallback(() => {
-    const normalizeConversationTitle = (value: string): string | null => {
-      const normalized = value.replace(/\s+/g, " ").trim();
-      if (!normalized || normalized.startsWith("/")) {
-        return null;
-      }
-      return normalized.slice(0, 100);
-    };
-
     if (firstUserQueryRef.current) {
       return firstUserQueryRef.current;
     }
@@ -2075,6 +2071,36 @@ export default function App({
 
     return null;
   }, []);
+  const generateConversationTitle = useCallback(async () => {
+    const fallback = deriveAutoConversationTitle();
+
+    // Heuristic-only when the experiment is off, on local backends, or for
+    // the agent-direct "default" conversation (which can't be forked safely).
+    if (!experimentManager.isEnabled("conversation_titles")) {
+      return fallback;
+    }
+    if (getBackend().capabilities.localModelCatalog) {
+      return fallback;
+    }
+    const conversationId = conversationIdRef.current;
+    if (!conversationId || conversationId === "default") {
+      return fallback;
+    }
+
+    try {
+      const client = await getClient();
+      const aiTitle = await generateConversationTitleFromFork(
+        client,
+        conversationId,
+      );
+      return aiTitle ?? fallback;
+    } catch (err) {
+      if (isDebugEnabled()) {
+        console.error("[DEBUG] generateConversationTitle failed:", err);
+      }
+      return fallback;
+    }
+  }, [deriveAutoConversationTitle]);
   const resetBootstrapReminderState = useCallback(() => {
     resetSharedReminderState(sharedReminderStateRef.current);
   }, []);
@@ -5180,7 +5206,7 @@ export default function App({
               conversationIdRef.current !== "default"
             ) {
               isAutoConversationTitleInFlightRef.current = true;
-              const conversationTitle = deriveAutoConversationTitle();
+              const conversationTitle = await generateConversationTitle();
               if (!conversationTitle) {
                 isAutoConversationTitleInFlightRef.current = false;
               } else {
@@ -9468,10 +9494,10 @@ export default function App({
             try {
               const client = await getClient();
               if (shouldAutoGenerate) {
-                const conversationTitle = deriveAutoConversationTitle();
+                const conversationTitle = await generateConversationTitle();
                 if (!conversationTitle) {
                   cmd.fail(
-                    "No user message available to derive a conversation title",
+                    "No conversation content available to generate a title",
                   );
                   return { submitted: true };
                 }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2039,13 +2039,42 @@ export default function App({
     !resumedExistingConversation,
   );
   const isAutoConversationTitleInFlightRef = useRef(false);
+  const firstUserQueryRef = useRef<string | null>(null);
   const setConversationAutoTitleEligibility = useCallback(
     (enabled: boolean) => {
       shouldAutoGenerateConversationTitleRef.current = enabled;
       isAutoConversationTitleInFlightRef.current = false;
+      firstUserQueryRef.current = null;
     },
     [],
   );
+  const deriveAutoConversationTitle = useCallback(() => {
+    const normalizeConversationTitle = (value: string): string | null => {
+      const normalized = value.replace(/\s+/g, " ").trim();
+      if (!normalized || normalized.startsWith("/")) {
+        return null;
+      }
+      return normalized.slice(0, 100);
+    };
+
+    if (firstUserQueryRef.current) {
+      return firstUserQueryRef.current;
+    }
+
+    for (const lineId of buffersRef.current.order) {
+      const line = buffersRef.current.byId.get(lineId);
+      if (!line || line.kind !== "user") {
+        continue;
+      }
+
+      const title = normalizeConversationTitle(line.text);
+      if (title) {
+        return title;
+      }
+    }
+
+    return null;
+  }, []);
   const resetBootstrapReminderState = useCallback(() => {
     resetSharedReminderState(sharedReminderStateRef.current);
   }, []);
@@ -5144,38 +5173,38 @@ export default function App({
               setNeedsEagerApprovalCheck(false);
             }
 
-            // Generate an auto title once the first assistant turn completes.
+            // Derive an auto title client-side once the first assistant turn completes.
             if (
               shouldAutoGenerateConversationTitleRef.current &&
               !isAutoConversationTitleInFlightRef.current &&
               conversationIdRef.current !== "default"
             ) {
               isAutoConversationTitleInFlightRef.current = true;
-              const client = await getClient();
-              client
-                .post(
-                  `/v1/conversations/${encodeURIComponent(conversationIdRef.current)}/generate-summary`,
-                  {
-                    body: {
-                      source: "auto_first_turn",
-                    },
-                  },
-                )
-                .then(() => {
-                  shouldAutoGenerateConversationTitleRef.current = false;
-                })
-                .catch((err) => {
-                  // Silently ignore - not critical.
-                  if (isDebugEnabled()) {
-                    console.error(
-                      "[DEBUG] Failed to generate conversation title:",
-                      err,
-                    );
-                  }
-                })
-                .finally(() => {
-                  isAutoConversationTitleInFlightRef.current = false;
-                });
+              const conversationTitle = deriveAutoConversationTitle();
+              if (!conversationTitle) {
+                isAutoConversationTitleInFlightRef.current = false;
+              } else {
+                const client = await getClient();
+                void client.conversations
+                  .update(conversationIdRef.current, {
+                    summary: conversationTitle,
+                  })
+                  .then(() => {
+                    shouldAutoGenerateConversationTitleRef.current = false;
+                  })
+                  .catch((err) => {
+                    // Silently ignore - not critical.
+                    if (isDebugEnabled()) {
+                      console.error(
+                        "[DEBUG] Failed to update conversation title:",
+                        err,
+                      );
+                    }
+                  })
+                  .finally(() => {
+                    isAutoConversationTitleInFlightRef.current = false;
+                  });
+              }
             }
 
             const trajectorySnapshot = sessionStatsRef.current.endTrajectory();
@@ -7836,6 +7865,19 @@ export default function App({
         );
       }
 
+      if (
+        shouldAutoGenerateConversationTitleRef.current &&
+        firstUserQueryRef.current === null &&
+        !isSystemOnly &&
+        userTextForInput.length > 0 &&
+        !userTextForInput.startsWith("/")
+      ) {
+        firstUserQueryRef.current = userTextForInput
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 100);
+      }
+
       // Block submission if waiting for explicit user action (approvals)
       // In this case, input is hidden anyway, so this shouldn't happen
       if (pendingApprovals.length > 0) {
@@ -9390,8 +9432,8 @@ export default function App({
               "Rename the current agent or conversation.",
               "",
               "USAGE",
-              "  /rename agent <name>      — rename the agent",
-              "  /rename convo [title]     — set a title, or auto-generate when omitted",
+              "  /rename agent [name]      — rename the agent",
+              "  /rename convo [name]      — rename the convo, or auto-generate when omitted",
               "  /rename help              — show this help",
             ].join("\n");
             cmd.finish(output, true);
@@ -9402,7 +9444,7 @@ export default function App({
             !subcommand ||
             (subcommand !== "agent" && subcommand !== "convo")
           ) {
-            cmd.fail("Usage: /rename agent <name> or /rename convo [title]");
+            cmd.fail("Usage: /rename agent [name] or /rename convo [name]");
             return { submitted: true };
           }
 
@@ -9413,9 +9455,7 @@ export default function App({
           }
 
           if (subcommand === "convo") {
-            const shouldAutoGenerate =
-              newValue.trim().length === 0 ||
-              newValue.trim().toLowerCase() === "auto";
+            const shouldAutoGenerate = newValue.trim().length === 0;
             cmd.update({
               output: shouldAutoGenerate
                 ? "Generating conversation title..."
@@ -9428,26 +9468,21 @@ export default function App({
             try {
               const client = await getClient();
               if (shouldAutoGenerate) {
-                const conversation = (await client.post(
-                  `/v1/conversations/${encodeURIComponent(conversationId)}/generate-summary`,
-                  {
-                    body: {
-                      source: "user_requested_auto",
-                      regenerate: true,
-                    },
-                  },
-                )) as { title?: string | null; summary?: string | null };
-                setConversationAutoTitleEligibility(false);
-                const conversationTitle =
-                  conversation.title ?? conversation.summary;
-                if (conversationTitle) {
-                  cmd.finish(
-                    `Conversation title set to "${conversationTitle}"`,
-                    true,
+                const conversationTitle = deriveAutoConversationTitle();
+                if (!conversationTitle) {
+                  cmd.fail(
+                    "No user message available to derive a conversation title",
                   );
-                } else {
-                  cmd.finish("No conversation title generated", true);
+                  return { submitted: true };
                 }
+                await client.conversations.update(conversationId, {
+                  summary: conversationTitle,
+                });
+                setConversationAutoTitleEligibility(false);
+                cmd.finish(
+                  `Conversation title set to "${conversationTitle}"`,
+                  true,
+                );
               } else {
                 await client.conversations.update(conversationId, {
                   summary: newValue,

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -2034,11 +2034,18 @@ export default function App({
     new Set<string>(),
   );
 
-  // Track if we've set the conversation summary for this new conversation
-  // Initialized to true for resumed conversations (they already have context)
-  const hasSetConversationSummaryRef = useRef(resumedExistingConversation);
-  // Store first user query for conversation summary
-  const firstUserQueryRef = useRef<string | null>(null);
+  // Only brand-new conversations without an explicit title should auto-generate one.
+  const shouldAutoGenerateConversationTitleRef = useRef(
+    !resumedExistingConversation,
+  );
+  const isAutoConversationTitleInFlightRef = useRef(false);
+  const setConversationAutoTitleEligibility = useCallback(
+    (enabled: boolean) => {
+      shouldAutoGenerateConversationTitleRef.current = enabled;
+      isAutoConversationTitleInFlightRef.current = false;
+    },
+    [],
+  );
   const resetBootstrapReminderState = useCallback(() => {
     resetSharedReminderState(sharedReminderStateRef.current);
   }, []);
@@ -5137,26 +5144,37 @@ export default function App({
               setNeedsEagerApprovalCheck(false);
             }
 
-            // Set conversation summary from first user query for new conversations
+            // Generate an auto title once the first assistant turn completes.
             if (
-              !hasSetConversationSummaryRef.current &&
-              firstUserQueryRef.current &&
+              shouldAutoGenerateConversationTitleRef.current &&
+              !isAutoConversationTitleInFlightRef.current &&
               conversationIdRef.current !== "default"
             ) {
-              hasSetConversationSummaryRef.current = true;
+              isAutoConversationTitleInFlightRef.current = true;
               const client = await getClient();
-              client.conversations
-                .update(conversationIdRef.current, {
-                  summary: firstUserQueryRef.current,
+              client
+                .post(
+                  `/v1/conversations/${encodeURIComponent(conversationIdRef.current)}/generate-summary`,
+                  {
+                    body: {
+                      source: "auto_first_turn",
+                    },
+                  },
+                )
+                .then(() => {
+                  shouldAutoGenerateConversationTitleRef.current = false;
                 })
                 .catch((err) => {
-                  // Silently ignore - not critical
+                  // Silently ignore - not critical.
                   if (isDebugEnabled()) {
                     console.error(
-                      "[DEBUG] Failed to set conversation summary:",
+                      "[DEBUG] Failed to generate conversation title:",
                       err,
                     );
                   }
+                })
+                .finally(() => {
+                  isAutoConversationTitleInFlightRef.current = false;
                 });
             }
 
@@ -7057,6 +7075,7 @@ export default function App({
 
         await maybeCarryOverActiveConversationModel(conversationId);
         setConversationIdAndRef(conversationId);
+        setConversationAutoTitleEligibility(false);
 
         pendingConversationSwitchRef.current = {
           origin: "fork",
@@ -7143,6 +7162,7 @@ export default function App({
       runEndHooks,
       maybeCarryOverActiveConversationModel,
       resetBootstrapReminderState,
+      setConversationAutoTitleEligibility,
       setConversationIdAndRef,
       setCommandRunning,
       setStreaming,
@@ -7242,6 +7262,7 @@ export default function App({
         const agentModelHandle = getPreferredAgentModelHandle(agent);
         setCurrentModelHandle(agentModelHandle);
         setConversationIdAndRef(targetConversationId);
+        setConversationAutoTitleEligibility(false);
 
         // Ensure bootstrap reminders are re-injected on the first user turn
         // after switching to a different conversation/agent context.
@@ -7313,6 +7334,7 @@ export default function App({
       resetTrajectoryBases,
       resetBootstrapReminderState,
       resetPendingReasoningCycle,
+      setConversationAutoTitleEligibility,
       setConversationIdAndRef,
     ],
   );
@@ -7419,6 +7441,7 @@ export default function App({
         const agentModelHandle = getPreferredAgentModelHandle(agent);
         setCurrentModelHandle(agentModelHandle);
         setConversationIdAndRef(targetConversationId);
+        setConversationAutoTitleEligibility(false);
 
         // Set conversation switch context for new agent switch
         pendingConversationSwitchRef.current = {
@@ -7467,6 +7490,7 @@ export default function App({
       resetDeferredToolCallCommits,
       resetTrajectoryBases,
       resetBootstrapReminderState,
+      setConversationAutoTitleEligibility,
       setConversationIdAndRef,
     ],
   );
@@ -7810,18 +7834,6 @@ export default function App({
           "user",
           currentModelId || "unknown",
         );
-      }
-
-      // Capture first user query for conversation summary (before any async work)
-      // Only for new conversations, non-commands, and if we haven't captured yet
-      if (
-        !hasSetConversationSummaryRef.current &&
-        firstUserQueryRef.current === null &&
-        !isSystemOnly &&
-        userTextForInput.length > 0 &&
-        !userTextForInput.startsWith("/")
-      ) {
-        firstUserQueryRef.current = userTextForInput.slice(0, 100);
       }
 
       // Block submission if waiting for explicit user action (approvals)
@@ -8993,11 +9005,7 @@ export default function App({
               ...(conversationName && { summary: conversationName }),
             });
 
-            // If we created the conversation with an explicit summary, mark it as set
-            // to prevent auto-summary from first user message overwriting it
-            if (conversationName) {
-              hasSetConversationSummaryRef.current = true;
-            }
+            setConversationAutoTitleEligibility(!conversationName);
             await maybeCarryOverActiveConversationModel(conversation.id);
 
             // Update conversationId state and ref together so the next turn
@@ -9080,8 +9088,8 @@ export default function App({
               await client.conversations.update(forked.id, {
                 summary: conversationSummary,
               });
-              hasSetConversationSummaryRef.current = true;
             }
+            setConversationAutoTitleEligibility(false);
 
             await maybeCarryOverActiveConversationModel(forked.id);
 
@@ -9178,6 +9186,7 @@ export default function App({
               isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
             });
 
+            setConversationAutoTitleEligibility(true);
             await maybeCarryOverActiveConversationModel(conversation.id);
             setConversationIdAndRef(conversation.id);
 
@@ -9382,7 +9391,8 @@ export default function App({
               "",
               "USAGE",
               "  /rename agent <name>      — rename the agent",
-              "  /rename convo <summary>   — rename the conversation",
+              "  /rename convo <title>     — set a manual conversation title",
+              "  /rename convo auto        — generate a conversation title",
               "  /rename help              — show this help",
             ].join("\n");
             cmd.finish(output, true);
@@ -9393,7 +9403,9 @@ export default function App({
             !subcommand ||
             (subcommand !== "agent" && subcommand !== "convo")
           ) {
-            cmd.fail("Usage: /rename agent <name> or /rename convo <summary>");
+            cmd.fail(
+              "Usage: /rename agent <name> or /rename convo <title|auto>",
+            );
             return { submitted: true };
           }
 
@@ -9401,15 +9413,18 @@ export default function App({
           if (!newValue) {
             cmd.fail(
               subcommand === "convo"
-                ? "Please provide a summary: /rename convo <summary>"
+                ? "Please provide a title or use /rename convo auto"
                 : "Please provide a name: /rename agent <name>",
             );
             return { submitted: true };
           }
 
           if (subcommand === "convo") {
+            const shouldAutoGenerate = newValue.trim().toLowerCase() === "auto";
             cmd.update({
-              output: `Renaming conversation to "${newValue}"...`,
+              output: shouldAutoGenerate
+                ? "Generating conversation title..."
+                : `Renaming conversation to "${newValue}"...`,
               phase: "running",
             });
 
@@ -9417,11 +9432,34 @@ export default function App({
 
             try {
               const client = await getClient();
-              await client.conversations.update(conversationId, {
-                summary: newValue,
-              });
-
-              cmd.finish(`Conversation renamed to "${newValue}"`, true);
+              if (shouldAutoGenerate) {
+                const conversation = (await client.post(
+                  `/v1/conversations/${encodeURIComponent(conversationId)}/generate-summary`,
+                  {
+                    body: {
+                      source: "user_requested_auto",
+                      regenerate: true,
+                    },
+                  },
+                )) as { title?: string | null; summary?: string | null };
+                setConversationAutoTitleEligibility(false);
+                const conversationTitle =
+                  conversation.title ?? conversation.summary;
+                if (conversationTitle) {
+                  cmd.finish(
+                    `Conversation title set to "${conversationTitle}"`,
+                    true,
+                  );
+                } else {
+                  cmd.finish("No conversation title generated", true);
+                }
+              } else {
+                await client.conversations.update(conversationId, {
+                  summary: newValue,
+                });
+                setConversationAutoTitleEligibility(false);
+                cmd.finish(`Conversation renamed to "${newValue}"`, true);
+              }
             } catch (error) {
               const errorDetails = formatErrorDetails(error, agentId);
               cmd.fail(`Failed: ${errorDetails}`);
@@ -9577,6 +9615,7 @@ export default function App({
 
                 // Only update state after validation succeeds
                 setConversationIdAndRef(targetConvId);
+                setConversationAutoTitleEligibility(false);
 
                 pendingConversationSwitchRef.current = {
                   origin: "resume-direct",
@@ -11272,6 +11311,7 @@ ${SYSTEM_REMINDER_CLOSE}
       systemInfoReminderEnabled,
       appendTaskNotificationEvents,
       maybeCarryOverActiveConversationModel,
+      setConversationAutoTitleEligibility,
       setConversationIdAndRef,
     ],
   );
@@ -13009,6 +13049,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 );
 
                 setConversationIdAndRef(action.conversationId);
+                setConversationAutoTitleEligibility(false);
 
                 pendingConversationSwitchRef.current = {
                   origin: "resume-selector",
@@ -13084,6 +13125,7 @@ ${SYSTEM_REMINDER_CLOSE}
     commandRunner.start,
     recoverRestoredPendingApprovals,
     resetBootstrapReminderState,
+    setConversationAutoTitleEligibility,
     setConversationIdAndRef,
   ]);
 
@@ -14921,6 +14963,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
 
                       // Only update state after validation succeeds
                       setConversationIdAndRef(convId);
+                      setConversationAutoTitleEligibility(false);
 
                       pendingConversationSwitchRef.current = {
                         origin: "resume-selector",
@@ -14932,11 +14975,6 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                         summary: selectorContext?.summary,
                         messageHistory: resumeData.messageHistory,
                       };
-
-                      // If the conversation already has a summary, prevent auto-summary from overwriting it
-                      if (selectorContext?.summary) {
-                        hasSetConversationSummaryRef.current = true;
-                      }
 
                       settingsManager.persistSession(agentId, convId);
 
@@ -15072,6 +15110,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                       conversation.id,
                     );
                     setConversationIdAndRef(conversation.id);
+                    setConversationAutoTitleEligibility(true);
                     settingsManager.persistSession(agentId, conversation.id);
 
                     // Build success command with agent + conversation info
@@ -15199,6 +15238,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                       );
 
                       setConversationIdAndRef(actualTargetConv);
+                      setConversationAutoTitleEligibility(false);
 
                       pendingConversationSwitchRef.current = {
                         origin: "search",

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -219,7 +219,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/rename": {
-    desc: "Rename agent or conversation (/rename agent|convo <name>)",
+    desc: "Rename agent or conversation (/rename agent <name>|convo [title])",
     order: 24,
     handler: () => {
       // Handled specially in App.tsx to access agent ID and client

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -219,7 +219,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/rename": {
-    desc: "Rename agent or conversation (/rename agent <name>|convo [title])",
+    desc: "Rename agent or conversation (/rename agent [name]|convo [name])",
     order: 24,
     handler: () => {
       // Handled specially in App.tsx to access agent ID and client

--- a/src/cli/helpers/conversationTitle.ts
+++ b/src/cli/helpers/conversationTitle.ts
@@ -1,0 +1,172 @@
+import type Letta from "@letta-ai/letta-client";
+import { forkConversation } from "../../backend/api/conversations";
+import { DEFAULT_SUMMARIZATION_MODEL } from "../../constants";
+import { isDebugEnabled } from "../../utils/debug";
+
+/**
+ * Maximum characters allowed for an auto-generated conversation title.
+ */
+export const CONVERSATION_TITLE_MAX_LENGTH = 100;
+
+/**
+ * Hard timeout on the fork-and-generate flow. Title generation is best-effort
+ * and we fall back to a heuristic on timeout.
+ */
+const CONVERSATION_TITLE_TIMEOUT_MS = 30_000;
+
+/**
+ * System prompt installed via `override_system` for the title-generation turn.
+ * Bypasses the agent's persisted system prompt so the model focuses on producing
+ * a single short title rather than its normal task behavior.
+ */
+const CONVERSATION_TITLE_SYSTEM_PROMPT = `You are a conversation title generator.
+
+Output ONLY a short, descriptive title for the conversation above.
+Rules:
+- 2 to 7 words
+- describe the actual topic, not the mood
+- no quotes, markdown, prefixes, or trailing punctuation
+- never call any tools — reply with plain text only
+- avoid generic titles like "New conversation" or "Help request"`;
+
+/**
+ * Final user-turn prompt sent to the forked conversation. The agent already
+ * has the original conversation's in-context messages (copied by fork), so
+ * this just nudges it to emit the title.
+ */
+const CONVERSATION_TITLE_USER_PROMPT =
+  "Based on the conversation above, output a short title (2-7 words) describing the topic. Reply with ONLY the title text — no quotes, no tools, no preamble.";
+
+/**
+ * Strip whitespace, surrounding quotes, and clamp to {@link CONVERSATION_TITLE_MAX_LENGTH}.
+ * Returns null when the input doesn't yield a usable title (empty, slash command, etc.).
+ */
+export function normalizeConversationTitle(value: string): string | null {
+  let normalized = value.replace(/\s+/g, " ").trim();
+
+  // Drop a single layer of surrounding quotes if the model added them despite the prompt.
+  if (
+    (normalized.startsWith('"') && normalized.endsWith('"')) ||
+    (normalized.startsWith("'") && normalized.endsWith("'"))
+  ) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  if (!normalized || normalized.startsWith("/")) {
+    return null;
+  }
+
+  return normalized.slice(0, CONVERSATION_TITLE_MAX_LENGTH);
+}
+
+/**
+ * Extract plain-text content from an assistant_message chunk's `content`
+ * field, which may be a raw string or an array of structured content parts.
+ */
+function extractAssistantText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    let collected = "";
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        collected += (part as { text: string }).text;
+      }
+    }
+    return collected;
+  }
+  return "";
+}
+
+/**
+ * Generate a conversation title by:
+ * 1. Forking the conversation as a hidden side conversation.
+ * 2. Sending a single one-step message to the fork with `override_model`
+ *    (DEFAULT_SUMMARIZATION_MODEL) and `override_system` so the agent only
+ *    emits a short title rather than running its full task loop.
+ * 3. Reading the assistant message text out of the stream.
+ * 4. Best-effort deleting the forked conversation so it doesn't pollute
+ *    the user's conversation list.
+ *
+ * Returns null on any failure or when the model produced empty output —
+ * the caller should fall back to a heuristic title.
+ */
+export async function generateConversationTitleFromFork(
+  client: Letta,
+  conversationId: string,
+): Promise<string | null> {
+  let forkId: string | null = null;
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(
+    () => abortController.abort(),
+    CONVERSATION_TITLE_TIMEOUT_MS,
+  );
+
+  try {
+    const fork = await forkConversation(conversationId, { hidden: true });
+    forkId = fork.id;
+
+    const stream = await client.conversations.messages.create(
+      forkId,
+      {
+        messages: [
+          {
+            role: "user",
+            content: CONVERSATION_TITLE_USER_PROMPT,
+          },
+        ],
+        override_model: DEFAULT_SUMMARIZATION_MODEL,
+        override_system: CONVERSATION_TITLE_SYSTEM_PROMPT,
+        max_steps: 1,
+        streaming: true,
+        stream_tokens: false,
+        include_pings: false,
+      },
+      { signal: abortController.signal },
+    );
+
+    let titleText = "";
+    for await (const chunk of stream) {
+      // Only collect assistant_message text. Tool calls / reasoning are ignored
+      // so a model that misbehaves and tries a tool call still falls back cleanly.
+      if (
+        chunk &&
+        typeof chunk === "object" &&
+        "message_type" in chunk &&
+        (chunk as { message_type?: string }).message_type ===
+          "assistant_message"
+      ) {
+        titleText += extractAssistantText(
+          (chunk as { content?: unknown }).content,
+        );
+      }
+    }
+
+    return normalizeConversationTitle(titleText);
+  } catch (err) {
+    if (isDebugEnabled()) {
+      console.error("[DEBUG] generateConversationTitleFromFork failed:", err);
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+    // Best-effort cleanup of the hidden fork. We don't await this on the
+    // hot path; if it errors we just leave the hidden convo and move on.
+    if (forkId) {
+      void client.conversations.delete(forkId).catch((err) => {
+        if (isDebugEnabled()) {
+          console.error(
+            "[DEBUG] failed to delete title-fork conversation:",
+            err,
+          );
+        }
+      });
+    }
+  }
+}

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -9,6 +9,12 @@ const ENABLED_TOGGLE_VALUES = new Set(["1", "true", "yes"]);
 
 const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
   {
+    id: "conversation_titles",
+    label: "conversation titles",
+    description:
+      "Generate conversation titles from the transcript with letta/auto (uses your credits).",
+  },
+  {
     id: "node",
     label: "node",
     description: "Route API requests through the Letta Node / TS core path.",

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -1,4 +1,4 @@
-export type ExperimentId = "node";
+export type ExperimentId = "conversation_titles" | "node";
 
 export type ExperimentSource = "override" | "env" | "default";
 

--- a/src/tests/cli/conversationTitle.test.ts
+++ b/src/tests/cli/conversationTitle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONVERSATION_TITLE_MAX_LENGTH,
+  normalizeConversationTitle,
+} from "../../cli/helpers/conversationTitle";
+
+describe("normalizeConversationTitle", () => {
+  test("returns null for empty input", () => {
+    expect(normalizeConversationTitle("")).toBeNull();
+    expect(normalizeConversationTitle("   ")).toBeNull();
+  });
+
+  test("returns null for slash-command-shaped values", () => {
+    expect(normalizeConversationTitle("/rename convo")).toBeNull();
+    expect(normalizeConversationTitle("  /resume  ")).toBeNull();
+  });
+
+  test("collapses internal whitespace", () => {
+    expect(normalizeConversationTitle("  Wire   up  fork  ")).toBe(
+      "Wire up fork",
+    );
+  });
+
+  test("strips a single layer of surrounding quotes", () => {
+    expect(normalizeConversationTitle('"Refactor auth flow"')).toBe(
+      "Refactor auth flow",
+    );
+    expect(normalizeConversationTitle("'Plan q4 roadmap'")).toBe(
+      "Plan q4 roadmap",
+    );
+  });
+
+  test("leaves mismatched / nested quotes alone", () => {
+    expect(normalizeConversationTitle('"Title with "quoted" word"')).toBe(
+      'Title with "quoted" word',
+    );
+  });
+
+  test("truncates to CONVERSATION_TITLE_MAX_LENGTH", () => {
+    const long = "a".repeat(CONVERSATION_TITLE_MAX_LENGTH + 50);
+    const result = normalizeConversationTitle(long);
+    expect(result).not.toBeNull();
+    expect(result?.length).toBe(CONVERSATION_TITLE_MAX_LENGTH);
+  });
+});

--- a/src/tests/experiments/manager.test.ts
+++ b/src/tests/experiments/manager.test.ts
@@ -42,6 +42,15 @@ afterEach(async () => {
 });
 
 describe("experimentManager", () => {
+  test("conversation title generation is opt-in by default", () => {
+    expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
+      id: "conversation_titles",
+      enabled: false,
+      source: "default",
+      override: null,
+    });
+  });
+
   test("falls back to LETTA_NODE when no override is stored", () => {
     process.env.LETTA_NODE = "1";
 
@@ -72,6 +81,26 @@ describe("experimentManager", () => {
       enabled: false,
       source: "override",
       override: false,
+    });
+  });
+
+  test("persists explicit conversation title overrides", async () => {
+    expect(experimentManager.set("conversation_titles", true)).toMatchObject({
+      id: "conversation_titles",
+      enabled: true,
+      source: "override",
+      override: true,
+    });
+    await settingsManager.flush();
+
+    await settingsManager.reset();
+    await settingsManager.initialize();
+
+    expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
+      id: "conversation_titles",
+      enabled: true,
+      source: "override",
+      override: true,
     });
   });
 });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -2278,13 +2278,13 @@ describe("listen-client experiment command handling", () => {
         type: "get_experiments_response",
         request_id: "experiments-get-1",
         success: true,
-        experiments: [
+        experiments: expect.arrayContaining([
           expect.objectContaining({
             id: "node",
             enabled: false,
             source: "default",
           }),
-        ],
+        ]),
       });
 
       socket.sentPayloads.length = 0;
@@ -2306,24 +2306,24 @@ describe("listen-client experiment command handling", () => {
         type: "set_experiment_response",
         request_id: "experiment-set-1",
         success: true,
-        experiments: [
+        experiments: expect.arrayContaining([
           expect.objectContaining({
             id: "node",
             enabled: true,
             source: "override",
           }),
-        ],
+        ]),
       });
       expect(deviceStatusUpdate).toMatchObject({
         type: "update_device_status",
         device_status: {
-          experiments: [
+          experiments: expect.arrayContaining([
             expect.objectContaining({
               id: "node",
               enabled: true,
               source: "override",
             }),
-          ],
+          ]),
         },
       });
     } finally {
@@ -2792,12 +2792,14 @@ describe("listen-client v2 status builders", () => {
         (deviceStatus.current_working_directory ?? "").length,
       ).toBeGreaterThan(0);
       expect(deviceStatus.current_toolset_preference).toBe("auto");
-      expect(deviceStatus.experiments).toEqual([
-        expect.objectContaining({
-          id: "node",
-          source: "default",
-        }),
-      ]);
+      expect(deviceStatus.experiments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "node",
+            source: "default",
+          }),
+        ]),
+      );
     } finally {
       if (originalNodeFlag === undefined) {
         delete process.env.LETTA_NODE;


### PR DESCRIPTION
## Summary
- derive auto conversation titles client-side from the first user message instead of calling the server-side generation endpoint (default behavior)
- add an opt-in `conversation_titles` experiment that, when enabled, runs title generation through a hidden fork of the active conversation:
  - fork the convo with `hidden: true` so it does not appear in listings
  - send a single `messages.create` turn against the fork with `override_model: letta/auto`, an `override_system` that constrains the model to title-only output, and `max_steps: 1`
  - collect `assistant_message` text from the stream, normalize, return
  - best-effort delete the forked convo on the way out so it does not pile up
  - 30s AbortController timeout, falls back to the heuristic on any failure / experiment off / local backend / `default` convo
- keep auto-title eligibility scoped to genuinely new conversations so resume, search, fork, and agent-switch flows do not accidentally retitle existing convos
- make `/rename {agent|convo} [name]` the documented shape, where bare `/rename convo` auto-generates a title (AI when experiment on, heuristic otherwise) and `/rename convo [name]` sets one manually
- both the bare `/rename convo` command and the post-first-turn auto path share `generateConversationTitle()`, so the AI path applies to both

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun test src/tests/cli/commandRunner.test.ts`
- [x] `bun test src/tests/cli/conversationTitle.test.ts` (normalize edge cases)
- [x] `bun test src/tests/experiments/manager.test.ts` (experiment toggle persistence)
- [ ] manually verify first-turn auto-title behavior in the CLI with `conversation_titles` off (heuristic) and on (AI via fork)
- [ ] manually verify `/rename convo` and `/rename convo [name]` in the CLI in both modes
- [ ] verify hidden fork is deleted (or at least hidden) after title generation

## Example

https://github.com/user-attachments/assets/3f12cc96-3903-4913-ae7a-cd55e97ad486

