### PR TITLE
fix(local): inherit parent model for subagents

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -197,12 +197,21 @@ export async function resolveSubagentModel(options: {
   billingTier?: string | null;
   availableHandles?: Set<string>;
   subagentType?: string;
+  backendMode?: BackendMode;
 }): Promise<string | null> {
   const { userModel, recommendedModel, parentModelHandle, billingTier } =
     options;
   const isFreeTier = billingTier?.toLowerCase() === "free";
 
   if (userModel) return userModel;
+
+  // Local backend has no server-side auto router. If the parent agent is
+  // already running successfully on a local model, spawned subagents should use
+  // that exact model instead of resolving auto/auto-memory to a provider
+  // default that may not match the active session.
+  if (options.backendMode === "local" && parentModelHandle) {
+    return parentModelHandle;
+  }
 
   if (options.subagentType === "reflection") {
     if (recommendedModel && recommendedModel !== "inherit") {
@@ -1333,6 +1342,10 @@ export async function spawnSubagent(
     existingAgentId || existingConversationId,
   );
 
+  const activeBackend = getBackend();
+  const backendMode: BackendMode = activeBackend.capabilities.localMemfs
+    ? "local"
+    : "api";
   const { handle: parentModelHandle, agent: parentAgent } =
     await getPrimaryAgentModelHandle();
   const billingTier = await getCurrentBillingTier();
@@ -1346,6 +1359,7 @@ export async function spawnSubagent(
         parentModelHandle,
         billingTier,
         subagentType: type,
+        backendMode,
       });
   const baseURL = getBaseURL();
 

--- a/src/tests/agent/subagent-model-resolution.test.ts
+++ b/src/tests/agent/subagent-model-resolution.test.ts
@@ -621,6 +621,43 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("letta/auto-memory");
   });
 
+  test("local backend subagents inherit the active parent model", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "inherit",
+      parentModelHandle: "chatgpt-plus-pro/gpt-5.3-codex",
+      backendMode: "local",
+      availableHandles: new Set(),
+    });
+
+    expect(result).toBe("chatgpt-plus-pro/gpt-5.3-codex");
+  });
+
+  test("local backend inherits parent model for non-reflection subagents", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "general-purpose",
+      recommendedModel: "anthropic/test-model",
+      parentModelHandle: "lmstudio/local-model",
+      backendMode: "local",
+      availableHandles: new Set(["anthropic/test-model"]),
+    });
+
+    expect(result).toBe("lmstudio/local-model");
+  });
+
+  test("explicit user model overrides local backend parent inheritance", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      userModel: "openai/gpt-5",
+      recommendedModel: "inherit",
+      parentModelHandle: "lmstudio/local-model",
+      backendMode: "local",
+      availableHandles: new Set(["openai/gpt-5"]),
+    });
+
+    expect(result).toBe("openai/gpt-5");
+  });
+
   test("uses letta/auto-memory for reflection subagents with no recommended model", async () => {
     const result = await resolveSubagentModel({
       subagentType: "reflection",


### PR DESCRIPTION
## Summary
- Make newly spawned local-backend subagents inherit the active parent agent model instead of resolving `auto` / `auto-memory` through provider defaults.
- Preserve explicit subagent model overrides and existing deployed-agent behavior.
- Add regression coverage for reflection, general-purpose, and explicit override local-backend model resolution.

## Linear
- LET-8887

## Test plan
- [x] `bun test src/tests/agent/subagent-model-resolution.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)