### PR TITLE
fix(cli): summarize worktree tool results

### DIFF
--- a/src/cli/components/CreateWorktreeResultRenderer.tsx
+++ b/src/cli/components/CreateWorktreeResultRenderer.tsx
@@ -1,0 +1,117 @@
+import { Box } from "ink";
+import { CLI_GLYPHS } from "../helpers/glyphs";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+import { Text } from "./Text";
+
+const PREFIX_WIDTH = 5; // `  └  ` or `     `
+const LABEL_WIDTH = 8;
+
+export interface CreateWorktreeDisplayResult {
+  path?: string;
+  branch?: string;
+  base?: string;
+  switchedCwd?: boolean;
+}
+
+export function parseCreateWorktreeResult(
+  text: string,
+): CreateWorktreeDisplayResult | null {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const firstLine = normalized.split("\n").find((line) => line.trim());
+  if (firstLine?.trim() !== "Created worktree.") {
+    return null;
+  }
+
+  const field = (name: string): string | undefined => {
+    const match = normalized.match(new RegExp(`^${name}:\\s*(.+)$`, "m"));
+    return match?.[1]?.trim();
+  };
+
+  const result: CreateWorktreeDisplayResult = {
+    path: field("Path"),
+    branch: field("Branch"),
+    base: field("Base"),
+  };
+
+  if (
+    normalized.includes(
+      "This conversation's working directory is now the new worktree.",
+    )
+  ) {
+    result.switchedCwd = true;
+  } else if (
+    normalized.includes(
+      "The conversation working directory was left unchanged.",
+    )
+  ) {
+    result.switchedCwd = false;
+  }
+
+  if (!result.path && !result.branch && !result.base) {
+    return null;
+  }
+
+  return result;
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  const columns = useTerminalWidth();
+  const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
+  const valueWidth = Math.max(0, contentWidth - LABEL_WIDTH);
+
+  return (
+    <Box flexDirection="row">
+      <Box width={PREFIX_WIDTH} flexShrink={0}>
+        <Text>{" ".repeat(PREFIX_WIDTH)}</Text>
+      </Box>
+      <Box flexGrow={1} width={contentWidth} flexDirection="row">
+        <Box width={LABEL_WIDTH} flexShrink={0}>
+          <Text dimColor>{label}:</Text>
+        </Box>
+        <Box flexGrow={1} width={valueWidth}>
+          <Text wrap="truncate-end">{value}</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+export function CreateWorktreeResultRenderer({
+  resultText,
+}: {
+  resultText: string;
+}) {
+  const parsed = parseCreateWorktreeResult(resultText);
+  const columns = useTerminalWidth();
+  const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
+
+  if (!parsed) {
+    return null;
+  }
+
+  const cwdStatus =
+    parsed.switchedCwd === undefined
+      ? undefined
+      : parsed.switchedCwd
+        ? "switched to worktree"
+        : "unchanged";
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Box width={PREFIX_WIDTH} flexShrink={0}>
+          <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
+        </Box>
+        <Box flexGrow={1} width={contentWidth}>
+          <Text>Created worktree</Text>
+        </Box>
+      </Box>
+      {parsed.path ? <DetailRow label="Path" value={parsed.path} /> : null}
+      {parsed.branch ? (
+        <DetailRow label="Branch" value={parsed.branch} />
+      ) : null}
+      {parsed.base ? <DetailRow label="Base" value={parsed.base} /> : null}
+      {cwdStatus ? <DetailRow label="CWD" value={cwdStatus} /> : null}
+    </Box>
+  );
+}

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -90,6 +90,10 @@ import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { AdvancedDiffRenderer } from "./AdvancedDiffRenderer";
 import { BlinkDot } from "./BlinkDot.js";
 import { CollapsedOutputDisplay } from "./CollapsedOutputDisplay";
+import {
+  CreateWorktreeResultRenderer,
+  parseCreateWorktreeResult,
+} from "./CreateWorktreeResultRenderer.js";
 import { colors } from "./colors.js";
 import {
   EditRenderer,
@@ -535,6 +539,14 @@ export const ToolCallMessage = memo(
             );
           }
           // Fall through to regular handling if parsing fails
+        }
+
+        // Check if this is CreateWorktree - show a compact structured summary
+        // instead of the full instructional tool return.
+        if (rawName === "CreateWorktree" && line.resultOk !== false) {
+          if (parseCreateWorktreeResult(extractedText)) {
+            return <CreateWorktreeResultRenderer resultText={extractedText} />;
+          }
         }
 
         // Check if this is ExitPlanMode - just show path, not plan content

--- a/src/tests/cli/create-worktree-result-renderer.test.tsx
+++ b/src/tests/cli/create-worktree-result-renderer.test.tsx
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { parseCreateWorktreeResult } from "../../cli/components/CreateWorktreeResultRenderer";
+import { ToolCallMessage } from "../../cli/components/ToolCallMessageRich";
+
+class CaptureStream extends Writable {
+  columns = 120;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+const createWorktreeResult = [
+  "Created worktree.",
+  "",
+  "Path: /Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+  "Branch: letta/render-test-worktree-a90824a8",
+  "Base: origin/main",
+  "",
+  "The conversation working directory was left unchanged.",
+  "",
+  "Next steps:",
+  "- Confirm you are in the new worktree with `git status` before editing.",
+  "- Read README, AGENTS.md, or other project setup docs before running commands.",
+].join("\n");
+
+async function renderCreateWorktreeToolCall(): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(
+    <ToolCallMessage
+      line={{
+        kind: "tool_call",
+        id: "call-create-worktree",
+        toolCallId: "call-create-worktree",
+        name: "CreateWorktree",
+        argsText: JSON.stringify({
+          name: "render-test-worktree",
+          switch_cwd: false,
+        }),
+        resultText: createWorktreeResult,
+        resultOk: true,
+        phase: "finished",
+      }}
+      isStreaming={false}
+    />,
+    {
+      stdout,
+      stdin: createInputStream(),
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("parses CreateWorktree tool result fields", () => {
+  expect(parseCreateWorktreeResult(createWorktreeResult)).toEqual({
+    path: "/Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+    branch: "letta/render-test-worktree-a90824a8",
+    base: "origin/main",
+    switchedCwd: false,
+  });
+});
+
+test("CreateWorktree tool result renders a compact structured summary", async () => {
+  const output = await renderCreateWorktreeToolCall();
+
+  expect(output).toContain("CreateWorktree");
+  expect(output).toContain("Created worktree");
+  expect(output).toContain("Path:");
+  expect(output).toContain("render-test-worktree");
+  expect(output).toContain("Branch:");
+  expect(output).toContain("letta/render-test-worktree-a90824a8");
+  expect(output).toContain("Base:");
+  expect(output).toContain("origin/main");
+  expect(output).toContain("CWD:");
+  expect(output).toContain("unchanged");
+  expect(output).not.toContain("Next steps");
+  expect(output).not.toContain("Confirm you are in the new worktree");
+});


### PR DESCRIPTION
## Summary
- Add a dedicated CreateWorktree result renderer that shows the important structured fields: path, branch, base, and cwd state.
- Hide the long next-steps boilerplate from the static TUI preview while preserving the full tool result for the transcript/model.
- Add parser and Ink rendering regression coverage for the compact worktree summary.

## Test plan
- [x] `bun test src/tests/cli/create-worktree-result-renderer.test.tsx`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)