### PR TITLE
fix(cli): refresh secrets before local secret commands

### DIFF
--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -6,7 +6,7 @@
 
 import {
   deleteSecretOnServer,
-  listSecretNames,
+  refreshAndListSecrets,
   setSecretOnServer,
 } from "../../utils/secretsStore";
 
@@ -58,7 +58,15 @@ export async function handleSecretCommand(
     }
 
     case "list": {
-      const names = listSecretNames();
+      let names: string[];
+      try {
+        const secrets = await refreshAndListSecrets();
+        names = secrets.map((secret) => secret.key);
+      } catch (error) {
+        return {
+          output: `Failed to list secrets: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
 
       if (names.length === 0) {
         return {

--- a/src/tests/cli/secret-command.test.ts
+++ b/src/tests/cli/secret-command.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { setCurrentAgentId } from "../../agent/context";
+import { handleSecretCommand } from "../../cli/commands/secret";
+import {
+  __testOverrideSecretsBackend,
+  clearSecretsCache,
+  loadSecrets,
+} from "../../utils/secretsStore";
+
+const AGENT_ID = "agent-secret-command";
+
+const retrieveAgentMock = mock((_agentId: string, _options?: unknown) =>
+  Promise.resolve({
+    secrets: [] as Array<{ key: string; value: string }>,
+  }),
+);
+
+const updateAgentMock = mock(
+  (_agentId: string, _body: unknown, _options?: unknown) =>
+    Promise.resolve({ id: AGENT_ID }),
+);
+
+const capabilities = {
+  remoteMemfs: true,
+  serverSideToolManagement: true,
+  serverSecrets: true,
+  agentFileImportExport: true,
+  promptRecompile: true,
+  byokProviderRefresh: true,
+  localModelCatalog: false,
+  localMemfs: false,
+};
+
+describe("/secret command", () => {
+  beforeEach(() => {
+    retrieveAgentMock.mockReset();
+    updateAgentMock.mockReset();
+    retrieveAgentMock.mockResolvedValue({ secrets: [] });
+    updateAgentMock.mockResolvedValue({ id: AGENT_ID });
+    setCurrentAgentId(AGENT_ID);
+    clearSecretsCache(AGENT_ID);
+    __testOverrideSecretsBackend({
+      capabilities,
+      retrieveAgent: retrieveAgentMock,
+      updateAgent: updateAgentMock,
+    });
+  });
+
+  afterEach(() => {
+    __testOverrideSecretsBackend(null);
+    clearSecretsCache(AGENT_ID);
+    setCurrentAgentId(null);
+  });
+
+  test("list refreshes server secrets instead of trusting an empty local cache", async () => {
+    retrieveAgentMock.mockResolvedValueOnce({
+      secrets: [{ key: "CLOUDFLARE_API_TOKEN", value: "cf-token" }],
+    });
+
+    const result = await handleSecretCommand(["list"]);
+
+    expect(retrieveAgentMock).toHaveBeenCalledWith(AGENT_ID, {
+      include: ["agent.secrets"],
+    });
+    expect(result.output).toContain("Available secrets (1):");
+    expect(result.output).toContain("$CLOUDFLARE_API_TOKEN");
+    expect(result.output).not.toContain("No secrets stored");
+    expect(loadSecrets(AGENT_ID)).toEqual({
+      CLOUDFLARE_API_TOKEN: "cf-token",
+    });
+  });
+
+  test("set refreshes before patching so existing server secrets are preserved", async () => {
+    retrieveAgentMock.mockResolvedValueOnce({
+      secrets: [{ key: "CLOUDFLARE_API_TOKEN", value: "cf-token" }],
+    });
+
+    const result = await handleSecretCommand(["set", "new_token", "new-value"]);
+
+    expect(result.output).toBe("Secret '$NEW_TOKEN' set.");
+    expect(updateAgentMock).toHaveBeenCalledWith(AGENT_ID, {
+      secrets: {
+        CLOUDFLARE_API_TOKEN: "cf-token",
+        NEW_TOKEN: "new-value",
+      },
+    });
+  });
+
+  test("unset refreshes before checking whether the secret exists", async () => {
+    retrieveAgentMock.mockResolvedValueOnce({
+      secrets: [{ key: "CLOUDFLARE_API_TOKEN", value: "cf-token" }],
+    });
+
+    const result = await handleSecretCommand(["unset", "CLOUDFLARE_API_TOKEN"]);
+
+    expect(result.output).toBe("Secret '$CLOUDFLARE_API_TOKEN' unset.");
+    expect(updateAgentMock).toHaveBeenCalledWith(AGENT_ID, { secrets: {} });
+  });
+});

--- a/src/utils/secretsStore.ts
+++ b/src/utils/secretsStore.ts
@@ -7,6 +7,30 @@
 import { getCurrentAgentId } from "../agent/context";
 import { getBackend } from "../backend";
 
+type SecretsBackend = {
+  capabilities: { serverSecrets: boolean };
+  retrieveAgent: (
+    agentId: string,
+    options?: { include?: string[] },
+  ) => Promise<{ secrets?: Array<{ key?: string; value?: string }> | null }>;
+  updateAgent: (
+    agentId: string,
+    body: { secrets: Record<string, string> },
+  ) => Promise<unknown>;
+};
+
+let testBackendOverride: SecretsBackend | null = null;
+
+export function __testOverrideSecretsBackend(
+  backend: SecretsBackend | null,
+): void {
+  testBackendOverride = backend;
+}
+
+function getSecretsBackend(): SecretsBackend {
+  return testBackendOverride ?? (getBackend() as SecretsBackend);
+}
+
 /** In-memory cache of secrets (populated on startup from server).
  *  Stored on globalThis via Symbol.for() to survive Bun bundle duplication. */
 const SECRETS_CACHE_KEY = Symbol.for("@letta/secretsCache");
@@ -58,13 +82,14 @@ export async function initSecretsFromServer(
   agentId: string,
   cachedAgent?: { secrets?: Array<{ key?: string; value?: string }> | null },
 ): Promise<void> {
-  if (!cachedAgent && !getBackend().capabilities.serverSecrets) {
+  const backend = getSecretsBackend();
+  if (!cachedAgent && !backend.capabilities.serverSecrets) {
     setCache(agentId, {});
     return;
   }
   const agent =
     cachedAgent ??
-    (await getBackend().retrieveAgent(agentId, {
+    (await backend.retrieveAgent(agentId, {
       include: ["agent.secrets"],
     }));
 
@@ -131,7 +156,8 @@ export async function applySecretBatch(
   },
   agentIdArg?: string,
 ): Promise<string[]> {
-  if (!getBackend().capabilities.serverSecrets) {
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
     throw new Error("Agent secrets are not supported by this backend yet");
   }
 
@@ -148,7 +174,7 @@ export async function applySecretBatch(
     delete next[rawKey.toUpperCase()];
   }
 
-  await getBackend().updateAgent(agentId, { secrets: next });
+  await backend.updateAgent(agentId, { secrets: next });
   setCache(agentId, next);
 
   return Object.keys(next).sort();
@@ -163,7 +189,8 @@ export async function setSecretOnServer(
   value: string,
   agentIdArg?: string,
 ): Promise<void> {
-  if (!getBackend().capabilities.serverSecrets) {
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
     throw new Error("Agent secrets are not supported by this backend yet");
   }
   const agentId = resolveSecretsAgentId(agentIdArg);
@@ -171,12 +198,14 @@ export async function setSecretOnServer(
     throw new Error("No agent context set. Agent ID is required.");
   }
 
+  await initSecretsFromServer(agentId);
+
   // Update cache first
   const secrets = { ...loadSecrets(agentId) };
   secrets[key] = value;
 
   // PATCH replaces entire map
-  await getBackend().updateAgent(agentId, { secrets });
+  await backend.updateAgent(agentId, { secrets });
 
   setCache(agentId, secrets);
 }
@@ -190,13 +219,17 @@ export async function deleteSecretOnServer(
   key: string,
   agentIdArg?: string,
 ): Promise<boolean> {
-  if (!getBackend().capabilities.serverSecrets) {
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
     throw new Error("Agent secrets are not supported by this backend yet");
   }
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
   }
+
+  await initSecretsFromServer(agentId);
+
   const secrets = { ...loadSecrets(agentId) };
 
   if (!(key in secrets)) {
@@ -205,7 +238,7 @@ export async function deleteSecretOnServer(
 
   delete secrets[key];
 
-  await getBackend().updateAgent(agentId, { secrets });
+  await backend.updateAgent(agentId, { secrets });
 
   setCache(agentId, secrets);
   return true;


### PR DESCRIPTION
## Summary
- Refresh `/secret list` from the server before rendering names so new/forked clients do not show stale empty cache state.
- Refresh before local `/secret set` and `/secret unset` mutations so PATCH preserves existing server-side secrets.
- Add regression coverage for stale empty-cache list/set/unset paths.

Validated with `bun test src/tests/cli/secret-command.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)