### PR TITLE
fix(local): retry transient provider stream failures

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -1,4 +1,5 @@
 import {
+  APICallError,
   tool as aiTool,
   convertToModelMessages,
   jsonSchema,
@@ -11,6 +12,12 @@ import {
   type UIMessageChunk,
   validateUIMessages,
 } from "ai";
+import {
+  getRetryDelayMs,
+  isQuotaLimitErrorDetail,
+  parseRetryAfterHeaderMs,
+  shouldRetryPreStreamTransientError,
+} from "../../agent/approval-recovery";
 import type { ClientTool } from "../../tools/manager";
 import type { LocalCompactionStats } from "../local/compaction";
 import type { LocalMessage } from "../local/LocalMessage";
@@ -33,6 +40,8 @@ import {
 
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
 type InputModality = "text" | "image" | "audio" | "video" | "pdf";
+const LOCAL_PROVIDER_MAX_RETRIES = 3;
+const LOCAL_PROVIDER_MAX_RETRY_DELAY_MS = 60_000;
 type AISDKUIMessageStreamFinish = {
   messages: LocalMessage[];
   responseMessage: LocalMessage;
@@ -85,6 +94,148 @@ export interface AISDKStreamAdapterOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValueForRetry(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function stringifyRetryValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function retryHeaderValue(
+  headers: Record<string, string> | undefined,
+  headerName: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const direct = headers[headerName];
+  if (direct !== undefined) return direct;
+  const lower = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) return value;
+  }
+  return undefined;
+}
+
+function retryAfterMsFromHeaders(
+  headers: Record<string, string> | undefined,
+): number | null {
+  const retryAfterMs = retryHeaderValue(headers, "retry-after-ms");
+  if (retryAfterMs) {
+    const parsed = Number.parseFloat(retryAfterMs);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.round(parsed);
+    }
+  }
+
+  return parseRetryAfterHeaderMs(retryHeaderValue(headers, "retry-after"));
+}
+
+function retryErrorDetail(error: unknown): string {
+  const parts: string[] = [];
+
+  if (error instanceof Error) {
+    parts.push(error.message);
+  } else {
+    const value = stringifyRetryValue(error);
+    if (value) parts.push(value);
+  }
+
+  if (APICallError.isInstance(error)) {
+    const responseBody = stringValueForRetry(error.responseBody);
+    if (responseBody) parts.push(responseBody);
+    const data = stringifyRetryValue(error.data);
+    if (data) parts.push(data);
+    const cause = error.cause;
+    if (isRecord(cause)) {
+      const code = stringValueForRetry(cause.code);
+      if (code) parts.push(code);
+      const causeMessage = stringValueForRetry(cause.message);
+      if (causeMessage) parts.push(causeMessage);
+    } else if (cause instanceof Error) {
+      parts.push(cause.message);
+    }
+  }
+
+  return parts.filter(Boolean).join("\n");
+}
+
+function isRetryableLocalProviderError(error: unknown): boolean {
+  if (isContextWindowOverflowError(error)) return false;
+
+  const detail = retryErrorDetail(error);
+  if (APICallError.isInstance(error)) {
+    if (isQuotaLimitErrorDetail(detail)) return false;
+    if (error.isRetryable === true) return true;
+    const status = error.statusCode;
+    if (status !== undefined && status >= 500) return true;
+    return shouldRetryPreStreamTransientError({ status, detail });
+  }
+
+  return shouldRetryPreStreamTransientError({
+    status: undefined,
+    detail,
+  });
+}
+
+function localProviderRetryDelayMs(error: unknown, attempt: number): number {
+  const retryAfterMs = APICallError.isInstance(error)
+    ? retryAfterMsFromHeaders(error.responseHeaders)
+    : null;
+  return Math.min(
+    getRetryDelayMs({
+      category: "transient_provider",
+      attempt,
+      detail: retryErrorDetail(error),
+      retryAfterMs,
+    }),
+    LOCAL_PROVIDER_MAX_RETRY_DELAY_MS,
+  );
+}
+
+function localProviderRetryMessage(error: unknown): string {
+  if (APICallError.isInstance(error)) {
+    const status =
+      error.statusCode !== undefined ? `HTTP ${error.statusCode}: ` : "";
+    return `${status}${error.message}`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isModelOutputEvent(event: ProviderStreamEvent): boolean {
+  return event.type === "ai-sdk-part" || event.type === "ai-sdk-ui-message";
+}
+
+async function sleepWithAbort(
+  delayMs: number,
+  abortSignal: AbortSignal | undefined,
+): Promise<void> {
+  if (delayMs <= 0) return;
+  if (abortSignal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function isClientTool(value: unknown): value is ClientTool {
@@ -634,9 +785,14 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
     let sawToolCall = false;
     let finishReason: string | undefined;
     for await (const part of result.fullStream) {
-      if (part.type === "error" && isContextWindowOverflowError(part.error)) {
-        streamError = part.error;
-        break;
+      if (part.type === "error") {
+        if (
+          isContextWindowOverflowError(part.error) ||
+          isRetryableLocalProviderError(part.error)
+        ) {
+          streamError = part.error;
+          break;
+        }
       }
       if (part.type === "tool-call") {
         sawToolCall = true;
@@ -675,25 +831,66 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
   }
 
   async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
-    try {
-      yield* this.streamOnce(input);
-    } catch (error) {
-      if (
-        !isContextWindowOverflowError(error) ||
-        !this.onContextWindowOverflow
-      ) {
-        throw error;
+    let activeInput = input;
+    let handledContextOverflow = false;
+    let transientRetries = 0;
+
+    while (true) {
+      let emittedModelOutput = false;
+      try {
+        for await (const event of this.streamOnce(activeInput)) {
+          if (isModelOutputEvent(event)) {
+            emittedModelOutput = true;
+          }
+          yield event;
+        }
+        return;
+      } catch (error) {
+        if (isContextWindowOverflowError(error)) {
+          if (handledContextOverflow || !this.onContextWindowOverflow) {
+            throw error;
+          }
+
+          const compaction = await this.onContextWindowOverflow(
+            activeInput,
+            error,
+          );
+          if (!compaction) throw error;
+
+          handledContextOverflow = true;
+          activeInput = {
+            ...activeInput,
+            uiMessages: compaction.uiMessages,
+          };
+          yield* this.emitCompactionChunks(
+            compaction,
+            "context_window_overflow",
+          );
+          continue;
+        }
+
+        if (
+          emittedModelOutput ||
+          transientRetries >= LOCAL_PROVIDER_MAX_RETRIES ||
+          !isRetryableLocalProviderError(error)
+        ) {
+          throw error;
+        }
+
+        transientRetries += 1;
+        const delayMs = localProviderRetryDelayMs(error, transientRetries);
+        yield providerLettaChunk({
+          message_type: "event_message",
+          event_type: "retry",
+          event_data: {
+            attempt: transientRetries,
+            max_attempts: LOCAL_PROVIDER_MAX_RETRIES,
+            delay_ms: delayMs,
+            message: localProviderRetryMessage(error),
+          },
+        } as never);
+        await sleepWithAbort(delayMs, this.abortSignal);
       }
-
-      const compaction = await this.onContextWindowOverflow(input, error);
-      if (!compaction) throw error;
-
-      yield* this.emitCompactionChunks(compaction, "context_window_overflow");
-
-      yield* this.streamOnce({
-        ...input,
-        uiMessages: compaction.uiMessages,
-      });
     }
   }
 }

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -170,6 +170,56 @@ function retryErrorDetail(error: unknown): string {
   return parts.filter(Boolean).join("\n");
 }
 
+function parseRetryableJSONRecord(
+  value: string,
+): Record<string, unknown> | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const candidates = [trimmed];
+  const jsonStart = trimmed.indexOf("{");
+  if (jsonStart > 0) {
+    candidates.push(trimmed.slice(jsonStart));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Continue to next candidate.
+    }
+  }
+  return null;
+}
+
+function isRetryableRateLimitJSONDetail(detail: string): boolean {
+  const candidates = [detail, ...detail.split("\n")];
+  for (const candidate of candidates) {
+    const parsed = parseRetryableJSONRecord(candidate);
+    if (!parsed) continue;
+
+    const type = stringValueForRetry(parsed.type)?.toLowerCase();
+    const topLevelCode = stringValueForRetry(parsed.code)?.toLowerCase();
+    const nestedError = isRecord(parsed.error) ? parsed.error : undefined;
+    const nestedType = stringValueForRetry(nestedError?.type)?.toLowerCase();
+    const nestedCode = stringValueForRetry(nestedError?.code)?.toLowerCase();
+
+    if (type === "error" && nestedType === "too_many_requests") return true;
+    if (
+      typeof topLevelCode === "string" &&
+      (topLevelCode.includes("exhausted") ||
+        topLevelCode.includes("unavailable"))
+    ) {
+      return true;
+    }
+    if (typeof nestedCode === "string" && nestedCode.includes("rate_limit")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function isRetryableLocalProviderError(error: unknown): boolean {
   if (isContextWindowOverflowError(error)) return false;
 
@@ -179,9 +229,13 @@ function isRetryableLocalProviderError(error: unknown): boolean {
     if (error.isRetryable === true) return true;
     const status = error.statusCode;
     if (status !== undefined && status >= 500) return true;
+    if (status === undefined && isRetryableRateLimitJSONDetail(detail)) {
+      return true;
+    }
     return shouldRetryPreStreamTransientError({ status, detail });
   }
 
+  if (isRetryableRateLimitJSONDetail(detail)) return true;
   return shouldRetryPreStreamTransientError({
     status: undefined,
     detail,

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -213,7 +213,16 @@ function localProviderRetryMessage(error: unknown): string {
 }
 
 function isModelOutputEvent(event: ProviderStreamEvent): boolean {
-  return event.type === "ai-sdk-part" || event.type === "ai-sdk-ui-message";
+  if (event.type === "ai-sdk-ui-message") return true;
+  if (event.type !== "ai-sdk-part") return false;
+  switch (event.part.type) {
+    case "text-delta":
+    case "reasoning-delta":
+    case "tool-call":
+      return true;
+    default:
+      return false;
+  }
 }
 
 async function sleepWithAbort(

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -386,6 +386,44 @@ describe("AISDKStreamAdapter", () => {
     ]);
   });
 
+  test("does not retry quota-limited provider 429 errors", async () => {
+    let calls = 0;
+    const quotaLimit = apiError({
+      message: "Rate limit exceeded",
+      statusCode: 429,
+      responseBody: '{"error":"Rate limited","reasons":["exceeded-quota"]}',
+      isRetryable: false,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          yield* (async function* () {})();
+          throw quotaLimit;
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await expect(
+      collect(
+        adapter.stream(
+          providerInput([
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            },
+          ]),
+        ),
+      ),
+    ).rejects.toThrow("Rate limit exceeded");
+    expect(calls).toBe(1);
+  });
+
   test("does not retry non-transient provider 4xx errors", async () => {
     let calls = 0;
     const authError = apiError({
@@ -462,6 +500,44 @@ describe("AISDKStreamAdapter", () => {
       ),
     ).rejects.toThrow("upstream connect error");
     expect(calls).toBe(1);
+  });
+
+  test("retries OpenCode-style JSON overload shapes before yielding output", async () => {
+    let calls = 0;
+    const retryableJson = new Error('{"code":"RESOURCE_EXHAUSTED"}');
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          if (calls === 1) throw retryableJson;
+          yield streamPart({ type: "text-delta", id: "text-1", text: "ok" });
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    const events = await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ]),
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "letta-chunk",
+      "ai-sdk-part",
+      "ai-sdk-part",
+    ]);
   });
 
   test("retries after non-output stream parts", async () => {

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -464,6 +464,60 @@ describe("AISDKStreamAdapter", () => {
     expect(calls).toBe(1);
   });
 
+  test("retries after non-output stream parts", async () => {
+    let calls = 0;
+    const retryable = apiError({
+      message: "upstream connect error",
+      statusCode: 503,
+      isRetryable: true,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          if (calls === 1) {
+            yield streamPart({ type: "start-step", request: {}, warnings: [] });
+            throw retryable;
+          }
+          yield streamPart({ type: "text-delta", id: "text-1", text: "ok" });
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    const events = await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ]),
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "ai-sdk-part",
+      "letta-chunk",
+      "ai-sdk-part",
+      "ai-sdk-part",
+    ]);
+    expect(events[0]).toMatchObject({
+      type: "ai-sdk-part",
+      part: { type: "start-step" },
+    });
+    expect(events[1]).toMatchObject({
+      type: "letta-chunk",
+      chunk: { message_type: "event_message", event_type: "retry" },
+    });
+  });
+
   test("derives the AI SDK model from agent model settings when no override is provided", async () => {
     const originalProvider = process.env.LETTA_CODE_DEV_AI_SDK_PROVIDER;
     const originalModel = process.env.LETTA_CODE_DEV_AI_SDK_MODEL;

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -5,6 +5,7 @@ import type {
   ToolSet,
   UIMessageChunk,
 } from "ai";
+import { APICallError } from "ai";
 import {
   AISDKStreamAdapter,
   type AISDKStreamTextFunction,
@@ -17,6 +18,25 @@ import type { LocalMessage } from "../../backend/local/LocalMessage";
 
 function streamPart(part: Record<string, unknown>): TextStreamPart<ToolSet> {
   return part as unknown as TextStreamPart<ToolSet>;
+}
+
+function apiError(options: {
+  message: string;
+  statusCode?: number;
+  isRetryable?: boolean;
+  responseBody?: string;
+  cause?: unknown;
+}): APICallError {
+  return new APICallError({
+    message: options.message,
+    url: "https://example.invalid/v1/responses",
+    requestBodyValues: {},
+    statusCode: options.statusCode,
+    responseHeaders: { "retry-after-ms": "0" },
+    responseBody: options.responseBody,
+    cause: options.cause,
+    isRetryable: options.isRetryable,
+  });
 }
 
 function uiMessageStream(chunks: Array<Record<string, unknown>>) {
@@ -222,6 +242,226 @@ describe("AISDKStreamAdapter", () => {
         ],
       },
     });
+  });
+
+  test("retries retryable AI SDK connection errors before yielding model output", async () => {
+    let calls = 0;
+    let capturedMaxRetries: number | undefined;
+    const retryable = apiError({
+      message:
+        "Cannot connect to API: The socket connection was closed unexpectedly.",
+      isRetryable: true,
+      cause: { code: "ECONNRESET" },
+    });
+    const streamText: AISDKStreamTextFunction = (options) => {
+      calls += 1;
+      capturedMaxRetries = options.maxRetries;
+      return {
+        fullStream: (async function* () {
+          if (calls === 1) throw retryable;
+          yield streamPart({ type: "text-delta", id: "text-1", text: "ok" });
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    const events = await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ]),
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(capturedMaxRetries).toBe(0);
+    expect(events[0]).toMatchObject({
+      type: "letta-chunk",
+      chunk: {
+        message_type: "event_message",
+        event_type: "retry",
+        event_data: { attempt: 1, max_attempts: 3, delay_ms: 0 },
+      },
+    });
+    expect(events.map((event) => event.type)).toEqual([
+      "letta-chunk",
+      "ai-sdk-part",
+      "ai-sdk-part",
+    ]);
+  });
+
+  test("retries practical provider 5xx errors even when AI SDK does not mark them retryable", async () => {
+    let calls = 0;
+    const provider500 = apiError({
+      message: "Anthropic API error: internal server error",
+      statusCode: 500,
+      responseBody: "internal server error",
+      isRetryable: false,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          if (calls === 1) {
+            yield streamPart({ type: "error", error: provider500 });
+            return;
+          }
+          yield streamPart({ type: "text-delta", id: "text-1", text: "ok" });
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    const events = await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ]),
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "letta-chunk",
+      "ai-sdk-part",
+      "ai-sdk-part",
+    ]);
+  });
+
+  test("retries non-quota provider rate limits", async () => {
+    let calls = 0;
+    const rateLimit = apiError({
+      message: "Rate limit exceeded, please try again",
+      statusCode: 429,
+      isRetryable: false,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          if (calls === 1) throw rateLimit;
+          yield streamPart({ type: "text-delta", id: "text-1", text: "ok" });
+          yield streamPart({ type: "finish", finishReason: "stop" });
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    const events = await collect(
+      adapter.stream(
+        providerInput([
+          {
+            id: "ui-user-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ]),
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "letta-chunk",
+      "ai-sdk-part",
+      "ai-sdk-part",
+    ]);
+  });
+
+  test("does not retry non-transient provider 4xx errors", async () => {
+    let calls = 0;
+    const authError = apiError({
+      message: "Authentication error: invalid API key",
+      statusCode: 401,
+      isRetryable: false,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          yield* (async function* () {})();
+          throw authError;
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await expect(
+      collect(
+        adapter.stream(
+          providerInput([
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            },
+          ]),
+        ),
+      ),
+    ).rejects.toThrow("Authentication error");
+    expect(calls).toBe(1);
+  });
+
+  test("does not retry once model output has already been yielded", async () => {
+    let calls = 0;
+    const retryable = apiError({
+      message: "upstream connect error",
+      statusCode: 503,
+      isRetryable: true,
+    });
+    const streamText: AISDKStreamTextFunction = () => {
+      calls += 1;
+      return {
+        fullStream: (async function* () {
+          yield streamPart({
+            type: "text-delta",
+            id: "text-1",
+            text: "partial",
+          });
+          throw retryable;
+        })(),
+      };
+    };
+    const adapter = new AISDKStreamAdapter({
+      createModel: () => ({}) as LanguageModel,
+      streamText,
+    });
+
+    await expect(
+      collect(
+        adapter.stream(
+          providerInput([
+            {
+              id: "ui-user-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            },
+          ]),
+        ),
+      ),
+    ).rejects.toThrow("upstream connect error");
+    expect(calls).toBe(1);
   });
 
   test("derives the AI SDK model from agent model settings when no override is provided", async () => {

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -696,6 +696,96 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("retries transient local AI SDK provider failures inside a single persisted turn", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-provider-retry-"),
+    );
+    try {
+      let streamCalls = 0;
+      const transient = new APICallError({
+        message:
+          "Cannot connect to API: The socket connection was closed unexpectedly.",
+        url: "https://example.invalid/v1/responses",
+        requestBodyValues: {},
+        responseHeaders: { "retry-after-ms": "0" },
+        cause: { code: "ECONNRESET" },
+        isRetryable: true,
+      });
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        streamText: () => {
+          streamCalls += 1;
+          return {
+            fullStream: (async function* () {
+              if (streamCalls === 1) throw transient;
+              yield {
+                type: "text-delta",
+                id: "retry-text",
+                text: "recovered response",
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: "assistant-recovered",
+              role: "assistant",
+              parts: [{ type: "text", text: "recovered response" }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Local Retry Agent",
+        system: "retry system",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("hello retry", agent.id),
+        ),
+      );
+
+      expect(streamCalls).toBe(2);
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          message_type: "event_message",
+          event_type: "retry",
+        }),
+      );
+      expect(JSON.stringify(chunks)).toContain("recovered response");
+      expect(chunks.at(-1)).toMatchObject({
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+      });
+
+      const runId = (chunks[0] as { run_id?: string } | undefined)?.run_id;
+      expect(runId).toBe("local-run-1");
+      await expect(backend.retrieveRun(runId ?? "")).resolves.toMatchObject({
+        status: "completed",
+        stop_reason: "end_turn",
+      });
+
+      const persistedMessages = await readPersistedLocalMessages(storageDir);
+      expect(persistedMessages.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+      ]);
+      expect(JSON.stringify(persistedMessages)).toContain("hello retry");
+      expect(JSON.stringify(persistedMessages)).toContain("recovered response");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("compacts local conversation history with the backend all-compaction prompt", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-compact-"));
     try {


### PR DESCRIPTION
## Summary
- Add OpenCode-style same-turn retry handling for local AI SDK provider streams before assistant output is emitted.
- Retry transient provider failures including AI SDK retryable connection errors, practical provider 5xx responses, and non-quota rate limits while preserving context-overflow compaction handling.
- Emit local retry event chunks and add adapter/local-backend regression coverage for recovered single-turn persistence.

## Test plan
- [x] bun run check
- [x] bun test src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/local-backend.test.ts src/tests/headless/dev-backend-smoke.test.ts

👾 Generated with [Letta Code](https://letta.com)