### PR TITLE
fix(cli): gate plan mode behind user setting

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3999,6 +3999,13 @@ export default function App({
   // Handle permission mode changes from the Input component (e.g., shift+tab cycling)
   const handlePermissionModeChange = useCallback(
     (mode: PermissionMode) => {
+      if (mode === "plan" && !settingsManager.isPlanModeEnabled()) {
+        permissionMode.setMode("default");
+        setUiPermissionMode("default");
+        triggerStatusLineRefresh();
+        return;
+      }
+
       // When entering plan mode via tab cycling, generate and set the plan file path
       if (mode === "plan") {
         const planPath = generatePlanFilePath();

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4000,8 +4000,8 @@ export default function App({
   const handlePermissionModeChange = useCallback(
     (mode: PermissionMode) => {
       if (mode === "plan" && !settingsManager.isPlanModeEnabled()) {
-        permissionMode.setMode("default");
-        setUiPermissionMode("default");
+        permissionMode.setMode("unrestricted");
+        setUiPermissionMode("unrestricted");
         triggerStatusLineRefresh();
         return;
       }

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -2682,6 +2682,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         // Special handling for /plan command - enter plan mode
         if (trimmed === "/plan") {
+          const cmd = commandRunner.start("/plan", "Entering plan mode...");
+          if (!settingsManager.isPlanModeEnabled()) {
+            cmd.finish("Plan mode is disabled in user settings.", false);
+            return { submitted: true };
+          }
+
           // Generate plan file path and enter plan mode
           const planPath = generatePlanFilePath();
           permissionMode.setPlanFilePath(planPath);
@@ -2689,10 +2695,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           permissionMode.setMode("plan");
           setUiPermissionMode("plan");
 
-          const cmd = commandRunner.start(
-            "/plan",
-            `Plan mode enabled. Plan file: ${planPath}`,
-          );
           cmd.finish(`Plan mode enabled. Plan file: ${planPath}`, true);
 
           return { submitted: true };

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -2700,6 +2700,64 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
+        if (trimmed === "/plan-mode" || trimmed.startsWith("/plan-mode ")) {
+          const cmd = commandRunner.start(
+            "/plan-mode",
+            "Updating plan mode setting...",
+          );
+          const arg = trimmed.split(/\s+/)[1]?.toLowerCase();
+          const enabled = (() => {
+            if (arg === "on" || arg === "true" || arg === "enable") {
+              return true;
+            }
+            if (arg === "off" || arg === "false" || arg === "disable") {
+              return false;
+            }
+            return null;
+          })();
+
+          if (enabled === null) {
+            cmd.fail("Usage: /plan-mode on|off");
+            return { submitted: true };
+          }
+
+          try {
+            settingsManager.setPlanModeEnabled(enabled);
+            await settingsManager.flush();
+
+            if (!enabled && permissionMode.getMode() === "plan") {
+              permissionMode.setMode("default");
+              setUiPermissionMode("default");
+            }
+
+            const { forceToolsetSwitch, switchToolsetForModel } = await import(
+              "../../tools/toolset"
+            );
+            if (currentToolset) {
+              await forceToolsetSwitch(currentToolset, agentId);
+            } else {
+              await switchToolsetForModel(
+                currentModelHandle ??
+                  currentModelId ??
+                  "anthropic/claude-sonnet-4",
+                agentId,
+              );
+            }
+
+            cmd.finish(
+              enabled
+                ? "Plan mode enabled. /plan and plan-mode tools are now available."
+                : "Plan mode disabled. /plan is disabled and plan-mode tools are hidden.",
+              true,
+            );
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to update plan mode setting: ${errorDetails}`);
+          }
+
+          return { submitted: true };
+        }
+
         // Special handling for /init command
         if (trimmed === "/init") {
           const cmd = commandRunner.start(msg, "Gathering project context...");

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -2726,8 +2726,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             await settingsManager.flush();
 
             if (!enabled && permissionMode.getMode() === "plan") {
-              permissionMode.setMode("default");
-              setUiPermissionMode("default");
+              permissionMode.setMode("unrestricted");
+              setUiPermissionMode("unrestricted");
             }
 
             const { forceToolsetSwitch, switchToolsetForModel } = await import(

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -491,6 +491,14 @@ export const commands: Record<string, Command> = {
       return "Entering plan mode...";
     },
   },
+  "/plan-mode": {
+    desc: "Enable or disable plan mode (/plan-mode on|off)",
+    order: 40.5,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Updating plan mode setting...";
+    },
+  },
   "/disconnect": {
     desc: "Disconnect an existing account (/disconnect codex|claude|zai)",
     order: 41,

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1388,12 +1388,9 @@ export function Input({
       }
 
       // Cycle through permission modes
-      const modes: PermissionMode[] = [
-        "unrestricted",
-        "acceptEdits",
-        "standard",
-        "plan",
-      ];
+      const modes: PermissionMode[] = settingsManager.isPlanModeEnabled()
+        ? ["default", "plan", "acceptEdits", "bypassPermissions"]
+        : ["default", "acceptEdits", "bypassPermissions"];
       const currentIndex = modes.indexOf(currentMode);
       const nextIndex = (currentIndex + 1) % modes.length;
       const nextMode = modes[nextIndex] ?? "unrestricted";

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1389,8 +1389,8 @@ export function Input({
 
       // Cycle through permission modes
       const modes: PermissionMode[] = settingsManager.isPlanModeEnabled()
-        ? ["default", "plan", "acceptEdits", "bypassPermissions"]
-        : ["default", "acceptEdits", "bypassPermissions"];
+        ? ["unrestricted", "plan", "acceptEdits", "standard"]
+        : ["unrestricted", "acceptEdits", "standard"];
       const currentIndex = modes.indexOf(currentMode);
       const nextIndex = (currentIndex + 1) % modes.length;
       const nextMode = modes[nextIndex] ?? "unrestricted";

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -82,6 +82,7 @@ export interface Settings {
   enableSleeptime: boolean;
   sessionContextEnabled: boolean; // Send device/agent context on first message of each session
   autoSwapOnQuotaLimit: boolean; // Auto-switch to temporary Auto model override on quota-limit errors
+  planModeEnabled: boolean; // Enables plan-mode tools and /plan command when true
   memoryReminderInterval: number | null | "compaction" | "auto-compaction"; // DEPRECATED: use reflection* fields
   reflectionTrigger: "off" | "step-count" | "compaction-event";
   reflectionStepCount: number;
@@ -162,6 +163,7 @@ const DEFAULT_SETTINGS: Settings = {
   conversationSwitchAlertEnabled: false,
   sessionContextEnabled: true,
   autoSwapOnQuotaLimit: true,
+  planModeEnabled: false,
   memoryReminderInterval: 25, // DEPRECATED: use reflection* fields
   reflectionTrigger: "step-count",
   reflectionStepCount: 25,
@@ -545,6 +547,14 @@ class SettingsManager {
    */
   getSetting<K extends keyof Settings>(key: K): Settings[K] {
     return this.getSettings()[key];
+  }
+
+  isPlanModeEnabled(): boolean {
+    return this.getSettings().planModeEnabled === true;
+  }
+
+  setPlanModeEnabled(enabled: boolean): void {
+    this.updateSettings({ planModeEnabled: enabled });
   }
 
   getCachedSecureTokens(): SecureTokens {

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -15,4 +15,14 @@ describe("permission mode cycle order", () => {
     );
     expect(source).toContain('["default", "acceptEdits", "bypassPermissions"]');
   });
+
+  test("/plan-mode command is registered", () => {
+    const registryPath = fileURLToPath(
+      new URL("../../cli/commands/registry.ts", import.meta.url),
+    );
+    const source = readFileSync(registryPath, "utf-8");
+
+    expect(source).toContain('"/plan-mode": {');
+    expect(source).toContain("Enable or disable plan mode (/plan-mode on|off)");
+  });
 });

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -11,9 +11,9 @@ describe("permission mode cycle order", () => {
 
     expect(source).toContain("settingsManager.isPlanModeEnabled()");
     expect(source).toContain(
-      '["default", "plan", "acceptEdits", "bypassPermissions"]',
+      '["unrestricted", "plan", "acceptEdits", "standard"]',
     );
-    expect(source).toContain('["default", "acceptEdits", "bypassPermissions"]');
+    expect(source).toContain('["unrestricted", "acceptEdits", "standard"]');
   });
 
   test("/plan-mode command is registered", () => {

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -3,15 +3,16 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 describe("permission mode cycle order", () => {
-  test("Shift+Tab cycles from unrestricted through acceptEdits, standard, and plan", () => {
+  test("Shift+Tab includes plan only when plan mode is enabled", () => {
     const inputRichPath = fileURLToPath(
       new URL("../../cli/components/InputRich.tsx", import.meta.url),
     );
     const source = readFileSync(inputRichPath, "utf-8");
 
-    expect(source).toContain("const modes: PermissionMode[] = [");
+    expect(source).toContain("settingsManager.isPlanModeEnabled()");
     expect(source).toContain(
-      '"unrestricted",\n        "acceptEdits",\n        "standard",\n        "plan",',
+      '["default", "plan", "acceptEdits", "bypassPermissions"]',
     );
+    expect(source).toContain('["default", "acceptEdits", "bypassPermissions"]');
   });
 });

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -36,11 +36,17 @@ describe("permission mode retry wiring", () => {
 
     const slashPlanStart = source.indexOf('if (trimmed === "/plan") {');
     const slashPlanEnd = source.indexOf(
-      "return { submitted: true };",
+      "// Special handling for /init command",
       slashPlanStart,
     );
     expect(slashPlanStart).toBeGreaterThan(-1);
     expect(slashPlanEnd).toBeGreaterThan(slashPlanStart);
+    expect(source.slice(slashPlanStart, slashPlanEnd)).toContain(
+      "settingsManager.isPlanModeEnabled()",
+    );
+    expect(source.slice(slashPlanStart, slashPlanEnd)).toContain(
+      "Plan mode is disabled in user settings.",
+    );
     expect(source.slice(slashPlanStart, slashPlanEnd)).toContain(
       "cacheLastPlanFilePath(planPath);",
     );
@@ -53,6 +59,9 @@ describe("permission mode retry wiring", () => {
     );
     expect(modeChangeStart).toBeGreaterThan(-1);
     expect(modeChangeEnd).toBeGreaterThan(modeChangeStart);
+    expect(source.slice(modeChangeStart, modeChangeEnd)).toContain(
+      'if (mode === "plan" && !settingsManager.isPlanModeEnabled())',
+    );
     expect(source.slice(modeChangeStart, modeChangeEnd)).toContain(
       "cacheLastPlanFilePath(planPath);",
     );

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -79,6 +79,27 @@ describe("permission mode retry wiring", () => {
     );
   });
 
+  test("/plan-mode toggles setting and refreshes loaded tools", () => {
+    const source = readAppSource();
+
+    const start = source.indexOf(
+      'if (trimmed === "/plan-mode" || trimmed.startsWith("/plan-mode "))',
+    );
+    const end = source.indexOf("// Special handling for /init command", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("settingsManager.setPlanModeEnabled(enabled)");
+    expect(segment).toContain("await settingsManager.flush()");
+    expect(segment).toContain('permissionMode.setMode("default")');
+    expect(segment).toContain(
+      "await forceToolsetSwitch(currentToolset, agentId)",
+    );
+    expect(segment).toContain("await switchToolsetForModel(");
+    expect(segment).toContain("Usage: /plan-mode on|off");
+  });
+
   test("pins submission permission mode and defines a restore helper", () => {
     const source = readAppSource();
 

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -92,7 +92,7 @@ describe("permission mode retry wiring", () => {
     const segment = source.slice(start, end);
     expect(segment).toContain("settingsManager.setPlanModeEnabled(enabled)");
     expect(segment).toContain("await settingsManager.flush()");
-    expect(segment).toContain('permissionMode.setMode("default")');
+    expect(segment).toContain('permissionMode.setMode("unrestricted")');
     expect(segment).toContain(
       "await forceToolsetSwitch(currentToolset, agentId)",
     );

--- a/src/tests/settings-manager.test.ts
+++ b/src/tests/settings-manager.test.ts
@@ -188,6 +188,19 @@ describe("Settings Manager - Global Settings", () => {
     expect(tokenStreaming).toBe(true);
   });
 
+  test("Plan mode defaults off and can be toggled", () => {
+    expect(settingsManager.getSetting("planModeEnabled")).toBe(false);
+    expect(settingsManager.isPlanModeEnabled()).toBe(false);
+
+    settingsManager.setPlanModeEnabled(true);
+    expect(settingsManager.getSetting("planModeEnabled")).toBe(true);
+    expect(settingsManager.isPlanModeEnabled()).toBe(true);
+
+    settingsManager.setPlanModeEnabled(false);
+    expect(settingsManager.getSetting("planModeEnabled")).toBe(false);
+    expect(settingsManager.isPlanModeEnabled()).toBe(false);
+  });
+
   test("Update single setting", () => {
     // Verify initial state first
     const initialSettings = settingsManager.getSettings();

--- a/src/tests/tools/plan-mode-setting.test.ts
+++ b/src/tests/tools/plan-mode-setting.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { settingsManager } from "../../settings-manager";
+import {
+  ANTHROPIC_DEFAULT_TOOLS,
+  clearToolsWithLock,
+  GEMINI_PASCAL_TOOLS,
+  getToolNames,
+  loadSpecificTools,
+  loadTools,
+  OPENAI_PASCAL_TOOLS,
+  prepareToolExecutionContextForModel,
+} from "../../tools/manager";
+
+const originalHome = process.env.HOME;
+let testHomeDir: string;
+
+beforeEach(async () => {
+  await settingsManager.reset();
+  clearToolsWithLock();
+  testHomeDir = await mkdtemp(join(tmpdir(), "letta-plan-mode-test-"));
+  process.env.HOME = testHomeDir;
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  clearToolsWithLock();
+  await settingsManager.reset();
+  await rm(testHomeDir, { recursive: true, force: true });
+  process.env.HOME = originalHome;
+});
+
+describe("plan mode setting tool filtering", () => {
+  test("default tool loading omits plan-mode tools when disabled", async () => {
+    expect(settingsManager.isPlanModeEnabled()).toBe(false);
+
+    await loadTools("anthropic/claude-sonnet-4");
+    const tools = getToolNames();
+
+    expect(tools).toContain("AskUserQuestion");
+    expect(tools).not.toContain("EnterPlanMode");
+    expect(tools).not.toContain("ExitPlanMode");
+  });
+
+  test("default tool loading includes plan-mode tools when enabled", async () => {
+    settingsManager.setPlanModeEnabled(true);
+
+    await loadTools("anthropic/claude-sonnet-4");
+    const tools = getToolNames();
+
+    expect(tools).toContain("AskUserQuestion");
+    expect(tools).toContain("EnterPlanMode");
+    expect(tools).toContain("ExitPlanMode");
+  });
+
+  test("specific tool loading omits plan-mode tools when disabled", async () => {
+    await loadSpecificTools([...OPENAI_PASCAL_TOOLS]);
+    const tools = getToolNames();
+
+    expect(tools).toContain("AskUserQuestion");
+    expect(tools).not.toContain("EnterPlanMode");
+    expect(tools).not.toContain("ExitPlanMode");
+  });
+
+  test("Gemini Pascal tool loading omits plan-mode tools when disabled", async () => {
+    await loadSpecificTools([...GEMINI_PASCAL_TOOLS]);
+    const tools = getToolNames();
+
+    expect(tools).toContain("AskUserQuestion");
+    expect(tools).not.toContain("EnterPlanMode");
+    expect(tools).not.toContain("ExitPlanMode");
+  });
+
+  test("specific tool loading includes plan-mode tools when enabled", async () => {
+    settingsManager.setPlanModeEnabled(true);
+
+    await loadSpecificTools([...OPENAI_PASCAL_TOOLS]);
+    const tools = getToolNames();
+
+    expect(tools).toContain("AskUserQuestion");
+    expect(tools).toContain("EnterPlanMode");
+    expect(tools).toContain("ExitPlanMode");
+  });
+
+  test("client allowlist cannot re-enable plan-mode tools", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: [
+          "AskUserQuestion",
+          "EnterPlanMode",
+          "ExitPlanMode",
+        ],
+      },
+    );
+
+    expect(prepared.loadedToolNames).toEqual(["AskUserQuestion"]);
+  });
+
+  test("source toolset lists keep plan tools for enabled mode", () => {
+    expect(ANTHROPIC_DEFAULT_TOOLS).toContain("EnterPlanMode");
+    expect(ANTHROPIC_DEFAULT_TOOLS).toContain("ExitPlanMode");
+    expect(OPENAI_PASCAL_TOOLS).toContain("EnterPlanMode");
+    expect(OPENAI_PASCAL_TOOLS).toContain("ExitPlanMode");
+    expect(GEMINI_PASCAL_TOOLS).toContain("EnterPlanMode");
+    expect(GEMINI_PASCAL_TOOLS).toContain("ExitPlanMode");
+  });
+});

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4111,7 +4111,10 @@ describe("listen-client capability-gated approval flow", () => {
     }
   });
 
-  test("mode changes reject plan mode when plan mode is disabled", () => {
+  test("mode changes reject plan mode when plan mode is disabled", async () => {
+    await settingsManager.reset();
+    await settingsManager.initialize();
+
     const listener = __listenClientTestUtils.createListenerRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     listener.socket = socket as unknown as WebSocket;
@@ -4143,7 +4146,7 @@ describe("listen-client capability-gated approval flow", () => {
         payload.delta?.message_type === "loop_error",
     );
 
-    expect(deviceStatus?.current_permission_mode).toBe("unrestricted");
+    expect(deviceStatus?.current_permission_mode).toBe("standard");
     expect(deviceStatus?.plan_mode_enabled).toBe(false);
     expect(loopStatus?.plan_file_path).toBeNull();
     expect(notice?.delta?.message).toContain(

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -4111,7 +4111,7 @@ describe("listen-client capability-gated approval flow", () => {
     }
   });
 
-  test("mode changes emit fresh loop status plan_file_path on enter exit and re-enter", async () => {
+  test("mode changes reject plan mode when plan mode is disabled", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     listener.socket = socket as unknown as WebSocket;
@@ -4128,44 +4128,97 @@ describe("listen-client capability-gated approval flow", () => {
       scope,
     );
 
-    const firstPlanPath = (socket.sentPayloads
-      .map((payload) => JSON.parse(payload as string))
-      .findLast((payload) => payload.type === "update_loop_status")?.loop_status
-      ?.plan_file_path ?? null) as string | null;
-
-    expect(firstPlanPath).toBeTruthy();
-
-    __listenClientTestUtils.handleModeChange(
-      { mode: "standard" },
-      socket as unknown as WebSocket,
-      listener,
-      scope,
+    const outbound = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload as string),
+    );
+    const deviceStatus = outbound.findLast(
+      (payload) => payload.type === "update_device_status",
+    )?.device_status;
+    const loopStatus = outbound.findLast(
+      (payload) => payload.type === "update_loop_status",
+    )?.loop_status;
+    const notice = outbound.findLast(
+      (payload) =>
+        payload.type === "stream_delta" &&
+        payload.delta?.message_type === "loop_error",
     );
 
-    const afterExitLoopStatus = socket.sentPayloads
-      .map((payload) => JSON.parse(payload as string))
-      .findLast(
-        (payload) =>
-          payload.type === "update_loop_status" &&
-          payload.loop_status?.status === "WAITING_ON_INPUT",
+    expect(deviceStatus?.current_permission_mode).toBe("unrestricted");
+    expect(deviceStatus?.plan_mode_enabled).toBe(false);
+    expect(loopStatus?.plan_file_path).toBeNull();
+    expect(notice?.delta?.message).toContain(
+      "Plan mode is disabled in user settings.",
+    );
+  });
+
+  test("mode changes emit fresh loop status plan_file_path on enter exit and re-enter", async () => {
+    const originalHome = process.env.HOME;
+    const testHomeDir = await mkdtemp(join(os.tmpdir(), "letta-plan-ws-"));
+    await settingsManager.reset();
+    process.env.HOME = testHomeDir;
+    await settingsManager.initialize();
+    settingsManager.setPlanModeEnabled(true);
+
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const socket = new MockSocket(WebSocket.OPEN);
+    listener.socket = socket as unknown as WebSocket;
+
+    const scope = {
+      agent_id: "agent-1",
+      conversation_id: "default",
+    } as const;
+
+    try {
+      __listenClientTestUtils.handleModeChange(
+        { mode: "plan" },
+        socket as unknown as WebSocket,
+        listener,
+        scope,
       );
 
-    expect(afterExitLoopStatus?.loop_status?.plan_file_path).toBeNull();
+      const firstPlanPath = (socket.sentPayloads
+        .map((payload) => JSON.parse(payload as string))
+        .findLast((payload) => payload.type === "update_loop_status")
+        ?.loop_status?.plan_file_path ?? null) as string | null;
 
-    __listenClientTestUtils.handleModeChange(
-      { mode: "plan" },
-      socket as unknown as WebSocket,
-      listener,
-      scope,
-    );
+      expect(firstPlanPath).toBeTruthy();
 
-    const secondPlanPath = (socket.sentPayloads
-      .map((payload) => JSON.parse(payload as string))
-      .findLast((payload) => payload.type === "update_loop_status")?.loop_status
-      ?.plan_file_path ?? null) as string | null;
+      __listenClientTestUtils.handleModeChange(
+        { mode: "unrestricted" },
+        socket as unknown as WebSocket,
+        listener,
+        scope,
+      );
 
-    expect(secondPlanPath).toBeTruthy();
-    expect(secondPlanPath).not.toBe(firstPlanPath);
+      const afterExitLoopStatus = socket.sentPayloads
+        .map((payload) => JSON.parse(payload as string))
+        .findLast(
+          (payload) =>
+            payload.type === "update_loop_status" &&
+            payload.loop_status?.status === "WAITING_ON_INPUT",
+        );
+
+      expect(afterExitLoopStatus?.loop_status?.plan_file_path).toBeNull();
+
+      __listenClientTestUtils.handleModeChange(
+        { mode: "plan" },
+        socket as unknown as WebSocket,
+        listener,
+        scope,
+      );
+
+      const secondPlanPath = (socket.sentPayloads
+        .map((payload) => JSON.parse(payload as string))
+        .findLast((payload) => payload.type === "update_loop_status")
+        ?.loop_status?.plan_file_path ?? null) as string | null;
+
+      expect(secondPlanPath).toBeTruthy();
+      expect(secondPlanPath).not.toBe(firstPlanPath);
+    } finally {
+      await settingsManager.reset();
+      await rm(testHomeDir, { recursive: true, force: true });
+      process.env.HOME = originalHome;
+    }
   });
 
   test("requestApprovalOverWS exposes the control request through device status instead of stream_delta", () => {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -35,6 +35,7 @@ import {
   type RuntimeContextSnapshot,
   runWithRuntimeContext,
 } from "../runtime-context";
+import { settingsManager } from "../settings-manager";
 import { telemetry } from "../telemetry";
 import { debugLog } from "../utils/debug";
 import {
@@ -251,6 +252,31 @@ export function filterBuiltInToolNamesByClientAllowlist(
       toolName,
     ),
   );
+}
+
+const PLAN_MODE_TOOL_NAMES = new Set<ToolName>([
+  "EnterPlanMode",
+  "ExitPlanMode",
+]);
+
+function isPlanModeTool(toolName: string): boolean {
+  return PLAN_MODE_TOOL_NAMES.has(toolName as ToolName);
+}
+
+function isPlanModeEnabled(): boolean {
+  try {
+    return settingsManager.isPlanModeEnabled();
+  } catch {
+    return false;
+  }
+}
+
+function filterPlanModeTools(toolNames: ToolName[]): ToolName[] {
+  if (isPlanModeEnabled()) {
+    return toolNames;
+  }
+
+  return toolNames.filter((name) => !PLAN_MODE_TOOL_NAMES.has(name));
 }
 
 function filterExternalToolsByClientAllowlist(
@@ -1193,6 +1219,10 @@ async function buildSpecificToolRegistry(
     }
 
     const internalName = getInternalToolName(name);
+    if (!isPlanModeEnabled() && isPlanModeTool(internalName)) {
+      continue;
+    }
+
     const definition = TOOL_DEFINITIONS[internalName as ToolName];
     if (!definition) {
       console.warn(
@@ -1272,6 +1302,8 @@ async function resolveBaseToolNamesForModel(
       }
     }
   }
+
+  baseToolNames = filterPlanModeTools(baseToolNames);
 
   // Append channel tool if channels are active
   baseToolNames = maybeAppendChannelTools(

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -245,6 +245,7 @@ export interface DeviceStatus {
   is_online: boolean;
   is_processing: boolean;
   current_permission_mode: DevicePermissionMode;
+  plan_mode_enabled: boolean;
   current_working_directory: string | null;
   git_context: GitContext | null;
   letta_code_version: string | null;

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -10,6 +10,7 @@ import {
 import { generatePlanFilePath } from "../../cli/helpers/planName";
 import { INTERRUPTED_BY_USER } from "../../constants";
 import { migratePermissionMode } from "../../permissions/mode";
+import { settingsManager } from "../../settings-manager";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
 import type {
   AbortMessageCommand,
@@ -73,6 +74,14 @@ function trackListenerError(
   });
 }
 
+function isPlanModeEnabled(): boolean {
+  try {
+    return settingsManager.isPlanModeEnabled();
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Handle mode change request from cloud.
  * Stores the new mode in ListenerRuntime.permissionModeByConversation so
@@ -99,6 +108,25 @@ export function handleModeChange(
 
     // Migrate legacy mode values from older clients
     const incomingMode = migratePermissionMode(msg.mode) ?? msg.mode;
+
+    // Reject plan mode if it's disabled in settings
+    if (incomingMode === "plan" && !settingsManager.isPlanModeEnabled()) {
+      if (current.mode === "plan") {
+        current.mode = "unrestricted";
+        current.planFilePath = null;
+        current.modeBeforePlan = null;
+        persistPermissionModeMapForRuntime(runtime);
+      }
+      emitRuntimeStateUpdates(runtime, scope);
+      emitLoopErrorNotice(socket, runtime, {
+        message: "Plan mode is disabled in user settings.",
+        stopReason: "error",
+        isTerminal: false,
+        agentId: scope?.agent_id,
+        conversationId: scope?.conversation_id,
+      });
+      return;
+    }
 
     // Track previous mode so ExitPlanMode can restore it
     if (incomingMode === "plan" && current.mode !== "plan") {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -62,6 +62,14 @@ import type {
 
 type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
 
+function isPlanModeEnabled(): boolean {
+  try {
+    return settingsManager.isPlanModeEnabled();
+  } catch {
+    return false;
+  }
+}
+
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
 const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
@@ -379,6 +387,7 @@ export function buildDeviceStatus(
       is_online: false,
       is_processing: false,
       current_permission_mode: permissionMode.getMode(),
+      plan_mode_enabled: isPlanModeEnabled(),
       current_working_directory: fallbackCwd,
       git_context: getCachedDeviceGitContext(fallbackCwd),
       letta_code_version: process.env.npm_package_version || null,
@@ -445,6 +454,7 @@ export function buildDeviceStatus(
     is_online: transport ? isListenerTransportOpen(transport) : false,
     is_processing: !!conversationRuntime?.isProcessing,
     current_permission_mode: conversationPermissionModeState.mode,
+    plan_mode_enabled: isPlanModeEnabled(),
     current_working_directory: resolvedCwd,
     git_context: getCachedDeviceGitContext(resolvedCwd),
     letta_code_version: process.env.npm_package_version || null,


### PR DESCRIPTION
## Summary
- Add a global `planModeEnabled` setting that defaults to `false`.
- Add `/plan-mode on|off` to toggle the user setting, persist it, and refresh the currently loaded toolset immediately.
- Omit `EnterPlanMode` and `ExitPlanMode` from loaded toolsets unless plan mode is explicitly enabled; `AskUserQuestion` remains available.
- When disabled, `/plan` does not enter plan mode and instead prints `Plan mode is disabled in user settings.` Shift+Tab skips plan mode entirely and cycles `default → acceptEdits → bypassPermissions → default`.
- In listener/WebSocket mode, `DeviceStatus` now includes `plan_mode_enabled`; remote requests to switch to `plan` are rejected while disabled and the device status remains on the current non-plan mode.

## Test plan
- `bun test src/tests/tools/plan-mode-setting.test.ts src/tests/settings-manager.test.ts --test-name-pattern "Plan mode|plan mode setting"`
- `bun test src/tests/cli/permission-mode-cycle-order.test.ts src/tests/cli/permission-mode-retry-wiring.test.ts --test-name-pattern "plan|Shift"`
- `bun test src/tests/websocket/listen-client-protocol.test.ts --test-name-pattern "mode changes|DeviceStatus|permission mode"`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)