### PR TITLE
fix(local): repair mismatched transcript manifests

### DIFF
--- a/src/backend/local/LocalStore.ts
+++ b/src/backend/local/LocalStore.ts
@@ -550,6 +550,21 @@ export class LocalTranscriptMigrationRequiredError extends Error {
   }
 }
 
+export class LocalTranscriptRepairRequiredError extends Error {
+  constructor(storageDir: string, conversationDir: string) {
+    const command = localTranscriptMigrationCommand(storageDir);
+    super(
+      [
+        "Local backend found a versioned transcript that still contains legacy UI-message rows.",
+        `Transcript: ${conversationDir}`,
+        `Run: ${command}`,
+        "The migration will back up and repair mismatched messages.jsonl files before startup.",
+      ].join("\n"),
+    );
+    this.name = "LocalTranscriptRepairRequiredError";
+  }
+}
+
 export function localTranscriptMigrationCommand(storageDir: string): string {
   const quotedStorageDir = `"${storageDir.replace(/"/g, '\\"')}"`;
   return `letta local-backend migrate-transcripts --storage-dir ${quotedStorageDir}`;
@@ -568,6 +583,21 @@ function hasNonEmptyJsonl(path: string): boolean {
   return readFileSync(path, "utf8")
     .split("\n")
     .some((line) => line.trim().length > 0);
+}
+
+function hasLegacyUiMessageRows(path: string): boolean {
+  if (!existsSync(path)) return false;
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .some((line) => {
+      const message = JSON.parse(line) as unknown;
+      return (
+        isRecord(message) &&
+        Array.isArray(message.parts) &&
+        (!Object.hasOwn(message, "content") || message.content === null)
+      );
+    });
 }
 
 function createLocalTranscriptManifest(
@@ -609,6 +639,9 @@ function validateLocalTranscriptManifest(
     throw new Error(
       `Unsupported local transcript format in ${conversationDir}. Run ${localTranscriptMigrationCommand(storageDir)} or start a new local conversation.`,
     );
+  }
+  if (hasLegacyUiMessageRows(transcriptMessagesPath(conversationDir))) {
+    throw new LocalTranscriptRepairRequiredError(storageDir, conversationDir);
   }
   return manifest;
 }

--- a/src/backend/local/transcriptMigration.ts
+++ b/src/backend/local/transcriptMigration.ts
@@ -43,6 +43,25 @@ function readJsonl(path: string): unknown[] {
     .map((line) => JSON.parse(line));
 }
 
+function isLegacyUiMessage(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.parts) &&
+    (!Object.hasOwn(value, "content") || value.content === null)
+  );
+}
+
+function isPiLocalMessage(value: unknown): value is LocalMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.role === "user" ||
+      value.role === "assistant" ||
+      value.role === "toolResult") &&
+    Object.hasOwn(value, "content")
+  );
+}
+
 function writeJsonl(path: string, items: unknown[]): void {
   writeFileSync(
     path,
@@ -256,17 +275,35 @@ function timestampSuffix(date = new Date()): string {
   ].join("");
 }
 
-function manifest(input: { backupPath?: string }): LocalTranscriptManifest {
+function manifest(input: {
+  backupPath?: string;
+  migratedFrom?: string;
+}): LocalTranscriptManifest {
   const now = new Date().toISOString();
   return {
     schema_version: LOCAL_TRANSCRIPT_SCHEMA_VERSION,
     message_format: LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
     provider_stack: LOCAL_TRANSCRIPT_PROVIDER_STACK,
     created_at: now,
-    migrated_from: "unversioned-legacy-local-message-jsonl",
+    migrated_from:
+      input.migratedFrom ?? "unversioned-legacy-local-message-jsonl",
     migrated_at: now,
     ...(input.backupPath ? { backup_path: input.backupPath } : {}),
   };
+}
+
+function convertMessages(
+  messages: unknown[],
+  mode: "legacy" | "repair-versioned",
+): LocalMessage[] {
+  if (mode === "legacy") {
+    return messages.flatMap(convertLegacyMessage);
+  }
+  return messages.flatMap((message) => {
+    if (isLegacyUiMessage(message)) return convertLegacyMessage(message);
+    if (isPiLocalMessage(message)) return [message];
+    return [];
+  });
 }
 
 export function migrateLocalBackendTranscripts(input: {
@@ -287,11 +324,13 @@ export function migrateLocalBackendTranscripts(input: {
     const conversationDir = join(conversationsDir, name);
     const messagesPath = join(conversationDir, "messages.jsonl");
     const manifestPath = join(conversationDir, "manifest.json");
-    if (existsSync(manifestPath)) {
+    const hasManifest = existsSync(manifestPath);
+    const legacyMessages = readJsonl(messagesPath);
+    const hasLegacyUiRows = legacyMessages.some(isLegacyUiMessage);
+    if (hasManifest && !hasLegacyUiRows) {
       result.skipped.push({ conversationDir, reason: "already-versioned" });
       continue;
     }
-    const legacyMessages = readJsonl(messagesPath);
     if (legacyMessages.length === 0) {
       result.skipped.push({ conversationDir, reason: "empty" });
       if (!input.dryRun) {
@@ -303,14 +342,27 @@ export function migrateLocalBackendTranscripts(input: {
       }
       continue;
     }
-    const converted = legacyMessages.flatMap(convertLegacyMessage);
+    const repairVersioned = hasManifest && hasLegacyUiRows;
+    const converted = convertMessages(
+      legacyMessages,
+      repairVersioned ? "repair-versioned" : "legacy",
+    );
     const backupPath = `${messagesPath}.pre-pi-backup-${timestampSuffix()}`;
     if (!input.dryRun) {
       copyFileSync(messagesPath, backupPath);
       writeJsonl(messagesPath, converted);
       writeFileSync(
         manifestPath,
-        `${JSON.stringify(manifest({ backupPath }), null, 2)}\n`,
+        `${JSON.stringify(
+          manifest({
+            backupPath,
+            migratedFrom: repairVersioned
+              ? "versioned-pi-transcript-with-legacy-ui-message-rows"
+              : undefined,
+          }),
+          null,
+          2,
+        )}\n`,
       );
     }
     result.converted.push({

--- a/src/tests/backend/local-backend.test.ts
+++ b/src/tests/backend/local-backend.test.ts
@@ -15,7 +15,10 @@ import { createOrUpdateLocalProvider } from "../../backend/local";
 import { LocalBackend } from "../../backend/local/LocalBackend";
 import { emptyLocalUsage } from "../../backend/local/LocalMessage";
 import { listLocalModels } from "../../backend/local/LocalModelConfig";
-import { LocalTranscriptMigrationRequiredError } from "../../backend/local/LocalStore";
+import {
+  LocalTranscriptMigrationRequiredError,
+  LocalTranscriptRepairRequiredError,
+} from "../../backend/local/LocalStore";
 import { migrateLocalBackendTranscripts } from "../../backend/local/transcriptMigration";
 
 async function firstConversationDir(storageDir: string): Promise<string> {
@@ -375,6 +378,63 @@ describe("local backend pi transcript", () => {
     expect(() => new LocalBackend({ storageDir, memfsEnabled: false })).toThrow(
       `letta local-backend migrate-transcripts --storage-dir "${storageDir}"`,
     );
+  });
+
+  test("refuses to load versioned transcripts with legacy UI rows and repairs them with migrate-transcripts", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-repair-"),
+    );
+    const conversationDir = join(storageDir, "conversations", "mismatched");
+    await mkdir(conversationDir, { recursive: true });
+    await writeFile(
+      join(conversationDir, "conversation.json"),
+      JSON.stringify({
+        id: "local-conv-1",
+        agent_id: "agent-local-default",
+        in_context_message_ids: ["ui-msg-1"],
+      }),
+    );
+    await writeFile(
+      join(conversationDir, "manifest.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        message_format: "pi-ai-message-jsonl",
+        provider_stack: "pi-ai",
+        created_at: new Date().toISOString(),
+      })}\n`,
+    );
+    await writeFile(
+      join(conversationDir, "messages.jsonl"),
+      `${JSON.stringify({ id: "ui-msg-1", role: "user", parts: [{ type: "text", text: "legacy after manifest" }] })}\n`,
+    );
+
+    expect(() => new LocalBackend({ storageDir, memfsEnabled: false })).toThrow(
+      LocalTranscriptRepairRequiredError,
+    );
+    expect(() => new LocalBackend({ storageDir, memfsEnabled: false })).toThrow(
+      `letta local-backend migrate-transcripts --storage-dir "${storageDir}"`,
+    );
+
+    const result = migrateLocalBackendTranscripts({ storageDir });
+    expect(result.converted).toHaveLength(1);
+    const manifest = JSON.parse(
+      await readFile(join(conversationDir, "manifest.json"), "utf8"),
+    );
+    expect(manifest.migrated_from).toBe(
+      "versioned-pi-transcript-with-legacy-ui-message-rows",
+    );
+    const converted = JSON.parse(
+      (await readFile(join(conversationDir, "messages.jsonl"), "utf8")).trim(),
+    );
+    expect(converted).toMatchObject({
+      id: "ui-msg-1",
+      role: "user",
+      content: [{ type: "text", text: "legacy after manifest" }],
+    });
+    expect(converted.parts).toBeUndefined();
+    expect(
+      () => new LocalBackend({ storageDir, memfsEnabled: false }),
+    ).not.toThrow();
   });
 
   test("migrates unversioned transcripts with a backup", async () => {


### PR DESCRIPTION
## Summary
- Detect versioned local transcripts that still contain legacy UI-message `parts` rows and fail startup with a targeted repair command instead of a generic `message.content.length` crash.
- Teach `letta local-backend migrate-transcripts` to repair those mismatched transcripts while preserving already-converted pi local messages and backing up the old file.
- Add regression coverage for the startup error and repair path.

## Test plan
- [x] `bun test src/tests/backend/local-backend.test.ts`
- [x] `bun run check`
- [x] Verified the new startup error against the corrupted local store in dry-run/debug flow

👾 Generated with [Letta Code](https://letta.com)