### PR TITLE
fix(cli): drop path/file_path labels from default args display

### DIFF
--- a/src/cli/helpers/formatArgsDisplay.ts
+++ b/src/cli/helpers/formatArgsDisplay.ts
@@ -382,20 +382,52 @@ export function formatArgsDisplay(
           const v = parsed[firstKey];
           display = typeof v === "string" ? v : String(v);
         } else {
-          display = Object.entries(parsed)
-            .map(([k, v]) => {
-              if (v === undefined || v === null) return `${k}: ${v}`;
-              if (typeof v === "boolean" || typeof v === "number")
-                return `${k}: ${v}`;
-              if (typeof v === "string")
-                return v.length > 50 ? `${k}: …` : `${k}: "${v}"`;
-              if (Array.isArray(v)) return `${k}: [${v.length} items]`;
-              if (typeof v === "object")
-                return `${k}: {${Object.keys(v as Record<string, unknown>).length} props}`;
-              const str = JSON.stringify(v);
-              return str.length > 50 ? `${k}: …` : `${k}: ${str}`;
-            })
-            .join(", ");
+          // For multi-key args with a path-like key, show path first without label
+          const pathKey = keys.find((k) =>
+            ["path", "file_path", "target_file", "target_directory"].includes(
+              k,
+            ),
+          );
+          if (pathKey) {
+            const pathVal = parsed[pathKey];
+            const pathDisplay =
+              typeof pathVal === "string"
+                ? formatDisplayPath(pathVal)
+                : String(pathVal);
+            const otherParts = Object.entries(parsed)
+              .filter(([k]) => k !== pathKey)
+              .map(([k, v]) => {
+                if (v === undefined || v === null) return `${k}: ${v}`;
+                if (typeof v === "boolean" || typeof v === "number")
+                  return `${k}: ${v}`;
+                if (typeof v === "string")
+                  return v.length > 50 ? `${k}: …` : `${k}: "${v}"`;
+                if (Array.isArray(v)) return `${k}: [${v.length} items]`;
+                if (typeof v === "object")
+                  return `${k}: {${Object.keys(v as Record<string, unknown>).length} props}`;
+                const str = JSON.stringify(v);
+                return str.length > 50 ? `${k}: …` : `${k}: ${str}`;
+              });
+            display =
+              otherParts.length > 0
+                ? `${pathDisplay}, ${otherParts.join(", ")}`
+                : pathDisplay;
+          } else {
+            display = Object.entries(parsed)
+              .map(([k, v]) => {
+                if (v === undefined || v === null) return `${k}: ${v}`;
+                if (typeof v === "boolean" || typeof v === "number")
+                  return `${k}: ${v}`;
+                if (typeof v === "string")
+                  return v.length > 50 ? `${k}: …` : `${k}: "${v}"`;
+                if (Array.isArray(v)) return `${k}: [${v.length} items]`;
+                if (typeof v === "object")
+                  return `${k}: {${Object.keys(v as Record<string, unknown>).length} props}`;
+                const str = JSON.stringify(v);
+                return str.length > 50 ? `${k}: …` : `${k}: ${str}`;
+              })
+              .join(", ");
+          }
         }
       }
     }

--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -17,7 +17,8 @@ export function getDisplayToolName(rawName: string): string {
   // Anthropic toolset
   if (rawName === "write") return "Write";
   if (rawName === "edit" || rawName === "multi_edit") return "Update";
-  if (rawName === "read") return "Read";
+  if (rawName === "read" || rawName === "read_lsp" || rawName === "ReadLSP")
+    return "Read";
   if (rawName === "view_image" || rawName === "ViewImage") return "View Image";
   if (rawName === "bash") return "Bash";
   if (rawName === "grep" || rawName === "Grep") return "Search";
@@ -191,7 +192,9 @@ export function isFileReadTool(name: string): boolean {
     name === "read_file_gemini" ||
     name === "ReadFileGemini" ||
     name === "read_many_files" ||
-    name === "ReadManyFiles"
+    name === "ReadManyFiles" ||
+    name === "read_lsp" ||
+    name === "ReadLSP"
   );
 }
 


### PR DESCRIPTION
## Summary
- When a tool falls through to the default handler with multiple args, path-like keys (`path`, `file_path`, `target_file`, `target_directory`) now show just the value without the key label
- Adds `ReadLSP`/`read_lsp` to `isFileReadTool` and display name mapping

## Before
```
• Read path: /Users/caren/..., offset: 10, limit: 30
```

## After
```
• Read /Users/caren/..., offset: 10, limit: 30
```

👾 Generated with [Letta Code](https://letta.com)