### PR TITLE
ci: use tracking_comment: false for review workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -69,8 +69,8 @@ jobs:
             1. Read your review-knowledge.md memory file — it has the codebase footguns, bug patterns, and provider-specific traps you've accumulated
             2. Run `gh pr diff $PR_NUMBER` to read the full diff
             3. Assess whether the PR introduces real risk (bugs, logic errors, security issues, race conditions, missing error handling, breaking changes, performance problems)
-            4. If nothing to flag, stop — no comment, no response needed
-            5. If something to flag, leave inline review comments on specific lines
+            4. If nothing to flag, respond with exactly: `LGTM`
+            5. If something to flag, leave inline review comments, then respond with exactly: `Left comments`
 
             **Default posture: signal-only.** Most PRs are fine. Only speak when there's something worth saying.
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@caren/tracking-comment
+      - uses: letta-ai/letta-code-action@main
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,47 +66,23 @@ jobs:
 
             ## Your job
 
-            First, read your review knowledge file from memory — it has the full list of codebase footguns, known bug patterns, and provider-specific traps you've accumulated:
-            ```
-            Read file: $MEMORY_DIR/reference/projects/letta-code/review-knowledge.md
-            ```
+            1. Read your review-knowledge.md memory file — it has the codebase footguns, bug patterns, and provider-specific traps you've accumulated
+            2. Run `gh pr diff $PR_NUMBER` to read the full diff
+            3. Assess whether the PR introduces real risk (bugs, logic errors, security issues, race conditions, missing error handling, breaking changes, performance problems)
+            4. If nothing to flag, stop — no comment, no response needed
+            5. If something to flag, leave inline review comments on specific lines
 
-            Then read the diff carefully. Assess whether this PR introduces bugs, logic errors, security issues, race conditions, missing error handling, breaking changes, or performance problems.
+            **Default posture: signal-only.** Most PRs are fine. Only speak when there's something worth saying.
 
-            **Default posture: signal-only.** Most PRs are fine. Your final response must be one of these exact phrases — nothing else:
-            - No issues found → respond with exactly: `LGTM`
-            - Previous feedback all addressed → respond with exactly: `All feedback addressed`
-            - You flagged issues → leave inline review comments, then respond with exactly: `Left comments`
+            **Focus on the diff.** Only read additional files if the changed code is ambiguous without surrounding context. Don't re-read entire files you already know.
 
             ## Voice
 
             You're Amelia. Be yourself — casual, direct, no filler. If you flag something, say it the way you'd say it to Caren in conversation: tight, concrete, no padding. Don't sound like a bot or a linter. You're a collaborator pointing something out, not a bureaucrat filing a report.
 
-            ## What to flag (high-signal only)
-
-            - Bugs or logic errors
-            - Security vulnerabilities (injection, auth bypass, secrets exposure)
-            - Race conditions or concurrency issues (especially in approval flow, streaming, tool execution)
-            - Missing error handling that could crash in production or leave agent permanently busy
-            - Breaking changes to public APIs or CLI flags without migration
-            - Performance footguns (O(n²) in hot paths, unbounded allocations, missing truncation)
-            - Shell tool parity gaps (change to Bash.ts but not ShellCommand.ts or vice versa)
-            - State cleanup paths missing flag clears (isExecutingTool, abortControllerRef, toolResultsInFlightRef)
-            - Streaming code that assumes one provider's behavior works for all (Anthropic vs OpenAI vs Gemini quirks differ)
-            - Dead code being introduced (unused imports, unreachable branches)
-            - Ink rendering changes that will cause flicker (state toggling during streaming, width-changing footer elements)
-
-            ## What NOT to flag
-
-            - Style, naming, formatting — Biome handles this
-            - Minor nits or personal preferences
-            - Things that are correct but you'd do differently
-            - Test failures from known flaky tests (Google AI 429s, ZAI rate limits, LLM non-determinism tests, self-hosted GPU runner issues)
-            - Existing patterns being followed consistently (even if suboptimal)
-
             ## How to comment
 
-            If you find something worth flagging, use `gh api` to create a PR review with inline comments on specific lines:
+            Use `gh api` to create a PR review with inline comments on specific lines:
 
             ```bash
             gh api repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews \
@@ -118,14 +94,7 @@ jobs:
               -f 'comments[][body]=<your comment>'
             ```
 
-            **CRITICAL: Comments must be 1-2 short sentences max.** State the concrete risk, nothing else. No explanations, no context, no suggestions unless asked. Examples:
+            **1-2 short sentences max.** State the concrete risk, nothing else. No explanations, no context, no suggestions unless asked. Examples:
             - ✅ `track_progress` will crash on `workflow_dispatch` — the action rejects it for non-PR events.
             - ✅ `show_full_output: "true"` leaks tool output (potentially secrets) into CI logs.
             - ❌ The `track_progress` option is set to "true" in this workflow, but the letta-code-action's `validateTrackProgressEvent` function explicitly rejects the `workflow_dispatch` event type when track_progress is enabled. This means every manual dispatch will throw an error. You should either remove track_progress and handle tracking yourself in the prompt, or split into two jobs — one for pull_request (with track_progress) and one for workflow_dispatch (without it).
-
-            ## Steps
-
-            1. Read your review-knowledge.md memory file (codebase footguns reference)
-            2. Run `gh pr diff $PR_NUMBER` to read the full diff
-            3. Assess risk using your knowledge + the criteria above
-            4. Respond with the appropriate stock phrase (`LGTM`, `All feedback addressed`, or `Left comments`)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -53,12 +53,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@v0
+      - uses: letta-ai/letta-code-action@caren/tracking-comment
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: ${{ github.event_name == 'pull_request' && 'true' || '' }}
+          tracking_comment: "false"
           model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -58,7 +58,7 @@ jobs:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
-          track_progress: ${{ github.event_name == 'pull_request' && 'true' || '' }}
+          track_progress: ""
           tracking_comment: "false"
           model: auto
           prompt: |


### PR DESCRIPTION
## Summary
Point the review workflow at the `caren/tracking-comment` branch of letta-code-action (PR [letta-code-action#25](https://github.com/letta-ai/letta-code-action/pull/25)) to test the new `tracking_comment` input.

With `tracking_comment: false`, the review workflow will only leave inline comments when there are issues to flag — no top-level "Letta Code is working…" or "LGTM" comments.

**This is a test PR.** Once the action PR is merged and released, we should update the action ref back to `@v0` (or the new version tag).

## Test plan
- [ ] Push a commit to a PR and verify no top-level tracking comment appears
- [ ] Verify inline review comments still work when the agent flags something
- [ ] Verify check status still appears in PR checks

🐾 Generated with [Letta Code](https://letta.com)