### PR TITLE
Add ci-failure-detector agent skill

### DIFF
--- a/.agents/skills/ci-failure-detector/SKILL.md
+++ b/.agents/skills/ci-failure-detector/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: ci-failure-detector
+description: The skill notifies us of non-flaky regressions in ci that we've missed
+---
+
+use this to notify tams of ci regressions, and ensure they are high signal regressions not just flaky one off failures or ephemeral provider outages


### PR DESCRIPTION
Adds a new agent skill at `.agents/skills/ci-failure-detector/SKILL.md`.