### PR TITLE
fix(cli): drop "path:" label from shell semantic List/Read/Search summaries

### DIFF
--- a/src/cli/helpers/shellSemanticDisplay.ts
+++ b/src/cli/helpers/shellSemanticDisplay.ts
@@ -546,14 +546,23 @@ function buildReadSummary(
       ? `${options.lastLines} lines`
       : undefined;
 
+  // Show just the file path (no "path:" label), matching Glob/Search/List style
+  // formatDisplayPath returns "" when path is cwd — skip in that case
+  const displayPath = formatDisplayPath(path);
+  const parts: string[] = [];
+  if (displayPath) {
+    parts.push(displayPath);
+  }
+  if (lineSummary) {
+    parts.push(`lines: ${lineSummary}`);
+  }
+  if (trailingSummary) {
+    parts.push(`last: ${trailingSummary}`);
+  }
   return {
     kind: "read",
     label: "Read",
-    summary: formatSummaryFields([
-      ["path", formatDisplayPath(path)],
-      ["lines", lineSummary],
-      ["last", trailingSummary],
-    ]),
+    summary: parts.join(", ") || ".",
     rawCommand: "",
   };
 }
@@ -562,17 +571,23 @@ function buildListSummary(
   path: string | undefined,
   options: { filter?: string; limit?: number } = {},
 ): ShellSemanticDisplay {
+  // Show just the directory path (no "path:" label), matching Glob/Search style
+  // formatDisplayPath returns "" when path is cwd — skip in that case
+  const displayPath = path ? formatDisplayPath(path) : null;
+  const parts: string[] = [];
+  if (displayPath) {
+    parts.push(displayPath);
+  }
+  if (options.filter) {
+    parts.push(`filter: ${quoteSummaryValue(options.filter)}`);
+  }
+  if (options.limit) {
+    parts.push(`limit: ${options.limit}`);
+  }
   return {
     kind: "list",
     label: "List",
-    summary: formatSummaryFields([
-      ["path", path ? formatDisplayPath(path) : "."],
-      [
-        "filter",
-        options.filter ? quoteSummaryValue(options.filter) : undefined,
-      ],
-      ["limit", options.limit],
-    ]),
+    summary: parts.join(", ") || ".",
     rawCommand: "",
   };
 }
@@ -582,14 +597,24 @@ function buildSearchSummary(
   path: string | undefined,
   options: { limit?: number } = {},
 ): ShellSemanticDisplay {
+  // Show "query" in path (no labels), matching Glob/Search tool display style
+  // formatDisplayPath returns "" when path is cwd — skip "in" in that case
+  const displayPath = path ? formatDisplayPath(path) : null;
+  const parts: string[] = [];
+  if (query && displayPath) {
+    parts.push(`${quoteSummaryValue(query)} in ${displayPath}`);
+  } else if (query) {
+    parts.push(quoteSummaryValue(query));
+  } else if (displayPath) {
+    parts.push(displayPath);
+  }
+  if (options.limit) {
+    parts.push(`limit: ${options.limit}`);
+  }
   return {
     kind: "search",
     label: "Search",
-    summary: formatSummaryFields([
-      ["query", query ? quoteSummaryValue(query) : "search"],
-      ["path", path ? formatDisplayPath(path) : undefined],
-      ["limit", options.limit],
-    ]),
+    summary: parts.join(", ") || "search",
     rawCommand: "",
   };
 }

--- a/src/tests/cli/formatArgsDisplay.test.ts
+++ b/src/tests/cli/formatArgsDisplay.test.ts
@@ -44,7 +44,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
 
     const formatted = formatArgsDisplay(args, "Bash");
     expect(formatted.display).toBe(
-      "path: src/cli/helpers/formatArgsDisplay.ts, lines: 1-80",
+      "src/cli/helpers/formatArgsDisplay.ts, lines: 1-80",
     );
     expect(formatted.shellSemantic).toMatchObject({
       kind: "read",

--- a/src/tests/cli/shellSemanticDisplay.test.ts
+++ b/src/tests/cli/shellSemanticDisplay.test.ts
@@ -6,7 +6,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay('rg -n "TODO" src')).toMatchObject({
       kind: "search",
       label: "Search",
-      summary: 'query: "TODO", path: src',
+      summary: '"TODO" in src',
     });
   });
 
@@ -16,7 +16,7 @@ describe("summarizeShellDisplay", () => {
     ).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: src/channels, limit: 50",
+      summary: "src/channels, limit: 50",
     });
   });
 
