### PR TITLE
fix: handle retryable run metadata in listener and headless for error recovery

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2508,6 +2508,7 @@ ${SYSTEM_REMINDER_CLOSE}
         try {
           let errorType: string | undefined;
           let detail = detailFromRun ?? latestErrorText ?? "";
+          let explicitRetryable: boolean | undefined;
 
           if (lastRunId) {
             const run = await getBackend().retrieveRun(lastRunId);
@@ -2516,14 +2517,21 @@ ${SYSTEM_REMINDER_CLOSE}
                   error_type?: string;
                   message?: string;
                   detail?: string;
+                  retryable?: boolean;
                   // Handle nested error structure (error.error) that can occur in some edge cases
-                  error?: { error_type?: string; detail?: string };
+                  error?: {
+                    error_type?: string;
+                    detail?: string;
+                    retryable?: boolean;
+                  };
                 }
               | undefined;
 
             // Check for llm_error at top level or nested (handles error.error nesting)
             errorType = metaError?.error_type ?? metaError?.error?.error_type;
             detail = metaError?.detail ?? metaError?.error?.detail ?? detail;
+            explicitRetryable =
+              metaError?.retryable ?? metaError?.error?.retryable;
           }
 
           // Special handling for empty response errors (Opus 4.6 SADs)
@@ -2579,7 +2587,11 @@ ${SYSTEM_REMINDER_CLOSE}
             continue;
           }
 
-          if (shouldRetryRunMetadataError(errorType, detail)) {
+          if (
+            explicitRetryable === true ||
+            (explicitRetryable !== false &&
+              shouldRetryRunMetadataError(errorType, detail))
+          ) {
             const attempt = llmApiErrorRetries + 1;
             const delayMs = getRetryDelayMs({
               category: "transient_provider",

--- a/src/tests/websocket/recovery.test.ts
+++ b/src/tests/websocket/recovery.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { __testSetBackend, type Backend } from "../../backend";
 import { isRetriablePostStopError } from "../../websocket/listener/recovery";
+
+const capabilities = {
+  remoteMemfs: false,
+  serverSideToolManagement: false,
+  serverSecrets: false,
+  agentFileImportExport: false,
+  promptRecompile: false,
+  byokProviderRefresh: false,
+  localModelCatalog: true,
+  localMemfs: false,
+};
+
+function setRunErrorMetadata(error: unknown): void {
+  __testSetBackend({
+    capabilities,
+    async retrieveRun(runId: string) {
+      return {
+        id: runId,
+        metadata: { error },
+      };
+    },
+  } as unknown as Backend);
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+});
 
 describe("websocket post-stop retry fallback", () => {
   test("retries formatted Cloudflare 521 detail without a run id", async () => {
@@ -8,6 +36,30 @@ describe("websocket post-stop retry fallback", () => {
 
     await expect(isRetriablePostStopError("error", null, detail)).resolves.toBe(
       true,
+    );
+  });
+
+  test("honors explicit retryable run metadata", async () => {
+    setRunErrorMetadata({
+      error_type: "internal_error",
+      detail: "Authentication error",
+      retryable: true,
+    });
+
+    await expect(isRetriablePostStopError("error", "run-1")).resolves.toBe(
+      true,
+    );
+  });
+
+  test("honors explicit non-retryable run metadata", async () => {
+    setRunErrorMetadata({
+      error_type: "llm_error",
+      detail: "HTTP 503: provider overloaded",
+      retryable: false,
+    });
+
+    await expect(isRetriablePostStopError("error", "run-1")).resolves.toBe(
+      false,
     );
   });
 });

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -150,12 +150,24 @@ export async function isRetriablePostStopError(
       | {
           error_type?: string;
           detail?: string;
-          error?: { error_type?: string; detail?: string };
+          retryable?: boolean;
+          error?: {
+            error_type?: string;
+            detail?: string;
+            retryable?: boolean;
+          };
         }
       | undefined;
 
     const errorType = metaError?.error_type ?? metaError?.error?.error_type;
     const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
+    const retryable = metaError?.retryable ?? metaError?.error?.retryable;
+    if (retryable === false) {
+      return false;
+    }
+    if (retryable === true) {
+      return true;
+    }
     return shouldRetryRunMetadataError(errorType, detail);
   } catch {
     return shouldRetryRunMetadataError(undefined, fallbackDetail);


### PR DESCRIPTION
## Summary
- bring listener and headless retry handling to TUI parity for explicit run metadata
- match the existing TUI decision order: honor retryable=false, then retryable=true, then fall back to shouldRetryRunMetadataError(...) string/pattern classification
- keep DB-specific retry classification out of letta-code; the cloud runtime PR is responsible for emitting retryable=true metadata for retryable DB failures
- add focused listener coverage for retryable=true and retryable=false metadata

## Context
The TUI path already reads run.metadata.error.retryable in src/cli/app/retry.ts before falling back to the shared string classifier. Listener/headless were only using the fallback classifier, so metadata emitted by the backend could be ignored in those modes. This PR copies the TUI metadata semantics into the listener/headless paths without expanding the shared retry classifier.

## Test plan
- bun test src/tests/websocket/recovery.test.ts src/tests/cli/retry.test.ts
- bun run typecheck
- git diff --check