### PR TITLE
feat: stop repeat tool calling

### DIFF
--- a/src/agent/tool-repeat-reminder.ts
+++ b/src/agent/tool-repeat-reminder.ts
@@ -1,0 +1,47 @@
+const REPEATED_TOOL_CALL_THRESHOLD = 3;
+
+export type RepeatToolCall = {
+  toolName: string;
+  toolArgs: string;
+};
+
+export type ToolRepeatTracker = Map<string, number>;
+
+export function createToolRepeatTracker(): ToolRepeatTracker {
+  return new Map();
+}
+
+function getRepeatKey(call: RepeatToolCall): string {
+  // Exact match: same tool name and the raw argument string as emitted by the model.
+  return `${call.toolName}\0${call.toolArgs}`;
+}
+
+export function buildRepeatedToolCallReminder(
+  tracker: ToolRepeatTracker,
+  calls: RepeatToolCall[],
+): string | null {
+  const repeated: RepeatToolCall[] = [];
+
+  for (const call of calls) {
+    const key = getRepeatKey(call);
+    const count = (tracker.get(key) ?? 0) + 1;
+    tracker.set(key, count);
+
+    if (count === REPEATED_TOOL_CALL_THRESHOLD) {
+      repeated.push(call);
+    }
+  }
+
+  if (repeated.length === 0) return null;
+
+  const toolList = repeated
+    .map((call) => `- ${call.toolName}(${call.toolArgs || "{}"})`)
+    .join("\n");
+
+  return `<system-reminder>
+You have called the same tool with the exact same arguments ${REPEATED_TOOL_CALL_THRESHOLD} times:
+${toolList}
+
+This usually indicates the current approach is stuck. Try a different approach instead of repeating the same exact tool call again.
+</system-reminder>`;
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -81,6 +81,11 @@ import {
 import { reconcileExistingAgentState } from "../agent/reconcileExistingAgentState";
 import { recordSessionEnd } from "../agent/sessionHistory";
 import { SessionStats } from "../agent/stats";
+import {
+  buildRepeatedToolCallReminder,
+  createToolRepeatTracker,
+  type RepeatToolCall,
+} from "../agent/tool-repeat-reminder";
 import { type ConversationMessageStreamBody, getBackend } from "../backend";
 import { getAgentContextOverview } from "../backend/api/agents";
 import { getClient, getServerUrl } from "../backend/api/client";
@@ -2870,6 +2875,24 @@ export default function App({
 
   // Canonical buffers stored in a ref (mutated by onChunk), PERSISTED for session
   const buffersRef = useRef(createBuffers());
+  const toolRepeatTrackerRef = useRef(createToolRepeatTracker());
+
+  const buildToolRepeatReminderMessage = useCallback(
+    (calls: RepeatToolCall[]): MessageCreate | null => {
+      const reminder = buildRepeatedToolCallReminder(
+        toolRepeatTrackerRef.current,
+        calls,
+      );
+      if (!reminder) return null;
+      return {
+        type: "message",
+        role: "system",
+        content: reminder,
+        otid: createClientOtid(),
+      };
+    },
+    [],
+  );
 
   // Context-window token tracking, decoupled from streaming buffers
   const contextTrackerRef = useRef(createContextTracker());
@@ -5084,6 +5107,7 @@ export default function App({
 
           // Case 1: Turn ended normally
           if (stopReasonToHandle === "end_turn") {
+            toolRepeatTrackerRef.current.clear();
             clearApprovalToolContext();
             setStreaming(false);
             const liveElapsedMs = (() => {
@@ -5678,6 +5702,12 @@ export default function App({
                 if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
                   const queuedContentParts =
                     buildQueuedContentParts(queuedItemsToAppend);
+                  const repeatReminderMessage = buildToolRepeatReminderMessage(
+                    autoAllowed.map((ac) => ({
+                      toolName: ac.approval.toolName,
+                      toolArgs: ac.approval.toolArgs || "{}",
+                    })),
+                  );
                   setThinkingMessage(getRandomThinkingVerb());
                   refreshDerived();
                   toolResultsInFlightRef.current = true;
@@ -5688,6 +5718,7 @@ export default function App({
                         approvals: allResults,
                         otid: createClientOtid(),
                       },
+                      ...(repeatReminderMessage ? [repeatReminderMessage] : []),
                       {
                         type: "message",
                         role: "user",
@@ -5732,6 +5763,13 @@ export default function App({
                 setThinkingMessage(getRandomThinkingVerb());
                 refreshDerived();
 
+                const repeatReminderMessage = buildToolRepeatReminderMessage(
+                  autoAllowed.map((ac) => ({
+                    toolName: ac.approval.toolName,
+                    toolArgs: ac.approval.toolArgs || "{}",
+                  })),
+                );
+
                 toolResultsInFlightRef.current = true;
                 await processConversation(
                   [
@@ -5740,6 +5778,7 @@ export default function App({
                       approvals: allResults,
                       otid: randomUUID(),
                     },
+                    ...(repeatReminderMessage ? [repeatReminderMessage] : []),
                   ],
                   { allowReentry: true },
                 );
@@ -11680,6 +11719,15 @@ ${SYSTEM_REMINDER_CLOSE}
               otid: createClientOtid(),
             },
           ];
+          const repeatReminderMessage = buildToolRepeatReminderMessage(
+            allDecisions.map((decision) => ({
+              toolName: decision.approval.toolName,
+              toolArgs: decision.approval.toolArgs || "{}",
+            })),
+          );
+          if (repeatReminderMessage) {
+            input.push(repeatReminderMessage);
+          }
           if (queuedItemsToAppend && queuedItemsToAppend.length > 0) {
             const queuedUserText = buildQueuedUserText(queuedItemsToAppend);
             const queuedUserOtid = createClientOtid();
@@ -11744,6 +11792,7 @@ ${SYSTEM_REMINDER_CLOSE}
       openTrajectorySegment,
       commitEligibleLines,
       prepareScopedToolExecutionContext,
+      buildToolRepeatReminderMessage,
     ],
   );
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -45,6 +45,10 @@ import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import type { SkillSource } from "./agent/skills";
 import { SessionStats } from "./agent/stats";
 import {
+  buildRepeatedToolCallReminder,
+  createToolRepeatTracker,
+} from "./agent/tool-repeat-reminder";
+import {
   type ConversationCreateBody,
   type ConversationMessageStreamBody,
   getBackend,
@@ -1822,6 +1826,7 @@ ${SYSTEM_REMINDER_CLOSE}
   let conversationBusyRetries = 0;
   let providerFallbackAttempted = false;
   let overrideModelHandle: string | undefined;
+  const toolRepeatTracker = createToolRepeatTracker();
   markMilestone("HEADLESS_FIRST_STREAM_START");
   measureSinceMilestone("headless-setup-total", "HEADLESS_CLIENT_READY");
 
@@ -2251,6 +2256,7 @@ ${SYSTEM_REMINDER_CLOSE}
 
       // Case 1: Turn ended normally
       if (stopReason === "end_turn") {
+        toolRepeatTracker.clear();
         // Reset retry counters on success
         llmApiErrorRetries = 0;
         emptyResponseRetries = 0;
@@ -2338,7 +2344,26 @@ ${SYSTEM_REMINDER_CLOSE}
           approvals: executedResults as ApprovalResult[],
           otid: randomUUID(),
         };
-        currentInput = [approvalInputWithOtid];
+        const repeatReminder = buildRepeatedToolCallReminder(
+          toolRepeatTracker,
+          decisions.map((decision) => ({
+            toolName: decision.approval.toolName,
+            toolArgs: decision.approval.toolArgs || "{}",
+          })),
+        );
+        currentInput = [
+          approvalInputWithOtid,
+          ...(repeatReminder
+            ? [
+                {
+                  type: "message" as const,
+                  role: "system" as const,
+                  content: repeatReminder,
+                  otid: randomUUID(),
+                },
+              ]
+            : []),
+        ];
         continue;
       }
 
@@ -2908,6 +2933,7 @@ async function runBidirectionalMode(
   let currentAbortController: AbortController | null = null;
   const reminderContextTracker = createContextTracker();
   const sharedReminderState = createSharedReminderState();
+  const toolRepeatTracker = createToolRepeatTracker();
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
 
   // Resolve pending approvals for this conversation before retrying user input.
@@ -3932,6 +3958,7 @@ async function runBidirectionalMode(
 
           // Case 1: Turn ended normally - break out of loop
           if (stopReason === "end_turn") {
+            toolRepeatTracker.clear();
             break;
           }
 
@@ -4079,7 +4106,26 @@ async function runBidirectionalMode(
               approvals: executedResults,
               otid: randomUUID(),
             };
-            currentInput = [approvalInputWithOtid as unknown as MessageCreate];
+            const repeatReminder = buildRepeatedToolCallReminder(
+              toolRepeatTracker,
+              decisions.map((decision) => ({
+                toolName: decision.approval.toolName,
+                toolArgs: decision.approval.toolArgs || "{}",
+              })),
+            );
+            currentInput = [
+              approvalInputWithOtid as unknown as MessageCreate,
+              ...(repeatReminder
+                ? [
+                    {
+                      type: "message" as const,
+                      role: "system" as const,
+                      content: repeatReminder,
+                      otid: randomUUID(),
+                    },
+                  ]
+                : []),
+            ];
 
             // Continue the loop to process the next stream
             continue;

--- a/src/tests/tool-repeat-reminder.test.ts
+++ b/src/tests/tool-repeat-reminder.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildRepeatedToolCallReminder,
+  createToolRepeatTracker,
+} from "../agent/tool-repeat-reminder";
+
+describe("tool repeat reminder", () => {
+  test("returns a reminder on the third exact same tool call", () => {
+    const tracker = createToolRepeatTracker();
+    const call = { toolName: "Read", toolArgs: '{"file_path":"README.md"}' };
+
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+
+    const reminder = buildRepeatedToolCallReminder(tracker, [call]);
+    expect(reminder).not.toBeNull();
+    expect(reminder).toContain(
+      "You have called the same tool with the exact same arguments 3 times",
+    );
+    expect(reminder).toContain('Read({"file_path":"README.md"})');
+  });
+
+  test("does not remind for same tool with different raw arguments", () => {
+    const tracker = createToolRepeatTracker();
+
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"file_path":"a.ts"}' },
+      ]),
+    ).toBeNull();
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"file_path":"b.ts"}' },
+      ]),
+    ).toBeNull();
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"file_path":"c.ts"}' },
+      ]),
+    ).toBeNull();
+  });
+
+  test("does not canonicalize json arguments", () => {
+    const tracker = createToolRepeatTracker();
+
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"a":1,"b":2}' },
+      ]),
+    ).toBeNull();
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"b":2,"a":1}' },
+      ]),
+    ).toBeNull();
+    expect(
+      buildRepeatedToolCallReminder(tracker, [
+        { toolName: "Read", toolArgs: '{"a":1,"b":2}' },
+      ]),
+    ).toBeNull();
+  });
+
+  test("does not remind again after the threshold without reset", () => {
+    const tracker = createToolRepeatTracker();
+    const call = { toolName: "Glob", toolArgs: '{"pattern":"**/*.ts"}' };
+
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).not.toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+  });
+
+  test("resetting the tracker allows a future reminder", () => {
+    const tracker = createToolRepeatTracker();
+    const call = { toolName: "Grep", toolArgs: '{"pattern":"foo"}' };
+
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).not.toBeNull();
+
+    tracker.clear();
+
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).toBeNull();
+    expect(buildRepeatedToolCallReminder(tracker, [call])).not.toBeNull();
+  });
+
+  test("tracks repeated calls inside a batch", () => {
+    const tracker = createToolRepeatTracker();
+    const call = { toolName: "Read", toolArgs: '{"file_path":"README.md"}' };
+
+    const reminder = buildRepeatedToolCallReminder(tracker, [call, call, call]);
+
+    expect(reminder).not.toBeNull();
+    expect(reminder).toContain('Read({"file_path":"README.md"})');
+  });
+});

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -1,3 +1,4 @@
+import { createToolRepeatTracker } from "../../agent/tool-repeat-reminder";
 import { createContextTracker } from "../../cli/helpers/contextTracker";
 import { createSharedReminderState } from "../../reminders/state";
 import type { PendingControlRequest } from "../../types/protocol_v2";
