### PR TITLE
fix(cli): clear stale ctrl+o hint when a newer tool call becomes last

### DIFF
--- a/src/cli/app/StaticTranscript.tsx
+++ b/src/cli/app/StaticTranscript.tsx
@@ -39,7 +39,7 @@ export function StaticTranscript({
 }) {
   return (
     <Static
-      key={`${renderEpoch}-${hiddenToolCallId ?? ""}`}
+      key={`${renderEpoch}-${hiddenToolCallId ?? ""}-${lastShellToolCallId ?? ""}`}
       items={items}
       style={{ flexDirection: "column" }}
     >


### PR DESCRIPTION
## Problem

When multiple shell tool calls run in sequence, all of them showed `(ctrl+o to expand)` instead of just the last one. The hint only cleared from older tool calls when ctrl+o was pressed (which forced a Static remount).

Root cause: `<Static>` items are frozen once committed. When `lastShellToolCallId` changed (new tool call finished), the Static key did not change so it did not remount — leaving older items rendered with `isLast=true`.

## Fix

Add `lastShellToolCallId` to the Static key so it remounts whenever the "last" shell tool call changes. One line change.

The cost — one Static remount per completed shell tool call — is acceptable since Ink appends to the terminal rather than redrawing, making remounts essentially invisible.

👾 Generated with [Letta Code](https://letta.com)