### PR TITLE
feat(desktop): support remote compact command

### DIFF
--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -1031,6 +1031,60 @@ describe("listen-client parseServerMessage", () => {
     }
   });
 
+  test("remote compact does not trigger reflection when compaction changes nothing", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "ws-compact-same-"));
+    try {
+      class NoopCompactBackend extends LocalBackend {
+        override async compactConversationMessages(
+          ..._args: Parameters<LocalBackend["compactConversationMessages"]>
+        ): ReturnType<LocalBackend["compactConversationMessages"]> {
+          throw {
+            status: 400,
+            error: {
+              detail: "Summarization failed to reduce the number of messages",
+            },
+          };
+        }
+      }
+
+      const backend = new NoopCompactBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "WS Noop Compact Agent",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        agent.id,
+        "default",
+      );
+      const socket = new MockSocket(WebSocket.OPEN);
+
+      await handleExecuteCommand(
+        {
+          type: "execute_command",
+          command_id: "compact",
+          request_id: "compact-noop-run-1",
+          runtime: { agent_id: agent.id, conversation_id: "default" },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {},
+      );
+
+      expect(runtime.contextTracker.pendingReflectionTrigger).toBe(false);
+      expect(socket.sentPayloads.join("\n")).toContain(
+        "Compaction run, but the number of messages is the same",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("runs remote set-max-context execute_command", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "ws-max-context-"));
     try {

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -943,6 +943,7 @@ describe("listen-client parseServerMessage", () => {
   test("advertises and parses remote set-max-context execute_command", () => {
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("set-max-context");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("goal");
+    expect(SUPPORTED_REMOTE_COMMANDS).toContain("compact");
 
     const command = parseServerMessage(
       Buffer.from(
@@ -961,6 +962,73 @@ describe("listen-client parseServerMessage", () => {
       command_id: "set-max-context",
       args: "10000 --override",
     });
+  });
+
+  test("runs remote compact execute_command against backend", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "ws-compact-"));
+    try {
+      class CompactRecordingBackend extends LocalBackend {
+        compactCalls: Parameters<
+          LocalBackend["compactConversationMessages"]
+        >[] = [];
+
+        override async compactConversationMessages(
+          ...args: Parameters<LocalBackend["compactConversationMessages"]>
+        ): ReturnType<LocalBackend["compactConversationMessages"]> {
+          this.compactCalls.push(args);
+          return {
+            num_messages_before: 7,
+            num_messages_after: 2,
+            summary: "compacted summary",
+          } as Awaited<ReturnType<LocalBackend["compactConversationMessages"]>>;
+        }
+      }
+
+      const backend = new CompactRecordingBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "WS Compact Agent",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        agent.id,
+        "default",
+      );
+      const socket = new MockSocket(WebSocket.OPEN);
+
+      await handleExecuteCommand(
+        {
+          type: "execute_command",
+          command_id: "compact",
+          request_id: "compact-run-1",
+          runtime: { agent_id: agent.id, conversation_id: "default" },
+          args: "sliding_window",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {},
+      );
+
+      expect(backend.compactCalls).toHaveLength(1);
+      expect(backend.compactCalls[0]?.[0]).toBe("default");
+      expect(backend.compactCalls[0]?.[1]).toMatchObject({
+        agent_id: agent.id,
+        compaction_settings: {
+          mode: "sliding_window",
+        },
+      });
+      expect(runtime.contextTracker.pendingReflectionTrigger).toBe(true);
+      expect(socket.sentPayloads.join("\n")).toContain(
+        "Compaction completed (mode: sliding_window). Message buffer length reduced from 7 to 2.",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("runs remote set-max-context execute_command", async () => {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -6,7 +6,9 @@ import {
 import { ISOLATED_BLOCK_LABELS } from "../../agent/memory";
 import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import { REMEMBER_PROMPT } from "../../agent/promptAssets";
+import type { ConversationMessageCompactBody } from "../../backend";
 import { getBackend } from "../../backend";
+import { formatErrorDetails } from "../../cli/helpers/errorFormatter";
 import {
   buildGoalContinuationPrompt,
   formatGoalSummary,
@@ -21,7 +23,12 @@ import {
   buildInitMessage,
   gatherInitGitContext,
 } from "../../cli/helpers/initCommand";
-import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "../../constants";
+import {
+  DEFAULT_SUMMARIZATION_MODEL,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from "../../constants";
+import { runPreCompactHooks } from "../../hooks";
 import { ralphMode } from "../../ralph/mode";
 import { settingsManager } from "../../settings-manager";
 import { trackBoundaryError } from "../../telemetry/errorReporting";
@@ -56,6 +63,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "init",
   "remember",
   "goal",
+  "compact",
   "set-max-context",
   "channels",
   "toolset",
@@ -138,6 +146,10 @@ export async function handleExecuteCommand(
         );
         break;
 
+      case "compact":
+        output = await handleCompactCommand(conversationRuntime, trimmedArgs);
+        break;
+
       case "set-max-context":
         output = await handleSetMaxContextCommand(
           conversationRuntime,
@@ -205,6 +217,121 @@ function emitSlashCommandEnd(
     ...fields,
   };
   emitCanonicalMessageDelta(socket, runtime, endDelta as StreamDelta, scope);
+}
+
+type CompactMode =
+  | "all"
+  | "sliding_window"
+  | "self_compact_all"
+  | "self_compact_sliding_window";
+
+const VALID_COMPACT_MODES = new Set<CompactMode>([
+  "all",
+  "sliding_window",
+  "self_compact_all",
+  "self_compact_sliding_window",
+]);
+
+function compactHelpOutput(): string {
+  return [
+    "/compact help",
+    "",
+    "Summarize conversation history (compaction).",
+    "",
+    "USAGE",
+    "  /compact                   — compact with default mode",
+    "  /compact all               — compact all messages",
+    "  /compact sliding_window    — compact with sliding window",
+    "  /compact self_compact_all  — compact with self compact all",
+    "  /compact self_compact_sliding_window  — compact with self compact sliding window",
+    "  /compact help              — show this help",
+  ].join("\n");
+}
+
+/** /compact — Summarize conversation history through the active Backend. */
+async function handleCompactCommand(
+  conversationRuntime: ConversationRuntime,
+  args: string | undefined,
+): Promise<string> {
+  const agentId = conversationRuntime.agentId;
+  if (!agentId) {
+    throw new Error("No agent ID available for /compact command");
+  }
+
+  const rawModeArg = args?.trim().split(/\s+/)[0];
+  if (rawModeArg === "help") {
+    return compactHelpOutput();
+  }
+
+  const modeArg = rawModeArg as CompactMode | undefined;
+  if (modeArg && !VALID_COMPACT_MODES.has(modeArg)) {
+    throw new Error(`Invalid mode "${modeArg}". Run /compact help for usage.`);
+  }
+
+  const preCompactResult = await runPreCompactHooks(
+    undefined,
+    undefined,
+    agentId,
+    conversationRuntime.conversationId,
+  );
+  if (preCompactResult.blocked) {
+    const feedback = preCompactResult.feedback.join("\n") || "Blocked by hook";
+    throw new Error(`Compact blocked: ${feedback}`);
+  }
+
+  const backend = getBackend();
+  const modeDisplay = modeArg ? ` (mode: ${modeArg})` : "";
+
+  try {
+    let compactParams: ConversationMessageCompactBody | undefined;
+    if (modeArg) {
+      const agent = await backend.retrieveAgent(agentId);
+      compactParams = {
+        compaction_settings: {
+          mode: modeArg,
+          model:
+            agent.compaction_settings?.model?.trim() ||
+            DEFAULT_SUMMARIZATION_MODEL,
+        },
+      } as ConversationMessageCompactBody;
+    }
+
+    const compactBody =
+      conversationRuntime.conversationId === "default"
+        ? ({
+            agent_id: agentId,
+            ...(compactParams ?? {}),
+          } as ConversationMessageCompactBody)
+        : compactParams;
+
+    const result = await backend.compactConversationMessages(
+      conversationRuntime.conversationId,
+      compactBody,
+    );
+
+    conversationRuntime.contextTracker.pendingReflectionTrigger = true;
+
+    return [
+      `Compaction completed${modeDisplay}. Message buffer length reduced from ${result.num_messages_before} to ${result.num_messages_after}.`,
+      "",
+      `Summary: ${result.summary}`,
+    ].join("\n");
+  } catch (error) {
+    const apiError = error as {
+      status?: number;
+      error?: { detail?: string };
+    };
+    const detail = apiError?.error?.detail;
+    if (
+      apiError?.status === 400 &&
+      detail?.includes("Summarization failed to reduce the number of messages")
+    ) {
+      conversationRuntime.contextTracker.pendingReflectionTrigger = true;
+      return "Compaction run, but the number of messages is the same";
+    }
+
+    throw new Error(formatErrorDetails(error, agentId));
+  }
 }
 
 /**

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -326,7 +326,6 @@ async function handleCompactCommand(
       apiError?.status === 400 &&
       detail?.includes("Summarization failed to reduce the number of messages")
     ) {
-      conversationRuntime.contextTracker.pendingReflectionTrigger = true;
       return "Compaction run, but the number of messages is the same";
     }
 


### PR DESCRIPTION
## Summary
- Advertise `compact` as a supported Desktop remote command.
- Handle `/compact` over `execute_command`, preserving mode parsing, PreCompact hooks, default conversation `agent_id` behavior, success/failure output, and post-compaction reflection trigger.
- Add listener protocol coverage for remote compact execution.

## Test plan
- [x] `bun test src/tests/websocket/listen-client-protocol.test.ts`
- [x] `bun run lint`

👾 Generated with [Letta Code](https://letta.com)