### PR TITLE
fix(cli): show memory block names for memory edits

### DIFF
--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -212,7 +212,12 @@ function getMemoryInfo(approval: ApprovalRequest): MemoryInfo | null {
     return {
       command,
       reason: typeof args.reason === "string" ? args.reason : undefined,
-      path: typeof args.path === "string" ? args.path : undefined,
+      path:
+        typeof args.file_path === "string"
+          ? args.file_path
+          : typeof args.path === "string"
+            ? args.path
+            : undefined,
       oldPath: typeof args.old_path === "string" ? args.old_path : undefined,
       newPath: typeof args.new_path === "string" ? args.new_path : undefined,
       oldString:
@@ -265,7 +270,12 @@ function getMemoryFileEditInfo(
     }
 
     const command = typeof args.command === "string" ? args.command : "";
-    const relPath = typeof args.path === "string" ? args.path : "";
+    const relPath =
+      typeof args.file_path === "string"
+        ? args.file_path
+        : typeof args.path === "string"
+          ? args.path
+          : "";
     const absPath = memoryDir && relPath ? `${memoryDir}/${relPath}` : relPath;
     const display = memoryDisplayPath(relPath);
 

--- a/src/cli/components/MemoryDiffRenderer.tsx
+++ b/src/cli/components/MemoryDiffRenderer.tsx
@@ -10,6 +10,21 @@ interface MemoryDiffRendererProps {
   toolName: string;
 }
 
+function stringArg(
+  args: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function memoryBlockName(path: string): string {
+  return path.split("/").pop() || path;
+}
+
 /**
  * Renders a diff view for memory tool operations.
  * Handles both `memory` (command-based) and `memory_apply_patch` (unified diff) tools.
@@ -21,7 +36,7 @@ export function MemoryDiffRenderer({
   const columns = useTerminalWidth();
 
   try {
-    const args = JSON.parse(argsText);
+    const args = JSON.parse(argsText) as Record<string, unknown>;
 
     // Handle memory_apply_patch tool (codex-style apply_patch input)
     if (toolName === "memory_apply_patch") {
@@ -33,15 +48,15 @@ export function MemoryDiffRenderer({
 
     // Handle memory tool (command-based)
     const command = args.command as string;
-    const path = args.path || args.old_path || "unknown";
+    const path = stringArg(args, "file_path", "path", "old_path") ?? "unknown";
 
     // Extract just the block name from the path (e.g., "/memories/project" -> "project")
-    const blockName = path.split("/").pop() || path;
+    const blockName = memoryBlockName(path);
 
     switch (command) {
       case "str_replace": {
-        const oldStr = args.old_string || args.old_str || "";
-        const newStr = args.new_string || args.new_str || "";
+        const oldStr = stringArg(args, "old_string", "old_str") ?? "";
+        const newStr = stringArg(args, "new_string", "new_str") ?? "";
         return (
           <MemoryStrReplaceDiff
             blockName={blockName}
@@ -53,7 +68,7 @@ export function MemoryDiffRenderer({
       }
 
       case "insert": {
-        const insertText = args.insert_text || "";
+        const insertText = stringArg(args, "insert_text") ?? "";
         const insertLine = args.insert_line;
         const prefixWidth = 4; // "    " indent
         const contentWidth = Math.max(0, columns - prefixWidth);
@@ -100,8 +115,8 @@ export function MemoryDiffRenderer({
       }
 
       case "create": {
-        const description = args.description || "";
-        const fileText = args.file_text || "";
+        const description = stringArg(args, "description") ?? "";
+        const fileText = stringArg(args, "file_text") ?? "";
         const prefixWidth = 4; // "    " indent
         const contentWidth = Math.max(0, columns - prefixWidth);
         return (
@@ -180,8 +195,8 @@ export function MemoryDiffRenderer({
       }
 
       case "rename": {
-        const newPath = args.new_path || "";
-        const newBlockName = newPath.split("/").pop() || newPath;
+        const newPath = stringArg(args, "new_path") ?? "";
+        const newBlockName = memoryBlockName(newPath);
         const description = args.description;
         const prefixWidth = 4;
         const contentWidth = Math.max(0, columns - prefixWidth);

--- a/src/tests/cli/memory-diff-renderer.test.tsx
+++ b/src/tests/cli/memory-diff-renderer.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { MemoryDiffRenderer } from "../../cli/components/MemoryDiffRenderer";
+
+class CaptureStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderMemoryDiff(
+  args: Record<string, unknown>,
+): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(
+    <MemoryDiffRenderer argsText={JSON.stringify(args)} toolName="memory" />,
+    {
+      stdout,
+      stdin: createInputStream(),
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("memory diff renderer uses file_path for memory block names", async () => {
+  const output = await renderMemoryDiff({
+    command: "str_replace",
+    reason: "Test memory display",
+    file_path: "system/human.md",
+    old_string: "before",
+    new_string: "after",
+  });
+
+  expect(output).toContain("Updated memory block human.md");
+  expect(output).not.toContain("Updated memory block unknown");
+});


### PR DESCRIPTION
Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Read memory edit target paths from `file_path` in completed memory diff rendering.
- Apply the same `file_path` fallback in memory approval preview paths.
- Add a regression test covering `Updated memory block unknown` for memory edits.

## Test plan
- [x] `bun test src/tests/cli/memory-diff-renderer.test.tsx`
- [x] `bun run lint`

👾 Generated with [Letta Code](https://letta.com)