### PR TITLE
fix(channels): respect Slack permission defaults

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -15,6 +15,7 @@ import type {
   TelegramChannelAccount,
 } from "./types";
 import {
+  DEFAULT_SLACK_PERMISSION_MODE,
   isDiscordChannelAccount,
   isFirstPartyChannelId,
   isSlackChannelAccount,
@@ -87,7 +88,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   }
   if (isSlackChannelAccount(next)) {
     const raw: string =
-      (next as SlackChannelAccount).defaultPermissionMode ?? "standard";
+      (next as SlackChannelAccount).defaultPermissionMode ??
+      DEFAULT_SLACK_PERMISSION_MODE;
     (next as SlackChannelAccount).defaultPermissionMode =
       (migratePermissionMode(raw) ?? raw) as SlackDefaultPermissionMode;
   }
@@ -149,7 +151,7 @@ function makeDefaultLegacyAccount(
     dmPolicy: config.dmPolicy,
     allowedUsers: [...config.allowedUsers],
     agentId: null,
-    defaultPermissionMode: "standard",
+    defaultPermissionMode: DEFAULT_SLACK_PERMISSION_MODE,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -237,6 +237,7 @@ export interface ChannelInboundDelivery {
   route: ChannelRoute;
   content: MessageCreate["content"];
   turnSources?: ChannelTurnSource[];
+  defaultPermissionMode?: SlackDefaultPermissionMode;
 }
 
 export type ChannelMessageHandler = (delivery: ChannelInboundDelivery) => void;
@@ -815,6 +816,7 @@ export class ChannelRegistry {
         turnSources: [
           buildChannelTurnSource(slackResult.route, preparedMessage),
         ],
+        defaultPermissionMode: config.defaultPermissionMode,
       });
       return;
     }
@@ -965,16 +967,14 @@ export class ChannelRegistry {
     };
 
     addRoute(msg.channel, route);
-    if (config.defaultPermissionMode !== "standard") {
-      this.eventHandler?.({
-        type: "slack_conversation_created",
-        channelId: "slack",
-        accountId: config.accountId,
-        agentId: config.agentId,
-        conversationId,
-        defaultPermissionMode: config.defaultPermissionMode,
-      });
-    }
+    this.eventHandler?.({
+      type: "slack_conversation_created",
+      channelId: "slack",
+      accountId: config.accountId,
+      agentId: config.agentId,
+      conversationId,
+      defaultPermissionMode: config.defaultPermissionMode,
+    });
     return route;
   }
 

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -67,6 +67,7 @@ import type {
   SupportedChannelId,
 } from "./types";
 import {
+  DEFAULT_SLACK_PERMISSION_MODE,
   isDiscordChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
@@ -472,7 +473,8 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
-    defaultPermissionMode: account.defaultPermissionMode ?? "standard",
+    defaultPermissionMode:
+      account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
   };
