### PR TITLE
feat(permissions): rename permission modes for clarity, make unrestricted the default

### DIFF
--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -82,7 +82,7 @@ export interface SubagentConfig {
   fork: boolean;
   /** Whether this subagent should run in the background by default. */
   background: boolean;
-  /** Permission mode for this subagent (default, acceptEdits, plan, memory, unrestricted) */
+  /** Permission mode for this subagent (unrestricted, standard, acceptEdits, plan, memory) */
   permissionMode?: string;
 }
 

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -82,7 +82,7 @@ export interface SubagentConfig {
   fork: boolean;
   /** Whether this subagent should run in the background by default. */
   background: boolean;
-  /** Permission mode for this subagent (default, acceptEdits, plan, memory, fullAccess) */
+  /** Permission mode for this subagent (default, acceptEdits, plan, memory, unrestricted) */
   permissionMode?: string;
 }
 

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -82,7 +82,7 @@ export interface SubagentConfig {
   fork: boolean;
   /** Whether this subagent should run in the background by default. */
   background: boolean;
-  /** Permission mode for this subagent (default, acceptEdits, plan, memory, bypassPermissions) */
+  /** Permission mode for this subagent (default, acceptEdits, plan, memory, fullAccess) */
   permissionMode?: string;
 }
 

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -85,9 +85,17 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.displayName = undefined;
   }
   if (isSlackChannelAccount(next)) {
-    (next as SlackChannelAccount).defaultPermissionMode = ((
-      next as SlackChannelAccount
-    ).defaultPermissionMode ?? "standard") as SlackDefaultPermissionMode;
+    const raw: string =
+      (next as SlackChannelAccount).defaultPermissionMode ?? "standard";
+    // Migrate legacy values: "default" → "standard", "bypassPermissions"/"fullAccess" → "unrestricted"
+    const migrated =
+      raw === "default"
+        ? "standard"
+        : raw === "bypassPermissions" || raw === "fullAccess"
+          ? "unrestricted"
+          : raw;
+    (next as SlackChannelAccount).defaultPermissionMode =
+      migrated as SlackDefaultPermissionMode;
   }
   return next;
 }

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { migratePermissionMode } from "../permissions/mode";
 import {
   getChannelAccountsPath,
   getChannelDir,
@@ -87,15 +88,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   if (isSlackChannelAccount(next)) {
     const raw: string =
       (next as SlackChannelAccount).defaultPermissionMode ?? "standard";
-    // Migrate legacy values: "default" → "standard", "bypassPermissions"/"fullAccess" → "unrestricted"
-    const migrated =
-      raw === "default"
-        ? "standard"
-        : raw === "bypassPermissions" || raw === "fullAccess"
-          ? "unrestricted"
-          : raw;
     (next as SlackChannelAccount).defaultPermissionMode =
-      migrated as SlackDefaultPermissionMode;
+      (migratePermissionMode(raw) ?? raw) as SlackDefaultPermissionMode;
   }
   return next;
 }

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -87,7 +87,7 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   if (isSlackChannelAccount(next)) {
     (next as SlackChannelAccount).defaultPermissionMode = ((
       next as SlackChannelAccount
-    ).defaultPermissionMode ?? "default") as SlackDefaultPermissionMode;
+    ).defaultPermissionMode ?? "standard") as SlackDefaultPermissionMode;
   }
   return next;
 }
@@ -147,7 +147,7 @@ function makeDefaultLegacyAccount(
     dmPolicy: config.dmPolicy,
     allowedUsers: [...config.allowedUsers],
     agentId: null,
-    defaultPermissionMode: "default",
+    defaultPermissionMode: "standard",
     createdAt: now,
     updatedAt: now,
   };

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -963,7 +963,7 @@ export class ChannelRegistry {
     };
 
     addRoute(msg.channel, route);
-    if (config.defaultPermissionMode !== "default") {
+    if (config.defaultPermissionMode !== "standard") {
       this.eventHandler?.({
         type: "slack_conversation_created",
         channelId: "slack",

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -472,7 +472,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
-    defaultPermissionMode: account.defaultPermissionMode ?? "default",
+    defaultPermissionMode: account.defaultPermissionMode ?? "standard",
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
   };
@@ -543,7 +543,7 @@ function createAccountFromPatch(
     botToken: normalizedPatch.botToken ?? "",
     appToken: normalizedPatch.appToken ?? "",
     agentId: normalizedPatch.agentId ?? null,
-    defaultPermissionMode: normalizedPatch.defaultPermissionMode ?? "default",
+    defaultPermissionMode: normalizedPatch.defaultPermissionMode ?? "standard",
     dmPolicy: normalizedPatch.dmPolicy ?? "open",
     allowedUsers: normalizedPatch.allowedUsers ?? [],
     createdAt: now,
@@ -734,7 +734,7 @@ export function getChannelConfigSnapshot(
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
-    defaultPermissionMode: account.defaultPermissionMode ?? "default",
+    defaultPermissionMode: account.defaultPermissionMode ?? "standard",
   };
 }
 

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -1,3 +1,4 @@
+import { migratePermissionMode } from "../../permissions/mode";
 import type { ChannelAccountConfigAdapter } from "../pluginTypes";
 import type { SlackChannelAccount, SlackDefaultPermissionMode } from "../types";
 
@@ -20,27 +21,15 @@ function isNullableString(value: unknown): value is string | null {
 function isDefaultPermissionMode(
   value: unknown,
 ): value is SlackDefaultPermissionMode {
+  // Also accepts legacy values that migratePermissionMode will map to current names.
   return (
     value === "standard" ||
     value === "acceptEdits" ||
     value === "unrestricted" ||
-    value === "default" || // legacy — migrated to "standard" on read
-    value === "bypassPermissions" || // legacy — migrated to "unrestricted" on read
-    value === "fullAccess" // legacy — migrated to "unrestricted" on read
+    value === "default" || // legacy → "standard"
+    value === "bypassPermissions" || // legacy → "unrestricted"
+    value === "fullAccess" // legacy → "unrestricted"
   );
-}
-
-function migratePermissionMode(
-  value:
-    | SlackDefaultPermissionMode
-    | "default"
-    | "bypassPermissions"
-    | "fullAccess",
-): SlackDefaultPermissionMode {
-  if (value === "default") return "standard";
-  if (value === "bypassPermissions" || value === "fullAccess")
-    return "unrestricted";
-  return value;
 }
 
 export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannelAccount> =
@@ -72,7 +61,9 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         defaultPermissionMode: isDefaultPermissionMode(
           config.default_permission_mode,
         )
-          ? migratePermissionMode(config.default_permission_mode)
+          ? (migratePermissionMode(
+              config.default_permission_mode,
+            ) as SlackDefaultPermissionMode)
           : undefined,
       };
     },

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -21,9 +21,7 @@ function isDefaultPermissionMode(
   value: unknown,
 ): value is SlackDefaultPermissionMode {
   return (
-    value === "default" ||
-    value === "acceptEdits" ||
-    value === "bypassPermissions"
+    value === "default" || value === "acceptEdits" || value === "fullAccess"
   );
 }
 
@@ -67,7 +65,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         has_bot_token: account.botToken.trim().length > 0,
         has_app_token: account.appToken.trim().length > 0,
         agent_id: account.agentId,
-        default_permission_mode: account.defaultPermissionMode ?? "default",
+        default_permission_mode: account.defaultPermissionMode ?? "standard",
       };
     },
 
@@ -77,7 +75,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         has_bot_token: account.botToken.trim().length > 0,
         has_app_token: account.appToken.trim().length > 0,
         agent_id: account.agentId,
-        default_permission_mode: account.defaultPermissionMode ?? "default",
+        default_permission_mode: account.defaultPermissionMode ?? "standard",
       };
     },
 

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -24,14 +24,17 @@ function isDefaultPermissionMode(
     value === "standard" ||
     value === "acceptEdits" ||
     value === "fullAccess" ||
-    value === "default" // legacy alias — migrated to "standard" on read
+    value === "default" || // legacy — migrated to "standard" on read
+    value === "bypassPermissions" // legacy — migrated to "fullAccess" on read
   );
 }
 
 function migratePermissionMode(
-  value: SlackDefaultPermissionMode | "default",
+  value: SlackDefaultPermissionMode | "default" | "bypassPermissions",
 ): SlackDefaultPermissionMode {
-  return value === "default" ? "standard" : value;
+  if (value === "default") return "standard";
+  if (value === "bypassPermissions") return "fullAccess";
+  return value;
 }
 
 export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannelAccount> =

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -23,17 +23,23 @@ function isDefaultPermissionMode(
   return (
     value === "standard" ||
     value === "acceptEdits" ||
-    value === "fullAccess" ||
+    value === "unrestricted" ||
     value === "default" || // legacy — migrated to "standard" on read
-    value === "bypassPermissions" // legacy — migrated to "fullAccess" on read
+    value === "bypassPermissions" || // legacy — migrated to "unrestricted" on read
+    value === "fullAccess" // legacy — migrated to "unrestricted" on read
   );
 }
 
 function migratePermissionMode(
-  value: SlackDefaultPermissionMode | "default" | "bypassPermissions",
+  value:
+    | SlackDefaultPermissionMode
+    | "default"
+    | "bypassPermissions"
+    | "fullAccess",
 ): SlackDefaultPermissionMode {
   if (value === "default") return "standard";
-  if (value === "bypassPermissions") return "fullAccess";
+  if (value === "bypassPermissions" || value === "fullAccess")
+    return "unrestricted";
   return value;
 }
 

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -21,8 +21,17 @@ function isDefaultPermissionMode(
   value: unknown,
 ): value is SlackDefaultPermissionMode {
   return (
-    value === "default" || value === "acceptEdits" || value === "fullAccess"
+    value === "standard" ||
+    value === "acceptEdits" ||
+    value === "fullAccess" ||
+    value === "default" // legacy alias — migrated to "standard" on read
   );
+}
+
+function migratePermissionMode(
+  value: SlackDefaultPermissionMode | "default",
+): SlackDefaultPermissionMode {
+  return value === "default" ? "standard" : value;
 }
 
 export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannelAccount> =
@@ -54,7 +63,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         defaultPermissionMode: isDefaultPermissionMode(
           config.default_permission_mode,
         )
