### PR TITLE
fix(local): route commands through backend abstraction

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -163,9 +163,8 @@ export async function hydrateMemfsSettingFromAgent(
 export async function isMemfsEnabledOnServer(
   agentId: string,
 ): Promise<boolean> {
-  const { getClient } = await import("../backend/api/client");
-  const client = await getClient();
-  const agent = await client.agents.retrieve(agentId, {
+  const { getBackend } = await import("../backend");
+  const agent = await getBackend().retrieveAgent(agentId, {
     include: ["agent.tags"],
   });
   const { GIT_MEMORY_ENABLED_TAG } = await import("./memoryGit");

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -297,6 +297,12 @@ function getMemoryRemoteUrl(agentId: string): string {
  * (env var → settings → OAuth refresh).
  */
 async function getAuthToken(): Promise<string> {
+  const { getBackend } = await import("../backend");
+  const backend = getBackend();
+  if (backend.capabilities.localMemfs && !backend.capabilities.remoteMemfs) {
+    return "";
+  }
+
   const client = await getClient();
   // The client constructor resolves the token; extract it
   // biome-ignore lint/suspicious/noExplicitAny: accessing internal client options
@@ -807,9 +813,9 @@ async function unsetLocalGitConfig(dir: string, key: string): Promise<void> {
 async function fetchAgentDisplayName(agentId: string): Promise<string | null> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    const client = await getClient();
+    const { getBackend } = await import("../backend");
     const agent = await Promise.race([
-      client.agents.retrieve(agentId),
+      getBackend().retrieveAgent(agentId),
       new Promise<null>((resolve) => {
         timeout = setTimeout(
           () => resolve(null),
@@ -1830,12 +1836,13 @@ export async function addGitMemoryTag(
   agentId: string,
   prefetchedAgent?: { tags?: string[] | null },
 ): Promise<void> {
-  const client = await getClient();
   try {
-    const agent = prefetchedAgent ?? (await client.agents.retrieve(agentId));
+    const { getBackend } = await import("../backend");
+    const backend = getBackend();
+    const agent = prefetchedAgent ?? (await backend.retrieveAgent(agentId));
     const tags = agent.tags || [];
     if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
-      await client.agents.update(agentId, {
+      await backend.updateAgent(agentId, {
         tags: [...tags, GIT_MEMORY_ENABLED_TAG],
       });
       debugLog("memfs-git", `Added ${GIT_MEMORY_ENABLED_TAG} tag`);
@@ -1852,12 +1859,13 @@ export async function addGitMemoryTag(
  * Remove the git-memory-enabled tag from an agent.
  */
 export async function removeGitMemoryTag(agentId: string): Promise<void> {
-  const client = await getClient();
   try {
-    const agent = await client.agents.retrieve(agentId);
+    const { getBackend } = await import("../backend");
+    const backend = getBackend();
+    const agent = await backend.retrieveAgent(agentId);
     const tags = agent.tags || [];
     if (tags.includes(GIT_MEMORY_ENABLED_TAG)) {
-      await client.agents.update(agentId, {
+      await backend.updateAgent(agentId, {
         tags: tags.filter((t) => t !== GIT_MEMORY_ENABLED_TAG),
       });
       debugLog("memfs-git", `Removed ${GIT_MEMORY_ENABLED_TAG} tag`);

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
 import { getBillingTier } from "../../backend/api/metadata";
 import { buildChatUrl } from "../../cli/helpers/appUrls";
 import {
@@ -103,8 +103,7 @@ async function getPrimaryAgentModelHandle(): Promise<{
 }> {
   try {
     const agentId = getCurrentAgentId();
-    const client = await getClient();
-    const agent = await client.agents.retrieve(agentId);
+    const agent = await getBackend().retrieveAgent(agentId);
     return { handle: getModelHandleFromAgent(agent), agent };
   } catch {
     return { handle: null, agent: null };
@@ -1257,7 +1256,7 @@ export async function spawnSubagent(
     try {
       const cachedParent =
         parentAgent ??
-        (await (await getClient()).agents.retrieve(resolvedParentAgentId));
+        (await getBackend().retrieveAgent(resolvedParentAgentId));
       if (forkedContext) {
         const systemReminder = buildForkSystemReminder(type);
         finalPrompt = systemReminder + prompt;

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -9636,11 +9636,10 @@ export default function App({
           setCommandRunning(true);
 
           try {
-            const agent = await getBackend().updateAgent(agentId, {
+            await getBackend().updateAgent(agentId, {
               name: newValue,
             });
             updateAgentName(newValue);
-            setAgentState(agent);
 
             cmd.agentHint = `Your name is now "${newValue}" — acknowledge this and save your new name to memory.`;
             cmd.finish(`Agent renamed to "${newValue}"`, true);
@@ -9686,11 +9685,13 @@ export default function App({
           setCommandRunning(true);
 
           try {
-            const agent = await getBackend().updateAgent(agentId, {
+            await getBackend().updateAgent(agentId, {
               description: newDescription,
             });
-            setAgentState(agent);
-            setAgentDescription(agent.description ?? null);
+            setAgentState((prev) =>
+              prev ? { ...prev, description: newDescription } : prev,
+            );
+            setAgentDescription(newDescription);
 
             cmd.finish(`Description updated to "${newDescription}"`, true);
           } catch (error) {
@@ -12943,19 +12944,24 @@ ${SYSTEM_REMINDER_CLOSE}
           // letta/auto so compaction uses a consistent summarization model.
           const existing = agentState?.compaction_settings;
           const existingModel = existing?.model?.trim();
+          const nextCompactionSettings = {
+            ...existing,
+            model: existingModel || DEFAULT_SUMMARIZATION_MODEL,
+            mode: mode as
+              | "all"
+              | "sliding_window"
+              | "self_compact_all"
+              | "self_compact_sliding_window",
+          };
 
-          const agent = await getBackend().updateAgent(agentId, {
-            compaction_settings: {
-              ...existing,
-              model: existingModel || DEFAULT_SUMMARIZATION_MODEL,
-              mode: mode as
-                | "all"
-                | "sliding_window"
-                | "self_compact_all"
-                | "self_compact_sliding_window",
-            },
+          await getBackend().updateAgent(agentId, {
+            compaction_settings: nextCompactionSettings,
           });
-          setAgentState(agent);
+          setAgentState((prev) =>
+            prev
+              ? { ...prev, compaction_settings: nextCompactionSettings }
+              : prev,
+          );
 
           cmd.finish(`Updated compaction mode to: ${mode}`, true);
         } catch (error) {
@@ -15604,11 +15610,10 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                   try {
                     // Rename if new name provided
                     if (newName && newName !== agentName) {
-                      const agent = await getBackend().updateAgent(agentId, {
+                      await getBackend().updateAgent(agentId, {
                         name: newName,
                       });
                       updateAgentName(newName);
-                      setAgentState(agent);
                     }
 
                     // Pin the agent

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -47,7 +47,7 @@ import {
   shouldRetryRunMetadataError,
 } from "../agent/approval-recovery";
 import { prefetchAvailableModelHandles } from "../agent/available-models";
-import { getResumeData } from "../agent/check-approval";
+import { getResumeDataFromBackend } from "../agent/check-approval";
 import { getCurrentAgentId, setCurrentAgentId } from "../agent/context";
 import { type AgentProvenance, createAgent } from "../agent/create";
 import { selectDefaultAgentModel } from "../agent/defaults";
@@ -84,7 +84,6 @@ import { SessionStats } from "../agent/stats";
 import { type ConversationMessageStreamBody, getBackend } from "../backend";
 import { getAgentContextOverview } from "../backend/api/agents";
 import { getClient, getServerUrl } from "../backend/api/client";
-import { forkConversation } from "../backend/api/conversations";
 import {
   getBalanceMetadata,
   getBillingTier,
@@ -3736,13 +3735,12 @@ export default function App({
       }
 
       try {
-        const client = await getClient();
         debugLog(
           "conversations",
           `retrieve(${conversationId}) [syncConversationModel]`,
         );
         const conversation =
-          await client.conversations.retrieve(conversationId);
+          await getBackend().retrieveConversation(conversationId);
         if (cancelled) return;
 
         const conversationModel = (conversation as { model?: string | null })
@@ -4509,10 +4507,14 @@ export default function App({
             ) {
               llmApiErrorRetriesRef.current += 1;
               try {
-                const client = await getClient();
-                const agent = await client.agents.retrieve(agentIdRef.current);
+                const agent = await getBackend().retrieveAgent(
+                  agentIdRef.current,
+                );
                 const { pendingApprovals: existingApprovals } =
-                  await getResumeData(client, agent, conversationIdRef.current);
+                  await getResumeDataFromBackend(
+                    agent,
+                    conversationIdRef.current,
+                  );
                 currentInput = rebuildInputWithFreshDenials(
                   currentInput,
                   existingApprovals ?? [],
@@ -4795,13 +4797,11 @@ export default function App({
               // We need to fetch the actual pending approvals and show them to the user.
               if (isInvalidToolCallIdsError(errorDetail)) {
                 try {
-                  const client = await getClient();
-                  const agent = await client.agents.retrieve(
+                  const agent = await getBackend().retrieveAgent(
                     agentIdRef.current,
                   );
                   const { pendingApprovals: serverApprovals } =
-                    await getResumeData(
-                      client,
+                    await getResumeDataFromBackend(
                       agent,
                       conversationIdRef.current,
                     );
@@ -4904,7 +4904,7 @@ export default function App({
               // (avoids a redundant agents.retrieve per turn).
               const agent =
                 prefetchedAgent ??
-                (await (await getClient()).agents.retrieve(agentIdRef.current));
+                (await getBackend().retrieveAgent(agentIdRef.current));
 
               // Keep model UI in sync with the agent configuration.
               // Note: many tiers share the same handle (e.g. gpt-5.2-none/high), so we
@@ -5210,9 +5210,8 @@ export default function App({
               if (!conversationTitle) {
                 isAutoConversationTitleInFlightRef.current = false;
               } else {
-                const client = await getClient();
-                void client.conversations
-                  .update(conversationIdRef.current, {
+                void getBackend()
+                  .updateConversation(conversationIdRef.current, {
                     summary: conversationTitle,
                   })
                   .then(() => {
@@ -5865,13 +5864,14 @@ export default function App({
 
           if (hasApprovalInPayload && invalidIdsDetected) {
             try {
-              const client = await getClient();
-              const agent = await client.agents.retrieve(agentIdRef.current);
-              const { pendingApprovals: serverApprovals } = await getResumeData(
-                client,
-                agent,
-                conversationIdRef.current,
+              const agent = await getBackend().retrieveAgent(
+                agentIdRef.current,
               );
+              const { pendingApprovals: serverApprovals } =
+                await getResumeDataFromBackend(
+                  agent,
+                  conversationIdRef.current,
+                );
 
               if (serverApprovals && serverApprovals.length > 0) {
                 // Preserve user message from current input (if any)
@@ -5965,10 +5965,14 @@ export default function App({
 
             try {
               // Fetch pending approvals and auto-deny them
-              const client = await getClient();
-              const agent = await client.agents.retrieve(agentIdRef.current);
+              const agent = await getBackend().retrieveAgent(
+                agentIdRef.current,
+              );
               const { pendingApprovals: existingApprovals } =
-                await getResumeData(client, agent, conversationIdRef.current);
+                await getResumeDataFromBackend(
+                  agent,
+                  conversationIdRef.current,
+                );
               currentInput = rebuildInputWithFreshDenials(
                 currentInput,
                 existingApprovals ?? [],
@@ -7037,9 +7041,12 @@ export default function App({
         const isDefault = conversationIdRef.current === "default";
 
         // Fork the conversation
-        const forked = await forkConversation(conversationIdRef.current, {
-          ...(isDefault ? { agentId } : {}),
-        });
+        const forked = await getBackend().forkConversation(
+          conversationIdRef.current,
+          {
+            ...(isDefault ? { agentId } : {}),
+          },
+        );
 
         debugLog("btw", "forked conversationId=%s", forked.id);
         setBtwState((prev) => ({
@@ -7100,7 +7107,6 @@ export default function App({
             ) {
               approvalRecoveryRetries += 1;
               try {
-                const client = await getClient();
                 const currentAgentId = agentIdRef.current ?? agentId;
                 if (!currentAgentId) {
                   currentInput = rebuildInputWithFreshDenials(
@@ -7111,9 +7117,9 @@ export default function App({
                   continue;
                 }
 
-                const agent = await client.agents.retrieve(currentAgentId);
+                const agent = await getBackend().retrieveAgent(currentAgentId);
                 const { pendingApprovals: existingApprovals } =
-                  await getResumeData(client, agent, forked.id);
+                  await getResumeDataFromBackend(agent, forked.id);
                 currentInput = rebuildInputWithFreshDenials(
                   currentInput,
                   existingApprovals ?? [],
@@ -7197,9 +7203,7 @@ export default function App({
           throw new Error("Agent state not available");
         }
 
-        const client = await getClient();
-        const resumeData = await getResumeData(
-          client,
+        const resumeData = await getResumeDataFromBackend(
           agentState,
           conversationId,
         );
@@ -7362,9 +7366,8 @@ export default function App({
       cmd.update({ output: "Switching agent...", phase: "running" });
 
       try {
-        const client = await getClient();
         // Fetch new agent
-        const agent = await client.agents.retrieve(targetAgentId);
+        const agent = await getBackend().retrieveAgent(targetAgentId);
 
         // Use specified conversation or default to the agent's default conversation
         const targetConversationId = opts?.conversationId ?? "default";
@@ -7494,8 +7497,7 @@ export default function App({
         const isSelfHosted = !getServerUrl().includes("api.letta.com");
         if (isSelfHosted) {
           try {
-            const client = await getClient();
-            const availableHandles = (await client.models.list())
+            const availableHandles = (await backend.listModels())
               .map((model) => model.handle)
               .filter((handle): handle is string => typeof handle === "string");
             effectiveModel = selectDefaultAgentModel({
@@ -7798,13 +7800,9 @@ export default function App({
     }
 
     try {
-      const client = await getClient();
-      const agent = await client.agents.retrieve(agentId);
-      const { pendingApprovals: existingApprovals } = await getResumeData(
-        client,
-        agent,
-        conversationIdRef.current,
-      );
+      const agent = await getBackend().retrieveAgent(agentId);
+      const { pendingApprovals: existingApprovals } =
+        await getResumeDataFromBackend(agent, conversationIdRef.current);
 
       if (!existingApprovals || existingApprovals.length === 0) {
         setNeedsEagerApprovalCheck(false);
@@ -8302,6 +8300,17 @@ export default function App({
           const afterMcp = msg.trim().slice(4).trim(); // Remove "/mcp" prefix
           const firstWord = afterMcp.split(/\s+/)[0]?.toLowerCase();
 
+          if (
+            firstWord !== "help" &&
+            !getBackend().capabilities.serverSideToolManagement
+          ) {
+            const cmd = commandRunner.start(msg, "Checking MCP support...");
+            cmd.fail(
+              "MCP server management is not supported by the local backend yet.",
+            );
+            return { submitted: true };
+          }
+
           // /mcp - open MCP server selector
           if (!firstWord) {
             startOverlayCommand(
@@ -8470,6 +8479,13 @@ export default function App({
           }
 
           const cmd = commandRunner.start(msg, "Starting listener...");
+          if (!getBackend().capabilities.remoteMemfs) {
+            cmd.fail(
+              "Remote listener mode is not supported by the local backend.",
+            );
+            return { submitted: true };
+          }
+
           const { handleListen, setActiveCommandId: setActiveListenCommandId } =
             await import("./commands/listen");
           setActiveListenCommandId(cmd.id);
@@ -9140,10 +9156,10 @@ export default function App({
           await runEndHooks();
 
           try {
-            const client = await getClient();
+            const backend = getBackend();
 
             // Create a new conversation for the current agent
-            const conversation = await client.conversations.create({
+            const conversation = await backend.createConversation({
               agent_id: agentId,
               isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
               ...(conversationName && { summary: conversationName }),
@@ -9218,17 +9234,19 @@ export default function App({
           await runEndHooks();
 
           try {
-            const client = await getClient();
-
             // For default conversation, pass agent_id
             const isDefault = conversationIdRef.current === "default";
-            const forked = await forkConversation(conversationIdRef.current, {
-              ...(isDefault ? { agentId } : {}),
-            });
+            const backend = getBackend();
+            const forked = await backend.forkConversation(
+              conversationIdRef.current,
+              {
+                ...(isDefault ? { agentId } : {}),
+              },
+            );
 
             // If we forked with an explicit summary, update it
             if (conversationSummary) {
-              await client.conversations.update(forked.id, {
+              await backend.updateConversation(forked.id, {
                 summary: conversationSummary,
               });
             }
@@ -9312,19 +9330,24 @@ export default function App({
           await runEndHooks();
 
           try {
-            const client = await getClient();
+            const backend = getBackend();
 
-            // Reset all messages on the agent only when in the default conversation.
+            // Reset all messages on the agent only when in the default API conversation.
+            // Local/headless backends model /clear by switching to a fresh conversation.
             // For named conversations, clearing just means starting a new conversation —
             // there is no reason to wipe the agent's entire message history.
-            if (conversationIdRef.current === "default") {
+            if (
+              conversationIdRef.current === "default" &&
+              !backend.capabilities.localModelCatalog
+            ) {
+              const client = await getClient();
               await client.agents.messages.reset(agentId, {
                 add_default_initial_messages: false,
               });
             }
 
             // Create a new conversation
-            const conversation = await client.conversations.create({
+            const conversation = await backend.createConversation({
               agent_id: agentId,
               isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
             });
@@ -9565,7 +9588,7 @@ export default function App({
             setCommandRunning(true);
 
             try {
-              const client = await getClient();
+              const backend = getBackend();
               if (shouldAutoGenerate) {
                 const conversationTitle = await generateConversationTitle();
                 if (!conversationTitle) {
@@ -9574,7 +9597,7 @@ export default function App({
                   );
                   return { submitted: true };
                 }
-                await client.conversations.update(conversationId, {
+                await backend.updateConversation(conversationId, {
                   summary: conversationTitle,
                 });
                 setConversationAutoTitleEligibility(false);
@@ -9583,7 +9606,7 @@ export default function App({
                   true,
                 );
               } else {
-                await client.conversations.update(conversationId, {
+                await backend.updateConversation(conversationId, {
                   summary: newValue,
                 });
                 setConversationAutoTitleEligibility(false);
@@ -9613,9 +9636,11 @@ export default function App({
           setCommandRunning(true);
 
           try {
-            const client = await getClient();
-            await client.agents.update(agentId, { name: newValue });
+            const agent = await getBackend().updateAgent(agentId, {
+              name: newValue,
+            });
             updateAgentName(newValue);
+            setAgentState(agent);
 
             cmd.agentHint = `Your name is now "${newValue}" — acknowledge this and save your new name to memory.`;
             cmd.finish(`Agent renamed to "${newValue}"`, true);
@@ -9661,10 +9686,11 @@ export default function App({
           setCommandRunning(true);
 
           try {
-            const client = await getClient();
-            await client.agents.update(agentId, {
+            const agent = await getBackend().updateAgent(agentId, {
               description: newDescription,
             });
+            setAgentState(agent);
+            setAgentDescription(agent.description ?? null);
 
             cmd.finish(`Description updated to "${newDescription}"`, true);
           } catch (error) {
@@ -9735,9 +9761,7 @@ export default function App({
               // Validate conversation exists BEFORE updating state
               // (getResumeData throws 404/422 for non-existent conversations)
               if (agentState) {
-                const client = await getClient();
-                const resumeData = await getResumeData(
-                  client,
+                const resumeData = await getResumeDataFromBackend(
                   agentState,
                   targetConvId,
                 );
@@ -10124,6 +10148,13 @@ export default function App({
             msg.trim(),
             "Exporting agent file...",
           );
+
+          if (!getBackend().capabilities.agentFileImportExport) {
+            cmd.fail(
+              "AgentFile export is not supported by the local backend yet.",
+            );
+            return { submitted: true };
+          }
 
           setCommandRunning(true);
 
@@ -10625,8 +10656,7 @@ export default function App({
             // the core behavioural instructions (filtered to strip dynamic content).
             let systemPrompt: string | undefined;
             try {
-              const client = await getClient();
-              const agent = await client.agents.retrieve(agentId);
+              const agent = await getBackend().retrieveAgent(agentId);
               systemPrompt = agent.system ?? undefined;
             } catch {
               // Non-fatal — the reflection payload will just omit the system prompt.
@@ -11123,8 +11153,7 @@ ${SYSTEM_REMINDER_CLOSE}
           // the core behavioural instructions (filtered to strip dynamic content).
           let systemPrompt: string | undefined;
           try {
-            const client = await getClient();
-            const agent = await client.agents.retrieve(agentId);
+            const agent = await getBackend().retrieveAgent(agentId);
             systemPrompt = agent.system ?? undefined;
           } catch {
             // Non-fatal — the reflection payload will just omit the system prompt.
@@ -11327,14 +11356,10 @@ ${SYSTEM_REMINDER_CLOSE}
         refreshDerived();
 
         try {
-          const client = await getClient();
           // Fetch fresh agent state to check for pending approvals with accurate in-context messages
-          const agent = await client.agents.retrieve(agentId);
-          const { pendingApprovals: existingApprovals } = await getResumeData(
-            client,
-            agent,
-            conversationIdRef.current,
-          );
+          const agent = await getBackend().retrieveAgent(agentId);
+          const { pendingApprovals: existingApprovals } =
+            await getResumeDataFromBackend(agent, conversationIdRef.current);
 
           // Remove eager check status
           buffersRef.current.byId.delete(eagerStatusId);
@@ -12913,14 +12938,13 @@ ${SYSTEM_REMINDER_CLOSE}
         });
 
         try {
-          const client = await getClient();
           // Spread existing compaction_settings to preserve model/other fields,
           // only override the mode. If no model is configured, default to
           // letta/auto so compaction uses a consistent summarization model.
           const existing = agentState?.compaction_settings;
           const existingModel = existing?.model?.trim();
 
-          await client.agents.update(agentId, {
+          const agent = await getBackend().updateAgent(agentId, {
             compaction_settings: {
               ...existing,
               model: existingModel || DEFAULT_SUMMARIZATION_MODEL,
@@ -12931,6 +12955,7 @@ ${SYSTEM_REMINDER_CLOSE}
                 | "self_compact_sliding_window",
             },
           });
+          setAgentState(agent);
 
           cmd.finish(`Updated compaction mode to: ${mode}`, true);
         } catch (error) {
@@ -13169,10 +13194,8 @@ ${SYSTEM_REMINDER_CLOSE}
             if (action.conversationId === conversationId) {
               cmd.finish("Already on this conversation", true);
             } else {
-              const client = await getClient();
               if (agentState) {
-                const resumeData = await getResumeData(
-                  client,
+                const resumeData = await getResumeDataFromBackend(
                   agentState,
                   action.conversationId,
                 );
@@ -15083,9 +15106,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                     // Validate conversation exists BEFORE updating state
                     // (getResumeData throws 404/422 for non-existent conversations)
                     if (agentState) {
-                      const client = await getClient();
-                      const resumeData = await getResumeData(
-                        client,
+                      const resumeData = await getResumeDataFromBackend(
                         agentState,
                         convId,
                       );
@@ -15229,8 +15250,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
 
                   try {
                     // Create a new conversation
-                    const client = await getClient();
-                    const conversation = await client.conversations.create({
+                    const conversation = await getBackend().createConversation({
                       agent_id: agentId,
                       isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
                     });
@@ -15359,9 +15379,7 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
 
                   try {
                     if (agentState) {
-                      const client = await getClient();
-                      const resumeData = await getResumeData(
-                        client,
+                      const resumeData = await getResumeDataFromBackend(
                         agentState,
                         actualTargetConv,
                       );
@@ -15584,12 +15602,13 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
                   });
 
                   try {
-                    const client = await getClient();
-
                     // Rename if new name provided
                     if (newName && newName !== agentName) {
-                      await client.agents.update(agentId, { name: newName });
+                      const agent = await getBackend().updateAgent(agentId, {
+                        name: newName,
+                      });
                       updateAgentName(newName);
+                      setAgentState(agent);
                     }
 
                     // Pin the agent

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,7 +1,7 @@
 // src/cli/commands/profile.ts
 // Profile command handlers for managing local agent profiles
 
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
 import { settingsManager } from "../../settings-manager";
 import type { Buffers, Line } from "../helpers/accumulator";
 import { formatErrorDetails } from "../helpers/errorFormatter";
@@ -174,9 +174,8 @@ export async function handleProfileSave(
   ctx.setCommandRunning(true);
 
   try {
-    const client = await getClient();
-    // Update agent name via API
-    await client.agents.update(ctx.agentId, { name: profileName });
+    // Update agent name through the active backend.
+    await getBackend().updateAgent(ctx.agentId, { name: profileName });
     ctx.updateAgentName(profileName);
 
     // Save profile to BOTH local and global settings
@@ -343,9 +342,7 @@ export async function handlePin(
   // If user provided a name, rename the agent first
   if (name && name !== ctx.agentName) {
     try {
-      const { getClient } = await import("../../backend/api/client");
-      const client = await getClient();
-      await client.agents.update(ctx.agentId, { name });
+      await getBackend().updateAgent(ctx.agentId, { name });
       ctx.updateAgentName(name);
     } catch (error) {
       addCommandResult(

--- a/src/cli/components/HooksManager.tsx
+++ b/src/cli/components/HooksManager.tsx
@@ -3,6 +3,7 @@
 
 import { Box, useInput } from "ink";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { getBackend } from "../../backend";
 import {
   type HookCommand,
   type HookEvent,
@@ -176,6 +177,9 @@ export const HooksManager = memo(function HooksManager({
 
     const fetchAgentTools = async () => {
       try {
+        if (!getBackend().capabilities.serverSideToolManagement) {
+          return;
+        }
         const { getClient } = await import("../../backend/api/client");
         const client = await getClient();
         // Use dedicated tools endpoint instead of fetching whole agent

--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -2,7 +2,7 @@ import type { Block } from "@letta-ai/letta-client/resources/agents/blocks";
 import { Box, useInput } from "ink";
 import Link from "ink-link";
 import { useEffect, useState } from "react";
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
 import { debugLog } from "../../utils/debug";
 import { buildChatUrl } from "../helpers/appUrls";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
@@ -52,8 +52,7 @@ export function MemoryTabViewer({
   useEffect(() => {
     const fetchBlocks = async () => {
       try {
-        const client = await getClient();
-        const agent = await client.agents.retrieve(agentId, {
+        const agent = await getBackend().retrieveAgent(agentId, {
           include: ["agent.blocks"],
         });
         setFreshBlocks(agent.memory?.blocks || []);

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -170,6 +170,8 @@ describe("approval recovery wiring", () => {
     expect(segment).toContain("getPreStreamErrorAction(");
     expect(segment).toContain("shouldAttemptApprovalRecovery(");
     expect(segment).toContain("rebuildInputWithFreshDenials(");
-    expect(segment).toContain("await getResumeData(client, agent, forked.id)");
+    expect(segment).toContain(
+      "await getResumeDataFromBackend(agent, forked.id)",
+    );
   });
 });

--- a/src/tests/cli/local-backend-command-wiring.test.ts
+++ b/src/tests/cli/local-backend-command-wiring.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const appPath = fileURLToPath(new URL("../../cli/App.tsx", import.meta.url));
+
+function appSource(): string {
+  return readFileSync(appPath, "utf-8");
+}
+
+function segmentBetween(
+  source: string,
+  startNeedle: string,
+  endNeedle: string,
+) {
+  const start = source.indexOf(startNeedle);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf(endNeedle, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("local backend command wiring", () => {
+  test("new, fork, clear, and resume route conversation operations through Backend", () => {
+    const source = appSource();
+    expect(source).toContain("getResumeDataFromBackend");
+    expect(source).not.toContain('from "../backend/api/conversations"');
+
+    const newSegment = segmentBetween(
+      source,
+      "const newMatch = msg.trim().match(/^\\/new(?:\\s+(.+))?$/);",
+      "// Special handling for /fork command",
+    );
+    expect(newSegment).toContain("const backend = getBackend();");
+    expect(newSegment).toContain("await backend.createConversation({");
+    expect(newSegment).not.toContain("await getClient()");
+
+    const forkSegment = segmentBetween(
+      source,
+      "// Special handling for /fork command",
+      "// Special handling for /btw command",
+    );
+    expect(forkSegment).toContain("await backend.forkConversation(");
+    expect(forkSegment).toContain("await backend.updateConversation(");
+    expect(forkSegment).not.toContain("await getClient()");
+
+    const clearSegment = segmentBetween(
+      source,
+      'if (msg.trim() === "/clear")',
+      "// Special handling for /compact command",
+    );
+    expect(clearSegment).toContain("const backend = getBackend();");
+    expect(clearSegment).toContain("await backend.createConversation({");
+    expect(clearSegment).toContain("!backend.capabilities.localModelCatalog");
+
+    const resumeSegment = segmentBetween(
+      source,
+      "// Special handling for /resume command",
+      "// Special handling for /search command",
+    );
+    expect(resumeSegment).toContain("await getResumeDataFromBackend(");
+    expect(resumeSegment).not.toContain("await getClient()");
+  });
+
+  test("agent and memory viewers use active backend instead of API client", () => {
+    const source = appSource();
+
+    const agentSelectSegment = segmentBetween(
+      source,
+      "const handleAgentSelect = useCallback(",
+      "// Handle creating a new agent and switching to it",
+    );
+    expect(agentSelectSegment).toContain(
+      "await getBackend().retrieveAgent(targetAgentId)",
+    );
+    expect(agentSelectSegment).not.toContain("await getClient()");
+
+    const renameSegment = segmentBetween(
+      source,
+      "// Special handling for /rename command",
+      "// Special handling for /description command",
+    );
+    expect(renameSegment).toContain("await backend.updateConversation(");
+    expect(renameSegment).toContain("await getBackend().updateAgent(");
+    expect(renameSegment).not.toContain("await getClient()");
+
+    const descriptionSegment = segmentBetween(
+      source,
+      "// Special handling for /description command",
+      "// Special handling for /agents command",
+    );
+    expect(descriptionSegment).toContain("await getBackend().updateAgent(");
+    expect(descriptionSegment).not.toContain("await getClient()");
+
+    const profilePath = fileURLToPath(
+      new URL("../../cli/commands/profile.ts", import.meta.url),
+    );
+    const profileSource = readFileSync(profilePath, "utf-8");
+    expect(profileSource).toContain(
+      'import { getBackend } from "../../backend";',
+    );
+    expect(profileSource).not.toContain("getClient");
+
+    const memoryViewerPath = fileURLToPath(
+      new URL("../../cli/components/MemoryTabViewer.tsx", import.meta.url),
+    );
+    const memoryViewerSource = readFileSync(memoryViewerPath, "utf-8");
+    expect(memoryViewerSource).toContain("getBackend().retrieveAgent(");
+    expect(memoryViewerSource).not.toContain("getClient");
+  });
+
+  test("local memfs helper paths avoid API client-only lookups", () => {
+    const memoryGitPath = fileURLToPath(
+      new URL("../../agent/memoryGit.ts", import.meta.url),
+    );
+    const memoryGitSource = readFileSync(memoryGitPath, "utf-8");
+
+    const authSegment = segmentBetween(
+      memoryGitSource,
+      "async function getAuthToken(): Promise<string>",
+      "export function buildGitAuthArgs",
+    );
+    expect(authSegment).toContain("backend.capabilities.localMemfs");
+    expect(authSegment).toContain("!backend.capabilities.remoteMemfs");
+
+    const fetchNameSegment = segmentBetween(
+      memoryGitSource,
+      "async function fetchAgentDisplayName",
+      "export async function ensureLocalMemfsGitConfig",
+    );
+    expect(fetchNameSegment).toContain("getBackend().retrieveAgent(agentId)");
+    expect(fetchNameSegment).not.toContain("getClient");
+
+    const tagSegment = segmentBetween(
+      memoryGitSource,
+      "export async function addGitMemoryTag",
+      "export async function removeGitMemoryTag",
+    );
+    expect(tagSegment).toContain("backend.retrieveAgent(agentId)");
+    expect(tagSegment).toContain("backend.updateAgent(agentId");
+    expect(tagSegment).not.toContain("getClient");
+  });
+});

--- a/src/utils/secretsStore.ts
+++ b/src/utils/secretsStore.ts
@@ -6,7 +6,6 @@
 
 import { getCurrentAgentId } from "../agent/context";
 import { getBackend } from "../backend";
-import { getClient } from "../backend/api/client";
 
 /** In-memory cache of secrets (populated on startup from server).
  *  Stored on globalThis via Symbol.for() to survive Bun bundle duplication. */
@@ -65,9 +64,7 @@ export async function initSecretsFromServer(
   }
   const agent =
     cachedAgent ??
-    (await (
-      await getClient()
-    ).agents.retrieve(agentId, {
+    (await getBackend().retrieveAgent(agentId, {
       include: ["agent.secrets"],
     }));
 
@@ -134,6 +131,10 @@ export async function applySecretBatch(
   },
   agentIdArg?: string,
 ): Promise<string[]> {
+  if (!getBackend().capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
+  }
+
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
@@ -147,8 +148,7 @@ export async function applySecretBatch(
     delete next[rawKey.toUpperCase()];
   }
 
-  const client = await getClient();
-  await client.agents.update(agentId, { secrets: next });
+  await getBackend().updateAgent(agentId, { secrets: next });
   setCache(agentId, next);
 
   return Object.keys(next).sort();
@@ -166,7 +166,6 @@ export async function setSecretOnServer(
   if (!getBackend().capabilities.serverSecrets) {
     throw new Error("Agent secrets are not supported by this backend yet");
   }
-  const client = await getClient();
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
@@ -177,7 +176,7 @@ export async function setSecretOnServer(
   secrets[key] = value;
 
   // PATCH replaces entire map
-  await client.agents.update(agentId, { secrets });
+  await getBackend().updateAgent(agentId, { secrets });
 
   setCache(agentId, secrets);
 }
@@ -206,9 +205,7 @@ export async function deleteSecretOnServer(
 
   delete secrets[key];
 
-  const client = await getClient();
-
-  await client.agents.update(agentId, { secrets });
+  await getBackend().updateAgent(agentId, { secrets });
 
   setCache(agentId, secrets);
   return true;


### PR DESCRIPTION
## Summary
- Route local-compatible slash command paths through `getBackend()` instead of API-client-only helpers so `/new`, `/fork`, `/clear`, `/resume`, `/rename`, `/description`, profile pin/save, memory viewer, and approval recovery work without `LETTA_API_KEY` in local mode.
- Add capability gates/user-facing unsupported messages for remote-only local-mode surfaces like MCP management, remote listener, and AgentFile export.
- Update local MemFS, subagent, and secrets helper lookups to avoid unnecessary `getClient()` calls in local backend mode.

## Test plan
- [x] `bun test src/tests/cli/local-backend-command-wiring.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/backend/local-backend.test.ts src/tests/agent/memoryGit.precommit.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)