### PR TITLE
fix(cli): carry max context into new conversations

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2835,6 +2835,9 @@ export default function App({
       ) {
         updateArgs.enable_reasoner = enableReasoner;
       }
+      if (typeof currentLlmConfig?.context_window === "number") {
+        updateArgs.context_window = currentLlmConfig.context_window;
+      }
 
       try {
         const { updateConversationLLMConfig } = await import(

--- a/src/tests/agent/model-preset-refresh.wiring.test.ts
+++ b/src/tests/agent/model-preset-refresh.wiring.test.ts
@@ -122,6 +122,9 @@ describe("model preset refresh wiring", () => {
     expect(segment).toContain("updateConversationLLMConfig(");
     expect(segment).toContain("preserveContextWindow: true");
     expect(segment).toContain(
+      "updateArgs.context_window = currentLlmConfig.context_window",
+    );
+    expect(segment).toContain(
       "Failed to carry over active model to new conversation",
     );
   });


### PR DESCRIPTION
## Summary
- Preserve the active conversation context window when carrying model overrides into fresh conversations.
- Keeps `/set-max-context` scoped like `/model`: default updates agent defaults, non-default applies to that conversation and propagates through new-conversation carry-over paths.

## Test plan
- [x] `bun test src/tests/agent/model-preset-refresh.wiring.test.ts src/tests/agent/max-context.test.ts`
- [x] `bun run lint`

👾 Generated with [Letta Code](https://letta.com)