### PR TITLE
test: isolate ambient Letta env in tests

### DIFF
--- a/src/integration-tests/headless-input-format.test.ts
+++ b/src/integration-tests/headless-input-format.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
-import { createIsolatedCliTestEnv } from "../tests/testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "../tests/testProcessEnv";
 import type {
   ControlResponse,
   ErrorMessage,
@@ -57,7 +57,7 @@ async function runBidirectionalOnce(
       ],
       {
         cwd: process.cwd(),
-        env: createIsolatedCliTestEnv(extraEnv),
+        env: createAuthenticatedCliTestEnv(extraEnv),
       },
     );
 

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { createIsolatedCliTestEnv } from "../tests/testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "../tests/testProcessEnv";
 import type {
   ResultMessage,
   StreamEvent,
@@ -44,7 +44,7 @@ async function runHeadlessCommandOnce(
       ],
       {
         cwd: process.cwd(),
-        env: createIsolatedCliTestEnv(),
+        env: createAuthenticatedCliTestEnv(),
       },
     );
 

--- a/src/integration-tests/lazy-approval-recovery.test.ts
+++ b/src/integration-tests/lazy-approval-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { createIsolatedCliTestEnv } from "../tests/testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "../tests/testProcessEnv";
 import {
   formatCapturedOutput,
   summarizeRecentMessages,
@@ -72,7 +72,7 @@ async function runLazyRecoveryTest(timeoutMs = 300000): Promise<{
       ],
       {
         cwd: process.cwd(),
-        env: createIsolatedCliTestEnv(),
+        env: createAuthenticatedCliTestEnv(),
       },
     );
 

--- a/src/integration-tests/prestream-approval-recovery.test.ts
+++ b/src/integration-tests/prestream-approval-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { createIsolatedCliTestEnv } from "../tests/testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "../tests/testProcessEnv";
 import {
   formatCapturedOutput,
   summarizeRecentMessages,
@@ -61,7 +61,7 @@ async function startPendingApprovalSession(
       ],
       {
         cwd: process.cwd(),
-        env: createIsolatedCliTestEnv(),
+        env: createAuthenticatedCliTestEnv(),
       },
     );
 
