### PR TITLE
chore: add Bedrock Opus 4.7 support

### DIFF
--- a/src/cli/app/constants.ts
+++ b/src/cli/app/constants.ts
@@ -24,11 +24,17 @@ export const TEMP_QUOTA_OVERRIDE_MODEL = "letta/auto";
 // Provider fallback: Anthropic model ID -> Bedrock model ID.
 // After 1 failed retry against Anthropic, automatically retry via Bedrock.
 export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
+  // Opus 4.7 variants -> Bedrock Opus 4.7
+  opus: "bedrock-opus-4.7",
+  "opus-4.7-low": "bedrock-opus-4.7",
+  "opus-4.7-high": "bedrock-opus-4.7",
+  "opus-4.7-xhigh": "bedrock-opus-4.7",
+  "opus-4.7-max": "bedrock-opus-4.7",
   // Opus 4.6 variants -> Bedrock Opus 4.6
-  opus: "bedrock-opus-4.6",
   "opus-4.6-no-reasoning": "bedrock-opus-4.6",
   "opus-4.6-low": "bedrock-opus-4.6",
   "opus-4.6-medium": "bedrock-opus-4.6",
+  "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
   // Sonnet 4.6 variants -> Bedrock Sonnet 4.6
   sonnet: "bedrock-sonnet-4.6",

