### PR TITLE
fix(tui): guard tool-call terminal states

### DIFF
--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -96,6 +96,32 @@ function cloneStreamingChunk(
   return JSON.parse(JSON.stringify(chunk)) as LettaStreamingResponse;
 }
 
+function localStreamProtocolError(message: string): RunErrorMetadata {
+  return {
+    message,
+    detail: message,
+    error_type: "local_backend_error",
+    retryable: false,
+  };
+}
+
+function localErrorChunk(info: RunErrorMetadata): LettaStreamingResponse {
+  return {
+    message_type: "error_message",
+    message: info.message,
+    detail: info.detail,
+    error_type: info.error_type,
+    retryable: info.retryable,
+  } as unknown as LettaStreamingResponse;
+}
+
+function localStopReasonChunk(stopReason: string): LettaStreamingResponse {
+  return {
+    message_type: "stop_reason",
+    stop_reason: stopReason,
+  } as LettaStreamingResponse;
+}
+
 function createReplayStream(
   chunks: LettaStreamingResponse[],
 ): Stream<LettaStreamingResponse> {
@@ -507,10 +533,14 @@ export class HeadlessBackend implements Backend {
       controller: stream.controller,
       async *[Symbol.asyncIterator]() {
         let sawStopReason = false;
+        let sawApprovalRequest = false;
         let pendingErrorInfo: RunErrorMetadata | undefined;
         try {
           for await (const rawChunk of stream) {
             const chunk = attachRunId(rawChunk, runId);
+            if (chunk.message_type === "approval_request_message") {
+              sawApprovalRequest = true;
+            }
             const errorInfo = runErrorInfo(chunk);
             if (errorInfo) {
               pendingErrorInfo = errorInfo;
@@ -536,8 +566,38 @@ export class HeadlessBackend implements Backend {
           if (!sawStopReason) {
             if (pendingErrorInfo) {
               backend.completeRun(runId, "error", pendingErrorInfo);
+              yield backend.recordRunChunk(
+                runId,
+                attachRunId(localStopReasonChunk("error"), runId),
+              );
+            } else if (sawApprovalRequest) {
+              backend.completeRun(runId, "requires_approval");
+              yield backend.recordRunChunk(
+                runId,
+                attachRunId(localStopReasonChunk("requires_approval"), runId),
+              );
             } else {
-              backend.completeRun(runId, "end_turn");
+              const info = localStreamProtocolError(
+                "Local provider stream ended without a stop reason.",
+              );
+              backend.completeRun(runId, "error", info);
+              for (const terminalChunk of [
+                localErrorChunk(info),
+                localStopReasonChunk("error"),
+              ]) {
+                const chunk = attachRunId(terminalChunk, runId);
+                const persisted = store.appendStreamChunk(
+                  conversationId,
+                  agentId,
+                  chunk,
+                );
+                if (!isLocalStateChunkOnly(persisted)) {
+                  yield backend.recordRunChunk(
+                    runId,
+                    attachRunId(persisted, runId),
+                  );
+                }
+              }
             }
           }
         } catch (error) {

--- a/src/backend/dev/ProviderTurnExecutor.ts
+++ b/src/backend/dev/ProviderTurnExecutor.ts
@@ -271,6 +271,11 @@ function createProviderLettaStream(
         }
         if (pendingStopReason) {
           yield pendingStopReason;
+        } else if (sawToolCall) {
+          yield {
+            message_type: "stop_reason",
+            stop_reason: "requires_approval",
+          } as LettaStreamingResponse;
         }
       } catch (error) {
         yield* createProviderErrorChunks(error);

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -617,6 +617,21 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           // next onSubmit, causing "Invalid tool call IDs" errors.
           queueApprovalResults(null);
         }
+      } catch (error) {
+        markIncompleteToolsAsCancelled(
+          buffersRef.current,
+          true,
+          "stream_error",
+        );
+        const errorDetails = formatErrorDetails(error, agentId);
+        appendError(errorDetails, {
+          ...extractErrorMeta(error),
+          context: "approval_send",
+        });
+        setStreaming(false);
+        closeTrajectorySegment();
+        syncTrajectoryElapsedBase();
+        refreshDerived();
       } finally {
         // Always release the execution guard, even if an error occurred
         clearApprovalToolContext();
@@ -628,6 +643,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       }
     },
     [
+      agentId,
       approvalResults,
       autoHandledResults,
       autoDeniedApprovals,
@@ -700,6 +716,11 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           setIsExecutingTool(false);
         }
       } catch (e) {
+        markIncompleteToolsAsCancelled(
+          buffersRef.current,
+          true,
+          "stream_error",
+        );
         const errorDetails = formatErrorDetails(e, agentId);
         appendError(errorDetails, {
           ...extractErrorMeta(e),
@@ -707,6 +728,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
         });
         setStreaming(false);
         setIsExecutingTool(false);
+        refreshDerived();
       }
     },
     [
@@ -716,6 +738,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       sendAllResults,
       appendError,
       isExecutingTool,
+      refreshDerived,
       setStreaming,
       setApprovalResults,
       setIsExecutingTool,
@@ -913,6 +936,21 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
                 otid: randomUUID(),
               },
             ]);
