### PR TITLE
feat(cli): add /reload command for soft TUI restart

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -207,6 +207,7 @@ export default function App({
   releaseNotes = null,
   updateNotification = null,
   systemInfoReminderEnabled = true,
+  onReload,
 }: AppProps) {
   // Warm the model-access cache in the background so /model is fast on first open.
   useEffect(() => {
@@ -3678,6 +3679,7 @@ export default function App({
     updateAgentName,
     updateMemorySyncCommand,
     userCancelledRef,
+    onReload,
   });
 
   const onSubmitRef = useRef(onSubmit);

--- a/src/cli/app/commandRouting.ts
+++ b/src/cli/app/commandRouting.ts
@@ -47,6 +47,7 @@ const NON_STATE_COMMANDS = new Set([
   "/exit", // session exit
   "/rename", // agent/convo rename
   "/btw",
+  "/reload", // soft TUI restart (has its own busy guard)
 ]);
 
 // Check if a command is interactive (opens overlay, should not be queued)

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -45,6 +45,8 @@ export type AppProps = {
   releaseNotes?: string | null; // Markdown release notes to display above header
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;
+  /** Callback to soft-restart the TUI (re-runs startup path, remounts App). */
+  onReload?: (agentId: string, conversationId: string) => void;
 };
 
 export type ActiveOverlay =

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -46,7 +46,7 @@ export type AppProps = {
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;
   /** Callback to soft-restart the TUI (re-runs startup path, remounts App). */
-  onReload?: (agentId: string, conversationId: string) => void;
+  onReload?: (agentId: string, conversationId: string) => Promise<void>;
 };
 
 export type ActiveOverlay =

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -3362,29 +3362,11 @@ ${SYSTEM_REMINDER_CLOSE}
       // Only do eager check when resuming a session (LET-7101) - otherwise lazy recovery handles it
       let eagerRecoveryDenials: ApprovalResult[] | null = null;
       if (needsEagerApprovalCheck && !queuedApprovalResults) {
-        // Log for debugging
-        const eagerStatusId = uid("status");
-        buffersRef.current.byId.set(eagerStatusId, {
-          kind: "status",
-          id: eagerStatusId,
-          lines: [
-            "[EAGER CHECK] Checking for pending approvals (resume mode)...",
-          ],
-        });
-        buffersRef.current.order.push(eagerStatusId);
-        refreshDerived();
-
         try {
           // Fetch fresh agent state to check for pending approvals with accurate in-context messages
           const agent = await getBackend().retrieveAgent(agentId);
           const { pendingApprovals: existingApprovals } =
             await getResumeDataFromBackend(agent, conversationIdRef.current);
-
-          // Remove eager check status
-          buffersRef.current.byId.delete(eagerStatusId);
-          buffersRef.current.order = buffersRef.current.order.filter(
-            (id: string) => id !== eagerStatusId,
-          );
 
           // Check if user cancelled while we were fetching approval state
           if (

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -304,7 +304,7 @@ type SubmitHandlerContext = {
     keepRunning?: boolean,
   ) => void;
   userCancelledRef: MutableRefObject<boolean>;
-  onReload?: (agentId: string, conversationId: string) => void;
+  onReload?: (agentId: string, conversationId: string) => Promise<void>;
 };
 
 export function useSubmitHandler(ctx: SubmitHandlerContext) {

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -727,6 +727,14 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         }
 
         if (trimmed === "/reload") {
+          if (isAgentBusy()) {
+            const cmd = commandRunner.start(
+              "/reload",
+              "Cannot reload while the agent is running.",
+            );
+            cmd.fail("Wait for the current turn to finish and try again.");
+            return { submitted: true };
+          }
           if (onReload) {
             const cmd = commandRunner.start(
               "/reload",

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -304,6 +304,7 @@ type SubmitHandlerContext = {
     keepRunning?: boolean,
   ) => void;
   userCancelledRef: MutableRefObject<boolean>;
+  onReload?: (agentId: string, conversationId: string) => void;
 };
 
 export function useSubmitHandler(ctx: SubmitHandlerContext) {
@@ -420,6 +421,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     updateAgentName,
     updateMemorySyncCommand,
     userCancelledRef,
+    onReload,
   } = ctx;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: moved from AppCoordinator; dependencies are preserved from the original callback.
@@ -721,6 +723,29 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             "Experiments dialog dismissed",
           );
           setActiveOverlay("experiment");
+          return { submitted: true };
+        }
+
+        if (trimmed === "/reload") {
+          if (onReload) {
+            const cmd = commandRunner.start(
+              "/reload",
+              "Reloading settings and restarting TUI effects...",
+            );
+            cmd.finish("Reloading...", true);
+            // Defer the reload to let the command UI render first
+            setTimeout(
+              () =>
+                onReload(
+                  agentIdRef.current,
+                  conversationIdRef.current ?? "default",
+                ),
+              0,
+            );
+          } else {
+            const cmd = commandRunner.start("/reload", "Reload not available");
+            cmd.fail("Reload is not available in this context");
+          }
           return { submitted: true };
         }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -270,6 +270,15 @@ export const commands: Record<string, Command> = {
       return "Opening experiments selector...";
     },
   },
+  "/reload": {
+    desc: "Reload settings and restart TUI effects",
+    order: 27.2,
+    noArgs: true,
+    handler: () => {
+      // Handled specially in AppCoordinator to trigger a soft restart
+      return "Reloading...";
+    },
+  },
   "/ade": {
     desc: "Open agent in ADE (browser)",
     order: 28,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1096,7 +1096,7 @@ async function main(): Promise<void> {
   markMilestone("REACT_IMPORT_START");
   const React = await import("react");
   const { render } = await import("ink");
-  const { useState, useEffect } = React;
+  const { useState, useEffect, useCallback } = React;
   const AppModule = await import("./cli/App");
   const App = AppModule.default;
 
@@ -1145,6 +1145,8 @@ async function main(): Promise<void> {
     const [isResumingSession, setIsResumingSession] = useState(false);
     const [resumedExistingConversation, setResumedExistingConversation] =
       useState(false);
+    // Epoch counter: incrementing forces App to remount via React key
+    const [appReloadEpoch, setAppReloadEpoch] = useState(0);
     const [agentProvenance, setAgentProvenance] =
       useState<AgentProvenance | null>(null);
     const [selectedGlobalAgentId, setSelectedGlobalAgentId] = useState<
@@ -1569,6 +1571,26 @@ async function main(): Promise<void> {
 
     // Main initialization effect - runs after profile selection
     const initStartedRef = React.useRef(false);
+
+    // Reload handler: re-triggers the startup path for the current agent/conversation,
+    // then remounts AppCoordinator via key change so all effects re-fire.
+    const handleReload = useCallback(
+      (currentAgentId: string, currentConversationId: string) => {
+        // Clear cached settings so the init path re-reads from disk
+        settingsManager.clearCaches();
+        initStartedRef.current = false;
+        setResumeData(null);
+        setAgentState(null);
+        setValidatedAgent(null);
+        setSelectedGlobalAgentId(currentAgentId);
+        setSelectedConversationId(currentConversationId);
+        setResumedExistingConversation(true);
+        setLoadingState("assembling");
+        setAppReloadEpoch((x) => x + 1);
+      },
+      [],
+    );
+
     useEffect(() => {
       if (loadingState !== "assembling") {
         // If init bounced back to a picker, allow the next user selection to
@@ -2302,6 +2324,7 @@ async function main(): Promise<void> {
     }
 
     return React.createElement(App, {
+      key: `${agentId}:${conversationId}:${appReloadEpoch}`,
       agentId,
       agentState,
       conversationId,
@@ -2318,6 +2341,7 @@ async function main(): Promise<void> {
       releaseNotes,
       updateNotification,
       systemInfoReminderEnabled: !noSystemInfoReminderFlag,
+      onReload: handleReload,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1575,9 +1575,13 @@ async function main(): Promise<void> {
     // Reload handler: re-triggers the startup path for the current agent/conversation,
     // then remounts AppCoordinator via key change so all effects re-fire.
     const handleReload = useCallback(
-      (currentAgentId: string, currentConversationId: string) => {
-        // Clear cached settings so the init path re-reads from disk
+      async (currentAgentId: string, currentConversationId: string) => {
+        // Clear cached settings and re-populate local project settings
+        // BEFORE triggering state updates. React components read local
+        // project settings synchronously during render (e.g. getConversationGoal),
+        // so the cache must be warm before the re-render cycle starts.
         settingsManager.clearCaches();
+        await settingsManager.loadLocalProjectSettings();
         initStartedRef.current = false;
         setResumeData(null);
         setAgentState(null);

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -2113,6 +2113,17 @@ class SettingsManager {
   }
 
   /**
+   * Clear in-memory caches so the next read re-loads from disk.
+   * Unlike reset(), this preserves the initialized state and pending writes.
+   * Used by /reload to pick up settings changes without a full restart.
+   */
+  clearCaches(): void {
+    this.localProjectSettings.clear();
+    this.projectSettings.clear();
+    this.clearSecureTokensCache();
+  }
+
+  /**
    * Reset the manager (mainly for testing).
    * Waits for pending writes to complete before resetting.
    */

--- a/src/tests/cli/reload-command.test.ts
+++ b/src/tests/cli/reload-command.test.ts
@@ -20,7 +20,7 @@ describe("/reload command", () => {
     const source = readFileSync(typesPath, "utf-8");
 
     expect(source).toContain(
-      "onReload?: (agentId: string, conversationId: string) => void",
+      "onReload?: (agentId: string, conversationId: string) => Promise<void>",
     );
   });
 

--- a/src/tests/cli/reload-command.test.ts
+++ b/src/tests/cli/reload-command.test.ts
@@ -34,6 +34,24 @@ describe("/reload command", () => {
     expect(source).toContain("onReload(");
   });
 
+  test("/reload has a busy guard", () => {
+    const submitHandlerPath = fileURLToPath(
+      new URL("../../cli/app/useSubmitHandler.ts", import.meta.url),
+    );
+    const source = readFileSync(submitHandlerPath, "utf-8");
+
+    expect(source).toContain("Cannot reload while the agent is running.");
+  });
+
+  test("/reload is in NON_STATE_COMMANDS for bypass routing", () => {
+    const commandRoutingPath = fileURLToPath(
+      new URL("../../cli/app/commandRouting.ts", import.meta.url),
+    );
+    const source = readFileSync(commandRoutingPath, "utf-8");
+
+    expect(source).toContain('"/reload"');
+  });
+
   test("LoadingApp passes onReload and key to App", () => {
     const indexPath = fileURLToPath(new URL("../../index.ts", import.meta.url));
     const source = readFileSync(indexPath, "utf-8");

--- a/src/tests/cli/reload-command.test.ts
+++ b/src/tests/cli/reload-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("/reload command", () => {
+  test("is registered in the command registry", () => {
+    const registryPath = fileURLToPath(
+      new URL("../../cli/commands/registry.ts", import.meta.url),
+    );
+    const source = readFileSync(registryPath, "utf-8");
+
+    expect(source).toContain('"/reload"');
+    expect(source).toContain("Reload settings and restart TUI effects");
+  });
+
+  test("AppProps includes onReload callback", () => {
+    const typesPath = fileURLToPath(
+      new URL("../../cli/app/types.ts", import.meta.url),
+    );
+    const source = readFileSync(typesPath, "utf-8");
+
+    expect(source).toContain(
+      "onReload?: (agentId: string, conversationId: string) => void",
+    );
+  });
+
+  test("useSubmitHandler handles /reload command", () => {
+    const submitHandlerPath = fileURLToPath(
+      new URL("../../cli/app/useSubmitHandler.ts", import.meta.url),
+    );
+    const source = readFileSync(submitHandlerPath, "utf-8");
+
+    expect(source).toContain('trimmed === "/reload"');
+    expect(source).toContain("onReload(");
+  });
+
+  test("LoadingApp passes onReload and key to App", () => {
+    const indexPath = fileURLToPath(new URL("../../index.ts", import.meta.url));
+    const source = readFileSync(indexPath, "utf-8");
+
+    expect(source).toContain("onReload: handleReload");
+    expect(source).toContain(
+      "key: `${agentId}:${conversationId}:${appReloadEpoch}`",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/reload` slash command that re-runs the full startup path without exiting the TUI
- Clears settings caches, re-fetches agent state from backend, re-loads message history, and remounts AppCoordinator via React key change
- All mount-time effects (memfs sync, cron scheduler, debug logging, watchers) re-fire automatically
- Future startup logic added by other developers will automatically run on reload — no dual maintenance needed

## How it works
1. `/reload` in AppCoordinator calls `onReload(agentId, conversationId)` passed from `LoadingApp`
2. `LoadingApp.handleReload` resets init state and sets `loadingState = "assembling"`, re-triggering the existing startup `init()` path
3. `AppCoordinator` remounts via React `key` change (`appReloadEpoch` counter), so all `useEffect` hooks run fresh
4. `settingsManager.clearCaches()` ensures settings are re-read from disk

## Use case
After toggling experiments, changing settings, or any configuration change that would normally require restarting the TUI.

## Test plan
- [x] Type check passes
- [x] Lint passes (no new warnings)
- [x] Unit tests for command registration, prop wiring, and handler presence
- [x] Settings manager tests pass
- [ ] Manual: run `/reload` in TUI, verify settings changes take effect
- [ ] Manual: toggle experiment, `/reload`, verify experiment is active

👾 Generated with [Letta Code](https://letta.com)