### PR TITLE
feat(cli): customizable terminal window title via /title command

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -78,6 +78,7 @@ import {
   isDebugEnabled,
 } from "../../utils/debug";
 import { recordTuiPerf } from "../../utils/tuiPerf";
+import { getVersion } from "../../version";
 import {
   type CommandFinishedEvent,
   type CommandHandle,
@@ -141,6 +142,10 @@ import {
 } from "../helpers/toolNameMapping";
 import { isTaskTool } from "../helpers/toolNameMapping.js";
 import { getTuiBlockedReason } from "../helpers/tuiQueueAdapter";
+import {
+  renderWindowTitle,
+  resolveWindowTitleConfig,
+} from "../helpers/windowTitleConfig";
 import { useConfigurableStatusLine } from "../hooks/useConfigurableStatusLine";
 import { useSuspend } from "../hooks/useSuspend/useSuspend.ts";
 import { useSyncedState } from "../hooks/useSyncedState";
@@ -239,6 +244,9 @@ export default function App({
 
   // Track current conversation (always created fresh on startup)
   const [conversationId, setConversationId] = useState(initialConversationId);
+  const [conversationSummary, setConversationSummary] = useState<string | null>(
+    null,
+  );
 
   // Keep a ref to the current agentId for use in callbacks that need the latest value
   const agentIdRef = useRef(agentId);
@@ -307,14 +315,6 @@ export default function App({
       setCurrentAgentId(agentId);
     }
   }, [agentId]);
-
-  // Set terminal title to "{Agent Name} | Letta Code"
-  useEffect(() => {
-    const title = agentState?.name
-      ? `${agentState.name} | Letta Code`
-      : "Letta Code";
-    process.stdout.write(`\x1b]0;${title}\x07`);
-  }, [agentState?.name]);
 
   // Whether a stream is in flight (disables input)
   // Uses synced state to keep ref in sync for reliable async checks
@@ -781,6 +781,19 @@ export default function App({
       null
     );
   }, [currentModelLabel, derivedReasoningEffort, llmConfig]);
+
+  // Set terminal title from window title config
+  useEffect(() => {
+    const items = resolveWindowTitleConfig(projectDirectory);
+    const title = renderWindowTitle(items, {
+      agentName: agentState?.name ?? null,
+      appName: "Letta Code",
+      version: getVersion(),
+      conversationSummary,
+    });
+    process.stdout.write(`\x1b]0;${title}\x07`);
+  }, [agentState?.name, conversationSummary, projectDirectory]);
+
   const currentModelProvider = llmConfig?.provider_name ?? null;
   const currentReasoningEffort: ModelReasoningEffort | null =
     currentModelLabel?.startsWith("letta/auto")
@@ -3274,6 +3287,7 @@ export default function App({
     setRestoreQueueOnCancel,
     setRestoredInput,
     setStreaming,
+    setConversationSummary,
     setTempModelOverride,
     setThinkingMessage,
     setTrajectoryElapsedBaseMs,
@@ -3573,6 +3587,7 @@ export default function App({
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setCurrentModelHandle,
     setInterruptRequested,
     setIsExecutingTool,
@@ -3690,6 +3705,7 @@ export default function App({
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setConversationOverrideContextWindowLimit,
     setConversationOverrideModelSettings,
     setCurrentPersonalityId,
@@ -4398,6 +4414,8 @@ export default function App({
       contextTrackerRef={contextTrackerRef}
       continueSession={continueSession}
       conversationId={conversationId}
+      conversationSummary={conversationSummary}
+      projectDirectory={projectDirectory}
       currentApproval={currentApproval}
       currentApprovalContext={currentApprovalContext}
       currentModelDisplay={currentModelDisplay}
@@ -4488,6 +4506,7 @@ export default function App({
       setCommandRunning={setCommandRunning}
       setConversationAutoTitleEligibility={setConversationAutoTitleEligibility}
       setConversationIdAndRef={setConversationIdAndRef}
+      setConversationSummary={setConversationSummary}
       setLines={setLines}
       setModelReasoningPrompt={setModelReasoningPrompt}
       setModelSelectorOptions={setModelSelectorOptions}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -61,6 +61,7 @@ import { ToolCallMessage } from "../components/ToolCallMessageRich";
 import { ToolsetSelector } from "../components/ToolsetSelector";
 import { UserMessage } from "../components/UserMessageRich";
 import { WelcomeScreen } from "../components/WelcomeScreen";
+import { WindowTitlePicker } from "../components/WindowTitlePicker";
 import { AnimationProvider } from "../contexts/AnimationContext";
 import { type Buffers, type Line, toLines } from "../helpers/accumulator";
 import { backfillBuffers } from "../helpers/backfill";
@@ -137,6 +138,8 @@ type AppViewProps = {
   contextTrackerRef: RefObject<ContextTracker>;
   continueSession: boolean;
   conversationId: string;
+  conversationSummary: string | null;
+  projectDirectory: string;
   currentApproval: ApprovalRequest | undefined;
   currentApprovalContext: ApprovalContext | undefined;
   currentModelDisplay: string | null;
@@ -269,6 +272,7 @@ type AppViewProps = {
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
+  setConversationSummary: (summary: string | null) => void;
   setLines: Dispatch<SetStateAction<Line[]>>;
   setModelReasoningPrompt: Dispatch<
     SetStateAction<ModelReasoningPrompt | null>
@@ -320,6 +324,8 @@ export function AppView(props: AppViewProps) {
     contextTrackerRef,
     continueSession,
     conversationId,
+    conversationSummary,
+    projectDirectory,
     currentApproval,
     currentApprovalContext,
     currentModelDisplay,
@@ -408,6 +414,7 @@ export function AppView(props: AppViewProps) {
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setLines,
     setModelReasoningPrompt,
     setModelSelectorOptions,
@@ -792,6 +799,16 @@ export function AppView(props: AppViewProps) {
               />
             )}
 
+            {/* Window Title Configurator - for customizing terminal title */}
+            {activeOverlay === "window-title" && (
+              <WindowTitlePicker
+                agentName={agentName ?? null}
+                projectDirectory={projectDirectory}
+                conversationSummary={conversationSummary}
+                onClose={closeOverlay}
+              />
+            )}
+
             {/* GitHub App Installer - setup Letta Code GitHub Action */}
             {activeOverlay === "install-github-app" && (
               <InstallGithubAppFlow
@@ -1042,6 +1059,7 @@ export function AppView(props: AppViewProps) {
                       // Only update state after validation succeeds
                       setConversationIdAndRef(convId);
                       setConversationAutoTitleEligibility(false);
+                      setConversationSummary(selectorContext?.summary ?? null);
 
                       pendingConversationSwitchRef.current = {
                         origin: "resume-selector",
@@ -1188,6 +1206,7 @@ export function AppView(props: AppViewProps) {
                     );
                     setConversationIdAndRef(conversation.id);
                     setConversationAutoTitleEligibility(true);
+                    setConversationSummary(null);
                     settingsManager.persistSession(agentId, conversation.id);
 
                     // Build success command with agent + conversation info

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -74,6 +74,7 @@ export type ActiveOverlay =
   | "hooks"
   | "connect"
   | "skills"
+  | "window-title"
   | null;
 
 export type QueuedOverlayAction =

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -201,6 +201,7 @@ type ConversationLoopContext = {
   setRestoreQueueOnCancel: Dispatch<SetStateAction<boolean>>;
   setRestoredInput: Dispatch<SetStateAction<string | null>>;
   setStreaming: (value: boolean) => void;
+  setConversationSummary: (summary: string | null) => void;
   setTempModelOverride: (next: string | null) => void;
   setThinkingMessage: Dispatch<SetStateAction<string>>;
   setTrajectoryElapsedBaseMs: Dispatch<SetStateAction<number>>;
@@ -289,6 +290,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     setRestoreQueueOnCancel,
     setRestoredInput,
     setStreaming,
+    setConversationSummary,
     setTempModelOverride,
     setThinkingMessage,
     setTrajectoryElapsedBaseMs,
@@ -1522,6 +1524,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                   })
                   .then(() => {
                     shouldAutoGenerateConversationTitleRef.current = false;
+                    setConversationSummary(conversationTitle);
                   })
                   .catch((err) => {
                     // Silently ignore - not critical.
@@ -2809,6 +2812,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       refreshDerived,
       refreshDerivedThrottled,
       setStreaming,
+      setConversationSummary,
       currentModelId,
       updateStreamingOutput,
       needsEagerApprovalCheck,

--- a/src/cli/app/useConversationSwitching.ts
+++ b/src/cli/app/useConversationSwitching.ts
@@ -103,6 +103,7 @@ type ConversationSwitchingContext = {
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
+  setConversationSummary: (summary: string | null) => void;
   setCurrentModelHandle: Dispatch<SetStateAction<string | null>>;
   setInterruptRequested: Dispatch<SetStateAction<boolean>>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
@@ -153,6 +154,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setCurrentModelHandle,
     setInterruptRequested,
     setIsExecutingTool,
@@ -354,6 +356,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         await maybeCarryOverActiveConversationModel(conversationId);
         setConversationIdAndRef(conversationId);
         setConversationAutoTitleEligibility(false);
+        setConversationSummary(null);
 
         pendingConversationSwitchRef.current = {
           origin: "fork",
@@ -442,6 +445,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       resetBootstrapReminderState,
       setConversationAutoTitleEligibility,
       setConversationIdAndRef,
+      setConversationSummary,
       setCommandRunning,
       setStreaming,
       recoverRestoredPendingApprovals,
@@ -555,6 +559,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         setCurrentModelHandle(agentModelHandle);
         setConversationIdAndRef(targetConversationId);
         setConversationAutoTitleEligibility(false);
+        setConversationSummary(null);
 
         // Ensure bootstrap reminders are re-injected on the first user turn
         // after switching to a different conversation/agent context.
@@ -628,6 +633,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       resetPendingReasoningCycle,
       setConversationAutoTitleEligibility,
       setConversationIdAndRef,
+      setConversationSummary,
       agentIdRef,
       pendingConversationSwitchRef,
       setActiveOverlay,
@@ -744,6 +750,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         setCurrentModelHandle(agentModelHandle);
         setConversationIdAndRef(targetConversationId);
         setConversationAutoTitleEligibility(false);
+        setConversationSummary(null);
 
         // Set conversation switch context for new agent switch
         pendingConversationSwitchRef.current = {
@@ -794,6 +801,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       resetBootstrapReminderState,
       setConversationAutoTitleEligibility,
       setConversationIdAndRef,
+      setConversationSummary,
       agentIdRef,
       pendingConversationSwitchRef,
       setActiveOverlay,

--- a/src/cli/app/useSubmitHandler.ts
+++ b/src/cli/app/useSubmitHandler.ts
@@ -259,6 +259,7 @@ type SubmitHandlerContext = {
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
+  setConversationSummary: (summary: string | null) => void;
   setConversationOverrideContextWindowLimit: Dispatch<
     SetStateAction<number | null>
   >;
@@ -735,6 +736,25 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             "Experiments dialog dismissed",
           );
           setActiveOverlay("experiment");
+          return { submitted: true };
+        }
+
+        if (trimmed === "/title") {
+          if (isAgentBusy()) {
+            const cmd = commandRunner.start(
+              "/title",
+              "Cannot configure title while the agent is running.",
+            );
+            cmd.fail("Wait for the current turn to finish and try again.");
+            return { submitted: true };
+          }
+          startOverlayCommand(
+            "window-title",
+            "/title",
+            "Opening title configurator...",
+            "Title configurator dismissed",
+          );
+          setActiveOverlay("window-title");
           return { submitted: true };
         }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -425,10 +425,19 @@ export const commands: Record<string, Command> = {
       return "Managing status line...";
     },
   },
+  "/title": {
+    desc: "Configure terminal window title",
+    noArgs: true,
+    order: 36.6,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Opening title configurator...";
+    },
+  },
   "/reasoning-tab": {
     desc: "Toggle Tab shortcut for reasoning tiers (/reasoning-tab on|off|status)",
     args: "[on|off|status]",
-    order: 36.6,
+    order: 36.7,
     handler: () => {
       // Handled specially in App.tsx
       return "Managing reasoning Tab shortcut...";

--- a/src/cli/components/MultiSelectPicker.tsx
+++ b/src/cli/components/MultiSelectPicker.tsx
@@ -1,0 +1,157 @@
+// Reusable multi-select checkbox picker for interactive configuration.
+//
+// Inspired by Codex's "Configure Terminal Title" UI and extracted from
+// InlineQuestionApproval's multi-select logic, but simplified:
+// - No custom input / "Type something" option
+// - No "Submit" button — Enter confirms directly
+// - Optional live preview line at the bottom
+// - Items are identified by key (string), not index
+
+import { Box, type Key, useInput } from "ink";
+import { memo, useCallback, useEffect, useState } from "react";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+import { colors } from "./colors";
+import { Text } from "./Text";
+
+export interface SelectableItem {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export interface MultiSelectPickerProps {
+  title: string;
+  description: string;
+  items: SelectableItem[];
+  selected: Set<string>;
+  onConfirm: (selectedKeys: string[]) => void;
+  onCancel: () => void;
+  onSelectionChange?: (selectedKeys: string[]) => void;
+  preview?: string;
+}
+
+export const MultiSelectPicker = memo(function MultiSelectPicker({
+  title,
+  description,
+  items,
+  selected,
+  onConfirm,
+  onCancel,
+  onSelectionChange,
+  preview,
+}: MultiSelectPickerProps) {
+  const [cursor, setCursor] = useState(0);
+  const [selectedSet, setSelectedSet] = useState<Set<string>>(
+    () => new Set(selected),
+  );
+  const columns = useTerminalWidth();
+
+  const toggle = useCallback((key: string) => {
+    setSelectedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  // Propagate selection changes to parent in a separate render cycle
+  useEffect(() => {
+    onSelectionChange?.([...selectedSet]);
+  }, [selectedSet, onSelectionChange]);
+
+  const handleInput = useCallback(
+    (input: string, key: Key) => {
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((c) => Math.min(items.length - 1, c + 1));
+        return;
+      }
+      if (key.escape) {
+        onCancel();
+        return;
+      }
+      if (key.return) {
+        onConfirm([...selectedSet]);
+        return;
+      }
+      // Space toggles checkbox
+      if (input === " ") {
+        const item = items[cursor];
+        if (item) {
+          toggle(item.key);
+        }
+        return;
+      }
+    },
+    [items, cursor, onCancel, onConfirm, selectedSet, toggle],
+  );
+
+  useInput(handleInput, { isActive: true });
+
+  return (
+    <Box flexDirection="column">
+      {/* Title */}
+      <Text bold>{title}</Text>
+
+      {/* Description */}
+      <Text dimColor>{description}</Text>
+
+      <Box height={1} />
+
+      {/* Items */}
+      <Box flexDirection="column">
+        {items.map((item, index) => {
+          const isCursor = index === cursor;
+          const isChecked = selectedSet.has(item.key);
+          const color = isCursor ? colors.approval.header : undefined;
+
+          return (
+            <Box key={item.key} flexDirection="row">
+              {/* Cursor indicator */}
+              <Box width={2} flexShrink={0}>
+                <Text color={color}>{isCursor ? "›" : " "}</Text>
+              </Box>
+              {/* Checkbox */}
+              <Box width={4} flexShrink={0}>
+                <Text color={isChecked ? "green" : color}>
+                  [{isChecked ? "✓" : " "}]{" "}
+                </Text>
+              </Box>
+              {/* Label + description */}
+              <Box flexGrow={1} width={Math.max(0, columns - 6)}>
+                <Text color={color} bold={isCursor} wrap="truncate-end">
+                  {item.label}
+                  {item.description && (
+                    <Text dimColor> · {item.description}</Text>
+                  )}
+                </Text>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Preview */}
+      {preview !== undefined && (
+        <>
+          <Box height={1} />
+          <Text bold>{preview}</Text>
+        </>
+      )}
+
+      {/* Hint */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          Space to toggle · ↑↓ to navigate · Enter to confirm · Esc to cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+});

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -1,0 +1,100 @@
+// Window title configuration picker.
+// Wraps MultiSelectPicker with window-title-specific logic.
+
+import { Box } from "ink";
+import { memo, useCallback, useMemo, useState } from "react";
+import { settingsManager } from "../../settings-manager";
+import { getVersion } from "../../version";
+import {
+  renderWindowTitle,
+  resolveWindowTitleConfig,
+  WINDOW_TITLE_FIELD_INFO,
+  WINDOW_TITLE_FIELDS,
+  type WindowTitleField,
+} from "../helpers/windowTitleConfig";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+import { MultiSelectPicker } from "./MultiSelectPicker";
+import { Text } from "./Text";
+
+const SOLID_LINE = "─";
+
+interface WindowTitlePickerProps {
+  agentName: string | null;
+  projectDirectory: string;
+  conversationSummary: string | null;
+  onClose: () => void;
+}
+
+export const WindowTitlePicker = memo(function WindowTitlePicker({
+  agentName,
+  projectDirectory,
+  conversationSummary,
+  onClose,
+}: WindowTitlePickerProps) {
+  const terminalWidth = useTerminalWidth();
+  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+
+  const currentItems = useMemo(
+    () => resolveWindowTitleConfig(projectDirectory),
+    [projectDirectory],
+  );
+
+  const [selectedKeys, setSelectedKeys] = useState<string[]>(currentItems);
+
+  const items = useMemo(
+    () =>
+      WINDOW_TITLE_FIELDS.map((key) => ({
+        key,
+        label: WINDOW_TITLE_FIELD_INFO[key].label,
+        description: WINDOW_TITLE_FIELD_INFO[key].description,
+      })),
+    [],
+  );
+
+  const titleData = useMemo(
+    () => ({
+      agentName,
+      appName: "Letta Code",
+      version: getVersion(),
+      conversationSummary,
+    }),
+    [agentName, conversationSummary],
+  );
+
+  const handleSelectionChange = useCallback(
+    (keys: string[]) => {
+      setSelectedKeys(keys);
+      // Update terminal title live so the user sees the effect immediately
+      const title = renderWindowTitle(keys as WindowTitleField[], titleData);
+      process.stdout.write(`\x1b]0;${title}\x07`);
+    },
+    [titleData],
+  );
+
+  const handleConfirm = useCallback(
+    (keys: string[]) => {
+      settingsManager.updateSettings({
+        windowTitle: { items: keys },
+      });
+      onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <>
+      <Text dimColor>{"> /title"}</Text>
+      <Text dimColor>{solidLine}</Text>
+      <Box height={1} />
+      <MultiSelectPicker
+        title="Configure Terminal Title"
+        description="Select which items to display in the terminal title."
+        items={items}
+        selected={new Set(selectedKeys)}
+        onConfirm={handleConfirm}
+        onCancel={onClose}
+        onSelectionChange={handleSelectionChange}
+      />
+    </>
+  );
+});

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -81,6 +81,14 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
     [onClose],
   );
 
+  const handleCancel = useCallback(() => {
+    // Revert terminal title to the persisted config
+    const savedItems = resolveWindowTitleConfig(projectDirectory);
+    const title = renderWindowTitle(savedItems, titleData);
+    process.stdout.write(`\x1b]0;${title}\x07`);
+    onClose();
+  }, [projectDirectory, titleData, onClose]);
+
   return (
     <>
       <Text dimColor>{"> /title"}</Text>
@@ -92,7 +100,7 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
         items={items}
         selected={new Set(selectedKeys)}
         onConfirm={handleConfirm}
-        onCancel={onClose}
+        onCancel={handleCancel}
         onSelectionChange={handleSelectionChange}
       />
     </>

--- a/src/cli/helpers/windowTitleConfig.ts
+++ b/src/cli/helpers/windowTitleConfig.ts
@@ -1,0 +1,148 @@
+// Config resolution and rendering for the terminal window title.
+// Precedence: local project > project > global settings.
+
+import { settingsManager } from "../../settings-manager";
+import { debugLog } from "../../utils/debug";
+
+/** All valid field keys for the window title. */
+export const WINDOW_TITLE_FIELDS = [
+  "agent-name",
+  "conversation-name",
+  "app-name",
+  "version",
+] as const;
+
+export type WindowTitleField = (typeof WINDOW_TITLE_FIELDS)[number];
+
+/** Human-readable labels and descriptions for each field. */
+export const WINDOW_TITLE_FIELD_INFO: Record<
+  WindowTitleField,
+  { label: string; description: string }
+> = {
+  "agent-name": {
+    label: "Agent Name",
+    description: "Current agent's name",
+  },
+  "app-name": {
+    label: "App Name",
+    description: 'Application name (e.g. "Letta Code")',
+  },
+  version: {
+    label: "Version",
+    description: "Letta Code version",
+  },
+  "conversation-name": {
+    label: "Conversation",
+    description: "Current conversation title (omitted when unavailable)",
+  },
+};
+
+/** Default items when no config is set. */
+export const DEFAULT_WINDOW_TITLE_ITEMS: WindowTitleField[] = [
+  "agent-name",
+  "app-name",
+];
+
+/** Data available for rendering the window title. */
+export interface WindowTitleData {
+  agentName?: string | null;
+  appName?: string | null;
+  version: string;
+  conversationSummary?: string | null;
+}
+
+/**
+ * Resolve the effective window title items from all settings levels.
+ * Returns the default items when no config is set.
+ */
+export function resolveWindowTitleConfig(
+  workingDirectory: string = process.cwd(),
+): WindowTitleField[] {
+  try {
+    // Local project settings (highest priority)
+    try {
+      const local =
+        settingsManager.getLocalProjectSettings(workingDirectory)?.windowTitle;
+      if (local?.items?.length) return local.items as WindowTitleField[];
+    } catch {
+      // Not loaded
+    }
+
+    // Project settings
+    try {
+      const project =
+        settingsManager.getProjectSettings(workingDirectory)?.windowTitle;
+      if (project?.items?.length) return project.items as WindowTitleField[];
+    } catch {
+      // Not loaded
+    }
+
+    // Global settings
+    try {
+      const global = settingsManager.getSettings().windowTitle;
+      if (global?.items?.length) return global.items as WindowTitleField[];
+    } catch {
+      // Not initialized
+    }
+
+    return [...DEFAULT_WINDOW_TITLE_ITEMS];
+  } catch (error) {
+    debugLog(
+      "windowtitle",
+      "resolveWindowTitleConfig: Failed to resolve config",
+      error,
+    );
+    return [...DEFAULT_WINDOW_TITLE_ITEMS];
+  }
+}
+
+/**
+ * Render the terminal window title from the selected items and available data.
+ *
+ * Format: `{selected items joined by | }`
+ * Unavailable values are omitted. Falls back to app name if nothing resolves.
+ */
+export function renderWindowTitle(
+  items: WindowTitleField[],
+  data: WindowTitleData,
+): string {
+  // Sort items to canonical field order before rendering
+  const ordered = items.slice().sort((a, b) => {
+    const aIdx = WINDOW_TITLE_FIELDS.indexOf(a);
+    const bIdx = WINDOW_TITLE_FIELDS.indexOf(b);
+    return aIdx - bIdx;
+  });
+
+  const segments: string[] = [];
+
+  for (const key of ordered) {
+    const value = resolveFieldValue(key, data);
+    if (value !== null) {
+      segments.push(value);
+    }
+  }
+
+  if (segments.length === 0) {
+    return data.appName || "Letta Code";
+  }
+
+  return segments.join(" | ");
+}
+
+function resolveFieldValue(
+  key: WindowTitleField,
+  data: WindowTitleData,
+): string | null {
+  switch (key) {
+    case "agent-name":
+      return data.agentName || null;
+    case "app-name":
+      return data.appName || null;
+    case "version":
+      return data.version;
+    case "conversation-name":
+      return data.conversationSummary || null;
+    default:
+      return null;
+  }
+}

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -46,6 +46,10 @@ export interface StatusLineConfig {
   prompt?: string; // Custom input prompt character (default "›")
 }
 
+export interface WindowTitleConfig {
+  items: string[]; // Ordered list of enabled field keys (e.g. ["agent-name", "model-name"])
+}
+
 /**
  * Per-agent settings stored in a flat array.
  * baseUrl is omitted/undefined for Letta API (api.letta.com).
@@ -106,6 +110,7 @@ export interface Settings {
   permissions?: PermissionRules;
   hooks?: HooksConfig; // Hook commands that run at various lifecycle points (includes disabled flag)
   statusLine?: StatusLineConfig; // Configurable status line command
+  windowTitle?: WindowTitleConfig; // Configurable terminal window title
   env?: Record<string, string>;
   experiments?: Partial<Record<ExperimentId, boolean>>;
   // Server-indexed settings (agent IDs are server-specific)
@@ -132,6 +137,7 @@ export interface Settings {
 export interface ProjectSettings {
   hooks?: HooksConfig; // Project-specific hook commands (checked in)
   statusLine?: StatusLineConfig; // Project-specific status line command
+  windowTitle?: WindowTitleConfig; // Project-specific terminal window title
 }
 
 export interface LocalProjectSettings {
@@ -140,6 +146,7 @@ export interface LocalProjectSettings {
   permissions?: PermissionRules;
   hooks?: HooksConfig; // Project-specific hook commands
   statusLine?: StatusLineConfig; // Local project-specific status line command
+  windowTitle?: WindowTitleConfig; // Local project-specific terminal window title
   profiles?: Record<string, string>; // DEPRECATED: old format, kept for migration
   pinnedAgents?: string[]; // DEPRECATED: kept for backwards compat, use pinnedAgentsByServer
   memoryReminderInterval?: number | null | "compaction" | "auto-compaction"; // DEPRECATED: use reflection* fields
@@ -767,6 +774,7 @@ class SettingsManager {
       const projectSettings: ProjectSettings = {
         hooks: rawSettings.hooks as HooksConfig | undefined,
         statusLine: rawSettings.statusLine as StatusLineConfig | undefined,
+        windowTitle: rawSettings.windowTitle as WindowTitleConfig | undefined,
       };
 
       this.projectSettings.set(workingDirectory, projectSettings);
@@ -810,6 +818,9 @@ class SettingsManager {
       }
       if ("statusLine" in updates) {
         globalUpdates.statusLine = updates.statusLine;
+      }
+      if ("windowTitle" in updates) {
+        globalUpdates.windowTitle = updates.windowTitle;
       }
       if (Object.keys(globalUpdates).length > 0) {
         this.updateSettings(globalUpdates);


### PR DESCRIPTION
## Summary
- Replace hardcoded `"{Agent Name} | Letta Code"` terminal title with a config-driven system
- Add `/title` command that opens an interactive multi-select checkbox picker to toggle which fields appear
- Terminal title updates live as you toggle items (before confirming)
- Config persists to global settings with 3-level precedence (local project > project > global)

**Fields:** agent-name, conversation-name, app-name, version
**Default:** `Amelia | Letta Code` (agent-name + app-name on)

**New files:**
- `MultiSelectPicker.tsx` — reusable checkbox picker component
- `WindowTitlePicker.tsx` — window-title-specific wrapper with live ANSI title updates
- `windowTitleConfig.ts` — config resolution, field definitions, title rendering

## Test plan
- [ ] Run `/title` and verify the picker opens under the input line with separator
- [ ] Toggle fields with space — terminal title should update live
- [ ] Confirm with Enter — settings should persist, title stays after dismiss
- [ ] Cancel with Esc — title should revert to previous config
- [ ] Run `/title` while agent is busy — should show "Cannot configure title while the agent is running"
- [ ] Resume a conversation with a summary — title should include conversation name
- [ ] Start a new conversation — conversation name should be omitted from title
- [ ] Verify `/title` appears in `/help` command list

👾 Generated with [Letta Code](https://letta.com)