### PR TITLE
feat(channels): add shared slash command router

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,0 +1,117 @@
+import { getChannelDisplayName } from "./pluginRegistry";
+import type { ChannelAdapter, InboundChannelMessage } from "./types";
+
+export type ChannelSlashCommandKind = "direct" | "agent-scoped";
+
+export type ParsedChannelSlashCommand = {
+  name: string;
+  args: string;
+  raw: string;
+};
+
+export type ChannelSlashCommandDefinition = {
+  name: string;
+  aliases?: string[];
+  kind: ChannelSlashCommandKind;
+  summary: string;
+};
+
+const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
+  {
+    name: "help",
+    kind: "direct",
+    summary: "Show channel usage guidance.",
+  },
+];
+
+function channelDisplayName(channelId: string): string {
+  try {
+    return getChannelDisplayName(channelId);
+  } catch {
+    return channelId;
+  }
+}
+
+export function listChannelSlashCommands(): ChannelSlashCommandDefinition[] {
+  return CHANNEL_SLASH_COMMANDS.map((definition) => ({
+    ...definition,
+    aliases: definition.aliases ? [...definition.aliases] : undefined,
+  }));
+}
+
+export function parseChannelSlashCommand(
+  text: string,
+): ParsedChannelSlashCommand | null {
+  const trimmed = text.trim();
+  const match = trimmed.match(
+    /^\/([A-Za-z][\w-]*)(?:@[A-Za-z0-9_]+)?(?:\s+(.*))?$/,
+  );
+  if (!match) {
+    return null;
+  }
+  const [, name, args] = match;
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name: name.toLowerCase(),
+    args: args?.trim() ?? "",
+    raw: trimmed,
+  };
+}
+
+export function buildChannelHelpMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  const supportedCommands = listChannelSlashCommands()
+    .filter((definition) => definition.kind === "direct")
+    .map((definition) => `/${definition.name}`)
+    .join(", ");
+
+  return [
+    `${displayName} is connected to Letta Code.`,
+    "Send a normal message here and the connected agent will reply in this chat.",
+    "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
+    `Supported slash commands here: ${supportedCommands}.`,
+    "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
+  ].join("\n\n");
+}
+
+export function buildUnsupportedChannelCommandMessage(
+  channelId: string,
+  command: ParsedChannelSlashCommand,
+): string {
+  const displayName = channelDisplayName(channelId);
+  const supportedCommands = listChannelSlashCommands()
+    .filter((definition) => definition.kind === "direct")
+    .map((definition) => `/${definition.name}`)
+    .join(", ");
+
+  return [
+    `${displayName} received ${command.raw}, but that slash command is not supported in channels yet.`,
+    `Supported slash commands here: ${supportedCommands}.`,
+    "Send normal messages without a leading slash to talk to the connected agent.",
+  ].join("\n\n");
+}
+
+export async function tryHandleChannelSlashCommand(
+  adapter: ChannelAdapter,
+  msg: InboundChannelMessage,
+): Promise<boolean> {
+  const command = parseChannelSlashCommand(msg.text);
+  if (!command) {
+    return false;
+  }
+
+  const text =
+    command.name === "help"
+      ? buildChannelHelpMessage(msg.channel)
+      : buildUnsupportedChannelCommandMessage(msg.channel, command);
+
+  await adapter.sendDirectReply(
+    msg.chatId,
+    text,
+    msg.messageId ? { replyToMessageId: msg.messageId } : undefined,
+  );
+  return true;
+}

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,6 +19,7 @@ import {
   listChannelAccounts,
   loadChannelAccounts,
 } from "./accounts";
