### PR TITLE
fix(cli): clarify resumed conversation message count

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -13125,7 +13125,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 }
 
                 cmd.finish(
-                  `Switched to conversation (${resumeData.messageHistory.length} messages)`,
+                  `Switched to conversation (${resumeData.messageHistory.length} previous messages)`,
                   true,
                 );
               }


### PR DESCRIPTION
## Summary
- clarify the `/resume` success copy so the count is clearly about previous messages in the selected conversation
- keep the change scoped to the user-facing wording only

## Test plan
- [x] `bun test src/tests/cli/conversationSwitchAlert.test.ts`
- [x] `cd "/Users/kian/Developer/letta-code/.letta/worktrees/update-conversation-scroll-copy" && bunx --bun @biomejs/biome@2.2.5 check src/cli/App.tsx`
- [ ] manual `/resume` flow in the CLI UI