### PR TITLE
feat(channels): schema-driven custom channels + user-plugin config snapshots

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",

--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -135,11 +135,16 @@ export function getChannelAccountConfigAdapter(
       customChannelAccountConfigAdapter
     );
   }
-  // User-installed plugin: prefer schema-driven adapter when a schema exists.
-  const metadata = getChannelPluginMetadata(channelId);
-  if (metadata.configSchema) {
-    return buildSchemaAdapter(metadata.configSchema);
-  }
+  // MVP: user-installed plugins (e.g. bluesky, my-webhook-app) all share
+  // the 'custom' channel's account-config shape and are managed through
+  // the same desktop dialog. Per-plugin schema-driven adapters are wired
+  // but not yet routed here — the dialog always sends the custom shape,
+  // so validating against a plugin-specific schema would reject the
+  // save (timeouts) until the dialog opts a plugin in.
+  //
+  // Schema-driven adapter retained for future use:
+  //   const metadata = getChannelPluginMetadata(channelId);
+  //   if (metadata.configSchema) return buildSchemaAdapter(metadata.configSchema);
   return customChannelAccountConfigAdapter;
 }
 

--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -1,6 +1,5 @@
 import { customAccountConfigAdapter } from "./custom/accountConfig";
 import { discordAccountConfigAdapter } from "./discord/accountConfig";
