### PR TITLE
fix: Anthropic prefill error on local retry after timeout

### DIFF
--- a/src/backend/dev/PiStreamAdapter.ts
+++ b/src/backend/dev/PiStreamAdapter.ts
@@ -137,7 +137,17 @@ function toPiTools(clientTools: unknown[]): Tool[] | undefined {
 }
 
 function toPiMessages(messages: LocalMessage[]): Message[] {
-  return messages.map((message) => {
+  // Strip trailing assistant messages — providers like Anthropic require the
+  // conversation to end with a user or tool-result message. A trailing
+  // assistant message can appear when a stream errors mid-turn (e.g. timeout)
+  // and the retry sends no new user input, leaving the partial assistant
+  // response as the last message.
+  let trimmed = messages;
+  while (trimmed.length > 0 && trimmed.at(-1)!.role === "assistant") {
+    trimmed = trimmed.slice(0, -1);
+  }
+
+  return trimmed.map((message) => {
     if (message.role === "user") {
       return {
         role: "user",

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -155,6 +155,58 @@ describe("PiStreamAdapter", () => {
     }
   });
 
+  test("strips trailing assistant messages from context before calling provider", async () => {
+    let capturedContext: Context | undefined;
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      context: Context,
+    ) => {
+      capturedContext = context;
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({ stream });
+
+    // Simulate the retry scenario: conversation ends with a partial assistant
+    // message (e.g. after a timeout), and the retry sends no new user input.
+    const inputWithTrailingAssistant: ProviderTurnInput = {
+      ...input(),
+      uiMessages: [
+        {
+          id: "ui-msg-1",
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: Date.now(),
+        },
+        {
+          id: "ui-msg-2",
+          role: "assistant",
+          content: [{ type: "text", text: "partial response" }],
+          api: "anthropic" as never,
+          provider: "anthropic" as never,
+          model: "claude-sonnet-4-6",
+          usage: emptyLocalUsage(),
+          stopReason: "stop",
+          timestamp: Date.now(),
+        } as never,
+      ],
+    };
+
+    for await (const _event of adapter.stream(inputWithTrailingAssistant)) {
+      // drain
+    }
+
+    expect(capturedContext).toBeDefined();
+    const messages = capturedContext!.messages;
+    // The trailing assistant message should be stripped
+    expect(messages.at(-1)?.role).toBe("user");
+    expect(messages).toHaveLength(1);
+  });
+
   test("retries retryable Codex transport errors before model output", async () => {
     let calls = 0;
     const stream: PiStreamFunction = () => {


### PR DESCRIPTION
## Summary
- Strip trailing assistant messages in `toPiMessages` before constructing the provider context, preventing Anthropic from rejecting requests where the conversation ends with an assistant message
- This happens when a local-mode Anthropic request times out mid-stream — the partial assistant response gets persisted, and the retry sends empty input, leaving the conversation ending with an assistant message

## Root cause
When a local-mode stream times out mid-turn (e.g. `llm_api_error`), the partial assistant response is persisted to the in-memory conversation via `appendStreamChunk`. The retry path sets `currentInput = []` (because `retryFromPersistedLocalState` is true), so no new user message is appended. The conversation sent to Anthropic then ends with the assistant message, which Anthropic rejects:

> "This model does not support assistant message prefill. The conversation must end with a user message."

```
• The dynamic import() calls weren't converted by the original codemod, and moving the test files broke them. Let me fix all of them in one pass — same approach as the original codemod but targeting dynamic
  imports in test files, plus the @/tests/ → @/test-utils/ references the migration script missed:
   
  • Unexpected downstream LLM API error, retrying...
   
  ⚠ {
    "error": {
      "error": {
  "message": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"This model does not support assistant message prefill. The conversation must end with a user
  message.\"},\"request_id\":\"req_011CbD4A61mCKFi9CXRnCztt\"}",
  "detail": "400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"This model does not support assistant message prefill. The conversation must end with a user
  message.\"},\"request_id\":\"req_011CbD4A61mCKFi9CXRnCztt\"}",
        "error_type": "local_backend_error",
        "retryable": false,
        "run_id": "local-run-42"
      },
      "run_id": "local-run-42"
    }
  }
   
  ⚠ Something went wrong? Use /feedback to report issues.
```
## Fix
Strip trailing assistant messages in `toPiMessages` before constructing the provider context. This is defensive — it catches the issue regardless of how the conversation got into this state, and ensures the conversation always ends with a user or tool-result message as required by Anthropic and other providers that don't support assistant prefill.

## Test plan
- [x] New test: `strips trailing assistant messages from context before calling provider`
- [x] All 47 backend tests pass
- [x] All 597 CLI tests pass
- [ ] Manual: trigger a timeout on a local Anthropic agent and verify the retry succeeds

👾 Generated with [Letta Code](https://letta.com)