### PR TITLE
fix(cli): trim finalized reasoning newlines

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -16,6 +16,7 @@ import { extractCompactionSummary } from "./backfill";
 import type { ContextTracker } from "./contextTracker";
 import { MAX_CONTEXT_HISTORY } from "./contextTracker";
 import { findLastSafeSplitPoint } from "./markdownSplit";
+import { trimFinishedReasoningText } from "./reasoningText";
 import { isShellOutputTool } from "./toolNameMapping";
 
 type CompactionSummaryMessageChunk = {
@@ -385,17 +386,32 @@ function markAsFinished(b: Buffers, id: string) {
   const line = b.byId.get(id);
   // console.log(`[MARK_FINISHED] Called for ${id}, line exists: ${!!line}, kind: ${line?.kind}, phase: ${(line as any)?.phase}`);
   if (line && "phase" in line && line.phase === "streaming") {
-    const updatedLine = { ...line, phase: "finished" as const };
+    const updatedLine =
+      line.kind === "reasoning"
+        ? {
+            ...line,
+            text: trimFinishedReasoningText(line.text),
+            phase: "finished" as const,
+          }
+        : { ...line, phase: "finished" as const };
     b.byId.set(id, updatedLine);
     // console.log(`[MARK_FINISHED] Successfully marked ${id} as finished`);
 
     // Track last reasoning content for hooks (PostToolUse and Stop will include it)
-    if (line.kind === "reasoning" && "text" in line && line.text) {
-      b.lastReasoning = line.text;
+    if (
+      updatedLine.kind === "reasoning" &&
+      "text" in updatedLine &&
+      updatedLine.text
+    ) {
+      b.lastReasoning = updatedLine.text;
     }
     // Track last assistant message for hooks (PostToolUse will include it)
-    if (line.kind === "assistant" && "text" in line && line.text) {
-      b.lastAssistantMessage = line.text;
+    if (
+      updatedLine.kind === "assistant" &&
+      "text" in updatedLine &&
+      updatedLine.text
+    ) {
+      b.lastAssistantMessage = updatedLine.text;
     }
   } else {
     // console.log(`[MARK_FINISHED] Did NOT mark ${id} as finished (conditions not met)`);
@@ -740,8 +756,6 @@ function trySplitContent(
 
   const beforeText = newText.substring(0, splitPoint);
   const afterText = newText.substring(splitPoint);
-  const committedText =
-    kind === "reasoning" ? beforeText.replace(/\n+$/g, "") : beforeText;
 
   // Get or initialize split counter for this original ID
   const counter = b.splitCounters.get(id) ?? 0;
@@ -754,7 +768,8 @@ function trySplitContent(
   const committedLine = {
     kind,
     id: commitId,
-    text: committedText,
+    text:
+      kind === "reasoning" ? trimFinishedReasoningText(beforeText) : beforeText,
     phase: "finished" as const,
     isContinuation: counter > 0, // First split shows bullet, subsequent don't
     messageId:

--- a/src/cli/helpers/backfill.ts
+++ b/src/cli/helpers/backfill.ts
@@ -12,6 +12,7 @@ import {
   SYSTEM_REMINDER_OPEN,
 } from "../../constants";
 import type { Buffers } from "./accumulator";
+import { trimFinishedReasoningText } from "./reasoningText";
 import { extractTaskNotificationsForDisplay } from "./taskNotifications";
 
 /**
@@ -247,7 +248,7 @@ export function backfillBuffers(buffers: Buffers, history: Message[]): void {
         buffers.byId.set(lineId, {
           kind: "reasoning",
           id: lineId,
-          text: msg.reasoning,
+          text: trimFinishedReasoningText(msg.reasoning ?? ""),
           phase: "finished",
           messageId: msg.id,
         });

--- a/src/cli/helpers/reasoningText.ts
+++ b/src/cli/helpers/reasoningText.ts
@@ -1,0 +1,3 @@
+export function trimFinishedReasoningText(text: string): string {
+  return text.replace(/\n+$/g, "");
+}

--- a/src/tests/cli/accumulator-usage.test.ts
+++ b/src/tests/cli/accumulator-usage.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
-import { createBuffers, onChunk } from "../../cli/helpers/accumulator";
+import {
+  createBuffers,
+  markCurrentLineAsFinished,
+  onChunk,
+} from "../../cli/helpers/accumulator";
 import { createContextTracker } from "../../cli/helpers/contextTracker";
 
 function usageChunk(
@@ -533,6 +537,25 @@ describe("accumulator usage statistics", () => {
     expect(live && "isContinuation" in live ? live.isContinuation : false).toBe(
       true,
     );
+  });
+
+  test("trims trailing reasoning newlines when finalizing unsplit reasoning", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-final-newline",
+      reasoning: "Creating a pull request\n\n",
+    } as unknown as LettaStreamingResponse);
+    markCurrentLineAsFinished(buffers);
+
+    const line = buffers.byId.get("reasoning-final-newline");
+    expect(line?.kind).toBe("reasoning");
+    expect(line && "text" in line ? line.text : "").toBe(
+      "Creating a pull request",
+    );
+    expect(line && "phase" in line ? line.phase : "").toBe("finished");
+    expect(buffers.lastReasoning).toBe("Creating a pull request");
   });
 
   test("reconciles optimistic user lines to the backend message id via otid", () => {

--- a/src/tests/cli/backfill-approval-response.test.ts
+++ b/src/tests/cli/backfill-approval-response.test.ts
@@ -4,6 +4,26 @@ import { createBuffers } from "../../cli/helpers/accumulator";
 import { backfillBuffers } from "../../cli/helpers/backfill";
 
 describe("backfill approval response handling", () => {
+  test("trims trailing newlines from backfilled reasoning messages", () => {
+    const buffers = createBuffers();
+    const history = [
+      {
+        id: "reasoning-1",
+        message_type: "reasoning_message",
+        reasoning: "Creating a pull request\n\n",
+      },
+    ] as unknown as Message[];
+
+    backfillBuffers(buffers, history);
+
+    const line = buffers.byId.get("reasoning-1");
+    expect(line).toMatchObject({
+      kind: "reasoning",
+      text: "Creating a pull request",
+      phase: "finished",
+    });
+  });
+
   test("merges local approval requests and tool returns into tool call lines", () => {
     const buffers = createBuffers();
     const history = [


### PR DESCRIPTION
## Summary
- Trim trailing newlines when reasoning transcript rows are finalized, so Responses reasoning chunks that end with `\n\n` do not leave extra blank rows in the TUI.
- Replace the previous static-split-only trimming with shared finalized-reasoning normalization, while preserving that split behavior.
- Apply the same normalization to backfilled reasoning messages so resumed transcripts render consistently.

## Test plan
- [x] `bun test src/tests/cli/accumulator-usage.test.ts src/tests/cli/backfill-approval-response.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)