### PR TITLE
feat(cli): memory tool shows "reason" in file_path

### DIFF
--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -11,6 +11,7 @@ import {
   isFileReadTool,
   isFileWriteTool,
   isGlobTool,
+  isMemoryTool,
   isPatchTool,
   isPlanTool,
   isSearchTool,
@@ -324,6 +325,20 @@ export function formatArgsDisplay(
               display = pattern;
             } else if (path) {
               display = formatDisplayPath(path);
+            }
+            return { display, parsed };
+          }
+
+          // Memory tools: show "reason" in file_path
+          if (isMemoryTool(toolName)) {
+            const reason = String(parsed.reason ?? "");
+            const filePath = parsed.file_path ? String(parsed.file_path) : null;
+            if (reason && filePath) {
+              display = `"${reason}" in ${formatDisplayPath(filePath)}`;
+            } else if (reason) {
+              display = `"${reason}"`;
+            } else if (filePath) {
+              display = formatDisplayPath(filePath);
             }
             return { display, parsed };
           }


### PR DESCRIPTION
## Summary
- Memory tool calls now display `"reason" in file_path` format instead of dumping all key-value args
- Consistent with Search/Glob `in` pattern

## Before
```
• memory command: "str_replace", reason: "Record key working preferences", file_path: "system/human.md", old_string: …, new_string: …
```

## After
```
• memory "Record key working preferences" in system/human.md
```

👾 Generated with [Letta Code](https://letta.com)