### PR TITLE
feat(ci): enable sticky comment for conversation persistence across review runs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # TODO: replace with SHA before merging to main
       - uses: letta-ai/letta-code-action@fix/agent-mode-tracking-comment-and-conversation-persistence
         if: steps.lint_wait.outputs.skipped != 'true'
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@f501f5f72b49d102125fdc90f280f9cdae6a0258
+      - uses: letta-ai/letta-code-action@fix/agent-mode-tracking-comment-and-conversation-persistence
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -73,7 +73,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: ""
-          tracking_comment: "false"
+          tracking_comment: "true"
+          use_sticky_comment: "true"
           model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.


### PR DESCRIPTION
## Summary
- Enable `tracking_comment: "true"` + `use_sticky_comment: "true"` on the review action
- This stores `conversation_id` in the comment metadata so subsequent pushes to the same PR resume the existing conversation instead of starting fresh
- Sticky comment = one comment per PR, updated in place — not noisy like the old per-push comments

## Why
Every review run was creating a brand new conversation because `tracking_comment: "false"` meant no comment was created, so there was nowhere to store the `<!-- letta-metadata conversation_id: conv-xxx -->` block. On the next push, `findExistingAgent()` found nothing and started from scratch. The agent had no memory of previous reviews on the same PR.

## Test plan
- [ ] Merge and observe on the next PR that gets multiple pushes
- [ ] Verify only one comment appears per PR (updated in place, not duplicated)
- [ ] Verify the agent references previous review context on re-review