### PR TITLE
feat(slack): support proactive DM targets

### DIFF
--- a/src/channels/slack/targetResolution.ts
+++ b/src/channels/slack/targetResolution.ts
@@ -8,6 +8,7 @@ import type { SlackChannelAccount } from "../types";
 import { createSlackWebApiClient } from "./webApiClient";
 
 const SLACK_CHANNEL_ID_PATTERN = /^[CG][A-Z0-9]+$/;
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]+$/;
 const SLACK_CHANNEL_TYPES = "public_channel,private_channel";
 const SLACK_LIST_LIMIT = 200;
 
@@ -35,7 +36,22 @@ type SlackReadClient = {
         next_cursor?: string;
       };
     }>;
+    open: (args: { users: string }) => Promise<{
+      ok?: boolean;
+      error?: string;
+      channel?: {
+        id?: string;
+      };
+    }>;
   };
+};
+
+type SlackListClient = {
+  conversations: Pick<SlackReadClient["conversations"], "list">;
+};
+
+type SlackOpenClient = {
+  conversations: Pick<SlackReadClient["conversations"], "open">;
 };
 
 type NormalizedSlackTarget =
@@ -48,6 +64,11 @@ type NormalizedSlackTarget =
       kind: "name";
       raw: string;
       name: string;
+    }
+  | {
+      kind: "user";
+      raw: string;
+      userId: string;
     };
 
 function normalizeSlackChannelName(value: string): string {
@@ -84,9 +105,14 @@ function normalizeSlackTarget(
       return normalizeSlackTarget(value);
     }
     if (prefix === "user") {
-      return 'Error: Slack proactive MessageChannel currently supports channel targets only. Use a channel target like "#general" or "channel:C123".';
+      return normalizeSlackUserTarget(value, trimmed);
     }
     return `Error: Unsupported Slack MessageChannel target prefix "${prefix}".`;
+  }
+
+  const normalizedUser = normalizeSlackUserTarget(trimmed, trimmed);
+  if (typeof normalizedUser !== "string") {
+    return normalizedUser;
   }
 
   if (SLACK_CHANNEL_ID_PATTERN.test(trimmed)) {
@@ -109,6 +135,27 @@ function normalizeSlackTarget(
   };
 }
 
