### PR TITLE
feat(ci): add Amelia as automated PR code reviewer

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Wait for CI lint
         if: github.event_name == 'pull_request'
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
-            --jq '.check_runs[] | select(.name == "Lint & Type Check") | .status + " " + .conclusion' \
-            | head -1
           # Poll until the lint check completes
           for i in $(seq 1 30); do
             STATUS=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -21,19 +21,47 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: read
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      # Wait for CI lint to pass before running review
+      - name: Wait for CI lint
+        if: github.event_name == 'pull_request'
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
+            --jq '.check_runs[] | select(.name == "Lint & Type Check") | .status + " " + .conclusion' \
+            | head -1
+          # Poll until the lint check completes
+          for i in $(seq 1 30); do
+            STATUS=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
+              --jq '.check_runs[] | select(.name == "Lint & Type Check") | .status')
+            if [ "$STATUS" = "completed" ]; then
+              CONCLUSION=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
+                --jq '.check_runs[] | select(.name == "Lint & Type Check") | .conclusion')
+              echo "Lint check completed: $CONCLUSION"
+              if [ "$CONCLUSION" != "success" ]; then
+                echo "Lint check failed or was cancelled ($CONCLUSION), skipping review"
+                exit 0
+              fi
+              break
+            fi
+            echo "Waiting for lint check... (attempt $i/30)"
+            sleep 10
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: letta-ai/letta-code-action@v0
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
-          track_progress: "true"
-          show_full_output: "true"
+          track_progress: ${{ github.event_name == 'pull_request' && 'true' || '' }}
           model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
@@ -86,8 +114,13 @@ jobs:
               -f body="" \
               -f 'comments[][path]=<file>' \
               -f 'comments[][line]=<line-number>' \
-              -f 'comments[][body]=<your comment — 1-2 sentences, state the risk concretely>'
+              -f 'comments[][body]=<your comment>'
             ```
+
+            **CRITICAL: Comments must be 1-2 short sentences max.** State the concrete risk, nothing else. No explanations, no context, no suggestions unless asked. Examples:
+            - ✅ `track_progress` will crash on `workflow_dispatch` — the action rejects it for non-PR events.
+            - ✅ `show_full_output: "true"` leaks tool output (potentially secrets) into CI logs.
+            - ❌ The `track_progress` option is set to "true" in this workflow, but the letta-code-action's `validateTrackProgressEvent` function explicitly rejects the `workflow_dispatch` event type when track_progress is enabled. This means every manual dispatch will throw an error. You should either remove track_progress and handle tracking yourself in the prompt, or split into two jobs — one for pull_request (with track_progress) and one for workflow_dispatch (without it).
 
             ## Steps
 
@@ -95,4 +128,4 @@ jobs:
             2. Run `gh pr diff $PR_NUMBER` to read the full diff
             3. Assess risk using your knowledge + the criteria above
             4. If nothing notable → exit silently (no comment, no output)
-            5. If something is risky → leave targeted inline review comments
+            5. If something is risky → leave targeted inline review comments (1-2 sentences each)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,6 +34,7 @@ jobs:
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: "true"
           show_full_output: "true"
+          model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,96 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+
+jobs:
+  review:
+    # Only run on Caren's PRs (auto-trigger) or manual dispatch
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.user.login == 'carenthomas')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: letta-ai/letta-code-action@v0
+        with:
+          letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          track_progress: "true"
+          prompt: |
+            You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
+
+            ## Your job
+
+            First, read your review knowledge file from memory — it has the full list of codebase footguns, known bug patterns, and provider-specific traps you've accumulated:
+            ```
+            Read file: $MEMORY_DIR/reference/projects/letta-code/review-knowledge.md
+            ```
+
+            Then read the diff carefully. Assess whether this PR introduces bugs, logic errors, security issues, race conditions, missing error handling, breaking changes, or performance problems.
+
+            **Default posture: silence.** Most PRs are fine. If you have nothing notable to flag, exit without commenting. No "LGTM", no summary, no praise — just exit. Silence means approval.
+
+            ## Voice
+
+            You're Amelia. Be yourself — casual, direct, no filler. If you flag something, say it the way you'd say it to Caren in conversation: tight, concrete, no padding. Don't sound like a bot or a linter. You're a collaborator pointing something out, not a bureaucrat filing a report.
+
+            ## What to flag (high-signal only)
+
+            - Bugs or logic errors
+            - Security vulnerabilities (injection, auth bypass, secrets exposure)
+            - Race conditions or concurrency issues (especially in approval flow, streaming, tool execution)
+            - Missing error handling that could crash in production or leave agent permanently busy
+            - Breaking changes to public APIs or CLI flags without migration
+            - Performance footguns (O(n²) in hot paths, unbounded allocations, missing truncation)
+            - Shell tool parity gaps (change to Bash.ts but not ShellCommand.ts or vice versa)
+            - State cleanup paths missing flag clears (isExecutingTool, abortControllerRef, toolResultsInFlightRef)
+            - Streaming code that assumes one provider's behavior works for all (Anthropic vs OpenAI vs Gemini quirks differ)
+            - Dead code being introduced (unused imports, unreachable branches)
+            - Ink rendering changes that will cause flicker (state toggling during streaming, width-changing footer elements)
+
+            ## What NOT to flag
+
+            - Style, naming, formatting — Biome handles this
+            - Minor nits or personal preferences
+            - Things that are correct but you'd do differently
+            - Test failures from known flaky tests (Google AI 429s, ZAI rate limits, LLM non-determinism tests, self-hosted GPU runner issues)
+            - Existing patterns being followed consistently (even if suboptimal)
+
+            ## How to comment
+
+            If you find something worth flagging, use `gh api` to create a PR review with inline comments on specific lines:
+
+            ```bash
+            gh api repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews \
+              -X POST \
+              -f event="COMMENT" \
+              -f body="" \
+              -f 'comments[][path]=<file>' \
+              -f 'comments[][line]=<line-number>' \
+              -f 'comments[][body]=<your comment — 1-2 sentences, state the risk concretely>'
+            ```
+
+            ## Steps
+
+            1. Read your review-knowledge.md memory file (codebase footguns reference)
+            2. Run `gh pr diff $PR_NUMBER` to read the full diff
+            3. Assess risk using your knowledge + the criteria above
+            4. If nothing notable → exit silently (no comment, no output)
+            5. If something is risky → leave targeted inline review comments

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,6 +33,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: "true"
+          show_full_output: "true"
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/review.yml` — triggers Amelia (stateful agent with accumulated codebase knowledge) to review PRs
- Default silent — only leaves inline comments when something is genuinely risky (bugs, race conditions, security, parity gaps)
- Scoped to `carenthomas` PRs only while we tune quality
- Supports `workflow_dispatch` to manually trigger on any PR number for testing

## How it works
- Uses `letta-code-action@v0` with `track_progress: true` (tag mode) — per-PR conversation persistence
- Pins to Amelia's agent ID so review knowledge accumulates over time
- First step: reads `review-knowledge.md` from agent memory (codebase footguns extracted from Charles' and Sarah's agents)
- Then reads diff, only comments if high-signal risk found

## Testing
- [ ] Verify `AMELIA_LETTA_API_KEY` secret is set in repo
- [ ] This PR should self-trigger (author is carenthomas) — check Actions tab
- [ ] Try manual dispatch on an existing PR to verify workflow_dispatch path

🐾 Generated with [Letta Code](https://letta.com)