### PR TITLE
fix(tui): wrap long highlighted user messages

### DIFF
--- a/src/cli/components/UserMessageRich.tsx
+++ b/src/cli/components/UserMessageRich.tsx
@@ -72,11 +72,49 @@ function inkStringWidth(text: string): number {
  */
 function wordWrap(text: string, width: number): string[] {
   if (width <= 0) return [text];
+
+  const hardWrap = (value: string): string[] => {
+    const chunks: string[] = [];
+    let current = "";
+    let currentWidth = 0;
+
+    for (let index = 0; index < value.length; ) {
+      const codePoint = value.codePointAt(index);
+      if (codePoint === undefined) break;
+      const character = String.fromCodePoint(codePoint);
+      const characterWidth = inkStringWidth(character);
+
+      if (current && currentWidth + characterWidth > width) {
+        chunks.push(current);
+        current = "";
+        currentWidth = 0;
+      }
+
+      current += character;
+      currentWidth += characterWidth;
+      index += character.length;
+    }
+
+    if (current) {
+      chunks.push(current);
+    }
+    return chunks.length > 0 ? chunks : [""];
+  };
+
   const words = text.split(" ");
   const lines: string[] = [];
   let current = "";
 
   for (const word of words) {
+    if (inkStringWidth(word) > width) {
+      if (current !== "") {
+        lines.push(current);
+        current = "";
+      }
+      lines.push(...hardWrap(word));
+      continue;
+    }
+
     if (current === "") {
       current = word;
     } else {

--- a/src/tests/cli/userMessageRich.test.ts
+++ b/src/tests/cli/userMessageRich.test.ts
@@ -58,4 +58,24 @@ describe("renderBlock", () => {
 
     expect(lines).toEqual([{ text: "> system context", highlighted: false }]);
   });
+
+  test("hard-wraps long unbroken highlighted content with continuation indentation", () => {
+    const columns = 12;
+    const lines = renderBlock(
+      "https://example.com/abcdef",
+      10,
+      columns,
+      true,
+      "> ",
+      "  ",
+    );
+
+    expect(lines).toEqual([
+      { text: " ".repeat(columns), highlighted: true },
+      { text: "> https://ex", highlighted: true },
+      { text: "  ample.com/", highlighted: true },
+      { text: `  abcdef${" ".repeat(4)}`, highlighted: true },
+      { text: " ".repeat(columns), highlighted: true },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Hard-wrap long unbroken user-message text before rendering highlighted transcript rows.
- Keeps wrapped URL continuations aligned under the prompt and preserves full-width background padding.
- Adds a regression test for long highlighted content wrapping.

👾 Generated with [Letta Code](https://letta.com)