@@ -543,7 +545,8 @@ function createAccountFromPatch(
     botToken: normalizedPatch.botToken ?? "",
     appToken: normalizedPatch.appToken ?? "",
     agentId: normalizedPatch.agentId ?? null,
-    defaultPermissionMode: normalizedPatch.defaultPermissionMode ?? "standard",
+    defaultPermissionMode:
+      normalizedPatch.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
     dmPolicy: normalizedPatch.dmPolicy ?? "open",
     allowedUsers: normalizedPatch.allowedUsers ?? [],
     createdAt: now,
@@ -624,7 +627,7 @@ function mergeAccountPatch(
     defaultPermissionMode:
       normalizedPatch.defaultPermissionMode ??
       existing.defaultPermissionMode ??
-      "default",
+      DEFAULT_SLACK_PERMISSION_MODE,
     dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
     allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
     updatedAt: nextUpdatedAt,
@@ -734,7 +737,8 @@ export function getChannelConfigSnapshot(
     hasBotToken: account.botToken.trim().length > 0,
     hasAppToken: account.appToken.trim().length > 0,
     agentId: account.agentId,
-    defaultPermissionMode: account.defaultPermissionMode ?? "standard",
+    defaultPermissionMode:
+      account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
   };
 }
 

--- a/src/channels/slack/accountConfig.ts
+++ b/src/channels/slack/accountConfig.ts
@@ -1,6 +1,10 @@
 import { migratePermissionMode } from "../../permissions/mode";
 import type { ChannelAccountConfigAdapter } from "../pluginTypes";
-import type { SlackChannelAccount, SlackDefaultPermissionMode } from "../types";
+import {
+  DEFAULT_SLACK_PERMISSION_MODE,
+  type SlackChannelAccount,
+  type SlackDefaultPermissionMode,
+} from "../types";
 
 const SLACK_CONFIG_KEYS = new Set([
   "bot_token",
@@ -26,7 +30,7 @@ function isDefaultPermissionMode(
     value === "standard" ||
     value === "acceptEdits" ||
     value === "unrestricted" ||
-    value === "default" || // legacy → "standard"
+    value === "default" || // legacy → current product default
     value === "bypassPermissions" || // legacy → "unrestricted"
     value === "fullAccess" // legacy → "unrestricted"
   );
@@ -74,7 +78,8 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         has_bot_token: account.botToken.trim().length > 0,
         has_app_token: account.appToken.trim().length > 0,
         agent_id: account.agentId,
-        default_permission_mode: account.defaultPermissionMode ?? "standard",
+        default_permission_mode:
+          account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
       };
     },
 
@@ -84,7 +89,8 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         has_bot_token: account.botToken.trim().length > 0,
         has_app_token: account.appToken.trim().length > 0,
         agent_id: account.agentId,
-        default_permission_mode: account.defaultPermissionMode ?? "standard",
+        default_permission_mode:
+          account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
       };
     },
 

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
 import { upsertChannelAccount } from "../accounts";
-import type { DmPolicy, SlackChannelAccount } from "../types";
+import {
+  DEFAULT_SLACK_PERMISSION_MODE,
+  type DmPolicy,
+  type SlackChannelAccount,
+} from "../types";
 import { resolveSlackAccountDisplayName } from "./adapter";
 import { ensureSlackRuntimeInstalled } from "./runtime";
 
@@ -92,7 +96,7 @@ export async function runSlackSetup(): Promise<boolean> {
       botToken,
       appToken,
       agentId: null,
-      defaultPermissionMode: "standard",
+      defaultPermissionMode: DEFAULT_SLACK_PERMISSION_MODE,
       dmPolicy: policy,
       allowedUsers,
       createdAt: now,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -25,6 +25,9 @@ export type SlackDefaultPermissionMode =
   | "acceptEdits"
   | "unrestricted";
 
+export const DEFAULT_SLACK_PERMISSION_MODE: SlackDefaultPermissionMode =
+  "unrestricted";
+
 export interface ChannelMessageAttachment {
   id?: string;
   name?: string;

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -38,7 +38,7 @@ export const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
 
 /**
  * Migrate legacy permission mode strings to their current equivalents.
- * - "default" → "standard" (renamed for clarity)
+ * - "default" → DEFAULT_PERMISSION_MODE (legacy name for the product default)
  * - "bypassPermissions" → "unrestricted" (renamed for clarity)
  * Returns null if the value is not a recognized mode (current or legacy).
  */
@@ -46,7 +46,7 @@ export function migratePermissionMode(value: string): PermissionMode | null {
   if (VALID_PERMISSION_MODES.includes(value as PermissionMode)) {
     return value as PermissionMode;
   }
-  if (value === "default") return "standard";
+  if (value === "default") return DEFAULT_PERMISSION_MODE;
   if (value === "bypassPermissions" || value === "fullAccess")
     return "unrestricted";
   return null;

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "../../channels/accounts";
+import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
   clearPairingStores,
@@ -57,7 +62,10 @@ describe("ChannelRegistry", () => {
       await registry.stopAll();
     }
     clearAllRoutes();
+    clearChannelAccountStores();
     clearPairingStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
     __testOverrideLoadPairingStore(null);
@@ -89,6 +97,80 @@ describe("ChannelRegistry", () => {
 
     await registry.stopAll();
     expect(getChannelRegistry()).toBeNull();
+  });
+
+  test("Slack deliveries carry the account default permission mode for existing routes", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "slack",
+        accountId: "acct-slack",
+        displayName: "Overlord",
+        enabled: true,
+        mode: "socket",
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        agentId: "agent-1",
+        defaultPermissionMode: "unrestricted",
+        dmPolicy: "open",
+        allowedUsers: [],
+        createdAt: "2026-05-15T00:00:00.000Z",
+        updatedAt: "2026-05-15T00:00:00.000Z",
+      },
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-15T00:00:00.000Z",
+    });
+
+    const registry = new ChannelRegistry();
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async () => {},
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Devansh",
+      text: "@Overlord summarize this",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: true,
+    });
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      route: {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+      defaultPermissionMode: "unrestricted",
+    });
   });
 });
 

