### PR TITLE
fix(lint): resolve pre-existing biome warnings

### DIFF
--- a/src/backend/local/transcriptMigration.ts
+++ b/src/backend/local/transcriptMigration.ts
@@ -241,7 +241,8 @@ function convertLegacyMessage(
   const result: LocalMessage[] = [];
 
   for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
-    const step = steps[stepIndex]!;
+    const step = steps[stepIndex];
+    if (!step) continue;
     // Single-step messages keep the original ID; multi-step messages get
     // fresh sequential IDs to avoid introducing a new ID format.
     const stepId = steps.length === 1 ? id : `ui-msg-${nextId()}`;

--- a/src/tests/cli/reload-command.test.ts
+++ b/src/tests/cli/reload-command.test.ts
@@ -58,6 +58,7 @@ describe("/reload command", () => {
 
     expect(source).toContain("onReload: handleReload");
     expect(source).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting source contains literal template string syntax
       "key: `${agentId}:${conversationId}:${appReloadEpoch}`",
     );
   });


### PR DESCRIPTION
## Summary

Fixes 2 pre-existing biome warnings that have been lingering in the codebase:

- **`noNonNullAssertion`** (`transcriptMigration.ts`): Replace `steps[stepIndex]!` with a safe early-continue — the bound check on the loop already guarantees the element exists, so no behavior change.
- **`noTemplateCurlyInString`** (`reload-command.test.ts`): Add `biome-ignore` with explanation — the string intentionally contains literal template syntax as a test assertion target.

## Test plan
- [ ] `bun run lint` passes with 0 warnings
- [ ] `bun tsc --noEmit` passes

👾 Generated with [Letta Code](https://letta.com)