### PR TITLE
Add Codex release watcher for harness drift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,10 @@
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas
 
+# Codex release watcher and source prompt provenance
+/.github/workflows/codex-release-watch.yml @kl2806
+/scripts/codex-watch/ @kl2806
+/src/agent/prompts/source_codex.md @kl2806
+
 # TUI/CLI runtime and UI
 /src/cli/ @cpacker @4shub @sarahwooders @jnjpng @carenthomas

--- a/.github/workflows/codex-release-watch.yml
+++ b/.github/workflows/codex-release-watch.yml
@@ -1,0 +1,54 @@
+name: Codex Release Watch
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      since_tag:
+        description: "Previous stable openai/codex tag to compare from"
+        required: false
+        type: string
+      current_tag:
+        description: "Current stable openai/codex tag to compare to"
+        required: false
+        type: string
+      dry_run:
+        description: "Print the issue body instead of creating an issue"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check latest stable Codex release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ARGS=()
+          if [ -n "${{ inputs.since_tag }}" ]; then
+            ARGS+=(--since "${{ inputs.since_tag }}")
+          fi
+          if [ -n "${{ inputs.current_tag }}" ]; then
+            ARGS+=(--current "${{ inputs.current_tag }}")
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          bun scripts/codex-watch/check-release.ts "${ARGS[@]}"

