### PR TITLE
fix(dev): use current Bun text loader syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "typecheck": "tsc --noEmit",
     "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check": "bun run scripts/check.js",
-    "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader:.md=text --loader:.mdx=text --loader:.txt=text run src/index.ts",
+    "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run src/index.ts",
     "build": "node scripts/postinstall-patches.js && bun run build.js",
     "test:update-chain:manual": "bun run src/tests/update-chain-smoke.ts --mode manual",
     "test:update-chain:startup": "bun run src/tests/update-chain-smoke.ts --mode startup",

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -92,9 +92,9 @@ describe("resolveSubagentLauncher", () => {
     expect(launcher).toEqual({
       command: execPath,
       args: [
-        "--loader:.md=text",
-        "--loader:.mdx=text",
-        "--loader:.txt=text",
+        "--loader=.md:text",
+        "--loader=.mdx:text",
+        "--loader=.txt:text",
         "run",
         expectedScriptPath,
         "--output-format",

--- a/src/tests/tools/shell-env.test.ts
+++ b/src/tests/tools/shell-env.test.ts
@@ -111,9 +111,9 @@ describe("shellEnv letta shim", () => {
     expect(invocation).toEqual({
       command: "/opt/homebrew/bin/bun",
       args: [
-        "--loader:.md=text",
-        "--loader:.mdx=text",
-        "--loader:.txt=text",
+        "--loader=.md:text",
+        "--loader=.mdx:text",
+        "--loader=.txt:text",
         "run",
         "/Users/example/dev/letta-code-prod/src/index.ts",
       ],
@@ -144,9 +144,9 @@ describe("shellEnv letta shim", () => {
     expect(invocation).toEqual({
       command: execPath,
       args: [
-        "--loader:.md=text",
-        "--loader:.mdx=text",
-        "--loader:.txt=text",
+        "--loader=.md:text",
+        "--loader=.mdx:text",
+        "--loader=.txt:text",
         "run",
         expectedScriptPath,
       ],

--- a/src/tools/impl/shellEnv.ts
+++ b/src/tools/impl/shellEnv.ts
@@ -138,9 +138,9 @@ export function resolveLettaInvocation(
       return {
         command: execPath,
         args: [
-          "--loader:.md=text",
-          "--loader:.mdx=text",
-          "--loader:.txt=text",
+          "--loader=.md:text",
+          "--loader=.mdx:text",
+          "--loader=.txt:text",
           "run",
           resolvedScriptPath,
         ],


### PR DESCRIPTION
## Summary
- update dev-mode Bun loader flags to the current `.ext:text` syntax for markdown/text prompt assets
- update `bun run dev` to use the same syntax
- update launcher tests to assert the working loader flags for subagent/dev launches

## Why
Reflection subagents in dev mode can run from the parent memory filesystem cwd instead of the `letta-code` repo cwd. In that cwd, Bun does not see `bunfig.toml`; with the old `--loader:.mdx=text` flags, Bun 1.3.4 parses `.mdx` prompt assets as code and crashes on frontmatter such as `label: human`.

## Verification
- `bun test src/tests/tools/shell-env.test.ts src/tests/agent/subagent-model-resolution.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run /Users/jinjpeng/letta/letta-code-bun-loader-fix/src/index.ts --help` from `/Users/jinjpeng/letta`
- `bun run dev --help`