### PR TITLE
revert: conversation persistence via Letta API

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@0ec0ec9ae27ae7533cd297ec070e61465e7d17e2
+      - uses: letta-ai/letta-code-action@f501f5f72b49d102125fdc90f280f9cdae6a0258
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}


### PR DESCRIPTION
The Letta API `summary` query param does substring matching, not exact matching. Searching for `pr-2201` returns conversations with summary `pr-2204`, `pr-2202`, etc. This causes cross-PR conversation contamination — PR reviews are being sent to the wrong conversation.

Reverts #2204 until we can fix the API or use a different lookup strategy.

👾 Generated with [Letta Code](https://letta.com)