### PR TITLE
fix(cli): harden nullable turn payloads

### DIFF
--- a/src/agent/approval-result-normalization.ts
+++ b/src/agent/approval-result-normalization.ts
@@ -71,13 +71,19 @@ function isToolReturnContent(value: unknown): value is ToolReturnContent {
   );
 }
 
+function coerceToolReturnContent(value: unknown): ToolReturnContent {
+  if (isToolReturnContent(value)) return value;
+  return normalizeToolReturnText(value);
+}
+
 function prependApprovalComment(
-  toolReturn: ToolReturnContent,
+  toolReturn: unknown,
   reason: string | undefined,
 ): ToolReturnContent {
+  const normalizedToolReturn = coerceToolReturnContent(toolReturn);
   const trimmedReason = reason?.trim();
   if (!trimmedReason) {
-    return toolReturn;
+    return normalizedToolReturn;
   }
 
   const commentPart = {
@@ -85,11 +91,13 @@ function prependApprovalComment(
     text: `${APPROVAL_COMMENT_PREFIX} "${trimmedReason}"`,
   };
 
-  if (typeof toolReturn === "string") {
-    return [commentPart, { type: "text" as const, text: toolReturn }];
+  if (typeof normalizedToolReturn === "string") {
+    return normalizedToolReturn.length > 0
+      ? [commentPart, { type: "text" as const, text: normalizedToolReturn }]
+      : [commentPart];
   }
 
-  return [commentPart, ...toolReturn];
+  return [commentPart, ...normalizedToolReturn];
 }
 
 export function normalizeApprovalResultsForPersistence(
@@ -108,8 +116,7 @@ export function normalizeApprovalResultsForPersistence(
       approval.type === "approval" &&
       "approve" in approval &&
       approval.approve === true &&
-      "tool_return" in approval &&
-      isToolReturnContent(approval.tool_return)
+      "tool_return" in approval
     ) {
       return {
         type: "tool",
@@ -118,7 +125,7 @@ export function normalizeApprovalResultsForPersistence(
           typeof approval.tool_call_id === "string"
             ? approval.tool_call_id
             : "",
-        tool_return: approval.tool_return,
+        tool_return: coerceToolReturnContent(approval.tool_return),
         status:
           "status" in approval && approval.status === "error"
             ? "error"
@@ -148,7 +155,7 @@ export function normalizeApprovalResultsForPersistence(
         ? approval.tool_call_id
         : "";
     const toolReturn = prependApprovalComment(
-      approval.tool_return as ToolReturnContent,
+      "tool_return" in approval ? approval.tool_return : "",
       "reason" in approval && typeof approval.reason === "string"
         ? approval.reason
         : undefined,

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -492,9 +492,10 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       };
 
       // Copy so we can safely mutate for retry recovery flows
-      let currentInput = [...initialInput];
+      const inputList = Array.isArray(initialInput) ? initialInput : [];
+      let currentInput = [...inputList];
       const allowReentry = options?.allowReentry ?? false;
-      const hasApprovalInput = initialInput.some(
+      const hasApprovalInput = inputList.some(
         (item) => item.type === "approval",
       );
       const hasExplicitTranscriptStart =
@@ -594,7 +595,9 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                       { type: "text" as const, text: INTERRUPT_RECOVERY_ALERT },
                       ...(typeof m.content === "string"
                         ? [{ type: "text" as const, text: m.content }]
-                        : m.content),
+                        : Array.isArray(m.content)
+                          ? m.content
+                          : []),
                     ],
                   }
                 : { ...m, otid: randomUUID() },
@@ -2729,6 +2732,12 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           return;
         }
       } catch (e) {
+        debugWarn(
+          "message_stream",
+          "Unhandled conversation error: %s",
+          e instanceof Error ? (e.stack ?? e.message) : String(e),
+        );
+
         // Mark incomplete tool calls as cancelled to prevent stuck blinking UI
         markIncompleteToolsAsCancelled(
           buffersRef.current,

--- a/src/queue/turnQueueRuntime.ts
+++ b/src/queue/turnQueueRuntime.ts
@@ -21,6 +21,14 @@ type MergeQueuedTurnInputOptions<TUserContent> = {
   separatorText?: string;
 };
 
+function stringifyUnexpectedContent(content: unknown): string {
+  try {
+    return JSON.stringify(content) ?? String(content);
+  } catch {
+    return String(content);
+  }
+}
+
 function appendContentParts(
   target: MessageContentParts,
   content: MessageCreate["content"],
@@ -29,6 +37,13 @@ function appendContentParts(
     target.push({ type: "text", text: content });
     return;
   }
+
+  if (!Array.isArray(content)) {
+    if (content === null || content === undefined) return;
+    target.push({ type: "text", text: stringifyUnexpectedContent(content) });
+    return;
+  }
+
   target.push(...content);
 }
 

--- a/src/tests/agent/approval-result-normalization.test.ts
+++ b/src/tests/agent/approval-result-normalization.test.ts
@@ -118,6 +118,52 @@ describe("normalizeApprovalResultsForPersistence", () => {
     });
   });
 
+  test("coerces malformed null tool returns before adding approval comments", () => {
+    const approvals: ApprovalResult[] = [
+      {
+        type: "tool",
+        tool_call_id: "call-null",
+        tool_return: null,
+        status: "success",
+        reason: "Approved",
+      } as unknown as ApprovalResult,
+    ];
+
+    const normalized = normalizeApprovalResultsForPersistence(approvals);
+
+    expect(normalized[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "call-null",
+      status: "success",
+      tool_return: [
+        {
+          type: "text",
+          text: 'The user approved the tool execution with the following comment: "Approved"',
+        },
+      ],
+    });
+  });
+
+  test("canonicalizes legacy approved approvals with null tool returns", () => {
+    const approvals: ApprovalResult[] = [
+      {
+        type: "approval",
+        tool_call_id: "call-legacy-null",
+        approve: true,
+        tool_return: null,
+      } as unknown as ApprovalResult,
+    ];
+
+    const normalized = normalizeApprovalResultsForPersistence(approvals);
+
+    expect(normalized[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "call-legacy-null",
+      tool_return: "",
+      status: "success",
+    });
+  });
+
   test("prepends verbose approval comment to structured tool returns", () => {
     const approvals: ApprovalResult[] = [
       {
@@ -198,5 +244,17 @@ describe("normalizeOutgoingApprovalMessages", () => {
       tool_call_id: "call-7",
       status: "error",
     });
+  });
+
+  test("normalizes null approvals arrays instead of forwarding them", () => {
+    const approvalMessage: ApprovalCreate = {
+      type: "approval",
+      approvals: null,
+    } as unknown as ApprovalCreate;
+
+    const messages = normalizeOutgoingApprovalMessages([approvalMessage]);
+    const normalizedApproval = messages[0] as ApprovalCreate;
+
+    expect(normalizedApproval.approvals).toEqual([]);
   });
 });

--- a/src/tests/queue/turnQueueRuntime.test.ts
+++ b/src/tests/queue/turnQueueRuntime.test.ts
@@ -53,6 +53,31 @@ describe("turnQueueRuntime", () => {
     expect(merged[1]).toEqual(content[1]);
   });
 
+  test("ignores null normalized content instead of spreading it", () => {
+    const queued: QueuedTurnInput<null>[] = [{ kind: "user", content: null }];
+
+    const merged = mergeQueuedTurnInput(queued, {
+      normalizeUserContent: () => null as unknown as MessageCreate["content"],
+    });
+
+    expect(merged).toBeNull();
+  });
+
+  test("stringifies unexpected normalized content instead of spreading it", () => {
+    const queued: QueuedTurnInput<Record<string, string>>[] = [
+      { kind: "user", content: { ref: "" } },
+    ];
+
+    const merged = mergeQueuedTurnInput(queued, {
+      normalizeUserContent: (content) =>
+        content as unknown as MessageCreate["content"],
+    });
+
+    expect(Array.isArray(merged)).toBe(true);
+    if (!Array.isArray(merged)) return;
+    expect(merged).toEqual([{ type: "text", text: '{"ref":""}' }]);
+  });
+
   test("returns null when no queued items exist", () => {
     expect(
       mergeQueuedTurnInput([], {


### PR DESCRIPTION
## Summary
- Coerce malformed approval tool returns before approval normalization adds comments, preventing nullable `tool_return` values from reaching spread paths.
- Harden queued turn content and interrupt recovery content handling so nullish or unexpected payloads do not trigger Bun’s opaque `Spread syntax requires ...iterable not be null or undefined` error.
- Log full conversation-loop error stacks to debug logs so `/feedback` diagnostics include the real source when a UI/runtime error still occurs.

## Validation
- `bun test src/tests/agent/approval-result-normalization.test.ts`
- `bun test src/tests/queue/turnQueueRuntime.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)