### PR TITLE
chore: bump version to 0.25.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/letta-code",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Letta Code is a CLI tool for interacting with stateful Letta agents from the terminal.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Bump version from 0.25.1 to 0.25.2 to publish the following fixes to npm:

- `93ffd35d` fix: auto-enable memfs for existing agents in headless mode (#2128)
- `a3a4d31b` fix(memfs): repair malformed memory remotes (#2138)
- `baf67fba` fix(listener): gate post-stop approval recovery (#2103)
- `65ce5222` fix: show Cloudflare transient error instead of generic LLM API error (#2136)
- `b7317bce` fix: include agent relationships in retrieveAgent re-fetches (#2134)
- `1fd0bc43` refactor(review): streamline review prompt, add tracking_comment, update action to @v0 (#2139)

The memfs fix is critical for the code review action — without it, the headless agent cannot read its memory files (review-knowledge.md), so it reviews PRs with zero codebase knowledge.

## Test plan
- [ ] Verify `bun run check` passes
- [ ] After merge, confirm `npm publish` publishes 0.25.2
- [ ] Re-run the review action on a test PR and verify the agent can read its memory files

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>