### PR TITLE
fix(subagents): restrict memory subagent file tools

### DIFF
--- a/src/agent/subagents/builtin/memory.md
+++ b/src/agent/subagents/builtin/memory.md
@@ -1,7 +1,7 @@
 ---
 name: memory
 description: Decompose and reorganize memory files into focused, single-purpose files using `/` naming
-tools: Read, Edit, Write, Glob, Grep, Bash, TaskOutput
+tools: Bash, TaskOutput
 model: auto
 memoryBlocks: none
 permissionMode: memory
@@ -105,10 +105,10 @@ ls $WORK/
 
 Then read relevant memory files:
 
-```
-Read({ file_path: "$WORK/project.md" })
-Read({ file_path: "$WORK/persona.md" })
-Read({ file_path: "$WORK/human.md" })
+```bash
+sed -n '1,240p' "$WORK/project.md"
+sed -n '1,240p' "$WORK/persona.md"
+sed -n '1,240p' "$WORK/human.md"
 ```
 
 ### Step 2: Identify system-managed files (skip)

--- a/src/agent/subagents/builtin/memory_local_memfs.md
+++ b/src/agent/subagents/builtin/memory_local_memfs.md
@@ -1,7 +1,7 @@
 ---
 name: memory
 description: Decompose and reorganize memory files into focused, single-purpose files using `/` naming
-tools: Read, Edit, Write, Glob, Grep, Bash, TaskOutput
+tools: Bash, TaskOutput
 model: auto
 memoryBlocks: none
 permissionMode: memory
@@ -103,10 +103,10 @@ ls $WORK/
 
 Then read relevant memory files:
 
-```
-Read({ file_path: "$WORK/project.md" })
-Read({ file_path: "$WORK/persona.md" })
-Read({ file_path: "$WORK/human.md" })
+```bash
+sed -n '1,240p' "$WORK/project.md"
+sed -n '1,240p' "$WORK/persona.md"
+sed -n '1,240p' "$WORK/human.md"
 ```
 
 ### Step 2: Identify system-managed files (skip)

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -1,7 +1,7 @@
 ---
 name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
-tools: Read, Edit, Write, Bash
+tools: Bash
 model: inherit
 memoryBlocks: none
 mode: stateless

--- a/src/agent/subagents/builtin/reflection_local_memfs.md
+++ b/src/agent/subagents/builtin/reflection_local_memfs.md
@@ -1,7 +1,7 @@
 ---
 name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
-tools: Read, Edit, Write, Bash
+tools: Bash
 model: inherit
 memoryBlocks: none
 mode: stateless

--- a/src/tests/agent/subagent-builtins.test.ts
+++ b/src/tests/agent/subagent-builtins.test.ts
@@ -55,6 +55,16 @@ describe("built-in subagents", () => {
     expect(configs.init?.permissionMode).toBe("memory");
   });
 
+  test("reflection and memory built-ins do not expose first-class file tools", async () => {
+    const configs = await getAllSubagentConfigs();
+    const removedFileTools = ["Read", "Edit", "Write", "Glob", "Grep"];
+
+    for (const tool of removedFileTools) {
+      expect(configs.reflection?.allowedTools).not.toContain(tool);
+      expect(configs.memory?.allowedTools).not.toContain(tool);
+    }
+  });
+
   test("parses subagent mode and defaults missing mode to stateful", async () => {
     const configs = await getAllSubagentConfigs();
 


### PR DESCRIPTION
## Summary

- Removes first-class `Read`, `Edit`, `Write`, `Glob`, and `Grep` tools from built-in `reflection` and `memory` subagents, including local MemFS variants.
- Updates memory subagent prompt examples to read files through shell commands instead of unavailable `Read(...)` calls.
- Adds a regression test ensuring the built-in reflection and memory configs do not expose those file tools.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src/tests/agent/subagent-builtins.test.ts`

👾 Generated with [Letta Code](https://letta.com)