### PR TITLE
fix(listener): expose remote plan-mode command

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -940,6 +940,7 @@ describe("listen-client parseServerMessage", () => {
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("set-max-context");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("goal");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("compact");
+    expect(SUPPORTED_REMOTE_COMMANDS).toContain("plan-mode");
 
     const command = parseServerMessage(
       Buffer.from(
@@ -958,6 +959,62 @@ describe("listen-client parseServerMessage", () => {
       command_id: "set-max-context",
       args: "10000 --override",
     });
+  });
+
+  test("runs remote plan-mode execute_command", async () => {
+    settingsManager.setPlanModeEnabled(false);
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    await handleExecuteCommand(
+      {
+        type: "execute_command",
+        command_id: "plan-mode",
+        request_id: "plan-mode-run-1",
+        runtime: { agent_id: "agent-1", conversation_id: "default" },
+        args: "on",
+      },
+      socket as unknown as WebSocket,
+      runtime,
+      {},
+    );
+
+    expect(settingsManager.isPlanModeEnabled()).toBe(true);
+    expect(socket.sentPayloads.join("\n")).toContain(
+      "Plan mode enabled. /plan and plan-mode tools are now available.",
+    );
+  });
+
+  test("returns usage for invalid remote plan-mode execute_command args", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    await handleExecuteCommand(
+      {
+        type: "execute_command",
+        command_id: "plan-mode",
+        request_id: "plan-mode-run-2",
+        runtime: { agent_id: "agent-1", conversation_id: "default" },
+        args: "maybe",
+      },
+      socket as unknown as WebSocket,
+      runtime,
+      {},
+    );
+
+    expect(socket.sentPayloads.join("\n")).toContain(
+      "Usage: /plan-mode on|off",
+    );
   });
 
   test("runs remote compact execute_command against backend", async () => {

--- a/src/websocket/listener/commands.plan-mode.test.ts
+++ b/src/websocket/listener/commands.plan-mode.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { settingsManager } from "@/settings-manager";
-import { __testHandlePlanModeCommand } from "@/websocket/listener/commands";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { __testHandlePlanModeCommand } from "@/websocket/listener/commands";
 
 describe("listener plan-mode command", () => {
   afterEach(async () => {

--- a/src/websocket/listener/commands.plan-mode.test.ts
+++ b/src/websocket/listener/commands.plan-mode.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { settingsManager } from "@/settings-manager";
+import { __testHandlePlanModeCommand } from "@/websocket/listener/commands";
+import { __listenClientTestUtils } from "@/websocket/listen-client";
+
+describe("listener plan-mode command", () => {
+  afterEach(async () => {
+    settingsManager.setPlanModeEnabled(false);
+    await settingsManager.flush();
+  });
+
+  test("enables plan mode through the remote command handler", async () => {
+    settingsManager.setPlanModeEnabled(false);
+    await settingsManager.flush();
+
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+
+    const result = await __testHandlePlanModeCommand(runtime, "on");
+
+    expect(settingsManager.isPlanModeEnabled()).toBe(true);
+    expect(result).toBe(
+      "Plan mode enabled. /plan and plan-mode tools are now available.",
+    );
+  });
+
+  test("returns usage text for invalid args", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+
+    const result = await __testHandlePlanModeCommand(runtime, "maybe");
+
+    expect(result).toBe("Usage: /plan-mode on|off");
+  });
+});

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -126,10 +126,7 @@ export async function handleExecuteCommand(
         break;
 
       case "plan-mode":
-        output = await handlePlanModeCommand(
-          conversationRuntime,
-          trimmedArgs,
-        );
+        output = await handlePlanModeCommand(conversationRuntime, trimmedArgs);
         break;
 
       case "compact":

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -125,6 +125,13 @@ export async function handleExecuteCommand(
         );
         break;
 
+      case "plan-mode":
+        output = await handlePlanModeCommand(
+          conversationRuntime,
+          trimmedArgs,
+        );
+        break;
+
       case "compact":
         output = await handleCompactCommand(conversationRuntime, trimmedArgs);
         break;
@@ -226,6 +233,50 @@ function compactHelpOutput(): string {
     "  /compact help              — show this help",
   ].join("\n");
 }
+
+async function handlePlanModeCommand(
+  conversationRuntime: ConversationRuntime,
+  args?: string,
+): Promise<string> {
+  const arg = args?.split(/\s+/)[0]?.toLowerCase();
+  const enabled = (() => {
+    if (arg === "on" || arg === "true" || arg === "enable") {
+      return true;
+    }
+    if (arg === "off" || arg === "false" || arg === "disable") {
+      return false;
+    }
+    return null;
+  })();
+
+  if (enabled === null) {
+    return "Usage: /plan-mode on|off";
+  }
+
+  settingsManager.setPlanModeEnabled(enabled);
+  await settingsManager.flush();
+
+  if (!enabled) {
+    const state = getOrCreateConversationPermissionModeStateRef(
+      conversationRuntime.listener,
+      conversationRuntime.agentId,
+      conversationRuntime.conversationId,
+    );
+    if (state.mode === "plan") {
+      state.mode = "bypassPermissions";
+      state.planFilePath = null;
+      state.modeBeforePlan = null;
+      persistPermissionModeMapForRuntime(conversationRuntime.listener);
+      emitListenerStatus(conversationRuntime.listener);
+    }
+  }
+
+  return enabled
+    ? "Plan mode enabled. /plan and plan-mode tools are now available."
+    : "Plan mode disabled. /plan is disabled and plan-mode tools are hidden.";
+}
+
+export const __testHandlePlanModeCommand = handlePlanModeCommand;
 
 /** /compact — Summarize conversation history through the active Backend. */
 async function handleCompactCommand(

--- a/src/websocket/listener/listener-constants.ts
+++ b/src/websocket/listener/listener-constants.ts
@@ -11,6 +11,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "init",
   "remember",
   "goal",
+  "plan-mode",
   "compact",
   "set-max-context",
   "channels",


### PR DESCRIPTION
Advertise /plan-mode in supported remote commands and handle execute_command toggles so desktop and cloud can surface the command palette entry.

👾 Generated with [Letta Code](https://letta.com)