### PR TITLE
feat(cli): drop offset/limit from Read tool display

### DIFF
--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -267,7 +267,13 @@ export function formatArgsDisplay(
             // Collect other non-hidden args
             const otherArgs: string[] = [];
             for (const [k, v] of Object.entries(parsed)) {
-              if (k === "file_path" || k === "path") continue;
+              if (
+                k === "file_path" ||
+                k === "path" ||
+                k === "offset" ||
+                k === "limit"
+              )
+                continue;
               if (v === undefined || v === null) continue;
               if (typeof v === "boolean" || typeof v === "number") {
                 otherArgs.push(`${k}: ${v}`);


### PR DESCRIPTION
## Summary
- Read tool calls now show just the file path, no offset/limit args

## Before

<img width="621" height="213" alt="Screenshot 2026-05-12 at 11 19 49 AM" src="https://github.com/user-attachments/assets/65aa33ef-1da4-4747-b086-aed1e43a079e" />

## After

<img width="651" height="281" alt="Screenshot 2026-05-12 at 11 20 04 AM" src="https://github.com/user-attachments/assets/34740916-66f2-4590-98a9-448a1fda12ae" />

👾 Generated with [Letta Code](https://letta.com)