--- a/src/tests/channels/service.test.ts
+++ b/src/tests/channels/service.test.ts
@@ -40,8 +40,14 @@ import {
   clearTargetStores,
   upsertChannelTarget,
 } from "../../channels/targets";
+import { DEFAULT_SLACK_PERMISSION_MODE } from "../../channels/types";
+import { DEFAULT_PERMISSION_MODE } from "../../permissions/mode";
 
 describe("channel service", () => {
+  test("Slack channel default permission mode follows the product default", () => {
+    expect(DEFAULT_SLACK_PERMISSION_MODE).toBe(DEFAULT_PERMISSION_MODE);
+  });
+
   function upsertTargetForRouteTest(chatId: string): string {
     const targetId = `target-${chatId}`;
     upsertChannelTarget("slack", {
@@ -171,7 +177,7 @@ describe("channel service", () => {
         configured: true,
         hasBotToken: true,
         hasAppToken: true,
-        defaultPermissionMode: "standard",
+        defaultPermissionMode: "unrestricted",
       }),
     );
 
@@ -356,7 +362,7 @@ describe("channel service", () => {
         dmPolicy: "pairing",
         allowedUsers: [],
         agentId: null,
-        defaultPermissionMode: "standard",
+        defaultPermissionMode: "unrestricted",
         createdAt: "2026-04-11T00:00:00.000Z",
         updatedAt: "2026-04-11T00:00:00.000Z",
       },
@@ -367,7 +373,7 @@ describe("channel service", () => {
     expect(snapshot?.displayName).toBeUndefined();
     expect(snapshot?.channelId).toBe("slack");
     if (snapshot?.channelId === "slack") {
-      expect(snapshot.defaultPermissionMode).toBe("standard");
+      expect(snapshot.defaultPermissionMode).toBe("unrestricted");
     }
   });
 

--- a/src/tests/permissions-mode.test.ts
+++ b/src/tests/permissions-mode.test.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { checkPermission } from "../permissions/checker";
 import { cliPermissions } from "../permissions/cli";
-import { permissionMode } from "../permissions/mode";
+import {
+  DEFAULT_PERMISSION_MODE,
+  migratePermissionMode,
+  permissionMode,
+} from "../permissions/mode";
 import type { PermissionRules } from "../permissions/types";
 
 // Clean up after each test
@@ -12,11 +16,16 @@ afterEach(() => {
   cliPermissions.clear();
 });
 
+test("legacy default permission mode migrates to the current product default", () => {
+  expect(DEFAULT_PERMISSION_MODE).toBe("unrestricted");
+  expect(migratePermissionMode("default")).toBe(DEFAULT_PERMISSION_MODE);
+});
+
 // ============================================================================
-// Permission Mode: default
+// Permission Mode: standard
 // ============================================================================
 
-test("default mode - no overrides", () => {
+test("standard mode - no overrides", () => {
   permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
@@ -37,7 +46,7 @@ test("default mode - no overrides", () => {
   expect(result.reason).toBe("Default behavior for tool");
 });
 
-test("default mode - auto-allows memory", () => {
+test("standard mode - auto-allows memory", () => {
   permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {
@@ -63,7 +72,7 @@ test("default mode - auto-allows memory", () => {
   expect(result.reason).toBe("Default behavior for tool");
 });
 
-test("default mode - auto-allows memory_apply_patch", () => {
+test("standard mode - auto-allows memory_apply_patch", () => {
   permissionMode.setMode("standard");
 
   const permissions: PermissionRules = {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -41,7 +41,11 @@ import {
 import { loadPersistedCwdMap } from "./cwd";
 import { createFileCommandSession } from "./file-commands";
 import { createListenerMessageHandler } from "./message-router";
-import { loadPersistedPermissionModeMap } from "./permissionMode";
+import {
+  getOrCreateConversationPermissionModeStateRef,
+  loadPersistedPermissionModeMap,
+  persistPermissionModeMapForRuntime,
+} from "./permissionMode";
 import {
   emitDeviceStatusUpdate,
   emitLoopStatusUpdate,
@@ -397,6 +401,20 @@ export async function wireChannelIngress(
       delivery.route.conversationId,
     );
     if (!rawRuntime) return;
+
+    if (delivery.defaultPermissionMode) {
+      const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+        listener,
+        delivery.route.agentId,
+        delivery.route.conversationId,
+      );
+      if (permissionModeState.mode !== delivery.defaultPermissionMode) {
+        permissionModeState.mode = delivery.defaultPermissionMode;
+        permissionModeState.planFilePath = null;
+        permissionModeState.modeBeforePlan = null;
+        persistPermissionModeMapForRuntime(listener);
+      }
+    }
 
     const conversationRuntime = ensureConversationQueueRuntime(
       listener,

--- a/src/websocket/listener/permissionMode.ts
+++ b/src/websocket/listener/permissionMode.ts
@@ -171,7 +171,7 @@ export function loadPersistedPermissionModeMap(): Map<
       return map;
     }
     for (const [key, persisted] of Object.entries(settings.permissionModeMap)) {
-      // Migrate legacy mode values ("default" → "standard", "bypassPermissions" → "unrestricted").
+      // Migrate legacy mode values ("default" → product default, "bypassPermissions" → "unrestricted").
       const rawMode =
         migratePermissionMode(persisted.mode) ?? DEFAULT_PERMISSION_MODE;
       const rawModeBeforePlan = persisted.modeBeforePlan


### PR DESCRIPTION
## Summary

This fixes Slack/channel permission defaults so channel-originated runs do not ask for tool approval when the account is configured for the current no-permission-prompt behavior.

The immediate problem was that Slack still had several hardcoded `standard` fallbacks even though the product default permission mode is now `unrestricted`. In addition, Slack only seeded a conversation permission mode when a route was first created and only for non-standard modes, so reused Slack routes could keep stale per-conversation permission state and leak generic tool approval prompts into Slack.

## What changed

- Added a Slack-specific default permission constant that currently matches the product default: `unrestricted`.
- Updated Slack account creation, setup, snapshots, config serialization, and loaded-account normalization to use that default instead of hardcoded `standard`.
- Changed legacy permission migration so the old `default` string maps to the current product default instead of permanently mapping to `standard`.
- Included Slack account default permission metadata on inbound deliveries for existing routes.
- Applied the Slack account default before queueing a channel turn, so stale persisted conversation state cannot override the channel account default.
- Always emits the Slack conversation-created permission seed event, including explicit `standard`, so intentional stricter account configs still work.

## Before / after

Before: a Slack account configured or expected to run without permission prompts could still ask for approval if the route already existed or if fallback config had silently become `standard`.

After: Slack conversations follow the account default consistently for new and reused routes. By default that means no generic tool approval prompt is sent to Slack. If an account is explicitly set to `standard`, that choice is still honored.

## Risk and tradeoffs

The main behavior change is that legacy Slack accounts without an explicit permission mode now inherit the current product default, `unrestricted`, instead of the older ask-flow behavior. That matches the current default permission model and the observed Slack expectation, but it is still a meaningful default change for old channel configs.

This does not remove `standard`; it only stops treating it as the implicit fallback/default.

## Validation

- `bun test src/tests/channels/registry.test.ts src/tests/channels/service.test.ts src/tests/channels/interactive.test.ts src/tests/permissions-mode.test.ts src/tests/websocket/listen-client-protocol.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/permissions/mode.ts src/channels/types.ts src/channels/accounts.ts src/channels/slack/accountConfig.ts src/channels/slack/setup.ts src/channels/service.ts src/channels/registry.ts src/websocket/listener/lifecycle.ts src/websocket/listener/permissionMode.ts src/tests/channels/registry.test.ts src/tests/channels/service.test.ts src/tests/permissions-mode.test.ts`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)
