### PR TITLE
fix(resume): preserve tool backfill on local resume

### DIFF
--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -17,15 +17,9 @@ import type { ApprovalRequest } from "../cli/helpers/stream";
 import { debugLog, debugWarn, isDebugEnabled } from "../utils/debug";
 
 // Backfill should feel like "the last turn(s)", not "the last N raw messages".
-// Tool-heavy turns can generate many tool_call/tool_return messages that would
-// otherwise push the most recent assistant/user messages out of the window.
+// Fetch every renderable message type so the TUI can reconstruct the transcript.
 const BACKFILL_PRIMARY_MESSAGE_LIMIT = 12; // user/assistant/reasoning/event/summary
 const BACKFILL_MAX_RENDERABLE_MESSAGES = 80; // safety cap
-
-// Note: We intentionally do not include tool-call / tool-return chatter in the
-// resume backfill. Pending approvals are handled via `pendingApprovals` and
-// shown separately in the UI. Including tool logs here makes resume feel like a
-// corrupted replay when the last "turn" was tool-heavy.
 
 // Stop fetching once we have enough actual conversational anchors.
 // Reasoning can be extremely tool-step heavy, so anchor on user/assistant.
@@ -43,23 +37,12 @@ const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
   "reasoning_message",
   "event_message",
   "summary_message",
-];
-
-const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
-  ...RESUME_BACKFILL_MESSAGE_TYPES,
   "approval_request_message",
   "tool_return_message",
   "approval_response_message",
 ];
 
