### PR TITLE
feat(cli): always show all skill source tabs in /skills dialog

### DIFF
--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -107,9 +107,9 @@ export const GLOBAL_SKILLS_DIR = join(
 );
 
 /**
- * Get the agent-scoped skills directory for a specific agent
- * @param agentId - The Letta agent ID (e.g., "agent-abc123")
- * @returns Path like ~/.letta/agents/agent-abc123/skills/
+ * Get the agent-scoped skills directory for a specific agent.
+ * Primary path is ~/.letta/agents/{id}/memory/skills/ (memfs).
+ * Falls back to ~/.letta/agents/{id}/skills/ for legacy installs.
  */
 export function getAgentSkillsDir(agentId: string): string {
   return join(
@@ -117,6 +117,18 @@ export function getAgentSkillsDir(agentId: string): string {
     ".letta/agents",
     agentId,
     "memory/skills",
+  );
+}
+
+/**
+ * Legacy agent skills path from before memfs migration (pre-Feb 2026).
+ */
+export function getLegacyAgentSkillsDir(agentId: string): string {
+  return join(
+    process.env.HOME || process.env.USERPROFILE || "~",
+    ".letta/agents",
+    agentId,
+    "skills",
   );
 }
 
@@ -209,7 +221,15 @@ export async function discoverSkills(
   }
 
   // 3. Add agent skills if agentId provided (override global)
+  //    Check legacy path first, then memfs path (memfs wins on conflict)
   if (agentId && includeSource("agent")) {
+    const legacyDir = getLegacyAgentSkillsDir(agentId);
+    const legacyResult = await discoverSkillsFromDir(legacyDir, "agent");
+    allErrors.push(...legacyResult.errors);
+    for (const skill of legacyResult.skills) {
+      skillsById.set(skill.id, skill);
+    }
+
     const agentSkillsDir = getAgentSkillsDir(agentId);
     const agentResult = await discoverSkillsFromDir(agentSkillsDir, "agent");
     allErrors.push(...agentResult.errors);

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -116,7 +116,7 @@ export function getAgentSkillsDir(agentId: string): string {
     process.env.HOME || process.env.USERPROFILE || "~",
     ".letta/agents",
     agentId,
-    "skills",
+    "memory/skills",
   );
 }
 

--- a/src/cli/components/SkillsDialog.tsx
+++ b/src/cli/components/SkillsDialog.tsx
@@ -26,7 +26,7 @@ function getTabDescription(tab: SkillTab, agentId: string): string {
     case "project":
       return ".skills/";
     case "agent":
-      return `~/.letta/agents/${shortId}/skills/`;
+      return `~/.letta/agents/${shortId}/memory/skills/`;
     case "global":
       return "~/.letta/skills/";
     case "bundled":

--- a/src/cli/components/SkillsDialog.tsx
+++ b/src/cli/components/SkillsDialog.tsx
@@ -81,11 +81,8 @@ export function SkillsDialog({ onClose, agentId }: SkillsDialogProps) {
     return grouped;
   }, [skills]);
 
-  // Only show tabs that have skills
-  const availableTabs = useMemo(
-    () => TAB_ORDER.filter((tab) => (skillsBySource.get(tab)?.length ?? 0) > 0),
-    [skillsBySource],
-  );
+  // Always show all tabs so users can discover empty sources
+  const availableTabs = useMemo(() => [...TAB_ORDER], []);
 
   const [activeTab, setActiveTab] = useState<SkillTab | null>(null);
 
@@ -241,13 +238,18 @@ export function SkillsDialog({ onClose, agentId }: SkillsDialogProps) {
         </Box>
       )}
 
+      {/* Empty state for active tab */}
+      {!loading && activeTab && currentSkills.length === 0 && (
+        <Box paddingLeft={2}>
+          <Text dimColor>No skills in this location</Text>
+        </Box>
+      )}
+
       {/* Footer */}
       <Box marginTop={1}>
         <Text dimColor>
           {"  "}
-          {availableTabs.length > 1
-            ? "↑↓ scroll · ←→/Tab switch · Esc to close"
-            : "Esc to close"}
+          {"↑↓ scroll · ←→/Tab switch · Esc to close"}
         </Text>
       </Box>
     </Box>

