### PR TITLE
fix(local): support sliding-window compaction

### DIFF
--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -19,6 +19,7 @@ import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
 } from "../dev/AISDKStreamAdapter";
+import { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
 import { HeadlessBackend } from "../dev/HeadlessBackend";
 import {
   DeterministicPongExecutor,
@@ -28,10 +29,15 @@ import type { ProviderTurnInput } from "../dev/ProviderTurnExecutor";
 import { ProviderTurnExecutor } from "../dev/ProviderTurnExecutor";
 import {
   estimateLocalMessageTokens,
+  LOCAL_DEFAULT_COMPACTION_MODE,
+  LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE,
+  type LocalCompactionMode,
   type LocalCompactionStats,
   type LocalGenerateTextFunction,
   packageLocalSummaryMessage,
+  planLocalSlidingWindowCompaction,
   summarizeLocalMessagesAll,
+  summarizeLocalMessagesSlidingWindow,
 } from "./compaction";
 import type { LocalMessage } from "./LocalMessage";
 import { listLocalModels, resolveLocalModelConfig } from "./LocalModelConfig";
@@ -124,6 +130,48 @@ function initialMemoryFilesFromCreateBody(
   return [...files.values()].sort((a, b) =>
     a.relativePath.localeCompare(b.relativePath),
   );
+}
+
+type LocalCompactionSettingsRecord = Record<string, unknown>;
+
+interface ResolvedLocalCompactionSettings {
+  mode: LocalCompactionMode;
+  prompt?: string | null;
+  clipChars?: number | null;
+  slidingWindowPercentage: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function compactionSettingsRecord(
+  value: unknown,
+): LocalCompactionSettingsRecord | null | undefined {
+  if (value === null) return null;
+  return isRecord(value) ? { ...value } : undefined;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key);
+}
+
+function localCompactionMode(value: unknown): LocalCompactionMode | undefined {
+  if (value === "all" || value === "sliding_window") return value;
+  return undefined;
+}
+
+function validateLocalCompactionSettingsRecord(
+  settings: LocalCompactionSettingsRecord,
+): void {
+  if (settings.mode === undefined || settings.mode === null) return;
+  if (!localCompactionMode(settings.mode)) {
+    throw new Error(
+      `Local backend compaction currently supports only modes "all" and "sliding_window" (received "${String(
+        settings.mode,
+      )}").`,
+    );
+  }
 }
 
 function createLocalExecutor(
@@ -225,7 +273,22 @@ export class LocalBackend extends HeadlessBackend {
     ...args: Parameters<HeadlessBackend["createAgent"]>
   ) {
     const [body] = args;
-    const agent = await super.createAgent(...args);
+    const requestedCompactionSettings = compactionSettingsRecord(
+      (body as Record<string, unknown>).compaction_settings,
+    );
+    if (
+      requestedCompactionSettings !== undefined &&
+      requestedCompactionSettings !== null
+    ) {
+      validateLocalCompactionSettingsRecord(requestedCompactionSettings);
+    }
+    let agent = await super.createAgent(...args);
+    if (requestedCompactionSettings !== undefined) {
+      agent = this.store.setAgentCompactionSettings(
+        agent.id,
+        requestedCompactionSettings,
+      );
+    }
     await this.ensureLocalMemoryRepo(
       agent.id,
       initialMemoryFilesFromCreateBody(body),
@@ -234,6 +297,26 @@ export class LocalBackend extends HeadlessBackend {
     await this.compileAndMaybePersistSystemPrompt("default", agent.id, {
       dryRun: false,
     });
+    return agent;
+  }
+
+  override async updateAgent(
+    ...args: Parameters<HeadlessBackend["updateAgent"]>
+  ) {
+    const [agentId, body] = args;
+    const bodyRecord = body as Record<string, unknown>;
+    const settings = hasOwn(bodyRecord, "compaction_settings")
+      ? compactionSettingsRecord(bodyRecord.compaction_settings)
+      : undefined;
+    if (settings !== undefined && settings !== null) {
+      validateLocalCompactionSettingsRecord(settings);
+    }
+    let agent = await super.updateAgent(...args);
+    if (hasOwn(bodyRecord, "compaction_settings")) {
+      if (settings !== undefined) {
+        agent = this.store.setAgentCompactionSettings(agentId, settings);
+      }
+    }
     return agent;
   }
 
@@ -275,7 +358,7 @@ export class LocalBackend extends HeadlessBackend {
       typeof bodyRecord.agent_id === "string" && bodyRecord.agent_id.length > 0
         ? bodyRecord.agent_id
         : this.store.resolveAgentIdForConversation(conversationId);
-    const result = await this.compactLocalConversationAll(
+    const result = await this.compactLocalConversation(
       conversationId,
       agentId,
       "manual",
@@ -338,13 +421,10 @@ export class LocalBackend extends HeadlessBackend {
     summary: string;
     stats?: LocalCompactionStats;
   } | null> {
-    const result = await this.compactLocalConversationAll(
+    const result = await this.compactLocalConversation(
       input.conversationId,
       input.agentId,
       "context_window_overflow",
-      {
-        compaction_settings: { mode: "all" },
-      } as ConversationMessageCompactBody,
     );
     return {
       uiMessages: this.store.listLocalMessages(
@@ -377,13 +457,10 @@ export class LocalBackend extends HeadlessBackend {
       return null;
     }
 
-    const result = await this.compactLocalConversationAll(
+    const result = await this.compactLocalConversation(
       input.conversationId,
       input.agentId,
       "context_window_limit",
-      {
-        compaction_settings: { mode: "all" },
-      } as ConversationMessageCompactBody,
     );
     return {
       uiMessages: this.store.listLocalMessages(
@@ -423,7 +500,64 @@ export class LocalBackend extends HeadlessBackend {
       : undefined;
   }
 
-  private async compactLocalConversationAll(
+  private resolveCompactionSettings(
+    agent: LocalAgentRecord,
+    body?: ConversationMessageCompactBody,
+  ): ResolvedLocalCompactionSettings {
+    const bodyRecord = (body ?? {}) as Record<string, unknown>;
+    const requestSettings = compactionSettingsRecord(
+      bodyRecord.compaction_settings,
+    );
+    if (requestSettings !== undefined && requestSettings !== null) {
+      validateLocalCompactionSettingsRecord(requestSettings);
+    }
+    const agentSettings = compactionSettingsRecord(agent.compaction_settings);
+    const baseSettings =
+      agentSettings && agentSettings !== null ? agentSettings : {};
+    const mergedSettings =
+      requestSettings && requestSettings !== null
+        ? { ...baseSettings, ...requestSettings }
+        : baseSettings;
+    const requestChangedMode =
+      requestSettings !== undefined &&
+      requestSettings !== null &&
+      hasOwn(requestSettings, "mode");
+    const requestChangedPrompt =
+      requestSettings !== undefined &&
+      requestSettings !== null &&
+      hasOwn(requestSettings, "prompt");
+    if (
+      requestChangedMode &&
+      !requestChangedPrompt &&
+      agentSettings &&
+      agentSettings !== null &&
+      agentSettings.mode !== requestSettings.mode
+    ) {
+      delete mergedSettings.prompt;
+    }
+
+    const mode =
+      localCompactionMode(mergedSettings.mode) ?? LOCAL_DEFAULT_COMPACTION_MODE;
+    return {
+      mode,
+      prompt:
+        typeof mergedSettings.prompt === "string" ||
+        mergedSettings.prompt === null
+          ? mergedSettings.prompt
+          : undefined,
+      clipChars:
+        typeof mergedSettings.clip_chars === "number" ||
+        mergedSettings.clip_chars === null
+          ? mergedSettings.clip_chars
+          : undefined,
+      slidingWindowPercentage:
+        typeof mergedSettings.sliding_window_percentage === "number"
+          ? mergedSettings.sliding_window_percentage
+          : LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE,
+    };
+  }
+
+  private async compactLocalConversation(
     conversationId: string,
     agentId: string,
     trigger: string,
@@ -434,31 +568,55 @@ export class LocalBackend extends HeadlessBackend {
     summary: string;
     stats: LocalCompactionStats;
   }> {
-    const settings = ((body ?? {}) as Record<string, unknown>)
-      .compaction_settings as Record<string, unknown> | null | undefined;
-    const mode = typeof settings?.mode === "string" ? settings.mode : "all";
-    if (mode !== "all") {
-      throw new Error(
-        `Local backend compaction currently supports only mode "all" (received "${mode}").`,
-      );
-    }
-
     const agent = this.store.retrieveAgentRecord(agentId);
+    const settings = this.resolveCompactionSettings(agent, body);
+    if (settings.mode === "sliding_window") {
+      try {
+        return await this.compactLocalConversationSlidingWindow(
+          conversationId,
+          agentId,
+          agent,
+          trigger,
+          settings,
+        );
+      } catch (error) {
+        if (isContextWindowOverflowError(error)) throw error;
+      }
+    }
+    return this.compactLocalConversationAll(
+      conversationId,
+      agentId,
+      agent,
+      trigger,
+      {
+        ...settings,
+        mode: "all",
+        prompt: settings.mode === "all" ? settings.prompt : undefined,
+      },
+    );
+  }
+
+  private async compactLocalConversationAll(
+    conversationId: string,
+    agentId: string,
+    agent: LocalAgentRecord,
+    trigger: string,
+    settings: ResolvedLocalCompactionSettings,
+  ): Promise<{
+    numMessagesBefore: number;
+    numMessagesAfter: number;
+    summary: string;
+    stats: LocalCompactionStats;
+  }> {
     const messages = this.store.listLocalMessages(conversationId, agentId);
     const contextTokensBefore = estimateLocalMessageTokens(messages);
-    const prompt =
-      typeof settings?.prompt === "string" ? settings.prompt : null;
-    const clipChars =
-      typeof settings?.clip_chars === "number" || settings?.clip_chars === null
-        ? settings.clip_chars
-        : undefined;
     const summary = await summarizeLocalMessagesAll({
       agent,
       messages,
       createModel: this.createModel,
       generateText: this.generateText,
-      prompt,
-      clipChars,
+      prompt: settings.prompt,
+      clipChars: settings.clipChars,
       localProviderAuthStorageDir: this.storageDir,
     });
     const stats: LocalCompactionStats = {
@@ -475,6 +633,60 @@ export class LocalBackend extends HeadlessBackend {
       summary,
       packedSummary: packageLocalSummaryMessage(summary, stats),
       stats,
+    });
+    return {
+      numMessagesBefore: storeResult.numMessagesBefore,
+      numMessagesAfter: storeResult.numMessagesAfter,
+      summary,
+      stats,
+    };
+  }
+
+  private async compactLocalConversationSlidingWindow(
+    conversationId: string,
+    agentId: string,
+    agent: LocalAgentRecord,
+    trigger: string,
+    settings: ResolvedLocalCompactionSettings,
+  ): Promise<{
+    numMessagesBefore: number;
+    numMessagesAfter: number;
+    summary: string;
+    stats: LocalCompactionStats;
+  }> {
+    const messages = this.store.listLocalMessages(conversationId, agentId);
+    const contextWindow = this.effectiveContextWindow(conversationId, agentId);
+    const plan = planLocalSlidingWindowCompaction(messages, {
+      slidingWindowPercentage: settings.slidingWindowPercentage,
+      contextWindow,
+    });
+    const summary = await summarizeLocalMessagesSlidingWindow({
+      agent,
+      messages: plan.messagesToSummarize,
+      createModel: this.createModel,
+      generateText: this.generateText,
+      prompt: settings.prompt,
+      clipChars: settings.clipChars,
+      localProviderAuthStorageDir: this.storageDir,
+    });
+    const contextTokensAfter =
+      Math.ceil(summary.length / 4) +
+      estimateLocalMessageTokens(plan.messagesToKeep);
+    const stats: LocalCompactionStats = {
+      trigger,
+      context_tokens_before: estimateLocalMessageTokens(messages),
+      context_tokens_after: contextTokensAfter,
+      context_window: contextWindow,
+      messages_count_before: messages.length,
+      messages_count_after: 1 + plan.messagesToKeep.length,
+    };
+    const storeResult = this.store.compactConversationAll({
+      conversationId,
+      agentId,
+      summary,
+      packedSummary: packageLocalSummaryMessage(summary, stats),
+      stats,
+      remainingMessages: plan.messagesToKeep,
     });
     return {
       numMessagesBefore: storeResult.numMessagesBefore,

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -19,7 +19,6 @@ import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
 } from "../dev/AISDKStreamAdapter";
-import { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
 import { HeadlessBackend } from "../dev/HeadlessBackend";
 import {
   DeterministicPongExecutor,
@@ -29,6 +28,7 @@ import type { ProviderTurnInput } from "../dev/ProviderTurnExecutor";
 import { ProviderTurnExecutor } from "../dev/ProviderTurnExecutor";
 import {
   estimateLocalMessageTokens,
+  isLocalSlidingWindowCompactionPlanningError,
   LOCAL_DEFAULT_COMPACTION_MODE,
   LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE,
   type LocalCompactionMode,
@@ -178,6 +178,21 @@ function validateLocalCompactionSettingsRecord(
   }
 }
 
+function localCompactionSettingsForStorage(
+  settings: LocalCompactionSettingsRecord | null | undefined,
+): LocalCompactionSettingsRecord | null | undefined {
+  if (settings === undefined || settings === null) return settings;
+
+  const hasLocalSetting =
+    hasOwn(settings, "mode") ||
+    hasOwn(settings, "prompt") ||
+    hasOwn(settings, "clip_chars") ||
+    hasOwn(settings, "sliding_window_percentage");
+  if (!hasLocalSetting) return undefined;
+
+  return { ...settings };
+}
+
 function createLocalExecutor(
   options: LocalBackendOptions,
   onContextWindowOverflow?: (
@@ -288,11 +303,14 @@ export class LocalBackend extends HeadlessBackend {
     ) {
       validateLocalCompactionSettingsRecord(requestedCompactionSettings);
     }
+    const compactionSettingsForStorage = localCompactionSettingsForStorage(
+      requestedCompactionSettings,
+    );
     let agent = await super.createAgent(...args);
-    if (requestedCompactionSettings !== undefined) {
+    if (compactionSettingsForStorage !== undefined) {
       agent = this.store.setAgentCompactionSettings(
         agent.id,
-        requestedCompactionSettings,
+        compactionSettingsForStorage,
       );
     }
     if (this.isLocalMemfsEnabled()) {
@@ -319,10 +337,15 @@ export class LocalBackend extends HeadlessBackend {
     if (settings !== undefined && settings !== null) {
       validateLocalCompactionSettingsRecord(settings);
     }
+    const compactionSettingsForStorage =
+      localCompactionSettingsForStorage(settings);
     let agent = await super.updateAgent(...args);
     if (hasOwn(bodyRecord, "compaction_settings")) {
-      if (settings !== undefined) {
-        agent = this.store.setAgentCompactionSettings(agentId, settings);
+      if (compactionSettingsForStorage !== undefined) {
+        agent = this.store.setAgentCompactionSettings(
+          agentId,
+          compactionSettingsForStorage,
+        );
       }
     }
     return agent;
@@ -592,7 +615,7 @@ export class LocalBackend extends HeadlessBackend {
           settings,
         );
       } catch (error) {
-        if (isContextWindowOverflowError(error)) throw error;
+        if (!isLocalSlidingWindowCompactionPlanningError(error)) throw error;
       }
     }
     return this.compactLocalConversationAll(

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -65,6 +65,7 @@ export interface LocalAgentRecord {
   tags: string[];
   model: string;
   model_settings: Record<string, unknown>;
+  compaction_settings?: Record<string, unknown> | null;
 }
 
 const DEFAULT_LOCAL_AGENT_NAME = "Letta Code";
@@ -266,6 +267,7 @@ function normalizeAgentRecord(
     modelSettings.max_tokens = legacyLlmConfig.max_tokens;
   }
 
+  const compactionSettings = optionalRecordOrNull(value.compaction_settings);
   return {
     id: value.id,
     name: optionalString(value.name) ?? "Letta Code",
@@ -277,6 +279,9 @@ function normalizeAgentRecord(
       optionalString(legacyLlmConfig.model) ??
       defaultAgentModel,
     model_settings: modelSettings,
+    ...(compactionSettings !== undefined
+      ? { compaction_settings: compactionSettings }
+      : {}),
   };
 }
 
@@ -313,6 +318,9 @@ function projectAgentState(
     tags: record.tags,
     model: record.model,
     model_settings: record.model_settings,
+    ...(record.compaction_settings !== undefined
+      ? { compaction_settings: record.compaction_settings }
+      : {}),
     message_ids: messageIds,
     in_context_message_ids: inContextMessageIds,
     ...(lastRunCompletion ? { last_run_completion: lastRunCompletion } : {}),
@@ -750,6 +758,23 @@ export class LocalStore {
     return this.projectAgent(updated);
   }
 
+  setAgentCompactionSettings(
+    agentId: string,
+    settings: Record<string, unknown> | null,
+  ): AgentState {
+    const existing = this.agents.get(agentId);
+    if (!existing) {
+      throw new LocalBackendNotFoundError("Agent", agentId);
+    }
+    const updated: LocalAgentRecord = {
+      ...existing,
+      compaction_settings: settings === null ? null : { ...settings },
+    };
+    this.agents.set(agentId, updated);
+    this.persistAgent(agentId);
+    return this.projectAgent(updated);
+  }
+
   createAgent(body: AgentCreateBody): AgentState {
     const agent = this.createAgentRecord(body);
     const agentId = agent.id;
@@ -1108,6 +1133,7 @@ export class LocalStore {
     summary: string;
     packedSummary: string;
     stats?: LocalCompactionStats;
+    remainingMessages?: LocalMessage[];
   }): LocalCompactionStoreResult {
     const conversation = this.ensureConversation(
       input.conversationId,
@@ -1132,8 +1158,14 @@ export class LocalStore {
       },
       parts: [{ type: "text", text: input.packedSummary } as LocalMessagePart],
     };
-    this.localMessagesByConversationKey.set(key, [summaryMessage]);
-    conversation.in_context_message_ids = [summaryMessage.id];
+    const compactedMessages = [
+      summaryMessage,
+      ...(input.remainingMessages ?? []).map(cloneLocalMessage),
+    ];
+    this.localMessagesByConversationKey.set(key, compactedMessages);
+    conversation.in_context_message_ids = compactedMessages.map(
+      (message) => message.id,
+    );
     conversation.last_message_at = date;
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
@@ -1141,7 +1173,7 @@ export class LocalStore {
     this.rebuildMessageIndex();
     return {
       numMessagesBefore: previousMessages.length,
-      numMessagesAfter: 1,
+      numMessagesAfter: compactedMessages.length,
       summaryMessage: cloneLocalMessage(summaryMessage),
     };
   }

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -15,6 +15,19 @@ export const LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE = 0.3;
 
 export type LocalCompactionMode = "all" | "sliding_window";
 
+export class LocalSlidingWindowCompactionPlanningError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalSlidingWindowCompactionPlanningError";
+  }
+}
+
+export function isLocalSlidingWindowCompactionPlanningError(
+  error: unknown,
+): error is LocalSlidingWindowCompactionPlanningError {
+  return error instanceof LocalSlidingWindowCompactionPlanningError;
+}
+
 export const LOCAL_ALL_COMPACTION_PROMPT = `Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
 This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context. Your summary should include the following sections:
 
@@ -279,7 +292,9 @@ export function planLocalSlidingWindowCompaction(
   options: { slidingWindowPercentage?: number; contextWindow?: number } = {},
 ): LocalSlidingWindowCompactionPlan {
   if (messages.length < 4) {
-    throw new Error("Not enough messages for sliding window compaction.");
+    throw new LocalSlidingWindowCompactionPlanningError(
+      "Not enough messages for sliding window compaction.",
+    );
   }
 
   const percentage = normalizedSlidingWindowPercentage(
@@ -327,7 +342,9 @@ export function planLocalSlidingWindowCompaction(
     };
   }
 
-  throw new Error("No assistant message found for sliding window compaction.");
+  throw new LocalSlidingWindowCompactionPlanningError(
+    "No assistant message found for sliding window compaction.",
+  );
 }
 
 export async function summarizeLocalMessagesSlidingWindow(

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -6,9 +6,14 @@ import type { LocalMessage } from "./LocalMessage";
 import type { LocalAgentRecord } from "./LocalStore";
 
 const ALL_WORD_LIMIT = 500;
+const SLIDING_WORD_LIMIT = 300;
 const SUMMARY_TRUNCATION_SUFFIX = "... [summary truncated to fit]";
 const TOOL_TRANSCRIPT_TRUNCATION_CHARS = 4000;
 const TRANSCRIPT_FALLBACK_MAX_CHARS = 120000;
+export const LOCAL_DEFAULT_COMPACTION_MODE = "sliding_window";
+export const LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE = 0.3;
+
+export type LocalCompactionMode = "all" | "sliding_window";
 
 export const LOCAL_ALL_COMPACTION_PROMPT = `Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
 This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context. Your summary should include the following sections:
@@ -33,6 +38,25 @@ This summary should be thorough in capturing technical details, code patterns, a
 Write in first person as a factual record of what occurred. Be concise but thorough - the goal is to preserve enough context that the recent messages make sense and important information isn't lost to prevent duplicate work or repeated mistakes.
 
 Keep your summary under ${ALL_WORD_LIMIT} words. Only output the summary.`;
+
+export const LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT = `The following messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after. Include the following sections:
+
+1.**High level goals**: What is the high level goal and ongoing task? Capture the user's explicit requests and intent in detail. If there is an existing summary in the transcript, make sure to take it into consideration to continue tracking the higher level goals and long-term progress.
+
+2. **What happened**: The conversations, tasks, and exchanges that took place. What did the user ask for? What did you do? How did things progress? If there is a previous summary being evicted, please extract a concise version of the critical info from it.
+
+3. **Important details**: Enumerate specific files and code sections examined, modified, or created, as well as important plan files, GitHub issues/PR links, and Linear ticket IDs. For each item, include why it matters and any relevant names, data, configs, or facts discussed.
+   - **Preserve identifiers verbatim** (plan filename/path, exact URL, issue/PR number, ticket ID); do not paraphrase or truncate.
+   - **Preserve referenced identifiers unless explicitly resolved**: Keep exact URLs/IDs from the conversation unless there is clear evidence they are no longer relevant.
+   - Do not omit details likely to be referenced later.
+
+4. **Errors and fixes**: List all errors that you ran into, and how you fixed them. Pay special attention to specific user feedback that you received and record verbatim if useful.
+
+5. **Lookup hints**: For any detailed content (long lists, extensive data, specific conversations) that couldn't fit in the summary, note the topic and key terms that could be used to find it in message history later.
+
+Write in first person as a factual record of what occurred. Be thorough and detailed - the goal is to preserve enough context that the recent messages make sense and important information isn't lost to prevent duplicate work or repeated mistakes.
+
+Keep your summary under ${SLIDING_WORD_LIMIT} words. Only output the summary.`;
 
 export interface LocalCompactionStats {
   trigger?: string;
@@ -61,6 +85,12 @@ export interface LocalAllCompactionInput {
   clipChars?: number | null;
   abortSignal?: AbortSignal;
   localProviderAuthStorageDir?: string;
+}
+
+export interface LocalSlidingWindowCompactionPlan {
+  messagesToSummarize: LocalMessage[];
+  messagesToKeep: LocalMessage[];
+  cutoffIndex: number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -150,6 +180,7 @@ export function formatLocalMessagesForSummary(
 async function runGenerateText(
   input: LocalAllCompactionInput,
   transcript: string,
+  defaultPrompt: string,
 ) {
   const run = input.generateText ?? generateText;
   return run({
@@ -160,7 +191,7 @@ async function runGenerateText(
         input.agent.model_settings,
         { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
       )(),
-    system: input.prompt ?? LOCAL_ALL_COMPACTION_PROMPT,
+    system: input.prompt ?? defaultPrompt,
     prompt: transcript,
     providerOptions: buildAISDKProviderOptions(
       input.agent.model,
@@ -171,21 +202,22 @@ async function runGenerateText(
   });
 }
 
-export async function summarizeLocalMessagesAll(
+async function summarizeLocalMessagesWithPrompt(
   input: LocalAllCompactionInput,
+  defaultPrompt: string,
 ): Promise<string> {
   if (input.messages.length === 0) return "No prior conversation messages.";
   const primaryTranscript = formatLocalMessagesForSummary(input.messages);
   let result: Awaited<ReturnType<typeof generateText>>;
   try {
-    result = await runGenerateText(input, primaryTranscript);
+    result = await runGenerateText(input, primaryTranscript, defaultPrompt);
   } catch (error) {
     if (!isContextWindowOverflowError(error)) throw error;
     const fallbackTranscript = formatLocalMessagesForSummary(input.messages, {
       truncationChars: TOOL_TRANSCRIPT_TRUNCATION_CHARS,
       maxChars: TRANSCRIPT_FALLBACK_MAX_CHARS,
     });
-    result = await runGenerateText(input, fallbackTranscript);
+    result = await runGenerateText(input, fallbackTranscript, defaultPrompt);
   }
 
   let summary = result.text.trim();
@@ -194,6 +226,117 @@ export async function summarizeLocalMessagesAll(
     summary = `${summary.slice(0, clipChars)}${SUMMARY_TRUNCATION_SUFFIX}`;
   }
   return summary;
+}
+
+export async function summarizeLocalMessagesAll(
+  input: LocalAllCompactionInput,
+): Promise<string> {
+  return summarizeLocalMessagesWithPrompt(input, LOCAL_ALL_COMPACTION_PROMPT);
+}
+
+function isSettledLocalToolState(state: unknown): boolean {
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "output-denied"
+  );
+}
+
+function hasPendingLocalToolPart(message: LocalMessage): boolean {
+  return message.parts.some((part) => {
+    if (!isRecord(part)) return false;
+    const partRecord: Record<string, unknown> = part;
+    return (
+      typeof partRecord.type === "string" &&
+      partRecord.type.startsWith("tool-") &&
+      !isSettledLocalToolState(partRecord.state)
+    );
+  });
+}
+
+function normalizedSlidingWindowPercentage(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE;
+  }
+  if (value <= 0) return 0.1;
+  if (value > 1) return 1;
+  return value;
+}
+
+function isValidSlidingWindowCutoff(
+  messages: LocalMessage[],
+  index: number,
+  maximumCutoffIndex: number,
+): boolean {
+  const message = messages[index];
+  return (
+    message?.role === "assistant" && index > 1 && index < maximumCutoffIndex
+  );
+}
+
+export function planLocalSlidingWindowCompaction(
+  messages: LocalMessage[],
+  options: { slidingWindowPercentage?: number; contextWindow?: number } = {},
+): LocalSlidingWindowCompactionPlan {
+  if (messages.length < 4) {
+    throw new Error("Not enough messages for sliding window compaction.");
+  }
+
+  const percentage = normalizedSlidingWindowPercentage(
+    options.slidingWindowPercentage,
+  );
+  const lastMessage = messages.at(-1);
+  const maximumCutoffIndex =
+    lastMessage && hasPendingLocalToolPart(lastMessage)
+      ? messages.length - 2
+      : messages.length - 1;
+  const goalTokens =
+    typeof options.contextWindow === "number" &&
+    Number.isFinite(options.contextWindow)
+      ? (1 - percentage) * options.contextWindow
+      : undefined;
+
+  for (
+    let evictionPercentage = percentage;
+    evictionPercentage < 1.0;
+    evictionPercentage += 0.1
+  ) {
+    const messageCutoffIndex = Math.min(
+      Math.round(evictionPercentage * messages.length),
+      messages.length - 1,
+    );
+    const cutoffIndex = [...Array(messageCutoffIndex + 1).keys()]
+      .reverse()
+      .find((index) =>
+        isValidSlidingWindowCutoff(messages, index, maximumCutoffIndex),
+      );
+    if (cutoffIndex === undefined) continue;
+
+    const messagesToKeep = messages.slice(cutoffIndex);
+    if (
+      goalTokens !== undefined &&
+      estimateLocalMessageTokens(messagesToKeep) >= goalTokens
+    ) {
+      continue;
+    }
+
+    return {
+      messagesToSummarize: messages.slice(0, cutoffIndex),
+      messagesToKeep,
+      cutoffIndex,
+    };
+  }
+
+  throw new Error("No assistant message found for sliding window compaction.");
+}
+
+export async function summarizeLocalMessagesSlidingWindow(
+  input: LocalAllCompactionInput,
+): Promise<string> {
+  return summarizeLocalMessagesWithPrompt(
+    input,
+    LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT,
+  );
 }
 
 export function estimateLocalMessageTokens(messages: LocalMessage[]): number {

--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -2,7 +2,12 @@ export { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
 export {
   formatLocalMessagesForSummary,
   LOCAL_ALL_COMPACTION_PROMPT,
+  LOCAL_DEFAULT_COMPACTION_MODE,
+  LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE,
+  LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT,
+  type LocalCompactionMode,
   type LocalCompactionStats,
+  planLocalSlidingWindowCompaction,
 } from "./compaction";
 export { LocalBackend, type LocalBackendOptions } from "./LocalBackend";
 export type {

--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -1,12 +1,14 @@
 export { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
 export {
   formatLocalMessagesForSummary,
+  isLocalSlidingWindowCompactionPlanningError,
   LOCAL_ALL_COMPACTION_PROMPT,
   LOCAL_DEFAULT_COMPACTION_MODE,
   LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE,
   LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT,
   type LocalCompactionMode,
   type LocalCompactionStats,
+  LocalSlidingWindowCompactionPlanningError,
   planLocalSlidingWindowCompaction,
 } from "./compaction";
 export { LocalBackend, type LocalBackendOptions } from "./LocalBackend";

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -862,6 +862,147 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("falls back to all compaction when sliding-window mode cannot plan a cutoff", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-sliding-plan-fallback-"),
+    );
+    try {
+      let capturedSystem: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: { system?: string }) => {
+          capturedSystem = options.system;
+          return { text: "fallback all summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "Sliding Plan Fallback Agent",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("only request", agent.id),
+        ),
+      );
+
+      const result = (await backend.compactConversationMessages(
+        conversation.id,
+      )) as {
+        num_messages_before: number;
+        num_messages_after: number;
+        summary: string;
+      };
+
+      expect(result).toEqual({
+        num_messages_before: 2,
+        num_messages_after: 1,
+        summary: "fallback all summary",
+      });
+      expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not fall back to all compaction for sliding-window summarizer failures", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-sliding-summarizer-error-"),
+    );
+    try {
+      let summarizeCalls = 0;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: { system?: string }) => {
+          summarizeCalls += 1;
+          if (options.system === LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT) {
+            throw new Error("synthetic sliding summarizer failure");
+          }
+          return { text: "unexpected all summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "Sliding Summarizer Error Agent",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("second request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("third request", agent.id),
+        ),
+      );
+
+      await expect(
+        backend.compactConversationMessages(conversation.id),
+      ).rejects.toThrow("synthetic sliding summarizer failure");
+      expect(summarizeCalls).toBe(1);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not persist cloud-only compaction model settings locally", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-cloud-compaction-model-"),
+    );
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+
+      const agent = await backend.createAgent({
+        name: "Cloud Model Settings Agent",
+        compaction_settings: { model: "letta/auto" },
+      } as never);
+      expect(agent.compaction_settings).toBeUndefined();
+
+      const agentFiles = await readdir(join(storageDir, "agents"));
+      expect(agentFiles).toHaveLength(1);
+      const agentPath = join(storageDir, "agents", agentFiles[0] ?? "");
+      let persisted = JSON.parse(await readFile(agentPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(persisted.compaction_settings).toBeUndefined();
+
+      const updated = await backend.updateAgent(agent.id, {
+        compaction_settings: { model: "letta/auto" },
+      } as never);
+      expect(updated.compaction_settings).toBeUndefined();
+
+      persisted = JSON.parse(await readFile(agentPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(persisted.compaction_settings).toBeUndefined();
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("uses saved local compaction settings as the default", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-saved-compact-settings-"),

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -36,6 +36,7 @@ import {
   createOrUpdateLocalProvider,
   getLocalProviderAuthPath,
   LOCAL_ALL_COMPACTION_PROMPT,
+  LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT,
   LocalBackend,
   listLocalModels,
   resolveLocalModelConfig,
@@ -729,6 +730,152 @@ describe("LocalBackend", () => {
       expect(JSON.stringify(persistedMessages[0])).toContain(
         "manual local summary",
       );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("compacts local conversation history with sliding-window mode", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-sliding-compact-"),
+    );
+    try {
+      let capturedSystem: string | undefined;
+      let capturedPrompt: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: {
+          system?: string;
+          prompt?: string;
+        }) => {
+          capturedSystem = options.system;
+          capturedPrompt = options.prompt;
+          return { text: "sliding local summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "Sliding Compact Agent",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("second request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("third request", agent.id),
+        ),
+      );
+
+      const result = (await backend.compactConversationMessages(
+        conversation.id,
+      )) as {
+        num_messages_before: number;
+        num_messages_after: number;
+        summary: string;
+      };
+
+      expect(result).toEqual({
+        num_messages_before: 6,
+        num_messages_after: 4,
+        summary: "sliding local summary",
+      });
+      expect(capturedSystem).toBe(LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT);
+      expect(capturedPrompt).toContain("first request");
+      expect(capturedPrompt).toContain("second request");
+      expect(capturedPrompt).not.toContain("third request");
+
+      const page = await backend.listConversationMessages(conversation.id, {
+        order: "asc",
+      } as ConversationMessageListBody);
+      const messages = page.getPaginatedItems();
+      expect(messages.map((message) => message.message_type)).toEqual([
+        "summary_message",
+        "assistant_message",
+        "user_message",
+        "assistant_message",
+      ]);
+      expect(JSON.stringify(messages[0])).toContain("sliding local summary");
+      expect(JSON.stringify(messages)).toContain("third request");
+      expect(JSON.stringify(messages)).not.toContain("first request");
+
+      const persistedMessages = await readPersistedLocalMessages(storageDir);
+      expect(persistedMessages).toHaveLength(4);
+      expect(JSON.stringify(persistedMessages[0])).toContain(
+        "sliding local summary",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses saved local compaction settings as the default", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-saved-compact-settings-"),
+    );
+    try {
+      let capturedSystem: string | undefined;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: { system?: string }) => {
+          capturedSystem = options.system;
+          return { text: "saved settings summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "Saved Compact Settings Agent",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("second request", agent.id),
+        ),
+      );
+
+      const updated = await backend.updateAgent(agent.id, {
+        compaction_settings: { mode: "all" },
+      } as never);
+      expect(updated.compaction_settings).toMatchObject({ mode: "all" });
+
+      const result = (await backend.compactConversationMessages(
+        conversation.id,
+      )) as {
+        num_messages_before: number;
+        num_messages_after: number;
+        summary: string;
+      };
+
+      expect(result).toEqual({
+        num_messages_before: 4,
+        num_messages_after: 1,
+        summary: "saved settings summary",
+      });
+      expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Add `sliding_window` support to local backend compaction and make it the default mode.
- Preserve recent local UI messages after summarizing the evicted prefix, with fallback to `all` mode when sliding-window compaction cannot reduce safely.
- Persist/project local `compaction_settings` and cover default plus saved-settings behavior in regression tests.

## Test plan
- [x] `bun run check`
- [x] `bun test src/tests/backend/local-backend.test.ts src/tests/backend/fake-headless-backend.test.ts`

👾 Generated with [Letta Code](https://letta.com)