### PR TITLE
fix(cli): fix Static transcript remounting on every tool call

### DIFF
--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -457,6 +457,7 @@ export function AppView(props: AppViewProps) {
         precomputedDiffs={precomputedDiffsRef.current}
         lastPlanFilePath={lastPlanFilePathRef.current}
         hiddenToolCallId={expandedToolCallId ?? undefined}
+        lastShellToolCallId={lastShellToolCallId ?? undefined}
       />
 
       <Box flexDirection="column">

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -457,7 +457,6 @@ export function AppView(props: AppViewProps) {
         precomputedDiffs={precomputedDiffsRef.current}
         lastPlanFilePath={lastPlanFilePathRef.current}
         hiddenToolCallId={expandedToolCallId ?? undefined}
-        lastShellToolCallId={lastShellToolCallId ?? undefined}
       />
 
       <Box flexDirection="column">

--- a/src/cli/app/StaticTranscript.tsx
+++ b/src/cli/app/StaticTranscript.tsx
@@ -25,6 +25,7 @@ export function StaticTranscript({
   precomputedDiffs,
   lastPlanFilePath,
   hiddenToolCallId,
+  lastShellToolCallId,
 }: {
   renderEpoch: number;
   items: StaticItem[];
@@ -34,6 +35,12 @@ export function StaticTranscript({
   precomputedDiffs: Map<string, AdvancedDiffSuccess>;
   lastPlanFilePath: string | null;
   hiddenToolCallId?: string;
+  /** Used to show ctrl+o hint on the last committed tool call.
+   *  Intentionally NOT included in the Static key — passing it here without
+   *  keying on it means the hint shows correctly when an item first commits,
+   *  and may be stale on older items (minor cosmetic issue, much better than
+   *  remounting on every tool call and re-printing history). */
+  lastShellToolCallId?: string;
 }) {
   return (
     <Static
@@ -59,7 +66,7 @@ export function StaticTranscript({
                   precomputedDiffs={precomputedDiffs}
                   lastPlanFilePath={lastPlanFilePath}
                   expandedToolCallId={hiddenToolCallId}
-                  lastShellToolCallId={undefined}
+                  lastShellToolCallId={lastShellToolCallId}
                 />
               ) : item.kind === "subagent_group" ? (
                 <SubagentGroupStatic agents={item.agents} />

--- a/src/cli/app/StaticTranscript.tsx
+++ b/src/cli/app/StaticTranscript.tsx
@@ -25,7 +25,6 @@ export function StaticTranscript({
   precomputedDiffs,
   lastPlanFilePath,
   hiddenToolCallId,
-  lastShellToolCallId,
 }: {
   renderEpoch: number;
   items: StaticItem[];
@@ -35,11 +34,10 @@ export function StaticTranscript({
   precomputedDiffs: Map<string, AdvancedDiffSuccess>;
   lastPlanFilePath: string | null;
   hiddenToolCallId?: string;
-  lastShellToolCallId?: string;
 }) {
   return (
     <Static
-      key={`${renderEpoch}-${hiddenToolCallId ?? ""}-${lastShellToolCallId ?? ""}`}
+      key={`${renderEpoch}-${hiddenToolCallId ?? ""}`}
       items={items}
       style={{ flexDirection: "column" }}
     >
@@ -61,7 +59,7 @@ export function StaticTranscript({
                   precomputedDiffs={precomputedDiffs}
                   lastPlanFilePath={lastPlanFilePath}
                   expandedToolCallId={hiddenToolCallId}
-                  lastShellToolCallId={lastShellToolCallId}
+                  lastShellToolCallId={undefined}
                 />
               ) : item.kind === "subagent_group" ? (
                 <SubagentGroupStatic agents={item.agents} />


### PR DESCRIPTION
## Problem

`lastShellToolCallId` was included in the `<Static key>` in `StaticTranscript.tsx` (added in #2322). This key changes on every shell tool call completion, forcing a full `<Static>` remount each time — which re-prints the entire transcript history. Users see old messages re-appearing when scrolling up.

## Fix

- Remove `lastShellToolCallId` from the `<Static key>` — stops the remounting and re-appending
- Keep passing `lastShellToolCallId` to `ToolCallMessage` inside Static so the `(ctrl+o to expand)` hint still shows when a tool call is first committed to Static
- The hint may appear stale on older committed items (minor cosmetic issue) — this is the same behavior as #2305 before #2322, and is a much better trade-off than re-printing history on every tool call

The ctrl+o feature continues to work correctly. The key only changes on `renderEpoch` (new conversation) and `expandedToolCallId` (ctrl+o pressed).

## Test plan

- [ ] Run a multi-tool session — scrolling up should not show duplicate history
- [ ] `(ctrl+o to expand)` hint appears on the last shell tool call after the agent finishes
- [ ] ctrl+o still expands/collapses the last shell tool call output

👾 Generated with [Letta Code](https://letta.com)