### PR TITLE
refactor(cli): migrate ToolsetSelector to SingleSelectPicker + OverlayShell

### DIFF
--- a/src/cli/components/SingleSelectPicker.tsx
+++ b/src/cli/components/SingleSelectPicker.tsx
@@ -29,25 +29,13 @@ export interface SingleSelectPickerProps {
   onSelect: (key: string) => void;
   /** Called when user presses Escape or Ctrl-C */
   onCancel: () => void;
-  /** Override the default footer hint line */
-  footerHint?: string;
-  /**
-   * Extra key handlers beyond the built-in ↑↓/Enter/Escape/Ctrl-C.
-   * Key is the input character, value is a callback with the current cursor index.
-   * Useful for shortcuts like "A" for show-all.
-   */
-  extraActions?: Record<string, (cursorIndex: number) => void>;
 }
-
-const DEFAULT_FOOTER_HINT = "  Enter select · ↑↓ navigate · Esc cancel";
 
 export const SingleSelectPicker = memo(function SingleSelectPicker({
   items,
   initialCursorIndex = 0,
   onSelect,
   onCancel,
-  footerHint = DEFAULT_FOOTER_HINT,
-  extraActions,
 }: SingleSelectPickerProps) {
   const [cursor, setCursor] = useState(initialCursorIndex);
 
@@ -82,15 +70,8 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
         onCancel();
         return;
       }
-      // Check extra actions
-      if (input && extraActions) {
-        const action = extraActions[input];
-        if (action) {
-          action(cursor);
-        }
-      }
     },
-    [items, cursor, onCancel, onSelect, extraActions],
+    [items, cursor, onCancel, onSelect],
   );
 
   useInput(handleInput, { isActive: true });
@@ -136,7 +117,7 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
 
       {/* Footer hint */}
       <Box marginTop={1}>
-        <Text dimColor>{footerHint}</Text>
+        <Text dimColor> Enter select · ↑↓ navigate · Esc cancel</Text>
       </Box>
     </Box>
   );

--- a/src/cli/components/ToolsetSelector.tsx
+++ b/src/cli/components/ToolsetSelector.tsx
@@ -1,14 +1,14 @@
-// Import useInput from vendored Ink for bracketed paste support
-import { Box, useInput } from "ink";
-import { useEffect, useMemo, useState } from "react";
-import { useTerminalWidth } from "@/cli/hooks/useTerminalWidth";
+// Toolset selector.
+// Wraps SingleSelectPicker with toolset-specific logic.
+
+import { memo, useCallback, useMemo, useState } from "react";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import { formatToolsetName } from "@/tools/toolset-labels";
-import { colors } from "./colors";
-import { Text } from "./Text";
+import { OverlayShell } from "./OverlayShell";
+import type { SelectableItem } from "./SingleSelectPicker";
+import { SingleSelectPicker } from "./SingleSelectPicker";
 
