### PR TITLE
fix(cli): skip deferred commit for tool calls that already have a result

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1661,6 +1661,15 @@ export default function App({
           isPatchTool(ln.name)
         );
       };
+
+      const shouldSkipDeferral = (ln: Line): boolean => {
+        if (ln.kind !== "tool_call") return false;
+        if (ln.phase !== "finished") return false;
+        // Skip deferral when the result is already available: the component height
+        // has already changed (header + result), so deferring only extends the
+        // live-area repaint window that causes ghost lines in the terminal scrollback.
+        return ln.resultText != null;
+      };
       if (!deferToolCalls && deferredCommits.size > 0) {
         deferredCommits.clear();
         setDeferredCommitAt(null);
@@ -1749,7 +1758,8 @@ export default function App({
           if (
             deferToolCalls &&
             ln.kind === "tool_call" &&
-            (!ln.name || !isTaskTool(ln.name))
+            (!ln.name || !isTaskTool(ln.name)) &&
+            !shouldSkipDeferral(ln)
           ) {
             const commitAt = deferredCommits.get(id);
             if (commitAt === undefined) {


### PR DESCRIPTION
## Summary

- Tool calls with a result were sitting in the live area for 50ms (the `TOOL_CALL_COMMIT_DEFER_MS` deferred commit window) before being promoted to static
- During that window, any Ink repaint re-renders the live area with the now-taller component (header + result row), leaving a ghost/duplicate line in the terminal scrollback from the previous shorter render
- Fix adds `shouldSkipDeferral`: when `resultText` is already populated, skip the 50ms wait and commit to static immediately
- The deferral is preserved for tool calls without a result yet (the running→finished transition) where it still prevents the original live-to-static flash that PR #778 was solving
- Applies to both local and API backends since `commitEligibleLines` is shared

## Bug Repro

```
• Run gh pr checks 2226 --repo letta-ai/letta-code 2>&1 | grep fail

• Run gh pr checks 2226 --repo letta-ai/letta-code 2>&1 | grep fail

• Run gh pr checks 2226 --repo letta-ai/letta-code 2>&1 | grep fail
  └  Linux arm64
     (ubuntu-24.04-arm)	fail	4m57s	https://github.com/letta-ai/letta-code/actions/runs/25758191013/job/75652255463
     Linux x64
     (ubuntu-24.04)	fail	4m48s	https://github.com/letta-ai/letta-code/actions/runs/25758191013/job/75652255679
     macOS arm64 (macos-14)	fail	4m25s	https://github.com/letta-a…
     … output clipped
```

## Test plan
- [ ] Run a series of sequential bash/gh commands in unrestricted mode — each tool call should appear exactly once with its result, no ghost/duplicate headers in the scrollback
- [ ] File edit/write tools still render correctly (they go through the approval preview path and are unaffected)
- [ ] No flicker when tool calls transition from live to static

👾 Generated with [Letta Code](https://letta.com)