### PR TITLE
Centralize local provider registry

### DIFF
--- a/src/backend/dev/AISDKModelFactory.ts
+++ b/src/backend/dev/AISDKModelFactory.ts
@@ -1,20 +1,16 @@
 import type { LanguageModel } from "ai";
+import { getLocalProviderApiKeyByName } from "../local/LocalProviderAuthStore";
 import {
-  getLocalProviderApiKeyByName,
-  LOCAL_ANTHROPIC_PROVIDER_NAME,
-  LOCAL_BEDROCK_PROVIDER_NAME,
-  LOCAL_GOOGLE_AI_PROVIDER_NAME,
-  LOCAL_KIMI_CODE_PROVIDER_NAME,
-  LOCAL_LMSTUDIO_PROVIDER_NAME,
-  LOCAL_MINIMAX_PROVIDER_NAME,
-  LOCAL_MOONSHOT_PROVIDER_NAME,
-  LOCAL_OLLAMA_CLOUD_PROVIDER_NAME,
-  LOCAL_OLLAMA_PROVIDER_NAME,
-  LOCAL_OPENAI_PROVIDER_NAME,
-  LOCAL_OPENROUTER_PROVIDER_NAME,
+  type AISDKProvider,
+  expectedAISDKProviderList,
+  getAISDKProviderSpec,
+  isAISDKProvider,
   LOCAL_ZAI_CODING_PROVIDER_NAME,
   LOCAL_ZAI_PROVIDER_NAME,
-} from "../local/LocalProviderAuthStore";
+  resolveProviderFromModelHandle,
+  resolveProviderFromProviderType,
+  stripProviderHandlePrefix,
+} from "./AISDKProviderRegistry";
 import { createAnthropicModelFactory } from "./AnthropicModel";
 import { createBedrockModelFactory } from "./BedrockModel";
 import { createChatGPTOAuthModelFactory } from "./ChatGPTOAuthModel";
@@ -23,20 +19,7 @@ import { createOpenAICompatibleModelFactory } from "./OpenAICompatibleModel";
 import { createOpenAIResponsesModelFactory } from "./OpenAIResponsesModel";
 
 export const DEFAULT_AI_SDK_PROVIDER = "openai-responses";
