### PR TITLE
fix(cli): expand shell command previews

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -703,7 +703,7 @@ const APPROVAL_PREVIEW_BUFFER = 4;
 const MIN_WRAP_WIDTH = 10;
 const TEXT_WRAP_GUTTER = 6;
 const DIFF_WRAP_GUTTER = 12;
-const SHELL_PREVIEW_MAX_LINES = 3;
+const SHELL_PREVIEW_MAX_LINES = 12;
 
 function countWrappedLines(text: string, width: number): number {
   if (!text) return 0;

--- a/src/cli/components/InlineBashApproval.tsx
+++ b/src/cli/components/InlineBashApproval.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 // Horizontal line character for Claude Code style
 const SOLID_LINE = "─";
-const BASH_PREVIEW_MAX_LINES = 3;
+const BASH_PREVIEW_MAX_LINES = 12;
 
 /**
  * InlineBashApproval - Renders bash/shell approval UI inline (Claude Code style)

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -102,7 +102,7 @@ import { StreamingOutputDisplay } from "./StreamingOutputDisplay";
 import { SyntaxHighlightedCommand } from "./SyntaxHighlightedCommand";
 import { TodoRenderer } from "./TodoRenderer.js";
 
-const LIVE_SHELL_ARGS_MAX_LINES = 2;
+const LIVE_SHELL_ARGS_MAX_LINES = 8;
 
 type ToolCallLine = {
   kind: "tool_call";

--- a/src/cli/components/previews/BashPreview.tsx
+++ b/src/cli/components/previews/BashPreview.tsx
@@ -6,7 +6,7 @@ import { SyntaxHighlightedCommand } from "../SyntaxHighlightedCommand";
 import { Text } from "../Text";
 
 const SOLID_LINE = "─";
-const BASH_PREVIEW_MAX_LINES = 3;
+const BASH_PREVIEW_MAX_LINES = 12;
 
 type Props = {
   command: string;

--- a/src/tests/cli/shellSemanticDisplay.test.ts
+++ b/src/tests/cli/shellSemanticDisplay.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { summarizeShellDisplay } from "../../cli/helpers/shellSemanticDisplay";
 
+const LONG_HEREDOC_COMMAND = [
+  "node - <<'NODE'",
+  "const lines = Array.from({ length: 12 }, (_, index) => `line-${" +
+    "index}`);",
+  'console.log(lines.join("\\n"));',
+  "NODE",
+].join("\n");
+
 describe("summarizeShellDisplay", () => {
   test("classifies rg search commands", () => {
     expect(summarizeShellDisplay('rg -n "TODO" src')).toMatchObject({
@@ -207,6 +215,15 @@ NODE`;
       kind: "run",
       label: "Run",
       rawCommand: command,
+    });
+  });
+
+  test("preserves long heredoc commands verbatim for preview rendering", () => {
+    expect(summarizeShellDisplay(LONG_HEREDOC_COMMAND)).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: LONG_HEREDOC_COMMAND,
+      summary: LONG_HEREDOC_COMMAND,
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand inline bash approval previews so long commands and heredocs show substantially more content before truncating
- keep eager approval preview budgeting in sync so large shell previews still reserve enough space without flicker
- expand live shell tool-call previews and add a focused regression test that preserves long heredoc commands verbatim for rendering

## Test plan
- [x] `bun test src/tests/cli/shellSemanticDisplay.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/App.tsx src/cli/components/InlineBashApproval.tsx src/cli/components/ToolCallMessageRich.tsx src/cli/components/previews/BashPreview.tsx src/tests/cli/shellSemanticDisplay.test.ts`