### PR TITLE
fix(local): compact on overflow and usage triggers

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -59,6 +59,7 @@ export type AISDKStreamTextFunction = (options: {
   providerOptions?: AISDKProviderOptions;
   maxRetries: number;
   abortSignal?: AbortSignal;
+  onError?: (event: { error: unknown }) => void;
 }) => {
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>;
   toUIMessageStream?: (options?: {
@@ -835,6 +836,9 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
       ),
       maxRetries: 0,
       abortSignal: this.abortSignal,
+      // We classify and handle stream errors in this adapter; suppress AI SDK's
+      // default console.error logging for each error chunk.
+      onError: () => {},
     });
     let uiMessageError: unknown;
     const finalUIMessage = captureFinalUIMessage(result, uiMessages).catch(

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -845,8 +845,6 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
 
     let streamError: unknown;
     let lastUsage: LanguageModelUsage | undefined;
-    let sawToolCall = false;
-    let finishReason: string | undefined;
     for await (const part of result.fullStream) {
       if (part.type === "error") {
         if (
@@ -857,14 +855,10 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
           break;
         }
       }
-      if (part.type === "tool-call") {
-        sawToolCall = true;
-      }
       if (part.type === "finish-step") {
         lastUsage = part.usage;
       }
       if (part.type === "finish") {
-        finishReason = part.finishReason;
         lastUsage ??= part.totalUsage;
       }
       yield providerStreamPart(part);
@@ -880,12 +874,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
     if (message) {
       yield providerUIMessage(message);
     }
-    if (
-      lastUsage &&
-      !sawToolCall &&
-      finishReason !== "tool-calls" &&
-      this.onContextUsage
-    ) {
+    if (lastUsage && this.onContextUsage) {
       const compaction = await this.onContextUsage(input, lastUsage);
       if (compaction) {
         yield* this.emitCompactionChunks(compaction, "context_window_limit");

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -42,6 +42,7 @@ type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
 type InputModality = "text" | "image" | "audio" | "video" | "pdf";
 const LOCAL_PROVIDER_MAX_RETRIES = 3;
 const LOCAL_PROVIDER_MAX_RETRY_DELAY_MS = 60_000;
+const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
 type AISDKUIMessageStreamFinish = {
   messages: LocalMessage[];
   responseMessage: LocalMessage;
@@ -884,7 +885,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
 
   async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
     let activeInput = input;
-    let handledContextOverflow = false;
+    let contextOverflowCompactions = 0;
     let transientRetries = 0;
 
     while (true) {
@@ -899,7 +900,10 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
         return;
       } catch (error) {
         if (isContextWindowOverflowError(error)) {
-          if (handledContextOverflow || !this.onContextWindowOverflow) {
+          if (
+            !this.onContextWindowOverflow ||
+            contextOverflowCompactions >= LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS
+          ) {
             throw error;
           }
 
@@ -909,7 +913,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
           );
           if (!compaction) throw error;
 
-          handledContextOverflow = true;
+          contextOverflowCompactions += 1;
           activeInput = {
             ...activeInput,
             uiMessages: compaction.uiMessages,

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -114,9 +114,6 @@ function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
   const totalTokens =
     typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
 
-  if (promptTokens !== undefined && completionTokens !== undefined) {
-    return promptTokens + completionTokens;
-  }
   if (totalTokens !== undefined) return totalTokens;
   if (promptTokens !== undefined || completionTokens !== undefined) {
     return (promptTokens ?? 0) + (completionTokens ?? 0);

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -106,6 +106,24 @@ function createLocalUIMessageChunk(
   ) as unknown as LettaStreamingResponse;
 }
 
+function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
+  const promptTokens =
+    typeof usage.inputTokens === "number" ? usage.inputTokens : undefined;
+  const completionTokens =
+    typeof usage.outputTokens === "number" ? usage.outputTokens : undefined;
+  const totalTokens =
+    typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
+
+  if (promptTokens !== undefined && completionTokens !== undefined) {
+    return promptTokens + completionTokens;
+  }
+  if (totalTokens !== undefined) return totalTokens;
+  if (promptTokens !== undefined || completionTokens !== undefined) {
+    return (promptTokens ?? 0) + (completionTokens ?? 0);
+  }
+  return undefined;
+}
+
 function createUsageStatisticsChunk(
   usage: LanguageModelUsage | undefined,
 ): LettaStreamingResponse | undefined {
@@ -113,10 +131,7 @@ function createUsageStatisticsChunk(
   const promptTokens = usage.inputTokens;
   const completionTokens = usage.outputTokens;
   const totalTokens = usage.totalTokens;
-  const contextTokens =
-    promptTokens !== undefined || completionTokens !== undefined
-      ? (promptTokens ?? 0) + (completionTokens ?? 0)
-      : totalTokens;
+  const contextTokens = contextTokensFromUsage(usage);
   const cachedInputTokens = usage.inputTokenDetails.cacheReadTokens;
   const cacheWriteTokens = usage.inputTokenDetails.cacheWriteTokens;
   const reasoningTokens = usage.outputTokenDetails.reasoningTokens;

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -113,6 +113,10 @@ function createUsageStatisticsChunk(
   const promptTokens = usage.inputTokens;
   const completionTokens = usage.outputTokens;
   const totalTokens = usage.totalTokens;
+  const contextTokens =
+    promptTokens !== undefined || completionTokens !== undefined
+      ? (promptTokens ?? 0) + (completionTokens ?? 0)
+      : totalTokens;
   const cachedInputTokens = usage.inputTokenDetails.cacheReadTokens;
   const cacheWriteTokens = usage.inputTokenDetails.cacheWriteTokens;
   const reasoningTokens = usage.outputTokenDetails.reasoningTokens;
@@ -142,7 +146,7 @@ function createUsageStatisticsChunk(
     ...(reasoningTokens !== undefined
       ? { reasoning_tokens: reasoningTokens }
       : {}),
-    ...(promptTokens !== undefined ? { context_tokens: promptTokens } : {}),
+    ...(contextTokens !== undefined ? { context_tokens: contextTokens } : {}),
   } as unknown as LettaStreamingResponse;
 }
 

--- a/src/backend/dev/contextWindowOverflow.ts
+++ b/src/backend/dev/contextWindowOverflow.ts
@@ -18,6 +18,19 @@ function contextOverflowHaystack(error: unknown): string {
     }
     if (value instanceof Error) {
       pieces.push(value.name, value.message);
+      if (APICallError.isInstance(value)) {
+        pieces.push(
+          String(value.statusCode ?? ""),
+          value.responseBody ?? "",
+          JSON.stringify(value.data ?? ""),
+        );
+      }
+      for (const [key, item] of Object.entries(
+        value as unknown as Record<string, unknown>,
+      )) {
+        pieces.push(key);
+        visit(item, depth + 1);
+      }
       visit((value as { cause?: unknown }).cause, depth + 1);
       return;
     }

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -195,13 +195,21 @@ function localCompactionSettingsForStorage(
 }
 
 function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
-  if (
-    typeof usage.inputTokens === "number" ||
-    typeof usage.outputTokens === "number"
-  ) {
-    return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+  const inputTokens =
+    typeof usage.inputTokens === "number" ? usage.inputTokens : undefined;
+  const outputTokens =
+    typeof usage.outputTokens === "number" ? usage.outputTokens : undefined;
+  const totalTokens =
+    typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
+
+  if (inputTokens !== undefined && outputTokens !== undefined) {
+    return inputTokens + outputTokens;
   }
-  return typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
+  if (totalTokens !== undefined) return totalTokens;
+  if (inputTokens !== undefined || outputTokens !== undefined) {
+    return (inputTokens ?? 0) + (outputTokens ?? 0);
+  }
+  return undefined;
 }
 
 function createLocalExecutor(

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -35,6 +35,7 @@ import {
   type LocalCompactionStats,
   type LocalGenerateTextFunction,
   packageLocalSummaryMessage,
+  planLocalAllCompaction,
   planLocalSlidingWindowCompaction,
   summarizeLocalMessagesAll,
   summarizeLocalMessagesSlidingWindow,
@@ -191,6 +192,16 @@ function localCompactionSettingsForStorage(
   if (!hasLocalSetting) return undefined;
 
   return { ...settings };
+}
+
+function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
+  if (
+    typeof usage.inputTokens === "number" ||
+    typeof usage.outputTokens === "number"
+  ) {
+    return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+  }
+  return typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
 }
 
 function createLocalExecutor(
@@ -479,7 +490,7 @@ export class LocalBackend extends HeadlessBackend {
     summary: string;
     stats?: LocalCompactionStats;
   } | null> {
-    const contextTokens = usage.inputTokens;
+    const contextTokens = contextTokensFromUsage(usage);
     const contextWindow = this.effectiveContextWindow(
       input.conversationId,
       input.agentId,
@@ -607,13 +618,20 @@ export class LocalBackend extends HeadlessBackend {
     const settings = this.resolveCompactionSettings(agent, body);
     if (settings.mode === "sliding_window") {
       try {
-        return await this.compactLocalConversationSlidingWindow(
+        const result = await this.compactLocalConversationSlidingWindow(
           conversationId,
           agentId,
           agent,
           trigger,
           settings,
         );
+        if (
+          result.stats.context_window === undefined ||
+          result.stats.context_tokens_after === undefined ||
+          result.stats.context_tokens_after < result.stats.context_window
+        ) {
+          return result;
+        }
       } catch (error) {
         if (!isLocalSlidingWindowCompactionPlanningError(error)) throw error;
       }
@@ -645,9 +663,10 @@ export class LocalBackend extends HeadlessBackend {
   }> {
     const messages = this.store.listLocalMessages(conversationId, agentId);
     const contextTokensBefore = estimateLocalMessageTokens(messages);
+    const plan = planLocalAllCompaction(messages);
     const summary = await summarizeLocalMessagesAll({
       agent,
-      messages,
+      messages: plan.messagesToSummarize,
       createModel: this.createModel,
       generateText: this.generateText,
       prompt: settings.prompt,
@@ -657,10 +676,12 @@ export class LocalBackend extends HeadlessBackend {
     const stats: LocalCompactionStats = {
       trigger,
       context_tokens_before: contextTokensBefore,
-      context_tokens_after: Math.ceil(summary.length / 4),
+      context_tokens_after:
+        Math.ceil(summary.length / 4) +
+        estimateLocalMessageTokens(plan.messagesToKeep),
       context_window: this.effectiveContextWindow(conversationId, agentId),
       messages_count_before: messages.length,
-      messages_count_after: 1,
+      messages_count_after: 1 + plan.messagesToKeep.length,
     };
     const storeResult = this.store.compactConversationAll({
       conversationId,
@@ -668,6 +689,7 @@ export class LocalBackend extends HeadlessBackend {
       summary,
       packedSummary: packageLocalSummaryMessage(summary, stats),
       stats,
+      remainingMessages: plan.messagesToKeep,
     });
     return {
       numMessagesBefore: storeResult.numMessagesBefore,

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -202,9 +202,6 @@ function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
   const totalTokens =
     typeof usage.totalTokens === "number" ? usage.totalTokens : undefined;
 
-  if (inputTokens !== undefined && outputTokens !== undefined) {
-    return inputTokens + outputTokens;
-  }
   if (totalTokens !== undefined) return totalTokens;
   if (inputTokens !== undefined || outputTokens !== undefined) {
     return (inputTokens ?? 0) + (outputTokens ?? 0);

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -92,6 +92,13 @@ export interface LocalCompactionStats {
   messages_count_after?: number;
 }
 
+function isChatGPTOAuthModel(agent: LocalAgentRecord): boolean {
+  return (
+    agent.model.startsWith("chatgpt-plus-pro/") ||
+    agent.model_settings.provider_type === "chatgpt_oauth"
+  );
+}
+
 export type LocalGenerateTextFunction = (options: {
   model: LanguageModel;
   system?: string;
@@ -213,6 +220,8 @@ async function runGenerateText(
   defaultPrompt: string,
 ): Promise<{ text: string }> {
   const systemPrompt = input.prompt ?? defaultPrompt;
+  const system =
+    isChatGPTOAuthModel(input.agent) === true ? undefined : systemPrompt;
   const run = input.generateText ?? generateText;
   const model =
     input.createModel?.() ??
@@ -229,7 +238,7 @@ async function runGenerateText(
   try {
     const result = await run({
       model,
-      system: systemPrompt,
+      system,
       prompt: transcript,
       providerOptions,
       maxRetries: 0,
@@ -250,11 +259,13 @@ async function runGenerateText(
     let text = "";
     const result = streamText({
       model,
-      system: systemPrompt,
+      system,
       prompt: transcript,
       providerOptions,
       maxRetries: 0,
       abortSignal: input.abortSignal,
+      // Compaction handles stream error parts directly below.
+      onError: () => {},
     });
     for await (const part of result.fullStream) {
       if (part.type === "text-delta") {

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -106,6 +106,11 @@ export interface LocalSlidingWindowCompactionPlan {
   cutoffIndex: number;
 }
 
+export interface LocalAllCompactionPlan {
+  messagesToSummarize: LocalMessage[];
+  messagesToKeep: LocalMessage[];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -283,7 +288,7 @@ function isValidSlidingWindowCutoff(
 ): boolean {
   const message = messages[index];
   return (
-    message?.role === "assistant" && index > 1 && index < maximumCutoffIndex
+    message?.role === "assistant" && index > 0 && index < maximumCutoffIndex
   );
 }
 
@@ -310,17 +315,22 @@ export function planLocalSlidingWindowCompaction(
     Number.isFinite(options.contextWindow)
       ? (1 - percentage) * options.contextWindow
       : undefined;
+  let approxTokenCount = options.contextWindow ?? Number.POSITIVE_INFINITY;
+  let cutoffIndex: number | undefined;
 
-  for (
-    let evictionPercentage = percentage;
-    evictionPercentage < 1.0;
-    evictionPercentage += 0.1
+  let evictionPercentage = percentage;
+  while (
+    (goalTokens === undefined
+      ? cutoffIndex === undefined
+      : approxTokenCount >= goalTokens) &&
+    evictionPercentage < 1.0
   ) {
+    evictionPercentage += 0.1;
     const messageCutoffIndex = Math.min(
       Math.round(evictionPercentage * messages.length),
       messages.length - 1,
     );
-    const cutoffIndex = [...Array(messageCutoffIndex + 1).keys()]
+    cutoffIndex = [...Array(messageCutoffIndex + 1).keys()]
       .reverse()
       .find((index) =>
         isValidSlidingWindowCutoff(messages, index, maximumCutoffIndex),
@@ -328,23 +338,43 @@ export function planLocalSlidingWindowCompaction(
     if (cutoffIndex === undefined) continue;
 
     const messagesToKeep = messages.slice(cutoffIndex);
-    if (
-      goalTokens !== undefined &&
-      estimateLocalMessageTokens(messagesToKeep) >= goalTokens
-    ) {
-      continue;
-    }
+    approxTokenCount = estimateLocalMessageTokens(messagesToKeep);
+  }
 
+  if (cutoffIndex === undefined || evictionPercentage >= 1.0) {
+    throw new LocalSlidingWindowCompactionPlanningError(
+      "No assistant message found for sliding window compaction.",
+    );
+  }
+
+  if (cutoffIndex >= maximumCutoffIndex) {
+    throw new LocalSlidingWindowCompactionPlanningError(
+      `Assistant message index ${cutoffIndex} is at the end of the message buffer, skipping compaction.`,
+    );
+  }
+
+  return {
+    messagesToSummarize: messages.slice(0, cutoffIndex),
+    messagesToKeep: messages.slice(cutoffIndex),
+    cutoffIndex,
+  };
+}
+
+export function planLocalAllCompaction(
+  messages: LocalMessage[],
+): LocalAllCompactionPlan {
+  const lastMessage = messages.at(-1);
+  if (lastMessage && hasPendingLocalToolPart(lastMessage)) {
     return {
-      messagesToSummarize: messages.slice(0, cutoffIndex),
-      messagesToKeep,
-      cutoffIndex,
+      messagesToSummarize: messages.slice(0, -1),
+      messagesToKeep: [lastMessage],
     };
   }
 
-  throw new LocalSlidingWindowCompactionPlanningError(
-    "No assistant message found for sliding window compaction.",
-  );
+  return {
+    messagesToSummarize: messages,
+    messagesToKeep: [],
+  };
 }
 
 export async function summarizeLocalMessagesSlidingWindow(

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -1,4 +1,4 @@
-import { generateText, type LanguageModel } from "ai";
+import { APICallError, generateText, type LanguageModel, streamText } from "ai";
 import { createAISDKModelFactoryFromAgent } from "../dev/AISDKModelFactory";
 import { buildAISDKProviderOptions } from "../dev/AISDKStreamAdapter";
 import { isContextWindowOverflowError } from "../dev/contextWindowOverflow";
@@ -211,25 +211,62 @@ async function runGenerateText(
   input: LocalAllCompactionInput,
   transcript: string,
   defaultPrompt: string,
-) {
+): Promise<{ text: string }> {
+  const systemPrompt = input.prompt ?? defaultPrompt;
   const run = input.generateText ?? generateText;
-  return run({
-    model:
-      input.createModel?.() ??
-      createAISDKModelFactoryFromAgent(
-        input.agent.model,
-        input.agent.model_settings,
-        { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
-      )(),
-    system: input.prompt ?? defaultPrompt,
-    prompt: transcript,
-    providerOptions: buildAISDKProviderOptions(
+  const model =
+    input.createModel?.() ??
+    createAISDKModelFactoryFromAgent(
       input.agent.model,
       input.agent.model_settings,
-    ),
-    maxRetries: 0,
-    abortSignal: input.abortSignal,
-  });
+      { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
+    )();
+  const providerOptions = buildAISDKProviderOptions(
+    input.agent.model,
+    input.agent.model_settings,
+    { systemPrompt },
+  );
+  try {
+    const result = await run({
+      model,
+      system: systemPrompt,
+      prompt: transcript,
+      providerOptions,
+      maxRetries: 0,
+      abortSignal: input.abortSignal,
+    });
+    return { text: result.text };
+  } catch (error) {
+    const detail = [
+      error instanceof Error ? error.message : "",
+      APICallError.isInstance(error) ? String(error.responseBody ?? "") : "",
+    ]
+      .join("\n")
+      .toLowerCase();
+    if (!detail.includes("stream must be set to true")) {
+      throw error;
+    }
+
+    let text = "";
+    const result = streamText({
+      model,
+      system: systemPrompt,
+      prompt: transcript,
+      providerOptions,
+      maxRetries: 0,
+      abortSignal: input.abortSignal,
+    });
+    for await (const part of result.fullStream) {
+      if (part.type === "text-delta") {
+        text += part.text;
+        continue;
+      }
+      if (part.type === "error") {
+        throw part.error;
+      }
+    }
+    return { text };
+  }
 }
 
 async function summarizeLocalMessagesWithPrompt(
@@ -238,7 +275,7 @@ async function summarizeLocalMessagesWithPrompt(
 ): Promise<string> {
   if (input.messages.length === 0) return "No prior conversation messages.";
   const primaryTranscript = formatLocalMessagesForSummary(input.messages);
-  let result: Awaited<ReturnType<typeof generateText>> | undefined;
+  let result: { text: string } | undefined;
   try {
     result = await runGenerateText(input, primaryTranscript, defaultPrompt);
   } catch (error) {

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -10,6 +10,18 @@ const SLIDING_WORD_LIMIT = 300;
 const SUMMARY_TRUNCATION_SUFFIX = "... [summary truncated to fit]";
 const TOOL_TRANSCRIPT_TRUNCATION_CHARS = 4000;
 const TRANSCRIPT_FALLBACK_MAX_CHARS = 120000;
+const TRANSCRIPT_FALLBACK_MAX_CHAR_STEPS = [
+  TRANSCRIPT_FALLBACK_MAX_CHARS,
+  90_000,
+  60_000,
+  40_000,
+  25_000,
+  15_000,
+  10_000,
+  6_000,
+  4_000,
+  2_000,
+] as const;
 export const LOCAL_DEFAULT_COMPACTION_MODE = "sliding_window";
 export const LOCAL_DEFAULT_SLIDING_WINDOW_PERCENTAGE = 0.3;
 
@@ -226,18 +238,38 @@ async function summarizeLocalMessagesWithPrompt(
 ): Promise<string> {
   if (input.messages.length === 0) return "No prior conversation messages.";
   const primaryTranscript = formatLocalMessagesForSummary(input.messages);
-  let result: Awaited<ReturnType<typeof generateText>>;
+  let result: Awaited<ReturnType<typeof generateText>> | undefined;
   try {
     result = await runGenerateText(input, primaryTranscript, defaultPrompt);
   } catch (error) {
     if (!isContextWindowOverflowError(error)) throw error;
-    const fallbackTranscript = formatLocalMessagesForSummary(input.messages, {
-      truncationChars: TOOL_TRANSCRIPT_TRUNCATION_CHARS,
-      maxChars: TRANSCRIPT_FALLBACK_MAX_CHARS,
-    });
-    result = await runGenerateText(input, fallbackTranscript, defaultPrompt);
+    let overflowError: unknown = error;
+    let previousTranscript: string | undefined;
+    for (const maxChars of TRANSCRIPT_FALLBACK_MAX_CHAR_STEPS) {
+      const fallbackTranscript = formatLocalMessagesForSummary(input.messages, {
+        truncationChars: TOOL_TRANSCRIPT_TRUNCATION_CHARS,
+        maxChars,
+      });
+      if (fallbackTranscript === previousTranscript) continue;
+      previousTranscript = fallbackTranscript;
+      try {
+        result = await runGenerateText(
+          input,
+          fallbackTranscript,
+          defaultPrompt,
+        );
+        break;
+      } catch (fallbackError) {
+        if (!isContextWindowOverflowError(fallbackError)) throw fallbackError;
+        overflowError = fallbackError;
+      }
+    }
+    if (!result) throw overflowError;
   }
 
+  if (!result) {
+    throw new Error("Compaction summarizer did not return a result.");
+  }
   let summary = result.text.trim();
   const clipChars = input.clipChars === undefined ? 50000 : input.clipChars;
   if (clipChars !== null && summary.length > clipChars) {

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -658,9 +658,11 @@ describe("AISDKStreamAdapter", () => {
     const model = {} as LanguageModel;
     let capturedSystem: string | undefined;
     let capturedProviderOptions: unknown;
+    let capturedOnError: ((event: { error: unknown }) => void) | undefined;
     const streamText: AISDKStreamTextFunction = (options) => {
       capturedSystem = options.system;
       capturedProviderOptions = options.providerOptions;
+      capturedOnError = options.onError;
       return {
         fullStream: (async function* () {
           yield streamPart({ type: "finish", finishReason: "stop" });
@@ -703,6 +705,7 @@ describe("AISDKStreamAdapter", () => {
         systemMessageMode: "remove",
       },
     });
+    expect(typeof capturedOnError).toBe("function");
   });
 
   test("passes provider reasoning options from local model settings", async () => {

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1352,6 +1352,106 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("uses total token fallback when usage output tokens are missing", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-usage-total-fallback-"),
+    );
+    try {
+      let summaryPrompt: string | undefined;
+      const usage: LanguageModelUsage = {
+        inputTokens: 90,
+        inputTokenDetails: {
+          noCacheTokens: 90,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: undefined,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: 102,
+      };
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryPrompt = options.prompt;
+          return { text: "usage-total-fallback summary" } as never;
+        }) as never,
+        streamText: () => {
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: "usage-fallback-text",
+                text: "limit response",
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish-step",
+                response: {},
+                usage,
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                providerMetadata: undefined,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                totalUsage: usage,
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: "assistant-usage-fallback",
+              role: "assistant",
+              parts: [{ type: "text", text: "limit response" }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Usage Fallback Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await backend.updateConversation(conversation.id, {
+        context_window_limit: 100,
+      } as never);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("limit trigger request", agent.id),
+        ),
+      );
+
+      const usageChunk = chunks.find(
+        (chunk) => chunk.message_type === "usage_statistics",
+      ) as
+        | {
+            context_tokens?: number;
+            prompt_tokens?: number;
+            total_tokens?: number;
+            completion_tokens?: number;
+          }
+        | undefined;
+      expect(usageChunk?.context_tokens).toBe(102);
+      expect(usageChunk?.prompt_tokens).toBe(90);
+      expect(usageChunk?.total_tokens).toBe(102);
+      expect(usageChunk?.completion_tokens).toBeUndefined();
+      expect(summaryPrompt).toContain("limit trigger request");
+      expect(summaryPrompt).toContain("limit response");
+      expect(JSON.stringify(chunks)).toContain("context_window_limit");
+      expect(JSON.stringify(chunks)).toContain("usage-total-fallback summary");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("compacts after usage-limit tool-call turns", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-usage-tool-compact-"),

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1262,6 +1262,219 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("keeps compacting the same turn when overflow persists after the first compaction", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-auto-compact-multi-"),
+    );
+    try {
+      let streamCalls = 0;
+      let compactionCalls = 0;
+      const modelMessagesByCall: ModelMessage[][] = [];
+      const overflow = {
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        message:
+          "Your input exceeds the context window of this model. Please adjust your input and try again.",
+        param: "input",
+      };
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async () => {
+          compactionCalls += 1;
+          return {
+            text:
+              compactionCalls === 1
+                ? "first compacted summary"
+                : "second compacted summary",
+          } as never;
+        }) as never,
+        streamText: (options) => {
+          streamCalls += 1;
+          modelMessagesByCall.push(options.messages);
+
+          if (streamCalls === 2 || streamCalls === 3) {
+            return {
+              fullStream: (async function* () {
+                yield {
+                  type: "error",
+                  error: overflow,
+                } as TextStreamPart<ToolSet>;
+              })(),
+            };
+          }
+
+          const text =
+            streamCalls === 1 ? "first response" : "after second compaction";
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: `text-${streamCalls}`,
+                text,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: `assistant-${streamCalls}`,
+              role: "assistant",
+              parts: [{ type: "text", text }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Auto Compact Multi Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("overflowing request", agent.id),
+        ),
+      );
+
+      expect(streamCalls).toBe(4);
+      expect(compactionCalls).toBe(2);
+      expect(
+        chunks.filter(
+          (chunk) =>
+            (chunk as { message_type?: string }).message_type ===
+            "summary_message",
+        ).length,
+      ).toBe(2);
+      expect(JSON.stringify(chunks)).toContain("after second compaction");
+      expect(JSON.stringify(modelMessagesByCall[3])).toContain(
+        "second compacted summary",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("shrinks compaction transcripts progressively when summarizer fallback still overflows", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-compact-shrink-fallback-"),
+    );
+    try {
+      let streamCalls = 0;
+      let summaryCalls = 0;
+      const summaryPromptLengths: number[] = [];
+      const overflowThresholdChars = 3_000;
+      const overflow = new APICallError({
+        message: "context_length_exceeded: maximum context length exceeded",
+        url: "https://example.invalid/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: {
+            type: "invalid_request_error",
+            code: "context_length_exceeded",
+            message:
+              "Your input exceeds the context window of this model. Please adjust your input and try again.",
+            param: "input",
+          },
+        }),
+        isRetryable: false,
+      });
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryCalls += 1;
+          const prompt = options.prompt ?? "";
+          summaryPromptLengths.push(prompt.length);
+          if (prompt.length > overflowThresholdChars) {
+            throw overflow;
+          }
+          return { text: "iteratively compacted summary" } as never;
+        }) as never,
+        streamText: (_options) => {
+          streamCalls += 1;
+          if (streamCalls === 2) {
+            return {
+              fullStream: (async function* () {
+                yield {
+                  type: "error",
+                  error: overflow,
+                } as TextStreamPart<ToolSet>;
+              })(),
+            };
+          }
+
+          const text =
+            streamCalls === 1 ? "first response" : "after iterative compaction";
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: `text-${streamCalls}`,
+                text,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: `assistant-${streamCalls}`,
+              role: "assistant",
+              parts: [{ type: "text", text }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Fallback Shrink Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody(`first request ${"x".repeat(9_000)}`, agent.id),
+        ),
+      );
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("overflowing request", agent.id),
+        ),
+      );
+
+      expect(streamCalls).toBe(3);
+      expect(summaryCalls).toBeGreaterThan(2);
+      expect(summaryPromptLengths[0]).toBeGreaterThan(overflowThresholdChars);
+      expect(summaryPromptLengths.at(-1)).toBeLessThanOrEqual(
+        overflowThresholdChars,
+      );
+      expect(JSON.stringify(chunks)).toContain("iteratively compacted summary");
+      expect(JSON.stringify(chunks)).toContain("after iterative compaction");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("compacts after local AI SDK usage exceeds the configured context window", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-usage-compact-"),

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1452,6 +1452,107 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("prefers provider total tokens when both total and split usage are present", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-usage-total-preferred-"),
+    );
+    try {
+      let summaryPrompt: string | undefined;
+      const usage: LanguageModelUsage = {
+        inputTokens: 90,
+        inputTokenDetails: {
+          noCacheTokens: 90,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: 12,
+        outputTokenDetails: {
+          textTokens: 12,
+          reasoningTokens: undefined,
+        },
+        // Deliberately differs from input+output to verify precedence.
+        totalTokens: 140,
+      };
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryPrompt = options.prompt;
+          return { text: "usage-total-preferred summary" } as never;
+        }) as never,
+        streamText: () => {
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: "usage-total-preferred-text",
+                text: "limit response",
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish-step",
+                response: {},
+                usage,
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                providerMetadata: undefined,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+                rawFinishReason: "stop",
+                totalUsage: usage,
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: "assistant-usage-total-preferred",
+              role: "assistant",
+              parts: [{ type: "text", text: "limit response" }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Usage Total Preferred Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await backend.updateConversation(conversation.id, {
+        context_window_limit: 120,
+      } as never);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("limit trigger request", agent.id),
+        ),
+      );
+
+      const usageChunk = chunks.find(
+        (chunk) => chunk.message_type === "usage_statistics",
+      ) as
+        | {
+            context_tokens?: number;
+            prompt_tokens?: number;
+            total_tokens?: number;
+            completion_tokens?: number;
+          }
+        | undefined;
+      expect(usageChunk?.context_tokens).toBe(140);
+      expect(usageChunk?.prompt_tokens).toBe(90);
+      expect(usageChunk?.completion_tokens).toBe(12);
+      expect(usageChunk?.total_tokens).toBe(140);
+      expect(summaryPrompt).toContain("limit trigger request");
+      expect(summaryPrompt).toContain("limit response");
+      expect(JSON.stringify(chunks)).toContain("context_window_limit");
+      expect(JSON.stringify(chunks)).toContain("usage-total-preferred summary");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("compacts after usage-limit tool-call turns", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-usage-tool-compact-"),

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -36,6 +36,7 @@ import {
 import {
   createOrUpdateLocalProvider,
   getLocalProviderAuthPath,
+  isContextWindowOverflowError,
   LOCAL_ALL_COMPACTION_PROMPT,
   LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT,
   LocalBackend,
@@ -920,12 +921,12 @@ describe("LocalBackend", () => {
 
       expect(result).toEqual({
         num_messages_before: 6,
-        num_messages_after: 4,
+        num_messages_after: 6,
         summary: "sliding local summary",
       });
       expect(capturedSystem).toBe(LOCAL_SLIDING_WINDOW_COMPACTION_PROMPT);
       expect(capturedPrompt).toContain("first request");
-      expect(capturedPrompt).toContain("second request");
+      expect(capturedPrompt).not.toContain("second request");
       expect(capturedPrompt).not.toContain("third request");
 
       const page = await backend.listConversationMessages(conversation.id, {
@@ -937,13 +938,15 @@ describe("LocalBackend", () => {
         "assistant_message",
         "user_message",
         "assistant_message",
+        "user_message",
+        "assistant_message",
       ]);
       expect(JSON.stringify(messages[0])).toContain("sliding local summary");
       expect(JSON.stringify(messages)).toContain("third request");
       expect(JSON.stringify(messages)).not.toContain("first request");
 
       const persistedMessages = await readPersistedLocalMessages(storageDir);
-      expect(persistedMessages).toHaveLength(4);
+      expect(persistedMessages).toHaveLength(6);
       expect(JSON.stringify(persistedMessages[0])).toContain(
         "sliding local summary",
       );
@@ -1265,7 +1268,7 @@ describe("LocalBackend", () => {
     );
     try {
       let summaryPrompt: string | undefined;
-      const usage = modelUsage(150, 12);
+      const usage = modelUsage(90, 12);
       const backend = new LocalBackend({
         storageDir,
         createModel: () => ({}) as LanguageModel,
@@ -1326,8 +1329,8 @@ describe("LocalBackend", () => {
       const usageChunk = chunks.find(
         (chunk) => chunk.message_type === "usage_statistics",
       ) as { context_tokens?: number; prompt_tokens?: number } | undefined;
-      expect(usageChunk?.context_tokens).toBe(150);
-      expect(usageChunk?.prompt_tokens).toBe(150);
+      expect(usageChunk?.context_tokens).toBe(102);
+      expect(usageChunk?.prompt_tokens).toBe(90);
       expect(summaryPrompt).toContain("limit trigger request");
       expect(summaryPrompt).toContain("limit response");
       expect(JSON.stringify(chunks)).toContain("context_window_limit");
@@ -1347,6 +1350,177 @@ describe("LocalBackend", () => {
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }
+  });
+
+  test("compacts after usage-limit tool-call turns", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-usage-tool-compact-"),
+    );
+    try {
+      let summaryPrompt: string | undefined;
+      const usage = modelUsage(90, 12);
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        generateText: (async (options: { prompt?: string }) => {
+          summaryPrompt = options.prompt;
+          return { text: "tool-call usage summary" } as never;
+        }) as never,
+        streamText: (options) => {
+          const hasToolOutput = JSON.stringify(options.messages).includes(
+            "read result after compaction",
+          );
+          if (hasToolOutput) {
+            return {
+              fullStream: (async function* () {
+                yield {
+                  type: "text-delta",
+                  id: "tool-result-text",
+                  text: "continued after compacted tool call",
+                } as TextStreamPart<ToolSet>;
+                yield {
+                  type: "finish",
+                  finishReason: "stop",
+                } as TextStreamPart<ToolSet>;
+              })(),
+              toUIMessageStream: uiMessageStreamWithFinish([], {
+                id: "assistant-tool-result",
+                role: "assistant",
+                parts: [
+                  { type: "text", text: "continued after compacted tool call" },
+                ],
+              } as LocalMessage),
+            };
+          }
+
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "tool-call",
+                toolCallId: "call-read",
+                toolName: "Read",
+                input: { path: "src/tools/toolDefinitions.ts" },
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish-step",
+                response: {},
+                usage,
+                finishReason: "tool-calls",
+                rawFinishReason: "tool-calls",
+                providerMetadata: undefined,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "tool-calls",
+                rawFinishReason: "tool-calls",
+                totalUsage: usage,
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish(
+              [],
+              {
+                id: "assistant-tool-call-limit",
+                role: "assistant",
+                parts: [
+                  {
+                    type: "tool-Read",
+                    toolCallId: "call-read",
+                    state: "input-available",
+                    input: { path: "src/tools/toolDefinitions.ts" },
+                  },
+                ],
+              } as LocalMessage,
+              "tool-calls",
+            ),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Usage Tool Compact Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await backend.updateConversation(conversation.id, {
+        context_window_limit: 100,
+      } as never);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("call read", agent.id),
+        ),
+      );
+
+      expect(JSON.stringify(chunks)).toContain("context_window_limit");
+      expect(JSON.stringify(chunks)).toContain("tool-call usage summary");
+      expect(summaryPrompt).toContain("call read");
+
+      const approvalChunk = chunks.find(
+        (chunk) => chunk.message_type === "approval_request_message",
+      ) as
+        | (LettaStreamingResponse & {
+            tool_call?: { tool_call_id?: string; name?: string };
+          })
+        | undefined;
+      expect(approvalChunk?.tool_call?.tool_call_id).toBe("call-read");
+
+      const persistedAfterCompaction =
+        await readPersistedLocalMessages(storageDir);
+      expect(persistedAfterCompaction.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+      ]);
+      expect(JSON.stringify(persistedAfterCompaction)).toContain(
+        "tool-call usage summary",
+      );
+      expect(JSON.stringify(persistedAfterCompaction)).toContain("call-read");
+
+      const continuationChunks = await collectStream(
+        await backend.createConversationMessageStream(conversation.id, {
+          ...createBody("", agent.id),
+          messages: [
+            {
+              type: "approval",
+              approvals: [
+                {
+                  type: "tool",
+                  tool_call_id: approvalChunk?.tool_call?.tool_call_id,
+                  tool_return: "read result after compaction",
+                  status: "success",
+                },
+              ],
+            },
+          ],
+        } as unknown as ConversationMessageCreateBody),
+      );
+      expect(JSON.stringify(continuationChunks)).toContain(
+        "continued after compacted tool call",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("detects context overflow from AI SDK API response bodies", () => {
+    const error = new APICallError({
+      message: "Bad Request",
+      url: "https://api.openai.com/v1/responses",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: {
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+          message: "Your input exceeds the context window of this model.",
+        },
+      }),
+      isRetryable: false,
+    });
+
+    expect(isContextWindowOverflowError(error)).toBe(true);
   });
 
   test("persists compiled system prompt snapshots and reuses them for turns", async () => {

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1154,6 +1154,70 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("uses ChatGPT OAuth instructions when running local compaction summaries", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-chatgpt-oauth-compact-"),
+    );
+    try {
+      let capturedSystem: string | undefined;
+      let capturedProviderOptions: unknown;
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        generateText: (async (options: {
+          system?: string;
+          providerOptions?: unknown;
+        }) => {
+          capturedSystem = options.system;
+          capturedProviderOptions = options.providerOptions;
+          return { text: "oauth compaction summary" } as never;
+        }) as never,
+      });
+
+      const agent = await backend.createAgent({
+        name: "ChatGPT OAuth Compact Agent",
+        model: "chatgpt-plus-pro/gpt-5.5",
+        model_settings: { provider_type: "chatgpt_oauth" },
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("second request", agent.id),
+        ),
+      );
+
+      const result = (await backend.compactConversationMessages(
+        conversation.id,
+        { agent_id: agent.id, compaction_settings: { mode: "all" } } as never,
+      )) as {
+        num_messages_before: number;
+        num_messages_after: number;
+        summary: string;
+      };
+
+      expect(result.summary).toBe("oauth compaction summary");
+      expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
+      expect(capturedProviderOptions).toMatchObject({
+        openai: {
+          instructions: LOCAL_ALL_COMPACTION_PROMPT,
+          systemMessageMode: "remove",
+          store: false,
+        },
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("auto-compacts and retries local AI SDK turns on context overflow", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-auto-compact-"),

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -1205,7 +1205,7 @@ describe("LocalBackend", () => {
       };
 
       expect(result.summary).toBe("oauth compaction summary");
-      expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
+      expect(capturedSystem).toBeUndefined();
       expect(capturedProviderOptions).toMatchObject({
         openai: {
           instructions: LOCAL_ALL_COMPACTION_PROMPT,


### PR DESCRIPTION
## Summary
- Route AI SDK context overflow response-body errors into local compaction instead of transient retry handling.
- Trigger local compaction when usage input + output exceeds the effective context window, including tool-call turns.
- Align local sliding/all compaction planning with core behavior by preserving pending tool-call state and falling back when sliding-window compaction remains over budget.

## Test plan
- [x] bun run check
- [x] bun test src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/local-backend.test.ts --timeout 15000
- [x] bun test src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/local-backend.test.ts src/tests/cli/accumulator-usage.test.ts src/tests/backend/provider-turn-executor.test.ts src/tests/headless/dev-backend-smoke.test.ts src/tests/backend/fake-headless-backend.test.ts --timeout 15000

👾 Generated with [Letta Code](https://letta.com)