+          } catch (error) {
+            markIncompleteToolsAsCancelled(
+              buffersRef.current,
+              true,
+              "stream_error",
+            );
+            const errorDetails = formatErrorDetails(error, agentId);
+            appendError(errorDetails, {
+              ...extractErrorMeta(error),
+              context: "approval_send",
+            });
+            setStreaming(false);
+            closeTrajectorySegment();
+            syncTrajectoryElapsedBase();
+            refreshDerived();
           } finally {
             setIsExecutingTool(false);
           }
@@ -934,10 +972,13 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       handleApproveCurrent,
       processConversation,
       refreshDerived,
+      appendError,
       isExecutingTool,
       setStreaming,
       setUiPermissionMode,
       openTrajectorySegment,
+      closeTrajectorySegment,
+      syncTrajectoryElapsedBase,
       prepareScopedToolExecutionContext,
       updateStreamingOutput,
       setApprovalContexts,
@@ -950,6 +991,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
     ],
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: buffersRef is stable; .current is read dynamically.
   const handleDenyCurrent = useCallback(
     async (reason: string) => {
       if (isExecutingTool) return;
@@ -981,6 +1023,11 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           setIsExecutingTool(false);
         }
       } catch (e) {
+        markIncompleteToolsAsCancelled(
+          buffersRef.current,
+          true,
+          "stream_error",
+        );
         const errorDetails = formatErrorDetails(e, agentId);
         appendError(errorDetails, {
           ...extractErrorMeta(e),
@@ -988,6 +1035,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
         });
         setStreaming(false);
         setIsExecutingTool(false);
+        refreshDerived();
       }
     },
     [
@@ -997,6 +1045,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       sendAllResults,
       appendError,
       isExecutingTool,
+      refreshDerived,
       setStreaming,
       setApprovalResults,
       setIsExecutingTool,

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -1291,6 +1291,30 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             stopReasonToHandle = "cancelled";
           }
 
