### PR TITLE
feat(skills): support slash skill invocation

### DIFF
--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -8,6 +8,7 @@ import {
   discoverSkills,
   GLOBAL_SKILLS_DIR,
   getAgentSkillsDir,
+  isModelInvocableSkill,
   SKILLS_DIR,
   type Skill,
   type SkillDiscoveryError,
@@ -341,6 +342,96 @@ function getPrimaryProjectSkillsDirectory(): string {
   return join(process.cwd(), ".agents", "skills");
 }
 
+export interface DiscoverClientSideSkillsOptions {
+  agentId?: string;
+  skillsDirectory?: string | null;
+  skillSources?: SkillSource[];
+  discoverSkillsFn?: typeof discoverSkills;
+}
+
+/**
+ * Discover all client-side skills from the same roots used for `client_skills`.
+ * This intentionally returns both model-invocable and manual-only skills; callers
+ * decide whether to filter for model invocation or slash-command invocation.
+ */
+export async function discoverClientSideSkills(
+  options: DiscoverClientSideSkillsOptions = {},
+): Promise<SkillDiscoveryResult> {
+  const { legacySkillsDirectory, skillSources } =
+    resolveSkillDiscoveryContext(options);
+  const discoverSkillsFn = options.discoverSkillsFn ?? discoverSkills;
+  const primaryProjectSkillsDirectory = getPrimaryProjectSkillsDirectory();
+  const skillsById = new Map<string, Skill>();
+  const errors: SkillDiscoveryError[] = [];
+
+  const nonProjectSources = skillSources.filter(
+    (source): source is SkillSource => source !== "project",
+  );
+
+  const discoveryRuns: Array<{ path: string; sources: SkillSource[] }> = [];
+
+  if (nonProjectSources.length > 0) {
+    discoveryRuns.push({
+      path: primaryProjectSkillsDirectory,
+      sources: nonProjectSources,
+    });
+  }
+
+  const includeProjectSource = skillSources.includes("project");
+
+  if (
+    includeProjectSource &&
+    legacySkillsDirectory !== primaryProjectSkillsDirectory
+  ) {
+    discoveryRuns.push({
+      path: legacySkillsDirectory,
+      sources: ["project"],
+    });
+  }
+
+  if (includeProjectSource) {
+    discoveryRuns.push({
+      path: primaryProjectSkillsDirectory,
+      sources: ["project"],
+    });
+  }
+
+  for (const run of discoveryRuns) {
+    try {
+      const discovery = await discoverSkillsFn(run.path, options.agentId, {
+        sources: run.sources,
+      });
+      errors.push(...discovery.errors);
+      for (const skill of discovery.skills) {
+        skillsById.set(skill.id, skill);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Unknown error: ${String(error)}`;
+      errors.push({ path: run.path, message });
+    }
+  }
+
+  if (skillSources.length > 0) {
+    const memoryDiscovery = await discoverMemorySkills(options.agentId);
+    errors.push(...memoryDiscovery.errors);
+    for (const skill of memoryDiscovery.skills) {
+      const existing = skillsById.get(skill.id);
+      if (existing?.source === "project" || existing?.source === "agent") {
+        continue;
+      }
+      skillsById.set(skill.id, skill);
+    }
+  }
+
+  return {
+    skills: [...skillsById.values()].sort(compareSkills),
+    errors,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Core function (with cache)
 // ---------------------------------------------------------------------------
@@ -470,7 +561,9 @@ export async function buildClientSkillsPayload(
     }
   }
 
-  const sortedSkills = [...skillsById.values()].sort(compareSkills);
+  const sortedSkills = [...skillsById.values()]
+    .filter(isModelInvocableSkill)
+    .sort(compareSkills);
 
   if (errors.length > 0) {
     const summarizedErrors = errors.map(

--- a/src/agent/clientSkills.ts
+++ b/src/agent/clientSkills.ts
@@ -349,49 +349,49 @@ export interface DiscoverClientSideSkillsOptions {
   discoverSkillsFn?: typeof discoverSkills;
 }
 
-/**
- * Discover all client-side skills from the same roots used for `client_skills`.
- * This intentionally returns both model-invocable and manual-only skills; callers
- * decide whether to filter for model invocation or slash-command invocation.
- */
-export async function discoverClientSideSkills(
-  options: DiscoverClientSideSkillsOptions = {},
+interface CollectClientSideSkillsOptions
+  extends DiscoverClientSideSkillsOptions {
+  legacySkillsDirectory: string;
+  primaryProjectSkillsDirectory: string;
+}
+
+async function collectClientSideSkills(
+  options: CollectClientSideSkillsOptions,
 ): Promise<SkillDiscoveryResult> {
-  const { legacySkillsDirectory, skillSources } =
-    resolveSkillDiscoveryContext(options);
   const discoverSkillsFn = options.discoverSkillsFn ?? discoverSkills;
-  const primaryProjectSkillsDirectory = getPrimaryProjectSkillsDirectory();
   const skillsById = new Map<string, Skill>();
   const errors: SkillDiscoveryError[] = [];
 
-  const nonProjectSources = skillSources.filter(
-    (source): source is SkillSource => source !== "project",
-  );
+  const nonProjectSources =
+    options.skillSources?.filter(
+      (source): source is SkillSource => source !== "project",
+    ) ?? [];
 
   const discoveryRuns: Array<{ path: string; sources: SkillSource[] }> = [];
 
   if (nonProjectSources.length > 0) {
     discoveryRuns.push({
-      path: primaryProjectSkillsDirectory,
+      path: options.primaryProjectSkillsDirectory,
       sources: nonProjectSources,
     });
   }
 
-  const includeProjectSource = skillSources.includes("project");
+  const includeProjectSource =
+    options.skillSources?.includes("project") ?? false;
 
   if (
     includeProjectSource &&
-    legacySkillsDirectory !== primaryProjectSkillsDirectory
+    options.legacySkillsDirectory !== options.primaryProjectSkillsDirectory
   ) {
     discoveryRuns.push({
-      path: legacySkillsDirectory,
+      path: options.legacySkillsDirectory,
       sources: ["project"],
     });
   }
 
   if (includeProjectSource) {
     discoveryRuns.push({
-      path: primaryProjectSkillsDirectory,
+      path: options.primaryProjectSkillsDirectory,
       sources: ["project"],
     });
   }
@@ -414,7 +414,7 @@ export async function discoverClientSideSkills(
     }
   }
 
-  if (skillSources.length > 0) {
+  if ((options.skillSources?.length ?? 0) > 0) {
     const memoryDiscovery = await discoverMemorySkills(options.agentId);
     errors.push(...memoryDiscovery.errors);
     for (const skill of memoryDiscovery.skills) {
@@ -430,6 +430,24 @@ export async function discoverClientSideSkills(
     skills: [...skillsById.values()].sort(compareSkills),
     errors,
   };
+}
+
+/**
+ * Discover all client-side skills from the same roots used for `client_skills`.
+ * This intentionally returns both model-invocable and manual-only skills; callers
+ * decide whether to filter for model invocation or slash-command invocation.
+ */
+export async function discoverClientSideSkills(
+  options: DiscoverClientSideSkillsOptions = {},
+): Promise<SkillDiscoveryResult> {
+  const { legacySkillsDirectory, skillSources } =
+    resolveSkillDiscoveryContext(options);
+  return collectClientSideSkills({
+    ...options,
+    legacySkillsDirectory,
+    skillSources,
+    primaryProjectSkillsDirectory: getPrimaryProjectSkillsDirectory(),
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -486,84 +504,16 @@ export async function buildClientSkillsPayload(
     }
   }
 
-  const skillsById = new Map<string, Skill>();
-  const errors: SkillDiscoveryError[] = [];
+  const discovery = await collectClientSideSkills({
+    ...options,
+    legacySkillsDirectory,
+    skillSources,
+    primaryProjectSkillsDirectory,
+    discoverSkillsFn,
+  });
+  const errors = discovery.errors;
 
-  const nonProjectSources = skillSources.filter(
-    (source): source is SkillSource => source !== "project",
-  );
-
-  const discoveryRuns: Array<{ path: string; sources: SkillSource[] }> = [];
-
-  // For bundled/global/agent sources, use the primary project root.
-  if (nonProjectSources.length > 0) {
-    discoveryRuns.push({
-      path: primaryProjectSkillsDirectory,
-      sources: nonProjectSources,
-    });
-  }
-
-  const includeProjectSource = skillSources.includes("project");
-
-  // Legacy project location (.skills): discovered first so primary path can override.
-  if (
-    includeProjectSource &&
-    legacySkillsDirectory !== primaryProjectSkillsDirectory
-  ) {
-    discoveryRuns.push({
-      path: legacySkillsDirectory,
-      sources: ["project"],
-    });
-  }
-
-  // Primary location for project-scoped client skills.
-  if (includeProjectSource) {
-    discoveryRuns.push({
-      path: primaryProjectSkillsDirectory,
-      sources: ["project"],
-    });
-  }
-
-  for (const run of discoveryRuns) {
-    try {
-      const discovery = await discoverSkillsFn(run.path, options.agentId, {
-        sources: run.sources,
-      });
-      errors.push(...discovery.errors);
-      for (const skill of discovery.skills) {
-        skillsById.set(skill.id, skill);
-      }
-    } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : `Unknown error: ${String(error)}`;
-      errors.push({ path: run.path, message });
-    }
-  }
-
-  // MemFS skills are discovered by the Skill tool, so include them in
-  // client_skills as well. This keeps the model's available-skills list in
-  // sync with actual Skill(...) resolution in desktop/listen mode.
-  if (skillSources.length > 0) {
-    const memoryDiscovery = await discoverMemorySkills(options.agentId);
-    errors.push(...memoryDiscovery.errors);
-    for (const skill of memoryDiscovery.skills) {
-      const existing = skillsById.get(skill.id);
-
-      // Preserve higher-priority skills: project and agent-scoped.
-      // MemFS should override only global/bundled or fill missing ids.
-      if (existing?.source === "project" || existing?.source === "agent") {
-        continue;
-      }
-
-      skillsById.set(skill.id, skill);
-    }
-  }
-
-  const sortedSkills = [...skillsById.values()]
-    .filter(isModelInvocableSkill)
-    .sort(compareSkills);
+  const sortedSkills = discovery.skills.filter(isModelInvocableSkill);
 
   if (errors.length > 0) {
     const summarizedErrors = errors.map(

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -46,8 +46,18 @@ export interface Skill {
   id: string;
   /** Human-readable name of the skill */
   name: string;
-  /** Description of what the skill does */
+  /** Description of what the skill does and when to use it */
   description: string;
+  /** Optional additional trigger guidance from `when_to_use` frontmatter */
+  whenToUse?: string;
+  /** Hint shown in slash-command autocomplete */
+  argumentHint?: string;
+  /** Named positional arguments for skill content substitution */
+  arguments?: string[];
+  /** If true, hide from model auto-invocation / Skill tool listings */
+  disableModelInvocation?: boolean;
+  /** If false, hide from slash-command user invocation */
+  userInvocable?: boolean;
   /** Optional category for organizing skills */
   category?: string;
   /** Optional tags for filtering/searching skills */
@@ -91,6 +101,60 @@ export function compareSkills(a: Skill, b: Skill): number {
     a.source.localeCompare(b.source) ||
     a.path.localeCompare(b.path)
   );
+}
+
+function stripSurroundingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function getFrontmatterString(
+  frontmatter: Record<string, string | string[]>,
+  key: string,
+): string | undefined {
+  const value = frontmatter[key];
+  return typeof value === "string" ? stripSurroundingQuotes(value) : undefined;
+}
+
+export function getFrontmatterStringList(
+  frontmatter: Record<string, string | string[]>,
+  key: string,
+): string[] | undefined {
+  const value = frontmatter[key];
+  if (Array.isArray(value)) {
+    return value.map(stripSurroundingQuotes).filter((item) => item.length > 0);
+  }
+  if (typeof value === "string") {
+    return stripSurroundingQuotes(value)
+      .split(/\s+/)
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+  return undefined;
+}
+
+export function getFrontmatterBoolean(
+  frontmatter: Record<string, string | string[]>,
+  key: string,
+): boolean | undefined {
+  const value = getFrontmatterString(frontmatter, key)?.toLowerCase();
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+export function isModelInvocableSkill(skill: Skill): boolean {
+  return skill.disableModelInvocation !== true;
+}
+
+export function isUserInvocableSkill(skill: Skill): boolean {
+  return skill.userInvocable !== false;
 }
 
 /**
@@ -362,41 +426,33 @@ async function parseSkillFile(
       .replace(/\b\w/g, (l) => l.toUpperCase());
 
   // Description is required - either from frontmatter or first paragraph of content
-  let description =
-    typeof frontmatter.description === "string"
-      ? frontmatter.description
-      : null;
+  let description = getFrontmatterString(frontmatter, "description") ?? null;
   if (!description) {
     // Extract first paragraph from content as description
     const firstParagraph = body.trim().split("\n\n")[0];
     description = firstParagraph || "No description available";
   }
-
-  // Strip surrounding quotes from description if present
   description = description.trim();
-  if (
-    (description.startsWith('"') && description.endsWith('"')) ||
-    (description.startsWith("'") && description.endsWith("'"))
-  ) {
-    description = description.slice(1, -1);
-  }
+
+  const whenToUse = getFrontmatterString(frontmatter, "when_to_use")?.trim();
+  const modelDescription = whenToUse
+    ? `${description}\n\nWhen to use: ${whenToUse}`
+    : description;
 
   // Extract tags (handle both string and array)
-  let tags: string[] | undefined;
-  if (Array.isArray(frontmatter.tags)) {
-    tags = frontmatter.tags;
-  } else if (typeof frontmatter.tags === "string") {
-    tags = [frontmatter.tags];
-  }
+  const tags = getFrontmatterStringList(frontmatter, "tags");
 
   return {
     id,
     name,
-    description,
-    category:
-      typeof frontmatter.category === "string"
-        ? frontmatter.category
-        : undefined,
+    description: modelDescription,
+    whenToUse,
+    argumentHint: getFrontmatterString(frontmatter, "argument-hint"),
+    arguments: getFrontmatterStringList(frontmatter, "arguments"),
+    disableModelInvocation:
+      getFrontmatterBoolean(frontmatter, "disable-model-invocation") ?? false,
+    userInvocable: getFrontmatterBoolean(frontmatter, "user-invocable") ?? true,
+    category: getFrontmatterString(frontmatter, "category"),
     tags,
     path: filePath,
     source,
@@ -410,13 +466,14 @@ async function parseSkillFile(
  * Format: `- name (source): description` for each skill.
  */
 export function formatSkillsAsSystemReminder(skills: Skill[]): string {
-  if (skills.length === 0) {
-    return "";
-  }
-
-  const lines = [...skills]
+  const lines = skills
+    .filter(isModelInvocableSkill)
     .sort(compareSkills)
     .map((s) => `- ${s.id} (${s.source}): ${s.description}`);
+
+  if (lines.length === 0) {
+    return "";
+  }
 
   return `<system-reminder>
 The following skills are available for use with the Skill tool:

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -10933,10 +10933,73 @@ export default function App({
           : null;
         const result = await executeCommand(aliasedMsg);
 
-        // If command not found, fall through to send as regular message to agent
+        // If command not found, try user-invocable skills before falling through.
         if (result.notFound) {
           if (registryCmd) {
             registryCmd.fail(`Unknown command: ${registryCommandName}`);
+          }
+
+          const skillCommandName = registryCommandName.slice(1);
+          const { discoverClientSideSkills } = await import(
+            "../agent/clientSkills"
+          );
+          const { getSkillSources } = await import("../agent/context");
+          const { isUserInvocableSkill } = await import("../agent/skills");
+          const skillDiscovery = await discoverClientSideSkills({
+            agentId,
+            skillSources: getSkillSources(),
+          });
+          const matchedSkill = skillDiscovery.skills.find(
+            (skill) =>
+              skill.id === skillCommandName && isUserInvocableSkill(skill),
+          );
+
+          if (matchedSkill) {
+            const cmd = commandRunner.start(
+              trimmed,
+              `Running /${matchedSkill.id}...`,
+            );
+
+            const approvalCheck = await checkPendingApprovalsForSlashCommand();
+            if (approvalCheck.blocked) {
+              cmd.fail(
+                `Pending approval(s). Resolve approvals before running /${matchedSkill.id}.`,
+              );
+              return { submitted: false };
+            }
+
+            const args = trimmed.slice(`/${matchedSkill.id}`.length).trim();
+            setCommandRunning(true);
+            try {
+              const { loadRenderedSkillContent, wrapSkillContent } =
+                await import("../tools/impl/Skill");
+              const skillContent = await loadRenderedSkillContent(
+                matchedSkill.id,
+                {
+                  agentId,
+                  args,
+                  allowDisabledModelInvocation: true,
+                },
+              );
+              cmd.finish("Running skill...", true);
+              await processConversationWithQueuedApprovals([
+                {
+                  type: "message",
+                  role: "user",
+                  content: buildTextParts(
+                    wrapSkillContent(matchedSkill.id, skillContent),
+                  ),
+                  otid: randomUUID(),
+                },
+              ]);
+            } catch (error) {
+              const errorDetails = formatErrorDetails(error, agentId);
+              cmd.fail(`Failed to run skill: ${errorDetails}`);
+            } finally {
+              setCommandRunning(false);
+            }
+
+            return { submitted: true };
           }
           // Don't treat as command - continue to regular message handling below
         } else {

--- a/src/cli/components/SlashCommandAutocomplete.tsx
+++ b/src/cli/components/SlashCommandAutocomplete.tsx
@@ -61,6 +61,7 @@ export function SlashCommandAutocomplete({
 }: AutocompleteProps) {
   const columns = useTerminalWidth();
   const [customCommands, setCustomCommands] = useState<CommandMatch[]>([]);
+  const [skillCommands, setSkillCommands] = useState<CommandMatch[]>([]);
 
   // Load custom commands once on mount
   useEffect(() => {
@@ -76,6 +77,40 @@ export function SlashCommandAutocomplete({
       });
     });
   }, []);
+
+  // Load user-invocable skills for slash-command autocomplete.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { discoverClientSideSkills } = await import(
+          "../../agent/clientSkills"
+        );
+        const { getSkillSources } = await import("../../agent/context");
+        const { isUserInvocableSkill } = await import("../../agent/skills");
+        const discovery = await discoverClientSideSkills({
+          agentId,
+          skillSources: getSkillSources(),
+        });
+        if (cancelled) return;
+        const matches: CommandMatch[] = discovery.skills
+          .filter(isUserInvocableSkill)
+          .map((skill) => ({
+            cmd: `/${skill.id}`,
+            desc: `${skill.description}${skill.argumentHint ? ` ${skill.argumentHint}` : ""} (${skill.source} skill)`,
+            order: 300,
+          }));
+        setSkillCommands(matches);
+      } catch {
+        if (!cancelled) {
+          setSkillCommands([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
 
   // Check pin status to conditionally show/hide pin/unpin commands, merge with custom commands
   const allCommands = useMemo(() => {
@@ -109,11 +144,19 @@ export function SlashCommandAutocomplete({
       }
     }
 
+    const reservedCommands = new Set([
+      ...builtins.map((cmd) => cmd.cmd),
+      ...customCommands.map((cmd) => cmd.cmd),
+    ]);
+    const visibleSkillCommands = skillCommands.filter(
+      (cmd) => !reservedCommands.has(cmd.cmd),
+    );
+
     // Merge with custom commands and sort by order
-    return [...builtins, ...customCommands].sort(
+    return [...builtins, ...customCommands, ...visibleSkillCommands].sort(
       (a, b) => (a.order ?? 100) - (b.order ?? 100),
     );
-  }, [agentId, workingDirectory, customCommands]);
+  }, [agentId, workingDirectory, customCommands, skillCommands]);
 
   const queryInfo = useMemo(
     () => extractSearchQuery(currentInput, cursorPosition),

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -75,6 +75,78 @@ describe("buildClientSkillsPayload", () => {
     expect(result.errors).toEqual([]);
   });
 
+  test("discovers manual-only skills for user slash invocation", async () => {
+    const { discoverClientSideSkills } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+      skills: [
+        {
+          ...baseSkill,
+          id: "manual-only",
+          description: "manual",
+          path: "/tmp/manual/SKILL.md",
+          source: "project",
+          disableModelInvocation: true,
+        },
+      ],
+      errors: [],
+    });
+
+    const result = await discoverClientSideSkills({
+      skillsDirectory: "/tmp/.skills",
+      skillSources: ["project"],
+      discoverSkillsFn,
+    });
+
+    expect(result.skills.map((skill) => skill.id)).toEqual(["manual-only"]);
+  });
+
+  test("excludes skills marked disable-model-invocation from client_skills", async () => {
+    const { buildClientSkillsPayload } = await import(
+      "../../agent/clientSkills"
+    );
+
+    const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+      skills: [
+        {
+          ...baseSkill,
+          id: "manual-only",
+          description: "manual",
+          path: "/tmp/manual/SKILL.md",
+          source: "project",
+          disableModelInvocation: true,
+        },
+        {
+          ...baseSkill,
+          id: "auto-ok",
+          description: "auto",
+          path: "/tmp/auto/SKILL.md",
+          source: "project",
+        },
+      ],
+      errors: [],
+    });
+
+    const result = await buildClientSkillsPayload({
+      skillsDirectory: "/tmp/.skills",
+      skillSources: ["project"],
+      discoverSkillsFn,
+    });
+
+    expect(result.clientSkills).toEqual([
+      {
+        name: "auto-ok",
+        description: "auto",
+        location: "/tmp/auto/SKILL.md",
+      },
+    ]);
+    expect(result.skillPathById).toEqual({
+      "auto-ok": "/tmp/auto/SKILL.md",
+    });
+  });
+
   test("treats .agents/skills as primary and .skills as legacy fallback", async () => {
     const { buildClientSkillsPayload } = await import(
       "../../agent/clientSkills"

--- a/src/tests/agent/skills-discovery.test.ts
+++ b/src/tests/agent/skills-discovery.test.ts
@@ -128,3 +128,60 @@ describe.skipIf(process.platform === "win32")(
     });
   },
 );
+
+describe("skills frontmatter metadata", () => {
+  const testDir = join(process.cwd(), ".test-skills-frontmatter");
+  const projectSkillsDir = join(testDir, ".skills");
+  const originalCwd = process.cwd();
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("parses invocation controls and appends when_to_use to description", async () => {
+    const skillDir = join(projectSkillsDir, "deploy");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: Deploy",
+        "description: Deploy the application",
+        "when_to_use: When the user asks to ship a release",
+        "argument-hint: [environment]",
+        "arguments: environment version",
+        "disable-model-invocation: true",
+        "user-invocable: false",
+        "---",
+        "",
+        "Deploy $environment at $version.",
+      ].join("\n"),
+    );
+
+    const result = await discoverSkills(projectSkillsDir, undefined, {
+      skipBundled: true,
+      sources: ["project"],
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.skills).toHaveLength(1);
+    const skill = result.skills[0];
+    expect(skill?.id).toBe("deploy");
+    expect(skill?.description).toContain("Deploy the application");
+    expect(skill?.description).toContain(
+      "When to use: When the user asks to ship a release",
+    );
+    expect(skill?.argumentHint).toBe("[environment]");
+    expect(skill?.arguments).toEqual(["environment", "version"]);
+    expect(skill?.disableModelInvocation).toBe(true);
+    expect(skill?.userInvocable).toBe(false);
+  });
+});

--- a/src/tests/agent/skills-format.test.ts
+++ b/src/tests/agent/skills-format.test.ts
@@ -35,6 +35,46 @@ describe("Skills formatting (system reminder)", () => {
     expect(result).toBe("");
   });
 
+  test("hides skills marked disable-model-invocation", () => {
+    const skills: Skill[] = [
+      {
+        id: "deploy",
+        name: "Deploy",
+        description: "Deploy production",
+        path: "/test/.skills/deploy/SKILL.md",
+        source: "project",
+        disableModelInvocation: true,
+      },
+      {
+        id: "api-conventions",
+        name: "API Conventions",
+        description: "API conventions",
+        path: "/test/.skills/api-conventions/SKILL.md",
+        source: "project",
+      },
+    ];
+
+    const result = formatSkillsAsSystemReminder(skills);
+
+    expect(result).toContain("api-conventions");
+    expect(result).not.toContain("deploy");
+  });
+
+  test("returns empty string when all skills are hidden from model invocation", () => {
+    const result = formatSkillsAsSystemReminder([
+      {
+        id: "deploy",
+        name: "Deploy",
+        description: "Deploy production",
+        path: "/test/.skills/deploy/SKILL.md",
+        source: "project",
+        disableModelInvocation: true,
+      },
+    ]);
+
+    expect(result).toBe("");
+  });
+
   test("includes skills from multiple sources", () => {
     const skills: Skill[] = [
       {

--- a/src/tests/tools/skill-tool.test.ts
+++ b/src/tests/tools/skill-tool.test.ts
@@ -13,7 +13,9 @@ import {
 const TEST_AGENT_ID = "agent-skill-memfs-test";
 let currentSkillsDirectory: string | null = null;
 
-const { skill } = await import("../../tools/impl/Skill");
+const { renderSkillContent, skill, wrapSkillContent } = await import(
+  "../../tools/impl/Skill"
+);
 
 function withSkillContext<T>(fn: () => Promise<T>) {
   return runWithRuntimeContext(
@@ -277,6 +279,75 @@ describe("Skill tool memory filesystem lookup", () => {
     expect(queued[0]?.content).toContain(
       "Loaded from USER_CWD project skills.",
     );
+  });
+
+  test("renders skill arguments and skill directory substitutions", () => {
+    const rendered = renderSkillContent(
+      "deploy",
+      [
+        "---",
+        "name: deploy",
+        "description: deploy",
+        "arguments: environment version",
+        "---",
+        "",
+        "Deploy $environment at $version from $" +
+          "{CLAUDE_SKILL_DIR}; all=$ARGUMENTS first=$0 second=$ARGUMENTS[1].",
+      ].join("\n"),
+      join(tempRoot, "deploy", "SKILL.md"),
+      { args: "prod v1" },
+    );
+
+    expect(rendered).toContain("Deploy prod at v1");
+    expect(rendered).toContain("all=prod v1");
+    expect(rendered).toContain("first=prod");
+    expect(rendered).toContain("second=v1");
+    expect(rendered).toContain(join(tempRoot, "deploy"));
+  });
+
+  test("appends arguments when no placeholder is present", () => {
+    const rendered = renderSkillContent(
+      "review",
+      "---\nname: review\ndescription: review\n---\n\nReview the code.",
+      join(tempRoot, "review", "SKILL.md"),
+      { args: "src/index.ts" },
+    );
+
+    expect(rendered).toContain("Review the code.");
+    expect(rendered).toContain("ARGUMENTS: src/index.ts");
+  });
+
+  test("blocks model invocation for manual-only skills unless explicitly allowed", () => {
+    const content =
+      "---\nname: deploy\ndescription: deploy\ndisable-model-invocation: true\n---\n\nDeploy.";
+    expect(() =>
+      renderSkillContent(
+        "deploy",
+        content,
+        join(tempRoot, "deploy", "SKILL.md"),
+      ),
+    ).toThrow("disable-model-invocation");
+
+    expect(
+      renderSkillContent(
+        "deploy",
+        content,
+        join(tempRoot, "deploy", "SKILL.md"),
+        {
+          allowDisabledModelInvocation: true,
+        },
+      ),
+    ).toContain("Deploy.");
+  });
+
+  test("wraps slash-containing skill names in a safe XML envelope", () => {
+    const wrapped = wrapSkillContent(
+      "integrations/oauth/letta-oauth",
+      "Use OAuth.",
+    );
+
+    expect(wrapped).toContain('<skill name="integrations/oauth/letta-oauth">');
+    expect(wrapped).toContain("Use OAuth.");
   });
 
   test("executeTool forwards parentScope to Skill for listener-scoped memfs lookup", async () => {

--- a/src/tools/impl/Skill.ts
+++ b/src/tools/impl/Skill.ts
@@ -7,9 +7,12 @@ import {
   GLOBAL_SKILLS_DIR,
   getAgentSkillsDir,
   getBundledSkills,
+  getFrontmatterBoolean,
+  getFrontmatterStringList,
   SKILLS_DIR,
 } from "../../agent/skills";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
+import { parseFrontmatter } from "../../utils/frontmatter";
 import { queueSkillContent } from "./skillContentRegistry";
 import { validateRequiredParams } from "./validation.js";
 
@@ -74,7 +77,7 @@ function hasAdditionalFiles(skillMdPath: string): boolean {
  * 4. Global skills (~/.letta/skills/)
  * 5. Bundled skills
  */
-async function readSkillContent(
+export async function readSkillContent(
   skillId: string,
   skillsDir: string,
   agentId?: string,
@@ -151,7 +154,7 @@ async function readSkillContent(
 /**
  * Get skills directory, trying multiple sources
  */
-async function getResolvedSkillsDir(): Promise<string> {
+export async function getResolvedSkillsDir(): Promise<string> {
   const skillsDir = getSkillsDirectory();
 
   if (skillsDir) {
@@ -174,6 +177,128 @@ function getResolvedAgentId(args: SkillArgs): string | undefined {
   }
 }
 
+function splitSkillArguments(args: string): string[] {
+  const parts: string[] = [];
+  const pattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|\S+/g;
+  for (const match of args.matchAll(pattern)) {
+    const raw = match[1] ?? match[2] ?? match[0];
+    parts.push(raw.replace(/\\(["'\\])/g, "$1"));
+  }
+  return parts;
+}
+
+function substituteSkillArguments(
+  content: string,
+  args: string | undefined,
+  argumentNames: string[] | undefined,
+): string {
+  const rawArgs = args?.trim() ?? "";
+  if (!rawArgs) {
+    return content;
+  }
+
+  const argParts = splitSkillArguments(rawArgs);
+  let result = content;
+  let substituted = false;
+
+  result = result.replace(/\$ARGUMENTS\[(\d+)\]/g, (_match, index) => {
+    substituted = true;
+    return argParts[Number(index)] ?? "";
+  });
+
+  result = result.replace(/\$ARGUMENTS/g, () => {
+    substituted = true;
+    return rawArgs;
+  });
+
+  result = result.replace(/\$(\d+)\b/g, (_match, index) => {
+    substituted = true;
+    return argParts[Number(index)] ?? "";
+  });
+
+  for (const [index, name] of (argumentNames ?? []).entries()) {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const namePattern = new RegExp(`\\$${escapedName}\\b`, "g");
+    result = result.replace(namePattern, () => {
+      substituted = true;
+      return argParts[index] ?? "";
+    });
+  }
+
+  if (!substituted) {
+    result = `${result.trimEnd()}\n\nARGUMENTS: ${rawArgs}`;
+  }
+
+  return result;
+}
+
+export interface RenderSkillContentOptions {
+  args?: string;
+  allowDisabledModelInvocation?: boolean;
+}
+
+export function renderSkillContent(
+  skillName: string,
+  skillContent: string,
+  skillPath: string,
+  options: RenderSkillContentOptions = {},
+): string {
+  const { frontmatter } = parseFrontmatter(skillContent);
+  if (
+    !options.allowDisabledModelInvocation &&
+    getFrontmatterBoolean(frontmatter, "disable-model-invocation") === true
+  ) {
+    throw new Error(
+      `Skill "${skillName}" is marked disable-model-invocation and can only be invoked directly by the user.`,
+    );
+  }
+
+  const skillDir = dirname(skillPath);
+  const hasExtras = hasAdditionalFiles(skillPath);
+  const argumentNames = getFrontmatterStringList(frontmatter, "arguments");
+  const withSkillDir = skillContent
+    .replace(/<SKILL_DIR>/g, skillDir)
+    .replace(/\$\{CLAUDE_SKILL_DIR\}/g, skillDir);
+  const withArguments = substituteSkillArguments(
+    withSkillDir,
+    options.args,
+    argumentNames,
+  );
+  const dirHeader = hasExtras ? `# Skill Directory: ${skillDir}\n\n` : "";
+  return `${dirHeader}${withArguments}`;
+}
+
+export async function loadRenderedSkillContent(
+  skillName: string,
+  options: RenderSkillContentOptions & {
+    agentId?: string;
+    skillsDir?: string;
+  } = {},
+): Promise<string> {
+  const skillsDir = options.skillsDir ?? (await getResolvedSkillsDir());
+  const { content: skillContent, path: skillPath } = await readSkillContent(
+    skillName,
+    skillsDir,
+    options.agentId,
+  );
+  return renderSkillContent(skillName, skillContent, skillPath, options);
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function wrapSkillContent(skillName: string, content: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(skillName)) {
+    return `<${skillName}>\n${content}\n</${skillName}>`;
+  }
+  return `<skill name="${escapeXmlAttribute(skillName)}">\n${content}\n</skill>`;
+}
+
 export async function skill(args: SkillArgs): Promise<SkillResult> {
   validateRequiredParams(args, ["skill"], "Skill");
   const { skill: skillName, toolCallId } = args;
@@ -188,31 +313,16 @@ export async function skill(args: SkillArgs): Promise<SkillResult> {
     const agentId = getResolvedAgentId(args);
     const skillsDir = await getResolvedSkillsDir();
 
-    // Read the SKILL.md content
-    const { content: skillContent, path: skillPath } = await readSkillContent(
-      skillName,
-      skillsDir,
+    const fullContent = await loadRenderedSkillContent(skillName, {
       agentId,
-    );
-
-    // Process the content: replace <SKILL_DIR> placeholder if skill has additional files
-    const skillDir = dirname(skillPath);
-    const hasExtras = hasAdditionalFiles(skillPath);
-    const processedContent = hasExtras
-      ? skillContent.replace(/<SKILL_DIR>/g, skillDir)
-      : skillContent;
-
-    // Build the full content with skill directory info if applicable
-    const dirHeader = hasExtras ? `# Skill Directory: ${skillDir}\n\n` : "";
-    const fullContent = `${dirHeader}${processedContent}`;
+      skillsDir,
+      args: args.args,
+    });
 
     // Queue the skill content for harness-level injection as a user message part
     // Wrap in <skill-name> XML tags so the agent can detect already-loaded skills
     if (toolCallId) {
-      queueSkillContent(
-        toolCallId,
-        `<${skillName}>\n${fullContent}\n</${skillName}>`,
-      );
+      queueSkillContent(toolCallId, wrapSkillContent(skillName, fullContent));
     }
 
     return { message: `Launching skill: ${skillName}` };


### PR DESCRIPTION
## Summary
- Adds support for skill frontmatter invocation controls, including `disable-model-invocation`, `user-invocable`, `when_to_use`, `argument-hint`, and named `arguments`.
- Filters manual-only skills out of model-visible `client_skills` while preserving direct user invocation through `/{skill_name}`.
- Wires skill slash autocomplete and renders direct skill invocations with argument and skill-directory substitution.

## Test plan
- [x] `bun run check`
- [x] `env -u MEMORY_DIR -u LETTA_MEMORY_DIR -u AGENT_ID -u LETTA_AGENT_ID bun test src/tests/agent/skills-discovery.test.ts src/tests/agent/skills-format.test.ts src/tests/agent/clientSkills.test.ts src/tests/tools/skill-tool.test.ts`

👾 Generated with [Letta Code](https://letta.com)