### PR TITLE
fix(memfs): repair malformed memory remotes

### DIFF
--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -51,6 +51,12 @@ const MISSING_CWD_GIT_ERROR_RE =
 const NON_FAST_FORWARD_PUSH_ERROR_RE =
   /(non-fast-forward|fetch first|failed to push some refs|updates were rejected|remote contains work that you do not have locally|tip of your current branch is behind)/i;
 
+const UNRELATED_HISTORY_PULL_ERROR_RE =
+  /(no common commits|refusing to merge unrelated histories)/i;
+
+const NO_UPSTREAM_PULL_ERROR_RE =
+  /(there is no tracking information for the current branch|no upstream configured|no tracking branch)/i;
+
 const AGENT_DISPLAY_NAME_TIMEOUT_MS = 3_000;
 
 export interface MemoryCommitAuthor {
@@ -152,6 +158,38 @@ export function isMemfsRemoteUrlForAgent(
   ).test(normalized);
 }
 
+/**
+ * Returns true when an origin URL is clearly intended to be a Letta MemFS
+ * remote for this agent, including older/broken forms we can safely repair.
+ */
+export function isRepairableMemfsRemoteUrl(
+  remoteUrl: string,
+  agentId: string,
+): boolean {
+  const normalized = normalizeRemoteUrl(remoteUrl);
+  const escapedAgentId = escapeRegex(agentId);
+
+  if (isMemfsRemoteUrlForAgent(normalized, agentId)) {
+    return true;
+  }
+
+  // Legacy remote shape: /v1/git/{agent_id}. Git appends /info/refs to this,
+  // which server-side compatibility now handles, but the persisted origin
+  // should still be repaired to the canonical /state.git URL.
+  if (
+    new RegExp(`^https?://[^\\s]+/v1/git/${escapedAgentId}$`, "i").test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  // Broken Desktop/local proxy shape observed in the wild: origin is just the
+  // git proxy prefix (/v1/git) with no agent or repo suffix. The CLI knows the
+  // active agent, so repair this before trying to sync.
+  return /^https?:\/\/[^\s]+\/v1\/git$/i.test(normalized);
+}
+
 /** Git remote URL for the agent's state repo */
 export function getGitRemoteUrl(agentId: string, baseUrl?: string): string {
   const resolvedBaseUrl = (baseUrl ?? getMemfsServerUrl())
@@ -183,7 +221,7 @@ export async function maybeUpdateMemoryRemoteOrigin(
     return;
   }
 
-  if (!isMemfsRemoteUrlForAgent(currentOrigin, agentId)) {
+  if (!isRepairableMemfsRemoteUrl(currentOrigin, agentId)) {
     return;
   }
 
@@ -1015,6 +1053,14 @@ function isNonFastForwardPushError(error: unknown): boolean {
   return NON_FAST_FORWARD_PUSH_ERROR_RE.test(message);
 }
 
+function isRecoverableMemoryPullHistoryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    UNRELATED_HISTORY_PULL_ERROR_RE.test(message) ||
+    NO_UPSTREAM_PULL_ERROR_RE.test(message)
+  );
+}
+
 async function prepareMemoryRepoForGitOps(
   memoryDir: string,
   agentId: string,
@@ -1025,6 +1071,73 @@ async function prepareMemoryRepoForGitOps(
   installPreCommitHook(memoryDir);
   installPostCommitHook(memoryDir);
   await ensureLocalMemfsGitConfig(memoryDir, agentId);
+}
+
+async function recoverMemoryPullByResettingToRemote(
+  memoryDir: string,
+  token: string,
+): Promise<string> {
+  const { stdout: status } = await runGit(memoryDir, ["status", "--porcelain"]);
+  if (status.trim()) {
+    throw new Error(
+      "Local memory repo has uncommitted changes; refusing to auto-reset unrelated history.",
+    );
+  }
+
+  await runGitWithRetry(memoryDir, ["fetch", "origin", "main"], token, {
+    operation: "fetch memory repo for reset",
+  });
+
+  const { stdout: remoteShaOut } = await runGit(memoryDir, [
+    "rev-parse",
+    "--verify",
+    "refs/remotes/origin/main",
+  ]);
+  const remoteSha = remoteShaOut.trim();
+  if (!remoteSha) {
+    throw new Error("Remote memory repo did not advertise origin/main.");
+  }
+
+  let backupRef: string | null = null;
+  try {
+    const { stdout: localShaOut } = await runGit(memoryDir, [
+      "rev-parse",
+      "--verify",
+      "HEAD",
+    ]);
+    const localSha = localShaOut.trim();
+    if (localSha && localSha !== remoteSha) {
+      backupRef = `refs/letta-backup/pre-sync-${Date.now()}`;
+      await runGit(memoryDir, ["update-ref", backupRef, localSha]);
+    }
+  } catch {
+    // No local HEAD to preserve.
+  }
+
+  await runGit(memoryDir, ["reset", "--hard", "refs/remotes/origin/main"]);
+  try {
+    await runGit(memoryDir, [
+      "branch",
+      "--set-upstream-to",
+      "origin/main",
+      "main",
+    ]);
+  } catch {
+    // Non-fatal; future explicit git commands can still name origin/main.
+  }
+
+  return backupRef
+    ? `Recovered memory repo by resetting to origin/main (${remoteSha.slice(0, 7)}). Previous local HEAD was preserved at ${backupRef}.`
+    : `Recovered memory repo by resetting to origin/main (${remoteSha.slice(0, 7)}).`;
+}
+
+async function hasMergeBaseWithUpstream(memoryDir: string): Promise<boolean> {
+  try {
+    await runGit(memoryDir, ["merge-base", "HEAD", "@{u}"]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function prepareLocalOnlyMemoryRepoForGitOps(
@@ -1584,6 +1697,22 @@ export async function pullMemory(
       summary: updated ? output.trim() : "Already up to date",
     };
   } catch {
+    if (!(await hasMergeBaseWithUpstream(dir))) {
+      try {
+        return {
+          updated: true,
+          summary: await recoverMemoryPullByResettingToRemote(dir, token),
+        };
+      } catch (recoverErr) {
+        const recoverMsg =
+          recoverErr instanceof Error ? recoverErr.message : String(recoverErr);
+        debugWarn(
+          "memfs-git",
+          `Automatic memory repo reset failed: ${recoverMsg}`,
+        );
+      }
+    }
+
     // If ff-only fails (diverged), try rebase
     debugWarn("memfs-git", "Fast-forward pull failed, trying rebase");
     try {
@@ -1595,6 +1724,24 @@ export async function pullMemory(
       );
       return { updated: true, summary: (stdout + stderr).trim() };
     } catch (rebaseErr) {
+      if (isRecoverableMemoryPullHistoryError(rebaseErr)) {
+        try {
+          return {
+            updated: true,
+            summary: await recoverMemoryPullByResettingToRemote(dir, token),
+          };
+        } catch (recoverErr) {
+          const recoverMsg =
+            recoverErr instanceof Error
+              ? recoverErr.message
+              : String(recoverErr);
+          debugWarn(
+            "memfs-git",
+            `Automatic memory repo reset failed: ${recoverMsg}`,
+          );
+        }
+      }
+
       const msg =
         rebaseErr instanceof Error ? rebaseErr.message : String(rebaseErr);
       debugWarn("memfs-git", `Pull failed: ${msg}`);

--- a/src/tests/agent/memoryGit.auth.test.ts
+++ b/src/tests/agent/memoryGit.auth.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -9,10 +15,14 @@ import {
   buildMemfsGitProxyArgs,
   buildNonInteractiveGitEnv,
   formatGitCredentialHelperPath,
+  getAgentRootDir,
   getGitRemoteUrl,
+  getMemoryRepoDir,
   isMemfsRemoteUrlForAgent,
+  isRepairableMemfsRemoteUrl,
   maybeUpdateMemoryRemoteOrigin,
   normalizeCredentialBaseUrl,
+  pullMemory,
   shouldConfigurePersistentMemfsCredentialHelper,
 } from "../../agent/memoryGit";
 import {
@@ -240,6 +250,27 @@ describe("normalizeCredentialBaseUrl", () => {
         false,
       );
     });
+
+    test("recognizes malformed but repairable memfs remotes", () => {
+      expect(
+        isRepairableMemfsRemoteUrl(
+          "http://localhost:57294/v1/git",
+          "agent-123",
+        ),
+      ).toBe(true);
+      expect(
+        isRepairableMemfsRemoteUrl(
+          "http://localhost:57294/v1/git/agent-123",
+          "agent-123",
+        ),
+      ).toBe(true);
+      expect(
+        isRepairableMemfsRemoteUrl(
+          "http://localhost:57294/v1/git/agent-999/state.git",
+          "agent-123",
+        ),
+      ).toBe(false);
+    });
   });
 
   test("strips trailing slashes", () => {
@@ -314,7 +345,9 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      expectedOrigin,
+    );
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
@@ -332,7 +365,37 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      "https://api.letta.com/v1/git/agent-123/state.git",
+    );
+  });
+
+  test("repairs malformed memfs origin missing agent and repo path", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+
+    process.env.LETTA_BASE_URL = "http://localhost:54085";
+    process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:54085";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+    git(repo, "remote add origin http://localhost:54085/v1/git");
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      "https://api.letta.com/v1/git/agent-123/state.git",
+    );
+  });
+
+  test("repairs legacy memfs origin missing state.git suffix", async () => {
+    const repo = makeGitRepo();
+    const agentId = "agent-123";
+
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    git(repo, "remote add origin https://api.letta.com/v1/git/agent-123");
+
+    await maybeUpdateMemoryRemoteOrigin(repo, agentId);
+
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
       "https://api.letta.com/v1/git/agent-123/state.git",
     );
   });
