### PR TITLE
fix(tui): add vertical padding to user highlights

### DIFF
--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -225,10 +225,7 @@ export function renderBlock(
 export const UserMessage = memo(
   ({ line, prompt }: { line: UserLine; prompt?: string }) => {
     const trackedColumns = useTerminalWidth();
-    const columns = Math.max(
-      trackedColumns,
-      getCurrentStdoutColumns() ?? trackedColumns,
-    );
+    const columns = getCurrentStdoutColumns() ?? trackedColumns;
     const promptPrefix = `${prompt || ">"} `;
     const prefixWidth = inkStringWidth(promptPrefix);
     const continuationPrefix = " ".repeat(prefixWidth);

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -23,6 +23,12 @@ type RenderedBlockLine = {
   highlighted: boolean;
 };
 
+function getCurrentStdoutColumns(): number | null {
+  if (typeof process === "undefined") return null;
+  const columns = (process.stdout as NodeJS.WriteStream | undefined)?.columns;
+  return typeof columns === "number" && columns > 0 ? columns : null;
+}
+
 /**
  * Word-wrap plain text to a given visible width.
  * Returns an array of lines, each at most `width` visible characters wide.
@@ -182,7 +188,11 @@ export function renderBlock(
  */
 export const UserMessage = memo(
   ({ line, prompt }: { line: UserLine; prompt?: string }) => {
-    const columns = useTerminalWidth();
+    const trackedColumns = useTerminalWidth();
+    const columns = Math.max(
+      trackedColumns,
+      getCurrentStdoutColumns() ?? trackedColumns,
+    );
     const promptPrefix = `${prompt || ">"} `;
     const prefixWidth = stringWidth(promptPrefix);
     const continuationPrefix = " ".repeat(prefixWidth);

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -1,6 +1,5 @@
 import { Box } from "ink";
 import { memo } from "react";
-import stringWidth from "string-width";
 import {
   SYSTEM_ALERT_CLOSE,
   SYSTEM_ALERT_OPEN,
@@ -29,6 +28,43 @@ function getCurrentStdoutColumns(): number | null {
   return typeof columns === "number" && columns > 0 ? columns : null;
 }
 
+function isInkFullWidthCodePoint(codePoint: number): boolean {
+  // Match Ink's @alcalzone/ansi-tokenize/is-fullwidth-code-point width
+  // semantics. In particular, U+26A0 WARNING SIGN is narrow here even though
+  // string-width reports it as wide, and Ink's output buffer follows this path.
+  return (
+    codePoint >= 0x1100 &&
+    (codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (0x2e80 <= codePoint && codePoint <= 0x3247 && codePoint !== 0x303f) ||
+      (0x3250 <= codePoint && codePoint <= 0x4dbf) ||
+      (0x4e00 <= codePoint && codePoint <= 0xa4c6) ||
+      (0xa960 <= codePoint && codePoint <= 0xa97c) ||
+      (0xac00 <= codePoint && codePoint <= 0xd7a3) ||
+      (0xf900 <= codePoint && codePoint <= 0xfaff) ||
+      (0xfe10 <= codePoint && codePoint <= 0xfe19) ||
+      (0xfe30 <= codePoint && codePoint <= 0xfe6b) ||
+      (0xff01 <= codePoint && codePoint <= 0xff60) ||
+      (0xffe0 <= codePoint && codePoint <= 0xffe6) ||
+      (0x1b000 <= codePoint && codePoint <= 0x1b001) ||
+      (0x1f200 <= codePoint && codePoint <= 0x1f251) ||
+      (0x20000 <= codePoint && codePoint <= 0x3fffd))
+  );
+}
+
+function inkStringWidth(text: string): number {
+  let width = 0;
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    width += isInkFullWidthCodePoint(codePoint) || character.length > 1 ? 2 : 1;
+    index += character.length;
+  }
+  return width;
+}
+
 /**
  * Word-wrap plain text to a given visible width.
  * Returns an array of lines, each at most `width` visible characters wide.
@@ -44,7 +80,7 @@ function wordWrap(text: string, width: number): string[] {
       current = word;
     } else {
       const candidate = `${current} ${word}`;
-      if (stringWidth(candidate) <= width) {
+      if (inkStringWidth(candidate) <= width) {
         current = candidate;
       } else {
         lines.push(current);
@@ -121,7 +157,7 @@ export function splitSystemReminderBlocks(
 }
 
 function padToColumns(text: string, columns: number): string {
-  const pad = Math.max(0, columns - stringWidth(text));
+  const pad = Math.max(0, columns - inkStringWidth(text));
   return `${text}${" ".repeat(pad)}`;
 }
 
@@ -194,7 +230,7 @@ export const UserMessage = memo(
       getCurrentStdoutColumns() ?? trackedColumns,
     );
     const promptPrefix = `${prompt || ">"} `;
-    const prefixWidth = stringWidth(promptPrefix);
+    const prefixWidth = inkStringWidth(promptPrefix);
     const continuationPrefix = " ".repeat(prefixWidth);
     const contentWidth = Math.max(1, columns - prefixWidth);
     const cleanedText = extractTaskNotificationsForDisplay(
@@ -236,6 +272,7 @@ export const UserMessage = memo(
             key={index}
             backgroundColor={line.highlighted ? background : undefined}
             color={line.highlighted ? textColor : undefined}
+            wrap={line.highlighted ? "end" : "wrap"}
           >
             {line.text}
           </Text>

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -46,9 +46,6 @@ function wordWrap(text: string, width: number): string[] {
   return lines.length > 0 ? lines : [""];
 }
 
-/** Right-padding (in characters) added after content on compact (single-line) messages. */
-const COMPACT_PAD = 1;
-
 /**
  * Split text into system-reminder blocks and user content blocks.
  * System-reminder blocks are identified by <system-reminder>...</system-reminder> tags.
@@ -111,12 +108,19 @@ export function splitSystemReminderBlocks(
   return blocks;
 }
 
+function renderHighlightedBlankLine(
+  columns: number,
+  colorAnsi: string,
+): string {
+  return `${colorAnsi}${" ".repeat(Math.max(0, columns))}\x1b[0m`;
+}
+
 /**
  * Render a block of text with a prompt prefix (first line) and matching-width
  * continuation spaces on subsequent lines.
  * If highlighted, applies background and foreground colors. Otherwise plain text.
  */
-function renderBlock(
+export function renderBlock(
   text: string,
   contentWidth: number,
   columns: number,
@@ -141,9 +145,7 @@ function renderBlock(
 
   if (outputLines.length === 0) return [];
 
-  const isSingleLine = outputLines.length === 1;
-
-  return outputLines.map((ol, i) => {
+  const renderedLines = outputLines.map((ol, i) => {
     const prefix = i === 0 ? promptPrefix : continuationPrefix;
 
     if (!highlighted) {
@@ -159,12 +161,16 @@ function renderBlock(
         ? `${promptPrefix.slice(0, -1)}${colorAnsi} ${ol}`
         : `${prefix}${ol}`;
     const visWidth = stringWidth(content);
-    if (isSingleLine) {
-      return `${colorAnsi}${content}${" ".repeat(COMPACT_PAD)}\x1b[0m`;
-    }
     const pad = Math.max(0, columns - visWidth);
     return `${colorAnsi}${content}${" ".repeat(pad)}\x1b[0m`;
   });
+
+  if (!highlighted) {
+    return renderedLines;
+  }
+
+  const blankLine = renderHighlightedBlankLine(columns, colorAnsi);
+  return [blankLine, ...renderedLines, blankLine];
 }
 
 /**
@@ -172,8 +178,8 @@ function renderBlock(
  *
  * Renders user messages as pre-formatted text with ANSI background codes:
  * - Custom prompt prefix on first line, matching-width spaces on subsequent lines
- * - Single-line messages: compact highlight (content + small padding)
- * - Multi-line messages: full-width highlight box extending to terminal edge
+ * - User content blocks: full-width highlight box extending to terminal edge
+ *   with one highlighted blank row above and below
  * - Word wrapping respects the prompt prefix width
  * - System-reminder parts are shown plain (no highlight), user parts highlighted
  */

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -108,11 +108,10 @@ export function splitSystemReminderBlocks(
   return blocks;
 }
 
-function renderHighlightedBlankLine(
-  columns: number,
-  colorAnsi: string,
-): string {
-  return `${colorAnsi}${" ".repeat(Math.max(0, columns))}\x1b[0m`;
+const ERASE_TO_END_OF_LINE = "\x1b[K";
+
+function renderHighlightedBlankLine(colorAnsi: string): string {
+  return `${colorAnsi}${ERASE_TO_END_OF_LINE}\x1b[0m`;
 }
 
 /**
@@ -123,7 +122,6 @@ function renderHighlightedBlankLine(
 export function renderBlock(
   text: string,
   contentWidth: number,
-  columns: number,
   highlighted: boolean,
   colorAnsi: string, // combined bg + fg ANSI codes
   promptPrefix: string,
@@ -160,16 +158,16 @@ export function renderBlock(
       i === 0
         ? `${promptPrefix.slice(0, -1)}${colorAnsi} ${ol}`
         : `${prefix}${ol}`;
-    const visWidth = stringWidth(content);
-    const pad = Math.max(0, columns - visWidth);
-    return `${colorAnsi}${content}${" ".repeat(pad)}\x1b[0m`;
+    // Fill to the terminal edge without printing trailing spaces. Padding with
+    // spaces can leave the final cell unpainted after Ink/terminal wrapping.
+    return `${colorAnsi}${content}${colorAnsi}${ERASE_TO_END_OF_LINE}\x1b[0m`;
   });
 
   if (!highlighted) {
     return renderedLines;
   }
 
-  const blankLine = renderHighlightedBlankLine(columns, colorAnsi);
+  const blankLine = renderHighlightedBlankLine(colorAnsi);
   return [blankLine, ...renderedLines, blankLine];
 }
 
@@ -217,7 +215,6 @@ export const UserMessage = memo(
       const blockLines = renderBlock(
         block.text,
         contentWidth,
-        columns,
         !block.isSystemReminder,
         colorAnsi,
         promptPrefix,

--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -1,3 +1,4 @@
+import { Box } from "ink";
 import { memo } from "react";
 import stringWidth from "string-width";
 import {
@@ -8,13 +9,18 @@ import {
 } from "../../constants";
 import { extractTaskNotificationsForDisplay } from "../helpers/taskNotifications";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
-import { colors, hexToBgAnsi, hexToFgAnsi } from "./colors";
+import { colors } from "./colors";
 import { Text } from "./Text";
 
 type UserLine = {
   kind: "user";
   id: string;
   text: string;
+};
+
+type RenderedBlockLine = {
+  text: string;
+  highlighted: boolean;
 };
 
 /**
@@ -108,10 +114,9 @@ export function splitSystemReminderBlocks(
   return blocks;
 }
 
-const ERASE_TO_END_OF_LINE = "\x1b[K";
-
-function renderHighlightedBlankLine(colorAnsi: string): string {
-  return `${colorAnsi}${ERASE_TO_END_OF_LINE}\x1b[0m`;
+function padToColumns(text: string, columns: number): string {
+  const pad = Math.max(0, columns - stringWidth(text));
+  return `${text}${" ".repeat(pad)}`;
 }
 
 /**
@@ -122,11 +127,11 @@ function renderHighlightedBlankLine(colorAnsi: string): string {
 export function renderBlock(
   text: string,
   contentWidth: number,
+  columns: number,
   highlighted: boolean,
-  colorAnsi: string, // combined bg + fg ANSI codes
   promptPrefix: string,
   continuationPrefix: string,
-): string[] {
+): RenderedBlockLine[] {
   const inputLines = text.split("\n");
   const outputLines: string[] = [];
 
@@ -145,29 +150,23 @@ export function renderBlock(
 
   const renderedLines = outputLines.map((ol, i) => {
     const prefix = i === 0 ? promptPrefix : continuationPrefix;
+    const content = `${prefix}${ol}`;
 
     if (!highlighted) {
-      return prefix + ol;
+      return { text: content, highlighted: false };
     }
 
-    // Re-apply colorAnsi after the prompt character on the first line because
-    // the prompt string may contain an ANSI reset (\x1b[0m) that clears
-    // the background highlight. Insert before the trailing space so it's
-    // also highlighted.
-    const content =
-      i === 0
-        ? `${promptPrefix.slice(0, -1)}${colorAnsi} ${ol}`
-        : `${prefix}${ol}`;
-    // Fill to the terminal edge without printing trailing spaces. Padding with
-    // spaces can leave the final cell unpainted after Ink/terminal wrapping.
-    return `${colorAnsi}${content}${colorAnsi}${ERASE_TO_END_OF_LINE}\x1b[0m`;
+    return { text: padToColumns(content, columns), highlighted: true };
   });
 
   if (!highlighted) {
     return renderedLines;
   }
 
-  const blankLine = renderHighlightedBlankLine(colorAnsi);
+  const blankLine = {
+    text: " ".repeat(Math.max(0, columns)),
+    highlighted: true,
+  };
   return [blankLine, ...renderedLines, blankLine];
 }
 
@@ -196,34 +195,43 @@ export const UserMessage = memo(
       return null;
     }
 
-    // Build combined ANSI code for background + optional foreground
     const { background, text: textColor } = colors.userMessage;
-    const bgAnsi = hexToBgAnsi(background);
-    const fgAnsi = textColor ? hexToFgAnsi(textColor) : "";
-    const colorAnsi = bgAnsi + fgAnsi;
 
     // Split into system-reminder blocks and user content blocks
     const blocks = splitSystemReminderBlocks(displayText);
 
-    const allLines: string[] = [];
+    const allLines: RenderedBlockLine[] = [];
 
     for (const block of blocks) {
       if (!block.text.trim()) continue;
       if (allLines.length > 0) {
-        allLines.push("");
+        allLines.push({ text: "", highlighted: false });
       }
       const blockLines = renderBlock(
         block.text,
         contentWidth,
+        columns,
         !block.isSystemReminder,
-        colorAnsi,
         promptPrefix,
         continuationPrefix,
       );
       allLines.push(...blockLines);
     }
 
-    return <Text>{allLines.join("\n")}</Text>;
+    return (
+      <Box flexDirection="column">
+        {allLines.map((line, index) => (
+          <Text
+            // biome-ignore lint/suspicious/noArrayIndexKey: rendered rows are static
+            key={index}
+            backgroundColor={line.highlighted ? background : undefined}
+            color={line.highlighted ? textColor : undefined}
+          >
+            {line.text}
+          </Text>
+        ))}
+      </Box>
+    );
   },
 );
 

--- a/src/cli/components/colors.ts
+++ b/src/cli/components/colors.ts
@@ -5,7 +5,11 @@
  * No colors should be hardcoded in components - all should reference this file.
  */
 
-import { getTerminalTheme } from "../helpers/terminalTheme";
+import {
+  getTerminalBackgroundColor,
+  getTerminalTheme,
+  type TerminalRgb,
+} from "../helpers/terminalTheme";
 
 /**
  * Parse a hex color (#RRGGBB) to RGB components.
@@ -17,6 +21,39 @@ function parseHex(hex: string): { r: number; g: number; b: number } {
     g: parseInt(h.slice(2, 4), 16),
     b: parseInt(h.slice(4, 6), 16),
   };
+}
+
+function rgbToHex({ r, g, b }: TerminalRgb): string {
+  const toHex = (value: number) => value.toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function isLightRgb({ r, g, b }: TerminalRgb): boolean {
+  return 0.299 * r + 0.587 * g + 0.114 * b > 128;
+}
+
+function blendRgb(
+  fg: TerminalRgb,
+  bg: TerminalRgb,
+  alpha: number,
+): TerminalRgb {
+  return {
+    r: Math.floor(fg.r * alpha + bg.r * (1 - alpha)),
+    g: Math.floor(fg.g * alpha + bg.g * (1 - alpha)),
+    b: Math.floor(fg.b * alpha + bg.b * (1 - alpha)),
+  };
+}
+
+function getCodexUserMessageBackground(): string {
+  const theme = getTerminalTheme();
+  const terminalBg =
+    getTerminalBackgroundColor() ??
+    (theme === "light" ? { r: 255, g: 255, b: 255 } : { r: 0, g: 0, b: 0 });
+  const overlay = isLightRgb(terminalBg)
+    ? { color: { r: 0, g: 0, b: 0 }, alpha: 0.04 }
+    : { color: { r: 255, g: 255, b: 255 }, alpha: 0.12 };
+
+  return rgbToHex(blendRgb(overlay.color, terminalBg, overlay.alpha));
 }
 
 /**
@@ -267,9 +304,8 @@ export const colors = {
   // User messages (past prompts) - theme-aware background
   // Uses getter to read theme at render time (after async init)
   get userMessage() {
-    const theme = getTerminalTheme();
     return {
-      background: theme === "light" ? "#dcddf2" : "#2d2d2d", // light purple for light, subtle gray for dark
+      background: getCodexUserMessageBackground(),
       text: undefined, // use default terminal text color
     };
   },

--- a/src/cli/helpers/terminalTheme.ts
+++ b/src/cli/helpers/terminalTheme.ts
@@ -1,7 +1,9 @@
 export type TerminalTheme = "light" | "dark";
+export type TerminalRgb = { r: number; g: number; b: number };
 
 // Cache for the detected theme
 let cachedTheme: TerminalTheme | null = null;
+let cachedBackground: TerminalRgb | null = null;
 
 /**
  * Normalize a hex color component of any length to 8-bit (0-255).
@@ -24,7 +26,7 @@ export function parseHexComponent(hex: string): number {
  */
 async function queryTerminalBackground(
   timeoutMs = 100,
-): Promise<{ r: number; g: number; b: number } | null> {
+): Promise<TerminalRgb | null> {
   // Skip if not a TTY
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return null;
@@ -124,6 +126,7 @@ export async function detectTerminalThemeAsync(): Promise<TerminalTheme> {
   // Try OSC 11 query first
   const bg = await queryTerminalBackground(100);
   if (bg) {
+    cachedBackground = bg;
     const luminance = calculateLuminance(bg.r, bg.g, bg.b);
     // Threshold: 0.5 is mid-gray, but use 0.4 to be more conservative
     // (most "light" themes have luminance > 0.7)
@@ -164,6 +167,14 @@ export function getTerminalTheme(): TerminalTheme {
   if (cachedTheme) return cachedTheme;
   cachedTheme = detectTerminalThemeSync();
   return cachedTheme;
+}
+
+/**
+ * Get the cached terminal background color from the OSC 11 query, if available.
+ * Returns null when the terminal did not respond or async detection has not run.
+ */
+export function getTerminalBackgroundColor(): TerminalRgb | null {
+  return cachedBackground;
 }
 
 /**

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import stripAnsi from "strip-ansi";
 import {
   renderBlock,
   splitSystemReminderBlocks,
@@ -34,31 +33,22 @@ describe("splitSystemReminderBlocks", () => {
 });
 
 describe("renderBlock", () => {
-  test("wraps highlighted user content in erase-to-line-end padding rows", () => {
-    const colorAnsi = "\x1b[48;2;45;45;45m";
-    const eraseToEndOfLine = "\x1b[K";
-    const lines = renderBlock("hello world", 22, true, colorAnsi, "> ", "  ");
+  test("wraps highlighted user content in full-width padding rows", () => {
+    const columns = 24;
+    const lines = renderBlock("hello world", 22, columns, true, "> ", "  ");
 
     expect(lines).toHaveLength(3);
-    expect(lines.every((line) => line.startsWith(colorAnsi))).toBe(true);
-    expect(lines[0]).toBe(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`);
-    expect(stripAnsi(lines[1] ?? "")).toBe("> hello world");
-    expect(lines[1]?.endsWith(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`)).toBe(
-      true,
+    expect(lines.every((line) => line.highlighted)).toBe(true);
+    expect(lines[0]?.text).toBe(" ".repeat(columns));
+    expect(lines[1]?.text).toBe(
+      `> hello world${" ".repeat(columns - "> hello world".length)}`,
     );
-    expect(lines[2]).toBe(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`);
+    expect(lines[2]?.text).toBe(" ".repeat(columns));
   });
 
   test("keeps unhighlighted blocks compact", () => {
-    const lines = renderBlock(
-      "system context",
-      22,
-      false,
-      "\x1b[48;2;45;45;45m",
-      "> ",
-      "  ",
-    );
+    const lines = renderBlock("system context", 22, 24, false, "> ", "  ");
 
-    expect(lines).toEqual(["> system context"]);
+    expect(lines).toEqual([{ text: "> system context", highlighted: false }]);
   });
 });

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -46,6 +46,13 @@ describe("renderBlock", () => {
     expect(lines[2]?.text).toBe(" ".repeat(columns));
   });
 
+  test("pads warning-sign rows using Ink width semantics", () => {
+    const columns = 12;
+    const lines = renderBlock("⚠ warn", 10, columns, true, "> ", "  ");
+
+    expect(lines[1]?.text).toBe(`> ⚠ warn${" ".repeat(4)}`);
+  });
+
   test("keeps unhighlighted blocks compact", () => {
     const lines = renderBlock("system context", 22, 24, false, "> ", "  ");
 

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -34,33 +34,25 @@ describe("splitSystemReminderBlocks", () => {
 });
 
 describe("renderBlock", () => {
-  test("wraps highlighted user content in full-width padding rows", () => {
+  test("wraps highlighted user content in erase-to-line-end padding rows", () => {
     const colorAnsi = "\x1b[48;2;45;45;45m";
-    const columns = 24;
-    const lines = renderBlock(
-      "hello world",
-      22,
-      columns,
-      true,
-      colorAnsi,
-      "> ",
-      "  ",
-    );
+    const eraseToEndOfLine = "\x1b[K";
+    const lines = renderBlock("hello world", 22, true, colorAnsi, "> ", "  ");
 
     expect(lines).toHaveLength(3);
     expect(lines.every((line) => line.startsWith(colorAnsi))).toBe(true);
-    expect(stripAnsi(lines[0] ?? "")).toBe(" ".repeat(columns));
-    expect(stripAnsi(lines[1] ?? "")).toBe(
-      `> hello world${" ".repeat(columns - "> hello world".length)}`,
+    expect(lines[0]).toBe(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`);
+    expect(stripAnsi(lines[1] ?? "")).toBe("> hello world");
+    expect(lines[1]?.endsWith(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`)).toBe(
+      true,
     );
-    expect(stripAnsi(lines[2] ?? "")).toBe(" ".repeat(columns));
+    expect(lines[2]).toBe(`${colorAnsi}${eraseToEndOfLine}\x1b[0m`);
   });
 
   test("keeps unhighlighted blocks compact", () => {
     const lines = renderBlock(
       "system context",
       22,
-      24,
       false,
       "\x1b[48;2;45;45;45m",
       "> ",

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { splitSystemReminderBlocks } from "../../cli/components/UserMessageRich";
+import stripAnsi from "strip-ansi";
+import {
+  renderBlock,
+  splitSystemReminderBlocks,
+} from "../../cli/components/UserMessageRich";
 
 describe("splitSystemReminderBlocks", () => {
   test("treats unmatched system-reminder opener as literal user text", () => {
@@ -26,5 +30,43 @@ describe("splitSystemReminderBlocks", () => {
 
     expect(blocks.some((b) => b.isSystemReminder)).toBe(true);
     expect(blocks.some((b) => b.text.includes("<system-alert>"))).toBe(true);
+  });
+});
+
+describe("renderBlock", () => {
+  test("wraps highlighted user content in full-width padding rows", () => {
+    const colorAnsi = "\x1b[48;2;45;45;45m";
+    const columns = 24;
+    const lines = renderBlock(
+      "hello world",
+      22,
+      columns,
+      true,
+      colorAnsi,
+      "> ",
+      "  ",
+    );
+
+    expect(lines).toHaveLength(3);
+    expect(lines.every((line) => line.startsWith(colorAnsi))).toBe(true);
+    expect(stripAnsi(lines[0] ?? "")).toBe(" ".repeat(columns));
+    expect(stripAnsi(lines[1] ?? "")).toBe(
+      `> hello world${" ".repeat(columns - "> hello world".length)}`,
+    );
+    expect(stripAnsi(lines[2] ?? "")).toBe(" ".repeat(columns));
+  });
+
+  test("keeps unhighlighted blocks compact", () => {
+    const lines = renderBlock(
+      "system context",
+      22,
+      24,
+      false,
+      "\x1b[48;2;45;45;45m",
+      "> ",
+      "  ",
+    );
+
+    expect(lines).toEqual(["> system context"]);
   });
 });


### PR DESCRIPTION
## Summary
- Render highlighted TUI user messages as full-width blocks with one highlighted spacer row above and below the content.
- Remove the compact single-line highlight path so short and wrapped prompts use the same Codex-like block treatment.
- Add regression coverage for highlighted user blocks and compact unhighlighted system-context blocks.

## Test plan
- [x] `bun test src/tests/cli/userMessageRich.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)