### PR TITLE
fix(cli): allow submit when autocomplete shows no matches

### DIFF
--- a/src/cli/components/SlashCommandAutocomplete.tsx
+++ b/src/cli/components/SlashCommandAutocomplete.tsx
@@ -212,18 +212,13 @@ export function SlashCommandAutocomplete({
     manageActiveState: false,
   });
 
-  // Manually manage active state to include the "no matches" case
+  // Manually manage active state - only active when there are matches to select
+  // When there are no matches, we don't block submit so the user can still
+  // run commands that aren't in the autocomplete registry (e.g., /help, /reflection)
   useLayoutEffect(() => {
-    const queryLength = queryInfo?.query.length ?? 0;
-    const isActive =
-      !hideAutocomplete && (matches.length > 0 || queryLength > 0);
+    const isActive = !hideAutocomplete && matches.length > 0;
     onActiveChange?.(isActive);
-  }, [
-    hideAutocomplete,
-    matches.length,
-    onActiveChange,
-    queryInfo?.query.length,
-  ]);
+  }, [hideAutocomplete, matches.length, onActiveChange]);
 
   // Don't show if input doesn't start with "/"
   if (!currentInput.startsWith("/")) {


### PR DESCRIPTION
## Summary
- Fix autocomplete blocking submit when showing "No matching commands"
- Change `isActive` logic to only be true when there are actual matches
- Allows users to submit commands not in the autocomplete registry (e.g., /help, /reflection)

## Test plan
- [ ] Type `/help` in the input - should show "No matching commands" but still allow Enter to submit
- [ ] Type `/reflection` - same behavior
- [ ] Type `/mod` (partial match) - autocomplete should still work normally and block submit while active
- [ ] Verify autocomplete selection still works with Tab/Enter

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>