### PR TITLE
fix(cli): align │ and └ glyphs, replace ⎿ with └

### DIFF
--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -69,6 +69,7 @@ import {
 } from "../helpers/contextTracker";
 import type { ConversationSwitchContext } from "../helpers/conversationSwitchAlert";
 import type { AdvancedDiffSuccess } from "../helpers/diff";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import {
   getReflectionSettings,
   type ReflectionSettings,
@@ -1046,13 +1047,13 @@ export function AppView(props: AppViewProps) {
                         resumeData.messageHistory.length > 0
                           ? [
                               `Resumed conversation with "${currentAgentName}"`,
-                              `⎿  Agent: ${agentId}`,
-                              `⎿  Conversation: ${convId}`,
+                              `${CLI_GLYPHS.result}  Agent: ${agentId}`,
+                              `${CLI_GLYPHS.result}  Conversation: ${convId}`,
                             ]
                           : [
                               `Switched to conversation with "${currentAgentName}"`,
-                              `⎿  Agent: ${agentId}`,
-                              `⎿  Conversation: ${convId} (empty)`,
+                              `${CLI_GLYPHS.result}  Agent: ${agentId}`,
+                              `${CLI_GLYPHS.result}  Conversation: ${convId} (empty)`,
                             ];
                       const successOutput = successLines.join("\n");
                       cmd.finish(successOutput, true);
@@ -1179,8 +1180,8 @@ export function AppView(props: AppViewProps) {
                     const shortConvId = conversation.id.slice(0, 20);
                     const successLines = [
                       `Started new conversation with "${currentAgentName}"`,
-                      `⎿  Agent: ${agentId}`,
-                      `⎿  Conversation: ${shortConvId}... (new)`,
+                      `${CLI_GLYPHS.result}  Agent: ${agentId}`,
+                      `${CLI_GLYPHS.result}  Conversation: ${shortConvId}... (new)`,
                     ];
                     const successOutput = successLines.join("\n");
                     cmd.finish(successOutput, true);
@@ -1314,7 +1315,7 @@ export function AppView(props: AppViewProps) {
                         agentState.name || "Unnamed Agent";
                       const successOutput = [
                         `Switched to conversation with "${currentAgentName}"`,
-                        `⎿  Conversation: ${actualTargetConv}`,
+                        `${CLI_GLYPHS.result}  Conversation: ${actualTargetConv}`,
                       ].join("\n");
                       cmd.finish(successOutput, true);
                       const successItem: StaticItem = {

--- a/src/cli/app/submitNavigationCommands.ts
+++ b/src/cli/app/submitNavigationCommands.ts
@@ -8,6 +8,7 @@ import { backfillBuffers } from "../helpers/backfill";
 import type { ContextTracker } from "../helpers/contextTracker";
 import { resetContextHistory } from "../helpers/contextTracker";
 import type { ConversationSwitchContext } from "../helpers/conversationSwitchAlert";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import type { ApprovalRequest } from "../helpers/stream";
 import { uid } from "./ids";
 import type { ActiveOverlay, AppCommandRunner, StaticItem } from "./types";
@@ -147,13 +148,13 @@ export async function handleNavigationCommand(
             resumeData.messageHistory.length > 0
               ? [
                   `Resumed conversation with "${currentAgentName}"`,
-                  `⎿  Agent: ${agentId}`,
-                  `⎿  Conversation: ${targetConvId}`,
+                  `${CLI_GLYPHS.result}  Agent: ${agentId}`,
+                  `${CLI_GLYPHS.result}  Conversation: ${targetConvId}`,
                 ]
               : [
                   `Switched to conversation with "${currentAgentName}"`,
-                  `⎿  Agent: ${agentId}`,
-                  `⎿  Conversation: ${targetConvId} (empty)`,
+                  `${CLI_GLYPHS.result}  Agent: ${agentId}`,
+                  `${CLI_GLYPHS.result}  Conversation: ${targetConvId} (empty)`,
                 ];
           const successOutput = successLines.join("\n");
           cmd.finish(successOutput, true);

--- a/src/cli/app/useConversationSwitching.ts
+++ b/src/cli/app/useConversationSwitching.ts
@@ -47,6 +47,7 @@ import {
 } from "../helpers/contextTracker";
 import type { ConversationSwitchContext } from "../helpers/conversationSwitchAlert";
 import { formatErrorDetails } from "../helpers/errorFormatter";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import type { ApprovalRequest } from "../helpers/stream";
 
 import { LLM_API_ERROR_MAX_RETRIES } from "./constants";
@@ -594,12 +595,12 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         const successOutput = isSpecificConv
           ? [
               `Switched to **${agentLabel}**`,
-              `⎿  Conversation: ${opts.conversationId}`,
+              `${CLI_GLYPHS.result}  Conversation: ${opts.conversationId}`,
             ].join("\n")
           : [
               `Resumed the default conversation with **${agentLabel}**.`,
-              `⎿  Type /resume to browse all conversations`,
-              `⎿  Type /new to start a new conversation`,
+              `${CLI_GLYPHS.result}  Type /resume to browse all conversations`,
+              `${CLI_GLYPHS.result}  Type /new to start a new conversation`,
             ].join("\n");
         const separator = {
           kind: "separator" as const,
@@ -711,8 +712,8 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           "Tip: use /init to initialize your agent's memory system!";
         const successOutput = [
           `Created **${agent.name || agent.id}** (use /pin to save)`,
-          `⎿  ${agentUrl}`,
-          `⎿  ${memfsTip}`,
+          `${CLI_GLYPHS.result}  ${agentUrl}`,
+          `${CLI_GLYPHS.result}  ${memfsTip}`,
         ].join("\n");
         cmd.finish(successOutput, true);
         const successItem: StaticItem = {

--- a/src/cli/components/AdvancedDiffRenderer.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.tsx
@@ -6,6 +6,7 @@ import {
   type AdvancedDiffSuccess,
   computeAdvancedDiff,
 } from "../helpers/diff";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { EditRenderer, MultiEditRenderer, WriteRenderer } from "./DiffRenderer";
@@ -239,7 +240,7 @@ export function AdvancedDiffRenderer(
         <Box width={gutterWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1}>
@@ -362,7 +363,7 @@ export function AdvancedDiffRenderer(
             <Box width={noChangesGutter} flexShrink={0}>
               <Text>
                 {"  "}
-                <Text dimColor>⎿</Text>
+                <Text dimColor>{CLI_GLYPHS.result}</Text>
               </Text>
             </Box>
             <Box flexGrow={1} width={Math.max(0, columns - noChangesGutter)}>
@@ -385,7 +386,7 @@ export function AdvancedDiffRenderer(
     );
   }
 
-  // Gutter width for "  ⎿" prefix (4 chars: 2 spaces + ⎿ + space)
+  // Gutter width for `  └` prefix (4 chars: 2 spaces + └ + space)
   const toolResultGutter = 4;
 
   return (
@@ -396,7 +397,7 @@ export function AdvancedDiffRenderer(
             <Box width={toolResultGutter} flexShrink={0}>
               <Text>
                 {"  "}
-                <Text dimColor>⎿</Text>
+                <Text dimColor>{CLI_GLYPHS.result}</Text>
               </Text>
             </Box>
             <Box flexGrow={1} width={Math.max(0, columns - toolResultGutter)}>

--- a/src/cli/components/BashCommandMessage.tsx
+++ b/src/cli/components/BashCommandMessage.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { INTERRUPTED_BY_USER } from "../../constants";
 import { clipToolReturn } from "../../tools/manager";
 import type { StreamingState } from "../helpers/accumulator";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { BlinkDot } from "./BlinkDot.js";
 import { CollapsedOutputDisplay } from "./CollapsedOutputDisplay";
@@ -76,7 +77,7 @@ export const BashCommandMessage = memo(
             // Red styling for interrupted commands (LET-7199)
             <Box flexDirection="row">
               <Box width={5} flexShrink={0}>
-                <Text>{"  ⎿  "}</Text>
+                <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
               </Box>
               <Text color={colors.status.interrupt}>{INTERRUPTED_BY_USER}</Text>
             </Box>
@@ -88,7 +89,7 @@ export const BashCommandMessage = memo(
         {!line.phase && line.output && (
           <Box flexDirection="row">
             <Box width={5} flexShrink={0}>
-              <Text>{"  ⎿  "}</Text>
+              <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
             </Box>
             <Box flexGrow={1} width={Math.max(0, columns - 5)}>
               <MarkdownDisplay

--- a/src/cli/components/CollapsedOutputDisplay.tsx
+++ b/src/cli/components/CollapsedOutputDisplay.tsx
@@ -1,11 +1,12 @@
 import { Box } from "ink";
 import { memo } from "react";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { MarkdownDisplay } from "./MarkdownDisplay";
 import { Text } from "./Text";
 
 const DEFAULT_COLLAPSED_LINES = 3;
-const PREFIX_WIDTH = 5; // "  ⎿  " or "     "
+const PREFIX_WIDTH = 5; // `  └  ` or `     `
 
 interface CollapsedOutputDisplayProps {
   output: string; // Full output from completion
@@ -56,10 +57,10 @@ export const CollapsedOutputDisplay = memo(
 
     return (
       <Box flexDirection="column">
-        {/* L-bracket on first line - matches ToolCallMessageRich format "  ⎿  " */}
+        {/* L-bracket on first line - matches ToolCallMessageRich result prefix */}
         <Box flexDirection="row">
           <Box width={PREFIX_WIDTH} flexShrink={0}>
-            <Text>{"  ⎿  "}</Text>
+            <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
           </Box>
           <Box flexGrow={1} width={contentWidth}>
             <MarkdownDisplay text={visibleLines[0] ?? ""} />

--- a/src/cli/components/CommandMessage.tsx
+++ b/src/cli/components/CommandMessage.tsx
@@ -26,7 +26,7 @@ type CommandLine = {
  * - Two-column layout with left gutter (2 chars) and right content area
  * - Proper terminal width calculation and wrapping
  * - Markdown rendering for output
- * - Consistent symbols (• for command, ⎿ for result)
+ * - Consistent symbols (• for command, └ for result)
  */
 export const CommandMessage = memo(({ line }: { line: CommandLine }) => {
   const columns = useTerminalWidth();
@@ -67,7 +67,7 @@ export const CommandMessage = memo(({ line }: { line: CommandLine }) => {
       {line.output && (
         <Box flexDirection="row">
           <Box width={5} flexShrink={0}>
-            <Text>{"  ⎿  "}</Text>
+            <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
           </Box>
           <Box flexGrow={1} width={Math.max(0, columns - 5)}>
             {line.preformatted ? (

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -7,6 +7,7 @@ import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Backend, getBackend } from "../../backend";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "../../constants";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
@@ -532,8 +533,8 @@ export function ConversationSelector({
     // Build preview content: (1) summary if exists, (2) preview lines, (3) message count fallback
     // Uses L-bracket indentation style for visual hierarchy
     const renderPreview = () => {
-      const bracket = <Text dimColor>{"⎿  "}</Text>;
-      const indent = "   "; // Same width as "⎿  " for alignment
+      const bracket = <Text dimColor>{`${CLI_GLYPHS.result}  `}</Text>;
+      const indent = "   "; // Same width as "└  " for alignment
 
       // Still loading message data
       if (previewLines === null) {

--- a/src/cli/components/DiffRenderer.tsx
+++ b/src/cli/components/DiffRenderer.tsx
@@ -1,5 +1,6 @@
 import { relative } from "node:path";
 import { Box } from "ink";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import {
@@ -150,7 +151,7 @@ export function WriteRenderer({ filePath, content }: WriteRendererProps) {
         <Box width={gutterWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>
@@ -209,7 +210,7 @@ export function EditRenderer({
         <Box width={gutterWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>
@@ -285,7 +286,7 @@ export function MultiEditRenderer({
         <Box width={gutterWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>

--- a/src/cli/components/EventMessage.tsx
+++ b/src/cli/components/EventMessage.tsx
@@ -112,7 +112,7 @@ export const EventMessage = memo(({ line }: { line: EventLine }) => {
             {/* Header line with L-bracket */}
             <Box flexDirection="row">
               <Box width={5} flexShrink={0}>
-                <Text dimColor>{"  ⎿  "}</Text>
+                <Text dimColor>{`  ${CLI_GLYPHS.result}  `}</Text>
               </Box>
               <Box flexGrow={1} width={Math.max(0, rightWidth - 3)}>
                 <Text dimColor>{COMPACTION_SUMMARY_HEADER}</Text>

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -884,7 +884,10 @@ const StreamingStatus = memo(function StreamingStatus({
     );
   }, [interruptRequested, statusHintSuffix]);
   const tipLineText = useMemo(() => {
-    return truncateEnd(`⎿  Tip: ${tipMessage}`, statusContentWidth);
+    return truncateEnd(
+      `${CLI_GLYPHS.result}  Tip: ${tipMessage}`,
+      statusContentWidth,
+    );
   }, [tipMessage, statusContentWidth]);
 
   if (!streaming || !visible) {

--- a/src/cli/components/MemoryDiffRenderer.tsx
+++ b/src/cli/components/MemoryDiffRenderer.tsx
@@ -1,5 +1,6 @@
 import * as Diff from "diff";
 import { Box } from "ink";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { Text } from "./Text";
@@ -62,7 +63,7 @@ export function MemoryDiffRenderer({
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>
                   {"  "}
-                  <Text dimColor>⎿</Text>
+                  <Text dimColor>{CLI_GLYPHS.result}</Text>
                 </Text>
               </Box>
               <Box flexGrow={1} width={contentWidth}>
@@ -109,7 +110,7 @@ export function MemoryDiffRenderer({
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>
                   {"  "}
-                  <Text dimColor>⎿</Text>
+                  <Text dimColor>{CLI_GLYPHS.result}</Text>
                 </Text>
               </Box>
               <Box flexGrow={1} width={contentWidth}>
@@ -163,7 +164,7 @@ export function MemoryDiffRenderer({
             <Box width={prefixWidth} flexShrink={0}>
               <Text>
                 {"  "}
-                <Text dimColor>⎿</Text>
+                <Text dimColor>{CLI_GLYPHS.result}</Text>
               </Text>
             </Box>
             <Box flexGrow={1} width={contentWidth}>
@@ -190,7 +191,7 @@ export function MemoryDiffRenderer({
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>
                   {"  "}
-                  <Text dimColor>⎿</Text>
+                  <Text dimColor>{CLI_GLYPHS.result}</Text>
                 </Text>
               </Box>
               <Box flexGrow={1} width={contentWidth}>
@@ -209,7 +210,7 @@ export function MemoryDiffRenderer({
             <Box width={prefixWidth} flexShrink={0}>
               <Text>
                 {"  "}
-                <Text dimColor>⎿</Text>
+                <Text dimColor>{CLI_GLYPHS.result}</Text>
               </Text>
             </Box>
             <Box flexGrow={1} width={contentWidth}>
@@ -236,7 +237,7 @@ export function MemoryDiffRenderer({
             <Box width={defaultPrefixWidth} flexShrink={0}>
               <Text>
                 {"  "}
-                <Text dimColor>⎿</Text>
+                <Text dimColor>{CLI_GLYPHS.result}</Text>
               </Text>
             </Box>
             <Box flexGrow={1} width={defaultContentWidth}>
@@ -350,7 +351,7 @@ function MemoryStrReplaceDiff({
         <Box width={prefixWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>
@@ -512,7 +513,7 @@ function PatchDiffRenderer({
         <Box width={prefixWidth} flexShrink={0}>
           <Text>
             {"  "}
-            <Text dimColor>⎿</Text>
+            <Text dimColor>{CLI_GLYPHS.result}</Text>
           </Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>

--- a/src/cli/components/PlanRenderer.tsx
+++ b/src/cli/components/PlanRenderer.tsx
@@ -1,5 +1,6 @@
 import { Box } from "ink";
 import type React from "react";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth.js";
 import { colors } from "./colors.js";
 import { Text } from "./Text";
@@ -19,7 +20,7 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
   explanation,
 }) => {
   const columns = useTerminalWidth();
-  const prefixWidth = 5; // "  ⎿  " or "     "
+  const prefixWidth = 5; // `  └  ` or `     `
   const contentWidth = Math.max(0, columns - prefixWidth);
 
   return (
@@ -27,7 +28,7 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
       {explanation && (
         <Box flexDirection="row">
           <Box width={prefixWidth} flexShrink={0}>
-            <Text>{"  ⎿  "}</Text>
+            <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
           </Box>
           <Box flexGrow={1} width={contentWidth}>
             <Text italic dimColor wrap="wrap">
@@ -65,7 +66,8 @@ export const PlanRenderer: React.FC<PlanRendererProps> = ({
         }
 
         // First item (or first after explanation) gets the prefix, others get indentation
-        const prefix = index === 0 && !explanation ? "  ⎿  " : "     ";
+        const prefix =
+          index === 0 && !explanation ? `  ${CLI_GLYPHS.result}  ` : "     ";
 
         return (
           <Box key={`${index}-${item.step.slice(0, 20)}`} flexDirection="row">

--- a/src/cli/components/StreamingOutputDisplay.tsx
+++ b/src/cli/components/StreamingOutputDisplay.tsx
@@ -1,6 +1,7 @@
 import { Box } from "ink";
 import { memo, useEffect, useState } from "react";
 import type { StreamingState } from "../helpers/accumulator";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { Text } from "./Text";
 
@@ -46,16 +47,16 @@ export const StreamingOutputDisplay = memo(
         <Box>
           <Text
             dimColor
-          >{`  ⎿  Running... (${elapsed}s)${interruptHint}`}</Text>
+          >{`  ${CLI_GLYPHS.result}  Running... (${elapsed}s)${interruptHint}`}</Text>
         </Box>
       );
     }
 
     return (
       <Box flexDirection="column">
-        {/* L-bracket on first line - matches ToolCallMessageRich format "  ⎿  " */}
+        {/* L-bracket on first line - matches ToolCallMessageRich result prefix */}
         <Box>
-          <Text dimColor>{"  ⎿  "}</Text>
+          <Text dimColor>{`  ${CLI_GLYPHS.result}  `}</Text>
           <Text
             dimColor={!firstLine.isStderr}
             color={firstLine.isStderr ? "red" : undefined}

--- a/src/cli/components/SubagentGroupDisplay.tsx
+++ b/src/cli/components/SubagentGroupDisplay.tsx
@@ -143,7 +143,7 @@ const AgentRow = memo(
                 <>
                   <Text color={colors.subagent.treeChar}>
                     {rowIndent}
-                    {continueChar} ⎿{" "}
+                    {continueChar} {CLI_GLYPHS.result}{" "}
                   </Text>
                   <Text dimColor>Launching...</Text>
                 </>
@@ -218,7 +218,7 @@ const AgentRow = memo(
           <Box flexDirection="row">
             <Text color={colors.subagent.treeChar}>
               {rowIndent}
-              {continueChar} ⎿{" "}
+              {continueChar} {CLI_GLYPHS.result}{" "}
             </Text>
             <Text dimColor>{"Subagent: "}</Text>
             <Text dimColor>{agent.agentURL}</Text>
@@ -270,7 +270,7 @@ const AgentRow = memo(
               <>
                 <Text color={colors.subagent.treeChar}>
                   {rowIndent}
-                  {continueChar} ⎿{" "}
+                  {continueChar} {CLI_GLYPHS.result}{" "}
                 </Text>
                 <Text dimColor>Launching...</Text>
               </>

--- a/src/cli/components/SubagentGroupStatic.tsx
+++ b/src/cli/components/SubagentGroupStatic.tsx
@@ -116,7 +116,7 @@ const AgentRow = memo(({ agent, isLast }: AgentRowProps) => {
         <Box flexDirection="row">
           <Text color={colors.subagent.treeChar}>
             {rowIndent}
-            {continueChar} ⎿{" "}
+            {continueChar} {CLI_GLYPHS.result}{" "}
           </Text>
           <Text dimColor>{"Subagent: "}</Text>
           <Text dimColor>{agent.agentURL}</Text>

--- a/src/cli/components/TodoRenderer.tsx
+++ b/src/cli/components/TodoRenderer.tsx
@@ -1,5 +1,6 @@
 import { Box } from "ink";
 import type React from "react";
+import { CLI_GLYPHS } from "../helpers/glyphs";
 import { useTerminalWidth } from "../hooks/useTerminalWidth.js";
 import { colors } from "./colors.js";
 import { Text } from "./Text";
@@ -17,7 +18,7 @@ interface TodoRendererProps {
 
 export const TodoRenderer: React.FC<TodoRendererProps> = ({ todos }) => {
   const columns = useTerminalWidth();
-  const prefixWidth = 5; // "  ⎿  " or "     "
+  const prefixWidth = 5; // `  └  ` or `     `
   const contentWidth = Math.max(0, columns - prefixWidth);
 
   return (
@@ -51,7 +52,7 @@ export const TodoRenderer: React.FC<TodoRendererProps> = ({ todos }) => {
         }
 
         // First item gets the prefix, others get indentation
-        const prefix = index === 0 ? "  ⎿  " : "     ";
+        const prefix = index === 0 ? `  ${CLI_GLYPHS.result}  ` : "     ";
 
         return (
           <Box key={todo.id || index} flexDirection="row">

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -138,7 +138,7 @@ type ToolCallLine = {
  * - Two-column layout for tool calls (2 chars for dot)
  * - Smart wrapping that keeps function name and args together when possible
  * - Blinking dots for pending/running states
- * - Result shown with ⎿ prefix underneath
+ * - Result shown with └ prefix underneath
  */
 export const ToolCallMessage = memo(
   ({
@@ -360,7 +360,7 @@ export const ToolCallMessage = memo(
         if (!line.resultText) return null;
 
         const extractedText = extractMessageFromResult(line.resultText);
-        const prefix = `  ⎿  `; // Match old format: 2 spaces, glyph, 2 spaces
+        const prefix = `  ${CLI_GLYPHS.result}  `; // 2 spaces, glyph, 2 spaces
         const prefixWidth = 5; // Total width of prefix
         const contentWidth = Math.max(0, columns - prefixWidth);
 
@@ -738,7 +738,7 @@ export const ToolCallMessage = memo(
                             <Box width={gutterWidth} flexShrink={0}>
                               <Text>
                                 {"  "}
-                                <Text dimColor>⎿</Text>
+                                <Text dimColor>{CLI_GLYPHS.result}</Text>
                               </Text>
                             </Box>
                             <Box flexGrow={1}>
@@ -995,13 +995,15 @@ export const ToolCallMessage = memo(
 
           {/* Shell command continuation lines with │ prefix */}
           {shellContinuationLines.map((spans) => {
-            const clipped = clipStyledSpans(spans, rightWidth - 2);
+            const clipped = clipStyledSpans(spans, columns - 5);
             const lineKey = spans.map((s) => s.text).join("");
             return (
               <Box key={lineKey} flexDirection="row">
-                <Box width={2} flexShrink={0}>
+                <Box width={5} flexShrink={0}>
                   <Text color={colors.shellSyntax.text}>
+                    {"  "}
                     {CLI_GLYPHS.continuation}
+                    {"  "}
                   </Text>
                 </Box>
                 <Box flexGrow={1}>

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -303,10 +303,11 @@ export const ToolCallMessage = memo(
         const highlightedLines = highlightCommand(shellCommand);
         const nameWidth = displayName.length + 1; // +1 for space separator
         const commandMaxColumns = Math.max(10, rightWidth - nameWidth);
-        const visibleLines = highlightedLines.slice(
-          0,
-          LIVE_SHELL_ARGS_MAX_LINES,
+        // Filter out empty lines (e.g. trailing newline from shiki tokenizer)
+        const nonEmptyLines = highlightedLines.filter((spans) =>
+          spans.some((s) => s.text.length > 0),
         );
+        const visibleLines = nonEmptyLines.slice(0, LIVE_SHELL_ARGS_MAX_LINES);
         const clippedFirstLine = clipStyledSpans(
           visibleLines[0] ?? [],
           commandMaxColumns,

--- a/src/cli/helpers/glyphs.ts
+++ b/src/cli/helpers/glyphs.ts
@@ -7,8 +7,8 @@ export const CLI_GLYPHS = {
   prompt: "›",
   /** Bullet for assistant/tool/status messages */
   bullet: "•",
-  /** Result continuation bracket */
-  result: "⎿",
+  /** Result continuation corner — aligns with continuation bar */
+  result: "└",
   /** Multi-line command continuation bar */
   continuation: "│",
 } as const;


### PR DESCRIPTION
## Summary
- Replaces `⎿` with `└` (box-drawing "light right and down") so it visually connects with `│` continuation lines
- Both glyphs now sit in the same column position for clean stacking
- Centralizes all `⎿`/`└` usages to reference `CLI_GLYPHS.result`
- Widens continuation line gutter from 2 to 5 chars to match result prefix alignment

## Before

## After

👾 Generated with [Letta Code](https://letta.com)