### PR TITLE
fix(cli): route /reflection alias through manual reflection launch

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -2561,8 +2561,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
-        // Special handling for /reflect command - manually launch reflection subagent
-        if (trimmed === "/reflect") {
+        // Special handling for /reflect and /reflection - manually launch reflection subagent
+        if (trimmed === "/reflect" || trimmed === "/reflection") {
           const cmd = commandRunner.start(msg, "Launching reflection agent...");
 
           if (!isActiveMemfsEnabled(agentId)) {

--- a/src/tests/cli/reflection-alias-wiring.test.ts
+++ b/src/tests/cli/reflection-alias-wiring.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readInteractiveAppSource } from "../helpers/readInteractiveAppSource";
+
+describe("reflection alias wiring", () => {
+  test("routes /reflection through the manual reflection launch path", () => {
+    const source = readInteractiveAppSource();
+
+    const start = source.indexOf(
+      '// Special handling for /reflect and /reflection - manually launch reflection subagent',
+    );
+    const end = source.indexOf(
+      '// Special handling for /plan command - enter plan mode',
+      start,
+    );
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain(
+      'if (trimmed === "/reflect" || trimmed === "/reflection") {',
+    );
+    expect(segment).toContain('spawnBackgroundSubagentTask({');
+    expect(segment).toContain('subagentType: "reflection"');
+  });
+});

--- a/src/tests/cli/reflection-alias-wiring.test.ts
+++ b/src/tests/cli/reflection-alias-wiring.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { readInteractiveAppSource } from "../helpers/readInteractiveAppSource";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function readSource(relativePath: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(relativePath, import.meta.url)),
+    "utf-8",
+  );
+}
 
 describe("reflection alias wiring", () => {
   test("routes /reflection through the manual reflection launch path", () => {
-    const source = readInteractiveAppSource();
+    const source = readSource("../../cli/app/use-submit-handler.ts");
 
     const start = source.indexOf(
-      '// Special handling for /reflect and /reflection - manually launch reflection subagent',
+      "// Special handling for /reflect and /reflection - manually launch reflection subagent",
     );
-    const end = source.indexOf(
-      '// Special handling for /plan command - enter plan mode',
-      start,
-    );
+    const end = source.indexOf("// Special handling for /init command", start);
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
@@ -20,7 +25,7 @@ describe("reflection alias wiring", () => {
     expect(segment).toContain(
       'if (trimmed === "/reflect" || trimmed === "/reflection") {',
     );
-    expect(segment).toContain('spawnBackgroundSubagentTask({');
+    expect(segment).toContain("spawnBackgroundSubagentTask({");
     expect(segment).toContain('subagentType: "reflection"');
   });
 });


### PR DESCRIPTION
## Summary
- route `/reflection` through the same manual reflection launch path as `/reflect`
- keep the existing payload generation and background subagent spawn logic unchanged by sharing the same branch
- add a regression test that verifies the interactive app source wires the alias into the reflection launch block

## Test plan
- [x] `git diff --check`
- [ ] `bun test src/tests/cli/reflection-alias-wiring.test.ts` *(bun is not installed in this workspace)*
- [ ] `bun run check` *(bun is not installed in this workspace)*

👾 Generated with [Letta Code](https://letta.com)
