### PR TITLE
feat(lint): enforce named exports, ban default exports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,29 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
   "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2 },
-  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noDefaultExport": "error"
+      }
+    }
+  },
   "files": { "experimentalScannerIgnores": ["vendor/**"] },
   "overrides": [
     {
       "includes": ["vendor/**"],
       "linter": { "enabled": false },
       "formatter": { "enabled": false }
+    },
+    {
+      "includes": ["**/*.d.ts"],
+      "linter": {
+        "rules": {
+          "style": { "noDefaultExport": "off" }
+        }
+      }
     }
   ]
 }

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -4,4 +4,4 @@
  * Implementation lives under `src/cli/app/`, mirroring the listener layout.
  */
 
-export { default } from "./app/App";
+export { App } from "./app/App";

--- a/src/cli/app/App.tsx
+++ b/src/cli/app/App.tsx
@@ -6,4 +6,4 @@
  * need without paging through the full TUI coordinator.
  */
 
-export { default } from "./AppCoordinator";
+export { App } from "./AppCoordinator";

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -197,7 +197,7 @@ import { useQueuedApprovalSubmit } from "./useQueuedApprovalSubmit";
 import { useReasoningCycle } from "./useReasoningCycle";
 import { useSubmitHandler } from "./useSubmitHandler";
 
-export default function App({
+export function App({
   agentId: initialAgentId,
   agentState: initialAgentState,
   conversationId: initialConversationId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1213,7 +1213,7 @@ async function main(): Promise<void> {
   const { render } = await import("ink");
   const { useState, useEffect, useCallback } = React;
   const AppModule = await import("./cli/App");
-  const App = AppModule.default;
+  const App = AppModule.App;
 
   function LoadingApp({
     forceNew,


### PR DESCRIPTION
## Summary

Adds `style/noDefaultExport` as a biome error rule so all exports are named.

**Why**: Named exports make the codebase grep-friendly — `export const Foo` and `import { Foo } from "..."` can be precisely located by ripgrep, agents, and IDEs without ambiguity. Default exports require knowing the import alias used at each call site.

## Changes

- `biome.json`: enable `style/noDefaultExport` as `"error"`, with an override to exempt `**/*.d.ts` files (ambient module declarations for `.md`/`.txt`/`.html` files legitimately use `export default`)
- `AppCoordinator.tsx`: convert `export default function App` → `export function App`
- `app/App.tsx`, `cli/App.tsx`: update re-export chain to `export { App }`
- `src/index.ts`: update dynamic import to use `AppModule.App`

## Test plan

- [ ] `bun run lint` passes with 0 errors
- [ ] `bun tsc --noEmit` passes
- [ ] App starts normally

👾 Generated with [Letta Code](https://letta.com)