### PR TITLE
feat(cli): Search shows "query in path" instead of "path:"

### DIFF
--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -52,8 +52,9 @@ function colorizeArgs(argsStr: string): ReactNode {
   // Group 2: filenames with extension (e.g. foo.tsx, package.json)
   // Group 3: labels before : (e.g. offset, limit)
   // Group 4: standalone numbers (e.g. 50, 10)
+  // Group 5: paths after " in " keyword (e.g. src in "query" in src)
   const re =
-    /([\w.*?\-@~/]+\/[\w.*?\-@~/]*)|((?<=[(\s,])[\w.-]+\.\w{1,5}(?=[)\s,]|$))|(\w+)(?=\s*:)|(\b\d+\b)/g;
+    /([\w.*?\-@~/]+\/[\w.*?\-@~/]*)|((?<=[(\s,])[\w.-]+\.\w{1,5}(?=[)\s,]|$))|(\w+)(?=\s*:)|(\b\d+\b)|(?<=\bin\s)([\w.*?\-@~/]+(?:\/[\w.*?\-@~/]*)?)/g;
 
   for (let m = re.exec(argsStr); m !== null; m = re.exec(argsStr)) {
     if (m.index > lastIndex) {
@@ -68,7 +69,9 @@ function colorizeArgs(argsStr: string): ReactNode {
         ? palette.string // filename.ext
         : m[3]
           ? palette.comment // label (dimmed)
-          : palette.number; // number
+          : m[5]
+            ? palette.string // path after "in" keyword
+            : palette.number; // number
 
     parts.push(
       <Text key={key++} color={color}>

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -52,9 +52,8 @@ function colorizeArgs(argsStr: string): ReactNode {
   // Group 2: filenames with extension (e.g. foo.tsx, package.json)
   // Group 3: labels before : (e.g. offset, limit)
   // Group 4: standalone numbers (e.g. 50, 10)
-  // Group 5: paths after " in " keyword (e.g. src in "query" in src)
   const re =
-    /([\w.*?\-@~/]+\/[\w.*?\-@~/]*)|((?<=[(\s,])[\w.-]+\.\w{1,5}(?=[)\s,]|$))|(\w+)(?=\s*:)|(\b\d+\b)|(?<=\bin\s)([\w.*?\-@~/]+(?:\/[\w.*?\-@~/]*)?)/g;
+    /([\w.*?\-@~/]+\/[\w.*?\-@~/]*)|((?<=[(\s,])[\w.-]+\.\w{1,5}(?=[)\s,]|$))|(\w+)(?=\s*:)|(\b\d+\b)/g;
 
   for (let m = re.exec(argsStr); m !== null; m = re.exec(argsStr)) {
     if (m.index > lastIndex) {
@@ -69,9 +68,7 @@ function colorizeArgs(argsStr: string): ReactNode {
         ? palette.string // filename.ext
         : m[3]
           ? palette.comment // label (dimmed)
-          : m[5]
-            ? palette.string // path after "in" keyword
-            : palette.number; // number
+          : palette.number; // number
 
     parts.push(
       <Text key={key++} color={color}>

--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -10,6 +10,7 @@ import {
   isFileEditTool,
   isFileReadTool,
   isFileWriteTool,
+  isGlobTool,
   isPatchTool,
   isPlanTool,
   isSearchTool,
@@ -303,6 +304,24 @@ export function formatArgsDisplay(
               display = `"${query}" in ${formatDisplayPath(path)}`;
             } else if (query) {
               display = `"${query}"`;
+            } else if (path) {
+              display = formatDisplayPath(path);
+            }
+            return { display, parsed };
+          }
+
+          // Glob tools: show "pattern in path" instead of "pattern: ..., path: ..."
+          if (isGlobTool(toolName)) {
+            const pattern = String(parsed.pattern ?? "");
+            const path = parsed.path
+              ? String(parsed.path)
+              : parsed.file_path
+                ? String(parsed.file_path)
+                : null;
+            if (pattern && path) {
+              display = `${pattern} in ${formatDisplayPath(path)}`;
+            } else if (pattern) {
+              display = pattern;
             } else if (path) {
               display = formatDisplayPath(path);
             }

--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -12,6 +12,7 @@ import {
   isFileWriteTool,
   isPatchTool,
   isPlanTool,
+  isSearchTool,
   isShellTool,
   isTodoTool,
 } from "./toolNameMapping.js";
@@ -286,6 +287,24 @@ export function formatArgsDisplay(
               display = `${relativePath}, ${otherArgs.join(", ")}`;
             } else {
               display = relativePath;
+            }
+            return { display, parsed };
+          }
+
+          // Search/Grep tools: show "query in path" instead of "query: ..., path: ..."
+          if (isSearchTool(toolName)) {
+            const query = String(parsed.query ?? parsed.pattern ?? "");
+            const path = parsed.path
+              ? String(parsed.path)
+              : parsed.file_path
+                ? String(parsed.file_path)
+                : null;
+            if (query && path) {
+              display = `"${query}" in ${formatDisplayPath(path)}`;
+            } else if (query) {
+              display = `"${query}"`;
+            } else if (path) {
+              display = formatDisplayPath(path);
             }
             return { display, parsed };
           }


### PR DESCRIPTION
## Summary
- Search/Grep tool calls now display `query in path` format instead of `query: ..., path: ...`

## Before

<img width="850" height="399" alt="Screenshot 2026-05-12 at 12 23 42 PM" src="https://github.com/user-attachments/assets/149a0d2c-c006-4ae6-aab1-8f9e1dff13c0" />

## After

<img width="663" height="394" alt="Screenshot 2026-05-12 at 12 23 15 PM" src="https://github.com/user-attachments/assets/d412ebcb-e0a4-4dce-9660-039d934672ba" />

👾 Generated with [Letta Code](https://letta.com)