--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -515,7 +515,7 @@ function detectSkillScript(
   }
 
   const agentRegex = new RegExp(
-    `^${escapeRegex(normalizedHomeDir)}/\\.letta/agents/[^/]+/memory/skills/(.+?)/scripts/`,
+    `^${escapeRegex(normalizedHomeDir)}/\\.letta/agents/[^/]+/(?:memory/)?skills/(.+?)/scripts/`,
   );
   const agentSkill = detect("agent-scoped", agentRegex);
   if (agentSkill) {

--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -515,7 +515,7 @@ function detectSkillScript(
   }
 
   const agentRegex = new RegExp(
-    `^${escapeRegex(normalizedHomeDir)}/\\.letta/agents/[^/]+/skills/(.+?)/scripts/`,
+    `^${escapeRegex(normalizedHomeDir)}/\\.letta/agents/[^/]+/memory/skills/(.+?)/scripts/`,
   );
   const agentSkill = detect("agent-scoped", agentRegex);
   if (agentSkill) {

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -64,7 +64,7 @@ Browse these repositories to discover available skills. Check the README for ski
 
 | Location | Path | When to Use |
 |----------|------|-------------|
-| **Agent-scoped** | `~/.letta/agents/<agent-id>/skills/<skill>/` | Skills for a single agent (default for agent-specific capabilities) |
+| **Agent-scoped** | `~/.letta/agents/<agent-id>/memory/skills/<skill>/` | Skills for a single agent (default for agent-specific capabilities) |
 | **Global** | `~/.letta/skills/<skill>/` | General-purpose skills useful across projects |
 | **Project** | `.skills/<skill>/` | Project-specific skills |
 
@@ -82,7 +82,7 @@ git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
 
 # 2. Copy the skill to your skills directory
 # For agent-scoped (recommended default):
-cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/skills/
+cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/memory/skills/
 # For global:
 # cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/skills/
 # For project:
@@ -96,13 +96,13 @@ rm -rf /tmp/skills-temp
 
 ```bash
 git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
-rsync -av /tmp/skills-temp/skills/webapp-testing/ ~/.letta/agents/<agent-id>/skills/webapp-testing/
+rsync -av /tmp/skills-temp/skills/webapp-testing/ ~/.letta/agents/<agent-id>/memory/skills/webapp-testing/
 rm -rf /tmp/skills-temp
 ```
 
 ## Registering New Skills
 
-After downloading a skill, it will be automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/skills/` directories.
+After downloading a skill, it will be automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
 
 ## Complete Example
 
@@ -114,7 +114,7 @@ User asks: "Can you help me test my React app's UI?"
 4. **Download** (trusted source):
    ```bash
    git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
-   cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/skills/
+   cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/memory/skills/
    rm -rf /tmp/skills-temp
    ```
 5. **Inspect scripts**: Read any .py or .ts files before using them

--- a/src/tests/permissions-analyzer.test.ts
+++ b/src/tests/permissions-analyzer.test.ts
@@ -388,13 +388,13 @@ test("Skill script in agent-scoped skill suggests agent-scoped message", () => {
   const context = analyzeApprovalContext(
     "Bash",
     {
-      command: `npx tsx ${home}/.letta/agents/agent-123/skills/finding-agents/scripts/main.ts --help`,
+      command: `npx tsx ${home}/.letta/agents/agent-123/memory/skills/finding-agents/scripts/main.ts --help`,
     },
     "/Users/test/project",
   );
 
   expect(context.recommendedRule).toBe(
-    `Bash(npx tsx ${home}/.letta/agents/agent-123/skills/finding-agents:*)`,
+    `Bash(npx tsx ${home}/.letta/agents/agent-123/memory/skills/finding-agents:*)`,
   );
   expect(context.approveAlwaysText).toBe(
     "Yes, and don't ask again for scripts in agent-scoped skill 'finding-agents'",


### PR DESCRIPTION
Show agent-scoped skills in `/skills`

<img width="511" height="232" alt="image" src="https://github.com/user-attachments/assets/bd44842f-3dc5-438e-8dd9-58d260a41b24" />


## Summary
- The `/skills` dialog previously hid tabs with zero skills, so the **Agent** tab was invisible unless the agent already had agent-scoped skills
- Now all four tabs (**Project**, **Agent**, **Global**, **Bundled**) always render in that order, with a "No skills in this location" empty state for sources with no skills

👾 Generated with [Letta Code](https://letta.com)