### PR TITLE
feat(models): add Gemini 3.5 Flash

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1458,6 +1458,18 @@
       }
     },
     {
+      "id": "gemini-3.5-flash",
+      "handle": "google_ai/gemini-3.5-flash",
+      "label": "Gemini 3.5 Flash",
+      "description": "Google's Gemini 3.5 Flash model",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1048576,
+        "temperature": 1.0,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-4.1",
       "handle": "openai/gpt-4.1",
       "label": "GPT-4.1",


### PR DESCRIPTION
## Summary
This PR adds Gemini 3.5 Flash to the Letta Code model registry in src/models.json.

The Cloud-side rollout is already in place: the provider sync exposes google_ai/gemini-3.5-flash and the letta-cloud pricing table now has the matching standard Gemini 3.5 Flash pricing. This change makes the model selectable from Letta Code via the short model id gemini-3.5-flash while preserving the Google AI handle used by Core.

The entry follows the existing Gemini model shape: Google AI provider handle, Gemini tool-compatible defaults, temperature 1.0, parallel tool calls enabled, and the 1,048,576-token context window from the provider metadata. I marked it featured so it appears alongside the current featured Gemini option.

## Validation
- Ran Prettier check for src/models.json.
- Ran targeted model registry and provider detection tests:
  - bun test src/tests/model-tier-selection.test.ts src/tests/tools/model-provider-detection.test.ts src/tests/websocket/listen-client-protocol.test.ts --test-name-pattern models.json|gemini|provider|model
- Commit hook ran Biome check/write and TypeScript no-emit successfully.

## Risk and follow-up
This is a registry-only change. The main risk is model availability depending on the backend environment having the new Core provider model and Cloud pricing metadata deployed; both were verified during the companion letta-cloud rollout.

👾 Generated with [Letta Code](https://letta.com)