### PR TITLE
Tag reviewers on actionable Codex watch issues

### DIFF
--- a/scripts/codex-watch/render-issue.ts
+++ b/scripts/codex-watch/render-issue.ts
@@ -5,6 +5,8 @@
 
 import type { ModelsDiff, Verdict } from "./diff-models-json.ts";
 
+const ACTION_REVIEWER = "@kl2806";
+
 export interface PathChangeSummary {
   path: string;
   /** One-line commit subjects under this path between the two refs. */
@@ -80,6 +82,10 @@ export function renderBody(input: RenderInput): string {
   parts.push("");
   parts.push(verdictRationale(input));
   parts.push("");
+  if (needsReviewerAttention(input)) {
+    parts.push(`Reviewer: ${ACTION_REVIEWER}`);
+    parts.push("");
+  }
 
   // Tool / schema deltas
   parts.push(`## Tool / schema deltas`);
@@ -173,6 +179,10 @@ export function renderBody(input: RenderInput): string {
   parts.push(`- Workflow run: ${input.workflow_run_url}`);
 
   return parts.join("\n");
+}
+
+function needsReviewerAttention(input: RenderInput): boolean {
+  return input.verdict !== "no-op";
 }
 
 function verdictRationale(input: RenderInput): string {

--- a/scripts/codex-watch/render-issue.ts
+++ b/scripts/codex-watch/render-issue.ts
@@ -5,7 +5,7 @@
 
 import type { ModelsDiff, Verdict } from "./diff-models-json.ts";
 
-const ACTION_REVIEWER = "@kl2806";
+const ACTION_REVIEWERS = ["@kl2806", "@devanshrj"];
 
 export interface PathChangeSummary {
   path: string;
@@ -83,7 +83,7 @@ export function renderBody(input: RenderInput): string {
   parts.push(verdictRationale(input));
   parts.push("");
   if (needsReviewerAttention(input)) {
-    parts.push(`Reviewer: ${ACTION_REVIEWER}`);
+    parts.push(`Reviewers: ${ACTION_REVIEWERS.join(" ")}`);
     parts.push("");
   }
 


### PR DESCRIPTION
## Summary
- mention @kl2806 and @devanshrj on generated codex-watch issues when the verdict is actionable
- leave no-op reports unmentioned to avoid unnecessary notifications

## Test plan
- [x] `bun test scripts/codex-watch/diff-models-json.test.ts`
- [x] `bun run typecheck`
- [x] `bunx --bun @biomejs/biome@2.2.5 check scripts/codex-watch .github/workflows/codex-release-watch.yml .github/CODEOWNERS src/agent/prompts/README.md`
- [x] `bun scripts/codex-watch/check-release.ts --dry-run --since rust-v0.130.0 --current rust-v0.131.0`

👾 Generated with [Letta Code](https://letta.com)