### PR TITLE
feat(cli): add OverlayShell and SingleSelectPicker, migrate PersonalitySelector

### DIFF
--- a/src/cli/components/OverlayShell.tsx
+++ b/src/cli/components/OverlayShell.tsx
@@ -1,0 +1,54 @@
+// Shared shell for overlay UIs.
+// Renders the "> /command" header, solid line, title, and optional footer.
+// Every overlay selector/dialog uses this pattern.
+
+import { Box } from "ink";
+import type { ReactNode } from "react";
+import { useTerminalWidth } from "../hooks/useTerminalWidth";
+import { colors } from "./colors";
+import { Text } from "./Text";
+
+const SOLID_LINE = "─";
+
+interface OverlayShellProps {
+  /** The command that opened this overlay, e.g. "/personality" */
+  command: string;
+  /** Title displayed below the solid line */
+  title: string;
+  children: ReactNode;
+  /** Optional footer content (e.g. hint line). If omitted, no footer is rendered. */
+  footer?: ReactNode;
+}
+
+export function OverlayShell({
+  command,
+  title,
+  children,
+  footer,
+}: OverlayShellProps) {
+  const terminalWidth = useTerminalWidth();
+  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+
+  return (
+    <Box flexDirection="column">
+      <Text dimColor>{`> ${command}`}</Text>
+      <Text dimColor>{solidLine}</Text>
+
+      <Box height={1} />
+
+      <Box marginBottom={1}>
+        <Text bold color={colors.selector.title}>
+          {title}
+        </Text>
+      </Box>
+
+      {children}
+
+      {footer && (
+        <Box marginTop={1}>
+          <Text dimColor>{footer}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/cli/components/PersonalitySelector.tsx
+++ b/src/cli/components/PersonalitySelector.tsx
@@ -1,14 +1,14 @@
-import { Box, useInput } from "ink";
-import { useState } from "react";
+// Personality selector.
+// Wraps SingleSelectPicker with personality-specific logic.
+
+import { memo, useMemo } from "react";
 import {
   PERSONALITY_OPTIONS,
   type PersonalityId,
 } from "../../agent/personality";
-import { useTerminalWidth } from "../hooks/useTerminalWidth";
-import { colors } from "./colors";
-import { Text } from "./Text";
-
-const SOLID_LINE = "─";
+import { OverlayShell } from "./OverlayShell";
+import type { SelectableItem } from "./SingleSelectPicker";
+import { SingleSelectPicker } from "./SingleSelectPicker";
 
 interface PersonalitySelectorProps {
   currentPersonalityId?: PersonalityId;
@@ -16,93 +16,29 @@ interface PersonalitySelectorProps {
   onCancel: () => void;
 }
 
-export function PersonalitySelector({
+export const PersonalitySelector = memo(function PersonalitySelector({
   currentPersonalityId,
   onSelect,
   onCancel,
 }: PersonalitySelectorProps) {
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
-  const [selectedIndex, setSelectedIndex] = useState(0);
-
-  useInput((input, key) => {
-    if (key.ctrl && input === "c") {
-      onCancel();
-      return;
-    }
-
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-      return;
-    }
-
-    if (key.downArrow) {
-      setSelectedIndex((prev) =>
-        Math.min(PERSONALITY_OPTIONS.length - 1, prev + 1),
-      );
-      return;
-    }
-
-    if (key.return) {
-      const selected = PERSONALITY_OPTIONS[selectedIndex];
-      if (selected) {
-        onSelect(selected.id);
-      }
-      return;
-    }
-
-    if (key.escape) {
-      onCancel();
-    }
-  });
+  const items = useMemo<SelectableItem[]>(
+    () =>
+      PERSONALITY_OPTIONS.map((option) => ({
+        key: option.id,
+        label: option.label,
+        description: option.description,
+        isCurrent: option.id === currentPersonalityId,
+      })),
+    [currentPersonalityId],
+  );
 
   return (
-    <Box flexDirection="column">
-      <Text dimColor>{"> /personality"}</Text>
-      <Text dimColor>{solidLine}</Text>
-
-      <Box height={1} />
-
-      <Box marginBottom={1}>
-        <Text bold color={colors.selector.title}>
-          Swap your agent personality
-        </Text>
-      </Box>
-
-      <Box flexDirection="column">
-        {PERSONALITY_OPTIONS.map((option, index) => {
-          const isSelected = index === selectedIndex;
-          const isCurrent = option.id === currentPersonalityId;
-
-          return (
-            <Box key={option.id} flexDirection="row">
-              <Text
-                color={isSelected ? colors.selector.itemHighlighted : undefined}
-              >
-                {isSelected ? "> " : "  "}
-              </Text>
-              <Text
-                bold={isSelected}
-                color={
-                  isSelected
-                    ? colors.selector.itemHighlighted
-                    : isCurrent
-                      ? colors.selector.itemCurrent
-                      : undefined
-                }
-              >
-                {option.label}
-                {isCurrent && " (current)"}
-              </Text>
-              <Text dimColor> ({option.description})</Text>
-            </Box>
-          );
-        })}
-      </Box>
-
-      <Box marginTop={1}>
-        <Text dimColor>{"  "}Enter select · ↑↓ navigate · Esc cancel</Text>
-      </Box>
-    </Box>
+    <OverlayShell command="/personality" title="Swap your agent personality">
+      <SingleSelectPicker
+        items={items}
+        onSelect={(key) => onSelect(key as PersonalityId)}
+        onCancel={onCancel}
+      />
+    </OverlayShell>
   );
-}
+});

--- a/src/cli/components/SingleSelectPicker.tsx
+++ b/src/cli/components/SingleSelectPicker.tsx
@@ -1,0 +1,140 @@
+// Reusable single-select vertical list picker.
+//
+// Renders a vertical list with cursor navigation (↑↓),
+// Enter to confirm, Escape to cancel.
+// Items are identified by key (string), not index.
+
+import { Box, type Key, useInput } from "ink";
+import { memo, useCallback, useEffect, useState } from "react";
+import { colors } from "./colors";
+import { Text } from "./Text";
+
+export interface SelectableItem {
+  key: string;
+  label: string;
+  description?: string;
+  /** When true, shows "(current)" marker and uses `colors.selector.itemCurrent` */
+  isCurrent?: boolean;
+  /** When true, item is dimmed and Enter is a no-op */
+  disabled?: boolean;
+}
+
+export interface SingleSelectPickerProps {
+  items: SelectableItem[];
+  /** Start cursor at this index (default 0) */
+  initialCursorIndex?: number;
+  /** Called when user presses Enter on an item */
+  onSelect: (key: string) => void;
+  /** Called when user presses Escape or Ctrl-C */
+  onCancel: () => void;
+  /** Override the default footer hint line */
+  footerHint?: string;
+  /**
+   * Extra key handlers beyond the built-in ↑↓/Enter/Escape/Ctrl-C.
+   * Key is the input character, value is a callback with the current cursor index.
+   * Useful for shortcuts like "A" for show-all.
+   */
+  extraActions?: Record<string, (cursorIndex: number) => void>;
+}
+
+const DEFAULT_FOOTER_HINT = "  Enter select · ↑↓ navigate · Esc cancel";
+
+export const SingleSelectPicker = memo(function SingleSelectPicker({
+  items,
+  initialCursorIndex = 0,
+  onSelect,
+  onCancel,
+  footerHint = DEFAULT_FOOTER_HINT,
+  extraActions,
+}: SingleSelectPickerProps) {
+  const [cursor, setCursor] = useState(initialCursorIndex);
+
+  // Clamp cursor when items change
+  useEffect(() => {
+    if (items.length === 0) return;
+    setCursor((c) => Math.min(c, items.length - 1));
+  }, [items.length]);
+
+  const handleInput = useCallback(
+    (input: string, key: Key) => {
+      if (key.ctrl && input === "c") {
+        onCancel();
+        return;
+      }
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((c) => Math.min(items.length - 1, c + 1));
+        return;
+      }
+      if (key.return) {
+        const item = items[cursor];
+        if (item && !item.disabled) {
+          onSelect(item.key);
+        }
+        return;
+      }
+      if (key.escape) {
+        onCancel();
+        return;
+      }
+      // Check extra actions
+      if (input && extraActions) {
+        const action = extraActions[input];
+        if (action) {
+          action(cursor);
+        }
+      }
+    },
+    [items, cursor, onCancel, onSelect, extraActions],
+  );
+
+  useInput(handleInput, { isActive: true });
+
+  return (
+    <Box flexDirection="column">
+      {items.map((item, index) => {
+        const isCursor = index === cursor;
+        const isCurrent = item.isCurrent ?? false;
+        const isDisabled = item.disabled ?? false;
+
+        const cursorColor = isDisabled
+          ? undefined
+          : isCursor
+            ? colors.selector.itemHighlighted
+            : undefined;
+        const labelColor = isDisabled
+          ? undefined
+          : isCursor
+            ? colors.selector.itemHighlighted
+            : isCurrent
+              ? colors.selector.itemCurrent
+              : undefined;
+
+        return (
+          <Box key={item.key} flexDirection="row">
+            <Text color={cursorColor}>{isCursor ? "> " : "  "}</Text>
+            <Text
+              color={labelColor}
+              bold={isCursor && !isDisabled}
+              dimColor={isDisabled}
+            >
+              {item.label}
+              {isCurrent && " (current)"}
+            </Text>
+            {item.description && (
+              <Text dimColor>{` · ${item.description}`}</Text>
+            )}
+          </Box>
+        );
+      })}
+
+      {/* Footer hint */}
+      <Box marginTop={1}>
+        <Text dimColor>{footerHint}</Text>
+      </Box>
+    </Box>
+  );
+});


### PR DESCRIPTION
## Summary

- Extract `OverlayShell` — shared wrapper for the `> /command` + solid line + title + footer pattern that every overlay uses
- Extract `SingleSelectPicker` — vertical list with cursor navigation (↑↓), Enter to confirm, Escape to cancel. Supports `isCurrent` markers, `disabled` items, `extraActions` for custom key shortcuts, and custom `footerHint`
- Migrate `PersonalitySelector` onto both components as the simplest proof-of-concept (pure wrapper, no custom logic)

This is PR 1 of the Phase 1 plan. Future PRs will migrate `SystemPromptSelector` (introduces "show all" pattern), `ToolsetSelector` (introduces `extraActions` + custom labels), and add `OverlayShell` to `ModelReasoningSelector`.

## What stays in each selector after migration

| Feature | Handled by |
|---------|-----------|
| Header + solid line + title | `OverlayShell` |
| Cursor navigation + colors | `SingleSelectPicker` |
| `(current)` marker | `SingleSelectPicker` (via `isCurrent`) |
| Footer hint | `SingleSelectPicker` |
| Item data mapping | **stays** in each selector |
| Domain-specific logic (show-all, extra keys) | **stays** in each selector |

## Test plan

- [ ] `/personality` opens selector, ↑↓ navigates, Enter selects, Esc cancels
- [ ] `(current)` marker shows on the active personality
- [ ] Behavior is identical to before the migration

👾 Generated with [Letta Code](https://letta.com)