@@ -349,7 +412,9 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      expectedOrigin,
+    );
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
@@ -369,7 +434,9 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      expectedOrigin,
+    );
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
@@ -387,7 +454,7 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(origin);
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(origin);
     expect(
       git(repo, "config --local --get-all remote.origin.pushurl").trim(),
     ).toBe(pushUrl);
@@ -409,10 +476,46 @@ describe("maybeUpdateMemoryRemoteOrigin", () => {
 
     await maybeUpdateMemoryRemoteOrigin(repo, agentId);
 
-    expect(git(repo, "remote get-url origin").trim()).toBe(expectedOrigin);
+    expect(git(repo, "config --get remote.origin.url").trim()).toBe(
+      expectedOrigin,
+    );
     expect(
       gitOrEmpty(repo, "config --local --get-all remote.origin.pushurl"),
     ).toBe("");
+  });
+});
+
+describe("pullMemory recovery", () => {
+  test("recovers clean unrelated local memory history by resetting to origin/main", async () => {
+    const remote = makeBareGitRepo();
+    const source = cloneRepo(remote);
+    commitFile(source, "remote.md", "remote memory");
+    git(source, "push -u origin main");
+
+    const agentId = `agent-test-${Date.now()}`;
+    const agentRoot = getAgentRootDir(agentId);
+    tempDirs.push(agentRoot);
+    const memoryDir = getMemoryRepoDir(agentId);
+    mkdirSync(memoryDir, { recursive: true });
+    execSync("git init -b main", { cwd: memoryDir, stdio: "ignore" });
+    git(memoryDir, "config user.name Test");
+    git(memoryDir, "config user.email test@example.com");
+    git(memoryDir, `remote add origin ${remote}`);
+    commitFile(memoryDir, "local.md", "local placeholder");
+    git(memoryDir, "fetch origin main");
+    git(memoryDir, "branch --set-upstream-to origin/main main");
+
+    process.env.LETTA_API_KEY = "test-token";
+    __testOverrideGetClient(async () => ({
+      _options: { apiKey: "test-token" },
+    }));
+
+    const result = await pullMemory(agentId);
+
+    expect(result.updated).toBe(true);
+    expect(result.summary).toContain("Recovered memory repo by resetting");
+    expect(existsSync(join(memoryDir, "remote.md"))).toBe(true);
+    expect(existsSync(join(memoryDir, "local.md"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Repair persisted MemFS git origins that are missing the agent/repo suffix, e.g. `http://localhost:<port>/v1/git`.
- Continue repairing legacy MemFS origins that omit `/state.git`.
- Recover clean unrelated local memory histories during `/memfs sync` by fetching `origin/main`, preserving the previous local HEAD under `refs/letta-backup/pre-sync-*`, and resetting to the remote state.

## Why
A user continued hitting the same sync issue after the server-side compatibility fix. Their local memory repo's `origin` was still:

```text
http://localhost:<port>/v1/git
```

That URL is missing both the agent id and `/state.git`, so every normal git operation targets the wrong endpoint. Manually changing it to:

```text
http://localhost:<port>/v1/git/<agent_id>/state.git
```

made the endpoint work, but then git reported unrelated histories. This fixes both client-side recovery steps automatically.

## Test plan
- [x] `bunx --bun @biomejs/biome@2.2.5 check --write src/agent/memoryGit.ts src/tests/agent/memoryGit.auth.test.ts`
- [x] `bun test src/tests/agent/memoryGit.auth.test.ts`

👾 Generated with [Letta Code](https://letta.com)