### PR TITLE
chore(cli): document App entrypoint re-export

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -5,3 +5,5 @@
  */
 
 export { default } from "./app/App";
+
+// Re-export the CLI app entrypoint from the app module.


### PR DESCRIPTION
## Summary
- Add a small comment documenting the CLI App entrypoint re-export.
- Keeps a dummy local change that survives formatting/pre-commit hooks.

## Test plan
- [x] Pre-commit hook ran Biome on staged files
- [x] Pre-commit hook ran `tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)