### PR TITLE
fix(channels): honor Discord open-channel mode in adapter

### DIFF
--- a/src/channels/discord-adapter.test.ts
+++ b/src/channels/discord-adapter.test.ts
@@ -1,9 +1,293 @@
-import { describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import {
   buildDiscordIngressMessageKey,
   buildDiscordReplyOptions,
+  createDiscordAdapter,
   shouldAutoThreadOnDiscordMention,
 } from "@/channels/discord/adapter";
+import { __testOverrideLoadDiscordModule } from "@/channels/discord/runtime";
+import type {
+  DiscordChannelAccount,
+  InboundChannelMessage,
+} from "@/channels/types";
+
+interface DiscordTestMessage {
+  id: string;
+  content: string;
+  channelId: string;
+  guildId: string;
+  author: {
+    id: string;
+    username: string;
+    globalName: string;
+    bot: boolean;
+  };
+  member: { displayName: string };
+  channel: {
+    name: string;
+    parentId: string | null;
+    isThread: () => boolean;
+  };
+  mentions: { has: (user: unknown) => boolean };
+  attachments: Map<string, never>;
+  createdTimestamp: number;
+  startThread: (options: {
+    name: string;
+    reason?: string;
+  }) => Promise<{ id: string; name: string }>;
+  react: (emoji: string) => Promise<void>;
+  reactions: { cache: Map<string, never> };
+}
+
+class FakeDiscordClient {
+  static instances: FakeDiscordClient[] = [];
+
+  readonly user = {
+    id: "bot-user",
+    username: "Loop",
+    tag: "Loop#0001",
+    bot: true,
+  };
+
+  readonly channels = {
+    fetch: mock(async () => null),
+  };
+
+  readonly login = mock(async (_token: string) => undefined);
+  readonly destroy = mock(() => {});
+  private readonly handlers = new Map<
+    string,
+    (...args: unknown[]) => unknown
+  >();
+
+  constructor(_options: { intents: unknown[]; partials?: unknown[] }) {
+    FakeDiscordClient.instances.push(this);
+  }
+
+  once(_event: string, _handler: (...args: unknown[]) => unknown): this {
+    return this;
+  }
+
+  on(event: string, handler: (...args: unknown[]) => unknown): this {
+    this.handlers.set(event, handler);
+    return this;
+  }
+
+  async emitMessageCreate(message: DiscordTestMessage): Promise<void> {
+    const handler = this.handlers.get("messageCreate");
+    if (!handler) {
+      throw new Error("messageCreate handler was not registered");
+    }
+    await handler(message);
+  }
+}
+
+function createFakeDiscordRuntime() {
+  return {
+    Client: FakeDiscordClient,
+    GatewayIntentBits: {
+      Guilds: "Guilds",
+      GuildMessages: "GuildMessages",
+      GuildMessageReactions: "GuildMessageReactions",
+      MessageContent: "MessageContent",
+      DirectMessages: "DirectMessages",
+      DirectMessageReactions: "DirectMessageReactions",
+    },
+    Partials: {
+      Channel: "Channel",
+      Message: "Message",
+      Reaction: "Reaction",
+      User: "User",
+    },
+  };
+}
+
+const discordAccountDefaults: Omit<DiscordChannelAccount, "allowedChannels"> = {
+  channel: "discord",
+  accountId: "discord-bot",
+  enabled: true,
+  token: "discord-token",
+  agentId: "agent-1",
+  defaultPermissionMode: "standard",
+  dmPolicy: "pairing",
+  allowedUsers: [],
+  createdAt: "2026-04-11T00:00:00.000Z",
+  updatedAt: "2026-04-11T00:00:00.000Z",
+};
+
+function createGuildMessage(
+  overrides: {
+    id?: string;
+    content?: string;
+    channelId?: string;
+    channelName?: string;
+    parentChannelId?: string | null;
+    isThread?: boolean;
+    mentioned?: boolean;
+  } = {},
+): DiscordTestMessage {
+  const channelId = overrides.channelId ?? "channel-open";
+  const isThread = overrides.isThread ?? false;
+  const mentioned = overrides.mentioned ?? false;
+  return {
+    id: overrides.id ?? `${channelId}-message`,
+    content: overrides.content ?? "ambient hello",
+    channelId,
+    guildId: "guild-1",
+    author: {
+      id: "user-1",
+      username: "cameron",
+      globalName: "Cameron",
+      bot: false,
+    },
+    member: { displayName: "Cameron" },
+    channel: {
+      name: overrides.channelName ?? channelId,
+      parentId: overrides.parentChannelId ?? null,
+      isThread: () => isThread,
+    },
+    mentions: { has: () => mentioned },
+    attachments: new Map<string, never>(),
+    createdTimestamp: 1712800000000,
+    startThread: mock(async () => ({
+      id: "created-thread",
+      name: "created thread",
+    })),
+    react: mock(async () => {}),
+    reactions: { cache: new Map<string, never>() },
+  };
+}
+
+async function startAdapterWithDeliveries(
+  allowedChannels: DiscordChannelAccount["allowedChannels"],
+): Promise<{
+  client: FakeDiscordClient;
+  deliveries: InboundChannelMessage[];
+}> {
+  const adapter = createDiscordAdapter({
+    ...discordAccountDefaults,
+    allowedChannels,
+  });
+  const deliveries: InboundChannelMessage[] = [];
+  adapter.onMessage = async (message) => {
+    deliveries.push(message);
+  };
+
+  await adapter.start();
+  const client = FakeDiscordClient.instances.at(-1);
+  if (!client) {
+    throw new Error("Discord client was not created");
+  }
+  return { client, deliveries };
+}
+
+beforeEach(() => {
+  FakeDiscordClient.instances.length = 0;
+  __testOverrideLoadDiscordModule(async () => createFakeDiscordRuntime());
+});
+
+afterEach(() => {
+  __testOverrideLoadDiscordModule(null);
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Discord adapter open-channel ingress ───────────────────────────────
+
+describe("Discord adapter open-channel ingress", () => {
+  test("passes non-mentioned guild messages from configured open channels", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries({
+      "channel-open": "open",
+    });
+
+    await client.emitMessageCreate(
+      createGuildMessage({ id: "msg-open", channelId: "channel-open" }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      channel: "discord",
+      accountId: "discord-bot",
+      chatId: "channel-open",
+      senderId: "user-1",
+      senderName: "Cameron",
+      text: "ambient hello",
+      messageId: "msg-open",
+      threadId: null,
+      parentChannelId: "channel-open",
+      chatType: "channel",
+      isMention: false,
+      isOpenChannel: true,
+    });
+  });
+
+  test("drops non-mentioned guild messages from legacy string allowlists", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries([
+      "channel-legacy",
+    ]);
+
+    await client.emitMessageCreate(
+      createGuildMessage({ id: "msg-legacy", channelId: "channel-legacy" }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("drops non-mentioned guild messages from mention-only channel maps", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries({
+      "channel-mention-only": "mention-only",
+    });
+
+    await client.emitMessageCreate(
+      createGuildMessage({
+        id: "msg-mention-only",
+        channelId: "channel-mention-only",
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("passes thread messages under open parents with parent metadata", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries({
+      "parent-open": "open",
+    });
+
+    await client.emitMessageCreate(
+      createGuildMessage({
+        id: "msg-thread-open",
+        channelId: "thread-1",
+        content: "thread hello",
+        parentChannelId: "parent-open",
+        isThread: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      channel: "discord",
+      accountId: "discord-bot",
+      chatId: "thread-1",
+      text: "thread hello",
+      messageId: "msg-thread-open",
+      threadId: "thread-1",
+      parentChannelId: "parent-open",
+      chatType: "channel",
+      isMention: false,
+      isOpenChannel: true,
+    });
+  });
+});
 
 // The Discord adapter's internal helpers are not exported, but we can test
 // the equivalent logic by reimplementing the pure functions here and verifying

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -8,7 +8,10 @@ import type {
   InboundChannelMessage,
   OutboundChannelMessage,
 } from "@/channels/types";
-import { isDiscordGuildChannelAllowed } from "./channel-gating";
+import {
+  isDiscordGuildChannelAllowed,
+  resolveDiscordChannelMode,
+} from "./channel-gating";
 import { formatDiscordDeliveryError } from "./error-reply";
 import {
   resolveDiscordInboundAttachments,
@@ -712,19 +715,28 @@ export function createDiscordAdapter(
         }
 
         // ── Guild handling ────────────────────────────────────────
-        // Outside a thread: only process @mentions (auto-create thread).
+        // Outside a thread:
+        //   - "open" channels process every non-bot message
+        //   - "mention-only" channels process @mentions only
         // Inside a thread: surface messages and let the registry decide whether
         // the thread is already routed, or whether a new mention is required.
-        if (!isThread && !wasMentioned) return;
+        const parentChannelId =
+          (message.channel as { parentId?: string | null }).parentId ?? null;
+        const channelMode = resolveDiscordChannelMode(
+          message.channelId,
+          parentChannelId,
+          isThread,
+          config.allowedChannels,
+        );
+        const isOpenChannel = channelMode === "open";
+        if (!isThread && !wasMentioned && !isOpenChannel) return;
 
         // Channel allowlist: when configured, only process guild messages whose
         // channel ID (or parent channel ID for thread messages) is allowed.
         if (
           !isDiscordGuildChannelAllowed({
             channelId: message.channelId,
-            parentChannelId:
-              (message.channel as { parentId?: string | null }).parentId ??
-              null,
+            parentChannelId,
             isThread,
             allowedChannels: config.allowedChannels,
           })
@@ -770,8 +782,12 @@ export function createDiscordAdapter(
           timestamp: message.createdTimestamp,
           messageId: message.id,
           threadId: effectiveThreadId,
+          parentChannelId: isThread
+            ? (parentChannelId ?? undefined)
+            : message.channelId,
           chatType: "channel",
           isMention: wasMentioned,
+          isOpenChannel,
           attachments,
           raw: message,
         };

--- a/src/channels/discord/runtime.ts
+++ b/src/channels/discord/runtime.ts
@@ -30,7 +30,20 @@ export interface DiscordRuntimeModuleLike {
   Partials: DiscordPartialsLike;
 }
 
+let loadDiscordModuleOverride:
+  | (() => Promise<DiscordRuntimeModuleLike>)
+  | null = null;
+
+export function __testOverrideLoadDiscordModule(
+  override: (() => Promise<DiscordRuntimeModuleLike>) | null,
+): void {
+  loadDiscordModuleOverride = override;
+}
+
 export async function loadDiscordModule(): Promise<DiscordRuntimeModuleLike> {
+  if (loadDiscordModuleOverride) {
+    return loadDiscordModuleOverride();
+  }
   return loadChannelRuntimeModule<DiscordRuntimeModuleLike>(
     "discord",
     "discord.js",


### PR DESCRIPTION
## Summary
- Resolve Discord channel mode in the adapter before the non-mention guild gate.
- Allow configured `open` channels to pass non-mention messages into the registry.
- Forward `isOpenChannel` and `parentChannelId` so existing route creation and delivery-time gating can work.

## Why
PR #2329 added per-channel `open` mode support in config/registry, but the adapter still returned early for non-thread guild messages without @mentions. As a result, open-channel configs could not receive ordinary channel messages.

## Test plan
- [x] `bun test src/channels/discord-adapter.test.ts src/channels/discord-channel-gating.test.ts src/channels/discord-registry.test.ts`
- [x] Commit hooks: biome check + `tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)
