### PR TITLE
feat(subagents): skip base tools for memory-focused subagents

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -52,6 +52,26 @@ import {
 } from "./contextBudget";
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Subagent types that don't need server-side base tools (web_search,
+ * fetch_webpage). These agents operate on local memory/git state and have
+ * no use for internet access. Spawning them with `--base-tools none`
+ * keeps their tool list minimal.
+ *
+ * fork/recall are excluded because they deploy the parent agent and
+ * never trigger fresh agent creation, so base tools are out of scope.
+ */
+const NO_BASE_TOOL_SUBAGENT_TYPES = new Set([
+  "reflection",
+  "memory",
+  "history-analyzer",
+  "init",
+]);
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -841,6 +861,12 @@ export function buildSubagentArgs(
     if (type === "reflection") {
       args.push("--no-system-info-reminder");
       args.push("--no-skills");
+    }
+
+    // Skip server-side base tools (web_search, fetch_webpage) for subagents
+    // that operate purely on local memory/git state.
+    if (NO_BASE_TOOL_SUBAGENT_TYPES.has(type)) {
+      args.push("--base-tools", "none");
     }
   }
 

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -360,6 +360,46 @@ describe("buildSubagentArgs", () => {
     expect(args).not.toContain("--no-system-info-reminder");
     expect(args).not.toContain("--no-skills");
   });
+
+  test.each([["reflection"], ["memory"], ["history-analyzer"], ["init"]])(
+    "injects --base-tools none for %s subagents",
+    (type) => {
+      const args = buildSubagentArgs(
+        type,
+        { ...baseConfig, name: type },
+        null,
+        "hello",
+      );
+
+      const idx = args.indexOf("--base-tools");
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(args[idx + 1]).toBe("none");
+    },
+  );
+
+  test("does not inject --base-tools for general-purpose subagents", () => {
+    const args = buildSubagentArgs(
+      "general-purpose",
+      baseConfig,
+      null,
+      "hello",
+    );
+
+    expect(args).not.toContain("--base-tools");
+  });
+
+  test("does not inject --base-tools when deploying an existing reflection agent", () => {
+    const args = buildSubagentArgs(
+      "reflection",
+      { ...baseConfig, name: "reflection" },
+      null,
+      "hello",
+      "agent-existing-reflection",
+    );
+
+    // --base-tools requires --new and only applies to fresh agent creation.
+    expect(args).not.toContain("--base-tools");
+  });
 });
 
 describe("getModelHandleFromAgent", () => {


### PR DESCRIPTION
## Summary
- Adds `NO_BASE_TOOL_SUBAGENT_TYPES` in `subagents/manager.ts` covering `reflection`, `memory`, `history-analyzer`, and `init` — subagents that operate purely on local memory/git state and have no use for `web_search`/`fetch_webpage`.
- `buildSubagentArgs` now emits `--base-tools none` for those types when spawning a fresh subagent agent. fork/recall are unaffected (they deploy the parent agent and never hit fresh agent creation). `general-purpose` keeps base tools for research use cases.
- No new frontmatter, no plumbing changes — the `--base-tools` flag is already wired through `headless.ts` → `createAgent()`.

## Test plan
- [x] `bun test src/tests/agent/subagent-model-resolution.test.ts` — 48 pass (6 new):
  - `--base-tools none` injected for reflection / memory / history-analyzer / init
  - not injected for `general-purpose`
  - not injected when deploying an existing reflection agent (since `--base-tools` requires `--new`)
- [x] **Live end-to-end check via `bun run dev`** (headless mode, `LETTA_CODE_AGENT_ROLE=subagent`, same flags `buildSubagentArgs` produces):
  - reflection-style spawn → `tools: []` (no `web_search`, no `fetch_webpage`) ✅
  - general-purpose-style spawn → `tools: ["fetch_webpage", "web_search"]` ✅
  - Both test agents cleaned up afterward.

👾 Generated with [Letta Code](https://letta.com)