### PR TITLE
fix(subagents): surface startup errors in task groups

### DIFF
--- a/src/cli/helpers/subagent-aggregation.ts
+++ b/src/cli/helpers/subagent-aggregation.ts
@@ -134,9 +134,11 @@ export function createSubagentGroupItem(
         id: subagent.id,
         type: subagent.type,
         description: subagent.description,
-        status: subagent.isBackground
-          ? "running"
-          : (subagent.status as "completed" | "error"),
+        status:
+          subagent.isBackground &&
+          (subagent.status === "pending" || subagent.status === "running")
+            ? "running"
+            : (subagent.status as "completed" | "error"),
         toolCount: getSubagentToolCount(subagent),
         totalTokens: subagent.totalTokens,
         agentURL: subagent.agentURL,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -210,6 +210,31 @@ function reportAndExitHeadless(
   process.exit(1);
 }
 
+async function reportStartupErrorAndExit(
+  errorType: string,
+  error: unknown,
+  context: string,
+  outputFormat: string,
+): Promise<never> {
+  trackHeadlessBoundaryError(errorType, error, context);
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (outputFormat === "stream-json") {
+    const errorMsg: ErrorMessage = {
+      type: "error",
+      message,
+      stop_reason: "error",
+      session_id: "startup",
+      uuid: `startup-error-${randomUUID()}`,
+    };
+    await writeWireMessageAsync(errorMsg);
+  } else {
+    console.error(`Error: ${message}`);
+  }
+
+  return await flushAndExit(1);
+}
+
 export type BidirectionalQueuedInput = QueuedTurnInput<
   MessageCreate["content"]
 >;
@@ -1093,7 +1118,18 @@ export async function handleHeadlessCommand(
       blockValues,
       tags: personalityOptions?.tags ?? tags,
     };
-    const result = await createAgent(createOptions);
+    let result: Awaited<ReturnType<typeof createAgent>>;
+    try {
+      result = await createAgent(createOptions);
+    } catch (error) {
+      await reportStartupErrorAndExit(
+        "headless_agent_create_failed",
+        error,
+        "headless_startup_agent_create",
+        values["output-format"] || "text",
+      );
+      throw error;
+    }
     agent = result.agent;
     autoEnableMemfsForFreshAgent = willAutoEnableMemfs;
   }


### PR DESCRIPTION
## Summary
- emit a structured stream-json `error` event when headless startup fails while creating a new subagent agent before the init event
- preserve errored/completed background subagent status when committing the live subagent group into the static transcript
- fixes the previous EOF masking behavior so startup failures like route-level 429s render as their real error message

## Root cause
When several subagents launched in parallel, some children hit `backend.createAgent` route rate limits before emitting an init event. Because stdout was empty, the parent fell back to parsing stdout and rendered `Failed to parse subagent output: JSON Parse error: Unexpected EOF` instead of the actual API error.

A second issue caused the live error to disappear after the group committed to static history: static aggregation coerced every background subagent to `running`, even if it had already reached `error`.

## Test plan
- [x] `bun run check`
- [x] Locally launched 6 parallel general-purpose subagents and verified `429 {"error":"Rate limit exceeded..."}` renders instead of EOF
- [x] Verified the static transcript preserves the error detail after the live group settles

👾 Generated with [Letta Code](https://letta.com)