### PR TITLE
fix(cli): render indented markdown fences

### DIFF
--- a/src/cli/components/MarkdownDisplay.tsx
+++ b/src/cli/components/MarkdownDisplay.tsx
@@ -20,7 +20,8 @@ interface MarkdownDisplayProps {
 
 // Regex patterns for markdown elements (defined outside component to avoid re-creation)
 const headerRegex = /^(#{1,6})\s+(.*)$/;
-const codeBlockRegex = /^```([^\s`]*)?.*$/;
+const codeBlockOpenRegex = /^ *(`{3,}|~{3,}) *([^\s`~]*)?.*$/;
+const codeBlockCloseRegex = /^ *(`{3,}|~{3,}) *$/;
 const listItemRegex = /^(\s*)([*\-+]|\d+\.)\s+(.*)$/;
 const blockquoteRegex = /^>\s*(.*)$/;
 const hrRegex = /^[-*_]{3,}$/;
@@ -70,6 +71,7 @@ export const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({
   let inCodeBlock = false;
   let codeBlockContent: string[] = [];
   let codeBlockLanguage: string | undefined;
+  let codeBlockFence = "";
 
   const resolveFenceLanguage = (rawLanguage: string | undefined) => {
     if (!rawLanguage) return undefined;
@@ -229,26 +231,35 @@ export const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({
     const key = `line-${index}`;
 
     // Handle code blocks
-    const codeBlockMatch = line.match(codeBlockRegex);
-    if (codeBlockMatch) {
-      if (!inCodeBlock) {
-        inCodeBlock = true;
-        codeBlockContent = [];
-        codeBlockLanguage = resolveFenceLanguage(codeBlockMatch[1]);
-      } else {
+    if (inCodeBlock) {
+      const codeBlockCloseMatch = line.match(codeBlockCloseRegex);
+      const fence = codeBlockCloseMatch?.[1] ?? "";
+      if (
+        codeBlockCloseMatch &&
+        fence.startsWith(codeBlockFence[0] ?? "") &&
+        fence.length >= codeBlockFence.length
+      ) {
         inCodeBlock = false;
         const code = codeBlockContent.join("\n");
         contentBlocks.push(renderCodeBlock(code, codeBlockLanguage, key));
         codeBlockContent = [];
         codeBlockLanguage = undefined;
+        codeBlockFence = "";
+        index++;
+        continue;
       }
+
+      codeBlockContent.push(line);
       index++;
       continue;
     }
 
-    // If we're inside a code block, collect the content
-    if (inCodeBlock) {
-      codeBlockContent.push(line);
+    const codeBlockOpenMatch = line.match(codeBlockOpenRegex);
+    if (codeBlockOpenMatch) {
+      inCodeBlock = true;
+      codeBlockContent = [];
+      codeBlockFence = codeBlockOpenMatch[1] ?? "";
+      codeBlockLanguage = resolveFenceLanguage(codeBlockOpenMatch[2]);
       index++;
       continue;
     }

--- a/src/tests/cli/markdown-display-code-highlighting.test.tsx
+++ b/src/tests/cli/markdown-display-code-highlighting.test.tsx
@@ -95,6 +95,27 @@ test("markdown code block fallback renders plain code content", async () => {
   expect(stripAnsi(output)).toContain("bun run check");
 });
 
+test("markdown renders indented fenced code blocks inside list items", async () => {
+  const output = await renderMarkdown(
+    [
+      "1. Immediately, via the tool result",
+      "   CreateWorktree returns text like:",
+      "   ```txt",
+      "   Created worktree.",
+      "",
+      "   Path: /tmp/worktree",
+      "   ```",
+    ].join("\n"),
+  );
+  const plain = stripAnsi(output);
+
+  expect(plain).toContain("1. Immediately, via the tool result");
+  expect(plain).toContain("Created worktree.");
+  expect(plain).toContain("Path: /tmp/worktree");
+  expect(plain).not.toContain("```txt");
+  expect(plain).not.toContain("```");
+});
+
 test("MarkdownDisplay wires fenced code blocks through syntax highlighting", () => {
   const sourcePath = fileURLToPath(
     new URL("../../cli/components/MarkdownDisplay.tsx", import.meta.url),


### PR DESCRIPTION
## Summary
- Allow assistant markdown code fences with leading indentation to enter the existing code-block render path.
- Track opening fence character/length so indented backtick and tilde fences close correctly.
- Add a regression for a numbered-list example with an indented `txt` fence so raw backticks no longer render in the TUI.

## Test plan
- [x] `bun test src/tests/cli/markdown-display-code-highlighting.test.tsx`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)