### PR TITLE
feat(telegram): improve channel response routing

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -7,6 +7,7 @@ import type {
   ToolReturn,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
+import type { ChannelTurnSource } from "../channels/types";
 import type { ApprovalRequest } from "../cli/helpers/stream";
 import { INTERRUPTED_BY_USER } from "../constants";
 import { getCurrentWorkingDirectory } from "../runtime-context";
@@ -201,6 +202,7 @@ async function executeSingleDecision(
     ) => void;
     toolContextId?: string;
     parentScope?: { agentId: string; conversationId: string };
+    channelTurnSources?: ChannelTurnSource[];
     onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<ApprovalResult> {
@@ -261,6 +263,7 @@ async function executeSingleDecision(
           toolCallId: decision.approval.toolCallId,
           toolContextId: options?.toolContextId,
           parentScope: options?.parentScope,
+          channelTurnSources: options?.channelTurnSources,
           onOutput: options?.onStreamingOutput
             ? (chunk, stream) =>
                 options.onStreamingOutput?.(
@@ -379,6 +382,7 @@ export async function executeApprovalBatch(
     toolContextId?: string;
     workingDirectory?: string;
     parentScope?: { agentId: string; conversationId: string };
+    channelTurnSources?: ChannelTurnSource[];
     onFileWrite?: (filePath: string, content: string) => void;
   },
 ): Promise<ApprovalResult[]> {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -575,12 +575,17 @@ export class ChannelRegistry {
     chatId: string,
     agentId: string,
     conversationId: string,
+    accountId?: string,
   ): ChannelRoute | null {
+    const normalizedAccountId = accountId?.trim();
     const matches = getRoutesForChannel(channel).filter(
       (route) =>
         route.chatId === chatId &&
         route.agentId === agentId &&
         route.conversationId === conversationId &&
+        (!normalizedAccountId ||
+          (route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID) ===
+            normalizedAccountId) &&
         route.enabled,
     );
 

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -601,6 +601,7 @@ export function createTelegramAdapter(
           );
         }
 
+        clearTypingForChat(msg.chatId);
         return { messageId: targetMessageId };
       }
 
@@ -733,6 +734,7 @@ export function createTelegramAdapter(
         formatChannelControlRequestPrompt(event),
         reply_parameters ? { reply_parameters } : {},
       );
+      clearTypingForChat(event.source.chatId);
     },
 
     onMessage: undefined,

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -10,6 +10,8 @@ import { formatChannelControlRequestPrompt } from "../interactive";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
   InboundChannelMessage,
   OutboundChannelMessage,
   TelegramChannelAccount,
@@ -191,6 +193,15 @@ function getTelegramChatType(chat: { type?: string }): "direct" | "channel" {
   return chat.type === "private" ? "direct" : "channel";
 }
 
+const TELEGRAM_TYPING_REFRESH_MS = 4_000;
+const TELEGRAM_TYPING_MAX_MS = 5 * 60 * 1000;
+
+type TelegramTypingEntry = {
+  sourceKeys: Set<string>;
+  timer: ReturnType<typeof setInterval>;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
 export function createTelegramAdapter(
   config: TelegramChannelAccount,
 ): ChannelAdapter {
@@ -198,6 +209,99 @@ export function createTelegramAdapter(
   let botModule: GrammYModule | null = null;
   let running = false;
   const bufferedMediaGroups = new Map<string, BufferedMediaGroup>();
+  const typingByChatId = new Map<string, TelegramTypingEntry>();
+
+  async function sendTypingAction(chatId: string): Promise<void> {
+    if (!running) return;
+    try {
+      const telegramBot = await ensureBot();
+      await telegramBot.api.sendChatAction(chatId, "typing");
+    } catch (error) {
+      console.warn(
+        `[Telegram] Failed to send typing action for chat ${chatId}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  function getTypingSourceKey(source: ChannelTurnSource): string | null {
+    const chatId = getTypingChatId(source);
+    if (!chatId) return null;
+    return [
+      source.accountId ?? "",
+      chatId,
+      source.threadId ?? "",
+      source.messageId ?? "",
+      source.agentId,
+      source.conversationId,
+    ].join(":");
+  }
+
+  function startTypingForSource(source: ChannelTurnSource): void {
+    const chatId = getTypingChatId(source);
+    const sourceKey = getTypingSourceKey(source);
+    if (!chatId || !sourceKey) return;
+
+    const existing = typingByChatId.get(chatId);
+    if (existing) {
+      existing.sourceKeys.add(sourceKey);
+      return;
+    }
+    void sendTypingAction(chatId);
+    const timer = setInterval(() => {
+      void sendTypingAction(chatId);
+    }, TELEGRAM_TYPING_REFRESH_MS);
+    const timeout = setTimeout(() => {
+      clearTypingForChat(chatId);
+    }, TELEGRAM_TYPING_MAX_MS);
+    if (typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref?: () => void }).unref?.();
+    }
+    if (typeof (timeout as { unref?: () => void }).unref === "function") {
+      (timeout as { unref?: () => void }).unref?.();
+    }
+    typingByChatId.set(chatId, {
+      sourceKeys: new Set([sourceKey]),
+      timer,
+      timeout,
+    });
+  }
+
+  function stopTypingForSource(source: ChannelTurnSource): void {
+    const chatId = getTypingChatId(source);
+    const sourceKey = getTypingSourceKey(source);
+    if (!chatId || !sourceKey) return;
+
+    const entry = typingByChatId.get(chatId);
+    if (!entry) return;
+    entry.sourceKeys.delete(sourceKey);
+    if (entry.sourceKeys.size === 0) {
+      clearTypingForChat(chatId);
+    }
+  }
+
+  function clearTypingForChat(chatId: string): void {
+    const entry = typingByChatId.get(chatId);
+    if (!entry) return;
+    clearInterval(entry.timer);
+    clearTimeout(entry.timeout);
+    typingByChatId.delete(chatId);
+  }
+
+  function clearAllTyping(): void {
+    for (const entry of typingByChatId.values()) {
+      clearInterval(entry.timer);
+      clearTimeout(entry.timeout);
+    }
+    typingByChatId.clear();
+  }
+
+  function getTypingChatId(source: ChannelTurnSource): string | null {
+    if (source.channel !== "telegram") return null;
+    const chatId = source.chatId;
+    if (typeof chatId !== "string" || chatId.length === 0) return null;
+    return chatId;
+  }
 
   async function ensureModule(): Promise<GrammYModule> {
     if (!botModule) {
@@ -453,6 +557,7 @@ export function createTelegramAdapter(
         clearTimeout(entry.timer);
       }
       bufferedMediaGroups.clear();
+      clearAllTyping();
 
       if (!running || !bot) return;
       await bot.stop();
@@ -549,6 +654,7 @@ export function createTelegramAdapter(
           }
         })();
 
+        clearTypingForChat(msg.chatId);
         return { messageId: String(result.message_id) };
       }
 
@@ -567,6 +673,7 @@ export function createTelegramAdapter(
         msg.text,
         opts,
       );
+      clearTypingForChat(msg.chatId);
       return { messageId: String(result.message_id) };
     },
 
@@ -586,6 +693,27 @@ export function createTelegramAdapter(
         text,
         reply_parameters ? { reply_parameters } : {},
       );
+    },
+
+    async handleTurnLifecycleEvent(
+      event: ChannelTurnLifecycleEvent,
+    ): Promise<void> {
+      if (!running) return;
+
+      if (event.type === "queued") {
+        return;
+      }
+
+      if (event.type === "processing") {
+        for (const source of event.sources) {
+          startTypingForSource(source);
+        }
+        return;
+      }
+
+      for (const source of event.sources) {
+        stopTypingForSource(source);
+      }
     },
 
     async handleControlRequestEvent(

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -212,6 +212,10 @@ export function buildChannelNotificationXml(
     `sender_id="${escapeXmlAttribute(msg.senderId)}"`,
   ];
 
+  if (msg.accountId) {
+    attrs.push(`account_id="${escapeXmlAttribute(msg.accountId)}"`);
+  }
+
   if (msg.senderName) {
     attrs.push(`sender_name="${escapeXmlAttribute(msg.senderName)}"`);
   }

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -317,6 +317,82 @@ describe("MessageChannel", () => {
     });
   });
 
+  test("infers accountId from channel turn source for duplicate Telegram chat routes", async () => {
+    const registry = new ChannelRegistry();
+
+    const oldSendMessage = mock(async () => ({ messageId: "old-msg" }));
+    const newSendMessage = mock(async () => ({ messageId: "new-msg" }));
+
+    const oldAdapter: ChannelAdapter = {
+      id: "telegram:old-account",
+      channelId: "telegram",
+      accountId: "old-account",
+      name: "Telegram Old",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: oldSendMessage,
+      sendDirectReply: async () => {},
+    };
+    const newAdapter: ChannelAdapter = {
+      id: "telegram:new-account",
+      channelId: "telegram",
+      accountId: "new-account",
+      name: "Telegram New",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: newSendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(oldAdapter);
+    registry.registerAdapter(newAdapter);
+
+    for (const accountId of ["old-account", "new-account"]) {
+      setRouteInMemory("telegram", {
+        accountId,
+        chatId: "7952253975",
+        agentId: "agent-1",
+        conversationId: "default",
+        enabled: true,
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      });
+    }
+
+    const result = await message_channel({
+      action: "send",
+      channel: "telegram",
+      chat_id: "7952253975",
+      message: "hello new bot",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+      channelTurnSources: [
+        {
+          channel: "telegram",
+          accountId: "new-account",
+          chatId: "7952253975",
+          agentId: "agent-1",
+          conversationId: "default",
+        },
+      ],
+    });
+
+    expect(result).toContain("Message sent to telegram");
+    expect(oldSendMessage).not.toHaveBeenCalled();
+    expect(newSendMessage).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "new-account",
+      chatId: "7952253975",
+      text: "hello new bot",
+      replyToMessageId: undefined,
+      parseMode: "HTML",
+    });
+  });
+
   test("uploads Telegram media through the routed account adapter", async () => {
     const registry = new ChannelRegistry();
 

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -893,3 +893,105 @@ test("telegram adapter ignores lifecycle events for non-telegram sources", async
 
   await adapter.stop();
 });
+
+test("telegram adapter clears typing after sending a reaction", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const turnSource = {
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "555",
+    chatType: "direct" as const,
+    messageId: "42",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [turnSource],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(1);
+
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "555",
+    text: "",
+    reaction: "👍",
+    targetMessageId: "42",
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-2",
+    sources: [turnSource],
+  });
+
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(2);
+
+  await adapter.stop();
+});
+
+test("telegram adapter clears typing after sending control request prompt", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const turnSource = {
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "555",
+    chatType: "direct" as const,
+    messageId: "42",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [turnSource],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(1);
+
+  await adapter.handleControlRequestEvent?.({
+    requestId: "req-1",
+    kind: "generic_tool_approval",
+    source: turnSource,
+    toolName: "Shell",
+    input: { command: "echo test" },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-2",
+    sources: [turnSource],
+  });
+
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(2);
+
+  await adapter.stop();
+});

--- a/src/tests/channels/telegram-adapter.test.ts
+++ b/src/tests/channels/telegram-adapter.test.ts
@@ -58,6 +58,7 @@ class FakeBot {
     sendAudio: mock(async () => ({ message_id: 1004 })),
     sendVoice: mock(async () => ({ message_id: 1005 })),
     sendAnimation: mock(async () => ({ message_id: 1006 })),
+    sendChatAction: mock(async () => true),
     getFile: mock(async (fileId: string) => FakeBot.nextGetFileImpl(fileId)),
   };
   catchHandler:
@@ -742,4 +743,153 @@ test("telegram adapter preserves photo mime type when Telegram download responds
     rmSync(channelRoot, { recursive: true, force: true });
     channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
   }
+});
+
+test("telegram adapter sends typing chat action while a turn is processing", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const turnSource = {
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "555",
+    chatType: "direct" as const,
+    messageId: "42",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: turnSource,
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendChatAction).not.toHaveBeenCalled();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [turnSource],
+  });
+
+  expect(bot?.api.sendChatAction).toHaveBeenCalledWith("555", "typing");
+  const initialCallCount = bot?.api.sendChatAction.mock.calls.length ?? 0;
+  expect(initialCallCount).toBeGreaterThanOrEqual(1);
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [turnSource],
+  });
+  expect(bot?.api.sendChatAction.mock.calls.length).toBe(initialCallCount);
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    sources: [turnSource],
+    outcome: "completed",
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-2",
+    sources: [turnSource],
+  });
+  expect(bot?.api.sendChatAction.mock.calls.length).toBe(initialCallCount + 1);
+
+  await adapter.stop();
+
+  const totalCallsAfterStop = bot?.api.sendChatAction.mock.calls.length ?? 0;
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(bot?.api.sendChatAction.mock.calls.length).toBe(totalCallsAfterStop);
+});
+
+test("telegram adapter stops refreshing typing after sending a message", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const turnSource = {
+    channel: "telegram",
+    accountId: "telegram-test-account",
+    chatId: "555",
+    chatType: "direct" as const,
+    messageId: "42",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [turnSource],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(1);
+
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "555",
+    text: "done",
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-2",
+    sources: [turnSource],
+  });
+
+  expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(2);
+
+  await adapter.stop();
+});
+
+test("telegram adapter ignores lifecycle events for non-telegram sources", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-account",
+      chatId: "C123",
+      messageId: "1",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendChatAction).not.toHaveBeenCalled();
+
+  await adapter.stop();
 });

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -68,6 +68,26 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain("Current local time on this device:");
   });
 
+  test("includes account id in notification xml without requiring it in reminder", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      accountId: "account-1",
+      chatId: "12345",
+      senderId: "67890",
+      text: "ping",
+      timestamp: Date.now(),
+    };
+
+    const reminder = buildChannelReminderText(msg);
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(reminder).toContain(
+      'Use action="send", channel="telegram", and chat_id="12345"',
+    );
+    expect(reminder).not.toContain('accountId="account-1"');
+    expect(xml).toContain('account_id="account-1"');
+  });
+
   test("mentions toolset-dependent local file/image inspection for attachment paths", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -23,6 +23,7 @@ import { resolveEligibleProactiveSlackAccount } from "../../channels/slack/proac
 import type {
   ChannelAdapter,
   ChannelRoute,
+  ChannelTurnSource,
   OutboundChannelMessage,
   SupportedChannelId,
 } from "../../channels/types";
@@ -484,6 +485,8 @@ interface MessageChannelArgs {
   title?: string;
   /** Injected by executeTool() — NOT read from global context. */
   parentScope?: { agentId: string; conversationId: string };
+  /** Injected by executeTool() for channel-originated turns. */
+  channelTurnSources?: ChannelTurnSource[];
 }
 
 interface NormalizedMessageChannelInput {
@@ -647,6 +650,40 @@ function buildSyntheticChannelRoute(params: {
   };
 }
 
+function inferAccountIdFromChannelTurnSources(params: {
+  input: NormalizedMessageChannelInput;
+  scope: { agentId: string; conversationId: string };
+  channelTurnSources?: ChannelTurnSource[];
+}): string | undefined {
+  const chatId = params.input.chatId;
+  if (!chatId) {
+    return undefined;
+  }
+
+  const accountIds = new Set<string>();
+  for (const source of params.channelTurnSources ?? []) {
+    if (
+      source.channel !== params.input.channel ||
+      source.chatId !== chatId ||
+      source.agentId !== params.scope.agentId ||
+      source.conversationId !== params.scope.conversationId
+    ) {
+      continue;
+    }
+    if (
+      params.input.threadId !== undefined &&
+      (source.threadId ?? null) !== (params.input.threadId ?? null)
+    ) {
+      continue;
+    }
+    if (source.accountId?.trim()) {
+      accountIds.add(source.accountId.trim());
+    }
+  }
+
+  return accountIds.size === 1 ? [...accountIds][0] : undefined;
+}
+
 async function resolveExplicitMessageChannelContext(params: {
   input: NormalizedMessageChannelInput;
   scope: { agentId: string; conversationId: string };
@@ -717,14 +754,24 @@ export async function message_channel(
   try {
     let executionContext: ResolvedMessageChannelExecutionContext | string;
     if (input.chatId) {
+      const resolvedAccountId =
+        input.accountId ??
+        inferAccountIdFromChannelTurnSources({
+          input,
+          scope,
+          channelTurnSources: args.channelTurnSources,
+        });
       const route: ChannelRoute | null = registry.getRouteForScope(
         input.channel,
         input.chatId,
         scope.agentId,
         scope.conversationId,
+        resolvedAccountId,
       );
       if (!route) {
-        return `Error: No route for chat_id "${input.chatId}" on "${input.channel}" for this agent/conversation.`;
+        return resolvedAccountId
+          ? `Error: No route for chat_id "${input.chatId}" on "${input.channel}" account "${resolvedAccountId}" for this agent/conversation.`
+          : `Error: No route for chat_id "${input.chatId}" on "${input.channel}" for this agent/conversation. If multiple channel accounts can receive this chat, pass accountId from the channel notification.`;
       }
 
       const adapter = registry.getAdapter(input.channel, route.accountId);

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -771,7 +771,7 @@ export async function message_channel(
       if (!route) {
         return resolvedAccountId
           ? `Error: No route for chat_id "${input.chatId}" on "${input.channel}" account "${resolvedAccountId}" for this agent/conversation.`
-          : `Error: No route for chat_id "${input.chatId}" on "${input.channel}" for this agent/conversation. If multiple channel accounts can receive this chat, pass accountId from the channel notification.`;
+          : `Error: No route for chat_id "${input.chatId}" on "${input.channel}" for this agent/conversation. If multiple channel accounts can receive this chat, pass accountId (from the channel notification's account_id) to disambiguate.`;
       }
 
       const adapter = registry.getAdapter(input.channel, route.accountId);

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -16,6 +16,7 @@ import {
   type MessageChannelToolDiscoveryScope,
 } from "../channels/messageTool";
 import { getActiveChannelIds } from "../channels/registry";
+import type { ChannelTurnSource } from "../channels/types";
 import { refreshFileIndex } from "../cli/helpers/fileIndex";
 import { INTERRUPTED_BY_USER } from "../constants";
 import {
@@ -1638,6 +1639,7 @@ export async function executeTool(
     onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
     toolContextId?: string;
     parentScope?: { agentId: string; conversationId: string };
+    channelTurnSources?: ChannelTurnSource[];
     /** Called after a file-mutating tool (Edit, Write, MultiEdit) writes to disk.
      *  The listener layer uses this to broadcast the new content via WebSocket. */
     onFileWrite?: (filePath: string, content: string) => void;
@@ -1775,8 +1777,16 @@ export async function executeTool(
       }
 
       // Inject parent scope for MessageChannel tool (per-execution, not global singleton)
-      if (internalName === "MessageChannel" && options?.parentScope) {
-        enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+      if (internalName === "MessageChannel") {
+        if (options?.parentScope) {
+          enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+        }
+        if (options?.channelTurnSources?.length) {
+          enhancedArgs = {
+            ...enhancedArgs,
+            channelTurnSources: options.channelTurnSources,
+          };
+        }
       }
 
       // Inject the execution context id for plan-mode tools so they can update

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -665,6 +665,7 @@ export async function resolveRecoveredApprovalResponse(
                 conversationId: recovered.conversationId,
               }
             : undefined,
+        channelTurnSources: runtime.activeChannelTurnSources ?? undefined,
       });
     } finally {
       emitToolExecutionOutput.flush();

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -510,6 +510,7 @@ export async function handleApprovalStop(params: {
       workingDirectory: turnWorkingDirectory,
       parentScope:
         agentId && conversationId ? { agentId, conversationId } : undefined,
+      channelTurnSources: runtime.activeChannelTurnSources ?? undefined,
       onFileWrite,
     });
   } finally {


### PR DESCRIPTION
## Summary
- add Telegram typing indicators that start when channel turns are processing and stop on first visible response / completion
- infer MessageChannel account scope from channel-originated turns so Telegram replies do not require manual accountId copying
- include inbound account_id metadata in channel notification XML for debugging
- add regression coverage for duplicate Telegram chat routes and typing lifecycle cleanup

## Validation
- bun test src/tests/channels/telegram-adapter.test.ts src/tests/channels/message-channel.test.ts src/tests/channels/xml.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/channels/telegram/adapter.ts src/tests/channels/telegram-adapter.test.ts
- bunx --bun tsc --noEmit
- bun run build

> "The model is ephemeral. The agent is not."

Written by Cameron ◯ Letta Code