### PR TITLE
feat(cli): TUI shadow cron scheduler behind tui_cron experiment

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -32,6 +32,15 @@ import { SessionStats } from "../../agent/stats";
 import { getBackend } from "../../backend";
 import { getClient } from "../../backend/api/client";
 import { getBillingTier } from "../../backend/api/metadata";
+import {
+  getTask,
+  handleMissedOneShot,
+  isProcessAlive,
+  readCronFile,
+  shouldFireTask,
+  updateTask,
+  wrapCronPrompt,
+} from "../../cron";
 import { experimentManager } from "../../experiments/manager";
 import { runSessionEndHooks, runSessionStartHooks } from "../../hooks";
 import type { ApprovalContext } from "../../permissions/analyzer";
@@ -97,6 +106,7 @@ import { setErrorContext } from "../helpers/errorContext";
 import { parsePatchOperations } from "../helpers/formatArgsDisplay";
 import { getReflectionSettings } from "../helpers/memoryReminder";
 import {
+  addToMessageQueue,
   type QueuedMessage,
   setMessageQueueAdder,
 } from "../helpers/messageQueueBridge";
@@ -1169,6 +1179,112 @@ export default function App({
     });
     return () => setMessageQueueAdder(null);
   }, []);
+
+  // ── Shadow cron scheduler ──────────────────────────────────────────
+  // When the tui_cron experiment is enabled, run a lightweight scheduler
+  // that fires cron tasks when the desktop app (WS listener) isn't running.
+  // The TUI never claims the scheduler lease — it defers to any active
+  // lease holder (the desktop app always wins, even old versions).
+  useEffect(() => {
+    if (!experimentManager.isEnabled("tui_cron")) return;
+    if (!agentId || agentId === "loading") return;
+
+    const TICK_INTERVAL_MS = 60_000;
+    const firedThisMinute = new Set<string>();
+    let lastMinuteKey = "";
+
+    function tick(): void {
+      const now = new Date();
+      const currentMinuteKey = (() => {
+        const d = now;
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+      })();
+
+      // Reset per-minute dedup when minute changes
+      if (currentMinuteKey !== lastMinuteKey) {
+        firedThisMinute.clear();
+        lastMinuteKey = currentMinuteKey;
+      }
+
+      // Check if another scheduler (desktop app) is active
+      const cronData = readCronFile();
+      if (cronData.scheduler_owner) {
+        const { pid } = cronData.scheduler_owner;
+        if (isProcessAlive(pid, cronData.scheduler_owner)) {
+          // Desktop app is running the scheduler — defer
+          return;
+        }
+      }
+
+      // No active scheduler — process tasks for this agent
+      const activeTasks = cronData.tasks.filter(
+        (t) => t.status === "active" && t.agent_id === agentIdRef.current,
+      );
+
+      for (const task of activeTasks) {
+        if (firedThisMinute.has(task.id)) continue;
+
+        // Handle missed one-shots
+        if (handleMissedOneShot(task, now)) continue;
+
+        if (shouldFireTask(task, now)) {
+          firedThisMinute.add(task.id);
+
+          // Apply jitter delay for recurring tasks (same as WS scheduler)
+          const jitterMs = task.recurring ? task.jitter_offset_ms : 0;
+          const taskId = task.id;
+          const doFire = () => {
+            // Revalidate: task may have been deleted/cancelled during jitter
+            const freshTask = getTask(taskId);
+            if (!freshTask || freshTask.status !== "active") return;
+
+            const text = wrapCronPrompt(freshTask);
+            addToMessageQueue({
+              kind: "user",
+              text,
+              agentId: freshTask.agent_id,
+              conversationId: freshTask.conversation_id,
+            });
+
+            // Update task state
+            const nowIso = new Date().toISOString();
+            if (freshTask.recurring) {
+              updateTask(freshTask.id, (t) => {
+                t.last_fired_at = nowIso;
+                t.fire_count += 1;
+              });
+            } else {
+              updateTask(freshTask.id, (t) => {
+                t.status = "fired";
+                t.fired_at = nowIso;
+                t.last_fired_at = nowIso;
+                t.fire_count = 1;
+              });
+            }
+
+            debugLog("cron", `TUI shadow scheduler fired task ${taskId}`);
+          };
+
+          if (jitterMs > 0) {
+            setTimeout(doFire, jitterMs);
+          } else {
+            doFire();
+          }
+        }
+      }
+    }
+
+    // Initial tick
+    tick();
+
+    const interval = setInterval(tick, TICK_INTERVAL_MS);
+    debugLog("cron", "TUI shadow scheduler started");
+
+    return () => {
+      clearInterval(interval);
+      debugLog("cron", "TUI shadow scheduler stopped");
+    };
+  }, [agentId]);
 
   const waitingForQueueCancelRef = useRef(false);
   const queueSnapshotRef = useRef<QueuedMessage[]>([]);

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1185,8 +1185,9 @@ export default function App({
   // that fires cron tasks when the desktop app (WS listener) isn't running.
   // The TUI never claims the scheduler lease — it defers to any active
   // lease holder (the desktop app always wins, even old versions).
+  // The experiment check is inside tick() so toggling the experiment
+  // takes effect without restarting the TUI.
   useEffect(() => {
-    if (!experimentManager.isEnabled("tui_cron")) return;
     if (!agentId || agentId === "loading") return;
 
     const TICK_INTERVAL_MS = 60_000;
@@ -1194,6 +1195,9 @@ export default function App({
     let lastMinuteKey = "";
 
     function tick(): void {
+      // Check experiment gate on each tick so toggling takes effect immediately
+      if (!experimentManager.isEnabled("tui_cron")) return;
+
       const now = new Date();
       const currentMinuteKey = (() => {
         const d = now;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1245,7 +1245,7 @@ export default function App({
             // (the WS scheduler uses wrapCronPrompt with XML, but the TUI
             // renders user messages as-is, so XML shows up raw)
             const text = [
-              `⏰ Scheduled task "${freshTask.name}" is firing.`,
+              `Scheduled task "${freshTask.name}" is firing.`,
               freshTask.recurring
                 ? `This is fire #${freshTask.fire_count + 1} (cron: ${freshTask.cron}).`
                 : `This is a one-off scheduled task.`,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -39,7 +39,6 @@ import {
   readCronFile,
   shouldFireTask,
   updateTask,
-  wrapCronPrompt,
 } from "../../cron";
 import { experimentManager } from "../../experiments/manager";
 import { runSessionEndHooks, runSessionStartHooks } from "../../hooks";
@@ -1242,7 +1241,17 @@ export default function App({
             const freshTask = getTask(taskId);
             if (!freshTask || freshTask.status !== "active") return;
 
-            const text = wrapCronPrompt(freshTask);
+            // Format as plain text for the TUI — no <system-reminder> wrapper
+            // (the WS scheduler uses wrapCronPrompt with XML, but the TUI
+            // renders user messages as-is, so XML shows up raw)
+            const text = [
+              `⏰ Scheduled task "${freshTask.name}" is firing.`,
+              freshTask.recurring
+                ? `This is fire #${freshTask.fire_count + 1} (cron: ${freshTask.cron}).`
+                : `This is a one-off scheduled task.`,
+              "",
+              freshTask.prompt,
+            ].join("\n");
             addToMessageQueue({
               kind: "user",
               text,

--- a/src/cron/cronFile.ts
+++ b/src/cron/cronFile.ts
@@ -204,7 +204,7 @@ function captureProcessIdentity(pid: number): {
   };
 }
 
-function isProcessAlive(
+export function isProcessAlive(
   pid: number,
   owner?: {
     process_start_ticks?: string | null;

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -13,6 +13,7 @@ export {
   getActiveTasks,
   getCronFileMtime,
   getTask,
+  isProcessAlive,
   listTasks,
   readCronFile,
   releaseSchedulerLease,
@@ -31,3 +32,9 @@ export {
   parseAt,
   parseEvery,
 } from "./parseInterval";
+
+export {
+  handleMissedOneShot,
+  shouldFireTask,
+  wrapCronPrompt,
+} from "./scheduler";

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -69,11 +69,11 @@ const GC_INTERVAL_MS = 60 * 60_000; // 1 hour
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-function minuteKey(date: Date): string {
+export function minuteKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}T${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
 }
 
-function wrapCronPrompt(task: CronTask): string {
+export function wrapCronPrompt(task: CronTask): string {
   const lines = [
     "<system-reminder>",
     `Scheduled task "${task.name}" is firing.`,
@@ -98,7 +98,7 @@ function refreshTaskCache(state: SchedulerState): void {
   }
 }
 
-function shouldFireTask(task: CronTask, now: Date): boolean {
+export function shouldFireTask(task: CronTask, now: Date): boolean {
   // One-shot: check if scheduled_for is now or past (jitter applied to scheduled time)
   if (!task.recurring && task.scheduled_for) {
     const scheduledMs =
@@ -168,7 +168,7 @@ function fireCronTask(
 }
 
 /** Returns true if the task was marked as missed (caller should skip firing). */
-function handleMissedOneShot(task: CronTask, now: Date): boolean {
+export function handleMissedOneShot(task: CronTask, now: Date): boolean {
   if (task.recurring || !task.scheduled_for) return false;
   // A one-shot is "missed" if it's been more than 5 minutes past scheduled time
   const scheduledMs = new Date(task.scheduled_for).getTime();

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -20,6 +20,12 @@ const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
     description: "Route API requests through the Letta Node / TS core path.",
     envVar: "LETTA_NODE",
   },
+  {
+    id: "tui_cron",
+    label: "TUI cron scheduler",
+    description:
+      "Fire scheduled tasks from the CLI when the desktop app isn't running.",
+  },
 ] as const;
 
 function isEnabledToggle(value: string | undefined): boolean {

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -1,4 +1,4 @@
-export type ExperimentId = "conversation_titles" | "node";
+export type ExperimentId = "conversation_titles" | "node" | "tui_cron";
 
 export type ExperimentSource = "override" | "env" | "default";
 


### PR DESCRIPTION
## Summary
- Adds a shadow cron scheduler to the TUI that fires scheduled tasks when the desktop app (WS listener) is not running
- The TUI never claims the scheduler lease, so the desktop app always wins — even old versions that do not know about priority fields
- Gated behind the `tui_cron` experiment flag (off by default, opt-in via `/experiments`)

## How it works
- 60s tick interval checks `scheduler_owner` PID in `crons.json`
- If PID is alive (desktop app running), skip all ticks
- If PID is dead/null, process active tasks and fire via `addToMessageQueue`
- Reuses `shouldFireTask`, `handleMissedOneShot` from the WS listener scheduler
- Cron prompts use plain text format (no `<system-reminder>` XML) so they render correctly as user messages in the TUI

## Test plan
- [x] Enable `tui_cron` experiment via `/experiments`
- [x] Schedule a one-shot task with `letta cron add --at "in 1m"`
- [x] Close desktop app, verify TUI fires the task on next tick
- [x] Verify task appears in queue while agent is busy
- [x] Verify cron prompt renders as plain text (no raw XML)
- [x] Verify task state is updated to `fired` in `crons.json`

## Known follow-ups
- Misleading warning when creating tasks from TUI ("No WS listener active")
- Experiment toggle requires TUI restart (could add experiment counter as effect dependency)
- Up to 60s fire delay from tick interval alignment

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>