+import { tryHandleChannelSlashCommand } from "./commands";
 import {
   formatChannelControlRequestPrompt,
   parseChannelControlRequestResponse,
@@ -116,16 +117,6 @@ export function buildUnboundRouteInstructions(
     `Open Channels > ${displayName} in Letta Code and connect this chat there.\n\n` +
     `Chat ID: ${chatId}`
   );
-}
-
-export function buildChannelHelpMessage(channelId: string): string {
-  const displayName = channelDisplayName(channelId);
-  return [
-    `${displayName} is connected to Letta Code.`,
-    "Send a normal message here and the connected agent will reply in this chat.",
-    "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
-    "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
-  ].join("\n\n");
 }
 
 function buildSlackAppSetupInstructions(): string {
@@ -807,12 +798,7 @@ export class ChannelRegistry {
       return;
     }
 
-    if (msg.text.trim().toLowerCase() === "/help") {
-      await adapter.sendDirectReply(
-        msg.chatId,
-        buildChannelHelpMessage(msg.channel),
-        msg.messageId ? { replyToMessageId: msg.messageId } : undefined,
-      );
+    if (await tryHandleChannelSlashCommand(adapter, msg)) {
       return;
     }
 

--- a/src/tests/channels/commands.test.ts
+++ b/src/tests/channels/commands.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChannelHelpMessage,
+  buildUnsupportedChannelCommandMessage,
+  listChannelSlashCommands,
+  parseChannelSlashCommand,
+} from "../../channels/commands";
+
+describe("channel slash commands", () => {
+  test("parses channel slash commands with bot suffixes and args", () => {
+    expect(parseChannelSlashCommand(" /HELP@LettaBot extra words ")).toEqual({
+      name: "help",
+      args: "extra words",
+      raw: "/HELP@LettaBot extra words",
+    });
+  });
+
+  test("ignores normal text and slash-like paths", () => {
+    expect(parseChannelSlashCommand("hello /help")).toBeNull();
+    expect(parseChannelSlashCommand("/tmp/file.txt")).toBeNull();
+  });
+
+  test("lists supported direct commands for channel help", () => {
+    expect(listChannelSlashCommands()).toContainEqual(
+      expect.objectContaining({ name: "help", kind: "direct" }),
+    );
+
+    const text = buildChannelHelpMessage("telegram");
+    expect(text).toContain("Telegram is connected to Letta Code.");
+    expect(text).toContain("Supported slash commands here: /help.");
+  });
+
+  test("builds a useful unsupported-command response", () => {
+    const command = parseChannelSlashCommand("/compact now");
+    expect(command).not.toBeNull();
+    if (!command) {
+      throw new Error("Expected /compact to parse as a channel slash command");
+    }
+
+    const text = buildUnsupportedChannelCommandMessage("telegram", command);
+    expect(text).toContain("Telegram received /compact now");
+    expect(text).toContain("not supported in channels yet");
+    expect(text).toContain("Supported slash commands here: /help.");
+    expect(text).toContain("without a leading slash");
+  });
+});

--- a/src/tests/channels/registry-community-copy.test.ts
+++ b/src/tests/channels/registry-community-copy.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { buildChannelHelpMessage } from "../../channels/commands";
 
-const {
-  buildChannelHelpMessage,
-  buildPairingInstructions,
-  buildUnboundRouteInstructions,
-} = await import("../../channels/registry");
+const { buildPairingInstructions, buildUnboundRouteInstructions } =
+  await import("../../channels/registry");
 
 describe("registry copy: first-party channels", () => {
   test("pairing instructions point at both desktop UI and CLI for telegram", () => {

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -164,6 +164,59 @@ describe("ChannelRegistry", () => {
     });
     expect(replies[0]?.text).toContain("Telegram is connected to Letta Code");
   });
+
+  test("unsupported slash commands get direct channel guidance instead of agent delivery", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      senderName: "Alice",
+      text: "/compact now",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({
+      chatId: "123",
+      replyToMessageId: "77",
+    });
+    expect(replies[0]?.text).toContain(
+      "Telegram received /compact now, but that slash command is not supported in channels yet.",
+    );
+  });
 });
 
 describe("buildSlackConversationSummary", () => {


### PR DESCRIPTION
## Summary

Linear: LET-8885 https://linear.app/letta/issue/LET-8885/add-shared-router-for-channel-slash-commands

This PR adds a shared channel slash-command router on top of PR #2266.

PR #2266 made /help work by intercepting it in the channel registry. This follow-up turns that one-off check into a small shared command surface so channel slash commands have one place to be parsed, listed, and handled.

## Problem

External channel messages currently enter the same registry ingress path as normal user text. Without a shared command layer, every slash command either needs adapter-specific handling or risks being delivered to the agent as ordinary text.

That is surprising for channel users. Someone typing /compact or /model in Telegram should not silently send that string into the agent conversation as if it were normal prose.

## Approach

This adds src/channels/commands.ts with:

- a parser for channel slash commands, including Telegram-style bot suffixes like /help@SomeBot
- command metadata for supported direct channel commands
- shared help copy that lists the supported channel commands
- unsupported-command copy that tells users the command is not available in channels yet and reminds them to send normal agent messages without a leading slash
- tryHandleChannelSlashCommand, called by the registry after pending approval replies and before normal route/pairing delivery

The only supported direct command remains /help. Unknown slash commands are now handled explicitly with channel-safe guidance instead of falling through to normal delivery.

## Before and after

Before:

/help was special-cased in the registry. Other slash-like commands could fall into pairing/routing or agent delivery depending on channel state.

After:

The registry delegates slash-command handling to a shared module. /help gets the existing direct help response, and unsupported slash commands get a direct reply explaining that the command is not supported in channels yet.

Normal messages and slash-like filesystem paths such as /tmp/file.txt are not treated as channel commands.

## Limits and tradeoffs

This PR intentionally does not implement the full TUI slash-command surface in channels. Stateful commands such as /compact, /model, /permissions, and /memory still need a clearer agent/conversation-scoped execution contract before they should be exposed through Slack, Telegram, or Discord.

The point here is to create the safe routing surface first, then add commands one by one.

## Stacking note

This PR is stacked on #2266 while that PR waits for human review. Once #2266 merges, this branch can be retargeted to main or rebased with only the router commit remaining.

## Validation

- [x] bun test src/tests/channels/commands.test.ts src/tests/channels/registry.test.ts src/tests/channels/registry-community-copy.test.ts
- [x] bun run lint

👾 Generated with [Letta Code](https://letta.com)
