### PR TITLE
fix(channels): clarify MessageChannel reply contract

### DIFF
--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -118,6 +118,7 @@ function buildDynamicMessageChannelSchemaFromDiscovery(
 function buildDynamicMessageChannelDescriptionFromDiscovery(
   baseDescription: string,
   discovery: ResolvedMessageChannelToolDiscovery,
+  scope?: MessageChannelToolDiscoveryScope | null,
 ): string {
   const description = baseDescription.trim();
   if (discovery.activeChannels.length === 0) {
@@ -129,7 +130,12 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
     .join(", ");
   const actionList = discovery.actions.join(", ");
 
-  return `${description}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+  const scopedReplyContract =
+    scope && scope.channels.length > 0
+      ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. For the user-visible reply, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply.'
+      : "";
+
+  return `${description}${scopedReplyContract}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
 export async function resolveMessageChannelToolDiscovery(
@@ -198,6 +204,7 @@ export async function buildDynamicMessageChannelToolDefinition(
     description: buildDynamicMessageChannelDescriptionFromDiscovery(
       baseDescription,
       discovery,
+      scope,
     ),
     schema: buildDynamicMessageChannelSchemaFromDiscovery(
       baseSchema,

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -48,9 +48,9 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
 
   const lines = [
     SYSTEM_REMINDER_OPEN,
-    `This message originated from an external ${escapedChannel} channel.`,
-    `If you want to ensure the user on ${escapedChannel} will see your reply, you must call the MessageChannel tool to send a message back on the same channel.`,
-    `Use action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}" when calling MessageChannel, and put your reply text in message.`,
+    `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
+    `To reply, your final action for this turn MUST be exactly one MessageChannel call with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
+    "Do not produce a plain text assistant response as the user-visible reply.",
     "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",
     "Only pass replyTo if you intentionally want the platform's quote/reply UI.",
     `Current local time on this device: ${localTime}`,

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -135,6 +135,12 @@ describe("buildDynamicMessageChannelSchema", () => {
       { enum?: string[] }
     >;
     expect(resolved.description).toContain("Currently active channels: Slack.");
+    expect(resolved.description).toContain(
+      "Plain assistant text is not delivered to that external user.",
+    );
+    expect(resolved.description).toContain(
+      "final action for the turn must be one MessageChannel call",
+    );
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -60,9 +60,14 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
 
     expect(reminder).toContain("<system-reminder>");
-    expect(reminder).toContain("must call the MessageChannel tool");
     expect(reminder).toContain(
-      'Use action="send", channel="telegram", and chat_id="12345"',
+      "Plain assistant text is not delivered to the user.",
+    );
+    expect(reminder).toContain(
+      'MUST be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+    );
+    expect(reminder).toContain(
+      "Do not produce a plain text assistant response as the user-visible reply.",
     );
     expect(reminder).toContain('action="react"');
     expect(reminder).toContain("Current local time on this device:");
@@ -82,7 +87,7 @@ describe("formatChannelNotification", () => {
     const xml = buildChannelNotificationXml(msg);
 
     expect(reminder).toContain(
-      'Use action="send", channel="telegram", and chat_id="12345"',
+      'MUST be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
     );
     expect(reminder).not.toContain('accountId="account-1"');
     expect(xml).toContain('account_id="account-1"');


### PR DESCRIPTION
## Summary
- Tighten routed channel reminder wording so plain assistant text is explicitly not delivered to the external user.
- Add the same scoped reply contract to dynamic MessageChannel tool descriptions for routed channel turns.
- Update channel XML and dynamic schema tests for the stricter contract.

## Test plan
- [x] bun test src/tests/channels/xml.test.ts src/tests/channels/message-tool-schema.test.ts
- [x] bun run lint

Fixes #2223

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)