### PR TITLE
feat: add listener provider fallback parity

### DIFF
--- a/src/tests/websocket/listener-provider-fallback.test.ts
+++ b/src/tests/websocket/listener-provider-fallback.test.ts
@@ -50,4 +50,20 @@ describe("listener provider fallback", () => {
     expect(maybeApplyProviderFallback(state, 2)).toBeNull();
     expect(state.overrideModel).toBeUndefined();
   });
+
+  test("maps Opus 4.7 aliases to Bedrock Opus 4.7", () => {
+    for (const [model, sourceModelId] of [
+      ["anthropic/claude-opus-4-7", "opus"],
+      ["opus-4.7-high", "opus-4.7-high"],
+      ["opus-4.7-max", "opus-4.7-max"],
+    ] as const) {
+      const state = createProviderFallbackState(agentWithModel(model));
+
+      expect(state.sourceModelId).toBe(sourceModelId);
+      expect(maybeApplyProviderFallback(state, 2)).toBe(
+        "bedrock/us.anthropic.claude-opus-4-7",
+      );
+      expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-opus-4-7");
+    }
+  });
 });

--- a/src/tests/websocket/listener-provider-fallback.test.ts
+++ b/src/tests/websocket/listener-provider-fallback.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import {
+  createProviderFallbackState,
+  maybeApplyProviderFallback,
+} from "../../websocket/listener/providerFallback";
+
+function agentWithModel(
+  model: string,
+  extra: Partial<AgentState["llm_config"]> = {},
+): AgentState {
+  return {
+    llm_config: {
+      context_window: 200000,
+      model,
+      model_endpoint_type: "anthropic",
+      ...extra,
+    },
+  } as AgentState;
+}
+
+describe("listener provider fallback", () => {
+  test("maps sonnet to Bedrock after the first retry attempt", () => {
+    const state = createProviderFallbackState(
+      agentWithModel("anthropic/claude-sonnet-4-6", {
+        reasoning_effort: "high",
+        enable_reasoner: true,
+      }),
+    );
+
+    expect(state.sourceModelId).toBe("sonnet");
+    expect(maybeApplyProviderFallback(state, 1)).toBeNull();
+
+    const fallbackHandle = maybeApplyProviderFallback(state, 2);
+    expect(fallbackHandle).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(state.attempted).toBe(true);
+    expect(maybeApplyProviderFallback(state, 3)).toBeNull();
+  });
+
+  test("leaves non-Anthropic models unchanged", () => {
+    const state = createProviderFallbackState(
+      agentWithModel("openai/gpt-5.4", {
+        model_endpoint_type: "openai",
+        reasoning_effort: "high",
+      }),
+    );
+
+    expect(state.sourceModelId).toBe("gpt-5.4-high");
+    expect(maybeApplyProviderFallback(state, 2)).toBeNull();
+    expect(state.overrideModel).toBeUndefined();
+  });
+});

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -11,11 +11,17 @@ export const MAX_PRE_STREAM_RECOVERY = 2;
 export const MAX_POST_STOP_APPROVAL_RECOVERY = 2;
 
 // Provider fallback: Anthropic model ID -> Bedrock model ID.
-// Mirrors the headless/TUI recovery path: after one failed retry against
-// Anthropic, retry the same turn using the Bedrock equivalent.
+// Mirrors the headless recovery path: after one failed retry against
+// Anthropic, retry the same turn using the Bedrock equivalent. Do not map
+// generic/latest aliases unless the Bedrock target is the same model family.
 export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
-  // Opus variants -> Bedrock Opus 4.6
-  opus: "bedrock-opus-4.6",
+  // Opus 4.7 variants -> Bedrock Opus 4.7.
+  opus: "bedrock-opus-4.7",
+  "opus-4.7-low": "bedrock-opus-4.7",
+  "opus-4.7-high": "bedrock-opus-4.7",
+  "opus-4.7-xhigh": "bedrock-opus-4.7",
+  "opus-4.7-max": "bedrock-opus-4.7",
+  // Opus 4.6 variants -> Bedrock Opus 4.6.
   "opus-4.6-no-reasoning": "bedrock-opus-4.6",
   "opus-4.6-low": "bedrock-opus-4.6",
   "opus-4.6-medium": "bedrock-opus-4.6",

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -9,3 +9,26 @@ export const LLM_API_ERROR_MAX_RETRIES = 3;
 export const EMPTY_RESPONSE_MAX_RETRIES = 2;
 export const MAX_PRE_STREAM_RECOVERY = 2;
 export const MAX_POST_STOP_APPROVAL_RECOVERY = 2;
