### PR TITLE
fix(local): skip hosted Auto quota fallback

### DIFF
--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -2217,10 +2217,13 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             continue;
           }
 
-          // Quota-limit fallback: set a temporary client-side override to Auto,
-          // append a brief continuation message, and continue the same turn.
+          // Quota-limit fallback: hosted Letta API can recover by switching to
+          // Auto. Local/embedded mode has no hosted Auto router, so surface the
+          // provider quota error and let the user choose/connect a local model.
           const autoSwapOnQuotaLimitEnabled =
             settingsManager.getSetting("autoSwapOnQuotaLimit") !== false;
+          const supportsHostedAutoQuotaFallback =
+            !getBackend().capabilities.localModelCatalog;
           const isQuotaLimit = isQuotaLimitErrorDetail(
             detailFromRun ?? fallbackError,
           );
@@ -2228,6 +2231,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             tempModelOverrideRef.current === TEMP_QUOTA_OVERRIDE_MODEL;
           const canAttemptQuotaAutoSwap =
             autoSwapOnQuotaLimitEnabled &&
+            supportsHostedAutoQuotaFallback &&
             isQuotaLimit &&
             !alreadyOnTempAuto &&
             !quotaAutoSwapAttemptedRef.current;

--- a/src/tests/cli/local-quota-fallback-wiring.test.ts
+++ b/src/tests/cli/local-quota-fallback-wiring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readInteractiveAppSource } from "../helpers/readInteractiveAppSource";
+
+describe("local quota fallback wiring", () => {
+  test("does not auto-swap local/embedded sessions to hosted Auto", () => {
+    const source = readInteractiveAppSource();
+    const start = source.indexOf("const supportsHostedAutoQuotaFallback =");
+    const end = source.indexOf("if (canAttemptQuotaAutoSwap) {", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("!getBackend().capabilities.localModelCatalog");
+    expect(segment).toContain("autoSwapOnQuotaLimitEnabled &&");
+    expect(segment).toContain("supportsHostedAutoQuotaFallback &&");
+    expect(segment).toContain("isQuotaLimit &&");
+    expect(segment).toContain("!quotaAutoSwapAttemptedRef.current");
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent local/embedded quota-limit recovery from switching to hosted `letta/auto`.
- Surface the original provider quota error in local mode so users can switch or connect a local provider.
- Add regression coverage for the local fallback guard.

> "The model is ephemeral. The agent is not."

Written by Cameron ◯ Letta Code