### PR TITLE
fix(channels): clarify interactive question prompts

### DIFF
--- a/src/channels/interactive.ts
+++ b/src/channels/interactive.ts
@@ -153,7 +153,100 @@ function matchQuestionOption(
     return exactLabel.label.trim();
   }
 
+  const trimmedLower = trimmed.toLowerCase();
+  const exactAlias = options.find((option) =>
+    optionAliases(option).some(
+      (alias) => normalizeWhitespace(alias).toLowerCase() === trimmedLower,
+    ),
+  );
+  if (exactAlias?.label?.trim()) {
+    return exactAlias.label.trim();
+  }
+
+  if (/^(recommended|default|defaults)$/i.test(trimmed)) {
+    const recommended = options.find((option) => {
+      const label = option.label?.toLowerCase() ?? "";
+      const description = option.description?.toLowerCase() ?? "";
+      return (
+        label.includes("recommended") || description.includes("recommended")
+      );
+    });
+    if (recommended?.label?.trim()) {
+      return recommended.label.trim();
+    }
+  }
+
   return trimmed;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function optionAliases(option: { label?: string }): string[] {
+  const aliases = new Set<string>();
+  const label = normalizeWhitespace(option.label ?? "");
+  if (label) {
+    aliases.add(label);
+    const withoutParenthetical = normalizeWhitespace(
+      label.replace(/\s*\([^)]*\)\s*/g, " "),
+    );
+    if (withoutParenthetical) {
+      aliases.add(withoutParenthetical);
+    }
+  }
+  return Array.from(aliases).filter((alias) => alias.length >= 3);
+}
+
+function containsPhrase(text: string, phrase: string): boolean {
+  const normalizedText = normalizeWhitespace(text);
+  const normalizedPhrase = normalizeWhitespace(phrase);
+  if (!normalizedText || !normalizedPhrase) {
+    return false;
+  }
+
+  const escapedPhrase = escapeRegExp(normalizedPhrase).replace(/\s+/g, "\\s+");
+  return new RegExp(`(^|\\W)${escapedPhrase}(?=$|\\W)`, "i").test(
+    normalizedText,
+  );
+}
+
+function inferQuestionAnswerFromText(
+  question: NonNullable<AskUserQuestionInput["questions"]>[number],
+  rawText: string,
+): string | null {
+  const options = question.options ?? [];
+  const matches = options
+    .filter((option) =>
+      optionAliases(option).some((alias) => containsPhrase(rawText, alias)),
+    )
+    .map((option) => option.label?.trim())
+    .filter((label): label is string => Boolean(label));
+
+  const uniqueMatches = Array.from(new Set(matches));
+  if (uniqueMatches.length === 1) {
+    return uniqueMatches[0] ?? null;
+  }
+
+  const normalized = normalizeWhitespace(rawText).toLowerCase();
+  if (
+    /\b(recommended|default|defaults|you decide|whatever you recommend)\b/.test(
+      normalized,
+    )
+  ) {
+    const recommended = options.find((option) => {
+      const label = option.label?.toLowerCase() ?? "";
+      const description = option.description?.toLowerCase() ?? "";
+      return (
+        label.includes("recommended") || description.includes("recommended")
+      );
+    });
+    if (recommended?.label?.trim()) {
+      return recommended.label.trim();
+    }
+  }
+
+  return null;
 }
 
 function matchQuestionAnswer(
@@ -219,6 +312,89 @@ function parseNumberedAnswers(
   return Object.keys(answers).length > 0 ? answers : null;
 }
 
+function parsePositionalAnswers(
+  rawText: string,
+  questions: NonNullable<AskUserQuestionInput["questions"]>,
+): Record<string, string> | null {
+  const lines = rawText
+    .split(/\r?\n/)
+    .map((line) => normalizeWhitespace(line))
+    .filter(Boolean);
+  if (lines.length === questions.length) {
+    const answers: Record<string, string> = {};
+    questions.forEach((question, index) => {
+      if (question.question) {
+        answers[question.question] = matchQuestionAnswer(
+          question,
+          lines[index] ?? "",
+        );
+      }
+    });
+    return answers;
+  }
+
+  const normalized = normalizeWhitespace(rawText);
+  const compactParts = normalized
+    .split(/\s*(?:,|\/|;)\s*/)
+    .map((part) => normalizeWhitespace(part))
+    .filter(Boolean);
+  if (
+    compactParts.length === questions.length &&
+    compactParts.every((part) => /^\d+$/.test(part))
+  ) {
+    const answers: Record<string, string> = {};
+    questions.forEach((question, index) => {
+      if (question.question) {
+        answers[question.question] = matchQuestionAnswer(
+          question,
+          compactParts[index] ?? "",
+        );
+      }
+    });
+    return answers;
+  }
+
+  return null;
+}
+
+function parseFlexibleMultiQuestionAnswers(
+  rawText: string,
+  questions: NonNullable<AskUserQuestionInput["questions"]>,
+): Record<string, string> | null {
+  const normalized = normalizeWhitespace(rawText);
+  if (!normalized) {
+    return null;
+  }
+
+  const positionalAnswers = parsePositionalAnswers(rawText, questions);
+  if (positionalAnswers) {
+    return positionalAnswers;
+  }
+
+  const answers: Record<string, string> = {};
+  for (const question of questions) {
+    if (!question.question) {
+      continue;
+    }
+    const inferred = inferQuestionAnswerFromText(question, rawText);
+    if (inferred) {
+      answers[question.question] = inferred;
+    }
+  }
+
+  const hasInferredAnswers = Object.keys(answers).length > 0;
+  for (const question of questions) {
+    if (!question.question || Object.hasOwn(answers, question.question)) {
+      continue;
+    }
+    answers[question.question] = hasInferredAnswers
+      ? `Not specified. Full user reply: ${normalized}`
+      : normalized;
+  }
+
+  return Object.keys(answers).length > 0 ? answers : null;
+}
+
 function buildAllowResponse(
   requestId: string,
   decision: ApprovalResponseDecision,
@@ -257,7 +433,7 @@ function formatAskUserQuestionPrompt(
   );
 
   const lines = [
-    "The agent needs an answer before it can continue.",
+    "SYSTEM MESSAGE — reply required to continue",
     "",
     ...questions.flatMap((question, index) =>
       buildQuestionPrompt(question, index),
@@ -274,11 +450,11 @@ function formatAskUserQuestionPrompt(
     );
   } else {
     lines.push(
-      "Reply with numbered lines, for example:",
+      "Reply in plain language, or answer each question separately with numbered lines:",
       "1: your answer",
       "2: your answer",
       "",
-      "You can also use option numbers or option labels. For multi-select questions, separate multiple answers with commas.",
+      "Option numbers/labels work too. For multi-select questions, separate multiple answers with commas.",
     );
   }
 
@@ -392,24 +568,13 @@ function parseAskUserQuestionResponse(
   }
 
   const numberedAnswers = parseNumberedAnswers(rawText, questions);
-  if (!numberedAnswers) {
+  const answers =
+    numberedAnswers ?? parseFlexibleMultiQuestionAnswers(rawText, questions);
+  if (!answers) {
     return {
       type: "reprompt",
       message:
-        "Please answer with numbered lines so I can map each reply to the right question.\nExample:\n1: your answer\n2: your answer",
-    };
-  }
-
-  const missingQuestions = questions.filter(
-    (question) =>
-      question.question && !Object.hasOwn(numberedAnswers, question.question),
-  );
-  if (missingQuestions.length > 0) {
-    return {
-      type: "reprompt",
-      message: `I still need answers for: ${missingQuestions
-        .map((question) => question.question)
-        .join(", ")}`,
+        "Please send a reply so I can pass it back to the agent. You can answer naturally or use numbered lines like `1: ...` and `2: ...`.",
     };
   }
 
@@ -421,7 +586,7 @@ function parseAskUserQuestionResponse(
         ...event.input,
         answers: {
           ...(input.answers ?? {}),
-          ...numberedAnswers,
+          ...answers,
         },
       },
     }),

--- a/src/tests/channels/interactive.test.ts
+++ b/src/tests/channels/interactive.test.ts
@@ -45,11 +45,73 @@ function createEvent(
   };
 }
 
+function createApproachEnvEvent(): ChannelControlRequestEvent {
+  return createEvent({
+    input: {
+      questions: [
+        {
+          question: "Which approach should we use?",
+          header: "Approach",
+          options: [
+            {
+              label: "Fast path",
+              description: "Ship the smallest safe patch",
+            },
+            {
+              label: "Deep refactor",
+              description: "Restructure the code more thoroughly",
+            },
+          ],
+          multiSelect: false,
+        },
+        {
+          question: "Which environment should we test in?",
+          header: "Env",
+          options: [
+            {
+              label: "Staging",
+              description: "Safer rollout path",
+            },
+            {
+              label: "Production",
+              description: "Use the live environment directly",
+            },
+          ],
+          multiSelect: false,
+        },
+      ],
+    },
+  });
+}
+
+function expectAllowAnswers(
+  parsed: ReturnType<typeof parseChannelControlRequestResponse>,
+  expectedAnswers: Record<string, string>,
+): void {
+  expect(parsed.type).toBe("response");
+  if (parsed.type !== "response") {
+    throw new Error("Expected response");
+  }
+  expect("decision" in parsed.response).toBe(true);
+  if (!("decision" in parsed.response)) {
+    throw new Error("Expected approval response decision");
+  }
+  const { decision } = parsed.response;
+  expect(decision.behavior).toBe("allow");
+  if (decision.behavior !== "allow") {
+    throw new Error("Expected allow decision");
+  }
+  expect(decision.updated_input?.answers).toEqual(expectedAnswers);
+}
+
 describe("channel interactive prompts", () => {
   test("formats AskUserQuestion prompts with options and reply instructions", () => {
     const prompt = formatChannelControlRequestPrompt(createEvent());
 
-    expect(prompt).toContain(
+    expect(
+      prompt.startsWith("SYSTEM MESSAGE — reply required to continue"),
+    ).toBe(true);
+    expect(prompt).not.toContain(
       "The agent needs an answer before it can continue.",
     );
     expect(prompt).toContain("1. Which approach should we use?");
@@ -194,37 +256,61 @@ describe("channel interactive prompts", () => {
     });
   });
 
-  test("requires numbered lines for multi-question replies", () => {
+  test("accepts freeform multi-question replies without requiring numbered lines", () => {
+    const parsed = parseChannelControlRequestResponse(
+      createApproachEnvEvent(),
+      "deep refactor please",
+    );
+
+    expectAllowAnswers(parsed, {
+      "Which approach should we use?": "Deep refactor",
+      "Which environment should we test in?":
+        "Not specified. Full user reply: deep refactor please",
+    });
+  });
+
+  test("passes ambiguous multi-question replies through instead of blocking", () => {
+    const rawReply =
+      "I'll add a token. Fill out everything but the token and I'll add it manually.";
     const parsed = parseChannelControlRequestResponse(
       createEvent({
         input: {
           questions: [
             {
-              question: "Which approach should we use?",
-              header: "Approach",
+              question:
+                "Does the existing $DISCORD_BOT_TOKEN already belong to a Discord application?",
+              header: "Bot token",
               options: [
                 {
-                  label: "Fast path",
-                  description: "Ship the smallest safe patch",
+                  label: "Yes, all set up",
+                  description: "Bot app exists and is already invited",
                 },
                 {
-                  label: "Deep refactor",
-                  description: "Restructure the code more thoroughly",
+                  label: "Bot exists, not invited yet",
+                  description: "Token is real but not yet in any server",
+                },
+                {
+                  label: "Need to create from scratch",
+                  description: "Token may be stale or the bot does not exist",
                 },
               ],
               multiSelect: false,
             },
             {
-              question: "Which environment should we test in?",
-              header: "Env",
+              question: "DM policy for who can message the bot?",
+              header: "DM policy",
               options: [
                 {
-                  label: "Staging",
-                  description: "Safer rollout path",
+                  label: "Pairing (Recommended)",
+                  description: "Require a pairing code",
                 },
                 {
-                  label: "Production",
-                  description: "Use the live environment directly",
+                  label: "Allowlist",
+                  description: "Only your Discord user ID can DM the bot",
+                },
+                {
+                  label: "Open",
+                  description: "Anyone who can DM the bot can talk to it",
                 },
               ],
               multiSelect: false,
@@ -232,13 +318,25 @@ describe("channel interactive prompts", () => {
           ],
         },
       }),
-      "deep refactor please",
+      rawReply,
     );
 
-    expect(parsed).toEqual({
-      type: "reprompt",
-      message:
-        "Please answer with numbered lines so I can map each reply to the right question.\nExample:\n1: your answer\n2: your answer",
+    expectAllowAnswers(parsed, {
+      "Does the existing $DISCORD_BOT_TOKEN already belong to a Discord application?":
+        rawReply,
+      "DM policy for who can message the bot?": rawReply,
+    });
+  });
+
+  test("maps compact multi-question option-number replies by position", () => {
+    const parsed = parseChannelControlRequestResponse(
+      createApproachEnvEvent(),
+      "2, 1",
+    );
+
+    expectAllowAnswers(parsed, {
+      "Which approach should we use?": "Deep refactor",
+      "Which environment should we test in?": "Staging",
     });
   });
 

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -417,7 +417,7 @@ describe("pending channel control requests", () => {
     });
   });
 
-  test("invalid multi-question channel replies reprompt instead of approving", async () => {
+  test("freeform multi-question channel replies approve instead of reprompting", async () => {
     const replies: Array<{
       chatId: string;
       text: string;
@@ -427,9 +427,9 @@ describe("pending channel control requests", () => {
     const adapter = createAdapter(replies);
     registry.registerAdapter(adapter);
 
-    let approvalCalls = 0;
-    registry.setApprovalResponseHandler(async () => {
-      approvalCalls += 1;
+    const approvalResponses: unknown[] = [];
+    registry.setApprovalResponseHandler(async ({ response }) => {
+      approvalResponses.push(response);
       return true;
     });
 
@@ -473,13 +473,45 @@ describe("pending channel control requests", () => {
 
     await adapter.onMessage?.(createInboundMessage("deep refactor please"));
 
-    expect(approvalCalls).toBe(0);
-    expect(replies).toHaveLength(1);
-    expect(replies[0]).toEqual({
-      chatId: "C123",
-      text: "Please answer with numbered lines so I can map each reply to the right question.\nExample:\n1: your answer\n2: your answer",
-      replyToMessageId: "1712790000.000050",
-    });
+    expect(replies).toHaveLength(0);
+    expect(approvalResponses).toEqual([
+      {
+        request_id: "req-ask-2",
+        decision: {
+          behavior: "allow",
+          updated_input: {
+            questions: [
+              {
+                question: "Which approach should we use?",
+                header: "Approach",
+                options: [
+                  { label: "Fast path", description: "Ship quickly" },
+                  { label: "Deep refactor", description: "Refactor more" },
+                ],
+                multiSelect: false,
+              },
+              {
+                question: "Which environment should we test in?",
+                header: "Env",
+                options: [
+                  { label: "Staging", description: "Safer rollout path" },
+                  {
+                    label: "Production",
+                    description: "Use the live environment",
+                  },
+                ],
+                multiSelect: false,
+              },
+            ],
+            answers: {
+              "Which approach should we use?": "Deep refactor",
+              "Which environment should we test in?":
+                "Not specified. Full user reply: deep refactor please",
+            },
+          },
+        },
+      },
+    ]);
   });
 
   test("bootstrapped persisted control requests intercept replies before the listener finishes reconnecting", async () => {

--- a/src/tests/websocket/listen-recovery.test.ts
+++ b/src/tests/websocket/listen-recovery.test.ts
@@ -309,7 +309,7 @@ describe("channel control request recovery", () => {
       {
         chatId: "C123",
         text: expect.stringContaining(
-          "The agent needs an answer before it can continue.",
+          "SYSTEM MESSAGE — reply required to continue",
         ),
         replyToMessageId: "1712790000.000050",
       },


### PR DESCRIPTION
## Summary
- Clarify channel AskUserQuestion prompts with a `SYSTEM MESSAGE` header and remove redundant paused-copy.
- Accept natural-language multi-question replies, compact positional option numbers, option aliases, and recommended/default hints instead of blocking on strict numbered-line replies.
- Update channel prompt and recovery tests for the new copy and parsing behavior.

## Example
Old channel prompt:
```text
The agent needs an answer before it can continue.

1. Does the existing DISCORD_BOT_TOKEN already belong to a Discord application?
   1) Yes, all set up — Bot application exists
   2) Bot exists, not invited yet — Token is real but not yet in any server
2. DM policy for who can message the bot?
   1) Pairing (Recommended) — Require a pairing code
   2) Allowlist — Only your Discord user ID can DM the bot

Reply with numbered lines, for example:
1: your answer
2: your answer
```

Old behavior for a natural-language reply:
```text
Please answer with numbered lines so I can map each reply to the right question.
Example:
1: your answer
2: your answer
```

New channel prompt:
```text
SYSTEM MESSAGE — reply required to continue

1. Does the existing DISCORD_BOT_TOKEN already belong to a Discord application?
   1) Yes, all set up — Bot application exists
   2) Bot exists, not invited yet — Token is real but not yet in any server
2. DM policy for who can message the bot?
   1) Pairing (Recommended) — Require a pairing code
   2) Allowlist — Only your Discord user ID can DM the bot

Reply in plain language, or answer each question separately with numbered lines:
1: your answer
2: your answer

Option numbers/labels work too. For multi-select questions, separate multiple answers with commas.
```

New behavior: a reply like `I will add a token. Fill out everything but the token and I will add it manually.` is accepted and passed back to the agent instead of re-prompting.

## Test plan
- [x] `bun test src/tests/channels/interactive.test.ts src/tests/websocket/listen-recovery.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/channels/interactive.ts src/tests/channels/interactive.test.ts src/tests/websocket/listen-recovery.test.ts`
- [x] `bun run typecheck` via pre-commit hook, with PATH pointed at a working nvm node because the Homebrew node install is missing simdjson

👾 Generated with [Letta Code](https://letta.com)