### PR TITLE
fix(local): settle interrupted tool calls

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -476,53 +476,85 @@ function replaceUnsupportedInputParts(
   return didChange ? transformed : messages;
 }
 
+function isToolUIPart(part: unknown): part is Record<string, unknown> {
+  return (
+    isRecord(part) &&
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-")
+  );
+}
+
+function normalizeToolPartForModelConversion(part: Record<string, unknown>): {
+  part: LocalMessage["parts"][number];
+  changed: boolean;
+} {
+  const hasInput = Object.hasOwn(part, "input");
+  if (part.state === "output-available" && Object.hasOwn(part, "output")) {
+    if (hasInput) {
+      return { part: part as LocalMessage["parts"][number], changed: false };
+    }
+    return {
+      part: { ...part, input: {} } as LocalMessage["parts"][number],
+      changed: true,
+    };
+  }
+
+  const errorText =
+    stringValue(part.errorText) ??
+    (part.state === "output-available"
+      ? "Tool output missing from previous turn."
+      : "Tool result missing from interrupted previous turn.");
+  const normalized = {
+    ...part,
+    state: "output-error",
+    input: hasInput ? part.input : {},
+    errorText,
+  } as Record<string, unknown>;
+  delete normalized.approval;
+  delete normalized.output;
+  return { part: normalized as LocalMessage["parts"][number], changed: true };
+}
+
+function normalizeToolPartsForModelConversion(
+  messages: LocalMessage[],
+): LocalMessage[] {
+  let didChange = false;
+  const transformed = messages.map((message) => {
+    if (message.role !== "assistant") return message;
+
+    let messageChanged = false;
+    const parts = message.parts.map((part) => {
+      if (!isToolUIPart(part)) return part;
+      const partRecord = part as Record<string, unknown>;
+      const normalized = normalizeToolPartForModelConversion(partRecord);
+      if (normalized.changed) {
+        messageChanged = true;
+        didChange = true;
+      }
+      return normalized.part;
+    });
+
+    return messageChanged ? { ...message, parts } : message;
+  });
+  return didChange ? transformed : messages;
+}
+
 function sanitizeUIMessagesForProvider(
   messages: LocalMessage[],
   provider: AISDKProviderKind,
   agent: ProviderTurnInput["agent"],
 ): LocalMessage[] {
-  const capabilitySanitizedMessages = replaceUnsupportedInputParts(
-    messages,
-    agent,
+  const settledMessages = normalizeToolPartsForModelConversion(
+    replaceUnsupportedInputParts(messages, agent),
   );
-  if (provider === "unknown") return capabilitySanitizedMessages;
-  return capabilitySanitizedMessages
+  if (provider === "unknown") return settledMessages;
+  return settledMessages
     .map((message) => {
       let messageChanged = false;
-      const normalizedParts =
-        message.role === "assistant"
-          ? message.parts.map((part) => {
-              if (
-                !isRecord(part) ||
-                typeof part.type !== "string" ||
-                !part.type.startsWith("tool-")
-              ) {
-                return part;
-              }
-              const partRecord = part as Record<string, unknown>;
-              const state = partRecord.state;
-              const settled =
-                state === "output-available" ||
-                state === "output-error" ||
-                state === "output-denied";
-              if (settled) return part;
-              messageChanged = true;
-              const normalized = {
-                ...partRecord,
-                state: "output-error",
-                errorText:
-                  stringValue(partRecord.errorText) ??
-                  "Tool result missing from interrupted previous turn.",
-              } as Record<string, unknown>;
-              delete normalized.approval;
-              return normalized as LocalMessage["parts"][number];
-            })
-          : message.parts;
-
-      const filteredParts = normalizedParts.filter((part) =>
+      const filteredParts = message.parts.filter((part) =>
         shouldKeepReasoningPart(part, provider),
       );
-      if (filteredParts.length !== normalizedParts.length) {
+      if (filteredParts.length !== message.parts.length) {
         messageChanged = true;
       }
       return messageChanged ? { ...message, parts: filteredParts } : message;

--- a/src/backend/dev/FakeHeadlessBackend.ts
+++ b/src/backend/dev/FakeHeadlessBackend.ts
@@ -307,6 +307,14 @@ export class HeadlessBackend implements Backend {
     const runId =
       this.activeRunByConversation.get(conversationIdOrAgentId) ??
       this.findActiveRunByAgentId(conversationIdOrAgentId);
+    const run = runId ? this.runs.get(runId) : undefined;
+    if (run?.conversation_id && run.agent_id) {
+      this.store.settleInterruptedToolCalls(run.conversation_id, {
+        agentId: run.agent_id,
+      });
+    } else {
+      this.store.settleInterruptedToolCalls(conversationIdOrAgentId);
+    }
     if (runId) {
       const controller = this.runControllerByRunId.get(runId);
       this.recordRunChunk(runId, {

--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -14,6 +14,7 @@ import type {
   Message,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import { INTERRUPTED_BY_USER } from "../../constants";
 import type {
   AgentCreateBody,
   AgentListBody,
@@ -1051,6 +1052,25 @@ export class LocalStore {
     ).map(cloneLocalMessage);
   }
 
+  settleInterruptedToolCalls(
+    conversationIdOrAgentId: string,
+    options: { agentId?: string; reason?: string } = {},
+  ): number {
+    const targets = this.toolSettlementTargets(
+      conversationIdOrAgentId,
+      options.agentId,
+    );
+    let settledCount = 0;
+    for (const target of targets) {
+      settledCount += this.settleInterruptedToolCallsForConversation(
+        target.conversationId,
+        target.agentId,
+        options.reason ?? INTERRUPTED_BY_USER,
+      );
+    }
+    return settledCount;
+  }
+
   resolveAgentIdForConversation(conversationId: string): string {
     return this.agentIdForConversation(conversationId);
   }
@@ -1435,6 +1455,56 @@ export class LocalStore {
     }
   }
 
+  private settleInterruptedToolCallsForConversation(
+    conversationId: string,
+    agentId: string,
+    reason: string,
+  ): number {
+    const conversation = this.findConversation(conversationId, agentId);
+    if (!conversation) return 0;
+
+    const messages = this.localMessagesForConversation(
+      conversation.id,
+      agentId,
+    );
+    const touchedMessages = new Set<LocalMessage>();
+    let settledCount = 0;
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+      for (const part of message.parts) {
+        if (!part || !isLocalToolPart(part)) continue;
+        const state = (part as { state?: unknown }).state;
+        if (isSettledLocalToolState(state)) continue;
+
+        const record = part as Record<string, unknown>;
+        delete record.approval;
+        Object.assign(record, {
+          state: "output-error",
+          input: Object.hasOwn(record, "input") ? record.input : {},
+          errorText:
+            typeof record.errorText === "string" && record.errorText.length > 0
+              ? record.errorText
+              : reason,
+        });
+        touchedMessages.add(message);
+        settledCount += 1;
+      }
+    }
+
+    if (settledCount > 0) {
+      for (const message of touchedMessages) {
+        this.touchLocalMessageForToolSettlement(
+          message,
+          conversation.id,
+          agentId,
+        );
+      }
+      this.persistConversationState(conversation.id, agentId);
+      this.rebuildMessageIndex();
+    }
+    return settledCount;
+  }
+
   private findToolPart(
     conversationId: string,
     agentId: string,
@@ -1524,6 +1594,21 @@ export class LocalStore {
       typeof message.metadata?.conversation_id === "string"
         ? message.metadata.conversation_id
         : "default";
+    const updatedAt = this.nextLocalMessageDate();
+    message.metadata = {
+      ...message.metadata,
+      updated_at: updatedAt,
+      agent_id: agentId,
+      conversation_id: conversationId,
+    };
+    this.touchConversationForLocalMessage(conversationId, agentId, message);
+  }
+
+  private touchLocalMessageForToolSettlement(
+    message: LocalMessage,
+    conversationId: string,
+    agentId: string,
+  ): void {
     const updatedAt = this.nextLocalMessageDate();
     message.metadata = {
       ...message.metadata,
@@ -1945,6 +2030,43 @@ export class LocalStore {
       if (conversation.id === conversationId) return conversation;
     }
     return undefined;
+  }
+
+  private toolSettlementTargets(
+    conversationIdOrAgentId: string,
+    agentId?: string,
+  ): Array<{ conversationId: string; agentId: string }> {
+    if (agentId) {
+      const conversation = this.findConversation(
+        conversationIdOrAgentId,
+        agentId,
+      );
+      return conversation
+        ? [{ conversationId: conversation.id, agentId: conversation.agent_id }]
+        : [];
+    }
+
+    const conversation = this.findConversation(conversationIdOrAgentId);
+    if (conversation) {
+      return [
+        { conversationId: conversation.id, agentId: conversation.agent_id },
+      ];
+    }
+
+    if (this.agents.has(conversationIdOrAgentId)) {
+      const defaultConversation = this.ensureConversation(
+        "default",
+        conversationIdOrAgentId,
+      );
+      return [
+        {
+          conversationId: defaultConversation.id,
+          agentId: defaultConversation.agent_id,
+        },
+      ];
+    }
+
+    return [];
   }
 
   private agentIdForConversation(conversationId: string): string {

--- a/src/tests/backend/ai-sdk-stream-adapter.test.ts
+++ b/src/tests/backend/ai-sdk-stream-adapter.test.ts
@@ -285,7 +285,37 @@ describe("AISDKStreamAdapter", () => {
       ),
     );
 
-    expect(capturedMessages).toBeDefined();
+    expect(capturedMessages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-stale",
+            toolName: "ShellCommand",
+            input: { command: "pwd" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-stale",
+            toolName: "ShellCommand",
+            output: {
+              type: "error-text",
+              value: "Tool result missing from interrupted previous turn.",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "keep going" }],
+      },
+    ]);
     expect(events.map((event) => event.type)).toEqual([
       "ai-sdk-part",
       "ai-sdk-part",

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -697,6 +697,89 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("settles pending local tool calls when a requires-approval turn is cancelled", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-tool-cancel-"),
+    );
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        streamText: () => ({
+          fullStream: (async function* () {
+            yield {
+              type: "tool-call",
+              toolCallId: "call-interrupted",
+              toolName: "ShellCommand",
+              input: { command: "sleep 10" },
+            } as TextStreamPart<ToolSet>;
+            yield {
+              type: "finish",
+              finishReason: "tool-calls",
+            } as TextStreamPart<ToolSet>;
+          })(),
+        }),
+      });
+
+      const agent = await backend.createAgent({
+        name: "Local Tool Agent",
+        system: "tool system",
+        model: "openrouter/test-model",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      const chunks = await collectStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("run a long command", agent.id),
+        ),
+      );
+      expect(chunks.at(-1)).toMatchObject({
+        message_type: "stop_reason",
+        stop_reason: "requires_approval",
+      });
+
+      await backend.cancelConversation(conversation.id);
+
+      const page = await backend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as ConversationMessageListBody);
+      const messages = page.getPaginatedItems();
+      expect(messages.map((message) => message.message_type)).toEqual([
+        "user_message",
+        "approval_request_message",
+        "tool_return_message",
+      ]);
+      expect(messages[2]).toMatchObject({
+        message_type: "tool_return_message",
+        tool_call_id: "call-interrupted",
+        status: "error",
+        tool_return: "Interrupted by user",
+      });
+
+      const persistedMessages = await readPersistedLocalMessages(storageDir);
+      const toolPart = persistedMessages
+        .flatMap((message) => message.parts ?? [])
+        .find(
+          (part): part is Record<string, unknown> =>
+            typeof part === "object" &&
+            part !== null &&
+            "toolCallId" in part &&
+            part.toolCallId === "call-interrupted",
+        );
+      expect(toolPart).toMatchObject({
+        state: "output-error",
+        errorText: "Interrupted by user",
+      });
+      expect(toolPart).not.toHaveProperty("approval");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("retries transient local AI SDK provider failures inside a single persisted turn", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-provider-retry-"),


### PR DESCRIPTION
## Summary
- Add OpenCode-style local tool-call healing before AI SDK model conversion so interrupted or malformed historical tool parts always get a synthetic error result.
- Persistently settle pending local tool calls on `cancelConversation`, including turns already stopped at `requires_approval`.
- Strengthen regression coverage for replay-time healing and durable cancellation of pending local tool calls.

## Test plan
- [x] `bun test src/tests/backend/ai-sdk-stream-adapter.test.ts`
- [x] `bun test src/tests/backend/local-backend.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)