### PR TITLE
fix(connect): add DeepSeek API support

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -159,6 +159,7 @@ function isProviderNotSupportedError(errorOutput: string): boolean {
 const BYOK_PROVIDER_TO_BASE: Record<string, string> = {
   "lc-anthropic": "anthropic",
   "lc-openai": "openai",
+  "lc-deepseek": "deepseek",
   "lc-zai": "zai",
   "lc-gemini": "google_ai",
   "lc-openrouter": "openrouter",

--- a/src/backend/dev/PiProviderRegistry.ts
+++ b/src/backend/dev/PiProviderRegistry.ts
@@ -9,6 +9,7 @@ import { getModels } from "@earendil-works/pi-ai";
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
 export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
 export const LOCAL_ANTHROPIC_PROVIDER_NAME = "lc-anthropic";
+export const LOCAL_DEEPSEEK_PROVIDER_NAME = "lc-deepseek";
 export const LOCAL_OPENROUTER_PROVIDER_NAME = "lc-openrouter";
 export const LOCAL_OLLAMA_PROVIDER_NAME = "lc-ollama";
 export const LOCAL_OLLAMA_CLOUD_PROVIDER_NAME = "lc-ollama-cloud";
@@ -39,6 +40,7 @@ function hasEnvValue(value: string | undefined): boolean {
 export type PiProvider =
   | "openai-responses"
   | "anthropic"
+  | "deepseek"
   | "openrouter"
   | "zai"
   | "minimax"
@@ -96,6 +98,18 @@ export const PI_PROVIDER_SPECS = [
     apiKeyEnv: () => process.env.ANTHROPIC_API_KEY,
     envConfigured: () => hasEnvValue(process.env.ANTHROPIC_API_KEY),
     catalogModelHandle: prefixedCatalogModelHandle("anthropic/"),
+  },
+  {
+    id: "deepseek",
+    piProvider: "deepseek",
+    providerTypes: ["deepseek"],
+    handlePrefixes: ["deepseek/"],
+    localProviderNames: [LOCAL_DEEPSEEK_PROVIDER_NAME],
+    defaultModel: "deepseek/deepseek-chat",
+    apiKeyEnv: () => process.env.DEEPSEEK_API_KEY,
+    baseUrlEnv: () => process.env.DEEPSEEK_BASE_URL,
+    envConfigured: () => hasEnvValue(process.env.DEEPSEEK_API_KEY),
+    catalogModelHandle: prefixedCatalogModelHandle("deepseek/"),
   },
   {
     id: "openrouter",

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -8,6 +8,7 @@ export type ConnectProviderCanonical =
   | "chatgpt"
   | "anthropic"
   | "openai"
+  | "deepseek"
   | "zai"
   | "zai-coding"
   | "minimax"
@@ -26,6 +27,7 @@ const ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
   codex: "chatgpt",
   anthropic: "anthropic",
   openai: "openai",
+  deepseek: "deepseek",
   zai: "zai",
   "zai-coding": "zai-coding",
   minimax: "minimax",
@@ -46,6 +48,7 @@ const CANONICAL_ORDER: ConnectProviderCanonical[] = [
   "chatgpt",
   "anthropic",
   "openai",
+  "deepseek",
   "zai",
   "zai-coding",
   "minimax",

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -212,10 +212,15 @@ export async function runConnectSubcommand(
     return 1;
   }
 
+  try {
+    await io.ensureSettingsReady();
+  } catch (error) {
+    io.stderr(`Failed to initialize settings: ${getErrorMessage(error)}`);
+    return 1;
+  }
+
   if (isConnectOAuthProvider(provider)) {
     try {
-      await io.ensureSettingsReady();
-
       if (await io.isChatGPTOAuthConnected()) {
         io.stdout(
           "Already connected to ChatGPT via OAuth. Disconnect first if you want to re-authenticate.",

--- a/src/models.json
+++ b/src/models.json
@@ -1387,6 +1387,26 @@
       }
     },
     {
+      "id": "deepseek-chat",
+      "handle": "deepseek/deepseek-chat",
+      "label": "DeepSeek Chat",
+      "description": "DeepSeek's chat model via the native DeepSeek API",
+      "updateArgs": {
+        "context_window": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "deepseek-reasoner",
+      "handle": "deepseek/deepseek-reasoner",
+      "label": "DeepSeek Reasoner",
+      "description": "DeepSeek's reasoning model via the native DeepSeek API",
+      "updateArgs": {
+        "context_window": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "glm-5.1",
       "handle": "zai/glm-5.1",
       "label": "GLM-5.1",

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -75,6 +75,13 @@ export const BYOK_PROVIDERS = [
     providerName: "lc-openai",
   },
   {
+    id: "deepseek",
+    displayName: "DeepSeek API",
+    description: "Connect a DeepSeek API key",
+    providerType: "deepseek",
+    providerName: "lc-deepseek",
+  },
+  {
     id: "zai",
     displayName: "zAI API",
     description: "Connect a zAI API key",

--- a/src/tests/cli/connect-subcommand.test.ts
+++ b/src/tests/cli/connect-subcommand.test.ts
@@ -48,6 +48,7 @@ describe("connect subcommand", () => {
     );
 
     expect(exitCode).toBe(0);
+    expect(deps.ensureSettingsReady).toHaveBeenCalledTimes(1);
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "anthropic",
       "sk-ant-123",
@@ -57,6 +58,41 @@ describe("connect subcommand", () => {
       "lc-anthropic",
       "sk-ant-123",
     );
+  });
+
+  test("connects DeepSeek API provider", async () => {
+    const { deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      ["deepseek", "sk-deepseek-123"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.ensureSettingsReady).toHaveBeenCalledTimes(1);
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "deepseek",
+      "sk-deepseek-123",
+    );
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "deepseek",
+      "lc-deepseek",
+      "sk-deepseek-123",
+    );
+  });
+
+  test("initializes settings before API-key provider validation", async () => {
+    const { stderr, deps } = createIoDeps();
+    deps.ensureSettingsReady.mockRejectedValueOnce(
+      new Error("Settings not initialized"),
+    );
+
+    const exitCode = await runConnectSubcommand(["openai", "sk-test"], deps);
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("Failed to initialize settings");
+    expect(deps.checkProviderApiKey).not.toHaveBeenCalled();
+    expect(deps.createOrUpdateProvider).not.toHaveBeenCalled();
   });
 
   test("returns error for missing key in non-TTY mode", async () => {
@@ -159,6 +195,7 @@ describe("connect subcommand", () => {
     );
 
     expect(exitCode).toBe(1);
+    expect(deps.ensureSettingsReady).toHaveBeenCalledTimes(1);
     expect(stderr.join("\n")).toContain("Missing IAM fields");
   });
 });

--- a/src/tests/providers/byok-provider-aliases.test.ts
+++ b/src/tests/providers/byok-provider-aliases.test.ts
@@ -20,6 +20,7 @@ describe("buildByokProviderAliases", () => {
 
     expect(aliases["lc-anthropic"]).toBe("anthropic");
     expect(aliases["lc-openai"]).toBe("openai");
+    expect(aliases["lc-deepseek"]).toBe("deepseek");
     expect(aliases["lc-zai"]).toBe("zai");
     expect(aliases["lc-gemini"]).toBe("google_ai");
     expect(aliases["lc-minimax"]).toBe("minimax");


### PR DESCRIPTION
## Summary

This PR wires native DeepSeek API support into the Letta Code provider connection path. A user reported from Discord that DeepSeek model entries and DEEPSEEK_API_KEY support existed in parts of the codebase, but letta connect could not actually resolve or save a DeepSeek provider.

## Problem

Before this change, native DeepSeek was not registered as a connectable BYOK provider. That meant letta connect deepseek was treated as unsupported even though DeepSeek models and environment-variable expectations were already present elsewhere. While tracing the connect path, I also confirmed the reported initialization bug: settings were only initialized inside the ChatGPT OAuth branch, so API-key and Bedrock provider paths could hit Settings not initialized before validation or save.

## Approach

The fix registers DeepSeek consistently across the same provider layers used by the other API-key providers: provider registry metadata, BYOK provider config, connect-provider normalization, BYOK aliasing for selectors/subagents, and the model catalog. DeepSeek is exposed as lc-deepseek with native model handles for deepseek-chat and deepseek-reasoner.

The settings initialization call now runs once after provider resolution and before dispatching into OAuth, API-key, or Bedrock-specific flows. This keeps unknown-provider help behavior unchanged while ensuring every real provider path has initialized settings before it reads or writes provider state.

## Before / after

Before: letta connect deepseek failed as an unknown provider, and non-OAuth connect flows could fail with Settings not initialized.

After: letta connect deepseek resolves to the DeepSeek API provider, validates/saves lc-deepseek, native DeepSeek model handles are available, and all supported provider dispatch paths initialize settings first.

## Risk and tradeoffs

Risk is low and scoped to provider registration and connect startup ordering. The change follows existing provider patterns and does not add a new validation strategy beyond the existing provider API path. I did not add a live DeepSeek API smoke test because that would require a real key in CI.

## Validation

- bun test src/tests/cli/connect-subcommand.test.ts src/tests/providers/byok-provider-aliases.test.ts
- bun run typecheck
- bunx --bun @biomejs/biome@2.2.5 check src/backend/dev/PiProviderRegistry.ts src/providers/byok-providers.ts src/cli/commands/connect-normalize.ts src/agent/subagents/manager.ts src/cli/subcommands/connect.ts src/tests/cli/connect-subcommand.test.ts src/tests/providers/byok-provider-aliases.test.ts
- bun run build

👾 Generated with [Letta Code](https://letta.com)