### PR TITLE
fix(local): align compaction formatting with API

### DIFF
--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -692,7 +692,7 @@ export class LocalBackend extends HeadlessBackend {
       conversationId,
       agentId,
       summary,
-      packedSummary: packageLocalSummaryMessage(summary, stats),
+      packedSummary: packageLocalSummaryMessage(summary, stats, settings.mode),
       stats,
       remainingMessages: plan.messagesToKeep,
     });
@@ -746,7 +746,7 @@ export class LocalBackend extends HeadlessBackend {
       conversationId,
       agentId,
       summary,
-      packedSummary: packageLocalSummaryMessage(summary, stats),
+      packedSummary: packageLocalSummaryMessage(summary, stats, settings.mode),
       stats,
       remainingMessages: plan.messagesToKeep,
     });

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -8,7 +8,7 @@ import type { LocalAgentRecord } from "./LocalStore";
 const ALL_WORD_LIMIT = 500;
 const SLIDING_WORD_LIMIT = 300;
 const SUMMARY_TRUNCATION_SUFFIX = "... [summary truncated to fit]";
-const TOOL_TRANSCRIPT_TRUNCATION_CHARS = 4000;
+const TOOL_RETURN_TRUNCATION_CHARS = 5000;
 const TRANSCRIPT_FALLBACK_MAX_CHARS = 120000;
 const TRANSCRIPT_FALLBACK_MAX_CHAR_STEPS = [
   TRANSCRIPT_FALLBACK_MAX_CHARS,
@@ -144,74 +144,227 @@ function stringifyUnknown(value: unknown): string {
   }
 }
 