-import { getChannelPluginMetadata } from "./pluginRegistry";
 import type {
   ChannelAccountConfigAdapter,
   ChannelAccountPatch,
@@ -102,7 +101,7 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
  * {@link ChannelConfigSchema}. Used as a fallback for user-installed plugins
  * that don't ship a hand-written adapter.
  */
-function buildSchemaAdapter(
+function _buildSchemaAdapter(
   schema: ChannelConfigSchema,
 ): ChannelAccountConfigAdapter<ChannelAccount> {
   return {

--- a/src/channels/accountConfig.ts
+++ b/src/channels/accountConfig.ts
@@ -1,11 +1,18 @@
+import { customAccountConfigAdapter } from "./custom/accountConfig";
 import { discordAccountConfigAdapter } from "./discord/accountConfig";
+import { getChannelPluginMetadata } from "./pluginRegistry";
 import type {
   ChannelAccountConfigAdapter,
   ChannelAccountPatch,
   ChannelConfigPatch,
+  ChannelConfigSchema,
   ChannelPluginAccountPatch,
   ChannelProtocolConfig,
 } from "./pluginTypes";
+import {
+  redactConfigForSnapshot,
+  validateConfigAgainstSchema,
+} from "./schemaConfig";
 import { slackAccountConfigAdapter } from "./slack/accountConfig";
 import { telegramAccountConfigAdapter } from "./telegram/accountConfig";
 import type { ChannelAccount } from "./types";
@@ -21,7 +28,39 @@ const CHANNEL_ACCOUNT_CONFIG_ADAPTERS: Record<
     slackAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
   discord:
     discordAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
+  custom:
+    customAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
 };
+
+/**
+ * Keys recognized as secrets across all user-installed plugins. These are
+ * never sent back to the client; only their `has_<key>` presence flag is
+ * exposed. Keep in sync with the secret-handling convention in
+ * `customAccountConfigAdapter` (which uses `bot_token` / `auth`).
+ */
+const KNOWN_SECRET_KEYS = new Set(["bot_token", "auth"]);
+
+/**
+ * Build a client-safe snapshot of a user-plugin account config when no
+ * schema is available. Surfaces every non-secret value from the stored
+ * config (so fields like `accounts_json` / `configs_json` / `agent_id`
+ * round-trip to the UI) while collapsing recognized secret keys to
+ * `has_<key>` booleans (Slack pattern).
+ */
+function redactSchemalessConfig(
+  storedConfig: Record<string, unknown>,
+): ChannelProtocolConfig {
+  const result: ChannelProtocolConfig = {};
+  for (const [key, value] of Object.entries(storedConfig)) {
+    if (KNOWN_SECRET_KEYS.has(key)) {
+      result[`has_${key}`] =
+        typeof value === "string" && value.trim().length > 0;
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
 
 const customChannelAccountConfigAdapter: ChannelAccountConfigAdapter<ChannelAccount> =
   {
@@ -36,6 +75,7 @@ const customChannelAccountConfigAdapter: ChannelAccountConfigAdapter<ChannelAcco
         return {};
       }
       return {
+        ...redactSchemalessConfig(account.config),
         configured: Object.keys(account.config).length > 0,
       };
     },
@@ -44,6 +84,7 @@ const customChannelAccountConfigAdapter: ChannelAccountConfigAdapter<ChannelAcco
         return {};
       }
       return {
+        ...redactSchemalessConfig(account.config),
         configured: Object.keys(account.config).length > 0,
       };
     },
@@ -56,13 +97,50 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Build a {@link ChannelAccountConfigAdapter} from a declared
+ * {@link ChannelConfigSchema}. Used as a fallback for user-installed plugins
+ * that don't ship a hand-written adapter.
+ */
+function buildSchemaAdapter(
+  schema: ChannelConfigSchema,
+): ChannelAccountConfigAdapter<ChannelAccount> {
+  return {
+    isValidConfig(config) {
+      return validateConfigAgainstSchema(schema, config).ok;
+    },
+    toAccountPatch() {
+      return {};
+    },
+    toAccountConfig(account) {
+      const config = isCustomChannelAccount(account) ? account.config : {};
+      return redactConfigForSnapshot(schema, config);
+    },
+    toConfigSnapshotConfig(account) {
+      const config = isCustomChannelAccount(account) ? account.config : {};
+      return redactConfigForSnapshot(schema, config);
+    },
+    shouldRefreshDisplayName() {
+      return false;
+    },
+  };
+}
+
 export function getChannelAccountConfigAdapter(
   channelId: string,
 ): ChannelAccountConfigAdapter<ChannelAccount> {
-  return isFirstPartyChannelId(channelId)
-    ? (CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId] ??
-        customChannelAccountConfigAdapter)
-    : customChannelAccountConfigAdapter;
+  if (isFirstPartyChannelId(channelId)) {
+    return (
+      CHANNEL_ACCOUNT_CONFIG_ADAPTERS[channelId] ??
+      customChannelAccountConfigAdapter
+    );
+  }
+  // User-installed plugin: prefer schema-driven adapter when a schema exists.
+  const metadata = getChannelPluginMetadata(channelId);
+  if (metadata.configSchema) {
+    return buildSchemaAdapter(metadata.configSchema);
+  }
+  return customChannelAccountConfigAdapter;
 }
 
 export function getChannelPluginConfig(

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -14,6 +14,7 @@ import type {
   TelegramChannelAccount,
 } from "./types";
 import {
+  isCustomChannelAccount,
   isDiscordChannelAccount,
   isFirstPartyChannelId,
   isSlackChannelAccount,
@@ -64,7 +65,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   const next = cloneAccount(account);
-  if (!isFirstPartyChannelId(next.channel)) {
+  // Both the "custom" first-party channel and all user-installed channels use
+  // the generic `config: Record<string, unknown>` shape, so make sure that
+  // field is present and well-formed before downstream code reads it.
+  if (isCustomChannelAccount(next) || !isFirstPartyChannelId(next.channel)) {
     (next as CustomChannelAccount).config = isRecord(
       (next as Partial<CustomChannelAccount>).config,
     )

--- a/src/channels/custom/accountConfig.ts
+++ b/src/channels/custom/accountConfig.ts
@@ -12,6 +12,7 @@ import type { CustomChannelAccount } from "../types";
  *   agent_id       — agent this app is bound to
  *   accounts_json  — user-supplied JSON describing accounts on the remote service
  *   configs_json   — user-supplied JSON of arbitrary configuration values
+ *   metadata_json  — user-supplied JSON scratchpad (notes, secret-manager refs, etc.)
  *
  * Tokens never round-trip back to the client; snapshots only expose
  * `has_bot_token` / `has_auth` boolean flags.
@@ -23,6 +24,7 @@ const CUSTOM_CONFIG_KEYS = new Set([
   "agent_id",
   "accounts_json",
   "configs_json",
+  "metadata_json",
 ]);
 
 function isString(value: unknown): value is string {
@@ -61,7 +63,8 @@ export const customAccountConfigAdapter: ChannelAccountConfigAdapter<CustomChann
         (config.agent_id === undefined || isNullableString(config.agent_id)) &&
         (config.accounts_json === undefined ||
           isString(config.accounts_json)) &&
-        (config.configs_json === undefined || isString(config.configs_json))
+        (config.configs_json === undefined || isString(config.configs_json)) &&
+        (config.metadata_json === undefined || isString(config.metadata_json))
       );
     },
 
@@ -82,6 +85,7 @@ export const customAccountConfigAdapter: ChannelAccountConfigAdapter<CustomChann
         agent_id: readNullableString(account, "agent_id"),
         accounts_json: readString(account, "accounts_json"),
         configs_json: readString(account, "configs_json"),
+        metadata_json: readString(account, "metadata_json"),
       };
     },
 

--- a/src/channels/custom/accountConfig.ts
+++ b/src/channels/custom/accountConfig.ts
@@ -1,0 +1,97 @@
+import type { ChannelAccountConfigAdapter } from "../pluginTypes";
+import type { CustomChannelAccount } from "../types";
+
+/**
+ * Account config adapter for the first-party "custom" channel.
+ *
+ * The "custom" channel forwards outbound agent messages to a user-configured
+ * webhook URL. Each account stores:
+ *   url            — webhook endpoint that receives outbound messages
+ *   bot_token      — sent as `Authorization: Bearer <bot_token>` (write-only)
+ *   auth           — sent as `X-Letta-Auth: <auth>` (write-only)
+ *   agent_id       — agent this app is bound to
+ *   accounts_json  — user-supplied JSON describing accounts on the remote service
+ *   configs_json   — user-supplied JSON of arbitrary configuration values
+ *
+ * Tokens never round-trip back to the client; snapshots only expose
+ * `has_bot_token` / `has_auth` boolean flags.
+ */
+const CUSTOM_CONFIG_KEYS = new Set([
+  "url",
+  "bot_token",
+  "auth",
+  "agent_id",
+  "accounts_json",
+  "configs_json",
+]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function readString(account: CustomChannelAccount, key: string): string {
+  const value = account.config[key];
+  return typeof value === "string" ? value : "";
+}
+
+function readNullableString(
+  account: CustomChannelAccount,
+  key: string,
+): string | null {
+  const value = account.config[key];
+  return value === null || typeof value === "string" ? value : null;
+}
+
+export const customAccountConfigAdapter: ChannelAccountConfigAdapter<CustomChannelAccount> =
+  {
+    isValidConfig(config) {
+      for (const key of Object.keys(config)) {
+        if (!CUSTOM_CONFIG_KEYS.has(key)) {
+          return false;
+        }
+      }
+      return (
+        (config.url === undefined || isString(config.url)) &&
+        (config.bot_token === undefined || isString(config.bot_token)) &&
+        (config.auth === undefined || isString(config.auth)) &&
+        (config.agent_id === undefined || isNullableString(config.agent_id)) &&
+        (config.accounts_json === undefined ||
+          isString(config.accounts_json)) &&
+        (config.configs_json === undefined || isString(config.configs_json))
+      );
+    },
+
+    toAccountPatch(config) {
+      // The "custom" channel doesn't use ChannelPluginAccountPatch fields;
+      // everything is preserved on the generic `config` bag via mergeAccountPatch.
+      // Returning {} signals "no specific field changes" — the caller already
+      // applies `patch.config` directly to `account.config`.
+      const _ = config;
+      return {};
+    },
+
+    toAccountConfig(account) {
+      return {
+        url: readString(account, "url"),
+        has_bot_token: readString(account, "bot_token").trim().length > 0,
+        has_auth: readString(account, "auth").trim().length > 0,
+        agent_id: readNullableString(account, "agent_id"),
+        accounts_json: readString(account, "accounts_json"),
+        configs_json: readString(account, "configs_json"),
+      };
+    },
+
+    toConfigSnapshotConfig(account) {
+      return this.toAccountConfig(account);
+    },
+
+    shouldRefreshDisplayName() {
+      // Display name is user-supplied (no token-based auto-derivation), so
+      // we never need to refresh it from a config patch.
+      return false;
+    },
+  };

--- a/src/channels/custom/accountConfig.ts
+++ b/src/channels/custom/accountConfig.ts
@@ -12,7 +12,9 @@ import type { CustomChannelAccount } from "../types";
  *   agent_id       — agent this app is bound to
  *   accounts_json  — user-supplied JSON describing accounts on the remote service
  *   configs_json   — user-supplied JSON of arbitrary configuration values
- *   metadata_json  — user-supplied JSON scratchpad (notes, secret-manager refs, etc.)
+ *   metadata_json  — user-supplied JSON of additional plugin configuration
+ *                    (anything that doesn't fit accounts_json / configs_json);
+ *                    plugins are free to read and interpret this however they want
  *
  * Tokens never round-trip back to the client; snapshots only expose
  * `has_bot_token` / `has_auth` boolean flags.

--- a/src/channels/custom/adapter.ts
+++ b/src/channels/custom/adapter.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+import type {
+  ChannelAdapter,
+  CustomChannelAccount,
+  OutboundChannelMessage,
+} from "../types";
+
+/**
+ * Outbound-only adapter for the first-party "custom" channel.
+ *
+ * `start()` / `stop()` toggle a local `running` flag — there is no inbound
+ * listener in this MVP. The agent's outbound messages are forwarded as JSON
+ * POSTs to the configured webhook URL.
+ */
+function readString(account: CustomChannelAccount, key: string): string | null {
+  const value = account.config[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+interface CustomWebhookResponse {
+  message_id?: unknown;
+}
+
+function extractMessageId(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = (value as CustomWebhookResponse).message_id;
+  if (typeof candidate === "string" && candidate.length > 0) {
+    return candidate;
+  }
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return String(candidate);
+  }
+  return null;
+}
+
+export function createCustomAdapter(
+  account: CustomChannelAccount,
+): ChannelAdapter {
+  let running = false;
+
+  async function deliver(
+    msg: OutboundChannelMessage,
+  ): Promise<{ messageId: string }> {
+    const url = readString(account, "url");
+    if (!url) {
+      throw new Error(
+        `Custom channel account ${account.accountId} is missing a webhook URL.`,
+      );
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const botToken = readString(account, "bot_token");
+    if (botToken) {
+      headers["Authorization"] = `Bearer ${botToken}`;
+    }
+    const auth = readString(account, "auth");
+    if (auth) {
+      headers["X-Letta-Auth"] = auth;
+    }
+
+    const body = JSON.stringify({
+      channel: "custom",
+      account_id: msg.accountId ?? account.accountId,
+      chat_id: msg.chatId,
+      text: msg.text,
+      reply_to_message_id: msg.replyToMessageId,
+      thread_id: msg.threadId ?? null,
+      parse_mode: msg.parseMode,
+      media_path: msg.mediaPath,
+      file_name: msg.fileName,
+      title: msg.title,
+    });
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `Custom webhook ${url} returned ${response.status}${text ? `: ${text}` : ""}`,
+      );
+    }
+
+    let parsed: unknown = null;
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.toLowerCase().includes("application/json")) {
+      try {
+        parsed = await response.json();
+      } catch {
+        parsed = null;
+      }
+    }
+
+    return { messageId: extractMessageId(parsed) ?? randomUUID() };
+  }
+
+  return {
+    id: `custom:${account.accountId}`,
+    channelId: "custom",
+    accountId: account.accountId,
+    name: account.displayName ?? "Custom",
+
+    async start() {
+      running = true;
+    },
+
+    async stop() {
+      running = false;
+    },
+
+    isRunning() {
+      return running;
+    },
+
+    async sendMessage(msg) {
+      return deliver(msg);
+    },
+
+    async sendDirectReply(chatId, text, options) {
+      await deliver({
+        channel: "custom",
+        accountId: account.accountId,
+        chatId,
+        text,
+        replyToMessageId: options?.replyToMessageId,
+      });
+    },
+  };
+}

--- a/src/channels/custom/adapter.ts
+++ b/src/channels/custom/adapter.ts
@@ -55,7 +55,7 @@ export function createCustomAdapter(
     };
     const botToken = readString(account, "bot_token");
     if (botToken) {
-      headers["Authorization"] = `Bearer ${botToken}`;
+      headers.Authorization = `Bearer ${botToken}`;
     }
     const auth = readString(account, "auth");
     if (auth) {

--- a/src/channels/custom/plugin.ts
+++ b/src/channels/custom/plugin.ts
@@ -1,0 +1,69 @@
+import type { ChannelConfigSchema, ChannelPlugin } from "../pluginTypes";
+import type { ChannelAccount, CustomChannelAccount } from "../types";
+import { createCustomAdapter } from "./adapter";
+
+/**
+ * Declarative config schema for the custom channel.
+ * Matches the field set used by CustomManageDialog so the desktop UI can
+ * render a dynamic form when it receives this schema from
+ * `channels_list_response`.
+ */
+export const CUSTOM_CHANNEL_CONFIG_SCHEMA: ChannelConfigSchema = {
+  version: 1,
+  fields: [
+    {
+      type: "text",
+      key: "url",
+      label: "Webhook URL",
+      required: false,
+      placeholder: "https://example.com/webhook",
+      description: "Letta Code will POST incoming agent messages to this URL.",
+    },
+    {
+      type: "secret",
+      key: "bot_token",
+      label: "Bot token",
+      placeholder: "Paste your bot token",
+      description:
+        "Used to authenticate Letta Code as a bot when posting to your service.",
+    },
+    {
+      type: "secret",
+      key: "auth",
+      label: "Auth token",
+      placeholder: "Optional secret or bearer token",
+      description:
+        "Optional. Used to authenticate requests sent to your webhook URL.",
+    },
+    {
+      type: "text",
+      key: "agent_id",
+      label: "Connected agent",
+    },
+    {
+      type: "text",
+      key: "accounts_json",
+      label: "Accounts (JSON)",
+    },
+    {
+      type: "text",
+      key: "configs_json",
+      label: "Config (JSON)",
+    },
+  ],
+};
+
+export const customChannelPlugin: ChannelPlugin = {
+  metadata: {
+    id: "custom",
+    displayName: "Custom",
+    runtimePackages: [],
+    runtimeModules: [],
+    source: "first-party",
+    firstParty: true,
+    configSchema: CUSTOM_CHANNEL_CONFIG_SCHEMA,
+  },
+  createAdapter(account: ChannelAccount) {
+    return createCustomAdapter(account as CustomChannelAccount);
+  },
+};

--- a/src/channels/custom/plugin.ts
+++ b/src/channels/custom/plugin.ts
@@ -50,6 +50,11 @@ export const CUSTOM_CHANNEL_CONFIG_SCHEMA: ChannelConfigSchema = {
       key: "configs_json",
       label: "Config (JSON)",
     },
+    {
+      type: "text",
+      key: "metadata_json",
+      label: "Metadata (JSON)",
+    },
   ],
 };
 

--- a/src/channels/custom/plugin.ts
+++ b/src/channels/custom/plugin.ts
@@ -15,7 +15,7 @@ export const CUSTOM_CHANNEL_CONFIG_SCHEMA: ChannelConfigSchema = {
       type: "text",
       key: "url",
       label: "Webhook URL",
-      required: false,
+      required: true,
       placeholder: "https://example.com/webhook",
       description: "Letta Code will POST incoming agent messages to this URL.",
     },

--- a/src/channels/custom/scaffolding.ts
+++ b/src/channels/custom/scaffolding.ts
@@ -175,7 +175,7 @@ export function scaffoldUserPlugin(displayName: string): string {
   };
   writeFileSync(
     join(channelDir, "channel.json"),
-    JSON.stringify(manifest, null, 2) + "\n",
+    `${JSON.stringify(manifest, null, 2)}\n`,
     "utf-8",
   );
 

--- a/src/channels/custom/scaffolding.ts
+++ b/src/channels/custom/scaffolding.ts
@@ -197,15 +197,12 @@ export function removeUserPlugin(channelId: string): void {
   if (FIRST_PARTY_SET.has(channelId)) {
     return;
   }
-  const channelDir = getChannelDir(channelId);
-  if (!existsSync(channelDir)) {
+  // Reject channel IDs that could escape the channels root via path traversal.
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(channelId)) {
     return;
   }
-  // Only remove the folder if it lives directly under the channels root,
-  // to avoid path traversal accidents.
-  const channelsRoot = getChannelsRoot();
-  const resolved = join(channelsRoot, channelId);
-  if (channelDir !== resolved) {
+  const channelDir = getChannelDir(channelId);
+  if (!existsSync(channelDir)) {
     return;
   }
   try {

--- a/src/channels/custom/scaffolding.ts
+++ b/src/channels/custom/scaffolding.ts
@@ -1,0 +1,219 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getChannelDir, getChannelsRoot } from "../config";
+import { FIRST_PARTY_CHANNEL_IDS } from "../types";
+
+// ── Slugification ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert a user-supplied display name into a valid channel ID.
+ *
+ * Rules:
+ *  - lowercase
+ *  - runs of non-alphanumeric chars collapsed to a single hyphen
+ *  - leading/trailing hyphens stripped
+ *  - max 40 characters
+ *  - must be at least 2 characters (pad with "app" if needed)
+ */
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+
+  if (slug.length === 0) return "custom-app";
+  if (slug.length === 1) return `${slug}-app`;
+  return slug;
+}
+
+// ── Stub plugin.mjs template ──────────────────────────────────────────────────
+
+function buildStubPlugin(id: string, displayName: string): string {
+  // Self-contained webhook forwarder — no imports from letta-code.
+  // Mirrors the logic in src/channels/custom/adapter.ts.
+  return `/**
+ * Auto-generated webhook channel plugin for Letta Code.
+ * Channel: ${displayName} (${id})
+ *
+ * This plugin forwards outbound agent messages to the configured webhook URL.
+ * Edit freely — changes take effect on the next listener restart.
+ *
+ * config keys (set via the Desktop UI):
+ *   url        — webhook endpoint (required)
+ *   bot_token  — sent as Authorization: Bearer <token>
+ *   auth       — sent as X-Letta-Auth: <value>
+ */
+
+function readStr(config, key) {
+  const v = config[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function extractMessageId(body) {
+  if (!body || typeof body !== 'object') return null;
+  const id = body.message_id;
+  if (typeof id === 'string' && id.length > 0) return id;
+  if (typeof id === 'number' && Number.isFinite(id)) return String(id);
+  return null;
+}
+
+export const channelPlugin = {
+  metadata: {
+    id: ${JSON.stringify(id)},
+    displayName: ${JSON.stringify(displayName)},
+    runtimePackages: [],
+    runtimeModules: [],
+  },
+
+  createAdapter(account) {
+    const config = account.config ?? {};
+    let running = false;
+
+    async function deliver(msg) {
+      const url = readStr(config, 'url');
+      if (!url) {
+        throw new Error(\`[\${account.displayName ?? ${JSON.stringify(id)}}] No webhook URL configured.\`);
+      }
+
+      const headers = { 'Content-Type': 'application/json' };
+      const token = readStr(config, 'bot_token');
+      if (token) headers['Authorization'] = \`Bearer \${token}\`;
+      const auth = readStr(config, 'auth');
+      if (auth) headers['X-Letta-Auth'] = auth;
+
+      const body = JSON.stringify({
+        channel: ${JSON.stringify(id)},
+        account_id: msg.accountId ?? account.accountId,
+        chat_id: msg.chatId,
+        text: msg.text,
+        reply_to_message_id: msg.replyToMessageId ?? null,
+        thread_id: msg.threadId ?? null,
+      });
+
+      const res = await fetch(url, { method: 'POST', headers, body });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(\`Webhook \${url} returned \${res.status}\${detail ? \`: \${detail}\` : ''}\`);
+      }
+
+      let parsed = null;
+      const ct = res.headers.get('content-type') ?? '';
+      if (ct.includes('application/json')) {
+        try { parsed = await res.json(); } catch {}
+      }
+
+      return { messageId: extractMessageId(parsed) ?? crypto.randomUUID() };
+    }
+
+    return {
+      id: \`${id}:\${account.accountId}\`,
+      channelId: ${JSON.stringify(id)},
+      accountId: account.accountId,
+      name: account.displayName ?? ${JSON.stringify(displayName)},
+
+      async start() { running = true; },
+      async stop()  { running = false; },
+      isRunning()   { return running; },
+
+      async sendMessage(msg) {
+        return deliver(msg);
+      },
+
+      async sendDirectReply(chatId, text, options) {
+        await deliver({
+          channel: ${JSON.stringify(id)},
+          accountId: account.accountId,
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+    };
+  },
+};
+`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+const FIRST_PARTY_SET = new Set<string>(FIRST_PARTY_CHANNEL_IDS);
+
+/**
+ * Creates `~/.letta/channels/<slug>/channel.json` and a stub `plugin.mjs`.
+ *
+ * Throws if:
+ *  - The slug is already taken by an existing folder (name must be unique)
+ *  - The slug collides with a first-party channel ID
+ *
+ * Returns the generated channel ID.
+ */
+export function scaffoldUserPlugin(displayName: string): string {
+  const id = slugify(displayName);
+
+  if (FIRST_PARTY_SET.has(id)) {
+    throw new Error(
+      `"${displayName}" conflicts with a built-in channel name. Please choose a different name.`,
+    );
+  }
+
+  const channelDir = getChannelDir(id);
+  if (existsSync(channelDir)) {
+    throw new Error(
+      `A custom app named "${displayName}" already exists. Please choose a unique name.`,
+    );
+  }
+
+  mkdirSync(channelDir, { recursive: true });
+
+  const manifest = {
+    id,
+    displayName,
+    entry: "./plugin.mjs",
+    runtimePackages: [],
+    runtimeModules: [],
+  };
+  writeFileSync(
+    join(channelDir, "channel.json"),
+    JSON.stringify(manifest, null, 2) + "\n",
+    "utf-8",
+  );
+
+  writeFileSync(
+    join(channelDir, "plugin.mjs"),
+    buildStubPlugin(id, displayName),
+    "utf-8",
+  );
+
+  return id;
+}
+
+/**
+ * Removes the plugin folder for a user-created channel.
+ * Safe to call even if the folder doesn't exist.
+ * No-op for first-party channels.
+ */
+export function removeUserPlugin(channelId: string): void {
+  if (FIRST_PARTY_SET.has(channelId)) {
+    return;
+  }
+  const channelDir = getChannelDir(channelId);
+  if (!existsSync(channelDir)) {
+    return;
+  }
+  // Only remove the folder if it lives directly under the channels root,
+  // to avoid path traversal accidents.
+  const channelsRoot = getChannelsRoot();
+  const resolved = join(channelsRoot, channelId);
+  if (channelDir !== resolved) {
+    return;
+  }
+  try {
+    rmSync(channelDir, { recursive: true, force: true });
+  } catch (err) {
+    console.error(
+      `[channels] Failed to remove plugin folder ${channelDir}:`,
+      err,
+    );
+  }
+}

--- a/src/channels/pluginRegistry.ts
+++ b/src/channels/pluginRegistry.ts
@@ -2,7 +2,13 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import { getChannelDir, getChannelsRoot } from "./config";
-import type { ChannelPlugin, ChannelPluginMetadata } from "./pluginTypes";
+import { CUSTOM_CHANNEL_CONFIG_SCHEMA } from "./custom/plugin";
+import type {
+  ChannelConfigSchema,
+  ChannelPlugin,
+  ChannelPluginMetadata,
+} from "./pluginTypes";
+import { parseChannelConfigSchema } from "./schemaConfig";
 import { FIRST_PARTY_CHANNEL_IDS, type FirstPartyChannelId } from "./types";
 
 type ChannelPluginRegistration = {
@@ -16,6 +22,7 @@ type ChannelManifest = {
   entry: string;
   runtimePackages: string[];
   runtimeModules: string[];
+  configSchema?: ChannelConfigSchema;
 };
 
 const CHANNEL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
@@ -66,6 +73,21 @@ const FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS: Record<
       return discordChannelPlugin;
     },
   },
+  custom: {
+    metadata: {
+      id: "custom",
+      displayName: "Custom",
+      runtimePackages: [],
+      runtimeModules: [],
+      source: "first-party",
+      firstParty: true,
+      configSchema: CUSTOM_CHANNEL_CONFIG_SCHEMA,
+    },
+    load: async () => {
+      const { customChannelPlugin } = await import("./custom/plugin");
+      return customChannelPlugin;
+    },
+  },
 };
 
 const loadedUserPlugins = new Map<string, Promise<ChannelPlugin>>();
@@ -104,12 +126,15 @@ function readChannelManifest(channelDir: string): ChannelManifest | null {
       return null;
     }
 
+    const configSchema = parseChannelConfigSchema(parsed.configSchema);
+
     return {
       id,
       displayName,
       entry,
       runtimePackages: readStringArray(parsed.runtimePackages),
       runtimeModules: readStringArray(parsed.runtimeModules),
+      configSchema: configSchema ?? undefined,
     };
   } catch {
     return null;
@@ -132,6 +157,7 @@ function createUserChannelRegistration(
     runtimeModules: manifest.runtimeModules,
     source: "user",
     firstParty: false,
+    configSchema: manifest.configSchema,
   };
 
   return {

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -25,7 +25,14 @@ export interface ChannelPluginMetadata {
   configSchema?: ChannelConfigSchema;
 }
 
-export type ChannelConfigFieldType = "text" | "secret" | "select" | "boolean";
+export type ChannelConfigFieldType =
+  | "text"
+  | "secret"
+  | "select"
+  | "boolean"
+  | "number"
+  | "string-array"
+  | "key-value-map";
 
 export interface ChannelConfigFieldBase {
   /** Snake-case key used in the plugin's stored config payload. */
@@ -33,6 +40,13 @@ export interface ChannelConfigFieldBase {
   label: string;
   description?: string;
   required?: boolean;
+  /**
+   * Advisory UI hint: when true the dialog renders a "restart required"
+   * chip near the field. Does not yet enforce restart semantics — that's
+   * future work. Plugins should still document which fields they hot-read
+   * vs. read once at startup.
+   */
+  restartRequired?: boolean;
 }
 
 export interface ChannelConfigTextField extends ChannelConfigFieldBase {
@@ -62,11 +76,47 @@ export interface ChannelConfigBooleanField extends ChannelConfigFieldBase {
   default?: boolean;
 }
 
+export interface ChannelConfigNumberField extends ChannelConfigFieldBase {
+  type: "number";
+  default?: number;
+  /** Inclusive lower bound (validated server-side + UI-rendered). */
+  min?: number;
+  /** Inclusive upper bound. */
+  max?: number;
+  /** Step granularity for the UI input (e.g. 0.05). */
+  step?: number;
+  /** Trailing adornment text rendered after the input (e.g. "ms", "%"). */
+  suffix?: string;
+  placeholder?: string;
+}
+
+export interface ChannelConfigStringArrayField extends ChannelConfigFieldBase {
+  type: "string-array";
+  default?: string[];
+  /** Placeholder shown inside each row's input. */
+  placeholder?: string;
+}
+
+export interface ChannelConfigKeyValueMapField extends ChannelConfigFieldBase {
+  type: "key-value-map";
+  /** Whether row values are typed strings or numbers. */
+  valueType: "string" | "number";
+  default?: Record<string, string | number>;
+  /** Column-header labels for the key/value columns. */
+  keyLabel?: string;
+  valueLabel?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+}
+
 export type ChannelConfigField =
   | ChannelConfigTextField
   | ChannelConfigSecretField
   | ChannelConfigSelectField
-  | ChannelConfigBooleanField;
+  | ChannelConfigBooleanField
+  | ChannelConfigNumberField
+  | ChannelConfigStringArrayField
+  | ChannelConfigKeyValueMapField;
 
 export interface ChannelConfigSchema {
   version: 1;

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -47,6 +47,16 @@ export interface ChannelConfigFieldBase {
    * vs. read once at startup.
    */
   restartRequired?: boolean;
+  /**
+   * Where this field lives in the storage model:
+   *   - 'app' (default): stored on the app's plugin config, shared across
+   *     all accounts. Rendered in the App settings tab.
+   *   - 'account': stored on each individual account (e.g. credentials,
+   *     per-handle identifiers). Rendered in the Accounts tab. The App
+   *     settings form omits these fields entirely.
+   * If unspecified, treat as 'app' to preserve backwards compatibility.
+   */
+  scope?: "app" | "account";
 }
 
 export interface ChannelConfigTextField extends ChannelConfigFieldBase {

--- a/src/channels/pluginTypes.ts
+++ b/src/channels/pluginTypes.ts
@@ -16,6 +16,61 @@ export interface ChannelPluginMetadata {
   runtimeModules: string[];
   source?: "first-party" | "user";
   firstParty?: boolean;
+  /**
+   * Optional declarative description of the plugin's account-config fields.
+   * When present, clients can render a dynamic settings form instead of
+   * relying on free-form JSON textareas. Surfaced to clients via
+   * `channels_list_response.channels[*].config_schema`.
+   */
+  configSchema?: ChannelConfigSchema;
+}
+
+export type ChannelConfigFieldType = "text" | "secret" | "select" | "boolean";
+
+export interface ChannelConfigFieldBase {
+  /** Snake-case key used in the plugin's stored config payload. */
+  key: string;
+  label: string;
+  description?: string;
+  required?: boolean;
+}
+
+export interface ChannelConfigTextField extends ChannelConfigFieldBase {
+  type: "text";
+  default?: string;
+  placeholder?: string;
+}
+
+export interface ChannelConfigSecretField extends ChannelConfigFieldBase {
+  type: "secret";
+  placeholder?: string;
+}
+
+export interface ChannelConfigSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface ChannelConfigSelectField extends ChannelConfigFieldBase {
+  type: "select";
+  options: ChannelConfigSelectOption[];
+  default?: string;
+}
+
+export interface ChannelConfigBooleanField extends ChannelConfigFieldBase {
+  type: "boolean";
+  default?: boolean;
+}
+
+export type ChannelConfigField =
+  | ChannelConfigTextField
+  | ChannelConfigSecretField
+  | ChannelConfigSelectField
+  | ChannelConfigBooleanField;
+
+export interface ChannelConfigSchema {
+  version: 1;
+  fields: ChannelConfigField[];
 }
 
 export type ChannelProtocolConfig = Record<string, unknown>;

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -383,19 +383,33 @@ export function validateConfigAgainstSchema(
   // Reserved JSON-bucket keys are always permitted regardless of whether
   // the plugin's schema declares them — they back the dedicated Accounts /
   // Config / Metadata tabs and are stored as opaque strings.
-  const reservedKeys = new Set([
+  // Reserved string-bucket keys: always accepted regardless of schema.
+  const reservedStringKeys = new Set([
     "accounts_json",
     "configs_json",
     "metadata_json",
   ]);
+  // Reserved nullable-string keys (e.g. agent binding) — also always
+  // accepted, but allow null as well as string.
+  const reservedNullableStringKeys = new Set(["agent_id"]);
   for (const key of Object.keys(config)) {
     if (fieldsByKey.has(key)) continue;
-    if (reservedKeys.has(key)) {
+    if (reservedStringKeys.has(key)) {
       const value = config[key];
       if (value !== undefined && typeof value !== "string") {
         return {
           ok: false,
           reason: `reserved field ${key} must be a string`,
+        };
+      }
+      continue;
+    }
+    if (reservedNullableStringKeys.has(key)) {
+      const value = config[key];
+      if (value !== undefined && value !== null && typeof value !== "string") {
+        return {
+          ok: false,
+          reason: `reserved field ${key} must be a string or null`,
         };
       }
       continue;
@@ -620,6 +634,14 @@ export function redactConfigForSnapshot(
     if (result[reservedKey] !== undefined) continue;
     const stored = storedConfig[reservedKey];
     result[reservedKey] = typeof stored === "string" ? stored : "";
+  }
+
+  // Reserved nullable-string keys: agent_id powers the Connected agent
+  // tab and must round-trip regardless of schema.
+  if (result.agent_id === undefined) {
+    const stored = storedConfig.agent_id;
+    result.agent_id =
+      typeof stored === "string" || stored === null ? stored : null;
   }
 
   return result;

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -85,6 +85,13 @@ function parseField(value: unknown): ChannelConfigField | null {
   ) {
     return null;
   }
+  if (
+    value.scope !== undefined &&
+    value.scope !== "app" &&
+    value.scope !== "account"
+  ) {
+    return null;
+  }
 
   const base = {
     key: value.key,
@@ -96,6 +103,9 @@ function parseField(value: unknown): ChannelConfigField | null {
       typeof value.restartRequired === "boolean"
         ? value.restartRequired
         : undefined,
+    scope: (value.scope === "app" || value.scope === "account"
+      ? value.scope
+      : undefined) as "app" | "account" | undefined,
   };
 
   if (type === "text") {

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -380,10 +380,27 @@ export function validateConfigAgainstSchema(
   config: ChannelProtocolConfig,
 ): SchemaValidationResult {
   const fieldsByKey = new Map(schema.fields.map((field) => [field.key, field]));
+  // Reserved JSON-bucket keys are always permitted regardless of whether
+  // the plugin's schema declares them — they back the dedicated Accounts /
+  // Config / Metadata tabs and are stored as opaque strings.
+  const reservedKeys = new Set([
+    "accounts_json",
+    "configs_json",
+    "metadata_json",
+  ]);
   for (const key of Object.keys(config)) {
-    if (!fieldsByKey.has(key)) {
-      return { ok: false, reason: `unknown field: ${key}` };
+    if (fieldsByKey.has(key)) continue;
+    if (reservedKeys.has(key)) {
+      const value = config[key];
+      if (value !== undefined && typeof value !== "string") {
+        return {
+          ok: false,
+          reason: `reserved field ${key} must be a string`,
+        };
+      }
+      continue;
     }
+    return { ok: false, reason: `unknown field: ${key}` };
   }
 
   for (const field of schema.fields) {

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -1,10 +1,13 @@
 import type {
   ChannelConfigBooleanField,
   ChannelConfigField,
+  ChannelConfigKeyValueMapField,
+  ChannelConfigNumberField,
   ChannelConfigSchema,
   ChannelConfigSecretField,
   ChannelConfigSelectField,
   ChannelConfigSelectOption,
+  ChannelConfigStringArrayField,
   ChannelConfigTextField,
   ChannelProtocolConfig,
 } from "./pluginTypes";
@@ -15,6 +18,9 @@ const FIELD_TYPES: ReadonlySet<ChannelConfigField["type"]> = new Set([
   "secret",
   "select",
   "boolean",
+  "number",
+  "string-array",
+  "key-value-map",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -73,6 +79,12 @@ function parseField(value: unknown): ChannelConfigField | null {
   if (value.required !== undefined && typeof value.required !== "boolean") {
     return null;
   }
+  if (
+    value.restartRequired !== undefined &&
+    typeof value.restartRequired !== "boolean"
+  ) {
+    return null;
+  }
 
   const base = {
     key: value.key,
@@ -80,6 +92,10 @@ function parseField(value: unknown): ChannelConfigField | null {
     description:
       typeof value.description === "string" ? value.description : undefined,
     required: typeof value.required === "boolean" ? value.required : undefined,
+    restartRequired:
+      typeof value.restartRequired === "boolean"
+        ? value.restartRequired
+        : undefined,
   };
 
   if (type === "text") {
@@ -152,7 +168,153 @@ function parseField(value: unknown): ChannelConfigField | null {
     return field;
   }
 
+  if (type === "number") {
+    if (value.default !== undefined && !isFiniteNumber(value.default)) {
+      return null;
+    }
+    if (value.min !== undefined && !isFiniteNumber(value.min)) {
+      return null;
+    }
+    if (value.max !== undefined && !isFiniteNumber(value.max)) {
+      return null;
+    }
+    if (value.step !== undefined && !isFiniteNumber(value.step)) {
+      return null;
+    }
+    if (
+      value.min !== undefined &&
+      value.max !== undefined &&
+      (value.min as number) > (value.max as number)
+    ) {
+      return null;
+    }
+    if (
+      value.default !== undefined &&
+      !numberWithinBounds(
+        value.default as number,
+        value.min as number | undefined,
+        value.max as number | undefined,
+      )
+    ) {
+      return null;
+    }
+    if (value.suffix !== undefined && typeof value.suffix !== "string") {
+      return null;
+    }
+    if (
+      value.placeholder !== undefined &&
+      typeof value.placeholder !== "string"
+    ) {
+      return null;
+    }
+    const field: ChannelConfigNumberField = {
+      ...base,
+      type: "number",
+      default: isFiniteNumber(value.default)
+        ? (value.default as number)
+        : undefined,
+      min: isFiniteNumber(value.min) ? (value.min as number) : undefined,
+      max: isFiniteNumber(value.max) ? (value.max as number) : undefined,
+      step: isFiniteNumber(value.step) ? (value.step as number) : undefined,
+      suffix: typeof value.suffix === "string" ? value.suffix : undefined,
+      placeholder:
+        typeof value.placeholder === "string" ? value.placeholder : undefined,
+    };
+    return field;
+  }
+
+  if (type === "string-array") {
+    if (value.default !== undefined) {
+      if (!Array.isArray(value.default)) {
+        return null;
+      }
+      if (!value.default.every((entry) => typeof entry === "string")) {
+        return null;
+      }
+    }
+    if (
+      value.placeholder !== undefined &&
+      typeof value.placeholder !== "string"
+    ) {
+      return null;
+    }
+    const field: ChannelConfigStringArrayField = {
+      ...base,
+      type: "string-array",
+      default: Array.isArray(value.default)
+        ? (value.default as string[]).slice()
+        : undefined,
+      placeholder:
+        typeof value.placeholder === "string" ? value.placeholder : undefined,
+    };
+    return field;
+  }
+
+  if (type === "key-value-map") {
+    if (value.valueType !== "string" && value.valueType !== "number") {
+      return null;
+    }
+    const valueType = value.valueType;
+    if (value.default !== undefined) {
+      if (!isRecord(value.default)) {
+        return null;
+      }
+      for (const entry of Object.values(value.default)) {
+        if (valueType === "string" && typeof entry !== "string") {
+          return null;
+        }
+        if (valueType === "number" && !isFiniteNumber(entry)) {
+          return null;
+        }
+      }
+    }
+    for (const key of [
+      "keyLabel",
+      "valueLabel",
+      "keyPlaceholder",
+      "valuePlaceholder",
+    ] as const) {
+      if (value[key] !== undefined && typeof value[key] !== "string") {
+        return null;
+      }
+    }
+    const field: ChannelConfigKeyValueMapField = {
+      ...base,
+      type: "key-value-map",
+      valueType,
+      default: isRecord(value.default)
+        ? ({ ...value.default } as Record<string, string | number>)
+        : undefined,
+      keyLabel: typeof value.keyLabel === "string" ? value.keyLabel : undefined,
+      valueLabel:
+        typeof value.valueLabel === "string" ? value.valueLabel : undefined,
+      keyPlaceholder:
+        typeof value.keyPlaceholder === "string"
+          ? value.keyPlaceholder
+          : undefined,
+      valuePlaceholder:
+        typeof value.valuePlaceholder === "string"
+          ? value.valuePlaceholder
+          : undefined,
+    };
+    return field;
+  }
+
   return null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function numberWithinBounds(
+  value: number,
+  min: number | undefined,
+  max: number | undefined,
+): boolean {
+  if (min !== undefined && value < min) return false;
+  if (max !== undefined && value > max) return false;
+  return true;
 }
 
 /**
@@ -262,6 +424,73 @@ export function validateConfigAgainstSchema(
         }
         break;
       }
+      case "number": {
+        if (!isFiniteNumber(value)) {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be a finite number`,
+          };
+        }
+        if (!numberWithinBounds(value, field.min, field.max)) {
+          return {
+            ok: false,
+            reason: `field ${field.key} is out of bounds`,
+          };
+        }
+        break;
+      }
+      case "string-array": {
+        if (!Array.isArray(value)) {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be an array of strings`,
+          };
+        }
+        for (const entry of value) {
+          if (typeof entry !== "string") {
+            return {
+              ok: false,
+              reason: `field ${field.key} must contain only strings`,
+            };
+          }
+        }
+        if (field.required && value.length === 0) {
+          return {
+            ok: false,
+            reason: `field ${field.key} is required`,
+          };
+        }
+        break;
+      }
+      case "key-value-map": {
+        if (!isRecord(value)) {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be an object`,
+          };
+        }
+        for (const entry of Object.values(value)) {
+          if (field.valueType === "string" && typeof entry !== "string") {
+            return {
+              ok: false,
+              reason: `field ${field.key} values must be strings`,
+            };
+          }
+          if (field.valueType === "number" && !isFiniteNumber(entry)) {
+            return {
+              ok: false,
+              reason: `field ${field.key} values must be finite numbers`,
+            };
+          }
+        }
+        if (field.required && Object.keys(value).length === 0) {
+          return {
+            ok: false,
+            reason: `field ${field.key} is required`,
+          };
+        }
+        break;
+      }
     }
   }
 
@@ -294,6 +523,50 @@ export function redactConfigForSnapshot(
         result[field.key] = stored;
       } else if (typeof field.default === "boolean") {
         result[field.key] = field.default;
+      }
+      continue;
+    }
+
+    if (field.type === "number") {
+      if (isFiniteNumber(stored)) {
+        result[field.key] = stored;
+      } else if (isFiniteNumber(field.default)) {
+        result[field.key] = field.default;
+      } else {
+        result[field.key] = 0;
+      }
+      continue;
+    }
+
+    if (field.type === "string-array") {
+      if (
+        Array.isArray(stored) &&
+        stored.every((entry) => typeof entry === "string")
+      ) {
+        result[field.key] = stored.slice();
+      } else if (Array.isArray(field.default)) {
+        result[field.key] = field.default.slice();
+      } else {
+        result[field.key] = [];
+      }
+      continue;
+    }
+
+    if (field.type === "key-value-map") {
+      if (isRecord(stored)) {
+        const filtered: Record<string, string | number> = {};
+        for (const [k, v] of Object.entries(stored)) {
+          if (field.valueType === "string" && typeof v === "string") {
+            filtered[k] = v;
+          } else if (field.valueType === "number" && isFiniteNumber(v)) {
+            filtered[k] = v;
+          }
+        }
+        result[field.key] = filtered;
+      } else if (isRecord(field.default)) {
+        result[field.key] = { ...field.default };
+      } else {
+        result[field.key] = {};
       }
       continue;
     }

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -1,0 +1,311 @@
+import type {
+  ChannelConfigBooleanField,
+  ChannelConfigField,
+  ChannelConfigSchema,
+  ChannelConfigSecretField,
+  ChannelConfigSelectField,
+  ChannelConfigSelectOption,
+  ChannelConfigTextField,
+  ChannelProtocolConfig,
+} from "./pluginTypes";
+
+const FIELD_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+const FIELD_TYPES: ReadonlySet<ChannelConfigField["type"]> = new Set([
+  "text",
+  "secret",
+  "select",
+  "boolean",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function parseSelectOptions(
+  value: unknown,
+): ChannelConfigSelectOption[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+  const options: ChannelConfigSelectOption[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      return null;
+    }
+    if (!isNonEmptyString(entry.value) || !isNonEmptyString(entry.label)) {
+      return null;
+    }
+    if (seen.has(entry.value)) {
+      return null;
+    }
+    seen.add(entry.value);
+    options.push({ value: entry.value, label: entry.label });
+  }
+  return options;
+}
+
+function parseField(value: unknown): ChannelConfigField | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const type = value.type;
+  if (typeof type !== "string" || !FIELD_TYPES.has(type as never)) {
+    return null;
+  }
+  if (!isNonEmptyString(value.key) || !FIELD_KEY_PATTERN.test(value.key)) {
+    return null;
+  }
+  if (!isNonEmptyString(value.label)) {
+    return null;
+  }
+  if (
+    value.description !== undefined &&
+    typeof value.description !== "string"
+  ) {
+    return null;
+  }
+  if (value.required !== undefined && typeof value.required !== "boolean") {
+    return null;
+  }
+
+  const base = {
+    key: value.key,
+    label: value.label,
+    description:
+      typeof value.description === "string" ? value.description : undefined,
+    required: typeof value.required === "boolean" ? value.required : undefined,
+  };
+
+  if (type === "text") {
+    if (value.default !== undefined && typeof value.default !== "string") {
+      return null;
+    }
+    if (
+      value.placeholder !== undefined &&
+      typeof value.placeholder !== "string"
+    ) {
+      return null;
+    }
+    const field: ChannelConfigTextField = {
+      ...base,
+      type: "text",
+      default: typeof value.default === "string" ? value.default : undefined,
+      placeholder:
+        typeof value.placeholder === "string" ? value.placeholder : undefined,
+    };
+    return field;
+  }
+
+  if (type === "secret") {
+    if (
+      value.placeholder !== undefined &&
+      typeof value.placeholder !== "string"
+    ) {
+      return null;
+    }
+    const field: ChannelConfigSecretField = {
+      ...base,
+      type: "secret",
+      placeholder:
+        typeof value.placeholder === "string" ? value.placeholder : undefined,
+    };
+    return field;
+  }
+
+  if (type === "select") {
+    const options = parseSelectOptions(value.options);
+    if (!options) {
+      return null;
+    }
+    if (value.default !== undefined) {
+      if (
+        typeof value.default !== "string" ||
+        !options.some((option) => option.value === value.default)
+      ) {
+        return null;
+      }
+    }
+    const field: ChannelConfigSelectField = {
+      ...base,
+      type: "select",
+      options,
+      default: typeof value.default === "string" ? value.default : undefined,
+    };
+    return field;
+  }
+
+  if (type === "boolean") {
+    if (value.default !== undefined && typeof value.default !== "boolean") {
+      return null;
+    }
+    const field: ChannelConfigBooleanField = {
+      ...base,
+      type: "boolean",
+      default: typeof value.default === "boolean" ? value.default : undefined,
+    };
+    return field;
+  }
+
+  return null;
+}
+
+/**
+ * Parse a JSON-like value into a {@link ChannelConfigSchema}. Returns `null`
+ * when the value violates the strict v1 contract, in which case callers should
+ * silently drop the schema (the channel still loads, just without dynamic
+ * config UI).
+ */
+export function parseChannelConfigSchema(
+  value: unknown,
+): ChannelConfigSchema | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (value.version !== 1) {
+    return null;
+  }
+  if (!Array.isArray(value.fields)) {
+    return null;
+  }
+
+  const fields: ChannelConfigField[] = [];
+  const seenKeys = new Set<string>();
+  for (const raw of value.fields) {
+    const field = parseField(raw);
+    if (!field) {
+      return null;
+    }
+    if (seenKeys.has(field.key)) {
+      return null;
+    }
+    seenKeys.add(field.key);
+    fields.push(field);
+  }
+
+  return { version: 1, fields };
+}
+
+export type SchemaValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Strictly validate a plugin config payload against a declared schema.
+ *
+ * - Unknown keys are rejected.
+ * - Each declared field's type must match the value type.
+ * - Required string fields, when present in the patch, must be non-empty.
+ * - Partial patches are allowed (omitted keys mean "no change").
+ */
+export function validateConfigAgainstSchema(
+  schema: ChannelConfigSchema,
+  config: ChannelProtocolConfig,
+): SchemaValidationResult {
+  const fieldsByKey = new Map(schema.fields.map((field) => [field.key, field]));
+  for (const key of Object.keys(config)) {
+    if (!fieldsByKey.has(key)) {
+      return { ok: false, reason: `unknown field: ${key}` };
+    }
+  }
+
+  for (const field of schema.fields) {
+    const present = Object.hasOwn(config, field.key);
+    if (!present) {
+      continue;
+    }
+    const value = config[field.key];
+
+    switch (field.type) {
+      case "text":
+      case "secret": {
+        if (typeof value !== "string") {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be a string`,
+          };
+        }
+        if (field.required && value.length === 0) {
+          return {
+            ok: false,
+            reason: `field ${field.key} is required`,
+          };
+        }
+        break;
+      }
+      case "select": {
+        if (typeof value !== "string") {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be a string`,
+          };
+        }
+        if (!field.options.some((option) => option.value === value)) {
+          return {
+            ok: false,
+            reason: `field ${field.key} has invalid value`,
+          };
+        }
+        break;
+      }
+      case "boolean": {
+        if (typeof value !== "boolean") {
+          return {
+            ok: false,
+            reason: `field ${field.key} must be a boolean`,
+          };
+        }
+        break;
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Build a redacted, client-safe view of a stored plugin config.
+ *
+ * - `secret` fields collapse to `has_<key>: boolean` (Slack pattern).
+ * - `text` / `select` / `boolean` fields fall through to their stored value,
+ *   or the schema default when nothing is stored and a default exists.
+ * - Stored keys not declared in the schema are omitted.
+ */
+export function redactConfigForSnapshot(
+  schema: ChannelConfigSchema,
+  storedConfig: Record<string, unknown>,
+): ChannelProtocolConfig {
+  const result: ChannelProtocolConfig = {};
+  for (const field of schema.fields) {
+    const stored = storedConfig[field.key];
+    if (field.type === "secret") {
+      result[`has_${field.key}`] =
+        typeof stored === "string" && stored.trim().length > 0;
+      continue;
+    }
+
+    if (field.type === "boolean") {
+      if (typeof stored === "boolean") {
+        result[field.key] = stored;
+      } else if (typeof field.default === "boolean") {
+        result[field.key] = field.default;
+      }
+      continue;
+    }
+
+    // text / select
+    if (typeof stored === "string") {
+      result[field.key] = stored;
+    } else if (typeof field.default === "string") {
+      result[field.key] = field.default;
+    } else {
+      result[field.key] = "";
+    }
+  }
+  return result;
+}

--- a/src/channels/schemaConfig.ts
+++ b/src/channels/schemaConfig.ts
@@ -590,5 +590,20 @@ export function redactConfigForSnapshot(
       result[field.key] = "";
     }
   }
+
+  // Always pass through Letta's reserved JSON-bucket keys regardless of
+  // whether the plugin declared them in its schema. These power the
+  // dedicated Accounts / Config / Metadata tabs in the desktop dialog
+  // and round-trip as opaque strings on the snapshot.
+  for (const reservedKey of [
+    "accounts_json",
+    "configs_json",
+    "metadata_json",
+  ]) {
+    if (result[reservedKey] !== undefined) continue;
+    const stored = storedConfig[reservedKey];
+    result[reservedKey] = typeof stored === "string" ? stored : "";
+  }
+
   return result;
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -593,6 +593,12 @@ function mergeAccountPatch(
   }
 
   if (!isSlackChannelAccount(existing)) {
+    // Custom channels (and user-installed plugins) hold all plugin-specific
+    // state in the generic `config` bag. Snapshots returned to clients redact
+    // secrets (e.g. `bot_token` is replaced with `has_bot_token: boolean`), so
+    // the client cannot send the secret back on every save. Merge the patch
+    // into the existing config so omitted keys are preserved; pass `null`
+    // explicitly to clear a key.
     return {
       ...existing,
       displayName:
@@ -604,7 +610,7 @@ function mergeAccountPatch(
       allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
       config:
         normalizedPatch.config !== undefined
-          ? { ...normalizedPatch.config }
+          ? { ...existing.config, ...normalizedPatch.config }
           : { ...existing.config },
       updatedAt: nextUpdatedAt,
     };

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -11,6 +11,7 @@ export const FIRST_PARTY_CHANNEL_IDS = [
   "telegram",
   "slack",
   "discord",
+  "custom",
 ] as const;
 export type FirstPartyChannelId = (typeof FIRST_PARTY_CHANNEL_IDS)[number];
 /**
@@ -400,6 +401,11 @@ export function isDiscordChannelAccount(
 export function isCustomChannelAccount(
   account: ChannelAccount,
 ): account is CustomChannelAccount {
+  // The "custom" first-party channel and all user-installed channels share the
+  // same generic config-bag shape (no specific fields like `token`).
+  if (account.channel === "custom") {
+    return "config" in account;
+  }
   return !isFirstPartyChannelId(account.channel) && "config" in account;
 }
 

--- a/src/tests/channels/custom-accountConfig.test.ts
+++ b/src/tests/channels/custom-accountConfig.test.ts
@@ -79,6 +79,7 @@ describe("customAccountConfigAdapter.toAccountConfig", () => {
       agent_id: "agent-123",
       accounts_json: "[1,2,3]",
       configs_json: '{"a":1}',
+      metadata_json: "",
     });
   });
 

--- a/src/tests/channels/custom-accountConfig.test.ts
+++ b/src/tests/channels/custom-accountConfig.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { customAccountConfigAdapter } from "../../channels/custom/accountConfig";
+import type { CustomChannelAccount } from "../../channels/types";
+
+function makeAccount(
+  config: Record<string, unknown>,
+  overrides: Partial<CustomChannelAccount> = {},
+): CustomChannelAccount {
+  return {
+    channel: "custom",
+    accountId: "acct-1",
+    displayName: "My Custom App",
+    enabled: true,
+    dmPolicy: "open",
+    allowedUsers: [],
+    config,
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("customAccountConfigAdapter.isValidConfig", () => {
+  test("accepts the documented keys", () => {
+    expect(
+      customAccountConfigAdapter.isValidConfig({
+        url: "https://example.com/webhook",
+        bot_token: "secret",
+        auth: "Bearer xyz",
+        agent_id: "agent-1",
+        accounts_json: "[]",
+        configs_json: "{}",
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts empty config", () => {
+    expect(customAccountConfigAdapter.isValidConfig({})).toBe(true);
+  });
+
+  test("accepts null agent_id", () => {
+    expect(customAccountConfigAdapter.isValidConfig({ agent_id: null })).toBe(
+      true,
+    );
+  });
+
+  test("rejects unknown keys", () => {
+    expect(
+      customAccountConfigAdapter.isValidConfig({ url: "x", extra: "y" }),
+    ).toBe(false);
+  });
+
+  test("rejects wrong types", () => {
+    expect(customAccountConfigAdapter.isValidConfig({ url: 42 })).toBe(false);
+    expect(
+      customAccountConfigAdapter.isValidConfig({ accounts_json: {} }),
+    ).toBe(false);
+    expect(customAccountConfigAdapter.isValidConfig({ agent_id: 7 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("customAccountConfigAdapter.toAccountConfig", () => {
+  test("redacts tokens and surfaces has_* flags", () => {
+    const account = makeAccount({
+      url: "https://example.com/webhook",
+      bot_token: "secret-token",
+      auth: "Bearer xyz",
+      agent_id: "agent-123",
+      accounts_json: "[1,2,3]",
+      configs_json: '{"a":1}',
+    });
+
+    expect(customAccountConfigAdapter.toAccountConfig(account)).toEqual({
+      url: "https://example.com/webhook",
+      has_bot_token: true,
+      has_auth: true,
+      agent_id: "agent-123",
+      accounts_json: "[1,2,3]",
+      configs_json: '{"a":1}',
+    });
+  });
+
+  test("missing tokens reported as has_* false", () => {
+    const account = makeAccount({ url: "https://example.com" });
+    expect(customAccountConfigAdapter.toAccountConfig(account)).toMatchObject({
+      url: "https://example.com",
+      has_bot_token: false,
+      has_auth: false,
+      agent_id: null,
+      accounts_json: "",
+      configs_json: "",
+    });
+  });
+
+  test("blank-only tokens reported as has_* false", () => {
+    const account = makeAccount({
+      url: "https://example.com",
+      bot_token: "   ",
+      auth: "",
+    });
+    expect(customAccountConfigAdapter.toAccountConfig(account)).toMatchObject({
+      has_bot_token: false,
+      has_auth: false,
+    });
+  });
+});
+
+describe("customAccountConfigAdapter.toAccountPatch", () => {
+  test("returns empty patch (config bag handled separately)", () => {
+    expect(
+      customAccountConfigAdapter.toAccountPatch({
+        url: "https://example.com",
+        bot_token: "secret",
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("customAccountConfigAdapter.shouldRefreshDisplayName", () => {
+  test("never auto-refreshes display name", () => {
+    expect(customAccountConfigAdapter.shouldRefreshDisplayName({})).toBe(false);
+  });
+});
+
+describe("customAccountConfigAdapter.toConfigSnapshotConfig", () => {
+  test("matches toAccountConfig", () => {
+    const account = makeAccount({
+      url: "https://example.com",
+      auth: "x",
+    });
+    expect(customAccountConfigAdapter.toConfigSnapshotConfig(account)).toEqual(
+      customAccountConfigAdapter.toAccountConfig(account),
+    );
+  });
+});

--- a/src/tests/channels/custom-adapter.test.ts
+++ b/src/tests/channels/custom-adapter.test.ts
@@ -99,7 +99,7 @@ describe("createCustomAdapter", () => {
 
     const headers = request.init.headers as Record<string, string>;
     expect(headers["Content-Type"]).toBe("application/json");
-    expect(headers["Authorization"]).toBe("Bearer secret-bot");
+    expect(headers.Authorization).toBe("Bearer secret-bot");
     expect(headers["X-Letta-Auth"]).toBe("secret-auth");
 
     const body = JSON.parse(request.init.body as string);
@@ -176,7 +176,7 @@ describe("createCustomAdapter", () => {
     const request = captured[0];
     if (!request) throw new Error("no request captured");
     const headers = request.init.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers.Authorization).toBeUndefined();
     expect(headers["X-Letta-Auth"]).toBe("secret-auth");
   });
 

--- a/src/tests/channels/custom-adapter.test.ts
+++ b/src/tests/channels/custom-adapter.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createCustomAdapter } from "../../channels/custom/adapter";
+import type { CustomChannelAccount } from "../../channels/types";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function makeAccount(
+  config: Record<string, unknown> = {},
+): CustomChannelAccount {
+  return {
+    channel: "custom",
+    accountId: "acct-1",
+    displayName: "My Custom App",
+    enabled: true,
+    dmPolicy: "open",
+    allowedUsers: [],
+    config: {
+      url: "https://example.com/webhook",
+      bot_token: "secret-bot",
+      auth: "secret-auth",
+      ...config,
+    },
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-06T00:00:00.000Z",
+  };
+}
+
+const originalFetch = globalThis.fetch;
+let captured: CapturedRequest[] = [];
+
+function setFetchResponse(response: Response | Promise<Response>): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured.push({
+      url: typeof input === "string" ? input : input.toString(),
+      init: init ?? {},
+    });
+    return response instanceof Promise ? response : response;
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  captured = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("createCustomAdapter", () => {
+  test("identity fields", () => {
+    const adapter = createCustomAdapter(makeAccount());
+    expect(adapter.id).toBe("custom:acct-1");
+    expect(adapter.channelId).toBe("custom");
+    expect(adapter.accountId).toBe("acct-1");
+    expect(adapter.name).toBe("My Custom App");
+  });
+
+  test("name falls back to 'Custom' when displayName missing", () => {
+    const account = makeAccount();
+    delete account.displayName;
+    const adapter = createCustomAdapter(account);
+    expect(adapter.name).toBe("Custom");
+  });
+
+  test("start/stop toggle isRunning", async () => {
+    const adapter = createCustomAdapter(makeAccount());
+    expect(adapter.isRunning()).toBe(false);
+    await adapter.start();
+    expect(adapter.isRunning()).toBe(true);
+    await adapter.stop();
+    expect(adapter.isRunning()).toBe(false);
+  });
+
+  test("sendMessage POSTs to the configured URL with auth headers", async () => {
+    setFetchResponse(
+      new Response(JSON.stringify({ message_id: "remote-7" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const adapter = createCustomAdapter(makeAccount());
+    const result = await adapter.sendMessage({
+      channel: "custom",
+      accountId: "acct-1",
+      chatId: "chat-9",
+      text: "hello",
+    });
+
+    expect(captured).toHaveLength(1);
+    const request = captured[0];
+    if (!request) throw new Error("no request captured");
+
+    expect(request.url).toBe("https://example.com/webhook");
+    expect(request.init.method).toBe("POST");
+
+    const headers = request.init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Authorization"]).toBe("Bearer secret-bot");
+    expect(headers["X-Letta-Auth"]).toBe("secret-auth");
+
+    const body = JSON.parse(request.init.body as string);
+    expect(body).toMatchObject({
+      channel: "custom",
+      account_id: "acct-1",
+      chat_id: "chat-9",
+      text: "hello",
+    });
+
+    expect(result.messageId).toBe("remote-7");
+  });
+
+  test("sendMessage falls back to a uuid when remote omits message_id", async () => {
+    setFetchResponse(new Response("ok", { status: 200 }));
+
+    const adapter = createCustomAdapter(makeAccount());
+    const result = await adapter.sendMessage({
+      channel: "custom",
+      accountId: "acct-1",
+      chatId: "chat-9",
+      text: "hello",
+    });
+
+    expect(typeof result.messageId).toBe("string");
+    expect(result.messageId.length).toBeGreaterThan(0);
+  });
+
+  test("sendMessage throws when URL is missing", async () => {
+    const account = makeAccount();
+    delete account.config.url;
+    const adapter = createCustomAdapter(account);
+
+    await expect(
+      adapter.sendMessage({
+        channel: "custom",
+        accountId: "acct-1",
+        chatId: "chat-9",
+        text: "hi",
+      }),
+    ).rejects.toThrow(/missing a webhook URL/i);
+  });
+
+  test("sendMessage throws on non-2xx response", async () => {
+    setFetchResponse(
+      new Response("server boom", {
+        status: 502,
+        statusText: "Bad Gateway",
+      }),
+    );
+
+    const adapter = createCustomAdapter(makeAccount());
+    await expect(
+      adapter.sendMessage({
+        channel: "custom",
+        accountId: "acct-1",
+        chatId: "chat-9",
+        text: "hi",
+      }),
+    ).rejects.toThrow(/502/);
+  });
+
+  test("sendMessage omits Authorization when bot_token blank", async () => {
+    setFetchResponse(new Response("ok", { status: 200 }));
+    const adapter = createCustomAdapter(makeAccount({ bot_token: "" }));
+
+    await adapter.sendMessage({
+      channel: "custom",
+      accountId: "acct-1",
+      chatId: "chat-9",
+      text: "hi",
+    });
+
+    const request = captured[0];
+    if (!request) throw new Error("no request captured");
+    const headers = request.init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-Letta-Auth"]).toBe("secret-auth");
+  });
+
+  test("sendDirectReply forwards through deliver", async () => {
+    setFetchResponse(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const adapter = createCustomAdapter(makeAccount());
+    await adapter.sendDirectReply("chat-1", "ping", {
+      replyToMessageId: "mid-7",
+    });
+
+    const request = captured[0];
+    if (!request) throw new Error("no request captured");
+    const body = JSON.parse(request.init.body as string);
+    expect(body.chat_id).toBe("chat-1");
+    expect(body.text).toBe("ping");
+    expect(body.reply_to_message_id).toBe("mid-7");
+  });
+});

--- a/src/tests/channels/custom-adapter.test.ts
+++ b/src/tests/channels/custom-adapter.test.ts
@@ -32,7 +32,7 @@ const originalFetch = globalThis.fetch;
 let captured: CapturedRequest[] = [];
 
 function setFetchResponse(response: Response | Promise<Response>): void {
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
     captured.push({
       url: typeof input === "string" ? input : input.toString(),
       init: init ?? {},

--- a/src/tests/channels/plugin-registry.test.ts
+++ b/src/tests/channels/plugin-registry.test.ts
@@ -182,15 +182,15 @@ test("user plugin configSchema is parsed from channel.json", () => {
   expect(isSupportedChannelId("schemademo")).toBe(true);
   const metadata = getChannelPluginMetadata("schemademo");
   expect(metadata.configSchema).not.toBeUndefined();
-  expect(metadata.configSchema!.version).toBe(1);
-  expect(metadata.configSchema!.fields).toHaveLength(4);
-  expect(metadata.configSchema!.fields[0]).toEqual({
+  expect(metadata.configSchema?.version).toBe(1);
+  expect(metadata.configSchema?.fields).toHaveLength(4);
+  expect(metadata.configSchema?.fields[0]).toEqual({
     type: "text",
     key: "endpoint",
     label: "Endpoint",
     required: true,
   });
-  expect(metadata.configSchema!.fields[1]).toEqual({
+  expect(metadata.configSchema?.fields[1]).toEqual({
     type: "secret",
     key: "api_key",
     label: "API Key",
@@ -240,10 +240,10 @@ test("user plugin with invalid configSchema still loads (schema dropped)", () =>
 test("first-party custom channel has configSchema", () => {
   const metadata = getChannelPluginMetadata("custom");
   expect(metadata.configSchema).not.toBeUndefined();
-  expect(metadata.configSchema!.version).toBe(1);
-  expect(metadata.configSchema!.fields.length).toBeGreaterThan(0);
-  const urlField = metadata.configSchema!.fields.find((f) => f.key === "url");
+  expect(metadata.configSchema?.version).toBe(1);
+  expect(metadata.configSchema?.fields.length).toBeGreaterThan(0);
+  const urlField = metadata.configSchema?.fields.find((f) => f.key === "url");
   expect(urlField).not.toBeUndefined();
-  expect(urlField!.type).toBe("text");
-  expect(urlField!.required).toBe(true);
+  expect(urlField?.type).toBe("text");
+  expect(urlField?.required).toBe(true);
 });

--- a/src/tests/channels/plugin-registry.test.ts
+++ b/src/tests/channels/plugin-registry.test.ts
@@ -130,3 +130,120 @@ test("user plugins can extend the MessageChannel action schema", async () => {
   expect(properties.action?.enum).toEqual(["send", "wave"]);
   expect(properties.intensity).toEqual({ type: "string" });
 });
+
+test("user plugin configSchema is parsed from channel.json", () => {
+  const channelDir = join(channelsRoot, "schemademo");
+  mkdirSync(channelDir, { recursive: true });
+  writeFileSync(
+    join(channelDir, "channel.json"),
+    `${JSON.stringify({
+      id: "schemademo",
+      displayName: "Schema Demo",
+      entry: "./plugin.mjs",
+      configSchema: {
+        version: 1,
+        fields: [
+          { type: "text", key: "endpoint", label: "Endpoint", required: true },
+          { type: "secret", key: "api_key", label: "API Key" },
+          {
+            type: "select",
+            key: "region",
+            label: "Region",
+            options: [
+              { value: "us", label: "US" },
+              { value: "eu", label: "EU" },
+            ],
+          },
+          { type: "boolean", key: "debug", label: "Debug", default: false },
+        ],
+      },
+    })}\n`,
+  );
+  writeFileSync(
+    join(channelDir, "plugin.mjs"),
+    `export const channelPlugin = {
+      metadata: { id: "schemademo", displayName: "Schema Demo" },
+      createAdapter(account) {
+        return {
+          id: "schemademo:" + account.accountId,
+          channelId: "schemademo",
+          accountId: account.accountId,
+          name: "Schema Demo",
+          start: async () => {},
+          stop: async () => {},
+          isRunning: () => true,
+          sendMessage: async () => ({ messageId: "sd-1" }),
+          sendDirectReply: async () => {}
+        };
+      }
+    };\n`,
+  );
+
+  expect(isSupportedChannelId("schemademo")).toBe(true);
+  const metadata = getChannelPluginMetadata("schemademo");
+  expect(metadata.configSchema).not.toBeUndefined();
+  expect(metadata.configSchema!.version).toBe(1);
+  expect(metadata.configSchema!.fields).toHaveLength(4);
+  expect(metadata.configSchema!.fields[0]).toEqual({
+    type: "text",
+    key: "endpoint",
+    label: "Endpoint",
+    required: true,
+  });
+  expect(metadata.configSchema!.fields[1]).toEqual({
+    type: "secret",
+    key: "api_key",
+    label: "API Key",
+  });
+});
+
+test("user plugin with invalid configSchema still loads (schema dropped)", () => {
+  const channelDir = join(channelsRoot, "badschema");
+  mkdirSync(channelDir, { recursive: true });
+  writeFileSync(
+    join(channelDir, "channel.json"),
+    `${JSON.stringify({
+      id: "badschema",
+      displayName: "Bad Schema",
+      entry: "./plugin.mjs",
+      configSchema: {
+        version: 99,
+        fields: [{ type: "unknown_type", key: "x", label: "X" }],
+      },
+    })}\n`,
+  );
+  writeFileSync(
+    join(channelDir, "plugin.mjs"),
+    `export const channelPlugin = {
+      metadata: { id: "badschema", displayName: "Bad Schema" },
+      createAdapter(account) {
+        return {
+          id: "badschema:" + account.accountId,
+          channelId: "badschema",
+          accountId: account.accountId,
+          name: "Bad Schema",
+          start: async () => {},
+          stop: async () => {},
+          isRunning: () => true,
+          sendMessage: async () => ({ messageId: "bs-1" }),
+          sendDirectReply: async () => {}
+        };
+      }
+    };\n`,
+  );
+
+  expect(isSupportedChannelId("badschema")).toBe(true);
+  const metadata = getChannelPluginMetadata("badschema");
+  expect(metadata.configSchema).toBeUndefined();
+});
+
+test("first-party custom channel has configSchema", () => {
+  const metadata = getChannelPluginMetadata("custom");
+  expect(metadata.configSchema).not.toBeUndefined();
+  expect(metadata.configSchema!.version).toBe(1);
+  expect(metadata.configSchema!.fields.length).toBeGreaterThan(0);
+  const urlField = metadata.configSchema!.fields.find((f) => f.key === "url");
+  expect(urlField).not.toBeUndefined();
+  expect(urlField!.type).toBe("text");
+  expect(urlField!.required).toBe(true);
+});

--- a/src/tests/channels/schema-config.test.ts
+++ b/src/tests/channels/schema-config.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelConfigSchema } from "../../channels/pluginTypes";
+import {
+  parseChannelConfigSchema,
+  redactConfigForSnapshot,
+  validateConfigAgainstSchema,
+} from "../../channels/schemaConfig";
+
+const SIMPLE_SCHEMA: ChannelConfigSchema = {
+  version: 1,
+  fields: [
+    { type: "text", key: "url", label: "URL", required: true },
+    { type: "secret", key: "api_key", label: "API Key" },
+    {
+      type: "select",
+      key: "mode",
+      label: "Mode",
+      options: [
+        { value: "fast", label: "Fast" },
+        { value: "slow", label: "Slow" },
+      ],
+      default: "fast",
+    },
+    { type: "boolean", key: "debug", label: "Debug", default: false },
+  ],
+};
+
+describe("parseChannelConfigSchema", () => {
+  test("parses a valid full schema", () => {
+    const result = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        { type: "text", key: "name", label: "Name" },
+        { type: "secret", key: "token", label: "Token" },
+        {
+          type: "select",
+          key: "region",
+          label: "Region",
+          options: [
+            { value: "us", label: "US" },
+            { value: "eu", label: "EU" },
+          ],
+        },
+        { type: "boolean", key: "enabled", label: "Enabled" },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fields).toHaveLength(4);
+    expect(result!.fields[0]).toEqual({
+      type: "text",
+      key: "name",
+      label: "Name",
+    });
+    expect(result!.fields[1]).toEqual({
+      type: "secret",
+      key: "token",
+      label: "Token",
+    });
+    expect(result!.fields[2]!.type).toBe("select");
+    expect((result!.fields[2] as any).options).toHaveLength(2);
+    expect(result!.fields[3]).toEqual({
+      type: "boolean",
+      key: "enabled",
+      label: "Enabled",
+    });
+  });
+
+  test("returns null for non-object input", () => {
+    expect(parseChannelConfigSchema(null)).toBeNull();
+    expect(parseChannelConfigSchema("string")).toBeNull();
+    expect(parseChannelConfigSchema(42)).toBeNull();
+  });
+
+  test("returns null for wrong version", () => {
+    expect(parseChannelConfigSchema({ version: 2, fields: [] })).toBeNull();
+    expect(parseChannelConfigSchema({ version: "1", fields: [] })).toBeNull();
+  });
+
+  test("returns null for missing fields array", () => {
+    expect(parseChannelConfigSchema({ version: 1 })).toBeNull();
+    expect(parseChannelConfigSchema({ version: 1, fields: {} })).toBeNull();
+  });
+
+  test("returns null for unknown field type", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "number", key: "count", label: "Count" }],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for invalid field key", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "text", key: "UPPER", label: "Upper" }],
+      }),
+    ).toBeNull();
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "text", key: "1starts_with_digit", label: "Bad" }],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for missing label", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "text", key: "name" }],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for duplicate keys", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          { type: "text", key: "name", label: "Name 1" },
+          { type: "text", key: "name", label: "Name 2" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for select with empty options", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "select", key: "mode", label: "Mode", options: [] }],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for select with invalid option shape", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "select",
+            key: "mode",
+            label: "Mode",
+            options: [{ value: 1, label: "One" }],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for select with duplicate option values", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "select",
+            key: "mode",
+            label: "Mode",
+            options: [
+              { value: "a", label: "A" },
+              { value: "a", label: "A2" },
+            ],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for select default not in options", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "select",
+            key: "mode",
+            label: "Mode",
+            options: [{ value: "a", label: "A" }],
+            default: "b",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for wrong default type", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [{ type: "text", key: "name", label: "Name", default: 42 }],
+      }),
+    ).toBeNull();
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          { type: "boolean", key: "flag", label: "Flag", default: "yes" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts optional description and required", () => {
+    const result = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        {
+          type: "text",
+          key: "url",
+          label: "URL",
+          description: "The endpoint URL",
+          required: true,
+        },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.fields[0]!.description).toBe("The endpoint URL");
+    expect(result!.fields[0]!.required).toBe(true);
+  });
+
+  test("accepts placeholder for text and secret", () => {
+    const result = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        { type: "text", key: "name", label: "Name", placeholder: "Enter name" },
+        {
+          type: "secret",
+          key: "key",
+          label: "Key",
+          placeholder: "Enter key",
+        },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect((result!.fields[0] as any).placeholder).toBe("Enter name");
+    expect((result!.fields[1] as any).placeholder).toBe("Enter key");
+  });
+});
+
+describe("validateConfigAgainstSchema", () => {
+  test("accepts valid config matching schema", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+      api_key: "secret123",
+      mode: "fast",
+      debug: true,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("accepts partial config (omitted keys are no-change)", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("rejects unknown keys", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+      unknown_field: "oops",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("unknown field");
+    }
+  });
+
+  test("rejects wrong type for text field", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      url: 42,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("must be a string");
+    }
+  });
+
+  test("rejects wrong type for boolean field", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      debug: "yes",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("must be a boolean");
+    }
+  });
+
+  test("rejects invalid select value", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      mode: "invalid",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("invalid value");
+    }
+  });
+
+  test("rejects empty required string", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      url: "",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("required");
+    }
+  });
+
+  test("allows empty non-required string", () => {
+    const result = validateConfigAgainstSchema(SIMPLE_SCHEMA, {
+      api_key: "",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("redactConfigForSnapshot", () => {
+  test("redacts secret fields to has_<key> booleans", () => {
+    const result = redactConfigForSnapshot(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+      api_key: "secret123",
+      mode: "fast",
+      debug: true,
+    });
+    expect(result).toEqual({
+      url: "https://example.com",
+      has_api_key: true,
+      mode: "fast",
+      debug: true,
+    });
+  });
+
+  test("emits has_<key>: false for empty secret", () => {
+    const result = redactConfigForSnapshot(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+      api_key: "",
+      mode: "slow",
+      debug: false,
+    });
+    expect(result).toEqual({
+      url: "https://example.com",
+      has_api_key: false,
+      mode: "slow",
+      debug: false,
+    });
+  });
+
+  test("emits has_<key>: false for missing secret", () => {
+    const result = redactConfigForSnapshot(SIMPLE_SCHEMA, {
+      url: "https://example.com",
+    });
+    expect(result).toEqual({
+      url: "https://example.com",
+      has_api_key: false,
+      mode: "fast", // default
+      debug: false, // default
+    });
+  });
+
+  test("falls through to empty string for text with no stored value and no default", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [{ type: "text", key: "name", label: "Name" }],
+    };
+    const result = redactConfigForSnapshot(schema, {});
+    expect(result).toEqual({ name: "" });
+  });
+
+  test("uses schema default for boolean when no stored value", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [{ type: "boolean", key: "flag", label: "Flag", default: true }],
+    };
+    const result = redactConfigForSnapshot(schema, {});
+    expect(result).toEqual({ flag: true });
+  });
+
+  test("omits undeclared stored keys", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [{ type: "text", key: "name", label: "Name" }],
+    };
+    const result = redactConfigForSnapshot(schema, {
+      name: "hello",
+      secret_backdoor: "oops",
+    });
+    expect(result).toEqual({ name: "hello" });
+  });
+});

--- a/src/tests/channels/schema-config.test.ts
+++ b/src/tests/channels/schema-config.test.ts
@@ -318,6 +318,14 @@ describe("validateConfigAgainstSchema", () => {
   });
 });
 
+// Reserved JSON-bucket keys that redactConfigForSnapshot always emits,
+// regardless of whether the schema declares them.
+const RESERVED_BASE = {
+  accounts_json: "",
+  configs_json: "",
+  metadata_json: "",
+};
+
 describe("redactConfigForSnapshot", () => {
   test("redacts secret fields to has_<key> booleans", () => {
     const result = redactConfigForSnapshot(SIMPLE_SCHEMA, {
@@ -327,6 +335,7 @@ describe("redactConfigForSnapshot", () => {
       debug: true,
     });
     expect(result).toEqual({
+      ...RESERVED_BASE,
       url: "https://example.com",
       has_api_key: true,
       mode: "fast",
@@ -342,6 +351,7 @@ describe("redactConfigForSnapshot", () => {
       debug: false,
     });
     expect(result).toEqual({
+      ...RESERVED_BASE,
       url: "https://example.com",
       has_api_key: false,
       mode: "slow",
@@ -354,6 +364,7 @@ describe("redactConfigForSnapshot", () => {
       url: "https://example.com",
     });
     expect(result).toEqual({
+      ...RESERVED_BASE,
       url: "https://example.com",
       has_api_key: false,
       mode: "fast", // default
@@ -367,7 +378,7 @@ describe("redactConfigForSnapshot", () => {
       fields: [{ type: "text", key: "name", label: "Name" }],
     };
     const result = redactConfigForSnapshot(schema, {});
-    expect(result).toEqual({ name: "" });
+    expect(result).toEqual({ ...RESERVED_BASE, name: "" });
   });
 
   test("uses schema default for boolean when no stored value", () => {
@@ -376,7 +387,7 @@ describe("redactConfigForSnapshot", () => {
       fields: [{ type: "boolean", key: "flag", label: "Flag", default: true }],
     };
     const result = redactConfigForSnapshot(schema, {});
-    expect(result).toEqual({ flag: true });
+    expect(result).toEqual({ ...RESERVED_BASE, flag: true });
   });
 
   test("omits undeclared stored keys", () => {
@@ -388,7 +399,7 @@ describe("redactConfigForSnapshot", () => {
       name: "hello",
       secret_backdoor: "oops",
     });
-    expect(result).toEqual({ name: "hello" });
+    expect(result).toEqual({ ...RESERVED_BASE, name: "hello" });
   });
 });
 
@@ -777,7 +788,7 @@ describe("redactConfigForSnapshot > new field types", () => {
       ],
     };
     const result = redactConfigForSnapshot(schema, { a: 42 });
-    expect(result).toEqual({ a: 42, b: 7, c: 0 });
+    expect(result).toEqual({ ...RESERVED_BASE, a: 42, b: 7, c: 0 });
   });
 
   test("string-array falls through to stored, default, then []", () => {
@@ -790,7 +801,12 @@ describe("redactConfigForSnapshot > new field types", () => {
       ],
     };
     const result = redactConfigForSnapshot(schema, { a: ["x", "y"] });
-    expect(result).toEqual({ a: ["x", "y"], b: ["en"], c: [] });
+    expect(result).toEqual({
+      ...RESERVED_BASE,
+      a: ["x", "y"],
+      b: ["en"],
+      c: [],
+    });
   });
 
   test("string-array ignores stored value with non-string members", () => {
@@ -801,7 +817,7 @@ describe("redactConfigForSnapshot > new field types", () => {
       ],
     };
     const result = redactConfigForSnapshot(schema, { a: ["x", 1] });
-    expect(result).toEqual({ a: ["fallback"] });
+    expect(result).toEqual({ ...RESERVED_BASE, a: ["fallback"] });
   });
 
   test("key-value-map filters stored entries by valueType", () => {
@@ -819,7 +835,7 @@ describe("redactConfigForSnapshot > new field types", () => {
     const result = redactConfigForSnapshot(schema, {
       tiers: { good: 1, bad: "two", nan: Number.NaN, ok: 3 },
     });
-    expect(result).toEqual({ tiers: { good: 1, ok: 3 } });
+    expect(result).toEqual({ ...RESERVED_BASE, tiers: { good: 1, ok: 3 } });
   });
 
   test("key-value-map falls through to default then {}", () => {
@@ -842,7 +858,7 @@ describe("redactConfigForSnapshot > new field types", () => {
       ],
     };
     const result = redactConfigForSnapshot(schema, {});
-    expect(result).toEqual({ a: {}, b: { x: "1" } });
+    expect(result).toEqual({ ...RESERVED_BASE, a: {}, b: { x: "1" } });
   });
 });
 
@@ -969,6 +985,7 @@ describe("bluesky-shape schema (integration)", () => {
     const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
     const snapshot = redactConfigForSnapshot(parsed, {});
     expect(snapshot).toEqual({
+      ...RESERVED_BASE,
       identifier: "",
       has_password: false,
       pds: "https://bsky.social",

--- a/src/tests/channels/schema-config.test.ts
+++ b/src/tests/channels/schema-config.test.ts
@@ -85,7 +85,7 @@ describe("parseChannelConfigSchema", () => {
     expect(
       parseChannelConfigSchema({
         version: 1,
-        fields: [{ type: "number", key: "count", label: "Count" }],
+        fields: [{ type: "rainbow", key: "color", label: "Color" }],
       }),
     ).toBeNull();
   });
@@ -389,5 +389,622 @@ describe("redactConfigForSnapshot", () => {
       secret_backdoor: "oops",
     });
     expect(result).toEqual({ name: "hello" });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 1 extension: number, string-array, key-value-map
+// ─────────────────────────────────────────────────────────────────────
+
+describe("parseChannelConfigSchema > number field", () => {
+  test("accepts a valid number field with bounds, default, suffix", () => {
+    const parsed = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        {
+          type: "number",
+          key: "threshold",
+          label: "Threshold",
+          default: 0.35,
+          min: 0,
+          max: 1,
+          step: 0.05,
+          suffix: "%",
+          placeholder: "0.35",
+          restartRequired: false,
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields[0]).toEqual({
+      type: "number",
+      key: "threshold",
+      label: "Threshold",
+      default: 0.35,
+      min: 0,
+      max: 1,
+      step: 0.05,
+      suffix: "%",
+      placeholder: "0.35",
+      description: undefined,
+      required: undefined,
+      restartRequired: false,
+    });
+  });
+
+  test("rejects non-numeric default", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "number",
+            key: "threshold",
+            label: "Threshold",
+            default: "0.35",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects NaN / Infinity bounds", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "number",
+            key: "threshold",
+            label: "Threshold",
+            min: Number.NaN,
+          },
+        ],
+      }),
+    ).toBeNull();
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "number",
+            key: "threshold",
+            label: "Threshold",
+            max: Number.POSITIVE_INFINITY,
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects inverted min/max", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "number",
+            key: "threshold",
+            label: "Threshold",
+            min: 10,
+            max: 5,
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects default outside declared bounds", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "number",
+            key: "threshold",
+            label: "Threshold",
+            min: 0,
+            max: 1,
+            default: 2,
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseChannelConfigSchema > string-array field", () => {
+  test("accepts a valid string-array with default", () => {
+    const parsed = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        {
+          type: "string-array",
+          key: "langs",
+          label: "Languages",
+          default: ["en"],
+          placeholder: "ISO-639 code",
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields[0]).toMatchObject({
+      type: "string-array",
+      key: "langs",
+      default: ["en"],
+      placeholder: "ISO-639 code",
+    });
+  });
+
+  test("rejects non-array default", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "string-array",
+            key: "langs",
+            label: "Languages",
+            default: "en",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects mixed-type default", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "string-array",
+            key: "langs",
+            label: "Languages",
+            default: ["en", 2],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseChannelConfigSchema > key-value-map field", () => {
+  test("accepts a numeric-valued map with default", () => {
+    const parsed = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        {
+          type: "key-value-map",
+          key: "entity_tiers",
+          label: "Entity tiers",
+          valueType: "number",
+          default: { "did:plc:abc": 1 },
+          keyLabel: "DID",
+          valueLabel: "Tier",
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields[0]).toMatchObject({
+      type: "key-value-map",
+      valueType: "number",
+      default: { "did:plc:abc": 1 },
+      keyLabel: "DID",
+      valueLabel: "Tier",
+    });
+  });
+
+  test("rejects missing valueType", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "key-value-map",
+            key: "entity_tiers",
+            label: "Entity tiers",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects default whose values don't match valueType", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "key-value-map",
+            key: "tiers",
+            label: "Tiers",
+            valueType: "number",
+            default: { abc: "one" },
+          },
+        ],
+      }),
+    ).toBeNull();
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "key-value-map",
+            key: "tiers",
+            label: "Tiers",
+            valueType: "string",
+            default: { abc: 1 },
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects non-object default", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "key-value-map",
+            key: "tiers",
+            label: "Tiers",
+            valueType: "number",
+            default: ["nope"],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseField > restartRequired metadata", () => {
+  test("accepts boolean restartRequired", () => {
+    const parsed = parseChannelConfigSchema({
+      version: 1,
+      fields: [
+        {
+          type: "number",
+          key: "interval_ms",
+          label: "Interval",
+          restartRequired: true,
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields[0]?.restartRequired).toBe(true);
+  });
+
+  test("rejects non-boolean restartRequired", () => {
+    expect(
+      parseChannelConfigSchema({
+        version: 1,
+        fields: [
+          {
+            type: "text",
+            key: "name",
+            label: "Name",
+            restartRequired: "yes",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("validateConfigAgainstSchema > new field types", () => {
+  const schema: ChannelConfigSchema = {
+    version: 1,
+    fields: [
+      {
+        type: "number",
+        key: "threshold",
+        label: "Threshold",
+        min: 0,
+        max: 1,
+      },
+      {
+        type: "string-array",
+        key: "tags",
+        label: "Tags",
+        required: true,
+      },
+      {
+        type: "key-value-map",
+        key: "tiers",
+        label: "Tiers",
+        valueType: "number",
+      },
+    ],
+  };
+
+  test("accepts a fully-valid config", () => {
+    expect(
+      validateConfigAgainstSchema(schema, {
+        threshold: 0.5,
+        tags: ["a", "b"],
+        tiers: { "did:abc": 1, "did:def": 2 },
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("rejects non-finite number", () => {
+    const result = validateConfigAgainstSchema(schema, {
+      threshold: Number.NaN,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects number outside bounds", () => {
+    const result = validateConfigAgainstSchema(schema, { threshold: 2 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects string-array with non-string members", () => {
+    const result = validateConfigAgainstSchema(schema, { tags: ["a", 1] });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects empty array when required", () => {
+    const result = validateConfigAgainstSchema(schema, { tags: [] });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects key-value-map with wrong value type", () => {
+    const result = validateConfigAgainstSchema(schema, {
+      tiers: { abc: "high" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects key-value-map that isn't an object", () => {
+    const result = validateConfigAgainstSchema(schema, {
+      tiers: [["abc", 1]],
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("redactConfigForSnapshot > new field types", () => {
+  test("number falls through to stored, default, then 0", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [
+        { type: "number", key: "a", label: "A" },
+        { type: "number", key: "b", label: "B", default: 7 },
+        { type: "number", key: "c", label: "C" },
+      ],
+    };
+    const result = redactConfigForSnapshot(schema, { a: 42 });
+    expect(result).toEqual({ a: 42, b: 7, c: 0 });
+  });
+
+  test("string-array falls through to stored, default, then []", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [
+        { type: "string-array", key: "a", label: "A" },
+        { type: "string-array", key: "b", label: "B", default: ["en"] },
+        { type: "string-array", key: "c", label: "C" },
+      ],
+    };
+    const result = redactConfigForSnapshot(schema, { a: ["x", "y"] });
+    expect(result).toEqual({ a: ["x", "y"], b: ["en"], c: [] });
+  });
+
+  test("string-array ignores stored value with non-string members", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [
+        { type: "string-array", key: "a", label: "A", default: ["fallback"] },
+      ],
+    };
+    const result = redactConfigForSnapshot(schema, { a: ["x", 1] });
+    expect(result).toEqual({ a: ["fallback"] });
+  });
+
+  test("key-value-map filters stored entries by valueType", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [
+        {
+          type: "key-value-map",
+          key: "tiers",
+          label: "Tiers",
+          valueType: "number",
+        },
+      ],
+    };
+    const result = redactConfigForSnapshot(schema, {
+      tiers: { good: 1, bad: "two", nan: Number.NaN, ok: 3 },
+    });
+    expect(result).toEqual({ tiers: { good: 1, ok: 3 } });
+  });
+
+  test("key-value-map falls through to default then {}", () => {
+    const schema: ChannelConfigSchema = {
+      version: 1,
+      fields: [
+        {
+          type: "key-value-map",
+          key: "a",
+          label: "A",
+          valueType: "string",
+        },
+        {
+          type: "key-value-map",
+          key: "b",
+          label: "B",
+          valueType: "string",
+          default: { x: "1" },
+        },
+      ],
+    };
+    const result = redactConfigForSnapshot(schema, {});
+    expect(result).toEqual({ a: {}, b: { x: "1" } });
+  });
+});
+
+describe("bluesky-shape schema (integration)", () => {
+  // Mirrors what bluesky-channel will declare in channel.json.
+  // Exercises parse → validate → redact together to catch field-type
+  // interaction bugs that single-type tests might miss.
+  const BLUESKY_SCHEMA_JSON = {
+    version: 1,
+    fields: [
+      {
+        type: "text",
+        key: "identifier",
+        label: "Bluesky handle or DID",
+        required: true,
+      },
+      {
+        type: "secret",
+        key: "password",
+        label: "App password",
+        required: true,
+      },
+      {
+        type: "text",
+        key: "pds",
+        label: "PDS URL",
+        default: "https://bsky.social",
+      },
+      {
+        type: "number",
+        key: "salience_threshold",
+        label: "Salience threshold",
+        default: 0.35,
+        min: 0,
+        max: 1,
+        step: 0.05,
+      },
+      {
+        type: "number",
+        key: "alert_poll_interval_ms",
+        label: "Alert poll interval",
+        default: 120000,
+        min: 30000,
+        suffix: "ms",
+        restartRequired: true,
+      },
+      {
+        type: "number",
+        key: "digest_interval_ms",
+        label: "Digest interval",
+        default: 3600000,
+        min: 60000,
+        suffix: "ms",
+        restartRequired: true,
+      },
+      {
+        type: "string-array",
+        key: "langs",
+        label: "Languages",
+        default: ["en"],
+      },
+      { type: "string-array", key: "keywords", label: "Keywords" },
+      { type: "string-array", key: "hot_topics", label: "Hot topics" },
+      {
+        type: "string-array",
+        key: "batch_types",
+        label: "Digest reasons",
+        default: ["like", "repost", "follow", "starterpack-joined"],
+      },
+      {
+        type: "key-value-map",
+        key: "entity_tiers",
+        label: "Entity tiers",
+        valueType: "number",
+        keyLabel: "DID",
+        valueLabel: "Tier",
+      },
+    ],
+  };
+
+  test("parses cleanly", () => {
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields).toHaveLength(11);
+    const fieldKeys = parsed!.fields.map((f) => f.key);
+    expect(fieldKeys).toEqual([
+      "identifier",
+      "password",
+      "pds",
+      "salience_threshold",
+      "alert_poll_interval_ms",
+      "digest_interval_ms",
+      "langs",
+      "keywords",
+      "hot_topics",
+      "batch_types",
+      "entity_tiers",
+    ]);
+    const alertPoll = parsed!.fields.find(
+      (f) => f.key === "alert_poll_interval_ms",
+    );
+    expect(alertPoll?.restartRequired).toBe(true);
+  });
+
+  test("validates a realistic config", () => {
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const result = validateConfigAgainstSchema(parsed, {
+      identifier: "shelley.bsky.social",
+      password: "abcd-efgh-ijkl-mnop",
+      pds: "https://bsky.social",
+      salience_threshold: 0.5,
+      alert_poll_interval_ms: 120000,
+      digest_interval_ms: 3600000,
+      langs: ["en"],
+      keywords: ["letta"],
+      hot_topics: [],
+      batch_types: ["like", "repost"],
+      entity_tiers: { "did:plc:abc": 1, "did:plc:xyz": 2 },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("redacts an empty stored config to schema defaults", () => {
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const snapshot = redactConfigForSnapshot(parsed, {});
+    expect(snapshot).toEqual({
+      identifier: "",
+      has_password: false,
+      pds: "https://bsky.social",
+      salience_threshold: 0.35,
+      alert_poll_interval_ms: 120000,
+      digest_interval_ms: 3600000,
+      langs: ["en"],
+      keywords: [],
+      hot_topics: [],
+      batch_types: ["like", "repost", "follow", "starterpack-joined"],
+      entity_tiers: {},
+    });
+  });
+
+  test("redacts a populated stored config (with secret) correctly", () => {
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const snapshot = redactConfigForSnapshot(parsed, {
+      identifier: "shelley.bsky.social",
+      password: "secret-value",
+      pds: "https://bsky.social",
+      salience_threshold: 0.5,
+      alert_poll_interval_ms: 90000,
+      digest_interval_ms: 1800000,
+      langs: ["en", "fr"],
+      keywords: ["letta", "ai"],
+      hot_topics: ["release"],
+      batch_types: ["like"],
+      entity_tiers: { "did:plc:abc": 1, "did:plc:xyz": 2 },
+    });
+    expect(snapshot).toMatchObject({
+      identifier: "shelley.bsky.social",
+      has_password: true,
+      keywords: ["letta", "ai"],
+      entity_tiers: { "did:plc:abc": 1, "did:plc:xyz": 2 },
+    });
+    // Secret must not leak through.
+    expect((snapshot as Record<string, unknown>).password).toBeUndefined();
   });
 });

--- a/src/tests/channels/schema-config.test.ts
+++ b/src/tests/channels/schema-config.test.ts
@@ -318,12 +318,13 @@ describe("validateConfigAgainstSchema", () => {
   });
 });
 
-// Reserved JSON-bucket keys that redactConfigForSnapshot always emits,
-// regardless of whether the schema declares them.
+// Reserved keys that redactConfigForSnapshot always emits, regardless of
+// whether the schema declares them.
 const RESERVED_BASE = {
   accounts_json: "",
   configs_json: "",
   metadata_json: "",
+  agent_id: null as string | null,
 };
 
 describe("redactConfigForSnapshot", () => {

--- a/src/tests/channels/schema-config.test.ts
+++ b/src/tests/channels/schema-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { ChannelConfigSchema } from "../../channels/pluginTypes";
+import type {
+  ChannelConfigSchema,
+  ChannelConfigSelectField,
+  ChannelConfigTextField,
+} from "../../channels/pluginTypes";
 import {
   parseChannelConfigSchema,
   redactConfigForSnapshot,
@@ -45,20 +49,22 @@ describe("parseChannelConfigSchema", () => {
       ],
     });
     expect(result).not.toBeNull();
-    expect(result!.fields).toHaveLength(4);
-    expect(result!.fields[0]).toEqual({
+    expect(result?.fields).toHaveLength(4);
+    expect(result?.fields[0]).toEqual({
       type: "text",
       key: "name",
       label: "Name",
     });
-    expect(result!.fields[1]).toEqual({
+    expect(result?.fields[1]).toEqual({
       type: "secret",
       key: "token",
       label: "Token",
     });
-    expect(result!.fields[2]!.type).toBe("select");
-    expect((result!.fields[2] as any).options).toHaveLength(2);
-    expect(result!.fields[3]).toEqual({
+    expect(result?.fields[2]?.type).toBe("select");
+    expect(
+      (result?.fields[2] as ChannelConfigSelectField).options,
+    ).toHaveLength(2);
+    expect(result?.fields[3]).toEqual({
       type: "boolean",
       key: "enabled",
       label: "Enabled",
@@ -218,8 +224,8 @@ describe("parseChannelConfigSchema", () => {
       ],
     });
     expect(result).not.toBeNull();
-    expect(result!.fields[0]!.description).toBe("The endpoint URL");
-    expect(result!.fields[0]!.required).toBe(true);
+    expect(result?.fields[0]?.description).toBe("The endpoint URL");
+    expect(result?.fields[0]?.required).toBe(true);
   });
 
   test("accepts placeholder for text and secret", () => {
@@ -236,8 +242,12 @@ describe("parseChannelConfigSchema", () => {
       ],
     });
     expect(result).not.toBeNull();
-    expect((result!.fields[0] as any).placeholder).toBe("Enter name");
-    expect((result!.fields[1] as any).placeholder).toBe("Enter key");
+    expect((result?.fields[0] as ChannelConfigTextField).placeholder).toBe(
+      "Enter name",
+    );
+    expect((result?.fields[1] as ChannelConfigTextField).placeholder).toBe(
+      "Enter key",
+    );
   });
 });
 
@@ -428,7 +438,7 @@ describe("parseChannelConfigSchema > number field", () => {
       ],
     });
     expect(parsed).not.toBeNull();
-    expect(parsed!.fields[0]).toEqual({
+    expect(parsed?.fields[0]).toEqual({
       type: "number",
       key: "threshold",
       label: "Threshold",
@@ -540,7 +550,7 @@ describe("parseChannelConfigSchema > string-array field", () => {
       ],
     });
     expect(parsed).not.toBeNull();
-    expect(parsed!.fields[0]).toMatchObject({
+    expect(parsed?.fields[0]).toMatchObject({
       type: "string-array",
       key: "langs",
       default: ["en"],
@@ -598,7 +608,7 @@ describe("parseChannelConfigSchema > key-value-map field", () => {
       ],
     });
     expect(parsed).not.toBeNull();
-    expect(parsed!.fields[0]).toMatchObject({
+    expect(parsed?.fields[0]).toMatchObject({
       type: "key-value-map",
       valueType: "number",
       default: { "did:plc:abc": 1 },
@@ -685,7 +695,7 @@ describe("parseField > restartRequired metadata", () => {
       ],
     });
     expect(parsed).not.toBeNull();
-    expect(parsed!.fields[0]?.restartRequired).toBe(true);
+    expect(parsed?.fields[0]?.restartRequired).toBe(true);
   });
 
   test("rejects non-boolean restartRequired", () => {
@@ -943,8 +953,8 @@ describe("bluesky-shape schema (integration)", () => {
   test("parses cleanly", () => {
     const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON);
     expect(parsed).not.toBeNull();
-    expect(parsed!.fields).toHaveLength(11);
-    const fieldKeys = parsed!.fields.map((f) => f.key);
+    expect(parsed?.fields).toHaveLength(11);
+    const fieldKeys = parsed?.fields.map((f) => f.key);
     expect(fieldKeys).toEqual([
       "identifier",
       "password",
@@ -958,14 +968,15 @@ describe("bluesky-shape schema (integration)", () => {
       "batch_types",
       "entity_tiers",
     ]);
-    const alertPoll = parsed!.fields.find(
+    const alertPoll = parsed?.fields.find(
       (f) => f.key === "alert_poll_interval_ms",
     );
     expect(alertPoll?.restartRequired).toBe(true);
   });
 
   test("validates a realistic config", () => {
-    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON);
+    if (!parsed) throw new Error("Failed to parse BLUESKY_SCHEMA_JSON");
     const result = validateConfigAgainstSchema(parsed, {
       identifier: "shelley.bsky.social",
       password: "abcd-efgh-ijkl-mnop",
@@ -983,7 +994,8 @@ describe("bluesky-shape schema (integration)", () => {
   });
 
   test("redacts an empty stored config to schema defaults", () => {
-    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON);
+    if (!parsed) throw new Error("Failed to parse BLUESKY_SCHEMA_JSON");
     const snapshot = redactConfigForSnapshot(parsed, {});
     expect(snapshot).toEqual({
       ...RESERVED_BASE,
@@ -1002,7 +1014,8 @@ describe("bluesky-shape schema (integration)", () => {
   });
 
   test("redacts a populated stored config (with secret) correctly", () => {
-    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON)!;
+    const parsed = parseChannelConfigSchema(BLUESKY_SCHEMA_JSON);
+    if (!parsed) throw new Error("Failed to parse BLUESKY_SCHEMA_JSON");
     const snapshot = redactConfigForSnapshot(parsed, {
       identifier: "shelley.bsky.social",
       password: "secret-value",

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -149,6 +149,7 @@ export interface ChannelConfigFieldBase {
   label: string;
   description?: string;
   required?: boolean;
+  restartRequired?: boolean;
 }
 
 export interface ChannelConfigTextField extends ChannelConfigFieldBase {
@@ -178,11 +179,40 @@ export interface ChannelConfigBooleanField extends ChannelConfigFieldBase {
   default?: boolean;
 }
 
+export interface ChannelConfigNumberField extends ChannelConfigFieldBase {
+  type: "number";
+  default?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  suffix?: string;
+  placeholder?: string;
+}
+
+export interface ChannelConfigStringArrayField extends ChannelConfigFieldBase {
+  type: "string-array";
+  default?: string[];
+  placeholder?: string;
+}
+
+export interface ChannelConfigKeyValueMapField extends ChannelConfigFieldBase {
+  type: "key-value-map";
+  valueType: "string" | "number";
+  default?: Record<string, string | number>;
+  keyLabel?: string;
+  valueLabel?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+}
+
 export type ChannelConfigField =
   | ChannelConfigTextField
   | ChannelConfigSecretField
   | ChannelConfigSelectField
-  | ChannelConfigBooleanField;
+  | ChannelConfigBooleanField
+  | ChannelConfigNumberField
+  | ChannelConfigStringArrayField
+  | ChannelConfigKeyValueMapField;
 
 export interface ChannelConfigSchema {
   version: 1;

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -142,6 +142,53 @@ export type ChannelId = string;
 
 export type ChannelPluginConfig = Record<string, unknown>;
 
+// ── Channel config schema (declarative plugin UI) ──
+
+export interface ChannelConfigFieldBase {
+  key: string;
+  label: string;
+  description?: string;
+  required?: boolean;
+}
+
+export interface ChannelConfigTextField extends ChannelConfigFieldBase {
+  type: "text";
+  default?: string;
+  placeholder?: string;
+}
+
+export interface ChannelConfigSecretField extends ChannelConfigFieldBase {
+  type: "secret";
+  placeholder?: string;
+}
+
+export interface ChannelConfigSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface ChannelConfigSelectField extends ChannelConfigFieldBase {
+  type: "select";
+  options: ChannelConfigSelectOption[];
+  default?: string;
+}
+
+export interface ChannelConfigBooleanField extends ChannelConfigFieldBase {
+  type: "boolean";
+  default?: boolean;
+}
+
+export type ChannelConfigField =
+  | ChannelConfigTextField
+  | ChannelConfigSecretField
+  | ChannelConfigSelectField
+  | ChannelConfigBooleanField;
+
+export interface ChannelConfigSchema {
+  version: 1;
+  fields: ChannelConfigField[];
+}
+
 export interface ChannelSummary {
   channel_id: ChannelId;
   display_name: string;
@@ -152,6 +199,8 @@ export interface ChannelSummary {
   pending_pairings_count: number;
   approved_users_count: number;
   routes_count: number;
+  /** Declarative config schema for dynamic settings UI, or null. */
+  config_schema: ChannelConfigSchema | null;
 }
 
 export interface ChannelConfigSnapshot {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -150,6 +150,7 @@ export interface ChannelConfigFieldBase {
   description?: string;
   required?: boolean;
   restartRequired?: boolean;
+  scope?: "app" | "account";
 }
 
 export interface ChannelConfigTextField extends ChannelConfigFieldBase {

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -3,6 +3,11 @@ import {
   channelPluginConfigShouldRefreshDisplayName,
   getChannelPluginConfig,
 } from "../../../channels/accountConfig";
+import {
+  removeUserPlugin,
+  scaffoldUserPlugin,
+} from "../../../channels/custom/scaffolding";
+import { getChannelPluginMetadata } from "../../../channels/pluginRegistry";
 import type { ChannelRegistryEvent } from "../../../channels/registry";
 import type { DequeuedBatch } from "../../../queue/queueRuntime";
 import type {
@@ -274,17 +279,29 @@ export async function handleChannelsProtocolCommand(
 
   const mapChannelSummary = (
     summary: ReturnType<typeof listChannelSummaries>[number],
-  ) => ({
-    channel_id: summary.channelId,
-    display_name: summary.displayName,
-    configured: summary.configured,
-    enabled: summary.enabled,
-    running: summary.running,
-    dm_policy: summary.dmPolicy,
-    pending_pairings_count: summary.pendingPairingsCount,
-    approved_users_count: summary.approvedUsersCount,
-    routes_count: summary.routesCount,
-  });
+  ) => {
+    let configSchema:
+      | import("../../../types/protocol_v2").ChannelConfigSchema
+      | null = null;
+    try {
+      configSchema =
+        getChannelPluginMetadata(summary.channelId).configSchema ?? null;
+    } catch {
+      // Unsupported channel — leave schema null.
+    }
+    return {
+      channel_id: summary.channelId,
+      display_name: summary.displayName,
+      configured: summary.configured,
+      enabled: summary.enabled,
+      running: summary.running,
+      dm_policy: summary.dmPolicy,
+      pending_pairings_count: summary.pendingPairingsCount,
+      approved_users_count: summary.approvedUsersCount,
+      routes_count: summary.routesCount,
+      config_schema: configSchema,
+    };
+  };
 
   const mapChannelConfig = (
     snapshot: ReturnType<typeof getChannelConfigSnapshot>,
@@ -509,10 +526,24 @@ export async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_account_create") {
     try {
+      // For the first-party "custom" channel, scaffold a dedicated user plugin
+      // folder so the new app gets its own channel ID (e.g. "my-webhook-app").
+      // The folder must exist before createChannelAccountLive validates the ID.
+      let effectiveChannelId = parsed.channel_id;
+      if (parsed.channel_id === "custom") {
+        const displayName =
+          typeof (parsed.account as Record<string, unknown>).display_name ===
+          "string"
+            ? ((parsed.account as Record<string, unknown>)
+                .display_name as string)
+            : "custom-app";
+        effectiveChannelId = scaffoldUserPlugin(displayName);
+      }
+
       const pluginConfig =
         getChannelPluginConfig(parsed.account as Record<string, unknown>) ?? {};
       const created = createChannelAccountLive(
-        parsed.channel_id,
+        effectiveChannelId,
         {
           displayName:
             "display_name" in parsed.account
@@ -535,7 +566,7 @@ export async function handleChannelsProtocolCommand(
         "display_name" in parsed.account
           ? created
           : await refreshChannelAccountDisplayNameLive(
-              parsed.channel_id,
+              effectiveChannelId,
               created.accountId,
               { force: true },
             );
@@ -546,17 +577,17 @@ export async function handleChannelsProtocolCommand(
           type: "channel_account_create_response",
           request_id: parsed.request_id,
           success: true,
-          channel_id: parsed.channel_id,
+          channel_id: effectiveChannelId,
           account: mapChannelAccount(account),
         },
         "listener_channels_send_failed",
         "listener_channels_command",
       );
       emitChannelAccountsUpdated(socket, safeSocketSend, {
-        channelId: parsed.channel_id,
+        channelId: effectiveChannelId,
         accountId: account.accountId,
       });
-      emitChannelsUpdated(socket, safeSocketSend, parsed.channel_id);
+      emitChannelsUpdated(socket, safeSocketSend, effectiveChannelId);
     } catch (err) {
       safeSocketSend(
         socket,
@@ -760,6 +791,10 @@ export async function handleChannelsProtocolCommand(
         "listener_channels_command",
       );
       if (deleted) {
+        // Remove the plugin folder if this was a user-scaffolded channel
+        // so the display name can be reused.
+        removeUserPlugin(parsed.channel_id);
+
         emitChannelAccountsUpdated(socket, safeSocketSend, {
           channelId: parsed.channel_id,
           accountId: parsed.account_id,


### PR DESCRIPTION

Introduces a schema-driven custom channel model and a generic user-plugin config snapshot path. Adds CUSTOM_CHANNEL_CONFIG_SCHEMA, schema validation and redaction helpers, and a snapshot adapter that surfaces non-secret fields (e.g. accounts_json, configs_json, agent_id, url) for user-installed plugins lacking a declared schema, while still redacting bot_token / auth to has_<key> booleans.