### PR TITLE
fix(lint): silence noNonNullAssertion warnings in PiStreamAdapter

### DIFF
--- a/src/backend/dev/PiStreamAdapter.ts
+++ b/src/backend/dev/PiStreamAdapter.ts
@@ -143,7 +143,7 @@ function toPiMessages(messages: LocalMessage[]): Message[] {
   // and the retry sends no new user input, leaving the partial assistant
   // response as the last message.
   let trimmed = messages;
-  while (trimmed.length > 0 && trimmed.at(-1)!.role === "assistant") {
+  while (trimmed.length > 0 && trimmed.at(-1)?.role === "assistant") {
     trimmed = trimmed.slice(0, -1);
   }
 

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -201,6 +201,7 @@ describe("PiStreamAdapter", () => {
     }
 
     expect(capturedContext).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: capturedContext is asserted defined on the line above
     const messages = capturedContext!.messages;
     // The trailing assistant message should be stripped
     expect(messages.at(-1)?.role).toBe("user");


### PR DESCRIPTION
## Summary
Clears two `noNonNullAssertion` biome warnings that have been appearing as noise in every PR run.

- **`PiStreamAdapter.ts`**: `trimmed.at(-1)!.role` → `trimmed.at(-1)?.role`. Safe — the `while` condition already guards `trimmed.length > 0`, so `at(-1)` is always defined here; the two are equivalent.
- **`pi-stream-adapter.test.ts`**: keep `capturedContext!.messages` but add `biome-ignore` — `capturedContext` is asserted defined on the preceding line so `!` is correct. Switching to `?.` would widen the type to `undefined` and break the assertions below.

## Test plan
- [ ] `bunx biome check src` → no warnings
- [ ] `bun tsc --noEmit` → clean

👾 Generated with [Letta Code](https://letta.com)