### PR TITLE
docs(tools): clarify Read file_path is literal, no env var expansion

### DIFF
--- a/src/tools/descriptions/Read.md
+++ b/src/tools/descriptions/Read.md
@@ -5,6 +5,7 @@ Assume this tool is able to read all files on the machine. If the User provides 
 
 Usage:
 - The file_path parameter must be an absolute path, not a relative path
+- `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated


### PR DESCRIPTION
## Summary

Adds the same path-expansion clarification to the `Read` tool description that #2088 added to `Edit` and `Write`.

The Read tool, like Edit and Write, treats `file_path` as a literal string — no shell-style expansion of `$VAR`, `$MEMORY_DIR`, `~`, etc. Without this note, the agent sometimes tries paths like `$TRANSCRIPT_PATH` or `$MEMORY_DIR/...` and gets confused when the read fails.

## Test plan
- [x] `bun run check` (auto-runs via lint-staged on commit)
- [ ] Verify the description appears in the agent context at runtime

👾 Generated with [Letta Code](https://letta.com)