### PR TITLE
fix(local): set explicit AI SDK timeouts

### DIFF
--- a/src/backend/dev/AISDKStreamAdapter.ts
+++ b/src/backend/dev/AISDKStreamAdapter.ts
@@ -37,6 +37,7 @@ import {
 } from "./ProviderTurnExecutor";
 
 type AISDKProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
+type AISDKTimeout = Parameters<typeof streamText>[0]["timeout"];
 type InputModality = "text" | "image" | "audio" | "video" | "pdf";
 const LOCAL_PROVIDER_MAX_RETRIES = 3;
 const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
@@ -56,6 +57,7 @@ export type AISDKStreamTextFunction = (options: {
   providerOptions?: AISDKProviderOptions;
   maxRetries: number;
   abortSignal?: AbortSignal;
+  timeout?: AISDKTimeout;
   onError?: (event: { error: unknown }) => void;
 }) => {
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>;
@@ -71,6 +73,7 @@ export type AISDKStreamTextFunction = (options: {
 export interface AISDKStreamAdapterOptions {
   createModel?: () => LanguageModel;
   abortSignal?: AbortSignal;
+  timeout?: AISDKTimeout;
   streamText?: AISDKStreamTextFunction;
   localProviderAuthStorageDir?: string;
   onContextWindowOverflow?: (
@@ -656,6 +659,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
   private readonly createModel?: () => LanguageModel;
   private readonly runStreamText: AISDKStreamTextFunction;
   private readonly abortSignal?: AbortSignal;
+  private readonly timeout?: AISDKTimeout;
   private readonly localProviderAuthStorageDir?: string;
   private readonly onContextWindowOverflow?: AISDKStreamAdapterOptions["onContextWindowOverflow"];
   private readonly onContextUsage?: AISDKStreamAdapterOptions["onContextUsage"];
@@ -664,6 +668,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
     this.createModel = options.createModel;
     this.runStreamText = options.streamText ?? defaultStreamText;
     this.abortSignal = options.abortSignal;
+    this.timeout = options.timeout;
     this.localProviderAuthStorageDir = options.localProviderAuthStorageDir;
     this.onContextWindowOverflow = options.onContextWindowOverflow;
     this.onContextUsage = options.onContextUsage;
@@ -727,6 +732,7 @@ export class AISDKStreamAdapter implements ProviderStreamAdapter {
       ),
       maxRetries: 0,
       abortSignal: this.abortSignal,
+      timeout: this.timeout,
       // We classify and handle stream errors in this adapter; suppress AI SDK's
       // default console.error logging for each error chunk.
       onError: () => {},

--- a/src/backend/local/LocalBackend.ts
+++ b/src/backend/local/LocalBackend.ts
@@ -60,6 +60,9 @@ import {
 
 export type LocalBackendExecutionMode = "ai-sdk" | "deterministic";
 
+const LOCAL_TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const LOCAL_COMPACTION_TIMEOUT_MS = 20 * 60 * 1000;
+
 export interface LocalBackendOptions {
   storageDir: string;
   defaultAgentId?: string;
@@ -68,6 +71,8 @@ export interface LocalBackendOptions {
   createModel?: () => LanguageModel;
   streamText?: AISDKStreamTextFunction;
   generateText?: LocalGenerateTextFunction;
+  turnTimeoutMs?: number;
+  compactionTimeoutMs?: number;
   memoryDir?: string;
   memfsEnabled?: boolean;
 }
@@ -194,6 +199,12 @@ function localCompactionSettingsForStorage(
   return { ...settings };
 }
 
+function localTimeoutMs(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
 function contextTokensFromUsage(usage: LanguageModelUsage): number | undefined {
   const inputTokens =
     typeof usage.inputTokens === "number" ? usage.inputTokens : undefined;
@@ -236,6 +247,7 @@ function createLocalExecutor(
     new AISDKStreamAdapter({
       createModel: options.createModel,
       streamText: options.streamText,
+      timeout: localTimeoutMs(options.turnTimeoutMs, LOCAL_TURN_TIMEOUT_MS),
       localProviderAuthStorageDir: options.storageDir,
       onContextWindowOverflow,
       onContextUsage,
@@ -259,6 +271,7 @@ export class LocalBackend extends HeadlessBackend {
   private readonly storageDir: string;
   private readonly createModel?: () => LanguageModel;
   private readonly generateText?: LocalGenerateTextFunction;
+  private readonly compactionTimeoutMs: number;
   private readonly memfsEnabledOverride?: boolean;
 
   constructor(options: LocalBackendOptions) {
@@ -299,6 +312,10 @@ export class LocalBackend extends HeadlessBackend {
     this.memoryDir = options.memoryDir;
     this.createModel = options.createModel;
     this.generateText = options.generateText;
+    this.compactionTimeoutMs = localTimeoutMs(
+      options.compactionTimeoutMs,
+      LOCAL_COMPACTION_TIMEOUT_MS,
+    );
     this.memfsEnabledOverride = options.memfsEnabled;
   }
 
@@ -676,6 +693,7 @@ export class LocalBackend extends HeadlessBackend {
       generateText: this.generateText,
       prompt: settings.prompt,
       clipChars: settings.clipChars,
+      timeout: this.compactionTimeoutMs,
       localProviderAuthStorageDir: this.storageDir,
     });
     const stats: LocalCompactionStats = {
@@ -729,6 +747,7 @@ export class LocalBackend extends HeadlessBackend {
       generateText: this.generateText,
       prompt: settings.prompt,
       clipChars: settings.clipChars,
+      timeout: this.compactionTimeoutMs,
       localProviderAuthStorageDir: this.storageDir,
     });
     const contextTokensAfter =

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -106,6 +106,7 @@ export type LocalGenerateTextFunction = (options: {
   providerOptions?: Parameters<typeof generateText>[0]["providerOptions"];
   maxRetries: number;
   abortSignal?: AbortSignal;
+  timeout?: Parameters<typeof generateText>[0]["timeout"];
 }) => ReturnType<typeof generateText>;
 
 export interface LocalAllCompactionInput {
@@ -116,6 +117,7 @@ export interface LocalAllCompactionInput {
   prompt?: string | null;
   clipChars?: number | null;
   abortSignal?: AbortSignal;
+  timeout?: Parameters<typeof generateText>[0]["timeout"];
   localProviderAuthStorageDir?: string;
 }
 
@@ -402,6 +404,7 @@ async function runGenerateText(
       providerOptions,
       maxRetries: 0,
       abortSignal: input.abortSignal,
+      timeout: input.timeout,
     });
     return { text: result.text };
   } catch (error) {
@@ -423,6 +426,7 @@ async function runGenerateText(
       providerOptions,
       maxRetries: 0,
       abortSignal: input.abortSignal,
+      timeout: input.timeout,
       // Compaction handles stream error parts directly below.
       onError: () => {},
     });

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -870,20 +870,77 @@ describe("LocalBackend", () => {
     }
   });
 
+  test("passes an explicit timeout to local AI SDK turns", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-turn-timeout-"),
+    );
+    try {
+      let capturedTimeout: unknown;
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        turnTimeoutMs: 60_000,
+        streamText: (options) => {
+          capturedTimeout = options.timeout;
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: "timeout-text",
+                text: "timeout response",
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: "assistant-timeout",
+              role: "assistant",
+              parts: [{ type: "text", text: "timeout response" }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Turn Timeout Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("hello timeout", agent.id),
+        ),
+      );
+
+      expect(capturedTimeout).toBe(60_000);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("compacts local conversation history with the backend all-compaction prompt", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-compact-"));
     try {
       let capturedSystem: string | undefined;
       let capturedPrompt: string | undefined;
+      let capturedTimeout: unknown;
       const backend = new LocalBackend({
         storageDir,
         executionMode: "deterministic",
         generateText: (async (options: {
           system?: string;
           prompt?: string;
+          timeout?: unknown;
         }) => {
           capturedSystem = options.system;
           capturedPrompt = options.prompt;
+          capturedTimeout = options.timeout;
           return { text: "manual local summary" } as never;
         }) as never,
       });
@@ -925,6 +982,7 @@ describe("LocalBackend", () => {
         summary: "manual local summary",
       });
       expect(capturedSystem).toBe(LOCAL_ALL_COMPACTION_PROMPT);
+      expect(capturedTimeout).toBe(20 * 60 * 1000);
       expect(capturedPrompt).toContain("first request");
       expect(capturedPrompt).toContain("second request");
 
@@ -1404,6 +1462,94 @@ describe("LocalBackend", () => {
       expect(
         page.getPaginatedItems().map((message) => message.message_type),
       ).toEqual(["summary_message", "assistant_message"]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("passes a dedicated timeout to local compaction after context overflow", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-auto-compact-timeout-"),
+    );
+    try {
+      let streamCalls = 0;
+      let summaryTimeout: unknown;
+      const overflow = new APICallError({
+        message: "context_length_exceeded: maximum context length exceeded",
+        url: "https://example.invalid/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseBody: "maximum context length exceeded",
+        isRetryable: false,
+      });
+      const backend = new LocalBackend({
+        storageDir,
+        createModel: () => ({}) as LanguageModel,
+        compactionTimeoutMs: 60_000,
+        generateText: (async (options: { timeout?: unknown }) => {
+          summaryTimeout = options.timeout;
+          return { text: "overflow local summary" } as never;
+        }) as never,
+        streamText: () => {
+          streamCalls += 1;
+          if (streamCalls === 2) {
+            return {
+              fullStream: (async function* () {
+                yield {
+                  type: "error",
+                  error: overflow,
+                } as TextStreamPart<ToolSet>;
+              })(),
+            };
+          }
+
+          const text =
+            streamCalls === 1 ? "first response" : "after compaction";
+          return {
+            fullStream: (async function* () {
+              yield {
+                type: "text-delta",
+                id: `text-${streamCalls}`,
+                text,
+              } as TextStreamPart<ToolSet>;
+              yield {
+                type: "finish",
+                finishReason: "stop",
+              } as TextStreamPart<ToolSet>;
+            })(),
+            toUIMessageStream: uiMessageStreamWithFinish([], {
+              id: `assistant-${streamCalls}`,
+              role: "assistant",
+              parts: [{ type: "text", text }],
+            } as LocalMessage),
+          };
+        },
+      });
+
+      const agent = await backend.createAgent({
+        name: "Auto Compact Timeout Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("first request", agent.id),
+        ),
+      );
+
+      await drainStream(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("overflowing request", agent.id),
+        ),
+      );
+
+      expect(streamCalls).toBe(3);
+      expect(summaryTimeout).toBe(60_000);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Set explicit AI SDK timeouts for local backend turns so provider calls do not inherit shorter transport defaults.
- Give local compaction a longer timeout budget and pass it through both generateText and streamText fallback paths.
- Add focused LocalBackend tests covering normal turn and compaction timeout wiring.

## Test plan
- [x] bun test src/tests/backend/local-backend.test.ts src/tests/backend/local-compaction-parity.test.ts
- [x] bun run lint
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)