### PR TITLE
Document local mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, 
 
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
 
-## Running locally versus with Constellation
+## Connecting to Constellation
 Constellation allows your agents to work on any machine, while still maintaining the same cohesive memory, identity, and experience. Agents on Constellation can be access from any machine through the CLI, or run on remote environments (any machine can be connected as a remote env by running `letta server` on it). 
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -2,20 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@letta-ai/letta-code.svg?style=flat-square)](https://www.npmjs.com/package/@letta-ai/letta-code) [![Discord](https://img.shields.io/badge/discord-join-blue?style=flat-square&logo=discord)](https://discord.gg/letta)
 
-Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience. 
-
-Instead of working in independent sessions, you work with a persisted agent whose memory is portable across models (Claude, GPT, Gemini, GLM, Kimi, and more) and environments. Agents automatically reconfigure themselves through updating their skills, memory, and system prompt to adapt what they know and how they act. 
-
-Run Letta Code in the [**CLI**](https://docs.letta.com/letta-code/cli), or download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
-You can also access Letta Code via [your phone](https://docs.letta.com/letta-code/remote-mobile) and [Slack/Telegram/Discord](https://docs.letta.com/letta-code/channels).
+Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience and maintain a cohesive identity across models (Claude, GPT, Gemini, GLM, Kimi, and more). Agents automatically reconfigure themselves through updating their skills, memory, and system prompt to adapt what they know and how they act. 
 
 You can interact with Letta Code agents through: 
 * A local [**CLI**](https://docs.letta.com/letta-code/cli)
 * The [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
-* In your browser (including [mobile]((https://docs.letta.com/letta-code/remote-mobile))) 
-* Through messaging integrations (Telegram, Slack, Whatsapp, or custom connectors) with `letta server`
-
-Letta Code agents are *stateful* to rely on having a centralized memory store. 
+* In your browser (including [mobile]((https://docs.letta.com/letta-code/remote-mobile))) at [chat.letta.com](chat.letta.com)
+* Through messaging integrations (Telegram, Slack, Whatsapp, or custom connectors)
 
 ![](https://github.com/letta-ai/letta-code/blob/main/assets/letta-code-demo.gif)
 
@@ -31,6 +24,10 @@ Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, 
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
 
 ## Connecting to Constellation
+Letta Code agents are *stateful* so rely on having a centralized, git-backed memory store. State can be stored on: 
+* **The current local machine**: Local storage, single machine (best for privacy-sensitive usecases)
+* **Constellation (remote)**: Agents can connect to or run on remote machines, and can communicate with agents across machines 
+
 Constellation allows your agents to work on any machine, while still maintaining the same cohesive memory, identity, and experience. Agents on Constellation can be access from any machine through the CLI, or run on remote environments (any machine can be connected as a remote env by running `letta server` on it). 
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience.
 
-Instead of working in independent sessions, you work with a persisted agent whose memory is portable across models (Claude, GPT, Gemini, GLM, Kimi, and more).
+Instead of working in independent sessions, you work with a persisted agent whose memory is portable across models (Claude, GPT, Gemini, GLM, Kimi, and more) and environments. 
 
 Run Letta Code in the [**CLI**](https://docs.letta.com/letta-code/cli), or download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
 You can also access Letta Code via [your phone](https://docs.letta.com/letta-code/remote-mobile) and [Slack/Telegram/Discord](https://docs.letta.com/letta-code/channels).
@@ -34,7 +34,7 @@ Letta Code is built around long-lived agents that persist across sessions and im
 **Letta Code** (Agent-Based)
 - Same agent across sessions
 - Persistent memory and learning over time
-- `/clear` starts a new conversation (aka "thread" or "session"), but memory persists
+- `/new` starts a new conversation (aka "thread" or "session"), but memory persists
 - Relationship: Like having a coworker or mentee that learns and remembers
 
 ## Agent Memory & Learning
@@ -50,6 +50,16 @@ Over time, the agent will update its memory as it learns. To actively guide your
 Letta Code works with skills (reusable modules that teach your agent new capabilities in a `.skills` directory), but additionally supports [skill learning](https://www.letta.com/blog/skill-learning). You can ask your agent to learn a skill from its current trajectory with the command: 
 ```bash
 > /skill [optional instructions on what skill to learn]
+```
+
+## Remote environments
+Letta Code agents can work on 
+
+## Messaging Integrations
+Letta Code supports [channels](https://docs.letta.com/letta-code/channels). 
+```bash
+letta channels configure telegram
+letta server --channels telegram
 ```
 
 Read the docs to learn more about [skills and skill learning](https://docs.letta.com/letta-code/skills).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience and maintain a cohesive identity across models (Claude, GPT, Gemini, GLM, Kimi, and more). Agents automatically reconfigure themselves through updating their skills, memory, and system prompt to adapt what they know and how they act. 
 
-You can interact with Letta Code agents through: 
+You can interact with Letta Code agents through:
 * A local [**CLI**](https://docs.letta.com/letta-code/cli)
-* The [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
-* In your browser (including [mobile]((https://docs.letta.com/letta-code/remote-mobile))) at [chat.letta.com](chat.letta.com)
-* Through messaging integrations (Telegram, Slack, Whatsapp, or custom connectors)
+* The [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux
+* Your browser, including [mobile](https://docs.letta.com/letta-code/remote-mobile), at [chat.letta.com](https://chat.letta.com)
+* Messaging integrations, including Telegram, Slack, WhatsApp, and custom connectors
 
 ![](https://github.com/letta-ai/letta-code/blob/main/assets/letta-code-demo.gif)
 
@@ -17,18 +17,74 @@ Install the package via [npm](https://docs.npmjs.com/downloading-and-installing-
 ```bash
 npm install -g @letta-ai/letta-code
 ```
-Navigate to your project directory and run `letta` (see various command-line options [on the docs](https://docs.letta.com/letta-code/commands)). 
+Navigate to your project directory and run `letta` (see command-line options [in the docs](https://docs.letta.com/letta-code/commands)).
+
+On first run, choose how you want to start:
+
+* **Proceed locally** keeps agent state on this device. This is the local-first path and does not require a Constellation login.
+* **Login to Constellation** syncs agent state through the Constellation so you can access the same agents from `chat.letta.com`, the desktop app, other machines, and messaging integrations.
 
 Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, zAI coding plan, etc.), and use `/model` to swap models.
 
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
 
-## Connecting to Constellation
-Letta Code agents are *stateful* so rely on having a centralized, git-backed memory store. State can be stored on: 
-* **The current local machine**: Local storage, single machine (best for privacy-sensitive usecases)
-* **Constellation (remote)**: Agents can connect to or run on remote machines, and can communicate with agents across machines 
+## Local mode
+Local mode runs an embedded Letta-compatible backend inside Letta Code. Agents, conversations, memory, provider connections, and secrets are stored on your machine.
 
-Constellation allows your agents to work on any machine, while still maintaining the same cohesive memory, identity, and experience. Agents on Constellation can be access from any machine through the CLI, or run on remote environments (any machine can be connected as a remote env by running `letta server` on it). 
+Local mode is a good fit when you want:
+
+* A self-contained agent runtime for local projects
+* Disposable agents for experiments or development
+* Inspectable state stored as ordinary local files
+* Local git-backed MemFS memory
+* Direct provider connections from your machine
+
+Local mode means local **state**, not necessarily local **inference**. If you connect a remote provider like OpenAI, Anthropic, Gemini, OpenRouter, Bedrock, or ChatGPT/Codex, prompts still go to that provider. For a fully local loop, connect a local inference provider like Ollama, LM Studio, or llama.cpp.
+
+You can enter local mode from the first-run setup menu, or explicitly with:
+
+```bash
+letta --backend local
+```
+
+Connect a provider from inside the TUI with `/connect`, or from the shell with `letta --backend local connect`:
+
+```bash
+letta --backend local connect anthropic --api-key "$ANTHROPIC_API_KEY"
+letta --backend local connect ollama
+letta --backend local connect lmstudio
+letta --backend local connect llama-cpp
+letta --backend local connect chatgpt
+```
+
+Then create a local agent:
+
+```bash
+letta --backend local --new-agent --model anthropic/claude-sonnet-4-6
+```
+
+Local backend state is stored by default in:
+
+```text
+~/.letta/lc-local-backend
+```
+
+You can override this location for isolated experiments:
+
+```bash
+export LETTA_LOCAL_BACKEND_DIR="$PWD/.letta-local"
+letta --backend local --new-agent
+```
+
+Local agents do not appear in the Constellation, but their memory is still a normal git repository under `~/.letta/lc-local-backend/memfs/<agent-id>/memory`.
+
+## Connecting to Constellation
+Letta Code agents are *stateful*: memory, identity, and conversation history persist across sessions. State can live in either:
+
+* **Local mode**: local storage on the current machine, best for local-first or privacy-sensitive work
+* **Constellation**: remote state so agents can follow you across devices, environments, and communication channels
+
+The Constellation allows your agents to work on any machine while maintaining the same cohesive memory, identity, and experience. Agents in the Constellation can be accessed from the CLI, desktop app, browser, mobile, or messaging integrations. Any machine can also be connected as a remote environment by running `letta server` on it.
 
 ```mermaid
 graph TD
@@ -70,7 +126,12 @@ Letta Code works with skills (reusable modules that teach your agent new capabil
 ```
 
 ## Remote environments
-Letta Code agents can work on 
+Letta Code agents in the Constellation can connect to remote environments. Run `letta server` on a machine to register it as an environment, then use the CLI, desktop app, web app, or messaging integrations to route agent work there.
+
+```bash
+letta server
+letta server --env-name "work-laptop"
+```
 
 ## Messaging Integrations
 Letta Code supports [channels](https://docs.letta.com/letta-code/channels). 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@
 
 [![npm](https://img.shields.io/npm/v/@letta-ai/letta-code.svg?style=flat-square)](https://www.npmjs.com/package/@letta-ai/letta-code) [![Discord](https://img.shields.io/badge/discord-join-blue?style=flat-square&logo=discord)](https://discord.gg/letta)
 
-Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience.
+Letta Code is a memory-first coding harness, designed for long-lived agents that can learn from experience. 
 
-Instead of working in independent sessions, you work with a persisted agent whose memory is portable across models (Claude, GPT, Gemini, GLM, Kimi, and more) and environments. 
+Instead of working in independent sessions, you work with a persisted agent whose memory is portable across models (Claude, GPT, Gemini, GLM, Kimi, and more) and environments. Agents automatically reconfigure themselves through updating their skills, memory, and system prompt to adapt what they know and how they act. 
 
 Run Letta Code in the [**CLI**](https://docs.letta.com/letta-code/cli), or download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
 You can also access Letta Code via [your phone](https://docs.letta.com/letta-code/remote-mobile) and [Slack/Telegram/Discord](https://docs.letta.com/letta-code/channels).
+
+You can interact with Letta Code agents through: 
+* A local [**CLI**](https://docs.letta.com/letta-code/cli)
+* The [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux.
+* In your browser (including [mobile]((https://docs.letta.com/letta-code/remote-mobile))) 
+* Through messaging integrations (Telegram, Slack, Whatsapp, or custom connectors) with `letta server`
+
+Letta Code agents are *stateful* to rely on having a centralized memory store. 
 
 ![](https://github.com/letta-ai/letta-code/blob/main/assets/letta-code-demo.gif)
 
@@ -21,6 +29,17 @@ Navigate to your project directory and run `letta` (see various command-line opt
 Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, zAI coding plan, etc.), and use `/model` to swap models.
 
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
+
+## Constellation 
+
+```mermaid
+graph TD
+    Constellation["⭐ Constellation"]
+    Constellation --> A["💻 Your Laptop"]
+    Constellation --> B["☁️ Letta Cloud"]
+    Constellation --> C["🖥️ Mac Mini"]
+    Constellation --> D["📦 Sandbox"]
+```
 
 ## Philosophy 
 Letta Code is built around long-lived agents that persist across sessions and improve with use. Rather than working in independent sessions, each session is tied to a persisted agent that learns.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Run `/connect` to configure your own LLM API keys (OpenAI / ChatGPT, Anthropic, 
 
 You can also download the [**desktop app**](https://docs.letta.com/letta-code/desktop-app) for MacOS, Windows, and Linux. Agents created in the CLI are available via the desktop app, and vice versa.
 
-## Constellation 
+## Running locally versus with Constellation
+Constellation allows your agents to work on any machine, while still maintaining the same cohesive memory, identity, and experience. Agents on Constellation can be access from any machine through the CLI, or run on remote environments (any machine can be connected as a remote env by running `letta server` on it). 
 
 ```mermaid
 graph TD


### PR DESCRIPTION
## Summary
- Document local mode, first-run choices, and local backend storage in the README.
- Clarify that local mode keeps state local but remote provider calls still leave the machine unless using Ollama, LM Studio, or llama.cpp.
- Paired with #2339: this is the README companion PR for the local-backend implementation changes.

## Test plan
- [x] `git diff --check README.md`
- [x] Docs-only change; no runtime tests run.

👾 Generated with [Letta Code](https://letta.com)