### PR TITLE
test(agent): gate remote skill import smoke test

### DIFF
--- a/src/tests/agent/import-skills.test.ts
+++ b/src/tests/agent/import-skills.test.ts
@@ -190,7 +190,8 @@ describe("skills extraction from .af files", () => {
     expect(extracted).toEqual([]);
   });
 
-  test.skipIf(process.env.CI === "true")(
+  // This reaches GitHub, so keep it out of the normal local/unit suite.
+  test.skipIf(process.env.LETTA_RUN_NETWORK_TESTS !== "true")(
     "fetches skill from remote source_url (integration)",
     async () => {
       const afContent = {
@@ -201,8 +202,8 @@ describe("skills extraction from .af files", () => {
         mcp_servers: [],
         skills: [
           {
-            name: "imessage",
-            source_url: "letta-ai/skills/main/tools/imessage",
+            name: "imsg",
+            source_url: "letta-ai/skills/main/tools/imsg",
           },
         ],
       };
@@ -211,8 +212,8 @@ describe("skills extraction from .af files", () => {
 
       const extracted = await extractSkillsFromAf(afPath, skillsDir);
 
-      expect(extracted).toEqual(["imessage"]);
-      expect(existsSync(join(skillsDir, "imessage", "SKILL.md"))).toBe(true);
+      expect(extracted).toEqual(["imsg"]);
+      expect(existsSync(join(skillsDir, "imsg", "SKILL.md"))).toBe(true);
     },
   );
 });


### PR DESCRIPTION
## Summary
- Require explicit `LETTA_RUN_NETWORK_TESTS=true` opt-in for the GitHub-backed remote skill import test.
- Update the opt-in test fixture from the removed `imessage` path to the existing `imsg` skill path.

## Test plan
- [x] `bun test src/tests/agent/import-skills.test.ts --timeout 15000`
- [x] `LETTA_RUN_NETWORK_TESTS=true bun test src/tests/agent/import-skills.test.ts --timeout 30000`

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)