### PR TITLE
fix(channels): hide raw lifecycle stop errors

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -1,4 +1,5 @@
 import { basename } from "node:path";
+import { normalizeChannelLifecycleErrorMessage } from "@/channels/lifecycleError";
 import type {
   ChannelAdapter,
   ChannelTurnLifecycleEvent,
@@ -272,7 +273,7 @@ export function buildDiscordReplyOptions(
 }
 
 function formatDiscordLifecycleErrorMessage(errorText: string): string {
-  const normalized = errorText.trim() || "Unknown error";
+  const normalized = normalizeChannelLifecycleErrorMessage(errorText);
   const truncated =
     normalized.length > DISCORD_LIFECYCLE_ERROR_TEXT_MAX
       ? `${normalized

--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+  normalizeChannelLifecycleErrorMessage,
+} from "./lifecycleError";
+
+describe("normalizeChannelLifecycleErrorMessage", () => {
+  test("keeps useful lifecycle details", () => {
+    expect(
+      normalizeChannelLifecycleErrorMessage(
+        "  ChatGPT usage limit reached. Resets at 1:00 PM.  ",
+      ),
+    ).toBe("ChatGPT usage limit reached. Resets at 1:00 PM.");
+  });
+
+  test("replaces raw generic loop errors with a stable user-facing fallback", () => {
+    expect(
+      normalizeChannelLifecycleErrorMessage("Unexpected stop reason: error"),
+    ).toBe(CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE);
+  });
+
+  test("uses the fallback for blank lifecycle details", () => {
+    expect(normalizeChannelLifecycleErrorMessage("   ")).toBe(
+      CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+    );
+  });
+});

--- a/src/channels/lifecycleError.ts
+++ b/src/channels/lifecycleError.ts
@@ -1,0 +1,14 @@
+const RAW_LOOP_ERROR_PATTERN = /^Unexpected stop reason:\s*error$/i;
+
+export const CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE =
+  "Something went wrong while processing that message. Please try again.";
+
+export function normalizeChannelLifecycleErrorMessage(
+  errorText: string | null | undefined,
+): string {
+  const normalized = errorText?.trim();
+  if (!normalized || RAW_LOOP_ERROR_PATTERN.test(normalized)) {
+    return CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE;
+  }
+  return normalized;
+}

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1234,6 +1234,47 @@ test("slack adapter dedupes lifecycle error posts by reply destination", async (
   });
 });
 
+test("slack adapter hides raw generic lifecycle errors", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-raw-error",
+    outcome: "error",
+    error: "Unexpected stop reason: error",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000501",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "Turn failed:\n```\nSomething went wrong while processing that message. Please try again.\n```",
+    thread_ts: "1712790000.000050",
+  });
+});
+
 test("slack adapter does not post an extra lifecycle message for cancelled turns", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -6,6 +6,7 @@ import {
   type InboundDebouncer,
 } from "@/channels/inboundDebounce";
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
+import { normalizeChannelLifecycleErrorMessage } from "@/channels/lifecycleError";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
@@ -710,7 +711,7 @@ export function createSlackAdapter(
   }
 
   function formatSlackLifecycleErrorMessage(errorText: string): string {
-    const normalized = errorText.trim();
+    const normalized = normalizeChannelLifecycleErrorMessage(errorText);
     const truncated =
       normalized.length > SLACK_LIFECYCLE_ERROR_TEXT_MAX
         ? `${normalized.slice(0, SLACK_LIFECYCLE_ERROR_TEXT_MAX - 1).trimEnd()}…`

--- a/src/channels/telegram-adapter.test.ts
+++ b/src/channels/telegram-adapter.test.ts
@@ -601,6 +601,44 @@ test("telegram adapter replies with lifecycle errors", async () => {
   );
 });
 
+test("telegram adapter hides raw generic lifecycle errors", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "error",
+    error: "Unexpected stop reason: error",
+    sources: [
+      {
+        channel: "telegram",
+        accountId: "telegram-test-account",
+        chatId: "123",
+        chatType: "direct",
+        messageId: "77",
+        threadId: null,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "123",
+    "Turn failed:\nSomething went wrong while processing that message. Please try again.",
+    { reply_parameters: { message_id: 77 } },
+  );
+});
+
 test("telegram adapter does not send lifecycle replies for completed turns", async () => {
   const adapter = createTelegramAdapter({
     ...telegramAccountDefaults,

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -7,6 +7,7 @@
 import type { ReactionType, ReactionTypeEmoji } from "@grammyjs/types";
 import type { Bot as GrammYBot, Context as GrammYContext } from "grammy";
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
+import { normalizeChannelLifecycleErrorMessage } from "@/channels/lifecycleError";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
@@ -211,7 +212,7 @@ function getTelegramLifecycleErrorReplyKey(
 }
 
 function formatTelegramLifecycleErrorMessage(errorText: string): string {
-  const normalized = errorText.trim() || "Unknown error";
+  const normalized = normalizeChannelLifecycleErrorMessage(errorText);
   const truncated =
     normalized.length > TELEGRAM_LIFECYCLE_ERROR_TEXT_MAX
       ? `${normalized


### PR DESCRIPTION
## Summary

Fixes https://github.com/letta-ai/letta-code/issues/2312.

Channel-routed turns could expose the internal lifecycle fallback `Unexpected stop reason: error` directly to users when the backend ended a run with `stop_reason: error` but did not provide a useful error detail. This was observed in Telegram, but Slack and Discord used the same class of lifecycle error reply path.

This PR adds a shared lifecycle error normalizer for channels. Useful backend details still pass through unchanged, while blank details and the raw generic stop reason become a stable user-facing fallback: “Something went wrong while processing that message. Please try again.” Telegram, Slack, and Discord lifecycle error formatting now all use that shared normalizer.

## Before / after

Before, Telegram could send:

Turn failed:
Unexpected stop reason: error

After, channels send:

Turn failed:
Something went wrong while processing that message. Please try again.

Specific actionable details, such as provider usage-limit messages, are preserved.

## Risk and tradeoffs

This is intentionally narrow: it does not change the underlying backend failure, retry behavior, or run metadata retrieval. It only prevents a known internal generic lifecycle string from leaking into external channels while keeping real details visible.

The fallback is shared across channel adapters so future lifecycle formatting stays consistent. Discord is covered by the shared normalizer even though the original report was Telegram.

## Validation

- bun test src/tests/channels/lifecycle-error.test.ts src/tests/channels/telegram-adapter.test.ts src/tests/channels/slack-adapter.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/channels/lifecycleError.ts src/channels/telegram/adapter.ts src/channels/slack/adapter.ts src/channels/discord/adapter.ts src/tests/channels/lifecycle-error.test.ts src/tests/channels/telegram-adapter.test.ts src/tests/channels/slack-adapter.test.ts

👾 Generated with [Letta Code](https://letta.com)