### PR TITLE
fix(local): repair image paste and MemFS paths

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -5,7 +5,10 @@ import type {
   forkConversation as forkConversationRequest,
 } from "./api/conversations";
 import { LocalBackend } from "./local/LocalBackend";
-import { getLocalBackendStorageDir as getLocalBackendStorageDirFromPaths } from "./local/paths";
+import {
+  getLocalBackendStorageDir as getLocalBackendStorageDirFromPaths,
+  LOCAL_BACKEND_EXPERIMENTAL_ENV,
+} from "./local/paths";
 
 export type APIClient = Awaited<ReturnType<typeof getClient>>;
 type GetAPIClient = typeof getClient;
@@ -472,6 +475,7 @@ export function getBackend(): Backend {
 
 export function configureBackendMode(mode: BackendMode): void {
   configuredBackendMode = mode;
+  process.env[LOCAL_BACKEND_EXPERIMENTAL_ENV] = mode === "local" ? "1" : "0";
   backend = createBackendForMode(mode);
 }
 

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -351,6 +351,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function localFilePartFromLegacyImage(
+  part: Record<string, unknown>,
+): LocalMessagePart | null {
+  if (part.type !== "image" || !isRecord(part.source)) {
+    return null;
+  }
+
+  const source = part.source;
+  if (source.type !== "base64") {
+    return null;
+  }
+
+  const mediaType = source.media_type;
+  const data = source.data;
+  if (typeof mediaType !== "string" || typeof data !== "string") {
+    return null;
+  }
+
+  return {
+    type: "file",
+    mediaType,
+    url: `data:${mediaType};base64,${data}`,
+  } as LocalMessagePart;
+}
+
+function normalizeLocalMessageForAISDK(message: LocalMessage): LocalMessage {
+  let didChange = false;
+  const parts = message.parts.map((part) => {
+    if (isRecord(part)) {
+      const filePart = localFilePartFromLegacyImage(part);
+      if (filePart) {
+        didChange = true;
+        return filePart;
+      }
+    }
+    return part;
+  });
+
+  return didChange ? { ...message, parts } : message;
+}
+
 function textFromContent(content: unknown): string {
   if (typeof content === "string") return content;
   if (Array.isArray(content)) {
@@ -1635,6 +1676,11 @@ export class LocalStore {
         parts.push({ type: "text", text: part.text } as LocalMessagePart);
         continue;
       }
+      const filePart = localFilePartFromLegacyImage(part);
+      if (filePart) {
+        parts.push(filePart);
+        continue;
+      }
       parts.push(part as LocalMessagePart);
     }
     return parts.length > 0 ? parts : textContent(textFromContent(content));
@@ -1685,7 +1731,7 @@ export class LocalStore {
         );
         const localMessages = readJsonlFile<LocalMessage>(
           join(conversationDir, "messages.jsonl"),
-        );
+        ).map(normalizeLocalMessageForAISDK);
         const compiledSystemPrompt = readJsonFile<LocalCompiledSystemPrompt>(
           join(conversationDir, "system-prompt.json"),
         );

--- a/src/cli/helpers/agentInfo.ts
+++ b/src/cli/helpers/agentInfo.ts
@@ -1,7 +1,8 @@
 // src/cli/helpers/agentInfo.ts
 // Generates agent info system reminder (agent identity, memory dir)
 
-import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { isLocalBackendEnvEnabled } from "../../backend/local/paths";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
 import { settingsManager } from "../../settings-manager";
 
@@ -65,13 +66,16 @@ export function buildAgentInfo(options: AgentInfoOptions): string {
 
     const showMemoryDir = (() => {
       try {
-        return settingsManager.isMemfsEnabled(agentInfo.id);
+        return (
+          isLocalBackendEnvEnabled() ||
+          settingsManager.isMemfsEnabled(agentInfo.id)
+        );
       } catch {
         return false;
       }
     })();
     const memoryDirLine = showMemoryDir
-      ? `\n- **Memory directory (also stored in \`MEMORY_DIR\` env var)**: \`${getMemoryFilesystemRoot(agentInfo.id)}\``
+      ? `\n- **Memory directory (also stored in \`MEMORY_DIR\` env var)**: \`${getScopedMemoryFilesystemRoot(agentInfo.id)}\``
       : "";
 
     const convLine = conversationId

--- a/src/tests/agent-info.test.ts
+++ b/src/tests/agent-info.test.ts
@@ -1,7 +1,40 @@
 import { describe, expect, test } from "bun:test";
-import { getMemoryFilesystemRoot } from "../agent/memoryFilesystem";
+import {
+  getMemoryFilesystemRoot,
+  getScopedMemoryFilesystemRoot,
+} from "../agent/memoryFilesystem";
+import { getLocalBackendMemoryFilesystemRoot } from "../backend/local/paths";
 import { buildAgentInfo } from "../cli/helpers/agentInfo";
 import { settingsManager } from "../settings-manager";
+
+function withTemporaryEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const original = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  ) as Record<string, string | undefined>;
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 describe("agent info reminder", () => {
   test("always includes AGENT_ID env var", () => {
@@ -74,6 +107,43 @@ describe("agent info reminder", () => {
       expect(context).toContain(
         `- **Memory directory (also stored in \`MEMORY_DIR\` env var)**: \`${getMemoryFilesystemRoot(agentId)}\``,
       );
+    } finally {
+      (
+        settingsManager as unknown as {
+          isMemfsEnabled: (id: string) => boolean;
+        }
+      ).isMemfsEnabled = original;
+    }
+  });
+
+  test("uses local backend MemFS path for local backend agents", () => {
+    const agentId = "agent-local-agent-info-enabled";
+    const original = settingsManager.isMemfsEnabled.bind(settingsManager);
+    (
+      settingsManager as unknown as {
+        isMemfsEnabled: (id: string) => boolean;
+      }
+    ).isMemfsEnabled = () => false;
+
+    try {
+      withTemporaryEnv({ LETTA_LOCAL_BACKEND_EXPERIMENTAL: "1" }, () => {
+        const context = buildAgentInfo({
+          agentInfo: {
+            id: agentId,
+            name: "Test Agent",
+            description: "Test description",
+            lastRunAt: null,
+          },
+        });
+
+        expect(getScopedMemoryFilesystemRoot(agentId)).toBe(
+          getLocalBackendMemoryFilesystemRoot(agentId),
+        );
+        expect(context).toContain(
+          `- **Memory directory (also stored in \`MEMORY_DIR\` env var)**: \`${getLocalBackendMemoryFilesystemRoot(agentId)}\``,
+        );
+        expect(context).not.toContain(getMemoryFilesystemRoot(agentId));
+      });
     } finally {
       (
         settingsManager as unknown as {

--- a/src/tests/backend/api-backend.test.ts
+++ b/src/tests/backend/api-backend.test.ts
@@ -150,11 +150,13 @@ describe("APIBackend", () => {
   test("configures the active backend mode explicitly", () => {
     configureBackendMode("local");
     expect(isLocalBackendEnabled()).toBe(true);
+    expect(process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL).toBe("1");
     expect(getBackend().capabilities.localMemfs).toBe(true);
     expect(getBackend().capabilities.localModelCatalog).toBe(true);
 
     configureBackendMode("api");
     expect(isLocalBackendEnabled()).toBe(false);
+    expect(process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL).toBe("0");
     expect(getBackend().capabilities.localMemfs).toBe(false);
     expect(getBackend().capabilities.remoteMemfs).toBe(true);
   });

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -46,6 +46,9 @@ import { projectLocalMessagesToStoredMessages } from "../../backend/local/LocalM
 import { LocalStore } from "../../backend/local/LocalStore";
 import { getLocalBackendMemoryFilesystemRoot } from "../../backend/local/paths";
 
+const TEST_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=";
+
 async function withLocalModelEnv<T>(
   env: {
     openAIKey?: string;
@@ -1889,6 +1892,111 @@ describe("LocalBackend", () => {
         "tool_return_message",
         "assistant_message",
       ]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("converts pasted Letta image parts to AI SDK file UI parts for local history", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-image-"));
+    try {
+      const modelMessagesByCall: ModelMessage[][] = [];
+      let streamCalls = 0;
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        streamText: (options) => {
+          streamCalls += 1;
+          modelMessagesByCall.push(options.messages);
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: `text-${streamCalls}`,
+                text: `image response ${streamCalls}`,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: `assistant-image-${streamCalls}`,
+              role: "assistant",
+              parts: [{ type: "text", text: `image response ${streamCalls}` }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Image Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(conversation.id, {
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "please inspect this" },
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: TEST_PNG_BASE64,
+                  },
+                },
+              ],
+            },
+          ],
+          streaming: true,
+          stream_tokens: true,
+          include_pings: true,
+          background: true,
+          client_tools: [],
+          client_skills: [],
+          agent_id: agent.id,
+        } as unknown as ConversationMessageCreateBody),
+      );
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("and now a text-only follow-up", agent.id),
+        ),
+      );
+
+      expect(modelMessagesByCall).toHaveLength(2);
+      expect(JSON.stringify(modelMessagesByCall[0])).toContain('"type":"file"');
+      expect(JSON.stringify(modelMessagesByCall[1])).toContain('"type":"file"');
+      expect(JSON.stringify(modelMessagesByCall[1])).not.toContain(
+        '"type":"image"',
+      );
+
+      const persistedMessages = await readPersistedLocalMessages(storageDir);
+      const persistedUserWithFile = persistedMessages.find(
+        (message) =>
+          message.role === "user" &&
+          message.parts?.some(
+            (part) =>
+              typeof part === "object" &&
+              part !== null &&
+              (part as { type?: unknown }).type === "file",
+          ),
+      );
+      expect(persistedUserWithFile).toBeDefined();
+      expect(JSON.stringify(persistedUserWithFile)).toContain(
+        "data:image/png;base64,",
+      );
+      expect(JSON.stringify(persistedUserWithFile)).not.toContain(
+        '"type":"image"',
+      );
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { configureBackendMode } from "../../backend";
+import { getLocalBackendMemoryFilesystemRoot } from "../../backend/local/paths";
 import { runWithRuntimeContext } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import {
@@ -410,6 +412,36 @@ test("getShellEnv injects MEMORY_DIR aliases when memfs is enabled", () => {
       ).isMemfsEnabled = original;
     }
   });
+});
+
+test("getShellEnv injects local backend MemFS path for --backend local", () => {
+  const agentId = `agent-local-shell-env-${Date.now()}`;
+  configureBackendMode("local");
+  try {
+    withTemporaryAgentEnv(agentId, () => {
+      const original = settingsManager.isMemfsEnabled.bind(settingsManager);
+      (
+        settingsManager as unknown as {
+          isMemfsEnabled: (id: string) => boolean;
+        }
+      ).isMemfsEnabled = () => false;
+
+      try {
+        const env = getShellEnv();
+        const expectedMemoryDir = getLocalBackendMemoryFilesystemRoot(agentId);
+        expect(env.LETTA_MEMORY_DIR).toBe(expectedMemoryDir);
+        expect(env.MEMORY_DIR).toBe(expectedMemoryDir);
+      } finally {
+        (
+          settingsManager as unknown as {
+            isMemfsEnabled: (id: string) => boolean;
+          }
+        ).isMemfsEnabled = original;
+      }
+    });
+  } finally {
+    configureBackendMode("api");
+  }
 });
 
 test("getShellEnv injects transient MemFS git proxy config for Desktop Bash commands", () => {


### PR DESCRIPTION
## Summary
- Convert Letta API-style pasted image parts into AI SDK `file` UI parts before local backend persistence, including legacy persisted image parts on load.
- Set the local backend env signal when `--backend local` is configured so memory tools and shell env resolve the local MemFS checkout.
- Show scoped local MemFS paths in agent info instead of the API-style memory path.

## Test plan
- [x] `bun test src/tests/backend/local-backend.test.ts src/tests/agent-info.test.ts src/tests/tools/shell-env.test.ts src/tests/backend/api-backend.test.ts src/tests/cli/local-backend-command-wiring.test.ts`
- [x] `bun run check`

Stacked on #2158.

👾 Generated with [Letta Code](https://letta.com)