### PR TITLE
fix(remote): retry environment registration rate limits

### DIFF
--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -9,10 +9,7 @@ import type { Buffers, Line } from "@/cli/helpers/accumulator";
 import { buildAgentReference } from "@/cli/helpers/appUrls";
 import { settingsManager } from "@/settings-manager";
 import { getErrorMessage } from "@/utils/error";
-import {
-  registerWithCloud,
-  registerWithCloudRetry,
-} from "@/websocket/listen-register";
+import { registerWithCloudRetry } from "@/websocket/listen-register";
 
 // tiny helper for unique ids
 function uid(prefix: string) {
@@ -226,14 +223,30 @@ export async function handleListen(
       throw new Error("Missing LETTA_API_KEY");
     }
 
-    // Register with cloud
+    // Register with cloud, retrying transient failures with a bounded backoff.
     const { connectionId, wsUrl, supportsSplitStatusChannels } =
-      await registerWithCloud({
-        serverUrl,
-        apiKey,
-        deviceId,
-        connectionName,
-      });
+      await registerWithCloudRetry(
+        {
+          serverUrl,
+          apiKey,
+          deviceId,
+          connectionName,
+        },
+        {
+          onRetry: (attempt, delayMs, error) => {
+            updateCommandResult(
+              ctx.buffersRef,
+              ctx.refreshDerived,
+              cmdId,
+              msg,
+              `Registering listener "${connectionName}"...\n` +
+                `Retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+              true,
+              "running",
+            );
+          },
+        },
+      );
 
     updateCommandResult(
       ctx.buffersRef,

--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -331,6 +331,7 @@ export async function handleListen(
             const reregisterResult = await registerWithCloudRetry(
               { serverUrl, apiKey, deviceId, connectionName },
               {
+                maxDurationMs: Infinity,
                 onRetry: (attempt, delayMs, error) => {
                   updateCommandResult(
                     ctx.buffersRef,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -607,6 +607,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
         connectionName,
       );
       const result = await registerWithCloudRetry(nextRegisterOptions, {
+        maxDurationMs: Infinity,
         onRetry: (attempt, delayMs, error) => {
           sessionLog.log(
             `Registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -21,7 +21,6 @@ import { telemetry } from "@/telemetry";
 import { RemoteSessionLog } from "@/websocket/listen-log";
 import {
   type RegisterOptions,
-  registerWithCloud,
   registerWithCloudRetry,
 } from "@/websocket/listen-register";
 
@@ -577,7 +576,18 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     );
 
     const { connectionId, wsUrl, supportsSplitStatusChannels } =
-      await registerWithCloud(registerOptions);
+      await registerWithCloudRetry(registerOptions, {
+        onRetry: (attempt, delayMs, error) => {
+          sessionLog.log(
+            `Initial registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+          );
+          if (debugMode) {
+            console.log(
+              `[${formatTimestamp()}] Initial registration retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+            );
+          }
+        },
+      });
 
     sessionLog.log(`Registered: connectionId=${connectionId}`);
     sessionLog.log(`wsUrl: ${wsUrl}`);

--- a/src/websocket/listen-register.test.ts
+++ b/src/websocket/listen-register.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { registerWithCloud } from "@/websocket/listen-register";
+import {
+  registerWithCloud,
+  registerWithCloudRetry,
+} from "@/websocket/listen-register";
 
 const defaultOpts = {
   serverUrl: "https://api.example.com",
@@ -123,5 +126,79 @@ describe("registerWithCloud", () => {
     await expect(
       registerWithCloud(defaultOpts, mockFetch as unknown as typeof fetch),
     ).rejects.toThrow("missing connectionId or wsUrl");
+  });
+
+  it("uses JSON error fields in rate limit messages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error:
+            "Rate limit exceeded for this endpoint. Please slow down and retry.",
+          errorCode: "route_rps_rate_limit_exceeded",
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      registerWithCloud(defaultOpts, mockFetch as unknown as typeof fetch),
+    ).rejects.toThrow("route_rps_rate_limit_exceeded");
+  });
+
+  it("retries rate limited registration instead of treating 429 as fatal", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error:
+              "Rate limit exceeded for this endpoint. Please slow down and retry.",
+            errorCode: "route_rps_rate_limit_exceeded",
+          }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "3",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            connectionId: "conn-3",
+            wsUrl: "wss://example.com",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const retryEvents: Array<{
+      attempt: number;
+      delayMs: number;
+      message: string;
+    }> = [];
+    const slept: number[] = [];
+    const result = await registerWithCloudRetry(defaultOpts, {
+      fetchImpl: mockFetch as unknown as typeof fetch,
+      sleep: async (delayMs) => {
+        slept.push(delayMs);
+      },
+      onRetry: (attempt, delayMs, error) => {
+        retryEvents.push({ attempt, delayMs, message: error.message });
+      },
+    });
+
+    expect(result.connectionId).toBe("conn-3");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(slept).toEqual([3000]);
+    expect(retryEvents).toEqual([
+      {
+        attempt: 1,
+        delayMs: 3000,
+        message:
+          "HTTP 429: Rate limit exceeded for this endpoint. Please slow down and retry. (route_rps_rate_limit_exceeded)",
+      },
+    ]);
   });
 });

