### PR TITLE
refactor: consolidate overlay command lifecycle into openOverlay/completeOverlay

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2351,7 +2351,12 @@ export function App({
       openingOutput: string,
       dismissOutput: string,
     ) => {
-      const cmd = startOverlayCommand(overlay, input, openingOutput, dismissOutput);
+      const cmd = startOverlayCommand(
+        overlay,
+        input,
+        openingOutput,
+        dismissOutput,
+      );
       setActiveOverlay(overlay);
       return cmd;
     },

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2343,6 +2343,38 @@ export function App({
     return pending.command;
   }, []);
 
+  // Combines startOverlayCommand + setActiveOverlay — these are always called together.
+  const openOverlay = useCallback(
+    (
+      overlay: NonNullable<ActiveOverlay>,
+      input: string,
+      openingOutput: string,
+      dismissOutput: string,
+    ) => {
+      const cmd = startOverlayCommand(overlay, input, openingOutput, dismissOutput);
+      setActiveOverlay(overlay);
+      return cmd;
+    },
+    [startOverlayCommand],
+  );
+
+  // Combines consumeOverlayCommand + the UI-reset side of closeOverlay, but WITHOUT
+  // calling cmd.finish(dismissOutput). Use this when the overlay completed successfully
+  // and the caller will finish the command with a real result. Contrast with
+  // closeOverlay() (cancel path) which does finish with the dismiss message.
+  const completeOverlay = useCallback(
+    (overlay: NonNullable<ActiveOverlay>) => {
+      const cmd = consumeOverlayCommand(overlay);
+      setActiveOverlay(null);
+      setFeedbackPrefill("");
+      setSearchQuery("");
+      setModelSelectorOptions({});
+      setModelReasoningPrompt(null);
+      return cmd;
+    },
+    [consumeOverlayCommand],
+  );
+
   useEffect(() => {
     const pending = pendingOverlayCommandRef.current;
     if (!pending || pending.overlay !== activeOverlay) {
@@ -3713,7 +3745,7 @@ export function App({
     sessionHooksRanRef,
     sessionStartFeedbackRef,
     sessionStatsRef,
-    setActiveOverlay,
+    openOverlay,
     setAgentDescription,
     setAgentState,
     setCommandRunning,
@@ -3745,7 +3777,6 @@ export function App({
     setUiRalphActive,
     sharedReminderStateRef,
     shouldAutoGenerateConversationTitleRef,
-    startOverlayCommand,
     streaming,
     systemInfoReminderEnabled,
     systemPromptRecompileByConversationRef:
@@ -4050,9 +4081,8 @@ export function App({
     agentId,
     agentName,
     billingTier,
-    closeOverlay,
+    completeOverlay,
     commandRunner,
-    consumeOverlayCommand,
     currentModelId,
     sessionStatsRef,
     withCommandLock,
@@ -4434,7 +4464,7 @@ export function App({
       closeOverlay={closeOverlay}
       columns={columns}
       commandRunner={commandRunner}
-      consumeOverlayCommand={consumeOverlayCommand}
+      completeOverlay={completeOverlay}
       contextTrackerRef={contextTrackerRef}
       continueSession={continueSession}
       conversationId={conversationId}
@@ -4545,7 +4575,7 @@ export function App({
       showApprovalPreview={showApprovalPreview}
       showCompactionsEnabled={showCompactionsEnabled}
       showExitStats={showExitStats}
-      startOverlayCommand={startOverlayCommand}
+      openOverlay={openOverlay}
       staticItems={staticItems}
       staticRenderEpoch={staticRenderEpoch}
       statusLine={statusLine}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -133,7 +133,9 @@ type AppViewProps = {
   closeOverlay: () => void;
   columns: number;
   commandRunner: AppCommandRunner;
-  completeOverlay: (overlay: NonNullable<ActiveOverlay>) => CommandHandle | null;
+  completeOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
+  ) => CommandHandle | null;
   contextTrackerRef: RefObject<ContextTracker>;
   continueSession: boolean;
   conversationId: string;
@@ -822,8 +824,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "install-github-app" && (
               <InstallGithubAppFlow
                 onComplete={(result) => {
-                  const overlayCommand =
-                    completeOverlay("install-github-app");
+                  const overlayCommand = completeOverlay("install-github-app");
 
                   const cmd =
                     overlayCommand ??

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -133,7 +133,7 @@ type AppViewProps = {
   closeOverlay: () => void;
   columns: number;
   commandRunner: AppCommandRunner;
-  consumeOverlayCommand: (overlay: ActiveOverlay) => CommandHandle | null;
+  completeOverlay: (overlay: NonNullable<ActiveOverlay>) => CommandHandle | null;
   contextTrackerRef: RefObject<ContextTracker>;
   continueSession: boolean;
   conversationId: string;
@@ -290,8 +290,8 @@ type AppViewProps = {
   showApprovalPreview: boolean;
   showCompactionsEnabled: boolean;
   showExitStats: boolean;
-  startOverlayCommand: (
-    overlay: ActiveOverlay,
+  openOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
     input: string,
     openingOutput: string,
     dismissOutput: string,
@@ -324,7 +324,7 @@ export function AppView(props: AppViewProps) {
     closeOverlay,
     columns,
     commandRunner,
-    consumeOverlayCommand,
+    completeOverlay,
     contextTrackerRef,
     continueSession,
     conversationId,
@@ -433,7 +433,7 @@ export function AppView(props: AppViewProps) {
     showApprovalPreview,
     showCompactionsEnabled,
     showExitStats,
-    startOverlayCommand,
+    openOverlay,
     staticItems,
     staticRenderEpoch,
     statusLine,
@@ -823,8 +823,7 @@ export function AppView(props: AppViewProps) {
               <InstallGithubAppFlow
                 onComplete={(result) => {
                   const overlayCommand =
-                    consumeOverlayCommand("install-github-app");
-                  closeOverlay();
+                    completeOverlay("install-github-app");
 
                   const cmd =
                     overlayCommand ??
@@ -901,9 +900,7 @@ export function AppView(props: AppViewProps) {
               <ProviderSelector
                 onCancel={closeOverlay}
                 onStartOAuth={async () => {
-                  const overlayCommand = consumeOverlayCommand("connect");
-                  // Close selector and start OAuth flow
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("connect");
                   const cmd =
                     overlayCommand ??
                     commandRunner.start("/connect", "Starting connection...");
@@ -923,13 +920,12 @@ export function AppView(props: AppViewProps) {
                             filterProvider: "chatgpt-plus-pro",
                             forceRefresh: true,
                           });
-                          startOverlayCommand(
+                          openOverlay(
                             "model",
                             "/model",
                             "Opening model selector...",
                             "Models dialog dismissed",
                           );
-                          setActiveOverlay("model");
                         },
                       },
                       "/connect chatgpt",
@@ -987,16 +983,14 @@ export function AppView(props: AppViewProps) {
               <AgentSelector
                 currentAgentId={agentId}
                 onSelect={async (id) => {
-                  const overlayCommand = consumeOverlayCommand("resume");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("resume");
                   await handleAgentSelect(id, {
                     commandId: overlayCommand?.id,
                   });
                 }}
                 onCancel={closeOverlay}
                 onCreateNewAgent={(name: string) => {
-                  const overlayCommand = consumeOverlayCommand("resume");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("resume");
                   void handleCreateNewAgent(name, {
                     commandId: overlayCommand?.id,
                   });
@@ -1011,8 +1005,7 @@ export function AppView(props: AppViewProps) {
                 agentName={agentName ?? undefined}
                 currentConversationId={conversationId}
                 onSelect={async (convId, selectorContext) => {
-                  const overlayCommand = consumeOverlayCommand("conversations");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("conversations");
 
                   // Skip if already on this conversation
                   if (convId === conversationId) {
@@ -1189,8 +1182,7 @@ export function AppView(props: AppViewProps) {
                   }
                 }}
                 onNewConversation={async () => {
-                  const overlayCommand = consumeOverlayCommand("conversations");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("conversations");
 
                   // Lock input for async operation
                   setCommandRunning(true);
@@ -1278,8 +1270,7 @@ export function AppView(props: AppViewProps) {
                   targetConvId,
                   searchContext,
                 ) => {
-                  const overlayCommand = consumeOverlayCommand("search");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("search");
 
                   // Different agent: use handleAgentSelect (which supports optional conversationId)
                   if (targetAgentId !== agentId) {
@@ -1495,8 +1486,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "mcp-connect" && (
               <McpConnectFlow
                 onComplete={(serverName, serverId, toolCount) => {
-                  const overlayCommand = consumeOverlayCommand("mcp-connect");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("mcp-connect");
                   const cmd =
                     overlayCommand ??
                     commandRunner.start(
@@ -1534,8 +1524,7 @@ export function AppView(props: AppViewProps) {
                 currentName={agentName || ""}
                 local={pinDialogLocal}
                 onSubmit={async (newName) => {
-                  const overlayCommand = consumeOverlayCommand("pin");
-                  closeOverlay();
+                  const overlayCommand = completeOverlay("pin");
                   setCommandRunning(true);
 
                   const cmd =

--- a/src/cli/app/submit-connection-commands.ts
+++ b/src/cli/app/submit-connection-commands.ts
@@ -21,11 +21,10 @@ type ConnectionCommandContext = {
   commandRunner: AppCommandRunner;
   conversationIdRef: MutableRefObject<string>;
   refreshDerived: () => void;
-  setActiveOverlay: Dispatch<SetStateAction<ActiveOverlay>>;
   setCommandRunning: (value: boolean) => void;
   setModelSelectorOptions: Dispatch<SetStateAction<ModelSelectorOptions>>;
-  startOverlayCommand: (
-    overlay: ActiveOverlay,
+  openOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
     input: string,
     openingOutput: string,
     dismissOutput: string,
@@ -43,10 +42,9 @@ export async function handleConnectionCommand(
     commandRunner,
     conversationIdRef,
     refreshDerived,
-    setActiveOverlay,
     setCommandRunning,
     setModelSelectorOptions,
-    startOverlayCommand,
+    openOverlay,
   } = ctx;
 
   if (trimmed.startsWith("/mcp")) {
@@ -71,13 +69,12 @@ export async function handleConnectionCommand(
     }
 
     if (!firstWord) {
-      startOverlayCommand(
+      openOverlay(
         "mcp",
         "/mcp",
         "Opening MCP server manager...",
         "MCP dialog dismissed",
       );
-      setActiveOverlay("mcp");
       return { submitted: true };
     }
 
@@ -94,13 +91,12 @@ export async function handleConnectionCommand(
     }
 
     if (firstWord === "connect") {
-      startOverlayCommand(
+      openOverlay(
         "mcp-connect",
         "/mcp connect",
         "Opening MCP connect flow...",
         "MCP connect dismissed",
       );
-      setActiveOverlay("mcp-connect");
       return { submitted: true };
     }
 
@@ -130,13 +126,12 @@ export async function handleConnectionCommand(
   }
 
   if (trimmed === "/connect") {
-    startOverlayCommand(
+    openOverlay(
       "connect",
       "/connect",
       "Opening provider selector...",
       "Connect dialog dismissed",
     );
-    setActiveOverlay("connect");
     return { submitted: true };
   }
 
@@ -156,13 +151,12 @@ export async function handleConnectionCommand(
               filterProvider: "chatgpt-plus-pro",
               forceRefresh: true,
             });
-            startOverlayCommand(
+            openOverlay(
               "model",
               "/model",
               "Opening model selector...",
               "Models dialog dismissed",
             );
-            setActiveOverlay("model");
           },
         },
         msg,

--- a/src/cli/app/submit-navigation-commands.ts
+++ b/src/cli/app/submit-navigation-commands.ts
@@ -32,7 +32,6 @@ type NavigationCommandContext = {
   resetBootstrapReminderState: () => void;
   resetDeferredToolCallCommits: () => void;
   resetTrajectoryBases: () => void;
-  setActiveOverlay: Dispatch<SetStateAction<ActiveOverlay>>;
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
@@ -40,8 +39,8 @@ type NavigationCommandContext = {
   setSearchQuery: Dispatch<SetStateAction<string>>;
   setStaticItems: Dispatch<SetStateAction<StaticItem[]>>;
   setStaticRenderEpoch: Dispatch<SetStateAction<number>>;
-  startOverlayCommand: (
-    overlay: ActiveOverlay,
+  openOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
     input: string,
     openingOutput: string,
     dismissOutput: string,
@@ -66,7 +65,6 @@ export async function handleNavigationCommand(
     resetBootstrapReminderState,
     resetDeferredToolCallCommits,
     resetTrajectoryBases,
-    setActiveOverlay,
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
@@ -74,7 +72,7 @@ export async function handleNavigationCommand(
     setSearchQuery,
     setStaticItems,
     setStaticRenderEpoch,
-    startOverlayCommand,
+    openOverlay,
   } = ctx;
 
   // Special handling for /agents command - show agent browser
@@ -83,13 +81,12 @@ export async function handleNavigationCommand(
     trimmed === "/pinned" ||
     trimmed === "/profiles"
   ) {
-    startOverlayCommand(
+    openOverlay(
       "resume",
       "/agents",
       "Opening agent browser...",
       "Agent browser dismissed",
     );
-    setActiveOverlay("resume");
     return { submitted: true };
   }
 
@@ -236,13 +233,12 @@ export async function handleNavigationCommand(
       return { submitted: true };
     }
 
-    startOverlayCommand(
+    openOverlay(
       "conversations",
       "/resume",
       "Opening conversation selector...",
       "Conversation selector dismissed",
     );
-    setActiveOverlay("conversations");
     return { submitted: true };
   }
 
@@ -251,13 +247,12 @@ export async function handleNavigationCommand(
     const [, ...rest] = trimmed.split(/\s+/);
     const query = rest.join(" ").trim();
     setSearchQuery(query);
-    startOverlayCommand(
+    openOverlay(
       "search",
       "/search",
       "Opening message search...",
       "Message search dismissed",
     );
-    setActiveOverlay("search");
     return { submitted: true };
   }
 

--- a/src/cli/app/submit-profile-commands.ts
+++ b/src/cli/app/submit-profile-commands.ts
@@ -35,14 +35,13 @@ type ProfileCommandRouterContext = {
     },
   ) => Promise<void>;
   refreshDerived: () => void;
-  setActiveOverlay: Dispatch<SetStateAction<ActiveOverlay>>;
   setCommandRunning: (value: boolean) => void;
   setPinDialogLocal: Dispatch<SetStateAction<boolean>>;
   setProfileConfirmPending: Dispatch<
     SetStateAction<ProfileConfirmPending | null>
   >;
-  startOverlayCommand: (
-    overlay: ActiveOverlay,
+  openOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
     input: string,
     openingOutput: string,
     dismissOutput: string,
@@ -62,11 +61,10 @@ export async function handleProfileCommand(
     commandRunner,
     handleAgentSelect,
     refreshDerived,
-    setActiveOverlay,
     setCommandRunning,
     setPinDialogLocal,
     setProfileConfirmPending,
-    startOverlayCommand,
+    openOverlay,
     updateAgentName,
   } = ctx;
 
@@ -86,13 +84,12 @@ export async function handleProfileCommand(
     };
 
     if (!subcommand) {
-      startOverlayCommand(
+      openOverlay(
         "resume",
         "/profile",
         "Opening agent browser...",
         "Agent browser dismissed",
       );
-      setActiveOverlay("resume");
       return { submitted: true };
     }
 
@@ -185,13 +182,12 @@ export async function handleProfileCommand(
 
     if (!hasNameArg) {
       setPinDialogLocal(isLocal);
-      startOverlayCommand(
+      openOverlay(
         "pin",
         "/pin",
         "Opening pin dialog...",
         "Pin dialog dismissed",
       );
-      setActiveOverlay("pin");
       return { submitted: true };
     }
 

--- a/src/cli/app/use-feedback-handler.ts
+++ b/src/cli/app/use-feedback-handler.ts
@@ -3,6 +3,7 @@
 import { type MutableRefObject, useCallback } from "react";
 import type { SessionStats } from "@/agent/stats";
 import { submitFeedbackMetadata } from "@/backend/api/metadata";
+import type { CommandHandle } from "@/cli/commands/runner";
 import { chunkLog } from "@/cli/helpers/chunk-log";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import { resolvePlaceholders } from "@/cli/helpers/paste-registry";
@@ -11,7 +12,6 @@ import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLogFile } from "@/utils/debug";
 import { getVersion } from "@/version";
-import type { CommandHandle } from "@/cli/commands/runner";
 import type { ActiveOverlay, CommandStarter } from "./types";
 
 type FeedbackHandlerContext = {
@@ -19,7 +19,9 @@ type FeedbackHandlerContext = {
   agentId: string;
   agentName: string | null;
   billingTier: string | null;
-  completeOverlay: (overlay: NonNullable<ActiveOverlay>) => CommandHandle | null;
+  completeOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
+  ) => CommandHandle | null;
   commandRunner: CommandStarter;
   currentModelId: string | null;
   sessionStatsRef: MutableRefObject<SessionStats>;

--- a/src/cli/app/use-feedback-handler.ts
+++ b/src/cli/app/use-feedback-handler.ts
@@ -11,16 +11,16 @@ import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLogFile } from "@/utils/debug";
 import { getVersion } from "@/version";
-import type { CommandStarter, OverlayCommandConsumer } from "./types";
+import type { CommandHandle } from "@/cli/commands/runner";
+import type { ActiveOverlay, CommandStarter } from "./types";
 
 type FeedbackHandlerContext = {
   agentDescription: string | null;
   agentId: string;
   agentName: string | null;
   billingTier: string | null;
-  closeOverlay: () => void;
+  completeOverlay: (overlay: NonNullable<ActiveOverlay>) => CommandHandle | null;
   commandRunner: CommandStarter;
-  consumeOverlayCommand: OverlayCommandConsumer;
   currentModelId: string | null;
   sessionStatsRef: MutableRefObject<SessionStats>;
   withCommandLock: (fn: () => Promise<void>) => Promise<void>;
@@ -32,9 +32,8 @@ export function useFeedbackHandler(ctx: FeedbackHandlerContext) {
     agentId,
     agentName,
     billingTier,
-    closeOverlay,
+    completeOverlay,
     commandRunner,
-    consumeOverlayCommand,
     currentModelId,
     sessionStatsRef,
     withCommandLock,
@@ -43,10 +42,7 @@ export function useFeedbackHandler(ctx: FeedbackHandlerContext) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: sessionStatsRef is stable; .current is read dynamically when feedback is submitted.
   const handleFeedbackSubmit = useCallback(
     async (message: string) => {
-      // Consume command handle BEFORE closing overlay; otherwise closeOverlay()
-      // finishes it as "Feedback dialog dismissed" and we emit a duplicate entry.
-      const overlayCommand = consumeOverlayCommand("feedback");
-      closeOverlay();
+      const overlayCommand = completeOverlay("feedback");
 
       await withCommandLock(async () => {
         const cmd =
@@ -135,9 +131,8 @@ export function useFeedbackHandler(ctx: FeedbackHandlerContext) {
       currentModelId,
       billingTier,
       commandRunner,
-      consumeOverlayCommand,
+      completeOverlay,
       withCommandLock,
-      closeOverlay,
     ],
   );
 

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -253,7 +253,12 @@ type SubmitHandlerContext = {
   sessionHooksRanRef: MutableRefObject<boolean>;
   sessionStartFeedbackRef: MutableRefObject<string[]>;
   sessionStatsRef: MutableRefObject<SessionStats>;
-  setActiveOverlay: Dispatch<SetStateAction<ActiveOverlay>>;
+  openOverlay: (
+    overlay: NonNullable<ActiveOverlay>,
+    input: string,
+    openingOutput: string,
+    dismissOutput: string,
+  ) => CommandHandle;
   setAgentDescription: Dispatch<SetStateAction<string | null>>;
   setAgentState: Dispatch<SetStateAction<AgentState | null | undefined>>;
   setCommandRunning: (value: boolean) => void;
@@ -291,12 +296,7 @@ type SubmitHandlerContext = {
   setUiRalphActive: Dispatch<SetStateAction<boolean>>;
   sharedReminderStateRef: MutableRefObject<SharedReminderState>;
   shouldAutoGenerateConversationTitleRef: MutableRefObject<boolean>;
-  startOverlayCommand: (
-    overlay: ActiveOverlay,
-    input: string,
-    openingOutput: string,
-    dismissOutput: string,
-  ) => CommandHandle;
+
   streaming: boolean;
   systemInfoReminderEnabled: boolean;
   systemPromptRecompileByConversationRef: MutableRefObject<
@@ -390,7 +390,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     sessionHooksRanRef,
     sessionStartFeedbackRef,
     sessionStatsRef,
-    setActiveOverlay,
+    openOverlay,
     setAgentDescription,
     setAgentState,
     setCommandRunning,
@@ -421,7 +421,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     setUiRalphActive,
     sharedReminderStateRef,
     shouldAutoGenerateConversationTitleRef,
-    startOverlayCommand,
+
     streaming,
     systemInfoReminderEnabled,
     systemPromptRecompileByConversationRef,
@@ -659,14 +659,13 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         // Special handling for /model command - opens selector
         if (trimmed === "/model") {
-          startOverlayCommand(
+          setModelSelectorOptions({}); // Clear any filters from previous connection
+          openOverlay(
             "model",
             "/model",
             "Opening model selector...",
             "Models dialog dismissed",
           );
-          setModelSelectorOptions({}); // Clear any filters from previous connection
-          setActiveOverlay("model");
           return { submitted: true };
         }
 
@@ -682,60 +681,55 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
             return { submitted: true };
           }
-          startOverlayCommand(
+          openOverlay(
             "install-github-app",
             "/install-github-app",
             "Opening GitHub App installer...",
             "GitHub App installer dismissed",
           );
-          setActiveOverlay("install-github-app");
           return { submitted: true };
         }
 
         // Special handling for /sleeptime command - opens reflection settings
         if (trimmed === "/sleeptime") {
-          startOverlayCommand(
+          openOverlay(
             "sleeptime",
             "/sleeptime",
             "Opening sleeptime settings...",
             "Sleeptime settings dismissed",
           );
-          setActiveOverlay("sleeptime");
           return { submitted: true };
         }
 
         // Special handling for /compaction command - opens compaction mode settings
         if (trimmed === "/compaction") {
-          startOverlayCommand(
+          openOverlay(
             "compaction",
             "/compaction",
             "Opening compaction settings...",
             "Compaction settings dismissed",
           );
-          setActiveOverlay("compaction");
           return { submitted: true };
         }
 
         // Special handling for /toolset command - opens selector
         if (trimmed === "/toolset") {
-          startOverlayCommand(
+          openOverlay(
             "toolset",
             "/toolset",
             "Opening toolset selector...",
             "Toolset dialog dismissed",
           );
-          setActiveOverlay("toolset");
           return { submitted: true };
         }
 
         if (trimmed === "/experiments") {
-          startOverlayCommand(
+          openOverlay(
             "experiment",
             "/experiments",
             "Opening experiments selector...",
             "Experiments dialog dismissed",
           );
-          setActiveOverlay("experiment");
           return { submitted: true };
         }
 
@@ -748,13 +742,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             cmd.fail("Wait for the current turn to finish and try again.");
             return { submitted: true };
           }
-          startOverlayCommand(
+          openOverlay(
             "window-title",
             "/title",
             "Opening title configurator...",
             "Title configurator dismissed",
           );
-          setActiveOverlay("window-title");
           return { submitted: true };
         }
 
@@ -852,19 +845,18 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         // Special handling for /system command - opens system prompt selector
         if (trimmed === "/system") {
-          startOverlayCommand(
+          openOverlay(
             "system",
             "/system",
             "Opening system prompt selector...",
             "System prompt dialog dismissed",
           );
-          setActiveOverlay("system");
           return { submitted: true };
         }
 
         // Special handling for /personality command - opens personality selector
         if (trimmed === "/personality") {
-          startOverlayCommand(
+          openOverlay(
             "personality",
             "/personality",
             "Opening personality selector...",
@@ -897,31 +889,28 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             setCurrentPersonalityId(null);
           }
 
-          setActiveOverlay("personality");
           return { submitted: true };
         }
 
         // Special handling for /subagents command - opens subagent manager
         if (trimmed === "/subagents") {
-          startOverlayCommand(
+          openOverlay(
             "subagent",
             "/subagents",
             "Opening subagent manager...",
             "Subagent manager dismissed",
           );
-          setActiveOverlay("subagent");
           return { submitted: true };
         }
 
         // Special handling for /memory command - opens memory viewer overlay
         if (trimmed === "/memory") {
-          startOverlayCommand(
+          openOverlay(
             "memory",
             "/memory",
             "Opening memory viewer...",
             "Memory viewer dismissed",
           );
-          setActiveOverlay("memory");
           return { submitted: true };
         }
 
@@ -974,10 +963,9 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             commandRunner,
             conversationIdRef,
             refreshDerived,
-            setActiveOverlay,
+            openOverlay,
             setCommandRunning,
             setModelSelectorOptions,
-            startOverlayCommand,
           },
         );
         if (connectionCommandResult) {
@@ -986,25 +974,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         // Special handling for /help command - opens help dialog
         if (trimmed === "/help") {
-          startOverlayCommand(
+          openOverlay(
             "help",
             "/help",
             "Opening help...",
             "Help dialog dismissed",
           );
-          setActiveOverlay("help");
           return { submitted: true };
         }
 
         // Special handling for /hooks command - opens hooks manager
         if (trimmed === "/hooks") {
-          startOverlayCommand(
+          openOverlay(
             "hooks",
             "/hooks",
             "Opening hooks manager...",
             "Hooks manager dismissed",
           );
-          setActiveOverlay("hooks");
           return { submitted: true };
         }
 
@@ -2098,7 +2084,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           resetBootstrapReminderState,
           resetDeferredToolCallCommits,
           resetTrajectoryBases,
-          setActiveOverlay,
+          openOverlay,
           setCommandRunning,
           setConversationAutoTitleEligibility,
           setConversationIdAndRef,
@@ -2106,7 +2092,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           setSearchQuery,
           setStaticItems,
           setStaticRenderEpoch,
-          startOverlayCommand,
         });
         if (navigationCommandResult) {
           return navigationCommandResult;
@@ -2119,11 +2104,10 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           commandRunner,
           handleAgentSelect,
           refreshDerived,
-          setActiveOverlay,
+          openOverlay,
           setCommandRunning,
           setPinDialogLocal,
           setProfileConfirmPending,
-          startOverlayCommand,
           updateAgentName,
         });
         if (profileCommandResult) {
@@ -2512,13 +2496,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         // /skills - browse available skills overlay
         if (trimmed === "/skills") {
-          startOverlayCommand(
+          openOverlay(
             "skills",
             "/skills",
             "Opening skills browser...",
             "Skills browser dismissed",
           );
-          setActiveOverlay("skills");
           return { submitted: true };
         }
 
@@ -2944,13 +2927,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         if (trimmed.startsWith("/feedback")) {
           const maybeMsg = msg.slice("/feedback".length).trim();
           setFeedbackPrefill(maybeMsg);
-          startOverlayCommand(
+          openOverlay(
             "feedback",
             "/feedback",
             "Opening feedback dialog...",
             "Feedback dialog dismissed",
           );
-          setActiveOverlay("feedback");
           return { submitted: true };
         }
 
@@ -3577,7 +3559,7 @@ ${SYSTEM_REMINDER_CLOSE}
       pendingApprovals,
       profileConfirmPending,
       handleAgentSelect,
-      startOverlayCommand,
+      openOverlay,
       tokenStreamingEnabled,
       isAgentBusy,
       setStreaming,


### PR DESCRIPTION
## Summary

- Adds `openOverlay(overlay, input, openMsg, dismissMsg)` to `AppCoordinator` — replaces the ~30 always-paired `startOverlayCommand(…) + setActiveOverlay(overlay)` call sites across `use-submit-handler`, `submit-connection/navigation/profile-commands`, and `AppView`
- Adds `completeOverlay(overlay)` to `AppCoordinator` — replaces the ~12 paired `consumeOverlayCommand(x) + closeOverlay()` call sites in `AppView` and `use-feedback-handler`. Unlike `closeOverlay()` (cancel path), `completeOverlay` does **not** call `cmd.finish(dismissOutput)` — the caller finishes the command with a real result
- Each affected context object type loses 2 props, gains 1 (`openOverlay`); `use-feedback-handler` loses both `consumeOverlayCommand` and `closeOverlay`, gains `completeOverlay`
- `consumeOverlayCommand` and `setActiveOverlay(null)` are intentionally unchanged in `use-configuration-handlers` and `use-conversation-switching` — those have distinct semantics (pop-without-close for deferred busy-queued actions)

## Test plan
- [ ] `bun run typecheck` passes (clean)
- [ ] Unit tests pass (pre-existing failures only: `detachMemoryTools`, `listen-client-concurrency`, `getShellEnv` — all fail on main too)
- [ ] No behavior change: overlay open/cancel/complete flows work the same as before

👾 Generated with [Letta Code](https://letta.com)