### PR TITLE
feat(cli): add New tab to agent browser for creating agents

### DIFF
--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -180,7 +180,10 @@ type AppViewProps = {
     mode: string,
     commandId?: string | null,
   ) => Promise<void>;
-  handleCreateNewAgent: (name: string) => Promise<void>;
+  handleCreateNewAgent: (
+    name: string,
+    opts?: { commandId?: string },
+  ) => Promise<void>;
   handleCycleReasoningEffort: () => void;
   handleDenyCurrent: (reason: string) => Promise<void>;
   handleEnterPlanModeApprove: (preserveMode?: boolean) => Promise<void>;
@@ -985,8 +988,11 @@ export function AppView(props: AppViewProps) {
                 }}
                 onCancel={closeOverlay}
                 onCreateNewAgent={(name: string) => {
+                  const overlayCommand = consumeOverlayCommand("resume");
                   closeOverlay();
-                  handleCreateNewAgent(name);
+                  void handleCreateNewAgent(name, {
+                    commandId: overlayCommand?.id,
+                  });
                 }}
               />
             )}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -43,7 +43,6 @@ import { MemoryTabViewer } from "../components/MemoryTabViewer";
 import { MessageSearch } from "../components/MessageSearch";
 import { ModelReasoningSelector } from "../components/ModelReasoningSelector";
 import { ModelSelector } from "../components/ModelSelector";
-import { NewAgentDialog } from "../components/NewAgentDialog";
 import { PendingApprovalStub } from "../components/PendingApprovalStub";
 import { PersonalitySelector } from "../components/PersonalitySelector";
 import { PinDialog } from "../components/PinDialog";
@@ -985,9 +984,9 @@ export function AppView(props: AppViewProps) {
                   });
                 }}
                 onCancel={closeOverlay}
-                onCreateNewAgent={() => {
+                onCreateNewAgent={(name: string) => {
                   closeOverlay();
-                  setActiveOverlay("new");
+                  handleCreateNewAgent(name);
                 }}
               />
             )}
