### PR TITLE
fix: show Cloudflare transient error instead of generic LLM API error

### DIFF
--- a/src/cli/helpers/errorFormatter.ts
+++ b/src/cli/helpers/errorFormatter.ts
@@ -25,6 +25,7 @@ const CLOUDFLARE_EDGE_5XX_MARKER_PATTERN =
   /(^|\s)(502|52[0-6])\s*<!doctype html|error code\s*(502|52[0-6])/i;
 const CLOUDFLARE_EDGE_5XX_TITLE_PATTERN = /\|\s*(502|52[0-6])\s*:/i;
 const CLOUDFLARE_EDGE_5XX_FORMATTED_PATTERN = /\bCloudflare\s+(502|52[0-6])\b/i;
+const CLOUDFLARE_JSON_5XX_PATTERN = /"cloudflare_error"\s*:\s*true/s;
 
 export function isCloudflareEdge52xHtmlError(text: string): boolean {
   const normalized = text.toLowerCase();
@@ -43,6 +44,7 @@ export function isCloudflareEdge52xHtmlError(text: string): boolean {
 export function isCloudflareEdge52xErrorText(text: string): boolean {
   return (
     CLOUDFLARE_EDGE_5XX_FORMATTED_PATTERN.test(text) ||
+    CLOUDFLARE_JSON_5XX_PATTERN.test(text) ||
     isCloudflareEdge52xHtmlError(text)
   );
 }
@@ -50,6 +52,21 @@ export function isCloudflareEdge52xErrorText(text: string): boolean {
 function parseCloudflareEdgeError(
   text: string,
 ): CloudflareEdgeErrorInfo | undefined {
+  // Try JSON-formatted Cloudflare error first (from Letta API proxy)
+  if (CLOUDFLARE_JSON_5XX_PATTERN.test(text)) {
+    try {
+      const obj = JSON.parse(text);
+      return {
+        code: String(obj.status),
+        statusText: obj.error_name || obj.title || undefined,
+        host: obj.zone || undefined,
+        rayId: obj.ray_id || undefined,
+      };
+    } catch {
+      // Not valid JSON, fall through to HTML parsing
+    }
+  }
+
   if (!isCloudflareEdge52xHtmlError(text)) return undefined;
 
   const code =
@@ -710,8 +727,9 @@ export function getRetryStatusMessage(
 ): string | null {
   if (!errorDetail) return DEFAULT_RETRY_MESSAGE;
 
-  // Cloudflare edge errors are transient and retried silently — no status line
-  if (isCloudflareEdge52xErrorText(errorDetail)) return null;
+  // Cloudflare edge errors are transient — show a specific message
+  if (isCloudflareEdge52xErrorText(errorDetail))
+    return "Cloudflare transient error, retrying...";
 
   if (checkZaiError(errorDetail)) return "Z.ai API error, retrying...";
 

--- a/src/tests/cli/errorFormatter.test.ts
+++ b/src/tests/cli/errorFormatter.test.ts
@@ -423,7 +423,26 @@ Cloudflare Ray ID: <strong>9d43b2d6dab269e2</strong>
         "Cloudflare 521: Web server is down for api.letta.com (Ray ID: 9e829917ee973824). This is usually a temporary edge/origin outage. Please retry in a moment.";
 
       expect(isCloudflareEdge52xErrorText(formatted)).toBe(true);
-      expect(getRetryStatusMessage(formatted)).toBeNull();
+      expect(getRetryStatusMessage(formatted)).toBe(
+        "Cloudflare transient error, retrying...",
+      );
+    });
+
+    test("detects JSON-formatted Cloudflare 520 error", () => {
+      const jsonError = JSON.stringify({
+        type: "https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520/",
+        title: "Error 520: Web server is returning an unknown error",
+        status: 520,
+        cloudflare_error: true,
+        error_name: "unknown_origin_error",
+        zone: "api.letta.com",
+        ray_id: "9f82e0806eb9eb2d",
+      });
+
+      expect(isCloudflareEdge52xErrorText(jsonError)).toBe(true);
+      expect(getRetryStatusMessage(jsonError)).toBe(
+        "Cloudflare transient error, retrying...",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
JSON-formatted Cloudflare errors (from the Letta API proxy, e.g. `{"cloudflare_error": true, "status": 520, ...}`) were not detected by the existing Cloudflare error patterns, which only matched HTML and plain-text formats. These fell through to the generic "Unexpected downstream LLM API error, retrying..." message.

Now shows: **`Cloudflare transient error, retrying...`**

## Changes
- **`errorFormatter.ts`**: Add `CLOUDFLARE_JSON_5XX_PATTERN` to detect `"cloudflare_error": true` in JSON bodies; update `isCloudflareEdge52xErrorText` and `parseCloudflareEdgeError` to handle JSON format; change retry message from silent (`null`) to explicit `"Cloudflare transient error, retrying..."`
- **`errorFormatter.test.ts`**: Update existing test expectation (was `null`, now the specific message); add test for JSON-formatted Cloudflare 520 error

## Test plan
- [x] All 25 errorFormatter tests pass
- [ ] CI passes

🐾 Generated with [Letta Code](https://letta.com)