-          ? config.default_permission_mode
+          ? migratePermissionMode(config.default_permission_mode)
           : undefined,
       };
     },

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -92,7 +92,7 @@ export async function runSlackSetup(): Promise<boolean> {
       botToken,
       appToken,
       agentId: null,
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
       dmPolicy: policy,
       allowedUsers,
       createdAt: now,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -21,9 +21,9 @@ export const SUPPORTED_CHANNEL_IDS = FIRST_PARTY_CHANNEL_IDS;
 export type SupportedChannelId = string;
 export type ChannelChatType = "direct" | "channel";
 export type SlackDefaultPermissionMode =
-  | "default"
+  | "standard"
   | "acceptEdits"
-  | "bypassPermissions";
+  | "fullAccess";
 
 export interface ChannelMessageAttachment {
   id?: string;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -23,7 +23,7 @@ export type ChannelChatType = "direct" | "channel";
 export type SlackDefaultPermissionMode =
   | "standard"
   | "acceptEdits"
-  | "fullAccess";
+  | "unrestricted";
 
 export interface ChannelMessageAttachment {
   id?: string;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3839,8 +3839,8 @@ export default function App({
       ralphMode.deactivate();
       setUiRalphActive(false);
       if (wasYolo) {
-        permissionMode.setMode("default");
-        setUiPermissionMode("default");
+        permissionMode.setMode("standard");
+        setUiPermissionMode("standard");
       }
     }
   }, [setUiPermissionMode]);

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -1112,13 +1112,13 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
         const previousMode = permissionMode.getModeBeforePlan();
         const restoreMode =
           // If the user was in YOLO before entering plan mode, always restore it.
-          previousMode === "bypassPermissions"
-            ? "bypassPermissions"
+          previousMode === "fullAccess"
+            ? "fullAccess"
             : acceptEdits
               ? "acceptEdits"
               : previousMode === "memory"
-                ? "default"
-                : (previousMode ?? "default");
+                ? "standard"
+                : (previousMode ?? "standard");
         permissionMode.setMode(restoreMode);
         setUiPermissionMode(restoreMode);
       } else {
@@ -1246,7 +1246,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           return;
         }
 
-        if (mode === "bypassPermissions") {
+        if (mode === "fullAccess") {
           // YOLO mode but no plan file yet — tell agent to write it first.
           const planFilePath = activePlanPath ?? fallbackPlanPath;
           const plansDir = join(homedir(), ".letta", "plans");
@@ -1512,14 +1512,14 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
   ]);
 
   // Guard EnterPlanMode:
-  // When in bypassPermissions (YOLO) mode, auto-approve EnterPlanMode and stay
+  // When in fullAccess (YOLO) mode, auto-approve EnterPlanMode and stay
   // in YOLO — the agent gets plan instructions but keeps full permissions.
   // ExitPlanMode still requires explicit user approval.
   useEffect(() => {
     const currentIndex = approvalResults.length;
     const approval = pendingApprovals[currentIndex];
     if (approval?.toolName === "EnterPlanMode") {
-      if (permissionMode.getMode() === "bypassPermissions") {
+      if (permissionMode.getMode() === "fullAccess") {
         if (
           lastAutoApprovedEnterPlanToolCallIdRef.current === approval.toolCallId
         ) {

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -1112,8 +1112,8 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
         const previousMode = permissionMode.getModeBeforePlan();
         const restoreMode =
           // If the user was in YOLO before entering plan mode, always restore it.
-          previousMode === "fullAccess"
-            ? "fullAccess"
+          previousMode === "unrestricted"
+            ? "unrestricted"
             : acceptEdits
               ? "acceptEdits"
               : previousMode === "memory"
@@ -1246,7 +1246,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           return;
         }
 
-        if (mode === "fullAccess") {
+        if (mode === "unrestricted") {
           // YOLO mode but no plan file yet — tell agent to write it first.
           const planFilePath = activePlanPath ?? fallbackPlanPath;
           const plansDir = join(homedir(), ".letta", "plans");
@@ -1512,14 +1512,14 @@ If using apply_patch, use this exact relative patch path: ${applyPatchRelativePa
   ]);
 
   // Guard EnterPlanMode:
-  // When in fullAccess (YOLO) mode, auto-approve EnterPlanMode and stay
+  // When in unrestricted (YOLO) mode, auto-approve EnterPlanMode and stay
   // in YOLO — the agent gets plan instructions but keeps full permissions.
   // ExitPlanMode still requires explicit user approval.
   useEffect(() => {
     const currentIndex = approvalResults.length;
     const approval = pendingApprovals[currentIndex];
     if (approval?.toolName === "EnterPlanMode") {
-      if (permissionMode.getMode() === "fullAccess") {
+      if (permissionMode.getMode() === "unrestricted") {
         if (
           lastAutoApprovedEnterPlanToolCallIdRef.current === approval.toolCallId
         ) {

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -18,8 +18,11 @@ import {
 } from "../../agent/approval-execution";
 import type { SessionStats } from "../../agent/stats";
 import type { ApprovalContext } from "../../permissions/analyzer";
-import type { PermissionMode } from "../../permissions/mode";
-import { permissionMode } from "../../permissions/mode";
+import {
+  DEFAULT_PERMISSION_MODE,
+  type PermissionMode,
+  permissionMode,
+} from "../../permissions/mode";
 import {
   analyzeToolApproval,
   checkToolPermission,
@@ -1117,8 +1120,8 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
             : acceptEdits
               ? "acceptEdits"
               : previousMode === "memory"
-                ? "standard"
-                : (previousMode ?? "standard");
+                ? DEFAULT_PERMISSION_MODE
+                : (previousMode ?? DEFAULT_PERMISSION_MODE);
         permissionMode.setMode(restoreMode);
         setUiPermissionMode(restoreMode);
       } else {

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -322,7 +322,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     ): Promise<void> => {
       // Transient pre-stream retries can yield for seconds.
       // Pin the user's permission mode for the duration of the submission so
-      // auto-approvals (YOLO / bypassPermissions) don't regress after a retry.
+      // auto-approvals (YOLO / fullAccess) don't regress after a retry.
       const pinnedPermissionMode = uiPermissionModeRef.current;
       const restorePinnedPermissionMode = () => {
         if (pinnedPermissionMode === "plan") return;
@@ -396,8 +396,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           ralphMode.deactivate();
           setUiRalphActive(false);
           if (wasYolo) {
-            permissionMode.setMode("default");
-            setUiPermissionMode("default");
+            permissionMode.setMode("standard");
+            setUiPermissionMode("standard");
           }
 
           // Add completion status to transcript
@@ -421,8 +421,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           ralphMode.deactivate();
           setUiRalphActive(false);
           if (wasYolo) {
-            permissionMode.setMode("default");
-            setUiPermissionMode("default");
+            permissionMode.setMode("standard");
+            setUiPermissionMode("standard");
           }
 
           // Add status to transcript
@@ -1179,8 +1179,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             }
           };
 
-          const isAutoApprovalMode =
-            pinnedPermissionMode === "bypassPermissions";
+          const isAutoApprovalMode = pinnedPermissionMode === "fullAccess";
           const isUserInitiated = currentInput.some(
             (item) => item.type === "message" && item.role === "user",
           );

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -322,7 +322,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     ): Promise<void> => {
       // Transient pre-stream retries can yield for seconds.
       // Pin the user's permission mode for the duration of the submission so
-      // auto-approvals (YOLO / fullAccess) don't regress after a retry.
+      // auto-approvals (YOLO / unrestricted) don't regress after a retry.
       const pinnedPermissionMode = uiPermissionModeRef.current;
       const restorePinnedPermissionMode = () => {
         if (pinnedPermissionMode === "plan") return;
@@ -1179,7 +1179,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             }
           };
 
-          const isAutoApprovalMode = pinnedPermissionMode === "fullAccess";
+          const isAutoApprovalMode = pinnedPermissionMode === "unrestricted";
           const isUserInitiated = currentInput.some(
             (item) => item.type === "message" && item.role === "user",
           );

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -580,8 +580,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         setPendingRalphConfig(null);
         justActivatedRalph = true;
         if (isYolo) {
-          permissionMode.setMode("bypassPermissions");
-          setUiPermissionMode("bypassPermissions");
+          permissionMode.setMode("fullAccess");
+          setUiPermissionMode("fullAccess");
         }
 
         const ralphState = ralphMode.getState();
@@ -1062,8 +1062,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
             setUiRalphActive(true);
             if (isYolo) {
-              permissionMode.setMode("bypassPermissions");
-              setUiPermissionMode("bypassPermissions");
+              permissionMode.setMode("fullAccess");
+              setUiPermissionMode("fullAccess");
             }
 
             const ralphState = ralphMode.getState();

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -580,8 +580,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         setPendingRalphConfig(null);
         justActivatedRalph = true;
         if (isYolo) {
-          permissionMode.setMode("fullAccess");
-          setUiPermissionMode("fullAccess");
+          permissionMode.setMode("unrestricted");
+          setUiPermissionMode("unrestricted");
         }
 
         const ralphState = ralphMode.getState();
@@ -1062,8 +1062,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
             setUiRalphActive(true);
             if (isYolo) {
-              permissionMode.setMode("fullAccess");
-              setUiPermissionMode("fullAccess");
+              permissionMode.setMode("unrestricted");
+              setUiPermissionMode("unrestricted");
             }
 
             const ralphState = ralphMode.getState();

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -364,7 +364,7 @@ export const ApprovalSwitch = memo(
     if (toolName === "ExitPlanMode" && onPlanApprove && onPlanKeepPlanning) {
       const showAcceptEditsOption =
         permissionMode.getMode() === "plan" &&
-        permissionMode.getModeBeforePlan() !== "bypassPermissions";
+        permissionMode.getModeBeforePlan() !== "fullAccess";
       return (
         <StaticPlanApproval
           onApprove={() => onPlanApprove(false)}

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -364,7 +364,7 @@ export const ApprovalSwitch = memo(
     if (toolName === "ExitPlanMode" && onPlanApprove && onPlanKeepPlanning) {
       const showAcceptEditsOption =
         permissionMode.getMode() === "plan" &&
-        permissionMode.getModeBeforePlan() !== "fullAccess";
+        permissionMode.getModeBeforePlan() !== "unrestricted";
       return (
         <StaticPlanApproval
           onApprove={() => onPlanApprove(false)}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1175,14 +1175,14 @@ export function Input({
 
       // Cycle through permission modes
       const modes: PermissionMode[] = [
-        "fullAccess",
+        "unrestricted",
         "acceptEdits",
         "standard",
         "plan",
       ];
       const currentIndex = modes.indexOf(currentMode);
       const nextIndex = (currentIndex + 1) % modes.length;
-      const nextMode = modes[nextIndex] ?? "fullAccess";
+      const nextMode = modes[nextIndex] ?? "unrestricted";
 
       // Update both singleton and local state
       permissionMode.setMode(nextMode);
@@ -1544,19 +1544,19 @@ export function Input({
       case "acceptEdits":
         return { name: "accept edits", color: colors.status.processing };
       case "standard":
-        return { name: "standard", color: colors.status.processing };
+        return {
+          name: "standard (request approval) mode",
+          color: colors.status.processingShimmer,
+        };
       case "plan":
         return {
           name: "plan (read-only) mode",
           color: colors.status.success,
           glyph: "⏸",
         };
-      case "fullAccess":
-        return {
-          name: "full access",
-          color: colors.status.error,
-          glyph: "⚡︎",
-        };
+      case "unrestricted":
+        // Default mode — show nothing so "Press / for commands" renders instead
+        return null;
       default:
         return null;
     }

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1175,14 +1175,14 @@ export function Input({
 
       // Cycle through permission modes
       const modes: PermissionMode[] = [
-        "default",
-        "plan",
+        "fullAccess",
         "acceptEdits",
-        "bypassPermissions",
+        "standard",
+        "plan",
       ];
       const currentIndex = modes.indexOf(currentMode);
       const nextIndex = (currentIndex + 1) % modes.length;
-      const nextMode = modes[nextIndex] ?? "default";
+      const nextMode = modes[nextIndex] ?? "fullAccess";
 
       // Update both singleton and local state
       permissionMode.setMode(nextMode);
@@ -1543,15 +1543,17 @@ export function Input({
     switch (currentMode) {
       case "acceptEdits":
         return { name: "accept edits", color: colors.status.processing };
+      case "standard":
+        return { name: "standard", color: colors.status.processing };
       case "plan":
         return {
           name: "plan (read-only) mode",
           color: colors.status.success,
           glyph: "⏸",
         };
-      case "bypassPermissions":
+      case "fullAccess":
         return {
-          name: "yolo (allow all) mode",
+          name: "full access",
           color: colors.status.error,
           glyph: "⚡︎",
         };

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1547,6 +1547,7 @@ export function Input({
         return {
           name: "standard (request approval) mode",
           color: colors.status.processingShimmer,
+          glyph: "▶",
         };
       case "plan":
         return {

--- a/src/cli/components/StaticPlanApproval.tsx
+++ b/src/cli/components/StaticPlanApproval.tsx
@@ -200,7 +200,7 @@ export const StaticPlanApproval = memo(
               >
                 {showAcceptEditsOption
                   ? "Yes, and auto-accept edits"
-                  : "Yes, proceed (bypassPermissions / yolo mode)"}
+                  : "Yes, proceed (full access)"}
               </Text>
             </Box>
           </Box>

--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -130,13 +130,13 @@ export function isFancyUITool(name: string): boolean {
 }
 
 /**
- * Checks if a tool always requires user interaction, even in yolo mode.
+ * Checks if a tool always requires user interaction, even in fullAccess mode.
  * These are tools that fundamentally need user input to proceed:
  * - AskUserQuestion: needs user to answer questions
  * - EnterPlanMode: needs user to approve entering plan mode
  * - ExitPlanMode: needs user to approve the plan
  *
- * Other tools (bash, file edits) should respect yolo mode and auto-approve.
+ * Other tools (bash, file edits) should respect fullAccess mode and auto-approve.
  */
 export function alwaysRequiresUserInput(name: string): boolean {
   return isInteractiveApprovalTool(name);

--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -130,13 +130,13 @@ export function isFancyUITool(name: string): boolean {
 }
 
 /**
- * Checks if a tool always requires user interaction, even in fullAccess mode.
+ * Checks if a tool always requires user interaction, even in unrestricted mode.
  * These are tools that fundamentally need user input to proceed:
  * - AskUserQuestion: needs user to answer questions
  * - EnterPlanMode: needs user to approve entering plan mode
  * - ExitPlanMode: needs user to approve the plan
  *
- * Other tools (bash, file edits) should respect fullAccess mode and auto-approve.
+ * Other tools (bash, file edits) should respect unrestricted mode and auto-approve.
  */
 export function alwaysRequiresUserInput(name: string): boolean {
   return isInteractiveApprovalTool(name);

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -474,21 +474,21 @@ export async function handleHeadlessCommand(
   if (yoloMode || permissionModeValue) {
     const { permissionMode } = await import("./permissions/mode");
     if (yoloMode) {
-      permissionMode.setMode("bypassPermissions");
+      permissionMode.setMode("fullAccess");
     } else if (permissionModeValue) {
       const validModes = [
-        "default",
+        "standard",
         "acceptEdits",
-        "bypassPermissions",
+        "fullAccess",
         "plan",
         "memory",
       ];
       if (validModes.includes(permissionModeValue)) {
         permissionMode.setMode(
           permissionModeValue as
-            | "default"
+            | "standard"
             | "acceptEdits"
-            | "bypassPermissions"
+            | "fullAccess"
             | "plan"
             | "memory",
         );

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -474,7 +474,7 @@ export async function handleHeadlessCommand(
   if (yoloMode || permissionModeValue) {
     const { permissionMode } = await import("./permissions/mode");
     if (yoloMode) {
-      permissionMode.setMode("fullAccess");
+      permissionMode.setMode("unrestricted");
     } else if (permissionModeValue) {
       const { migratePermissionMode } = await import("./permissions/mode");
       const migrated = migratePermissionMode(permissionModeValue);

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -476,22 +476,10 @@ export async function handleHeadlessCommand(
     if (yoloMode) {
       permissionMode.setMode("fullAccess");
     } else if (permissionModeValue) {
-      const validModes = [
-        "standard",
-        "acceptEdits",
-        "fullAccess",
-        "plan",
-        "memory",
-      ];
-      if (validModes.includes(permissionModeValue)) {
-        permissionMode.setMode(
-          permissionModeValue as
-            | "standard"
-            | "acceptEdits"
-            | "fullAccess"
-            | "plan"
-            | "memory",
-        );
+      const { migratePermissionMode } = await import("./permissions/mode");
+      const migrated = migratePermissionMode(permissionModeValue);
+      if (migrated) {
+        permissionMode.setMode(migrated);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,11 @@ import {
   validateRegistryHandleOrThrow,
 } from "./cli/startupFlagValidation";
 import { runSubcommand } from "./cli/subcommands/router";
-import { permissionMode } from "./permissions/mode";
+import {
+  migratePermissionMode,
+  permissionMode,
+  VALID_PERMISSION_MODES,
+} from "./permissions/mode";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
 import { startStartupAutoUpdateCheck } from "./startup-auto-update";
 import { telemetry } from "./telemetry";
@@ -1034,20 +1038,12 @@ async function main(): Promise<void> {
       // --yolo is an alias for --permission-mode fullAccess
       permissionMode.setMode("fullAccess");
     } else if (permissionModeValue) {
-      const mode = permissionModeValue;
-      const validModes = [
-        "standard",
-        "acceptEdits",
-        "plan",
-        "memory",
-        "fullAccess",
-      ] as const;
-
-      if (validModes.includes(mode as (typeof validModes)[number])) {
-        permissionMode.setMode(mode as (typeof validModes)[number]);
+      const migrated = migratePermissionMode(permissionModeValue);
+      if (migrated) {
+        permissionMode.setMode(migrated);
       } else {
         console.error(
-          `Invalid permission mode: ${mode}. Valid modes: ${validModes.join(", ")}`,
+          `Invalid permission mode: ${permissionModeValue}. Valid modes: ${VALID_PERMISSION_MODES.join(", ")}`,
         );
         process.exit(1);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1031,16 +1031,16 @@ async function main(): Promise<void> {
 
   if (yoloMode || permissionModeValue) {
     if (yoloMode) {
-      // --yolo is an alias for --permission-mode bypassPermissions
-      permissionMode.setMode("bypassPermissions");
+      // --yolo is an alias for --permission-mode fullAccess
+      permissionMode.setMode("fullAccess");
     } else if (permissionModeValue) {
       const mode = permissionModeValue;
       const validModes = [
-        "default",
+        "standard",
         "acceptEdits",
         "plan",
         "memory",
-        "bypassPermissions",
+        "fullAccess",
       ] as const;
 
       if (validModes.includes(mode as (typeof validModes)[number])) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1035,8 +1035,8 @@ async function main(): Promise<void> {
 
   if (yoloMode || permissionModeValue) {
     if (yoloMode) {
-      // --yolo is an alias for --permission-mode fullAccess
-      permissionMode.setMode("fullAccess");
+      // --yolo is an alias for --permission-mode unrestricted
+      permissionMode.setMode("unrestricted");
     } else if (permissionModeValue) {
       const migrated = migratePermissionMode(permissionModeValue);
       if (migrated) {

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -24,6 +24,9 @@ export type PermissionMode =
   | "memory"
   | "unrestricted";
 
+/** The default starting permission mode. */
+export const DEFAULT_PERMISSION_MODE: PermissionMode = "unrestricted";
+
 /** All valid current permission mode values. */
 export const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
   "unrestricted",
@@ -120,7 +123,7 @@ function buildWriteOutsideRootsReason(
 function getGlobalMode(): PermissionMode {
   const global = globalThis as GlobalWithMode;
   if (!global[MODE_KEY]) {
-    global[MODE_KEY] = "unrestricted";
+    global[MODE_KEY] = DEFAULT_PERMISSION_MODE;
   }
   return global[MODE_KEY];
 }
@@ -705,7 +708,7 @@ class PermissionModeManager {
    * Reset to default mode
    */
   reset(): void {
-    this.currentMode = "unrestricted";
+    this.currentMode = DEFAULT_PERMISSION_MODE;
     setGlobalPlanFilePath(null);
     setGlobalModeBeforePlan(null);
   }

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -1,5 +1,5 @@
 // src/permissions/mode.ts
-// Permission mode management (fullAccess, standard, acceptEdits, plan, memory)
+// Permission mode management (unrestricted, standard, acceptEdits, plan, memory)
 
 import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
@@ -22,11 +22,11 @@ export type PermissionMode =
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "fullAccess";
+  | "unrestricted";
 
 /** All valid current permission mode values. */
 export const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
-  "fullAccess",
+  "unrestricted",
   "standard",
   "acceptEdits",
   "plan",
@@ -36,7 +36,7 @@ export const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
 /**
  * Migrate legacy permission mode strings to their current equivalents.
  * - "default" → "standard" (renamed for clarity)
- * - "bypassPermissions" → "fullAccess" (renamed for clarity)
+ * - "bypassPermissions" → "unrestricted" (renamed for clarity)
  * Returns null if the value is not a recognized mode (current or legacy).
  */
 export function migratePermissionMode(value: string): PermissionMode | null {
@@ -44,7 +44,8 @@ export function migratePermissionMode(value: string): PermissionMode | null {
     return value as PermissionMode;
   }
   if (value === "default") return "standard";
-  if (value === "bypassPermissions") return "fullAccess";
+  if (value === "bypassPermissions" || value === "fullAccess")
+    return "unrestricted";
   return null;
 }
 
@@ -119,7 +120,7 @@ function buildWriteOutsideRootsReason(
 function getGlobalMode(): PermissionMode {
   const global = globalThis as GlobalWithMode;
   if (!global[MODE_KEY]) {
-    global[MODE_KEY] = "fullAccess";
+    global[MODE_KEY] = "unrestricted";
   }
   return global[MODE_KEY];
 }
@@ -283,7 +284,7 @@ class PermissionModeManager {
 
   /**
    * Get the permission mode that was active before entering plan mode.
-   * Used to restore the user's previous setting (e.g., fullAccess).
+   * Used to restore the user's previous setting (e.g., unrestricted).
    */
   getModeBeforePlan(): PermissionMode | null {
     return getGlobalModeBeforePlan();
@@ -335,8 +336,8 @@ class PermissionModeManager {
         ? planFilePathOverride
         : this.getPlanFilePath();
     switch (effectiveMode) {
-      case "fullAccess":
-        // ExitPlanMode always requires human approval, even in fullAccess mode
+      case "unrestricted":
+        // ExitPlanMode always requires human approval, even in unrestricted mode
         if (toolName === "ExitPlanMode" || toolName === "exit_plan_mode") {
           return null;
         }
@@ -704,7 +705,7 @@ class PermissionModeManager {
    * Reset to default mode
    */
   reset(): void {
-    this.currentMode = "fullAccess";
+    this.currentMode = "unrestricted";
     setGlobalPlanFilePath(null);
     setGlobalModeBeforePlan(null);
   }

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -1,5 +1,5 @@
 // src/permissions/mode.ts
-// Permission mode management (default, acceptEdits, plan, memory, bypassPermissions)
+// Permission mode management (fullAccess, standard, acceptEdits, plan, memory)
 
 import { homedir } from "node:os";
 import { isAbsolute, join, relative } from "node:path";
@@ -18,11 +18,11 @@ import {
 import { unwrapShellLauncherCommand } from "./shell-command-normalization";
 
 export type PermissionMode =
-  | "default"
+  | "standard"
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "bypassPermissions";
+  | "fullAccess";
 
 /**
  * Result of a permission-mode check. Includes a decision and an optional
@@ -95,7 +95,7 @@ function buildWriteOutsideRootsReason(
 function getGlobalMode(): PermissionMode {
   const global = globalThis as GlobalWithMode;
   if (!global[MODE_KEY]) {
-    global[MODE_KEY] = "default";
+    global[MODE_KEY] = "fullAccess";
   }
   return global[MODE_KEY];
 }
@@ -259,7 +259,7 @@ class PermissionModeManager {
 
   /**
    * Get the permission mode that was active before entering plan mode.
-   * Used to restore the user's previous setting (e.g., bypassPermissions).
+   * Used to restore the user's previous setting (e.g., fullAccess).
    */
   getModeBeforePlan(): PermissionMode | null {
     return getGlobalModeBeforePlan();
@@ -311,8 +311,8 @@ class PermissionModeManager {
         ? planFilePathOverride
         : this.getPlanFilePath();
     switch (effectiveMode) {
-      case "bypassPermissions":
-        // ExitPlanMode always requires human approval, even in yolo mode
+      case "fullAccess":
+        // ExitPlanMode always requires human approval, even in fullAccess mode
         if (toolName === "ExitPlanMode" || toolName === "exit_plan_mode") {
           return null;
         }
@@ -667,7 +667,7 @@ class PermissionModeManager {
         };
       }
 
-      case "default":
+      case "standard":
         // No mode overrides, use normal permission flow
         return null;
 
@@ -680,7 +680,7 @@ class PermissionModeManager {
    * Reset to default mode
    */
   reset(): void {
-    this.currentMode = "default";
+    this.currentMode = "fullAccess";
     setGlobalPlanFilePath(null);
     setGlobalModeBeforePlan(null);
   }

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -24,6 +24,30 @@ export type PermissionMode =
   | "memory"
   | "fullAccess";
 
+/** All valid current permission mode values. */
+export const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
+  "fullAccess",
+  "standard",
+  "acceptEdits",
+  "plan",
+  "memory",
+] as const;
+
+/**
+ * Migrate legacy permission mode strings to their current equivalents.
+ * - "default" → "standard" (renamed for clarity)
+ * - "bypassPermissions" → "fullAccess" (renamed for clarity)
+ * Returns null if the value is not a recognized mode (current or legacy).
+ */
+export function migratePermissionMode(value: string): PermissionMode | null {
+  if (VALID_PERMISSION_MODES.includes(value as PermissionMode)) {
+    return value as PermissionMode;
+  }
+  if (value === "default") return "standard";
+  if (value === "bypassPermissions") return "fullAccess";
+  return null;
+}
+
 /**
  * Result of a permission-mode check. Includes a decision and an optional
  * `reason` string the caller can surface to the agent (e.g. denial guidance

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -157,7 +157,7 @@ const PERMISSION_MODE_DESCRIPTIONS = {
   plan: "Read-only mode. Focus on exploration and planning.",
   memory:
     "Memory-scoped mode. Reads are broad; mutations are limited to allowed memory roots.",
-  fullAccess: "All tools auto-approved. Bias toward action.",
+  unrestricted: "All tools auto-approved. Bias toward action.",
 } as const;
 
 async function buildPermissionModeReminder(
@@ -169,8 +169,8 @@ async function buildPermissionModeReminder(
   const shouldEmit = (() => {
     if (context.mode === "interactive" || context.mode === "listen") {
       if (previousMode === null) {
-        // First turn: only remind if not in the default mode (fullAccess).
-        return currentMode !== "fullAccess";
+        // First turn: only remind if not in the default mode (unrestricted).
+        return currentMode !== "unrestricted";
       }
       return previousMode !== currentMode;
     }

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -152,12 +152,12 @@ async function buildPlanModeReminder(
 }
 
 const PERMISSION_MODE_DESCRIPTIONS = {
-  default: "Normal approval flow.",
+  standard: "Normal approval flow.",
   acceptEdits: "File edits auto-approved.",
   plan: "Read-only mode. Focus on exploration and planning.",
   memory:
     "Memory-scoped mode. Reads are broad; mutations are limited to allowed memory roots.",
-  bypassPermissions: "All tools auto-approved. Bias toward action.",
+  fullAccess: "All tools auto-approved. Bias toward action.",
 } as const;
 
 async function buildPermissionModeReminder(
@@ -169,8 +169,8 @@ async function buildPermissionModeReminder(
   const shouldEmit = (() => {
     if (context.mode === "interactive" || context.mode === "listen") {
       if (previousMode === null) {
-        // First turn: only remind if in a non-default mode (e.g. bypassPermissions).
-        return currentMode !== "default";
+        // First turn: only remind if not in the default mode (fullAccess).
+        return currentMode !== "fullAccess";
       }
       return previousMode !== currentMode;
     }

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -6,7 +6,7 @@ export type RuntimePermissionMode =
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "fullAccess";
+  | "unrestricted";
 
 export interface RuntimeContextSnapshot {
   agentId?: string | null;

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -2,11 +2,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { SkillSource } from "./agent/skills";
 
 export type RuntimePermissionMode =
-  | "default"
+  | "standard"
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "bypassPermissions";
+  | "fullAccess";
 
 export interface RuntimeContextSnapshot {
   agentId?: string | null;

--- a/src/tests/agent/subagent-env-composition.test.ts
+++ b/src/tests/agent/subagent-env-composition.test.ts
@@ -26,7 +26,7 @@ describe("composeSubagentChildEnv", () => {
     const env = composeSubagentChildEnv({
       parentProcessEnv: { HOME: "/home/user" },
       parentAgentId: PARENT_ID,
-      permissionMode: "default",
+      permissionMode: "standard",
       inheritedPrimaryRoot: PARENT_MEMORY_DIR,
     });
 
@@ -101,7 +101,7 @@ describe("composeSubagentChildEnv", () => {
         MEMORY_DIR: existingMemoryDir,
       },
       parentAgentId: PARENT_ID,
-      permissionMode: "default",
+      permissionMode: "standard",
       inheritedPrimaryRoot: PARENT_MEMORY_DIR,
     });
 
@@ -199,7 +199,7 @@ describe("composeSubagentChildEnv", () => {
         HOME: "/home/user",
       },
       parentAgentId: PARENT_ID,
-      permissionMode: "default",
+      permissionMode: "standard",
       inheritedPrimaryRoot: null,
     });
 
@@ -233,7 +233,7 @@ describe("composeSubagentChildEnv", () => {
         CUSTOM_VAR: "preserved",
       },
       parentAgentId: PARENT_ID,
-      permissionMode: "default",
+      permissionMode: "standard",
       inheritedPrimaryRoot: null,
     });
 

--- a/src/tests/channels/message-channel.test.ts
+++ b/src/tests/channels/message-channel.test.ts
@@ -597,7 +597,7 @@ describe("MessageChannel", () => {
       botToken: "xoxb-test-token",
       appToken: "xapp-test-token",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
     upsertChannelTarget("slack", {
       accountId: "account-1",
@@ -702,7 +702,7 @@ describe("MessageChannel", () => {
       botToken: "xoxb-test-token-1",
       appToken: "xapp-test-token-1",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
     upsertChannelAccount("slack", {
       channel: "slack",
@@ -717,7 +717,7 @@ describe("MessageChannel", () => {
       botToken: "xoxb-test-token-2",
       appToken: "xapp-test-token-2",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
 
     const result = await message_channel({
@@ -784,7 +784,7 @@ describe("MessageChannel", () => {
       botToken: "xoxb-test-token",
       appToken: "xapp-test-token",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
 
     const result = await message_channel({

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -178,7 +178,7 @@ describe("channel service", () => {
     const updated = updateChannelAccountLive("slack", "docsbot", {
       displayName: "DocsBot Support",
       enabled: true,
-      defaultPermissionMode: "fullAccess",
+      defaultPermissionMode: "unrestricted",
     });
     expect(updated.displayName).toBe("DocsBot Support");
     expect(updated.enabled).toBe(true);
@@ -186,7 +186,7 @@ describe("channel service", () => {
     if (updated.channelId !== "slack") {
       throw new Error("Expected Slack account snapshot");
     }
-    expect(updated.defaultPermissionMode).toBe("fullAccess");
+    expect(updated.defaultPermissionMode).toBe("unrestricted");
 
     const bound = bindChannelAccountLive(
       "slack",
@@ -205,7 +205,7 @@ describe("channel service", () => {
         accountId: "docsbot",
         displayName: "DocsBot Support",
         agentId: "agent-docs",
-        defaultPermissionMode: "fullAccess",
+        defaultPermissionMode: "unrestricted",
       }),
     );
 

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -171,14 +171,14 @@ describe("channel service", () => {
         configured: true,
         hasBotToken: true,
         hasAppToken: true,
-        defaultPermissionMode: "default",
+        defaultPermissionMode: "standard",
       }),
     );
 
     const updated = updateChannelAccountLive("slack", "docsbot", {
       displayName: "DocsBot Support",
       enabled: true,
-      defaultPermissionMode: "bypassPermissions",
+      defaultPermissionMode: "fullAccess",
     });
     expect(updated.displayName).toBe("DocsBot Support");
     expect(updated.enabled).toBe(true);
@@ -186,7 +186,7 @@ describe("channel service", () => {
     if (updated.channelId !== "slack") {
       throw new Error("Expected Slack account snapshot");
     }
-    expect(updated.defaultPermissionMode).toBe("bypassPermissions");
+    expect(updated.defaultPermissionMode).toBe("fullAccess");
 
     const bound = bindChannelAccountLive(
       "slack",
@@ -205,7 +205,7 @@ describe("channel service", () => {
         accountId: "docsbot",
         displayName: "DocsBot Support",
         agentId: "agent-docs",
-        defaultPermissionMode: "bypassPermissions",
+        defaultPermissionMode: "fullAccess",
       }),
     );
 
@@ -356,7 +356,7 @@ describe("channel service", () => {
         dmPolicy: "pairing",
         allowedUsers: [],
         agentId: null,
-        defaultPermissionMode: "default",
+        defaultPermissionMode: "standard",
         createdAt: "2026-04-11T00:00:00.000Z",
         updatedAt: "2026-04-11T00:00:00.000Z",
       },
@@ -367,7 +367,7 @@ describe("channel service", () => {
     expect(snapshot?.displayName).toBeUndefined();
     expect(snapshot?.channelId).toBe("slack");
     if (snapshot?.channelId === "slack") {
-      expect(snapshot.defaultPermissionMode).toBe("default");
+      expect(snapshot.defaultPermissionMode).toBe("standard");
     }
   });
 
@@ -420,7 +420,7 @@ describe("channel service", () => {
     });
 
     expect(snapshot.accountId).not.toBe(LEGACY_CHANNEL_ACCOUNT_ID);
-    expect(snapshot.accountId).not.toBe("default");
+    expect(snapshot.accountId).not.toBe("standard");
     expect(snapshot.displayName).toBeUndefined();
 
     expect(getChannelConfigSnapshot("telegram")).toEqual(snapshot);

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -197,7 +197,7 @@ const slackAccountDefaults = {
   accountId: "slack-test-account",
   displayName: "Test Workspace",
   agentId: null,
-  defaultPermissionMode: "default",
+  defaultPermissionMode: "standard",
   createdAt: "2026-04-11T00:00:00.000Z",
   updatedAt: "2026-04-11T00:00:00.000Z",
 } as const;

--- a/src/tests/channels/slack-target-resolution.test.ts
+++ b/src/tests/channels/slack-target-resolution.test.ts
@@ -26,7 +26,7 @@ function makeSlackAccount(accountId: string): SlackChannelAccount {
     botToken: `xoxb-${accountId}`,
     appToken: `xapp-${accountId}`,
     agentId: "agent-1",
-    defaultPermissionMode: "default",
+    defaultPermissionMode: "standard",
   };
 }
 

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 describe("permission mode cycle order", () => {
-  test("Shift+Tab cycles from fullAccess through acceptEdits, standard, and plan", () => {
+  test("Shift+Tab cycles from unrestricted through acceptEdits, standard, and plan", () => {
     const inputRichPath = fileURLToPath(
       new URL("../../cli/components/InputRich.tsx", import.meta.url),
     );
@@ -11,7 +11,7 @@ describe("permission mode cycle order", () => {
 
     expect(source).toContain("const modes: PermissionMode[] = [");
     expect(source).toContain(
-      '"fullAccess",\n        "acceptEdits",\n        "standard",\n        "plan",',
+      '"unrestricted",\n        "acceptEdits",\n        "standard",\n        "plan",',
     );
   });
 });

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 describe("permission mode cycle order", () => {
-  test("Shift+Tab cycles from default to plan before edit and yolo modes", () => {
+  test("Shift+Tab cycles from fullAccess through acceptEdits, standard, and plan", () => {
     const inputRichPath = fileURLToPath(
       new URL("../../cli/components/InputRich.tsx", import.meta.url),
     );
@@ -11,8 +11,7 @@ describe("permission mode cycle order", () => {
 
     expect(source).toContain("const modes: PermissionMode[] = [");
     expect(source).toContain(
-      '"default",\n        "plan",\n        "acceptEdits",',
+      '"fullAccess",\n        "acceptEdits",\n        "standard",\n        "plan",',
     );
-    expect(source).toContain('"acceptEdits",\n        "bypassPermissions",');
   });
 });

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -149,7 +149,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain('permissionMode.setMode("plan")');
   });
 
-  test("auto-approves EnterPlanMode in bypassPermissions mode", () => {
+  test("auto-approves EnterPlanMode in fullAccess mode", () => {
     const source = readAppSource();
 
     const guardStart = source.indexOf("Guard EnterPlanMode:");
@@ -163,9 +163,7 @@ describe("permission mode retry wiring", () => {
 
     const segment = source.slice(guardStart, guardEnd);
     expect(segment).toContain('approval?.toolName === "EnterPlanMode"');
-    expect(segment).toContain(
-      'permissionMode.getMode() === "bypassPermissions"',
-    );
+    expect(segment).toContain('permissionMode.getMode() === "fullAccess"');
     expect(segment).toContain("handleEnterPlanModeApprove(true)");
   });
 
@@ -188,7 +186,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain("lastPlanFilePathRef.current = planFilePath;");
   });
 
-  test("restores bypassPermissions when it was active before plan approval", () => {
+  test("restores fullAccess when it was active before plan approval", () => {
     const source = readAppSource();
 
     const start = source.indexOf("const handlePlanApprove = useCallback(");
@@ -203,11 +201,11 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain(
       "const previousMode = permissionMode.getModeBeforePlan();",
     );
-    expect(segment).toContain('previousMode === "bypassPermissions"');
-    expect(segment).toContain('"bypassPermissions"');
+    expect(segment).toContain('previousMode === "fullAccess"');
+    expect(segment).toContain('"fullAccess"');
   });
 
-  test("does not auto-approve ExitPlanMode in bypassPermissions mode", () => {
+  test("does not auto-approve ExitPlanMode in fullAccess mode", () => {
     const source = readAppSource();
 
     const guardStart = source.indexOf("Guard ExitPlanMode:");

--- a/src/tests/cli/permission-mode-retry-wiring.test.ts
+++ b/src/tests/cli/permission-mode-retry-wiring.test.ts
@@ -149,7 +149,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain('permissionMode.setMode("plan")');
   });
 
-  test("auto-approves EnterPlanMode in fullAccess mode", () => {
+  test("auto-approves EnterPlanMode in unrestricted mode", () => {
     const source = readAppSource();
 
     const guardStart = source.indexOf("Guard EnterPlanMode:");
@@ -163,7 +163,7 @@ describe("permission mode retry wiring", () => {
 
     const segment = source.slice(guardStart, guardEnd);
     expect(segment).toContain('approval?.toolName === "EnterPlanMode"');
-    expect(segment).toContain('permissionMode.getMode() === "fullAccess"');
+    expect(segment).toContain('permissionMode.getMode() === "unrestricted"');
     expect(segment).toContain("handleEnterPlanModeApprove(true)");
   });
 
@@ -186,7 +186,7 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain("lastPlanFilePathRef.current = planFilePath;");
   });
 
-  test("restores fullAccess when it was active before plan approval", () => {
+  test("restores unrestricted when it was active before plan approval", () => {
     const source = readAppSource();
 
     const start = source.indexOf("const handlePlanApprove = useCallback(");
@@ -201,11 +201,11 @@ describe("permission mode retry wiring", () => {
     expect(segment).toContain(
       "const previousMode = permissionMode.getModeBeforePlan();",
     );
-    expect(segment).toContain('previousMode === "fullAccess"');
-    expect(segment).toContain('"fullAccess"');
+    expect(segment).toContain('previousMode === "unrestricted"');
+    expect(segment).toContain('"unrestricted"');
   });
 
-  test("does not auto-approve ExitPlanMode in fullAccess mode", () => {
+  test("does not auto-approve ExitPlanMode in unrestricted mode", () => {
     const source = readAppSource();
 
     const guardStart = source.indexOf("Guard ExitPlanMode:");

--- a/src/tests/cli/statusline-payload.test.ts
+++ b/src/tests/cli/statusline-payload.test.ts
@@ -25,7 +25,7 @@ describe("statusLinePayload", () => {
       reflectionStepCount: 10,
       memfsEnabled: true,
       memfsDirectory: "/Users/test/.letta/agents/agent-123/memory",
-      permissionMode: "default",
+      permissionMode: "standard",
       networkPhase: "download",
       terminalWidth: 120,
     });
@@ -45,7 +45,7 @@ describe("statusLinePayload", () => {
     expect(payload.memfs.memory_dir).toBe(
       "/Users/test/.letta/agents/agent-123/memory",
     );
-    expect(payload.permission_mode).toBe("default");
+    expect(payload.permission_mode).toBe("standard");
     expect(payload.network_phase).toBe("download");
     expect(payload.terminal_width).toBe(120);
   });

--- a/src/tests/hooks/integration.test.ts
+++ b/src/tests/hooks/integration.test.ts
@@ -20,6 +20,7 @@ import {
   runUserPromptSubmitHooks,
 } from "../../hooks";
 import { checkPermissionWithHooks } from "../../permissions/checker";
+import { permissionMode } from "../../permissions/mode";
 import { settingsManager } from "../../settings-manager";
 
 // Skip on Windows - test commands use bash syntax (&&, >&2, etc.)
@@ -32,6 +33,7 @@ describe.skipIf(isWindows)("Hooks Integration Tests", () => {
   let originalHome: string | undefined;
 
   beforeEach(async () => {
+    permissionMode.setMode("standard");
     // Reset settings manager FIRST before changing HOME
     await settingsManager.reset();
 

--- a/src/tests/permissions-checker.test.ts
+++ b/src/tests/permissions-checker.test.ts
@@ -1,7 +1,17 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import { checkPermission } from "../permissions/checker";
+import { permissionMode } from "../permissions/mode";
 import { sessionPermissions } from "../permissions/session";
 import type { PermissionRules } from "../permissions/types";
+
+beforeEach(() => {
+  permissionMode.setMode("standard");
+});
+
+afterEach(() => {
+  permissionMode.reset();
+  sessionPermissions.clear();
+});
 
 // ============================================================================
 // Working Directory Tests

--- a/src/tests/permissions-cli.test.ts
+++ b/src/tests/permissions-cli.test.ts
@@ -1,11 +1,17 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import { checkPermission } from "../permissions/checker";
 import { cliPermissions } from "../permissions/cli";
+import { permissionMode } from "../permissions/mode";
 import type { PermissionRules } from "../permissions/types";
+
+beforeEach(() => {
+  permissionMode.setMode("standard");
+});
 
 // Clean up after each test
 afterEach(() => {
   cliPermissions.clear();
+  permissionMode.reset();
 });
 
 // ============================================================================

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 // ============================================================================
 
 test("default mode - no overrides", () => {
-  permissionMode.setMode("default");
+  permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -38,7 +38,7 @@ test("default mode - no overrides", () => {
 });
 
 test("default mode - auto-allows memory", () => {
-  permissionMode.setMode("default");
+  permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -64,7 +64,7 @@ test("default mode - auto-allows memory", () => {
 });
 
 test("default mode - auto-allows memory_apply_patch", () => {
-  permissionMode.setMode("default");
+  permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -88,7 +88,7 @@ test("default mode - auto-allows memory_apply_patch", () => {
 });
 
 test("default mode - treats Agent like Task for safe subagent auto-approval", () => {
-  permissionMode.setMode("default");
+  permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -112,11 +112,11 @@ test("default mode - treats Agent like Task for safe subagent auto-approval", ()
 });
 
 // ============================================================================
-// Permission Mode: bypassPermissions
+// Permission Mode: fullAccess
 // ============================================================================
 
-test("bypassPermissions mode - allows all tools", () => {
-  permissionMode.setMode("bypassPermissions");
+test("fullAccess mode - allows all tools", () => {
+  permissionMode.setMode("fullAccess");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -131,7 +131,7 @@ test("bypassPermissions mode - allows all tools", () => {
     "/Users/test/project",
   );
   expect(bashResult.decision).toBe("allow");
-  expect(bashResult.reason).toBe("Permission mode: bypassPermissions");
+  expect(bashResult.reason).toBe("Permission mode: fullAccess");
 
   const writeResult = checkPermission(
     "Write",
@@ -142,8 +142,8 @@ test("bypassPermissions mode - allows all tools", () => {
   expect(writeResult.decision).toBe("allow");
 });
 
-test("bypassPermissions mode - ExitPlanMode always requires approval", () => {
-  permissionMode.setMode("bypassPermissions");
+test("fullAccess mode - ExitPlanMode always requires approval", () => {
+  permissionMode.setMode("fullAccess");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -178,8 +178,8 @@ test("bypassPermissions mode - ExitPlanMode always requires approval", () => {
   expect(enterResult.decision).toBe("allow");
 });
 
-test("bypassPermissions mode - does NOT override deny rules", () => {
-  permissionMode.setMode("bypassPermissions");
+test("fullAccess mode - does NOT override deny rules", () => {
+  permissionMode.setMode("fullAccess");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -194,7 +194,7 @@ test("bypassPermissions mode - does NOT override deny rules", () => {
     "/Users/test/project",
   );
 
-  // Deny rules take precedence even in bypassPermissions mode
+  // Deny rules take precedence even in fullAccess mode
   expect(result.decision).toBe("deny");
   expect(result.reason).toBe("Matched deny rule");
 });
@@ -1403,7 +1403,7 @@ test("plan mode - denies WebFetch", () => {
 // ============================================================================
 
 test("Deny rules override permission mode", () => {
-  permissionMode.setMode("bypassPermissions");
+  permissionMode.setMode("fullAccess");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -1418,7 +1418,7 @@ test("Deny rules override permission mode", () => {
     "/Users/test/project",
   );
 
-  // Deny rule takes precedence over bypassPermissions
+  // Deny rule takes precedence over fullAccess
   expect(result.decision).toBe("deny");
   expect(result.reason).toBe("Matched deny rule");
 });
@@ -1452,17 +1452,17 @@ test("Permission mode takes precedence over CLI allowedTools", () => {
 });
 
 test("plan mode - remembers and restores previous mode", () => {
-  permissionMode.setMode("bypassPermissions");
-  expect(permissionMode.getMode()).toBe("bypassPermissions");
+  permissionMode.setMode("fullAccess");
+  expect(permissionMode.getMode()).toBe("fullAccess");
 
   // Enter plan mode - should remember prior mode.
   permissionMode.setMode("plan");
   expect(permissionMode.getMode()).toBe("plan");
-  expect(permissionMode.getModeBeforePlan()).toBe("bypassPermissions");
+  expect(permissionMode.getModeBeforePlan()).toBe("fullAccess");
 
   // Exit plan mode by restoring previous mode.
-  permissionMode.setMode(permissionMode.getModeBeforePlan() ?? "default");
-  expect(permissionMode.getMode()).toBe("bypassPermissions");
+  permissionMode.setMode(permissionMode.getModeBeforePlan() ?? "fullAccess");
+  expect(permissionMode.getMode()).toBe("fullAccess");
 
   // Once we leave plan mode, the remembered mode is consumed.
   expect(permissionMode.getModeBeforePlan()).toBe(null);

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -112,11 +112,11 @@ test("default mode - treats Agent like Task for safe subagent auto-approval", ()
 });
 
 // ============================================================================
-// Permission Mode: fullAccess
+// Permission Mode: unrestricted
 // ============================================================================
 
-test("fullAccess mode - allows all tools", () => {
-  permissionMode.setMode("fullAccess");
+test("unrestricted mode - allows all tools", () => {
+  permissionMode.setMode("unrestricted");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -131,7 +131,7 @@ test("fullAccess mode - allows all tools", () => {
     "/Users/test/project",
   );
   expect(bashResult.decision).toBe("allow");
-  expect(bashResult.reason).toBe("Permission mode: fullAccess");
+  expect(bashResult.reason).toBe("Permission mode: unrestricted");
 
   const writeResult = checkPermission(
     "Write",
@@ -142,8 +142,8 @@ test("fullAccess mode - allows all tools", () => {
   expect(writeResult.decision).toBe("allow");
 });
 
-test("fullAccess mode - ExitPlanMode always requires approval", () => {
-  permissionMode.setMode("fullAccess");
+test("unrestricted mode - ExitPlanMode always requires approval", () => {
+  permissionMode.setMode("unrestricted");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -178,8 +178,8 @@ test("fullAccess mode - ExitPlanMode always requires approval", () => {
   expect(enterResult.decision).toBe("allow");
 });
 
-test("fullAccess mode - does NOT override deny rules", () => {
-  permissionMode.setMode("fullAccess");
+test("unrestricted mode - does NOT override deny rules", () => {
+  permissionMode.setMode("unrestricted");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -194,7 +194,7 @@ test("fullAccess mode - does NOT override deny rules", () => {
     "/Users/test/project",
   );
 
-  // Deny rules take precedence even in fullAccess mode
+  // Deny rules take precedence even in unrestricted mode
   expect(result.decision).toBe("deny");
   expect(result.reason).toBe("Matched deny rule");
 });
@@ -1403,7 +1403,7 @@ test("plan mode - denies WebFetch", () => {
 // ============================================================================
 
 test("Deny rules override permission mode", () => {
-  permissionMode.setMode("fullAccess");
+  permissionMode.setMode("unrestricted");
 
   const permissions: PermissionRules = {
     allow: [],
@@ -1418,7 +1418,7 @@ test("Deny rules override permission mode", () => {
     "/Users/test/project",
   );
 
-  // Deny rule takes precedence over fullAccess
+  // Deny rule takes precedence over unrestricted
   expect(result.decision).toBe("deny");
   expect(result.reason).toBe("Matched deny rule");
 });
@@ -1452,17 +1452,17 @@ test("Permission mode takes precedence over CLI allowedTools", () => {
 });
 
 test("plan mode - remembers and restores previous mode", () => {
-  permissionMode.setMode("fullAccess");
-  expect(permissionMode.getMode()).toBe("fullAccess");
+  permissionMode.setMode("unrestricted");
+  expect(permissionMode.getMode()).toBe("unrestricted");
 
   // Enter plan mode - should remember prior mode.
   permissionMode.setMode("plan");
   expect(permissionMode.getMode()).toBe("plan");
-  expect(permissionMode.getModeBeforePlan()).toBe("fullAccess");
+  expect(permissionMode.getModeBeforePlan()).toBe("unrestricted");
 
   // Exit plan mode by restoring previous mode.
-  permissionMode.setMode(permissionMode.getModeBeforePlan() ?? "fullAccess");
-  expect(permissionMode.getMode()).toBe("fullAccess");
+  permissionMode.setMode(permissionMode.getModeBeforePlan() ?? "unrestricted");
+  expect(permissionMode.getMode()).toBe("unrestricted");
 
   // Once we leave plan mode, the remembered mode is consumed.
   expect(permissionMode.getModeBeforePlan()).toBe(null);

--- a/src/tests/permissions.test.ts
+++ b/src/tests/permissions.test.ts
@@ -1,7 +1,16 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import { analyzeApprovalContext } from "../permissions/analyzer";
 import { checkPermission } from "../permissions/checker";
+import { permissionMode } from "../permissions/mode";
 import type { PermissionRules } from "../permissions/types";
+
+beforeEach(() => {
+  permissionMode.setMode("standard");
+});
+
+afterEach(() => {
+  permissionMode.reset();
+});
 
 test("Read within working directory is auto-allowed", () => {
   if (process.platform === "win32") return; // Skip on Windows - Unix paths

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -385,8 +385,8 @@ describe("evaluateCrossAgentGuard", () => {
 describe("checkPermission integration", () => {
   const permissions = { allow: [], deny: [], ask: [] };
 
-  test("fullAccess mode does NOT let you write another agent's memory", () => {
-    permissionMode.setMode("fullAccess");
+  test("unrestricted mode does NOT let you write another agent's memory", () => {
+    permissionMode.setMode("unrestricted");
     const result = checkPermission(
       "Write",
       { file_path: otherMemory("system/a.md") },
@@ -441,7 +441,7 @@ describe("checkPermission integration", () => {
       "acceptEdits",
       "plan",
       "memory",
-      "fullAccess",
+      "unrestricted",
     ] as const;
     for (const mode of modes) {
       permissionMode.setMode(mode);
@@ -458,7 +458,12 @@ describe("checkPermission integration", () => {
 
   test("own-memory access is unaffected by guard in every mode", () => {
     process.env.MEMORY_DIR = selfMemory();
-    const modes = ["standard", "acceptEdits", "memory", "fullAccess"] as const;
+    const modes = [
+      "standard",
+      "acceptEdits",
+      "memory",
+      "unrestricted",
+    ] as const;
     for (const mode of modes) {
       permissionMode.setMode(mode);
       const result = checkPermission(
@@ -473,8 +478,8 @@ describe("checkPermission integration", () => {
     }
   });
 
-  test("bash against another agent's memory is denied even in fullAccess", () => {
-    permissionMode.setMode("fullAccess");
+  test("bash against another agent's memory is denied even in unrestricted", () => {
+    permissionMode.setMode("unrestricted");
     const result = checkPermission(
       "Bash",
       { command: `git -C ${otherMemory()} log` },

--- a/src/tests/permissions/crossAgentGuard.test.ts
+++ b/src/tests/permissions/crossAgentGuard.test.ts
@@ -385,8 +385,8 @@ describe("evaluateCrossAgentGuard", () => {
 describe("checkPermission integration", () => {
   const permissions = { allow: [], deny: [], ask: [] };
 
-  test("bypassPermissions mode does NOT let you write another agent's memory", () => {
-    permissionMode.setMode("bypassPermissions");
+  test("fullAccess mode does NOT let you write another agent's memory", () => {
+    permissionMode.setMode("fullAccess");
     const result = checkPermission(
       "Write",
       { file_path: otherMemory("system/a.md") },
@@ -437,11 +437,11 @@ describe("checkPermission integration", () => {
 
   test("reads against another agent's memory are denied across all modes", () => {
     const modes = [
-      "default",
+      "standard",
       "acceptEdits",
       "plan",
       "memory",
-      "bypassPermissions",
+      "fullAccess",
     ] as const;
     for (const mode of modes) {
       permissionMode.setMode(mode);
@@ -458,12 +458,7 @@ describe("checkPermission integration", () => {
 
   test("own-memory access is unaffected by guard in every mode", () => {
     process.env.MEMORY_DIR = selfMemory();
-    const modes = [
-      "default",
-      "acceptEdits",
-      "memory",
-      "bypassPermissions",
-    ] as const;
+    const modes = ["standard", "acceptEdits", "memory", "fullAccess"] as const;
     for (const mode of modes) {
       permissionMode.setMode(mode);
       const result = checkPermission(
@@ -478,8 +473,8 @@ describe("checkPermission integration", () => {
     }
   });
 
-  test("bash against another agent's memory is denied even in bypassPermissions", () => {
-    permissionMode.setMode("bypassPermissions");
+  test("bash against another agent's memory is denied even in fullAccess", () => {
+    permissionMode.setMode("fullAccess");
     const result = checkPermission(
       "Bash",
       { command: `git -C ${otherMemory()} log` },

--- a/src/tests/reminders/permission-mode.test.ts
+++ b/src/tests/reminders/permission-mode.test.ts
@@ -29,35 +29,35 @@ function baseContext(
 }
 
 afterEach(() => {
-  permissionMode.setMode("default");
+  permissionMode.setMode("standard");
 });
 
 describe("shared permission-mode reminder", () => {
   test("emits on first headless turn", async () => {
-    permissionMode.setMode("default");
+    permissionMode.setMode("standard");
     const provider = sharedReminderProviders["permission-mode"];
     const reminder = await provider(baseContext("headless-one-shot"));
-    expect(reminder).toContain("Permission mode active: default");
+    expect(reminder).toContain("Permission mode active: standard");
   });
 
-  test("interactive does not emit on first turn in default mode", async () => {
-    permissionMode.setMode("default");
+  test("interactive emits on first turn in standard mode (not the default anymore)", async () => {
+    permissionMode.setMode("standard");
     const provider = sharedReminderProviders["permission-mode"];
     const context = baseContext("interactive");
 
     const first = await provider(context);
-    expect(first).toBeNull();
+    expect(first).toContain("Permission mode active: standard");
 
-    permissionMode.setMode("bypassPermissions");
+    permissionMode.setMode("fullAccess");
     const second = await provider(context);
-    expect(second).toContain("Permission mode changed to: bypassPermissions");
+    expect(second).toContain("Permission mode changed to: fullAccess");
   });
 
-  test("interactive emits on first turn in bypassPermissions mode", async () => {
-    permissionMode.setMode("bypassPermissions");
+  test("interactive does not emit on first turn in fullAccess mode (it is the default)", async () => {
+    permissionMode.setMode("fullAccess");
     const provider = sharedReminderProviders["permission-mode"];
     const reminder = await provider(baseContext("interactive"));
-    expect(reminder).toContain("Permission mode active: bypassPermissions");
+    expect(reminder).toBeNull();
   });
 
   test("interactive emits on first turn in acceptEdits mode", async () => {

--- a/src/tests/reminders/permission-mode.test.ts
+++ b/src/tests/reminders/permission-mode.test.ts
@@ -48,13 +48,13 @@ describe("shared permission-mode reminder", () => {
     const first = await provider(context);
     expect(first).toContain("Permission mode active: standard");
 
-    permissionMode.setMode("fullAccess");
+    permissionMode.setMode("unrestricted");
     const second = await provider(context);
-    expect(second).toContain("Permission mode changed to: fullAccess");
+    expect(second).toContain("Permission mode changed to: unrestricted");
   });
 
-  test("interactive does not emit on first turn in fullAccess mode (it is the default)", async () => {
-    permissionMode.setMode("fullAccess");
+  test("interactive does not emit on first turn in unrestricted mode (it is the default)", async () => {
+    permissionMode.setMode("unrestricted");
     const provider = sharedReminderProviders["permission-mode"];
     const reminder = await provider(baseContext("interactive"));
     expect(reminder).toBeNull();

--- a/src/tests/tools/exitplanmode.test.ts
+++ b/src/tests/tools/exitplanmode.test.ts
@@ -5,24 +5,24 @@ import { exit_plan_mode } from "../../tools/impl/ExitPlanMode";
 describe("ExitPlanMode tool", () => {
   test("restores prior permission mode when exiting plan mode", async () => {
     permissionMode.reset();
-    permissionMode.setMode("bypassPermissions");
+    permissionMode.setMode("fullAccess");
     permissionMode.setMode("plan");
     permissionMode.setPlanFilePath("/tmp/test-plan.md");
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("bypassPermissions");
+    expect(permissionMode.getMode()).toBe("fullAccess");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 
-  test("falls back to default mode when previous mode is unavailable", async () => {
+  test("restores to fullAccess when entering plan from reset state", async () => {
     permissionMode.reset();
     permissionMode.setMode("plan");
     permissionMode.setPlanFilePath("/tmp/test-plan.md");
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("default");
+    expect(permissionMode.getMode()).toBe("fullAccess");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 
@@ -34,7 +34,7 @@ describe("ExitPlanMode tool", () => {
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("default");
+    expect(permissionMode.getMode()).toBe("standard");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 

--- a/src/tests/tools/exitplanmode.test.ts
+++ b/src/tests/tools/exitplanmode.test.ts
@@ -5,24 +5,24 @@ import { exit_plan_mode } from "../../tools/impl/ExitPlanMode";
 describe("ExitPlanMode tool", () => {
   test("restores prior permission mode when exiting plan mode", async () => {
     permissionMode.reset();
-    permissionMode.setMode("fullAccess");
+    permissionMode.setMode("unrestricted");
     permissionMode.setMode("plan");
     permissionMode.setPlanFilePath("/tmp/test-plan.md");
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("fullAccess");
+    expect(permissionMode.getMode()).toBe("unrestricted");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 
-  test("restores to fullAccess when entering plan from reset state", async () => {
+  test("restores to unrestricted when entering plan from reset state", async () => {
     permissionMode.reset();
     permissionMode.setMode("plan");
     permissionMode.setPlanFilePath("/tmp/test-plan.md");
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("fullAccess");
+    expect(permissionMode.getMode()).toBe("unrestricted");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 

--- a/src/tests/tools/exitplanmode.test.ts
+++ b/src/tests/tools/exitplanmode.test.ts
@@ -34,7 +34,7 @@ describe("ExitPlanMode tool", () => {
 
     await exit_plan_mode();
 
-    expect(permissionMode.getMode()).toBe("standard");
+    expect(permissionMode.getMode()).toBe("unrestricted");
     expect(permissionMode.getPlanFilePath()).toBeNull();
   });
 

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -433,7 +433,7 @@ describe("tool execution context snapshot", () => {
       botToken: "xoxb-test-token",
       appToken: "xapp-test-token",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
 
     const scope = resolveConversationChannelToolScope("agent-1", "default");
@@ -469,7 +469,7 @@ describe("tool execution context snapshot", () => {
       botToken: "xoxb-test-token",
       appToken: "xapp-test-token",
       agentId: "agent-1",
-      defaultPermissionMode: "default",
+      defaultPermissionMode: "standard",
     });
     setRouteInMemory("slack", {
       accountId: "acct-slack",

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -2237,7 +2237,7 @@ describe("listen-client multi-worker concurrency", () => {
       command: {
         type: "change_device_state",
         runtime: { agent_id: "agent-1", conversation_id: "conv-mid" },
-        payload: { mode: "fullAccess" },
+        payload: { mode: "unrestricted" },
       },
       socket: socket as unknown as WebSocket,
       opts: {},
@@ -2248,7 +2248,7 @@ describe("listen-client multi-worker concurrency", () => {
 
     await turnPromise;
 
-    expect(capturedModeAtClassification === "fullAccess").toBe(true);
+    expect(capturedModeAtClassification === "unrestricted").toBe(true);
     const continuationMessages = sendMessageStreamMock.mock.calls[1]?.[1] as
       | Array<Record<string, unknown>>
       | undefined;

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -2414,7 +2414,7 @@ describe("listen-client multi-worker concurrency", () => {
 
     const [resumeConversationId, resumeParams] =
       conversationMessagesStreamMock.mock.calls[0] ?? [];
-    expect(resumeConversationId).toBe("standard");
+    expect(resumeConversationId).toBe("default");
     expect(resumeParams).toMatchObject({
       agent_id: "agent-409-default",
       otid: "otid-default",

--- a/src/tests/websocket/listen-client-concurrency.test.ts
+++ b/src/tests/websocket/listen-client-concurrency.test.ts
@@ -2237,7 +2237,7 @@ describe("listen-client multi-worker concurrency", () => {
       command: {
         type: "change_device_state",
         runtime: { agent_id: "agent-1", conversation_id: "conv-mid" },
-        payload: { mode: "bypassPermissions" },
+        payload: { mode: "fullAccess" },
       },
       socket: socket as unknown as WebSocket,
       opts: {},
@@ -2248,7 +2248,7 @@ describe("listen-client multi-worker concurrency", () => {
 
     await turnPromise;
 
-    expect(capturedModeAtClassification === "bypassPermissions").toBe(true);
+    expect(capturedModeAtClassification === "fullAccess").toBe(true);
     const continuationMessages = sendMessageStreamMock.mock.calls[1]?.[1] as
       | Array<Record<string, unknown>>
       | undefined;
@@ -2267,7 +2267,7 @@ describe("listen-client multi-worker concurrency", () => {
       command: {
         type: "change_device_state",
         runtime: { agent_id: "agent-1", conversation_id: "default" },
-        payload: { mode: "default" },
+        payload: { mode: "standard" },
       },
       socket: socket as unknown as WebSocket,
       opts: {},
@@ -2414,7 +2414,7 @@ describe("listen-client multi-worker concurrency", () => {
 
     const [resumeConversationId, resumeParams] =
       conversationMessagesStreamMock.mock.calls[0] ?? [];
-    expect(resumeConversationId).toBe("default");
+    expect(resumeConversationId).toBe("standard");
     expect(resumeParams).toMatchObject({
       agent_id: "agent-409-default",
       otid: "otid-default",

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -2426,7 +2426,7 @@ describe("listen-client permission mode scope keys", () => {
         accountId: "acct-1",
         agentId: "agent-123",
         conversationId: "conv-slack-1",
-        defaultPermissionMode: "fullAccess",
+        defaultPermissionMode: "unrestricted",
       },
       socket as unknown as WebSocket,
       listener,
@@ -2437,11 +2437,11 @@ describe("listen-client permission mode scope keys", () => {
       conversation_id: "conv-slack-1",
     });
 
-    expect(status.current_permission_mode).toBe("fullAccess");
+    expect(status.current_permission_mode).toBe("unrestricted");
     expect(
       listener.permissionModeByConversation.get("conversation:conv-slack-1"),
     ).toEqual({
-      mode: "fullAccess",
+      mode: "unrestricted",
       planFilePath: null,
       modeBeforePlan: null,
     });

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -356,7 +356,7 @@ describe("listen-client parseServerMessage", () => {
         JSON.stringify({
           type: "change_device_state",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
-          payload: { mode: "default" },
+          payload: { mode: "standard" },
         }),
       ),
     );
@@ -2426,7 +2426,7 @@ describe("listen-client permission mode scope keys", () => {
         accountId: "acct-1",
         agentId: "agent-123",
         conversationId: "conv-slack-1",
-        defaultPermissionMode: "bypassPermissions",
+        defaultPermissionMode: "fullAccess",
       },
       socket as unknown as WebSocket,
       listener,
@@ -2437,11 +2437,11 @@ describe("listen-client permission mode scope keys", () => {
       conversation_id: "conv-slack-1",
     });
 
-    expect(status.current_permission_mode).toBe("bypassPermissions");
+    expect(status.current_permission_mode).toBe("fullAccess");
     expect(
       listener.permissionModeByConversation.get("conversation:conv-slack-1"),
     ).toEqual({
-      mode: "bypassPermissions",
+      mode: "fullAccess",
       planFilePath: null,
       modeBeforePlan: null,
     });
@@ -2808,7 +2808,7 @@ describe("listen-client v2 status builders", () => {
       {
         mode: "plan",
         planFilePath: "/tmp/listener-plan.md",
-        modeBeforePlan: "default",
+        modeBeforePlan: "standard",
       },
     );
 
@@ -3980,7 +3980,7 @@ describe("listen-client capability-gated approval flow", () => {
     expect(firstPlanPath).toBeTruthy();
 
     __listenClientTestUtils.handleModeChange(
-      { mode: "default" },
+      { mode: "standard" },
       socket as unknown as WebSocket,
       listener,
       scope,

--- a/src/tests/websocket/listener-permission-mode.test.ts
+++ b/src/tests/websocket/listener-permission-mode.test.ts
@@ -73,7 +73,7 @@ describe("listener permission mode helpers", () => {
       "agent-1",
       "conv-prune",
     );
-    ref2.mode = "bypassPermissions";
+    ref2.mode = "fullAccess";
 
     const prunedNonDefault = pruneConversationPermissionModeStateIfDefault(
       listener,

--- a/src/tests/websocket/listener-permission-mode.test.ts
+++ b/src/tests/websocket/listener-permission-mode.test.ts
@@ -73,7 +73,7 @@ describe("listener permission mode helpers", () => {
       "agent-1",
       "conv-prune",
     );
-    ref2.mode = "fullAccess";
+    ref2.mode = "acceptEdits";
 
     const prunedNonDefault = pruneConversationPermissionModeStateIfDefault(
       listener,

--- a/src/tools/impl/ExitPlanMode.ts
+++ b/src/tools/impl/ExitPlanMode.ts
@@ -3,7 +3,10 @@
  * Exits plan mode - the plan is read from the plan file by the UI
  */
 
-import { permissionMode } from "../../permissions/mode";
+import {
+  DEFAULT_PERMISSION_MODE,
+  permissionMode,
+} from "../../permissions/mode";
 import { getExecutionContextPermissionModeState } from "../manager";
 
 interface ExitPlanModeArgs {
@@ -28,14 +31,20 @@ export async function exit_plan_mode(
     if (scopedState.mode === "plan") {
       const prev = scopedState.modeBeforePlan;
       // Restore the previous mode, but never restore "memory" — fall back to
-      // "standard" so the user isn't stuck in a restricted mode after plan approval.
-      scopedState.mode = prev === "memory" ? "standard" : (prev ?? "standard");
+      // DEFAULT_PERMISSION_MODE so the user isn't stuck in a restricted mode after plan approval.
+      scopedState.mode =
+        prev === "memory"
+          ? DEFAULT_PERMISSION_MODE
+          : (prev ?? DEFAULT_PERMISSION_MODE);
       scopedState.modeBeforePlan = null;
       scopedState.planFilePath = null;
     }
   } else if (permissionMode.getMode() === "plan") {
     const prev = permissionMode.getModeBeforePlan();
-    const restoredMode = prev === "memory" ? "standard" : (prev ?? "standard");
+    const restoredMode =
+      prev === "memory"
+        ? DEFAULT_PERMISSION_MODE
+        : (prev ?? DEFAULT_PERMISSION_MODE);
     permissionMode.setMode(restoredMode);
   }
 

--- a/src/tools/impl/ExitPlanMode.ts
+++ b/src/tools/impl/ExitPlanMode.ts
@@ -28,14 +28,14 @@ export async function exit_plan_mode(
     if (scopedState.mode === "plan") {
       const prev = scopedState.modeBeforePlan;
       // Restore the previous mode, but never restore "memory" — fall back to
-      // "default" so the user isn't stuck in a restricted mode after plan approval.
-      scopedState.mode = prev === "memory" ? "default" : (prev ?? "default");
+      // "standard" so the user isn't stuck in a restricted mode after plan approval.
+      scopedState.mode = prev === "memory" ? "standard" : (prev ?? "standard");
       scopedState.modeBeforePlan = null;
       scopedState.planFilePath = null;
     }
   } else if (permissionMode.getMode() === "plan") {
     const prev = permissionMode.getModeBeforePlan();
-    const restoredMode = prev === "memory" ? "default" : (prev ?? "default");
+    const restoredMode = prev === "memory" ? "standard" : (prev ?? "standard");
     permissionMode.setMode(restoredMode);
   }
 

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -36,7 +36,7 @@ export type DevicePermissionMode =
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "fullAccess";
+  | "unrestricted";
 
 export type ToolsetName =
   | "codex"

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -32,11 +32,11 @@ export interface RuntimeEnvelope {
 }
 
 export type DevicePermissionMode =
-  | "default"
+  | "standard"
   | "acceptEdits"
   | "plan"
   | "memory"
-  | "bypassPermissions";
+  | "fullAccess";
 
 export type ToolsetName =
   | "codex"

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -9,6 +9,7 @@ import {
 } from "../../cli/helpers/fileIndex";
 import { generatePlanFilePath } from "../../cli/helpers/planName";
 import { INTERRUPTED_BY_USER } from "../../constants";
+import { migratePermissionMode } from "../../permissions/mode";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
 import type {
   AbortMessageCommand,
@@ -96,19 +97,22 @@ export function handleModeChange(
       conversationId,
     );
 
+    // Migrate legacy mode values from older clients
+    const incomingMode = migratePermissionMode(msg.mode) ?? msg.mode;
+
     // Track previous mode so ExitPlanMode can restore it
-    if (msg.mode === "plan" && current.mode !== "plan") {
+    if (incomingMode === "plan" && current.mode !== "plan") {
       current.modeBeforePlan = current.mode;
     }
-    current.mode = msg.mode;
+    current.mode = incomingMode;
 
     // Generate plan file path when entering plan mode
-    if (msg.mode === "plan" && !current.planFilePath) {
+    if (incomingMode === "plan" && !current.planFilePath) {
       current.planFilePath = generatePlanFilePath();
     }
 
     // Clear plan-related state when leaving plan mode
-    if (msg.mode !== "plan") {
+    if (incomingMode !== "plan") {
       current.planFilePath = null;
       current.modeBeforePlan = null;
     }

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -170,7 +170,7 @@ export function loadPersistedPermissionModeMap(): Map<
       // If "plan" was somehow saved, restore to the pre-plan mode.
       const restoredMode: PermissionMode =
         persisted.mode === "plan"
-          ? (persisted.modeBeforePlan ?? "default")
+          ? (persisted.modeBeforePlan ?? "standard")
           : persisted.mode;
       map.set(key, {
         mode: restoredMode,
@@ -196,7 +196,7 @@ export function persistPermissionModeMapForRuntime(
 /**
  * Serialize the permission mode map and persist to remote-settings.json.
  * Strips planFilePath (ephemeral). Converts "plan" mode to modeBeforePlan.
- * Skips entries that are effectively "default" (lean map).
+ * Skips entries that are effectively "standard" (lean map).
  */
 function persistPermissionModeMap(
   map: Map<string, ConversationPermissionModeState>,
@@ -210,10 +210,10 @@ function persistPermissionModeMap(
     // If currently in plan mode, persist the effective mode as modeBeforePlan
     // so we don't restore into plan mode (plan file path is ephemeral).
     const modeToSave: PermissionMode =
-      state.mode === "plan" ? (state.modeBeforePlan ?? "default") : state.mode;
+      state.mode === "plan" ? (state.modeBeforePlan ?? "standard") : state.mode;
 
-    // Skip entries that are just "default" with no context — lean map.
-    if (modeToSave === "default" && state.modeBeforePlan === null) {
+    // Skip entries that are just "standard" with no context — lean map.
+    if (modeToSave === "standard" && state.modeBeforePlan === null) {
       continue;
     }
 

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -7,8 +7,11 @@
  * - A scope key derived from agentId + conversationId is used as the map key.
  */
 
-import type { PermissionMode } from "../../permissions/mode";
-import { permissionMode as globalPermissionMode } from "../../permissions/mode";
+import {
+  permissionMode as globalPermissionMode,
+  migratePermissionMode,
+  type PermissionMode,
+} from "../../permissions/mode";
 import { loadRemoteSettings, saveRemoteSettings } from "./remote-settings";
 import { normalizeConversationId, normalizeCwdAgentId } from "./scope";
 import type { ListenerRuntime } from "./types";
@@ -167,11 +170,14 @@ export function loadPersistedPermissionModeMap(): Map<
       return map;
     }
     for (const [key, persisted] of Object.entries(settings.permissionModeMap)) {
+      // Migrate legacy mode values ("default" → "standard", "bypassPermissions" → "fullAccess").
+      const rawMode = migratePermissionMode(persisted.mode) ?? "standard";
+      const rawModeBeforePlan = persisted.modeBeforePlan
+        ? (migratePermissionMode(persisted.modeBeforePlan) ?? null)
+        : null;
       // If "plan" was somehow saved, restore to the pre-plan mode.
       const restoredMode: PermissionMode =
-        persisted.mode === "plan"
-          ? (persisted.modeBeforePlan ?? "standard")
-          : persisted.mode;
+        rawMode === "plan" ? (rawModeBeforePlan ?? "standard") : rawMode;
       map.set(key, {
         mode: restoredMode,
         planFilePath: null,

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -172,7 +172,8 @@ export function loadPersistedPermissionModeMap(): Map<
     }
     for (const [key, persisted] of Object.entries(settings.permissionModeMap)) {
       // Migrate legacy mode values ("default" → "standard", "bypassPermissions" → "unrestricted").
-      const rawMode = migratePermissionMode(persisted.mode) ?? "standard";
+      const rawMode =
+        migratePermissionMode(persisted.mode) ?? DEFAULT_PERMISSION_MODE;
       const rawModeBeforePlan = persisted.modeBeforePlan
         ? (migratePermissionMode(persisted.modeBeforePlan) ?? null)
         : null;

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  DEFAULT_PERMISSION_MODE,
   permissionMode as globalPermissionMode,
   migratePermissionMode,
   type PermissionMode,
@@ -177,7 +178,9 @@ export function loadPersistedPermissionModeMap(): Map<
         : null;
       // If "plan" was somehow saved, restore to the pre-plan mode.
       const restoredMode: PermissionMode =
-        rawMode === "plan" ? (rawModeBeforePlan ?? "standard") : rawMode;
+        rawMode === "plan"
+          ? (rawModeBeforePlan ?? DEFAULT_PERMISSION_MODE)
+          : rawMode;
       map.set(key, {
         mode: restoredMode,
         planFilePath: null,
@@ -216,11 +219,13 @@ function persistPermissionModeMap(
     // If currently in plan mode, persist the effective mode as modeBeforePlan
     // so we don't restore into plan mode (plan file path is ephemeral).
     const modeToSave: PermissionMode =
-      state.mode === "plan" ? (state.modeBeforePlan ?? "standard") : state.mode;
+      state.mode === "plan"
+        ? (state.modeBeforePlan ?? DEFAULT_PERMISSION_MODE)
+        : state.mode;
 
-    // Skip entries that match the current global default with no context — lean map.
+    // Skip entries that are just the default starting mode with no context — lean map.
     if (
-      modeToSave === globalPermissionMode.getMode() &&
+      modeToSave === DEFAULT_PERMISSION_MODE &&
       state.modeBeforePlan === null
     ) {
       continue;

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -170,7 +170,7 @@ export function loadPersistedPermissionModeMap(): Map<
       return map;
     }
     for (const [key, persisted] of Object.entries(settings.permissionModeMap)) {
-      // Migrate legacy mode values ("default" → "standard", "bypassPermissions" → "fullAccess").
+      // Migrate legacy mode values ("default" → "standard", "bypassPermissions" → "unrestricted").
       const rawMode = migratePermissionMode(persisted.mode) ?? "standard";
       const rawModeBeforePlan = persisted.modeBeforePlan
         ? (migratePermissionMode(persisted.modeBeforePlan) ?? null)
@@ -202,7 +202,7 @@ export function persistPermissionModeMapForRuntime(
 /**
  * Serialize the permission mode map and persist to remote-settings.json.
  * Strips planFilePath (ephemeral). Converts "plan" mode to modeBeforePlan.
- * Skips entries that are effectively "standard" (lean map).
+ * Skips entries that match the current global default mode (lean map).
  */
 function persistPermissionModeMap(
   map: Map<string, ConversationPermissionModeState>,
@@ -218,8 +218,11 @@ function persistPermissionModeMap(
     const modeToSave: PermissionMode =
       state.mode === "plan" ? (state.modeBeforePlan ?? "standard") : state.mode;
 
-    // Skip entries that are just "standard" with no context — lean map.
-    if (modeToSave === "standard" && state.modeBeforePlan === null) {
+    // Skip entries that match the current global default with no context — lean map.
+    if (
+      modeToSave === globalPermissionMode.getMode() &&
+      state.modeBeforePlan === null
+    ) {
       continue;
     }
 

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -70,7 +70,7 @@ export type ProcessQueuedTurn = (
 ) => Promise<void>;
 
 export interface ModeChangePayload {
-  mode: "standard" | "acceptEdits" | "plan" | "memory" | "fullAccess";
+  mode: "standard" | "acceptEdits" | "plan" | "memory" | "unrestricted";
 }
 
 export interface ChangeCwdMessage {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -70,7 +70,7 @@ export type ProcessQueuedTurn = (
 ) => Promise<void>;
 
 export interface ModeChangePayload {
-  mode: "default" | "acceptEdits" | "plan" | "memory" | "bypassPermissions";
+  mode: "standard" | "acceptEdits" | "plan" | "memory" | "fullAccess";
 }
 
 export interface ChangeCwdMessage {


### PR DESCRIPTION
## Summary
- Renames `bypassPermissions` → `unrestricted` (consistency with Letta desktop; previously intermediate name `fullAccess`)
- Renames permission mode `"default"` → `"standard"` (more descriptive of behavior)
- Makes `unrestricted` the default starting permission mode
- Updates cycle order to `unrestricted → acceptEdits → standard → plan` (most → least permissive)
- `unrestricted` mode shows no status label (falls through to "Press / for commands")
- `standard` mode shows "standard (request approval) mode" in light lavender
- Suppresses first-turn reminder for `unrestricted` (it is now the default)
- Centralizes legacy mode migration in `migratePermissionMode()` in `permissions/mode.ts`:
  - `"default"` → `"standard"`, `"bypassPermissions"` / `"fullAccess"` → `"unrestricted"`
  - Applied at all external ingress points: CLI flags, `remote-settings.json`, Slack config
- Fixes persist prune logic to use `globalPermissionMode.getMode()` dynamically
- Resets permission mode in checker tests to prevent global state leakage in CI

## Motivation
- `bypassPermissions` / `fullAccess` leaked implementation details into the UI as "yolo" — `unrestricted` is clearer and matches Letta desktop
- `"default"` as a mode name was confusing once it was no longer the actual default — `"standard"` better describes what it does (ask for approval on everything)
- Making `unrestricted` the default reduces friction for the common case

## UI

### New unrestricted mode as default - same as before

<img width="588" height="202" alt="Screenshot 2026-05-11 at 3 20 20 PM" src="https://github.com/user-attachments/assets/1ce04e5f-ff0b-4dcc-a061-92979311ce6a" />

### New standard (request approval) mode:

<img width="594" height="205" alt="Screenshot 2026-05-11 at 3 20 40 PM" src="https://github.com/user-attachments/assets/b98320ee-dc7f-44ff-afc1-0a373fe7e184" />

## Test plan
- [ ] Verify TUI starts in unrestricted mode showing "Press / for commands" (no mode label)
- [ ] Verify Shift+Tab cycles: `unrestricted → accept edits → standard (request approval) mode → plan`
- [ ] Verify `--yolo` flag still works (alias unchanged)
- [ ] Verify `--permission-mode standard` works as CLI flag
- [ ] Verify `--permission-mode unrestricted` works as CLI flag
- [ ] Verify legacy `--permission-mode default` and `--permission-mode bypassPermissions` still work (migrated)

👾 Generated with [Letta Code](https://letta.com)