### PR TITLE
fix(cli): Fix subagent prompt transport for large prompts

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -817,6 +817,19 @@ function capReflectionStartupPrompt(
   return hardTruncateReflectionPrompt(userPrompt, allowedPromptChars);
 }
 
+export function buildSubagentPrompt(
+  type: string,
+  config: SubagentConfig,
+  userPrompt: string,
+): string {
+  return capReflectionStartupPrompt(type, config.systemPrompt, userPrompt);
+}
+
+interface BuildSubagentArgsOptions {
+  backendMode?: BackendMode;
+  promptTransport?: "argv" | "stdin";
+}
+
 /**
  * Build CLI arguments for spawning a subagent
  */
@@ -828,7 +841,7 @@ export function buildSubagentArgs(
   existingAgentId?: string,
   existingConversationId?: string,
   maxTurns?: number,
-  options: { backendMode?: BackendMode } = {},
+  options: BuildSubagentArgsOptions = {},
 ): string[] {
   const args: string[] = [];
   const isDeployingExisting = Boolean(
@@ -877,12 +890,9 @@ export function buildSubagentArgs(
     }
   }
 
-  const boundedUserPrompt = capReflectionStartupPrompt(
-    type,
-    config.systemPrompt,
-    userPrompt,
-  );
-  args.push("-p", boundedUserPrompt);
+  if (options.promptTransport !== "stdin") {
+    args.push("-p", buildSubagentPrompt(type, config, userPrompt));
+  }
   args.push("--output-format", "stream-json");
 
   // Use subagent's configured permission mode, or inherit from parent
@@ -986,6 +996,7 @@ async function executeSubagent(
     const backendMode: BackendMode = activeBackend.capabilities.localMemfs
       ? "local"
       : "api";
+    const boundedUserPrompt = buildSubagentPrompt(type, config, userPrompt);
     const cliArgs = buildSubagentArgs(
       type,
       config,
@@ -994,7 +1005,7 @@ async function executeSubagent(
       existingAgentId,
       existingConversationId,
       maxTurns,
-      { backendMode },
+      { backendMode, promptTransport: "stdin" },
     );
 
     const launcher = resolveSubagentLauncher(cliArgs);
@@ -1057,6 +1068,8 @@ async function executeSubagent(
       cwd: subagentWorkingDirectory,
       env: childEnv,
     });
+    proc.stdin.on("error", () => {});
+    proc.stdin.end(boundedUserPrompt);
 
     // Consider execution "running" once the child process has successfully spawned.
     // This avoids waiting on subagent init events (e.g. agentURL) to reflect progress.

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../agent/subagents/contextBudget";
 import {
   buildSubagentArgs,
+  buildSubagentPrompt,
   getModelHandleFromAgent,
   resolveSubagentLauncher,
   resolveSubagentModel,
@@ -309,6 +310,43 @@ describe("buildSubagentArgs", () => {
     expect(promptArg).toContain("<memory_filesystem>");
     expect(promptArg).toContain("Reflection startup context truncated");
     expect(promptArg.length).toBeLessThan(userPrompt.length);
+  });
+
+  test("can pass subagent prompt by stdin without leaking prompt text into argv", () => {
+    const longPrompt = "prompt ".repeat(40_000);
+
+    const args = buildSubagentArgs(
+      "general-purpose",
+      baseConfig,
+      null,
+      longPrompt,
+      undefined,
+      undefined,
+      undefined,
+      { promptTransport: "stdin" },
+    );
+
+    expect(args).not.toContain("--prompt-file");
+    expect(args).not.toContain("-p");
+    expect(args).not.toContain(longPrompt);
+  });
+
+  test("buildSubagentPrompt preserves reflection startup budget before stdin transport", () => {
+    const systemPrompt = "system ".repeat(1_000);
+    const memoryPreview = `<parent_memory>\n<memory_filesystem>\n/memory/\n└── system/\n</memory_filesystem>\n${"memory ".repeat(40_000)}\n</parent_memory>`;
+    const userPrompt = `Review transcript via $TRANSCRIPT_PATH\n\n${memoryPreview}`;
+
+    const prompt = buildSubagentPrompt(
+      "reflection",
+      { ...baseConfig, name: "reflection", systemPrompt },
+      userPrompt,
+    );
+
+    expect(
+      estimateStartupContextTokens(`${systemPrompt}\n${prompt}`),
+    ).toBeLessThanOrEqual(REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT);
+    expect(prompt).toContain("Review transcript via $TRANSCRIPT_PATH");
+    expect(prompt).toContain("Reflection startup context truncated");
   });
 
   test("does not cap non-reflection initial messages", () => {


### PR DESCRIPTION
## Summary
- send internally spawned subagent prompts through stdin instead of putting the full prompt in argv
- keep public `letta -p "..."` and existing stdin headless behavior unchanged
- keep reflection startup-budget capping before transport, then pass the bounded prompt over stdin

## Compatibility / regression analysis
- No new CLI flag is introduced. This avoids mixed-version failures where a newer parent might launch an older child through `LETTA_CODE_BIN`.
- Existing public headless usage remains compatible: `letta -p "..."` still uses the argv prompt path, and piped stdin still works as before.
- Internal subagent callers still pass a `prompt: string`; only `executeSubagent` changes the child-process transport.
- `buildSubagentArgs()` still defaults to `-p` for existing direct helper/test usage unless explicitly asked for stdin transport.
- `resolveSubagentLauncher()` is unchanged. Launcher selection is independent of the prompt transport.
- This should work with older child binaries too, because headless stdin prompt ingestion already existed before this PR.

## Tests
- `bun test src/tests/agent/subagent-model-resolution.test.ts src/tests/cli/args.test.ts`
- `bun run typecheck`
- `bun run lint` (exits 0 with existing unrelated warning in `src/cli/helpers/shellSemanticDisplay.ts`)
- Manual smoke: piped ~84 KB prompt through `fake-headless` returned `pong`
- Manual smoke: existing `-p ping` through `fake-headless` returned `pong`