### PR TITLE
fix(local): recover from interrupted turns that leave text after tool calls

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -484,6 +484,62 @@ function isToolUIPart(part: unknown): part is Record<string, unknown> {
   );
 }
 
+/**
+ * When the user interrupts a multi-step turn mid-stream, the last assistant
+ * message can end up with a text part immediately following a tool part in the
+ * same step (i.e., between two `step-start` markers). The AI SDK's
+ * `convertToModelMessages` will then produce an assistant content block that
+ * contains both a `tool_use` block and a `text` block, which Anthropic rejects
+ * because text may not follow `tool_use` when a `tool_result` is expected next.
+ *
+ * This function inserts a `step-start` marker before any such trailing text
+ * part, splitting the text into its own step so that `convertToModelMessages`
+ * places it in a separate assistant message block.
+ */
+function separateTrailingTextAfterToolCalls(
+  messages: LocalMessage[],
+): LocalMessage[] {
+  let didChange = false;
+  const transformed = messages.map((message) => {
+    if (message.role !== "assistant") return message;
+
+    let messageChanged = false;
+    const newParts: LocalMessage["parts"] = [];
+    let stepHasToolCall = false;
+
+    for (const part of message.parts) {
+      if (!part) continue;
+
+      if (part.type === "step-start") {
+        stepHasToolCall = false;
+        newParts.push(part);
+        continue;
+      }
+
+      if (isToolUIPart(part)) {
+        stepHasToolCall = true;
+        newParts.push(part);
+        continue;
+      }
+
+      if (stepHasToolCall && (part as { type?: unknown }).type === "text") {
+        // Insert a step-start to separate the trailing text from the tool call,
+        // preventing a mixed tool_use+text block in the converted model message.
+        newParts.push({ type: "step-start" } as LocalMessage["parts"][number]);
+        stepHasToolCall = false;
+        messageChanged = true;
+        didChange = true;
+      }
+
+      newParts.push(part);
+    }
+
+    return messageChanged ? { ...message, parts: newParts } : message;
+  });
+
+  return didChange ? transformed : messages;
+}
+
 function normalizeToolPartForModelConversion(part: Record<string, unknown>): {
   part: LocalMessage["parts"][number];
   changed: boolean;
@@ -545,7 +601,9 @@ function sanitizeUIMessagesForProvider(
   agent: ProviderTurnInput["agent"],
 ): LocalMessage[] {
   const settledMessages = normalizeToolPartsForModelConversion(
-    replaceUnsupportedInputParts(messages, agent),
+    separateTrailingTextAfterToolCalls(
+      replaceUnsupportedInputParts(messages, agent),
+    ),
   );
   if (provider === "unknown") return settledMessages;
   return settledMessages


### PR DESCRIPTION
## Summary

- When a user interrupts a multi-step agent turn mid-stream, the last assistant UI message can end up with a `text` part in the same step as a tool call, without an intervening `step-start` marker
- The `step-start` that normally precedes continuation text is emitted by the AI SDK streaming pipeline, which gets aborted before it fires
- When this message is later passed through `convertToModelMessages`, the AI SDK produces an assistant content block with both `tool_use` and `text` — which Anthropic rejects with: _"tool_use ids were found without tool_result blocks immediately after"_
- Fix adds a `separateTrailingTextAfterToolCalls` sanitization pass in `sanitizeUIMessagesForProvider` that inserts a `step-start` before any text part immediately following a tool part in the same step, so `convertToModelMessages` places it in a clean separate assistant block

## Error
```
⚠ {
  "error": {
  "error": {
  "message": "messages.1387: `tool_use` ids were found without `tool_result` blocks immediately after:
  toolu_01BoNBm53xna53eBvo89hqRA. Each `tool_use` block must have a corresponding `tool_result` block in the next
  message.",
  "detail": "messages.1387: `tool_use` ids were found without `tool_result` blocks immediately after:
  toolu_01BoNBm53xna53eBvo89hqRA. Each `tool_use` block must have a corresponding `tool_result` block in the next
  message.\n{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.1387:
  `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01BoNBm53xna53eBvo89hqRA. Each
  `tool_use` block must have a corresponding `tool_result` block in the next
  message.\"},\"request_id\":\"req_011CayG9yEpJKn2JPQeYzJSw\"}\n{\"type\":\"error\",\"error\":{\"type\":\"invalid
  _request_error\",\"message\":\"messages.1387: `tool_use` ids were found without `tool_result` blocks
  immediately after: toolu_01BoNBm53xna53eBvo89hqRA. Each `tool_use` block must have a corresponding
  `tool_result` block in the next message.\"}}",
  "error_type": "llm_error",
  "retryable": false,
  "run_id": "local-run-1"
  },
  "run_id": "local-run-1"
  }
  }

⚠ Something went wrong? Use /feedback to report issues.
```

## Test plan

- [ ] Interrupt an agent mid-stream while it is executing a tool call, then resume the conversation — should no longer get the Anthropic `tool_use`/`tool_result` mismatch error
- [ ] Normal (non-interrupted) multi-step tool turns continue to work correctly
- [ ] Existing unit tests pass: `bun test src/tests/headless/`

👾 Generated with [Letta Code](https://letta.com)