### PR TITLE
refactor(cli): strip shell from MultiSelectPicker, use OverlayShell in WindowTitlePicker

### DIFF
--- a/src/cli/components/MultiSelectPicker.tsx
+++ b/src/cli/components/MultiSelectPicker.tsx
@@ -1,7 +1,8 @@
 // Reusable multi-select checkbox picker for interactive configuration.
 //
-// Inspired by Codex's "Configure Terminal Title" UI and extracted from
-// InlineQuestionApproval's multi-select logic, but simplified:
+// Pure list + input handling. Wrappers provide the shell
+// (header, title, footer) via OverlayShell.
+//
 // - No custom input / "Type something" option
 // - No "Submit" button — Enter confirms directly
 // - Optional live preview line at the bottom
@@ -17,11 +18,11 @@ export interface SelectableItem {
   key: string;
   label: string;
   description: string;
+  /** When true, Space does not toggle this item and it renders dimmed. */
+  disabled?: boolean;
 }
 
 export interface MultiSelectPickerProps {
-  title: string;
-  description: string;
   items: SelectableItem[];
   selected: Set<string>;
   onConfirm: (selectedKeys: string[]) => void;
@@ -31,8 +32,6 @@ export interface MultiSelectPickerProps {
 }
 
 export const MultiSelectPicker = memo(function MultiSelectPicker({
-  title,
-  description,
   items,
   selected,
   onConfirm,
@@ -81,10 +80,10 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
         onConfirm([...selectedSet]);
         return;
       }
-      // Space toggles checkbox
+      // Space toggles checkbox (no-op for disabled items)
       if (input === " ") {
         const item = items[cursor];
-        if (item) {
+        if (item && !item.disabled) {
           toggle(item.key);
         }
         return;
@@ -97,20 +96,17 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
 
   return (
     <Box flexDirection="column">
-      {/* Title */}
-      <Text bold>{title}</Text>
-
-      {/* Description */}
-      <Text dimColor>{description}</Text>
-
-      <Box height={1} />
-
       {/* Items */}
       <Box flexDirection="column">
         {items.map((item, index) => {
           const isCursor = index === cursor;
           const isChecked = selectedSet.has(item.key);
-          const color = isCursor ? colors.approval.header : undefined;
+          const isDisabled = item.disabled ?? false;
+          const color = isDisabled
+            ? undefined
+            : isCursor
+              ? colors.approval.header
+              : undefined;
 
           return (
             <Box key={item.key} flexDirection="row">
@@ -120,13 +116,21 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
               </Box>
               {/* Checkbox */}
               <Box width={4} flexShrink={0}>
-                <Text color={isChecked ? "green" : color}>
+                <Text
+                  color={isDisabled ? undefined : isChecked ? "green" : color}
+                  dimColor={isDisabled}
+                >
                   [{isChecked ? "✓" : " "}]{" "}
                 </Text>
               </Box>
               {/* Label + description */}
               <Box flexGrow={1} width={Math.max(0, columns - 6)}>
-                <Text color={color} bold={isCursor} wrap="truncate-end">
+                <Text
+                  color={color}
+                  bold={isCursor && !isDisabled}
+                  dimColor={isDisabled}
+                  wrap="truncate-end"
+                >
                   {item.label}
                   {item.description && (
                     <Text dimColor> · {item.description}</Text>

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -1,7 +1,6 @@
 // Window title configuration picker.
 // Wraps MultiSelectPicker with window-title-specific logic.
 
-import { Box } from "ink";
 import { memo, useCallback, useMemo, useState } from "react";
 import { settingsManager } from "../../settings-manager";
 import { getVersion } from "../../version";
@@ -12,11 +11,8 @@ import {
   WINDOW_TITLE_FIELDS,
   type WindowTitleField,
 } from "../helpers/windowTitleConfig";
-import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { MultiSelectPicker } from "./MultiSelectPicker";
-import { Text } from "./Text";
-
-const SOLID_LINE = "─";
+import { OverlayShell } from "./OverlayShell";
 
 interface WindowTitlePickerProps {
   agentName: string | null;
@@ -31,9 +27,6 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
   conversationSummary,
   onClose,
 }: WindowTitlePickerProps) {
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
-
   const currentItems = useMemo(
     () => resolveWindowTitleConfig(projectDirectory),
     [projectDirectory],
@@ -90,19 +83,14 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
   }, [projectDirectory, titleData, onClose]);
 
   return (
-    <>
-      <Text dimColor>{"> /title"}</Text>
-      <Text dimColor>{solidLine}</Text>
-      <Box height={1} />
+    <OverlayShell command="/title" title="Configure Terminal Title">
       <MultiSelectPicker
-        title="Configure Terminal Title"
-        description="Select which items to display in the terminal title."
         items={items}
         selected={new Set(selectedKeys)}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
         onSelectionChange={handleSelectionChange}
       />
-    </>
+    </OverlayShell>
   );
 });


### PR DESCRIPTION
## Summary

- `MultiSelectPicker` no longer renders `title`, `description`, or its own header/footer shell. It is now purely list + input handling, matching `SingleSelectPicker`.
- `WindowTitlePicker` updated to use `OverlayShell` instead of manual `> /command` + solid line rendering.
- Carries forward the `disabled` item support from PR #2341 so it will not conflict when that merges.

Both pickers now follow the same pattern: the wrapper composes `OverlayShell` then picker. The picker owns its own hint line.

## Test plan

- [ ] `/title` opens the window title picker, behavior unchanged
- [ ] Space toggles checkboxes, up/down navigates, Enter confirms, Esc cancels
- [ ] Live preview still updates terminal title on toggle

👾 Generated with [Letta Code](https://letta.com)