### PR TITLE
chore: remove dead commented blocks and deprecated helpers

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -1,18 +1,15 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import type Letta from "@letta-ai/letta-client";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   Message,
   MessageType,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import { getResumeData } from "@/agent/check-approval";
+import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { __testSetBackend, type Backend } from "@/backend";
 
 type ResumeAgentState = AgentState & {
   in_context_message_ids?: string[] | null;
 };
-
-const dummyClient = {} as Letta;
 
 function installBackend(overrides: Record<string, unknown>): void {
   __testSetBackend(overrides as unknown as Backend);
@@ -96,7 +93,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(dummyClient, makeAgent(), "conv-abc", {
+    const resume = await getResumeDataFromBackend(makeAgent(), "conv-abc", {
       includeMessageHistory: false,
     });
 
@@ -127,8 +124,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({
         message_ids: ["msg-last"],
         in_context_message_ids: ["msg-last"],
@@ -156,8 +152,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({
         message_ids: ["msg-stale"],
         in_context_message_ids: ["msg-live"],
@@ -184,8 +179,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({ in_context_message_ids: [] }),
       "default",
       { includeMessageHistory: false },
@@ -215,8 +209,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({ in_context_message_ids: ["msg-last"] }),
       "default",
     );
@@ -278,7 +271,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(dummyClient, makeAgent(), "conv-abc");
+    const resume = await getResumeDataFromBackend(makeAgent(), "conv-abc");
 
     expect(conversationsList).toHaveBeenCalledWith("conv-abc", {
       limit: 200,
@@ -337,8 +330,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({ in_context_message_ids: ["provider-msg-2"] }),
       "default",
     );
@@ -383,8 +375,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({
         message_ids: ["provider-msg-2"],
         in_context_message_ids: ["provider-msg-2"],
@@ -440,8 +431,7 @@ describe("getResumeData", () => {
       retrieveMessage: messagesRetrieve,
     });
 
-    const resume = await getResumeData(
-      dummyClient,
+    const resume = await getResumeDataFromBackend(
       makeAgent({
         message_ids: ["ui-msg-122"],
         in_context_message_ids: ["ui-msg-122"],

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -1,7 +1,6 @@
 // src/agent/check-approval.ts
 // Check for pending approvals and retrieve recent message history when resuming an agent/conversation
 
-import type Letta from "@letta-ai/letta-client";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
@@ -674,16 +673,4 @@ export async function getResumeDataFromBackend(
     console.error("Error getting resume data:", error);
     return { pendingApproval: null, pendingApprovals: [], messageHistory: [] };
   }
-}
-
-/**
- * @deprecated Pass through for older call sites. Resume data is loaded through getBackend().
- */
-export async function getResumeData(
-  _client: Letta,
-  agent: AgentState,
-  conversationId?: string,
-  options: GetResumeDataOptions = {},
-): Promise<ResumeData> {
-  return getResumeDataFromBackend(agent, conversationId, options);
 }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -166,15 +166,6 @@ export const commands: Record<string, Command> = {
       return "Opening provider connection...";
     },
   },
-  // "/remote": {
-  //   desc: "Connect to Letta Cloud (device connect mode)",
-  //   args: "[--env-name <name>]",
-  //   order: 17.5,
-  //   handler: () => {
-  //     // Handled specially in App.tsx
-  //     return "Starting listener...";
-  //   },
-  // },
   "/clear": {
     desc: "Clear in-context messages",
     order: 18,

--- a/src/cli/components/EventMessage.tsx
+++ b/src/cli/components/EventMessage.tsx
@@ -72,20 +72,6 @@ export const EventMessage = memo(({ line }: { line: EventLine }) => {
     <Text color={colors.tool.completed}>{CLI_GLYPHS.bullet}</Text>
   );
 
-  // Format the args display (message count or fallback)
-  // Commented out for now - we show a simple "Conversation compacted" message instead
-  // const formatArgs = (): string => {
-  //   const stats = line.stats;
-  //   if (
-  //     stats?.messagesCountBefore !== undefined &&
-  //     stats?.messagesCountAfter !== undefined
-  //   ) {
-  //     return `${stats.messagesCountBefore} → ${stats.messagesCountAfter} messages`;
-  //   }
-  //   return "...";
-  // };
-  // const argsDisplay = formatArgs();
-
   return (
     <Box flexDirection="column">
       {/* Main tool call line */}

--- a/src/cli/task-notifications.test.ts
+++ b/src/cli/task-notifications.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@/utils/message-queue-bridge";
 import {
   formatTaskNotification,
-  formatTaskNotifications,
   type TaskNotification,
 } from "@/utils/task-notifications";
 
@@ -118,41 +117,6 @@ describe("taskNotifications", () => {
       expect(formatted).toContain("tool_uses: 4");
       expect(formatted).toContain("duration_ms: 5678");
       expect(formatted).toContain("</usage>");
-    });
-  });
-
-  describe("formatTaskNotifications", () => {
-    test("formats multiple notifications", () => {
-      const notifications: TaskNotification[] = [
-        {
-          taskId: "task_1",
-          status: "completed",
-          summary: 'Agent "Task1" completed',
-          result: "Result 1",
-          outputFile: "/tmp/task_1.log",
-        },
-        {
-          taskId: "task_2",
-          status: "failed",
-          summary: 'Agent "Task2" failed',
-          result: "Error occurred",
-          outputFile: "/tmp/task_2.log",
-        },
-      ];
-
-      const formatted = formatTaskNotifications(notifications);
-
-      // Should have two notification blocks
-      expect(formatted.split("<task-notification>").length).toBe(3); // 2 blocks + 1 empty prefix
-      expect(formatted).toContain("<task-id>task_1</task-id>");
-      expect(formatted).toContain("<task-id>task_2</task-id>");
-      expect(formatted).toContain("<status>completed</status>");
-      expect(formatted).toContain("<status>failed</status>");
-    });
-
-    test("returns empty string for empty array", () => {
-      const formatted = formatTaskNotifications([]);
-      expect(formatted).toBe("");
     });
   });
 });

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1117,16 +1117,6 @@ export function getToolPermissions(toolName: string) {
 }
 
 /**
- * Check if a tool requires approval before execution.
- * @param toolName - The name of the tool
- * @returns true if the tool requires approval, false otherwise
- * @deprecated Use checkToolPermission instead for full permission system support
- */
-export function requiresApproval(toolName: string): boolean {
-  return TOOL_PERMISSIONS[toolName as ToolName]?.requiresApproval ?? false;
-}
-
-/**
  * Check permission for a tool execution using the full permission system.
  * @param toolName - Name of the tool
  * @param toolArgs - Tool arguments

--- a/src/utils/task-notifications.ts
+++ b/src/utils/task-notifications.ts
@@ -146,17 +146,3 @@ export function appendTaskNotificationEventsToBuffer(
   flush?.();
   return true;
 }
-
-/**
- * Format multiple notifications as XML string.
- * @deprecated Use formatTaskNotification and queue individually
- */
-export function formatTaskNotifications(
-  notifications: TaskNotification[],
-): string {
-  if (notifications.length === 0) {
-    return "";
-  }
-
-  return notifications.map(formatTaskNotification).join("\n\n");
-}


### PR DESCRIPTION
## Summary
- remove dead commented-out code from `EventMessage.tsx`
- remove the dead commented `/remote` autocomplete entry from `registry.ts`
- remove deprecated helpers with zero non-test callers: `getResumeData()`, `requiresApproval()`, and `formatTaskNotifications()`
- update tests to target the supported APIs directly (`getResumeDataFromBackend()` / `formatTaskNotification()`)

## Audit evidence
- `EventMessage.tsx`: the commented `formatArgs()` block was disabled in `5ddce473` ("simplify compaction display to Conversation compacted") and never re-enabled
- `registry.ts`: the commented `/remote` entry is dead because `/remote` is handled specially in `src/cli/app/submit-connection-commands.ts`; it is intentionally not a registry-backed slash command
- `getResumeData()`: added as a deprecated passthrough in `b8d09097`; repo-wide audit found only test callers in `check-approval-resume-data.test.ts` and zero non-test callers
- `requiresApproval()`: marked deprecated at introduction in `70ac7604`; repo-wide audit found zero callers outside its own definition
- `formatTaskNotifications()`: marked deprecated in `48ccd8f22`; repo-wide audit found only test callers in `task-notifications.test.ts` and zero non-test callers

## Test plan
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)