### PR TITLE
fix(cli): render overlay footer nodes without nesting in Text

### DIFF
--- a/src/cli/components/OverlayShell.tsx
+++ b/src/cli/components/OverlayShell.tsx
@@ -44,11 +44,7 @@ export function OverlayShell({
 
       {children}
 
-      {footer && (
-        <Box marginTop={1}>
-          <Text dimColor>{footer}</Text>
-        </Box>
-      )}
+      {footer && <Box marginTop={1}>{footer}</Box>}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- fix `OverlayShell` to render footer content directly instead of wrapping every footer in `<Text>`
- this prevents Ink from crashing when a footer passes layout nodes like `<Box>`
- fixes `/model` on latest main, where `ModelSelector` passes a boxed multi-line footer

## Root cause
`OverlayShell` accepted `footer?: ReactNode` but still rendered it as `<Text dimColor>{footer}</Text>`. After the tab/overlay consistency refactor, `ModelSelector` started passing a `<Box>` footer, which caused Ink to throw: `<Box> can’t be nested inside <Text> component`.

## Test plan
- [x] `bun run check`
- [ ] open `/model` and verify the dialog renders without crashing

👾 Generated with [Letta Code](https://letta.com)