### PR TITLE
chore: remove dead unused exports

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -114,13 +114,6 @@ export function getSkillSources(): SkillSource[] {
 }
 
 /**
- * Backwards-compat helper: returns true when bundled skills are disabled.
- */
-export function getNoSkills(): boolean {
-  return !context.skillSources.includes("bundled");
-}
-
-/**
  * Set the current conversation ID
  * @param conversationId - The conversation ID, or null to clear
  */

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -1,9 +1,4 @@
-import type {
-  Api,
-  KnownProvider,
-  Model,
-  Provider,
-} from "@earendil-works/pi-ai";
+import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
 import { getModels } from "@earendil-works/pi-ai";
 
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
@@ -325,12 +320,6 @@ export function stripProviderHandlePrefix(
   return prefix ? model.slice(prefix.length) : model;
 }
 
-export function hasKnownProviderHandlePrefix(model: string): boolean {
-  return PI_PROVIDER_SPECS.some((provider) =>
-    provider.handlePrefixes.some((prefix) => model.startsWith(prefix)),
-  );
-}
-
 export function localProviderType(provider: PiProvider): string {
   return getPiProviderSpec(provider).providerTypes[0] ?? "openai";
 }
@@ -397,13 +386,4 @@ export function piProviderFromModel(
     resolveProviderFromModelHandle(modelHandle) ??
     resolveProviderFromProviderType(modelSettings.provider_type)
   );
-}
-
-export function piProviderNameForModel(
-  modelHandle: string,
-  modelSettings: Record<string, unknown>,
-): Provider | undefined {
-  const provider = piProviderFromModel(modelHandle, modelSettings);
-  const spec = provider ? getPiProviderSpec(provider) : undefined;
-  return spec?.piProvider;
 }

--- a/src/cli/app/approval-diffs.ts
+++ b/src/cli/app/approval-diffs.ts
@@ -1,89 +1,8 @@
-import type { ClassifiedApproval } from "@/cli/helpers/approval-classification";
-import {
-  type AdvancedDiffSuccess,
-  computeAdvancedDiff,
-  parsePatchToAdvancedDiff,
-} from "@/cli/helpers/diff";
-import { parsePatchOperations } from "@/cli/helpers/format-args-display";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
-import {
-  isFileEditTool,
-  isFileWriteTool,
-  isPatchTool,
-} from "@/cli/helpers/tool-name-mapping";
 
 export function buildApprovalBatchKey(approvals: ApprovalRequest[]): string {
   return approvals
     .map((approval) => approval.toolCallId)
     .sort()
     .join("|");
-}
-
-export function _precomputeDiffsForApprovalBatch(
-  approvals: Array<Pick<ClassifiedApproval, "approval" | "parsedArgs">>,
-  precomputedDiffs: Map<string, AdvancedDiffSuccess>,
-): void {
-  for (const ac of approvals) {
-    const toolName = ac.approval.toolName;
-    const toolCallId = ac.approval.toolCallId;
-    const args = ac.parsedArgs;
-
-    try {
-      if (isFileWriteTool(toolName)) {
-        const filePath = args.file_path as string | undefined;
-        if (filePath) {
-          const result = computeAdvancedDiff({
-            kind: "write",
-            filePath,
-            content: (args.content as string) || "",
-          });
-          if (result.mode === "advanced") {
-            precomputedDiffs.set(toolCallId, result);
-          }
-        }
-      } else if (isFileEditTool(toolName)) {
-        const filePath = args.file_path as string | undefined;
-        if (filePath) {
-          if (args.edits && Array.isArray(args.edits)) {
-            const result = computeAdvancedDiff({
-              kind: "multi_edit",
-              filePath,
-              edits: args.edits as Array<{
-                old_string: string;
-                new_string: string;
-                replace_all?: boolean;
-              }>,
-            });
-            if (result.mode === "advanced") {
-              precomputedDiffs.set(toolCallId, result);
-            }
-          } else {
-            const result = computeAdvancedDiff({
-              kind: "edit",
-              filePath,
-              oldString: (args.old_string as string) || "",
-              newString: (args.new_string as string) || "",
-              replaceAll: args.replace_all as boolean | undefined,
-            });
-            if (result.mode === "advanced") {
-              precomputedDiffs.set(toolCallId, result);
-            }
-          }
-        }
-      } else if (isPatchTool(toolName) && args.input) {
-        const operations = parsePatchOperations(args.input as string);
-        for (const op of operations) {
-          const key = `${toolCallId}:${op.path}`;
-          if (op.kind === "add" || op.kind === "update") {
-            const result = parsePatchToAdvancedDiff(op.patchLines, op.path);
-            if (result) {
-              precomputedDiffs.set(key, result);
-            }
-          }
-        }
-      }
-    } catch {
-      // Ignore diff computation errors for approval previews.
-    }
-  }
 }

