### PR TITLE
fix(local): support LM Studio connect base URL

### DIFF
--- a/src/backend/dev/AISDKModelFactory.ts
+++ b/src/backend/dev/AISDKModelFactory.ts
@@ -1,5 +1,8 @@
 import type { LanguageModel } from "ai";
-import { getLocalProviderApiKeyByName } from "../local/LocalProviderAuthStore";
+import {
+  getLocalProviderApiKeyByName,
+  getLocalProviderBaseUrlByName,
+} from "../local/LocalProviderAuthStore";
 import {
   type AISDKProvider,
   expectedAISDKProviderList,
@@ -26,7 +29,15 @@ export interface AISDKModelFactoryOptions {
   model?: string;
   createOpenAIResponsesModel?: (model: string) => LanguageModel;
   createAnthropicModel?: (model: string) => LanguageModel;
-  createOpenAICompatibleModel?: (model: string) => LanguageModel;
+  createOpenAICompatibleModel?: (
+    model: string,
+    options: {
+      apiKey?: string;
+      baseURL: string;
+      providerName: string;
+      headers?: Record<string, string>;
+    },
+  ) => LanguageModel;
   createChatGPTOAuthModel?: (model: string) => LanguageModel;
   createGoogleModel?: (model: string) => LanguageModel;
   createBedrockModel?: (model: string) => LanguageModel;
@@ -89,6 +100,18 @@ function localProviderApiKey(
   for (const providerName of providerNames) {
     const key = getLocalProviderApiKeyByName(providerName, storageDir);
     if (key) return key;
+  }
+  return envValue;
+}
+
+function localProviderBaseURL(
+  providerNames: readonly string[],
+  envValue: string | undefined,
+  storageDir?: string,
+): string | undefined {
+  for (const providerName of providerNames) {
+    const baseURL = getLocalProviderBaseUrlByName(providerName, storageDir);
+    if (baseURL) return baseURL;
   }
   return envValue;
 }
@@ -164,6 +187,11 @@ export function createAISDKModelFactory(
     spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
     storageDir,
   );
+  const baseURL = localProviderBaseURL(
+    spec.localProviderNames,
+    spec.baseURL?.(),
+    storageDir,
+  );
 
   switch (spec.sdk) {
     case "openai-responses":
@@ -176,7 +204,7 @@ export function createAISDKModelFactory(
       return createAnthropicModelFactory({
         model,
         providerName: spec.providerName,
-        baseURL: spec.baseURL?.(),
+        baseURL,
         apiKey,
         createModel: options.createAnthropicModel,
       });
@@ -197,7 +225,7 @@ export function createAISDKModelFactory(
       return createOpenAICompatibleModelFactory({
         model,
         providerName: spec.providerName ?? provider,
-        baseURL: spec.baseURL?.() ?? "",
+        baseURL: baseURL ?? "",
         apiKey,
         headers: spec.headers?.(),
         createModel: options.createOpenAICompatibleModel,
@@ -207,7 +235,7 @@ export function createAISDKModelFactory(
       return createGoogleModelFactory({
         model,
         apiKey,
-        baseURL: spec.baseURL?.(),
+        baseURL,
         createModel: options.createGoogleModel,
       });
     case "bedrock":

--- a/src/backend/dev/OpenAICompatibleModel.ts
+++ b/src/backend/dev/OpenAICompatibleModel.ts
@@ -7,7 +7,15 @@ export interface OpenAICompatibleModelFactoryOptions {
   baseURL: string;
   providerName: string;
   headers?: Record<string, string>;
-  createModel?: (model: string) => LanguageModel;
+  createModel?: (
+    model: string,
+    options: {
+      apiKey?: string;
+      baseURL: string;
+      providerName: string;
+      headers?: Record<string, string>;
+    },
+  ) => LanguageModel;
 }
 
 function createDefaultOpenAICompatibleModel(options: {
@@ -48,5 +56,11 @@ export function createOpenAICompatibleModelFactory(
         providerName: options.providerName,
         headers: options.headers,
       }));
-  return () => createModel(model);
+  return () =>
+    createModel(model, {
+      apiKey: options.apiKey,
+      baseURL: options.baseURL,
+      providerName: options.providerName,
+      headers: options.headers,
+    });
 }

--- a/src/backend/local/LocalProviderAuthStore.ts
+++ b/src/backend/local/LocalProviderAuthStore.ts
@@ -167,6 +167,7 @@ export async function createOrUpdateLocalProvider(input: {
   accessKey?: string;
   region?: string;
   profile?: string;
+  baseUrl?: string;
   storageDir?: string;
 }): Promise<ProviderResponse> {
   if (!isLocalProviderTypeSupported(input.providerType)) {
@@ -191,6 +192,7 @@ export async function createOrUpdateLocalProvider(input: {
     ...(input.accessKey ? { access_key: input.accessKey } : {}),
     ...(input.region ? { region: input.region } : {}),
     ...(input.profile ? { profile: input.profile } : {}),
+    ...(input.baseUrl ? { base_url: input.baseUrl } : {}),
     created_at: existing?.created_at ?? now,
     updated_at: now,
   };
@@ -205,6 +207,7 @@ export async function updateLocalProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
   storageDir?: string,
 ): Promise<ProviderResponse> {
   const existing = listLocalProviderRecords(storageDir).find(
@@ -220,6 +223,7 @@ export async function updateLocalProvider(
     accessKey,
     region,
     profile,
+    baseUrl,
     storageDir,
   });
 }
@@ -253,6 +257,14 @@ export function getLocalProviderApiKeyByName(
 ): string | undefined {
   const record = getLocalProviderRecordByName(providerName, storageDir);
   return record?.auth.type === "api" ? record.auth.key : undefined;
+}
+
+export function getLocalProviderBaseUrlByName(
+  providerName: string,
+  storageDir?: string,
+): string | undefined {
+  const record = getLocalProviderRecordByName(providerName, storageDir);
+  return record?.base_url;
 }
 
 export function getLocalProviderApiKeyByType(

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -152,3 +152,29 @@ export function isConnectZaiBaseProvider(
 ): boolean {
   return provider.canonical === "zai";
 }
+
+export function supportsConnectBaseUrl(
+  provider: ResolvedConnectProvider,
+): boolean {
+  return provider.canonical === "ollama" || provider.canonical === "lmstudio";
+}
+
+export function normalizeConnectBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Base URL cannot be empty.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid base URL: ${value}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must start with http:// or https://.");
+  }
+
+  return trimmed.replace(/\/+$/, "");
+}

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -25,8 +25,10 @@ import {
   isConnectZaiBaseProvider,
   listConnectProvidersForHelp,
   listConnectProviderTokens,
+  normalizeConnectBaseUrl,
   type ResolvedConnectProvider,
   resolveConnectProvider,
+  supportsConnectBaseUrl,
 } from "./connect-normalize";
 import {
   isChatGPTOAuthConnected,
@@ -121,6 +123,7 @@ function formatConnectUsage(): string {
     "  /connect codex",
     "  /connect anthropic <api_key>",
     "  /connect openai <api_key>",
+    "  /connect lmstudio --base-url http://127.0.0.1:1234/v1",
     "  /connect bedrock iam --access-key <id> --secret-key <key> --region <region>",
     "  /connect bedrock profile --profile <name> --region <region>",
   ].join("\n");
@@ -206,7 +209,7 @@ function formatBedrockUsage(): string {
 function formatApiKeyUsage(provider: ResolvedConnectProvider): string {
   if (defaultConnectApiKey(provider)) {
     return [
-      `Usage: /connect ${provider.canonical} [api_key]`,
+      `Usage: /connect ${provider.canonical} [api_key]${supportsConnectBaseUrl(provider) ? " [--base-url <url>]" : ""}`,
       "",
       `Connect to ${provider.byokProvider.displayName}. API key is optional for this local provider.`,
     ].join("\n");
@@ -216,6 +219,51 @@ function formatApiKeyUsage(provider: ResolvedConnectProvider): string {
     "",
     `Connect to ${provider.byokProvider.displayName} by providing your API key.`,
   ].join("\n");
+}
+
+function parseApiKeyFlags(
+  args: string[],
+  provider: ResolvedConnectProvider,
+): { apiKey: string; baseUrl?: string; error?: string } {
+  const positionals: string[] = [];
+  let baseUrl: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index] ?? "";
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+
+    if (token !== "--base-url") {
+      return { apiKey: "", error: `Unexpected option: ${token}` };
+    }
+
+    if (!supportsConnectBaseUrl(provider)) {
+      return {
+        apiKey: "",
+        error: `--base-url is not supported for ${provider.canonical}.`,
+      };
+    }
+
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      return { apiKey: "", error: "Missing value for --base-url" };
+    }
+
+    try {
+      baseUrl = normalizeConnectBaseUrl(value);
+    } catch (error) {
+      return { apiKey: "", error: getErrorMessage(error) };
+    }
+    index += 1;
+  }
+
+  if (positionals.length > 1) {
+    return { apiKey: "", error: `Unexpected argument: ${positionals[1]}` };
+  }
+
+  return { apiKey: positionals[0] ?? "", baseUrl };
 }
 
 function formatZaiCodingPlanPrompt(apiKey?: string): string {
@@ -305,6 +353,7 @@ async function handleConnectApiKeyProvider(
   msg: string,
   provider: ResolvedConnectProvider,
   apiKey: string,
+  baseUrl?: string,
 ): Promise<void> {
   const cmdId = addCommandResult(
     ctx.buffersRef,
@@ -334,6 +383,10 @@ async function handleConnectApiKeyProvider(
       provider.byokProvider.providerType,
       provider.byokProvider.providerName,
       apiKey,
+      undefined,
+      undefined,
+      undefined,
+      baseUrl,
     );
 
     updateCommandResult(
@@ -521,7 +574,19 @@ export async function handleConnect(
   }
 
   if (isConnectApiKeyProvider(provider)) {
-    const apiKey = parts.slice(2).join("") || defaultConnectApiKey(provider);
+    const parsed = parseApiKeyFlags(parts.slice(2), provider);
+    if (parsed.error) {
+      addCommandResult(
+        ctx.buffersRef,
+        ctx.refreshDerived,
+        msg,
+        `${parsed.error}\n\n${formatApiKeyUsage(provider)}`,
+        false,
+      );
+      return;
+    }
+
+    const apiKey = parsed.apiKey || defaultConnectApiKey(provider);
     if (!apiKey) {
       if (isConnectZaiBaseProvider(provider)) {
         addCommandResult(
@@ -542,7 +607,13 @@ export async function handleConnect(
       }
       return;
     }
-    await handleConnectApiKeyProvider(ctx, msg, provider, apiKey);
+    await handleConnectApiKeyProvider(
+      ctx,
+      msg,
+      provider,
+      apiKey,
+      parsed.baseUrl,
+    );
   }
 }
 

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -16,7 +16,9 @@ import {
   isConnectZaiBaseProvider,
   listConnectProvidersForHelp,
   listConnectProviderTokens,
+  normalizeConnectBaseUrl,
   resolveConnectProvider,
+  supportsConnectBaseUrl,
 } from "../commands/connect-normalize";
 import {
   type ChatGPTOAuthFlowCallbacks,
@@ -32,6 +34,7 @@ const CONNECT_OPTIONS = {
   "secret-key": { type: "string" },
   region: { type: "string" },
   profile: { type: "string" },
+  "base-url": { type: "string" },
 } as const;
 
 interface ConnectSubcommandDeps {
@@ -54,6 +57,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    baseUrl?: string,
   ) => Promise<unknown>;
   isChatGPTOAuthConnected: () => Promise<boolean>;
   runChatGPTOAuthConnectFlow: (
@@ -95,6 +99,7 @@ function formatUsage(): string {
     "  letta connect codex",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
+    "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1",
     "  letta connect bedrock --method iam --access-key <id> --secret-key <key> --region <region>",
     "  letta connect bedrock --method profile --profile <name> --region <region>",
   ].join("\n");
@@ -269,6 +274,20 @@ export async function runConnectSubcommand(
   if (isConnectApiKeyProvider(provider)) {
     let apiKey =
       readStringOption(parsed.values["api-key"]) ?? restPositionals[0] ?? "";
+    let baseUrl: string | undefined;
+    const baseUrlOption = readStringOption(parsed.values["base-url"]);
+    if (baseUrlOption !== undefined) {
+      if (!supportsConnectBaseUrl(provider)) {
+        io.stderr(`--base-url is not supported for ${provider.canonical}.`);
+        return 1;
+      }
+      try {
+        baseUrl = normalizeConnectBaseUrl(baseUrlOption);
+      } catch (error) {
+        io.stderr(getErrorMessage(error));
+        return 1;
+      }
+    }
     apiKey ||= defaultConnectApiKey(provider) ?? "";
     if (!apiKey && isConnectZaiBaseProvider(provider)) {
       io.stdout(
@@ -304,6 +323,10 @@ export async function runConnectSubcommand(
         provider.byokProvider.providerType,
         provider.byokProvider.providerName,
         apiKey,
+        undefined,
+        undefined,
+        undefined,
+        baseUrl,
       );
 
       io.stdout(

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -339,6 +339,7 @@ export async function createProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
     return createOrUpdateLocalProvider({
@@ -348,6 +349,7 @@ export async function createProvider(
       accessKey,
       region,
       profile,
+      baseUrl,
     });
   }
   return createProviderRequest(
@@ -369,9 +371,17 @@ export async function updateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
-    return updateLocalProvider(providerId, apiKey, accessKey, region, profile);
+    return updateLocalProvider(
+      providerId,
+      apiKey,
+      accessKey,
+      region,
+      profile,
+      baseUrl,
+    );
   }
   return updateProviderRequest(providerId, apiKey, accessKey, region, profile);
 }
@@ -398,6 +408,7 @@ export async function createOrUpdateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseUrl?: string,
 ): Promise<ProviderResponse> {
   if (isLocalProviderStoreEnabled()) {
     return createOrUpdateLocalProvider({
@@ -407,6 +418,7 @@ export async function createOrUpdateProvider(
       accessKey,
       region,
       profile,
+      baseUrl,
     });
   }
   return createOrUpdateProviderRequest(

--- a/src/tests/backend/ai-sdk-model-factory.test.ts
+++ b/src/tests/backend/ai-sdk-model-factory.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { LanguageModel } from "ai";
 import {
   createAISDKModelFactory,
@@ -8,6 +11,7 @@ import {
   resolveAISDKProvider,
   resolveAISDKProviderFromAgent,
 } from "../../backend/dev/AISDKModelFactory";
+import { createOrUpdateLocalProvider } from "../../backend/local";
 
 function withAISDKEnv<T>(
   env: {
@@ -148,6 +152,39 @@ describe("AISDKModelFactory", () => {
 
     expect(factory()).toBe(model);
     expect(capturedAnthropicModel).toBe("claude-dev");
+  });
+
+  test("uses saved LM Studio base URL for local provider factories", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "lmstudio-base-url-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "lmstudio",
+        providerName: "lc-lmstudio",
+        apiKey: "not-needed",
+        baseUrl: "http://localhost:3210/v1",
+      });
+
+      let capturedBaseURL: string | undefined;
+      let capturedProviderName: string | undefined;
+      const model = {} as LanguageModel;
+      const factory = createAISDKModelFactory({
+        provider: "lmstudio",
+        model: "google/gemma-3n-e4b",
+        localProviderAuthStorageDir: storageDir,
+        createOpenAICompatibleModel: (_model, options) => {
+          capturedBaseURL = options.baseURL;
+          capturedProviderName = options.providerName;
+          return model;
+        },
+      });
+
+      expect(factory()).toBe(model);
+      expect(capturedProviderName).toBe("lmstudio");
+      expect(capturedBaseURL).toBe("http://localhost:3210/v1");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("rejects unknown providers", () => {

--- a/src/tests/cli/connect-subcommand.test.ts
+++ b/src/tests/cli/connect-subcommand.test.ts
@@ -55,6 +55,10 @@ describe("connect subcommand", () => {
       "anthropic",
       "lc-anthropic",
       "sk-ant-123",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -97,6 +101,49 @@ describe("connect subcommand", () => {
       "ollama",
       "lc-ollama",
       "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  test("connects LM Studio with a custom base URL", async () => {
+    const { deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      ["lmstudio", "--base-url", "http://127.0.0.1:1234/v1/"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.promptSecret).not.toHaveBeenCalled();
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "lmstudio",
+      "not-needed",
+    );
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "lmstudio",
+      "lc-lmstudio",
+      "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      "http://127.0.0.1:1234/v1",
+    );
+  });
+
+  test("rejects base URL for providers that do not support it", async () => {
+    const { stderr, deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      ["anthropic", "--base-url", "http://localhost:1234/v1"],
+      deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "--base-url is not supported for anthropic",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/letta-ai/letta-code/issues/2258.

This PR makes the documented local-provider command path real for LM Studio:

```bash
letta --backend local connect lmstudio --base-url http://127.0.0.1:1234/v1
```

It adds `--base-url` support to both the standalone `letta connect ...` subcommand and the in-app `/connect ...` command for local OpenAI-compatible providers where a custom endpoint is meaningful.

## Problem

PR #2251 documented a local LM Studio command using `--base-url`, but the merged CLI did not accept that option. Users following the PR instructions hit an unknown option / unsupported surface even though LM Studio itself was present in provider normalization. The local provider store also already had a `base_url` response field shape, but local provider creation did not persist it and AI SDK model construction did not read it back.

## Approach

The fix keeps the scope narrow:

- Allow `--base-url` only for local OpenAI-compatible providers that need endpoint configuration today: `lmstudio` and `ollama`.
- Validate and normalize the URL once in connect normalization helpers.
- Persist `base_url` into the local provider auth record.
- Prefer the stored provider `base_url` when creating AI SDK model factories, falling back to the existing env/default URL behavior.
- Keep API/cloud provider behavior unchanged; `baseUrl` is only used by the local provider store path.

## Before / after

Before:

- `letta --backend local connect lmstudio --base-url ...` rejected `--base-url`.
- A custom LM Studio endpoint could only be supplied through env/default paths, not the documented connect flow.

After:

- `letta --backend local connect lmstudio --base-url http://127.0.0.1:1234/v1` is accepted.
- `/connect lmstudio --base-url http://127.0.0.1:1234/v1` is also accepted in the app.
- The saved local provider URL is used when constructing the LM Studio AI SDK model factory.

## Risk / tradeoffs

This intentionally does not add arbitrary `--base-url` support to all providers. That avoids implying cloud BYOK provider APIs accept custom endpoint URLs when this PR only wires local provider storage and local AI SDK factories. If we want custom OpenAI-compatible endpoints for other providers later, that should be a separate, explicit provider/API design.

The callback type for test model creation now receives the resolved OpenAI-compatible factory options as a second argument. Existing callers that only accept the model string continue to work in TypeScript/JavaScript, and this lets tests assert the actual endpoint selected by the factory.

## Validation

- `bun install --frozen-lockfile`
- `bun test src/tests/backend/ai-sdk-model-factory.test.ts src/tests/cli/connect-subcommand.test.ts src/tests/cli/connect-normalize.test.ts`
- `bun run lint`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)