### PR TITLE
feat(cli): add ANSI color parsing to statusline

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -324,29 +324,6 @@ function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
       }
     }
 
-    // Handle 256-color foreground: 38;5;N
-    if (code === 38 && match[2] === "5") {
-      const n = match[3];
-      if (n) {
-        const text = line.slice(lastIndex, match.index);
-        if (text || currentColor || currentBgColor) {
-          parts.push(
-            <Text
-              key={`${keyPrefix}-${lastIndex}`}
-              color={currentColor}
-              backgroundColor={currentBgColor}
-            >
-              {text}
-            </Text>,
-          );
-        }
-        lastIndex = match.index + fullMatch.length;
-        const color256 = get256Color(parseInt(n, 10));
-        if (color256) currentColor = color256;
-        continue;
-      }
-    }
-
     // Handle 256-color background: 48;5;N
     if (code === 48 && match[2] === "5") {
       const n = match[3];

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -135,13 +135,16 @@ function findCursorLine(
 }
 
 // Combined regex for ANSI colors (256-color and 24-bit) and OSC 8 hyperlinks
-// 256-color: \x1b[38;5;Nm (fg), \x1b[48;5;Nm (bg)
-// 24-bit: \x1b[38;2;R;G;Bm, \x1b[48;2;R;G;Bm
-// Reset: \x1b[0m
+// Captures: p1[;p2[;p3[;p4[;p5]]]]m
+// 256-color fg: 38;5;N     → p1=38, p2=5,  p3=N
+// 256-color bg: 48;5;N     → p1=48, p2=5,  p3=N
+// 24-bit fg:    38;2;R;G;B → p1=38, p2=2,  p3=R, p4=G, p5=B
+// 24-bit bg:    48;2;R;G;B → p1=48, p2=2,  p3=R, p4=G, p5=B
+// Reset:        0m         → p1=0
 // OSC 8: \x1b]8;;URL\x1b\DISPLAY\x1b]8;;\x1b\
 const COMBINED_STYLE_REGEX =
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI/OSC escape sequences require control characters
-  /\x1b\[(\d+)(?:;(\d+);(\d+)(?:;(\d+);(\d+);(\d+))?)?m|\x1b\]8;;([^\x1b]*)\x1b\\([^\x1b]*)\x1b\]8;;\x1b\\/g;
+  /\x1b\[(\d+)(?:;(\d+)(?:;(\d+)(?:;(\d+)(?:;(\d+))?)?)?)?m|\x1b\]8;;([^\x1b]*)\x1b\\([^\x1b]*)\x1b\]8;;\x1b\\/g;
 
 // 256-color palette lookup (simplified - standard xterm colors 0-255)
 // Returns hex color for palette index
@@ -198,9 +201,9 @@ function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
   for (let match = regex.exec(line); match !== null; match = regex.exec(line)) {
     const fullMatch = match[0];
 
-    // Handle OSC 8 hyperlink: groups 7=URL, 8=display text (after ANSI color groups)
-    const osc8Url = match[7];
-    const osc8Display = match[8];
+    // Handle OSC 8 hyperlink: groups 6=URL, 7=display text
+    const osc8Url = match[6];
+    const osc8Display = match[7];
     if (osc8Url !== undefined && osc8Display !== undefined) {
       // Flush any pending text with current color before the link
       if (match.index > lastIndex) {
@@ -253,7 +256,7 @@ function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
       continue;
     }
 
-    // Handle 24-bit foreground color: 38;2;R;G;B
+    // Handle 24-bit foreground color: 38;2;R;G;B → p1=38,p2=2,p3=R,p4=G,p5=B
     if (code === 38 && match[2] === "2") {
       const r = match[3];
       const g = match[4];
@@ -300,7 +303,7 @@ function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
       }
     }
 
-    // Handle 24-bit background color: 48;2;R;G;B
+    // Handle 24-bit background color: 48;2;R;G;B → p1=48,p2=2,p3=R,p4=G,p5=B
     if (code === 48 && match[2] === "2") {
       const r = match[3];
       const g = match[4];

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -134,40 +134,262 @@ function findCursorLine(
   };
 }
 
-// Matches OSC 8 hyperlink sequences: \x1b]8;;URL\x1b\DISPLAY\x1b]8;;\x1b\
-// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC 8 escape sequences require \x1b
-const OSC8_REGEX = /\x1b\]8;;([^\x1b]*)\x1b\\([^\x1b]*)\x1b\]8;;\x1b\\/g;
+// Combined regex for ANSI colors (256-color and 24-bit) and OSC 8 hyperlinks
+// 256-color: \x1b[38;5;Nm (fg), \x1b[48;5;Nm (bg)
+// 24-bit: \x1b[38;2;R;G;Bm, \x1b[48;2;R;G;Bm
+// Reset: \x1b[0m
+// OSC 8: \x1b]8;;URL\x1b\DISPLAY\x1b]8;;\x1b\
+const COMBINED_STYLE_REGEX =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI/OSC escape sequences require control characters
+  /\x1b\[(\d+)(?:;(\d+);(\d+)(?:;(\d+);(\d+);(\d+))?)?m|\x1b\]8;;([^\x1b]*)\x1b\\([^\x1b]*)\x1b\]8;;\x1b\\/g;
 
