### PR TITLE
fix(cli): allow blank keys for local providers

### DIFF
--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -1,6 +1,7 @@
 import {
   type ByokProvider,
   type ByokProviderId,
+  defaultProviderApiKey,
   getProviderConfig,
 } from "../../providers/byok-providers";
 
@@ -141,15 +142,7 @@ export function isConnectApiKeyProvider(
 export function defaultConnectApiKey(
   provider: ResolvedConnectProvider,
 ): string | undefined {
-  if (
-    "requiresApiKey" in provider.byokProvider &&
-    provider.byokProvider.requiresApiKey === false
-  ) {
-    return "defaultApiKey" in provider.byokProvider
-      ? provider.byokProvider.defaultApiKey
-      : "not-needed";
-  }
-  return undefined;
+  return defaultProviderApiKey(provider.byokProvider);
 }
 
 export function isConnectZaiBaseProvider(

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -6,6 +6,7 @@ import {
   type ByokProvider,
   checkProviderApiKey,
   createOrUpdateProvider,
+  defaultProviderApiKey,
   getConnectedProviders,
   type ProviderField,
   type ProviderResponse,
@@ -36,6 +37,13 @@ interface ProviderSelectorProps {
   onCancel: () => void;
   /** Called when ChatGPT/Codex OAuth flow should start */
   onStartOAuth?: () => void;
+}
+
+export function providerApiKeyFromInput(
+  provider: ByokProvider,
+  input: string,
+): string | undefined {
+  return input.trim() || defaultProviderApiKey(provider);
 }
 
 export function ProviderSelector({
@@ -214,9 +222,10 @@ export function ProviderSelector({
   // Handle API key validation and saving
   const handleValidateAndSave = useCallback(async () => {
     if (viewState.type !== "input") return;
-    if (!apiKeyInput.trim()) return;
 
     const { provider } = viewState;
+    const apiKey = providerApiKeyFromInput(provider, apiKeyInput);
+    if (!apiKey) return;
 
     // If already validated, save
     if (validationState === "valid") {
@@ -225,7 +234,7 @@ export function ProviderSelector({
         await createOrUpdateProvider(
           provider.providerType,
           provider.providerName,
-          apiKeyInput.trim(),
+          apiKey,
         );
         // Refresh connected providers
         const providers = await getConnectedProviders();
@@ -251,7 +260,7 @@ export function ProviderSelector({
     setValidationError(null);
 
     try {
-      await checkProviderApiKey(provider.providerType, apiKeyInput.trim());
+      await checkProviderApiKey(provider.providerType, apiKey);
       if (mountedRef.current) {
         setValidationState("valid");
       }
@@ -602,6 +611,8 @@ export function ProviderSelector({
   const renderInputView = () => {
     if (viewState.type !== "input") return null;
     const { provider } = viewState;
+    const hasDefaultApiKey = defaultProviderApiKey(provider) !== undefined;
+    const hasTypedApiKey = Boolean(apiKeyInput.trim());
 
     const statusText =
       validationState === "validating"
@@ -632,13 +643,22 @@ export function ProviderSelector({
       <>
         <Box flexDirection="column" marginBottom={1}>
           <Text>
-            {"  "}Connect your {provider.displayName} key:
+            {"  "}
+            {hasDefaultApiKey
+              ? `Connect ${provider.displayName} (API key optional):`
+              : `Connect your ${provider.displayName} key:`}
           </Text>
         </Box>
 
         <Box flexDirection="row">
           <Text color={colors.selector.itemHighlighted}>{"> "}</Text>
-          <Text>{apiKeyInput ? maskApiKey(apiKeyInput) : "(enter key)"}</Text>
+          <Text>
+            {apiKeyInput
+              ? maskApiKey(apiKeyInput)
+              : hasDefaultApiKey
+                ? "(press Enter for no key)"
+                : "(enter key)"}
+          </Text>
           <Text
             color={statusColor}
             dimColor={
@@ -652,7 +672,9 @@ export function ProviderSelector({
         <Box marginTop={1}>
           <Text dimColor>
             {"  "}
-            {footerText}
+            {hasDefaultApiKey && !hasTypedApiKey && validationState === "idle"
+              ? "Enter to validate without a key · Esc cancel"
+              : footerText}
           </Text>
         </Box>
       </>

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -194,6 +194,15 @@ export const BYOK_PROVIDERS = [
 export type ByokProviderId = (typeof BYOK_PROVIDERS)[number]["id"];
 export type ByokProvider = (typeof BYOK_PROVIDERS)[number];
 
+export function defaultProviderApiKey(
+  provider: ByokProvider,
+): string | undefined {
+  if ("requiresApiKey" in provider && provider.requiresApiKey === false) {
+    return "defaultApiKey" in provider ? provider.defaultApiKey : "not-needed";
+  }
+  return undefined;
+}
+
 export function isLocalProviderStoreEnabled(): boolean {
   return getBackend().capabilities.localModelCatalog;
 }

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { providerApiKeyFromInput } from "../../cli/components/ProviderSelector";
+import {
+  BYOK_PROVIDERS,
+  type ByokProvider,
+  defaultProviderApiKey,
+} from "../../providers/byok-providers";
+
+function providerById(id: string): ByokProvider {
+  const provider = BYOK_PROVIDERS.find((candidate) => candidate.id === id);
+  if (!provider) {
+    throw new Error(`Expected provider ${id} to exist`);
+  }
+  return provider;
+}
+
+describe("ProviderSelector local provider API keys", () => {
+  test("uses default key placeholders for API-key optional local providers", () => {
+    expect(defaultProviderApiKey(providerById("ollama"))).toBe("not-needed");
+    expect(defaultProviderApiKey(providerById("lmstudio"))).toBe("not-needed");
+    expect(defaultProviderApiKey(providerById("llama-cpp"))).toBe("not-needed");
+  });
+
+  test("allows blank input only when the selected provider has a default key", () => {
+    expect(providerApiKeyFromInput(providerById("lmstudio"), "")).toBe(
+      "not-needed",
+    );
+    expect(providerApiKeyFromInput(providerById("ollama"), "   ")).toBe(
+      "not-needed",
+    );
+    expect(providerApiKeyFromInput(providerById("openai"), "")).toBe(undefined);
+  });
+
+  test("uses explicitly typed keys over local provider defaults", () => {
+    expect(providerApiKeyFromInput(providerById("lmstudio"), " lm-key ")).toBe(
+      "lm-key",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Allow the interactive provider picker to validate/save API-key-optional local providers with blank input.
- Share default API-key resolution between direct connect commands and the picker.
- Add regression coverage for Ollama, LM Studio, llama.cpp, and required-key providers.

## Test plan
- [x] bun test src/tests/cli/connect-normalize.test.ts src/tests/cli/connect-subcommand.test.ts src/tests/cli/provider-selector-local-provider.test.ts
- [x] bunx --bun @biomejs/biome@2.2.5 check src/cli/components/ProviderSelector.tsx src/providers/byok-providers.ts src/cli/commands/connect-normalize.ts src/tests/cli/provider-selector-local-provider.test.ts
- [x] git diff --check -- src/cli/components/ProviderSelector.tsx src/providers/byok-providers.ts src/cli/commands/connect-normalize.ts src/tests/cli/provider-selector-local-provider.test.ts
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)