### PR TITLE
chore(ts): enable noImplicitReturns

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2808,6 +2808,7 @@ export default function App({
         cancelled = true;
       };
     }
+    return undefined;
   }, [loadingState, agentId, initialAgentState]);
 
   // Keep effective model state in sync with the active conversation override.

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1227,6 +1227,7 @@ export function Input({
       const timer = setTimeout(() => setCursorPos(undefined), 0);
       return () => clearTimeout(timer);
     }
+    return undefined;
   }, [cursorPos]);
 
   // Reset bash exit arming when leaving bash mode

--- a/src/cli/components/PasteAwareTextInput.tsx
+++ b/src/cli/components/PasteAwareTextInput.tsx
@@ -711,6 +711,7 @@ export function PasteAwareTextInput({
       const t = setTimeout(() => setNudgeCursorOffset(undefined), 0);
       return () => clearTimeout(t);
     }
+    return undefined;
   }, [nudgeCursorOffset]);
 
   return (

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -433,6 +433,7 @@ export async function checkAndAutoUpdate(): Promise<
       return { updateApplied: true, latestVersion: result.latestVersion };
     }
   }
+  return undefined;
 }
 
 export async function manualUpdate(): Promise<{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
+    "noImplicitReturns": true,
 
     // Some stricter flags (disabled by default)
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

Enables `noImplicitReturns: true` in `tsconfig.json`. This catches functions where some code paths return a value but others fall through implicitly without returning.

Only 4 violations across the codebase — all `useEffect` callbacks or async functions with conditional cleanup/return branches. Fixed with explicit `return undefined` in the implicit paths.

## Files changed
| File | Fix |
|---|---|
| `AppCoordinator.tsx` | `useEffect` with cleanup only in the `if` branch |
| `InputRich.tsx` | `useEffect` with cleanup only when `cursorPos` is defined |
| `PasteAwareTextInput.tsx` | `useEffect` with cleanup only when `nudgeCursorOffset` is defined |
| `auto-update.ts` | `checkAndAutoUpdate` falls through when update runs but neither significant-update condition is met |

## Test plan
- [ ] `bun tsc --noEmit` passes with 0 errors
- [ ] `bun run lint` passes

👾 Generated with [Letta Code](https://letta.com)