-function parseOsc8Line(line: string, keyPrefix: string): ReactNode[] {
+// 256-color palette lookup (simplified - standard xterm colors 0-255)
+// Returns hex color for palette index
+function get256Color(index: number): string | undefined {
+  if (index < 0 || index > 255) return undefined;
+
+  // Standard 16 colors (0-15)
+  const standardColors = [
+    "#000000",
+    "#800000",
+    "#008000",
+    "#808000",
+    "#000080",
+    "#800080",
+    "#008080",
+    "#c0c0c0",
+    "#808080",
+    "#ff0000",
+    "#00ff00",
+    "#ffff00",
+    "#0000ff",
+    "#ff00ff",
+    "#00ffff",
+    "#ffffff",
+  ];
+  if (index < 16) return standardColors[index];
+
+  // 216 color cube (16-231): 6x6x6 cube
+  if (index < 232) {
+    const cubeIndex = index - 16;
+    const r = Math.floor(cubeIndex / 36) % 6;
+    const g = Math.floor(cubeIndex / 6) % 6;
+    const b = cubeIndex % 6;
+    // Convert 0-5 to 0-255 range (0, 95, 135, 175, 215, 255)
+    const values = [0, 95, 135, 175, 215, 255];
+    const toHex = (v: number) => v.toString(16).padStart(2, "0");
+    return `#${toHex(values[r] ?? 0)}${toHex(values[g] ?? 0)}${toHex(values[b] ?? 0)}`;
+  }
+
+  // Grayscale (232-255): 24 shades from black to white
+  const grayValue = 8 + (index - 232) * 10;
+  const hex = grayValue.toString(16).padStart(2, "0");
+  return `#${hex}${hex}${hex}`;
+}
+
+function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
   const parts: ReactNode[] = [];
   let lastIndex = 0;
-  const regex = new RegExp(OSC8_REGEX.source, "g");
+  let currentColor: string | undefined;
+  let currentBgColor: string | undefined;
+
+  const regex = new RegExp(COMBINED_STYLE_REGEX.source, "g");
 
   for (let match = regex.exec(line); match !== null; match = regex.exec(line)) {
-    if (match.index > lastIndex) {
+    const fullMatch = match[0];
+
+    // Handle OSC 8 hyperlink: groups 7=URL, 8=display text (after ANSI color groups)
+    const osc8Url = match[7];
+    const osc8Display = match[8];
+    if (osc8Url !== undefined && osc8Display !== undefined) {
+      // Flush any pending text with current color before the link
+      if (match.index > lastIndex) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+      }
+      // Create link with display text (ANSI colors inside link text not supported for now)
       parts.push(
-        <Text key={`${keyPrefix}-${lastIndex}`}>
-          {line.slice(lastIndex, match.index)}
+        <Link key={`${keyPrefix}-${match.index}`} url={osc8Url}>
+          <Text color={currentColor} backgroundColor={currentBgColor}>
+            {osc8Display}
+          </Text>
+        </Link>,
+      );
+      lastIndex = match.index + fullMatch.length;
+      continue;
+    }
+
+    const code = parseInt(match[1] ?? "0", 10);
+
+    // Handle reset
+    if (code === 0) {
+      if (lastIndex > 0 || currentColor || currentBgColor) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+      }
+      lastIndex = match.index + fullMatch.length;
+      currentColor = undefined;
+      currentBgColor = undefined;
+      continue;
+    }
+
+    // Handle 24-bit foreground color: 38;2;R;G;B
+    if (code === 38 && match[2] === "2") {
+      const r = match[3];
+      const g = match[4];
+      const b = match[5];
+      if (r && g && b) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+        lastIndex = match.index + fullMatch.length;
+        currentColor = `#${parseInt(r, 10).toString(16).padStart(2, "0")}${parseInt(g, 10).toString(16).padStart(2, "0")}${parseInt(b, 10).toString(16).padStart(2, "0")}`;
+        continue;
+      }
+    }
+
+    // Handle 256-color foreground: 38;5;N
+    if (code === 38 && match[2] === "5") {
+      const n = match[3];
+      if (n) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+        lastIndex = match.index + fullMatch.length;
+        const color256 = get256Color(parseInt(n, 10));
+        if (color256) currentColor = color256;
+        continue;
+      }
+    }
+
+    // Handle 24-bit background color: 48;2;R;G;B
+    if (code === 48 && match[2] === "2") {
+      const r = match[3];
+      const g = match[4];
+      const b = match[5];
+      if (r && g && b) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+        lastIndex = match.index + fullMatch.length;
+        currentBgColor = `#${parseInt(r, 10).toString(16).padStart(2, "0")}${parseInt(g, 10).toString(16).padStart(2, "0")}${parseInt(b, 10).toString(16).padStart(2, "0")}`;
+        continue;
+      }
+    }
+
+    // Handle 256-color foreground: 38;5;N
+    if (code === 38 && match[2] === "5") {
+      const n = match[3];
+      if (n) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+        lastIndex = match.index + fullMatch.length;
+        const color256 = get256Color(parseInt(n, 10));
+        if (color256) currentColor = color256;
+        continue;
+      }
+    }
+
+    // Handle 256-color background: 48;5;N
+    if (code === 48 && match[2] === "5") {
+      const n = match[3];
+      if (n) {
+        const text = line.slice(lastIndex, match.index);
+        if (text || currentColor || currentBgColor) {
+          parts.push(
+            <Text
+              key={`${keyPrefix}-${lastIndex}`}
+              color={currentColor}
+              backgroundColor={currentBgColor}
+            >
+              {text}
+            </Text>,
+          );
+        }
+        lastIndex = match.index + fullMatch.length;
+        const color256 = get256Color(parseInt(n, 10));
+        if (color256) currentBgColor = color256;
+      }
+    }
+  }
+
+  // Add remaining text with current color
+  if (lastIndex < line.length) {
+    const text = line.slice(lastIndex);
+    if (text || currentColor || currentBgColor) {
+      parts.push(
+        <Text
+          key={`${keyPrefix}-${lastIndex}`}
+          color={currentColor}
+          backgroundColor={currentBgColor}
+        >
+          {text}
         </Text>,
       );
     }
-    const url = match[1] ?? "";
-    const display = match[2] ?? "";
-    parts.push(
-      <Link key={`${keyPrefix}-${match.index}`} url={url}>
-        <Text>{display}</Text>
-      </Link>,
-    );
-    lastIndex = match.index + match[0].length;
   }