-// Horizontal line character (matches approval dialogs)
-const SOLID_LINE = "─";
+const SHOW_ALL_KEY = "__show_all__";
 
 interface ToolsetOption {
   id: ToolsetPreference;
@@ -67,21 +67,21 @@ interface ToolsetSelectorProps {
   onCancel: () => void;
 }
 
-export function ToolsetSelector({
+export const ToolsetSelector = memo(function ToolsetSelector({
   currentToolset,
   currentPreference = "auto",
   onSelect,
   onCancel,
 }: ToolsetSelectorProps) {
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
   const [showAll, setShowAll] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const featuredToolsets = useMemo(
     () => toolsets.filter((toolset) => toolset.isFeatured),
     [],
   );
+
+  const hasShowAllOption =
+    !showAll && featuredToolsets.length < toolsets.length;
 
   const visibleToolsets = useMemo(() => {
     if (showAll) return toolsets;
@@ -89,101 +89,59 @@ export function ToolsetSelector({
     return toolsets;
   }, [featuredToolsets, showAll]);
 
-  const canToggleShowAll = featuredToolsets.length < toolsets.length;
+  const items = useMemo<SelectableItem[]>(() => {
+    const toolsetItems: SelectableItem[] = visibleToolsets.map((toolset) => {
+      const isCurrent = toolset.id === currentPreference;
 
-  useEffect(() => {
-    if (selectedIndex >= visibleToolsets.length) {
-      setSelectedIndex(Math.max(0, visibleToolsets.length - 1));
-    }
-  }, [selectedIndex, visibleToolsets.length]);
-
-  useInput((input, key) => {
-    // CTRL-C: immediately cancel
-    if (key.ctrl && input === "c") {
-      onCancel();
-      return;
-    }
-
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex((prev) =>
-        Math.min(visibleToolsets.length - 1, prev + 1),
-      );
-    } else if (key.return) {
-      const selectedToolset = visibleToolsets[selectedIndex];
-      if (selectedToolset) {
-        onSelect(selectedToolset.id);
+      // For "auto" when current, show resolved name in the label and skip
+      // isCurrent to avoid double "(current)". For all others, let
+      // SingleSelectPicker's isCurrent handle the "(current)" marker.
+      if (toolset.id === "auto" && isCurrent) {
+        return {
+          key: toolset.id,
+          label: `Auto (current - ${formatToolsetName(currentToolset)})`,
+          description: toolset.description,
+          isCurrent: false,
+        };
       }
-    } else if (canToggleShowAll && (input === "a" || input === "A")) {
-      setShowAll((prev) => !prev);
-    } else if (key.escape) {
-      onCancel();
+
+      return {
+        key: toolset.id,
+        label: toolset.label,
+        description: toolset.description,
+        isCurrent,
+      };
+    });
+
+    if (hasShowAllOption) {
+      toolsetItems.push({
+        key: SHOW_ALL_KEY,
+        label: "Show all toolsets",
+        dimLabel: true,
+      });
     }
-  });
+
+    return toolsetItems;
+  }, [visibleToolsets, hasShowAllOption, currentPreference, currentToolset]);
+
+  const handleSelect = useCallback(
+    (key: string) => {
+      if (key === SHOW_ALL_KEY) {
+        setShowAll(true);
+        return;
+      }
+      onSelect(key as ToolsetPreference);
+    },
+    [onSelect],
+  );
 
   return (
-    <Box flexDirection="column">
-      {/* Command header */}
-      <Text dimColor>{"> /toolset"}</Text>
-      <Text dimColor>{solidLine}</Text>
-
-      <Box height={1} />
-
-      {/* Title */}
-      <Box marginBottom={1}>
-        <Text bold color={colors.selector.title}>
-          Swap your agent's toolset
-        </Text>
-      </Box>
-
-      <Box flexDirection="column">
-        {visibleToolsets.map((toolset, index) => {
-          const isSelected = index === selectedIndex;
-          const isCurrent = toolset.id === currentPreference;
-
-          const labelText =
-            toolset.id === "auto"
-              ? isCurrent
-                ? `Auto (current - ${formatToolsetName(currentToolset)})`
-                : "Auto"
-              : isCurrent
-                ? `${toolset.label} (current)`
-                : toolset.label;
-
-          return (
-            <Box key={toolset.id} flexDirection="row">
-              <Text
-                color={isSelected ? colors.selector.itemHighlighted : undefined}
-              >
-                {isSelected ? "> " : "  "}
-              </Text>
-              <Text
-                bold={isSelected}
-                color={
-                  isSelected
-                    ? colors.selector.itemHighlighted
-                    : isCurrent
-                      ? colors.selector.itemCurrent
-                      : undefined
-                }
-              >
-                {labelText}
-              </Text>
-              <Text dimColor>{` · ${toolset.description}`}</Text>
-            </Box>
-          );
-        })}
-      </Box>
-
-      {/* Footer */}
-      <Box marginTop={1}>
-        <Text dimColor>
-          {canToggleShowAll
-            ? "  Enter select · ↑↓ navigate · A show all · Esc cancel"
-            : "  Enter select · ↑↓ navigate · Esc cancel"}
-        </Text>
-      </Box>
-    </Box>
+    <OverlayShell command="/toolset" title="Swap your agent's toolset">
+      <SingleSelectPicker
+        items={items}
+        onSelect={handleSelect}
+        onCancel={onCancel}
+      />
+    </OverlayShell>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Migrate ToolsetSelector to use shared `SingleSelectPicker` and `OverlayShell` components
- "Show all" toggle uses a pseudo-item at the bottom of the list (matching SystemPromptSelector) instead of a keyboard shortcut
- Remove unused `extraActions` and `footerHint` props from `SingleSelectPicker`

## Test plan
- [x] `/toolset` renders correctly with vertical picker
- [x] "Show all toolsets" pseudo-item expands the list
- [x] Current toolset shows `(current)` marker correctly
- [x] Auto toolset shows resolved name: `Auto (current - Claude)`
- [ ] CI green

👾 Generated with [Letta Code](https://letta.com)