### PR TITLE
fix(channels): support /cancel slash command

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -133,6 +133,55 @@ Plugins that need Slack/Discord-style auto-routing or rich Desktop management
 remain first-party/bundled work for now. Custom plugins can still expose custom
 `MessageChannel` actions and schema fragments via `messageActions`.
 
+## Slack app manifest notes
+
+The bundled Slack channel runs in Socket Mode. The Slack app must still declare
+the events, scopes, and slash commands that Slack should deliver to Letta Code.
+For `/cancel`, add the `commands` bot scope and a native slash command entry:
+
+```yaml
+features:
+  slash_commands:
+    - command: /cancel
+      url: https://example.com/slack/commands
+      description: Cancel the in-progress Letta agent turn
+      usage_hint: ""
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - chat:write
+      - commands
+      - files:read
+      - files:write
+      - groups:history
+      - im:history
+      - reactions:read
+      - reactions:write
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - message.im
+      - reaction_added
+      - reaction_removed
+  socket_mode_enabled: true
+```
+
+Slack-native slash command payloads do not identify a thread. If `/cancel` is
+sent through Slack's native command UI in a channel, Letta Code can target the
+sole routed thread in that channel; if multiple Letta threads are routed there,
+send `/cancel` as a normal thread message instead so the thread route is
+unambiguous.
+
+The slash command `url` is present because Slack manifests require one; the
+Socket Mode listener receives the command over the app-level WebSocket.
+
 ## First-party vs user plugins
 
 First-party plugins are bundled in `src/channels/<id>/` and registered by the

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -16,11 +16,28 @@ export type ChannelSlashCommandDefinition = {
   summary: string;
 };
 
+export type ChannelSlashCommandHandlerResult = {
+  handled: boolean;
+  text?: string;
+};
+
+export type ChannelSlashCommandHandlers = {
+  cancel?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+};
+
 const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
   {
     name: "help",
     kind: "direct",
     summary: "Show channel usage guidance.",
+  },
+  {
+    name: "cancel",
+    kind: "agent-scoped",
+    summary: "Cancel the in-progress agent turn for this chat.",
   },
 ];
 
