### PR TITLE
fix: wrap /btw in approval recovery

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -7048,14 +7048,90 @@ export default function App({
           forkedConversationId: forked.id,
         }));
 
-        // Send the question to the forked conversation
-        const stream = await getBackend().createConversationMessageStream(
-          forked.id,
+        let currentInput: Array<MessageCreate | ApprovalCreate> = [
           {
-            messages: [{ role: "user", content: question }],
-            stream_tokens: true,
+            role: "user",
+            content: question,
+            otid: randomUUID(),
           },
-        );
+        ];
+        let approvalRecoveryRetries = 0;
+        let stream: Awaited<ReturnType<typeof sendMessageStream>>;
+
+        while (true) {
+          try {
+            const preparedToolContext = await prepareScopedToolExecutionContext(
+              tempModelOverrideRef.current ?? undefined,
+            );
+            stream = await sendMessageStream(forked.id, currentInput, {
+              overrideModel: tempModelOverrideRef.current ?? undefined,
+              preparedToolContext: preparedToolContext.preparedToolContext,
+            });
+            break;
+          } catch (preStreamError) {
+            debugLog(
+              "btw",
+              "Pre-stream error: %s (status=%s)",
+              preStreamError instanceof Error
+                ? preStreamError.message
+                : String(preStreamError),
+              preStreamError instanceof APIError
+                ? preStreamError.status
+                : "none",
+            );
+
+            const errorDetail = extractConflictDetail(preStreamError);
+            const preStreamAction = getPreStreamErrorAction(errorDetail, 0, 0, {
+              status:
+                preStreamError instanceof APIError
+                  ? preStreamError.status
+                  : undefined,
+              transientRetries: approvalRecoveryRetries,
+              maxTransientRetries: 0,
+            });
+
+            if (
+              shouldAttemptApprovalRecovery({
+                approvalPendingDetected:
+                  preStreamAction === "resolve_approval_pending",
+                retries: approvalRecoveryRetries,
+                maxRetries: LLM_API_ERROR_MAX_RETRIES,
+              })
+            ) {
+              approvalRecoveryRetries += 1;
+              try {
+                const client = await getClient();
+                const currentAgentId = agentIdRef.current ?? agentId;
+                if (!currentAgentId) {
+                  currentInput = rebuildInputWithFreshDenials(
+                    currentInput,
+                    [],
+                    "",
+                  );
+                  continue;
+                }
+
+                const agent = await client.agents.retrieve(currentAgentId);
+                const { pendingApprovals: existingApprovals } =
+                  await getResumeData(client, agent, forked.id);
+                currentInput = rebuildInputWithFreshDenials(
+                  currentInput,
+                  existingApprovals ?? [],
+                  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+                );
+              } catch {
+                currentInput = rebuildInputWithFreshDenials(
+                  currentInput,
+                  [],
+                  "",
+                );
+              }
+              continue;
+            }
+
+            throw preStreamError;
+          }
+        }
 
         let responseText = "";
         for await (const chunk of stream) {
@@ -7085,7 +7161,7 @@ export default function App({
         }));
       }
     },
-    [agentId],
+    [agentId, prepareScopedToolExecutionContext],
   );
 
   const handleBtwJump = useCallback(

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -145,4 +145,31 @@ describe("approval recovery wiring", () => {
       expect(segment).not.toContain("await processConversation([");
     }
   });
+
+  test("/btw side-question flow routes pre-stream approval conflicts through shared recovery helpers", () => {
+    const appPath = fileURLToPath(
+      new URL("../../cli/App.tsx", import.meta.url),
+    );
+    const source = readFileSync(appPath, "utf-8");
+
+    const start = source.indexOf("const handleBtwCommand = useCallback(");
+    const end = source.indexOf("const handleBtwJump = useCallback(", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+
+    expect(segment).toContain(
+      "await sendMessageStream(forked.id, currentInput",
+    );
+    expect(segment).not.toContain(
+      "getBackend().createConversationMessageStream(",
+    );
+    expect(segment).toContain("extractConflictDetail(preStreamError)");
+    expect(segment).toContain("getPreStreamErrorAction(");
+    expect(segment).toContain("shouldAttemptApprovalRecovery(");
+    expect(segment).toContain("rebuildInputWithFreshDenials(");
+    expect(segment).toContain("await getResumeData(client, agent, forked.id)");
+  });
 });


### PR DESCRIPTION
## Summary
- route the /btw side-question send path through sendMessageStream instead of the raw backend stream call
- reuse the shared pre-stream approval recovery policy so pending approvals on the forked conversation are auto-denied and retried like the main CLI path
- add a CLI wiring test that locks in the shared recovery wrapper for /btw

## Testing
- bun test src/tests/cli/approval-recovery-wiring.test.ts src/tests/cli/btw-command.test.ts
- tsc --noEmit