### PR TITLE
fix(local): route message search through backend

### DIFF
--- a/src/backend/messageSearch.ts
+++ b/src/backend/messageSearch.ts
@@ -1,0 +1,256 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { MessageSearchResponse } from "@letta-ai/letta-client/resources/messages";
+import { searchMessages, warmSearchCache } from "./api/search";
+import { type Backend, getBackend } from "./backend";
+
+type SearchMode = "vector" | "fts" | "hybrid";
+
+type MessageSearchBody = {
+  query?: unknown;
+  search_mode?: unknown;
+  limit?: unknown;
+  agent_id?: unknown;
+  conversation_id?: unknown;
+  start_date?: unknown;
+  end_date?: unknown;
+};
+
+type LocalSearchMessage = {
+  id?: string;
+  date?: string;
+  message_type?: string;
+  content?: unknown;
+  reasoning?: string;
+  summary?: string;
+  tool_call?: { name?: string; arguments?: string };
+  tool_calls?: Array<{ name?: string; arguments?: string }>;
+  tool_return?: unknown;
+  func_response?: unknown;
+  agent_id?: string;
+  conversation_id?: string;
+};
+
+const LOCAL_SEARCH_SCAN_LIMIT = 1000;
+
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof part.text === "string"
+      ) {
+        return part.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function stringifySearchValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function searchableText(message: LocalSearchMessage): string {
+  const toolCalls = Array.isArray(message.tool_calls)
+    ? message.tool_calls
+    : message.tool_call
+      ? [message.tool_call]
+      : [];
+  return [
+    message.message_type,
+    textFromContent(message.content),
+    message.reasoning,
+    message.summary,
+    ...toolCalls.flatMap((call) => [call.name, call.arguments]),
+    stringifySearchValue(message.tool_return),
+    stringifySearchValue(message.func_response),
+  ]
+    .filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    )
+    .join("\n");
+}
+
+function matchesQuery(message: LocalSearchMessage, query: string): boolean {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean);
+  if (terms.length === 0) return false;
+  const haystack = searchableText(message).toLowerCase();
+  return terms.every((term) => haystack.includes(term));
+}
+
+function withinDateRange(
+  message: LocalSearchMessage,
+  startDate: string | undefined,
+  endDate: string | undefined,
+): boolean {
+  if (!startDate && !endDate) return true;
+  if (!message.date) return true;
+  const time = new Date(message.date).getTime();
+  if (Number.isNaN(time)) return true;
+  const startTime = startDate ? new Date(startDate).getTime() : 0;
+  const endTime = endDate
+    ? new Date(endDate).getTime()
+    : Number.POSITIVE_INFINITY;
+  return time >= startTime && time <= endTime;
+}
+
+function toSearchResult(
+  message: LocalSearchMessage,
+): MessageSearchResponse[number] {
+  const createdAt = message.date ?? new Date(0).toISOString();
+  return {
+    ...message,
+    message_id: message.id ?? `${message.agent_id ?? "local"}:${createdAt}`,
+    created_at: createdAt,
+    agent_id: message.agent_id ?? null,
+    conversation_id: message.conversation_id ?? null,
+  } as MessageSearchResponse[number];
+}
+
+async function localConversationMessages(
+  backend: Backend,
+  conversationId: string,
+  agentId?: string,
+): Promise<LocalSearchMessage[]> {
+  try {
+    const page = await backend.listConversationMessages(conversationId, {
+      limit: LOCAL_SEARCH_SCAN_LIMIT,
+      order: "desc",
+      ...(agentId ? { agent_id: agentId } : {}),
+    } as never);
+    return pageItems<LocalSearchMessage>(page);
+  } catch {
+    return [];
+  }
+}
+
+async function localAgentMessages(
+  backend: Backend,
+  agentId: string,
+): Promise<LocalSearchMessage[]> {
+  const messages = [
+    ...(await localConversationMessages(backend, "default", agentId)),
+  ];
+  try {
+    const conversationsPage = await backend.listConversations({
+      agent_id: agentId,
+      limit: LOCAL_SEARCH_SCAN_LIMIT,
+    } as never);
+    const conversations = pageItems<{ id?: string }>(conversationsPage);
+    for (const conversation of conversations) {
+      if (!conversation.id || conversation.id === "default") continue;
+      messages.push(
+        ...(await localConversationMessages(backend, conversation.id, agentId)),
+      );
+    }
+  } catch {
+    // Best-effort local search: default conversation results are still useful.
+  }
+  return messages;
+}
+
+async function localSearchMessages(
+  backend: Backend,
+  body: MessageSearchBody,
+): Promise<MessageSearchResponse> {
+  const query = typeof body.query === "string" ? body.query.trim() : "";
+  if (!query) return [];
+  const limit = typeof body.limit === "number" ? body.limit : 100;
+  const agentId = typeof body.agent_id === "string" ? body.agent_id : undefined;
+  const conversationId =
+    typeof body.conversation_id === "string" ? body.conversation_id : undefined;
+  const startDate =
+    typeof body.start_date === "string" ? body.start_date : undefined;
+  const endDate = typeof body.end_date === "string" ? body.end_date : undefined;
+
+  let messages: LocalSearchMessage[] = [];
+  if (conversationId) {
+    messages = await localConversationMessages(
+      backend,
+      conversationId,
+      agentId,
+    );
+  } else if (agentId) {
+    messages = await localAgentMessages(backend, agentId);
+  } else {
+    const agentsPage = await backend.listAgents({
+      limit: LOCAL_SEARCH_SCAN_LIMIT,
+    } as never);
+    const agents = pageItems<AgentState>(agentsPage);
+    for (const agent of agents) {
+      messages.push(...(await localAgentMessages(backend, agent.id)));
+    }
+  }
+
+  return messages
+    .filter((message) => matchesQuery(message, query))
+    .filter((message) => withinDateRange(message, startDate, endDate))
+    .sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""))
+    .slice(0, limit)
+    .map(toSearchResult);
+}
+
+export async function searchMessagesForBackend<T = MessageSearchResponse>(
+  body: MessageSearchBody,
+  backend: Backend = getBackend(),
+): Promise<T> {
+  if (backend.capabilities.localModelCatalog) {
+    return (await localSearchMessages(backend, body)) as T;
+  }
+
+  return searchMessages<T>({
+    ...body,
+    search_mode:
+      body.search_mode === "vector" ||
+      body.search_mode === "fts" ||
+      body.search_mode === "hybrid"
+        ? (body.search_mode as SearchMode)
+        : body.search_mode,
+  } as Record<string, unknown>);
+}
+
+export async function warmMessageSearchCacheForBackend<T>(
+  body: Record<string, unknown>,
+  backend: Backend = getBackend(),
+): Promise<T> {
+  if (backend.capabilities.localModelCatalog) {
+    return {
+      collection: body.collection ?? "messages",
+      status: "local-backend-noop",
+      warmed: false,
+    } as T;
+  }
+  return warmSearchCache<T>(body);
+}

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -8096,6 +8096,16 @@ export default function App({
 
         // Special handling for /install-github-app command - interactive setup wizard
         if (trimmed === "/install-github-app") {
+          if (getBackend().capabilities.localModelCatalog) {
+            const cmd = commandRunner.start(
+              trimmed,
+              "Checking GitHub App installer support...",
+            );
+            cmd.fail(
+              "GitHub App installation is not supported by the local backend.",
+            );
+            return { submitted: true };
+          }
           startOverlayCommand(
             "install-github-app",
             "/install-github-app",

--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -1,7 +1,10 @@
 import type { MessageSearchResponse } from "@letta-ai/letta-client/resources/messages";
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { searchMessages, warmSearchCache } from "../../backend/api/search";
+import {
+  searchMessagesForBackend,
+  warmMessageSearchCacheForBackend,
+} from "../../backend/messageSearch";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { Text } from "./Text";
@@ -55,7 +58,7 @@ export async function warmMessageSearchCache() {
     scope: {},
   };
 
-  return warmSearchCache<SearchCacheWarmResponse>(body);
+  return warmMessageSearchCacheForBackend<SearchCacheWarmResponse>(body);
 }
 
 function isSearchRangeAvailable(
@@ -267,7 +270,7 @@ export function MessageSearch({
         body.conversation_id = conversationId;
       }
 
-      return searchMessages<MessageSearchResponse>(body);
+      return searchMessagesForBackend<MessageSearchResponse>(body);
     },
     [agentId, conversationId],
   );

--- a/src/cli/subcommands/agents.ts
+++ b/src/cli/subcommands/agents.ts
@@ -7,7 +7,7 @@ import {
   enableMemfsForCreatedAgent,
   resolvePersonalityId,
 } from "../../agent/personality";
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
 import { settingsManager } from "../../settings-manager";
 
 function printUsage(): void {
@@ -176,9 +176,8 @@ async function runCreateAction(
       settingsManager.pinGlobal(agentId);
     }
 
-    // Re-fetch agent to get updated tags in output
-    const client = await getClient();
-    const updatedAgent = await client.agents.retrieve(agentId);
+    // Re-fetch agent through the active backend to get updated output.
+    const updatedAgent = await getBackend().retrieveAgent(agentId);
 
     console.log(JSON.stringify(updatedAgent, null, 2));
     return 0;
@@ -218,8 +217,7 @@ async function runListAction(
   }
 
   try {
-    const client = await getClient();
-    const result = await client.agents.list(params);
+    const result = await getBackend().listAgents(params);
     console.log(JSON.stringify(result, null, 2));
     return 0;
   } catch (error) {

--- a/src/cli/subcommands/blocks.ts
+++ b/src/cli/subcommands/blocks.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "node:util";
+import { getBackend } from "../../backend";
 import { getClient } from "../../backend/api/client";
 import { settingsManager } from "../../settings-manager";
 
@@ -292,6 +293,12 @@ export async function runBlocksSubcommand(argv: string[]): Promise<number> {
 
   try {
     await settingsManager.initialize();
+    if (getBackend().capabilities.localMemfs) {
+      console.error(
+        "The blocks subcommand manages server memory blocks and is not supported with --backend local. Use the local MemFS files instead.",
+      );
+      return 1;
+    }
     const client = await getClient();
 
     if (action === "list") {

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -1,7 +1,8 @@
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
-import { getClient } from "../../backend/api/client";
+import { getBackend } from "../../backend";
+import { searchMessagesForBackend } from "../../backend/messageSearch";
 import { settingsManager } from "../../settings-manager";
 
 type SearchMode = "vector" | "fts" | "hybrid";
@@ -106,6 +107,23 @@ function getAgentId(agentFromArgs?: string, agentIdFromArgs?: string): string {
   return agentFromArgs || agentIdFromArgs || process.env.LETTA_AGENT_ID || "";
 }
 
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
 const MESSAGES_OPTIONS = {
   help: { type: "boolean", short: "h" },
   query: { type: "string" },
@@ -154,7 +172,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
 
   try {
     await settingsManager.initialize();
-    const client = await getClient();
+    const backend = getBackend();
 
     const renderText = (value: unknown): string => {
       if (typeof value === "string") return value;
@@ -274,7 +292,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
       let cursorBefore: string | undefined;
 
       for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
-        const page = await client.conversations.messages.list(conversationId, {
+        const page = await backend.listConversationMessages(conversationId, {
           limit: pageLimit,
           order: "desc",
           ...(conversationId === "default" && agentIdForDefault
@@ -283,7 +301,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
           ...(cursorBefore ? { before: cursorBefore } : {}),
         });
 
-        const items = page.getPaginatedItems() as TranscriptMessage[];
+        const items = pageItems<TranscriptMessage>(page);
         if (items.length === 0) {
           break;
         }
@@ -328,7 +346,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         return 1;
       }
 
-      const result = await client.messages.search({
+      const result = await searchMessagesForBackend({
         query,
         agent_id: allAgents ? undefined : agentId,
         search_mode: parseMode(parsed.values.mode) ?? "hybrid",
@@ -360,7 +378,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         return 1;
       }
 
-      const response = await client.agents.messages.list(agentId, {
+      const response = await backend.listAgentMessages(agentId, {
         conversation_id: "default",
         limit: parseLimit(parsed.values.limit, 20),
         after: parsed.values.after,
@@ -368,7 +386,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         order,
       });
 
-      const messages = response.getPaginatedItems() ?? [];
+      const messages = pageItems<TranscriptMessage>(response);
       const startDate = parsed.values["start-date"];
       const endDate = parsed.values["end-date"];
 

--- a/src/tests/backend/message-search.test.ts
+++ b/src/tests/backend/message-search.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentCreateBody,
+  ConversationCreateBody,
+  ConversationMessageCreateBody,
+} from "../../backend";
+import { LocalBackend } from "../../backend/local";
+import {
+  searchMessagesForBackend,
+  warmMessageSearchCacheForBackend,
+} from "../../backend/messageSearch";
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _chunk of stream) {
+    // drain
+  }
+}
+
+function createBody(
+  text: string,
+  agentId: string,
+): ConversationMessageCreateBody {
+  return {
+    messages: [{ role: "user", content: text }],
+    streaming: true,
+    stream_tokens: true,
+    include_pings: true,
+    background: true,
+    client_tools: [],
+    client_skills: [],
+    agent_id: agentId,
+  } as unknown as ConversationMessageCreateBody;
+}
+
+describe("message search backend routing", () => {
+  test("searches local backend conversation history without API search", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      const agent = await backend.createAgent({
+        name: "Search Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drain(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("needle in local haystack", agent.id),
+        ),
+      );
+
+      const results = await searchMessagesForBackend(
+        {
+          query: "needle haystack",
+          agent_id: agent.id,
+          search_mode: "hybrid",
+          limit: 10,
+        },
+        backend,
+      );
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(JSON.stringify(results)).toContain("needle in local haystack");
+      expect(results[0]?.agent_id).toBe(agent.id);
+      expect(results[0]?.conversation_id).toBe(conversation.id);
+
+      const warm = await warmMessageSearchCacheForBackend<{
+        collection: string;
+        status: string;
+        warmed: boolean;
+      }>({ collection: "messages", scope: {} }, backend);
+      expect(warm).toEqual({
+        collection: "messages",
+        status: "local-backend-noop",
+        warmed: false,
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tests/cli/local-backend-command-wiring.test.ts
+++ b/src/tests/cli/local-backend-command-wiring.test.ts
@@ -140,4 +140,55 @@ describe("local backend command wiring", () => {
     expect(tagSegment).toContain("backend.updateAgent(agentId");
     expect(tagSegment).not.toContain("getClient");
   });
+
+  test("message search and subcommands avoid unguarded API-only paths in local mode", () => {
+    const source = appSource();
+
+    const searchSegment = segmentBetween(
+      source,
+      "// Special handling for /search command",
+      "// Special handling for /profile command",
+    );
+    expect(searchSegment).not.toContain("getClient");
+
+    const installGithubAppSegment = segmentBetween(
+      source,
+      "// Special handling for /install-github-app command",
+      "// Special handling for /sleeptime command",
+    );
+    expect(installGithubAppSegment).toContain(
+      "getBackend().capabilities.localModelCatalog",
+    );
+
+    const messageSearchPath = fileURLToPath(
+      new URL("../../cli/components/MessageSearch.tsx", import.meta.url),
+    );
+    const messageSearchSource = readFileSync(messageSearchPath, "utf-8");
+    expect(messageSearchSource).toContain("searchMessagesForBackend");
+    expect(messageSearchSource).not.toContain("../../backend/api/search");
+
+    const messagesSubcommandPath = fileURLToPath(
+      new URL("../../cli/subcommands/messages.ts", import.meta.url),
+    );
+    const messagesSubcommandSource = readFileSync(
+      messagesSubcommandPath,
+      "utf-8",
+    );
+    expect(messagesSubcommandSource).toContain("getBackend");
+    expect(messagesSubcommandSource).toContain("searchMessagesForBackend");
+    expect(messagesSubcommandSource).not.toContain("getClient");
+
+    const agentsSubcommandPath = fileURLToPath(
+      new URL("../../cli/subcommands/agents.ts", import.meta.url),
+    );
+    const agentsSubcommandSource = readFileSync(agentsSubcommandPath, "utf-8");
+    expect(agentsSubcommandSource).toContain("getBackend");
+    expect(agentsSubcommandSource).not.toContain("getClient");
+
+    const blocksSubcommandPath = fileURLToPath(
+      new URL("../../cli/subcommands/blocks.ts", import.meta.url),
+    );
+    const blocksSubcommandSource = readFileSync(blocksSubcommandPath, "utf-8");
+    expect(blocksSubcommandSource).toContain("capabilities.localMemfs");
+  });
 });


### PR DESCRIPTION
## Summary
- Route message search through an active-backend helper so `/search` uses local persisted conversation history instead of API-only `/v1/messages/search` in local mode.
- Move `letta messages` search/list/transcript and `letta agents` list/create output through the backend abstraction; explicitly reject `letta blocks` in local mode because it manages server memory blocks.
- Guard `/install-github-app` in local mode before opening its API-backed setup flow.

## Test plan
- [x] `bun test src/tests/backend/message-search.test.ts src/tests/cli/local-backend-command-wiring.test.ts src/tests/cli/message-search-cache-warm.test.ts src/tests/backend/local-backend.test.ts src/tests/cli/local-backend-command-wiring.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)