### PR TITLE
fix(tui): render retry events as status lines

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -326,6 +326,60 @@ function ensure<T extends Line>(b: Buffers, id: string, make: () => T): T {
   return created;
 }
 
+function numericEventDataValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function stringEventDataValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function formatRetryDelay(delayMs: number): string {
+  if (delayMs < 1000) return `${Math.max(0, Math.round(delayMs))}ms`;
+  return `${Math.round(delayMs / 1000)}s`;
+}
+
+function formatRetryEventStatusLines(
+  eventData: Record<string, unknown>,
+): string[] {
+  const attempt = numericEventDataValue(eventData.attempt);
+  const maxAttempts = numericEventDataValue(eventData.max_attempts);
+  const delayMs = numericEventDataValue(eventData.delay_ms);
+  const message = stringEventDataValue(eventData.message);
+
+  const metadata: string[] = [];
+  if (attempt !== undefined) {
+    metadata.push(
+      maxAttempts !== undefined
+        ? `attempt ${attempt}/${maxAttempts}`
+        : `attempt ${attempt}`,
+    );
+  }
+  if (delayMs !== undefined) {
+    metadata.push(`in ${formatRetryDelay(delayMs)}`);
+  }
+
+  return [
+    `Provider stream error, retrying${
+      metadata.length > 0 ? ` (${metadata.join(", ")})` : ""
+    }${message ? `: ${message}` : ""}`,
+  ];
+}
+
+function upsertStatusLine(b: Buffers, id: string, lines: string[]): void {
+  const existing = b.byId.get(id);
+  if (existing?.kind === "status") {
+    existing.lines = lines;
+    return;
+  }
+  b.byId.set(id, { kind: "status", id, lines });
+  if (!existing) b.order.push(id);
+}
+
 // Mark a line as finished if it has a phase (immutable update)
 function markAsFinished(b: Buffers, id: string) {
   const line = b.byId.get(id);
@@ -1253,22 +1307,35 @@ export function onChunk(
         const eventChunk = chunk as LettaStreamingResponse & {
           id?: string;
           otid?: string;
+          run_id?: string;
+          seq_id?: number;
           event_type?: string;
           event_data?: Record<string, unknown>;
         };
-        const id = eventChunk.otid || eventChunk.id;
+        const eventType = eventChunk.event_type || "unknown";
+        const eventData = eventChunk.event_data || {};
+        const id =
+          eventChunk.otid ||
+          eventChunk.id ||
+          (eventType === "retry" && eventChunk.run_id && eventChunk.seq_id
+            ? `${eventChunk.run_id}-retry-${eventChunk.seq_id}`
+            : undefined);
         if (!id) break;
 
         // Handle otid transition (mark previous line as finished)
         handleOtidTransition(b, id);
 
-        const eventType = eventChunk.event_type || "unknown";
+        if (eventType === "retry") {
+          upsertStatusLine(b, id, formatRetryEventStatusLines(eventData));
+          break;
+        }
+
         ensure(b, id, () => ({
           kind: "event",
           id,
           eventType,
-          eventData: eventChunk.event_data || {},
-          phase: "running",
+          eventData,
+          phase: eventType === "compaction" ? "running" : "finished",
         }));
 
         // Fire PreCompact hooks when server-side auto-compaction starts

--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -90,6 +90,11 @@ describe("accumulator usage statistics", () => {
     );
 
     expect(tracker.pendingReflectionTrigger).toBe(false);
+    expect(buffers.byId.get("evt-compaction-1")).toMatchObject({
+      kind: "event",
+      eventType: "compaction",
+      phase: "running",
+    });
 
     onChunk(
       buffers,
@@ -103,6 +108,70 @@ describe("accumulator usage statistics", () => {
 
     expect(tracker.pendingCompaction).toBe(true);
     expect(tracker.pendingReflectionTrigger).toBe(true);
+    expect(buffers.byId.get("evt-compaction-1")).toMatchObject({
+      kind: "event",
+      eventType: "compaction",
+      phase: "finished",
+    });
+  });
+
+  test("renders retry event messages as status lines", () => {
+    const buffers = createBuffers("agent-1");
+
+    onChunk(buffers, {
+      message_type: "event_message",
+      id: "retry-event-1",
+      event_type: "retry",
+      event_data: {
+        attempt: 1,
+        max_attempts: 3,
+        delay_ms: 2000,
+        message: "Cannot connect to API",
+      },
+    } as unknown as LettaStreamingResponse);
+
+    expect(buffers.byId.get("retry-event-1")).toEqual({
+      kind: "status",
+      id: "retry-event-1",
+      lines: [
+        "Provider stream error, retrying (attempt 1/3, in 2s): Cannot connect to API",
+      ],
+    });
+  });
+
+  test("uses run sequence fallback ids for retry status events", () => {
+    const buffers = createBuffers("agent-1");
+
+    onChunk(buffers, {
+      message_type: "event_message",
+      run_id: "local-run-1",
+      seq_id: 7,
+      event_type: "retry",
+      event_data: { attempt: 2, delay_ms: 250 },
+    } as unknown as LettaStreamingResponse);
+
+    expect(buffers.byId.get("local-run-1-retry-7")).toEqual({
+      kind: "status",
+      id: "local-run-1-retry-7",
+      lines: ["Provider stream error, retrying (attempt 2, in 250ms)"],
+    });
+  });
+
+  test("marks non-compaction event messages as finished immediately", () => {
+    const buffers = createBuffers("agent-1");
+
+    onChunk(buffers, {
+      message_type: "event_message",
+      id: "event-custom-1",
+      event_type: "custom_notification",
+      event_data: {},
+    } as unknown as LettaStreamingResponse);
+
+    expect(buffers.byId.get("event-custom-1")).toMatchObject({
+      kind: "event",
+      eventType: "custom_notification",
+      phase: "finished",
+    });
   });
 
   test("sets reflection trigger for legacy compaction summary user_message", () => {


### PR DESCRIPTION
## Summary
- Convert retry `event_message` chunks into status lines so they do not remain as running events in the active TUI area.
- Keep compaction as the only long-running event lifecycle; mark other event messages finished immediately.
- Add accumulator regressions for retry status rendering, fallback retry IDs, and compaction running/finished behavior.

## Test plan
- [x] bun test src/tests/cli/accumulator-usage.test.ts
- [x] bun run check
- [x] bun test src/tests/cli/accumulator-usage.test.ts src/tests/backend/ai-sdk-stream-adapter.test.ts src/tests/backend/local-backend.test.ts

👾 Generated with [Letta Code](https://letta.com)