### PR TITLE
feat(listener): per-device default working directory for remote connections

### DIFF
--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -44,6 +44,7 @@ import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import {
   getConversationWorkingDirectory,
   setConversationWorkingDirectory,
+  setDeviceDefaultWorkingDirectory,
 } from "./cwd";
 import {
   consumeInterruptQueue,
@@ -117,6 +118,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   activeConversationId: string;
   socket: WebSocket | null;
   workingDirectoryByConversation: Map<string, string>;
+  deviceDefaultCwdByDeviceId: Map<string, string>;
   permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
   reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
   contextTrackerByConversation: ListenerRuntime["contextTrackerByConversation"];
@@ -125,6 +127,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   bootWorkingDirectory: string;
   connectionId: string | null;
   connectionName: string | null;
+  deviceId: string | null;
   sessionId: string;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
@@ -156,6 +159,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     activeConversationId: string;
     socket: WebSocket | null;
     workingDirectoryByConversation: Map<string, string>;
+    deviceDefaultCwdByDeviceId: Map<string, string>;
     permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
     reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
     contextTrackerByConversation: ListenerRuntime["contextTrackerByConversation"];
@@ -164,6 +168,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     bootWorkingDirectory: string;
     connectionId: string | null;
     connectionName: string | null;
+    deviceId: string | null;
     sessionId: string;
     eventSeqCounter: number;
     queueEmitScheduled: boolean;
@@ -199,6 +204,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.workingDirectoryByConversation,
       set: (value: Map<string, string>) => {
         listener.workingDirectoryByConversation = value;
+      },
+    },
+    deviceDefaultCwdByDeviceId: {
+      get: () => listener.deviceDefaultCwdByDeviceId,
+      set: (value: Map<string, string>) => {
+        listener.deviceDefaultCwdByDeviceId = value;
       },
     },
     permissionModeByConversation: {
@@ -249,6 +260,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.connectionName,
       set: (value: string | null) => {
         listener.connectionName = value;
+      },
+    },
+    deviceId: {
+      get: () => listener.deviceId,
+      set: (value: string | null) => {
+        listener.deviceId = value;
       },
     },
     sessionId: {
@@ -453,6 +470,7 @@ export const __listenClientTestUtils = {
   clearPendingApprovalBatchIds,
   populateInterruptQueue,
   setConversationWorkingDirectory,
+  setDeviceDefaultWorkingDirectory,
   consumeInterruptQueue,
   stashRecoveredApprovalInterrupts,
   extractInterruptToolReturns,

--- a/src/websocket/listener/commands/settings.ts
+++ b/src/websocket/listener/commands/settings.ts
@@ -149,6 +149,7 @@ export async function handleReflectionSettingsCommand(
     listener,
     parsed.runtime.agent_id,
     parsed.runtime.conversation_id,
+    listener.deviceId,
   );
 
   if (parsed.type === "get_reflection_settings") {

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -24,6 +24,7 @@ import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import {
   getConversationWorkingDirectory,
   setConversationWorkingDirectory,
+  setDeviceDefaultWorkingDirectory,
 } from "./cwd";
 import { isGitWorktreeRoot } from "./file-commands";
 import { stashRecoveredApprovalInterrupts } from "./interrupts";
@@ -585,6 +586,7 @@ export async function handleCwdChange(
     runtime.listener,
     agentId,
     conversationId,
+    msg.deviceId ?? runtime.listener.deviceId,
   );
 
   try {
@@ -608,6 +610,17 @@ export async function handleCwdChange(
       conversationId,
       normalizedPath,
     );
+
+    // Also persist as the device's default CWD so future conversations
+    // from this device start in the same directory.
+    const deviceId = msg.deviceId ?? runtime.listener.deviceId;
+    if (deviceId) {
+      setDeviceDefaultWorkingDirectory(
+        runtime.listener,
+        deviceId,
+        normalizedPath,
+      );
+    }
 
     // Invalidate session-context only (not agent-info) so the agent gets
     // updated CWD/git info on the next turn.

--- a/src/websocket/listener/cwd-change.ts
+++ b/src/websocket/listener/cwd-change.ts
@@ -10,6 +10,7 @@ import {
 import {
   getWorkingDirectoryScopeKey,
   setConversationWorkingDirectory,
+  setDeviceDefaultWorkingDirectory,
 } from "./cwd";
 import { isGitWorktreeRoot } from "./file-commands";
 import { emitDeviceStatusUpdate } from "./protocol-outbound";
@@ -63,6 +64,8 @@ export async function switchConversationWorkingDirectory(params: {
   runtime: ListenerRuntime;
   agentId: string | null;
   conversationId: string;
+  /** Device ID from the connected client. When provided, also persists as device default CWD. */
+  deviceId?: string | null;
   workingDirectory: string;
   emitStatus?: boolean;
   statusRuntime?: ConversationRuntime | ListenerRuntime;
@@ -81,6 +84,13 @@ export async function switchConversationWorkingDirectory(params: {
     conversationId,
     workingDirectory,
   );
+
+  // Also persist as the device's default CWD so future conversations
+  // from this device start in the same directory.
+  const deviceId = params.deviceId ?? runtime.deviceId;
+  if (deviceId) {
+    setDeviceDefaultWorkingDirectory(runtime, deviceId, workingDirectory);
+  }
 
   if (params.updateCurrentRuntimeContext !== false) {
     updateRuntimeContext({ workingDirectory });

--- a/src/websocket/listener/cwd.ts
+++ b/src/websocket/listener/cwd.ts
@@ -20,12 +20,25 @@ export function getConversationWorkingDirectory(
   runtime: ListenerRuntime,
   agentId?: string | null,
   conversationId?: string | null,
+  deviceId?: string | null,
 ): string {
   const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
-  return (
-    runtime.workingDirectoryByConversation.get(scopeKey) ??
-    runtime.bootWorkingDirectory
-  );
+  const conversationCwd = runtime.workingDirectoryByConversation.get(scopeKey);
+  if (conversationCwd) {
+    return conversationCwd;
+  }
+
+  // Fall back to device-scoped default CWD if a deviceId is provided.
+  if (deviceId) {
+    const deviceCwd =
+      runtime.deviceDefaultCwdByDeviceId.get(deviceId) ??
+      loadPersistedDeviceCwdMap().get(deviceId);
+    if (deviceCwd) {
+      return deviceCwd;
+    }
+  }
+
+  return runtime.bootWorkingDirectory;
 }
 
 /**
@@ -56,6 +69,44 @@ export function loadPersistedCwdMap(): Map<string, string> {
 
 export function persistCwdMap(map: Map<string, string>): void {
   saveRemoteSettings({ cwdMap: Object.fromEntries(map) });
+}
+
+export function loadPersistedDeviceCwdMap(): Map<string, string> {
+  try {
+    const settings = loadRemoteSettings();
+    const map = new Map<string, string>();
+    if (settings.deviceCwdMap) {
+      for (const [key, value] of Object.entries(settings.deviceCwdMap)) {
+        map.set(key, value);
+      }
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+export function persistDeviceCwdMap(map: Map<string, string>): void {
+  saveRemoteSettings({ deviceCwdMap: Object.fromEntries(map) });
+}
+
+export function setDeviceDefaultWorkingDirectory(
+  runtime: ListenerRuntime,
+  deviceId: string,
+  workingDirectory: string,
+): void {
+  runtime.deviceDefaultCwdByDeviceId.set(deviceId, workingDirectory);
+  persistDeviceCwdMap(runtime.deviceDefaultCwdByDeviceId);
+}
+
+export function getDeviceDefaultWorkingDirectory(
+  runtime: ListenerRuntime,
+  deviceId: string,
+): string | undefined {
+  return (
+    runtime.deviceDefaultCwdByDeviceId.get(deviceId) ??
+    loadPersistedDeviceCwdMap().get(deviceId)
+  );
 }
 
 export function setConversationWorkingDirectory(

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -63,7 +63,7 @@ import {
   findFallbackRuntime,
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
-import { loadPersistedCwdMap } from "./cwd";
+import { loadPersistedCwdMap, loadPersistedDeviceCwdMap } from "./cwd";
 import { createFileCommandSession } from "./file-commands";
 import { createListenerMessageHandler } from "./message-router";
 import {
@@ -832,6 +832,7 @@ export function createRuntime(): ListenerRuntime {
     reminderState: createSharedReminderState(),
     bootWorkingDirectory,
     workingDirectoryByConversation: loadPersistedCwdMap(),
+    deviceDefaultCwdByDeviceId: loadPersistedDeviceCwdMap(),
     worktreeWatcherByConversation: new Map(),
     permissionModeByConversation: loadPersistedPermissionModeMap(),
     reminderStateByConversation: new Map(),
@@ -840,6 +841,7 @@ export function createRuntime(): ListenerRuntime {
     queuedSystemPromptRecompileByConversation: new Set(),
     connectionId: null,
     connectionName: null,
+    deviceId: null,
     conversationRuntimes: new Map(),
     approvalRuntimeKeyByRequestId: new Map(),
     memfsSyncedAgents: new Map(),
@@ -1110,6 +1112,7 @@ export async function startListenerClient(
   runtime.onWsEvent = opts.onWsEvent;
   runtime.connectionId = opts.connectionId;
   runtime.connectionName = opts.connectionName;
+  runtime.deviceId = opts.deviceId;
   setActiveRuntime(runtime);
   telemetry.setSurface(getListenerTelemetrySurface());
   telemetry.init();
@@ -1143,6 +1146,7 @@ export async function startLocalChannelListener(
   runtime.onWsEvent = opts.onWsEvent;
   runtime.connectionId = opts.connectionId;
   runtime.connectionName = opts.connectionName;
+  runtime.deviceId = opts.deviceId;
   setActiveRuntime(runtime);
   telemetry.setSurface(getListenerTelemetrySurface());
   telemetry.init();

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -438,6 +438,7 @@ export function buildDeviceStatus(
     listener,
     scopedAgentId,
     scopedConversationId,
+    listener.deviceId,
   );
   const reflectionSettings = (() => {
     if (!scopedAgentId) {

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -500,6 +500,7 @@ export async function resolveRecoveredApprovalResponse(
     runtime.listener,
     recovered.agentId,
     recovered.conversationId,
+    runtime.listener.deviceId,
   );
   const respondedEntry = recovered.approvalsByRequestId.get(requestId);
   if (

--- a/src/websocket/listener/remote-settings.ts
+++ b/src/websocket/listener/remote-settings.ts
@@ -18,6 +18,8 @@ export interface PersistedPermissionModeState {
 
 export interface RemoteSettings {
   cwdMap?: Record<string, string>;
+  /** Per-device default working directory, keyed by deviceId. Survives restarts. */
+  deviceCwdMap?: Record<string, string>;
   permissionModeMap?: Record<string, PersistedPermissionModeState>;
 }
 
@@ -62,6 +64,17 @@ export function loadRemoteSettings(): RemoteSettings {
       }
     }
     loaded.cwdMap = validCwdMap;
+  }
+
+  // Validate deviceCwdMap entries — filter out stale paths.
+  if (loaded.deviceCwdMap) {
+    const validDeviceCwdMap: Record<string, string> = {};
+    for (const [key, value] of Object.entries(loaded.deviceCwdMap)) {
+      if (typeof value === "string" && existsSync(value)) {
+        validDeviceCwdMap[key] = value;
+      }
+    }
+    loaded.deviceCwdMap = validDeviceCwdMap;
   }
 
   // One-time migration: load legacy cwd-cache.json if cwdMap not present.

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -319,6 +319,7 @@ export async function resolveStaleApprovals(
       runtime.listener,
       runtime.agentId,
       recoveryConversationId,
+      runtime.listener.deviceId,
     );
   const scope = {
     agent_id: runtime.agentId,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -441,6 +441,7 @@ export async function handleIncomingMessage(
     runtime.listener,
     normalizedAgentId,
     conversationId,
+    runtime.listener.deviceId,
   );
 
   // Get the canonical mutable permission mode state ref for this turn.

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -85,6 +85,7 @@ export interface ModeChangePayload {
 export interface ChangeCwdMessage {
   agentId?: string | null;
   conversationId?: string | null;
+  deviceId?: string | null;
   cwd: string;
 }
 
@@ -192,6 +193,8 @@ export type ListenerRuntime = {
   reminderState: SharedReminderState;
   bootWorkingDirectory: string;
   workingDirectoryByConversation: Map<string, string>;
+  /** Per-device default working directory. Keyed by deviceId. */
+  deviceDefaultCwdByDeviceId: Map<string, string>;
   /** Per-conversation permission mode state. Mirrors workingDirectoryByConversation. */
   permissionModeByConversation: Map<
     string,
@@ -206,6 +209,8 @@ export type ListenerRuntime = {
   queuedSystemPromptRecompileByConversation: Set<string>;
   connectionId: string | null;
   connectionName: string | null;
+  /** Device ID of the connected desktop client, if available. */
+  deviceId: string | null;
   conversationRuntimes: Map<string, ConversationRuntime>;
   approvalRuntimeKeyByRequestId: Map<string, string>;
   /** Per-conversation worktree directory watchers for CWD auto-detection fallback. */

--- a/src/websocket/listener/worktree-watcher.ts
+++ b/src/websocket/listener/worktree-watcher.ts
@@ -45,7 +45,12 @@ export function startWorktreeWatcher(params: {
   conversationId: string;
 }): WorktreeWatcherState | null {
   const { runtime, agentId, conversationId } = params;
-  const cwd = getConversationWorkingDirectory(runtime, agentId, conversationId);
+  const cwd = getConversationWorkingDirectory(
+    runtime,
+    agentId,
+    conversationId,
+    runtime.deviceId,
+  );
   const worktreesDir = path.join(cwd, WORKTREES_DIR);
 
   const abort = new AbortController();
@@ -200,6 +205,7 @@ async function handleNewWorktree(params: {
     runtime,
     agentId,
     conversationId,
+    runtime.deviceId,
   );
   if (currentCwd === newWorktreePath) {
     clearExpectedWorktreePath(conversationRuntime);


### PR DESCRIPTION
## Summary
- Adds a device-scoped CWD layer so remote desktop clients can declare and persist their preferred default working directory
- New fallback chain: conversation CWD -> device default CWD -> boot CWD
- Previously, all remote devices fell back to the server process CWD (bootWorkingDirectory), which is the server own working directory, not the devices

## Changes
- RemoteSettings.deviceCwdMap - persisted per-device CWD defaults in remote-settings.json
- ListenerRuntime.deviceDefaultCwdByDeviceId - in-memory map loaded at startup
- ListenerRuntime.deviceId - stores the connected device ID on the runtime
- ChangeCwdMessage.deviceId - desktop can declare which device is changing CWD
- getConversationWorkingDirectory() - accepts optional deviceId parameter for device-scoped fallback
- setDeviceDefaultWorkingDirectory() / getDeviceDefaultWorkingDirectory() - new helpers
- handleCwdChange and switchConversationWorkingDirectory - auto-persist device default when deviceId is available
- All key CWD resolution paths (turn.ts, protocol-outbound.ts, send.ts, recovery.ts, settings.ts, worktree-watcher.ts) now pass listener.deviceId

## Test plan
- [ ] Start a desktop client against a remote listener, verify CWD defaults to the device last-used directory
- [ ] Change CWD from desktop, restart listener, verify device default persists across restarts
- [ ] Multiple devices: verify each device maintains independent CWD defaults
- [ ] Existing behavior: conversations with explicit CWD overrides still take precedence over device defaults
- [ ] No deviceId (TUI mode): verify fallback to bootWorkingDirectory unchanged