--- a/src/cli/helpers/safe-json-parse.ts
+++ b/src/cli/helpers/safe-json-parse.ts
@@ -1,25 +1,10 @@
 /**
- * Safe JSON parser that never throws
- * Returns parsed value on success, or null on failure
- */
-export function safeJsonParse<T = unknown>(
-  json: string,
-): { success: true; data: T } | { success: false; error: string } {
-  try {
-    const data = JSON.parse(json) as T;
-    return { success: true, data };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
-/**
  * Safe JSON parser that returns the parsed value or a default value
  */
 export function safeJsonParseOr<T>(json: string, defaultValue: T): T {
-  const result = safeJsonParse<T>(json);
-  return result.success ? result.data : defaultValue;
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return defaultValue;
+  }
 }

--- a/src/cli/helpers/thinking-messages.ts
+++ b/src/cli/helpers/thinking-messages.ts
@@ -122,18 +122,6 @@ export function getRandomPastTenseVerb(): string {
   return PAST_TENSE_VERBS[verb] ?? "completed";
 }
 
-// Get a random thinking message (full string with agent name)
-export function getRandomThinkingMessage(agentName?: string | null): string {
-  const verb = getRandomVerb();
-
-  if (agentName) {
-    return `${agentName} is ${verb}`;
-  }
-
-  // Fallback to capitalized verb if no agent name
-  return verb.charAt(0).toUpperCase() + verb.slice(1);
-}
-
 export function getRandomThinkingTip(options?: {
   includeSystemPromptUpgradeTip?: boolean;
 }): string {

--- a/src/cli/thinking-messages.test.ts
+++ b/src/cli/thinking-messages.test.ts
@@ -1,54 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
-  getRandomThinkingMessage,
   getRandomThinkingTip,
   SYSTEM_PROMPT_UPGRADE_TIP,
   THINKING_TIPS,
 } from "@/cli/helpers/thinking-messages";
 
 describe("Thinking messages", () => {
-  test("returns formatted message with agent name", () => {
-    const message = getRandomThinkingMessage("Letta");
-
-    // Should be in format "Letta is <verb/phrase>"
-    expect(message).toMatch(/^Letta is .+$/);
-    expect(message.startsWith("Letta is ")).toBe(true);
-  });
-
-  test("returns capitalized verb without agent name", () => {
-    const message = getRandomThinkingMessage();
-
-    // Should be a capitalized verb/phrase (e.g., "Thinking", "Processing", "Absolutely right")
-    expect(message).toMatch(/^[A-Z].+$/);
-    expect(message[0]).toMatch(/[A-Z]/);
-  });
-
-  test("handles null agent name", () => {
-    const message = getRandomThinkingMessage(null);
-
-    // Should fall back to capitalized verb/phrase
-    expect(message).toMatch(/^[A-Z].+$/);
-  });
-
-  test("handles empty string agent name", () => {
-    const message = getRandomThinkingMessage("");
-
-    // Should fall back to capitalized verb/phrase (empty string is falsy)
-    expect(message).toMatch(/^[A-Z].+$/);
-  });
-
-  test("generates different messages on multiple calls", () => {
-    const messages = new Set<string>();
-
-    // Generate 10 messages, should get some variety
-    for (let i = 0; i < 10; i++) {
-      messages.add(getRandomThinkingMessage("Agent"));
-    }
-
-    // Should have more than 1 unique message (with high probability)
-    expect(messages.size).toBeGreaterThan(1);
-  });
-
   test("returns a tip from the configured tip list", () => {
     const tip = getRandomThinkingTip({
       includeSystemPromptUpgradeTip: false,

--- a/src/utils/aws-credentials.ts
+++ b/src/utils/aws-credentials.ts
@@ -100,21 +100,3 @@ function parseIniFile(
     }
   }
 }
-
-/**
- * Get a specific profile by name
- */
-export async function getAwsProfile(
-  profileName: string,
-): Promise<AwsProfile | null> {
-  const profiles = await parseAwsCredentials();
-  return profiles.find((p) => p.name === profileName) || null;
-}
-
-/**
- * Get list of available profile names
- */
-export async function getAwsProfileNames(): Promise<string[]> {
-  const profiles = await parseAwsCredentials();
-  return profiles.map((p) => p.name);
-}


### PR DESCRIPTION
## Summary
- remove dead exported helpers that had no non-test external callers
- delete test coverage that only existed for removed dead exports
- simplify `safeJsonParseOr()` to inline the dead helper it was the only caller of

## Audit evidence
Removed only symbols with clear evidence of no non-test external use:
- `getNoSkills()` in `src/agent/context.ts` — repo-wide search found only the definition itself
- `getRandomThinkingMessage()` in `src/cli/helpers/thinking-messages.ts` — only referenced by `src/cli/thinking-messages.test.ts`
- `getAwsProfile()` / `getAwsProfileNames()` in `src/utils/aws-credentials.ts` — repo-wide search found only their definitions; production code uses `parseAwsCredentials()` directly
- `safeJsonParse()` in `src/cli/helpers/safe-json-parse.ts` — only called by `safeJsonParseOr()` in the same file
- `_precomputeDiffsForApprovalBatch()` in `src/cli/app/approval-diffs.ts` — repo-wide search found only the definition; `buildApprovalBatchKey()` remains in use by `use-approval-flow.ts`
- `hasKnownProviderHandlePrefix()` / `piProviderNameForModel()` in `src/backend/dev/pi-provider-registry.ts` — repo-wide search found only their definitions

Explicitly kept because they are still used:
- `mergeBidirectionalQueuedInput()` — used in `src/headless.ts`
- `parseSemver()` — used in `src/utils/version.ts`
- `localProviderErrorDetail()` — used internally in `src/backend/dev/local-provider-errors.ts`
- `generatePlanName()` — used internally in `src/utils/plan-name.ts`
- `stripProviderHandlePrefix()` — used in `src/backend/dev/pi-model-factory.ts`
- `piProviderFromModel()` — used internally in `src/backend/dev/pi-provider-registry.ts`

## Test plan
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)