### PR TITLE
fix: auto-enable memfs for existing agents in headless mode

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1181,17 +1181,19 @@ export async function handleHeadlessCommand(
   let effectiveReflectionSettings: ReflectionSettings;
 
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
-  const startupMemfsFlag = autoEnableMemfsForFreshAgent ? true : memfsFlag;
+  let startupMemfsFlag: boolean | undefined = autoEnableMemfsForFreshAgent
+    ? true
+    : memfsFlag;
 
   if (backend.capabilities.remoteMemfs && !autoEnableMemfsForFreshAgent) {
-    const { hydrateMemfsSettingFromAgent } = await import(
+    const { hydrateMemfsSettingFromAgent, isLettaCloud } = await import(
       "./agent/memoryFilesystem"
     );
     const memfsEnabled = await hydrateMemfsSettingFromAgent(agent);
-    if (!memfsEnabled) {
-      console.warn(
-        "Warning: this agent does not have git-backed memory enabled. Run `/memfs enable` to enable MemFS.",
-      );
+    if (!memfsEnabled && !noMemfsFlag && (await isLettaCloud())) {
+      // Auto-enable memfs for existing agents that don't have it yet.
+      // Matches interactive mode behavior where memfs defaults to enabled.
+      startupMemfsFlag = true;
     }
   }
 


### PR DESCRIPTION
## Summary
When an existing agent does not have the `git-memory-enabled` tag and `--no-memfs` was not explicitly passed, auto-enable memfs instead of just printing a warning. This matches interactive mode behavior where memfs defaults to enabled.

**Note:** The root cause of tags being stripped from `retrieveAgent` calls was fixed separately in #2134 (now merged). This PR handles the remaining case where an agent genuinely lacks the tag (e.g. created outside letta-code, or before memfs was available).

## Changes
- **`src/headless.ts`**: Change `startupMemfsFlag` from `const` to `let`, and when `hydrateMemfsSettingFromAgent` returns false and `--no-memfs` was not passed, set `startupMemfsFlag = true` instead of logging a warning

## Test plan
- [ ] Headless with `--agent <id>` where agent genuinely has no tag → auto-enables memfs instead of warning
- [ ] Headless with `--agent <id> --no-memfs` → opt-out still respected
- [ ] Headless with `--agent <id>` where agent has the tag → memfs initializes normally (no change)

🐾 Generated with [Letta Code](https://letta.com)