### PR TITLE
fix(tui): share terminal theme cache in bundled CLI

### DIFF
--- a/src/cli/helpers/terminalTheme.ts
+++ b/src/cli/helpers/terminalTheme.ts
@@ -1,9 +1,25 @@
 export type TerminalTheme = "light" | "dark";
 export type TerminalRgb = { r: number; g: number; b: number };
 
-// Cache for the detected theme
-let cachedTheme: TerminalTheme | null = null;
-let cachedBackground: TerminalRgb | null = null;
+type TerminalThemeState = {
+  cachedTheme: TerminalTheme | null;
+  cachedBackground: TerminalRgb | null;
+};
+
+const TERMINAL_THEME_STATE_KEY = Symbol.for("letta.terminalThemeState");
+
+function getTerminalThemeState(): TerminalThemeState {
+  const globalObject = globalThis as typeof globalThis & {
+    [TERMINAL_THEME_STATE_KEY]?: TerminalThemeState;
+  };
+
+  globalObject[TERMINAL_THEME_STATE_KEY] ??= {
+    cachedTheme: null,
+    cachedBackground: null,
+  };
+
+  return globalObject[TERMINAL_THEME_STATE_KEY];
+}
 
 /**
  * Normalize a hex color component of any length to 8-bit (0-255).
@@ -126,7 +142,7 @@ export async function detectTerminalThemeAsync(): Promise<TerminalTheme> {
   // Try OSC 11 query first
   const bg = await queryTerminalBackground(100);
   if (bg) {
-    cachedBackground = bg;
+    getTerminalThemeState().cachedBackground = bg;
     const luminance = calculateLuminance(bg.r, bg.g, bg.b);
     // Threshold: 0.5 is mid-gray, but use 0.4 to be more conservative
     // (most "light" themes have luminance > 0.7)
@@ -164,9 +180,10 @@ export function detectTerminalThemeSync(): TerminalTheme {
  * Call initTerminalTheme() early in app startup for async detection.
  */
 export function getTerminalTheme(): TerminalTheme {
-  if (cachedTheme) return cachedTheme;
-  cachedTheme = detectTerminalThemeSync();
-  return cachedTheme;
+  const state = getTerminalThemeState();
+  if (state.cachedTheme) return state.cachedTheme;
+  state.cachedTheme = detectTerminalThemeSync();
+  return state.cachedTheme;
 }
 
 /**
@@ -174,7 +191,7 @@ export function getTerminalTheme(): TerminalTheme {
  * Returns null when the terminal did not respond or async detection has not run.
  */
 export function getTerminalBackgroundColor(): TerminalRgb | null {
-  return cachedBackground;
+  return getTerminalThemeState().cachedBackground;
 }
 
 /**
@@ -182,6 +199,7 @@ export function getTerminalBackgroundColor(): TerminalRgb | null {
  * Should be called early in app startup before UI renders.
  */
 export async function initTerminalTheme(): Promise<TerminalTheme> {
-  cachedTheme = await detectTerminalThemeAsync();
-  return cachedTheme;
+  const state = getTerminalThemeState();
+  state.cachedTheme = await detectTerminalThemeAsync();
+  return state.cachedTheme;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import {
 import { formatErrorDetails } from "./cli/helpers/errorFormatter";
 import { ensureFileIndex } from "./cli/helpers/fileIndex";
 import type { ApprovalRequest } from "./cli/helpers/stream";
+import { initTerminalTheme } from "./cli/helpers/terminalTheme";
 import { ProfileSelectionInline } from "./cli/profile-selection";
 import {
   validateConversationDefaultRequiresAgent,
@@ -400,7 +401,6 @@ async function main(): Promise<void> {
 
   // Everything below only runs for interactive TUI mode
   await settingsManager.initialize();
-  const { initTerminalTheme } = await import("./cli/helpers/terminalTheme");
   await initTerminalTheme();
 
   const settings = await settingsManager.getSettingsWithSecureTokens();


### PR DESCRIPTION
## Summary
- Store terminal theme detection state on a global symbol so duplicated bundled module copies share the same OSC background cache.
- Statically import `initTerminalTheme` from the CLI entrypoint while preserving the existing Ink/Codex-style user highlight color path.
- Fixes packaged CLI user-message highlights falling back to the wrong brown-ish color despite looking correct in `bun run dev`.

## Test plan
- [x] `bun test src/tests/helpers/terminalTheme.test.ts src/tests/cli/userMessageRich.test.ts`
- [x] `bun run check`
- [x] `bun run build`
- [x] Manually ran built `./letta.js` and verified user highlight color is neutral grey in Desktop.

👾 Generated with [Letta Code](https://letta.com)