@@ -1514,14 +1513,6 @@ export function AppView(props: AppViewProps) {
             {/* Hooks Manager - for managing hooks configuration */}
             {activeOverlay === "hooks" && (
               <HooksManager onClose={closeOverlay} agentId={agentId} />
-            )}
-
-            {/* New Agent Dialog - for naming new agent before creation */}
-            {activeOverlay === "new" && (
-              <NewAgentDialog
-                onSubmit={handleCreateNewAgent}
-                onCancel={closeOverlay}
-              />
             )}
 
             {/* Pin Dialog - for naming agent before pinning */}

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -66,7 +66,6 @@ export type ActiveOverlay =
   | "memory"
   | "memfs-sync"
   | "pin"
-  | "new"
   | "mcp"
   | "mcp-connect"
   | "install-github-app"

--- a/src/cli/app/useConversationSwitching.ts
+++ b/src/cli/app/useConversationSwitching.ts
@@ -650,15 +650,17 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
   // Handle creating a new agent and switching to it
   // biome-ignore lint/correctness/useExhaustiveDependencies: switch refs are stable objects; .current is read dynamically during agent creation.
   const handleCreateNewAgent = useCallback(
-    async (name: string) => {
+    async (name: string, opts?: { commandId?: string }) => {
       // Close dialog immediately
       setActiveOverlay(null);
 
       // Lock input for async operation
       setCommandRunning(true);
 
-      const inputCmd = "/new";
-      const cmd = commandRunner.start(inputCmd, `Creating agent "${name}"...`);
+      const cmd = opts?.commandId
+        ? commandRunner.getHandle(opts.commandId, "/new")
+        : commandRunner.start("/new", `Creating agent "${name}"...`);
+      cmd.update({ output: `Creating agent "${name}"...`, phase: "running" });
 
       try {
         // Pre-determine memfs mode so the agent is created with the correct prompt.

--- a/src/cli/app/useConversationSwitching.ts
+++ b/src/cli/app/useConversationSwitching.ts
@@ -723,16 +723,6 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           `${CLI_GLYPHS.result}  ${agentUrl}`,
           `${CLI_GLYPHS.result}  ${memfsTip}`,
         ].join("\n");
-        cmd.finish(successOutput, true);
-        const successItem: StaticItem = {
-          kind: "command",
-          id: cmd.id,
-          input: cmd.input,
-          output: successOutput,
-          phase: "finished",
-          success: true,
-        };
-
         // Clear current transcript and static items
         buffersRef.current.byId.clear();
         buffersRef.current.order = [];
@@ -782,9 +772,8 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           id: uid("sep"),
         };
 
-        setStaticItems([separator, successItem]);
-        // Sync lines display after clearing buffers
-        setLines(toLines(buffersRef.current));
+        setStaticItems([separator]);
+        cmd.finish(successOutput, true);
       } catch (error) {
         const errorDetails = formatErrorDetails(error, agentId);
         cmd.fail(`Failed to create agent: ${errorDetails}`);

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -3,10 +3,13 @@ import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getModelDisplayName } from "../../agent/model";
 import { type Backend, getBackend } from "../../backend";
+import { DEFAULT_AGENT_NAME } from "../../constants";
 import { settingsManager } from "../../settings-manager";
 import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
+import { PasteAwareTextInput } from "./PasteAwareTextInput";
+import { validateAgentName } from "./PinDialog";
 import { Text } from "./Text";
 
 // Horizontal line character (matches approval dialogs)
@@ -16,13 +19,13 @@ interface AgentSelectorProps {
   currentAgentId: string;
   onSelect: (agentId: string) => void;
   onCancel: () => void;
-  /** Called when user presses N to create a new agent */
-  onCreateNewAgent?: () => void;
+  /** Called when user creates a new agent (from New tab or N shortcut) */
+  onCreateNewAgent?: (name: string) => void;
   /** The command that triggered this selector (e.g., "/agents" or "/resume") */
   command?: string;
 }
 
-type TabId = "pinned" | "letta-code" | "all";
+type TabId = "pinned" | "letta-code" | "all" | "new";
 
 type ViewState =
   | { type: "list" }
@@ -39,18 +42,21 @@ const TABS: { id: TabId; label: string }[] = [
   { id: "pinned", label: "Pinned" },
   { id: "letta-code", label: "Letta Code" },
   { id: "all", label: "All" },
+  { id: "new", label: "New" },
 ];
 
 const TAB_DESCRIPTIONS: Record<TabId, string> = {
   pinned: "Save agents for easy access by pinning them with /pin",
   "letta-code": "Displaying agents created inside of Letta Code",
   all: "Displaying all available agents",
+  new: "Create a brand new agent",
 };
 
 const TAB_EMPTY_STATES: Record<TabId, string> = {
   pinned: "No pinned agents, use /pin to save",
   "letta-code": "No agents with tag 'origin:letta-code'",
   all: "No agents found",
+  new: "",
 };
 
 const DISPLAY_PAGE_SIZE = 5;
@@ -169,6 +175,10 @@ export function AgentSelector({
   const [viewState, setViewState] = useState<ViewState>({ type: "list" });
   const [deleteConfirmInput, setDeleteConfirmInput] = useState("");
   const [deleteLoading, setDeleteLoading] = useState(false);
+
+  // New agent tab state
+  const [newAgentNameInput, setNewAgentNameInput] = useState("");
+  const [newAgentNameError, setNewAgentNameError] = useState("");
 
   // Load pinned agents
   const loadPinnedAgents = useCallback(async () => {
@@ -507,6 +517,37 @@ export function AgentSelector({
 
     if (currentLoading) return;
 
+    // New tab has its own input handling (name input, not list navigation)
+    if (activeTab === "new") {
+      if (key.return) {
+        const trimmed = newAgentNameInput.trim();
+        if (!trimmed) {
+          onCreateNewAgent?.(DEFAULT_AGENT_NAME);
+          return;
+        }
+        const validationError = validateAgentName(trimmed);
+        if (validationError) {
+          setNewAgentNameError(validationError);
+          return;
+        }
+        onCreateNewAgent?.(trimmed);
+      } else if (key.escape) {
+        if (newAgentNameInput) {
+          setNewAgentNameInput("");
+          setNewAgentNameError("");
+        } else {
+          onCancel();
+        }
+      } else if (key.backspace || key.delete) {
+        setNewAgentNameInput((prev) => prev.slice(0, -1));
+        setNewAgentNameError("");
+      } else if (input && !key.ctrl && !key.meta && !key.tab) {
+        setNewAgentNameInput((prev) => prev + input);
+        setNewAgentNameError("");
+      }
+      return;
+    }
+
     const maxIndex =
       activeTab === "pinned"
         ? pinnedPageAgents.length - 1
@@ -644,8 +685,8 @@ export function AgentSelector({
         setDeleteConfirmInput("");
       }
     } else if (input === "n" || input === "N") {
-      // Create new agent
-      onCreateNewAgent?.();
+      // Switch to New tab
+      setActiveTab("new");
     } else if (activeTab !== "pinned" && input && !key.ctrl && !key.meta) {
       // Type to search (list tabs only)
       setSearchInput((prev) => prev + input);
@@ -923,8 +964,61 @@ export function AgentSelector({
           </Box>
         )}
 
+      {/* New tab content */}
+      {activeTab === "new" && (
+        <Box flexDirection="column">
+          <Box height={1} />
+          <Box paddingLeft={2}>
+            <Text>
+              Enter a name for your new agent, or press Enter for default.
+            </Text>
+          </Box>
+          <Box height={1} />
+          <Box flexDirection="column">
+            <Box paddingLeft={2}>
+              <Text>Agent name:</Text>
+            </Box>
+            <Box>
+              <Text color={colors.selector.itemHighlighted}>{">"}</Text>
+              <Text> </Text>
+              <PasteAwareTextInput
+                value={newAgentNameInput}
+                onChange={(val) => {
+                  setNewAgentNameInput(val);
+                  setNewAgentNameError("");
+                }}
+                onSubmit={(text) => {
+                  const trimmed = text.trim();
+                  if (!trimmed) {
+                    onCreateNewAgent?.(DEFAULT_AGENT_NAME);
+                    return;
+                  }
+                  const validationError = validateAgentName(trimmed);
+                  if (validationError) {
+                    setNewAgentNameError(validationError);
+                    return;
+                  }
+                  onCreateNewAgent?.(trimmed);
+                }}
+                placeholder={DEFAULT_AGENT_NAME}
+              />
+            </Box>
+          </Box>
+          {newAgentNameError && (
+            <Box paddingLeft={2} marginTop={1}>
+              <Text color="red">{newAgentNameError}</Text>
+            </Box>
+          )}
+          <Box height={1} />
+          <Box paddingLeft={2}>
+            <Text dimColor>Enter create · Esc cancel</Text>
+          </Box>
+        </Box>
+      )}
+
       {/* Footer */}
-      {!currentLoading &&
+      {activeTab !== "new" &&
+        !currentLoading &&
         ((activeTab === "pinned" && validPinnedAgents.length > 0) ||
           (activeTab === "letta-code" &&
             !lettaCodeError &&
@@ -938,7 +1032,7 @@ export function AgentSelector({
               : activeTab === "letta-code"
                 ? `Page ${lettaCodePage + 1}${lettaCodeHasMore ? "+" : `/${lettaCodeTotalPages || 1}`}${lettaCodeLoadingMore ? " (loading...)" : ""}`
                 : `Page ${allPage + 1}${allHasMore ? "+" : `/${allTotalPages || 1}`}${allLoadingMore ? " (loading...)" : ""}`;
-          const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? " · P unpin" : ""}${onCreateNewAgent ? " · N new" : ""} · Esc cancel`;
+          const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? " · P unpin" : ""} · Esc cancel`;
 
           return (
             <Box flexDirection="column">

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -517,33 +517,16 @@ export function AgentSelector({
 
     if (currentLoading) return;
 
-    // New tab has its own input handling (name input, not list navigation)
+    // New tab has its own input handling via PasteAwareTextInput.
+    // Only handle Escape here.
     if (activeTab === "new") {
-      if (key.return) {
-        const trimmed = newAgentNameInput.trim();
-        if (!trimmed) {
-          onCreateNewAgent?.(DEFAULT_AGENT_NAME);
-          return;
-        }
-        const validationError = validateAgentName(trimmed);
-        if (validationError) {
-          setNewAgentNameError(validationError);
-          return;
-        }
-        onCreateNewAgent?.(trimmed);
-      } else if (key.escape) {
+      if (key.escape) {
         if (newAgentNameInput) {
           setNewAgentNameInput("");
           setNewAgentNameError("");
         } else {
           onCancel();
         }
-      } else if (key.backspace || key.delete) {
-        setNewAgentNameInput((prev) => prev.slice(0, -1));
-        setNewAgentNameError("");
-      } else if (input && !key.ctrl && !key.meta && !key.tab) {
-        setNewAgentNameInput((prev) => prev + input);
-        setNewAgentNameError("");
       }
       return;
     }

--- a/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
+++ b/src/tests/cli/bootstrap-reminders-reset-wiring.test.ts
@@ -21,7 +21,7 @@ describe("bootstrap reminder reset wiring", () => {
 
     const anchors = [
       'origin: "agent-switch"',
-      'const inputCmd = "/new";', // new-agent creation flow
+      'commandRunner.start("/new"', // new-agent creation flow
       "const newMatch = msg.trim().match(/^\\/new(?:\\s+(.+))?$/);",
       'if (msg.trim() === "/clear")',
       'origin: "resume-direct"',
@@ -45,7 +45,7 @@ describe("bootstrap reminder reset wiring", () => {
   test("new-agent creation flow resets routing to default conversation", () => {
     const source = readInteractiveAppSource();
 
-    const anchor = 'const inputCmd = "/new";';
+    const anchor = 'commandRunner.start("/new"';
     const anchorIndex = source.indexOf(anchor);
     expect(anchorIndex).toBeGreaterThanOrEqual(0);
 


### PR DESCRIPTION
## Summary
- Adds a "New" tab to the `/agents` browser tab bar (after Pinned, Letta Code, All)
- Makes agent creation discoverable — no longer hidden behind the N shortcut
- N key still works as a power-user shortcut that jumps to the New tab
- Removes the separate `NewAgentDialog` overlay (creation now happens inline)
- Removes `"new"` from the `ActiveOverlay` type union (dead code)

## Test plan
- [ ] Run `/agents` and verify "New" tab appears in the tab bar
- [ ] Tab over to "New" — should show name input with placeholder
- [ ] Type a name and press Enter — agent should be created
- [ ] Press Enter with empty input — should create with default name
- [ ] Press Esc with input — should clear input first
- [ ] Press Esc with empty input — should close the browser
- [ ] Press N from any tab — should jump to New tab
- [ ] Verify list tabs (Pinned, Letta Code, All) still work normally

👾 Generated with [Letta Code](https://letta.com)