### PR TITLE
fix(channels): render Telegram block quotes

### DIFF
--- a/src/tests/channels/message-channel-formatting.test.ts
+++ b/src/tests/channels/message-channel-formatting.test.ts
@@ -81,6 +81,18 @@ test("renders markdown links with balanced parentheses and escaped attributes", 
   );
 });
 
+test("renders Telegram block quotes as HTML blockquote tags", () => {
+  expect(markdownToTelegramHtml("> quoted\n> **bold** & safe\n\nnormal")).toBe(
+    "<blockquote>quoted\n<b>bold</b> &amp; safe</blockquote>\n\nnormal",
+  );
+});
+
+test("does not render block quote markers inside Telegram code blocks", () => {
+  expect(markdownToTelegramHtml("```\n> quoted\n```")).toBe(
+    "<pre>&gt; quoted</pre>",
+  );
+});
+
 test("does not treat spaced arithmetic operators as italic markup", () => {
   expect(markdownToTelegramHtml("2 * 3 * 4")).toBe("2 * 3 * 4");
 });

--- a/src/tools/impl/MessageChannel.ts
+++ b/src/tools/impl/MessageChannel.ts
@@ -234,9 +234,46 @@ function applyTelegramInlineFormatting(text: string): string {
     .replace(/(^|[^\w_])_([^\s_](?:[\s\S]*?[^\s_])?)_(?!\w)/g, "$1<i>$2</i>");
 }
 
+function replaceTelegramBlockQuotes(
+  text: string,
+  placeholders: string[],
+): string {
+  const lines = text.split("\n");
+  const formattedLines: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const quoteMatch = lines[index]?.match(/^ {0,3}> ?(.*)$/);
+    if (!quoteMatch) {
+      formattedLines.push(lines[index] ?? "");
+      continue;
+    }
+
+    const quoteLines: string[] = [quoteMatch[1] ?? ""];
+    while (index + 1 < lines.length) {
+      const nextMatch = lines[index + 1]?.match(/^ {0,3}> ?(.*)$/);
+      if (!nextMatch) {
+        break;
+      }
+      quoteLines.push(nextMatch[1] ?? "");
+      index++;
+    }
+
+    formattedLines.push(
+      createTelegramPlaceholder(
+        placeholders,
+        `<blockquote>${formatTelegramText(quoteLines.join("\n"), {
+          enableBlockQuotes: false,
+        })}</blockquote>`,
+      ),
+    );
+  }
+
+  return formattedLines.join("\n");
+}
+
 function formatTelegramText(
   text: string,
-  options?: { enableLinks?: boolean },
+  options?: { enableBlockQuotes?: boolean; enableLinks?: boolean },
 ): string {
   const placeholders: string[] = [];
   let result = replaceFencedCodeBlocks(text, placeholders);
@@ -244,8 +281,15 @@ function formatTelegramText(
 
   if (options?.enableLinks !== false) {
     result = replaceMarkdownLinks(result, placeholders, (label) =>
-      formatTelegramText(label, { enableLinks: false }),
+      formatTelegramText(label, {
+        enableBlockQuotes: false,
+        enableLinks: false,
+      }),
     );
+  }
+
+  if (options?.enableBlockQuotes !== false) {
+    result = replaceTelegramBlockQuotes(result, placeholders);
   }
 
   result = escapeTelegramHtml(result);


### PR DESCRIPTION
## Summary
- Render Markdown block quote lines as Telegram HTML `<blockquote>` tags for outgoing channel messages.
- Preserve inline formatting inside quotes while leaving quote markers inside code blocks untouched.

## Test plan
- [x] `bun test /home/cameron/code/letta-code/src/tests/channels/message-channel-formatting.test.ts`
- [x] `bun run typecheck`
- [x] `bunx --bun @biomejs/biome@2.2.5 check /home/cameron/code/letta-code/src/tools/impl/MessageChannel.ts /home/cameron/code/letta-code/src/tests/channels/message-channel-formatting.test.ts`

Written by Cameron ◯ Letta Code