### PR TITLE
feat(cli): ctrl+o to expand/collapse last shell tool call output

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -136,6 +136,7 @@ import {
   isFileEditTool,
   isFileWriteTool,
   isPatchTool,
+  isShellOutputTool,
   isShellTool,
 } from "../helpers/toolNameMapping";
 import { isTaskTool } from "../helpers/toolNameMapping.js";
@@ -328,6 +329,11 @@ export default function App({
     permissionMode.getMode(),
   );
   const uiPermissionModeRef = useRef<PermissionMode>(uiPermissionMode);
+
+  // Track which tool call output is expanded (ctrl+o toggles last one)
+  const [expandedToolCallId, setExpandedToolCallId] = useState<string | null>(
+    null,
+  );
 
   // Store the last plan file path for post-approval rendering
   // (needed because plan mode is exited before rendering the result)
@@ -4036,6 +4042,40 @@ export default function App({
     }
   }, [setUiPermissionMode]);
 
+  // Toggle expand/collapse for a specific tool call ID
+  const handleToggleExpandedToolCall = useCallback((id: string) => {
+    setExpandedToolCallId((prev) => (prev === id ? null : id));
+  }, []);
+
+  // The ID of the last finished shell tool call — used for the ctrl+o hint and handler.
+  // lines is intentionally in the dep array to recompute when buffers change (buffersRef is a ref).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: lines triggers recompute when buffer changes
+  const lastShellToolCallId = useMemo(() => {
+    const order = buffersRef.current.order;
+    for (let i = order.length - 1; i >= 0; i--) {
+      const id = order[i];
+      if (!id) continue;
+      const ln = buffersRef.current.byId.get(id);
+      if (
+        ln?.kind === "tool_call" &&
+        ln.phase === "finished" &&
+        ln.resultText &&
+        ln.name &&
+        isShellOutputTool(ln.name)
+      ) {
+        return id;
+      }
+    }
+    return null;
+  }, [lines]);
+
+  // ctrl+o toggles the last shell tool call output
+  const handleCtrlO = useCallback(() => {
+    if (lastShellToolCallId) {
+      handleToggleExpandedToolCall(lastShellToolCallId);
+    }
+  }, [lastShellToolCallId, handleToggleExpandedToolCall]);
+
   // Handle permission mode changes from the Input component (e.g., shift+tab cycling)
   const handlePermissionModeChange = useCallback(
     (mode: PermissionMode) => {
@@ -4363,6 +4403,9 @@ export default function App({
       currentSystemPromptId={currentSystemPromptId}
       currentToolset={currentToolset}
       currentToolsetPreference={currentToolsetPreference}
+      expandedToolCallId={expandedToolCallId}
+      lastShellToolCallId={lastShellToolCallId}
+      handleCtrlO={handleCtrlO}
       emittedIdsRef={emittedIdsRef}
       feedbackPrefill={feedbackPrefill}
       footerUpdateText={footerUpdateText}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -149,6 +149,10 @@ type AppViewProps = {
   currentToolset: ToolsetName | null;
   currentToolsetPreference: ToolsetPreference;
   emittedIdsRef: RefObject<Set<string>>;
+  expandedToolCallId: string | null;
+  lastShellToolCallId: string | null;
+  handleCtrlO: () => void;
+
   feedbackPrefill: string;
   footerUpdateText: string | null;
   handleAgentSelect: (
@@ -328,6 +332,9 @@ export function AppView(props: AppViewProps) {
     currentToolset,
     currentToolsetPreference,
     emittedIdsRef,
+    expandedToolCallId,
+    lastShellToolCallId,
+    handleCtrlO,
     feedbackPrefill,
     footerUpdateText,
     handleAgentSelect,
@@ -435,6 +442,8 @@ export function AppView(props: AppViewProps) {
         showCompactionsEnabled={showCompactionsEnabled}
         precomputedDiffs={precomputedDiffsRef.current}
         lastPlanFilePath={lastPlanFilePathRef.current}
+        hiddenToolCallId={expandedToolCallId ?? undefined}
+        lastShellToolCallId={lastShellToolCallId ?? undefined}
       />
 
       <Box flexDirection="column">
@@ -577,6 +586,8 @@ export function AppView(props: AppViewProps) {
                             precomputedDiffs={precomputedDiffsRef.current}
                             lastPlanFilePath={lastPlanFilePathRef.current}
                             isStreaming={streaming}
+                            expandedToolCallId={expandedToolCallId}
+                            lastShellToolCallId={lastShellToolCallId}
                           />
                         ) : ln.kind === "error" ? (
                           <ErrorMessage line={ln} />
@@ -693,6 +704,7 @@ export function AppView(props: AppViewProps) {
                 }
                 onExit={handleExit}
                 onInterrupt={handleInterrupt}
+                onCtrlO={handleCtrlO}
                 interruptRequested={interruptRequested}
                 agentId={agentId}
                 agentName={agentName}

--- a/src/cli/app/StaticTranscript.tsx
+++ b/src/cli/app/StaticTranscript.tsx
@@ -24,6 +24,8 @@ export function StaticTranscript({
   showCompactionsEnabled,
   precomputedDiffs,
   lastPlanFilePath,
+  hiddenToolCallId,
+  lastShellToolCallId,
 }: {
   renderEpoch: number;
   items: StaticItem[];
@@ -32,9 +34,15 @@ export function StaticTranscript({
   showCompactionsEnabled: boolean;
   precomputedDiffs: Map<string, AdvancedDiffSuccess>;
   lastPlanFilePath: string | null;
+  hiddenToolCallId?: string;
+  lastShellToolCallId?: string;
 }) {
   return (
-    <Static key={renderEpoch} items={items} style={{ flexDirection: "column" }}>
+    <Static
+      key={`${renderEpoch}-${hiddenToolCallId ?? ""}`}
+      items={items}
+      style={{ flexDirection: "column" }}
+    >
       {(item: StaticItem, index: number) => {
         try {
           return (
@@ -52,6 +60,8 @@ export function StaticTranscript({
                   line={item}
                   precomputedDiffs={precomputedDiffs}
                   lastPlanFilePath={lastPlanFilePath}
+                  expandedToolCallId={hiddenToolCallId}
+                  lastShellToolCallId={lastShellToolCallId}
                 />
               ) : item.kind === "subagent_group" ? (
                 <SubagentGroupStatic agents={item.agents} />

--- a/src/cli/components/CollapsedOutputDisplay.tsx
+++ b/src/cli/components/CollapsedOutputDisplay.tsx
@@ -12,19 +12,23 @@ interface CollapsedOutputDisplayProps {
   output: string; // Full output from completion
   maxLines?: number; // Max lines to show before collapsing (Infinity = show all)
   maxChars?: number; // Max chars to show before clipping
+  expanded?: boolean; // Whether to show full output
+  isLast?: boolean; // Whether this is the last shell tool call (shows ctrl+o hint)
 }
 
 /**
  * Display component for bash output after completion.
  * Shows first 3 lines with count of hidden lines.
  * Uses proper two-column layout with width constraints for correct wrapping.
- * Note: expand/collapse (ctrl+o) is deferred to a future PR.
+ * Toggle expand/collapse with ctrl+o (handled by AppCoordinator).
  */
 export const CollapsedOutputDisplay = memo(
   ({
     output,
     maxLines = DEFAULT_COLLAPSED_LINES,
     maxChars,
+    expanded = false,
+    isLast = false,
   }: CollapsedOutputDisplayProps) => {
     const columns = useTerminalWidth();
     const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
@@ -32,6 +36,7 @@ export const CollapsedOutputDisplay = memo(
     let displayOutput = output;
     let clippedByChars = false;
     if (
+      !expanded &&
       typeof maxChars === "number" &&
       maxChars > 0 &&
       output.length > maxChars
@@ -51,7 +56,8 @@ export const CollapsedOutputDisplay = memo(
       return null;
     }
 
-    const showAll = maxLines === Infinity || maxLines >= lines.length;
+    const showAll =
+      expanded || maxLines === Infinity || maxLines >= lines.length;
     const visibleLines = showAll ? lines : lines.slice(0, maxLines);
     const hiddenCount = showAll ? 0 : Math.max(0, lines.length - maxLines);
 
@@ -78,25 +84,40 @@ export const CollapsedOutputDisplay = memo(
             </Box>
           </Box>
         ))}
-        {/* Hidden count hint */}
+        {/* Hidden count hint with ctrl+o toggle */}
         {hiddenCount > 0 && (
           <Box flexDirection="row">
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
             <Box flexGrow={1} width={contentWidth}>
-              <Text dimColor>… +{hiddenCount} lines</Text>
+              <Text dimColor>
+                … +{hiddenCount} lines{isLast ? " (ctrl+o to expand)" : ""}
+              </Text>
             </Box>
           </Box>
         )}
-        {/* Character clipping hint (only if not already showing line count) */}
+        {/* Collapse hint when expanded */}
+        {expanded && lines.length > maxLines && (
+          <Box flexDirection="row">
+            <Box width={PREFIX_WIDTH} flexShrink={0}>
+              <Text>{"     "}</Text>
+            </Box>
+            <Box flexGrow={1} width={contentWidth}>
+              <Text dimColor>(ctrl+o to collapse)</Text>
+            </Box>
+          </Box>
+        )}
+        {/* Character clipping hint with ctrl+o hint (only if not already showing line count) */}
         {clippedByChars && hiddenCount === 0 && (
           <Box flexDirection="row">
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
             <Box flexGrow={1} width={contentWidth}>
-              <Text dimColor>… output clipped</Text>
+              <Text dimColor>
+                … output clipped{isLast ? " (ctrl+o to expand)" : ""}
+              </Text>
             </Box>
           </Box>
         )}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -968,6 +968,7 @@ export function Input({
   onPermissionModeChange,
   onExit,
   onInterrupt,
+  onCtrlO,
   interruptRequested = false,
   agentId,
   agentName,
@@ -1013,6 +1014,7 @@ export function Input({
   onPermissionModeChange?: (mode: PermissionMode) => void;
   onExit?: () => void;
   onInterrupt?: () => void;
+  onCtrlO?: () => void;
   interruptRequested?: boolean;
   agentId?: string;
   agentName?: string | null;
@@ -1329,6 +1331,12 @@ export function Input({
 
   useInput((input, key) => {
     if (!interactionEnabled) return;
+
+    // Handle CTRL-O to expand/collapse the last tool call output
+    if (input === "o" && key.ctrl) {
+      if (onCtrlO) onCtrlO();
+      return;
+    }
 
     // Handle CTRL-C for double-ctrl-c-to-exit
     // In bash mode, CTRL-C wipes input but doesn't exit bash mode

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -146,11 +146,15 @@ export const ToolCallMessage = memo(
     precomputedDiffs,
     lastPlanFilePath,
     isStreaming,
+    expandedToolCallId,
+    lastShellToolCallId,
   }: {
     line: ToolCallLine;
     precomputedDiffs?: Map<string, AdvancedDiffSuccess>;
     lastPlanFilePath?: string | null;
     isStreaming?: boolean;
+    expandedToolCallId?: string | null;
+    lastShellToolCallId?: string | null;
   }) => {
     const columns = useTerminalWidth();
     try {
@@ -1025,6 +1029,10 @@ export const ToolCallMessage = memo(
               <CollapsedOutputDisplay
                 output={extractMessageFromResult(line.resultText)}
                 maxChars={300}
+                expanded={
+                  expandedToolCallId != null && expandedToolCallId === line.id
+                }
+                isLast={lastShellToolCallId === line.id}
               />
             )}
 


### PR DESCRIPTION
## Summary

Adds ctrl+o to expand/collapse the output of the last shell tool call. Addresses the common case where a long bash/shell output is clipped and you want to see the full result without rerunning the command.

## Behavior
- The last finished shell tool call shows `… +N lines (ctrl+o to expand)` hint
- Older tool calls show `… +N lines` with no hint (they cannot be expanded)
- ctrl+o expands in-place, preserving conversation order
- ctrl+o again collapses back to the 3-line preview

### Default UI

<img width="806" height="408" alt="Screenshot 2026-05-18 at 3 12 06 PM" src="https://github.com/user-attachments/assets/b9de319a-3b79-4d1e-9988-0ec2ec53d79b" />

### Expanded UI

<img width="807" height="467" alt="Screenshot 2026-05-18 at 3 12 21 PM" src="https://github.com/user-attachments/assets/2a7287c2-a7ed-4161-8a42-124eca918c52" />

## Implementation
- `CollapsedOutputDisplay`: `expanded` prop (skips clipping), `isLast` prop (controls hint)
- `AppCoordinator`: `expandedToolCallId` state + `lastShellToolCallId` (memoized) + `handleCtrlO`
- `StaticTranscript`: remounts with new key on expand/collapse so in-place rendering works within Ink `<Static>`
- `InputRich`: handles ctrl+o keystroke

👾 Generated with [Letta Code](https://letta.com)