### PR TITLE
feat(local): Add local backend CLI flag

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -241,6 +241,8 @@ interface APIBackendDeps {
   forkConversation?: ForkConversation;
 }
 
+export type BackendMode = "api" | "local";
+
 export class APIBackend implements Backend {
   readonly capabilities: BackendCapabilities = {
     remoteMemfs: true,
@@ -428,7 +430,7 @@ function isTruthyEnv(value: string | undefined): boolean {
 }
 
 export function isExperimentalLocalBackendEnabled(): boolean {
-  return isTruthyEnv(process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL);
+  return resolveBackendMode() === "local";
 }
 
 export function getLocalBackendStorageDir(homeDir = homedir()): string {
@@ -445,16 +447,36 @@ function createExperimentalLocalBackend(): Backend {
   });
 }
 
+let configuredBackendMode: BackendMode | null = null;
+
+function resolveBackendMode(): BackendMode {
+  if (configuredBackendMode) return configuredBackendMode;
+  return isTruthyEnv(process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL)
+    ? "local"
+    : "api";
+}
+
+function createBackendForMode(mode: BackendMode): Backend {
+  return mode === "local" ? createExperimentalLocalBackend() : new APIBackend();
+}
+
 function createInitialBackend(): Backend {
-  return isExperimentalLocalBackendEnabled()
-    ? createExperimentalLocalBackend()
-    : new APIBackend();
+  return createBackendForMode(resolveBackendMode());
 }
 
 let backend: Backend = createInitialBackend();
 
 export function getBackend(): Backend {
   return backend;
+}
+
+export function configureBackendMode(mode: BackendMode): void {
+  configuredBackendMode = mode;
+  backend = createBackendForMode(mode);
+}
+
+export function isLocalBackendEnabled(): boolean {
+  return resolveBackendMode() === "local";
 }
 
 function devBackendStoreOptions() {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 
 export type CliFlagMode = "interactive" | "headless" | "both";
+export type CliBackendMode = "api" | "local";
 
 type CliFlagParserConfig = {
   type: "string" | "boolean";
@@ -135,6 +136,14 @@ export const CLI_FLAG_CATALOG = {
   // They remain in the shared catalog for strict parsing parity.
   run: { parser: { type: "boolean" }, mode: "headless" },
   "dev-backend": { parser: { type: "string" }, mode: "headless" },
+  backend: {
+    parser: { type: "string" },
+    mode: "both",
+    help: {
+      argLabel: "<mode>",
+      description: 'Backend mode: "api" or "local"',
+    },
+  },
   tools: { parser: { type: "string" }, mode: "both" },
   allowedTools: { parser: { type: "string" }, mode: "both" },
   disallowedTools: { parser: { type: "string" }, mode: "both" },
@@ -382,3 +391,44 @@ export function parseCliArgs(args: string[], strict: boolean) {
 }
 
 export type ParsedCliArgs = ReturnType<typeof parseCliArgs>;
+
+export function parseBackendModeFlag(
+  value: string | undefined,
+): CliBackendMode | undefined {
+  if (value === undefined) return undefined;
+  if (value === "api" || value === "local") return value;
+  throw new Error(
+    `Invalid --backend value "${value}". Expected "api" or "local".`,
+  );
+}
+
+export function extractBackendFlag(args: string[]): {
+  backend?: CliBackendMode;
+  args: string[];
+} {
+  const filtered: string[] = [];
+  let backend: CliBackendMode | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === undefined) continue;
+    if (arg === "--backend") {
+      const value = args[index + 1];
+      if (value === undefined) {
+        throw new Error(
+          'Missing value for --backend. Expected "api" or "local".',
+        );
+      }
+      backend = parseBackendModeFlag(value);
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("--backend=")) {
+      backend = parseBackendModeFlag(arg.slice("--backend=".length));
+      continue;
+    }
+    filtered.push(arg);
+  }
+
+  return { backend, args: filtered };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,14 @@ import {
 import type { MemoryPromptMode } from "./agent/promptAssets";
 import { resolveSkillSourcesSelection } from "./agent/skillSources";
 import { LETTA_CLOUD_API_URL } from "./auth/oauth";
-import { getBackend, isExperimentalLocalBackendEnabled } from "./backend";
+import {
+  configureBackendMode,
+  getBackend,
+  isExperimentalLocalBackendEnabled,
+} from "./backend";
 import { getBillingTier } from "./backend/api/metadata";
 import {
+  extractBackendFlag,
   type ParsedCliArgs,
   parseCliArgs,
   preprocessCliArgs,
@@ -365,10 +370,30 @@ async function getPinnedAgentNames(): Promise<{ id: string; name: string }[]> {
 async function main(): Promise<void> {
   markMilestone("CLI_START");
 
+  const rawCliArgs = process.argv.slice(2);
+  let subcommandArgs = rawCliArgs;
+  try {
+    const backendSelection = extractBackendFlag(rawCliArgs);
+    subcommandArgs = backendSelection.args;
+    if (backendSelection.backend) {
+      configureBackendMode(backendSelection.backend);
+    }
+  } catch (error) {
+    trackCliBoundaryError(
+      "cli_backend_flag_parse_failed",
+      error,
+      "startup_backend_flag_parse",
+    );
+    console.error(
+      error instanceof Error ? `Error: ${error.message}` : String(error),
+    );
+    process.exit(1);
+  }
+
   // Early exit for CLI subcommands (e.g., `letta server`, `letta memory`).
   // Subcommands handle their own setup and don't need TUI init, theme
   // detection, or base tool bootstrapping.
-  const subcommandResult = await runSubcommand(process.argv.slice(2));
+  const subcommandResult = await runSubcommand(subcommandArgs);
   if (subcommandResult !== null) {
     process.exit(subcommandResult);
   }

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -117,10 +117,16 @@ const getClientMock = mock(async () => ({
   },
 }));
 
-import { APIBackend } from "../../backend";
+import {
+  APIBackend,
+  configureBackendMode,
+  getBackend,
+  isLocalBackendEnabled,
+} from "../../backend";
 
 describe("APIBackend", () => {
   beforeEach(() => {
+    configureBackendMode("api");
     getClientMock.mockClear();
     createAgentMock.mockClear();
     retrieveAgentMock.mockClear();
@@ -139,6 +145,18 @@ describe("APIBackend", () => {
     retrieveRunMock.mockClear();
     streamRunMessagesMock.mockClear();
     forkConversationMock.mockClear();
+  });
+
+  test("configures the active backend mode explicitly", () => {
+    configureBackendMode("local");
+    expect(isLocalBackendEnabled()).toBe(true);
+    expect(getBackend().capabilities.localMemfs).toBe(true);
+    expect(getBackend().capabilities.localModelCatalog).toBe(true);
+
+    configureBackendMode("api");
+    expect(isLocalBackendEnabled()).toBe(false);
+    expect(getBackend().capabilities.localMemfs).toBe(false);
+    expect(getBackend().capabilities.remoteMemfs).toBe(true);
   });
 
   test("delegates core conversation and run operations to the Letta API", async () => {

--- a/src/tests/cli/args.test.ts
+++ b/src/tests/cli/args.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   CLI_FLAG_CATALOG,
   CLI_OPTIONS,
+  extractBackendFlag,
+  parseBackendModeFlag,
   parseCliArgs,
   preprocessCliArgs,
   renderCliOptionsHelp,
@@ -52,6 +54,7 @@ describe("shared CLI arg schema", () => {
   test("rendered OPTIONS help is generated from catalog metadata", () => {
     const help = renderCliOptionsHelp();
     expect(help).toContain("-h, --help");
+    expect(help).toContain("--backend <mode>");
     expect(help).toContain("--memfs-startup <m>");
     expect(help).toContain("Default: text");
     expect(help).not.toContain("--run");
@@ -106,6 +109,36 @@ describe("shared CLI arg schema", () => {
     expect(parsed.values["max-turns"]).toBe("3");
     expect(parsed.values["block-value"]).toEqual(["persona=hello"]);
     expect(parsed.values["dev-backend"]).toBe("fake-headless");
+  });
+
+  test("recognizes backend mode flag in strict mode", () => {
+    const parsed = parseCliArgs(
+      preprocessCliArgs(["node", "script", "--backend", "local", "-p", "hi"]),
+      true,
+    );
+    expect(parsed.values.backend).toBe("local");
+  });
+
+  test("validates backend mode values", () => {
+    expect(parseBackendModeFlag(undefined)).toBeUndefined();
+    expect(parseBackendModeFlag("api")).toBe("api");
+    expect(parseBackendModeFlag("local")).toBe("local");
+    expect(() => parseBackendModeFlag("server")).toThrow(
+      'Invalid --backend value "server"',
+    );
+  });
+
+  test("extracts backend flag before routing subcommands", () => {
+    expect(
+      extractBackendFlag(["--backend", "local", "connect", "help"]),
+    ).toEqual({ backend: "local", args: ["connect", "help"] });
+    expect(extractBackendFlag(["connect", "help", "--backend=api"])).toEqual({
+      backend: "api",
+      args: ["connect", "help"],
+    });
+    expect(() => extractBackendFlag(["--backend"])).toThrow(
+      "Missing value for --backend",
+    );
   });
 
   test("rejects removed system-append flag in strict mode", () => {


### PR DESCRIPTION
## Summary
- Add `--backend api|local` as a first-class CLI flag so users can run the local backend without setting `LETTA_LOCAL_BACKEND_EXPERIMENTAL`.
- Configure backend mode before subcommand routing, so global forms like `letta --backend local connect ...` work without leaking `--backend` into subcommand parsers.
- Keep `LETTA_LOCAL_BACKEND_EXPERIMENTAL` as a fallback for compatibility, while making the explicit CLI flag take precedence.

## Test plan
- [x] `bun test src/tests/cli/args.test.ts src/tests/backend/api-backend.test.ts src/tests/backend/local-backend.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)