+          const approvalsFromStream =
+            approvals && approvals.length > 0
+              ? approvals
+              : approval
+                ? [approval]
+                : [];
+          if (
+            stopReasonToHandle === "end_turn" &&
+            approvalsFromStream.length > 0
+          ) {
+            telemetry.trackError(
+              "stream_end_turn_with_pending_approvals_tui_guard",
+              "Stream returned end_turn after emitting approval_request_message chunks; continuing approval flow",
+              "message_stream",
+              { runId: lastRunId ?? undefined },
+            );
+            debugWarn(
+              "stream",
+              "Coercing end_turn to requires_approval because %d approval chunk(s) were collected",
+              approvalsFromStream.length,
+            );
+            stopReasonToHandle = "requires_approval";
+          }
+
           // Case 1: Turn ended normally
           if (stopReasonToHandle === "end_turn") {
             clearApprovalToolContext();
@@ -1567,12 +1591,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             pendingInterruptRecoveryConversationIdRef.current = null;
 
             // Use new approvals array, fallback to legacy approval for backward compat
-            const approvalsToProcess =
-              approvals && approvals.length > 0
-                ? approvals
-                : approval
-                  ? [approval]
-                  : [];
+            const approvalsToProcess = approvalsFromStream;
 
             if (approvalsToProcess.length === 0) {
               clearApprovalToolContext();

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -585,6 +585,22 @@ export async function drainStream(
   const approval: ApprovalRequest | null = approvals[0] || null;
   streamProcessor.pendingApprovals.clear();
 
+  if (stopReason === "end_turn" && approvals.length > 0) {
+    debugWarn(
+      "drainStream",
+      "Coercing end_turn to requires_approval because approval_request_message chunks were received",
+    );
+    telemetry.trackError(
+      "stream_end_turn_with_pending_approvals",
+      "Stream ended with end_turn after emitting approval_request_message chunks",
+      "stream_drain",
+      {
+        runId: streamProcessor.lastRunId || undefined,
+      },
+    );
+    stopReason = "requires_approval";
+  }
+
   if (
     stopReason === "requires_approval" &&
     approvals.length === 0 &&
@@ -898,6 +914,25 @@ export async function drainStreamWithResume(
           });
           result.approval = result.approvals[0] ?? null;
         }
+      } else if (
+        result.stopReason === "end_turn" &&
+        (originalApprovals?.length ?? 0) > 0
+      ) {
+        debugWarn(
+          "stream",
+          "[MID-STREAM RESUME] Coercing resumed end_turn to requires_approval because the original stream had approval chunks",
+        );
+        telemetry.trackError(
+          "stream_resume_end_turn_with_original_approvals",
+          "Resumed stream ended with end_turn after original stream emitted approval_request_message chunks",
+          "stream_resume",
+          {
+            runId: result.lastRunId ?? undefined,
+          },
+        );
+        result.stopReason = "requires_approval";
+        result.approvals = originalApprovals;
+        result.approval = originalApproval;
       }
     } catch (resumeError) {
       // Resume failed - cancel tools and finalize the streaming line now

--- a/src/tests/backend/provider-turn-executor.test.ts
+++ b/src/tests/backend/provider-turn-executor.test.ts
@@ -178,6 +178,136 @@ describe("ProviderTurnExecutor", () => {
     ).toEqual(["user_message", "approval_request_message"]);
   });
 