+function normalizeSlackUserTarget(
+  rawUserTarget: string,
+  rawTarget: string,
+): Extract<NormalizedSlackTarget, { kind: "user" }> | string {
+  const userId = rawUserTarget
+    .trim()
+    .replace(/^<@/, "")
+    .replace(/>$/, "")
+    .trim();
+
+  if (!SLACK_USER_ID_PATTERN.test(userId)) {
+    return 'Error: Slack user targets must be Slack user IDs like "user:U12345678".';
+  }
+
+  return {
+    kind: "user",
+    raw: rawTarget,
+    userId,
+  };
+}
+
 function findCachedSlackTarget(params: {
   accountId: string;
   normalizedTarget: NormalizedSlackTarget;
@@ -118,6 +165,9 @@ function findCachedSlackTarget(params: {
 
   const matches = targets.filter((target) => {
     const normalizedTarget = params.normalizedTarget;
+    if (normalizedTarget.kind === "user") {
+      return false;
+    }
     if (normalizedTarget.kind === "id") {
       return (
         target.targetId === normalizedTarget.chatId ||
@@ -144,7 +194,7 @@ function findCachedSlackTarget(params: {
 
 export async function listSlackChannels(
   account: SlackChannelAccount,
-  existingClient?: SlackReadClient,
+  existingClient?: SlackListClient,
 ): Promise<SlackConversationRecord[]> {
   const client =
     existingClient ??
@@ -188,11 +238,47 @@ export async function listSlackChannels(
   return channels;
 }
 
+export async function openSlackDirectMessage(
+  account: SlackChannelAccount,
+  userId: string,
+  existingClient?: SlackOpenClient,
+): Promise<SlackConversationRecord> {
+  const client =
+    existingClient ??
+    (await createSlackWebApiClient<SlackReadClient>(account.botToken, {
+      retryConfig: {
+        retries: 0,
+      },
+    }));
+
+  const response = await client.conversations.open({ users: userId });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to open Slack DM with ${userId}: ${response.error ?? "unknown error"}`,
+    );
+  }
+
+  const channelId = response.channel?.id;
+  if (!channelId) {
+    throw new Error(
+      `Failed to open Slack DM with ${userId}: missing channel id`,
+    );
+  }
+
+  return {
+    id: channelId,
+    name: userId,
+  };
+}
+
 function findSlackChannelByTarget(params: {
   channels: SlackConversationRecord[];
   normalizedTarget: NormalizedSlackTarget;
 }): SlackConversationRecord | string | null {
   const normalizedTarget = params.normalizedTarget;
+  if (normalizedTarget.kind === "user") {
+    return null;
+  }
   if (normalizedTarget.kind === "id") {
     return (
       params.channels.find(
@@ -236,10 +322,26 @@ export async function resolveSlackMessageTarget(params: {
   lookupChannels?: (
     account: SlackChannelAccount,
   ) => Promise<SlackConversationRecord[]>;
+  openDirectMessage?: (
+    account: SlackChannelAccount,
+    userId: string,
+  ) => Promise<SlackConversationRecord>;
 }): Promise<ChannelResolvedMessageTarget> {
   const normalizedTarget = normalizeSlackTarget(params.target);
   if (typeof normalizedTarget === "string") {
     throw new Error(normalizedTarget);
+  }
+
+  if (normalizedTarget.kind === "user") {
+    const dm = await (params.openDirectMessage ?? openSlackDirectMessage)(
+      params.account,
+      normalizedTarget.userId,
+    );
+    return {
+      chatId: dm.id,
+      chatType: "direct",
+      label: `@${normalizedTarget.userId}`,
+    };
   }
 
   const cachedTarget = findCachedSlackTarget({

--- a/src/tests/channels/slack-target-resolution.test.ts
+++ b/src/tests/channels/slack-target-resolution.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   listSlackChannels,
+  openSlackDirectMessage,
   resolveSlackMessageTarget,
 } from "../../channels/slack/targetResolution";
 import {
@@ -141,14 +142,83 @@ describe("Slack MessageChannel target resolution", () => {
     });
   });
 
-  test("rejects unsupported Slack user targets in proactive mode", async () => {
+  test("opens Slack DMs for explicit user targets", async () => {
+    const openDirectMessage = mock(async () => ({
+      id: "D12345678",
+      name: "U12345678",
+    }));
+
+    const resolved = await resolveSlackMessageTarget({
+      account: makeSlackAccount("docsbot"),
+      target: "user:U12345678",
+      openDirectMessage,
+    });
+
+    expect(resolved).toEqual({
+      chatId: "D12345678",
+      chatType: "direct",
+      label: "@U12345678",
+    });
+    expect(openDirectMessage).toHaveBeenCalledWith(
+      makeSlackAccount("docsbot"),
+      "U12345678",
+    );
+  });
+
+  test("treats raw Slack user ids as direct-message targets", async () => {
+    const lookupChannels = mock(async () => {
+      throw new Error("user targets should not list channels");
+    });
+    const openDirectMessage = mock(async () => ({
+      id: "D87654321",
+      name: "U87654321",
+    }));
+
+    const resolved = await resolveSlackMessageTarget({
+      account: makeSlackAccount("docsbot"),
+      target: "U87654321",
+      lookupChannels,
+      openDirectMessage,
+    });
+
+    expect(resolved).toEqual({
+      chatId: "D87654321",
+      chatType: "direct",
+      label: "@U87654321",
+    });
+    expect(lookupChannels).not.toHaveBeenCalled();
+    expect(openDirectMessage).toHaveBeenCalledWith(
+      makeSlackAccount("docsbot"),
+      "U87654321",
+    );
+  });
+
+  test("opens Slack DMs through conversations.open", async () => {
+    const open = mock(async () => ({
+      ok: true,
+      channel: { id: "D12345678" },
+    }));
+
+    const resolved = await openSlackDirectMessage(
+      makeSlackAccount("docsbot"),
+      "U12345678",
+      {
+        conversations: { open },
+      },
+    );
+
+    expect(resolved).toEqual({ id: "D12345678", name: "U12345678" });
+    expect(open).toHaveBeenCalledWith({ users: "U12345678" });
+  });
+
+  test("rejects malformed Slack user targets", async () => {
     await expect(
       resolveSlackMessageTarget({
         account: makeSlackAccount("docsbot"),
-        target: "user:U12345678",
+        target: "user:cameron",
       }),
     ).rejects.toThrow(
-      'Error: Slack proactive MessageChannel currently supports channel targets only. Use a channel target like "#general" or "channel:C123".',
+      'Error: Slack user targets must be Slack user IDs like "user:U12345678".',
     );
   });
 });

--- a/src/tools/schemas/MessageChannel.json
+++ b/src/tools/schemas/MessageChannel.json
@@ -15,7 +15,7 @@
     },
     "target": {
       "type": "string",
-      "description": "Explicit outbound target for proactive sends on supported channels (for example, a Slack channel like '#general' or 'channel:C12345678')."
+      "description": "Explicit outbound target for proactive sends on supported channels (for example, a Slack channel like '#general' or 'channel:C12345678', or a Slack user DM like 'user:U12345678')."
     },
     "accountId": {
       "type": "string",


### PR DESCRIPTION
Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Add Slack MessageChannel proactive targets for Slack user IDs, including `user:U12345678` and raw `U12345678` forms.
- Open a DM with `conversations.open` and send through the returned DM channel.
- Update the MessageChannel target schema description and add focused resolver tests.

## Test plan
- [x] `bun test src/tests/channels/slack-target-resolution.test.ts src/tests/channels/message-channel.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)