### PR TITLE
refactor(cli): migrate ConversationSelector to SingleSelectPicker + OverlayShell

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -3,18 +3,16 @@ import type {
   MessageType,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
-import { Box, useInput } from "ink";
+import { Box, type Key, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Backend, getBackend } from "@/backend";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
-import { useTerminalWidth } from "@/cli/hooks/useTerminalWidth";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { colors } from "./colors";
-import { MarkdownDisplay } from "./MarkdownDisplay";
+import { OverlayShell } from "./OverlayShell";
+import type { SelectableItem } from "./SingleSelectPicker";
+import { SingleSelectPicker } from "./SingleSelectPicker";
 import { Text } from "./Text";
-
-// Horizontal line character (matches approval dialogs)
-const SOLID_LINE = "─";
 
 interface ConversationSelectorProps {
   agentId: string;
@@ -238,8 +236,7 @@ export function ConversationSelector({
   const [error, setError] = useState<string | null>(null);
   const [enriching, setEnriching] = useState(false);
 
-  // Selection state
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  // Pagination state
   const [page, setPage] = useState(0);
 
   // Enrich a single conversation with message data, updating state in-place
@@ -366,7 +363,6 @@ export function ConversationSelector({
             : nonEmptyList;
           setConversations(allConversations);
           setPage(0);
-          setSelectedIndex(0);
         }
         setCursor(newCursor);
         setHasMore(newCursor !== null);
@@ -460,43 +456,35 @@ export function ConversationSelector({
     await loadConversations(cursor);
   }, [loadingMore, hasMore, cursor, loadConversations]);
 
-  useInput((input, key) => {
-    // CTRL-C: immediately cancel
-    if (key.ctrl && input === "c") {
-      onCancel();
-      return;
-    }
+  // Build SelectableItem[] from pageConversations
+  const items: SelectableItem[] = pageConversations.map((enrichedConv) => ({
+    key: enrichedConv.conversation.id,
+    label: "", // Not used — renderItem handles all rendering
+    isCurrent: enrichedConv.conversation.id === currentConversationId,
+  }));
 
-    if (loading) return;
-
-    if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-    } else if (key.downArrow) {
-      setSelectedIndex((prev) =>
-        Math.min(pageConversations.length - 1, prev + 1),
-      );
-    } else if (key.return) {
-      const selected = pageConversations[selectedIndex];
+  // Handle select
+  const handleSelect = useCallback(
+    (key: string) => {
+      const selected = conversations.find((c) => c.conversation.id === key);
       if (selected?.conversation.id) {
         onSelect(selected.conversation.id, {
           summary: selected.conversation.summary ?? undefined,
           messageCount: selected.messageCount,
         });
       }
-    } else if (key.escape) {
-      onCancel();
-    } else if (input === "n" || input === "N") {
-      // New conversation
-      onNewConversation();
-    } else if (key.leftArrow) {
-      // Previous page
-      if (page > 0) {
-        setPage((prev) => prev - 1);
-        setSelectedIndex(0);
+    },
+    [conversations, onSelect],
+  );
+
+  // Handle unhandled keys (←→ for pagination, N for new conversation)
+  const handleUnhandledKey = useCallback(
+    (input: string, key: Key) => {
+      if (loading) return;
+      if (key.leftArrow && page > 0) {
+        setPage((p) => p - 1);
       }
-    } else if (key.rightArrow) {
-      // Next page
-      if (canGoNext) {
+      if (key.rightArrow && canGoNext) {
         const nextPageIndex = page + 1;
         const nextStartIndex = nextPageIndex * DISPLAY_PAGE_SIZE;
 
@@ -506,150 +494,169 @@ export function ConversationSelector({
 
         if (nextStartIndex < conversations.length) {
           setPage(nextPageIndex);
-          setSelectedIndex(0);
         }
       }
-    }
-  });
+      if (input === "n" || input === "N") {
+        onNewConversation();
+      }
+    },
+    [
+      loading,
+      page,
+      canGoNext,
+      conversations.length,
+      hasMore,
+      fetchMore,
+      onNewConversation,
+    ],
+  );
 
-  // Render conversation item
-  const renderConversationItem = (
-    enrichedConv: EnrichedConversation,
-    _index: number,
-    isSelected: boolean,
-  ) => {
-    const {
-      conversation: conv,
-      previewLines,
-      lastActiveAt,
-      messageCount,
-    } = enrichedConv;
-    const isCurrent = conv.id === currentConversationId;
+  // Render item callback — full multi-line conversation display
+  const renderItem = useCallback(
+    (item: SelectableItem, _index: number, isSelected: boolean) => {
+      const enrichedConv = pageConversations.find(
+        (c) => c.conversation.id === item.key,
+      );
+      if (!enrichedConv) return null;
 
-    // Format timestamps
-    const activeTime = formatRelativeTime(lastActiveAt);
-    const createdTime = formatRelativeTime(conv.created_at);
+      const {
+        conversation: conv,
+        previewLines,
+        lastActiveAt,
+        messageCount,
+      } = enrichedConv;
+      const isCurrent = conv.id === currentConversationId;
 
-    // Build preview content: (1) summary if exists, (2) preview lines, (3) message count fallback
-    // Uses L-bracket indentation style for visual hierarchy
-    const renderPreview = () => {
-      const bracket = <Text dimColor>{`${CLI_GLYPHS.result}  `}</Text>;
-      const indent = "   "; // Same width as "└  " for alignment
+      // Format timestamps
+      const activeTime = formatRelativeTime(lastActiveAt);
+      const createdTime = formatRelativeTime(conv.created_at);
 
-      // Still loading message data
-      if (previewLines === null) {
+      // Build preview content: (1) summary if exists, (2) preview lines, (3) message count fallback
+      // Uses L-bracket indentation style for visual hierarchy
+      const renderPreview = () => {
+        const bracket = <Text dimColor>{`${CLI_GLYPHS.result}  `}</Text>;
+        const indent = "   "; // Same width as "└  " for alignment
+
+        // Still loading message data
+        if (previewLines === null) {
+          return (
+            <Box flexDirection="row" marginLeft={2}>
+              {bracket}
+              <Text dimColor italic>
+                Loading preview...
+              </Text>
+            </Box>
+          );
+        }
+
+        // Has preview lines from messages
+        if (previewLines.length > 0) {
+          return (
+            <>
+              {previewLines.map((line, idx) => (
+                <Box
+                  key={`${line.role}-${idx}`}
+                  flexDirection="row"
+                  marginLeft={2}
+                >
+                  {idx === 0 ? bracket : <Text>{indent}</Text>}
+                  <Text dimColor>
+                    {line.role === "assistant" ? "👾 " : "👤 "}
+                  </Text>
+                  <Text dimColor italic>
+                    {line.text}
+                  </Text>
+                </Box>
+              ))}
+            </>
+          );
+        }
+
+        // Priority 3: Message count fallback
+        if (messageCount > 0) {
+          return (
+            <Box flexDirection="row" marginLeft={2}>
+              {bracket}
+              <Text dimColor italic>
+                {messageCount} message{messageCount === 1 ? "" : "s"} (no
+                in-context user/agent messages)
+              </Text>
+            </Box>
+          );
+        }
+
         return (
           <Box flexDirection="row" marginLeft={2}>
             {bracket}
             <Text dimColor italic>
-              Loading preview...
+              No in-context messages
             </Text>
           </Box>
         );
-      }
+      };
 
-      // Has preview lines from messages
-      if (previewLines.length > 0) {
-        return (
-          <>
-            {previewLines.map((line, idx) => (
-              <Box
-                key={`${line.role}-${idx}`}
-                flexDirection="row"
-                marginLeft={2}
-              >
-                {idx === 0 ? bracket : <Text>{indent}</Text>}
-                <Text dimColor>
-                  {line.role === "assistant" ? "👾 " : "👤 "}
-                </Text>
-                <Text dimColor italic>
-                  {line.text}
-                </Text>
-              </Box>
-            ))}
-          </>
-        );
-      }
-
-      // Priority 3: Message count fallback
-      if (messageCount > 0) {
-        return (
-          <Box flexDirection="row" marginLeft={2}>
-            {bracket}
-            <Text dimColor italic>
-              {messageCount} message{messageCount === 1 ? "" : "s"} (no
-              in-context user/agent messages)
-            </Text>
-          </Box>
-        );
-      }
+      const isDefault = conv.id === "default";
 
       return (
-        <Box flexDirection="row" marginLeft={2}>
-          {bracket}
-          <Text dimColor italic>
-            No in-context messages
-          </Text>
+        <Box flexDirection="column" marginBottom={1}>
+          <Box flexDirection="row">
+            <Text
+              color={isSelected ? colors.selector.itemHighlighted : undefined}
+            >
+              {isSelected ? ">" : " "}
+            </Text>
+            <Text> </Text>
+            <Text
+              bold={isSelected}
+              color={isSelected ? colors.selector.itemHighlighted : undefined}
+            >
+              {conv.summary
+                ? `${conv.summary.length > 40 ? `${conv.summary.slice(0, 37)}...` : conv.summary} (${conv.id})`
+                : isDefault
+                  ? "default"
+                  : conv.id}
+            </Text>
+            {!conv.summary && isDefault && (
+              <Text dimColor> (agent's default conversation)</Text>
+            )}
+            {isCurrent && (
+              <Text color={colors.selector.itemCurrent}> (current)</Text>
+            )}
+          </Box>
+          {renderPreview()}
+          <Box flexDirection="row" marginLeft={2}>
+            <Text dimColor>
+              Active {activeTime} · Created {createdTime}
+            </Text>
+          </Box>
         </Box>
       );
-    };
+    },
+    [pageConversations, currentConversationId],
+  );
 
-    const isDefault = conv.id === "default";
+  const showPicker = !loading && !error && conversations.length > 0;
 
-    return (
-      <Box key={conv.id} flexDirection="column" marginBottom={1}>
-        <Box flexDirection="row">
-          <Text
-            color={isSelected ? colors.selector.itemHighlighted : undefined}
-          >
-            {isSelected ? ">" : " "}
-          </Text>
-          <Text> </Text>
-          <Text
-            bold={isSelected}
-            color={isSelected ? colors.selector.itemHighlighted : undefined}
-          >
-            {conv.summary
-              ? `${conv.summary.length > 40 ? `${conv.summary.slice(0, 37)}...` : conv.summary} (${conv.id})`
-              : isDefault
-                ? "default"
-                : conv.id}
-          </Text>
-          {!conv.summary && isDefault && (
-            <Text dimColor> (agent's default conversation)</Text>
-          )}
-          {isCurrent && (
-            <Text color={colors.selector.itemCurrent}> (current)</Text>
-          )}
-        </Box>
-        {renderPreview()}
-        <Box flexDirection="row" marginLeft={2}>
-          <Text dimColor>
-            Active {activeTime} · Created {createdTime}
-          </Text>
-        </Box>
-      </Box>
-    );
-  };
-
-  const terminalWidth = useTerminalWidth();
-  const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+  // Handle Ctrl-C/Escape/N when picker is not shown (loading, error, empty states)
+  useInput(
+    (input, key) => {
+      if (key.ctrl && input === "c") {
+        onCancel();
+        return;
+      }
+      if (key.escape) {
+        onCancel();
+        return;
+      }
+      if (!loading && !error && (input === "n" || input === "N")) {
+        onNewConversation();
+      }
+    },
+    { isActive: !showPicker },
+  );
 
   return (
-    <Box flexDirection="column">
-      {/* Command header */}
-      <Text dimColor>{"> /resume"}</Text>
-      <Text dimColor>{solidLine}</Text>
-
-      <Box height={1} />
-
-      {/* Title */}
-      <Box marginBottom={1}>
-        <Text bold color={colors.selector.title}>
-          Resume a previous conversation
-        </Text>
-      </Box>
-
+    <OverlayShell command="/resume" title="Resume a previous conversation">
       {/* Error state */}
       {error && (
         <Box flexDirection="column">
@@ -684,42 +691,29 @@ export function ConversationSelector({
         </Box>
       )}
 
-      {/* Conversation list */}
-      {!loading && !error && conversations.length > 0 && (
-        <Box flexDirection="column">
-          {pageConversations.map((conv, index) =>
-            renderConversationItem(conv, index, index === selectedIndex),
-          )}
-        </Box>
-      )}
-
-      {/* Footer */}
-      {!loading &&
-        !error &&
-        conversations.length > 0 &&
-        (() => {
-          const footerWidth = Math.max(0, terminalWidth - 2);
-          const pageText = `Page ${page + 1}${hasMore ? "+" : `/${totalPages || 1}`}${loadingMore ? " (loading...)" : ""}`;
-          const hintsText =
-            "Enter select · ↑↓ navigate · ←→ page · N new · Esc cancel";
-
-          return (
+      {/* Picker */}
+      {showPicker && (
+        <SingleSelectPicker
+          key={page}
+          items={items}
+          onSelect={handleSelect}
+          onCancel={onCancel}
+          renderItem={renderItem}
+          onUnhandledKey={handleUnhandledKey}
+          footer={
             <Box flexDirection="column">
-              <Box flexDirection="row">
-                <Box width={2} flexShrink={0} />
-                <Box flexGrow={1} width={footerWidth}>
-                  <MarkdownDisplay text={pageText} dimColor />
-                </Box>
-              </Box>
-              <Box flexDirection="row">
-                <Box width={2} flexShrink={0} />
-                <Box flexGrow={1} width={footerWidth}>
-                  <MarkdownDisplay text={hintsText} dimColor />
-                </Box>
-              </Box>
+              <Text dimColor>
+                {"  "}Page {page + 1}
+                {hasMore ? "+" : `/${totalPages || 1}`}
+                {loadingMore ? " (loading...)" : ""}
+              </Text>
+              <Text dimColor>
+                {"  "}Enter select · ↑↓ navigate · ←→ page · N new · Esc cancel
+              </Text>
             </Box>
-          );
-        })()}
-    </Box>
+          }
+        />
+      )}
+    </OverlayShell>
   );
 }

--- a/src/cli/components/SingleSelectPicker.tsx
+++ b/src/cli/components/SingleSelectPicker.tsx
@@ -5,7 +5,7 @@
 // Items are identified by key (string), not index.
 
 import { Box, type Key, useInput } from "ink";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, type ReactNode, useCallback, useEffect, useState } from "react";
 import { colors } from "./colors";
 import { Text } from "./Text";
 
@@ -29,6 +29,27 @@ export interface SingleSelectPickerProps {
   onSelect: (key: string) => void;
   /** Called when user presses Escape or Ctrl-C */
   onCancel: () => void;
+  /**
+   * Override item rendering. When provided, the picker uses this
+   * instead of its default label + description rendering.
+   * The picker still handles cursor state and input.
+   */
+  renderItem?: (
+    item: SelectableItem,
+    index: number,
+    isSelected: boolean,
+  ) => ReactNode;
+  /**
+   * Called for keys the picker doesn't handle itself
+   * (anything that isn't ↑↓/Enter/Escape/Ctrl-C).
+   * Useful for pagination (←→), shortcuts (N), etc.
+   */
+  onUnhandledKey?: (input: string, key: Key) => void;
+  /**
+   * Override the footer content. When provided, replaces the default
+   * "Enter select · ↑↓ navigate · Esc cancel" hint.
+   */
+  footer?: ReactNode;
 }
 
 export const SingleSelectPicker = memo(function SingleSelectPicker({
@@ -36,6 +57,9 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
   initialCursorIndex = 0,
   onSelect,
   onCancel,
+  renderItem,
+  onUnhandledKey,
+  footer,
 }: SingleSelectPickerProps) {
   const [cursor, setCursor] = useState(initialCursorIndex);
 
@@ -70,8 +94,12 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
         onCancel();
         return;
       }
+      // Pass unhandled keys to the wrapper
+      if (onUnhandledKey) {
+        onUnhandledKey(input, key);
+      }
     },
-    [items, cursor, onCancel, onSelect],
+    [items, cursor, onCancel, onSelect, onUnhandledKey],
   );
 
   useInput(handleInput, { isActive: true });
@@ -80,6 +108,11 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
     <Box flexDirection="column">
       {items.map((item, index) => {
         const isCursor = index === cursor;
+
+        if (renderItem) {
+          return <Box key={item.key}>{renderItem(item, index, isCursor)}</Box>;
+        }
+
         const isCurrent = item.isCurrent ?? false;
         const isDisabled = item.disabled ?? false;
         const isDimLabel = item.dimLabel ?? false;
@@ -115,9 +148,11 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
         );
       })}
 
-      {/* Footer hint */}
-      <Box marginTop={1}>
-        <Text dimColor> Enter select · ↑↓ navigate · Esc cancel</Text>
+      {/* Footer */}
+      <Box marginTop={footer ? 0 : 1}>
+        {footer ?? (
+          <Text dimColor> Enter select · ↑↓ navigate · Esc cancel</Text>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Migrate ConversationSelector from manual overlay rendering, cursor state, and useInput handling to shared SingleSelectPicker and OverlayShell components
- Extend SingleSelectPicker with `renderItem` (rich multi-line item rendering), `onUnhandledKey` (pagination, shortcuts), and `footer` (custom footer content) props
- ConversationSelector uses renderItem for multi-line conversation previews, onUnhandledKey for ←→ pagination and N shortcut, and a custom footer for page info + hints

## Test plan
- [ ] Run `/resume` and verify conversation list renders correctly
- [ ] Verify footer shows page info + hints on two lines with proper indentation
- [ ] Verify ←→ pagination works
- [ ] Verify N creates new conversation
- [ ] Verify ↑↓ navigation, Enter select, Esc cancel
- [ ] Verify loading/empty/error states render correctly

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>