### PR TITLE
fix(ci): cap headless scenario per-attempt runtime at 6 minutes

### DIFF
--- a/src/test-utils/headless-scenario.ts
+++ b/src/test-utils/headless-scenario.ts
@@ -187,11 +187,24 @@ async function runCLI(args: Args): Promise<RunResult> {
     args.model,
   );
 
+  // Cap each attempt at 6 minutes. The scenario should complete in ~2-3 min
+  // under normal conditions. Without a timeout, a WS proxy timeout mid-turn
+  // (observed at ~14 min in CI) can block a single attempt for 30+ minutes,
+  // consuming all retries with no useful signal. Killing early lets the outer
+  // retry loop start fresh with a clean agent context.
+  const RUN_TIMEOUT_MS = 6 * 60 * 1000;
+
   return new Promise((resolve, reject) => {
     const proc = spawn("bun", cliArgs, { env });
 
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+    }, RUN_TIMEOUT_MS);
 
     proc.stdout.on("data", (data) => {
       stdout += data.toString();
@@ -202,9 +215,11 @@ async function runCLI(args: Args): Promise<RunResult> {
     });
 
     proc.on("close", (code) => {
-      if (code !== 0) {
+      clearTimeout(timeoutHandle);
+      const effectiveCode = timedOut ? 124 : (code ?? 1);
+      if (effectiveCode !== 0) {
         console.error(
-          `CLI failed (${args.backend} / ${args.model} / ${args.output}).\n${formatCapturedOutput(
+          `CLI ${timedOut ? `timed out after ${RUN_TIMEOUT_MS / 1000}s` : `failed`} (${args.backend} / ${args.model} / ${args.output}).\n${formatCapturedOutput(
             {
               stdout,
               stderr,
@@ -212,7 +227,7 @@ async function runCLI(args: Args): Promise<RunResult> {
           )}`,
         );
       }
-      resolve({ stdout, stderr, code: code ?? 1, localStorageDir });
+      resolve({ stdout, stderr, code: effectiveCode, localStorageDir });
     });
 
     proc.on("error", reject);


### PR DESCRIPTION
## Summary

- Adds a 6-minute wall-clock timeout to each `runCLI` attempt in `headless-scenario.ts`
- Timed-out runs kill the child process with SIGTERM and resolve with exit code 124
- Error message distinguishes timeout from other failures for easier CI log reading

## Background

The `stream-json` variant of this CI job was consistently taking 27+ minutes. Root cause from log analysis:

1. At ~14 minutes into attempt 1, the OpenAI WS proxy timed out mid-turn — the internal `drainStreamWithResume` retry handled this correctly and started a new stream
2. The resumed stream ran for another 17 minutes before the model generated a whitespace-only ShellCommand (`\t\t\t\n`), the server returned `stop_reason: llm_api_error`, and the CLI exited 1
3. Total: ~32 minutes for attempt 1 alone, burning the entire CI budget with no useful recovery

With a 6-minute timeout, a stuck attempt fails fast and the retry loop starts fresh with a clean agent/context. The ceiling is ~2x the expected happy-path runtime (~2-3 min) and leaves headroom for a single legitimate WS retry to complete.

## Test plan
- [ ] Happy-path runs (text, json, stream-json) complete well within 6 minutes — no change in behavior
- [ ] A stuck run (e.g. WS proxy timeout mid-turn) is killed at 6 min rather than running for 30+

👾 Generated with [Letta Code](https://letta.com)