### PR TITLE
fix(local): guard unsupported image history by model modality

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -23,6 +23,10 @@ function supportsDistinctAnthropicXHighEffort(modelHandle: string): boolean {
   return modelHandle.includes("claude-opus-4-7");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Builds model_settings from updateArgs based on provider type.
  * Always ensures parallel_tool_calls is enabled.
@@ -201,6 +205,16 @@ function buildModelSettings(
   ) {
     (settings as Record<string, unknown>).max_output_tokens =
       updateArgs.max_output_tokens;
+  }
+
+  // Preserve OpenCode-style modality metadata when present so local-model
+  // transforms can decide whether file/image parts are safe to send.
+  if (isRecord(updateArgs?.modalities)) {
+    (settings as Record<string, unknown>).modalities = updateArgs.modalities;
+  }
+  if (isRecord(updateArgs?.capabilities)) {
+    (settings as Record<string, unknown>).capabilities =
+      updateArgs.capabilities;
   }
 
   return settings;

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -32,6 +32,7 @@ import {
 } from "./ProviderTurnExecutor";
 
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
+type InputModality = "text" | "image" | "audio" | "video" | "pdf";
 type AISDKUIMessageStreamFinish = {
   messages: LocalMessage[];
   responseMessage: LocalMessage;
@@ -248,12 +249,201 @@ function shouldKeepReasoningPart(
   return true;
 }
 
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+    ? value
+    : undefined;
+}
+
+function mimeToModality(mime: string): InputModality | undefined {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("video/")) return "video";
+  if (mime === "application/pdf") return "pdf";
+  return undefined;
+}
+
+function modalitiesFromModelSettings(
+  modelSettings: Record<string, unknown>,
+): Set<InputModality> | undefined {
+  const modalities = isRecord(modelSettings.modalities)
+    ? modelSettings.modalities
+    : undefined;
+  const input = stringArray(modalities?.input);
+  if (!input) return undefined;
+
+  return new Set(
+    input.filter((entry): entry is InputModality =>
+      ["text", "image", "audio", "video", "pdf"].includes(entry),
+    ),
+  );
+}
+
+function capabilitiesFromModelSettings(
+  modelSettings: Record<string, unknown>,
+): Set<InputModality> | undefined {
+  const capabilities = isRecord(modelSettings.capabilities)
+    ? modelSettings.capabilities
+    : undefined;
+  const input = isRecord(capabilities?.input) ? capabilities.input : undefined;
+  if (!input) return undefined;
+
+  const supported = new Set<InputModality>(["text"]);
+  for (const modality of ["image", "audio", "video", "pdf"] as const) {
+    if (input[modality] === true) supported.add(modality);
+  }
+  return supported;
+}
+
+function knownModelInputModalities(
+  modelHandle: string,
+  modelSettings: Record<string, unknown>,
+): Set<InputModality> {
+  const explicitModalities = modalitiesFromModelSettings(modelSettings);
+  if (explicitModalities) return explicitModalities;
+
+  const explicitCapabilities = capabilitiesFromModelSettings(modelSettings);
+  if (explicitCapabilities) return explicitCapabilities;
+
+  const handle = modelHandle.toLowerCase();
+  const supported = new Set<InputModality>(["text"]);
+
+  // Built-in local defaults. Custom/OpenAI-compatible models can opt in via
+  // model_settings.modalities.input, matching OpenCode's configuration shape.
+  if (
+    handle.startsWith("anthropic/") ||
+    handle.startsWith("claude-pro-max/") ||
+    handle.startsWith("bedrock/") ||
+    handle.startsWith("google_ai/") ||
+    handle.startsWith("google_vertex/") ||
+    handle.includes("gemini") ||
+    handle.includes("claude") ||
+    handle.includes("gpt-4o") ||
+    handle.includes("gpt-4.1") ||
+    handle.includes("gpt-5") ||
+    handle.includes("o3") ||
+    handle.includes("o4") ||
+    handle.includes("vision") ||
+    handle.includes("qwen-vl") ||
+    handle.includes("qwen2-vl") ||
+    handle.includes("qwen2.5-vl") ||
+    handle.includes("qwen3-vl") ||
+    handle.includes("llava") ||
+    handle.includes("bakllava") ||
+    handle.includes("moondream")
+  ) {
+    supported.add("image");
+  }
+
+  return supported;
+}
+
+function modelSupportsInputModality(
+  modelHandle: string,
+  modelSettings: Record<string, unknown>,
+  modality: InputModality,
+): boolean {
+  if (modality === "text") return true;
+  return knownModelInputModalities(modelHandle, modelSettings).has(modality);
+}
+
+function isEmptyBase64DataUrl(data: unknown): boolean {
+  if (typeof data !== "string" || !data.startsWith("data:")) return false;
+  const match = data.match(/^data:([^;]+);base64,(.*)$/);
+  return Boolean(match && (!match[2] || match[2].length === 0));
+}
+
+function filePartMediaType(part: Record<string, unknown>): string | undefined {
+  if (typeof part.mediaType === "string") return part.mediaType;
+  if (typeof part.mime === "string") return part.mime;
+  return undefined;
+}
+
+function imagePartMediaType(part: Record<string, unknown>): string | undefined {
+  if (typeof part.image === "string" && part.image.startsWith("data:")) {
+    return part.image.split(";")[0]?.replace("data:", "");
+  }
+  if (isRecord(part.source) && typeof part.source.media_type === "string") {
+    return part.source.media_type;
+  }
+  return undefined;
+}
+
+function partFilename(part: Record<string, unknown>): string | undefined {
+  return stringValue(part.filename) ?? stringValue(part.name);
+}
+
+function replaceUnsupportedInputPart(
+  part: LocalMessage["parts"][number],
+  agent: ProviderTurnInput["agent"],
+): LocalMessage["parts"][number] {
+  if (!isRecord(part)) return part;
+  const record = part as Record<string, unknown>;
+  const partType = typeof record.type === "string" ? record.type : undefined;
+  if (partType !== "file" && partType !== "image") {
+    return part;
+  }
+
+  if (partType === "image" && isEmptyBase64DataUrl(record.image)) {
+    return {
+      type: "text",
+      text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
+    } as LocalMessage["parts"][number];
+  }
+
+  const mime =
+    partType === "image"
+      ? imagePartMediaType(record)
+      : filePartMediaType(record);
+  if (!mime) return part;
+
+  const modality = mimeToModality(mime);
+  if (!modality) return part;
+
+  if (modelSupportsInputModality(agent.model, agent.model_settings, modality)) {
+    return part;
+  }
+
+  const name = partFilename(record);
+  return {
+    type: "text",
+    text: `ERROR: Cannot read ${name ? `"${name}"` : modality} (this model does not support ${modality} input). Inform the user.`,
+  } as LocalMessage["parts"][number];
+}
+
+function replaceUnsupportedInputParts(
+  messages: LocalMessage[],
+  agent: ProviderTurnInput["agent"],
+): LocalMessage[] {
+  let didChange = false;
+  const transformed = messages.map((message) => {
+    if (message.role !== "user") return message;
+    let messageDidChange = false;
+    const parts = message.parts.map((part) => {
+      const replacement = replaceUnsupportedInputPart(part, agent);
+      if (replacement !== part) {
+        didChange = true;
+        messageDidChange = true;
+      }
+      return replacement;
+    });
+    return messageDidChange ? { ...message, parts } : message;
+  });
+  return didChange ? transformed : messages;
+}
+
 function sanitizeUIMessagesForProvider(
   messages: LocalMessage[],
   provider: AISDKProviderKind,
+  agent: ProviderTurnInput["agent"],
 ): LocalMessage[] {
-  if (provider === "unknown") return messages;
-  return messages
+  const capabilitySanitizedMessages = replaceUnsupportedInputParts(
+    messages,
+    agent,
+  );
+  if (provider === "unknown") return capabilitySanitizedMessages;
+  return capabilitySanitizedMessages
     .map((message) => {
       const parts = message.parts.filter((part) =>
         shouldKeepReasoningPart(part, provider),
@@ -401,7 +591,11 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
       input.agent.model_settings,
     );
     const uiMessages = await validateUIMessages<LocalMessage>({
-      messages: sanitizeUIMessagesForProvider(input.uiMessages, provider),
+      messages: sanitizeUIMessagesForProvider(
+        input.uiMessages,
+        provider,
+        input.agent,
+      ),
       tools: tools as never,
     });
     const result = this.runStreamText({

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -694,6 +694,153 @@ describe("AISDKStreamAdapter", () => {
     expect(serialized).not.toContain("openai reasoning");
   });
 
+  test("replaces unsupported image file parts with explicit text before AI SDK conversion", async () => {
+    let capturedMessages: unknown[] | undefined;
+    const streamText: AISDKStreamTextFunction = (options) => {
+      capturedMessages = options.messages;
+      return {
+        fullStream: (async function* () {
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await collect(
+      adapter.stream(
+        providerInput(
+          [
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [
+                { type: "text", text: "what is in this screenshot?" },
+                {
+                  type: "file",
+                  mediaType: "image/png",
+                  url: "data:image/png;base64,aGVsbG8=",
+                  filename: "screenshot.png",
+                },
+              ],
+            },
+          ],
+          {
+            id: "agent-test",
+            name: "Test Agent",
+            description: null,
+            system: "agent system prompt",
+            tags: [],
+            model: "ollama/llama2",
+            model_settings: { provider_type: "ollama" },
+          },
+        ),
+      ),
+    );
+
+    const serialized = JSON.stringify(capturedMessages);
+    expect(serialized).toContain(
+      'ERROR: Cannot read \\"screenshot.png\\" (this model does not support image input). Inform the user.',
+    );
+    expect(serialized).not.toContain('"type":"file"');
+    expect(serialized).not.toContain("data:image/png");
+  });
+
+  test("preserves image file parts when model modalities include image input", async () => {
+    let capturedMessages: unknown[] | undefined;
+    const streamText: AISDKStreamTextFunction = (options) => {
+      capturedMessages = options.messages;
+      return {
+        fullStream: (async function* () {
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await collect(
+      adapter.stream(
+        providerInput(
+          [
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [
+                { type: "text", text: "what is in this screenshot?" },
+                {
+                  type: "file",
+                  mediaType: "image/png",
+                  url: "data:image/png;base64,aGVsbG8=",
+                  filename: "screenshot.png",
+                },
+              ],
+            },
+          ],
+          {
+            id: "agent-test",
+            name: "Test Agent",
+            description: null,
+            system: "agent system prompt",
+            tags: [],
+            model: "ollama/llama2",
+            model_settings: {
+              provider_type: "ollama",
+              modalities: { input: ["text", "image"], output: ["text"] },
+            },
+          },
+        ),
+      ),
+    );
+
+    const serialized = JSON.stringify(capturedMessages);
+    expect(serialized).toContain('"type":"file"');
+    expect(serialized).toContain("data:image/png;base64,aGVsbG8=");
+    expect(serialized).not.toContain("this model does not support image input");
+  });
+
+  test("turns empty legacy image data URLs into an explicit user-visible error", async () => {
+    let capturedMessages: unknown[] | undefined;
+    const streamText: AISDKStreamTextFunction = (options) => {
+      capturedMessages = options.messages;
+      return {
+        fullStream: (async function* () {
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [
+              {
+                type: "image",
+                image: "data:image/png;base64,",
+              } as unknown as LocalMessage["parts"][number],
+            ],
+          },
+        ]),
+      ),
+    );
+
+    const serialized = JSON.stringify(capturedMessages);
+    expect(serialized).toContain(
+      "ERROR: Image file is empty or corrupted. Please provide a valid image.",
+    );
+  });
+
   test("projects UI tool outputs without AI SDK approval protocol parts", async () => {
     let capturedMessages: unknown[] | undefined;
     const streamText: AISDKStreamTextFunction = (options) => {

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1931,7 +1931,7 @@ describe("LocalBackend", () => {
 
       const agent = await backend.createAgent({
         name: "Image Agent",
-        model: "openai/gpt-test",
+        model: "openai/gpt-4.1",
       } as AgentCreateBody);
       const conversation = await backend.createConversation({
         agent_id: agent.id,


### PR DESCRIPTION
## Summary
- Add an OpenCode-style local AI SDK transform that maps file/image MIME types to modalities and replaces unsupported user parts with explicit text before `validateUIMessages` / `convertToModelMessages`.
- Honor `model_settings.modalities.input` / `model_settings.capabilities.input` for custom model capability declarations, while preserving known built-in vision defaults.
- Preserve modality/capability metadata from model presets when building model settings.

## Test plan
- [x] `bun test src/tests/backend/ai-sdk-stream-adapter.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)