### PR TITLE
fix(slack): retain forwarded message text in history

### DIFF
--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -22,6 +22,11 @@ type SlackFileLike = {
 };
 
 type SlackAttachmentLike = {
+  text?: string;
+  fallback?: string;
+  pretext?: string;
+  author_name?: string;
+  title?: string;
   image_url?: string;
   files?: SlackFileLike[];
 };
@@ -50,6 +55,7 @@ type SlackRepliesPageMessage = {
   bot_id?: string;
   ts?: string;
   files?: unknown[];
+  attachments?: unknown[];
 };
 
 type SlackRepliesPage = {
@@ -120,11 +126,46 @@ function normalizeSlackAttachmentLike(
     : undefined;
 
   return {
+    text: isNonEmptyString(record.text) ? record.text : undefined,
+    fallback: isNonEmptyString(record.fallback) ? record.fallback : undefined,
+    pretext: isNonEmptyString(record.pretext) ? record.pretext : undefined,
+    author_name: isNonEmptyString(record.author_name)
+      ? record.author_name
+      : undefined,
+    title: isNonEmptyString(record.title) ? record.title : undefined,
     image_url: isNonEmptyString(record.image_url)
       ? record.image_url
       : undefined,
     files,
   };
+}
+
+function uniqueNonEmptyStrings(values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const value of values) {
+    const text = value?.trim();
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    normalized.push(text);
+  }
+
+  return normalized;
+}
+
+function resolveSlackAttachmentText(attachment: SlackAttachmentLike): string {
+  const parts = uniqueNonEmptyStrings([
+    attachment.pretext,
+    attachment.author_name,
+    attachment.title,
+    attachment.text,
+    attachment.fallback,
+  ]);
+
+  return parts.join("\n");
 }
 
 function resolveSlackThreadMessageText(
@@ -133,6 +174,18 @@ function resolveSlackThreadMessageText(
   const text = typeof message.text === "string" ? message.text.trim() : "";
   if (text) {
     return text;
+  }
+
+  const attachmentTexts = Array.isArray(message.attachments)
+    ? message.attachments
+        .map((entry) => normalizeSlackAttachmentLike(entry))
+        .filter((entry): entry is SlackAttachmentLike => Boolean(entry))
+        .map((attachment) => resolveSlackAttachmentText(attachment))
+        .filter(isNonEmptyString)
+    : [];
+
+  if (attachmentTexts.length > 0) {
+    return attachmentTexts.join("\n\n");
   }
 
   const files = Array.isArray(message.files)

--- a/src/tests/channels/slack-media.test.ts
+++ b/src/tests/channels/slack-media.test.ts
@@ -1,10 +1,13 @@
 import { expect, mock, test } from "bun:test";
-import {
-  resolveSlackChannelHistory,
-  resolveSlackThreadStarter,
-} from "../../channels/slack/media";
+
+async function loadSlackMediaModule() {
+  return import(
+    `../../channels/slack/media.ts?slack-media-test=${Date.now()}-${Math.random()}`
+  );
+}
 
 test("resolveSlackThreadStarter falls back to forwarded Slack attachment text", async () => {
+  const { resolveSlackThreadStarter } = await loadSlackMediaModule();
   const client = {
     conversations: {
       history: mock(async () => ({ messages: [] })),
@@ -42,6 +45,7 @@ test("resolveSlackThreadStarter falls back to forwarded Slack attachment text", 
 });
 
 test("resolveSlackChannelHistory retains forwarded Slack attachment text", async () => {
+  const { resolveSlackChannelHistory } = await loadSlackMediaModule();
   const client = {
     conversations: {
       history: mock(async () => ({

--- a/src/tests/channels/slack-media.test.ts
+++ b/src/tests/channels/slack-media.test.ts
@@ -1,0 +1,80 @@
+import { expect, mock, test } from "bun:test";
+import {
+  resolveSlackChannelHistory,
+  resolveSlackThreadStarter,
+} from "../../channels/slack/media";
+
+test("resolveSlackThreadStarter falls back to forwarded Slack attachment text", async () => {
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "",
+            attachments: [
+              {
+                author_name: "Forwarded from Product",
+                text: "Can someone fix the Slack forwarding context?",
+                fallback: "Can someone fix the Slack forwarding context?",
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  };
+
+  await expect(
+    resolveSlackThreadStarter({
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      client,
+    }),
+  ).resolves.toEqual({
+    text: "Forwarded from Product\nCan someone fix the Slack forwarding context?",
+    userId: "U111",
+    botId: undefined,
+    ts: "1712790000.000050",
+  });
+});
+
+test("resolveSlackChannelHistory retains forwarded Slack attachment text", async () => {
+  const client = {
+    conversations: {
+      history: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000090",
+            user: "U222",
+            text: "",
+            attachments: [
+              {
+                title: "Forwarded message",
+                text: "Here is the context from the original channel.",
+              },
+            ],
+          },
+        ],
+      })),
+      replies: mock(async () => ({ messages: [] })),
+    },
+  };
+
+  await expect(
+    resolveSlackChannelHistory({
+      channelId: "C123",
+      beforeTs: "1712800000.000100",
+      client,
+    }),
+  ).resolves.toEqual([
+    {
+      text: "Forwarded message\nHere is the context from the original channel.",
+      userId: "U222",
+      botId: undefined,
+      ts: "1712790000.000090",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Preserve forwarded Slack message text from attachment fields during thread starter, thread history, and recent channel history hydration.
- Add focused Slack media tests for forwarded attachment text in thread starters and channel history.

## Test plan
- [x] bun test src/tests/channels/slack-adapter.test.ts src/tests/channels/slack-media.test.ts
- [x] bun run lint (passes with existing unrelated warning in src/cli/helpers/shellSemanticDisplay.ts)

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)