--- a/src/cli/app/modelConfig.ts
+++ b/src/cli/app/modelConfig.ts
@@ -149,14 +149,19 @@ export function getErrorHintForStopReason(
       ? PROVIDER_STATUS_PAGES[modelEndpointType]
       : undefined;
 
-  // Build the /model swap suggestion -- mention Bedrock Opus if applicable
-  const isOpus46 = currentModelId?.startsWith("opus-4.6") ?? false;
-  const hasBedrockOpus =
-    isOpus46 &&
+  // Build the /model swap suggestion -- mention Bedrock Opus if applicable.
+  const bedrockOpusSuggestion =
     modelEndpointType === "anthropic" &&
-    getModelInfo("bedrock-opus-4.6");
-  const modelSwapSuffix = hasBedrockOpus
-    ? " (e.g. Opus 4.6 via Amazon Bedrock)"
+    (currentModelId === "opus" || currentModelId?.startsWith("opus-4.7")) &&
+    getModelInfo("bedrock-opus-4.7")
+      ? "Opus 4.7 via Amazon Bedrock"
+      : modelEndpointType === "anthropic" &&
+          currentModelId?.startsWith("opus-4.6") &&
+          getModelInfo("bedrock-opus-4.6")
+        ? "Opus 4.6 via Amazon Bedrock"
+        : null;
+  const modelSwapSuffix = bedrockOpusSuggestion
+    ? ` (e.g. ${bedrockOpusSuggestion})`
     : "";
 
   if (statusInfo) {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -162,6 +162,12 @@ const EMPTY_RESPONSE_MAX_RETRIES = 2;
 // Provider fallback: Anthropic model ID → Bedrock model ID.
 // After 1 failed retry against Anthropic, automatically retry via Bedrock.
 const PROVIDER_FALLBACK_MAP: Record<string, string> = {
+  // Opus 4.7 variants → Bedrock Opus 4.7
+  opus: "bedrock-opus-4.7",
+  "opus-4.7-low": "bedrock-opus-4.7",
+  "opus-4.7-high": "bedrock-opus-4.7",
+  "opus-4.7-xhigh": "bedrock-opus-4.7",
+  "opus-4.7-max": "bedrock-opus-4.7",
   // Opus 4.6 variants → Bedrock Opus 4.6
   "opus-4.6-no-reasoning": "bedrock-opus-4.6",
   "opus-4.6-low": "bedrock-opus-4.6",

--- a/src/models.json
+++ b/src/models.json
@@ -462,6 +462,20 @@
       }
     },
     {
+      "id": "bedrock-opus-4.7",
+      "handle": "bedrock/us.anthropic.claude-opus-4-7",
+      "label": "Bedrock Opus 4.7",
+      "shortLabel": "Opus 4.7 BR",
+      "description": "Anthropic's Opus 4.7 (via AWS Bedrock)",
+      "updateArgs": {
+        "context_window": 200000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "medium",
+        "enable_reasoner": true,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "bedrock-sonnet-4.6",
       "handle": "bedrock/us.anthropic.claude-sonnet-4-6",
       "label": "Bedrock Sonnet 4.6",

--- a/src/tests/backend/pi-model-factory.test.ts
+++ b/src/tests/backend/pi-model-factory.test.ts
@@ -111,6 +111,17 @@ describe("pi model factory", () => {
     }
   });
 
+  test("resolves Bedrock Opus 4.7 from the Pi model catalog", async () => {
+    const resolved = await resolvePiModelForAgent(
+      "bedrock/us.anthropic.claude-opus-4-7",
+      { provider_type: "bedrock" },
+    );
+
+    expect(resolved.provider).toBe("bedrock");
+    expect(resolved.model.id).toBe("us.anthropic.claude-opus-4-7");
+    expect(resolved.model.reasoning).toBe(true);
+  });
+
   test("maps local Bedrock profile records to pi provider options", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-bedrock-profile-"));
     try {

--- a/src/tests/model-tier-selection.test.ts
+++ b/src/tests/model-tier-selection.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  getModelInfo,
   getModelInfoForLlmConfig,
   getReasoningTierOptionsForHandle,
 } from "../agent/model";
+
+describe("getModelInfo", () => {
+  test("includes Bedrock Opus 4.7", () => {
+    const info = getModelInfo("bedrock-opus-4.7");
+    expect(info?.handle).toBe("bedrock/us.anthropic.claude-opus-4-7");
+    expect(info?.label).toBe("Bedrock Opus 4.7");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 200000,
+      reasoning_effort: "medium",
+      enable_reasoner: true,
+    });
+  });
+});
 
 describe("getModelInfoForLlmConfig", () => {
   test("selects gpt-5.4 tier by reasoning_effort", () => {

--- a/src/tests/provider-fallback-map.test.ts
+++ b/src/tests/provider-fallback-map.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { PROVIDER_FALLBACK_MAP } from "../cli/app/constants";
+
+const headlessSource = readFileSync(
+  path.resolve(import.meta.dir, "../headless.ts"),
+  "utf8",
+);
+
+describe("provider fallback maps", () => {
+  test("interactive Opus 4.7 fallbacks use Bedrock Opus 4.7", () => {
+    expect(PROVIDER_FALLBACK_MAP.opus).toBe("bedrock-opus-4.7");
+    expect(PROVIDER_FALLBACK_MAP["opus-4.7-low"]).toBe("bedrock-opus-4.7");
+    expect(PROVIDER_FALLBACK_MAP["opus-4.7-high"]).toBe("bedrock-opus-4.7");
+    expect(PROVIDER_FALLBACK_MAP["opus-4.7-xhigh"]).toBe("bedrock-opus-4.7");
+    expect(PROVIDER_FALLBACK_MAP["opus-4.7-max"]).toBe("bedrock-opus-4.7");
+  });
+
+  test("headless Opus 4.7 fallbacks use Bedrock Opus 4.7", () => {
+    expect(headlessSource).toContain('opus: "bedrock-opus-4.7"');
+    for (const model of [
+      "opus-4.7-low",
+      "opus-4.7-high",
+      "opus-4.7-xhigh",
+      "opus-4.7-max",
+    ]) {
+      expect(headlessSource).toContain(`"${model}": "bedrock-opus-4.7"`);
+    }
+  });
+});

--- a/src/tests/websocket/listen-client-protocol.test.ts
+++ b/src/tests/websocket/listen-client-protocol.test.ts
@@ -63,6 +63,7 @@ import {
   getRecoverableRetryNoticeVisibility,
   getRecoverableStatusNoticeVisibility,
 } from "../../websocket/listener/recoverable-notices";
+import { resetRemoteSettingsCache } from "../../websocket/listener/remote-settings";
 
 class MockSocket {
   readyState: number;
@@ -4112,7 +4113,13 @@ describe("listen-client capability-gated approval flow", () => {
   });
 
   test("mode changes reject plan mode when plan mode is disabled", async () => {
+    const originalHome = process.env.HOME;
+    const testHomeDir = await mkdtemp(
+      join(os.tmpdir(), "letta-plan-disabled-"),
+    );
     await settingsManager.reset();
+    process.env.HOME = testHomeDir;
+    resetRemoteSettingsCache();
     await settingsManager.initialize();
 
     const listener = __listenClientTestUtils.createListenerRuntime();
@@ -4124,34 +4131,50 @@ describe("listen-client capability-gated approval flow", () => {
       conversation_id: "default",
     } as const;
 
-    __listenClientTestUtils.handleModeChange(
-      { mode: "plan" },
-      socket as unknown as WebSocket,
-      listener,
-      scope,
+    listener.permissionModeByConversation.set(
+      "agent:agent-1::conversation:default",
+      {
+        mode: "standard",
+        planFilePath: null,
+        modeBeforePlan: null,
+      },
     );
 
-    const outbound = socket.sentPayloads.map((payload) =>
-      JSON.parse(payload as string),
-    );
-    const deviceStatus = outbound.findLast(
-      (payload) => payload.type === "update_device_status",
-    )?.device_status;
-    const loopStatus = outbound.findLast(
-      (payload) => payload.type === "update_loop_status",
-    )?.loop_status;
-    const notice = outbound.findLast(
-      (payload) =>
-        payload.type === "stream_delta" &&
-        payload.delta?.message_type === "loop_error",
-    );
+    try {
+      __listenClientTestUtils.handleModeChange(
+        { mode: "plan" },
+        socket as unknown as WebSocket,
+        listener,
+        scope,
+      );
 
-    expect(deviceStatus?.current_permission_mode).toBe("standard");
-    expect(deviceStatus?.plan_mode_enabled).toBe(false);
-    expect(loopStatus?.plan_file_path).toBeNull();
-    expect(notice?.delta?.message).toContain(
-      "Plan mode is disabled in user settings.",
-    );
+      const outbound = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      const deviceStatus = outbound.findLast(
+        (payload) => payload.type === "update_device_status",
+      )?.device_status;
+      const loopStatus = outbound.findLast(
+        (payload) => payload.type === "update_loop_status",
+      )?.loop_status;
+      const notice = outbound.findLast(
+        (payload) =>
+          payload.type === "stream_delta" &&
+          payload.delta?.message_type === "loop_error",
+      );
+
+      expect(deviceStatus?.current_permission_mode).toBe("standard");
+      expect(deviceStatus?.plan_mode_enabled).toBe(false);
+      expect(loopStatus?.plan_file_path).toBeNull();
+      expect(notice?.delta?.message).toContain(
+        "Plan mode is disabled in user settings.",
+      );
+    } finally {
+      await settingsManager.reset();
+      await rm(testHomeDir, { recursive: true, force: true });
+      process.env.HOME = originalHome;
+      resetRemoteSettingsCache();
+    }
   });
 
   test("mode changes emit fresh loop status plan_file_path on enter exit and re-enter", async () => {
@@ -4159,6 +4182,7 @@ describe("listen-client capability-gated approval flow", () => {
     const testHomeDir = await mkdtemp(join(os.tmpdir(), "letta-plan-ws-"));
     await settingsManager.reset();
     process.env.HOME = testHomeDir;
+    resetRemoteSettingsCache();
     await settingsManager.initialize();
     settingsManager.setPlanModeEnabled(true);
 
@@ -4221,6 +4245,7 @@ describe("listen-client capability-gated approval flow", () => {
       await settingsManager.reset();
       await rm(testHomeDir, { recursive: true, force: true });
       process.env.HOME = originalHome;
+      resetRemoteSettingsCache();
     }
   });
 

--- a/src/tests/websocket/listener-provider-fallback.test.ts
+++ b/src/tests/websocket/listener-provider-fallback.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import {
+  createProviderFallbackState,
+  maybeApplyProviderFallback,
+} from "../../websocket/listener/providerFallback";
+
+function agentWithModel(
+  model: string,
+  extra: Partial<AgentState["llm_config"]> = {},
+): AgentState {
+  return {
+    llm_config: {
+      context_window: 200000,
+      model,
+      model_endpoint_type: "anthropic",
+      ...extra,
+    },
+  } as AgentState;
+}
+
+describe("listener provider fallback", () => {
+  test("maps sonnet to Bedrock after the first retry attempt", () => {
+    const state = createProviderFallbackState(
+      agentWithModel("anthropic/claude-sonnet-4-6", {
+        reasoning_effort: "high",
+        enable_reasoner: true,
+      }),
+    );
+
+    expect(state.sourceModelId).toBe("sonnet");
+    expect(maybeApplyProviderFallback(state, 1)).toBeNull();
+
+    const fallbackHandle = maybeApplyProviderFallback(state, 2);
+    expect(fallbackHandle).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(state.attempted).toBe(true);
+    expect(maybeApplyProviderFallback(state, 3)).toBeNull();
+  });
+
+  test("leaves non-Anthropic models unchanged", () => {
+    const state = createProviderFallbackState(
+      agentWithModel("openai/gpt-5.4", {
+        model_endpoint_type: "openai",
+        reasoning_effort: "high",
+      }),
+    );
+
+    expect(state.sourceModelId).toBe("gpt-5.4-high");
+    expect(maybeApplyProviderFallback(state, 2)).toBeNull();
+    expect(state.overrideModel).toBeUndefined();
+  });
+
+  test("maps Opus 4.7 aliases to Bedrock Opus 4.7", () => {
+    for (const [model, sourceModelId] of [
+      ["anthropic/claude-opus-4-7", "opus"],
+      ["opus-4.7-high", "opus-4.7-high"],
+      ["opus-4.7-max", "opus-4.7-max"],
+    ] as const) {
+      const state = createProviderFallbackState(agentWithModel(model));
+
+      expect(state.sourceModelId).toBe(sourceModelId);
+      expect(maybeApplyProviderFallback(state, 2)).toBe(
+        "bedrock/us.anthropic.claude-opus-4-7",
+      );
+      expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-opus-4-7");
+    }
+  });
+});

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -9,3 +9,32 @@ export const LLM_API_ERROR_MAX_RETRIES = 3;
 export const EMPTY_RESPONSE_MAX_RETRIES = 2;
 export const MAX_PRE_STREAM_RECOVERY = 2;
 export const MAX_POST_STOP_APPROVAL_RECOVERY = 2;
+
+// Provider fallback: Anthropic model ID -> Bedrock model ID.
+// Mirrors the headless recovery path: after one failed retry against
+// Anthropic, retry the same turn using the Bedrock equivalent. Do not map
+// generic/latest aliases unless the Bedrock target is the same model family.
+export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
+  // Opus 4.7 variants -> Bedrock Opus 4.7.
+  opus: "bedrock-opus-4.7",
+  "opus-4.7-low": "bedrock-opus-4.7",
+  "opus-4.7-high": "bedrock-opus-4.7",
+  "opus-4.7-xhigh": "bedrock-opus-4.7",
+  "opus-4.7-max": "bedrock-opus-4.7",
+  // Opus 4.6 variants -> Bedrock Opus 4.6.
+  "opus-4.6-no-reasoning": "bedrock-opus-4.6",
+  "opus-4.6-low": "bedrock-opus-4.6",
+  "opus-4.6-medium": "bedrock-opus-4.6",
+  "opus-4.6-high": "bedrock-opus-4.6",
+  "opus-4.6-xhigh": "bedrock-opus-4.6",
+  // Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  sonnet: "bedrock-sonnet-4.6",
+  "sonnet-1m": "bedrock-sonnet-4.6",
+  "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",
+  "sonnet-4.6-low": "bedrock-sonnet-4.6",
+  "sonnet-4.6-medium": "bedrock-sonnet-4.6",
+  "sonnet-4.6-xhigh": "bedrock-sonnet-4.6",
+};
+
+export const PROVIDER_FALLBACK_NOTICE =
+  "Anthropic API error; falling back to Bedrock...";

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -110,7 +110,7 @@ export function handleModeChange(
     const incomingMode = migratePermissionMode(msg.mode) ?? msg.mode;
 
     // Reject plan mode if it's disabled in settings
-    if (incomingMode === "plan" && !settingsManager.isPlanModeEnabled()) {
+    if (incomingMode === "plan" && !isPlanModeEnabled()) {
       if (current.mode === "plan") {
         current.mode = "unrestricted";
         current.planFilePath = null;

--- a/src/websocket/listener/providerFallback.ts
+++ b/src/websocket/listener/providerFallback.ts
@@ -1,0 +1,46 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getModelInfo, getModelInfoForLlmConfig } from "../../agent/model";
+import { PROVIDER_FALLBACK_MAP } from "./constants";
+
+export type ProviderFallbackState = {
+  sourceModelId: string | null;
+  attempted: boolean;
+  overrideModel?: string;
+};
+
+export function createProviderFallbackState(
+  agent: AgentState | null | undefined,
+): ProviderFallbackState {
+  const llmConfig = agent?.llm_config;
+  const model = llmConfig?.model;
+  if (!model) {
+    return { sourceModelId: null, attempted: false };
+  }
+
+  const modelInfo =
+    getModelInfoForLlmConfig(model, llmConfig) ?? getModelInfo(model);
+
+  return {
+    sourceModelId: modelInfo?.id ?? model,
+    attempted: false,
+  };
+}
+
+export function maybeApplyProviderFallback(
+  state: ProviderFallbackState | undefined,
+  attempt: number,
+): string | null {
+  if (!state || state.attempted || attempt < 2 || !state.sourceModelId) {
+    return null;
+  }
+
+  const fallbackId = PROVIDER_FALLBACK_MAP[state.sourceModelId];
+  const fallbackHandle = fallbackId ? getModelInfo(fallbackId)?.handle : null;
+  if (!fallbackHandle) {
+    return null;
+  }
+
+  state.attempted = true;
+  state.overrideModel = fallbackHandle;
+  return fallbackHandle;
+}

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -27,6 +27,7 @@ import {
 import {
   LLM_API_ERROR_MAX_RETRIES,
   MAX_PRE_STREAM_RECOVERY,
+  PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import { getOrCreateConversationPermissionModeStateRef } from "./permissionMode";
@@ -35,7 +36,12 @@ import {
   emitRetryDelta,
   setLoopStatus,
 } from "./protocol-outbound";
+import {
+  maybeApplyProviderFallback,
+  type ProviderFallbackState,
+} from "./providerFallback";
 import { consumeQueuedTurn } from "./queue";
+import { emitRecoverableRetryNotice } from "./recoverable-notices";
 import {
   drainRecoveryStreamWithEmission,
   finalizeHandledRecoveryTurn,
@@ -240,11 +246,15 @@ export async function sendMessageStreamWithRetry(
   socket: ListenerTransport,
   runtime: ConversationRuntime,
   abortSignal?: AbortSignal,
+  retryOptions: {
+    providerFallback?: ProviderFallbackState;
+  } = {},
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
   let transientRetries = 0;
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
+  let currentOpts = opts;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -261,7 +271,7 @@ export async function sendMessageStreamWithRetry(
       return await sendMessageStream(
         conversationId,
         messages,
-        opts,
+        currentOpts,
         abortSignal
           ? { maxRetries: 0, signal: abortSignal }
           : { maxRetries: 0 },
@@ -329,6 +339,26 @@ export async function sendMessageStreamWithRetry(
           conversation_id: conversationId,
         });
         const attempt = transientRetries + 1;
+        transientRetries = attempt;
+        const fallbackHandle = maybeApplyProviderFallback(
+          retryOptions.providerFallback,
+          attempt,
+        );
+        if (fallbackHandle) {
+          currentOpts = { ...currentOpts, overrideModel: fallbackHandle };
+          emitRecoverableRetryNotice(socket, runtime, {
+            kind: "transient_provider_retry",
+            message: PROVIDER_FALLBACK_NOTICE,
+            reason: "llm_api_error",
+            attempt,
+            maxAttempts: LLM_API_ERROR_MAX_RETRIES,
+            delayMs: 0,
+            agentId: runtime.agentId ?? undefined,
+            conversationId,
+          });
+          continue;
+        }
+
         const retryAfterMs =
           preStreamError instanceof APIError
             ? parseRetryAfterHeaderMs(
@@ -341,7 +371,6 @@ export async function sendMessageStreamWithRetry(
           detail: errorDetail,
           retryAfterMs,
         });
-        transientRetries = attempt;
 
         const retryMessage = getRetryStatusMessage(errorDetail);
         if (retryMessage) {
@@ -454,6 +483,7 @@ export async function sendApprovalContinuationWithRetry(
   abortSignal?: AbortSignal,
   retryOptions: {
     allowApprovalRecovery?: boolean;
+    providerFallback?: ProviderFallbackState;
   } = {},
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>> | null> {
   const allowApprovalRecovery = retryOptions.allowApprovalRecovery ?? true;
@@ -461,6 +491,7 @@ export async function sendApprovalContinuationWithRetry(
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
   const MAX_CONVERSATION_BUSY_RETRIES = 3;
+  let currentOpts = opts;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -477,7 +508,7 @@ export async function sendApprovalContinuationWithRetry(
       return await sendMessageStream(
         conversationId,
         messages,
-        opts,
+        currentOpts,
         abortSignal
           ? { maxRetries: 0, signal: abortSignal }
           : { maxRetries: 0 },
@@ -557,6 +588,26 @@ export async function sendApprovalContinuationWithRetry(
           conversation_id: conversationId,
         });
         const attempt = transientRetries + 1;
+        transientRetries = attempt;
+        const fallbackHandle = maybeApplyProviderFallback(
+          retryOptions.providerFallback,
+          attempt,
+        );
+        if (fallbackHandle) {
+          currentOpts = { ...currentOpts, overrideModel: fallbackHandle };
+          emitRecoverableRetryNotice(socket, runtime, {
+            kind: "transient_provider_retry",
+            message: PROVIDER_FALLBACK_NOTICE,
+            reason: "llm_api_error",
+            attempt,
+            maxAttempts: LLM_API_ERROR_MAX_RETRIES,
+            delayMs: 0,
+            agentId: runtime.agentId ?? undefined,
+            conversationId,
+          });
+          continue;
+        }
+
         const retryAfterMs =
           preStreamError instanceof APIError
             ? parseRetryAfterHeaderMs(
@@ -569,7 +620,6 @@ export async function sendApprovalContinuationWithRetry(
           detail: errorDetail,
           retryAfterMs,
         });
-        transientRetries = attempt;
 
         const retryMessage = getRetryStatusMessage(errorDetail);
         if (retryMessage) {

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -48,6 +48,7 @@ import {
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
+import type { ProviderFallbackState } from "./providerFallback";
 import { consumeQueuedTurn } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import { debugLogApprovalResumeState } from "./recovery";
@@ -167,6 +168,7 @@ export async function handleApprovalStop(params: {
   buildSendOptions: () => Parameters<
     typeof sendApprovalContinuationWithRetry
   >[2];
+  providerFallback?: ProviderFallbackState;
 }): Promise<ApprovalBranchResult> {
   const {
     approvals,
@@ -182,6 +184,7 @@ export async function handleApprovalStop(params: {
     currentInput,
     turnToolContextId,
     buildSendOptions,
+    providerFallback,
   } = params;
   const abortController = runtime.activeAbortController;
 
@@ -586,6 +589,7 @@ export async function handleApprovalStop(params: {
       socket,
       runtime,
       abortController.signal,
+      { providerFallback },
     );
   } catch (error) {
     if (shouldInterrupt()) {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -62,6 +62,7 @@ import { debugLog, debugWarn, isDebugEnabled } from "../../utils/debug";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
+  PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
@@ -86,6 +87,10 @@ import {
   emitRuntimeStateUpdates,
   setLoopStatus,
 } from "./protocol-outbound";
+import {
+  createProviderFallbackState,
+  maybeApplyProviderFallback,
+} from "./providerFallback";
 import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
@@ -586,6 +591,7 @@ export async function handleIncomingMessage(
     }
 
     let currentInput = messagesToSend;
+    const providerFallback = createProviderFallbackState(cachedAgent);
     let pendingNormalizationInterruptedToolCallIds = [
       ...queuedInterruptedToolCallIds,
     ];
@@ -609,6 +615,9 @@ export async function handleIncomingMessage(
       permissionModeState: turnPermissionModeState,
       preparedToolContext: preparedToolContext.preparedToolContext,
       skipImageNormalization: true,
+      ...(providerFallback.overrideModel
+        ? { overrideModel: providerFallback.overrideModel }
+        : {}),
       // Forward cloud-api's per-WS acting user id so the outbound
       // createMessage HTTP call carries X-Letta-Acting-User-Id and
       // cloud can attribute credits to the actual sender on
@@ -635,6 +644,7 @@ export async function handleIncomingMessage(
           socket,
           runtime,
           turnAbortSignal,
+          { providerFallback },
         )
       : await sendMessageStreamWithRetry(
           conversationId,
@@ -643,6 +653,7 @@ export async function handleIncomingMessage(
           socket,
           runtime,
           turnAbortSignal,
+          { providerFallback },
         );
     currentInput = currentInputWithSkillContent;
     if (!stream) {
@@ -868,6 +879,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -876,6 +888,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -953,6 +966,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -961,6 +975,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -986,14 +1001,21 @@ export async function handleIncomingMessage(
         if (retriable && llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           llmApiErrorRetries += 1;
           const attempt = llmApiErrorRetries;
-          const delayMs = getRetryDelayMs({
-            category: "transient_provider",
+          const fallbackHandle = maybeApplyProviderFallback(
+            providerFallback,
             attempt,
-            detail: errorDetail,
-          });
-          const retryMessage =
-            getRetryStatusMessage(errorDetail) ||
-            `LLM API error encountered, retrying (attempt ${attempt}/${LLM_API_ERROR_MAX_RETRIES})...`;
+          );
+          const delayMs = fallbackHandle
+            ? 0
+            : getRetryDelayMs({
+                category: "transient_provider",
+                attempt,
+                detail: errorDetail,
+              });
+          const retryMessage = fallbackHandle
+            ? PROVIDER_FALLBACK_NOTICE
+            : getRetryStatusMessage(errorDetail) ||
+              `LLM API error encountered, retrying (attempt ${attempt}/${LLM_API_ERROR_MAX_RETRIES})...`;
           emitRecoverableRetryNotice(socket, runtime, {
             kind: "transient_provider_retry",
             message: retryMessage,
@@ -1006,7 +1028,9 @@ export async function handleIncomingMessage(
             conversationId,
           });
 
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          if (!fallbackHandle) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
@@ -1028,6 +1052,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               )
             : await sendMessageStreamWithRetry(
                 conversationId,
@@ -1036,6 +1061,7 @@ export async function handleIncomingMessage(
                 socket,
                 runtime,
                 turnAbortSignal,
+                { providerFallback },
               );
           currentInput = retryInputWithSkillContent;
           if (!stream) {
@@ -1111,6 +1137,7 @@ export async function handleIncomingMessage(
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
         buildSendOptions,
+        providerFallback,
       });
       if (approvalResult.terminated || !approvalResult.stream) {
         return;


### PR DESCRIPTION
## Summary
- add `bedrock-opus-4.7` to the local model registry using the Cloud-synced Bedrock handle `bedrock/us.anthropic.claude-opus-4-7`
- route Opus 4.7 provider fallbacks (`opus`, `opus-4.7-*`) to Bedrock Opus 4.7 in headless and interactive paths
- update provider error hints to suggest Bedrock Opus 4.7 for Anthropic Opus 4.7 failures
- add tests for the registry alias, fallback maps, and Pi catalog resolution

## Validation
- `bun test src/tests/model-tier-selection.test.ts src/tests/provider-fallback-map.test.ts src/tests/backend/pi-model-factory.test.ts`
- `bun run typecheck`