### PR TITLE
feat(personality): add blank personality

### DIFF
--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -23,7 +23,7 @@ const PRIMARY_HUMAN_RELATIVE_PATH = "system/human.md";
 const LEGACY_HUMAN_RELATIVE_PATH = "memory/system/human.md";
 
 export interface PersonalityOption {
-  id: "kawaii" | "codex" | "claude" | "linus" | "memo";
+  id: "blank" | "kawaii" | "codex" | "claude" | "linus" | "memo";
   label: string;
   description: string;
   /** Model ID from models.json to use when no explicit model is provided. */
@@ -35,6 +35,11 @@ export const PERSONALITY_OPTIONS: PersonalityOption[] = [
     id: "memo",
     label: "Letta Code",
     description: "The memory-first agent",
+  },
+  {
+    id: "blank",
+    label: "Blank",
+    description: "Blank starter — you provide the personality",
   },
   {
     id: "linus",
@@ -63,6 +68,7 @@ export type PersonalityId = PersonalityOption["id"];
 
 export const DEFAULT_CREATE_AGENT_PERSONALITIES = [
   "memo",
+  "blank",
   "linus",
   "kawaii",
 ] as const;
@@ -267,6 +273,10 @@ export function getPersonalityContent(personalityId: PersonalityId): string {
     return getPromptBody("persona_memo.mdx");
   }
 
+  if (personalityId === "blank") {
+    return getPromptBody("persona_blank.mdx");
+  }
+
   if (personalityId === "kawaii") {
     return getPromptBody("persona_kawaii.mdx");
   }
@@ -301,6 +311,10 @@ export function getPersonalityHumanContent(
     return getPromptBody("human_kawaii.mdx");
   }
 
+  if (personalityId === "blank") {
+    return getDefaultHumanContent();
+  }
+
   return getDefaultHumanContent();
 }
 
@@ -322,11 +336,13 @@ export function getPersonalityBlockDefinitions(personalityId: PersonalityId): {
   const personaTemplatePromptAssetName =
     personalityId === "memo"
       ? "persona_memo.mdx"
-      : personalityId === "kawaii"
-        ? "persona_kawaii.mdx"
-        : personalityId === "linus"
-          ? "persona_linus.mdx"
-          : "persona.mdx";
+      : personalityId === "blank"
+        ? "persona_blank.mdx"
+        : personalityId === "kawaii"
+          ? "persona_kawaii.mdx"
+          : personalityId === "linus"
+            ? "persona_linus.mdx"
+            : "persona.mdx";
   const humanTemplatePromptAssetName =
     personalityId === "memo"
       ? "human_memo.mdx"

--- a/src/agent/promptAssets.ts
+++ b/src/agent/promptAssets.ts
@@ -12,6 +12,7 @@ import lettaNoMemfsPrompt from "./prompts/letta_no_memfs.md";
 import memoryCheckReminder from "./prompts/memory_check_reminder.txt";
 import memoryFilesystemPrompt from "./prompts/memory_filesystem.mdx";
 import personaPrompt from "./prompts/persona.mdx";
+import personaBlankPrompt from "./prompts/persona_blank.mdx";
 import personaKawaiiPrompt from "./prompts/persona_kawaii.mdx";
 import personaLinusPrompt from "./prompts/persona_linus.mdx";
 import personaMemoPrompt from "./prompts/persona_memo.mdx";
@@ -38,6 +39,7 @@ export const SLEEPTIME_MEMORY_PERSONA = sleeptimePersona;
 
 export const MEMORY_PROMPTS: Record<string, string> = {
   "persona.mdx": personaPrompt,
+  "persona_blank.mdx": personaBlankPrompt,
   "persona_kawaii.mdx": personaKawaiiPrompt,
   "persona_linus.mdx": personaLinusPrompt,
   "persona_memo.mdx": personaMemoPrompt,

--- a/src/agent/prompts/README.md
+++ b/src/agent/prompts/README.md
@@ -45,6 +45,7 @@ Default values for agent memory blocks. Loaded via `MEMORY_PROMPTS` in `promptAs
 | File | Used | Description |
 |------|------|-------------|
 | `persona.mdx` | Default persona for all new agents | Blank-slate "ready to be shaped" |
+| `persona_blank.mdx` | Overrides persona for the Blank personality | Prompts user to provide a personality |
 | `persona_memo.mdx` | Overrides persona for the default Letta Code agent | Warm, curious collaborator personality |
 | `persona_kawaii.mdx` | Not wired into any agent creation flow | Kawaii voice persona preset |
 | `human.mdx` | Default human block for all new agents | Placeholder for learning about the user |

--- a/src/agent/prompts/persona_blank.mdx
+++ b/src/agent/prompts/persona_blank.mdx
@@ -1,0 +1,6 @@
+---
+label: persona
+description: Blank starter personality — awaiting user-provided personality prompt.
+---
+
+This is a blank starter personality. You must ask the user to provide a personality prompt or preference.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -879,7 +879,7 @@ export async function handleHeadlessCommand(
     : null;
   if (personalityInput && !personality) {
     console.error(
-      `Error: Unknown personality "${personalityInput}". Valid: letta-code, linus, kawaii, claude, codex`,
+      `Error: Unknown personality "${personalityInput}". Valid: letta-code, blank, linus, kawaii, claude, codex`,
     );
     process.exit(1);
   }

--- a/src/tests/agent/personality.test.ts
+++ b/src/tests/agent/personality.test.ts
@@ -63,9 +63,10 @@ describe("personality helpers", () => {
     expect(getPersonalityHumanContent("codex")).toBe(defaultHuman);
   });
 
-  test("default create-agent personalities are exactly memo, linus, and kawaii", () => {
+  test("default create-agent personalities are exactly memo, blank, linus, and kawaii", () => {
     expect(DEFAULT_CREATE_AGENT_PERSONALITIES).toEqual([
       "memo",
+      "blank",
       "linus",
       "kawaii",
     ]);
@@ -112,5 +113,16 @@ describe("personality helpers", () => {
     const definitions = getPersonalityBlockDefinitions("kawaii");
     expect(definitions.persona.description).toContain("sparkly memory");
     expect(definitions.human.description).toContain("senpai");
+  });
+
+  test("blank personality uses persona_blank.mdx content", () => {
+    const content = getPersonalityContent("blank");
+    expect(content).toContain("blank starter personality");
+    expect(content).toContain("ask the user to provide a personality prompt");
+  });
+
+  test("blank personality uses the default human block", () => {
+    const defaultHuman = getDefaultHumanContent();
+    expect(getPersonalityHumanContent("blank")).toBe(defaultHuman);
   });
 });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -201,9 +201,10 @@ describe("listen-client parseServerMessage", () => {
   });
 
   describe("listen-client create_agent command handling", () => {
-    test("creates the memo, linus, and kawaii presets through the shared helper", async () => {
+    test("creates the default presets through the shared helper", async () => {
       expect(DEFAULT_CREATE_AGENT_PERSONALITIES).toEqual([
         "memo",
+        "blank",
         "linus",
         "kawaii",
       ]);

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -967,7 +967,7 @@ export interface CreateAgentCommand {
   /** Echoed back in the response for request correlation. */
   request_id: string;
   /** Built-in personality preset to create. */
-  personality: "memo" | "linus" | "kawaii";
+  personality: "memo" | "blank" | "linus" | "kawaii";
   /** Model identifier (e.g. "sonnet", "gpt-4o"). Uses default if omitted. */
   model?: string;
   /** Whether to pin the agent globally after creation. Defaults to true. */

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -838,6 +838,7 @@ export function isCreateAgentCommand(
     c.type === "create_agent" &&
     typeof c.request_id === "string" &&
     (c.personality === "memo" ||
+      c.personality === "blank" ||
       c.personality === "linus" ||
       c.personality === "kawaii") &&
     (c.model === undefined || typeof c.model === "string") &&


### PR DESCRIPTION
## Summary
- Adds a "blank" personality option that prompts the user to provide their own personality prompt, instead of shipping with a pre-defined personality like memo/linus/kawaii
- The blank persona reads: *"This is a blank starter personality. You must ask the user to provide a personality prompt or preference."*
- Blank appears in the `/personality` selector as "Blank — Blank starter — you provide the personality" and is available via `--personality blank` in headless mode

## Test plan
- [ ] Run `bun test src/tests/agent/personality.test.ts` — all 13 tests pass (including new blank-specific tests)
- [ ] Run `/personality` in the TUI and verify "Blank" appears as an option
- [ ] Select "Blank" and verify the persona block contains the blank starter text
- [ ] Verify `--personality blank --new-agent` works in headless mode

👾 Generated with [Letta Code](https://letta.com)