### PR TITLE
fix(channels): clarify channel opt-out envelope

### DIFF
--- a/src/channels/messageTool.ts
+++ b/src/channels/messageTool.ts
@@ -132,7 +132,7 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
 
   const scopedReplyContract =
     scope && scope.channels.length > 0
-      ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. For the user-visible reply, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply.'
+      ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply. If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement.'
       : "";
 
   return `${description}${scopedReplyContract}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -49,7 +49,8 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const lines = [
     SYSTEM_REMINDER_OPEN,
     `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
-    `To reply, your final action for this turn MUST be exactly one MessageChannel call with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
+    `If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
+    "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
     "Do not produce a plain text assistant response as the user-visible reply.",
     "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",
     "Only pass replyTo if you intentionally want the platform's quote/reply UI.",

--- a/src/tests/channels/message-tool-schema.test.ts
+++ b/src/tests/channels/message-tool-schema.test.ts
@@ -139,7 +139,10 @@ describe("buildDynamicMessageChannelSchema", () => {
       "Plain assistant text is not delivered to that external user.",
     );
     expect(resolved.description).toContain(
-      "final action for the turn must be one MessageChannel call",
+      "If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call",
+    );
+    expect(resolved.description).toContain(
+      "If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement.",
     );
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);

--- a/src/tests/channels/xml.test.ts
+++ b/src/tests/channels/xml.test.ts
@@ -64,7 +64,10 @@ describe("formatChannelNotification", () => {
       "Plain assistant text is not delivered to the user.",
     );
     expect(reminder).toContain(
-      'MUST be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+      'If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+    );
+    expect(reminder).toContain(
+      "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
     );
     expect(reminder).toContain(
       "Do not produce a plain text assistant response as the user-visible reply.",
@@ -87,7 +90,7 @@ describe("formatChannelNotification", () => {
     const xml = buildChannelNotificationXml(msg);
 
     expect(reminder).toContain(
-      'MUST be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+      'If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
     );
     expect(reminder).not.toContain('accountId="account-1"');
     expect(xml).toContain('account_id="account-1"');


### PR DESCRIPTION
## Summary
This updates the Slack/channel notification envelope and scoped MessageChannel tool description so agents can tell the difference between two cases:

1. The external user should receive a visible reply, in which case the final action still needs to be a MessageChannel send.
2. No visible reply is appropriate, in which case the agent should simply not call MessageChannel and should not send an empty acknowledgement.

## Problem
The existing envelope was intentionally forceful because plain assistant text is not visible to Slack users. That helped prevent missed replies, but it over-corrected by saying the final action MUST be exactly one MessageChannel call. In threads where the right behavior is silence, agents can interpret that as needing to call MessageChannel anyway, which matches the empty-message behavior Cameron called out.

## Approach
I kept the important routed-channel contract intact: plain assistant text still is not the user-visible reply, and real external replies still go through MessageChannel with the notification channel and chat_id. The change is only to make the conditional explicit: reply via MessageChannel if a user-visible response is appropriate; otherwise do not call the tool and do not send an empty acknowledgement.

I updated both places that reinforce this behavior:
- the system-reminder text generated for inbound channel notifications
- the scoped dynamic MessageChannel tool description shown during routed external channel turns

## Before / after
Before: the envelope said the final action MUST be exactly one MessageChannel call, even for turns where silence was intended.

After: the envelope still directs visible replies through MessageChannel, but explicitly says that opting out means not calling MessageChannel at all.

## Risk
This slightly softens the channel reply instruction. The risk is that some agents may under-reply in Slack if they over-interpret the opt-out clause. The wording tries to keep that bounded by only allowing silence when no user-visible response is appropriate, while preserving the plain-text-is-not-delivered warning.

## Validation
- bun test src/tests/channels/xml.test.ts
- bun test src/tests/channels/message-tool-schema.test.ts

👾 Generated with [Letta Code](https://letta.com)
