### PR TITLE
fix(byok): validate OpenRouter keys directly

### DIFF
--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -428,7 +428,14 @@ async function handleConnectApiKeyProvider(
   ctx.setCommandRunning(true);
 
   try {
-    await checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+    await checkProviderApiKey(
+      provider.byokProvider.providerType,
+      apiKey,
+      undefined,
+      undefined,
+      undefined,
+      { timeout: options.timeout },
+    );
 
     updateCommandResult(
       ctx.buffersRef,

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -51,6 +51,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    options?: ProviderConnectionOptions,
   ) => Promise<void>;
   createOrUpdateProvider: (
     providerType: string,
@@ -350,7 +351,14 @@ export async function runConnectSubcommand(
 
     try {
       io.stdout(`Validating ${provider.byokProvider.displayName} API key...`);
-      await io.checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+      await io.checkProviderApiKey(
+        provider.byokProvider.providerType,
+        apiKey,
+        undefined,
+        undefined,
+        undefined,
+        connectionOptions,
+      );
 
       io.stdout("Saving provider...");
       if (hasConnectionOptions(connectionOptions)) {

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -29,6 +29,8 @@ import type { LocalProviderTimeout } from "../backend/local/LocalProviderTimeout
 
 export type { ProviderResponse } from "../backend/api/providers";
 
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
 export interface ProviderConnectionOptions {
   baseURL?: string;
   timeout?: LocalProviderTimeout;
@@ -326,6 +328,10 @@ export async function checkProviderApiKey(
     assertLocalProviderSupported(providerType);
     return;
   }
+  if (providerType === "openrouter") {
+    await checkOpenRouterApiKey(apiKey);
+    return;
+  }
   await checkProviderApiKeyRequest(
     providerType,
     apiKey,
@@ -333,6 +339,37 @@ export async function checkProviderApiKey(
     region,
     profile,
   );
+}
+
+async function checkOpenRouterApiKey(apiKey: string): Promise<void> {
+  const response = await fetch(`${OPENROUTER_BASE_URL}/key`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (response.ok) {
+    return;
+  }
+
+  let message = "Invalid OpenRouter API key";
+  try {
+    const body = (await response.json()) as {
+      error?: { message?: unknown };
+      message?: unknown;
+    };
+    const bodyMessage =
+      typeof body.error?.message === "string"
+        ? body.error.message
+        : typeof body.message === "string"
+          ? body.message
+          : undefined;
+    if (bodyMessage) {
+      message = bodyMessage;
+    }
+  } catch {
+    // Keep the generic validation error.
+  }
+
+  throw new Error(message);
 }
 
 /**

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -323,13 +323,14 @@ export async function checkProviderApiKey(
   accessKey?: string,
   region?: string,
   profile?: string,
+  options: ProviderConnectionOptions = {},
 ): Promise<void> {
   if (isLocalProviderStoreEnabled()) {
     assertLocalProviderSupported(providerType);
     return;
   }
   if (providerType === "openrouter") {
-    await checkOpenRouterApiKey(apiKey);
+    await checkOpenRouterApiKey(apiKey, options.timeout);
     return;
   }
   await checkProviderApiKeyRequest(
@@ -341,9 +342,15 @@ export async function checkProviderApiKey(
   );
 }
 
-async function checkOpenRouterApiKey(apiKey: string): Promise<void> {
+async function checkOpenRouterApiKey(
+  apiKey: string,
+  timeout?: LocalProviderTimeout,
+): Promise<void> {
   const response = await fetch(`${OPENROUTER_BASE_URL}/key`, {
     headers: { Authorization: `Bearer ${apiKey}` },
+    ...(typeof timeout === "number"
+      ? { signal: AbortSignal.timeout(timeout) }
+      : {}),
   });
 
   if (response.ok) {

--- a/src/tests/providers/byok-provider-aliases.test.ts
+++ b/src/tests/providers/byok-provider-aliases.test.ts
@@ -137,4 +137,26 @@ describe("checkProviderApiKey", () => {
       checkProviderApiKey("openrouter", "sk-or-v1-invalid"),
     ).rejects.toThrow("User not found.");
   });
+
+  test("passes configured timeout to OpenRouter validation", async () => {
+    const fetchMock = mock(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return new Response(JSON.stringify({ data: { label: "test" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await checkProviderApiKey(
+      "openrouter",
+      "sk-or-v1-test",
+      undefined,
+      undefined,
+      undefined,
+      { timeout: 1_000 },
+    );
+  });
 });

--- a/src/tests/providers/byok-provider-aliases.test.ts
+++ b/src/tests/providers/byok-provider-aliases.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   BYOK_PROVIDERS,
   buildByokProviderAliases,
+  checkProviderApiKey,
   isByokHandleForSelector,
 } from "../../providers/byok-providers";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("buildByokProviderAliases", () => {
   test("derives default aliases from all built-in BYOK_PROVIDERS", () => {
@@ -94,5 +101,40 @@ describe("isByokHandleForSelector", () => {
 
   test("rejects handles without a slash", () => {
     expect(isByokHandleForSelector("somemodel", defaultAliases)).toBe(false);
+  });
+});
+
+describe("checkProviderApiKey", () => {
+  test("validates OpenRouter keys against OpenRouter directly", async () => {
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      expect(String(url)).toBe("https://openrouter.ai/api/v1/key");
+      return new Response(JSON.stringify({ data: { label: "test" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      checkProviderApiKey("openrouter", "sk-or-v1-test"),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects invalid OpenRouter keys with the upstream message", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ error: { message: "User not found." } }),
+          {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      checkProviderApiKey("openrouter", "sk-or-v1-invalid"),
+    ).rejects.toThrow("User not found.");
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes OpenRouter BYOK validation in Letta Code. The existing setup path sent the user-entered OpenRouter key through the generic Letta provider check endpoint. During investigation, that endpoint returned success for a deliberately bogus OpenRouter key, so users could save an invalid key and only discover the problem later when model traffic failed with an OpenRouter auth error.

The change special-cases OpenRouter validation in the shared BYOK provider client. For OpenRouter, Letta Code now calls OpenRouter's key endpoint directly before saving the provider. Successful responses allow the connection flow to continue. Failed responses surface OpenRouter's upstream error message, so invalid keys are rejected during connect instead of creating a broken provider configuration.

Before this change, OpenRouter validation could succeed for any string and model listing could still appear to work. After this change, invalid OpenRouter keys fail at validation time, while other BYOK providers continue using the existing Letta provider check path. Local-mode behavior is unchanged: local provider validation remains storage-support validation only.

Risk is low and isolated to OpenRouter BYOK validation. The main tradeoff is that the CLI now depends directly on OpenRouter's key validation endpoint for this provider, which is preferable to accepting bad credentials silently.

## Test plan

- bun test src/tests/providers/byok-provider-aliases.test.ts src/tests/cli/connect-normalize.test.ts
- bun test src/tests/backend/local-backend.test.ts --timeout 30000
- bunx --bun @biomejs/biome@2.2.5 check src/providers/byok-providers.ts src/tests/providers/byok-provider-aliases.test.ts
- git diff --check

👾 Generated with [Letta Code](https://letta.com)