@@ -202,6 +203,7 @@ export function createConversationRuntime(
         listener.contextTrackerByConversation.set(runtimeKey, tracker);
         return tracker;
       })(),
+    toolRepeatTracker: createToolRepeatTracker(),
   };
   listener.conversationRuntimes.set(
     conversationRuntime.key,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -9,6 +9,7 @@ import {
   type ApprovalResult,
   executeApprovalBatch,
 } from "../../agent/approval-execution";
+import { buildRepeatedToolCallReminder } from "../../agent/tool-repeat-reminder";
 import { getChannelRegistry } from "../../channels/registry";
 import type { ChannelTurnSource } from "../../channels/types";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
@@ -557,6 +558,21 @@ export async function handleApprovalStop(params: {
       otid: crypto.randomUUID(),
     },
   ];
+  const repeatReminder = buildRepeatedToolCallReminder(
+    runtime.toolRepeatTracker,
+    decisions.map((decision) => ({
+      toolName: decision.approval.toolName,
+      toolArgs: decision.approval.toolArgs || "{}",
+    })),
+  );
+  if (repeatReminder) {
+    nextInput.push({
+      type: "message",
+      role: "system",
+      content: repeatReminder,
+      otid: crypto.randomUUID(),
+    });
+  }
   let continuationBatchId = dequeuedBatchId;
   const consumedQueuedTurn = consumeQueuedTurn(runtime);
   if (consumedQueuedTurn) {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -737,6 +737,7 @@ export async function handleIncomingMessage(
       }
 
       if (stopReason === "end_turn") {
+        runtime.toolRepeatTracker.clear();
         try {
           const transcriptLines = toLines(buffers);
           if (transcriptLines.length > 0) {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalDecision,
   ApprovalResult,
 } from "../../agent/approval-execution";
+import type { ToolRepeatTracker } from "../../agent/tool-repeat-reminder";
 import type { ChannelTurnSource } from "../../channels/types";
 import type { ContextTracker } from "../../cli/helpers/contextTracker";
 import type { ApprovalRequest } from "../../cli/helpers/stream";
@@ -157,6 +158,8 @@ export type ConversationRuntime = {
   reminderState: SharedReminderState;
   /** Per-conversation tracker for compaction/reflection cadence. */
   contextTracker: ContextTracker;
+  /** Per-conversation tracker for repeated exact tool calls. */
+  toolRepeatTracker: ToolRepeatTracker;
 };
 
 export type ListenerRuntime = {


### PR DESCRIPTION
## Summary
- Track repeated exact tool calls per turn and inject a system reminder when the same tool + raw args are used 3 times.
- Wire the reminder through TUI, headless, and websocket approval continuations.
- Add unit tests for exact-match behavior, thresholding, reset, and batched repeats.

## Test plan
- [x] bun test src/tests/tool-repeat-reminder.test.ts
- [x] bun run lint
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)