### PR TITLE
fix(channels): include CLI pairing instructions

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -90,7 +90,9 @@ export function buildPairingInstructions(
     );
   }
   return (
-    `To connect this chat to a Letta agent, open Channels > ${displayName} in Letta Code and finish connecting this chat there.\n\n` +
+    `To connect this chat to a Letta agent, either open Channels > ${displayName} in Letta Code and finish connecting this chat there, or run this on the machine where your listener runs:\n\n` +
+    `letta channels pair --channel ${channelId} --code ${code} --agent <agent-id>\n\n` +
+    `Find your agent id with letta agents list.\n\n` +
     `Pairing code: ${code}\n\n` +
     `This code expires in 15 minutes.`
   );

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -4,12 +4,15 @@ const { buildPairingInstructions, buildUnboundRouteInstructions } =
   await import("../../channels/registry");
 
 describe("registry copy: first-party channels", () => {
-  test("pairing instructions point at the desktop UI for telegram", () => {
+  test("pairing instructions point at both desktop UI and CLI for telegram", () => {
     const text = buildPairingInstructions("telegram", "ABC123");
     expect(text).toContain("open Channels >");
     expect(text).toContain("Telegram");
     expect(text).toContain("Pairing code: ABC123");
-    expect(text).not.toContain("letta channels pair");
+    expect(text).toContain(
+      "letta channels pair --channel telegram --code ABC123 --agent <agent-id>",
+    );
+    expect(text).toContain("Find your agent id with letta agents list.");
     expect(text).not.toContain("(community channel)");
   });
 
@@ -22,10 +25,13 @@ describe("registry copy: first-party channels", () => {
     expect(text).not.toContain("(community channel)");
   });
 
-  test("first-party discord pairing keeps the desktop wording", () => {
+  test("first-party discord pairing includes the CLI pairing command", () => {
     const text = buildPairingInstructions("discord", "XYZ789");
     expect(text).toContain("open Channels >");
     expect(text).toContain("Discord");
+    expect(text).toContain(
+      "letta channels pair --channel discord --code XYZ789 --agent <agent-id>",
+    );
   });
 
   test("first-party copy uses 'Letta agent' consistently", () => {


### PR DESCRIPTION
## Summary
- Add `letta channels pair ...` copy to first-party channel pairing messages alongside Desktop instructions.
- Update registry copy tests for Telegram and Discord pairing text.

"Prefer the path that works when the UI is somewhere else."

Written by Cameron ◯ Letta Code