### PR TITLE
feat(reflection): pass $TRANSCRIPT_PATH as env var instead of literal path

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -617,6 +617,11 @@ export interface ComposeSubagentChildEnvOptions {
   inheritedApiKey?: string | null;
   /** Forwarded base URL to avoid per-subagent settings lookups. */
   inheritedBaseUrl?: string | null;
+  /** Optional path to a transcript payload file, exposed to the child as
+   * the TRANSCRIPT_PATH env var. Used by reflection subagents so the prompt
+   * can reference `$TRANSCRIPT_PATH` (resolved via Bash) instead of
+   * interpolating the absolute path. Unset → no TRANSCRIPT_PATH in child. */
+  transcriptPath?: string | null;
 }
 
 /**
@@ -652,6 +657,7 @@ export function composeSubagentChildEnv(
     inheritedPrimaryRoot,
     inheritedApiKey,
     inheritedBaseUrl,
+    transcriptPath,
   } = options;
 
   const childEnv: NodeJS.ProcessEnv = {
@@ -660,6 +666,7 @@ export function composeSubagentChildEnv(
     ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
     LETTA_CODE_AGENT_ROLE: "subagent",
     ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
+    ...(transcriptPath && { TRANSCRIPT_PATH: transcriptPath }),
   };
 
   if (backendMode === "local") {
@@ -957,6 +964,7 @@ async function executeSubagent(
   existingConversationId?: string,
   maxTurns?: number,
   parentAgentIdOverride?: string,
+  transcriptPath?: string,
 ): Promise<SubagentResult> {
   // Check if already aborted before starting
   if (signal?.aborted) {
@@ -1042,6 +1050,7 @@ async function executeSubagent(
       inheritedPrimaryRoot,
       inheritedApiKey,
       inheritedBaseUrl,
+      transcriptPath,
     });
 
     const proc = spawn(launcher.command, launcher.args, {
@@ -1146,6 +1155,7 @@ async function executeSubagent(
             undefined, // existingConversationId
             maxTurns,
             parentAgentIdOverride,
+            transcriptPath,
           );
         }
       }
@@ -1292,6 +1302,7 @@ export async function spawnSubagent(
   maxTurns?: number,
   forkedContext?: boolean,
   parentAgentId?: string,
+  transcriptPath?: string,
 ): Promise<SubagentResult> {
   const allConfigs = await getAllSubagentConfigs();
   const config = allConfigs[type];
@@ -1373,6 +1384,7 @@ export async function spawnSubagent(
     existingConversationId,
     maxTurns,
     resolvedParentAgentId,
+    transcriptPath,
   );
 
   return result;

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -2601,7 +2601,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             const memoryDir = getScopedMemoryFilesystemRoot(agentId);
             const parentMemory = await buildParentMemorySnapshot(memoryDir);
             const reflectionPrompt = buildReflectionSubagentPrompt({
-              transcriptPath: autoPayload.payloadPath,
               memoryDir,
               parentMemory,
             });
@@ -2615,6 +2614,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               prompt: reflectionPrompt,
               description: "Reflecting on conversation",
               silentCompletion: true,
+              transcriptPath: autoPayload.payloadPath,
               parentScope: {
                 agentId,
                 conversationId: reflectionConversationId,
@@ -3163,7 +3163,6 @@ ${SYSTEM_REMINDER_CLOSE}
           const memoryDir = getScopedMemoryFilesystemRoot(agentId);
           const parentMemory = await buildParentMemorySnapshot(memoryDir);
           const reflectionPrompt = buildReflectionSubagentPrompt({
-            transcriptPath: autoPayload.payloadPath,
             memoryDir,
             parentMemory,
           });
@@ -3177,6 +3176,7 @@ ${SYSTEM_REMINDER_CLOSE}
             prompt: reflectionPrompt,
             description: AUTO_REFLECTION_DESCRIPTION,
             silentCompletion: true,
+            transcriptPath: autoPayload.payloadPath,
             parentScope: {
               agentId,
               conversationId: reflectionConversationId,

--- a/src/cli/helpers/reflectionTranscript.ts
+++ b/src/cli/helpers/reflectionTranscript.ts
@@ -57,7 +57,6 @@ export interface AutoReflectionPayload {
 }
 
 export interface ReflectionPromptInput {
-  transcriptPath: string;
   memoryDir: string;
   parentMemory?: string;
 }
@@ -68,7 +67,7 @@ export function buildReflectionSubagentPrompt(
   const lines: string[] = [];
 
   lines.push(
-    `Review the conversation transcript and update memory files. The current conversation transcript has been saved to: ${input.transcriptPath}`,
+    "Review the conversation transcript and update memory files. The current conversation transcript path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Edit/Read/Write `file_path` is literal and does NOT expand env vars.",
     "",
     `The primary agent's memory filesystem is located at: ${input.memoryDir}`,
     "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the parent agent's system prompt.",

--- a/src/tests/agent/subagent-env-composition.test.ts
+++ b/src/tests/agent/subagent-env-composition.test.ts
@@ -125,6 +125,41 @@ describe("composeSubagentChildEnv", () => {
     expect(env.LETTA_MEMORY_DIR).toBe(PARENT_MEMORY_DIR);
   });
 
+  test("transcriptPath is forwarded as TRANSCRIPT_PATH env var when set", () => {
+    const env = composeSubagentChildEnv({
+      parentProcessEnv: { HOME: "/home/user" },
+      parentAgentId: PARENT_ID,
+      permissionMode: "memory",
+      inheritedPrimaryRoot: PARENT_MEMORY_DIR,
+      transcriptPath: "/tmp/payload-auto-abc123.json",
+    });
+
+    expect(env.TRANSCRIPT_PATH).toBe("/tmp/payload-auto-abc123.json");
+  });
+
+  test("TRANSCRIPT_PATH not set when transcriptPath omitted", () => {
+    const env = composeSubagentChildEnv({
+      parentProcessEnv: { HOME: "/home/user" },
+      parentAgentId: PARENT_ID,
+      permissionMode: "memory",
+      inheritedPrimaryRoot: PARENT_MEMORY_DIR,
+    });
+
+    expect(env.TRANSCRIPT_PATH).toBeUndefined();
+  });
+
+  test("TRANSCRIPT_PATH not set when transcriptPath is null", () => {
+    const env = composeSubagentChildEnv({
+      parentProcessEnv: { HOME: "/home/user" },
+      parentAgentId: PARENT_ID,
+      permissionMode: "memory",
+      inheritedPrimaryRoot: PARENT_MEMORY_DIR,
+      transcriptPath: null,
+    });
+
+    expect(env.TRANSCRIPT_PATH).toBeUndefined();
+  });
+
   test("API key + base URL forwarded when provided", () => {
     const env = composeSubagentChildEnv({
       parentProcessEnv: { HOME: "/home/user" },

--- a/src/tests/agent/subagent-retry-parent-scope.test.ts
+++ b/src/tests/agent/subagent-retry-parent-scope.test.ts
@@ -10,7 +10,7 @@ const managerSource = readFileSync(
 describe("executeSubagent provider fallback wiring", () => {
   test("forwards parentAgentIdOverride through the provider retry call", () => {
     const retryCallMatch = managerSource.match(
-      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*baseURL,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*\);/s,
+      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*baseURL,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*\);/s,
     );
 
     expect(retryCallMatch).toBeTruthy();

--- a/src/tests/cli/reflection-auto-launch-wiring.test.ts
+++ b/src/tests/cli/reflection-auto-launch-wiring.test.ts
@@ -25,6 +25,15 @@ describe("reflection auto-launch wiring", () => {
     expect(reflectionPromptBlocks.some((block) => block.includes("cwd:"))).toBe(
       false,
     );
+    // Prompt blocks should no longer include a transcriptPath field — the
+    // transcript path is now passed via TRANSCRIPT_PATH env var on the
+    // spawned subagent's child process, not interpolated into the prompt.
+    expect(
+      reflectionPromptBlocks.some((block) => block.includes("transcriptPath:")),
+    ).toBe(false);
+    // ...but the spawn call should still receive the transcript path so it
+    // can be forwarded as $TRANSCRIPT_PATH to the subagent.
+    expect(appSource).toContain("transcriptPath: autoPayload.payloadPath");
     expect(appSource).toContain("maybeLaunchReflectionSubagent,");
 
     expect(engineSource).toContain(

--- a/src/tests/cli/reflection-transcript.test.ts
+++ b/src/tests/cli/reflection-transcript.test.ts
@@ -336,7 +336,6 @@ describe("reflectionTranscript helper", () => {
 
   test("buildReflectionSubagentPrompt uses expanded reflection instructions", () => {
     const prompt = buildReflectionSubagentPrompt({
-      transcriptPath: "/tmp/transcript.json",
       memoryDir: "/tmp/memory",
       parentMemory: "<parent_memory>snapshot</parent_memory>",
     });
@@ -344,8 +343,13 @@ describe("reflectionTranscript helper", () => {
     expect(prompt).toContain("Review the conversation transcript");
     expect(prompt).not.toContain("Your current working directory is:");
     expect(prompt).toContain(
-      "The current conversation transcript has been saved",
+      "The current conversation transcript path is available as the",
     );
+    // Prompt references the $TRANSCRIPT_PATH env var (resolved via Bash),
+    // not a literal absolute path.
+    expect(prompt).toContain("$TRANSCRIPT_PATH");
+    expect(prompt).toContain("cat $TRANSCRIPT_PATH");
+    expect(prompt).not.toContain("/tmp/transcript");
     expect(prompt).toContain(
       "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below.",
     );

--- a/src/tools/impl/Task.ts
+++ b/src/tools/impl/Task.ts
@@ -78,6 +78,14 @@ export interface SpawnBackgroundSubagentTaskArgs {
   /** Parent conversation scope for routing notifications in listener mode. */
   parentScope?: { agentId: string; conversationId: string };
   /**
+   * Optional path to a transcript/payload file the subagent should read.
+   * Exposed to the child process as the `TRANSCRIPT_PATH` env var so
+   * prompts can reference `$TRANSCRIPT_PATH` (resolved via Bash) instead
+   * of interpolating an absolute path. Currently used by reflection
+   * subagents.
+   */
+  transcriptPath?: string;
+  /**
    * When true, skip injecting the completion notification into the primary
    * agent's message queue and hide from SubagentGroupDisplay.
    * Use `onComplete` to show a user-facing notification without leaking
@@ -319,6 +327,7 @@ export function spawnBackgroundSubagentTask(
     emitCompletionNotification,
     completionSummary,
     onComplete,
+    transcriptPath,
     deps,
   } = args;
   const shouldEmitCompletionNotification =
@@ -388,6 +397,7 @@ export function spawnBackgroundSubagentTask(
     maxTurns,
     forkedContext,
     parentAgentIdForSpawn,
+    transcriptPath,
   )
     .then(async (result) => {
       bgTask.status = result.success ? "completed" : "failed";

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -226,7 +226,6 @@ function buildMaybeLaunchReflectionSubagent(params: {
       const memoryDir = getMemoryFilesystemRoot(agentId);
       const parentMemory = await buildParentMemorySnapshot(memoryDir);
       const reflectionPrompt = buildReflectionSubagentPrompt({
-        transcriptPath: autoPayload.payloadPath,
         memoryDir,
         parentMemory,
       });
@@ -238,6 +237,7 @@ function buildMaybeLaunchReflectionSubagent(params: {
         prompt: reflectionPrompt,
         description: AUTO_REFLECTION_DESCRIPTION,
         silentCompletion: true,
+        transcriptPath: autoPayload.payloadPath,
         parentScope: { agentId, conversationId },
         onComplete: async ({ success, error, agentId: reflectionAgentId }) => {
           telemetry.trackReflectionEnd(triggerSource, success, {


### PR DESCRIPTION
## Summary

Reflection subagents previously had the absolute transcript payload path interpolated directly into their user prompt:

> "The current conversation transcript has been saved to: `/Users/.../payload-auto-abc123.json`"

This PR changes the prompt to reference `$TRANSCRIPT_PATH` (a shell env var, resolved via Bash) and threads the actual path through to the subagent process env via a new optional `transcriptPath` plumbing path.

Motivation: matches the existing `$MEMORY_DIR` pattern, makes it explicit that path resolution happens via Bash (which DOES expand env vars), and steers subagents away from feeding `$TRANSCRIPT_PATH` into Edit/Read/Write `file_path` (which does NOT expand env vars — well-documented gotcha).

## Changes

- `src/cli/helpers/reflectionTranscript.ts` — `buildReflectionSubagentPrompt()` no longer takes `transcriptPath`; prompt text now says `$TRANSCRIPT_PATH` literally and includes a one-liner clarifying that the env var only expands in shell commands (Edit/Read/Write `file_path` is literal).
- `src/agent/subagents/manager.ts` — `ComposeSubagentChildEnvOptions` gains an optional `transcriptPath`; when set, child env gets `TRANSCRIPT_PATH=<path>`. Plumbed via `spawnSubagent` -> `executeSubagent` -> `composeSubagentChildEnv` (and through the provider-retry call).
- `src/tools/impl/Task.ts` — `SpawnBackgroundSubagentTaskArgs` gains an optional `transcriptPath` forwarded to `spawnSubagent`.
- `src/websocket/listener/turn.ts` and `src/cli/app/useSubmitHandler.ts` (2 sites) — pass `transcriptPath: autoPayload.payloadPath` to `spawnBackgroundSubagentTask` instead of into the prompt.
- Tests updated:
  - `reflection-transcript.test.ts` — asserts prompt contains `$TRANSCRIPT_PATH` / `cat $TRANSCRIPT_PATH` and no literal path.
  - `reflection-auto-launch-wiring.test.ts` — asserts `transcriptPath:` is no longer in `buildReflectionSubagentPrompt({...})` blocks but IS passed to spawn call.
  - `subagent-env-composition.test.ts` — adds 3 cases (set / omitted / null transcriptPath).
  - `subagent-retry-parent-scope.test.ts` — regex updated to allow new trailing `transcriptPath` arg.

## Test plan

- [x] `bun run check` (biome + tsc) passes
- [x] `bun test src/tests/cli/reflection-transcript.test.ts src/tests/cli/reflection-auto-launch-wiring.test.ts src/tests/agent/subagent-env-composition.test.ts src/tests/agent/subagent-retry-parent-scope.test.ts` — 35 pass / 0 fail
- [x] `bun test src/tests/agent/ src/tests/cli/ src/tests/tools/` — 1289 pass; 2 pre-existing failures on origin/main (unrelated: `memory prompt integration > custom system prompts...`, `skills extraction from .af files > fetches skill from remote source_url`)
- [ ] Manual: trigger a reflection (e.g., via `/compact` or step-count auto-launch) and confirm subagent uses Bash with `$TRANSCRIPT_PATH` rather than seeing the absolute path.

👾 Generated with [Letta Code](https://letta.com)