### PR TITLE
test(wiring): auto-discover interactive app source files

### DIFF
--- a/src/tests/helpers/readInteractiveAppSource.ts
+++ b/src/tests/helpers/readInteractiveAppSource.ts
@@ -1,28 +1,63 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const INTERACTIVE_APP_SOURCE_FILES = [
-  "../../cli/app/useSubmitHandler.ts",
-  "../../cli/app/useConversationLoop.ts",
-  "../../cli/app/useConfigurationHandlers.ts",
-  "../../cli/app/useInterruptHandler.ts",
-  "../../cli/app/AppCoordinator.tsx",
-  "../../cli/app/AppView.tsx",
-  "../../cli/app/useReasoningCycle.ts",
-  "../../cli/app/useApprovalFlow.ts",
-  "../../cli/app/useConversationSwitching.ts",
-  "../../cli/app/useBashHandlers.ts",
-  "../../cli/app/useQueuedApprovalSubmit.ts",
-  "../../cli/app/useFeedbackHandler.ts",
-  "../../cli/app/submitDiagnosticsCommands.ts",
-  "../../cli/app/submitConnectionCommands.ts",
-  "../../cli/app/submitNavigationCommands.ts",
-  "../../cli/app/submitProfileCommands.ts",
+const APP_DIR = fileURLToPath(new URL("../../cli/app", import.meta.url));
+const LEGACY_ORDER = [
+  "useSubmitHandler.ts",
+  "useConversationLoop.ts",
+  "useConfigurationHandlers.ts",
+  "useInterruptHandler.ts",
+  "AppCoordinator.tsx",
+  "AppView.tsx",
+  "useReasoningCycle.ts",
+  "useApprovalFlow.ts",
+  "useConversationSwitching.ts",
+  "useBashHandlers.ts",
+  "useQueuedApprovalSubmit.ts",
+  "useFeedbackHandler.ts",
+  "submitDiagnosticsCommands.ts",
+  "submitConnectionCommands.ts",
+  "submitNavigationCommands.ts",
+  "submitProfileCommands.ts",
 ];
 
+function collectSourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && /\.(tsx?|mts|cts)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
 export function readInteractiveAppSource(): string {
-  return INTERACTIVE_APP_SOURCE_FILES.map((relativePath) => {
-    const path = fileURLToPath(new URL(relativePath, import.meta.url));
-    return readFileSync(path, "utf-8");
-  }).join("\n");
+  const sourceFiles = collectSourceFiles(APP_DIR).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  const sourceFileSet = new Set(sourceFiles);
+  const orderedFiles: string[] = [];
+
+  for (const fileName of LEGACY_ORDER) {
+    const fullPath = join(APP_DIR, fileName);
+    if (sourceFileSet.has(fullPath)) {
+      orderedFiles.push(fullPath);
+      sourceFileSet.delete(fullPath);
+    }
+  }
+
+  orderedFiles.push(
+    ...Array.from(sourceFileSet).sort((a, b) => a.localeCompare(b)),
+  );
+
+  return orderedFiles.map((path) => readFileSync(path, "utf-8")).join("\n");
 }


### PR DESCRIPTION
Summary: replace readInteractiveAppSource hardcoded file list with recursive src/cli/app TypeScript discovery; keep legacy ordering for known files to preserve index-based wiring assertions; append new files in sorted order for future-proof coverage. Test: targeted wiring suite 86 pass, biome check on helper file, and git diff --check.