### PR TITLE
feat(cli): add ctrl+d queue defer mode

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1403,7 +1403,9 @@ export default function App({
   // between each sequential tool call, making defer indistinguishable from immediate).
   const deferModeSupported = !isLocalAgentId(agentId);
   // When 'immediate' (default), they fire on any turn end.
-  const [queueMode, setQueueMode] = useState<"immediate" | "defer">("immediate");
+  const [queueMode, setQueueMode] = useState<"immediate" | "defer">(
+    "immediate",
+  );
   const handleCtrlD = useCallback(() => {
     if (!deferModeSupported) return;
     setQueueMode((prev) => (prev === "immediate" ? "defer" : "immediate"));
@@ -1413,7 +1415,6 @@ export default function App({
   queueModeRef.current = queueMode;
   // Tracks the stop reason of the last completed turn, set by useConversationLoop.
   const lastStopReasonRef = useRef<string | null>(null);
-
 
   // Track last dequeued message for restoration on error
   // If an error occurs after dequeue, we restore this to the input field (if input is empty)
@@ -3804,7 +3805,6 @@ export default function App({
         (lastStopReasonRef.current === "end_turn" &&
           processingConversationRef.current === 0))
     ) {
-
       // consumeItems(n) fires onDequeued → setQueueDisplay(prev => prev.slice(n)).
       const batch = tuiQueueRef.current?.consumeItems(queueLen);
       if (!batch) return;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -92,6 +92,7 @@ import {
   type Line,
   toLines,
 } from "../helpers/accumulator";
+import { isLocalAgentId } from "../helpers/appUrls";
 import { backfillBuffers } from "../helpers/backfill";
 import { chunkLog } from "../helpers/chunkLog";
 import {
@@ -1396,6 +1397,23 @@ export default function App({
   const [dequeueEpoch, setDequeueEpoch] = useState(0);
   // Strict lock to ensure dequeue submit path is at-most-once while onSubmit is in flight.
   const dequeueInFlightRef = useRef(false);
+
+  // Queue defer mode: when 'defer', queued messages only fire on end_turn stop reason.
+  // Defer mode is only meaningful in API backend mode (local backend fires end_turn
+  // between each sequential tool call, making defer indistinguishable from immediate).
+  const deferModeSupported = !isLocalAgentId(agentId);
+  // When 'immediate' (default), they fire on any turn end.
+  const [queueMode, setQueueMode] = useState<"immediate" | "defer">("immediate");
+  const handleCtrlD = useCallback(() => {
+    if (!deferModeSupported) return;
+    setQueueMode((prev) => (prev === "immediate" ? "defer" : "immediate"));
+  }, [deferModeSupported]);
+  // Ref mirror of queueMode so useConversationLoop can read it without stale closures.
+  const queueModeRef = useRef<"immediate" | "defer">("immediate");
+  queueModeRef.current = queueMode;
+  // Tracks the stop reason of the last completed turn, set by useConversationLoop.
+  const lastStopReasonRef = useRef<string | null>(null);
+
 
   // Track last dequeued message for restoration on error
   // If an error occurs after dequeue, we restore this to the input field (if input is empty)
@@ -3237,6 +3255,7 @@ export default function App({
     clearApprovalToolContext,
     closeTrajectorySegment,
     consumeQueuedMessages,
+    queueModeRef,
     contextTrackerRef,
     conversationBusyRetriesRef,
     conversationGenerationRef,
@@ -3279,6 +3298,7 @@ export default function App({
     setCurrentModelHandle,
     setCurrentModelId,
     setDequeueEpoch,
+    lastStopReasonRef,
     setIsExecutingTool,
     setLlmConfig,
     setNeedsEagerApprovalCheck,
@@ -3338,6 +3358,7 @@ export default function App({
     commandRunner,
     commitEligibleLines,
     consumeQueuedMessages,
+    queueModeRef,
     conversationGenerationRef,
     conversationId,
     conversationIdRef,
@@ -3775,8 +3796,15 @@ export default function App({
       !waitingForQueueCancelRef.current && // Don't dequeue while waiting for cancel
       !userCancelledRef.current && // Don't dequeue if user just cancelled
       !abortControllerRef.current && // Don't dequeue while processConversation is still active
-      !dequeueInFlightRef.current // Don't dequeue while previous dequeue submit is still in flight
+      !dequeueInFlightRef.current && // Don't dequeue while previous dequeue submit is still in flight
+      // In defer mode, only dequeue when the agent is truly done:
+      // - last stop reason was end_turn (not requires_approval or error)
+      // - processingConversationRef === 0 (no nested processConversation calls outstanding)
+      (queueMode === "immediate" ||
+        (lastStopReasonRef.current === "end_turn" &&
+          processingConversationRef.current === 0))
     ) {
+
       // consumeItems(n) fires onDequeued → setQueueDisplay(prev => prev.slice(n)).
       const batch = tuiQueueRef.current?.consumeItems(queueLen);
       if (!batch) return;
@@ -3808,6 +3836,8 @@ export default function App({
       // Lock prevents re-entrant dequeue if deps churn before processConversation
       // sets abortControllerRef (which is the normal long-term gate).
       dequeueInFlightRef.current = true;
+      // Reset to immediate mode after each dequeue — defer is opt-in per batch.
+      setQueueMode("immediate");
       void onSubmitRef.current(concatenatedMessage).finally(() => {
         dequeueInFlightRef.current = false;
         // If more items arrived while in-flight, bump epoch so the effect re-runs.
@@ -3845,6 +3875,7 @@ export default function App({
     anySelectorOpen,
     dequeueEpoch,
     queuedOverlayAction,
+    queueMode,
   ]);
 
   const {
@@ -4430,6 +4461,9 @@ export default function App({
       expandedToolCallId={expandedToolCallId}
       lastShellToolCallId={lastShellToolCallId}
       handleCtrlO={handleCtrlO}
+      queueMode={queueMode}
+      deferModeSupported={deferModeSupported}
+      handleCtrlD={handleCtrlD}
       emittedIdsRef={emittedIdsRef}
       feedbackPrefill={feedbackPrefill}
       footerUpdateText={footerUpdateText}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -155,6 +155,9 @@ type AppViewProps = {
   expandedToolCallId: string | null;
   lastShellToolCallId: string | null;
   handleCtrlO: () => void;
+  queueMode: "immediate" | "defer";
+  deferModeSupported: boolean;
+  handleCtrlD: () => void;
 
   feedbackPrefill: string;
   footerUpdateText: string | null;
@@ -341,6 +344,9 @@ export function AppView(props: AppViewProps) {
     expandedToolCallId,
     lastShellToolCallId,
     handleCtrlO,
+    queueMode,
+    deferModeSupported,
+    handleCtrlD,
     feedbackPrefill,
     footerUpdateText,
     handleAgentSelect,
@@ -712,6 +718,9 @@ export function AppView(props: AppViewProps) {
                 onExit={handleExit}
                 onInterrupt={handleInterrupt}
                 onCtrlO={handleCtrlO}
+                onCtrlD={handleCtrlD}
+                queueMode={queueMode}
+                deferModeSupported={deferModeSupported}
                 interruptRequested={interruptRequested}
                 agentId={agentId}
                 agentName={agentName}

--- a/src/cli/app/useApprovalFlow.ts
+++ b/src/cli/app/useApprovalFlow.ts
@@ -97,6 +97,7 @@ type ApprovalFlowContext = {
     opts?: { deferToolCalls?: boolean },
   ) => void;
   consumeQueuedMessages: () => QueuedMessage[] | null;
+  queueModeRef: MutableRefObject<"immediate" | "defer">;
   conversationGenerationRef: MutableRefObject<number>;
   conversationId: string;
   conversationIdRef: MutableRefObject<string>;
@@ -164,6 +165,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
     commandRunner,
     commitEligibleLines,
     consumeQueuedMessages,
+    queueModeRef,
     conversationGenerationRef,
     conversationId,
     conversationIdRef,
@@ -572,7 +574,10 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           waitingForQueueCancelRef.current = false;
           queueSnapshotRef.current = [];
         } else {
-          const queuedItemsToAppend = consumeQueuedMessages();
+          const queuedItemsToAppend =
+            queueModeRef.current === "immediate"
+              ? consumeQueuedMessages()
+              : null;
           const queuedNotifications = queuedItemsToAppend
             ? getQueuedNotificationSummaries(queuedItemsToAppend)
             : [];

--- a/src/cli/app/useConversationLoop.ts
+++ b/src/cli/app/useConversationLoop.ts
@@ -147,6 +147,7 @@ type ConversationLoopContext = {
   clearApprovalToolContext: () => void;
   closeTrajectorySegment: () => void;
   consumeQueuedMessages: () => QueuedMessage[] | null;
+  queueModeRef: MutableRefObject<"immediate" | "defer">;
   contextTrackerRef: MutableRefObject<ContextTracker>;
   conversationBusyRetriesRef: MutableRefObject<number>;
   conversationGenerationRef: MutableRefObject<number>;
@@ -193,6 +194,7 @@ type ConversationLoopContext = {
   setCurrentModelHandle: Dispatch<SetStateAction<string | null>>;
   setCurrentModelId: Dispatch<SetStateAction<string | null>>;
   setDequeueEpoch: Dispatch<SetStateAction<number>>;
+  lastStopReasonRef: MutableRefObject<string | null>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setLlmConfig: Dispatch<SetStateAction<LlmConfig | null>>;
   setNeedsEagerApprovalCheck: Dispatch<SetStateAction<boolean>>;
@@ -240,6 +242,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     clearApprovalToolContext,
     closeTrajectorySegment,
     consumeQueuedMessages,
+    queueModeRef,
     contextTrackerRef,
     conversationBusyRetriesRef,
     conversationGenerationRef,
@@ -282,6 +285,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     setCurrentModelHandle,
     setCurrentModelId,
     setDequeueEpoch,
+    lastStopReasonRef,
     setIsExecutingTool,
     setLlmConfig,
     setNeedsEagerApprovalCheck,
@@ -1389,6 +1393,9 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             stopReasonToHandle = "requires_approval";
           }
 
+          // Record the final stop reason so the dequeue gate can check it.
+          lastStopReasonRef.current = stopReasonToHandle;
+
           // Case 1: Turn ended normally
           if (stopReasonToHandle === "end_turn") {
             clearApprovalToolContext();
@@ -1966,8 +1973,13 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                   return;
                 }
 
-                // Append queued messages if any (from 15s append mode)
-                const queuedItemsToAppend = consumeQueuedMessages();
+                // Append queued messages if any (from 15s append mode).
+                // In defer mode, skip mid-run bundling — let the dequeue gate
+                // handle dispatch after the agent is fully done (end_turn).
+                const queuedItemsToAppend =
+                  queueModeRef.current === "immediate"
+                    ? consumeQueuedMessages()
+                    : null;
                 const queuedNotifications = queuedItemsToAppend
                   ? getQueuedNotificationSummaries(queuedItemsToAppend)
                   : [];
@@ -2788,6 +2800,17 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
 
         abortControllerRef.current = null;
 
+        // Decrement BEFORE bumping the epoch so that when the dequeue effect
+        // fires synchronously (Ink legacy mode), processingConversationRef.current
+        // already reflects the true count. The defer gate checks === 0 to confirm
+        // no more nested processConversation calls are outstanding.
+        if (!isStale) {
+          processingConversationRef.current = Math.max(
+            0,
+            processingConversationRef.current - 1,
+          );
+        }
+
         // Trigger dequeue effect now that processConversation is no longer active.
         // The dequeue effect checks abortControllerRef (a ref, not state), so it
         // won't re-run on its own — bump dequeueEpoch to force re-evaluation.
@@ -2795,15 +2818,6 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         // cancelled and queued messages should NOT be auto-submitted.
         if (!isStale && (tuiQueueRef.current?.length ?? 0) > 0) {
           setDequeueEpoch((e: number) => e + 1);
-        }
-
-        // Only decrement ref if this conversation is still current.
-        // If stale (ESC was pressed), handleInterrupt already reset ref to 0.
-        if (!isStale) {
-          processingConversationRef.current = Math.max(
-            0,
-            processingConversationRef.current - 1,
-          );
         }
       }
     },

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -455,6 +455,8 @@ const InputFooter = memo(function InputFooter({
   footerNotification,
   goalStatusText,
   hasQueuedMessages = false,
+  queueMode = "immediate",
+  deferModeSupported = false,
 }: {
   ctrlCPressed: boolean;
   escapePressed: boolean;
@@ -477,6 +479,8 @@ const InputFooter = memo(function InputFooter({
   footerNotification?: string | null;
   goalStatusText?: string | null;
   hasQueuedMessages?: boolean;
+  queueMode?: "immediate" | "defer";
+  deferModeSupported?: boolean;
 }) {
   const hideFooterContent = hideFooter;
 
@@ -642,7 +646,13 @@ const InputFooter = memo(function InputFooter({
             {footerNotification}
           </Text>
         ) : hasQueuedMessages ? (
-          <Text dimColor>press ↑ to edit queued message</Text>
+          <Text dimColor>
+            {deferModeSupported
+              ? queueMode === "defer"
+                ? "press ↑ to edit · ctrl+d to release queue"
+                : "press ↑ to edit · ctrl+d to hold queue until done"
+              : "press ↑ to edit"}
+          </Text>
         ) : (
           <Text dimColor>Press / for commands</Text>
         )}
@@ -969,6 +979,9 @@ export function Input({
   onExit,
   onInterrupt,
   onCtrlO,
+  onCtrlD,
+  queueMode = "immediate",
+  deferModeSupported = false,
   interruptRequested = false,
   agentId,
   agentName,
@@ -1015,6 +1028,9 @@ export function Input({
   onExit?: () => void;
   onInterrupt?: () => void;
   onCtrlO?: () => void;
+  onCtrlD?: () => void;
+  queueMode?: "immediate" | "defer";
+  deferModeSupported?: boolean;
   interruptRequested?: boolean;
   agentId?: string;
   agentName?: string | null;
@@ -1330,6 +1346,17 @@ export function Input({
   });
 
   useInput((input, key) => {
+    // Handle CTRL-D to toggle queue defer mode — works even while agent is running
+    // since that's exactly when messages are queued and the toggle is useful.
+    if (
+      input === "d" &&
+      key.ctrl &&
+      (messageQueue?.filter((m) => m.kind === "user").length ?? 0) > 0
+    ) {
+      if (onCtrlD) onCtrlD();
+      return;
+    }
+
     if (!interactionEnabled) return;
 
     // Handle CTRL-O to expand/collapse the last tool call output
@@ -1836,7 +1863,7 @@ export function Input({
       <>
         {/* Queue display - show whenever there are queued messages */}
         {messageQueue && messageQueue.length > 0 && (
-          <QueuedMessages messages={messageQueue} />
+          <QueuedMessages messages={messageQueue} queueMode={queueMode} />
         )}
 
         {interactionEnabled ? (
@@ -1942,6 +1969,8 @@ export function Input({
                   (messageQueue?.filter((m) => m.kind === "user").length ?? 0) >
                   0
                 }
+                queueMode={queueMode}
+                deferModeSupported={deferModeSupported}
               />
             )}
           </Box>
@@ -1995,6 +2024,7 @@ export function Input({
     promptChar,
     promptVisualWidth,
     suppressDividers,
+    queueMode,
   ]);
 
   // If not visible, render nothing but keep component mounted to preserve state

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -649,9 +649,9 @@ const InputFooter = memo(function InputFooter({
           <Text dimColor>
             {deferModeSupported
               ? queueMode === "defer"
-                ? "press ↑ to edit · ctrl+d to release queue"
-                : "press ↑ to edit · ctrl+d to hold queue until done"
-              : "press ↑ to edit"}
+                ? "press ↑ to edit queued message · ctrl+d to release queue"
+                : "press ↑ to edit queued message · ctrl+d to hold queue until done"
+              : "press ↑ to edit queued message"}
           </Text>
         ) : (
           <Text dimColor>Press / for commands</Text>

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -2025,6 +2025,7 @@ export function Input({
     promptVisualWidth,
     suppressDividers,
     queueMode,
+    deferModeSupported,
   ]);
 
   // If not visible, render nothing but keep component mounted to preserve state

--- a/src/cli/components/QueuedMessages.tsx
+++ b/src/cli/components/QueuedMessages.tsx
@@ -6,44 +6,49 @@ import { Text } from "./Text";
 
 interface QueuedMessagesProps {
   messages: QueuedMessage[];
+  queueMode?: "immediate" | "defer";
 }
 
-export const QueuedMessages = memo(({ messages }: QueuedMessagesProps) => {
-  const maxDisplay = 5;
-  const displayMessages = messages
-    .filter((msg) => msg.kind === "user")
-    .map((msg) => msg.text.trim())
-    .filter((msg) => msg.length > 0);
+export const QueuedMessages = memo(
+  ({ messages, queueMode = "immediate" }: QueuedMessagesProps) => {
+    const maxDisplay = 5;
+    const displayMessages = messages
+      .filter((msg) => msg.kind === "user")
+      .map((msg) => msg.text.trim())
+      .filter((msg) => msg.length > 0);
 
-  if (displayMessages.length === 0) {
-    return null;
-  }
+    if (displayMessages.length === 0) {
+      return null;
+    }
 
-  return (
-    <Box flexDirection="column" marginBottom={1}>
-      {displayMessages.slice(0, maxDisplay).map((msg, index) => (
-        <Box key={`${index}-${msg.slice(0, 50)}`} flexDirection="row">
-          <Box width={2} flexShrink={0}>
-            <Text dimColor>{CLI_GLYPHS.prompt}</Text>
-          </Box>
-          <Box flexGrow={1}>
-            <Text dimColor>{msg}</Text>
-          </Box>
-        </Box>
-      ))}
+    const bullet = queueMode === "defer" ? "○" : CLI_GLYPHS.prompt;
 
-      {displayMessages.length > maxDisplay && (
-        <Box flexDirection="row">
-          <Box width={2} flexShrink={0} />
-          <Box flexGrow={1}>
-            <Text dimColor>
-              ...and {displayMessages.length - maxDisplay} more
-            </Text>
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        {displayMessages.slice(0, maxDisplay).map((msg, index) => (
+          <Box key={`${index}-${msg.slice(0, 50)}`} flexDirection="row">
+            <Box width={2} flexShrink={0}>
+              <Text dimColor>{bullet}</Text>
+            </Box>
+            <Box flexGrow={1}>
+              <Text dimColor>{msg}</Text>
+            </Box>
           </Box>
-        </Box>
-      )}
-    </Box>
-  );
-});
+        ))}
+
+        {displayMessages.length > maxDisplay && (
+          <Box flexDirection="row">
+            <Box width={2} flexShrink={0} />
+            <Box flexGrow={1}>
+              <Text dimColor>
+                ...and {displayMessages.length - maxDisplay} more
+              </Text>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
 
 QueuedMessages.displayName = "QueuedMessages";

--- a/src/tests/cli/queue-edit-wiring.test.ts
+++ b/src/tests/cli/queue-edit-wiring.test.ts
@@ -40,7 +40,7 @@ describe("queue edit wiring", () => {
     const source = readFileSync(path, "utf-8");
 
     expect(source).toContain("hasQueuedMessages");
-    expect(source).toContain("press ↑ to edit");
+    expect(source).toContain("press ↑ to edit queued message");
   });
 
   test("InputRich has onQueueEdit prop for up-arrow edit", () => {

--- a/src/tests/cli/queue-edit-wiring.test.ts
+++ b/src/tests/cli/queue-edit-wiring.test.ts
@@ -40,7 +40,7 @@ describe("queue edit wiring", () => {
     const source = readFileSync(path, "utf-8");
 
     expect(source).toContain("hasQueuedMessages");
-    expect(source).toContain("press ↑ to edit queued message");
+    expect(source).toContain("press ↑ to edit");
   });
 
   test("InputRich has onQueueEdit prop for up-arrow edit", () => {


### PR DESCRIPTION
## Summary

- Adds `ctrl+d` to toggle **defer mode** for the message queue (API backend only)
- In defer mode, queued messages hold until the agent fully completes its turn (`end_turn` + no outstanding `processConversation` calls), rather than firing at any turn boundary including `requires_approval` pauses
- Queue bullets change from `›` to `○` in defer mode as a visual indicator
- Hint text updates: `ctrl+d to hold queue until done` / `ctrl+d to release queue`
- Mode resets to immediate after each dequeue (opt-in per batch, not sticky)
- Feature gated to API backend only — local backend fires `end_turn` between sequential tool calls making defer indistinguishable from immediate

## Implementation details

- `lastStopReasonRef` tracked in `useConversationLoop` and read by the dequeue gate in `AppCoordinator`
- `processingConversationRef` decremented **before** `dequeueEpoch` bump so the gate sees the correct nested-call depth
- `consumeQueuedMessages()` suppressed in defer mode in both `useConversationLoop` and `useApprovalFlow` mid-run bundling paths
- `deferModeSupported` flag (`!isLocalAgentId(agentId)`) propagated to `InputRich` to hide ctrl+d hint and make the toggle a no-op on local backend

## Test plan

- [ ] API backend: queue a message during a multi-tool run → confirm it waits until agent is fully done before firing
- [ ] API backend: `ctrl+d` while queue is active toggles `○` bullets and hint text
- [ ] API backend: `ctrl+d` in defer mode releases the queue immediately
- [ ] API backend: mode resets to immediate after dequeue
- [ ] Local backend: `ctrl+d` does nothing, no hint text shown, queue fires normally
- [ ] Standard permission mode: queued messages hold through all approval pauses, fire only at final `end_turn`

👾 Generated with [Letta Code](https://letta.com)