### PR TITLE
feat: enforce layer boundary rules (backend, providers)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,6 +25,13 @@ if ! bun run check:cycles --no-spinner 2>/dev/null; then
   exit 1
 fi
 
+# Check architectural layer boundaries (fast, catches misplaced imports early)
+if ! node scripts/check-layer-boundaries.js 2>/dev/null; then
+  echo ""
+  echo "❌ Layer boundary violation — run 'bun run check:boundaries' for details."
+  exit 1
+fi
+
 # Lint staged files only (fast)
 # Guard: lint-staged v16 exits code 1 when no files match, which would
 # fail the hook even on empty commits. Only run if lintable files are staged.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "fix": "bunx --bun @biomejs/biome@2.2.5 check --write src",
     "typecheck": "tsc --noEmit",
     "check:cycles": "madge --circular --extensions ts,tsx src/",
+    "check:boundaries": "node scripts/check-layer-boundaries.js",
     "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check": "bun run scripts/check.js",
     "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run src/index.ts",

--- a/scripts/check-layer-boundaries.js
+++ b/scripts/check-layer-boundaries.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Enforces architectural import boundaries between top-level modules.
+ *
+ * Rules:
+ *   backend/  must not import from  cli/  or  websocket/
+ *   providers/ must not import from  agent/  or  cli/
+ *
+ * These are currently violation-free. Adding a rule here means you must
+ * also ensure no existing code violates it.
+ *
+ * To add a new rule, append an entry to RULES below.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { glob } from "glob";
+
+const rootDir = process.cwd();
+const srcDir = join(rootDir, "src");
+
+/**
+ * Each rule: files under `layer` must not contain an import from any of `forbidden`.
+ * `description` is shown on violation.
+ */
+const RULES = [
+  {
+    layer: "backend",
+    forbidden: ["cli", "websocket"],
+    description:
+      "backend/ is a low-level abstraction — it must not import from cli/ or websocket/",
+  },
+  {
+    layer: "providers",
+    forbidden: ["agent", "cli"],
+    description:
+      "providers/ are pure LLM adapters — they must not import from agent/ or cli/",
+  },
+];
+
+// Matches: import ... from "@/forbidden/..." (static and dynamic)
+function buildPattern(forbidden) {
+  return new RegExp(
+    `from\\s+["'\`]@/(${forbidden.join("|")})/`,
+    "g",
+  );
+}
+
+let violations = 0;
+
+for (const rule of RULES) {
+  const files = await glob(`src/${rule.layer}/**/*.{ts,tsx}`, {
+    cwd: rootDir,
+    ignore: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"],
+  });
+
+  const pattern = buildPattern(rule.forbidden);
+
+  for (const file of files.sort()) {
+    const content = readFileSync(join(rootDir, file), "utf-8");
+    const lines = content.split("\n");
+
+    lines.forEach((line, i) => {
+      // Reset lastIndex for global regex reuse
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) {
+        if (violations === 0) {
+          console.error("\n❌ Layer boundary violations found:\n");
+        }
+        console.error(`  ${file}:${i + 1}`);
+        console.error(`    ${line.trim()}`);
+        console.error(`    ↳ ${rule.description}\n`);
+        violations++;
+      }
+    });
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `Found ${violations} boundary violation${violations === 1 ? "" : "s"}.`,
+  );
+  console.error(
+    "Fix by moving the helper to a shared layer (utils/, types/) or inverting the dependency.\n",
+  );
+  process.exit(1);
+} else {
+  console.log("✅ No layer boundary violations found.");
+}

--- a/scripts/check-layer-boundaries.js
+++ b/scripts/check-layer-boundaries.js
@@ -38,7 +38,7 @@ const RULES = [
   },
 ];
 
-// Matches: import ... from "@/forbidden/..." (static and dynamic)
+// Matches: import ... from "@/forbidden/..." (static imports only)
 function buildPattern(forbidden) {
   return new RegExp(
     `from\\s+["'\`]@/(${forbidden.join("|")})/`,

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -20,6 +20,19 @@ try {
   failed = true;
 }
 
+// Check architectural layer boundaries
+console.log("🏗️  Checking layer boundaries...");
+try {
+  await $`bun run check:boundaries`;
+  console.log("✅ Layer boundaries clean\n");
+} catch (error) {
+  console.error("❌ Layer boundary violations found\n");
+  console.error(
+    "Fix by moving the import to a shared layer (utils/, types/) or inverting the dependency.\n",
+  );
+  failed = true;
+}
+
 // Run test mock isolation check
 console.log("🧪 Checking Bun module mock isolation...");
 try {


### PR DESCRIPTION
## Summary
- Adds `scripts/check-layer-boundaries.js` enforcing two architectural boundary rules
- Wired into pre-commit hook and CI (`scripts/check.js`)

## Rules

| Layer | May not import from | Rationale |
|-------|-------------------|-----------|
| `backend/` | `cli/`, `websocket/` | Low-level abstraction used in headless and local modes — must be usable without the UI/WS stack |
| `providers/` | `agent/`, `cli/` | Pure LLM adapters — importing domain or UI code prevents provider swapping and isolation testing |

## Current state
Both rules are **violation-free today** — enforcing them costs nothing now and prevents future drift.

## How violations are reported
```
❌ Layer boundary violations found:

  src/backend/local/SomeFile.ts:12
    import { something } from "@/cli/helpers/foo"
    ↳ backend/ is a low-level abstraction — it must not import from cli/ or websocket/
```

## Adding new rules
Append to the `RULES` array in `scripts/check-layer-boundaries.js`. Audit for existing violations first.

## Test plan
- [ ] `bun run check:boundaries` → `✅ No layer boundary violations found.`
- [ ] `bun run check` → all checks pass
- [ ] Manually add a forbidden import → pre-commit hook blocks the commit

👾 Generated with [Letta Code](https://letta.com)