### PR TITLE
feat(cli): add git-branch field to window title config

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -144,6 +144,7 @@ import { isTaskTool } from "../helpers/toolNameMapping.js";
 import { getTuiBlockedReason } from "../helpers/tuiQueueAdapter";
 import {
   renderWindowTitle,
+  resolveGitBranch,
   resolveWindowTitleConfig,
 } from "../helpers/windowTitleConfig";
 import { useConfigurableStatusLine } from "../hooks/useConfigurableStatusLine";
@@ -790,6 +791,7 @@ export default function App({
       appName: "Letta Code",
       version: getVersion(),
       conversationSummary,
+      gitBranch: resolveGitBranch(projectDirectory),
     });
     process.stdout.write(`\x1b]0;${title}\x07`);
   }, [agentState?.name, conversationSummary, projectDirectory]);

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -7,6 +7,7 @@ import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
 import {
   renderWindowTitle,
+  resolveGitBranch,
   resolveWindowTitleConfig,
   WINDOW_TITLE_FIELD_INFO,
   WINDOW_TITLE_FIELDS,
@@ -57,8 +58,9 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
       appName: "Letta Code",
       version: getVersion(),
       conversationSummary,
+      gitBranch: resolveGitBranch(projectDirectory),
     }),
-    [agentName, conversationSummary],
+    [agentName, conversationSummary, projectDirectory],
   );
 
   const handleSelectionChange = useCallback(

--- a/src/cli/helpers/windowTitleConfig.ts
+++ b/src/cli/helpers/windowTitleConfig.ts
@@ -1,6 +1,7 @@
 // Config resolution and rendering for the terminal window title.
 // Precedence: local project > project > global settings.
 
+import { execSync } from "node:child_process";
 import { settingsManager } from "../../settings-manager";
 import { debugLog } from "../../utils/debug";
 
@@ -8,6 +9,7 @@ import { debugLog } from "../../utils/debug";
 export const WINDOW_TITLE_FIELDS = [
   "agent-name",
   "conversation-name",
+  "git-branch",
   "app-name",
   "version",
 ] as const;
@@ -23,6 +25,14 @@ export const WINDOW_TITLE_FIELD_INFO: Record<
     label: "Agent Name",
     description: "Current agent's name",
   },
+  "conversation-name": {
+    label: "Conversation",
+    description: "Current conversation title (omitted when unavailable)",
+  },
+  "git-branch": {
+    label: "Git Branch",
+    description: "Current git branch name (omitted when not in a repo)",
+  },
   "app-name": {
     label: "App Name",
     description: 'Application name (e.g. "Letta Code")',
@@ -30,10 +40,6 @@ export const WINDOW_TITLE_FIELD_INFO: Record<
   version: {
     label: "Version",
     description: "Letta Code version",
-  },
-  "conversation-name": {
-    label: "Conversation",
-    description: "Current conversation title (omitted when unavailable)",
   },
 };
 
@@ -49,6 +55,7 @@ export interface WindowTitleData {
   appName?: string | null;
   version: string;
   conversationSummary?: string | null;
+  gitBranch?: string | null;
 }
 
 /**
@@ -142,7 +149,24 @@ function resolveFieldValue(
       return data.version;
     case "conversation-name":
       return data.conversationSummary || null;
+    case "git-branch":
+      return data.gitBranch || null;
     default:
       return null;
+  }
+}
+
+/** Resolve the current git branch name, or null if not in a git repo. */
+export function resolveGitBranch(
+  workingDirectory: string = process.cwd(),
+): string | null {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd: workingDirectory,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- Add "Git Branch" as a toggleable field in the `/title` picker
- Placed after conversation-name, before app-name
- Resolved via `git rev-parse --abbrev-ref HEAD`, omitted when not in a git repo
- Off by default (not in `DEFAULT_WINDOW_TITLE_ITEMS`)

## Test plan
- [ ] Run `/title` and verify "Git Branch" appears in the picker
- [ ] Toggle it on — terminal title should show the branch name
- [ ] Toggle it off — branch name should disappear from title
- [ ] Confirm with Enter — settings should persist
- [ ] Cancel with Esc — title should revert to previous config

👾 Generated with [Letta Code](https://letta.com)