### PR TITLE
chore(ci): review workflow conversation persistence via Letta API

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -74,6 +74,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: ""
+          tracking_comment: "false"
           model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,8 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: replace with SHA before merging to main
-      - uses: letta-ai/letta-code-action@feat/conversation-lookup-via-api
+      - uses: letta-ai/letta-code-action@0ec0ec9ae27ae7533cd297ec070e61465e7d17e2
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,14 +66,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@f501f5f72b49d102125fdc90f280f9cdae6a0258
+      # TODO: replace with SHA before merging to main
+      - uses: letta-ai/letta-code-action@feat/conversation-lookup-via-api
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           track_progress: ""
-          tracking_comment: "false"
           model: auto
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.


### PR DESCRIPTION
## Summary
- Updates the code review workflow to use conversation persistence via the Letta API
- On each review run, the action searches for an existing conversation matching `letta-ai/letta-code/pr-N` and resumes it instead of starting fresh
- Pins action ref to `0ec0ec9` (merged in letta-ai/letta-code-action#27)

## Why
Previously each push to a PR triggered a completely new conversation for the reviewer agent. Now the agent retains context across pushes to the same PR, so it can track what it already reviewed and avoid re-flagging the same things.

👾 Generated with [Letta Code](https://letta.com)