@@ -64,7 +81,6 @@ export function parseChannelSlashCommand(
 export function buildChannelHelpMessage(channelId: string): string {
   const displayName = channelDisplayName(channelId);
   const supportedCommands = listChannelSlashCommands()
-    .filter((definition) => definition.kind === "direct")
     .map((definition) => `/${definition.name}`)
     .join(", ");
 
@@ -83,7 +99,6 @@ export function buildUnsupportedChannelCommandMessage(
 ): string {
   const displayName = channelDisplayName(channelId);
   const supportedCommands = listChannelSlashCommands()
-    .filter((definition) => definition.kind === "direct")
     .map((definition) => `/${definition.name}`)
     .join(", ");
 
@@ -94,19 +109,50 @@ export function buildUnsupportedChannelCommandMessage(
   ].join("\n\n");
 }
 
+export function buildChannelCancelUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return [
+    `${displayName} received /cancel, but this chat is not connected to an active Letta Code conversation yet.`,
+    "Send a normal message first to connect this chat to an agent.",
+  ].join("\n\n");
+}
+
+export function buildChannelCancelNoActiveTurnMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} received /cancel, but there is no in-progress agent turn to cancel for this chat.`;
+}
+
+export function buildChannelCancelAcceptedMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cancelled the in-progress agent turn for this chat.`;
+}
+
 export async function tryHandleChannelSlashCommand(
   adapter: ChannelAdapter,
   msg: InboundChannelMessage,
+  handlers: ChannelSlashCommandHandlers = {},
 ): Promise<boolean> {
   const command = parseChannelSlashCommand(msg.text);
   if (!command) {
     return false;
   }
 
-  const text =
-    command.name === "help"
-      ? buildChannelHelpMessage(msg.channel)
-      : buildUnsupportedChannelCommandMessage(msg.channel, command);
+  let text: string;
+  if (command.name === "help") {
+    text = buildChannelHelpMessage(msg.channel);
+  } else if (command.name === "cancel" && handlers.cancel) {
+    const result = await handlers.cancel(command, msg);
+    if (!result.handled) {
+      return false;
+    }
+    text = result.text ?? buildChannelCancelAcceptedMessage(msg.channel);
+  } else {
+    text = buildUnsupportedChannelCommandMessage(msg.channel, command);
+  }
 
   await adapter.sendDirectReply(
     msg.chatId,

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,7 +19,12 @@ import {
   listChannelAccounts,
   loadChannelAccounts,
 } from "./accounts";
-import { tryHandleChannelSlashCommand } from "./commands";
+import {
+  buildChannelCancelNoActiveTurnMessage,
+  buildChannelCancelUnavailableMessage,
+  parseChannelSlashCommand,
+  tryHandleChannelSlashCommand,
+} from "./commands";
 import {
   formatChannelControlRequestPrompt,
   parseChannelControlRequestResponse,
@@ -249,6 +254,13 @@ export type ChannelApprovalResponseHandler = (params: {
   response: ApprovalResponseBody;
 }) => Promise<boolean>;
 
+export type ChannelCancelHandler = (params: {
+  runtime: {
+    agent_id: string;
+    conversation_id: string;
+  };
+}) => Promise<boolean>;
+
 type PendingChannelControlRequest = {
   event: ChannelControlRequestEvent;
   deliveredThisProcess: boolean;
@@ -288,6 +300,7 @@ export class ChannelRegistry {
   private messageHandler: ChannelMessageHandler | null = null;
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private approvalResponseHandler: ChannelApprovalResponseHandler | null = null;
+  private cancelHandler: ChannelCancelHandler | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
   private readonly pendingControlRequestsById = new Map<
     string,
@@ -418,6 +431,10 @@ export class ChannelRegistry {
     handler: ChannelApprovalResponseHandler | null,
   ): void {
     this.approvalResponseHandler = handler;
+  }
+
+  setCancelHandler(handler: ChannelCancelHandler | null): void {
+    this.cancelHandler = handler;
   }
 
   setEventHandler(
@@ -710,6 +727,7 @@ export class ChannelRegistry {
     this.messageHandler = null;
     this.eventHandler = null;
     this.approvalResponseHandler = null;
+    this.cancelHandler = null;
   }
 
   /**
@@ -726,6 +744,7 @@ export class ChannelRegistry {
     this.messageHandler = null;
     this.eventHandler = null;
     this.approvalResponseHandler = null;
+    this.cancelHandler = null;
     this.pendingControlRequestsById.clear();
     this.pendingControlRequestIdByScope.clear();
     instance = null;
@@ -737,6 +756,11 @@ export class ChannelRegistry {
     adapter: ChannelAdapter,
     msg: InboundChannelMessage,
   ): Promise<boolean> {
+    const slashCommand = parseChannelSlashCommand(msg.text);
+    if (slashCommand?.name === "cancel") {
+      return false;
+    }
+
     const scopeKey = getChannelApprovalScopeKey({
       channel: msg.channel,
       accountId: msg.accountId,
@@ -796,6 +820,39 @@ export class ChannelRegistry {
     return true;
   }
 
+  private async handleCancelSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.getRoute(
+      msg.channel,
+      msg.chatId,
+      msg.accountId,
+      msg.threadId,
+    );
+    if (!route?.enabled || !this.cancelHandler) {
+      return {
+        handled: true,
+        text: buildChannelCancelUnavailableMessage(msg.channel),
+      };
+    }
+
+    const cancelled = await this.cancelHandler({
+      runtime: {
+        agent_id: route.agentId,
+        conversation_id: route.conversationId,
+      },
+    });
+
+    if (!cancelled) {
+      return {
+        handled: true,
+        text: buildChannelCancelNoActiveTurnMessage(msg.channel),
+      };
+    }
+
+    return { handled: true };
+  }
+
   private async handleInboundMessage(
     msg: InboundChannelMessage,
   ): Promise<void> {
@@ -806,7 +863,12 @@ export class ChannelRegistry {
       return;
     }
 
-    if (await tryHandleChannelSlashCommand(adapter, msg)) {
+    if (
+      await tryHandleChannelSlashCommand(adapter, msg, {
+        cancel: async (_command, commandMsg) =>
+          this.handleCancelSlashCommand(commandMsg),
+      })
+    ) {
       return;
     }
 

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -823,12 +823,7 @@ export class ChannelRegistry {
   private async handleCancelSlashCommand(
     msg: InboundChannelMessage,
   ): Promise<{ handled: boolean; text?: string }> {
-    const route = this.getRoute(
-      msg.channel,
-      msg.chatId,
-      msg.accountId,
-      msg.threadId,
-    );
+    const route = this.getCancelRoute(msg);
     if (!route?.enabled || !this.cancelHandler) {
       return {
         handled: true,
@@ -851,6 +846,42 @@ export class ChannelRegistry {
     }
 
     return { handled: true };
+  }
+
+  private getCancelRoute(msg: InboundChannelMessage): ChannelRoute | null {
+    let route = this.getRoute(
+      msg.channel,
+      msg.chatId,
+      msg.accountId,
+      msg.threadId,
+    );
+    if (route) {
+      return route;
+    }
+
+    loadRoutes(msg.channel);
+    route = this.getRoute(msg.channel, msg.chatId, msg.accountId, msg.threadId);
+    if (route) {
+      return route;
+    }
+
+    if (
+      msg.channel !== "slack" ||
+      msg.chatType !== "channel" ||
+      msg.threadId != null
+    ) {
+      return null;
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const matches = getRoutesForChannel(msg.channel, accountId).filter(
+      (candidate) =>
+        candidate.chatId === msg.chatId &&
+        candidate.chatType === "channel" &&
+        candidate.enabled,
+    );
+
+    return matches.length === 1 ? (matches[0] ?? null) : null;
   }
 
   private async handleInboundMessage(

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -78,6 +78,16 @@ type SlackReactionEvent = {
   event_ts?: string;
 };
 
+type SlackCommandPayload = {
+  command?: string;
+  text?: string;
+  user_id?: string;
+  user_name?: string;
+  channel_id?: string;
+  channel_name?: string;
+  trigger_id?: string;
+};
+
 type Constructor = abstract new (...args: never[]) => unknown;
 
 function isConstructorFunction<T extends Constructor>(
@@ -1111,6 +1121,51 @@ export function createSlackAdapter(
         });
       } catch (error) {
         console.error("[Slack] Error handling channel mention:", error);
+      }
+    });
+
+    instance.command("/cancel", async ({ command, ack }) => {
+      await ack();
+
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      const payload = command as SlackCommandPayload;
+      if (
+        !isNonEmptyString(payload.channel_id) ||
+        !isNonEmptyString(payload.user_id)
+      ) {
+        return;
+      }
+
+      const commandText = isNonEmptyString(payload.text)
+        ? `/cancel ${payload.text.trim()}`
+        : "/cancel";
+
+      const inbound: InboundChannelMessage = {
+        channel: "slack",
+        accountId: config.accountId,
+        chatId: payload.channel_id,
+        senderId: payload.user_id,
+        senderName: firstNonEmptyString(payload.user_name, payload.user_id),
+        chatLabel: firstNonEmptyString(
+          payload.channel_name,
+          payload.channel_id,
+        ),
+        text: commandText,
+        timestamp: Date.now(),
+        messageId: firstNonEmptyString(payload.trigger_id, payload.command),
+        threadId: null,
+        chatType: resolveSlackChatType(payload.channel_id),
+        isMention: false,
+        raw: command,
+      };
+
+      try {
+        await adapter.onMessage(inbound);
+      } catch (error) {
+        console.error("[Slack] Error handling /cancel command:", error);
       }
     });
 

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -31,9 +31,12 @@ export async function runSlackSetup(): Promise<boolean> {
     console.log(
       "  4. Enable App Home messages and subscribe to app_mention + message.channels + message.groups + message.im + reaction_added + reaction_removed\n",
     );
+    console.log(
+      "  5. Add the /cancel slash command if you want Slack-native cancellation\n",
+    );
     console.log("Recommended bot token scopes:");
     console.log(
-      "  app_mentions:read, channels:history, chat:write, groups:history, im:history, users:read",
+      "  app_mentions:read, channels:history, chat:write, commands, groups:history, im:history, users:read",
     );
     console.log("  reactions:read, reactions:write, files:read, files:write\n");
 

--- a/src/tests/channels/commands.test.ts
+++ b/src/tests/channels/commands.test.ts
@@ -24,10 +24,13 @@ describe("channel slash commands", () => {
     expect(listChannelSlashCommands()).toContainEqual(
       expect.objectContaining({ name: "help", kind: "direct" }),
     );
+    expect(listChannelSlashCommands()).toContainEqual(
+      expect.objectContaining({ name: "cancel", kind: "agent-scoped" }),
+    );
 
     const text = buildChannelHelpMessage("telegram");
     expect(text).toContain("Telegram is connected to Letta Code.");
-    expect(text).toContain("Supported slash commands here: /help.");
+    expect(text).toContain("Supported slash commands here: /help, /cancel.");
   });
 
   test("builds a useful unsupported-command response", () => {
@@ -40,7 +43,7 @@ describe("channel slash commands", () => {
     const text = buildUnsupportedChannelCommandMessage("telegram", command);
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
-    expect(text).toContain("Supported slash commands here: /help.");
+    expect(text).toContain("Supported slash commands here: /help, /cancel.");
     expect(text).toContain("without a leading slash");
   });
 });

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -217,6 +217,137 @@ describe("ChannelRegistry", () => {
       "Telegram received /compact now, but that slash command is not supported in channels yet.",
     );
   });
+
+  test("/cancel invokes the channel cancel handler for the routed chat", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    const cancellations: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Slack cancelled the in-progress agent turn for this chat.",
+        replyToMessageId: "1712800000.000200",
+      },
+    ]);
+  });
+
+  test("/cancel reports when the routed chat has no active turn", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    registry.setMessageHandler(() => {});
+    registry.setCancelHandler(async () => false);
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("telegram", {
+      accountId: "acct-telegram",
+      chatId: "123",
+      chatType: "direct",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(replies[0]?.text).toBe(
+      "Telegram received /cancel, but there is no in-progress agent turn to cancel for this chat.",
+    );
+  });
 });
 
 describe("buildSlackConversationSummary", () => {
@@ -542,6 +673,62 @@ describe("pending channel control requests", () => {
         },
       },
     });
+  });
+
+  test("/cancel bypasses pending channel control prompts", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+    registry.setMessageHandler(() => {});
+
+    const approvalResponses: unknown[] = [];
+    registry.setApprovalResponseHandler(async (params) => {
+      approvalResponses.push(params);
+      return true;
+    });
+    const cancellations: unknown[] = [];
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    await registry.registerPendingControlRequest(
+      createPendingControlRequestEvent(),
+    );
+
+    await adapter.onMessage?.(createInboundMessage("/cancel"));
+
+    expect(approvalResponses).toHaveLength(0);
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Slack cancelled the in-progress agent turn for this chat.",
+        replyToMessageId: "1712800000.000200",
+      },
+    ]);
   });
 
   test("freeform multi-question channel replies approve instead of reprompting", async () => {

--- a/src/tests/channels/registry.test.ts
+++ b/src/tests/channels/registry.test.ts
@@ -348,6 +348,76 @@ describe("ChannelRegistry", () => {
       "Telegram received /cancel, but there is no in-progress agent turn to cancel for this chat.",
     );
   });
+
+  test("/cancel can target the sole Slack thread route when native commands omit thread metadata", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const cancellations: unknown[] = [];
+    const registry = new ChannelRegistry();
+    registry.setMessageHandler(() => {});
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "trigger-1",
+      threadId: null,
+      chatType: "channel",
+    });
+
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies[0]?.text).toBe(
+      "Slack cancelled the in-progress agent turn for this chat.",
+    );
+  });
 });
 
 describe("buildSlackConversationSummary", () => {

--- a/src/tests/channels/slack-adapter.test.ts
+++ b/src/tests/channels/slack-adapter.test.ts
@@ -37,6 +37,19 @@ type SlackEventHandler = (args: {
   };
 }) => Promise<void>;
 
+type SlackCommandHandler = (args: {
+  command: {
+    command?: string;
+    text?: string;
+    user_id?: string;
+    user_name?: string;
+    channel_id?: string;
+    channel_name?: string;
+    trigger_id?: string;
+  };
+  ack: () => Promise<void>;
+}) => Promise<void>;
+
 class FakeSlackApp {
   static instances: FakeSlackApp[] = [];
 
@@ -82,6 +95,7 @@ class FakeSlackApp {
 
   messageHandler: SlackMessageHandler | null = null;
   eventHandlers = new Map<string, SlackEventHandler>();
+  commandHandlers = new Map<string, SlackCommandHandler>();
   errorHandler: ((error: Error) => Promise<void>) | null = null;
   readonly init = mock(async () => {});
   readonly start = mock(async () => {});
@@ -97,6 +111,10 @@ class FakeSlackApp {
 
   event(name: string, handler: SlackEventHandler): void {
     this.eventHandlers.set(name, handler);
+  }
+
+  command(name: string, handler: SlackCommandHandler): void {
+    this.commandHandlers.set(name, handler);
   }
 
   error(handler: (error: Error) => Promise<void>): void {
@@ -272,6 +290,59 @@ test("slack adapter start does not re-run bolt init", async () => {
   expect(app).toBeDefined();
   expect(app?.init).not.toHaveBeenCalled();
   expect(app?.start).toHaveBeenCalledTimes(1);
+});
+
+test("slack adapter forwards native /cancel command as channel slash input", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const messages: unknown[] = [];
+  adapter.onMessage = async (message) => {
+    messages.push(message);
+  };
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.commandHandlers.get("/cancel");
+  if (!handler) {
+    throw new Error("Expected /cancel command handler");
+  }
+
+  const ack = mock(async () => {});
+  await handler({
+    command: {
+      command: "/cancel",
+      text: "",
+      user_id: "U123",
+      user_name: "Alice",
+      channel_id: "C123",
+      channel_name: "eng",
+      trigger_id: "trigger-1",
+    },
+    ack,
+  });
+
+  expect(ack).toHaveBeenCalledTimes(1);
+  expect(messages).toHaveLength(1);
+  expect(messages[0]).toMatchObject({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    senderId: "U123",
+    senderName: "Alice",
+    chatLabel: "eng",
+    text: "/cancel",
+    messageId: "trigger-1",
+    threadId: null,
+    chatType: "channel",
+  });
 });
 
 test("resolveSlackAccountDisplayName prefers the Slack bot profile display name", async () => {

--- a/src/tests/tools/tool-execution-context.test.ts
+++ b/src/tests/tools/tool-execution-context.test.ts
@@ -17,7 +17,12 @@ import {
 } from "../../channels/accounts";
 import { clearDynamicMessageChannelToolCache } from "../../channels/messageTool";
 import { ChannelRegistry, getChannelRegistry } from "../../channels/registry";
-import { setRouteInMemory } from "../../channels/routing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  setRouteInMemory,
+} from "../../channels/routing";
 import type { ChannelAdapter } from "../../channels/types";
 import { runWithRuntimeContext } from "../../runtime-context";
 import {
@@ -77,6 +82,9 @@ describe("tool execution context snapshot", () => {
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
     clearExternalTools();
+    clearAllRoutes();
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
     clearChannelAccountStores();
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
@@ -411,6 +419,8 @@ describe("tool execution context snapshot", () => {
 
   test("does not leak MessageChannel into conversations that only share an agent-level Slack account", async () => {
     installChannelAccountTestOverrides();
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
     await loadSpecificTools(["Read"]);
 
     const registry = new ChannelRegistry();
@@ -447,6 +457,8 @@ describe("tool execution context snapshot", () => {
 
   test("includes MessageChannel in scoped snapshots when the conversation has a Slack route", async () => {
     installChannelAccountTestOverrides();
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
     await loadSpecificTools(["Read"]);
 
     const registry = new ChannelRegistry();

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -404,7 +404,7 @@ export async function handleAbortMessageInput(
   listener: ListenerRuntime,
   params: {
     command: AbortMessageCommand;
-    socket: WebSocket;
+    socket: ListenerTransport;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];
       connectionId?: string;

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -439,6 +439,20 @@ export async function wireChannelIngress(
     }),
   );
 
+  registry.setCancelHandler(async ({ runtime }) =>
+    handleAbortMessageInput(listener, {
+      command: {
+        type: "abort_message",
+        runtime,
+        request_id: `channel-cancel-${crypto.randomUUID()}`,
+        run_id: null,
+      },
+      socket,
+      opts,
+      processQueuedTurn,
+    }),
+  );
+
   registry.setReady();
 }
 


### PR DESCRIPTION
## Summary
This adds `/cancel` as a supported Letta channel slash command so Slack, Telegram, Discord, and custom-channel users can interrupt an in-progress agent turn from the channel surface. It mirrors the TUI Esc behavior by routing the command through the listener's existing `abort_message` handling instead of inventing a separate cancellation path.

It also wires Slack-native `/cancel` command payloads into the same shared channel ingress path, and documents the required Slack app manifest/setup changes so the runtime change is not mistaken for automatic Slack app configuration.

## Problem
Channel users currently have no direct equivalent of pressing Esc in the TUI. If a channel-originated turn is running too long, stuck on a tool, or waiting on a control prompt, the user has to switch surfaces or wait for the run to finish.

Slack has two relevant command surfaces: normal channel messages that begin with `/cancel`, and Slack-native slash commands configured in the Slack app manifest. The shared channel parser can handle the first case by itself; the second case only works when the Slack app declares the command and the adapter receives a Bolt command payload.

## Approach
The shared channel slash-command router now advertises `/cancel` and accepts an agent-scoped handler. `ChannelRegistry` resolves the inbound chat/thread to its existing channel route, bypasses pending control-prompt replies for `/cancel`, and calls a listener-provided cancel handler. `wireChannelIngress` connects that handler to `handleAbortMessageInput`, which already sets cancellation state, aborts active controllers, rejects pending approvals, updates runtime status, and calls backend conversation cancellation.

The Slack adapter registers a native `/cancel` Bolt command handler and converts it into a normal `InboundChannelMessage`, so both native Slack commands and typed channel messages use the same cancellation logic. Because Slack-native slash command payloads do not identify the originating thread, the registry targets the sole routed thread for that Slack channel when there is exactly one unambiguous match; otherwise users can still send `/cancel` as a normal thread message.

The channel README now includes the Slack manifest additions for `/cancel`, including the `commands` bot scope, and the Slack setup prompt calls out the native command setup step.

## Before / after
Before: `/cancel` in a channel was treated as unsupported slash-command text or could be swallowed as a pending control-prompt reply. A Slack-native `/cancel` command was not registered by the adapter and would not reach Letta Code even if configured in Slack.

After: `/cancel` for a routed channel chat cancels the in-progress turn for that agent conversation. If there is no active turn, the channel gets an explicit no-op message. If the chat is not routed/connected yet, the channel gets connection guidance. A configured Slack-native `/cancel` command now reaches the same path.

## Risk and limits
Risk is mostly in channel command routing order and Slack thread ambiguity. The new tests cover routed cancellation, no-active-turn behavior, pending-control bypass, Slack-native command adapter routing, route-store isolation, and the sole-thread fallback for native Slack commands. The change intentionally does not expose other TUI slash commands in channels.

Slack-native command payloads still cannot identify one thread among many routed threads in the same channel. In that ambiguous case, users should send `/cancel` as a normal message in the target thread.

## Validation
- `bun test src/tests/channels/slack-adapter.test.ts src/tests/tools/tool-execution-context.test.ts src/tests/channels/commands.test.ts src/tests/channels/registry.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check --write src/channels/README.md src/channels/registry.ts src/channels/slack/setup.ts src/tests/channels/registry.test.ts src/channels/slack/adapter.ts src/tests/channels/slack-adapter.test.ts src/tests/tools/tool-execution-context.test.ts`
- `git diff --check`

👾 Generated with [Letta Code](https://letta.com)