--- a/scripts/codex-watch/check-release.ts
+++ b/scripts/codex-watch/check-release.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env bun
+/**
+ * Watches stable openai/codex releases for tool/schema changes that may affect
+ * the letta-code harness.
+ *
+ * Usage:
+ *   bun scripts/codex-watch/check-release.ts --dry-run
+ *   bun scripts/codex-watch/check-release.ts --dry-run --since rust-v0.129.0
+ *   bun scripts/codex-watch/check-release.ts --repo letta-ai/letta-code
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  decideVerdict,
+  diffModelsJson,
+  type ModelsDiff,
+  type ModelsJson,
+} from "./diff-models-json.ts";
+import {
+  type PathChangeSummary,
+  renderBody,
+  renderTitle,
+} from "./render-issue.ts";
+
+const CODEX_REPO = "openai/codex";
+const DEFAULT_TARGET_REPO =
+  process.env.GITHUB_REPOSITORY || "letta-ai/letta-code";
+const WATCHED_PATHS = [
+  "codex-rs/models-manager/models.json",
+  "codex-rs/models-manager/prompt.md",
+  "codex-rs/core/src/tools",
+  "codex-rs/apply-patch",
+];
+
+interface Release {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  html_url: string;
+  body: string | null;
+  published_at: string | null;
+}
+
+interface Args {
+  dryRun: boolean;
+  sinceTag: string | null;
+  currentTag: string | null;
+  repo: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    dryRun: false,
+    sinceTag: null,
+    currentTag: null,
+    repo: DEFAULT_TARGET_REPO,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--since") args.sinceTag = argv[++i] ?? null;
+    else if (a === "--current") args.currentTag = argv[++i] ?? null;
+    else if (a === "--repo") args.repo = argv[++i] ?? args.repo;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        `Usage: bun scripts/codex-watch/check-release.ts [--dry-run] [--since TAG] [--current TAG] [--repo OWNER/REPO]`,
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function gh<T>(args: string[], input?: string): T {
+  const res = spawnSync("gh", args, {
+    encoding: "utf8",
+    input,
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed:\n${res.stderr}`);
+  }
+  return JSON.parse(res.stdout) as T;
+}
+
+function git(args: string[], cwd?: string): string {
+  const res = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${res.stderr}`);
+  }
+  return res.stdout;
+}
+
+function isStableRelease(release: Release): boolean {
+  if (release.draft || release.prerelease) return false;
+  return /^(rust-v|v)?\d+\.\d+\.\d+$/.test(release.tag_name);
+}
+
+async function listStableReleases(): Promise<Release[]> {
+  const releases: Release[] = [];
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  for (let page = 1; page <= 10; page++) {
+    const url = `https://api.github.com/repos/${CODEX_REPO}/releases?per_page=100&page=${page}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(
+        `GitHub releases API failed (${res.status}): ${await res.text()}`,
+      );
+    }
+    const batch = (await res.json()) as Release[];
+    releases.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return releases
+    .filter(isStableRelease)
+    .sort((a, b) => (a.published_at ?? "").localeCompare(b.published_at ?? ""));
+}
+
+function findPreviousStable(
+  stables: Release[],
+  currentTag: string,
+): Release | null {
+  const idx = stables.findIndex((r) => r.tag_name === currentTag);
+  if (idx <= 0) return null;
+  return stables[idx - 1] ?? null;
+}
+
+function hasReportedTag(targetRepo: string, tag: string): boolean {
+  const issues = gh<Array<{ title: string }>>([
+    "issue",
+    "list",
+    "--repo",
+    targetRepo,
+    "--state",
+    "all",
+    "--search",
+    `[codex-watch] openai/codex ${tag} in:title`,
+    "--limit",
+    "20",
+    "--json",
+    "title",
+  ]);
+  return issues.some((i) =>
+    i.title.startsWith(`[codex-watch] openai/codex ${tag} `),
+  );
+}
+
+function cloneCodex(tmp: string): string {
+  const dir = join(tmp, "codex");
+  git([
+    "clone",
+    "--filter=blob:none",
+    "--no-checkout",
+    `https://github.com/${CODEX_REPO}.git`,
+    dir,
+  ]);
+  return dir;
+}
+
+function showFile(repoDir: string, tag: string, path: string): string | null {
+  const res = spawnSync("git", ["show", `${tag}:${path}`], {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) return null;
+  return res.stdout;
+}
+
+function changedFiles(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+): string[] {
+  return git(["diff", "--name-only", `${prevTag}..${currTag}`], repoDir)
+    .split("\n")
+    .filter(Boolean);
+}
+
+function commitsForPath(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+  path: string,
+): string[] {
+  const out = git(
+    ["log", "--format=%h %s", `${prevTag}..${currTag}`, "--", path],
+    repoDir,
+  );
+  return out.split("\n").filter(Boolean).slice(0, 12);
+}
+
+function diffPreview(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+  path: string,
+): string | null {
+  const out = git(
+    ["diff", "--unified=2", `${prevTag}..${currTag}`, "--", path],
+    repoDir,
+  );
+  if (!out.trim()) return null;
+  return out.split("\n").slice(0, 120).join("\n");
+}
+
+function createIssue(
+  repo: string,
+  title: string,
+  body: string,
+  verdict: string,
+): void {
+  const labels = ["codex-watch", "automation"];
+  if (verdict === "tool-schema update needed") labels.push("priority/review");
+  if (verdict === "no-op") labels.push("informational");
+
+  ensureLabels(repo, labels);
+
+  const bodyFile = join(tmpdir(), `codex-watch-${Date.now()}.md`);
+  writeFileSync(bodyFile, body);
+  try {
+    const args = [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+      "--body-file",
+      bodyFile,
+    ];
+    for (const label of labels) args.push("--label", label);
+    const res = spawnSync("gh", args, { encoding: "utf8" });
+    if (res.status !== 0) {
+      throw new Error(`gh ${args.join(" ")} failed:\n${res.stderr}`);
+    }
+    console.log(res.stdout.trim());
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+function ensureLabels(repo: string, labels: string[]): void {
+  for (const label of labels) {
+    const res = spawnSync("gh", ["label", "create", label, "--repo", repo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (res.status !== 0 && !res.stderr.includes("already exists")) {
+      throw new Error(`gh label create ${label} failed:\n${res.stderr}`);
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const stables = await listStableReleases();
+  if (stables.length === 0) throw new Error("No stable Codex releases found");
+
+  const current = args.currentTag
+    ? stables.find((r) => r.tag_name === args.currentTag)
+    : stables.at(-1);
+  if (!current)
+    throw new Error(`Could not find current release ${args.currentTag}`);
+
+  const previous = args.sinceTag
+    ? (stables.find((r) => r.tag_name === args.sinceTag) ??
+      ({ tag_name: args.sinceTag } as Release))
+    : findPreviousStable(stables, current.tag_name);
+  if (!previous)
+    throw new Error(
+      `Could not find previous stable before ${current.tag_name}`,
+    );
+
+  const alreadyReported = args.dryRun
+    ? false
+    : hasReportedTag(args.repo, current.tag_name);
+  if (alreadyReported) {
+    console.log(`Already reported ${current.tag_name}; nothing to do.`);
+    return;
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "codex-watch-"));
+  try {
+    const repoDir = cloneCodex(tmp);
+    git(
+      [
+        "fetch",
+        "--filter=blob:none",
+        "origin",
+        `refs/tags/${previous.tag_name}:refs/tags/${previous.tag_name}`,
+      ],
+      repoDir,
+    );
+    git(
+      [
+        "fetch",
+        "--filter=blob:none",
+        "origin",
+        `refs/tags/${current.tag_name}:refs/tags/${current.tag_name}`,
+      ],
+      repoDir,
+    );
+
+    let modelsDiff: ModelsDiff | null = null;
+    let parseError = false;
+    try {
+      const prevRaw = showFile(
+        repoDir,
+        previous.tag_name,
+        "codex-rs/models-manager/models.json",
+      );
+      const currRaw = showFile(
+        repoDir,
+        current.tag_name,
+        "codex-rs/models-manager/models.json",
+      );
+      if (!prevRaw || !currRaw)
+        throw new Error("missing models.json at one tag");
+      modelsDiff = diffModelsJson(
+        JSON.parse(prevRaw) as ModelsJson,
+        JSON.parse(currRaw) as ModelsJson,
+      );
+    } catch (err) {
+      parseError = true;
+      console.error(`Failed to parse/diff models.json: ${String(err)}`);
+    }
+
+    const changed = changedFiles(repoDir, previous.tag_name, current.tag_name);
+    const changedSet = new Set(changed);
+    const promptMdChanged = changedSet.has("codex-rs/models-manager/prompt.md");
+    const toolsDirChanged = changed.some((f) =>
+      f.startsWith("codex-rs/core/src/tools/"),
+    );
+    const applyPatchDirChanged = changed.some((f) =>
+      f.startsWith("codex-rs/apply-patch/"),
+    );
+    const verdict = decideVerdict({
+      models_diff: modelsDiff,
+      prompt_md_changed: promptMdChanged,
+      tools_dir_changed: toolsDirChanged,
+      apply_patch_dir_changed: applyPatchDirChanged,
+      parse_error: parseError,
+    });
+
+    const pathChanges: PathChangeSummary[] = WATCHED_PATHS.map((path) => ({
+      path,
+      commits: commitsForPath(
+        repoDir,
+        previous.tag_name,
+        current.tag_name,
+        path,
+      ),
+    })).filter((p) => p.commits.length > 0);
+
+    const workflowUrl =
+      process.env.GITHUB_SERVER_URL &&
+      process.env.GITHUB_REPOSITORY &&
+      process.env.GITHUB_RUN_ID
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : "local dry-run";
+
+    const input = {
+      previous_tag: previous.tag_name,
+      current_tag: current.tag_name,
+      release_url: current.html_url,
+      release_notes_md: current.body ?? "",
+      verdict,
+      models_diff: modelsDiff,
+      prompt_md_changed: promptMdChanged,
+      prompt_md_diff_preview: promptMdChanged
+        ? diffPreview(
+            repoDir,
+            previous.tag_name,
+            current.tag_name,
+            "codex-rs/models-manager/prompt.md",
+          )
+        : null,
+      path_changes: pathChanges,
+      workflow_run_url: workflowUrl,
+    };
+
+    const title = renderTitle(input);
+    const body = renderBody(input);
+
+    if (args.dryRun) {
+      console.log(`# ${title}\n\n${body}`);
+    } else {
+      createIssue(args.repo, title, body, verdict);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/codex-watch/check-release.ts
+++ b/scripts/codex-watch/check-release.ts
@@ -34,6 +34,7 @@ const WATCHED_PATHS = [
   "codex-rs/core/src/tools",
   "codex-rs/apply-patch",
 ];
+const MAX_COMMITS_PER_PATH = 8;
 
 interface Release {
   tag_name: string;
@@ -203,7 +204,12 @@ function commitsForPath(
     ["log", "--format=%h %s", `${prevTag}..${currTag}`, "--", path],
     repoDir,
   );
-  return out.split("\n").filter(Boolean).slice(0, 12);
+  const commits = out.split("\n").filter(Boolean);
+  if (commits.length <= MAX_COMMITS_PER_PATH) return commits;
+  return [
+    ...commits.slice(0, MAX_COMMITS_PER_PATH),
+    `…and ${commits.length - MAX_COMMITS_PER_PATH} more commits`,
+  ];
 }
 
 function diffPreview(

--- a/scripts/codex-watch/check-release.ts
+++ b/scripts/codex-watch/check-release.ts
@@ -227,7 +227,12 @@ function createIssue(
   verdict: string,
 ): void {
   const labels = ["codex-watch", "automation"];
-  if (verdict === "tool-schema update needed") labels.push("priority/review");
+  if (
+    verdict === "tool-schema update needed" ||
+    verdict === "tool-surface review needed"
+  ) {
+    labels.push("priority/review");
+  }
   if (verdict === "no-op") labels.push("informational");
 
   ensureLabels(repo, labels);

--- a/scripts/codex-watch/diff-models-json.test.ts
+++ b/scripts/codex-watch/diff-models-json.test.ts
@@ -89,7 +89,7 @@ describe("decideVerdict", () => {
     ).toBe("no-op");
   });
 
-  test("returns tool-schema update needed when tools dir changed", () => {
+  test("returns tool-surface review needed when tools dir changed", () => {
     const models_diff = diffModelsJson(
       models(model("gpt-5.5")),
       models(model("gpt-5.5")),
@@ -99,6 +99,22 @@ describe("decideVerdict", () => {
         models_diff,
         prompt_md_changed: false,
         tools_dir_changed: true,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("tool-surface review needed");
+  });
+
+  test("returns tool-schema update needed for models.json schema fields", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5", { shell_type: "unified_exec" })),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: false,
+        tools_dir_changed: false,
         apply_patch_dir_changed: false,
         parse_error: false,
       }),

--- a/scripts/codex-watch/diff-models-json.test.ts
+++ b/scripts/codex-watch/diff-models-json.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decideVerdict,
+  diffModelsJson,
+  type ModelsJson,
+} from "./diff-models-json.ts";
+
+function model(slug: string, extra: Record<string, unknown> = {}) {
+  return {
+    slug,
+    apply_patch_tool_type: "freeform",
+    shell_type: "shell_command",
+    supports_parallel_tool_calls: true,
+    supports_search_tool: true,
+    experimental_supported_tools: [],
+    base_instructions: "Use apply_patch and multi_tool_use.parallel.",
+    model_messages: {
+      instructions_template: "You may call view_image when needed.",
+    },
+    ...extra,
+  };
+}
+
+function models(...entries: Array<Record<string, unknown>>): ModelsJson {
+  return { models: entries };
+}
+
+describe("diffModelsJson", () => {
+  test("detects tool schema field changes", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5", { shell_type: "unified_exec" })),
+    );
+
+    expect(diff.has_tool_schema_change).toBe(true);
+    expect(diff.field_deltas).toEqual([
+      {
+        slug: "gpt-5.5",
+        field: "shell_type",
+        previous: "shell_command",
+        current: "unified_exec",
+      },
+    ]);
+  });
+
+  test("detects prompt tool mention changes separately", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(
+        model("gpt-5.5", {
+          base_instructions: "Use apply_patch and web_search.",
+          model_messages: { instructions_template: "No image tool mention." },
+        }),
+      ),
+    );
+
+    expect(diff.has_tool_schema_change).toBe(false);
+    expect(diff.has_prompt_tool_change).toBe(true);
+    expect(diff.field_deltas.map((d) => d.field)).toEqual([
+      "prompt_tool_mentions",
+    ]);
+  });
+
+  test("reports added and removed models", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.4"), model("gpt-5.5")),
+      models(model("gpt-5.5"), model("gpt-5.6")),
+    );
+
+    expect(diff.added_models).toEqual(["gpt-5.6"]);
+    expect(diff.removed_models).toEqual(["gpt-5.4"]);
+  });
+});
+
+describe("decideVerdict", () => {
+  test("returns no-op for empty diff", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5")),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: false,
+        tools_dir_changed: false,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("no-op");
+  });
+
+  test("returns tool-schema update needed when tools dir changed", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5")),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: false,
+        tools_dir_changed: true,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("tool-schema update needed");
+  });
+
+  test("returns prompt-only update for prompt changes", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5")),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: true,
+        tools_dir_changed: false,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("prompt-only update");
+  });
+
+  test("returns manual review on parse error", () => {
+    expect(
+      decideVerdict({
+        models_diff: null,
+        prompt_md_changed: false,
+        tools_dir_changed: false,
+        apply_patch_dir_changed: false,
+        parse_error: true,
+      }),
+    ).toBe("manual review required");
+  });
+});

--- a/scripts/codex-watch/diff-models-json.ts
+++ b/scripts/codex-watch/diff-models-json.ts
@@ -1,0 +1,206 @@
+/**
+ * Structured diff of openai/codex `codex-rs/models-manager/models.json`.
+ *
+ * We don't care about every field — only the ones that affect the tool/schema
+ * surface exposed to the model. When any of these change, the letta-code
+ * harness (src/agent/prompts/source_codex.md and src/tools/*) may need updating.
+ */
+
+/** Tool-relevant fields lifted off each model entry in models.json. */
+export interface ModelToolConfig {
+  slug: string;
+  apply_patch_tool_type?: string;
+  web_search_tool_type?: string;
+  shell_type?: string;
+  supports_search_tool?: boolean;
+  supports_parallel_tool_calls?: boolean;
+  supports_image_detail_original?: boolean;
+  experimental_supported_tools?: string[];
+  input_modalities?: string[];
+  truncation_policy?: unknown;
+  /** Tool names mentioned anywhere in base_instructions / instructions_template. */
+  prompt_tool_mentions: string[];
+}
+
+/** Substrings we treat as "this prompt mentions tool X". */
+const TOOL_MENTIONS = [
+  "apply_patch",
+  "exec_command",
+  "view_image",
+  "multi_tool_use.parallel",
+  "web_search",
+  "update_plan",
+  "container.exec",
+];
+
+export interface ModelsJson {
+  models: Array<Record<string, unknown>>;
+}
+
+export interface ToolFieldDelta {
+  slug: string;
+  field: string;
+  previous: unknown;
+  current: unknown;
+}
+
+export interface ModelsDiff {
+  added_models: string[];
+  removed_models: string[];
+  field_deltas: ToolFieldDelta[];
+  /** True if any field_delta is in TOOL_SCHEMA_FIELDS. */
+  has_tool_schema_change: boolean;
+  /** True if any prompt_tool_mentions added or removed. */
+  has_prompt_tool_change: boolean;
+}
+
+/** Fields whose change implies a tool-schema update may be needed in letta-code. */
+export const TOOL_SCHEMA_FIELDS = new Set([
+  "apply_patch_tool_type",
+  "web_search_tool_type",
+  "shell_type",
+  "supports_search_tool",
+  "supports_parallel_tool_calls",
+  "experimental_supported_tools",
+  "input_modalities",
+  "truncation_policy",
+]);
+
+function collectMentions(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of TOOL_MENTIONS) {
+    if (text.includes(m)) found.add(m);
+  }
+  return Array.from(found).sort();
+}
+
+export function extractToolConfig(
+  model: Record<string, unknown>,
+): ModelToolConfig {
+  const slug = typeof model.slug === "string" ? model.slug : "<unknown>";
+  const promptText = [
+    typeof model.base_instructions === "string" ? model.base_instructions : "",
+    typeof model.model_messages === "object" && model.model_messages !== null
+      ? JSON.stringify(model.model_messages)
+      : "",
+  ].join("\n");
+  return {
+    slug,
+    apply_patch_tool_type: model.apply_patch_tool_type as string | undefined,
+    web_search_tool_type: model.web_search_tool_type as string | undefined,
+    shell_type: model.shell_type as string | undefined,
+    supports_search_tool: model.supports_search_tool as boolean | undefined,
+    supports_parallel_tool_calls: model.supports_parallel_tool_calls as
+      | boolean
+      | undefined,
+    supports_image_detail_original: model.supports_image_detail_original as
+      | boolean
+      | undefined,
+    experimental_supported_tools: model.experimental_supported_tools as
+      | string[]
+      | undefined,
+    input_modalities: model.input_modalities as string[] | undefined,
+    truncation_policy: model.truncation_policy,
+    prompt_tool_mentions: collectMentions(promptText),
+  };
+}
+
+function equal(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Compute the diff between two models.json payloads. */
+export function diffModelsJson(prev: ModelsJson, curr: ModelsJson): ModelsDiff {
+  const prevBySlug = new Map<string, ModelToolConfig>();
+  const currBySlug = new Map<string, ModelToolConfig>();
+  for (const m of prev.models) {
+    const cfg = extractToolConfig(m);
+    prevBySlug.set(cfg.slug, cfg);
+  }
+  for (const m of curr.models) {
+    const cfg = extractToolConfig(m);
+    currBySlug.set(cfg.slug, cfg);
+  }
+
+  const added_models: string[] = [];
+  const removed_models: string[] = [];
+  for (const slug of currBySlug.keys()) {
+    if (!prevBySlug.has(slug)) added_models.push(slug);
+  }
+  for (const slug of prevBySlug.keys()) {
+    if (!currBySlug.has(slug)) removed_models.push(slug);
+  }
+
+  const field_deltas: ToolFieldDelta[] = [];
+  let has_tool_schema_change = false;
+  let has_prompt_tool_change = false;
+
+  const fieldsToCompare = [
+    ...TOOL_SCHEMA_FIELDS,
+    "supports_image_detail_original",
+    "prompt_tool_mentions",
+  ];
+
+  for (const [slug, prevCfg] of prevBySlug) {
+    const currCfg = currBySlug.get(slug);
+    if (!currCfg) continue;
+    for (const field of fieldsToCompare) {
+      const p = (prevCfg as unknown as Record<string, unknown>)[field];
+      const c = (currCfg as unknown as Record<string, unknown>)[field];
+      if (!equal(p, c)) {
+        field_deltas.push({ slug, field, previous: p, current: c });
+        if (TOOL_SCHEMA_FIELDS.has(field)) has_tool_schema_change = true;
+        if (field === "prompt_tool_mentions") has_prompt_tool_change = true;
+      }
+    }
+  }
+
+  return {
+    added_models,
+    removed_models,
+    field_deltas,
+    has_tool_schema_change,
+    has_prompt_tool_change,
+  };
+}
+
+export type Verdict =
+  | "no-op"
+  | "prompt-only update"
+  | "tool-schema update needed"
+  | "manual review required";
+
+export interface VerdictInput {
+  models_diff: ModelsDiff | null;
+  prompt_md_changed: boolean;
+  tools_dir_changed: boolean;
+  apply_patch_dir_changed: boolean;
+  parse_error: boolean;
+}
+
+/** Decide which verdict best describes the upstream change set. */
+export function decideVerdict(input: VerdictInput): Verdict {
+  if (input.parse_error) return "manual review required";
+  if (!input.models_diff) return "manual review required";
+
+  const removedModels = input.models_diff.removed_models.length > 0;
+  if (removedModels) return "manual review required";
+
+  if (
+    input.models_diff.has_tool_schema_change ||
+    input.tools_dir_changed ||
+    input.apply_patch_dir_changed
+  ) {
+    return "tool-schema update needed";
+  }
+
+  if (input.models_diff.has_prompt_tool_change || input.prompt_md_changed) {
+    return "prompt-only update";
+  }
+
+  if (input.models_diff.field_deltas.length > 0) {
+    return "prompt-only update";
+  }
+
+  return "no-op";
+}

--- a/scripts/codex-watch/diff-models-json.ts
+++ b/scripts/codex-watch/diff-models-json.ts
@@ -168,6 +168,7 @@ export type Verdict =
   | "no-op"
   | "prompt-only update"
   | "tool-schema update needed"
+  | "tool-surface review needed"
   | "manual review required";
 
 export interface VerdictInput {
@@ -186,12 +187,12 @@ export function decideVerdict(input: VerdictInput): Verdict {
   const removedModels = input.models_diff.removed_models.length > 0;
   if (removedModels) return "manual review required";
 
-  if (
-    input.models_diff.has_tool_schema_change ||
-    input.tools_dir_changed ||
-    input.apply_patch_dir_changed
-  ) {
+  if (input.models_diff.has_tool_schema_change) {
     return "tool-schema update needed";
+  }
+
+  if (input.tools_dir_changed || input.apply_patch_dir_changed) {
+    return "tool-surface review needed";
   }
 
   if (input.models_diff.has_prompt_tool_change || input.prompt_md_changed) {

--- a/scripts/codex-watch/render-issue.ts
+++ b/scripts/codex-watch/render-issue.ts
@@ -157,14 +157,6 @@ export function renderBody(input: RenderInput): string {
     parts.push("");
   }
 
-  // Release notes
-  parts.push(`<details><summary>Release notes</summary>`);
-  parts.push("");
-  parts.push(input.release_notes_md || "_(empty)_");
-  parts.push("");
-  parts.push(`</details>`);
-  parts.push("");
-
   // Suggested actions
   parts.push(`## Suggested actions`);
   parts.push("");
@@ -174,7 +166,7 @@ export function renderBody(input: RenderInput): string {
   // Provenance
   parts.push(`## How this was generated`);
   parts.push("");
-  parts.push(`- Release: ${input.release_url}`);
+  parts.push(`- Release/notes: ${input.release_url}`);
   parts.push(
     `- Compare: https://github.com/openai/codex/compare/${input.previous_tag}...${input.current_tag}`,
   );
@@ -186,15 +178,15 @@ export function renderBody(input: RenderInput): string {
 function verdictRationale(input: RenderInput): string {
   switch (input.verdict) {
     case "no-op":
-      return "No tool-relevant changes detected in watched paths. Filed for audit trail.";
+      return "No watched tool-surface changes detected.";
     case "prompt-only update":
-      return "Prompt text or tool mentions changed. `src/agent/prompts/source_codex.md` should be re-extracted; no tool implementation changes needed.";
+      return "Prompt text or tool mentions changed; `src/agent/prompts/source_codex.md` may need re-extraction.";
     case "tool-schema update needed":
-      return "Upstream changed tool-config fields in `models.json`. Review the table below and update the matching letta-code tool schema, description, implementation, or prompt mirror if the new model contract diverges.";
+      return "Upstream changed tool-config fields in `models.json`. Review local mirrors only where the model contract changed.";
     case "tool-surface review needed":
-      return "No tool-config field deltas were detected in `models.json`, but upstream changed watched tool implementation paths. Review the commits below to decide whether letta-code needs matching tool schema, prompt, or behavior updates.";
+      return "No `models.json` tool-field deltas, but upstream tool implementation paths changed. Check whether letta-code has a mirror.";
     case "manual review required":
-      return "Could not classify automatically (parse error or removed model). Please review the diff manually.";
+      return "Could not classify automatically; review the upstream diff manually.";
   }
 }
 
@@ -207,34 +199,34 @@ function potentialImpacts(input: RenderInput): string[] {
 
   if (input.models_diff?.field_deltas.length) {
     out.push(
-      "`models.json` changed tool-related model fields. Use the table above to update the listed local mirror paths if the field controls tool naming, availability, or prompt instructions in letta-code.",
+      "`models.json` field deltas: inspect listed local mirrors for schema, availability, or prompt drift.",
     );
   }
 
   if (hasPath(input, "codex-rs/core/src/tools")) {
     out.push(
-      "`codex-rs/core/src/tools` changed. Check whether upstream changed built-in tool specs or runtime semantics, then compare against `src/tools/toolDefinitions.ts`, `src/tools/schemas/*.json`, `src/tools/descriptions/*.md`, `src/tools/impl/*`, and `src/tools/manager.ts`.",
+      "Core tools changed: compare relevant commits against `src/tools/toolDefinitions.ts`, `schemas/`, `descriptions/`, `impl/`, and `manager.ts`.",
     );
     out.push(
-      "Map commit subjects to local tools before editing: `view_image` maps to `ViewImage`, shell/exec changes map to `ShellCommand`/`Bash`, `apply_patch` changes map to `ApplyPatch`, and MCP/search/approval changes may be upstream-only if letta-code has no equivalent exposed tool.",
+      "Likely mirrors: `view_image` → `ViewImage`, shell/exec → `ShellCommand`/`Bash`, `apply_patch` → `ApplyPatch`; MCP/search/approval may be upstream-only.",
     );
   }
 
   if (hasPath(input, "codex-rs/apply-patch")) {
     out.push(
-      "`codex-rs/apply-patch` changed. Compare parser and failure semantics with `src/tools/impl/ApplyPatch.ts`, `src/tools/impl/MemoryApplyPatch.ts`, `src/tools/descriptions/ApplyPatch.md`, and the apply-patch tests.",
+      "`apply-patch` changed: compare parser/failure semantics with `ApplyPatch.ts`, `MemoryApplyPatch.ts`, descriptions, and tests.",
     );
   }
 
   if (input.prompt_md_changed) {
     out.push(
-      "`codex-rs/models-manager/prompt.md` changed. Re-extract or reconcile `src/agent/prompts/source_codex.md` and update `src/agent/prompts/README.md` provenance.",
+      "Prompt changed: reconcile `src/agent/prompts/source_codex.md` and README provenance.",
     );
   }
 
   if (input.verdict === "no-op") {
     out.push(
-      "No watched tool surfaces changed. Skim release notes for untracked harness risks, then close if nothing applies.",
+      "No watched tool surfaces changed. Skim release notes, then close if nothing applies.",
     );
   }
 
@@ -244,29 +236,22 @@ function potentialImpacts(input: RenderInput): string[] {
 function suggestedActions(input: RenderInput): string[] {
   const out: string[] = [];
   if (input.verdict === "no-op") {
-    out.push("Skim the release notes; close this issue if nothing stands out.");
+    out.push("Skim release notes; close if nothing stands out.");
     return out;
   }
   if (input.verdict === "prompt-only update" || input.prompt_md_changed) {
     out.push(
-      "Re-extract `src/agent/prompts/source_codex.md` from upstream `codex-rs/models-manager/models.json` (`instructions_template` with `personality_pragmatic`).",
+      "Re-extract/reconcile `src/agent/prompts/source_codex.md` if prompt semantics changed.",
     );
-    out.push("Update provenance line in `src/agent/prompts/README.md`.");
   }
   if (input.verdict === "tool-schema update needed") {
     out.push(
-      "For each `models.json` row above, inspect the listed local mirror path and update letta-code only if the new field value changes the exposed tool contract.",
-    );
-    out.push(
-      "If a schema/description/implementation changes, add or update the matching test under `src/tests/tools/`.",
+      "Inspect each `models.json` delta; update local schema/description/impl/tests only if the exposed contract changed.",
     );
   }
   if (input.verdict === "tool-surface review needed") {
     out.push(
-      "Review the upstream commits under watched paths and decide whether each one has a letta-code mirror or is upstream-only.",
-    );
-    out.push(
-      "If letta-code should mirror a change, update the relevant `src/tools/schemas`, `src/tools/descriptions`, `src/tools/impl`, prompt source, and tests together.",
+      "Review watched-path commits; if a change has a letta-code mirror, update schema/description/impl/prompt/tests together.",
     );
   }
   if (input.verdict === "manual review required") {

--- a/scripts/codex-watch/render-issue.ts
+++ b/scripts/codex-watch/render-issue.ts
@@ -29,16 +29,26 @@ const LOCAL_MIRRORS: Record<string, string[]> = {
   apply_patch_tool_type: [
     "src/agent/prompts/source_codex.md",
     "src/tools/impl/",
+    "src/tools/schemas/ApplyPatch.json",
+    "src/tools/descriptions/ApplyPatch.md",
   ],
-  web_search_tool_type: ["src/tools/impl/"],
-  shell_type: ["src/tools/impl/", "src/agent/prompts/source_codex.md"],
-  supports_search_tool: ["src/tools/impl/"],
+  web_search_tool_type: ["src/tools/toolDefinitions.ts", "src/tools/impl/"],
+  shell_type: [
+    "src/tools/toolDefinitions.ts",
+    "src/tools/schemas/ShellCommand.json",
+    "src/tools/descriptions/ShellCommand.md",
+    "src/tools/impl/",
+    "src/agent/prompts/source_codex.md",
+  ],
+  supports_search_tool: ["src/tools/filter.ts", "src/tools/toolDefinitions.ts"],
   supports_parallel_tool_calls: ["src/agent/prompts/source_codex.md"],
   experimental_supported_tools: [
     "src/tools/toolDefinitions.ts",
+    "src/tools/schemas/",
+    "src/tools/descriptions/",
     "src/tools/impl/",
   ],
-  input_modalities: ["src/tools/impl/"],
+  input_modalities: ["src/tools/toolDefinitions.ts", "src/tools/impl/"],
   truncation_policy: ["src/agent/prompts/source_codex.md"],
   prompt_tool_mentions: ["src/agent/prompts/source_codex.md"],
 };
@@ -129,6 +139,14 @@ export function renderBody(input: RenderInput): string {
     parts.push("");
   }
 
+  const impacts = potentialImpacts(input);
+  if (impacts.length > 0) {
+    parts.push(`## Potential letta-code impact`);
+    parts.push("");
+    for (const impact of impacts) parts.push(`- ${impact}`);
+    parts.push("");
+  }
+
   // Prompt diff preview
   if (input.prompt_md_changed && input.prompt_md_diff_preview) {
     parts.push(`## \`codex-rs/models-manager/prompt.md\` diff (preview)`);
@@ -172,10 +190,55 @@ function verdictRationale(input: RenderInput): string {
     case "prompt-only update":
       return "Prompt text or tool mentions changed. `src/agent/prompts/source_codex.md` should be re-extracted; no tool implementation changes needed.";
     case "tool-schema update needed":
-      return "Upstream changed tool-config fields in `models.json` and/or `codex-rs/core/src/tools/`. Letta-code's tool definitions may need to mirror the new shape.";
+      return "Upstream changed tool-config fields in `models.json`. Review the table below and update the matching letta-code tool schema, description, implementation, or prompt mirror if the new model contract diverges.";
+    case "tool-surface review needed":
+      return "No tool-config field deltas were detected in `models.json`, but upstream changed watched tool implementation paths. Review the commits below to decide whether letta-code needs matching tool schema, prompt, or behavior updates.";
     case "manual review required":
       return "Could not classify automatically (parse error or removed model). Please review the diff manually.";
   }
+}
+
+function hasPath(input: RenderInput, prefix: string): boolean {
+  return input.path_changes.some((p) => p.path.startsWith(prefix));
+}
+
+function potentialImpacts(input: RenderInput): string[] {
+  const out: string[] = [];
+
+  if (input.models_diff?.field_deltas.length) {
+    out.push(
+      "`models.json` changed tool-related model fields. Use the table above to update the listed local mirror paths if the field controls tool naming, availability, or prompt instructions in letta-code.",
+    );
+  }
+
+  if (hasPath(input, "codex-rs/core/src/tools")) {
+    out.push(
+      "`codex-rs/core/src/tools` changed. Check whether upstream changed built-in tool specs or runtime semantics, then compare against `src/tools/toolDefinitions.ts`, `src/tools/schemas/*.json`, `src/tools/descriptions/*.md`, `src/tools/impl/*`, and `src/tools/manager.ts`.",
+    );
+    out.push(
+      "Map commit subjects to local tools before editing: `view_image` maps to `ViewImage`, shell/exec changes map to `ShellCommand`/`Bash`, `apply_patch` changes map to `ApplyPatch`, and MCP/search/approval changes may be upstream-only if letta-code has no equivalent exposed tool.",
+    );
+  }
+
+  if (hasPath(input, "codex-rs/apply-patch")) {
+    out.push(
+      "`codex-rs/apply-patch` changed. Compare parser and failure semantics with `src/tools/impl/ApplyPatch.ts`, `src/tools/impl/MemoryApplyPatch.ts`, `src/tools/descriptions/ApplyPatch.md`, and the apply-patch tests.",
+    );
+  }
+
+  if (input.prompt_md_changed) {
+    out.push(
+      "`codex-rs/models-manager/prompt.md` changed. Re-extract or reconcile `src/agent/prompts/source_codex.md` and update `src/agent/prompts/README.md` provenance.",
+    );
+  }
+
+  if (input.verdict === "no-op") {
+    out.push(
+      "No watched tool surfaces changed. Skim release notes for untracked harness risks, then close if nothing applies.",
+    );
+  }
+
+  return out;
 }
 
 function suggestedActions(input: RenderInput): string[] {
@@ -192,10 +255,18 @@ function suggestedActions(input: RenderInput): string[] {
   }
   if (input.verdict === "tool-schema update needed") {
     out.push(
-      "Inspect changed fields above and update matching tool definitions under `src/tools/` if behavior diverges.",
+      "For each `models.json` row above, inspect the listed local mirror path and update letta-code only if the new field value changes the exposed tool contract.",
     );
     out.push(
-      "Check `src/tools/toolDefinitions.ts` for any tool whose schema should mirror an upstream change.",
+      "If a schema/description/implementation changes, add or update the matching test under `src/tests/tools/`.",
+    );
+  }
+  if (input.verdict === "tool-surface review needed") {
+    out.push(
+      "Review the upstream commits under watched paths and decide whether each one has a letta-code mirror or is upstream-only.",
+    );
+    out.push(
+      "If letta-code should mirror a change, update the relevant `src/tools/schemas`, `src/tools/descriptions`, `src/tools/impl`, prompt source, and tests together.",
     );
   }
   if (input.verdict === "manual review required") {

--- a/scripts/codex-watch/render-issue.ts
+++ b/scripts/codex-watch/render-issue.ts
@@ -1,0 +1,207 @@
+/**
+ * Renders a GitHub issue body summarizing a Codex release's impact on the
+ * letta-code harness.
+ */
+
+import type { ModelsDiff, Verdict } from "./diff-models-json.ts";
+
+export interface PathChangeSummary {
+  path: string;
+  /** One-line commit subjects under this path between the two refs. */
+  commits: string[];
+}
+
+export interface RenderInput {
+  previous_tag: string;
+  current_tag: string;
+  release_url: string;
+  release_notes_md: string;
+  verdict: Verdict;
+  models_diff: ModelsDiff | null;
+  prompt_md_changed: boolean;
+  prompt_md_diff_preview: string | null;
+  path_changes: PathChangeSummary[];
+  workflow_run_url: string;
+}
+
+/** Mapping from upstream concept to local letta-code file(s) to inspect. */
+const LOCAL_MIRRORS: Record<string, string[]> = {
+  apply_patch_tool_type: [
+    "src/agent/prompts/source_codex.md",
+    "src/tools/impl/",
+  ],
+  web_search_tool_type: ["src/tools/impl/"],
+  shell_type: ["src/tools/impl/", "src/agent/prompts/source_codex.md"],
+  supports_search_tool: ["src/tools/impl/"],
+  supports_parallel_tool_calls: ["src/agent/prompts/source_codex.md"],
+  experimental_supported_tools: [
+    "src/tools/toolDefinitions.ts",
+    "src/tools/impl/",
+  ],
+  input_modalities: ["src/tools/impl/"],
+  truncation_policy: ["src/agent/prompts/source_codex.md"],
+  prompt_tool_mentions: ["src/agent/prompts/source_codex.md"],
+};
+
+function localMirror(field: string): string {
+  const mirrors = LOCAL_MIRRORS[field];
+  if (!mirrors || mirrors.length === 0) return "—";
+  return mirrors.join(", ");
+}
+
+function fmtVal(v: unknown): string {
+  if (v === undefined) return "_(unset)_";
+  if (v === null) return "`null`";
+  const s = JSON.stringify(v);
+  return s.length > 80 ? `\`${s.slice(0, 77)}...\`` : `\`${s}\``;
+}
+
+export function renderTitle(input: RenderInput): string {
+  return `[codex-watch] openai/codex ${input.current_tag} — ${input.verdict}`;
+}
+
+export function renderBody(input: RenderInput): string {
+  const parts: string[] = [];
+
+  // Verdict
+  parts.push(`## Verdict`);
+  parts.push("");
+  parts.push(`**${input.verdict}**`);
+  parts.push("");
+  parts.push(verdictRationale(input));
+  parts.push("");
+
+  // Tool / schema deltas
+  parts.push(`## Tool / schema deltas`);
+  parts.push("");
+  if (
+    input.models_diff &&
+    (input.models_diff.field_deltas.length > 0 ||
+      input.models_diff.added_models.length > 0 ||
+      input.models_diff.removed_models.length > 0)
+  ) {
+    if (input.models_diff.added_models.length > 0) {
+      parts.push(
+        `**Added models:** ${input.models_diff.added_models.map((s) => `\`${s}\``).join(", ")}`,
+      );
+      parts.push("");
+    }
+    if (input.models_diff.removed_models.length > 0) {
+      parts.push(
+        `**Removed models:** ${input.models_diff.removed_models.map((s) => `\`${s}\``).join(", ")}`,
+      );
+      parts.push("");
+    }
+    if (input.models_diff.field_deltas.length > 0) {
+      parts.push(
+        "| Model | Field | Previous | New | Affected letta-code path |",
+      );
+      parts.push(
+        "|-------|-------|----------|-----|--------------------------|",
+      );
+      for (const d of input.models_diff.field_deltas) {
+        parts.push(
+          `| \`${d.slug}\` | \`${d.field}\` | ${fmtVal(d.previous)} | ${fmtVal(d.current)} | ${localMirror(d.field)} |`,
+        );
+      }
+      parts.push("");
+    }
+  } else {
+    parts.push("_No tool-field deltas detected in `models.json`._");
+    parts.push("");
+  }
+
+  // Upstream changes by path
+  parts.push(`## Upstream changes by path`);
+  parts.push("");
+  if (input.path_changes.length > 0) {
+    for (const p of input.path_changes) {
+      parts.push(`### \`${p.path}\``);
+      if (p.commits.length === 0) {
+        parts.push("_No commits touching this path between releases._");
+      } else {
+        for (const c of p.commits) parts.push(`- ${c}`);
+      }
+      parts.push("");
+    }
+  } else {
+    parts.push("_No changes under watched paths._");
+    parts.push("");
+  }
+
+  // Prompt diff preview
+  if (input.prompt_md_changed && input.prompt_md_diff_preview) {
+    parts.push(`## \`codex-rs/models-manager/prompt.md\` diff (preview)`);
+    parts.push("");
+    parts.push("```diff");
+    parts.push(input.prompt_md_diff_preview);
+    parts.push("```");
+    parts.push("");
+  }
+
+  // Release notes
+  parts.push(`<details><summary>Release notes</summary>`);
+  parts.push("");
+  parts.push(input.release_notes_md || "_(empty)_");
+  parts.push("");
+  parts.push(`</details>`);
+  parts.push("");
+
+  // Suggested actions
+  parts.push(`## Suggested actions`);
+  parts.push("");
+  for (const a of suggestedActions(input)) parts.push(`- [ ] ${a}`);
+  parts.push("");
+
+  // Provenance
+  parts.push(`## How this was generated`);
+  parts.push("");
+  parts.push(`- Release: ${input.release_url}`);
+  parts.push(
+    `- Compare: https://github.com/openai/codex/compare/${input.previous_tag}...${input.current_tag}`,
+  );
+  parts.push(`- Workflow run: ${input.workflow_run_url}`);
+
+  return parts.join("\n");
+}
+
+function verdictRationale(input: RenderInput): string {
+  switch (input.verdict) {
+    case "no-op":
+      return "No tool-relevant changes detected in watched paths. Filed for audit trail.";
+    case "prompt-only update":
+      return "Prompt text or tool mentions changed. `src/agent/prompts/source_codex.md` should be re-extracted; no tool implementation changes needed.";
+    case "tool-schema update needed":
+      return "Upstream changed tool-config fields in `models.json` and/or `codex-rs/core/src/tools/`. Letta-code's tool definitions may need to mirror the new shape.";
+    case "manual review required":
+      return "Could not classify automatically (parse error or removed model). Please review the diff manually.";
+  }
+}
+
+function suggestedActions(input: RenderInput): string[] {
+  const out: string[] = [];
+  if (input.verdict === "no-op") {
+    out.push("Skim the release notes; close this issue if nothing stands out.");
+    return out;
+  }
+  if (input.verdict === "prompt-only update" || input.prompt_md_changed) {
+    out.push(
+      "Re-extract `src/agent/prompts/source_codex.md` from upstream `codex-rs/models-manager/models.json` (`instructions_template` with `personality_pragmatic`).",
+    );
+    out.push("Update provenance line in `src/agent/prompts/README.md`.");
+  }
+  if (input.verdict === "tool-schema update needed") {
+    out.push(
+      "Inspect changed fields above and update matching tool definitions under `src/tools/` if behavior diverges.",
+    );
+    out.push(
+      "Check `src/tools/toolDefinitions.ts` for any tool whose schema should mirror an upstream change.",
+    );
+  }
+  if (input.verdict === "manual review required") {
+    out.push(
+      "Diff `openai/codex` between the two tags manually and decide whether letta-code needs to react.",
+    );
+  }
+  return out;
+}

--- a/src/agent/prompts/README.md
+++ b/src/agent/prompts/README.md
@@ -30,6 +30,7 @@ Selectable via the `/system` command. Each preset is a complete system prompt. P
 - **Version:** Extracted from `codex-rs/models-manager/models.json` @ openai/codex `main` (May 2026)
 - **Reference:** https://github.com/openai/codex
 - **Notes:** gpt-5.5 uses `model_messages.instructions_template` with a `{{ personality }}` placeholder; this snapshot renders the template substituted with `personality_pragmatic` (the default). Major drift from the prior gpt-5.3-codex snapshot: new senior-engineer framing, expanded engineering judgment guidance, substantially expanded frontend guidance, softer dirty-worktree handling, updated autonomy/compaction instructions, revised formatting/file-link rules, and new anti-creature-language guidance.
+- **Automation:** `.github/workflows/codex-release-watch.yml` polls stable `openai/codex` releases and files a `codex-watch` issue when upstream tool/schema fields or tool implementation paths change.
 
 #### source_gemini.md
 


### PR DESCRIPTION
## Summary
- Add an hourly GitHub Actions watcher for stable openai/codex releases.
- Diff tool-relevant upstream surfaces (`models.json`, `codex-rs/core/src/tools`, and `codex-rs/apply-patch`) and file codex-watch issues with a deterministic verdict.
- Document the source_codex automation and add CODEOWNERS coverage for the watcher.

## Test plan
- [x] `bun test scripts/codex-watch/diff-models-json.test.ts`
- [x] `bun run typecheck`
- [x] `bunx --bun @biomejs/biome@2.2.5 check scripts/codex-watch .github/workflows/codex-release-watch.yml .github/CODEOWNERS src/agent/prompts/README.md`
- [x] `bun scripts/codex-watch/check-release.ts --dry-run --since rust-v0.129.0 --current rust-v0.130.0`

👾 Generated with [Letta Code](https://letta.com)