### PR TITLE
fix(local): allow no-memfs sessions

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -392,7 +392,8 @@ export async function applyMemfsFlags(
 
   if (backend.capabilities.localMemfs) {
     if (noMemfsFlag) {
-      throw new Error("Disabling MemFS is not supported by the local backend.");
+      settingsManager.setMemfsEnabled(agentId, false);
+      return { action: "disabled" };
     }
     const memoryDir = getScopedMemoryFilesystemRoot(agentId);
     const { initializeLocalMemoryRepo } = await import("./memoryGit");

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -40,7 +40,10 @@ import type {
   LocalStoreOptions,
   StoredMessage,
 } from "./LocalStore";
-import { getLocalBackendMemoryFilesystemRoot } from "./paths";
+import {
+  getLocalBackendMemoryFilesystemRoot,
+  isLocalBackendNoMemfsEnvEnabled,
+} from "./paths";
 import {
   appendAvailableSkillsBlock,
   compileLocalSystemPrompt,
@@ -59,6 +62,7 @@ export interface LocalBackendOptions {
   streamText?: AISDKStreamTextFunction;
   generateText?: LocalGenerateTextFunction;
   memoryDir?: string;
+  memfsEnabled?: boolean;
 }
 
 function sanitizeFrontmatterValue(value: string): string {
@@ -176,6 +180,7 @@ export class LocalBackend extends HeadlessBackend {
   private readonly storageDir: string;
   private readonly createModel?: () => LanguageModel;
   private readonly generateText?: LocalGenerateTextFunction;
+  private readonly memfsEnabledOverride?: boolean;
 
   constructor(options: LocalBackendOptions) {
     const localBackendRef: { current?: LocalBackend } = {};
@@ -215,6 +220,7 @@ export class LocalBackend extends HeadlessBackend {
     this.memoryDir = options.memoryDir;
     this.createModel = options.createModel;
     this.generateText = options.generateText;
+    this.memfsEnabledOverride = options.memfsEnabled;
   }
 
   override async listModels() {
@@ -226,11 +232,13 @@ export class LocalBackend extends HeadlessBackend {
   ) {
     const [body] = args;
     const agent = await super.createAgent(...args);
-    await this.ensureLocalMemoryRepo(
-      agent.id,
-      initialMemoryFilesFromCreateBody(body),
-      agent.name ?? undefined,
-    );
+    if (this.isLocalMemfsEnabled()) {
+      await this.ensureLocalMemoryRepo(
+        agent.id,
+        initialMemoryFilesFromCreateBody(body),
+        agent.name ?? undefined,
+      );
+    }
     await this.compileAndMaybePersistSystemPrompt("default", agent.id, {
       dryRun: false,
     });
@@ -315,6 +323,10 @@ export class LocalBackend extends HeadlessBackend {
       this.memoryDir ??
       getLocalBackendMemoryFilesystemRoot(agentId, this.storageDir)
     );
+  }
+
+  private isLocalMemfsEnabled(): boolean {
+    return this.memfsEnabledOverride ?? !isLocalBackendNoMemfsEnvEnabled();
   }
 
   private async ensureLocalMemoryRepo(
@@ -494,13 +506,15 @@ export class LocalBackend extends HeadlessBackend {
       conversationId,
       agentId,
     );
-    const memfsRevision = await getMemoryHeadRevision(
-      this.memoryDirForAgent(agentId),
-    );
+    const memfsEnabled = this.isLocalMemfsEnabled();
+    const memfsRevision = memfsEnabled
+      ? await getMemoryHeadRevision(this.memoryDirForAgent(agentId))
+      : undefined;
     if (
       existing?.rawSystemHash === hashRawSystemPrompt(agent.system) &&
-      memfsRevision !== null &&
-      existing.memfsRevision === memfsRevision
+      (memfsEnabled
+        ? memfsRevision !== null && existing.memfsRevision === memfsRevision
+        : existing.memfsRevision === undefined)
     ) {
       return existing;
     }
@@ -516,7 +530,10 @@ export class LocalBackend extends HeadlessBackend {
     options: { dryRun: boolean; previousMessageCount?: number },
   ): Promise<LocalCompiledSystemPrompt> {
     const agent = this.store.retrieveAgentRecord(agentId);
-    await this.ensureLocalMemoryRepo(agentId, [], agent.name);
+    const memfsEnabled = this.isLocalMemfsEnabled();
+    if (memfsEnabled) {
+      await this.ensureLocalMemoryRepo(agentId, [], agent.name);
+    }
     const previousMessageCount =
       options.previousMessageCount ??
       this.store.listConversationMessages(conversationId, {
@@ -527,7 +544,8 @@ export class LocalBackend extends HeadlessBackend {
       agent,
       conversationId,
       previousMessageCount,
-      memoryDir: this.memoryDirForAgent(agentId),
+      memoryDir: memfsEnabled ? this.memoryDirForAgent(agentId) : undefined,
+      includeMemfs: memfsEnabled,
     });
     if (!options.dryRun) {
       this.store.setCompiledSystemPrompt(conversationId, agentId, compiled);

--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -64,4 +64,6 @@ export {
   getLocalBackendMemoryFilesystemRoot,
   getLocalBackendStorageDir,
   isLocalBackendEnvEnabled,
+  isLocalBackendNoMemfsEnvEnabled,
+  LOCAL_BACKEND_NO_MEMFS_ENV,
 } from "./paths";

--- a/src/backend/local/paths.ts
+++ b/src/backend/local/paths.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 export const LOCAL_BACKEND_DIR_ENV = "LETTA_LOCAL_BACKEND_DIR";
 export const LOCAL_BACKEND_EXPERIMENTAL_ENV =
   "LETTA_LOCAL_BACKEND_EXPERIMENTAL";
+export const LOCAL_BACKEND_NO_MEMFS_ENV = "LETTA_LOCAL_BACKEND_NO_MEMFS";
 
 function isTruthyEnv(value: string | undefined): boolean {
   return value === "1" || value?.toLowerCase() === "true";
@@ -13,6 +14,12 @@ export function isLocalBackendEnvEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return isTruthyEnv(env[LOCAL_BACKEND_EXPERIMENTAL_ENV]);
+}
+
+export function isLocalBackendNoMemfsEnvEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isTruthyEnv(env[LOCAL_BACKEND_NO_MEMFS_ENV]);
 }
 
 export function getLocalBackendStorageDir(homeDir = homedir()): string {

--- a/src/backend/local/systemPromptCompilation.ts
+++ b/src/backend/local/systemPromptCompilation.ts
@@ -27,6 +27,7 @@ export interface CompileLocalSystemPromptOptions {
   agent: LocalAgentRecord;
   conversationId: string;
   memoryDir?: string;
+  includeMemfs?: boolean;
   now?: Date;
   previousMessageCount?: number;
 }
@@ -430,7 +431,10 @@ export function compileLocalSystemPrompt(
   const compiledAt = options.now ?? new Date();
   const memoryDir =
     options.memoryDir ?? getMemoryFilesystemRoot(options.agent.id);
-  const memfs = renderMemfsProjection(memoryDir);
+  const memfs =
+    options.includeMemfs === false
+      ? { content: "", revision: undefined }
+      : renderMemfsProjection(memoryDir);
   const metadata = compileMemoryMetadata({
     agentId: options.agent.id,
     conversationId: options.conversationId,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -49,6 +49,10 @@ import {
   type ConversationMessageStreamBody,
   getBackend,
 } from "./backend";
+import {
+  isLocalBackendNoMemfsEnvEnabled,
+  LOCAL_BACKEND_NO_MEMFS_ENV,
+} from "./backend/local/paths";
 import type { ParsedCliArgs } from "./cli/args";
 import {
   normalizeConversationShorthandFlags,
@@ -602,6 +606,13 @@ export async function handleHeadlessCommand(
   const skillSourcesRaw = values["skill-sources"];
   const memfsFlag = values.memfs;
   const noMemfsFlag = values["no-memfs"];
+  const localNoMemfsRequested = Boolean(
+    backend.capabilities.localMemfs &&
+      (noMemfsFlag || isLocalBackendNoMemfsEnvEnabled()),
+  );
+  if (localNoMemfsRequested) {
+    process.env[LOCAL_BACKEND_NO_MEMFS_ENV] = "1";
+  }
   // Startup policy for the git-backed memory pull on session init.
   // "blocking" (default): await the pull before proceeding.
   // "background": fire the pull async, emit init without waiting.
@@ -613,7 +624,7 @@ export async function handleHeadlessCommand(
       : "blocking";
   const requestedMemoryPromptMode: "memfs" | "standard" | undefined = memfsFlag
     ? "memfs"
-    : noMemfsFlag
+    : noMemfsFlag || localNoMemfsRequested
       ? "standard"
       : undefined;
   if (memfsFlag && !backend.capabilities.remoteMemfs) {
@@ -625,7 +636,8 @@ export async function handleHeadlessCommand(
     console.error("Error: --memfs is not supported by this backend yet");
     process.exit(1);
   }
-  const shouldAutoEnableMemfsForNewAgent = !memfsFlag && !noMemfsFlag;
+  const shouldAutoEnableMemfsForNewAgent =
+    !memfsFlag && !noMemfsFlag && !localNoMemfsRequested;
   const fromAfFile = resolveImportFlagAlias({
     importFlagValue: values.import,
     fromAfFlagValue: values["from-af"],
@@ -1054,7 +1066,9 @@ export async function handleHeadlessCommand(
       (await isLettaCloud());
     const effectiveMemoryMode: MemoryPromptMode | undefined = backend
       .capabilities.localMemfs
-      ? "local-memfs"
+      ? localNoMemfsRequested
+        ? "standard"
+        : "local-memfs"
       : (requestedMemoryPromptMode ??
         (willAutoEnableMemfs ? "memfs" : undefined));
 
@@ -1215,12 +1229,8 @@ export async function handleHeadlessCommand(
   //   "skip"                 – skip the pull this session.
   if (!backend.capabilities.remoteMemfs) {
     if (backend.capabilities.localMemfs) {
-      if (noMemfsFlag) {
-        console.error("Disabling MemFS is not supported by the local backend.");
-        process.exit(1);
-      }
-      settingsManager.setMemfsEnabled(agent.id, true);
-    } else if (noMemfsFlag) {
+      settingsManager.setMemfsEnabled(agent.id, !localNoMemfsRequested);
+    } else if (noMemfsFlag || localNoMemfsRequested) {
       settingsManager.setMemfsEnabled(agent.id, false);
     }
   } else if (memfsStartupPolicy === "skip") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ import {
 } from "./backend";
 import { getBillingTier } from "./backend/api/metadata";
 import {
+  isLocalBackendNoMemfsEnvEnabled,
+  LOCAL_BACKEND_NO_MEMFS_ENV,
+} from "./backend/local/paths";
+import {
   extractBackendFlag,
   type ParsedCliArgs,
   parseCliArgs,
@@ -556,12 +560,21 @@ async function main(): Promise<void> {
   const skillsDirectory = values.skills ?? undefined;
   const memfsFlag = values.memfs;
   const noMemfsFlag = values["no-memfs"];
+  const startupBackend = getBackend();
+  const localNoMemfsRequested = Boolean(
+    startupBackend.capabilities.localMemfs &&
+      (noMemfsFlag || isLocalBackendNoMemfsEnvEnabled()),
+  );
+  if (localNoMemfsRequested) {
+    process.env[LOCAL_BACKEND_NO_MEMFS_ENV] = "1";
+  }
   const requestedMemoryPromptMode: "memfs" | "standard" | undefined = memfsFlag
     ? "memfs"
-    : noMemfsFlag
+    : noMemfsFlag || localNoMemfsRequested
       ? "standard"
       : undefined;
-  const shouldAutoEnableMemfsForNewAgent = !memfsFlag && !noMemfsFlag;
+  const shouldAutoEnableMemfsForNewAgent =
+    !memfsFlag && !noMemfsFlag && !localNoMemfsRequested;
   const noSkillsFlag = values["no-skills"];
   const noBundledSkillsFlag = values["no-bundled-skills"];
   const skillSourcesRaw = values["skill-sources"];
@@ -1750,7 +1763,9 @@ async function main(): Promise<void> {
             shouldAutoEnableMemfsForNewAgent && (await isLettaCloud());
           const effectiveMemoryMode: MemoryPromptMode | undefined = backend
             .capabilities.localMemfs
-            ? "local-memfs"
+            ? localNoMemfsRequested
+              ? "standard"
+              : "local-memfs"
             : (requestedMemoryPromptMode ??
               (willAutoEnableMemfs ? "memfs" : undefined));
 
@@ -1857,20 +1872,20 @@ async function main(): Promise<void> {
             )
           : Promise.resolve().then(() => {
               if (backend.capabilities.localMemfs) {
-                if (noMemfsFlag) {
-                  throw new Error(
-                    "Disabling MemFS is not supported by the local backend.",
-                  );
-                }
-                settingsManager.setMemfsEnabled(agentId, true);
-                return { action: "enabled" };
+                settingsManager.setMemfsEnabled(
+                  agentId,
+                  !localNoMemfsRequested,
+                );
+                return {
+                  action: localNoMemfsRequested ? "disabled" : "enabled",
+                };
               }
               if (memfsFlag) {
                 throw new Error(
                   "MemFS is not supported by the active backend.",
                 );
               }
-              if (noMemfsFlag) {
+              if (noMemfsFlag || localNoMemfsRequested) {
                 settingsManager.setMemfsEnabled(agentId, false);
               }
               return null;

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -26,6 +26,7 @@ import type {
   ConversationCreateBody,
   ConversationMessageCreateBody,
   ConversationMessageListBody,
+  ConversationRecompileBody,
   RunMessageStreamBody,
 } from "../../backend";
 import {
@@ -579,6 +580,44 @@ describe("LocalBackend", () => {
       ).join("\n");
       expect(persistedMessageText).toContain('"id":"ui-msg-');
       expect(persistedMessageText).not.toContain("fake-headless");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("can run local turns without creating a local MemFS repo", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-no-memfs-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+
+      const agent = await backend.createAgent({
+        name: "No MemFS Local Agent",
+        system: "Plain local system prompt.",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("ping", agent.id),
+        ),
+      );
+
+      await expect(
+        stat(getLocalBackendMemoryFilesystemRoot(agent.id, storageDir)),
+      ).rejects.toThrow();
+      await expect(
+        backend.recompileConversation(conversation.id, {
+          agent_id: agent.id,
+          dry_run: true,
+        } as ConversationRecompileBody),
+      ).resolves.toContain("Plain local system prompt.");
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/tests/backend/local-system-prompt-compilation.test.ts
+++ b/src/tests/backend/local-system-prompt-compilation.test.ts
@@ -167,6 +167,33 @@ describe("local system prompt compilation", () => {
     expect(compiled.content).toContain("<memory_metadata>");
   });
 
+  test("can compile without projecting local MemFS", async () => {
+    const memoryDir = await mkdtemp(join(tmpdir(), "local-prompt-no-memfs-"));
+    try {
+      await writeMemoryFile(
+        memoryDir,
+        "system/persona.md",
+        "Who the agent is",
+        "This should not be projected.",
+      );
+      initAndCommitMemory(memoryDir);
+
+      const compiled = compileLocalSystemPrompt({
+        agent: agent("plain {CORE_MEMORY}"),
+        conversationId: "local-conv-test",
+        memoryDir,
+        includeMemfs: false,
+      });
+
+      expect(compiled.memfsRevision).toBeUndefined();
+      expect(compiled.content).toContain("plain <memory_metadata>");
+      expect(compiled.content).not.toContain("This should not be projected.");
+      expect(compiled.content).not.toContain("$MEMORY_DIR");
+    } finally {
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+
   test("renders available skills as request-scoped prompt content", () => {
     const skillsBlock = compileAvailableSkillsBlock([
       {

--- a/src/tests/headless/dev-backend-smoke.test.ts
+++ b/src/tests/headless/dev-backend-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execFile as execFileCb, spawn } from "node:child_process";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -558,6 +558,37 @@ describe("headless dev backend smoke", () => {
       expect(
         await readFile(join(memoryDir, "system", "human.md"), "utf8"),
       ).toContain("person");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("runs env-selected local backend with --no-memfs without creating MemFS", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "lc-local-no-memfs-"));
+    try {
+      const result = await runCli(
+        [
+          "-p",
+          "ping",
+          "--new-agent",
+          "--permission-mode",
+          "plan",
+          "--no-skills",
+          "--no-memfs",
+        ],
+        {
+          LETTA_LOCAL_BACKEND_EXPERIMENTAL: "true",
+          LETTA_LOCAL_BACKEND_DIR: storageDir,
+          LETTA_LOCAL_BACKEND_EXECUTOR: "deterministic",
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("pong");
+      expect(result.stderr).not.toContain(
+        "Disabling MemFS is not supported by the local backend",
+      );
+      await expect(stat(join(storageDir, "memfs"))).rejects.toThrow();
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -3,7 +3,10 @@ import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { configureBackendMode } from "../../backend";
-import { getLocalBackendMemoryFilesystemRoot } from "../../backend/local/paths";
+import {
+  getLocalBackendMemoryFilesystemRoot,
+  LOCAL_BACKEND_NO_MEMFS_ENV,
+} from "../../backend/local/paths";
 import { runWithRuntimeContext } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 import {
@@ -438,6 +441,37 @@ test("getShellEnv injects local backend MemFS path for --backend local", () => {
           }
         ).isMemfsEnabled = original;
       }
+    });
+  } finally {
+    configureBackendMode("api");
+  }
+});
+
+test("getShellEnv does not inject local backend MemFS path when local --no-memfs is active", () => {
+  const agentId = `agent-local-no-memfs-shell-env-${Date.now()}`;
+  configureBackendMode("local");
+  try {
+    withTemporaryEnv({ [LOCAL_BACKEND_NO_MEMFS_ENV]: "1" }, () => {
+      withTemporaryAgentEnv(agentId, () => {
+        const original = settingsManager.isMemfsEnabled.bind(settingsManager);
+        (
+          settingsManager as unknown as {
+            isMemfsEnabled: (id: string) => boolean;
+          }
+        ).isMemfsEnabled = () => true;
+
+        try {
+          const env = getShellEnv();
+          expect(env.LETTA_MEMORY_DIR).toBeUndefined();
+          expect(env.MEMORY_DIR).toBeUndefined();
+        } finally {
+          (
+            settingsManager as unknown as {
+              isMemfsEnabled: (id: string) => boolean;
+            }
+          ).isMemfsEnabled = original;
+        }
+      });
     });
   } finally {
     configureBackendMode("api");

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -15,6 +15,7 @@ import {
   resolveScopedMemoryDir,
 } from "../../agent/memoryFilesystem";
 import { getServerUrl } from "../../backend/api/client";
+import { isLocalBackendNoMemfsEnvEnabled } from "../../backend/local/paths";
 import { getCurrentWorkingDirectory } from "../../runtime-context";
 import { settingsManager } from "../../settings-manager";
 
@@ -317,10 +318,13 @@ export function getShellEnv(): NodeJS.ProcessEnv {
     env.AGENT_ID = agentId;
 
     try {
-      if (
-        settingsManager.isMemfsEnabled(agentId) ||
+      const localBackendNoMemfs = isLocalBackendNoMemfsEnvEnabled();
+      const localBackendEnabled =
         process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL === "1" ||
-        process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL?.toLowerCase() === "true"
+        process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL?.toLowerCase() === "true";
+      if (
+        !localBackendNoMemfs &&
+        (settingsManager.isMemfsEnabled(agentId) || localBackendEnabled)
       ) {
         const memoryDir = resolveScopedMemoryDir({ agentId });
         if (!memoryDir) {


### PR DESCRIPTION
## Summary
- Allow local backend `--no-memfs` runs to start by setting the local MemFS setting to disabled instead of rejecting the flag.
- Skip local MemFS repo initialization and compile local prompts without memory projection when local MemFS is disabled.
- Avoid injecting `MEMORY_DIR` / `LETTA_MEMORY_DIR` into shell tools when local no-MemFS mode is active.

## Test plan
- [x] `bun test src/tests/tools/shell-env.test.ts src/tests/backend/local-system-prompt-compilation.test.ts src/tests/backend/local-backend.test.ts src/tests/headless/dev-backend-smoke.test.ts`
- [x] `bun test src/tests/agent/memoryFilesystem.test.ts src/tests/agent/memoryPrompt.test.ts src/tests/settings-manager.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)