### PR TITLE
fix(cli): prevent missing space between tool name and args

### DIFF
--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -269,12 +269,7 @@ export const ToolCallMessage = memo(
           const truncatedDisplay = needsTruncation
             ? `${normalizedDisplay.slice(0, maxArgsChars - 1)}…`
             : normalizedDisplay;
-          if (rawName.toLowerCase() === "taskoutput") {
-            const separator = truncatedDisplay.startsWith("(") ? "" : " ";
-            args = colorizeArgs(separator + truncatedDisplay);
-          } else {
-            args = colorizeArgs(` ${truncatedDisplay}`);
-          }
+          args = colorizeArgs(truncatedDisplay);
         }
       }
 
@@ -950,13 +945,13 @@ export const ToolCallMessage = memo(
                   {isMemoryTool(rawName) ? (
                     <>
                       <Text bold color={colors.tool.memoryName}>
-                        {displayName}
+                        {displayName}{" "}
                       </Text>
                       {args}
                     </>
                   ) : (
                     <>
-                      <Text bold>{displayName}</Text>
+                      <Text bold>{displayName} </Text>
                       {args}
                     </>
                   )}
@@ -969,7 +964,7 @@ export const ToolCallMessage = memo(
                       isMemoryTool(rawName) ? colors.tool.memoryName : undefined
                     }
                   >
-                    {displayName}
+                    {displayName}{" "}
                   </Text>
                   {shellFirstLineSpans ? (
                     <Box
@@ -977,14 +972,13 @@ export const ToolCallMessage = memo(
                       width={Math.max(0, rightWidth - displayName.length - 1)}
                     >
                       <Text color={colors.shellSyntax.text}>
-                        {" "}
                         {renderSpans(shellFirstLineSpans)}
                       </Text>
                     </Box>
                   ) : args ? (
                     <Box
                       flexGrow={1}
-                      width={Math.max(0, rightWidth - displayName.length)}
+                      width={Math.max(0, rightWidth - displayName.length - 1)}
                     >
                       <Text wrap="wrap">{args}</Text>
                     </Box>


### PR DESCRIPTION
## Summary
- Moves the space separator from a standalone `{" "}` text node into the displayName `<Text>` node, so Ink can never collapse it on re-render
- Fixes inconsistent width calculation between shell and args paths (both now subtract 1 for the space)
- Removes the now-redundant space prefix from `colorizeArgs` calls

## Before
Intermittent `Rungh api ...` instead of `Run gh api ...`

## After

👾 Generated with [Letta Code](https://letta.com)