### PR TITLE
feat(ws): add remove_queue_item command

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1584,6 +1584,24 @@ export interface ExecuteCommandCommand {
 }
 
 // ─────────────────────────────────────────────────
+//  Queue item commands
+// ─────────────────────────────────────────────────
+
+/**
+ * Remove a specific item from the queue by ID.
+ * Used by desktop to implement queue editing (load into input, remove from queue).
+ */
+export interface RemoveQueueItemCommand {
+  type: "remove_queue_item";
+  /** Correlation id (echoed back in the response for request correlation). */
+  request_id: string;
+  /** Runtime scope — identifies which agent + conversation this targets. */
+  runtime: RuntimeScope;
+  /** The queue item ID to remove. */
+  item_id: string;
+}
+
+// ─────────────────────────────────────────────────
 //  Git branch commands
 // ─────────────────────────────────────────────────
 
@@ -1695,6 +1713,13 @@ export interface SecretApplyResponse {
   error?: string;
 }
 
+export interface RemoveQueueItemResponse {
+  type: "remove_queue_item_response";
+  request_id: string;
+  success: boolean;
+  item_id: string;
+}
+
 export type WsProtocolCommand =
   | InputCommand
   | ChangeDeviceStateCommand
@@ -1758,6 +1783,7 @@ export type WsProtocolCommand =
   | ChannelRouteRemoveCommand
   | ChannelRouteUpdateCommand
   | ExecuteCommandCommand
+  | RemoveQueueItemCommand
   | SearchBranchesCommand
   | CheckoutBranchCommand
   | SecretListCommand
@@ -1800,6 +1826,7 @@ export type WsProtocolMessage =
   | ChannelRoutesUpdatedMessage
   | ChannelTargetsUpdatedMessage
   | SecretListResponse
-  | SecretApplyResponse;
+  | SecretApplyResponse
+  | RemoveQueueItemResponse;
 
 export type { StopReasonType };

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -35,7 +35,10 @@ import {
   parseServerLifecycleMessage,
   parseServerMessage,
 } from "./protocol-inbound";
-import { emitDeviceStatusUpdate } from "./protocol-outbound";
+import {
+  emitDeviceStatusUpdate,
+  emitQueueUpdateIfOpen,
+} from "./protocol-outbound";
 import {
   scheduleQueuePump,
   shouldProcessInboundMessageDirectly,
@@ -432,6 +435,35 @@ export function createListenerMessageHandler(
           },
           processQueuedTurn,
         });
+        return;
+      }
+
+      if (parsed.type === "remove_queue_item") {
+        const scopedRuntime = getOrCreateScopedRuntime(
+          runtime,
+          parsed.runtime.agent_id,
+          parsed.runtime.conversation_id || "default",
+        );
+        const removed = scopedRuntime.queueRuntime.removeItem(parsed.item_id);
+        // Emit a response so the client knows if the item was found/removed
+        safeSocketSend(
+          socket,
+          {
+            type: "remove_queue_item_response",
+            request_id: parsed.request_id,
+            success: removed !== null,
+            item_id: parsed.item_id,
+          },
+          "remove_queue_item_response",
+          "remove_queue_item",
+        );
+        // Broadcast the updated queue so all connected clients see the change
+        if (removed !== null) {
+          emitQueueUpdateIfOpen(runtime, {
+            agent_id: parsed.runtime.agent_id,
+            conversation_id: parsed.runtime.conversation_id,
+          });
+        }
         return;
       }
 

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -49,6 +49,7 @@ import type {
   MemoryHistoryCommand,
   ReadFileCommand,
   ReadMemoryFileCommand,
+  RemoveQueueItemCommand,
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
@@ -1509,6 +1510,24 @@ export function isExecuteCommandCommand(
   );
 }
 
+export function isRemoveQueueItemCommand(
+  value: unknown,
+): value is RemoveQueueItemCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    runtime?: unknown;
+    item_id?: unknown;
+  };
+  return (
+    c.type === "remove_queue_item" &&
+    typeof c.request_id === "string" &&
+    isRuntimeScope(c.runtime) &&
+    typeof c.item_id === "string"
+  );
+}
+
 export function parseServerLifecycleMessage(
   data: WebSocket.RawData,
 ): ServerLifecycleMessage | null {
@@ -1597,6 +1616,7 @@ export function parseServerMessage(
       isChannelRouteUpdateCommand(parsed) ||
       isChannelRouteRemoveCommand(parsed) ||
       isExecuteCommandCommand(parsed) ||
+      isRemoveQueueItemCommand(parsed) ||
       isSearchBranchesCommand(parsed) ||
       isCheckoutBranchCommand(parsed) ||
       isSecretListCommand(parsed) ||


### PR DESCRIPTION
## Summary
- Add `remove_queue_item` websocket protocol command so connected clients (desktop) can remove a specific item from the queue by ID
- This is the letta-code side of the queue editing feature for desktop

## Changes
- `protocol_v2.ts`: Add `RemoveQueueItemCommand` + `RemoveQueueItemResponse` types, add to `WsProtocolCommand` / `WsProtocolMessage` unions
- `protocol-inbound.ts`: Add `isRemoveQueueItemCommand` type guard, wire into `parseServerMessage`
- `message-router.ts`: Handle `remove_queue_item` — resolve scoped runtime, call `queueRuntime.removeItem()`, send response with success/failure

## Protocol
**Request:**
```json
{
  "type": "remove_queue_item",
  "request_id": "uuid",
  "runtime": { "agent_id": "...", "conversation_id": "..." },
  "item_id": "queue-item-id"
}
```

**Response:**
```json
{
  "type": "remove_queue_item_response",
  "request_id": "uuid",
  "success": true,
  "item_id": "queue-item-id"
}
```

## Test plan
- [ ] Connect desktop to a letta-code listener
- [ ] Queue multiple user messages while agent is busy
- [ ] Send `remove_queue_item` for a queued item ID
- [ ] Verify response has `success: true` and item is removed from queue
- [ ] Verify `success: false` for non-existent item ID
- [ ] Verify queue snapshot updates reflect the removal

🤖 Generated with [Letta Code](https://letta.com)