-
-export type AISDKProvider =
-  | "openai-responses"
-  | "anthropic"
-  | "openrouter"
-  | "zai"
-  | "minimax"
-  | "moonshot"
-  | "google-ai"
-  | "ollama"
-  | "ollama-cloud"
-  | "lmstudio"
-  | "bedrock"
-  | "chatgpt-oauth";
+export type { AISDKProvider } from "./AISDKProviderRegistry";
 
 export interface AISDKModelFactoryOptions {
   provider?: string;
@@ -72,24 +55,11 @@ export function resolveAISDKProvider(
     inferDefaultProviderFromStandardKeys(),
 ): AISDKProvider {
   if (provider === "openai") return "openai-responses";
-  if (
-    provider === "openai-responses" ||
-    provider === "anthropic" ||
-    provider === "openrouter" ||
-    provider === "zai" ||
-    provider === "minimax" ||
-    provider === "moonshot" ||
-    provider === "google-ai" ||
-    provider === "ollama" ||
-    provider === "ollama-cloud" ||
-    provider === "lmstudio" ||
-    provider === "bedrock" ||
-    provider === "chatgpt-oauth"
-  ) {
+  if (isAISDKProvider(provider)) {
     return provider;
   }
   throw new Error(
-    `Unknown AI SDK provider "${provider}". Expected "openai-responses", "anthropic", "openrouter", "zai", "minimax", "moonshot", "google-ai", "ollama", "ollama-cloud", "lmstudio", "bedrock", or "chatgpt-oauth".`,
+    `Unknown AI SDK provider "${provider}". Expected ${expectedAISDKProviderList()}.`,
   );
 }
 
@@ -97,102 +67,30 @@ export function resolveAISDKProviderFromAgent(
   model: string | undefined,
   modelSettings: AISDKModelSettings = {},
 ): AISDKProvider {
-  if (model?.startsWith("chatgpt-plus-pro/")) return "chatgpt-oauth";
-  if (model?.startsWith("openrouter/")) return "openrouter";
-  if (model?.startsWith("zai/")) return "zai";
-  if (model?.startsWith("minimax/")) return "minimax";
-  if (model?.startsWith("moonshot/") || model?.startsWith("moonshot_coding/")) {
-    return "moonshot";
-  }
-  if (model?.startsWith("google_ai/")) return "google-ai";
-  if (model?.startsWith("ollama/")) return "ollama";
-  if (model?.startsWith("ollama-cloud/")) return "ollama-cloud";
-  if (model?.startsWith("lmstudio/")) return "lmstudio";
-  if (model?.startsWith("bedrock/")) return "bedrock";
-  if (model?.startsWith("anthropic/")) return "anthropic";
-  if (model?.startsWith("openai/") || model?.startsWith("openai-responses/")) {
-    return "openai-responses";
-  }
-
-  const providerType = modelSettings.provider_type;
-  if (providerType === "anthropic") return "anthropic";
-  if (providerType === "openrouter") return "openrouter";
-  if (providerType === "zai" || providerType === "zai_coding") return "zai";
-  if (providerType === "minimax") return "minimax";
-  if (providerType === "moonshot" || providerType === "moonshot_coding") {
-    return "moonshot";
-  }
-  if (providerType === "google_ai") return "google-ai";
-  if (providerType === "ollama") return "ollama";
-  if (providerType === "ollama_cloud") return "ollama-cloud";
-  if (providerType === "lmstudio") return "lmstudio";
-  if (providerType === "bedrock") return "bedrock";
-  if (providerType === "chatgpt_oauth") return "chatgpt-oauth";
-  if (providerType === "openai" || providerType === "openai-responses") {
-    return "openai-responses";
-  }
-  return resolveAISDKProvider();
+  return (
+    resolveProviderFromModelHandle(model) ??
+    resolveProviderFromProviderType(modelSettings.provider_type) ??
+    resolveAISDKProvider()
+  );
 }
 
 export function resolveAISDKModelFromAgent(
   model: string | undefined,
   provider: AISDKProvider,
 ): string | undefined {
-  if (!model) return process.env.LETTA_CODE_DEV_AI_SDK_MODEL;
-  if (provider === "anthropic" && model.startsWith("anthropic/")) {
-    return model.slice("anthropic/".length);
-  }
-  if (
-    provider === "openai-responses" &&
-    model.startsWith("openai-responses/")
-  ) {
-    return model.slice("openai-responses/".length);
-  }
-  if (provider === "openai-responses" && model.startsWith("openai/")) {
-    return model.slice("openai/".length);
-  }
-  if (provider === "openrouter" && model.startsWith("openrouter/")) {
-    return model.slice("openrouter/".length);
-  }
-  if (provider === "zai" && model.startsWith("zai/")) {
-    return model.slice("zai/".length);
-  }
-  if (provider === "minimax" && model.startsWith("minimax/")) {
-    return model.slice("minimax/".length);
-  }
-  if (provider === "moonshot" && model.startsWith("moonshot/")) {
-    return model.slice("moonshot/".length);
-  }
-  if (provider === "moonshot" && model.startsWith("moonshot_coding/")) {
-    return model.slice("moonshot_coding/".length);
-  }
-  if (provider === "google-ai" && model.startsWith("google_ai/")) {
-    return model.slice("google_ai/".length);
-  }
-  if (provider === "ollama" && model.startsWith("ollama/")) {
-    return model.slice("ollama/".length);
-  }
-  if (provider === "ollama-cloud" && model.startsWith("ollama-cloud/")) {
-    return model.slice("ollama-cloud/".length);
-  }
-  if (provider === "lmstudio" && model.startsWith("lmstudio/")) {
-    return model.slice("lmstudio/".length);
-  }
-  if (provider === "bedrock" && model.startsWith("bedrock/")) {
-    return model.slice("bedrock/".length);
-  }
-  if (provider === "chatgpt-oauth" && model.startsWith("chatgpt-plus-pro/")) {
-    return model.slice("chatgpt-plus-pro/".length);
-  }
-  return model;
+  return stripProviderHandlePrefix(model, provider);
 }
 
 function localProviderApiKey(
-  providerName: string,
+  providerNames: readonly string[],
   envValue: string | undefined,
   storageDir?: string,
 ): string | undefined {
-  return getLocalProviderApiKeyByName(providerName, storageDir) ?? envValue;
+  for (const providerName of providerNames) {
+    const key = getLocalProviderApiKeyByName(providerName, storageDir);
+    if (key) return key;
+  }
+  return envValue;
 }
 
 export interface ZaiConnection {
@@ -258,140 +156,65 @@ export function createAISDKModelFactory(
   options: AISDKModelFactoryOptions = {},
 ): () => LanguageModel {
   const provider = resolveAISDKProvider(options.provider);
+  const spec = getAISDKProviderSpec(provider);
   const model = options.model ?? process.env.LETTA_CODE_DEV_AI_SDK_MODEL;
   const storageDir = options.localProviderAuthStorageDir;
+  const apiKey = localProviderApiKey(
+    spec.localProviderNames,
+    spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
+    storageDir,
+  );
 
-  switch (provider) {
+  switch (spec.sdk) {
     case "openai-responses":
       return createOpenAIResponsesModelFactory({
         model,
-        apiKey: localProviderApiKey(
-          LOCAL_OPENAI_PROVIDER_NAME,
-          process.env.OPENAI_API_KEY,
-          storageDir,
-        ),
+        apiKey,
         createModel: options.createOpenAIResponsesModel,
       });
     case "anthropic":
       return createAnthropicModelFactory({
         model,
-        apiKey: localProviderApiKey(
-          LOCAL_ANTHROPIC_PROVIDER_NAME,
-          process.env.ANTHROPIC_API_KEY,
-          storageDir,
-        ),
+        providerName: spec.providerName,
+        baseURL: spec.baseURL?.(),
+        apiKey,
         createModel: options.createAnthropicModel,
       });
-    case "openrouter":
-      return createOpenAICompatibleModelFactory({
-        model,
-        providerName: "openrouter",
-        baseURL:
-          process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
-        apiKey: localProviderApiKey(
-          LOCAL_OPENROUTER_PROVIDER_NAME,
-          process.env.OPENROUTER_API_KEY,
+    case "openai-compatible": {
+      if (provider === "zai") {
+        const zaiConnection = resolveZaiConnection({
           storageDir,
-        ),
-        headers: { "X-Title": "Letta Code" },
-        createModel: options.createOpenAICompatibleModel,
-      });
-    case "zai": {
-      const zaiConnection = resolveZaiConnection({
-        storageDir,
-        preferredProviderType: options.zaiProviderType,
-      });
+          preferredProviderType: options.zaiProviderType,
+        });
+        return createOpenAICompatibleModelFactory({
+          model,
+          providerName: zaiConnection.providerName,
+          baseURL: zaiConnection.baseURL,
+          apiKey: zaiConnection.apiKey,
+          createModel: options.createOpenAICompatibleModel,
+        });
+      }
       return createOpenAICompatibleModelFactory({
         model,
-        providerName: zaiConnection.providerName,
-        baseURL: zaiConnection.baseURL,
-        apiKey: zaiConnection.apiKey,
+        providerName: spec.providerName ?? provider,
+        baseURL: spec.baseURL?.() ?? "",
+        apiKey,
+        headers: spec.headers?.(),
         createModel: options.createOpenAICompatibleModel,
       });
     }
-    case "minimax":
-      return createAnthropicModelFactory({
-        model,
-        providerName: "minimax",
-        baseURL:
-          process.env.MINIMAX_BASE_URL ?? "https://api.minimax.io/anthropic/v1",
-        apiKey: localProviderApiKey(
-          LOCAL_MINIMAX_PROVIDER_NAME,
-          process.env.MINIMAX_API_KEY,
-          storageDir,
-        ),
-        createModel: options.createAnthropicModel,
-      });
-    case "moonshot":
-      return createOpenAICompatibleModelFactory({
-        model,
-        providerName: "moonshot",
-        baseURL: process.env.MOONSHOT_BASE_URL ?? "https://api.moonshot.ai/v1",
-        apiKey:
-          getLocalProviderApiKeyByName(
-            LOCAL_KIMI_CODE_PROVIDER_NAME,
-            storageDir,
-          ) ??
-          getLocalProviderApiKeyByName(
-            LOCAL_MOONSHOT_PROVIDER_NAME,
-            storageDir,
-          ) ??
-          process.env.MOONSHOT_API_KEY,
-        createModel: options.createOpenAICompatibleModel,
-      });
-    case "google-ai":
+    case "google":
       return createGoogleModelFactory({
         model,
-        apiKey: localProviderApiKey(
-          LOCAL_GOOGLE_AI_PROVIDER_NAME,
-          process.env.GOOGLE_GENERATIVE_AI_API_KEY ??
-            process.env.GEMINI_API_KEY,
-          storageDir,
-        ),
-        baseURL: process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
+        apiKey,
+        baseURL: spec.baseURL?.(),
         createModel: options.createGoogleModel,
-      });
-    case "ollama":
-      return createOpenAICompatibleModelFactory({
-        model,
-        providerName: "ollama",
-        baseURL: process.env.OLLAMA_BASE_URL ?? "http://localhost:11434/v1",
-        apiKey: localProviderApiKey(
-          LOCAL_OLLAMA_PROVIDER_NAME,
-          process.env.OLLAMA_LOCAL_API_KEY ?? "not-needed",
-          storageDir,
-        ),
-        createModel: options.createOpenAICompatibleModel,
-      });
-    case "ollama-cloud":
-      return createOpenAICompatibleModelFactory({
-        model,
-        providerName: "ollama-cloud",
-        baseURL: process.env.OLLAMA_CLOUD_BASE_URL ?? "https://ollama.com/v1",
-        apiKey: localProviderApiKey(
-          LOCAL_OLLAMA_CLOUD_PROVIDER_NAME,
-          process.env.OLLAMA_API_KEY,
-          storageDir,
-        ),
-        createModel: options.createOpenAICompatibleModel,
-      });
-    case "lmstudio":
-      return createOpenAICompatibleModelFactory({
-        model,
-        providerName: "lmstudio",
-        baseURL: process.env.LMSTUDIO_BASE_URL ?? "http://127.0.0.1:1234/v1",
-        apiKey: localProviderApiKey(
-          LOCAL_LMSTUDIO_PROVIDER_NAME,
-          process.env.LMSTUDIO_API_KEY ?? "not-needed",
-          storageDir,
-        ),
-        createModel: options.createOpenAICompatibleModel,
       });
     case "bedrock":
       return createBedrockModelFactory({
         model,
         storageDir,
-        providerName: LOCAL_BEDROCK_PROVIDER_NAME,
+        providerName: spec.localProviderNames[0] ?? "lc-bedrock",
         createModel: options.createBedrockModel,
       });
     case "chatgpt-oauth":

--- a/src/backend/dev/AISDKProviderRegistry.ts
+++ b/src/backend/dev/AISDKProviderRegistry.ts
@@ -1,0 +1,439 @@
+import modelsData from "../../models.json";
+import { DEFAULT_ANTHROPIC_MODEL } from "./AnthropicModel";
+import { DEFAULT_OPENAI_RESPONSES_MODEL } from "./OpenAIResponsesModel";
+
+export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
+export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
+export const LOCAL_ANTHROPIC_PROVIDER_NAME = "lc-anthropic";
+export const LOCAL_OPENROUTER_PROVIDER_NAME = "lc-openrouter";
+export const LOCAL_OLLAMA_PROVIDER_NAME = "lc-ollama";
+export const LOCAL_OLLAMA_CLOUD_PROVIDER_NAME = "lc-ollama-cloud";
+export const LOCAL_LMSTUDIO_PROVIDER_NAME = "lc-lmstudio";
+export const LOCAL_ZAI_PROVIDER_NAME = "lc-zai";
+export const LOCAL_ZAI_CODING_PROVIDER_NAME = "lc-zai-coding";
+export const LOCAL_MINIMAX_PROVIDER_NAME = "lc-minimax";
+export const LOCAL_MOONSHOT_PROVIDER_NAME = "lc-moonshot";
+export const LOCAL_KIMI_CODE_PROVIDER_NAME = "lc-kimi-code";
+export const LOCAL_GOOGLE_AI_PROVIDER_NAME = "lc-gemini";
+export const LOCAL_BEDROCK_PROVIDER_NAME = "lc-bedrock";
+
+const OLLAMA_LOCAL_MODELS = [
+  "ollama/llama2",
+  "ollama/llama3.1:8b",
+  "ollama/qwen3-coder:30b",
+  "ollama/gpt-oss:20b",
+] as const;
+
+const OLLAMA_CLOUD_MODELS = [
+  "ollama-cloud/glm-4.7",
+  "ollama-cloud/qwen3-coder:480b",
+  "ollama-cloud/gpt-oss:20b",
+  "ollama-cloud/gpt-oss:120b",
+  "ollama-cloud/kimi-k2.5",
+  "ollama-cloud/minimax-m2.1",
+  "ollama-cloud/deepseek-v3.2",
+] as const;
+
+const LMSTUDIO_LOCAL_MODELS = [
+  "lmstudio/google/gemma-3n-e4b",
+  "lmstudio/openai/gpt-oss-20b",
+  "lmstudio/qwen/qwen3-30b-a3b-2507",
+  "lmstudio/qwen/qwen3-coder-30b",
+] as const;
+
+const MOONSHOT_MODELS = [
+  "moonshot/kimi-k2-thinking-turbo",
+  "moonshot/kimi-k2-turbo-preview",
+  "moonshot/kimi-k2.5",
+  "moonshot/kimi-k2-0711-preview",
+  "moonshot/kimi-k2-thinking",
+  "moonshot/kimi-k2-0905-preview",
+] as const;
+
+function hasEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
+export type AISDKProvider =
+  | "openai-responses"
+  | "anthropic"
+  | "openrouter"
+  | "zai"
+  | "minimax"
+  | "moonshot"
+  | "google-ai"
+  | "ollama"
+  | "ollama-cloud"
+  | "lmstudio"
+  | "bedrock"
+  | "chatgpt-oauth";
+
+export type AISDKProviderKind = "anthropic" | "openai" | "unknown";
+
+export type AISDKProviderSDK =
+  | "openai-responses"
+  | "anthropic"
+  | "openai-compatible"
+  | "google"
+  | "bedrock"
+  | "chatgpt-oauth";
+
+export interface AISDKProviderSpec {
+  id: AISDKProvider;
+  sdk: AISDKProviderSDK;
+  providerName?: string;
+  providerTypes: readonly string[];
+  handlePrefixes: readonly string[];
+  localProviderNames: readonly string[];
+  defaultModel: string;
+  baseURL?: () => string | undefined;
+  apiKeyEnv?: () => string | undefined;
+  fallbackApiKey?: string;
+  headers?: () => Record<string, string> | undefined;
+  catalogPrefixes?: readonly string[];
+  staticModels?: readonly string[];
+  providerOptionsKind: AISDKProviderKind;
+  envConfigured?: () => boolean;
+  catalogModelHandle?: (modelHandle: string) => string | undefined;
+}
+
+function defaultCatalogModelHandle(
+  prefixes: readonly string[],
+): (modelHandle: string) => string | undefined {
+  return (modelHandle) =>
+    prefixes.some((prefix) => modelHandle.startsWith(prefix))
+      ? modelHandle
+      : undefined;
+}
+
+export const AISDK_PROVIDER_SPECS = [
+  {
+    id: "openai-responses",
+    sdk: "openai-responses",
+    providerTypes: ["openai", "openai-responses"],
+    handlePrefixes: ["openai/", "openai-responses/"],
+    localProviderNames: [LOCAL_OPENAI_PROVIDER_NAME],
+    defaultModel: DEFAULT_OPENAI_RESPONSES_MODEL,
+    catalogPrefixes: ["openai/"],
+    providerOptionsKind: "openai",
+    apiKeyEnv: () => process.env.OPENAI_API_KEY,
+    envConfigured: () => hasEnvValue(process.env.OPENAI_API_KEY),
+  },
+  {
+    id: "anthropic",
+    sdk: "anthropic",
+    providerTypes: ["anthropic"],
+    handlePrefixes: ["anthropic/"],
+    localProviderNames: [LOCAL_ANTHROPIC_PROVIDER_NAME],
+    defaultModel: DEFAULT_ANTHROPIC_MODEL,
+    catalogPrefixes: ["anthropic/"],
+    providerOptionsKind: "anthropic",
+    apiKeyEnv: () => process.env.ANTHROPIC_API_KEY,
+    envConfigured: () => hasEnvValue(process.env.ANTHROPIC_API_KEY),
+  },
+  {
+    id: "openrouter",
+    sdk: "openai-compatible",
+    providerName: "openrouter",
+    providerTypes: ["openrouter"],
+    handlePrefixes: ["openrouter/"],
+    localProviderNames: [LOCAL_OPENROUTER_PROVIDER_NAME],
+    defaultModel: "openrouter/deepseek/deepseek-v4-pro",
+    catalogPrefixes: ["openrouter/"],
+    providerOptionsKind: "unknown",
+    baseURL: () =>
+      process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
+    apiKeyEnv: () => process.env.OPENROUTER_API_KEY,
+    headers: () => ({ "X-Title": "Letta Code" }),
+    envConfigured: () => hasEnvValue(process.env.OPENROUTER_API_KEY),
+  },
+  {
+    id: "zai",
+    sdk: "openai-compatible",
+    providerName: "zai",
+    providerTypes: ["zai", "zai_coding"],
+    handlePrefixes: ["zai/"],
+    localProviderNames: [
+      LOCAL_ZAI_PROVIDER_NAME,
+      LOCAL_ZAI_CODING_PROVIDER_NAME,
+    ],
+    defaultModel: "zai/glm-5.1",
+    catalogPrefixes: ["zai/"],
+    providerOptionsKind: "unknown",
+    envConfigured: () =>
+      hasEnvValue(process.env.ZAI_API_KEY) ||
+      hasEnvValue(process.env.ZHIPU_API_KEY) ||
+      hasEnvValue(process.env.ZAI_CODING_API_KEY),
+  },
+  {
+    id: "minimax",
+    sdk: "anthropic",
+    providerName: "minimax",
+    providerTypes: ["minimax"],
+    handlePrefixes: ["minimax/"],
+    localProviderNames: [LOCAL_MINIMAX_PROVIDER_NAME],
+    defaultModel: "minimax/MiniMax-M2.7",
+    catalogPrefixes: ["minimax/"],
+    providerOptionsKind: "unknown",
+    baseURL: () =>
+      process.env.MINIMAX_BASE_URL ?? "https://api.minimax.io/anthropic/v1",
+    apiKeyEnv: () => process.env.MINIMAX_API_KEY,
+    envConfigured: () => hasEnvValue(process.env.MINIMAX_API_KEY),
+  },
+  {
+    id: "moonshot",
+    sdk: "openai-compatible",
+    providerName: "moonshot",
+    providerTypes: ["moonshot", "moonshot_coding"],
+    handlePrefixes: ["moonshot/", "moonshot_coding/"],
+    localProviderNames: [
+      LOCAL_KIMI_CODE_PROVIDER_NAME,
+      LOCAL_MOONSHOT_PROVIDER_NAME,
+    ],
+    defaultModel: "moonshot/kimi-k2.5",
+    staticModels: MOONSHOT_MODELS,
+    providerOptionsKind: "unknown",
+    baseURL: () =>
+      process.env.MOONSHOT_BASE_URL ?? "https://api.moonshot.ai/v1",
+    apiKeyEnv: () => process.env.MOONSHOT_API_KEY,
+    envConfigured: () => hasEnvValue(process.env.MOONSHOT_API_KEY),
+  },
+  {
+    id: "google-ai",
+    sdk: "google",
+    providerTypes: ["google_ai"],
+    handlePrefixes: ["google_ai/"],
+    localProviderNames: [LOCAL_GOOGLE_AI_PROVIDER_NAME],
+    defaultModel: "google_ai/gemini-3.1-pro-preview",
+    catalogPrefixes: ["google_ai/"],
+    providerOptionsKind: "unknown",
+    baseURL: () => process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
+    apiKeyEnv: () =>
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? process.env.GEMINI_API_KEY,
+    envConfigured: () =>
+      hasEnvValue(process.env.GOOGLE_GENERATIVE_AI_API_KEY) ||
+      hasEnvValue(process.env.GEMINI_API_KEY),
+  },
+  {
+    id: "bedrock",
+    sdk: "bedrock",
+    providerTypes: ["bedrock"],
+    handlePrefixes: ["bedrock/"],
+    localProviderNames: [LOCAL_BEDROCK_PROVIDER_NAME],
+    defaultModel: "bedrock/us.anthropic.claude-sonnet-4-6",
+    catalogPrefixes: ["bedrock/"],
+    providerOptionsKind: "unknown",
+    envConfigured: () =>
+      (hasEnvValue(process.env.AWS_ACCESS_KEY_ID) &&
+        hasEnvValue(process.env.AWS_SECRET_ACCESS_KEY)) ||
+      hasEnvValue(process.env.AWS_PROFILE) ||
+      hasEnvValue(process.env.AWS_BEARER_TOKEN_BEDROCK),
+  },
+  {
+    id: "ollama",
+    sdk: "openai-compatible",
+    providerName: "ollama",
+    providerTypes: ["ollama"],
+    handlePrefixes: ["ollama/"],
+    localProviderNames: [LOCAL_OLLAMA_PROVIDER_NAME],
+    defaultModel: "ollama/llama2",
+    staticModels: OLLAMA_LOCAL_MODELS,
+    providerOptionsKind: "unknown",
+    baseURL: () => process.env.OLLAMA_BASE_URL ?? "http://localhost:11434/v1",
+    apiKeyEnv: () => process.env.OLLAMA_LOCAL_API_KEY,
+    fallbackApiKey: "not-needed",
+  },
+  {
+    id: "ollama-cloud",
+    sdk: "openai-compatible",
+    providerName: "ollama-cloud",
+    providerTypes: ["ollama_cloud"],
+    handlePrefixes: ["ollama-cloud/"],
+    localProviderNames: [LOCAL_OLLAMA_CLOUD_PROVIDER_NAME],
+    defaultModel: "ollama-cloud/gpt-oss:20b",
+    staticModels: OLLAMA_CLOUD_MODELS,
+    providerOptionsKind: "unknown",
+    baseURL: () => process.env.OLLAMA_CLOUD_BASE_URL ?? "https://ollama.com/v1",
+    apiKeyEnv: () => process.env.OLLAMA_API_KEY,
+    envConfigured: () => hasEnvValue(process.env.OLLAMA_API_KEY),
+  },
+  {
+    id: "lmstudio",
+    sdk: "openai-compatible",
+    providerName: "lmstudio",
+    providerTypes: ["lmstudio"],
+    handlePrefixes: ["lmstudio/"],
+    localProviderNames: [LOCAL_LMSTUDIO_PROVIDER_NAME],
+    defaultModel: "lmstudio/google/gemma-3n-e4b",
+    staticModels: LMSTUDIO_LOCAL_MODELS,
+    providerOptionsKind: "unknown",
+    baseURL: () => process.env.LMSTUDIO_BASE_URL ?? "http://127.0.0.1:1234/v1",
+    apiKeyEnv: () => process.env.LMSTUDIO_API_KEY,
+    fallbackApiKey: "not-needed",
+    envConfigured: () => hasEnvValue(process.env.LMSTUDIO_API_KEY),
+  },
+  {
+    id: "chatgpt-oauth",
+    sdk: "chatgpt-oauth",
+    providerTypes: ["chatgpt_oauth"],
+    handlePrefixes: ["chatgpt-plus-pro/"],
+    localProviderNames: [LOCAL_CHATGPT_PROVIDER_NAME],
+    defaultModel: `chatgpt-plus-pro/${DEFAULT_OPENAI_RESPONSES_MODEL}`,
+    providerOptionsKind: "openai",
+    catalogModelHandle: (modelHandle) =>
+      modelHandle.startsWith("openai/")
+        ? `chatgpt-plus-pro/${modelHandle.slice("openai/".length)}`
+        : undefined,
+  },
+] as const satisfies readonly AISDKProviderSpec[];
+
+export const SUPPORTED_LOCAL_PROVIDER_TYPES: ReadonlySet<string> = new Set(
+  AISDK_PROVIDER_SPECS.flatMap((provider) => provider.providerTypes),
+);
+
+export const KNOWN_AISDK_PROVIDERS = new Set(
+  AISDK_PROVIDER_SPECS.map((provider) => provider.id),
+);
+
+export const PROVIDER_TYPE_TO_BASE_PROVIDER = Object.fromEntries(
+  AISDK_PROVIDER_SPECS.flatMap((provider) =>
+    provider.providerTypes.map((providerType) => [
+      providerType,
+      provider.handlePrefixes[0]?.slice(0, -1) ?? provider.id,
+    ]),
+  ),
+) as Record<string, string>;
+
+export function getAISDKProviderSpec(
+  provider: AISDKProvider,
+): AISDKProviderSpec {
+  const spec = AISDK_PROVIDER_SPECS.find((entry) => entry.id === provider);
+  if (!spec) {
+    throw new Error(`Unknown AI SDK provider "${provider}".`);
+  }
+  return spec;
+}
+
+export function isAISDKProvider(provider: string): provider is AISDKProvider {
+  return KNOWN_AISDK_PROVIDERS.has(provider as AISDKProvider);
+}
+
+export function expectedAISDKProviderList(): string {
+  return AISDK_PROVIDER_SPECS.map((provider) => `"${provider.id}"`).join(", ");
+}
+
+export function resolveProviderFromModelHandle(
+  model: string | undefined,
+): AISDKProvider | undefined {
+  if (!model) return undefined;
+  return AISDK_PROVIDER_SPECS.find((provider) =>
+    provider.handlePrefixes.some((prefix) => model.startsWith(prefix)),
+  )?.id;
+}
+
+export function resolveProviderFromProviderType(
+  providerType: unknown,
+): AISDKProvider | undefined {
+  if (typeof providerType !== "string") return undefined;
+  return AISDK_PROVIDER_SPECS.find((provider) =>
+    (provider.providerTypes as readonly string[]).includes(providerType),
+  )?.id;
+}
+
+export function stripProviderHandlePrefix(
+  model: string | undefined,
+  provider: AISDKProvider,
+): string | undefined {
+  if (!model) return process.env.LETTA_CODE_DEV_AI_SDK_MODEL;
+  const spec = getAISDKProviderSpec(provider);
+  const prefix = spec.handlePrefixes.find((prefix) => model.startsWith(prefix));
+  return prefix ? model.slice(prefix.length) : model;
+}
+
+export function hasKnownProviderHandlePrefix(model: string): boolean {
+  return AISDK_PROVIDER_SPECS.some((provider) =>
+    provider.handlePrefixes.some((prefix) => model.startsWith(prefix)),
+  );
+}
+
+export function localProviderType(provider: AISDKProvider): string {
+  return getAISDKProviderSpec(provider).providerTypes[0] ?? "openai";
+}
+
+export function localModelHandle(
+  provider: AISDKProvider,
+  model: string,
+): string {
+  if (hasKnownProviderHandlePrefix(model)) return model;
+  const prefix = getAISDKProviderSpec(provider).handlePrefixes[0];
+  return prefix ? `${prefix}${model}` : model;
+}
+
+export function resolveLocalModel(provider: AISDKProvider): string {
+  return getAISDKProviderSpec(provider).defaultModel;
+}
+
+export function isProviderConfigured(
+  provider: AISDKProviderSpec,
+  localProviderNames: Set<string>,
+): boolean {
+  return (
+    provider.localProviderNames.some((name) => localProviderNames.has(name)) ||
+    Boolean(provider.envConfigured?.())
+  );
+}
+
+export function listConfiguredAISDKProviders(
+  localProviderNames: Set<string>,
+): AISDKProvider[] {
+  return AISDK_PROVIDER_SPECS.filter((provider) =>
+    isProviderConfigured(provider, localProviderNames),
+  ).map((provider) => provider.id);
+}
+
+export function listCatalogModelsForProvider(
+  provider: AISDKProvider,
+): string[] {
+  const spec = getAISDKProviderSpec(provider);
+  const seen = new Set<string>();
+  const models: string[] = [];
+  const add = (model: string | undefined) => {
+    if (!model || seen.has(model)) return;
+    seen.add(model);
+    models.push(model);
+  };
+
+  add(spec.defaultModel);
+  const mapCatalogModel =
+    spec.catalogModelHandle ??
+    (spec.catalogPrefixes
+      ? defaultCatalogModelHandle(spec.catalogPrefixes)
+      : undefined);
+  if (mapCatalogModel) {
+    for (const model of modelsData.models) {
+      add(mapCatalogModel(model.handle));
+    }
+  }
+  for (const model of spec.staticModels ?? []) {
+    add(model);
+  }
+
+  return models;
+}
+
+export function aiSDKProviderKindFromModel(
+  modelHandle: string,
+  modelSettings: Record<string, unknown>,
+): AISDKProviderKind {
+  const providerFromModel = resolveProviderFromModelHandle(modelHandle);
+  if (providerFromModel) {
+    return getAISDKProviderSpec(providerFromModel).providerOptionsKind;
+  }
+  const providerFromSettings = resolveProviderFromProviderType(
+    modelSettings.provider_type,
+  );
+  if (providerFromSettings) {
+    return getAISDKProviderSpec(providerFromSettings).providerOptionsKind;
+  }
+  return "unknown";
+}

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -15,6 +15,10 @@ import type { ClientTool } from "../../tools/manager";
 import type { LocalCompactionStats } from "../local/compaction";
 import type { LocalMessage } from "../local/LocalMessage";
 import { createAISDKModelFactoryFromAgent } from "./AISDKModelFactory";
+import {
+  type AISDKProviderKind,
+  aiSDKProviderKindFromModel,
+} from "./AISDKProviderRegistry";
 import { isContextWindowOverflowError } from "./contextWindowOverflow";
 import type {
   ProviderStreamAdapter,
@@ -28,7 +32,6 @@ import {
 } from "./ProviderTurnExecutor";
 
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
-type AISDKProviderKind = "anthropic" | "openai" | "unknown";
 type AISDKUIMessageStreamFinish = {
   messages: LocalMessage[];
   responseMessage: LocalMessage;
@@ -194,42 +197,7 @@ function aiSDKProviderKind(
   modelHandle: string,
   modelSettings: Record<string, unknown>,
 ): AISDKProviderKind {
-  if (modelHandle.startsWith("anthropic/")) return "anthropic";
-  if (
-    modelHandle.startsWith("openai/") ||
-    modelHandle.startsWith("openai-codex/") ||
-    modelHandle.startsWith("chatgpt-plus-pro/")
-  ) {
-    return "openai";
-  }
-  if (
-    modelHandle.startsWith("openrouter/") ||
-    modelHandle.startsWith("zai/") ||
-    modelHandle.startsWith("moonshot/") ||
-    modelHandle.startsWith("moonshot_coding/") ||
-    modelHandle.startsWith("minimax/") ||
-    modelHandle.startsWith("google_ai/") ||
-    modelHandle.startsWith("ollama/") ||
-    modelHandle.startsWith("ollama-cloud/") ||
-    modelHandle.startsWith("lmstudio/") ||
-    modelHandle.startsWith("bedrock/")
-  ) {
-    return "unknown";
-  }
-
-  const providerType = stringValue(modelSettings.provider_type);
-  if (
-    providerType === "openai" ||
-    providerType === "openai-responses" ||
-    modelHandle.startsWith("openai/") ||
-    modelHandle.startsWith("openai-codex/")
-  ) {
-    return "openai";
-  }
-  if (providerType === "anthropic" || modelHandle.startsWith("anthropic/")) {
-    return "anthropic";
-  }
-  return "unknown";
+  return aiSDKProviderKindFromModel(modelHandle, modelSettings);
 }
 
 function partProviderMetadata(

--- a/src/backend/local/LocalModelConfig.ts
+++ b/src/backend/local/LocalModelConfig.ts
@@ -1,24 +1,15 @@
-import modelsData from "../../models.json";
-import type { AISDKProvider } from "../dev/AISDKModelFactory";
-import { DEFAULT_ANTHROPIC_MODEL } from "../dev/AnthropicModel";
-import { DEFAULT_OPENAI_RESPONSES_MODEL } from "../dev/OpenAIResponsesModel";
 import {
-  LOCAL_ANTHROPIC_PROVIDER_NAME,
-  LOCAL_BEDROCK_PROVIDER_NAME,
-  LOCAL_CHATGPT_PROVIDER_NAME,
-  LOCAL_GOOGLE_AI_PROVIDER_NAME,
-  LOCAL_KIMI_CODE_PROVIDER_NAME,
-  LOCAL_LMSTUDIO_PROVIDER_NAME,
-  LOCAL_MINIMAX_PROVIDER_NAME,
-  LOCAL_MOONSHOT_PROVIDER_NAME,
-  LOCAL_OLLAMA_CLOUD_PROVIDER_NAME,
-  LOCAL_OLLAMA_PROVIDER_NAME,
-  LOCAL_OPENAI_PROVIDER_NAME,
-  LOCAL_OPENROUTER_PROVIDER_NAME,
-  LOCAL_ZAI_CODING_PROVIDER_NAME,
-  LOCAL_ZAI_PROVIDER_NAME,
-  listLocalProviderRecords,
-} from "./LocalProviderAuthStore";
+  type AISDKProvider,
+  DEFAULT_AI_SDK_PROVIDER,
+} from "../dev/AISDKModelFactory";
+import {
+  listCatalogModelsForProvider,
+  listConfiguredAISDKProviders,
+  localModelHandle,
+  localProviderType,
+  resolveLocalModel,
+} from "../dev/AISDKProviderRegistry";
+import { listLocalProviderRecords } from "./LocalProviderAuthStore";
 
 export interface LocalModelConfig {
   provider: AISDKProvider;
@@ -33,246 +24,20 @@ interface LocalModelListEntry {
   model_endpoint_type: string;
 }
 
-function hasEnvValue(value: string | undefined): boolean {
-  return typeof value === "string" && value.length > 0;
-}
-
-const OLLAMA_LOCAL_MODELS = [
-  "ollama/llama2",
-  "ollama/llama3.1:8b",
-  "ollama/qwen3-coder:30b",
-  "ollama/gpt-oss:20b",
-];
-
-const OLLAMA_CLOUD_MODELS = [
-  "ollama-cloud/glm-4.7",
-  "ollama-cloud/qwen3-coder:480b",
-  "ollama-cloud/gpt-oss:20b",
-  "ollama-cloud/gpt-oss:120b",
-  "ollama-cloud/kimi-k2.5",
-  "ollama-cloud/minimax-m2.1",
-  "ollama-cloud/deepseek-v3.2",
-];
-
-const LMSTUDIO_LOCAL_MODELS = [
-  "lmstudio/google/gemma-3n-e4b",
-  "lmstudio/openai/gpt-oss-20b",
-  "lmstudio/qwen/qwen3-30b-a3b-2507",
-  "lmstudio/qwen/qwen3-coder-30b",
-];
-
 function localProviderNames(storageDir?: string): Set<string> {
   return new Set(
     listLocalProviderRecords(storageDir).map((record) => record.name),
   );
 }
 
-function inferLocalProviderFromStandardKeys(
-  storageDir?: string,
-): AISDKProvider {
-  const providers = localProviderNames(storageDir);
-  const hasOpenAIKey =
-    hasEnvValue(process.env.OPENAI_API_KEY) ||
-    providers.has(LOCAL_OPENAI_PROVIDER_NAME);
-  const hasAnthropicKey =
-    hasEnvValue(process.env.ANTHROPIC_API_KEY) ||
-    providers.has(LOCAL_ANTHROPIC_PROVIDER_NAME);
-  const hasOpenRouterKey =
-    hasEnvValue(process.env.OPENROUTER_API_KEY) ||
-    providers.has(LOCAL_OPENROUTER_PROVIDER_NAME);
-  const hasZaiKey =
-    hasEnvValue(process.env.ZAI_API_KEY) ||
-    hasEnvValue(process.env.ZHIPU_API_KEY) ||
-    providers.has(LOCAL_ZAI_PROVIDER_NAME) ||
-    providers.has(LOCAL_ZAI_CODING_PROVIDER_NAME);
-  const hasChatGPT = providers.has(LOCAL_CHATGPT_PROVIDER_NAME);
-  const hasMinimax =
-    hasEnvValue(process.env.MINIMAX_API_KEY) ||
-    providers.has(LOCAL_MINIMAX_PROVIDER_NAME);
-  const hasMoonshot =
-    hasEnvValue(process.env.MOONSHOT_API_KEY) ||
-    providers.has(LOCAL_MOONSHOT_PROVIDER_NAME) ||
-    providers.has(LOCAL_KIMI_CODE_PROVIDER_NAME);
-  const hasGoogleAI =
-    hasEnvValue(process.env.GOOGLE_GENERATIVE_AI_API_KEY) ||
-    hasEnvValue(process.env.GEMINI_API_KEY) ||
-    providers.has(LOCAL_GOOGLE_AI_PROVIDER_NAME);
-  const hasBedrock =
-    (hasEnvValue(process.env.AWS_ACCESS_KEY_ID) &&
-      hasEnvValue(process.env.AWS_SECRET_ACCESS_KEY)) ||
-    providers.has(LOCAL_BEDROCK_PROVIDER_NAME);
-  const hasOllama = providers.has(LOCAL_OLLAMA_PROVIDER_NAME);
-  const hasOllamaCloud =
-    hasEnvValue(process.env.OLLAMA_API_KEY) ||
-    providers.has(LOCAL_OLLAMA_CLOUD_PROVIDER_NAME);
-  const hasLMStudio =
-    hasEnvValue(process.env.LMSTUDIO_API_KEY) ||
-    providers.has(LOCAL_LMSTUDIO_PROVIDER_NAME);
-
-  if (!hasOpenAIKey && hasAnthropicKey) return "anthropic";
-  if (!hasOpenAIKey && !hasAnthropicKey && hasOpenRouterKey) {
-    return "openrouter";
-  }
-  if (!hasOpenAIKey && !hasAnthropicKey && !hasOpenRouterKey && hasZaiKey) {
-    return "zai";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    hasMinimax
-  ) {
-    return "minimax";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    hasMoonshot
-  ) {
-    return "moonshot";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    hasGoogleAI
-  ) {
-    return "google-ai";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    !hasGoogleAI &&
-    hasBedrock
-  ) {
-    return "bedrock";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    !hasGoogleAI &&
-    !hasBedrock &&
-    hasOllama
-  ) {
-    return "ollama";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    !hasGoogleAI &&
-    !hasBedrock &&
-    !hasOllama &&
-    hasOllamaCloud
-  ) {
-    return "ollama-cloud";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    !hasGoogleAI &&
-    !hasBedrock &&
-    !hasOllama &&
-    !hasOllamaCloud &&
-    hasLMStudio
-  ) {
-    return "lmstudio";
-  }
-  if (
-    !hasOpenAIKey &&
-    !hasAnthropicKey &&
-    !hasOpenRouterKey &&
-    !hasZaiKey &&
-    !hasMinimax &&
-    !hasMoonshot &&
-    !hasGoogleAI &&
-    !hasBedrock &&
-    !hasOllama &&
-    !hasOllamaCloud &&
-    !hasLMStudio &&
-    hasChatGPT
-  ) {
-    return "chatgpt-oauth";
-  }
-  return "openai-responses";
-}
-
 export function resolveLocalProvider(storageDir?: string): AISDKProvider {
-  return inferLocalProviderFromStandardKeys(storageDir);
+  return (
+    listConfiguredAISDKProviders(localProviderNames(storageDir))[0] ??
+    DEFAULT_AI_SDK_PROVIDER
+  );
 }
 
-export function resolveLocalModel(provider = resolveLocalProvider()): string {
-  if (provider === "anthropic") return DEFAULT_ANTHROPIC_MODEL;
-  if (provider === "openrouter") return "openrouter/deepseek/deepseek-v4-pro";
-  if (provider === "zai") return "zai/glm-5.1";
-  if (provider === "minimax") return "minimax/MiniMax-M2.7";
-  if (provider === "moonshot") return "moonshot/kimi-k2.5";
-  if (provider === "google-ai") return "google_ai/gemini-3.1-pro-preview";
-  if (provider === "ollama") return "ollama/llama2";
-  if (provider === "ollama-cloud") return "ollama-cloud/gpt-oss:20b";
-  if (provider === "lmstudio") return "lmstudio/google/gemma-3n-e4b";
-  if (provider === "bedrock") return "bedrock/us.anthropic.claude-sonnet-4-6";
-  if (provider === "chatgpt-oauth") {
-    return `chatgpt-plus-pro/${DEFAULT_OPENAI_RESPONSES_MODEL}`;
-  }
-  return DEFAULT_OPENAI_RESPONSES_MODEL;
-}
-
-export function localModelHandle(
-  provider: AISDKProvider,
-  model: string,
-): string {
-  if (model.includes("/")) return model;
-  if (provider === "anthropic") return `anthropic/${model}`;
-  if (provider === "openrouter") return `openrouter/${model}`;
-  if (provider === "zai") return `zai/${model}`;
-  if (provider === "minimax") return `minimax/${model}`;
-  if (provider === "moonshot") return `moonshot/${model}`;
-  if (provider === "google-ai") return `google_ai/${model}`;
-  if (provider === "ollama") return `ollama/${model}`;
-  if (provider === "ollama-cloud") return `ollama-cloud/${model}`;
-  if (provider === "lmstudio") return `lmstudio/${model}`;
-  if (provider === "bedrock") return `bedrock/${model}`;
-  if (provider === "chatgpt-oauth") return `chatgpt-plus-pro/${model}`;
-  return `openai/${model}`;
-}
-
-export function localProviderType(provider: AISDKProvider): string {
-  if (provider === "anthropic") return "anthropic";
-  if (provider === "openrouter") return "openrouter";
-  if (provider === "zai") return "zai";
-  if (provider === "minimax") return "minimax";
-  if (provider === "moonshot") return "moonshot";
-  if (provider === "google-ai") return "google_ai";
-  if (provider === "ollama") return "ollama";
-  if (provider === "ollama-cloud") return "ollama_cloud";
-  if (provider === "lmstudio") return "lmstudio";
-  if (provider === "bedrock") return "bedrock";
-  if (provider === "chatgpt-oauth") return "chatgpt_oauth";
-  return "openai";
-}
+export { localModelHandle, localProviderType, resolveLocalModel };
 
 export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
   const provider = resolveLocalProvider(storageDir);
@@ -287,8 +52,6 @@ export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
 
 export function listLocalModels(storageDir?: string) {
   const configured = resolveLocalModelConfig(storageDir);
-  const openAIModel = DEFAULT_OPENAI_RESPONSES_MODEL;
-  const anthropicModel = DEFAULT_ANTHROPIC_MODEL;
   const models: LocalModelListEntry[] = [];
   const addModel = (provider: AISDKProvider, model: string) => {
     const handle = localModelHandle(provider, model);
@@ -301,133 +64,11 @@ export function listLocalModels(storageDir?: string) {
   };
 
   addModel(configured.provider, configured.model);
-  const providers = localProviderNames(storageDir);
-  const hasOpenAI =
-    hasEnvValue(process.env.OPENAI_API_KEY) ||
-    providers.has(LOCAL_OPENAI_PROVIDER_NAME);
-  const hasAnthropic =
-    hasEnvValue(process.env.ANTHROPIC_API_KEY) ||
-    providers.has(LOCAL_ANTHROPIC_PROVIDER_NAME);
-  const hasOpenRouter =
-    hasEnvValue(process.env.OPENROUTER_API_KEY) ||
-    providers.has(LOCAL_OPENROUTER_PROVIDER_NAME);
-  const hasZai =
-    hasEnvValue(process.env.ZAI_API_KEY) ||
-    hasEnvValue(process.env.ZHIPU_API_KEY) ||
-    providers.has(LOCAL_ZAI_PROVIDER_NAME) ||
-    providers.has(LOCAL_ZAI_CODING_PROVIDER_NAME);
-  const hasChatGPT = providers.has(LOCAL_CHATGPT_PROVIDER_NAME);
-  const hasMinimax =
-    hasEnvValue(process.env.MINIMAX_API_KEY) ||
-    providers.has(LOCAL_MINIMAX_PROVIDER_NAME);
-  const hasMoonshot =
-    hasEnvValue(process.env.MOONSHOT_API_KEY) ||
-    providers.has(LOCAL_MOONSHOT_PROVIDER_NAME) ||
-    providers.has(LOCAL_KIMI_CODE_PROVIDER_NAME);
-  const hasGoogleAI =
-    hasEnvValue(process.env.GOOGLE_GENERATIVE_AI_API_KEY) ||
-    hasEnvValue(process.env.GEMINI_API_KEY) ||
-    providers.has(LOCAL_GOOGLE_AI_PROVIDER_NAME);
-  const hasBedrock =
-    (hasEnvValue(process.env.AWS_ACCESS_KEY_ID) &&
-      hasEnvValue(process.env.AWS_SECRET_ACCESS_KEY)) ||
-    providers.has(LOCAL_BEDROCK_PROVIDER_NAME);
-  const hasOllama = providers.has(LOCAL_OLLAMA_PROVIDER_NAME);
-  const hasOllamaCloud =
-    hasEnvValue(process.env.OLLAMA_API_KEY) ||
-    providers.has(LOCAL_OLLAMA_CLOUD_PROVIDER_NAME);
-  const hasLMStudio =
-    hasEnvValue(process.env.LMSTUDIO_API_KEY) ||
-    providers.has(LOCAL_LMSTUDIO_PROVIDER_NAME);
-
-  if (hasOpenAI) {
-    addModel("openai-responses", openAIModel);
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("openai/")) {
-        addModel("openai-responses", model.handle);
-      }
-    }
-  }
-  if (hasAnthropic) {
-    addModel("anthropic", anthropicModel);
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("anthropic/")) {
-        addModel("anthropic", model.handle);
-      }
-    }
-  }
-  if (hasOpenRouter) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("openrouter/")) {
-        addModel("openrouter", model.handle);
-      }
-    }
-  }
-  if (hasZai) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("zai/")) {
-        addModel("zai", model.handle);
-      }
-    }
-  }
-  if (hasMinimax) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("minimax/")) {
-        addModel("minimax", model.handle);
-      }
-    }
-  }
-  if (hasMoonshot) {
-    const addMoonshotModel = (model: string) => addModel("moonshot", model);
-    for (const model of modelsData.models) {
-      if (
-        model.handle.startsWith("moonshot/") ||
-        model.handle.startsWith("moonshot_coding/")
-      ) {
-        addMoonshotModel(model.handle);
-      }
-    }
-    addMoonshotModel("moonshot/kimi-k2-thinking-turbo");
-    addMoonshotModel("moonshot/kimi-k2-turbo-preview");
-    addMoonshotModel("moonshot/kimi-k2.5");
-    addMoonshotModel("moonshot/kimi-k2-0711-preview");
-    addMoonshotModel("moonshot/kimi-k2-thinking");
-    addMoonshotModel("moonshot/kimi-k2-0905-preview");
-  }
-  if (hasGoogleAI) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("google_ai/")) {
-        addModel("google-ai", model.handle);
-      }
-    }
-  }
-  if (hasBedrock) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("bedrock/")) {
-        addModel("bedrock", model.handle);
-      }
-    }
-  }
-  if (hasOllama) {
-    for (const model of OLLAMA_LOCAL_MODELS) {
-      addModel("ollama", model);
-    }
-  }
-  if (hasOllamaCloud) {
-    for (const model of OLLAMA_CLOUD_MODELS) {
-      addModel("ollama-cloud", model);
-    }
-  }
-  if (hasLMStudio) {
-    for (const model of LMSTUDIO_LOCAL_MODELS) {
-      addModel("lmstudio", model);
-    }
-  }
-  if (hasChatGPT) {
-    for (const model of modelsData.models) {
-      if (model.handle.startsWith("chatgpt-plus-pro/")) {
-        addModel("chatgpt-oauth", model.handle);
-      }
+  for (const provider of listConfiguredAISDKProviders(
+    localProviderNames(storageDir),
+  )) {
+    for (const model of listCatalogModelsForProvider(provider)) {
+      addModel(provider, model);
     }
   }
   return models;

--- a/src/backend/local/LocalProviderAuthStore.ts
+++ b/src/backend/local/LocalProviderAuthStore.ts
@@ -7,7 +7,28 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ProviderResponse } from "../api/providers";
+import {
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  SUPPORTED_LOCAL_PROVIDER_TYPES,
+} from "../dev/AISDKProviderRegistry";
 import { getLocalBackendStorageDir } from "./paths";
+
+export {
+  LOCAL_ANTHROPIC_PROVIDER_NAME,
+  LOCAL_BEDROCK_PROVIDER_NAME,
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  LOCAL_GOOGLE_AI_PROVIDER_NAME,
+  LOCAL_KIMI_CODE_PROVIDER_NAME,
+  LOCAL_LMSTUDIO_PROVIDER_NAME,
+  LOCAL_MINIMAX_PROVIDER_NAME,
+  LOCAL_MOONSHOT_PROVIDER_NAME,
+  LOCAL_OLLAMA_CLOUD_PROVIDER_NAME,
+  LOCAL_OLLAMA_PROVIDER_NAME,
+  LOCAL_OPENAI_PROVIDER_NAME,
+  LOCAL_OPENROUTER_PROVIDER_NAME,
+  LOCAL_ZAI_CODING_PROVIDER_NAME,
+  LOCAL_ZAI_PROVIDER_NAME,
+} from "../dev/AISDKProviderRegistry";
 
 export type LocalProviderAuthType = "api" | "oauth";
 
@@ -45,38 +66,6 @@ interface LocalProviderAuthFile {
   version: 1;
   providers: Record<string, LocalProviderRecord>;
 }
-
-export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
-export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
-export const LOCAL_ANTHROPIC_PROVIDER_NAME = "lc-anthropic";
-export const LOCAL_OPENROUTER_PROVIDER_NAME = "lc-openrouter";
-export const LOCAL_OLLAMA_PROVIDER_NAME = "lc-ollama";
-export const LOCAL_OLLAMA_CLOUD_PROVIDER_NAME = "lc-ollama-cloud";
-export const LOCAL_LMSTUDIO_PROVIDER_NAME = "lc-lmstudio";
-export const LOCAL_ZAI_PROVIDER_NAME = "lc-zai";
-export const LOCAL_ZAI_CODING_PROVIDER_NAME = "lc-zai-coding";
-export const LOCAL_MINIMAX_PROVIDER_NAME = "lc-minimax";
-export const LOCAL_MOONSHOT_PROVIDER_NAME = "lc-moonshot";
-export const LOCAL_KIMI_CODE_PROVIDER_NAME = "lc-kimi-code";
-export const LOCAL_GOOGLE_AI_PROVIDER_NAME = "lc-gemini";
-export const LOCAL_BEDROCK_PROVIDER_NAME = "lc-bedrock";
-
-const SUPPORTED_LOCAL_PROVIDER_TYPES = new Set([
-  "openai",
-  "anthropic",
-  "openrouter",
-  "ollama",
-  "ollama_cloud",
-  "lmstudio",
-  "zai",
-  "zai_coding",
-  "minimax",
-  "moonshot",
-  "moonshot_coding",
-  "google_ai",
-  "bedrock",
-  "chatgpt_oauth",
-]);
 
 export function isLocalProviderTypeSupported(providerType: string): boolean {
   return SUPPORTED_LOCAL_PROVIDER_TYPES.has(providerType);

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -15,6 +15,7 @@ import {
   updateProvider as updateProviderRequest,
 } from "../backend/api/providers";
 import { getBackend } from "../backend/backend";
+import { PROVIDER_TYPE_TO_BASE_PROVIDER } from "../backend/dev/AISDKProviderRegistry";
 import {
   createOrUpdateLocalProvider,
   deleteLocalProvider,
@@ -201,28 +202,7 @@ function assertLocalProviderSupported(providerType: string): void {
 /** Prefixes that always indicate a BYOK handle (ChatGPT OAuth + lc-* providers) */
 export const STATIC_BYOK_PROVIDER_PREFIXES = ["chatgpt-plus-pro/", "lc-"];
 
-/**
- * Maps provider_type → base provider string used in model handles.
- * Used to translate BYOK provider names back to their canonical handle prefix
- * (e.g., "lc-anthropic/claude-sonnet-4" → "anthropic/claude-sonnet-4").
- */
-export const PROVIDER_TYPE_TO_BASE_PROVIDER: Record<string, string> = {
-  chatgpt_oauth: "chatgpt-plus-pro",
-  anthropic: "anthropic",
-  openai: "openai",
-  zai: "zai",
-  zai_coding: "zai",
-  google_ai: "google_ai",
-  google_vertex: "google_vertex",
-  minimax: "minimax",
-  moonshot: "moonshot",
-  moonshot_coding: "moonshot_coding",
-  openrouter: "openrouter",
-  ollama: "ollama",
-  ollama_cloud: "ollama-cloud",
-  lmstudio: "lmstudio",
-  bedrock: "bedrock",
-};
+export { PROVIDER_TYPE_TO_BASE_PROVIDER };
 
 /**
  * Build a mapping of BYOK provider names → base provider strings.


### PR DESCRIPTION
## Summary
- Add a single AI SDK provider registry modeled after OpenCode's provider metadata pattern: SDK kind, provider types, handle prefixes, local provider names, env fallbacks, base URLs, default models, and static local model entries live in one place.
- Refactor provider resolution, model-prefix stripping, local model listing, supported local provider type checks, BYOK alias derivation, and provider option classification to read from the registry instead of duplicated switch/prefix logic.
- Collapse `AISDKModelFactory` down to SDK-family construction (`openai-responses`, `anthropic`, `openai-compatible`, `google`, `bedrock`, `chatgpt-oauth`) with only the Z.AI regular-vs-coding endpoint as a special case.

## Test plan
- [x] `bun test src/tests/backend/local-backend.test.ts src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/ai-sdk-model-factory.test.ts src/tests/cli/connect-subcommand.test.ts src/tests/cli/connect-normalize.test.ts src/tests/providers`
- [x] `bun run check`

Stacked on #2126.

👾 Generated with [Letta Code](https://letta.com)