-  if (lastIndex < line.length) {
-    parts.push(
-      <Text key={`${keyPrefix}-${lastIndex}`}>{line.slice(lastIndex)}</Text>,
-    );
-  }
+
   if (parts.length === 0) {
     parts.push(<Text key={keyPrefix}>{line}</Text>);
   }
+
   return parts;
 }
 
@@ -180,30 +402,26 @@ function formatModeLabel(modeName: string, modeGlyph?: string | null): string {
 
 function StatusLineContent({
   text,
-  padding,
+  _padding,
   modeName,
   modeColor,
   modeGlyph,
   showExitHint,
 }: {
   text: string;
-  padding: number;
+  _padding: number;
   modeName: string | null;
   modeColor: string | null;
   modeGlyph?: string | null;
   showExitHint: boolean;
 }) {
   const lines = text.split("\n");
-  const paddingStr = padding > 0 ? " ".repeat(padding) : "";
   const parts: ReactNode[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (i > 0) {
       parts.push("\n");
     }
-    if (paddingStr) {
-      parts.push(paddingStr);
-    }
-    parts.push(...parseOsc8Line(lines[i] ?? "", `l${i}`));
+    parts.push(...parseStyledLine(lines[i] ?? "", `l${i}`));
   }
   return (
     <Text wrap="wrap">
@@ -408,7 +626,7 @@ const InputFooter = memo(function InputFooter({
         ) : statusLineText ? (
           <StatusLineContent
             text={statusLineText}
-            padding={statusLinePadding ?? 0}
+            _padding={statusLinePadding ?? 0}
             modeName={modeName}
             modeColor={modeColor}
             modeGlyph={modeGlyph}
@@ -447,7 +665,7 @@ const InputFooter = memo(function InputFooter({
         ) : statusLineRight ? (
           statusLineRight.split("\n").map((line, i) => (
             <Text key={`${i}-${line}`} wrap="truncate-end">
-              {parseOsc8Line(line, `r${i}`)}
+              {parseStyledLine(line, `r${i}`)}
             </Text>
           ))
         ) : backgroundAgents.length > 0 ? (

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -345,6 +345,10 @@ function parseStyledLine(line: string, keyPrefix: string): ReactNode[] {
         if (color256) currentBgColor = color256;
       }
     }
+
+    // Fallback: unrecognized SGR code (bold, underline, standard 16-color, etc.)
+    // Advance lastIndex past the matched sequence so raw escape bytes don't leak into rendered text
+    lastIndex = match.index + fullMatch.length;
   }
 
   // Add remaining text with current color


### PR DESCRIPTION
## Summary
Add ANSI color code parsing to statusline for Spotify integration and 256-color support. Replaces the old OSC 8-only parser with a combined parser that handles:
- 256-color codes (\x1b[38;5;Nm, \x1b[48;5;Nm)
- 24-bit true color (\x1b[38;2;R;G;Bm, \x1b[48;2;R;G;Bm)
- Reset codes (\x1b[0m)
- OSC 8 hyperlinks (preserved from original)

Also removes padding from statusline rendering so content is left-aligned (matches Claude Code style).

## Test plan
- [x] `bun test src/tests/cli/statusline` - all 36 tests pass
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/InputRich.tsx`
- [x] `bun run typecheck`
