### PR TITLE
fix(cli): move plan mode to end of Shift+Tab cycling order

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1389,7 +1389,7 @@ export function Input({
 
       // Cycle through permission modes
       const modes: PermissionMode[] = settingsManager.isPlanModeEnabled()
-        ? ["unrestricted", "plan", "acceptEdits", "standard"]
+        ? ["unrestricted", "acceptEdits", "standard", "plan"]
         : ["unrestricted", "acceptEdits", "standard"];
       const currentIndex = modes.indexOf(currentMode);
       const nextIndex = (currentIndex + 1) % modes.length;

--- a/src/tests/cli/permission-mode-cycle-order.test.ts
+++ b/src/tests/cli/permission-mode-cycle-order.test.ts
@@ -11,7 +11,7 @@ describe("permission mode cycle order", () => {
 
     expect(source).toContain("settingsManager.isPlanModeEnabled()");
     expect(source).toContain(
-      '["unrestricted", "plan", "acceptEdits", "standard"]',
+      '["unrestricted", "acceptEdits", "standard", "plan"]',
     );
     expect(source).toContain('["unrestricted", "acceptEdits", "standard"]');
   });


### PR DESCRIPTION
## Summary
- Plan mode is the least permissive mode, so it should cycle last in the Shift+Tab order (most-permissive → least-permissive: unrestricted → acceptEdits → standard → plan)
- Follow-up to #2184

## Test plan
- [x] `bun test src/tests/cli/permission-mode-cycle-order.test.ts` passes
- [ ] Manual: enable plan mode, verify Shift+Tab cycles unrestricted → acceptEdits → standard → plan

👾 Generated with [Letta Code](https://letta.com)