### PR TITLE
refactor(cli): migrate SystemPromptSelector and ExperimentSelector to shared picker components

### DIFF
--- a/src/cli/components/ExperimentSelector.tsx
+++ b/src/cli/components/ExperimentSelector.tsx
@@ -1,14 +1,10 @@
 // Experiment toggle picker.
 // Wraps MultiSelectPicker with experiment-specific logic.
 
-import { Box } from "ink";
 import { memo, useCallback, useMemo } from "react";
 import type { ExperimentId, ExperimentSnapshot } from "../../experiments/types";
-import { useTerminalWidth } from "../hooks/useTerminalWidth";
 import { MultiSelectPicker } from "./MultiSelectPicker";
-import { Text } from "./Text";
-
-const SOLID_LINE = "─";
+import { OverlayShell } from "./OverlayShell";
 
 interface ExperimentSelectorProps {
   experiments: ExperimentSnapshot[];
@@ -23,9 +19,6 @@ export const ExperimentSelector = memo(function ExperimentSelector({
   onConfirm,
   onCancel,
 }: ExperimentSelectorProps) {
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
-
   const items = useMemo(
     () =>
       experiments.map((exp) => ({
@@ -62,18 +55,13 @@ export const ExperimentSelector = memo(function ExperimentSelector({
   );
 
   return (
-    <>
-      <Text dimColor>{"> /experiments"}</Text>
-      <Text dimColor>{solidLine}</Text>
-      <Box height={1} />
+    <OverlayShell command="/experiments" title="Toggle Experiments">
       <MultiSelectPicker
-        title="Toggle Experiments"
-        description="Select which experiments to enable."
         items={items}
         selected={initialSelected}
         onConfirm={handleConfirm}
         onCancel={onCancel}
       />
-    </>
+    </OverlayShell>
   );
 });

--- a/src/cli/components/SingleSelectPicker.tsx
+++ b/src/cli/components/SingleSelectPicker.tsx
@@ -17,6 +17,8 @@ export interface SelectableItem {
   isCurrent?: boolean;
   /** When true, item is dimmed and Enter is a no-op */
   disabled?: boolean;
+  /** When true, label renders dimmed but item is still selectable */
+  dimLabel?: boolean;
 }
 
 export interface SingleSelectPickerProps {
@@ -99,6 +101,7 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
         const isCursor = index === cursor;
         const isCurrent = item.isCurrent ?? false;
         const isDisabled = item.disabled ?? false;
+        const isDimLabel = item.dimLabel ?? false;
 
         const cursorColor = isDisabled
           ? undefined
@@ -119,7 +122,7 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
             <Text
               color={labelColor}
               bold={isCursor && !isDisabled}
-              dimColor={isDisabled}
+              dimColor={isDisabled || isDimLabel}
             >
               {item.label}
               {isCurrent && " (current)"}

--- a/src/cli/components/SystemPromptSelector.tsx
+++ b/src/cli/components/SystemPromptSelector.tsx
@@ -47,6 +47,7 @@ export const SystemPromptSelector = memo(function SystemPromptSelector({
       promptItems.push({
         key: SHOW_ALL_KEY,
         label: "Show all prompts",
+        dimLabel: true,
       });
     }
     return promptItems;

--- a/src/cli/components/SystemPromptSelector.tsx
+++ b/src/cli/components/SystemPromptSelector.tsx
@@ -1,13 +1,13 @@
-// Import useInput from vendored Ink for bracketed paste support
-import { Box, useInput } from "ink";
-import { useMemo, useState } from "react";
-import { SYSTEM_PROMPTS } from "../../agent/promptAssets";
-import { useTerminalWidth } from "../hooks/useTerminalWidth";
-import { colors } from "./colors";
-import { Text } from "./Text";
+// System prompt selector.
+// Wraps SingleSelectPicker with system-prompt-specific logic.
 
-// Horizontal line character (matches approval dialogs)
-const SOLID_LINE = "─";
+import { memo, useCallback, useMemo, useState } from "react";
+import { SYSTEM_PROMPTS } from "../../agent/promptAssets";
+import { OverlayShell } from "./OverlayShell";
+import type { SelectableItem } from "./SingleSelectPicker";
+import { SingleSelectPicker } from "./SingleSelectPicker";
+
+const SHOW_ALL_KEY = "__show_all__";
 
 interface SystemPromptSelectorProps {
   currentPromptId?: string;
@@ -15,15 +15,12 @@ interface SystemPromptSelectorProps {
   onCancel: () => void;
 }
 
-export function SystemPromptSelector({
+export const SystemPromptSelector = memo(function SystemPromptSelector({
   currentPromptId,
   onSelect,
   onCancel,
 }: SystemPromptSelectorProps) {
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
   const [showAll, setShowAll] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const featuredPrompts = useMemo(
     () => SYSTEM_PROMPTS.filter((prompt) => prompt.isFeatured),
@@ -36,97 +33,43 @@ export function SystemPromptSelector({
     return SYSTEM_PROMPTS.slice(0, 3);
   }, [featuredPrompts, showAll]);
 
-  const hasHiddenPrompts = visiblePrompts.length < SYSTEM_PROMPTS.length;
-  const hasShowAllOption = !showAll && hasHiddenPrompts;
+  const hasShowAllOption =
+    !showAll && visiblePrompts.length < SYSTEM_PROMPTS.length;
 
-  const totalItems = visiblePrompts.length + (hasShowAllOption ? 1 : 0);
-
-  useInput((input, key) => {
-    // CTRL-C: immediately cancel
-    if (key.ctrl && input === "c") {
-      onCancel();
-      return;
+  const items = useMemo<SelectableItem[]>(() => {
+    const promptItems: SelectableItem[] = visiblePrompts.map((prompt) => ({
+      key: prompt.id,
+      label: prompt.label,
+      description: prompt.description,
+      isCurrent: prompt.id === currentPromptId,
+    }));
+    if (hasShowAllOption) {
+      promptItems.push({
+        key: SHOW_ALL_KEY,
+        label: "Show all prompts",
+      });
     }
+    return promptItems;
+  }, [visiblePrompts, hasShowAllOption, currentPromptId]);
 
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex((prev) => Math.min(totalItems - 1, prev + 1));
-    } else if (key.return) {
-      if (hasShowAllOption && selectedIndex === visiblePrompts.length) {
+  const handleSelect = useCallback(
+    (key: string) => {
+      if (key === SHOW_ALL_KEY) {
         setShowAll(true);
-        setSelectedIndex(0);
-      } else {
-        const selectedPrompt = visiblePrompts[selectedIndex];
-        if (selectedPrompt) {
-          onSelect(selectedPrompt.id);
-        }
+        return;
       }
-    } else if (key.escape) {
-      onCancel();
-    }
-  });
+      onSelect(key);
+    },
+    [onSelect],
+  );
 
   return (
-    <Box flexDirection="column">
-      {/* Command header */}
-      <Text dimColor>{"> /prompt"}</Text>
-      <Text dimColor>{solidLine}</Text>
-
-      <Box height={1} />
-
-      {/* Title */}
-      <Box marginBottom={1}>
-        <Text bold color={colors.selector.title}>
-          Swap your agent's system prompt
-        </Text>
-      </Box>
-
-      <Box flexDirection="column">
-        {visiblePrompts.map((prompt, index) => {
-          const isSelected = index === selectedIndex;
-          const isCurrent = prompt.id === currentPromptId;
-
-          return (
-            <Box key={prompt.id} flexDirection="row">
-              <Text
-                color={isSelected ? colors.selector.itemHighlighted : undefined}
-              >
-                {isSelected ? "> " : "  "}
-              </Text>
-              <Text
-                bold={isSelected}
-                color={isSelected ? colors.selector.itemHighlighted : undefined}
-              >
-                {prompt.label}
-                {isCurrent && (
-                  <Text color={colors.selector.itemCurrent}> (current)</Text>
-                )}
-              </Text>
-              <Text dimColor> · {prompt.description}</Text>
-            </Box>
-          );
-        })}
-        {hasShowAllOption && (
-          <Box flexDirection="row">
-            <Text
-              color={
-                selectedIndex === visiblePrompts.length
-                  ? colors.selector.itemHighlighted
-                  : undefined
-              }
-            >
-              {selectedIndex === visiblePrompts.length ? "> " : "  "}
-            </Text>
-            <Text dimColor>Show all prompts</Text>
-          </Box>
-        )}
-      </Box>
-
-      {/* Footer */}
-      <Box marginTop={1}>
-        <Text dimColor>{"  "}Enter select · ↑↓ navigate · Esc cancel</Text>
-      </Box>
-    </Box>
+    <OverlayShell command="/prompt" title="Swap your agent's system prompt">
+      <SingleSelectPicker
+        items={items}
+        onSelect={handleSelect}
+        onCancel={onCancel}
+      />
+    </OverlayShell>
   );
-}
+});


### PR DESCRIPTION
## Summary

- **SystemPromptSelector**: wraps `OverlayShell` + `SingleSelectPicker`. The "show all" toggle stays in the wrapper — it manages which items are visible and appends a pseudo-item with a special key (`__show_all__`). When selected, the wrapper intercepts `onSelect` and calls `setShowAll(true)` instead.
- **ExperimentSelector**: fix stale `title`/`description` props (from before `MultiSelectPicker` shell was stripped in #2345). Now uses `OverlayShell` like `WindowTitlePicker`.

Net: -69 lines. Both selectors now follow the same composition pattern as `PersonalitySelector` and `WindowTitlePicker`.

## Test plan

- [ ] `/prompt` opens selector, featured prompts shown, "Show all prompts" at bottom
- [ ] Selecting "Show all prompts" expands the list
- [ ] `(current)` marker shows on active prompt
- [ ] `/experiments` opens selector, checkboxes work, disabled items dimmed
- [ ] Esc cancels, Enter confirms on both

👾 Generated with [Letta Code](https://letta.com)