### PR TITLE
feat: enforce export function declarations over export const arrows

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -32,6 +32,13 @@ if ! node scripts/check-layer-boundaries.js 2>/dev/null; then
   exit 1
 fi
 
+# Check exported function style (.ts only — .tsx components use memo() which is exempt)
+if ! node scripts/check-exported-functions.js 2>/dev/null; then
+  echo ""
+  echo "❌ Exported arrow function found — run 'bun run check:exported-functions' for details."
+  exit 1
+fi
+
 # Lint staged files only (fast)
 # Guard: lint-staged v16 exits code 1 when no files match, which would
 # fail the hook even on empty commits. Only run if lintable files are staged.

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "typecheck": "tsc --noEmit",
     "check:cycles": "madge --circular --extensions ts,tsx src/",
     "check:boundaries": "node scripts/check-layer-boundaries.js",
+    "check:exported-functions": "node scripts/check-exported-functions.js",
     "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check": "bun run scripts/check.js",
     "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run src/index.ts",

--- a/scripts/check-exported-functions.js
+++ b/scripts/check-exported-functions.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Enforces that exported functions use `export function` declarations
+ * rather than `export const fn = () =>` or `export const fn = async () =>`.
+ *
+ * Rationale: `export function` declarations are greppable (`grep "export function"`
+ * reliably finds all exported functions), hoisted, and easier for agents to locate.
+ *
+ * Scope: .ts files only — NOT .tsx. React components in .tsx legitimately use
+ * `export const Foo = memo(...)` which cannot be a function declaration.
+ *
+ * Value exports (singletons, data, re-exports) are not flagged.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { glob } from "glob";
+
+const rootDir = process.cwd();
+
+// Matches: export const name = (...) => or export const name = async (...) =>
+// Also catches: export const name = () => and export const name = async () =>
+const ARROW_EXPORT = /^export const \w+ = (async )?\(/;
+
+const files = await glob("src/**/*.ts", {
+  cwd: rootDir,
+  ignore: ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"],
+});
+
+let violations = 0;
+
+for (const file of files.sort()) {
+  const content = readFileSync(join(rootDir, file), "utf-8");
+  const lines = content.split("\n");
+
+  lines.forEach((line, i) => {
+    if (ARROW_EXPORT.test(line)) {
+      if (violations === 0) {
+        console.error("\n❌ Exported arrow functions found:\n");
+      }
+      console.error(`  ${file}:${i + 1}`);
+      console.error(`    ${line.trim()}`);
+      console.error(
+        `    ↳ Use 'export function name() {}' instead of 'export const name = () =>'\n`,
+      );
+      violations++;
+    }
+  });
+}
+
+if (violations > 0) {
+  console.error(
+    `Found ${violations} exported arrow function${violations === 1 ? "" : "s"}.`,
+  );
+  process.exit(1);
+} else {
+  console.log("✅ No exported arrow functions found.");
+}

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -33,6 +33,19 @@ try {
   failed = true;
 }
 
+// Check exported function style
+console.log("🔤 Checking exported function style...");
+try {
+  await $`bun run check:exported-functions`;
+  console.log("✅ Exported function style clean\n");
+} catch (error) {
+  console.error("❌ Exported arrow functions found\n");
+  console.error(
+    "Use 'export function name() {}' instead of 'export const name = () =>'\n",
+  );
+  failed = true;
+}
+
 // Run test mock isolation check
 console.log("🧪 Checking Bun module mock isolation...");
 try {

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -31,10 +31,14 @@ export interface BackgroundTask {
 export const backgroundProcesses = new Map<string, BackgroundProcess>();
 export const backgroundTasks = new Map<string, BackgroundTask>();
 let bashIdCounter = 1;
-export const getNextBashId = () => `bash_${bashIdCounter++}`;
+export function getNextBashId() {
+  return `bash_${bashIdCounter++}`;
+}
 
 let taskIdCounter = 1;
-export const getNextTaskId = () => `task_${taskIdCounter++}`;
+export function getNextTaskId() {
+  return `task_${taskIdCounter++}`;
+}
 
 interface BackgroundRetentionConfig {
   completedEntryTtlMs: number;


### PR DESCRIPTION
## Summary
- Adds `scripts/check-exported-functions.js` enforcing `export function` over `export const fn = () =>`
- Fixes 2 pre-existing violations in `process_manager.ts`
- Wired into pre-commit hook and CI

## Why
`export function` declarations are greppable (`grep "export function"` reliably finds all exported functions), hoisted, and easier for agents to locate. `export const fn = () =>` is a value assignment that requires reading to the `=` to know it is a function.

## Scope: `.ts` only, not `.tsx`
React components in `.tsx` legitimately use `export const Foo = memo(...)` — these cannot be function declarations since `memo()` returns a value. The script only scans `.ts` files.

Value exports (singletons, data, re-exports) are not flagged — only `export const name = (...) =>` patterns.

## Violations fixed
`src/tools/impl/process_manager.ts`:
```ts
// before
export const getNextBashId = () => `bash_${bashIdCounter++}`;
export const getNextTaskId = () => `task_${taskIdCounter++}`;

// after
export function getNextBashId() { return `bash_${bashIdCounter++}`; }
export function getNextTaskId() { return `task_${taskIdCounter++}`; }
```

## Test plan
- [ ] `bun run check:exported-functions` → `✅ No exported arrow functions found.`
- [ ] `bun run check` → all checks pass
- [ ] Add an `export const fn = () => {}` to a `.ts` file → pre-commit blocks it

👾 Generated with [Letta Code](https://letta.com)