### PR TITLE
fix(cli): preserve bash preview prompt spacing

### DIFF
--- a/src/cli/components/SyntaxHighlightedCommand.tsx
+++ b/src/cli/components/SyntaxHighlightedCommand.tsx
@@ -7,7 +7,8 @@ import { Text } from "./Text";
 
 const lowlight = createLowlight(common);
 const BASH_LANGUAGE = "bash";
-const FIRST_LINE_PREFIX = "$ ";
+const FIRST_LINE_PROMPT = "$";
+const PROMPT_COLUMN_WIDTH = 2;
 
 type Props = {
   command: string;
@@ -398,9 +399,11 @@ export const SyntaxHighlightedCommand = memo(
           return (
             <Box key={`${lineIdx}:${lineKey}`}>
               {showPrompt ? (
-                <Text color={palette.prompt}>
-                  {lineIdx === 0 ? FIRST_LINE_PREFIX : "  "}
-                </Text>
+                <Box width={PROMPT_COLUMN_WIDTH} flexShrink={0}>
+                  {lineIdx === 0 ? (
+                    <Text color={palette.prompt}>{FIRST_LINE_PROMPT}</Text>
+                  ) : null}
+                </Box>
               ) : null}
               <Text color={palette.text}>
                 {lineIdx === 0 && prefix ? prefix : null}

--- a/src/tests/cli/bash-preview-rendering.test.tsx
+++ b/src/tests/cli/bash-preview-rendering.test.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { BashPreview } from "../../cli/components/previews/BashPreview";
+
+class CaptureStream extends Writable {
+  columns = 80;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderPreview(command: string): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(<BashPreview command={command} />, {
+    stdout,
+    stdin: createInputStream(),
+    debug: false,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("bash approval previews keep a visible space after the shell prompt", async () => {
+  const output = await renderPreview("mkdir -p /tmp/letta-code-preview");
+
+  expect(output).toContain("  $ mkdir -p /tmp/letta-code-preview");
+  expect(output).not.toContain("  $mkdir -p /tmp/letta-code-preview");
+});


### PR DESCRIPTION
## Summary
- Fixes bash/shell approval previews rendering commands as `$mkdir` by moving the prompt spacing into Ink layout instead of a trailing text space.
- Adds a regression render test that verifies preview output contains `$ mkdir` and not `$mkdir`.

## Test plan
- [x] `bun test src/tests/cli/bash-preview-rendering.test.tsx`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)