+
+// Provider fallback: Anthropic model ID -> Bedrock model ID.
+// Mirrors the headless/TUI recovery path: after one failed retry against
+// Anthropic, retry the same turn using the Bedrock equivalent.
+export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
+  // Opus variants -> Bedrock Opus 4.6
+  opus: "bedrock-opus-4.6",
+  "opus-4.6-no-reasoning": "bedrock-opus-4.6",
+  "opus-4.6-low": "bedrock-opus-4.6",
+  "opus-4.6-medium": "bedrock-opus-4.6",
+  "opus-4.6-high": "bedrock-opus-4.6",
+  "opus-4.6-xhigh": "bedrock-opus-4.6",
+  // Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  sonnet: "bedrock-sonnet-4.6",
+  "sonnet-1m": "bedrock-sonnet-4.6",
+  "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",
+  "sonnet-4.6-low": "bedrock-sonnet-4.6",
+  "sonnet-4.6-medium": "bedrock-sonnet-4.6",
+  "sonnet-4.6-xhigh": "bedrock-sonnet-4.6",
+};
+
+export const PROVIDER_FALLBACK_NOTICE =
+  "Anthropic API error; falling back to Bedrock...";

--- a/src/websocket/listener/providerFallback.ts
+++ b/src/websocket/listener/providerFallback.ts
@@ -1,0 +1,46 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getModelInfo, getModelInfoForLlmConfig } from "../../agent/model";
+import { PROVIDER_FALLBACK_MAP } from "./constants";
+
+export type ProviderFallbackState = {
+  sourceModelId: string | null;
+  attempted: boolean;
+  overrideModel?: string;
+};
+
+export function createProviderFallbackState(
+  agent: AgentState | null | undefined,
+): ProviderFallbackState {
+  const llmConfig = agent?.llm_config;
+  const model = llmConfig?.model;
+  if (!model) {
+    return { sourceModelId: null, attempted: false };
+  }
+
+  const modelInfo =
+    getModelInfoForLlmConfig(model, llmConfig) ?? getModelInfo(model);
+
+  return {
+    sourceModelId: modelInfo?.id ?? model,
+    attempted: false,
+  };
+}
+
+export function maybeApplyProviderFallback(
+  state: ProviderFallbackState | undefined,
+  attempt: number,
+): string | null {
+  if (!state || state.attempted || attempt < 2 || !state.sourceModelId) {
+    return null;
+  }
+
+  const fallbackId = PROVIDER_FALLBACK_MAP[state.sourceModelId];
+  const fallbackHandle = fallbackId ? getModelInfo(fallbackId)?.handle : null;
+  if (!fallbackHandle) {
+    return null;
+  }
+
+  state.attempted = true;
+  state.overrideModel = fallbackHandle;
+  return fallbackHandle;
+}

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -27,6 +27,7 @@ import {
 import {
   LLM_API_ERROR_MAX_RETRIES,
   MAX_PRE_STREAM_RECOVERY,
+  PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import { getOrCreateConversationPermissionModeStateRef } from "./permissionMode";
@@ -35,7 +36,12 @@ import {
   emitRetryDelta,
   setLoopStatus,
 } from "./protocol-outbound";
+import {
+  maybeApplyProviderFallback,
+  type ProviderFallbackState,
+} from "./providerFallback";
 import { consumeQueuedTurn } from "./queue";
+import { emitRecoverableRetryNotice } from "./recoverable-notices";
 import {
   drainRecoveryStreamWithEmission,
   finalizeHandledRecoveryTurn,
@@ -240,11 +246,15 @@ export async function sendMessageStreamWithRetry(
   socket: ListenerTransport,
   runtime: ConversationRuntime,
   abortSignal?: AbortSignal,
+  retryOptions: {
+    providerFallback?: ProviderFallbackState;
+  } = {},
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
   let transientRetries = 0;
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
+  let currentOpts = opts;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -261,7 +271,7 @@ export async function sendMessageStreamWithRetry(
       return await sendMessageStream(
         conversationId,
         messages,
-        opts,
+        currentOpts,
         abortSignal
           ? { maxRetries: 0, signal: abortSignal }
           : { maxRetries: 0 },
@@ -329,6 +339,26 @@ export async function sendMessageStreamWithRetry(
           conversation_id: conversationId,
         });
         const attempt = transientRetries + 1;
+        transientRetries = attempt;
+        const fallbackHandle = maybeApplyProviderFallback(
+          retryOptions.providerFallback,
+          attempt,
+        );
+        if (fallbackHandle) {
+          currentOpts = { ...currentOpts, overrideModel: fallbackHandle };
+          emitRecoverableRetryNotice(socket, runtime, {
+            kind: "transient_provider_retry",
+            message: PROVIDER_FALLBACK_NOTICE,
+            reason: "llm_api_error",
+            attempt,
+            maxAttempts: LLM_API_ERROR_MAX_RETRIES,
+            delayMs: 0,
+            agentId: runtime.agentId ?? undefined,
+            conversationId,
+          });
+          continue;
+        }
+
         const retryAfterMs =
           preStreamError instanceof APIError
             ? parseRetryAfterHeaderMs(
@@ -341,7 +371,6 @@ export async function sendMessageStreamWithRetry(
           detail: errorDetail,
           retryAfterMs,
         });
-        transientRetries = attempt;
 
         const retryMessage = getRetryStatusMessage(errorDetail);
         if (retryMessage) {
@@ -454,6 +483,7 @@ export async function sendApprovalContinuationWithRetry(
   abortSignal?: AbortSignal,
   retryOptions: {
     allowApprovalRecovery?: boolean;
+    providerFallback?: ProviderFallbackState;
   } = {},
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>> | null> {
   const allowApprovalRecovery = retryOptions.allowApprovalRecovery ?? true;
@@ -461,6 +491,7 @@ export async function sendApprovalContinuationWithRetry(
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
+  let currentOpts = opts;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -477,7 +508,7 @@ export async function sendApprovalContinuationWithRetry(
       return await sendMessageStream(
         conversationId,
         messages,
-        opts,
+        currentOpts,
         abortSignal
           ? { maxRetries: 0, signal: abortSignal }
           : { maxRetries: 0 },
@@ -557,6 +588,26 @@ export async function sendApprovalContinuationWithRetry(
           conversation_id: conversationId,
         });
         const attempt = transientRetries + 1;
+        transientRetries = attempt;
+        const fallbackHandle = maybeApplyProviderFallback(
+          retryOptions.providerFallback,
+          attempt,
+        );
+        if (fallbackHandle) {
+          currentOpts = { ...currentOpts, overrideModel: fallbackHandle };
+          emitRecoverableRetryNotice(socket, runtime, {
+            kind: "transient_provider_retry",
+            message: PROVIDER_FALLBACK_NOTICE,
+            reason: "llm_api_error",
+            attempt,
+            maxAttempts: LLM_API_ERROR_MAX_RETRIES,
+            delayMs: 0,
+            agentId: runtime.agentId ?? undefined,
+            conversationId,
+          });
+          continue;
+        }
+
         const retryAfterMs =
           preStreamError instanceof APIError
             ? parseRetryAfterHeaderMs(
@@ -569,7 +620,6 @@ export async function sendApprovalContinuationWithRetry(
           detail: errorDetail,
           retryAfterMs,
         });
-        transientRetries = attempt;
 
         const retryMessage = getRetryStatusMessage(errorDetail);
         if (retryMessage) {

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -48,6 +48,7 @@ import {
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
+import type { ProviderFallbackState } from "./providerFallback";
 import { consumeQueuedTurn } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import { debugLogApprovalResumeState } from "./recovery";
@@ -167,6 +168,7 @@ export async function handleApprovalStop(params: {
   buildSendOptions: () => Parameters<
     typeof sendApprovalContinuationWithRetry
   >[2];
+  providerFallback?: ProviderFallbackState;
 }): Promise<ApprovalBranchResult> {
   const {
     approvals,
@@ -182,6 +184,7 @@ export async function handleApprovalStop(params: {
     currentInput,
     turnToolContextId,
     buildSendOptions,
+    providerFallback,
   } = params;
   const abortController = runtime.activeAbortController;
 
@@ -586,6 +589,7 @@ export async function handleApprovalStop(params: {
       socket,
       runtime,
       abortController.signal,
+      { providerFallback },
     );
   } catch (error) {
     if (shouldInterrupt()) {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -62,6 +62,7 @@ import { debugLog, debugWarn, isDebugEnabled } from "../../utils/debug";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
+  PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
@@ -86,6 +87,10 @@ import {
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
+import {
+  createProviderFallbackState,
+  maybeApplyProviderFallback,
+} from "./providerFallback";
 import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
@@ -586,6 +591,7 @@ export async function handleIncomingMessage(
     }
 
     let currentInput = messagesToSend;
+    const providerFallback = createProviderFallbackState(cachedAgent);
     let pendingNormalizationInterruptedToolCallIds = [
       ...queuedInterruptedToolCallIds,
     ];
@@ -609,6 +615,9 @@ export async function handleIncomingMessage(
       permissionModeState: turnPermissionModeState,
       preparedToolContext: preparedToolContext.preparedToolContext,
       skipImageNormalization: true,
+      ...(providerFallback.overrideModel
+        ? { overrideModel: providerFallback.overrideModel }
+        : {}),
       // Forward cloud-api's per-WS acting user id so the outbound
       // createMessage HTTP call carries X-Letta-Acting-User-Id and
       // cloud can attribute credits to the actual sender on
@@ -635,6 +644,7 @@ export async function handleIncomingMessage(
           socket,
           runtime,
           turnAbortSignal,
+          { providerFallback },
         )
       : await sendMessageStreamWithRetry(
           conversationId,
@@ -643,6 +653,7 @@ export async function handleIncomingMessage(
           socket,
           runtime,
           turnAbortSignal,
+          { providerFallback },
         );
     currentInput = currentInputWithSkillContent;
     if (!stream) {
@@ -868,6 +879,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -876,6 +888,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -953,6 +966,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -961,6 +975,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -986,14 +1001,21 @@ export async function handleIncomingMessage(
         if (retriable && llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           llmApiErrorRetries += 1;
           const attempt = llmApiErrorRetries;
-          const delayMs = getRetryDelayMs({
-            category: "transient_provider",
+          const fallbackHandle = maybeApplyProviderFallback(
+            providerFallback,
             attempt,
-            detail: errorDetail,
-          });
-          const retryMessage =
-            getRetryStatusMessage(errorDetail) ||
-            `LLM API error encountered, retrying (attempt ${attempt}/${LLM_API_ERROR_MAX_RETRIES})...`;
+          );
+          const delayMs = fallbackHandle
+            ? 0
+            : getRetryDelayMs({
+                category: "transient_provider",
+                attempt,
+                detail: errorDetail,
+              });
+          const retryMessage = fallbackHandle
+            ? PROVIDER_FALLBACK_NOTICE
+            : getRetryStatusMessage(errorDetail) ||
+              `LLM API error encountered, retrying (attempt ${attempt}/${LLM_API_ERROR_MAX_RETRIES})...`;
           emitRecoverableRetryNotice(socket, runtime, {
             kind: "transient_provider_retry",
             message: retryMessage,
@@ -1006,7 +1028,9 @@ export async function handleIncomingMessage(
             conversationId,
           });
 
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          if (!fallbackHandle) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
@@ -1028,6 +1052,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -1036,6 +1061,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -1111,6 +1137,7 @@ export async function handleIncomingMessage(
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
         buildSendOptions,
+        providerFallback,
       });
       if (approvalResult.terminated || !approvalResult.stream) {
         return;


### PR DESCRIPTION
## Summary
- add listener provider fallback mapping for Anthropic model IDs to Bedrock equivalents
- apply request-scoped override_model fallback in both pre-stream and post-stream listener retry paths
- carry fallback state through approval continuation retries so fallback remains turn-scoped and does not mutate persisted agent config

## Testing
- bun test src/tests/websocket/listener-provider-fallback.test.ts
- bun run typecheck
- bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/send.ts src/websocket/listener/turn.ts src/websocket/listener/turn-approval.ts src/websocket/listener/constants.ts src/websocket/listener/providerFallback.ts src/tests/websocket/listener-provider-fallback.test.ts
- bun run lint (passes with pre-existing unrelated warnings in shellSemanticDisplay/control-inputs)
