### PR TITLE
fix(local): add OpenCode-style provider timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Navigate to your project directory and run `letta` (see various command-line opt
 
 Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, zAI coding plan, etc.), and use `/model` to swap models.
 
+For slow local inference servers, configure a provider-level timeout when connecting. For example, LM Studio-compatible llama-server backends that need up to 10 minutes for large-context compaction can use:
+
+```bash
+letta --backend local connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s
+```
+
+Timeouts are stored per local provider in milliseconds; pass `--no-timeout` or `--timeout false` to disable the provider timeout.
+
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
 
 ## Philosophy 

--- a/src/backend/api/providers.ts
+++ b/src/backend/api/providers.ts
@@ -8,6 +8,7 @@ export interface ProviderResponse {
   provider_category?: "base" | "byok" | null;
   api_key?: string;
   base_url?: string;
+  timeout?: number | false;
   access_key?: string;
   region?: string;
 }

--- a/src/backend/dev/AISDKModelFactory.ts
+++ b/src/backend/dev/AISDKModelFactory.ts
@@ -1,5 +1,12 @@
 import type { LanguageModel } from "ai";
-import { getLocalProviderApiKeyByName } from "../local/LocalProviderAuthStore";
+import {
+  getLocalProviderRecordByName,
+  type LocalProviderRecord,
+} from "../local/LocalProviderAuthStore";
+import {
+  type LocalProviderTimeout,
+  resolveLocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 import {
   type AISDKProvider,
   expectedAISDKProviderList,
@@ -81,47 +88,91 @@ export function resolveAISDKModelFromAgent(
   return stripProviderHandlePrefix(model, provider);
 }
 
-function localProviderApiKey(
+function localProviderRecord(
+  providerNames: readonly string[],
+  storageDir?: string,
+): LocalProviderRecord | null {
+  for (const providerName of providerNames) {
+    const record = getLocalProviderRecordByName(providerName, storageDir);
+    if (record) return record;
+  }
+  return null;
+}
+
+function apiKeyFromRecord(
+  record: LocalProviderRecord | null,
+): string | undefined {
+  return record?.auth.type === "api" ? record.auth.key : undefined;
+}
+
+function localProviderConnection(
   providerNames: readonly string[],
   envValue: string | undefined,
   storageDir?: string,
-): string | undefined {
-  for (const providerName of providerNames) {
-    const key = getLocalProviderApiKeyByName(providerName, storageDir);
-    if (key) return key;
-  }
-  return envValue;
+): {
+  apiKey?: string;
+  baseURL?: string;
+  timeout: LocalProviderTimeout;
+} {
+  const record = localProviderRecord(providerNames, storageDir);
+  return {
+    apiKey: apiKeyFromRecord(record) ?? envValue,
+    baseURL: record?.base_url,
+    timeout: resolveLocalProviderTimeout({
+      configuredTimeout: record?.timeout,
+      providerIds: providerNames,
+    }),
+  };
 }
 
 export interface ZaiConnection {
   apiKey?: string;
   baseURL: string;
   providerName: "zai" | "zai-coding";
+  timeout: LocalProviderTimeout;
 }
 
 export function resolveZaiConnection(options: {
   storageDir?: string;
   preferredProviderType?: "zai" | "zai_coding";
 }): ZaiConnection {
+  const regularRecord = getLocalProviderRecordByName(
+    LOCAL_ZAI_PROVIDER_NAME,
+    options.storageDir,
+  );
+  const codingRecord = getLocalProviderRecordByName(
+    LOCAL_ZAI_CODING_PROVIDER_NAME,
+    options.storageDir,
+  );
   const regularKey =
-    getLocalProviderApiKeyByName(LOCAL_ZAI_PROVIDER_NAME, options.storageDir) ??
+    apiKeyFromRecord(regularRecord) ??
     process.env.ZAI_API_KEY ??
     process.env.ZHIPU_API_KEY;
   const codingKey =
-    getLocalProviderApiKeyByName(
-      LOCAL_ZAI_CODING_PROVIDER_NAME,
-      options.storageDir,
-    ) ?? process.env.ZAI_CODING_API_KEY;
+    apiKeyFromRecord(codingRecord) ?? process.env.ZAI_CODING_API_KEY;
   const regularConnection: ZaiConnection = {
     providerName: "zai",
-    baseURL: process.env.ZAI_BASE_URL ?? "https://api.z.ai/api/paas/v4",
+    baseURL:
+      regularRecord?.base_url ??
+      process.env.ZAI_BASE_URL ??
+      "https://api.z.ai/api/paas/v4",
     apiKey: regularKey,
+    timeout: resolveLocalProviderTimeout({
+      configuredTimeout: regularRecord?.timeout,
+      providerIds: [LOCAL_ZAI_PROVIDER_NAME, "zai"],
+    }),
   };
   const codingConnection: ZaiConnection = {
     providerName: "zai-coding",
     baseURL:
-      process.env.ZAI_CODING_BASE_URL ?? "https://api.z.ai/api/coding/paas/v4",
+      codingRecord?.base_url ??
+      process.env.ZAI_CODING_BASE_URL ??
+      "https://api.z.ai/api/coding/paas/v4",
     apiKey: codingKey,
+    timeout: resolveLocalProviderTimeout({
+      configuredTimeout: codingRecord?.timeout,
+      providerIds: [LOCAL_ZAI_CODING_PROVIDER_NAME, "zai-coding"],
+    }),
   };
 
   if (options.preferredProviderType === "zai_coding" && codingKey) {
@@ -159,25 +210,30 @@ export function createAISDKModelFactory(
   const spec = getAISDKProviderSpec(provider);
   const model = options.model ?? process.env.LETTA_CODE_DEV_AI_SDK_MODEL;
   const storageDir = options.localProviderAuthStorageDir;
-  const apiKey = localProviderApiKey(
+  const connection = localProviderConnection(
     spec.localProviderNames,
     spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
     storageDir,
   );
+  const apiKey = connection.apiKey;
+  const baseURL = connection.baseURL ?? spec.baseURL?.();
 
   switch (spec.sdk) {
     case "openai-responses":
       return createOpenAIResponsesModelFactory({
         model,
         apiKey,
+        baseURL,
+        timeout: connection.timeout,
         createModel: options.createOpenAIResponsesModel,
       });
     case "anthropic":
       return createAnthropicModelFactory({
         model,
         providerName: spec.providerName,
-        baseURL: spec.baseURL?.(),
+        baseURL,
         apiKey,
+        timeout: connection.timeout,
         createModel: options.createAnthropicModel,
       });
     case "openai-compatible": {
@@ -191,15 +247,17 @@ export function createAISDKModelFactory(
           providerName: zaiConnection.providerName,
           baseURL: zaiConnection.baseURL,
           apiKey: zaiConnection.apiKey,
+          timeout: zaiConnection.timeout,
           createModel: options.createOpenAICompatibleModel,
         });
       }
       return createOpenAICompatibleModelFactory({
         model,
         providerName: spec.providerName ?? provider,
-        baseURL: spec.baseURL?.() ?? "",
+        baseURL: baseURL ?? "",
         apiKey,
         headers: spec.headers?.(),
+        timeout: connection.timeout,
         createModel: options.createOpenAICompatibleModel,
       });
     }
@@ -207,7 +265,8 @@ export function createAISDKModelFactory(
       return createGoogleModelFactory({
         model,
         apiKey,
-        baseURL: spec.baseURL?.(),
+        baseURL,
+        timeout: connection.timeout,
         createModel: options.createGoogleModel,
       });
     case "bedrock":
@@ -221,6 +280,7 @@ export function createAISDKModelFactory(
       return createChatGPTOAuthModelFactory({
         model,
         storageDir,
+        timeout: connection.timeout,
         createModel: options.createChatGPTOAuthModel,
       });
   }

--- a/src/backend/dev/AnthropicModel.ts
+++ b/src/backend/dev/AnthropicModel.ts
@@ -1,5 +1,9 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import type { LanguageModel } from "ai";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 
@@ -9,6 +13,7 @@ export interface AnthropicModelFactoryOptions {
   baseURL?: string;
   providerName?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
@@ -18,12 +23,16 @@ function createDefaultAnthropicModel(options: {
   baseURL?: string;
   providerName?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const provider = createAnthropic({
     apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
     baseURL: options.baseURL,
     name: options.providerName,
-    fetch: options.fetch,
+    fetch: createLocalProviderFetch({
+      fetch: options.fetch,
+      timeout: options.timeout,
+    }),
   });
   return provider(options.model);
 }
@@ -44,6 +53,7 @@ export function createAnthropicModelFactory(
         baseURL: options.baseURL,
         providerName: options.providerName,
         fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/dev/BedrockModel.ts
+++ b/src/backend/dev/BedrockModel.ts
@@ -2,11 +2,17 @@ import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import type { LanguageModel } from "ai";
 import { getAwsProfile } from "../../utils/aws-credentials";
 import { getLocalProviderRecordByName } from "../local/LocalProviderAuthStore";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 export interface BedrockModelFactoryOptions {
   model?: string;
   storageDir?: string;
   providerName: string;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
@@ -28,6 +34,8 @@ function createDefaultBedrockModel(options: {
   model: string;
   storageDir?: string;
   providerName: string;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const record = getLocalProviderRecordByName(
     options.providerName,
@@ -41,6 +49,10 @@ function createDefaultBedrockModel(options: {
 
   const provider = createAmazonBedrock({
     region,
+    fetch: createLocalProviderFetch({
+      fetch: options.fetch,
+      timeout: options.timeout ?? record?.timeout,
+    }),
     ...(accessKeyId && secretAccessKey ? { accessKeyId, secretAccessKey } : {}),
     ...(profile && !accessKeyId && !secretAccessKey
       ? { credentialProvider: () => resolveProfileCredentials(profile) }
@@ -63,6 +75,8 @@ export function createBedrockModelFactory(
         model,
         storageDir: options.storageDir,
         providerName: options.providerName,
+        fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/dev/ChatGPTOAuthModel.ts
+++ b/src/backend/dev/ChatGPTOAuthModel.ts
@@ -10,6 +10,10 @@ import {
   type LocalProviderOAuthAuth,
   setLocalChatGPTOAuth,
 } from "../local/LocalProviderAuthStore";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 const OAUTH_DUMMY_KEY = "chatgpt-oauth";
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
@@ -19,6 +23,7 @@ export interface ChatGPTOAuthModelFactoryOptions {
   model?: string;
   storageDir?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
@@ -99,8 +104,12 @@ async function getFreshAuth(
 function createChatGPTFetch(options: {
   storageDir?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): typeof fetch {
-  const baseFetch = options.fetch ?? fetch;
+  const baseFetch = createLocalProviderFetch({
+    fetch: options.fetch,
+    timeout: options.timeout,
+  });
   return (async (input, init) => {
     const request =
       input instanceof Request
@@ -128,12 +137,14 @@ function createDefaultChatGPTOAuthModel(options: {
   model: string;
   storageDir?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const provider = createOpenAI({
     apiKey: OAUTH_DUMMY_KEY,
     fetch: createChatGPTFetch({
       storageDir: options.storageDir,
       fetch: options.fetch,
+      timeout: options.timeout,
     }),
   });
   return provider.responses(options.model);
@@ -153,6 +164,7 @@ export function createChatGPTOAuthModelFactory(
         model,
         storageDir: options.storageDir,
         fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/dev/GoogleModel.ts
+++ b/src/backend/dev/GoogleModel.ts
@@ -1,10 +1,16 @@
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { LanguageModel } from "ai";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 export interface GoogleModelFactoryOptions {
   model?: string;
   apiKey?: string;
   baseURL?: string;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
@@ -12,6 +18,8 @@ function createDefaultGoogleModel(options: {
   model: string;
   apiKey?: string;
   baseURL?: string;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const provider = createGoogleGenerativeAI({
     apiKey:
@@ -20,6 +28,10 @@ function createDefaultGoogleModel(options: {
       process.env.GEMINI_API_KEY,
     baseURL: options.baseURL,
     name: "google-ai",
+    fetch: createLocalProviderFetch({
+      fetch: options.fetch,
+      timeout: options.timeout,
+    }),
   });
   return provider(options.model);
 }
@@ -38,6 +50,8 @@ export function createGoogleModelFactory(
         model,
         apiKey: options.apiKey,
         baseURL: options.baseURL,
+        fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/dev/OpenAICompatibleModel.ts
+++ b/src/backend/dev/OpenAICompatibleModel.ts
@@ -1,5 +1,9 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 export interface OpenAICompatibleModelFactoryOptions {
   model?: string;
@@ -7,6 +11,8 @@ export interface OpenAICompatibleModelFactoryOptions {
   baseURL: string;
   providerName: string;
   headers?: Record<string, string>;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
@@ -16,12 +22,18 @@ function createDefaultOpenAICompatibleModel(options: {
   baseURL: string;
   providerName: string;
   headers?: Record<string, string>;
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const provider = createOpenAI({
     name: options.providerName,
     apiKey: options.apiKey,
     baseURL: options.baseURL,
     headers: options.headers,
+    fetch: createLocalProviderFetch({
+      fetch: options.fetch,
+      timeout: options.timeout,
+    }),
   });
   return provider.chat(options.model);
 }
@@ -47,6 +59,8 @@ export function createOpenAICompatibleModelFactory(
         baseURL: options.baseURL,
         providerName: options.providerName,
         headers: options.headers,
+        fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/dev/OpenAIResponsesModel.ts
+++ b/src/backend/dev/OpenAIResponsesModel.ts
@@ -1,23 +1,35 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
+import {
+  createLocalProviderFetch,
+  type LocalProviderTimeout,
+} from "../local/LocalProviderTimeout";
 
 export const DEFAULT_OPENAI_RESPONSES_MODEL = "gpt-5.5";
 
 export interface OpenAIResponsesModelFactoryOptions {
   model?: string;
   apiKey?: string;
+  baseURL?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
   createModel?: (model: string) => LanguageModel;
 }
 
 function createDefaultOpenAIResponsesModel(options: {
   model: string;
   apiKey?: string;
+  baseURL?: string;
   fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
 }): LanguageModel {
   const provider = createOpenAI({
     apiKey: options.apiKey ?? process.env.OPENAI_API_KEY,
-    fetch: options.fetch,
+    baseURL: options.baseURL,
+    fetch: createLocalProviderFetch({
+      fetch: options.fetch,
+      timeout: options.timeout,
+    }),
   });
   return provider.responses(options.model);
 }
@@ -35,7 +47,9 @@ export function createOpenAIResponsesModelFactory(
       createDefaultOpenAIResponsesModel({
         model,
         apiKey: options.apiKey,
+        baseURL: options.baseURL,
         fetch: options.fetch,
+        timeout: options.timeout,
       }));
   return () => createModel(model);
 }

--- a/src/backend/local/LocalProviderAuthStore.ts
+++ b/src/backend/local/LocalProviderAuthStore.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_CHATGPT_PROVIDER_NAME,
   SUPPORTED_LOCAL_PROVIDER_TYPES,
 } from "../dev/AISDKProviderRegistry";
+import type { LocalProviderTimeout } from "./LocalProviderTimeout";
 import { getLocalBackendStorageDir } from "./paths";
 
 export {
@@ -58,6 +59,7 @@ export interface LocalProviderRecord {
   region?: string;
   profile?: string;
   base_url?: string;
+  timeout?: LocalProviderTimeout;
   created_at: string;
   updated_at: string;
 }
@@ -117,6 +119,7 @@ function providerResponse(record: LocalProviderRecord): ProviderResponse {
     provider_type: record.provider_type,
     provider_category: record.provider_category,
     ...(record.base_url ? { base_url: record.base_url } : {}),
+    ...(record.timeout !== undefined ? { timeout: record.timeout } : {}),
     ...(record.access_key ? { access_key: record.access_key } : {}),
     ...(record.region ? { region: record.region } : {}),
   };
@@ -167,6 +170,8 @@ export async function createOrUpdateLocalProvider(input: {
   accessKey?: string;
   region?: string;
   profile?: string;
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
   storageDir?: string;
 }): Promise<ProviderResponse> {
   if (!isLocalProviderTypeSupported(input.providerType)) {
@@ -191,6 +196,14 @@ export async function createOrUpdateLocalProvider(input: {
     ...(input.accessKey ? { access_key: input.accessKey } : {}),
     ...(input.region ? { region: input.region } : {}),
     ...(input.profile ? { profile: input.profile } : {}),
+    ...((input.baseURL ?? existing?.base_url)
+      ? { base_url: input.baseURL ?? existing?.base_url }
+      : {}),
+    ...(input.timeout !== undefined
+      ? { timeout: input.timeout }
+      : existing?.timeout !== undefined
+        ? { timeout: existing.timeout }
+        : {}),
     created_at: existing?.created_at ?? now,
     updated_at: now,
   };
@@ -206,6 +219,7 @@ export async function updateLocalProvider(
   region?: string,
   profile?: string,
   storageDir?: string,
+  options: { baseURL?: string; timeout?: LocalProviderTimeout } = {},
 ): Promise<ProviderResponse> {
   const existing = listLocalProviderRecords(storageDir).find(
     (provider) => provider.id === providerIdValue,
@@ -221,6 +235,8 @@ export async function updateLocalProvider(
     region,
     profile,
     storageDir,
+    baseURL: options.baseURL,
+    timeout: options.timeout,
   });
 }
 

--- a/src/backend/local/LocalProviderTimeout.ts
+++ b/src/backend/local/LocalProviderTimeout.ts
@@ -1,0 +1,128 @@
+export type LocalProviderTimeout = number | false;
+
+export const DEFAULT_LOCAL_PROVIDER_TIMEOUT_MS = 5 * 60 * 1000;
+
+const GLOBAL_LOCAL_PROVIDER_TIMEOUT_ENV =
+  "LETTA_CODE_LOCAL_PROVIDER_TIMEOUT_MS";
+
+function normalizeProviderEnvStem(providerId: string): string {
+  return providerId
+    .replace(/^lc-/, "")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
+
+function timeoutEnvNames(providerIds: readonly string[]): string[] {
+  const names = new Set<string>();
+  for (const providerId of providerIds) {
+    const stem = normalizeProviderEnvStem(providerId);
+    if (!stem) continue;
+    names.add(`LETTA_CODE_${stem}_TIMEOUT_MS`);
+    names.add(`${stem}_TIMEOUT_MS`);
+  }
+  names.add(GLOBAL_LOCAL_PROVIDER_TIMEOUT_ENV);
+  return [...names];
+}
+
+export function parseLocalProviderTimeout(
+  value: string | undefined,
+): LocalProviderTimeout | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (["false", "off", "none", "disabled", "disable"].includes(normalized)) {
+    return false;
+  }
+
+  const match = normalized.match(
+    /^(\d+(?:\.\d+)?)(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes)?$/,
+  );
+  if (!match) {
+    throw new Error(
+      `Invalid local provider timeout "${value}". Use milliseconds, a duration like 600s or 10m, or false to disable.`,
+    );
+  }
+
+  const amount = Number.parseFloat(match[1] ?? "");
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error(
+      `Invalid local provider timeout "${value}". Timeout must be greater than zero, or false to disable.`,
+    );
+  }
+
+  const unit = match[2] ?? "ms";
+  const multiplier =
+    unit.startsWith("m") && unit !== "ms" ? 60_000 : unit === "ms" ? 1 : 1_000;
+  return Math.round(amount * multiplier);
+}
+
+export function resolveLocalProviderTimeout(options: {
+  configuredTimeout?: LocalProviderTimeout;
+  providerIds?: readonly string[];
+  fallback?: LocalProviderTimeout;
+}): LocalProviderTimeout {
+  if (options.configuredTimeout !== undefined) return options.configuredTimeout;
+
+  for (const envName of timeoutEnvNames(options.providerIds ?? [])) {
+    const parsed = parseLocalProviderTimeout(process.env[envName]);
+    if (parsed !== undefined) return parsed;
+  }
+
+  return options.fallback ?? DEFAULT_LOCAL_PROVIDER_TIMEOUT_MS;
+}
+
+function combineAbortSignals(signals: AbortSignal[]): AbortSignal | undefined {
+  if (signals.length === 0) return undefined;
+  if (signals.length === 1) return signals[0];
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(signals);
+  }
+
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+  };
+  for (const signal of signals) {
+    if (signal.aborted) {
+      abort(signal);
+      break;
+    }
+    signal.addEventListener("abort", () => abort(signal), { once: true });
+  }
+  return controller.signal;
+}
+
+export function createLocalProviderFetch(options: {
+  fetch?: typeof fetch;
+  timeout?: LocalProviderTimeout;
+}): typeof fetch {
+  const baseFetch = options.fetch ?? fetch;
+  const timeout = resolveLocalProviderTimeout({
+    configuredTimeout: options.timeout,
+  });
+
+  return (async (input, init) => {
+    const signals: AbortSignal[] = [];
+    if (input instanceof Request) signals.push(input.signal);
+    if (init?.signal) signals.push(init.signal);
+    if (timeout !== false) signals.push(AbortSignal.timeout(timeout));
+    const signal = combineAbortSignals(signals);
+    const nextInit = {
+      ...init,
+      ...(signal ? { signal } : {}),
+      // Bun has its own transport timeout. Match OpenCode by disabling it and
+      // using our provider-level AbortSignal timeout instead.
+      timeout: false,
+    } as RequestInit & { timeout: false };
+    return baseFetch(input, nextInit);
+  }) as typeof fetch;
+}
+
+export function formatLocalProviderTimeout(
+  timeout: LocalProviderTimeout,
+): string {
+  return timeout === false ? "disabled" : `${timeout}ms`;
+}

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -2,6 +2,11 @@
 // Command handlers for provider connection management in TUI slash commands
 
 import {
+  formatLocalProviderTimeout,
+  type LocalProviderTimeout,
+  parseLocalProviderTimeout,
+} from "../../backend/local/LocalProviderTimeout";
+import {
   checkProviderApiKey,
   createOrUpdateProvider,
   getProviderByName,
@@ -121,6 +126,7 @@ function formatConnectUsage(): string {
     "  /connect codex",
     "  /connect anthropic <api_key>",
     "  /connect openai <api_key>",
+    "  /connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
     "  /connect bedrock iam --access-key <id> --secret-key <key> --region <region>",
     "  /connect bedrock profile --profile <name> --region <region>",
   ].join("\n");
@@ -209,13 +215,116 @@ function formatApiKeyUsage(provider: ResolvedConnectProvider): string {
       `Usage: /connect ${provider.canonical} [api_key]`,
       "",
       `Connect to ${provider.byokProvider.displayName}. API key is optional for this local provider.`,
+      "Optional: --base-url <url> --timeout <ms|duration|false>",
     ].join("\n");
   }
   return [
     `Usage: /connect ${provider.canonical} <api_key>`,
     "",
     `Connect to ${provider.byokProvider.displayName} by providing your API key.`,
+    "Optional: --base-url <url> --timeout <ms|duration|false>",
   ].join("\n");
+}
+
+function readFlagValue(
+  args: string[],
+  index: number,
+  flag: string,
+): { value?: string; nextIndex: number; error?: string } {
+  const token = args[index] ?? "";
+  const equalsPrefix = `${flag}=`;
+  if (token.startsWith(equalsPrefix)) {
+    const value = token.slice(equalsPrefix.length);
+    return value
+      ? { value, nextIndex: index }
+      : { nextIndex: index, error: `Missing value for ${flag}` };
+  }
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    return { nextIndex: index, error: `Missing value for ${flag}` };
+  }
+  return { value, nextIndex: index + 1 };
+}
+
+function parseApiProviderArgs(args: string[]): {
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
+  error?: string;
+} {
+  const positionals: string[] = [];
+  let apiKey: string | undefined;
+  let baseURL: string | undefined;
+  let timeout: LocalProviderTimeout | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i] ?? "";
+    if (token === "--no-timeout") {
+      timeout = false;
+      continue;
+    }
+
+    if (token === "--api-key" || token.startsWith("--api-key=")) {
+      const parsed = readFlagValue(args, i, "--api-key");
+      if (parsed.error) return { error: parsed.error };
+      apiKey = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+
+    if (token === "--base-url" || token.startsWith("--base-url=")) {
+      const parsed = readFlagValue(args, i, "--base-url");
+      if (parsed.error) return { error: parsed.error };
+      baseURL = parsed.value;
+      i = parsed.nextIndex;
+      continue;
+    }
+
+    if (token === "--timeout" || token.startsWith("--timeout=")) {
+      const parsed = readFlagValue(args, i, "--timeout");
+      if (parsed.error) return { error: parsed.error };
+      try {
+        timeout = parseLocalProviderTimeout(parsed.value);
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+      i = parsed.nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--")) {
+      return { error: `Unknown option: ${token}` };
+    }
+
+    positionals.push(token);
+  }
+
+  return {
+    apiKey: apiKey ?? positionals.join(""),
+    baseURL,
+    timeout,
+  };
+}
+
+function providerOptionsSummary(options: {
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
+}): string {
+  const lines: string[] = [];
+  if (options.baseURL) lines.push(`Base URL: ${options.baseURL}`);
+  if (options.timeout !== undefined) {
+    lines.push(`Timeout: ${formatLocalProviderTimeout(options.timeout)}`);
+  }
+  return lines.length ? `\n${lines.join("\n")}` : "";
+}
+
+function hasProviderOptions(options: {
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
+}): boolean {
+  return options.baseURL !== undefined || options.timeout !== undefined;
 }
 
 function formatZaiCodingPlanPrompt(apiKey?: string): string {
@@ -305,6 +414,7 @@ async function handleConnectApiKeyProvider(
   msg: string,
   provider: ResolvedConnectProvider,
   apiKey: string,
+  options: { baseURL?: string; timeout?: LocalProviderTimeout } = {},
 ): Promise<void> {
   const cmdId = addCommandResult(
     ctx.buffersRef,
@@ -330,11 +440,23 @@ async function handleConnectApiKeyProvider(
       "running",
     );
 
-    await createOrUpdateProvider(
-      provider.byokProvider.providerType,
-      provider.byokProvider.providerName,
-      apiKey,
-    );
+    if (hasProviderOptions(options)) {
+      await createOrUpdateProvider(
+        provider.byokProvider.providerType,
+        provider.byokProvider.providerName,
+        apiKey,
+        undefined,
+        undefined,
+        undefined,
+        options,
+      );
+    } else {
+      await createOrUpdateProvider(
+        provider.byokProvider.providerType,
+        provider.byokProvider.providerName,
+        apiKey,
+      );
+    }
 
     updateCommandResult(
       ctx.buffersRef,
@@ -342,7 +464,8 @@ async function handleConnectApiKeyProvider(
       cmdId,
       msg,
       `✓ Successfully connected to ${provider.byokProvider.displayName}!\n\n` +
-        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel()}.`,
+        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel()}.` +
+        providerOptionsSummary(options),
       true,
       "finished",
     );
@@ -521,7 +644,18 @@ export async function handleConnect(
   }
 
   if (isConnectApiKeyProvider(provider)) {
-    const apiKey = parts.slice(2).join("") || defaultConnectApiKey(provider);
+    const parsed = parseApiProviderArgs(parts.slice(2));
+    if (parsed.error) {
+      addCommandResult(
+        ctx.buffersRef,
+        ctx.refreshDerived,
+        msg,
+        `${parsed.error}\n\n${formatApiKeyUsage(provider)}`,
+        false,
+      );
+      return;
+    }
+    const apiKey = parsed.apiKey || defaultConnectApiKey(provider);
     if (!apiKey) {
       if (isConnectZaiBaseProvider(provider)) {
         addCommandResult(
@@ -542,7 +676,10 @@ export async function handleConnect(
       }
       return;
     }
-    await handleConnectApiKeyProvider(ctx, msg, provider, apiKey);
+    await handleConnectApiKeyProvider(ctx, msg, provider, apiKey, {
+      baseURL: parsed.baseURL,
+      timeout: parsed.timeout,
+    });
   }
 }
 

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -1,9 +1,11 @@
 import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
 import { parseArgs } from "node:util";
+import { parseLocalProviderTimeout } from "../../backend/local/LocalProviderTimeout";
 import {
   checkProviderApiKey,
   createOrUpdateProvider,
+  type ProviderConnectionOptions,
   providerStorageTargetLabel,
 } from "../../providers/byok-providers";
 import { settingsManager } from "../../settings-manager";
@@ -32,6 +34,9 @@ const CONNECT_OPTIONS = {
   "secret-key": { type: "string" },
   region: { type: "string" },
   profile: { type: "string" },
+  "base-url": { type: "string" },
+  timeout: { type: "string" },
+  "no-timeout": { type: "boolean" },
 } as const;
 
 interface ConnectSubcommandDeps {
@@ -54,6 +59,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    options?: ProviderConnectionOptions,
   ) => Promise<unknown>;
   isChatGPTOAuthConnected: () => Promise<boolean>;
   runChatGPTOAuthConnectFlow: (
@@ -95,9 +101,30 @@ function formatUsage(): string {
     "  letta connect codex",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
+    "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
     "  letta connect bedrock --method iam --access-key <id> --secret-key <key> --region <region>",
     "  letta connect bedrock --method profile --profile <name> --region <region>",
   ].join("\n");
+}
+
+function connectionOptionsFromArgs(
+  values: ReturnType<typeof parseArgs>["values"],
+): ProviderConnectionOptions {
+  const baseURL = readStringOption(values["base-url"]);
+  const timeoutValue = readStringOption(values.timeout);
+  const noTimeout = values["no-timeout"] === true;
+  return {
+    ...(baseURL ? { baseURL } : {}),
+    ...(noTimeout
+      ? { timeout: false as const }
+      : timeoutValue !== undefined
+        ? { timeout: parseLocalProviderTimeout(timeoutValue) }
+        : {}),
+  };
+}
+
+function hasConnectionOptions(options: ProviderConnectionOptions): boolean {
+  return options.baseURL !== undefined || options.timeout !== undefined;
 }
 
 function formatBedrockUsage(): string {
@@ -215,6 +242,13 @@ export async function runConnectSubcommand(
     const secretKey = readStringOption(parsed.values["secret-key"]) ?? "";
     const region = readStringOption(parsed.values.region) ?? "";
     const profile = readStringOption(parsed.values.profile) ?? "";
+    let connectionOptions: ProviderConnectionOptions;
+    try {
+      connectionOptions = connectionOptionsFromArgs(parsed.values);
+    } catch (error) {
+      io.stderr(getErrorMessage(error));
+      return 1;
+    }
 
     if (!method || (method !== "iam" && method !== "profile")) {
       io.stderr("Bedrock method must be `iam` or `profile`.");
@@ -247,14 +281,26 @@ export async function runConnectSubcommand(
       );
 
       io.stdout("Saving provider...");
-      await io.createOrUpdateProvider(
-        provider.byokProvider.providerType,
-        provider.byokProvider.providerName,
-        method === "iam" ? secretKey : "",
-        method === "iam" ? accessKey : undefined,
-        region,
-        method === "profile" ? profile : undefined,
-      );
+      if (hasConnectionOptions(connectionOptions)) {
+        await io.createOrUpdateProvider(
+          provider.byokProvider.providerType,
+          provider.byokProvider.providerName,
+          method === "iam" ? secretKey : "",
+          method === "iam" ? accessKey : undefined,
+          region,
+          method === "profile" ? profile : undefined,
+          connectionOptions,
+        );
+      } else {
+        await io.createOrUpdateProvider(
+          provider.byokProvider.providerType,
+          provider.byokProvider.providerName,
+          method === "iam" ? secretKey : "",
+          method === "iam" ? accessKey : undefined,
+          region,
+          method === "profile" ? profile : undefined,
+        );
+      }
 
       io.stdout(
         `Connected ${provider.byokProvider.displayName} (${provider.byokProvider.providerName}) in ${providerStorageTargetLabel()}.`,
@@ -269,6 +315,13 @@ export async function runConnectSubcommand(
   if (isConnectApiKeyProvider(provider)) {
     let apiKey =
       readStringOption(parsed.values["api-key"]) ?? restPositionals[0] ?? "";
+    let connectionOptions: ProviderConnectionOptions;
+    try {
+      connectionOptions = connectionOptionsFromArgs(parsed.values);
+    } catch (error) {
+      io.stderr(getErrorMessage(error));
+      return 1;
+    }
     apiKey ||= defaultConnectApiKey(provider) ?? "";
     if (!apiKey && isConnectZaiBaseProvider(provider)) {
       io.stdout(
@@ -300,11 +353,23 @@ export async function runConnectSubcommand(
       await io.checkProviderApiKey(provider.byokProvider.providerType, apiKey);
 
       io.stdout("Saving provider...");
-      await io.createOrUpdateProvider(
-        provider.byokProvider.providerType,
-        provider.byokProvider.providerName,
-        apiKey,
-      );
+      if (hasConnectionOptions(connectionOptions)) {
+        await io.createOrUpdateProvider(
+          provider.byokProvider.providerType,
+          provider.byokProvider.providerName,
+          apiKey,
+          undefined,
+          undefined,
+          undefined,
+          connectionOptions,
+        );
+      } else {
+        await io.createOrUpdateProvider(
+          provider.byokProvider.providerType,
+          provider.byokProvider.providerName,
+          apiKey,
+        );
+      }
 
       io.stdout(
         `Connected ${provider.byokProvider.displayName} (${provider.byokProvider.providerName}) in ${providerStorageTargetLabel()}.`,

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -25,8 +25,14 @@ import {
   removeLocalProviderByName,
   updateLocalProvider,
 } from "../backend/local/LocalProviderAuthStore";
+import type { LocalProviderTimeout } from "../backend/local/LocalProviderTimeout";
 
 export type { ProviderResponse } from "../backend/api/providers";
+
+export interface ProviderConnectionOptions {
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
+}
 
 // Field definition for multi-field providers (like Bedrock)
 export interface ProviderField {
@@ -339,6 +345,7 @@ export async function createProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  options: ProviderConnectionOptions = {},
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
     return createOrUpdateLocalProvider({
@@ -348,6 +355,8 @@ export async function createProvider(
       accessKey,
       region,
       profile,
+      baseURL: options.baseURL,
+      timeout: options.timeout,
     });
   }
   return createProviderRequest(
@@ -369,9 +378,18 @@ export async function updateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  options: ProviderConnectionOptions = {},
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
-    return updateLocalProvider(providerId, apiKey, accessKey, region, profile);
+    return updateLocalProvider(
+      providerId,
+      apiKey,
+      accessKey,
+      region,
+      profile,
+      undefined,
+      options,
+    );
   }
   return updateProviderRequest(providerId, apiKey, accessKey, region, profile);
 }
@@ -398,6 +416,7 @@ export async function createOrUpdateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  options: ProviderConnectionOptions = {},
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
     return createOrUpdateLocalProvider({
@@ -407,6 +426,8 @@ export async function createOrUpdateProvider(
       accessKey,
       region,
       profile,
+      baseURL: options.baseURL,
+      timeout: options.timeout,
     });
   }
   return createOrUpdateProviderRequest(

--- a/src/tests/backend/local-provider-timeout.test.ts
+++ b/src/tests/backend/local-provider-timeout.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveZaiConnection } from "../../backend/dev/AISDKModelFactory";
+import {
+  createOrUpdateLocalProvider,
+  getLocalProviderByName,
+} from "../../backend/local/LocalProviderAuthStore";
+import {
+  createLocalProviderFetch,
+  parseLocalProviderTimeout,
+} from "../../backend/local/LocalProviderTimeout";
+
+describe("local provider timeout", () => {
+  test("parses OpenCode-style provider timeout values", () => {
+    expect(parseLocalProviderTimeout("300000")).toBe(300_000);
+    expect(parseLocalProviderTimeout("600s")).toBe(600_000);
+    expect(parseLocalProviderTimeout("10m")).toBe(600_000);
+    expect(parseLocalProviderTimeout("false")).toBe(false);
+    expect(() => parseLocalProviderTimeout("soon")).toThrow(
+      "Invalid local provider timeout",
+    );
+  });
+
+  test("wraps provider fetch with a provider timeout and disables Bun fetch timeout", async () => {
+    let capturedInit: (RequestInit & { timeout?: unknown }) | undefined;
+    const wrapped = createLocalProviderFetch({
+      timeout: 600_000,
+      fetch: (async (_input, init) => {
+        capturedInit = init as RequestInit & { timeout?: unknown };
+        return new Response("ok");
+      }) as typeof fetch,
+    });
+
+    const response = await wrapped("https://example.invalid/v1/chat", {
+      method: "POST",
+    });
+
+    expect(await response.text()).toBe("ok");
+    expect(capturedInit?.timeout).toBe(false);
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("stores provider base URL and timeout for local model resolution", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-provider-timeout-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "lmstudio",
+        providerName: "lc-lmstudio",
+        apiKey: "not-needed",
+        baseURL: "http://127.0.0.1:1234/v1",
+        timeout: 600_000,
+      });
+      const stored = await getLocalProviderByName("lc-lmstudio", storageDir);
+      expect(stored).toMatchObject({
+        base_url: "http://127.0.0.1:1234/v1",
+        timeout: 600_000,
+      });
+
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "zai_coding",
+        providerName: "lc-zai-coding",
+        apiKey: "test-zai-coding-key",
+        baseURL: "http://localhost:9999/v1",
+        timeout: false,
+      });
+      expect(
+        resolveZaiConnection({
+          storageDir,
+          preferredProviderType: "zai_coding",
+        }),
+      ).toMatchObject({
+        apiKey: "test-zai-coding-key",
+        baseURL: "http://localhost:9999/v1",
+        providerName: "zai-coding",
+        timeout: false,
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tests/cli/connect-subcommand.test.ts
+++ b/src/tests/cli/connect-subcommand.test.ts
@@ -100,6 +100,35 @@ describe("connect subcommand", () => {
     );
   });
 
+  test("passes local provider base URL and timeout options", async () => {
+    const { deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      [
+        "lmstudio",
+        "--base-url",
+        "http://127.0.0.1:1234/v1",
+        "--timeout",
+        "600s",
+      ],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "lmstudio",
+      "lc-lmstudio",
+      "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      {
+        baseURL: "http://127.0.0.1:1234/v1",
+        timeout: 600_000,
+      },
+    );
+  });
+
   test("validates bedrock iam required flags", async () => {
     const { stderr, deps } = createIoDeps();
 


### PR DESCRIPTION
## Summary
- Add provider-level local timeout handling modeled after OpenCode: model provider fetches now merge the caller signal with an AbortSignal timeout and pass `timeout: false` to Bun fetch.
- Persist per-local-provider `base_url` and `timeout` settings, with `/connect` and `letta connect` flags like `--timeout 600s`, `--timeout false`, `--no-timeout`, and `--base-url`.
- Document the LM Studio / llama-server slow compaction example and cover timeout parsing, fetch wrapping, storage, and CLI wiring with tests.

## Context
This is a parallel alternative to #2242 that moves the timeout to the provider fetch layer, matching OpenCode's approach more closely than AI SDK call-level `timeout` options.

## Test plan
- [x] `bun test src/tests/backend/local-provider-timeout.test.ts src/tests/backend/ai-sdk-model-factory.test.ts`
- [x] `bun test src/tests/cli/connect-subcommand.test.ts`
- [x] `bun test src/tests/backend/local-backend.test.ts`
- [x] `bun test src/tests/backend/ai-sdk-stream-adapter.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)