### PR TITLE
fix(permissions): auto-approve EnterPlanMode in unrestricted mode

### DIFF
--- a/src/cli/helpers/toolNameMapping.ts
+++ b/src/cli/helpers/toolNameMapping.ts
@@ -3,6 +3,7 @@
  * Centralizes tool name remapping logic used across the UI.
  */
 
+import { permissionMode } from "../../permissions/mode";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { MEMORY_TOOL_NAMES } from "../../tools/toolset";
 
@@ -133,12 +134,21 @@ export function isFancyUITool(name: string): boolean {
  * Checks if a tool always requires user interaction, even in unrestricted mode.
  * These are tools that fundamentally need user input to proceed:
  * - AskUserQuestion: needs user to answer questions
- * - EnterPlanMode: needs user to approve entering plan mode
  * - ExitPlanMode: needs user to approve the plan
+ *
+ * EnterPlanMode is exempted in unrestricted mode — the agent gets plan
+ * instructions but keeps full permissions (no code changes happen until
+ * ExitPlanMode is approved). ExitPlanMode always requires approval.
  *
  * Other tools (bash, file edits) should respect unrestricted mode and auto-approve.
  */
 export function alwaysRequiresUserInput(name: string): boolean {
+  if (
+    permissionMode.getMode() === "unrestricted" &&
+    (name === "EnterPlanMode" || name === "enter_plan_mode")
+  ) {
+    return false;
+  }
   return isInteractiveApprovalTool(name);
 }
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -84,6 +84,7 @@ import {
   type DrainStreamHook,
   drainStreamWithResume,
 } from "./cli/helpers/stream";
+import { alwaysRequiresUserInput } from "./cli/helpers/toolNameMapping";
 import {
   validateConversationDefaultRequiresAgent,
   validateFlagConflicts,
@@ -2147,7 +2148,7 @@ ${SYSTEM_REMINDER_CLOSE}
             !autoApprovalEmitted.has(updatedApproval.toolCallId)
           ) {
             const { autoAllowed } = await classifyApprovals([updatedApproval], {
-              alwaysRequiresUserInput: isInteractiveApprovalTool,
+              alwaysRequiresUserInput,
               requireArgsForAutoApprove: true,
               missingNameReason: "Tool call incomplete - missing name",
             });
@@ -2291,7 +2292,7 @@ ${SYSTEM_REMINDER_CLOSE}
 
         const { autoAllowed, autoDenied, needsUserInput } =
           await classifyApprovals(approvals, {
-            alwaysRequiresUserInput: isInteractiveApprovalTool,
+            alwaysRequiresUserInput,
             requireArgsForAutoApprove: true,
             missingNameReason: "Tool call incomplete - missing name",
           });
@@ -3979,7 +3980,7 @@ async function runBidirectionalMode(
 
             const { autoAllowed, autoDenied, needsUserInput } =
               await classifyApprovals(approvals, {
-                alwaysRequiresUserInput: isInteractiveApprovalTool,
+                alwaysRequiresUserInput,
                 requireArgsForAutoApprove: true,
                 missingNameReason: "Tool call incomplete - missing name",
               });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -112,10 +112,7 @@ import { writeWireMessage, writeWireMessageAsync } from "./streamJsonWriter";
 import { telemetry } from "./telemetry";
 import { trackBoundaryError } from "./telemetry/errorReporting";
 import { extractTelemetryInputText } from "./telemetry/input";
-import {
-  isHeadlessAutoAllowTool,
-  isInteractiveApprovalTool,
-} from "./tools/interactivePolicy";
+import { isHeadlessAutoAllowTool } from "./tools/interactivePolicy";
 import {
   type ExternalToolDefinition,
   registerExternalTools,

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -27,7 +27,6 @@ import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
 import { alwaysRequiresUserInput } from "../../cli/helpers/toolNameMapping";
 import { formatPermissionDenial } from "../../permissions/formatDenial";
-import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
 import type {
   ApprovalResponseBody,

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -25,6 +25,7 @@ import {
 import { getBackend } from "../../backend";
 import { createBuffers } from "../../cli/helpers/accumulator";
 import { drainStreamWithResume } from "../../cli/helpers/stream";
+import { alwaysRequiresUserInput } from "../../cli/helpers/toolNameMapping";
 import { formatPermissionDenial } from "../../permissions/formatDenial";
 import { isInteractiveApprovalTool } from "../../tools/interactivePolicy";
 import { prepareToolExecutionContextForScope } from "../../tools/toolset";
@@ -508,7 +509,7 @@ export async function resolveRecoveredApprovalResponse(
       const reclassified = await classifyApprovalsWithSuggestions(
         remainingRecoveredEntries.map((entry) => entry.approval),
         {
-          alwaysRequiresUserInput: isInteractiveApprovalTool,
+          alwaysRequiresUserInput,
           requireArgsForAutoApprove: true,
           missingNameReason: "Tool call incomplete - missing name",
           workingDirectory,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -14,10 +14,7 @@ import type { ChannelTurnSource } from "../../channels/types";
 import { alwaysRequiresUserInput } from "../../cli/helpers/toolNameMapping";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { formatPermissionDenial } from "../../permissions/formatDenial";
-import {
-  getInteractiveApprovalKind,
-  isInteractiveApprovalTool,
-} from "../../tools/interactivePolicy";
+import { getInteractiveApprovalKind } from "../../tools/interactivePolicy";
 import type {
   ApprovalResponseBody,
   ApprovalResponseDecision,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -11,6 +11,7 @@ import {
 } from "../../agent/approval-execution";
 import { getChannelRegistry } from "../../channels/registry";
 import type { ChannelTurnSource } from "../../channels/types";
+import { alwaysRequiresUserInput } from "../../cli/helpers/toolNameMapping";
 import { computeDiffPreviews } from "../../helpers/diffPreview";
 import { formatPermissionDenial } from "../../permissions/formatDenial";
 import {
@@ -231,7 +232,7 @@ export async function handleApprovalStop(params: {
 
   const { autoAllowed, autoDenied, needsUserInput } =
     await classifyApprovalsWithSuggestions(approvals, {
-      alwaysRequiresUserInput: isInteractiveApprovalTool,
+      alwaysRequiresUserInput,
       treatAskAsDeny: false,
       requireArgsForAutoApprove: true,
       missingNameReason: "Tool call incomplete - missing name",
@@ -394,7 +395,7 @@ export async function handleApprovalStop(params: {
             const reclassified = await classifyApprovalsWithSuggestions(
               pendingNeedsUserInput.map((entry) => entry.approval),
               {
-                alwaysRequiresUserInput: isInteractiveApprovalTool,
+                alwaysRequiresUserInput,
                 treatAskAsDeny: false,
                 requireArgsForAutoApprove: true,
                 missingNameReason: "Tool call incomplete - missing name",


### PR DESCRIPTION
## Summary
- EnterPlanMode no longer requires user approval in unrestricted (YOLO) mode
- ExitPlanMode still always requires approval (no behavior change)
- Make `alwaysRequiresUserInput()` mode-aware: returns `false` for EnterPlanMode when in unrestricted mode
- Wire the mode-aware version through all classification call sites (websocket listener, recovery, headless) instead of raw `isInteractiveApprovalTool`

## Root cause
`alwaysRequiresUserInput` was a raw passthrough to `isInteractiveApprovalTool`, which unconditionally flags EnterPlanMode. This forced the tool into `needsUserInput` even when `checkModeOverride` returned "allow" in unrestricted mode. The classification layer (`approvalClassification.ts` line 135) then overrode the "allow" decision to "ask", showing the approval dialog unnecessarily.

## Test plan
- [x] Existing `permissions-mode.test.ts` passes (61/61) — confirms EnterPlanMode is auto-approved via `checkPermission` in unrestricted mode
- [x] Existing `interactivepolicy.test.ts` passes — confirms `isInteractiveApprovalTool` still correctly identifies EnterPlanMode as an interactive tool
- [x] Pre-commit hooks (biome, tsc) pass
- [ ] Manual: switch to unrestricted mode, trigger EnterPlanMode — should auto-approve without dialog
- [ ] Manual: ExitPlanMode still shows approval dialog in unrestricted mode