### PR TITLE
fix(local): Fix local ChatGPT OAuth requests

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -40,6 +40,11 @@ type AISDKUIMessageStreamFinish = {
   finishReason?: unknown;
 };
 
+export const CHATGPT_OAUTH_CODEX_INSTRUCTIONS = [
+  "You are Letta Code, an interactive CLI tool that helps users with software engineering tasks.",
+  "Use the instructions below and the tools available to you to assist the user.",
+].join("\n\n");
+
 export type AISDKStreamTextFunction = (options: {
   model: LanguageModel;
   system?: string;
@@ -200,6 +205,16 @@ function aiSDKProviderKind(
   return aiSDKProviderKindFromModel(modelHandle, modelSettings);
 }
 
+function isChatGPTOAuthModel(
+  modelHandle: string,
+  modelSettings: Record<string, unknown>,
+): boolean {
+  return (
+    modelHandle.startsWith("chatgpt-plus-pro/") ||
+    stringValue(modelSettings.provider_type) === "chatgpt_oauth"
+  );
+}
+
 function partProviderMetadata(
   part: unknown,
 ): Record<string, unknown> | undefined {
@@ -264,6 +279,7 @@ export function buildAISDKProviderOptions(
   const provider = aiSDKProviderKind(modelHandle, modelSettings);
 
   if (provider === "openai") {
+    const chatgptOAuth = isChatGPTOAuthModel(modelHandle, modelSettings);
     const reasoning = isRecord(modelSettings.reasoning)
       ? modelSettings.reasoning
       : undefined;
@@ -273,6 +289,9 @@ export function buildAISDKProviderOptions(
     const textVerbosity = openAITextVerbosity(modelSettings.verbosity);
     const parallelToolCalls = boolValue(modelSettings.parallel_tool_calls);
     const openai = {
+      ...(chatgptOAuth
+        ? { instructions: CHATGPT_OAUTH_CODEX_INSTRUCTIONS, store: false }
+        : {}),
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
       ...(textVerbosity !== undefined ? { textVerbosity } : {}),
       ...(parallelToolCalls !== undefined ? { parallelToolCalls } : {}),

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -40,11 +40,6 @@ type AISDKUIMessageStreamFinish = {
   finishReason?: unknown;
 };
 
-export const CHATGPT_OAUTH_CODEX_INSTRUCTIONS = [
-  "You are Letta Code, an interactive CLI tool that helps users with software engineering tasks.",
-  "Use the instructions below and the tools available to you to assist the user.",
-].join("\n\n");
-
 export type AISDKStreamTextFunction = (options: {
   model: LanguageModel;
   system?: string;
@@ -275,6 +270,7 @@ function sanitizeUIMessagesForProvider(
 export function buildAISDKProviderOptions(
   modelHandle: string,
   modelSettings: Record<string, unknown>,
+  options: { systemPrompt?: string } = {},
 ): AISDKProviderOptions | undefined {
   const provider = aiSDKProviderKind(modelHandle, modelSettings);
 
@@ -290,7 +286,11 @@ export function buildAISDKProviderOptions(
     const parallelToolCalls = boolValue(modelSettings.parallel_tool_calls);
     const openai = {
       ...(chatgptOAuth
-        ? { instructions: CHATGPT_OAUTH_CODEX_INSTRUCTIONS, store: false }
+        ? {
+            instructions: options.systemPrompt,
+            store: false,
+            systemMessageMode: "remove" as const,
+          }
         : {}),
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
       ...(textVerbosity !== undefined ? { textVerbosity } : {}),
@@ -412,12 +412,17 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
           input.agent.model_settings,
           { localProviderAuthStorageDir: this.localProviderAuthStorageDir },
         )(),
-      system: input.systemPrompt ?? input.agent.system,
+      system:
+        provider === "openai" &&
+        isChatGPTOAuthModel(input.agent.model, input.agent.model_settings)
+          ? undefined
+          : (input.systemPrompt ?? input.agent.system),
       messages: await convertToModelMessages(uiMessages, { tools }),
       tools,
       providerOptions: buildAISDKProviderOptions(
         input.agent.model,
         input.agent.model_settings,
+        { systemPrompt: input.systemPrompt ?? input.agent.system },
       ),
       maxRetries: 0,
       abortSignal: this.abortSignal,

--- a/src/backend/dev/ChatGPTOAuthModel.ts
+++ b/src/backend/dev/ChatGPTOAuthModel.ts
@@ -111,6 +111,8 @@ function createChatGPTFetch(options: {
 
     next.headers.delete("authorization");
     next.headers.set("authorization", `Bearer ${auth.access}`);
+    next.headers.set("OpenAI-Beta", "responses=v1");
+    next.headers.set("OpenAI-Originator", "codex");
     if (auth.accountId) {
       next.headers.set("ChatGPT-Account-Id", auth.accountId);
     }

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -4,6 +4,7 @@ import { Box } from "ink";
 import { useEffect, useState } from "react";
 import type { AgentProvenance } from "../../agent/create";
 import { getModelDisplayName } from "../../agent/model";
+import { isLocalBackendEnabled } from "../../backend";
 import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
@@ -26,7 +27,8 @@ function toTildePath(absolutePath: string): string {
  * Synchronously determine auth method from env vars (for initial render).
  * Returns null if we need to check keychain/settings asynchronously.
  */
-function getInitialAuthMethod(): "url" | "api-key" | null {
+function getInitialAuthMethod(): "local" | "url" | "api-key" | null {
+  if (isLocalBackendEnabled()) return "local";
   if (process.env.LETTA_BASE_URL) return "url";
   if (process.env.LETTA_API_KEY) return "api-key";
   return null; // Need async check for keychain/settings
@@ -35,7 +37,8 @@ function getInitialAuthMethod(): "url" | "api-key" | null {
 /**
  * Determine the auth method used (async for keychain access)
  */
-async function getAuthMethod(): Promise<"url" | "api-key" | "oauth"> {
+async function getAuthMethod(): Promise<"local" | "url" | "api-key" | "oauth"> {
+  if (isLocalBackendEnabled()) return "local";
   // Check if custom URL is being used
   if (process.env.LETTA_BASE_URL) {
     return "url";
@@ -96,9 +99,9 @@ export function WelcomeScreen({
 
   // Get auth method - use sync check for env vars, async only for keychain
   const initialAuth = getInitialAuthMethod();
-  const [authMethod, setAuthMethod] = useState<"url" | "api-key" | "oauth">(
-    initialAuth ?? "oauth",
-  );
+  const [authMethod, setAuthMethod] = useState<
+    "local" | "url" | "api-key" | "oauth"
+  >(initialAuth ?? "oauth");
 
   useEffect(() => {
     // Only run async check if env vars didn't determine auth method
@@ -107,11 +110,13 @@ export function WelcomeScreen({
     }
   }, [initialAuth]);
   const authDisplay =
-    authMethod === "url"
-      ? process.env.LETTA_BASE_URL || "Custom URL"
-      : authMethod === "api-key"
-        ? "API key auth"
-        : "OAuth";
+    authMethod === "local"
+      ? "Local"
+      : authMethod === "url"
+        ? process.env.LETTA_BASE_URL || "Custom URL"
+        : authMethod === "api-key"
+          ? "API key auth"
+          : "OAuth";
 
   // Check if memfs (context repositories) is enabled for this agent
   const memfsEnabled = agentState?.id

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -9,7 +9,6 @@ import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
   buildAISDKProviderOptions,
-  CHATGPT_OAUTH_CODEX_INSTRUCTIONS,
 } from "../../backend/dev/AISDKStreamAdapter";
 import type { LocalAgentRecord } from "../../backend/dev/FakeHeadlessStore";
 import type { HeadlessTurnBody } from "../../backend/dev/HeadlessTurnExecutor";
@@ -285,6 +284,57 @@ describe("AISDKStreamAdapter", () => {
     expect(capturedSystem).toBe("agent system prompt");
   });
 
+  test("sends ChatGPT OAuth system prompt as instructions, not system input", async () => {
+    const model = {} as LanguageModel;
+    let capturedSystem: string | undefined;
+    let capturedProviderOptions: unknown;
+    const streamText: AISDKStreamTextFunction = (options) => {
+      capturedSystem = options.system;
+      capturedProviderOptions = options.providerOptions;
+      return {
+        fullStream: (async function* () {
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => model,
+      streamText,
+    });
+
+    await collect(
+      adapter.stream(
+        providerInput(
+          [
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            },
+          ],
+          {
+            id: "agent-test",
+            name: "Test Agent",
+            description: null,
+            system: "compiled Letta system prompt",
+            tags: [],
+            model: "chatgpt-plus-pro/gpt-5.5",
+            model_settings: { provider_type: "chatgpt_oauth" },
+          },
+        ),
+      ),
+    );
+
+    expect(capturedSystem).toBeUndefined();
+    expect(capturedProviderOptions).toEqual({
+      openai: {
+        instructions: "compiled Letta system prompt",
+        store: false,
+        systemMessageMode: "remove",
+      },
+    });
+  });
+
   test("passes provider reasoning options from local model settings", async () => {
     const model = {} as LanguageModel;
     let capturedProviderOptions: unknown;
@@ -413,17 +463,22 @@ describe("AISDKStreamAdapter", () => {
     ).toBeUndefined();
   });
 
-  test("sets Codex instructions for ChatGPT OAuth models", () => {
+  test("moves the local system prompt to instructions for ChatGPT OAuth models", () => {
     expect(
-      buildAISDKProviderOptions("chatgpt-plus-pro/gpt-5.5", {
-        provider_type: "chatgpt_oauth",
-        reasoning_effort: "high",
-        verbosity: "low",
-      }),
+      buildAISDKProviderOptions(
+        "chatgpt-plus-pro/gpt-5.5",
+        {
+          provider_type: "chatgpt_oauth",
+          reasoning_effort: "high",
+          verbosity: "low",
+        },
+        { systemPrompt: "compiled Letta system prompt" },
+      ),
     ).toEqual({
       openai: {
-        instructions: CHATGPT_OAUTH_CODEX_INSTRUCTIONS,
+        instructions: "compiled Letta system prompt",
         store: false,
+        systemMessageMode: "remove",
         reasoningEffort: "high",
         textVerbosity: "low",
       },

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
   buildAISDKProviderOptions,
+  CHATGPT_OAUTH_CODEX_INSTRUCTIONS,
 } from "../../backend/dev/AISDKStreamAdapter";
 import type { LocalAgentRecord } from "../../backend/dev/FakeHeadlessStore";
 import type { HeadlessTurnBody } from "../../backend/dev/HeadlessTurnExecutor";
@@ -410,6 +411,23 @@ describe("AISDKStreamAdapter", () => {
         verbosity: "medium",
       }),
     ).toBeUndefined();
+  });
+
+  test("sets Codex instructions for ChatGPT OAuth models", () => {
+    expect(
+      buildAISDKProviderOptions("chatgpt-plus-pro/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+        reasoning_effort: "high",
+        verbosity: "low",
+      }),
+    ).toEqual({
+      openai: {
+        instructions: CHATGPT_OAUTH_CODEX_INSTRUCTIONS,
+        store: false,
+        reasoningEffort: "high",
+        textVerbosity: "low",
+      },
+    });
   });
 
   test("maps Claude 4.7 thinking to adaptive summarized output", () => {


### PR DESCRIPTION
## Summary
- Mirror the Letta core ChatGPT OAuth payload shape by moving the compiled local system prompt into the Responses API `instructions` field and removing it from the AI SDK system input for `chatgpt-plus-pro/*` requests.
- Keep `store: false`, set `systemMessageMode: "remove"`, and preserve reasoning/verbosity options for ChatGPT OAuth models.
- Add the ChatGPT backend headers used by Letta core (`OpenAI-Beta: responses=v1`, `OpenAI-Originator: codex`) and show local backend sessions as `Local` in the welcome header instead of `OAuth`.

## Test plan
- [x] `bun test src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/local-backend.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)