+  test("keeps approval flow alive when provider stream ends after a tool call without finish", async () => {
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        yield streamPart({
+          type: "tool-call",
+          toolCallId: "provider-tool-no-finish",
+          toolName: "ShellCommand",
+          input: { command: "pwd" },
+        });
+      },
+    };
+    const backend = new FakeHeadlessBackend(
+      "agent-provider",
+      new ProviderTurnExecutor(adapter),
+    );
+    const conversation = await backend.createConversation({
+      agent_id: "agent-provider",
+    });
+
+    const chunks = await collectStream(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("call a tool without finish"),
+      ),
+    );
+
+    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
+      "approval_request_message",
+      "stop_reason",
+    ]);
+    expect(chunks.at(-1)).toMatchObject({
+      message_type: "stop_reason",
+      stop_reason: "requires_approval",
+    });
+    const runId = (chunks[0] as { run_id?: string } | undefined)?.run_id;
+    await expect(backend.retrieveRun(runId ?? "")).resolves.toMatchObject({
+      status: "completed",
+      stop_reason: "requires_approval",
+    });
+  });
+
+  test("synthesizes requires_approval when executor emits approval without terminal stop", async () => {
+    const backend = new FakeHeadlessBackend("agent-provider", {
+      async execute() {
+        return {
+          controller: new AbortController(),
+          async *[Symbol.asyncIterator]() {
+            yield {
+              message_type: "approval_request_message",
+              tool_call: {
+                tool_call_id: "raw-tool-no-stop",
+                name: "ShellCommand",
+                arguments: '{"command":"pwd"}',
+              },
+            } as LettaStreamingResponse;
+          },
+        } as never;
+      },
+    });
+    const conversation = await backend.createConversation({
+      agent_id: "agent-provider",
+    });
+
+    const chunks = await collectStream(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("raw approval without stop"),
+      ),
+    );
+
+    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
+      "approval_request_message",
+      "stop_reason",
+    ]);
+    expect(chunks.at(-1)).toMatchObject({
+      message_type: "stop_reason",
+      stop_reason: "requires_approval",
+    });
+    const runId = (chunks[0] as { run_id?: string } | undefined)?.run_id;
+    await expect(backend.retrieveRun(runId ?? "")).resolves.toMatchObject({
+      status: "completed",
+      stop_reason: "requires_approval",
+    });
+  });
+
+  test("surfaces a protocol error when executor stream ends without any stop reason", async () => {
+    const backend = new FakeHeadlessBackend("agent-provider", {
+      async execute() {
+        return {
+          controller: new AbortController(),
+          async *[Symbol.asyncIterator]() {
+            yield {
+              message_type: "assistant_message",
+              content: [{ type: "text", text: "partial" }],
+            } as LettaStreamingResponse;
+          },
+        } as never;
+      },
+    });
+    const conversation = await backend.createConversation({
+      agent_id: "agent-provider",
+    });
+
+    const chunks = await collectStream(
+      await backend.createConversationMessageStream(
+        conversation.id,
+        createBody("raw stream without stop"),
+      ),
+    );
+
+    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
+      "assistant_message",
+      "error_message",
+      "stop_reason",
+    ]);
+    expect(chunks[1]).toMatchObject({
+      message_type: "error_message",
+      message: "Local provider stream ended without a stop reason.",
+    });
+    expect(chunks.at(-1)).toMatchObject({
+      message_type: "stop_reason",
+      stop_reason: "error",
+    });
+    const runId = (chunks[0] as { run_id?: string } | undefined)?.run_id;
+    await expect(backend.retrieveRun(runId ?? "")).resolves.toMatchObject({
+      status: "failed",
+      stop_reason: "error",
+    });
+  });
+
   test("marks retryable provider failures after model output as llm_api_error runs", async () => {
     const providerError = new APICallError({
       message: "upstream connect error",

--- a/src/tests/cli/stream-stop-reason-wiring.test.ts
+++ b/src/tests/cli/stream-stop-reason-wiring.test.ts
@@ -73,6 +73,42 @@ describe("drainStream stop reason wiring", () => {
     expect(result.sawStopReasonChunk).toBe(true);
   });
 
+  test("coerces end_turn with pending approvals into requires_approval", async () => {
+    const fakeStream = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "approval_request_message",
+          tool_call: {
+            tool_call_id: "tc-end-turn",
+            name: "ShellCommand",
+            arguments: '{"command":"pwd"}',
+          },
+        } as LettaStreamingResponse;
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const result = await drainStream(
+      fakeStream,
+      createBuffers("agent-test"),
+      () => {},
+    );
+
+    expect(result.stopReason).toBe("requires_approval");
+    expect(result.sawStopReasonChunk).toBe(true);
+    expect(result.approvals).toEqual([
+      {
+        toolCallId: "tc-end-turn",
+        toolName: "ShellCommand",
+        toolArgs: '{"command":"pwd"}',
+      },
+    ]);
+  });
+
   test("stream error cancels in-progress tool calls by default (skipCancelToolsOnError=false)", async () => {
     const buffers = createBuffers("agent-test");
     await drainStream(makeStreamWithToolCall("tc-1"), buffers, () => {});


### PR DESCRIPTION
## Summary
- Keep local provider tool-call turns in approval flow when the provider stream ends after a tool call without a finish/stop chunk.
- Prevent approval chunks from being silently paired with `end_turn` by coercing that impossible state back to `requires_approval` in stream draining/TUI handling.
- Surface protocol errors for streams that end without any stop reason, and cancel unfinished tool UI when approval execution/continuation fails.

## Test plan
- [x] bun run check
- [x] bun test src/tests/backend/provider-turn-executor.test.ts src/tests/cli/stream-stop-reason-wiring.test.ts
- [x] bun test src/tests/backend/provider-turn-executor.test.ts src/tests/cli/stream-stop-reason-wiring.test.ts src/tests/backend/local-backend.test.ts src/tests/backend/ai-sdk-stream-adapter.test.ts

👾 Generated with [Letta Code](https://letta.com)