### PR TITLE
fix(cli): load settings before cwd switches

### DIFF
--- a/src/tests/tools/create-worktree.test.ts
+++ b/src/tests/tools/create-worktree.test.ts
@@ -213,6 +213,9 @@ describe("CreateWorktree tool", () => {
         "conv-b",
       ),
     ).toBe(repo);
+    expect(() =>
+      settingsManager.getConversationGoal("conv-a", result.worktree_path),
+    ).not.toThrow();
   });
 
   test("switches the current session cwd outside listener mode", async () => {
@@ -241,6 +244,9 @@ describe("CreateWorktree tool", () => {
     expect(result.switched_cwd).toBe(true);
     expect(process.cwd()).toBe(result.worktree_path);
     expect(process.env.USER_CWD).toBe(result.worktree_path);
+    expect(() =>
+      settingsManager.getConversationGoal("conv-plain", result.worktree_path),
+    ).not.toThrow();
     expect(result.content[0]?.text).toContain(
       "This conversation's working directory is now the new worktree.",
     );

--- a/src/websocket/listener/cwd-change.ts
+++ b/src/websocket/listener/cwd-change.ts
@@ -6,6 +6,7 @@ import {
   setIndexRoot,
 } from "../../cli/helpers/fileIndex";
 import { updateRuntimeContext } from "../../runtime-context";
+import { settingsManager } from "../../settings-manager";
 import {
   getWorkingDirectoryScopeKey,
   setConversationWorkingDirectory,
@@ -39,9 +40,19 @@ async function refreshIndexForWorkingDirectory(
   void ensureFileIndex();
 }
 
+async function loadSettingsForWorkingDirectory(
+  workingDirectory: string,
+): Promise<void> {
+  await Promise.all([
+    settingsManager.loadProjectSettings(workingDirectory),
+    settingsManager.loadLocalProjectSettings(workingDirectory),
+  ]);
+}
+
 export async function switchCurrentRuntimeWorkingDirectory(
   workingDirectory: string,
 ): Promise<void> {
+  await loadSettingsForWorkingDirectory(workingDirectory);
   process.chdir(workingDirectory);
   process.env.USER_CWD = workingDirectory;
   updateRuntimeContext({ workingDirectory });
@@ -61,6 +72,8 @@ export async function switchConversationWorkingDirectory(params: {
   const { runtime, workingDirectory } = params;
   const agentId = normalizeCwdAgentId(params.agentId);
   const conversationId = normalizeConversationId(params.conversationId);
+
+  await loadSettingsForWorkingDirectory(workingDirectory);
 
   setConversationWorkingDirectory(
     runtime,


### PR DESCRIPTION
## Summary
- Load project and local project settings before switching the active working directory.
- Covers both plain CLI cwd changes and per-conversation worktree cwd switches so synchronous UI reads after `CreateWorktree` do not hit an unloaded settings cache.
- Add CreateWorktree regression assertions for the new cwd settings cache.

## Test plan
- [x] `bun test src/tests/tools/create-worktree.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)