@@ -26,7 +26,7 @@ describe("summarizeShellDisplay", () => {
     ).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: webview/src",
+      summary: "webview/src",
     });
   });
 
@@ -36,7 +36,7 @@ describe("summarizeShellDisplay", () => {
     ).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: src/channels, limit: 20",
+      summary: "src/channels, limit: 20",
     });
   });
 
@@ -44,7 +44,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("find . -name '*.rs'")).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: .",
+      summary: ".",
     });
   });
 
@@ -52,7 +52,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("exa -I target .")).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: .",
+      summary: ".",
     });
   });
 
@@ -60,7 +60,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("sed -n '1,120p' src/foo.ts")).toMatchObject({
       kind: "read",
       label: "Read",
-      summary: "path: src/foo.ts, lines: 1-120",
+      summary: "src/foo.ts, lines: 1-120",
     });
   });
 
@@ -68,7 +68,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("head -n 80 src/foo.ts")).toMatchObject({
       kind: "read",
       label: "Read",
-      summary: "path: src/foo.ts, lines: 1-80",
+      summary: "src/foo.ts, lines: 1-80",
     });
   });
 
@@ -76,7 +76,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("tail -n 40 src/foo.ts")).toMatchObject({
       kind: "read",
       label: "Read",
-      summary: "path: src/foo.ts, last: 40 lines",
+      summary: "src/foo.ts, last: 40 lines",
     });
   });
 
@@ -86,7 +86,7 @@ describe("summarizeShellDisplay", () => {
     ).toMatchObject({
       kind: "search",
       label: "Search",
-      summary: 'query: "queue", path: src/websocket',
+      summary: '"queue" in src/websocket',
       rawCommand: "git grep queue src/websocket",
     });
   });
@@ -95,7 +95,7 @@ describe("summarizeShellDisplay", () => {
     expect(summarizeShellDisplay("cd app && rg --files")).toMatchObject({
       kind: "list",
       label: "List",
-      summary: "path: app",
+      summary: "app",
     });
   });
 
@@ -132,7 +132,6 @@ describe("summarizeShellDisplay", () => {
       label: "List",
       rawCommand: command,
     });
-    expect(summary.summary).toContain("path: .");
     expect(summary.summary).toContain("filter:");
     expect(summary.summary).toContain("apps/code-desktop");
     expect(summary.summary).toContain("pnpm-workspace");
@@ -145,7 +144,7 @@ describe("summarizeShellDisplay", () => {
       kind: "read",
       label: "Read",
       rawCommand: command,
-      summary: "path: apps/desktop-ui/vite.config.ts, lines: 1-240",
+      summary: "apps/desktop-ui/vite.config.ts, lines: 1-240",
     });
   });
 
@@ -158,7 +157,7 @@ describe("summarizeShellDisplay", () => {
       label: "List",
       rawCommand: command,
     });
-    expect(summary.summary).toContain("path: apps/code-desktop/ui");
+    expect(summary.summary).toContain("apps/code-desktop/ui");
     expect(summary.summary).toContain("filter:");
     expect(summary.summary).toContain("vite");
     expect(summary.summary).toContain("project");
@@ -173,7 +172,7 @@ describe("summarizeShellDisplay", () => {
       label: "List",
       rawCommand: command,
     });
-    expect(summary.summary).toContain("path: apps/code-desktop");
+    expect(summary.summary).toContain("apps/code-desktop");
     expect(summary.summary).toContain("filter:");
     expect(summary.summary).toContain("electron-builder");
   });
@@ -187,7 +186,7 @@ describe("summarizeShellDisplay", () => {
       label: "List",
       rawCommand: command,
     });
-    expect(summary.summary).toContain("path: apps/code-desktop/dist/assets");
+    expect(summary.summary).toContain("apps/code-desktop/dist/assets");
   });
 
   test("keeps the exact node heredoc capture on the run path", () => {


### PR DESCRIPTION
## Summary
- The "List path: src/cli/app" display was actually a Bash tool (`ls`) going through the shell semantic display, not the LS tool
- Shell semantic summaries for List, Read, and Search all used `formatSummaryFields` which produces `key: value` format — now they show just the path/query directly, matching the Glob/Search tool display style
- Also handles the cwd trap: `formatDisplayPath` returns `""` when path is cwd, so List/Search skip the path entirely in that case

## Before
```
• List path: src/cli/app
• Read path: src/foo.ts, lines: 1-80
• Search query: "TODO", path: src
```

## After
```
• List src/cli/app
• Read src/foo.ts, lines: 1-80
• Search "TODO" in src
```

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>