### PR TITLE
fix(local): route MemFS UI to local backend paths

### DIFF
--- a/src/agent/memoryFilesystem.ts
+++ b/src/agent/memoryFilesystem.ts
@@ -183,6 +183,16 @@ export async function isMemfsEnabledOnServer(
  * when the repo is missing.
  */
 export async function ensureLocalMemfsCheckout(agentId: string): Promise<void> {
+  if (isLocalBackendEnvEnabled()) {
+    const { initializeLocalMemoryRepo } = await import("./memoryGit");
+    await initializeLocalMemoryRepo({
+      memoryDir: getScopedMemoryFilesystemRoot(agentId),
+      agentId,
+      files: [],
+    });
+    return;
+  }
+
   const { isGitRepo, cloneMemoryRepo } = await import("./memoryGit");
   if (isGitRepo(agentId)) {
     return;
@@ -528,7 +538,7 @@ export async function applyMemfsFlags(
         : "unchanged";
   return {
     action,
-    memoryDir: isEnabled ? getMemoryFilesystemRoot(agentId) : undefined,
+    memoryDir: isEnabled ? getScopedMemoryFilesystemRoot(agentId) : undefined,
     pullSummary,
   };
 }

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -106,11 +106,6 @@ export function getScopedMemoryRepoDir(agentId: string): string {
     : getMemoryRepoDir(agentId);
 }
 
-/** Check if a specific directory is a git repo. */
-export function isGitRepoAtPath(memoryDir: string): boolean {
-  return existsSync(join(memoryDir, ".git"));
-}
-
 function getMemoryRepositoryRepoDir(agentId: string): string {
   return getScopedMemoryRepoDir(agentId);
 }
@@ -1536,7 +1531,7 @@ export async function commitAndSyncMemoryWrite(
 
 /** Check if the memory directory is a git repo */
 export function isGitRepo(agentId: string): boolean {
-  return isGitRepoAtPath(getScopedMemoryRepoDir(agentId));
+  return existsSync(join(getScopedMemoryRepoDir(agentId), ".git"));
 }
 
 export interface InitializeLocalMemoryRepoFile {

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -30,11 +30,8 @@ import {
   getMemfsGitProxyRewriteConfig,
   getMemfsServerUrl,
 } from "../backend/api/memfs-git-proxy";
-import {
-  getLocalBackendMemoryFilesystemRoot,
-  isLocalBackendEnvEnabled,
-} from "../backend/local/paths";
 import { debugLog, debugWarn } from "../utils/debug";
+import { getScopedMemoryFilesystemRoot } from "./memoryFilesystem";
 
 const execFile = promisify(execFileCb);
 
@@ -94,20 +91,8 @@ export function getMemoryRepoDir(agentId: string): string {
   return join(getAgentRootDir(agentId), "memory");
 }
 
-/**
- * Get the active memory repo directory for the current backend scope.
- *
- * API-backed MemFS uses ~/.letta/agents/{id}/memory, while local backend
- * MemFS uses ~/.letta/lc-local-backend/memfs/{id}/memory.
- */
-export function getScopedMemoryRepoDir(agentId: string): string {
-  return isLocalBackendEnvEnabled()
-    ? getLocalBackendMemoryFilesystemRoot(agentId)
-    : getMemoryRepoDir(agentId);
-}
-
 function getMemoryRepositoryRepoDir(agentId: string): string {
-  return getScopedMemoryRepoDir(agentId);
+  return getScopedMemoryFilesystemRoot(agentId);
 }
 
 /**
@@ -1531,7 +1516,7 @@ export async function commitAndSyncMemoryWrite(
 
 /** Check if the memory directory is a git repo */
 export function isGitRepo(agentId: string): boolean {
-  return existsSync(join(getScopedMemoryRepoDir(agentId), ".git"));
+  return existsSync(join(getScopedMemoryFilesystemRoot(agentId), ".git"));
 }
 
 export interface InitializeLocalMemoryRepoFile {
@@ -1824,7 +1809,7 @@ export interface MemoryGitStatus {
 export async function getMemoryGitStatus(
   agentId: string,
 ): Promise<MemoryGitStatus> {
-  const dir = getScopedMemoryRepoDir(agentId);
+  const dir = getScopedMemoryFilesystemRoot(agentId);
 
   // Check for uncommitted changes
   const { stdout: statusOut } = await runGit(dir, ["status", "--porcelain"]);

--- a/src/agent/memoryGit.ts
+++ b/src/agent/memoryGit.ts
@@ -94,10 +94,25 @@ export function getMemoryRepoDir(agentId: string): string {
   return join(getAgentRootDir(agentId), "memory");
 }
 
-function getMemoryRepositoryRepoDir(agentId: string): string {
+/**
+ * Get the active memory repo directory for the current backend scope.
+ *
+ * API-backed MemFS uses ~/.letta/agents/{id}/memory, while local backend
+ * MemFS uses ~/.letta/lc-local-backend/memfs/{id}/memory.
+ */
+export function getScopedMemoryRepoDir(agentId: string): string {
   return isLocalBackendEnvEnabled()
     ? getLocalBackendMemoryFilesystemRoot(agentId)
     : getMemoryRepoDir(agentId);
+}
+
+/** Check if a specific directory is a git repo. */
+export function isGitRepoAtPath(memoryDir: string): boolean {
+  return existsSync(join(memoryDir, ".git"));
+}
+
+function getMemoryRepositoryRepoDir(agentId: string): string {
+  return getScopedMemoryRepoDir(agentId);
 }
 
 /**
@@ -1521,7 +1536,7 @@ export async function commitAndSyncMemoryWrite(
 
 /** Check if the memory directory is a git repo */
 export function isGitRepo(agentId: string): boolean {
-  return existsSync(join(getMemoryRepoDir(agentId), ".git"));
+  return isGitRepoAtPath(getScopedMemoryRepoDir(agentId));
 }
 
 export interface InitializeLocalMemoryRepoFile {
@@ -1814,7 +1829,7 @@ export interface MemoryGitStatus {
 export async function getMemoryGitStatus(
   agentId: string,
 ): Promise<MemoryGitStatus> {
-  const dir = getMemoryRepoDir(agentId);
+  const dir = getScopedMemoryRepoDir(agentId);
 
   // Check for uncommitted changes
   const { stdout: statusOut } = await runGit(dir, ["status", "--porcelain"]);

--- a/src/agent/memoryRuntime.ts
+++ b/src/agent/memoryRuntime.ts
@@ -1,0 +1,28 @@
+import { getBackend } from "../backend";
+import { settingsManager } from "../settings-manager";
+import { getScopedMemoryFilesystemRoot } from "./memoryFilesystem";
+
+/**
+ * Runtime MemFS state for the active backend.
+ *
+ * Cloud/API MemFS is an agent setting. Local backend MemFS is a backend
+ * capability unless explicitly disabled before backend construction, so most
+ * UI surfaces should treat local backend agents as MemFS-enabled even before a
+ * persisted per-agent setting exists.
+ */
+export function isActiveMemfsEnabled(agentId: string): boolean {
+  return (
+    getBackend().capabilities.localMemfs ||
+    settingsManager.isMemfsEnabled(agentId)
+  );
+}
+
+export function getActiveMemoryDirectory(agentId: string): string | undefined {
+  return isActiveMemfsEnabled(agentId)
+    ? getScopedMemoryFilesystemRoot(agentId)
+    : undefined;
+}
+
+export function isLocalMemfsActive(): boolean {
+  return getBackend().capabilities.localMemfs;
+}

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -492,7 +492,11 @@ export async function updateAgentSystemPromptMemfs(
     const { settingsManager } = await import("../settings-manager");
     const { isKnownPreset, buildSystemPrompt } = await import("./promptAssets");
 
-    const newMode = enableMemfs ? "memfs" : "standard";
+    const newMode = enableMemfs
+      ? getBackend().capabilities.localMemfs
+        ? "local-memfs"
+        : "memfs"
+      : "standard";
     const storedPreset = settingsManager.isReady
       ? settingsManager.getSystemPromptPreset(agentId)
       : undefined;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -19,6 +19,7 @@ import { prefetchAvailableModelHandles } from "../../agent/available-models";
 import { getResumeDataFromBackend } from "../../agent/check-approval";
 import { setCurrentAgentId } from "../../agent/context";
 import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { isActiveMemfsEnabled } from "../../agent/memoryRuntime";
 import {
   getModelInfoForLlmConfig,
   getModelShortName,
@@ -1966,7 +1967,7 @@ export default function App({
   // Configurable status line hook
   const sessionStatsSnapshot = sessionStatsRef.current.getSnapshot();
   const reflectionSettings = getReflectionSettings(agentId);
-  const memfsEnabled = settingsManager.isMemfsEnabled(agentId);
+  const memfsEnabled = isActiveMemfsEnabled(agentId);
   const _memfsDirectory =
     memfsEnabled && agentId && agentId !== "loading"
       ? getScopedMemoryFilesystemRoot(agentId)

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -6,6 +6,7 @@ import { Box } from "ink";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { getResumeDataFromBackend } from "../../agent/check-approval";
 import { ISOLATED_BLOCK_LABELS } from "../../agent/memory";
+import { isActiveMemfsEnabled } from "../../agent/memoryRuntime";
 import type { ModelReasoningEffort } from "../../agent/model";
 import type { PersonalityId } from "../../agent/personality";
 import type { SessionStats } from "../../agent/stats";
@@ -762,7 +763,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "sleeptime" && (
               <SleeptimeSelector
                 initialSettings={getReflectionSettings(agentId)}
-                memfsEnabled={settingsManager.isMemfsEnabled(agentId)}
+                memfsEnabled={isActiveMemfsEnabled(agentId)}
                 onSave={handleSleeptimeModeSelect}
                 onCancel={closeOverlay}
               />
@@ -1413,7 +1414,7 @@ export function AppView(props: AppViewProps) {
             {/* Memory Viewer - conditionally mounted as overlay */}
             {/* Use tree view for memfs-enabled agents, tab view otherwise */}
             {activeOverlay === "memory" &&
-              (settingsManager.isMemfsEnabled(agentId) ? (
+              (isActiveMemfsEnabled(agentId) ? (
                 <MemfsTreeViewer
                   agentId={agentId}
                   agentName={agentState?.name}

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -27,6 +27,11 @@ import {
   ensureMemoryFilesystemDirs,
   getScopedMemoryFilesystemRoot,
 } from "../../agent/memoryFilesystem";
+import {
+  getActiveMemoryDirectory,
+  isActiveMemfsEnabled,
+  isLocalMemfsActive,
+} from "../../agent/memoryRuntime";
 import type { ModelReasoningEffort } from "../../agent/model";
 import {
   detectPersonalityFromPersonaFile,
@@ -806,7 +811,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             "Personality selector dismissed",
           );
 
-          if (settingsManager.isMemfsEnabled(agentId)) {
+          if (isActiveMemfsEnabled(agentId)) {
             try {
               const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
               const personaCandidates = [
@@ -867,7 +872,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             "Opening Memory Palace...",
           );
 
-          if (!settingsManager.isMemfsEnabled(agentId)) {
+          if (!isActiveMemfsEnabled(agentId)) {
             cmd.finish(
               "Memory Palace requires memfs. Run /memfs enable first.",
               false,
@@ -2194,7 +2199,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
           if (subcommand === "status") {
             // Show status
-            const enabled = settingsManager.isMemfsEnabled(agentId);
+            const enabled = isActiveMemfsEnabled(agentId);
             let output: string;
             if (enabled) {
               const memoryDir = getScopedMemoryFilesystemRoot(agentId);
@@ -2246,7 +2251,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
           if (subcommand === "sync") {
             // Check if memfs is enabled for this agent
-            if (!settingsManager.isMemfsEnabled(agentId)) {
+            if (!isActiveMemfsEnabled(agentId)) {
               cmd.fail(
                 "Memory filesystem is disabled. Run `/memfs enable` first.",
               );
@@ -2592,7 +2597,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         if (trimmed === "/reflect") {
           const cmd = commandRunner.start(msg, "Launching reflection agent...");
 
-          if (!settingsManager.isMemfsEnabled(agentId)) {
+          if (!isActiveMemfsEnabled(agentId)) {
             cmd.fail(
               "Memory filesystem is not enabled. Use /remember instead.",
             );
@@ -2813,9 +2818,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
 
             const { context: gitContext } = gatherInitGitContext();
-            const memoryDir = settingsManager.isMemfsEnabled(agentId)
-              ? getScopedMemoryFilesystemRoot(agentId)
-              : undefined;
+            const memoryDir = getActiveMemoryDirectory(agentId);
 
             const initMessage = buildInitMessage({
               gitContext,
@@ -2859,9 +2862,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
 
             const { context: gitContext } = gatherInitGitContext();
-            const memoryDir = settingsManager.isMemfsEnabled(agentId)
-              ? getScopedMemoryFilesystemRoot(agentId)
-              : undefined;
+            const memoryDir = getActiveMemoryDirectory(agentId);
 
             const doctorMessage = buildDoctorMessage({
               gitContext,
@@ -3178,24 +3179,23 @@ ${SYSTEM_REMINDER_CLOSE}
       }
 
       const reflectionSettings = getReflectionSettings(agentId);
-      const memfsEnabledForAgent = settingsManager.isMemfsEnabled(agentId);
+      const memfsEnabledForAgent = isActiveMemfsEnabled(agentId);
 
       // Build git memory sync reminder if uncommitted changes or unpushed commits
       let memoryGitReminder = "";
       const gitStatus = pendingGitReminderRef.current;
       if (gitStatus) {
+        const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+        const localMemfs = isLocalMemfsActive();
+        const syncInstructions = localMemfs
+          ? `Commit when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\n\`\`\``
+          : `Sync when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\ngit push\n\`\`\``;
         memoryGitReminder = `${SYSTEM_REMINDER_OPEN}
-MEMORY SYNC: Your memory directory has uncommitted changes or is ahead of the remote.
+${localMemfs ? "MEMORY COMMIT" : "MEMORY SYNC"}: Your memory directory has uncommitted changes${localMemfs ? "." : " or is ahead of the remote."}
 
 ${gitStatus.summary}
 
-Sync when convenient by running these commands:
-\`\`\`bash
-cd ~/.letta/agents/${agentId}/memory
-git add system/
-git commit -m "<type>: <what changed>"
-git push
-\`\`\`
+${syncInstructions}
 
 You should do this soon to avoid losing memory updates. It only takes a few seconds.
 ${SYSTEM_REMINDER_CLOSE}

--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -2,8 +2,8 @@ import { existsSync } from "node:fs";
 import { Box, useInput } from "ink";
 import Link from "ink-link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
-import { isGitRepo } from "../../agent/memoryGit";
+import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { isGitRepoAtPath } from "../../agent/memoryGit";
 import {
   getFileNodes,
   readFileContent,
@@ -66,9 +66,9 @@ export function MemfsTreeViewer({
   const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Get memory filesystem root
-  const memoryRoot = getMemoryFilesystemRoot(agentId);
+  const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
   const memoryExists = existsSync(memoryRoot);
-  const hasGitRepo = useMemo(() => isGitRepo(agentId), [agentId]);
+  const hasGitRepo = useMemo(() => isGitRepoAtPath(memoryRoot), [memoryRoot]);
 
   function showStatus(msg: string, durationMs: number) {
     if (statusTimerRef.current) clearTimeout(statusTimerRef.current);

--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -1,9 +1,9 @@
 import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { Box, useInput } from "ink";
 import Link from "ink-link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
-import { isGitRepoAtPath } from "../../agent/memoryGit";
 import {
   getFileNodes,
   readFileContent,
@@ -68,7 +68,10 @@ export function MemfsTreeViewer({
   // Get memory filesystem root
   const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
   const memoryExists = existsSync(memoryRoot);
-  const hasGitRepo = useMemo(() => isGitRepoAtPath(memoryRoot), [memoryRoot]);
+  const hasGitRepo = useMemo(
+    () => existsSync(join(memoryRoot, ".git")),
+    [memoryRoot],
+  );
 
   function showStatus(msg: string, durationMs: number) {
     if (statusTimerRef.current) clearTimeout(statusTimerRef.current);

--- a/src/cli/helpers/systemPromptWarning.ts
+++ b/src/cli/helpers/systemPromptWarning.ts
@@ -3,8 +3,8 @@
  * Uses same heuristic as context_doctor to estimate system prompt token count on startup
  */
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
-import { getMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
-import { settingsManager } from "../../settings-manager";
+import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { isActiveMemfsEnabled } from "../../agent/memoryRuntime";
 import { debugWarn } from "../../utils/debug";
 import {
   estimateSystemPromptTokensFromMemoryDir,
@@ -53,8 +53,8 @@ export function refreshSystemPromptDoctorState(
   try {
     let estimatedSystemPromptTokens = 0;
 
-    if (settingsManager.isMemfsEnabled(agentId)) {
-      const memoryDir = getMemoryFilesystemRoot(agentId);
+    if (isActiveMemfsEnabled(agentId)) {
+      const memoryDir = getScopedMemoryFilesystemRoot(agentId);
       estimatedSystemPromptTokens =
         estimateSystemPromptTokensFromMemoryDir(memoryDir);
     } else {

--- a/src/cli/subcommands/memory.ts
+++ b/src/cli/subcommands/memory.ts
@@ -1,14 +1,14 @@
 import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import {
   getMemoryGitStatus,
-  getMemoryRepoDir,
+  getScopedMemoryRepoDir,
   isGitRepo,
   pullMemory,
 } from "../../agent/memoryGit";
+import { isLocalBackendEnvEnabled } from "../../backend/local/paths";
 import { runMemoryTokensAction } from "./memoryTokens";
 
 function printUsage(): void {
@@ -70,11 +70,11 @@ function parseMemoryArgs(argv: string[]) {
 }
 
 function getMemoryRoot(agentId: string): string {
-  return join(homedir(), ".letta", "agents", agentId, "memory");
+  return getScopedMemoryRepoDir(agentId);
 }
 
 function getAgentRoot(agentId: string): string {
-  return join(homedir(), ".letta", "agents", agentId);
+  return dirname(getMemoryRoot(agentId));
 }
 
 function formatBackupTimestamp(date = new Date()): string {
@@ -185,7 +185,7 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
       const { execFile: execFileCb } = await import("node:child_process");
       const { promisify } = await import("node:util");
       const execFile = promisify(execFileCb);
-      const dir = getMemoryRepoDir(agentId);
+      const dir = getScopedMemoryRepoDir(agentId);
       const { stdout } = await execFile("git", ["diff"], { cwd: dir });
       if (stdout.trim()) {
         console.log(stdout);
@@ -199,6 +199,20 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
       if (!isGitRepo(agentId)) {
         console.error("Not a git repo. Enable git-backed memory first.");
         return 1;
+      }
+      if (isLocalBackendEnvEnabled()) {
+        console.log(
+          JSON.stringify(
+            {
+              updated: false,
+              summary:
+                "Local backend MemFS is stored locally; no remote pull is required.",
+            },
+            null,
+            2,
+          ),
+        );
+        return 0;
       }
       const result = await pullMemory(agentId);
       console.log(JSON.stringify(result, null, 2));

--- a/src/cli/subcommands/memory.ts
+++ b/src/cli/subcommands/memory.ts
@@ -2,9 +2,9 @@ import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
+import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
 import {
   getMemoryGitStatus,
-  getScopedMemoryRepoDir,
   isGitRepo,
   pullMemory,
 } from "../../agent/memoryGit";
@@ -70,7 +70,7 @@ function parseMemoryArgs(argv: string[]) {
 }
 
 function getMemoryRoot(agentId: string): string {
-  return getScopedMemoryRepoDir(agentId);
+  return getScopedMemoryFilesystemRoot(agentId);
 }
 
 function getAgentRoot(agentId: string): string {
@@ -185,7 +185,7 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
       const { execFile: execFileCb } = await import("node:child_process");
       const { promisify } = await import("node:util");
       const execFile = promisify(execFileCb);
-      const dir = getScopedMemoryRepoDir(agentId);
+      const dir = getScopedMemoryFilesystemRoot(agentId);
       const { stdout } = await execFile("git", ["diff"], { cwd: dir });
       if (stdout.trim()) {
         console.log(stdout);

--- a/src/tests/agent/memoryGit.local-scope.test.ts
+++ b/src/tests/agent/memoryGit.local-scope.test.ts
@@ -2,11 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  getMemoryRepoDir,
-  getScopedMemoryRepoDir,
-  isGitRepo,
-} from "../../agent/memoryGit";
+import { getScopedMemoryFilesystemRoot } from "../../agent/memoryFilesystem";
+import { getMemoryRepoDir, isGitRepo } from "../../agent/memoryGit";
 import { getLocalBackendMemoryFilesystemRoot } from "../../backend/local/paths";
 
 function withTemporaryEnv<T>(
@@ -50,14 +47,14 @@ describe("memoryGit local backend scoping", () => {
           LETTA_LOCAL_BACKEND_DIR: storageDir,
         },
         () => {
-          expect(getScopedMemoryRepoDir(agentId)).toBe(
+          expect(getScopedMemoryFilesystemRoot(agentId)).toBe(
             getLocalBackendMemoryFilesystemRoot(agentId, storageDir),
           );
-          expect(getScopedMemoryRepoDir(agentId)).not.toBe(
+          expect(getScopedMemoryFilesystemRoot(agentId)).not.toBe(
             getMemoryRepoDir(agentId),
           );
 
-          const scopedDir = getScopedMemoryRepoDir(agentId);
+          const scopedDir = getScopedMemoryFilesystemRoot(agentId);
           mkdirSync(scopedDir, { recursive: true });
           Bun.spawnSync(["git", "init"], { cwd: scopedDir });
           expect(existsSync(join(scopedDir, ".git"))).toBe(true);

--- a/src/tests/agent/memoryGit.local-scope.test.ts
+++ b/src/tests/agent/memoryGit.local-scope.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getMemoryRepoDir,
+  getScopedMemoryRepoDir,
+  isGitRepo,
+} from "../../agent/memoryGit";
+import { getLocalBackendMemoryFilesystemRoot } from "../../backend/local/paths";
+
+function withTemporaryEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const original = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  ) as Record<string, string | undefined>;
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe("memoryGit local backend scoping", () => {
+  test("uses the local backend memfs repo when local backend is enabled", () => {
+    const storageDir = mkdtempSync(join(tmpdir(), "letta-local-memfs-"));
+    const agentId = "agent-local-scope-test";
+
+    try {
+      withTemporaryEnv(
+        {
+          LETTA_LOCAL_BACKEND_EXPERIMENTAL: "1",
+          LETTA_LOCAL_BACKEND_DIR: storageDir,
+        },
+        () => {
+          expect(getScopedMemoryRepoDir(agentId)).toBe(
+            getLocalBackendMemoryFilesystemRoot(agentId, storageDir),
+          );
+          expect(getScopedMemoryRepoDir(agentId)).not.toBe(
+            getMemoryRepoDir(agentId),
+          );
+
+          const scopedDir = getScopedMemoryRepoDir(agentId);
+          mkdirSync(scopedDir, { recursive: true });
+          Bun.spawnSync(["git", "init"], { cwd: scopedDir });
+          expect(existsSync(join(scopedDir, ".git"))).toBe(true);
+          expect(isGitRepo(agentId)).toBe(true);
+        },
+      );
+    } finally {
+      rmSync(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -11,8 +11,8 @@ import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { getMemoryFilesystemRoot } from "../agent/memoryFilesystem";
-import { getMemoryRepoDir, isGitRepo } from "../agent/memoryGit";
+import { getScopedMemoryFilesystemRoot } from "../agent/memoryFilesystem";
+import { isGitRepoAtPath } from "../agent/memoryGit";
 import {
   getFileNodes,
   readFileContent,
@@ -21,6 +21,7 @@ import {
 import { getAgentContextOverview } from "../backend/api/agents";
 import { getClient, getServerUrl } from "../backend/api/client";
 import { apiRequest } from "../backend/api/request";
+import { collectLocalMemoryContextData } from "./local-memory-context";
 import memoryViewerTemplate from "./memory-viewer-template.txt";
 import type {
   ContextData,
@@ -345,98 +346,115 @@ async function collectMemoryData(
   let agentName = agentId;
   let context: ContextData | undefined;
   let messages: MessageInfo[] | undefined;
+  let conversations: ConversationInfo[] | undefined;
   let model = "unknown";
 
-  // Try SDK client for agent name + model info
   try {
-    const client = await getClient();
-    const agent = await client.agents.retrieve(agentId);
-    if (agent.name) agentName = agent.name;
-    model = agent.llm_config?.model ?? "unknown";
-
-    // Fetch context breakdown via API seam (not in SDK)
-    const contextWindow = agent.llm_config?.context_window ?? 0;
-    try {
-      const overview = await getAgentContextOverview<ContextOverviewResponse>(
-        agentId,
-        { signal: AbortSignal.timeout(5000) },
-      );
-      messages = messagesFromOverview(overview);
-      context = contextFromOverview(overview, model, contextWindow);
-    } catch {
-      // Context fetch failed - continue without it
-    }
+    const localData = await collectLocalMemoryContextData(
+      agentId,
+      conversationId,
+    );
+    if (localData.agentName) agentName = localData.agentName;
+    if (localData.model) model = localData.model;
+    context = localData.context;
+    messages = localData.messages;
+    conversations = localData.conversations;
   } catch {
-    // SDK client failed - try raw API with env key as fallback
+    // Local backend context collection failed - fall back to API paths below.
+  }
+
+  // Try SDK client for agent name + model info
+  if (!context) {
     try {
-      const apiKey = process.env.LETTA_API_KEY || "";
-      if (apiKey && serverUrl) {
-        // Fetch agent info + context in parallel
-        const [agentData, overview] = await Promise.all([
-          apiRequest<{
-            name?: string;
-            llm_config?: { model?: string; context_window?: number };
-          }>("GET", `/v1/agents/${agentId}`, undefined, {
-            baseUrl: serverUrl,
-            apiKey,
-            signal: AbortSignal.timeout(5000),
-          }).catch(() => null),
-          apiRequest<ContextOverviewResponse>(
-            "GET",
-            `/v1/agents/${agentId}/context`,
-            undefined,
-            {
+      const client = await getClient();
+      const agent = await client.agents.retrieve(agentId);
+      if (agent.name) agentName = agent.name;
+      model = agent.llm_config?.model ?? "unknown";
+
+      // Fetch context breakdown via API seam (not in SDK)
+      const contextWindow = agent.llm_config?.context_window ?? 0;
+      try {
+        const overview = await getAgentContextOverview<ContextOverviewResponse>(
+          agentId,
+          { signal: AbortSignal.timeout(5000) },
+        );
+        messages = messagesFromOverview(overview);
+        context = contextFromOverview(overview, model, contextWindow);
+      } catch {
+        // Context fetch failed - continue without it
+      }
+    } catch {
+      // SDK client failed - try raw API with env key as fallback
+      try {
+        const apiKey = process.env.LETTA_API_KEY || "";
+        if (apiKey && serverUrl) {
+          // Fetch agent info + context in parallel
+          const [agentData, overview] = await Promise.all([
+            apiRequest<{
+              name?: string;
+              llm_config?: { model?: string; context_window?: number };
+            }>("GET", `/v1/agents/${agentId}`, undefined, {
               baseUrl: serverUrl,
               apiKey,
               signal: AbortSignal.timeout(5000),
-            },
-          ).catch(() => null),
-        ]);
+            }).catch(() => null),
+            apiRequest<ContextOverviewResponse>(
+              "GET",
+              `/v1/agents/${agentId}/context`,
+              undefined,
+              {
+                baseUrl: serverUrl,
+                apiKey,
+                signal: AbortSignal.timeout(5000),
+              },
+            ).catch(() => null),
+          ]);
 
-        if (agentData?.name) agentName = agentData.name;
-        if (agentData?.llm_config?.model) model = agentData.llm_config.model;
+          if (agentData?.name) agentName = agentData.name;
+          if (agentData?.llm_config?.model) model = agentData.llm_config.model;
 
-        if (overview) {
-          messages = messagesFromOverview(overview);
-          context = contextFromOverview(
-            overview,
-            model,
-            agentData?.llm_config?.context_window,
-          );
+          if (overview) {
+            messages = messagesFromOverview(overview);
+            context = contextFromOverview(
+              overview,
+              model,
+              agentData?.llm_config?.context_window,
+            );
+          }
         }
+      } catch {
+        // All API calls failed - continue without context
       }
-    } catch {
-      // All API calls failed - continue without context
     }
   }
 
   // Fetch recent conversations (best-effort)
-  let conversations: ConversationInfo[] | undefined;
-
-  try {
-    const client = await getClient();
-    const convPage = await client.conversations.list({
-      agent_id: agentId,
-      limit: 10,
-      order: "desc",
-      order_by: "last_run_completion",
-    });
-    const convItems = convPage as ConversationListItem[];
-    conversations = convItems.flatMap((c) => {
-      if (!c.id || !c.created_at) {
-        return [];
-      }
-      return [
-        {
-          id: c.id,
-          created_at: c.created_at,
-          last_run_completion: c.last_run_completion ?? null,
-          label: c.label ?? null,
-        },
-      ];
-    });
-  } catch {
-    // Conversation fetch failed - continue without it
+  if (!conversations) {
+    try {
+      const client = await getClient();
+      const convPage = await client.conversations.list({
+        agent_id: agentId,
+        limit: 10,
+        order: "desc",
+        order_by: "last_run_completion",
+      });
+      const convItems = convPage as ConversationListItem[];
+      conversations = convItems.flatMap((c) => {
+        if (!c.id || !c.created_at) {
+          return [];
+        }
+        return [
+          {
+            id: c.id,
+            created_at: c.created_at,
+            last_run_completion: c.last_run_completion ?? null,
+            label: c.label ?? null,
+          },
+        ];
+      });
+    } catch {
+      // Conversation fetch failed - continue without it
+    }
   }
 
   return {
@@ -460,10 +478,10 @@ export async function generateAndOpenMemoryViewer(
   agentId: string,
   options?: { agentName?: string; conversationId?: string },
 ): Promise<GenerateResult> {
-  const repoDir = getMemoryRepoDir(agentId);
-  const memoryRoot = getMemoryFilesystemRoot(agentId);
+  const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
+  const repoDir = memoryRoot;
 
-  if (!isGitRepo(agentId)) {
+  if (!isGitRepoAtPath(repoDir)) {
     throw new Error("Memory viewer requires memfs. Run /memfs enable first.");
   }
 

--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -12,7 +12,6 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { getScopedMemoryFilesystemRoot } from "../agent/memoryFilesystem";
-import { isGitRepoAtPath } from "../agent/memoryGit";
 import {
   getFileNodes,
   readFileContent,
@@ -481,7 +480,7 @@ export async function generateAndOpenMemoryViewer(
   const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
   const repoDir = memoryRoot;
 
-  if (!isGitRepoAtPath(repoDir)) {
+  if (!existsSync(join(repoDir, ".git"))) {
     throw new Error("Memory viewer requires memfs. Run /memfs enable first.");
   }
 

--- a/src/web/local-memory-context.ts
+++ b/src/web/local-memory-context.ts
@@ -1,0 +1,145 @@
+import { getBackend } from "../backend";
+import { estimateSystemTokens } from "../utils/systemPromptSize";
+import type { ContextData, ConversationInfo, MessageInfo } from "./types";
+
+type PaginatedItems<T> = T[] | { getPaginatedItems?: () => T[] };
+
+type BackendMessageItem = {
+  id?: string | null;
+  role?: string | null;
+  message_type?: string | null;
+  content?: string | unknown[] | unknown;
+  conversation_id?: string | null;
+  date?: string | null;
+  created_at?: string | null;
+};
+
+type ConversationListItem = {
+  id?: string | null;
+  created_at?: string | null;
+  last_run_completion?: string | null;
+  label?: string | null;
+};
+
+export interface LocalMemoryContextData {
+  agentName?: string;
+  model?: string;
+  context?: ContextData;
+  messages?: MessageInfo[];
+  conversations?: ConversationInfo[];
+}
+
+function getPaginatedItems<T>(value: PaginatedItems<T>): T[] {
+  if (Array.isArray(value)) return value;
+  return value.getPaginatedItems?.() ?? [];
+}
+
+function estimateStoredMessageTokens(messages: BackendMessageItem[]): number {
+  const chars = messages.reduce(
+    (total, message) => total + JSON.stringify(message).length,
+    0,
+  );
+  return Math.ceil(chars / 4);
+}
+
+function messageInfoFromBackendMessage(
+  message: BackendMessageItem,
+): MessageInfo | null {
+  const id = message.id;
+  const createdAt = message.date ?? message.created_at;
+  if (!id || !createdAt) return null;
+  return {
+    id,
+    role: message.role ?? message.message_type ?? "unknown",
+    content:
+      typeof message.content === "string" || Array.isArray(message.content)
+        ? message.content
+        : message.content === undefined
+          ? ""
+          : [message.content],
+    conversation_id: message.conversation_id ?? null,
+    created_at: createdAt,
+  };
+}
+
+export async function collectLocalMemoryContextData(
+  agentId: string,
+  conversationId?: string,
+): Promise<LocalMemoryContextData> {
+  const backend = getBackend();
+  if (!backend.capabilities.localMemfs) return {};
+
+  const targetConversationId = conversationId ?? "default";
+  const agent = await backend.retrieveAgent(agentId);
+  const agentName = agent.name ?? undefined;
+  const model = agent.llm_config?.model ?? agent.model ?? "unknown";
+  const contextWindow = agent.llm_config?.context_window ?? 0;
+
+  const [compiledPrompt, messagePage, conversationPage] = await Promise.all([
+    backend
+      .recompileConversation(targetConversationId, {
+        agent_id: agentId,
+        dry_run: true,
+        update_timestamp: false,
+      } as never)
+      .catch(() => ""),
+    backend.listConversationMessages(targetConversationId, {
+      agent_id: agentId,
+      order: "asc",
+    } as never),
+    backend
+      .listConversations({
+        agent_id: agentId,
+        limit: 10,
+        order: "desc",
+        order_by: "last_run_completion",
+      } as never)
+      .catch(() => []),
+  ]);
+
+  const backendMessages = getPaginatedItems(
+    messagePage as PaginatedItems<BackendMessageItem>,
+  );
+  const messages = backendMessages.flatMap((message) => {
+    const info = messageInfoFromBackendMessage(message);
+    return info ? [info] : [];
+  });
+  const systemTokens =
+    typeof compiledPrompt === "string" && compiledPrompt.length > 0
+      ? estimateSystemTokens(compiledPrompt)
+      : 0;
+  const messageTokens = estimateStoredMessageTokens(backendMessages);
+  const conversations = getPaginatedItems(
+    conversationPage as PaginatedItems<ConversationListItem>,
+  ).flatMap((conversation) => {
+    if (!conversation.id || !conversation.created_at) return [];
+    return [
+      {
+        id: conversation.id,
+        created_at: conversation.created_at,
+        last_run_completion: conversation.last_run_completion ?? null,
+        label: conversation.label ?? null,
+      },
+    ];
+  });
+
+  return {
+    agentName,
+    model,
+    messages,
+    conversations,
+    context: {
+      contextWindow,
+      usedTokens: systemTokens + messageTokens,
+      model,
+      breakdown: {
+        system: systemTokens,
+        coreMemory: 0,
+        externalMemory: 0,
+        summaryMemory: 0,
+        tools: 0,
+        messages: messageTokens,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Route MemFS git/path helpers through backend-aware local paths for local backend agents.
- Centralize active MemFS checks and update CLI surfaces like `/palace`, `/memory`, `/reflect`, `/init`, and status reminders.
- Populate Memory Palace context data from local backend conversations instead of cloud-only context APIs.

## Test plan
- [x] `bun test src/tests/agent/memoryGit.local-scope.test.ts src/tests/agent/memoryPrompt.test.ts src/tests/agent-info.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`

👾 Generated with [Letta Code](https://letta.com)