### PR TITLE
feat: add onboarding memory for Linus and Kawaii agents

### DIFF
--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -96,6 +96,19 @@ export interface PersonalityBlockDefinition {
   templatePromptAssetName: string;
 }
 
+export const ONBOARDING_PERSONALITIES = [
+  "linus",
+  "kawaii",
+] as const satisfies readonly PersonalityId[];
+
+export function supportsOnboardingBlock(
+  personalityId: PersonalityId,
+): personalityId is (typeof ONBOARDING_PERSONALITIES)[number] {
+  return (ONBOARDING_PERSONALITIES as readonly PersonalityId[]).includes(
+    personalityId,
+  );
+}
+
 const FRONTMATTER_REGEX = /^(---\n[\s\S]*?\n---)\n*/;
 const EDITABLE_FRONTMATTER_KEYS = [
   "description",
@@ -318,6 +331,7 @@ export function getPersonalityBlockValues(personalityId: PersonalityId): {
 export function getPersonalityBlockDefinitions(personalityId: PersonalityId): {
   persona: PersonalityBlockDefinition;
   human: PersonalityBlockDefinition;
+  onboarding?: PersonalityBlockDefinition;
 } {
   const personaTemplatePromptAssetName =
     personalityId === "memo"
@@ -349,6 +363,16 @@ export function getPersonalityBlockDefinitions(personalityId: PersonalityId): {
         .description,
       templatePromptAssetName: humanTemplatePromptAssetName,
     },
+    ...(supportsOnboardingBlock(personalityId)
+      ? {
+          onboarding: {
+            value: getPromptBody("onboarding.mdx"),
+            description:
+              getEditablePromptFrontmatter("onboarding.mdx").description,
+            templatePromptAssetName: "onboarding.mdx",
+          },
+        }
+      : {}),
   };
 }
 
@@ -364,41 +388,49 @@ export async function buildCreateAgentOptionsForPersonality(params: {
   const blockDefinitions = getPersonalityBlockDefinitions(personalityId);
   const defaultMemoryBlocks = await getDefaultMemoryBlocks();
 
+  const memoryBlocks = defaultMemoryBlocks.map((block) => {
+    if (block.label === "persona") {
+      return {
+        label: block.label,
+        value: blockDefinitions.persona.value,
+        description:
+          blockDefinitions.persona.description ??
+          block.description ??
+          undefined,
+      };
+    }
+
+    if (block.label === "human") {
+      return {
+        label: block.label,
+        value: blockDefinitions.human.value,
+        description:
+          blockDefinitions.human.description ?? block.description ?? undefined,
+      };
+    }
+
+    return {
+      label: block.label,
+      value: block.value,
+      description: block.description ?? undefined,
+    };
+  });
+
+  if (blockDefinitions.onboarding) {
+    memoryBlocks.push({
+      label: "onboarding",
+      value: blockDefinitions.onboarding.value,
+      description: blockDefinitions.onboarding.description,
+    });
+  }
+
   return {
     name: name ?? personality.label,
     description: description ?? personality.description,
     model: model ?? personality.defaultModel,
     tags,
     memoryPromptMode: "memfs",
-    memoryBlocks: defaultMemoryBlocks.map((block) => {
-      if (block.label === "persona") {
-        return {
-          label: block.label,
-          value: blockDefinitions.persona.value,
-          description:
-            blockDefinitions.persona.description ??
-            block.description ??
-            undefined,
-        };
-      }
-
-      if (block.label === "human") {
-        return {
-          label: block.label,
-          value: blockDefinitions.human.value,
-          description:
-            blockDefinitions.human.description ??
-            block.description ??
-            undefined,
-        };
-      }
-
-      return {
-        label: block.label,
-        value: block.value,
-        description: block.description ?? undefined,
-      };
-    }),
+    memoryBlocks,
   };
 }
 

--- a/src/agent/promptAssets.ts
+++ b/src/agent/promptAssets.ts
@@ -11,6 +11,7 @@ import lettaLocalMemfsPrompt from "./prompts/letta_local_memfs.md";
 import lettaNoMemfsPrompt from "./prompts/letta_no_memfs.md";
 import memoryCheckReminder from "./prompts/memory_check_reminder.txt";
 import memoryFilesystemPrompt from "./prompts/memory_filesystem.mdx";
+import onboardingPrompt from "./prompts/onboarding.mdx";
 import personaPrompt from "./prompts/persona.mdx";
 import personaKawaiiPrompt from "./prompts/persona_kawaii.mdx";
 import personaLinusPrompt from "./prompts/persona_linus.mdx";
@@ -48,6 +49,7 @@ export const MEMORY_PROMPTS: Record<string, string> = {
   "project.mdx": projectPrompt,
 
   "memory_filesystem.mdx": memoryFilesystemPrompt,
+  "onboarding.mdx": onboardingPrompt,
   "style.mdx": stylePrompt,
 };
 

--- a/src/agent/prompts/onboarding.mdx
+++ b/src/agent/prompts/onboarding.mdx
@@ -1,0 +1,43 @@
+---
+label: onboarding
+description: Onboarding tasklist for new users. Delete this block as soon as all tasks are completed, or if the user asks you to.
+---
+The person you are working with is new to Letta Code. You should guide them through different aspects of Letta Code's features. The goal is for *you* and the user to collaboratively try out the features in Letta Code through you taking actions demonstrating your capabilities.
+
+The goal of this is to help the user understand that *you* have the power to evolve yourself and Letta Code to their needs. For most things they want to achieve, they can simply ask you.
+
+Keep track of each of the actions and if you have performed them yet. Once you have performed all actions, you should delete this memory block to conserve space.
+
+The user has been active since: <TODO: fill this out>
+
+Memory
+- [ ] Make a `human` memory edit: ask the user if there is something they want you to know about them.
+- [ ] Make a `persona` memory edit: ask the user if there's a way they want you to behave, or to adapt your identity in some way.
+- [ ] Creating a profile picture: remind the user that they can give you a profile picture. Offer to create one yourself.
+- [ ] Memory initialization: let the user know that they can ask you to initialize your memory in a given working directory to build up your memory.
+- [ ] Memory doctor: if you notice your system prompt becoming very large, recommend to the user that they run the "doctor" (you can also just run it).
+- [ ] Memory push/pull: you should be able to push and pull from remote. Check this off once you have verified it is properly working. Repair your configurations if needed.
+
+Subagents
+- [ ] Forked subagents: let the user know what you can fork off of the current conversation, for example, self-review with multiple different models running extensions of your current context.
+- [ ] Parallel subagents: let the user know you can run multiple concurrent subagents, such as to explore different parts of the codebase.
+- [ ] Claude Code / Codex: let the user know that you can run other coding agents, and also review past sessions to learn from them.
+
+Skills
+- [ ] Discovering skills: tell the user that you can find and install new skills yourself. Ask the user what kind of things they want you to be good at doing. Recommend skills that may be best for the type of work they want to do with you.
+- [ ] Creating a skill: ask the user to walk you through a complex process that they would like you to do independently. Learn a skill from it.
+- [ ] Adding an MCP: ask the user if there are any MCP tools they would like to connect, and connect them.
+
+Search
+- [ ] Searching agents: let the user know that you can search for other agents, or message other agents.
+- [ ] Searching messages: let the user know that they can ask you to search past conversations.
+
+Schedules
+- [ ] Create a schedule: create a scheduled task in the future to check in with the user about their onboarding process.
+- [ ] Create a cron: you can set up repeated scheduled tasks. Ask the user if there is something they want you to do on a regular cadence, e.g. check their email, check skills, etc.
+
+Other
+- [ ] Make a permissions edit: let the user know that you can modify permissions (what commands are automatically approved/denied). Ask them if there are certain actions they would like you to avoid.
+- [ ] Creating a channel: help the user create a channel so you can talk to them from Slack, Discord, etc.
+- [ ] Worktrees: let the user know that you can help them orchestrate many agents in parallel, and also work in parallel to other agents. Offer to create a worktree that you work in (if they are not interested in worktrees or software, you may skip this and auto-check this off).
+- [ ] Moving machines: ask the user to add another remote environment (they can either run another desktop instance or run `letta server` on another machine) and run you there instead.

--- a/src/tests/agent/personality.test.ts
+++ b/src/tests/agent/personality.test.ts
@@ -8,6 +8,7 @@ import {
   getPersonalityBlockValues,
   getPersonalityContent,
   getPersonalityHumanContent,
+  ONBOARDING_PERSONALITIES,
   PERSONALITY_OPTIONS,
   replaceBodyPreservingFrontmatter,
   resolvePersonalityId,
@@ -96,6 +97,37 @@ describe("personality helpers", () => {
       });
       expect(personaBlock?.value).toBe(definitions.persona.value);
       expect(humanBlock?.value).toBe(definitions.human.value);
+    }
+  });
+
+  test("linus and kawaii include onboarding memory by default", async () => {
+    expect(ONBOARDING_PERSONALITIES).toEqual(["linus", "kawaii"]);
+
+    for (const personality of ["linus", "kawaii"] as const) {
+      const options = await buildCreateAgentOptionsForPersonality({
+        personalityId: personality,
+      });
+      const onboardingBlock = options.memoryBlocks?.find(
+        (block): block is { label: string; value: string } =>
+          "label" in block && block.label === "onboarding",
+      );
+
+      expect(onboardingBlock?.value).toContain(
+        "The person you are working with is new to Letta Code.",
+      );
+    }
+  });
+
+  test("letta-code and vanilla source personalities do not include onboarding", async () => {
+    for (const personality of ["memo", "claude", "codex"] as const) {
+      const options = await buildCreateAgentOptionsForPersonality({
+        personalityId: personality,
+      });
+      expect(
+        options.memoryBlocks?.some(
+          (block) => "label" in block && block.label === "onboarding",
+        ),
+      ).toBe(false);
     }
   });
 


### PR DESCRIPTION
## Summary
- Adds an `onboarding.mdx` memory prompt with proper Markdown task-list checkboxes.
- Automatically includes onboarding memory for the Linus and Kawaii personality presets while leaving Letta Code, Claude, and Codex unchanged.
- Adds personality tests covering onboarding inclusion and exclusion.

Validated with `bunx --bun @biomejs/biome@2.2.5 check src/agent/personality.ts src/agent/promptAssets.ts src/tests/agent/personality.test.ts` and `bun test src/tests/agent/personality.test.ts`.

👾 Generated with [Letta Code](https://letta.com)