### PR TITLE
fix(ci): conversation persistence with correct API param

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@f501f5f72b49d102125fdc90f280f9cdae6a0258
+      - uses: letta-ai/letta-code-action@daa80f29e345315623ff759f5ecf5018946bbc15
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}


### PR DESCRIPTION
## Summary
- Updates review workflow to action SHA `a7a521a` which fixes conversation lookup

## What was wrong
The previous attempt used `summary` as the query param, but the Letta API expects `summary_search`. The unknown param was silently ignored, so the API returned all conversations for the agent sorted by recency — every PR got routed to the same (most recent) conversation.

## What this fixes
- Uses `summary_search` query param (maps to SQL `LIKE %value%`)
- Adds client-side exact match (`c.summary === summary`) since substring search can still match across similar PR numbers
- Fetches up to 10 results to find the exact match in case it is not the most recent

👾 Generated with [Letta Code](https://letta.com)