-function truncate(value: string, maxChars: number): string {
-  if (value.length <= maxChars) return value;
-  return `${value.slice(0, maxChars)}… [truncated ${value.length - maxChars} chars]`;
+function truncateToolReturn(content: string, limit?: number): string {
+  if (limit === undefined || content.length <= limit) return content;
+  return `${content.slice(0, limit)}... [truncated ${content.length - limit} chars]`;
 }
 
-function toolPartSummary(
-  part: Record<string, unknown>,
-  truncationChars?: number,
-) {
-  const toolName = String(part.type).slice("tool-".length);
-  const input = truncate(
-    stringifyUnknown(part.input),
-    truncationChars ?? Number.POSITIVE_INFINITY,
-  );
-  const state = typeof part.state === "string" ? part.state : "unknown";
-  const output =
-    part.output !== undefined || part.errorText !== undefined
-      ? `\noutput: ${truncate(
-          stringifyUnknown(part.output ?? part.errorText),
-          truncationChars ?? Number.POSITIVE_INFINITY,
-        )}`
-      : "";
-  return `[tool ${toolName} state=${state}]\ninput: ${input}${output}`;
+function middleTruncateText(
+  text: string,
+  budgetChars: number,
+  headFrac = 0.3,
+  tailFrac = 0.3,
+): string {
+  if (budgetChars <= 0 || text.length <= budgetChars) return text;
+  const headLength = Math.max(0, Math.floor(budgetChars * headFrac));
+  let tailLength = Math.max(0, Math.floor(budgetChars * tailFrac));
+  if (headLength + tailLength > budgetChars) {
+    tailLength = Math.max(0, budgetChars - headLength);
+  }
+
+  const head = text.slice(0, headLength);
+  const tail = tailLength > 0 ? text.slice(-tailLength) : "";
+  const dropped = Math.max(0, text.length - (head.length + tail.length));
+  const marker = `\n[TRUNCATED: dropped ${dropped} middle chars due to context budget]\n`;
+  return `${head}${marker}${tail}`;
 }
 
-function partText(
-  part: LocalMessage["parts"][number],
-  truncationChars?: number,
-) {
-  if (!isRecord(part)) return stringifyUnknown(part);
-  if (
-    (part.type === "text" || part.type === "reasoning") &&
-    typeof part.text === "string"
-  ) {
-    return part.type === "reasoning" ? `[reasoning]\n${part.text}` : part.text;
+type SummaryOpenAIMessage = {
+  role: "assistant" | "developer" | "system" | "tool" | "user";
+  content?: string | null | Array<{ text?: string } | string>;
+  tool_calls?: Array<{
+    function?: {
+      name?: string;
+      arguments?: string;
+    };
+  }>;
+};
+
+function textFromContentParts(
+  parts: LocalMessage["parts"],
+): string | undefined {
+  const textParts: string[] = [];
+  let imageCount = 0;
+  for (const part of parts) {
+    if (!isRecord(part)) continue;
+    if (
+      (part.type === "text" || part.type === "reasoning") &&
+      typeof part.text === "string"
+    ) {
+      textParts.push(part.text);
+      continue;
+    }
+    if (part.type === "file" && typeof part.mediaType === "string") {
+      if (part.mediaType.startsWith("image/")) imageCount += 1;
+      continue;
+    }
+    if (part.type === "source-url" || part.type === "source-document") {
+      textParts.push(stringifyUnknown(part));
+    }
   }
-  if (typeof part.type === "string" && part.type.startsWith("tool-")) {
-    return toolPartSummary(part, truncationChars);
+
+  let textContent = textParts.join("\n\n");
+  if (imageCount > 0) {
+    const placeholder =
+      imageCount === 1 ? "[Image omitted]" : `[${imageCount} images omitted]`;
+    textContent = `${textContent}${textContent ? " " : ""}${placeholder}`;
   }
-  return truncate(
-    stringifyUnknown(part),
-    truncationChars ?? Number.POSITIVE_INFINITY,
+  return textContent || undefined;
+}
+
+function toolNameFromPart(part: Record<string, unknown>): string {
+  return typeof part.type === "string" && part.type.startsWith("tool-")
+    ? part.type.slice("tool-".length)
+    : "?";
+}
+
+function localToolCallArguments(input: unknown): string {
+  return typeof input === "string" ? input : stringifyUnknown(input ?? {});
+}
+
+function toolReturnToText(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return stringifyUnknown(value);
+
+  const textParts: string[] = [];
+  let imageCount = 0;
+  for (const item of value) {
+    if (
+      isRecord(item) &&
+      item.type === "text" &&
+      typeof item.text === "string"
+    ) {
+      textParts.push(item.text);
+      continue;
+    }
+    if (isRecord(item) && item.type === "image") {
+      imageCount += 1;
+    }
+  }
+  let result = textParts.join("\n");
+  if (imageCount > 0) {
+    const placeholder =
+      imageCount === 1 ? "[Image omitted]" : `[${imageCount} images omitted]`;
+    result = `${result}${result ? " " : ""}${placeholder}`;
+  }
+  return result || undefined;
+}
+
+function isLocalToolOutputState(state: unknown): boolean {
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "output-denied"
   );
+}
+
+function localMessagesToSummaryOpenAIDicts(
+  messages: LocalMessage[],
+  options: { toolReturnTruncationChars?: number } = {},
+): SummaryOpenAIMessage[] {
+  const result: SummaryOpenAIMessage[] = [];
+  for (const message of messages) {
+    if (message.role === "system") continue;
+
+    const toolParts: Record<string, unknown>[] = [];
+    for (const part of message.parts) {
+      if (
+        isRecord(part) &&
+        typeof part.type === "string" &&
+        part.type.startsWith("tool-")
+      ) {
+        toolParts.push(part);
+      }
+    }
+
+    if (message.role === "assistant") {
+      const content = textFromContentParts(message.parts) ?? null;
+      if (content !== null || toolParts.length > 0) {
+        result.push({
+          role: "assistant",
+          content,
+          ...(toolParts.length > 0
+            ? {
+                tool_calls: toolParts.map((part) => ({
+                  function: {
+                    name: toolNameFromPart(part),
+                    arguments: localToolCallArguments(part.input),
+                  },
+                })),
+              }
+            : {}),
+        });
+      }
+
+      for (const part of toolParts) {
+        if (!isLocalToolOutputState(part.state)) continue;
+        const returnText = toolReturnToText(part.output ?? part.errorText);
+        result.push({
+          role: "tool",
+          content: returnText
+            ? truncateToolReturn(returnText, options.toolReturnTruncationChars)
+            : null,
+        });
+      }
+      continue;
+    }
+
+    const content = textFromContentParts(message.parts);
+    if (content !== undefined) {
+      result.push({
+        role: message.role === "user" ? "user" : "developer",
+        content,
+      });
+    }
+  }
+  return result;
+}
+
+function simpleFormatter(messages: SummaryOpenAIMessage[]): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    try {
+      const role = message.role ?? "?";
+      let content: unknown = message.content;
+      if (Array.isArray(content)) {
+        content = content
+          .map((block) =>
+            isRecord(block) && typeof block.text === "string"
+              ? block.text
+              : String(block),
+          )
+          .join(" ");
+      }
+      let text = typeof content === "string" ? content : "";
+      if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+        const callParts = message.tool_calls.map((toolCall) => {
+          const fn = toolCall.function ?? {};
+          return `${fn.name ?? "?"}(${fn.arguments ?? ""})`;
+        });
+        text = `${text}${text ? " " : ""}-> ${callParts.join(", ")}`;
+      }
+      if (text) lines.push(`[${role}] ${text}`);
+    } catch {
+      lines.push(JSON.stringify(message));
+    }
+  }
+
+  return ` \n${lines.join("\n")}\n \n. Generate the summary.`;
 }
 
 export function formatLocalMessagesForSummary(
   messages: LocalMessage[],
   options: { truncationChars?: number; maxChars?: number } = {},
 ): string {
-  const transcript = messages
-    .map((message, index) => {
-      const compactionSummary = message.metadata?.compaction?.summary;
-      const body =
-        typeof compactionSummary === "string"
-          ? compactionSummary
-          : message.parts
-              .map((part) => partText(part, options.truncationChars))
-              .filter((text) => text.length > 0)
-              .join("\n");
-      return `<message index="${index + 1}" role="${message.role}">\n${body}\n</message>`;
-    })
-    .join("\n\n");
-  if (options.maxChars && transcript.length > options.maxChars) {
-    return `${transcript.slice(
-      transcript.length - options.maxChars,
-    )}\n\n[Earlier transcript content was truncated to fit the summarizer context window.]`;
-  }
-  return transcript;
+  const transcript = simpleFormatter(
+    localMessagesToSummaryOpenAIDicts(messages, {
+      toolReturnTruncationChars: options.truncationChars,
+    }),
+  );
+  return options.maxChars
+    ? middleTruncateText(transcript, options.maxChars)
+    : transcript;
 }
 
 async function runGenerateText(
@@ -295,7 +448,7 @@ async function summarizeLocalMessagesWithPrompt(
     let previousTranscript: string | undefined;
     for (const maxChars of TRANSCRIPT_FALLBACK_MAX_CHAR_STEPS) {
       const fallbackTranscript = formatLocalMessagesForSummary(input.messages, {
-        truncationChars: TOOL_TRANSCRIPT_TRUNCATION_CHARS,
+        truncationChars: TOOL_RETURN_TRUNCATION_CHARS,
         maxChars,
       });
       if (fallbackTranscript === previousTranscript) continue;
@@ -477,8 +630,23 @@ export function estimateLocalMessageTokens(messages: LocalMessage[]): number {
 export function packageLocalSummaryMessage(
   summary: string,
   stats?: LocalCompactionStats,
+  mode?: LocalCompactionMode,
 ): string {
-  const message = `Note: prior messages with the user are available in external context. Messages are a record of the conversation history, or "events," containing user or system/automated inputs, reasoning traces, agent outputs, tool calls, and tool responses. As a Letta agent, your conversation history is automatically managed by the system — old messages will be periodically evicted from the conversation history and replaced with a recursive summary ("compaction"), yet all messages are persisted and remain retrievable through active tool calling.\nThe following is an in-context recursive summary of the prior messages: ${summary}`;
+  let message: string;
+  if (mode?.includes("sliding_window")) {
+    if (
+      stats?.messages_count_before !== undefined &&
+      stats.messages_count_after !== undefined
+    ) {
+      const numEvicted =
+        stats.messages_count_before - stats.messages_count_after;
+      message = `Note: ${numEvicted} messages from the beginning of the conversation have been hidden from view due to memory constraints.\nThe following is a summary of the previous messages:\n ${summary}`;
+    } else {
+      message = `Note: prior messages from the beginning of the conversation have been hidden from view due to conversation memory constraints.\nThe following is a summary of the previous messages:\n ${summary}`;
+    }
+  } else {
+    message = `Note: prior messages have been hidden from view due to conversation memory constraints.\nThe following is a summary of the previous messages:\n ${summary}`;
+  }
   return JSON.stringify({
     type: "system_alert",
     message,

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -267,6 +267,12 @@ function localMessagesToSummaryOpenAIDicts(
   for (const message of messages) {
     if (message.role === "system") continue;
 
+    const compactionSummary = message.metadata?.compaction?.summary;
+    if (typeof compactionSummary === "string") {
+      result.push({ role: "user", content: compactionSummary });
+      continue;
+    }
+
     const toolParts: Record<string, unknown>[] = [];
     for (const part of message.parts) {
       if (

--- a/src/tests/backend/local-compaction-parity.test.ts
+++ b/src/tests/backend/local-compaction-parity.test.ts
@@ -82,6 +82,34 @@ describe("local compaction API parity", () => {
     );
   });
 
+  test("uses raw compaction summaries for recursive compaction", () => {
+    const packedSummary = JSON.stringify({
+      type: "system_alert",
+      message:
+        "Note: prior messages have been hidden from view due to conversation memory constraints.\nThe following is a summary of the previous messages:\n raw recursive summary",
+      time: "2026-01-01T00:00:00.000Z",
+    });
+
+    const transcript = formatLocalMessagesForSummary([
+      message({
+        id: "summary-1",
+        role: "user",
+        metadata: {
+          compaction: {
+            summary: "raw recursive summary",
+          },
+        },
+        parts: [{ type: "text", text: packedSummary }],
+      } as LocalMessage),
+    ]);
+
+    expect(transcript).toBe(
+      " \n[user] raw recursive summary\n \n. Generate the summary.",
+    );
+    expect(transcript).not.toContain("system_alert");
+    expect(transcript).not.toContain("prior messages have been hidden");
+  });
+
   test("packs all-mode summaries like API package_summarize_message_no_counts", () => {
     const stats: LocalCompactionStats = {
       trigger: "manual",

--- a/src/tests/backend/local-compaction-parity.test.ts
+++ b/src/tests/backend/local-compaction-parity.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatLocalMessagesForSummary,
+  type LocalCompactionStats,
+  packageLocalSummaryMessage,
+} from "../../backend/local/compaction";
+import type { LocalMessage } from "../../backend/local/LocalMessage";
+
+function message(message: LocalMessage): LocalMessage {
+  return message;
+}
+
+describe("local compaction API parity", () => {
+  test("formats local messages with the API simple_formatter transcript contract", () => {
+    const transcript = formatLocalMessagesForSummary([
+      message({
+        id: "sys-1",
+        role: "system",
+        parts: [{ type: "text", text: "system prompt is excluded" }],
+      } as LocalMessage),
+      message({
+        id: "user-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "Please inspect this screenshot." },
+          {
+            type: "file",
+            mediaType: "image/png",
+            url: "data:image/png;base64,aGVsbG8=",
+            filename: "screenshot.png",
+          },
+        ],
+      } as LocalMessage),
+      message({
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "step-start" },
+          { type: "reasoning", text: "I should inspect the directory first." },
+          {
+            type: "tool-ShellCommand",
+            toolCallId: "call-shell",
+            state: "output-available",
+            input: { command: "ls", workdir: "/repo" },
+            output: "README.md\nsrc",
+          },
+          { type: "text", text: "The repo has source and docs." },
+        ],
+      } as LocalMessage),
+    ]);
+
+    expect(transcript).toBe(
+      ' \n[user] Please inspect this screenshot. [Image omitted]\n[assistant] I should inspect the directory first.\n\nThe repo has source and docs. -> ShellCommand({"command":"ls","workdir":"/repo"})\n[tool] README.md\nsrc\n \n. Generate the summary.',
+    );
+    expect(transcript).not.toContain("step-start");
+    expect(transcript).not.toContain("<message");
+    expect(transcript).not.toContain("state=output-available");
+  });
+
+  test("uses API tool-return truncation semantics in fallback transcripts", () => {
+    const transcript = formatLocalMessagesForSummary(
+      [
+        message({
+          id: "assistant-tool",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-ShellCommand",
+              toolCallId: "call-big",
+              state: "output-available",
+              input: { command: "cat huge.log" },
+              output: `${"x".repeat(12)}END`,
+            },
+          ],
+        } as LocalMessage),
+      ],
+      { truncationChars: 10 },
+    );
+
+    expect(transcript).toBe(
+      ' \n[assistant] -> ShellCommand({"command":"cat huge.log"})\n[tool] xxxxxxxxxx... [truncated 5 chars]\n \n. Generate the summary.',
+    );
+  });
+
+  test("packs all-mode summaries like API package_summarize_message_no_counts", () => {
+    const stats: LocalCompactionStats = {
+      trigger: "manual",
+      messages_count_before: 12,
+      messages_count_after: 1,
+    };
+
+    const packed = JSON.parse(
+      packageLocalSummaryMessage("summary body", stats, "all"),
+    ) as Record<string, unknown>;
+
+    expect(packed.type).toBe("system_alert");
+    expect(packed.message).toBe(
+      "Note: prior messages have been hidden from view due to conversation memory constraints.\nThe following is a summary of the previous messages:\n summary body",
+    );
+    expect(packed.compaction_stats).toEqual(stats);
+    expect(typeof packed.time).toBe("string");
+  });
+
+  test("packs sliding-window summaries like API package_summarize_message_no_counts", () => {
+    const stats: LocalCompactionStats = {
+      trigger: "context_window_overflow",
+      messages_count_before: 10,
+      messages_count_after: 4,
+    };
+
+    const packed = JSON.parse(
+      packageLocalSummaryMessage("sliding body", stats, "sliding_window"),
+    ) as Record<string, unknown>;
+
+    expect(packed.type).toBe("system_alert");
+    expect(packed.message).toBe(
+      "Note: 6 messages from the beginning of the conversation have been hidden from view due to memory constraints.\nThe following is a summary of the previous messages:\n sliding body",
+    );
+    expect(packed.compaction_stats).toEqual(stats);
+    expect(typeof packed.time).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace local compaction's XML-ish AI SDK part transcript with an API `simple_formatter`-style transcript.
- Pack local summary messages with API `package_summarize_message_no_counts` wording for `all` vs `sliding_window`.
- Add golden parity tests covering formatter output, tool-return truncation, and summary packing.

## Test plan
- [x] `bun test src/tests/backend/local-compaction-parity.test.ts`
- [x] `bun test src/tests/backend/local-backend.test.ts src/tests/backend/local-compaction-parity.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)