-function isPrimaryMessageType(messageType: string | undefined): boolean {
-  return (
-    messageType === "user_message" ||
-    messageType === "assistant_message" ||
-    messageType === "event_message" ||
-    messageType === "summary_message"
-  );
-}
+const DEFAULT_RESUME_MESSAGE_TYPES = RESUME_BACKFILL_MESSAGE_TYPES;
 
 function isAnchorMessageType(messageType: string | undefined): boolean {
   return messageType === "user_message" || messageType === "assistant_message";
@@ -195,10 +178,10 @@ function pendingApprovalsFromMessageVariants(messages: Message[]): {
   pendingApproval: ApprovalRequest | null;
   pendingApprovals: ApprovalRequest[];
 } {
-  const approvalRequest = messages.find(
+  const approvalRequests = messages.filter(
     (msg) => msg.message_type === "approval_request_message",
   );
-  if (!approvalRequest) {
+  if (approvalRequests.length === 0) {
     return {
       messageToCheck: messages[0],
       pendingApproval: null,
@@ -207,25 +190,35 @@ function pendingApprovalsFromMessageVariants(messages: Message[]): {
   }
 
   const completedToolCallIds = completedToolCallIdsFromMessages(messages);
-  const pendingApprovals = approvalRequestsFromMessage(approvalRequest).filter(
-    (approval) => !completedToolCallIds.has(approval.toolCallId),
-  );
+  const pendingByToolCallId = new Map<string, ApprovalRequest>();
+  for (const approvalRequest of approvalRequests) {
+    for (const approval of approvalRequestsFromMessage(approvalRequest)) {
+      if (completedToolCallIds.has(approval.toolCallId)) continue;
+      if (!pendingByToolCallId.has(approval.toolCallId)) {
+        pendingByToolCallId.set(approval.toolCallId, approval);
+      }
+    }
+  }
+  const pendingApprovals = Array.from(pendingByToolCallId.values());
   const pendingApproval = pendingApprovals[0] || null;
+  const latestApprovalRequest =
+    approvalRequests[approvalRequests.length - 1] ?? messages[0];
 
   logPendingApprovals(pendingApprovals);
 
-  return { messageToCheck: approvalRequest, pendingApproval, pendingApprovals };
+  return {
+    messageToCheck: latestApprovalRequest,
+    pendingApproval,
+    pendingApprovals,
+  };
 }
 
 /**
  * Prepare message history for backfill, trimming orphaned tool returns.
  * Messages should already be in chronological order (oldest first).
  */
-// Exported for tests: resume UX depends on strict message-type filtering.
-export function prepareMessageHistory(
-  messages: Message[],
-  opts?: { primaryOnly?: boolean },
-): Message[] {
+// Exported for tests: resume UX depends on deterministic message-type filtering.
+export function prepareMessageHistory(messages: Message[]): Message[] {
   const isRenderable = (msg: Message): boolean => {
     const t = msg.message_type;
     if (
@@ -245,48 +238,6 @@ export function prepareMessageHistory(
   };
 
   const renderable = messages.filter(isRenderable);
-  if (opts?.primaryOnly) {
-    // Resume view should prioritize the actual conversation (user/assistant + events).
-    // Reasoning can be extremely tool-step heavy and will crowd out assistant messages.
-    const convo = renderable.filter((m) =>
-      isPrimaryMessageType(m.message_type),
-    );
-    let trimmed = convo.slice(-BACKFILL_PRIMARY_MESSAGE_LIMIT);
-
-    // Hardening: if the last N items are all user/system-y content, ensure we
-    // still include the most recent assistant message when one exists.
-    const hasAssistant = trimmed.some(
-      (m) => m.message_type === "assistant_message",
-    );
-    if (!hasAssistant) {
-      const lastAssistantIndex = convo
-        .map((m) => m.message_type)
-        .lastIndexOf("assistant_message");
-      if (lastAssistantIndex >= 0) {
-        const lastAssistant = convo[lastAssistantIndex];
-        if (lastAssistant) {
-          // Preserve recency: keep the newest tail and prepend the last assistant.
-          const tailLimit = Math.max(BACKFILL_PRIMARY_MESSAGE_LIMIT - 1, 0);
-          const newestTail = tailLimit > 0 ? convo.slice(-tailLimit) : [];
-          trimmed = [lastAssistant, ...newestTail];
-        }
-      }
-    }
-    if (trimmed.length > 0) return trimmed;
-
-    // If we have no user/assistant/event/summary (rare), fall back to reasoning.
-    // If reasoning is also absent, show a small tail of whatever renderable
-    // messages exist so resume isn't blank.
-    const reasoning = renderable.filter(
-      (m) => m.message_type === "reasoning_message",
-    );
-    if (reasoning.length > 0) {
-      return reasoning.slice(-BACKFILL_PRIMARY_MESSAGE_LIMIT);
-    }
-    // Last resort: show a small reasoning-only slice.
-    // Do not fall back to tool chatter.
-    return [];
-  }
 
   // Walk backwards until we've captured enough "primary" messages to anchor
   // the replay (user/assistant/reasoning + high-level events), but include tool
@@ -482,9 +433,7 @@ export async function getResumeDataFromBackend(
             return {
               pendingApproval: null,
               pendingApprovals: [],
-              messageHistory: prepareMessageHistory(backfill, {
-                primaryOnly: true,
-              }),
+              messageHistory: prepareMessageHistory(backfill),
             };
           } catch (backfillError) {
             debugWarn(

--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -1,5 +1,4 @@
 import {
-  APICallError,
   tool as aiTool,
   convertToModelMessages,
   jsonSchema,
@@ -12,12 +11,6 @@ import {
   type UIMessageChunk,
   validateUIMessages,
 } from "ai";
-import {
-  getRetryDelayMs,
-  isQuotaLimitErrorDetail,
-  parseRetryAfterHeaderMs,
-  shouldRetryPreStreamTransientError,
-} from "../../agent/approval-recovery";
 import type { ClientTool } from "../../tools/manager";
 import type { LocalCompactionStats } from "../local/compaction";
 import type { LocalMessage } from "../local/LocalMessage";
@@ -27,6 +20,11 @@ import {
   aiSDKProviderKindFromModel,
 } from "./AISDKProviderRegistry";
 import { isContextWindowOverflowError } from "./contextWindowOverflow";
+import {
+  isRetryableLocalProviderError,
+  localProviderRetryDelayMs,
+  localProviderRetryMessage,
+} from "./LocalProviderErrors";
 import type {
   ProviderStreamAdapter,
   ProviderStreamEvent,
@@ -41,7 +39,6 @@ import {
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
 type InputModality = "text" | "image" | "audio" | "video" | "pdf";
 const LOCAL_PROVIDER_MAX_RETRIES = 3;
-const LOCAL_PROVIDER_MAX_RETRY_DELAY_MS = 60_000;
 const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
 type AISDKUIMessageStreamFinish = {
   messages: LocalMessage[];
@@ -96,176 +93,6 @@ export interface AISDKStreamAdapterOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValueForRetry(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function stringifyRetryValue(value: unknown): string | undefined {
-  if (value === undefined || value === null) return undefined;
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return undefined;
-  }
-}
-
-function retryHeaderValue(
-  headers: Record<string, string> | undefined,
-  headerName: string,
-): string | undefined {
-  if (!headers) return undefined;
-  const direct = headers[headerName];
-  if (direct !== undefined) return direct;
-  const lower = headerName.toLowerCase();
-  for (const [key, value] of Object.entries(headers)) {
-    if (key.toLowerCase() === lower) return value;
-  }
-  return undefined;
-}
-
-function retryAfterMsFromHeaders(
-  headers: Record<string, string> | undefined,
-): number | null {
-  const retryAfterMs = retryHeaderValue(headers, "retry-after-ms");
-  if (retryAfterMs) {
-    const parsed = Number.parseFloat(retryAfterMs);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      return Math.round(parsed);
-    }
-  }
-
-  return parseRetryAfterHeaderMs(retryHeaderValue(headers, "retry-after"));
-}
-
-function retryErrorDetail(error: unknown): string {
-  const parts: string[] = [];
-
-  if (error instanceof Error) {
-    parts.push(error.message);
-  } else {
-    const value = stringifyRetryValue(error);
-    if (value) parts.push(value);
-  }
-
-  if (APICallError.isInstance(error)) {
-    const responseBody = stringValueForRetry(error.responseBody);
-    if (responseBody) parts.push(responseBody);
-    const data = stringifyRetryValue(error.data);
-    if (data) parts.push(data);
-    const cause = error.cause;
-    if (isRecord(cause)) {
-      const code = stringValueForRetry(cause.code);
-      if (code) parts.push(code);
-      const causeMessage = stringValueForRetry(cause.message);
-      if (causeMessage) parts.push(causeMessage);
-    } else if (cause instanceof Error) {
-      parts.push(cause.message);
-    }
-  }
-
-  return parts.filter(Boolean).join("\n");
-}
-
-function parseRetryableJSONRecord(
-  value: string,
-): Record<string, unknown> | null {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const candidates = [trimmed];
-  const jsonStart = trimmed.indexOf("{");
-  if (jsonStart > 0) {
-    candidates.push(trimmed.slice(jsonStart));
-  }
-
-  for (const candidate of candidates) {
-    try {
-      const parsed = JSON.parse(candidate);
-      if (isRecord(parsed)) return parsed;
-    } catch {
-      // Continue to next candidate.
-    }
-  }
-  return null;
-}
-
-function isRetryableRateLimitJSONDetail(detail: string): boolean {
-  const candidates = [detail, ...detail.split("\n")];
-  for (const candidate of candidates) {
-    const parsed = parseRetryableJSONRecord(candidate);
-    if (!parsed) continue;
-
-    const type = stringValueForRetry(parsed.type)?.toLowerCase();
-    const topLevelCode = stringValueForRetry(parsed.code)?.toLowerCase();
-    const nestedError = isRecord(parsed.error) ? parsed.error : undefined;
-    const nestedType = stringValueForRetry(nestedError?.type)?.toLowerCase();
-    const nestedCode = stringValueForRetry(nestedError?.code)?.toLowerCase();
-
-    if (type === "error" && nestedType === "too_many_requests") return true;
-    if (
-      typeof topLevelCode === "string" &&
-      (topLevelCode.includes("exhausted") ||
-        topLevelCode.includes("unavailable"))
-    ) {
-      return true;
-    }
-    if (typeof nestedCode === "string" && nestedCode.includes("rate_limit")) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function isRetryableLocalProviderError(error: unknown): boolean {
-  if (isContextWindowOverflowError(error)) return false;
-
-  const detail = retryErrorDetail(error);
-  if (APICallError.isInstance(error)) {
-    if (isQuotaLimitErrorDetail(detail)) return false;
-    if (error.isRetryable === true) return true;
-    const status = error.statusCode;
-    if (status !== undefined && status >= 500) return true;
-    if (status === undefined && isRetryableRateLimitJSONDetail(detail)) {
-      return true;
-    }
-    return shouldRetryPreStreamTransientError({ status, detail });
-  }
-
-  if (isRetryableRateLimitJSONDetail(detail)) return true;
-  return shouldRetryPreStreamTransientError({
-    status: undefined,
-    detail,
-  });
-}
-
-function localProviderRetryDelayMs(error: unknown, attempt: number): number {
-  const retryAfterMs = APICallError.isInstance(error)
-    ? retryAfterMsFromHeaders(error.responseHeaders)
-    : null;
-  return Math.min(
-    getRetryDelayMs({
-      category: "transient_provider",
-      attempt,
-      detail: retryErrorDetail(error),
-      retryAfterMs,
-    }),
-    LOCAL_PROVIDER_MAX_RETRY_DELAY_MS,
-  );
-}
-
-function localProviderRetryMessage(error: unknown): string {
-  if (APICallError.isInstance(error)) {
-    const status =
-      error.statusCode !== undefined ? `HTTP ${error.statusCode}: ` : "";
-    return `${status}${error.message}`;
-  }
-  return error instanceof Error ? error.message : String(error);
 }
 
 function isModelOutputEvent(event: ProviderStreamEvent): boolean {

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -23,6 +23,10 @@ import {
   DeterministicPongExecutor,
   type HeadlessTurnExecutor,
 } from "./HeadlessTurnExecutor";
+import {
+  type LocalProviderErrorInfo,
+  normalizeLocalProviderError,
+} from "./LocalProviderErrors";
 
 function createPage<T>(items: T[]) {
   return {
@@ -40,10 +44,37 @@ function runStopReason(chunk: LettaStreamingResponse): string | undefined {
   return typeof stopReason === "string" ? stopReason : undefined;
 }
 
-function runErrorMessage(chunk: LettaStreamingResponse): string | undefined {
+type RunErrorMetadata = Pick<
+  LocalProviderErrorInfo,
+  "message" | "detail" | "error_type" | "retryable"
+> & { run_id?: string };
+
+function runErrorInfo(
+  chunk: LettaStreamingResponse,
+): RunErrorMetadata | undefined {
   if (chunk.message_type !== "error_message") return undefined;
-  const message = (chunk as { message?: unknown }).message;
-  return typeof message === "string" ? message : undefined;
+  const record = chunk as {
+    message?: unknown;
+    detail?: unknown;
+    error_type?: unknown;
+    retryable?: unknown;
+  };
+  const message = typeof record.message === "string" ? record.message : "";
+  const detail =
+    typeof record.detail === "string"
+      ? record.detail
+      : message || "Unknown local backend error";
+  const errorType =
+    record.error_type === "llm_error" ||
+    record.error_type === "local_backend_error"
+      ? record.error_type
+      : "local_backend_error";
+  return {
+    message: message || detail,
+    detail,
+    error_type: errorType,
+    retryable: record.retryable === true,
+  };
 }
 
 function attachRunId(
@@ -379,7 +410,11 @@ export class HeadlessBackend implements Backend {
     return run;
   }
 
-  private completeRun(runId: string, stopReason: string): void {
+  private completeRun(
+    runId: string,
+    stopReason: string,
+    errorInfo?: RunErrorMetadata,
+  ): void {
     const run = this.runs.get(runId);
     if (!run) return;
     if (isTerminalRun(run)) return;
@@ -395,6 +430,16 @@ export class HeadlessBackend implements Backend {
       status,
       stop_reason: stopReason as Run["stop_reason"],
       completed_at: completedAt,
+      metadata:
+        status === "failed" && errorInfo
+          ? {
+              ...(run.metadata ?? {}),
+              error: {
+                ...errorInfo,
+                run_id: runId,
+              },
+            }
+          : run.metadata,
     });
     if (run.conversation_id) {
       this.activeRunByConversation.delete(run.conversation_id);
@@ -406,17 +451,19 @@ export class HeadlessBackend implements Backend {
     const run = this.runs.get(runId);
     if (!run) return;
     if (isTerminalRun(run)) return;
-    const message = error instanceof Error ? error.message : String(error);
+    const info = normalizeLocalProviderError(error);
     this.runs.set(runId, {
       ...run,
       status: "failed",
-      stop_reason: "error",
+      stop_reason: info.stop_reason as Run["stop_reason"],
       completed_at: timestampForRun(this.runSeq + this.runs.size),
       metadata: {
         ...(run.metadata ?? {}),
         error: {
-          message,
-          error_type: "local_backend_error",
+          message: info.message,
+          detail: info.detail,
+          error_type: info.error_type,
+          retryable: info.retryable,
           run_id: runId,
         },
       },
@@ -460,17 +507,18 @@ export class HeadlessBackend implements Backend {
       controller: stream.controller,
       async *[Symbol.asyncIterator]() {
         let sawStopReason = false;
+        let pendingErrorInfo: RunErrorMetadata | undefined;
         try {
           for await (const rawChunk of stream) {
             const chunk = attachRunId(rawChunk, runId);
-            const errorMessage = runErrorMessage(chunk);
-            if (errorMessage) {
-              backend.failRun(runId, new Error(errorMessage));
+            const errorInfo = runErrorInfo(chunk);
+            if (errorInfo) {
+              pendingErrorInfo = errorInfo;
             }
             const stopReason = runStopReason(chunk);
             if (stopReason) {
               sawStopReason = true;
-              backend.completeRun(runId, stopReason);
+              backend.completeRun(runId, stopReason, pendingErrorInfo);
             }
 
             const persisted = store.appendStreamChunk(
@@ -486,7 +534,11 @@ export class HeadlessBackend implements Backend {
             }
           }
           if (!sawStopReason) {
-            backend.completeRun(runId, "end_turn");
+            if (pendingErrorInfo) {
+              backend.completeRun(runId, "error", pendingErrorInfo);
+            } else {
+              backend.completeRun(runId, "end_turn");
+            }
           }
         } catch (error) {
           backend.failRun(runId, error);

--- a/src/backend/dev/LocalProviderErrors.ts
+++ b/src/backend/dev/LocalProviderErrors.ts
@@ -1,0 +1,239 @@
+import { APICallError } from "ai";
+import {
+  getRetryDelayMs,
+  isQuotaLimitErrorDetail,
+  parseRetryAfterHeaderMs,
+  shouldRetryPreStreamTransientError,
+} from "../../agent/turn-recovery-policy";
+import { isContextWindowOverflowError } from "./contextWindowOverflow";
+
+export interface LocalProviderErrorInfo {
+  message: string;
+  detail: string;
+  error_type: "llm_error" | "local_backend_error";
+  retryable: boolean;
+  stop_reason: "llm_api_error" | "error";
+}
+
+const LOCAL_PROVIDER_MAX_RETRY_DELAY_MS = 60_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function stringifyValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function fallbackErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (isRecord(error) && typeof error.message === "string" && error.message) {
+    return error.message;
+  }
+  if (isRecord(error) && isRecord(error.data)) {
+    const dataMessage = error.data.message;
+    if (typeof dataMessage === "string" && dataMessage) return dataMessage;
+  }
+  const text = String(error);
+  if (text && text !== "[object Object]") return text;
+  const serialized = stringifyValue(error);
+  if (serialized && serialized !== "{}") return serialized;
+  return "Unknown local provider error";
+}
+
+function retryHeaderValue(
+  headers: Record<string, string> | undefined,
+  headerName: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const direct = headers[headerName];
+  if (direct !== undefined) return direct;
+  const lower = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) return value;
+  }
+  return undefined;
+}
+
+function retryAfterMsFromHeaders(
+  headers: Record<string, string> | undefined,
+): number | null {
+  const retryAfterMs = retryHeaderValue(headers, "retry-after-ms");
+  if (retryAfterMs) {
+    const parsed = Number.parseFloat(retryAfterMs);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.round(parsed);
+    }
+  }
+
+  return parseRetryAfterHeaderMs(retryHeaderValue(headers, "retry-after"));
+}
+
+export function localProviderErrorDetail(error: unknown): string {
+  const parts: string[] = [];
+
+  const message = fallbackErrorMessage(error);
+  if (message) parts.push(message);
+
+  if (APICallError.isInstance(error)) {
+    const responseBody = stringValue(error.responseBody);
+    if (responseBody) parts.push(responseBody);
+    const data = stringifyValue(error.data);
+    if (data) parts.push(data);
+    const cause = error.cause;
+    if (isRecord(cause)) {
+      const code = stringValue(cause.code);
+      if (code) parts.push(code);
+      const causeMessage = stringValue(cause.message);
+      if (causeMessage) parts.push(causeMessage);
+    } else if (cause instanceof Error) {
+      parts.push(cause.message);
+    }
+  }
+
+  return [...new Set(parts.filter(Boolean))].join("\n");
+}
+
+function parseRetryableJSONRecord(
+  value: string,
+): Record<string, unknown> | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const candidates = [trimmed];
+  const jsonStart = trimmed.indexOf("{");
+  if (jsonStart > 0) {
+    candidates.push(trimmed.slice(jsonStart));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function isRetryableRateLimitJSONDetail(detail: string): boolean {
+  const candidates = [detail, ...detail.split("\n")];
+  for (const candidate of candidates) {
+    const parsed = parseRetryableJSONRecord(candidate);
+    if (!parsed) continue;
+
+    const type = stringValue(parsed.type)?.toLowerCase();
+    const topLevelCode = stringValue(parsed.code)?.toLowerCase();
+    const nestedError = isRecord(parsed.error) ? parsed.error : undefined;
+    const nestedType = stringValue(nestedError?.type)?.toLowerCase();
+    const nestedCode = stringValue(nestedError?.code)?.toLowerCase();
+
+    if (type === "error" && nestedType === "too_many_requests") return true;
+    if (
+      typeof topLevelCode === "string" &&
+      (topLevelCode.includes("exhausted") ||
+        topLevelCode.includes("unavailable"))
+    ) {
+      return true;
+    }
+    if (typeof nestedCode === "string" && nestedCode.includes("rate_limit")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isRetryableLocalProviderError(error: unknown): boolean {
+  if (isContextWindowOverflowError(error)) return false;
+
+  const detail = localProviderErrorDetail(error);
+  if (APICallError.isInstance(error)) {
+    if (isQuotaLimitErrorDetail(detail)) return false;
+    if (error.isRetryable === true) return true;
+    const status = error.statusCode;
+    if (status !== undefined && status >= 500) return true;
+    if (status === undefined && isRetryableRateLimitJSONDetail(detail)) {
+      return true;
+    }
+    return shouldRetryPreStreamTransientError({ status, detail });
+  }
+
+  if (isRetryableRateLimitJSONDetail(detail)) return true;
+  return shouldRetryPreStreamTransientError({
+    status: undefined,
+    detail,
+  });
+}
+
+function isLikelyProviderError(error: unknown, retryable: boolean): boolean {
+  if (retryable || isContextWindowOverflowError(error)) return true;
+  if (APICallError.isInstance(error)) return true;
+  const detail = localProviderErrorDetail(error).toLowerCase();
+  return (
+    detail.includes("api") ||
+    detail.includes("provider") ||
+    detail.includes("rate limit") ||
+    detail.includes("too many requests") ||
+    detail.includes("overloaded") ||
+    detail.includes("connection") ||
+    detail.includes("socket") ||
+    detail.includes("stream")
+  );
+}
+
+export function normalizeLocalProviderError(
+  error: unknown,
+): LocalProviderErrorInfo {
+  const retryable = isRetryableLocalProviderError(error);
+  const detail = localProviderErrorDetail(error);
+  const message = fallbackErrorMessage(error);
+  const isProviderError = isLikelyProviderError(error, retryable);
+  return {
+    message,
+    detail,
+    error_type: isProviderError ? "llm_error" : "local_backend_error",
+    retryable,
+    stop_reason: retryable ? "llm_api_error" : "error",
+  };
+}
+
+export function localProviderRetryDelayMs(
+  error: unknown,
+  attempt: number,
+): number {
+  const retryAfterMs = APICallError.isInstance(error)
+    ? retryAfterMsFromHeaders(error.responseHeaders)
+    : null;
+  return Math.min(
+    getRetryDelayMs({
+      category: "transient_provider",
+      attempt,
+      detail: localProviderErrorDetail(error),
+      retryAfterMs,
+    }),
+    LOCAL_PROVIDER_MAX_RETRY_DELAY_MS,
+  );
+}
+
+export function localProviderRetryMessage(error: unknown): string {
+  if (APICallError.isInstance(error)) {
+    const status =
+      error.statusCode !== undefined ? `HTTP ${error.statusCode}: ` : "";
+    return `${status}${fallbackErrorMessage(error)}`;
+  }
+  return fallbackErrorMessage(error);
+}

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -14,6 +14,7 @@ import type {
   HeadlessTurnExecutor,
   HeadlessTurnExecutorInput,
 } from "./HeadlessTurnExecutor";
+import { normalizeLocalProviderError } from "./LocalProviderErrors";
 
 export interface ProviderTurnInput {
   conversationId: string;
@@ -94,16 +95,29 @@ function stringifyToolInput(input: unknown): string {
   return JSON.stringify(input ?? {});
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function createLocalUIMessageChunk(
   message: LocalMessage,
 ): LettaStreamingResponse {
   return markLocalStateChunkOnly(
     attachLocalUIMessage({ message_type: "local_ui_message" }, message),
   ) as unknown as LettaStreamingResponse;
+}
+
+function createProviderErrorChunks(error: unknown): LettaStreamingResponse[] {
+  const info = normalizeLocalProviderError(error);
+  return [
+    {
+      message_type: "error_message",
+      message: info.message,
+      detail: info.detail,
+      error_type: info.error_type,
+      retryable: info.retryable,
+    } as unknown as LettaStreamingResponse,
+    {
+      message_type: "stop_reason",
+      stop_reason: info.stop_reason,
+    } as LettaStreamingResponse,
+  ];
 }
 
 function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
@@ -177,14 +191,7 @@ function createProviderLettaStream(
       try {
         for await (const event of events) {
           if (event.type === "error") {
-            yield {
-              message_type: "error_message",
-              message: errorMessage(event.error),
-            } as LettaStreamingResponse;
-            yield {
-              message_type: "stop_reason",
-              stop_reason: "error",
-            } as LettaStreamingResponse;
+            yield* createProviderErrorChunks(event.error);
             return;
           }
 
@@ -258,14 +265,7 @@ function createProviderLettaStream(
           }
 
           if (part.type === "error") {
-            yield {
-              message_type: "error_message",
-              message: errorMessage(part.error),
-            } as LettaStreamingResponse;
-            yield {
-              message_type: "stop_reason",
-              stop_reason: "error",
-            } as LettaStreamingResponse;
+            yield* createProviderErrorChunks(part.error);
             return;
           }
         }
@@ -273,14 +273,7 @@ function createProviderLettaStream(
           yield pendingStopReason;
         }
       } catch (error) {
-        yield {
-          message_type: "error_message",
-          message: errorMessage(error),
-        } as LettaStreamingResponse;
-        yield {
-          message_type: "stop_reason",
-          stop_reason: "error",
-        } as LettaStreamingResponse;
+        yield* createProviderErrorChunks(error);
       }
     },
   } as unknown as Stream<LettaStreamingResponse>;

--- a/src/backend/local/LocalMessageProjection.ts
+++ b/src/backend/local/LocalMessageProjection.ts
@@ -271,13 +271,29 @@ export function projectLocalMessagesToStoredMessages(
   fallbackAgentId: string,
   fallbackConversationId: string,
 ): StoredMessage[] {
-  return messages.flatMap((message, index) =>
-    projectLocalMessageToStoredMessages(
+  return messages.flatMap((message, index) => {
+    const projected = projectLocalMessageToStoredMessages(
       message,
       fallbackAgentId,
       fallbackConversationId,
       new Date(Date.UTC(2026, 0, 1, 0, 0, index + 1)).toISOString(),
-    ),
+    );
+    return withProjectedMessageDates(projected, index);
+  });
+}
+
+export function withProjectedMessageDates(
+  messages: StoredMessage[],
+  sourceMessageIndex: number,
+): StoredMessage[] {
+  return messages.map(
+    (message, projectedIndex) =>
+      ({
+        ...message,
+        date: new Date(
+          Date.UTC(2026, 0, 1, 0, 0, sourceMessageIndex + 1, projectedIndex),
+        ).toISOString(),
+      }) as StoredMessage,
   );
 }
 

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -449,6 +449,19 @@ function getCursor(
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+function getIncludedMessageTypes(
+  body?: ConversationMessageListBody | AgentMessageListBody,
+): Set<string> | undefined {
+  const value = (body as Record<string, unknown> | undefined)
+    ?.include_return_message_types;
+  if (!Array.isArray(value)) return undefined;
+
+  const messageTypes = value.filter(
+    (item): item is string => typeof item === "string" && item.length > 0,
+  );
+  return messageTypes.length > 0 ? new Set(messageTypes) : undefined;
+}
+
 function toStoredOutputFields(chunk: Record<string, unknown>) {
   const { id: _id, date: _date, agent_id, conversation_id, ...fields } = chunk;
   void agent_id;
@@ -1567,6 +1580,13 @@ export class LocalStore {
     body?: ConversationMessageListBody | AgentMessageListBody,
   ): StoredMessage[] {
     let items = messages;
+    const includedMessageTypes = getIncludedMessageTypes(body);
+    if (includedMessageTypes) {
+      items = items.filter((message) =>
+        includedMessageTypes.has(message.message_type),
+      );
+    }
+
     const before = getCursor(body, "before");
     if (before) {
       const beforeIndex = items.findIndex((message) => message.id === before);

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -35,6 +35,7 @@ import {
   projectedMessageLookupKeys,
   projectLocalMessagesToStoredMessages,
   projectLocalMessageToStoredMessages,
+  withProjectedMessageDates,
 } from "./LocalMessageProjection";
 import {
   getAttachedLocalUIMessage,
@@ -1625,11 +1626,14 @@ export class LocalStore {
     for (let index = 0; index < localMessages.length; index++) {
       const localMessage = localMessages[index];
       if (!localMessage) continue;
-      const projected = projectLocalMessageToStoredMessages(
-        localMessage,
-        agentId,
-        resolvedConversationId,
-        new Date(Date.UTC(2026, 0, 1, 0, 0, index + 1)).toISOString(),
+      const projected = withProjectedMessageDates(
+        projectLocalMessageToStoredMessages(
+          localMessage,
+          agentId,
+          resolvedConversationId,
+          new Date(Date.UTC(2026, 0, 1, 0, 0, index + 1)).toISOString(),
+        ),
+        index,
       );
       messages.push(...projected);
       for (const [lookupKey, lookupMessages] of projectedMessageLookupKeys(

--- a/src/cli/app/retry.ts
+++ b/src/cli/app/retry.ts
@@ -34,14 +34,23 @@ export async function isRetriableError(
         | {
             error_type?: string;
             detail?: string;
+            retryable?: boolean;
             // Handle nested error structure (error.error) that can occur in some edge cases
-            error?: { error_type?: string; detail?: string };
+            error?: {
+              error_type?: string;
+              detail?: string;
+              retryable?: boolean;
+            };
           }
         | undefined;
 
       // Check for llm_error at top level or nested (handles error.error nesting)
       const errorType = metaError?.error_type ?? metaError?.error?.error_type;
       const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
+      const retryable = metaError?.retryable ?? metaError?.error?.retryable;
+
+      if (retryable === false) return false;
+      if (retryable === true) return true;
 
       if (shouldRetryRunMetadataError(errorType, detail)) {
         return true;

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -16,10 +16,6 @@ import {
   type ApprovalResult,
   getDisplayableToolReturn,
 } from "../../agent/approval-execution";
-import {
-  buildFreshDenialApprovals,
-  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
-} from "../../agent/approval-recovery";
 import type { SessionStats } from "../../agent/stats";
 import type { ApprovalContext } from "../../permissions/analyzer";
 import type { PermissionMode } from "../../permissions/mode";
@@ -247,7 +243,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
   const recoverRestoredPendingApprovals = useCallback(
     async (
       approvals: ApprovalRequest[],
-      _options: { notifyOnManualApproval?: boolean } = {},
+      options: { notifyOnManualApproval?: boolean } = {},
     ): Promise<void> => {
       if (approvals.length === 0) {
         return;
@@ -303,16 +299,10 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           return;
         }
 
-        const staleDenials = buildFreshDenialApprovals(
-          approvals,
-          STALE_APPROVAL_RECOVERY_DENIAL_REASON,
-        ) as ApprovalResult[];
-        if (staleDenials.length > 0) {
-          queueApprovalResults(staleDenials, {
-            conversationId: conversationIdRef.current,
-            generation: generationAtStart,
-          });
-          setNeedsEagerApprovalCheck(false);
+        await restorePendingApprovalUi(approvals);
+        setNeedsEagerApprovalCheck(false);
+        if (options.notifyOnManualApproval) {
+          sendDesktopNotification("Approval needed");
         }
 
         restoredApprovalRecoveryRef.current = {
@@ -323,10 +313,11 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       } catch (error) {
         debugLog(
           "approvals",
-          "Failed to recover restored approvals automatically: %O",
+          "Failed to restore pending approval UI: %O",
           error,
         );
         await restorePendingApprovalUi(approvals);
+        setNeedsEagerApprovalCheck(false);
         setAutoHandledResults([]);
         setAutoDeniedApprovals([]);
         sendDesktopNotification("Approval needed");
@@ -338,7 +329,6 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       }
     },
     [
-      queueApprovalResults,
       restorePendingApprovalUi,
       restoredApprovalRecoveryRef,
       setApprovalContexts,

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -2414,8 +2414,16 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             }
 
             if (!cancelled) {
-              // Post-stream retry is a new request/run, so refresh OTIDs.
-              currentInput = refreshInputOtidsForNewRequest(currentInput);
+              const backendCapabilities = getBackend().capabilities;
+              const retryFromPersistedLocalState =
+                backendCapabilities.localModelCatalog &&
+                !backendCapabilities.remoteMemfs;
+              // Local already appended the turn input before the failed run.
+              // Continue from persisted conversation state instead of duplicating
+              // user/approval messages into the retry run.
+              currentInput = retryFromPersistedLocalState
+                ? []
+                : refreshInputOtidsForNewRequest(currentInput);
               // Reset seq_id threshold — new run starts from seq_id 1, not a resume.
               highestSeqIdSeen = null;
               // Reset interrupted flag so retry stream chunks are processed

--- a/src/tests/agent/getResumeData.test.ts
+++ b/src/tests/agent/getResumeData.test.ts
@@ -18,16 +18,12 @@ function installBackend(overrides: Record<string, unknown>): void {
   __testSetBackend(overrides as unknown as Backend);
 }
 
-const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
+const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
   "user_message",
   "assistant_message",
   "reasoning_message",
   "event_message",
   "summary_message",
-];
-
-const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
-  ...RESUME_BACKFILL_MESSAGE_TYPES,
   "approval_request_message",
   "tool_return_message",
   "approval_response_message",
@@ -237,6 +233,68 @@ describe("getResumeData", () => {
     expect(resume.messageHistory.length).toBeGreaterThan(0);
   });
 
+  test("explicit conversation backfill requests and preserves tool messages", async () => {
+    const sameDate = "2026-01-01T00:00:02.000Z";
+    const conversationsRetrieve = mock(async () => ({
+      in_context_message_ids: ["provider-msg-2"],
+    }));
+    const conversationsList = mock(async () => ({
+      getPaginatedItems: () => [
+        datedMessage("provider-msg-2:assistant", "assistant_message", sameDate),
+        datedMessage(
+          "provider-msg-2:tool:call-1:return",
+          "tool_return_message",
+          sameDate,
+          {
+            tool_call_id: "call-1",
+            status: "success",
+            tool_return: "ok",
+          },
+        ),
+        datedMessage(
+          "provider-msg-2:tool:call-1:request",
+          "approval_request_message",
+          sameDate,
+          {
+            tool_call: {
+              tool_call_id: "call-1",
+              name: "Read",
+              arguments: '{"path":"src/index.ts"}',
+            },
+          },
+        ),
+        datedMessage(
+          "provider-msg-1",
+          "user_message",
+          "2026-01-01T00:00:01.000Z",
+        ),
+      ],
+    }));
+    const messagesRetrieve = mock(async () => []);
+
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeData(dummyClient, makeAgent(), "conv-abc");
+
+    expect(conversationsList).toHaveBeenCalledWith("conv-abc", {
+      limit: 200,
+      order: "desc",
+      include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
+    });
+    expect(
+      resume.messageHistory.map((message) => message.message_type),
+    ).toEqual([
+      "user_message",
+      "approval_request_message",
+      "tool_return_message",
+      "assistant_message",
+    ]);
+  });
+
   test("default conversation backfill orders equal-timestamp local tool messages before assistant text", async () => {
     const sameDate = "2026-01-01T00:00:02.000Z";
     const listedMessages = [
@@ -338,5 +396,64 @@ describe("getResumeData", () => {
     expect(messagesRetrieve).toHaveBeenCalledWith("provider-msg-2");
     expect(resume.pendingApprovals).toEqual([]);
     expect(resume.pendingApproval).toBeNull();
+  });
+
+  test("uses latest pending approval variant when message has many tool variants", async () => {
+    const messagesRetrieve = mock(async () => [
+      datedMessage(
+        "ui-msg-122:tool:call-old:request",
+        "approval_request_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call: {
+            tool_call_id: "call-old",
+            name: "ShellCommand",
+            arguments: '{"command":"echo old"}',
+          },
+        },
+      ),
+      datedMessage(
+        "ui-msg-122:tool:call-old:return",
+        "tool_return_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call_id: "call-old",
+          status: "success",
+          tool_return: "ok",
+        },
+      ),
+      datedMessage(
+        "ui-msg-122:tool:call-latest:request",
+        "approval_request_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call: {
+            tool_call_id: "call-latest",
+            name: "ApplyPatch",
+            arguments: '{"input":"*** Begin Patch"}',
+          },
+        },
+      ),
+    ]);
+
+    installBackend({
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeData(
+      dummyClient,
+      makeAgent({
+        message_ids: ["ui-msg-122"],
+        in_context_message_ids: ["ui-msg-122"],
+      }),
+      "default",
+      { includeMessageHistory: false },
+    );
+
+    expect(messagesRetrieve).toHaveBeenCalledWith("ui-msg-122");
+    expect(resume.pendingApprovals).toHaveLength(1);
+    expect(resume.pendingApprovals[0]?.toolCallId).toBe("call-latest");
+    expect(resume.pendingApprovals[0]?.toolName).toBe("ApplyPatch");
+    expect(resume.pendingApproval?.toolCallId).toBe("call-latest");
   });
 });

--- a/src/tests/backend/fake-headless-backend.test.ts
+++ b/src/tests/backend/fake-headless-backend.test.ts
@@ -862,6 +862,15 @@ describe("FakeHeadlessBackend", () => {
       "tool_return_message",
       "assistant_message",
     ]);
+
+    const filteredPage = await backend.listAgentMessages("agent-tool", {
+      conversation_id: conversation.id,
+      order: "desc",
+      include_return_message_types: ["user_message", "assistant_message"],
+    } as AgentMessageListBody);
+    expect(
+      filteredPage.getPaginatedItems().map((message) => message.message_type),
+    ).toEqual(["assistant_message", "user_message"]);
   });
 
   test("forks conversations by copying LocalMessage transcript state", async () => {

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -2409,9 +2409,55 @@ describe("LocalBackend", () => {
       "2026-01-01T00:00:02.000Z",
       "2026-01-01T00:00:03.000Z",
       "2026-01-01T00:00:04.000Z",
-      "2026-01-01T00:00:04.000Z",
-      "2026-01-01T00:00:04.000Z",
+      "2026-01-01T00:00:04.001Z",
+      "2026-01-01T00:00:04.002Z",
     ]);
+  });
+
+  test("projects local tool variants with stable intra-message ordering", () => {
+    const projected = projectLocalMessagesToStoredMessages(
+      [
+        {
+          id: "ui-assistant-tools",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-ShellCommand",
+              toolCallId: "call-done",
+              state: "output-available",
+              input: { command: "pwd" },
+              output: "/tmp/project",
+            },
+            {
+              type: "tool-ApplyPatch",
+              toolCallId: "call-pending",
+              state: "input-streaming",
+              input: { input: "*** Begin Patch" },
+            },
+          ],
+        },
+      ],
+      "agent-local-test",
+      "default",
+    );
+
+    expect(projected.map((message) => message.id)).toEqual([
+      "ui-assistant-tools:tool:call-done:request",
+      "ui-assistant-tools:tool:call-done:return",
+      "ui-assistant-tools:tool:call-pending:pending",
+    ]);
+    expect(projected.map((message) => message.date)).toEqual([
+      "2026-01-01T00:00:01.000Z",
+      "2026-01-01T00:00:01.001Z",
+      "2026-01-01T00:00:01.002Z",
+    ]);
+
+    const chronologicalAfterDescList = [...projected]
+      .reverse()
+      .sort((a, b) => Date.parse(a.date) - Date.parse(b.date));
+    expect(chronologicalAfterDescList.map((message) => message.id)).toEqual(
+      projected.map((message) => message.id),
+    );
   });
 
   test("projects local reasoning parts as reasoning messages", () => {

--- a/src/tests/backend/provider-turn-executor.test.ts
+++ b/src/tests/backend/provider-turn-executor.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { APICallError } from "ai";
 import type {
   ConversationMessageCreateBody,
   ConversationMessageListBody,
@@ -175,6 +176,84 @@ describe("ProviderTurnExecutor", () => {
     expect(
       page.getPaginatedItems().map((message) => message.message_type),
     ).toEqual(["user_message", "approval_request_message"]);
+  });
+
+  test("marks retryable provider failures after model output as llm_api_error runs", async () => {
+    const providerError = new APICallError({
+      message: "upstream connect error",
+      url: "https://example.invalid/v1/responses",
+      requestBodyValues: {},
+      statusCode: 503,
+      responseHeaders: { "retry-after-ms": "0" },
+      responseBody: '{"type":"server_error"}',
+      isRetryable: true,
+    });
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        yield streamPart({
+          type: "text-delta",
+          id: "text-1",
+          text: "partial output",
+        });
+        throw providerError;
+      },
+    };
+    const backend = new FakeHeadlessBackend(
+      "agent-provider",
+      new ProviderTurnExecutor(adapter),
+    );
+    const conversation = await backend.createConversation({
+      agent_id: "agent-provider",
+    });
+
+    const chunks = await collectStream(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("fail after output"),
+      ),
+    );
+
+    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
+      "assistant_message",
+      "error_message",
+      "stop_reason",
+    ]);
+    const errorChunk = chunks.find(
+      (chunk) => chunk.message_type === "error_message",
+    ) as LettaStreamingResponse & {
+      error_type?: string;
+      detail?: string;
+      retryable?: boolean;
+    };
+    expect(errorChunk).toMatchObject({
+      message_type: "error_message",
+      message: "upstream connect error",
+      error_type: "llm_error",
+      retryable: true,
+    });
+    expect(errorChunk.detail).toContain("upstream connect error");
+    expect(errorChunk.detail).toContain('{"type":"server_error"}');
+    expect(errorChunk.detail).not.toContain("[object Object]");
+    expect(chunks.at(-1)).toMatchObject({
+      message_type: "stop_reason",
+      stop_reason: "llm_api_error",
+    });
+
+    const runId = (chunks[0] as { run_id?: string }).run_id ?? "";
+    await expect(backend.retrieveRun(runId)).resolves.toMatchObject({
+      id: runId,
+      status: "failed",
+      stop_reason: "llm_api_error",
+      metadata: {
+        error: {
+          message: "upstream connect error",
+          detail: expect.stringContaining("upstream connect error"),
+          error_type: "llm_error",
+          retryable: true,
+          run_id: runId,
+        },
+      },
+    });
   });
 
   test("passes persisted UIMessage tool outputs through continuations", async () => {

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -74,8 +74,11 @@ describe("approval recovery wiring", () => {
 
     const recoverSegment = source.slice(recoverStart, recoverEnd);
     expect(recoverSegment).toContain("const hasQueuedRealResults =");
-    expect(recoverSegment).toContain("buildFreshDenialApprovals(");
-    expect(recoverSegment).toContain("queueApprovalResults(staleDenials");
+    expect(recoverSegment).toContain(
+      "await restorePendingApprovalUi(approvals)",
+    );
+    expect(recoverSegment).not.toContain("buildFreshDenialApprovals(");
+    expect(recoverSegment).not.toContain("queueApprovalResults(staleDenials");
     expect(recoverSegment).not.toContain("queueApprovalResults(null)");
     expect(recoverSegment).not.toContain(
       "await classifyApprovals(approvals, {",

--- a/src/tests/cli/approval-recovery-wiring.test.ts
+++ b/src/tests/cli/approval-recovery-wiring.test.ts
@@ -37,6 +37,25 @@ describe("approval recovery wiring", () => {
     expect(segment).not.toContain("!hasApprovalInPayload &&");
   });
 
+  test("local post-stream retry continues from persisted state instead of replaying input", () => {
+    const source = readInteractiveAppSource();
+
+    const start = source.indexOf("const retryFromPersistedLocalState =");
+    const end = source.indexOf(
+      "// Reset seq_id threshold — new run starts from seq_id 1",
+      start,
+    );
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("backendCapabilities.localModelCatalog");
+    expect(segment).toContain("!backendCapabilities.remoteMemfs");
+    expect(segment).toContain("? []");
+    expect(segment).toContain(": refreshInputOtidsForNewRequest(currentInput)");
+  });
+
   test("tool interrupt branch includes backend cancel call before early return", () => {
     const source = readInteractiveAppSource();
 

--- a/src/tests/cli/prepareMessageHistory.test.ts
+++ b/src/tests/cli/prepareMessageHistory.test.ts
@@ -17,7 +17,7 @@ function msg(
 }
 
 describe("prepareMessageHistory", () => {
-  test("primaryOnly returns only primary message types", () => {
+  test("keeps renderable tool messages in transcript order", () => {
     const base = 1_700_000_000_000;
     const messages: Message[] = [
       msg("user_message", "u1", base + 1),
@@ -31,83 +31,53 @@ describe("prepareMessageHistory", () => {
       msg("summary_message", "s1", base + 9),
     ];
 
-    const out = prepareMessageHistory(messages, { primaryOnly: true });
+    const out = prepareMessageHistory(messages);
     expect(out.map((m) => m.message_type)).toEqual([
       "user_message",
+      "tool_call_message",
+      "approval_request_message",
+      "tool_return_message",
       "assistant_message",
+      "reasoning_message",
+      "approval_response_message",
       "event_message",
       "summary_message",
     ]);
   });
 
-  test("primaryOnly includes most recent assistant even if last N primary messages lack it", () => {
+  test("uses primary anchors for recency without dropping intervening tools", () => {
     const base = 1_700_000_000_000;
     const messages: Message[] = [];
 
-    // An older assistant message, then many user/event messages.
-    messages.push(msg("assistant_message", "a1", base + 1));
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < 14; i += 1) {
       messages.push(msg("user_message", `u${i}`, base + 10 + i));
+      if (i === 12) {
+        messages.push(msg("approval_request_message", "tool-12", base + 100));
+        messages.push(msg("tool_return_message", "return-12", base + 101));
+      }
     }
+    messages.push(msg("assistant_message", "a1", base + 200));
 
-    const out = prepareMessageHistory(messages, { primaryOnly: true });
-    expect(out.some((m) => m.message_type === "assistant_message")).toBe(true);
-    expect(
-      out.every((m) =>
-        [
-          "user_message",
-          "assistant_message",
-          "event_message",
-          "summary_message",
-        ].includes(m.message_type as string),
-      ),
-    ).toBe(true);
-    // Preserve recency: keep latest tail and prepend last assistant anchor.
+    const out = prepareMessageHistory(messages);
     expect(out.map((m) => m.id)).toEqual([
+      "u3",
+      "u4",
+      "u5",
+      "u6",
+      "u7",
+      "u8",
+      "u9",
+      "u10",
+      "u11",
+      "u12",
+      "tool-12",
+      "return-12",
+      "u13",
       "a1",
-      "u19",
-      "u20",
-      "u21",
-      "u22",
-      "u23",
-      "u24",
-      "u25",
-      "u26",
-      "u27",
-      "u28",
-      "u29",
     ]);
   });
 
-  test("primaryOnly falls back to reasoning when no primary messages exist", () => {
-    const base = 1_700_000_000_000;
-    const messages: Message[] = [
-      msg("tool_return_message", "tr1", base + 1),
-      msg("reasoning_message", "r1", base + 2),
-      msg("tool_return_message", "tr2", base + 3),
-      msg("reasoning_message", "r2", base + 4),
-    ];
-
-    const out = prepareMessageHistory(messages, { primaryOnly: true });
-    expect(out.map((m) => m.message_type)).toEqual([
-      "reasoning_message",
-      "reasoning_message",
-    ]);
-  });
-
-  test("primaryOnly returns [] when no primary or reasoning messages exist", () => {
-    const base = 1_700_000_000_000;
-    const messages: Message[] = [
-      msg("tool_return_message", "tr1", base + 1),
-      msg("approval_request_message", "ar1", base + 2),
-      msg("approval_response_message", "ap1", base + 3),
-    ];
-
-    const out = prepareMessageHistory(messages, { primaryOnly: true });
-    expect(out).toEqual([]);
-  });
-
-  test("non-primaryOnly skips orphaned leading tool_return_message", () => {
+  test("skips orphaned leading tool_return_message", () => {
     const base = 1_700_000_000_000;
     const messages: Message[] = [
       msg("tool_return_message", "tr1", base + 1),

--- a/src/tests/cli/retry.test.ts
+++ b/src/tests/cli/retry.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import { __testSetBackend, type Backend } from "../../backend";
+import { isRetriableError } from "../../cli/app/retry";
+
+const capabilities = {
+  remoteMemfs: false,
+  serverSideToolManagement: false,
+  serverSecrets: false,
+  agentFileImportExport: false,
+  promptRecompile: false,
+  byokProviderRefresh: false,
+  localModelCatalog: true,
+  localMemfs: false,
+};
+
+function setRunErrorMetadata(error: unknown): void {
+  __testSetBackend({
+    capabilities,
+    async retrieveRun(runId: string) {
+      return {
+        id: runId,
+        metadata: { error },
+      };
+    },
+  } as unknown as Backend);
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+});
+
+describe("post-stream retry classification", () => {
+  test("honors explicit retryable local run metadata", async () => {
+    setRunErrorMetadata({
+      error_type: "llm_error",
+      detail: "HTTP 503: provider overloaded",
+      retryable: true,
+    });
+
+    await expect(
+      isRetriableError("error" as StopReasonType, "local-run-1"),
+    ).resolves.toBe(true);
+  });
+
+  test("honors explicit non-retryable local run metadata", async () => {
+    setRunErrorMetadata({
+      error_type: "llm_error",
+      detail: "Authentication error",
+      retryable: false,
+    });
+
+    await expect(
+      isRetriableError("error" as StopReasonType, "local-run-1"),
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep resume backfill on the full renderable transcript, including tool request/return/approval records
- restore startup/resume pending approvals into the TUI instead of auto-denying them
- keep local list-message filtering API-compatible while fixing callers to request tool messages

## Tests
- bun test src/tests/agent/getResumeData.test.ts src/tests/cli/prepareMessageHistory.test.ts src/tests/cli/approval-recovery-wiring.test.ts src/tests/backend/fake-headless-backend.test.ts --timeout 15000
- bun test src/tests/backend/local-backend.test.ts src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/headless/dev-backend-smoke.test.ts --timeout 15000
- bun run check