--- a/src/websocket/listen-register.test.ts
+++ b/src/websocket/listen-register.test.ts
@@ -181,6 +181,7 @@ describe("registerWithCloud", () => {
     const slept: number[] = [];
     const result = await registerWithCloudRetry(defaultOpts, {
       fetchImpl: mockFetch as unknown as typeof fetch,
+      random: () => 0,
       sleep: async (delayMs) => {
         slept.push(delayMs);
       },
@@ -200,5 +201,73 @@ describe("registerWithCloud", () => {
           "HTTP 429: Rate limit exceeded for this endpoint. Please slow down and retry. (route_rps_rate_limit_exceeded)",
       },
     ]);
+  });
+
+  it("retries 429 without Retry-After using exponential backoff", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error:
+              "Rate limit exceeded for this endpoint. Please slow down and retry.",
+            errorCode: "route_rps_rate_limit_exceeded",
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            connectionId: "conn-4",
+            wsUrl: "wss://example.com",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    const slept: number[] = [];
+
+    const result = await registerWithCloudRetry(defaultOpts, {
+      fetchImpl: mockFetch as unknown as typeof fetch,
+      random: () => 0,
+      sleep: async (delayMs) => {
+        slept.push(delayMs);
+      },
+    });
+
+    expect(result.connectionId).toBe("conn-4");
+    expect(slept).toEqual([1000]);
+  });
+
+  it("adds bounded positive jitter to retry delays", async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response("Bad Gateway", { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            connectionId: "conn-5",
+            wsUrl: "wss://example.com",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    const slept: number[] = [];
+
+    await registerWithCloudRetry(defaultOpts, {
+      fetchImpl: mockFetch as unknown as typeof fetch,
+      random: () => 0.5,
+      sleep: async (delayMs) => {
+        slept.push(delayMs);
+      },
+    });
+
+    expect(slept).toEqual([1125]);
   });
 });

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -25,22 +25,47 @@ type FetchImpl = typeof fetch;
  */
 export class RegistrationError extends Error {
   readonly statusCode: number;
-  constructor(message: string, statusCode: number) {
+  readonly retryAfterMs?: number;
+  constructor(message: string, statusCode: number, retryAfterMs?: number) {
     super(message);
     this.name = "RegistrationError";
     this.statusCode = statusCode;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
 /** Returns true for errors that are likely transient and worth retrying. */
 function isTransientRegistrationError(error: unknown): boolean {
   if (error instanceof RegistrationError) {
+    // 429 = rate limit. The server explicitly asked us to slow down, not stop.
     // 5xx = server errors (including Cloudflare 521/522/523/524)
     // 0 = network-level failure (DNS, TCP, TLS)
-    return error.statusCode === 0 || error.statusCode >= 500;
+    return (
+      error.statusCode === 0 ||
+      error.statusCode === 429 ||
+      error.statusCode >= 500
+    );
   }
   // Non-RegistrationError from fetch (e.g. TypeError for DNS failure)
   return true;
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return undefined;
 }
 
 /**
@@ -78,12 +103,22 @@ export async function registerWithCloud(
 
   if (!response.ok) {
     let detail = `HTTP ${response.status}`;
+    const retryAfterMs = parseRetryAfterMs(response.headers.get("Retry-After"));
     const text = await response.text().catch(() => "");
     if (text) {
       try {
-        const parsed = JSON.parse(text) as { message?: string };
+        const parsed = JSON.parse(text) as {
+          error?: string;
+          errorCode?: string;
+          message?: string;
+        };
         if (parsed.message) {
           detail = parsed.message;
+        } else if (parsed.error) {
+          detail = `HTTP ${response.status}: ${parsed.error}`;
+          if (parsed.errorCode) {
+            detail += ` (${parsed.errorCode})`;
+          }
         } else {
           detail += `: ${text.slice(0, 200)}`;
         }
@@ -91,7 +126,7 @@ export async function registerWithCloud(
         detail += `: ${text.slice(0, 200)}`;
       }
     }
-    throw new RegistrationError(detail, response.status);
+    throw new RegistrationError(detail, response.status, retryAfterMs);
   }
 
   let body: unknown;
@@ -129,6 +164,12 @@ const REGISTER_MAX_DURATION_MS = 2 * 60 * 1_000; // 2 minutes
 export interface RegisterRetryCallbacks {
   /** Called before each retry attempt. */
   onRetry?: (attempt: number, delayMs: number, error: Error) => void;
+  /** Maximum total retry duration. Defaults to two minutes. Use Infinity for long-running listeners. */
+  maxDurationMs?: number;
+  /** Test seam for avoiding real sleeps. */
+  sleep?: (delayMs: number) => Promise<void>;
+  /** Test seam for injecting fetch. */
+  fetchImpl?: FetchImpl;
 }
 
 /**
@@ -140,32 +181,38 @@ export async function registerWithCloudRetry(
   callbacks?: RegisterRetryCallbacks,
 ): Promise<RegisterResult> {
   const startTime = Date.now();
+  const maxDurationMs = callbacks?.maxDurationMs ?? REGISTER_MAX_DURATION_MS;
+  const sleep =
+    callbacks?.sleep ??
+    ((delayMs: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
   let attempt = 0;
 
   for (;;) {
     try {
-      return await registerWithCloud(opts);
+      return await registerWithCloud(opts, callbacks?.fetchImpl);
     } catch (error) {
       const elapsed = Date.now() - startTime;
 
-      if (
-        !isTransientRegistrationError(error) ||
-        elapsed >= REGISTER_MAX_DURATION_MS
-      ) {
+      if (!isTransientRegistrationError(error) || elapsed >= maxDurationMs) {
         throw error;
       }
 
       attempt++;
-      const delay = Math.min(
+      const backoffDelay = Math.min(
         REGISTER_INITIAL_DELAY_MS * 2 ** (attempt - 1),
         REGISTER_MAX_DELAY_MS,
       );
+      const delay =
+        error instanceof RegistrationError && error.retryAfterMs !== undefined
+          ? Math.max(error.retryAfterMs, backoffDelay)
+          : backoffDelay;
 
       if (error instanceof Error) {
         callbacks?.onRetry?.(attempt, delay, error);
       }
 
-      await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
     }
   }
 }

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -160,6 +160,8 @@ export async function registerWithCloud(
 const REGISTER_INITIAL_DELAY_MS = 1_000;
 const REGISTER_MAX_DELAY_MS = 30_000;
 const REGISTER_MAX_DURATION_MS = 2 * 60 * 1_000; // 2 minutes
+const REGISTER_MAX_JITTER_MS = 1_000;
+const REGISTER_JITTER_RATIO = 0.25;
 
 export interface RegisterRetryCallbacks {
   /** Called before each retry attempt. */
@@ -170,11 +172,13 @@ export interface RegisterRetryCallbacks {
   sleep?: (delayMs: number) => Promise<void>;
   /** Test seam for injecting fetch. */
   fetchImpl?: FetchImpl;
+  /** Test seam for deterministic retry jitter. */
+  random?: () => number;
 }
 
 /**
- * Register with Cloud, retrying on transient errors (5xx, network failures)
- * with exponential backoff. Fails immediately on client errors (4xx).
+ * Register with Cloud, retrying on transient errors (429, 5xx, network failures)
+ * with exponential backoff. Fails immediately on other client errors (4xx).
  */
 export async function registerWithCloudRetry(
   opts: RegisterOptions,
@@ -207,12 +211,21 @@ export async function registerWithCloudRetry(
         error instanceof RegistrationError && error.retryAfterMs !== undefined
           ? Math.max(error.retryAfterMs, backoffDelay)
           : backoffDelay;
+      const jitterWindow = Math.min(
+        REGISTER_MAX_JITTER_MS,
+        Math.floor(delay * REGISTER_JITTER_RATIO),
+      );
+      const jitter =
+        jitterWindow > 0
+          ? Math.floor((callbacks?.random ?? Math.random)() * jitterWindow)
+          : 0;
+      const retryDelay = delay + jitter;
 
       if (error instanceof Error) {
-        callbacks?.onRetry?.(attempt, delay, error);
+        callbacks?.onRetry?.(attempt, retryDelay, error);
       }
 
-      await sleep(delay);
+      await sleep(retryDelay);
     }
   }
 }


### PR DESCRIPTION
## Summary

Remote listener environment registration could fail hard on endpoint rate limits. A long-running listener can receive Environment not found, attempt to register a fresh environment, hit a short /v1/environments/register 429, and then exit entirely. For channel runs, that tears down the channel adapters, which matches the observed Telegram Bot stopped cascade.

This PR changes the registration retry policy so 429 is handled like a backoff signal rather than a terminal failure. The helper now preserves Retry-After when present, parses the backend error and errorCode fields into the surfaced message, and adds bounded jitter so multiple listeners do not retry in lockstep. Initial registration uses the existing bounded retry window; re-registration for an already-running listener retries indefinitely so established servers slow down instead of dying.

Before this change, a single route_rps_rate_limit_exceeded response during re-registration killed the remote server. After this change, the listener logs the retry, waits with backoff/jitter, and resumes once registration succeeds.

This is a client-side resilience fix. It prevents server termination when Cloud asks the client to slow down. The companion backend fix is to give POST /v1/environments/register an explicit route limit instead of leaving it behind the generic 1 RPS mutating cap.

## Validation

- bun test src/websocket/listen-register.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/websocket/listen-register.ts src/websocket/listen-register.test.ts src/cli/subcommands/listen.tsx src/cli/commands/listen.ts
- git diff --check

Note: bun run typecheck could not run in this worktree because tsc is not installed in node_modules.

👾 Generated with [Letta Code](https://letta.com)
