### PR TITLE
fix(cli): hide /reflection alias from autocomplete menu

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -81,6 +81,7 @@ export const commands: Record<string, Command> = {
   "/reflection": {
     desc: "Alias for /reflect",
     args: "[transcript_file]",
+    hidden: true,
     handler: () => {
       // Handled specially in App.tsx
       return "Launching reflection agent...";


### PR DESCRIPTION
Hides `/reflection` from the `/` commands list using the existing `hidden: true` flag, while keeping it functional when typed directly.

Reduces menu clutter without breaking backwards compatibility.

👾 Generated with [Letta Code](https://letta.com)