@@ -227,7 +227,7 @@ async function runOneShotAgainstConversation(
       ],
       {
         cwd: process.cwd(),
-        env: createIsolatedCliTestEnv(),
+        env: createAuthenticatedCliTestEnv(),
       },
     );
 

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { createIsolatedCliTestEnv } from "../tests/testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "../tests/testProcessEnv";
 import {
   formatAttemptDiagnostics,
   formatCapturedOutput,
@@ -31,7 +31,7 @@ async function runCli(
       (resolve, reject) => {
         const proc = spawn("bun", ["run", "dev", "--no-memfs", ...args], {
           cwd: projectRoot,
-          env: createIsolatedCliTestEnv(),
+          env: createAuthenticatedCliTestEnv(),
         });
 
         let stdout = "";

--- a/src/tests/agent/clientSkills.test.ts
+++ b/src/tests/agent/clientSkills.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
@@ -11,6 +11,7 @@ import type {
   SkillDiscoveryResult,
   SkillSource,
 } from "../../agent/skills";
+import { isolateAmbientLettaTestEnv } from "../testProcessEnv";
 
 /** Normalize path separators so assertions work on Windows too. */
 const normalize = (p: string): string => p.replace(/\\/g, "/");
@@ -22,6 +23,19 @@ const baseSkill: Skill = {
   path: "/tmp/base/SKILL.md",
   source: "project",
 };
+
+let restoreAmbientEnv: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreAmbientEnv = isolateAmbientLettaTestEnv();
+  invalidateClientSkillsPayloadCache();
+});
+
+afterEach(() => {
+  invalidateClientSkillsPayloadCache();
+  restoreAmbientEnv?.();
+  restoreAmbientEnv = undefined;
+});
 
 describe("buildClientSkillsPayload", () => {
   test("returns deterministically sorted client skills and path map", async () => {

--- a/src/tests/agent/memoryFilesystem.integration.test.ts
+++ b/src/tests/agent/memoryFilesystem.integration.test.ts
@@ -1,8 +1,9 @@
 /**
  * Integration tests for memory filesystem block tagging.
- * These tests hit the real Letta API and require LETTA_API_KEY to be set.
+ * These tests hit the real Letta API and require
+ * LETTA_RUN_API_INTEGRATION_TESTS=true plus LETTA_API_KEY.
  *
- * Run with: bun test src/tests/agent/memoryFilesystem.integration.test.ts
+ * Run with: LETTA_RUN_API_INTEGRATION_TESTS=true bun test src/tests/agent/memoryFilesystem.integration.test.ts
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -12,8 +13,11 @@ import Letta from "@letta-ai/letta-client";
 const LETTA_API_KEY = process.env.LETTA_API_KEY;
 const LETTA_BASE_URL = process.env.LETTA_BASE_URL || "https://api.letta.com";
 const API_KEY = LETTA_API_KEY ?? "";
+const RUN_API_INTEGRATION_TESTS =
+  process.env.LETTA_RUN_API_INTEGRATION_TESTS === "true";
 
-const describeIntegration = LETTA_API_KEY ? describe : describe.skip;
+const describeIntegration =
+  RUN_API_INTEGRATION_TESTS && LETTA_API_KEY ? describe : describe.skip;
 
 describeIntegration("block tagging integration", () => {
   let client: Letta;

--- a/src/tests/agent/memoryPrompt.integration.test.ts
+++ b/src/tests/agent/memoryPrompt.integration.test.ts
@@ -3,9 +3,11 @@ import { createAgent } from "../../agent/create";
 import { updateAgentSystemPromptMemfs } from "../../agent/modify";
 import { getClient } from "../../backend/api/client";
 
-const describeIntegration = process.env.LETTA_API_KEY
-  ? describe
-  : describe.skip;
+const describeIntegration =
+  process.env.LETTA_RUN_API_INTEGRATION_TESTS === "true" &&
+  process.env.LETTA_API_KEY
+    ? describe
+    : describe.skip;
 
 describeIntegration("memory prompt integration", () => {
   const createdAgentIds: string[] = [];

--- a/src/tests/agent/models-auto.integration.test.ts
+++ b/src/tests/agent/models-auto.integration.test.ts
@@ -2,6 +2,7 @@
  * Live API regression test for Cloud model availability.
  *
  * Runs only when:
+ * - LETTA_RUN_API_INTEGRATION_TESTS=true
  * - LETTA_API_KEY is set
  * - LETTA_BASE_URL points to Letta Cloud (api.letta.com)
  */
@@ -11,6 +12,8 @@ import Letta from "@letta-ai/letta-client";
 
 const LETTA_API_KEY = process.env.LETTA_API_KEY;
 const LETTA_BASE_URL = process.env.LETTA_BASE_URL || "https://api.letta.com";
+const RUN_API_INTEGRATION_TESTS =
+  process.env.LETTA_RUN_API_INTEGRATION_TESTS === "true";
 
 function isCloudBaseUrl(value: string): boolean {
   try {
@@ -21,7 +24,9 @@ function isCloudBaseUrl(value: string): boolean {
 }
 
 const describeIntegration =
-  LETTA_API_KEY && isCloudBaseUrl(LETTA_BASE_URL) ? describe : describe.skip;
+  RUN_API_INTEGRATION_TESTS && LETTA_API_KEY && isCloudBaseUrl(LETTA_BASE_URL)
+    ? describe
+    : describe.skip;
 
 async function listModelHandlesWithRetry(
   client: Letta,

--- a/src/tests/headless-scenario.ts
+++ b/src/tests/headless-scenario.ts
@@ -19,7 +19,10 @@ import {
   formatAttemptDiagnostics,
   formatCapturedOutput,
 } from "../integration-tests/processDiagnostics";
-import { createIsolatedCliTestEnv } from "./testProcessEnv";
+import {
+  createAuthenticatedCliTestEnv,
+  createIsolatedCliTestEnv,
+} from "./testProcessEnv";
 
 const execFile = promisify(execFileCb);
 
@@ -150,20 +153,14 @@ async function runCLI(args: Args): Promise<RunResult> {
       ? await mkdtemp(join(tmpdir(), "lc-local-headless-scenario-"))
       : undefined;
   const provider = args.provider ?? inferLocalProvider(args.model);
-  const env = createIsolatedCliTestEnv(
+  const env =
     args.backend === "local"
-      ? {
+      ? createIsolatedCliTestEnv({
           LETTA_LOCAL_BACKEND_EXPERIMENTAL: "true",
           LETTA_LOCAL_BACKEND_DIR: localStorageDir,
           LETTA_CODE_DEV_AI_SDK_PROVIDER: providerEnvValue(provider),
-        }
-      : {},
-  );
-  if (args.backend === "local") {
-    delete env.LETTA_API_KEY;
-    delete env.LETTA_BASE_URL;
-    delete env.LETTA_API_BASE;
-  }
+        })
+      : createAuthenticatedCliTestEnv();
 
   const cliArgs = [
     "run",

--- a/src/tests/headless-windows.ts
+++ b/src/tests/headless-windows.ts
@@ -13,7 +13,7 @@
  *   bun run src/tests/headless-windows.ts --model haiku
  */
 
-import { createIsolatedCliTestEnv } from "./testProcessEnv";
+import { createAuthenticatedCliTestEnv } from "./testProcessEnv";
 
 type Args = {
   model: string;
@@ -74,7 +74,7 @@ async function runCLI(
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
-    env: createIsolatedCliTestEnv(),
+    env: createAuthenticatedCliTestEnv(),
   });
   const out = await new Response(proc.stdout).text();
   const err = await new Response(proc.stderr).text();

--- a/src/tests/testProcessEnv.test.ts
+++ b/src/tests/testProcessEnv.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createAuthenticatedCliTestEnv,
+  createIsolatedCliTestEnv,
+  isolateAmbientLettaTestEnv,
+} from "./testProcessEnv";
+
+const restores: Array<() => void> = [];
+
+afterEach(() => {
+  while (restores.length > 0) {
+    restores.pop()?.();
+  }
+});
+
+describe("test process env helpers", () => {
+  test("createIsolatedCliTestEnv strips ambient agent, API, and memory env", () => {
+    restores.push(
+      isolateAmbientLettaTestEnv({
+        AGENT_ID: "agent-ambient",
+        CONVERSATION_ID: "conv-ambient",
+        LETTA_AGENT_ID: "agent-letta",
+        LETTA_API_KEY: "sk-ambient",
+        LETTA_CODE_AGENT_ROLE: "subagent",
+        LETTA_MEMORY_DIR: "/tmp/letta-memory",
+        MEMORY_DIR: "/tmp/memory",
+      }),
+    );
+
+    const env = createIsolatedCliTestEnv();
+
+    expect(env.AGENT_ID).toBeUndefined();
+    expect(env.CONVERSATION_ID).toBeUndefined();
+    expect(env.LETTA_AGENT_ID).toBeUndefined();
+    expect(env.LETTA_API_KEY).toBeUndefined();
+    expect(env.LETTA_CODE_AGENT_ROLE).toBeUndefined();
+    expect(env.LETTA_MEMORY_DIR).toBeUndefined();
+    expect(env.MEMORY_DIR).toBeUndefined();
+    expect(env.LETTA_DISABLE_SESSION_PERSIST).toBe("1");
+    expect(env.DISABLE_AUTOUPDATER).toBe("1");
+  });
+
+  test("extra env opts back into values deliberately", () => {
+    restores.push(
+      isolateAmbientLettaTestEnv({
+        LETTA_API_KEY: "sk-ambient",
+        MEMORY_DIR: "/tmp/ambient-memory",
+      }),
+    );
+
+    const env = createIsolatedCliTestEnv({
+      LETTA_API_KEY: "sk-explicit",
+      MEMORY_DIR: "/tmp/explicit-memory",
+    });
+
+    expect(env.LETTA_API_KEY).toBe("sk-explicit");
+    expect(env.MEMORY_DIR).toBe("/tmp/explicit-memory");
+  });
+
+  test("createAuthenticatedCliTestEnv preserves only explicit API connection env", () => {
+    restores.push(
+      isolateAmbientLettaTestEnv({
+        AGENT_ID: "agent-ambient",
+        LETTA_API_KEY: "sk-ambient",
+        LETTA_BASE_URL: "https://api.example.test",
+        MEMORY_DIR: "/tmp/ambient-memory",
+      }),
+    );
+
+    const env = createAuthenticatedCliTestEnv();
+
+    expect(env.LETTA_API_KEY).toBe("sk-ambient");
+    expect(env.LETTA_BASE_URL).toBe("https://api.example.test");
+    expect(env.AGENT_ID).toBeUndefined();
+    expect(env.MEMORY_DIR).toBeUndefined();
+  });
+});

--- a/src/tests/testProcessEnv.ts
+++ b/src/tests/testProcessEnv.ts
@@ -3,11 +3,90 @@ export function createIsolatedCliTestEnv(
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    LETTA_DISABLE_SESSION_PERSIST: "1",
-    DISABLE_AUTOUPDATER: "1",
-    ...extraEnv,
   };
 
-  delete env.LETTA_CODE_AGENT_ROLE;
+  stripAmbientLettaTestEnv(env);
+
+  Object.assign(env, {
+    LETTA_DISABLE_SESSION_PERSIST: "1",
+    DISABLE_AUTOUPDATER: "1",
+  });
+
+  applyEnvOverrides(env, extraEnv);
+
   return env;
+}
+
+export function createAuthenticatedCliTestEnv(
+  extraEnv: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return createIsolatedCliTestEnv({
+    LETTA_API_KEY: process.env.LETTA_API_KEY,
+    LETTA_BASE_URL: process.env.LETTA_BASE_URL,
+    LETTA_API_BASE: process.env.LETTA_API_BASE,
+    ...extraEnv,
+  });
+}
+
+export const AMBIENT_LETTA_TEST_ENV_KEYS = [
+  "AGENT_ID",
+  "CONVERSATION_ID",
+  "LETTA_ACCESS_TOKEN",
+  "LETTA_AGENT_ID",
+  "LETTA_API_BASE",
+  "LETTA_API_KEY",
+  "LETTA_BASE_URL",
+  "LETTA_CODE_AGENT_ROLE",
+  "LETTA_CONVERSATION_ID",
+  "LETTA_MEMORY_DIR",
+  "LETTA_PARENT_AGENT_ID",
+  "LETTA_REFRESH_TOKEN",
+  "MEMORY_DIR",
+] as const;
+
+export function stripAmbientLettaTestEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of AMBIENT_LETTA_TEST_ENV_KEYS) {
+    delete env[key];
+  }
+}
+
+function applyEnvOverrides(
+  env: NodeJS.ProcessEnv,
+  overrides: NodeJS.ProcessEnv,
+): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+}
+
+export function snapshotAmbientLettaTestEnv(): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    AMBIENT_LETTA_TEST_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+}
+
+export function restoreAmbientLettaTestEnv(snapshot: NodeJS.ProcessEnv): void {
+  for (const key of AMBIENT_LETTA_TEST_ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+export function isolateAmbientLettaTestEnv(
+  extraEnv: NodeJS.ProcessEnv = {},
+): () => void {
+  const snapshot = snapshotAmbientLettaTestEnv();
+
+  stripAmbientLettaTestEnv(process.env);
+  applyEnvOverrides(process.env, extraEnv);
+
+  return () => restoreAmbientLettaTestEnv(snapshot);
 }


### PR DESCRIPTION
## Summary
- Strip ambient Letta credentials, agent IDs, conversation IDs, and memory roots from `createIsolatedCliTestEnv()` by default.
- Add explicit authenticated test env helper for API-backed integration tests that still need credentials.
- Keep API integration tests under `src/tests` skipped unless `LETTA_RUN_API_INTEGRATION_TESTS=true` is set.
- Isolate `clientSkills` tests from ambient agent/memfs env and cover the env helper behavior directly.

## Test plan
- [x] `bun test src/tests/testProcessEnv.test.ts src/tests/startup-flow.test.ts src/tests/agent/clientSkills.test.ts src/tests/agent/memoryPrompt.integration.test.ts --timeout 15000`
- [x] `bun test src/tests/agent/models-auto.integration.test.ts src/tests/agent/memoryFilesystem.integration.test.ts src/tests/agent/memoryPrompt.integration.test.ts --timeout 15000`
- [x] `bun run typecheck`
- [x] `bun run lint`

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)