### PR TITLE
fix: include agent relationships in retrieveAgent re-fetches

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -252,7 +252,9 @@ export async function updateAgentLLMConfig(
     }),
   });
 
-  const finalAgent = await backend.retrieveAgent(agentId);
+  const finalAgent = await backend.retrieveAgent(agentId, {
+    include: ["agent.secrets", "agent.tools", "agent.tags"],
+  });
   return finalAgent;
 }
 
@@ -439,8 +441,11 @@ export async function updateAgentSystemPrompt(
       }
     }
 
-    // Re-fetch agent to get updated state
-    const agent = await backend.retrieveAgent(agentId);
+    // Re-fetch agent to get updated state (include relationships so
+    // callers that rely on agent.tags/tools/secrets aren't broken).
+    const agent = await backend.retrieveAgent(agentId, {
+      include: ["agent.secrets", "agent.tools", "agent.tags"],
+    });
 
     return {
       success: true,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -976,7 +976,9 @@ export async function handleHeadlessCommand(
       const conversation = await backend.retrieveConversation(
         specifiedConversationId,
       );
-      agent = await backend.retrieveAgent(conversation.agent_id);
+      agent = await backend.retrieveAgent(conversation.agent_id, {
+        include: ["agent.secrets", "agent.tools", "agent.tags"],
+      });
     } catch (error) {
       trackHeadlessBoundaryError(
         "headless_conversation_lookup_failed",
@@ -1353,7 +1355,9 @@ export async function handleHeadlessCommand(
         const expected = rebuildPrompt(storedPreset, memoryMode);
         if (agent.system !== expected) {
           await backend.updateAgent(agent.id, { system: expected });
-          agent = await backend.retrieveAgent(agent.id);
+          agent = await backend.retrieveAgent(agent.id, {
+            include: ["agent.secrets", "agent.tools", "agent.tags"],
+          });
         }
       } else {
         settingsManager.clearSystemPromptPreset(agent.id);


### PR DESCRIPTION
## Summary
Several `retrieveAgent()` calls omit the `include` parameter, causing the Letta API to return empty arrays for relationship fields (`tags`, `tools`, `secrets`, `blocks`, `sources`). When these re-fetched agent objects overwrite the original, downstream code that reads `agent.tags` or `agent.tools` sees empty arrays and behaves incorrectly.

In headless mode, this breaks memfs initialization:
- The `--conversation` path (line 979) never included tags
- The `--agent` path strips them via `updateAgentLLMConfig` (triggered by `--model`) before the memfs check runs

## Changes
**`src/agent/modify.ts`**
- `updateAgentLLMConfig()`: add `include: ["agent.secrets", "agent.tools", "agent.tags"]` to the post-update `retrieveAgent` call
- `updateAgentSystemPrompt()`: same fix on its post-update re-fetch

**`src/headless.ts`**
- `--conversation` path (line 979): add `include: ["agent.secrets", "agent.tools", "agent.tags"]`
- Auto-heal system prompt re-fetch (line 1358): same fix

## Test plan
- [x] `letta --conversation <id> -m auto` — no memfs warning, `memfs_enabled: true`
- [x] `letta --agent <id> --new -m auto` — no memfs warning, `memfs_enabled: true`
- [ ] CI passes (lint, typecheck, tests)

🐾 Generated with [Letta Code](https://letta.com)