### PR TITLE
fix(slack): keep message list markers ASCII-safe

### DIFF
--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -54,8 +54,9 @@ test("preserves existing Slack angle-bracket tokens", () => {
   ).toBe("hi <@U123> see <https://example.com|docs> and <!here>");
 });
 
-test("renders bullet lists for Slack", () => {
-  expect(markdownToSlackMrkdwn("- one\n- two")).toBe("• one\n• two");
+test("keeps Slack bullet lists ASCII-safe", () => {
+  expect(markdownToSlackMrkdwn("- one\n- two")).toBe("- one\n- two");
+  expect(markdownToSlackMrkdwn("+ one\n* two")).toBe("- one\n- two");
 });
 
 test("renders headings as bold text for Slack", () => {

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -409,7 +409,7 @@ function normalizeSlackBlockFormatting(text: string): string {
 
       const bulletMatch = line.match(/^(\s*)[-+*]\s+(.+)$/);
       if (bulletMatch) {
-        return `${bulletMatch[1] ?? ""}• ${bulletMatch[2] ?? ""}`;
+        return `${bulletMatch[1] ?? ""}- ${bulletMatch[2] ?? ""}`;
       }
 
       return line;


### PR DESCRIPTION
Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)
Conversation ID: conv-90849c6b-5f5c-41f9-9290-aed8fa70d89d

## Summary
- Keep outbound Slack list markers ASCII-safe by preserving `- item` instead of rewriting to Unicode bullets.
- Normalize `+` and `*` Markdown list markers to ASCII hyphens for Slack output.
- Update Slack formatter tests to assert ASCII-safe list output.

## Test plan
- [x] `bun test src/tests/channels/interactive.test.ts`
- [x] `bun test src/tests/channels/message-channel-formatting.test.ts`
- [x] `bun run lint`

Fixes #2205

👾 Generated with [Letta Code](https://letta.com)