### PR TITLE
feat(cli): modernize streaming spinner

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -874,6 +874,11 @@ export function App({
   // Live, approximate token counter (resets each turn)
   const [tokenCount, setTokenCount] = useState(0);
 
+  // Live total context tokens (history + system + output). Mirrors
+  // `contextTrackerRef.current.lastContextTokens` into reactive state so
+  // UI can react during streaming — the ref itself doesn't trigger renders.
+  const [usedContextTokens, setUsedContextTokens] = useState(0);
+
   // Trajectory token/time bases (accumulated across runs)
   const [trajectoryTokenBase, setTrajectoryTokenBase] = useState(0);
   const [trajectoryElapsedBaseMs, setTrajectoryElapsedBaseMs] = useState(0);
@@ -2252,6 +2257,7 @@ export function App({
   const refreshDerived = useCallback(() => {
     const b = buffersRef.current;
     setTokenCount(b.tokenCount);
+    setUsedContextTokens(contextTrackerRef.current.lastContextTokens);
     const newLines = toLines(b);
     setLines(newLines);
     commitEligibleLines(b);
@@ -4588,6 +4594,8 @@ export function App({
       stubDescriptions={stubDescriptions}
       thinkingMessage={thinkingMessage}
       trajectoryTokenDisplay={trajectoryTokenDisplay}
+      usedContextTokens={usedContextTokens}
+      contextWindowSize={effectiveContextWindowSize}
       uiPermissionMode={uiPermissionMode}
       uiRalphActive={uiRalphActive}
       updateAgentName={updateAgentName}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -305,6 +305,8 @@ type AppViewProps = {
   stubDescriptions: Map<string, string>;
   thinkingMessage: string;
   trajectoryTokenDisplay: number;
+  usedContextTokens: number;
+  contextWindowSize: number | null | undefined;
   uiPermissionMode: PermissionMode;
   uiRalphActive: boolean;
   updateAgentName: (name: string) => void;
@@ -443,6 +445,8 @@ export function AppView(props: AppViewProps) {
     stubDescriptions,
     thinkingMessage,
     trajectoryTokenDisplay,
+    usedContextTokens,
+    contextWindowSize,
     uiPermissionMode,
     uiRalphActive,
     updateAgentName,
@@ -700,6 +704,8 @@ export function AppView(props: AppViewProps) {
                 visible={inputVisible}
                 streaming={streaming}
                 tokenCount={trajectoryTokenDisplay}
+                usedContextTokens={usedContextTokens}
+                contextWindowSize={contextWindowSize}
                 elapsedBaseMs={liveTrajectoryElapsedBaseMs}
                 thinkingMessage={thinkingMessage}
                 includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}

--- a/src/cli/components/BlinkingSpinner.tsx
+++ b/src/cli/components/BlinkingSpinner.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useState } from "react";
 import stringWidth from "string-width";
 import { useAnimation } from "@/cli/contexts/AnimationContext.js";
 import { colors } from "./colors.js";
+import { useFrameCycle } from "./spinners/use-frame-cycle.js";
 import { Text } from "./Text";
 
 export const BRAILLE_SPINNER_FRAMES = [
@@ -44,18 +45,8 @@ export const BlinkingSpinner = memo(
     const shouldAnimate =
       shouldAnimateProp === false ? false : shouldAnimateContext;
 
-    const [frameIndex, setFrameIndex] = useState(0);
+    const frameIndex = useFrameCycle(frames, intervalMs, shouldAnimate);
     const [blinkOn, setBlinkOn] = useState(true);
-
-    useEffect(() => {
-      if (!shouldAnimate || frames.length === 0) return;
-
-      const timer = setInterval(() => {
-        setFrameIndex((v) => (v + 1) % frames.length);
-      }, intervalMs);
-
-      return () => clearInterval(timer);
-    }, [shouldAnimate, frames, intervalMs]);
 
     useEffect(() => {
       if (!shouldAnimate || !pulse) return;

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -44,6 +44,10 @@ import { InputAssist } from "./InputAssist";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { QueuedMessages } from "./QueuedMessages";
 import { ShimmerText } from "./ShimmerText";
+import {
+  contextTierFromRatio,
+  spinnerWidthForTier,
+} from "./spinners/animations.js";
 import { StreamingStatusSpinner } from "./spinners/StreamingStatusSpinner.js";
 import { Text } from "./Text";
 
@@ -711,6 +715,8 @@ const StreamingStatus = memo(function StreamingStatus({
   streaming,
   visible,
   tokenCount,
+  usedContextTokens,
+  contextWindowSize,
   elapsedBaseMs,
   thinkingMessage,
   includeSystemPromptUpgradeTip,
@@ -723,6 +729,8 @@ const StreamingStatus = memo(function StreamingStatus({
   streaming: boolean;
   visible: boolean;
   tokenCount: number;
+  usedContextTokens: number;
+  contextWindowSize: number | null | undefined;
   elapsedBaseMs: number;
   thinkingMessage: string;
   includeSystemPromptUpgradeTip: boolean;
@@ -763,6 +771,28 @@ const StreamingStatus = memo(function StreamingStatus({
   }, []);
 
   const animate = shouldAnimate && !isResizing;
+
+  // Context-usage tier drives both the spinner animation and its column
+  // width — wider as the conversation fills up.
+  const contextRatio =
+    contextWindowSize && contextWindowSize > 0
+      ? usedContextTokens / contextWindowSize
+      : 0;
+  const contextTier = contextTierFromRatio(contextRatio);
+  const spinnerColumnWidth = spinnerWidthForTier(contextTier) + 1;
+
+  // Bump a counter on each false→true streaming edge so the spinner
+  // remounts (via key={}) and re-picks from its tier pool. Without this
+  // the useState initializer can persist a pick across messages when
+  // the JSX shape and tier value are unchanged between streams.
+  const [streamSeed, setStreamSeed] = useState(0);
+  const prevStreamingRef = useRef(false);
+  useEffect(() => {
+    if (streaming && !prevStreamingRef.current) {
+      setStreamSeed((s) => s + 1);
+    }
+    prevStreamingRef.current = streaming;
+  }, [streaming]);
 
   const [shimmerOffset, setShimmerOffset] = useState(-3);
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -842,7 +872,10 @@ const StreamingStatus = memo(function StreamingStatus({
   // Avoid painting into the terminal's last column; some terminals will soft-wrap
   // padded Ink rows at the edge which breaks Ink's line-clearing accounting and
   // leaves duplicate status rows behind during streaming/resizes.
-  const statusContentWidth = Math.max(0, terminalWidth - 3);
+  const statusContentWidth = Math.max(
+    0,
+    terminalWidth - 1 - spinnerColumnWidth,
+  );
   const minMessageWidth = 12;
   const statusHintParts = useMemo(() => {
     const parts: string[] = [];
@@ -910,9 +943,16 @@ const StreamingStatus = memo(function StreamingStatus({
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row">
-        <Box width={2} flexShrink={0}>
+        <Box width={spinnerColumnWidth} flexShrink={0}>
           <Text color={colors.status.processing}>
-            {animate ? <StreamingStatusSpinner /> : CLI_GLYPHS.bullet}
+            {animate ? (
+              <StreamingStatusSpinner
+                tier={contextTier}
+                streamSeed={streamSeed}
+              />
+            ) : (
+              CLI_GLYPHS.bullet
+            )}
           </Text>
         </Box>
         <Box width={statusContentWidth} flexShrink={0} flexDirection="row">
@@ -933,7 +973,7 @@ const StreamingStatus = memo(function StreamingStatus({
         </Box>
       </Box>
       <Box flexDirection="row">
-        <Box width={2} flexShrink={0} />
+        <Box width={spinnerColumnWidth} flexShrink={0} />
         <Box width={statusContentWidth} flexShrink={0}>
           <Text color={colors.subagent.hint} wrap="truncate-end">
             {tipLineText}
@@ -956,6 +996,8 @@ export function Input({
   visible = true,
   streaming,
   tokenCount,
+  usedContextTokens = 0,
+  contextWindowSize,
   elapsedBaseMs = 0,
   thinkingMessage,
   includeSystemPromptUpgradeTip = true,
@@ -1004,6 +1046,8 @@ export function Input({
   visible?: boolean;
   streaming: boolean;
   tokenCount: number;
+  usedContextTokens?: number;
+  contextWindowSize?: number | null;
   elapsedBaseMs?: number;
   thinkingMessage: string;
   includeSystemPromptUpgradeTip?: boolean;
@@ -2028,6 +2072,8 @@ export function Input({
         streaming={streaming}
         visible={visible}
         tokenCount={tokenCount}
+        usedContextTokens={usedContextTokens}
+        contextWindowSize={contextWindowSize}
         elapsedBaseMs={elapsedBaseMs}
         thinkingMessage={thinkingMessage}
         includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -5,9 +5,7 @@ import { stdin } from "node:process";
 import chalk from "chalk";
 import { Box, useInput } from "ink";
 import Link from "ink-link";
-import SpinnerLib from "ink-spinner";
 import {
-  type ComponentType,
   memo,
   type ReactNode,
   useCallback,
@@ -46,10 +44,8 @@ import { InputAssist } from "./InputAssist";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { QueuedMessages } from "./QueuedMessages";
 import { ShimmerText } from "./ShimmerText";
+import { StreamingStatusSpinner } from "./spinners/StreamingStatusSpinner.js";
 import { Text } from "./Text";
-
-// Type assertion for ink-spinner compatibility
-const Spinner = SpinnerLib as ComponentType<{ type?: string }>;
 
 // Window for double-escape to clear input
 const ESC_CLEAR_WINDOW_MS = 2500;
@@ -916,7 +912,7 @@ const StreamingStatus = memo(function StreamingStatus({
       <Box flexDirection="row">
         <Box width={2} flexShrink={0}>
           <Text color={colors.status.processing}>
-            {animate ? <Spinner type="layer" /> : CLI_GLYPHS.bullet}
+            {animate ? <StreamingStatusSpinner /> : CLI_GLYPHS.bullet}
           </Text>
         </Box>
         <Box width={statusContentWidth} flexShrink={0} flexDirection="row">

--- a/src/cli/components/spinners/StreamingStatusSpinner.tsx
+++ b/src/cli/components/spinners/StreamingStatusSpinner.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import stringWidth from "string-width";
 import { colors } from "@/cli/components/colors.js";
 import { Text } from "@/cli/components/Text";
@@ -6,6 +6,7 @@ import { useAnimation } from "@/cli/contexts/AnimationContext.js";
 import {
   BRAILLE_ANIMATIONS,
   type BrailleAnimationKey,
+  CONTEXT_TIER_ANIMATIONS,
   STREAMING_STATUS_ANIMATION_KEYS,
 } from "./animations.js";
 import { useFrameCycle } from "./use-frame-cycle.js";
@@ -13,44 +14,78 @@ import { useFrameCycle } from "./use-frame-cycle.js";
 interface StreamingStatusSpinnerProps {
   color?: string;
   /**
-   * Override the randomly-picked animation. Primarily for tests; leave
-   * unset in production so streams get a random pick on mount.
+   * Explicit animation override. Wins over `tier`. Used by tests and
+   * temporary local hardcodes.
    */
   animation?: BrailleAnimationKey;
+  /**
+   * Context-usage tier (0–3). When set, the spinner picks one animation
+   * from `CONTEXT_TIER_ANIMATIONS[tier]`. Ignored if `animation` is
+   * provided.
+   */
+  tier?: number;
+  /**
+   * Monotonically increasing integer that selects which animation in
+   * the pool. The parent bumps it on each new stream so consecutive
+   * streams rotate through the pool deterministically (round-robin).
+   * Stable within a stream → stable animation within a stream.
+   */
+  streamSeed?: number;
   /** Target cell width; the frame is centered and space-padded. */
   width?: number;
   marginRight?: number;
 }
 
-function pickRandomAnimationKey(): BrailleAnimationKey {
-  const pool = STREAMING_STATUS_ANIMATION_KEYS;
-  const idx = Math.floor(Math.random() * pool.length);
+function pickFromPool(
+  pool: readonly BrailleAnimationKey[],
+  seed: number,
+): BrailleAnimationKey {
+  if (pool.length === 0) return "orbit";
+  const idx = ((seed % pool.length) + pool.length) % pool.length;
   return pool[idx] ?? pool[0] ?? "orbit";
+}
+
+function resolveAnimationKey(
+  animation: BrailleAnimationKey | undefined,
+  tier: number | undefined,
+  seed: number,
+): BrailleAnimationKey {
+  if (animation) return animation;
+  if (tier !== undefined) {
+    const clamped = Math.max(
+      0,
+      Math.min(CONTEXT_TIER_ANIMATIONS.length - 1, tier),
+    );
+    return pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? [], seed);
+  }
+  return pickFromPool(STREAMING_STATUS_ANIMATION_KEYS, seed);
 }
 
 /**
  * Spinner for the streaming-status row of the chat input.
  *
- * On mount, picks one animation at random from
- * {@link STREAMING_STATUS_ANIMATION_KEYS} and cycles its frames via
- * {@link useFrameCycle}. Honors the global `AnimationContext` — when
- * animations are disabled, the first frame is held static.
+ * Selection priority:
+ *   1. `animation` prop (explicit override)
+ *   2. `tier` + `streamSeed` — `pool[streamSeed % pool.length]`. The
+ *      parent increments `streamSeed` on each new stream so consecutive
+ *      streams rotate through the tier's pool; mid-stream tier crossings
+ *      pick from the new tier's pool at the same seed.
+ *   3. Random-ish from the unconstrained 1-cell pool using the seed.
  *
- * Replaces the previous `<Spinner type="layer" />` from `ink-spinner`
- * at the streaming-status site; that dependency is retained for other
- * call sites (e.g. `ListenerStatusUI`).
+ * Honors the global `AnimationContext` — when animations are disabled,
+ * the first frame is held static.
  */
 export const StreamingStatusSpinner = memo(
   ({
     color = colors.status.processing,
     animation,
+    tier,
+    streamSeed = 0,
     width = 1,
     marginRight = 0,
   }: StreamingStatusSpinnerProps) => {
     const { shouldAnimate } = useAnimation();
-    const [animationKey] = useState<BrailleAnimationKey>(
-      () => animation ?? pickRandomAnimationKey(),
-    );
+    const animationKey = resolveAnimationKey(animation, tier, streamSeed);
     const { frames, intervalMs } = BRAILLE_ANIMATIONS[animationKey];
 
     const frameIndex = useFrameCycle(frames, intervalMs, shouldAnimate);

--- a/src/cli/components/spinners/StreamingStatusSpinner.tsx
+++ b/src/cli/components/spinners/StreamingStatusSpinner.tsx
@@ -1,0 +1,73 @@
+import { memo, useState } from "react";
+import stringWidth from "string-width";
+import { colors } from "@/cli/components/colors.js";
+import { Text } from "@/cli/components/Text";
+import { useAnimation } from "@/cli/contexts/AnimationContext.js";
+import {
+  BRAILLE_ANIMATIONS,
+  type BrailleAnimationKey,
+  STREAMING_STATUS_ANIMATION_KEYS,
+} from "./animations.js";
+import { useFrameCycle } from "./use-frame-cycle.js";
+
+interface StreamingStatusSpinnerProps {
+  color?: string;
+  /**
+   * Override the randomly-picked animation. Primarily for tests; leave
+   * unset in production so streams get a random pick on mount.
+   */
+  animation?: BrailleAnimationKey;
+  /** Target cell width; the frame is centered and space-padded. */
+  width?: number;
+  marginRight?: number;
+}
+
+function pickRandomAnimationKey(): BrailleAnimationKey {
+  const pool = STREAMING_STATUS_ANIMATION_KEYS;
+  const idx = Math.floor(Math.random() * pool.length);
+  return pool[idx] ?? pool[0] ?? "orbit";
+}
+
+/**
+ * Spinner for the streaming-status row of the chat input.
+ *
+ * On mount, picks one animation at random from
+ * {@link STREAMING_STATUS_ANIMATION_KEYS} and cycles its frames via
+ * {@link useFrameCycle}. Honors the global `AnimationContext` — when
+ * animations are disabled, the first frame is held static.
+ *
+ * Replaces the previous `<Spinner type="layer" />` from `ink-spinner`
+ * at the streaming-status site; that dependency is retained for other
+ * call sites (e.g. `ListenerStatusUI`).
+ */
+export const StreamingStatusSpinner = memo(
+  ({
+    color = colors.status.processing,
+    animation,
+    width = 1,
+    marginRight = 0,
+  }: StreamingStatusSpinnerProps) => {
+    const { shouldAnimate } = useAnimation();
+    const [animationKey] = useState<BrailleAnimationKey>(
+      () => animation ?? pickRandomAnimationKey(),
+    );
+    const { frames, intervalMs } = BRAILLE_ANIMATIONS[animationKey];
+
+    const frameIndex = useFrameCycle(frames, intervalMs, shouldAnimate);
+    const frame = frames[frameIndex] ?? frames[0] ?? "·";
+
+    const frameWidth = stringWidth(frame);
+    const targetWidth = Math.max(1, width);
+    const totalPadding = Math.max(0, targetWidth - frameWidth);
+    const leftPadding = Math.floor(totalPadding / 2);
+    const rightPadding = totalPadding - leftPadding;
+    const paddedFrame =
+      " ".repeat(leftPadding) + frame + " ".repeat(rightPadding);
+
+    const output = paddedFrame + " ".repeat(Math.max(0, marginRight));
+
+    return <Text color={color}>{output}</Text>;
+  },
+);
+
+StreamingStatusSpinner.displayName = "StreamingStatusSpinner";

--- a/src/cli/components/spinners/animations.ts
+++ b/src/cli/components/spinners/animations.ts
@@ -2,63 +2,477 @@
  * Braille spinner animations available to {@link StreamingStatusSpinner}.
  *
  * Frames are pre-computed from the procedural generators in
- * `gunnargray-dev/unicode-animations`. Each entry below renders as a
- * single braille character (1 terminal cell) so animations can be swapped
- * without disturbing surrounding layout — keep new entries to a 2x4 dot
- * grid (W=2 in the upstream generator) for the same width guarantee.
+ * `gunnargray-dev/unicode-animations`. The `cellWidth` field is the
+ * number of terminal cells each frame occupies (2 dot-columns per cell);
+ * the consumer reads this to size its layout slot.
  *
  * To add a new animation:
  *   1. Define a {@link BrailleAnimation} entry below.
- *   2. Append its key to {@link STREAMING_STATUS_ANIMATION_KEYS}.
+ *   2. Add it to {@link BRAILLE_ANIMATIONS}.
+ *   3. Optionally include it in {@link STREAMING_STATUS_ANIMATION_KEYS}
+ *      (the unconstrained random pool) or in
+ *      {@link CONTEXT_TIER_ANIMATIONS} (the context-tier router).
  */
 
 export type BrailleAnimation = {
   readonly frames: readonly string[];
   readonly intervalMs: number;
+  readonly cellWidth: number;
 };
 
 /** 2-dot "comet" rotating clockwise around a 2x4 ring. */
 const ORBIT: BrailleAnimation = {
   frames: ["⠃", "⠉", "⠘", "⠰", "⢠", "⣀", "⡄", "⠆"],
   intervalMs: 100,
+  cellWidth: 1,
 };
 
-/** Cell fills from a single dot to all 8, holds, then deflates back. */
+/**
+ * Center-outward bloom: middle cells fill first (rows 1-2), then corner cells
+ * (rows 0 and 3); on exit, corners drain first and the middle dots collapse
+ * back to the center. Fully time-symmetric (exhale = inhale reversed).
+ */
 const BREATHE: BrailleAnimation = {
   frames: [
     "⠀",
     "⠂",
-    "⠌",
-    "⡑",
-    "⢕",
-    "⢝",
-    "⣫",
-    "⣟",
+    "⠢",
+    "⠲",
+    "⠶",
+    "⠷",
+    "⢷",
+    "⢿",
     "⣿",
-    "⣟",
-    "⣫",
-    "⢝",
-    "⢕",
-    "⡑",
-    "⠌",
+    "⢿",
+    "⢷",
+    "⠷",
+    "⠶",
+    "⠲",
+    "⠢",
     "⠂",
     "⠀",
   ],
   intervalMs: 100,
+  cellWidth: 1,
+};
+
+/**
+ * 4-cell tail traversing a continuous 60-cell loop through a 4x4 grid:
+ *   phase 1 - row zigzag down
+ *   phase 2 - column zigzag up
+ *   phase 3 - row zigzag up (inverted phase 1)
+ *   phase 4 - column zigzag down (inverted phase 2)
+ * End connects back to start via an adjacent step — no jumps.
+ */
+const SNAKE: BrailleAnimation = {
+  frames: [
+    "⡇⠀",
+    "⠏⠀",
+    "⠋⠁",
+    "⠉⠉",
+    "⠈⠙",
+    "⠀⠛",
+    "⠐⠚",
+    "⠒⠒",
+    "⠖⠂",
+    "⠶⠀",
+    "⠦⠄",
+    "⠤⠤",
+    "⠠⢤",
+    "⠀⣤",
+    "⢀⣠",
+    "⣀⣀",
+    "⣄⡀",
+    "⣆⠀",
+    "⡇⠀",
+    "⠏⠀",
+    "⠛⠀",
+    "⠹⠀",
+    "⢸⠀",
+    "⢰⡀",
+    "⢠⡄",
+    "⢀⡆",
+    "⠀⡇",
+    "⠀⠏",
+    "⠀⠛",
+    "⠀⠹",
+    "⠀⢸",
+    "⠀⣰",
+    "⢀⣠",
+    "⣀⣀",
+    "⣄⡀",
+    "⣤⠀",
+    "⡤⠄",
+    "⠤⠤",
+    "⠠⠴",
+    "⠀⠶",
+    "⠐⠲",
+    "⠒⠒",
+    "⠓⠂",
+    "⠛⠀",
+    "⠋⠁",
+    "⠉⠉",
+    "⠈⠙",
+    "⠀⠹",
+    "⠀⢸",
+    "⠀⣰",
+    "⠀⣤",
+    "⠀⣆",
+    "⠀⡇",
+    "⠈⠇",
+    "⠘⠃",
+    "⠸⠁",
+    "⢸⠀",
+    "⣰⠀",
+    "⣤⠀",
+    "⣆⠀",
+  ],
+  intervalMs: 80,
+  cellWidth: 2,
+};
+
+/** Concentric rings expanding outward from the center of a 6x4 grid. */
+const PULSE: BrailleAnimation = {
+  frames: ["⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈"],
+  intervalMs: 180,
+  cellWidth: 3,
+};
+
+/**
+ * "Grains" falling and piling into a single braille cell. Sourced from
+ * `cli-spinners.sand` (not the procedural unicode-animations registry).
+ */
+const SAND: BrailleAnimation = {
+  frames: [
+    "⠁",
+    "⠂",
+    "⠄",
+    "⡀",
+    "⡈",
+    "⡐",
+    "⡠",
+    "⣀",
+    "⣁",
+    "⣂",
+    "⣄",
+    "⣌",
+    "⣔",
+    "⣤",
+    "⣥",
+    "⣦",
+    "⣮",
+    "⣶",
+    "⣷",
+    "⣿",
+    "⡿",
+    "⠿",
+    "⢟",
+    "⠟",
+    "⡛",
+    "⠛",
+    "⠫",
+    "⢋",
+    "⠋",
+    "⠍",
+    "⡉",
+    "⠉",
+    "⠑",
+    "⠡",
+    "⢁",
+  ],
+  intervalMs: 80,
+  cellWidth: 1,
+};
+
+/**
+ * Long looping "wagon wheel" cycle from cli-spinners.dots12.
+ * 56 frames distributed across two adjacent braille cells.
+ */
+const DOTS12: BrailleAnimation = {
+  frames: [
+    "⢀⠀",
+    "⡀⠀",
+    "⠄⠀",
+    "⢂⠀",
+    "⡂⠀",
+    "⠅⠀",
+    "⢃⠀",
+    "⡃⠀",
+    "⠍⠀",
+    "⢋⠀",
+    "⡋⠀",
+    "⠍⠁",
+    "⢋⠁",
+    "⡋⠁",
+    "⠍⠉",
+    "⠋⠉",
+    "⠋⠉",
+    "⠉⠙",
+    "⠉⠙",
+    "⠉⠩",
+    "⠈⢙",
+    "⠈⡙",
+    "⢈⠩",
+    "⡀⢙",
+    "⠄⡙",
+    "⢂⠩",
+    "⡂⢘",
+    "⠅⡘",
+    "⢃⠨",
+    "⡃⢐",
+    "⠍⡐",
+    "⢋⠠",
+    "⡋⢀",
+    "⠍⡁",
+    "⢋⠁",
+    "⡋⠁",
+    "⠍⠉",
+    "⠋⠉",
+    "⠋⠉",
+    "⠉⠙",
+    "⠉⠙",
+    "⠉⠩",
+    "⠈⢙",
+    "⠈⡙",
+    "⠈⠩",
+    "⠀⢙",
+    "⠀⡙",
+    "⠀⠩",
+    "⠀⢘",
+    "⠀⡘",
+    "⠀⠨",
+    "⠀⢐",
+    "⠀⡐",
+    "⠀⠠",
+    "⠀⢀",
+    "⠀⡀",
+  ],
+  intervalMs: 80,
+  cellWidth: 2,
+};
+
+/** Diagonal wipe across a 4x4 grid that fills and unfills. */
+const DIAGSWIPE: BrailleAnimation = {
+  frames: [
+    "⠁⠀",
+    "⠋⠀",
+    "⠟⠁",
+    "⡿⠋",
+    "⣿⠟",
+    "⣿⡿",
+    "⣿⣿",
+    "⣿⣿",
+    "⣾⣿",
+    "⣴⣿",
+    "⣠⣾",
+    "⢀⣴",
+    "⠀⣠",
+    "⠀⢀",
+    "⠀⠀",
+    "⠀⠀",
+  ],
+  intervalMs: 60,
+  cellWidth: 2,
+};
+
+/**
+ * Two-dot-wide diagonal stripes flowing continuously downward-right.
+ * Pattern: `floor((r + c + offset) / 2) % 2 === 0`. Period of 4 — each
+ * frame shifts the pattern by one dot along the (1,1) diagonal.
+ */
+const CHECKERBOARD: BrailleAnimation = {
+  frames: ["⢋⡴⢋", "⣡⠞⣡", "⡴⢋⡴", "⠞⣡⠞"],
+  intervalMs: 80,
+  cellWidth: 3,
+};
+
+/**
+ * Sine-wave bars traveling continuously across a 6x4 grid. Each column is a
+ * histogram bar whose height oscillates with a sine wave; columns are phase-
+ * shifted by a half-period each, so a wave appears to travel left-to-right
+ * with no reset/empty frame in the cycle.
+ */
+const COLUMNS: BrailleAnimation = {
+  frames: [
+    "⣄⢀⣴",
+    "⣆⠀⣰",
+    "⣦⡀⣠",
+    "⣷⡀⢀",
+    "⣷⣄⢀",
+    "⣿⣆⠀",
+    "⣾⣦⡀",
+    "⣾⣷⡀",
+    "⣴⣷⣄",
+    "⣰⣿⣆",
+    "⣠⣾⣦",
+    "⢀⣾⣷",
+    "⢀⣴⣷",
+    "⠀⣰⣿",
+    "⡀⣠⣾",
+    "⡀⢀⣾",
+  ],
+  intervalMs: 100,
+  cellWidth: 3,
+};
+
+/** Sine wave traveling across an 8x4 grid, with sparkle scatter. */
+const WAVEROWS: BrailleAnimation = {
+  frames: [
+    "⠖⠉⠉⠑",
+    "⡠⠖⠉⠉",
+    "⣠⡠⠖⠉",
+    "⣄⣠⡠⠖",
+    "⠢⣄⣠⡠",
+    "⠙⠢⣄⣠",
+    "⠉⠙⠢⣄",
+    "⠊⠉⠙⠢",
+    "⠜⠊⠉⠙",
+    "⡤⠜⠊⠉",
+    "⣀⡤⠜⠊",
+    "⢤⣀⡤⠜",
+    "⠣⢤⣀⡤",
+    "⠑⠣⢤⣀",
+    "⠉⠑⠣⢤",
+    "⠋⠉⠑⠣",
+  ],
+  intervalMs: 90,
+  cellWidth: 4,
+};
+
+/** Falling-drop pattern across 4 cells; cycles every 6 frames. */
+const RAIN: BrailleAnimation = {
+  frames: [
+    "⢁⠂⠔⠈",
+    "⠂⠌⡠⠐",
+    "⠄⡐⢀⠡",
+    "⡈⠠⠀⢂",
+    "⠐⢀⠁⠄",
+    "⠠⠁⠊⡀",
+    "⢁⠂⠔⠈",
+    "⠂⠌⡠⠐",
+    "⠄⡐⢀⠡",
+    "⡈⠠⠀⢂",
+    "⠐⢀⠁⠄",
+    "⠠⠁⠊⡀",
+  ],
+  intervalMs: 100,
+  cellWidth: 4,
+};
+
+/** Two interleaved sine helices crossing the grid. */
+const HELIX: BrailleAnimation = {
+  frames: [
+    "⢌⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+  ],
+  intervalMs: 80,
+  cellWidth: 4,
+};
+
+/** Diagonal sweep across an 8x4 grid. */
+const CASCADE: BrailleAnimation = {
+  frames: [
+    "⠀⠀⠀⠀",
+    "⠀⠀⠀⠀",
+    "⠁⠀⠀⠀",
+    "⠋⠀⠀⠀",
+    "⠞⠁⠀⠀",
+    "⡴⠋⠀⠀",
+    "⣠⠞⠁⠀",
+    "⢀⡴⠋⠀",
+    "⠀⣠⠞⠁",
+    "⠀⢀⡴⠋",
+    "⠀⠀⣠⠞",
+    "⠀⠀⢀⡴",
+    "⠀⠀⠀⣠",
+    "⠀⠀⠀⢀",
+  ],
+  intervalMs: 60,
+  cellWidth: 4,
 };
 
 export const BRAILLE_ANIMATIONS = {
   orbit: ORBIT,
   breathe: BREATHE,
+  sand: SAND,
+  snake: SNAKE,
+  dots12: DOTS12,
+  diagswipe: DIAGSWIPE,
+  pulse: PULSE,
+  checkerboard: CHECKERBOARD,
+  columns: COLUMNS,
+  cascade: CASCADE,
+  waverows: WAVEROWS,
+  rain: RAIN,
+  helix: HELIX,
 } as const satisfies Readonly<Record<string, BrailleAnimation>>;
 
 export type BrailleAnimationKey = keyof typeof BRAILLE_ANIMATIONS;
 
 /**
- * Pool that {@link StreamingStatusSpinner} picks from at random on mount.
- * Order is irrelevant — picks are uniform across this list.
+ * Unconstrained random pool used when no tier is specified. Keep this
+ * list to 1-cell-wide animations so the spinner is a true drop-in.
  */
 export const STREAMING_STATUS_ANIMATION_KEYS: readonly BrailleAnimationKey[] = [
   "orbit",
   "breathe",
+  "sand",
 ];
+
+/**
+ * Tier 0 — 0–25% context used. Width 1.
+ * Tier 1 — 25–50%. Width 2.
+ * Tier 2 — 50–75%. Width 3.
+ * Tier 3 — 75–100%. Width 4.
+ *
+ * Each tier is a pool; the spinner picks one entry at random when the
+ * tier becomes active and holds that choice until the tier changes.
+ */
+export const CONTEXT_TIER_ANIMATIONS: readonly (readonly BrailleAnimationKey[])[] =
+  [
+    ["orbit", "breathe", "sand"],
+    ["snake", "dots12", "diagswipe"],
+    ["pulse", "checkerboard", "columns"],
+    ["cascade", "waverows", "rain", "helix"],
+  ];
+
+export const CONTEXT_TIER_COUNT = CONTEXT_TIER_ANIMATIONS.length;
+
+/**
+ * Map a context-usage ratio (0..1) to a tier index in
+ * {@link CONTEXT_TIER_ANIMATIONS}. Anything outside [0, 1] clamps.
+ */
+export function contextTierFromRatio(ratio: number): number {
+  if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+  if (ratio >= 0.75) return 3;
+  if (ratio >= 0.5) return 2;
+  if (ratio >= 0.25) return 1;
+  return 0;
+}
+
+/**
+ * Cell width reserved for the spinner at a given tier. The consumer
+ * uses this to size its layout slot so animations render without
+ * truncation.
+ */
+export function spinnerWidthForTier(tier: number): number {
+  const clamped = Math.max(0, Math.min(CONTEXT_TIER_COUNT - 1, tier));
+  const pool = CONTEXT_TIER_ANIMATIONS[clamped];
+  const firstKey = pool?.[0];
+  if (!firstKey) return 1;
+  return BRAILLE_ANIMATIONS[firstKey].cellWidth;
+}

--- a/src/cli/components/spinners/animations.ts
+++ b/src/cli/components/spinners/animations.ts
@@ -1,0 +1,64 @@
+/**
+ * Braille spinner animations available to {@link StreamingStatusSpinner}.
+ *
+ * Frames are pre-computed from the procedural generators in
+ * `gunnargray-dev/unicode-animations`. Each entry below renders as a
+ * single braille character (1 terminal cell) so animations can be swapped
+ * without disturbing surrounding layout — keep new entries to a 2x4 dot
+ * grid (W=2 in the upstream generator) for the same width guarantee.
+ *
+ * To add a new animation:
+ *   1. Define a {@link BrailleAnimation} entry below.
+ *   2. Append its key to {@link STREAMING_STATUS_ANIMATION_KEYS}.
+ */
+
+export type BrailleAnimation = {
+  readonly frames: readonly string[];
+  readonly intervalMs: number;
+};
+
+/** 2-dot "comet" rotating clockwise around a 2x4 ring. */
+const ORBIT: BrailleAnimation = {
+  frames: ["⠃", "⠉", "⠘", "⠰", "⢠", "⣀", "⡄", "⠆"],
+  intervalMs: 100,
+};
+
+/** Cell fills from a single dot to all 8, holds, then deflates back. */
+const BREATHE: BrailleAnimation = {
+  frames: [
+    "⠀",
+    "⠂",
+    "⠌",
+    "⡑",
+    "⢕",
+    "⢝",
+    "⣫",
+    "⣟",
+    "⣿",
+    "⣟",
+    "⣫",
+    "⢝",
+    "⢕",
+    "⡑",
+    "⠌",
+    "⠂",
+    "⠀",
+  ],
+  intervalMs: 100,
+};
+
+export const BRAILLE_ANIMATIONS = {
+  orbit: ORBIT,
+  breathe: BREATHE,
+} as const satisfies Readonly<Record<string, BrailleAnimation>>;
+
+export type BrailleAnimationKey = keyof typeof BRAILLE_ANIMATIONS;
+
+/**
+ * Pool that {@link StreamingStatusSpinner} picks from at random on mount.
+ * Order is irrelevant — picks are uniform across this list.
+ */
+export const STREAMING_STATUS_ANIMATION_KEYS: readonly BrailleAnimationKey[] = [
+  "orbit",
+  "breathe",
+];

--- a/src/cli/components/spinners/use-frame-cycle.ts
+++ b/src/cli/components/spinners/use-frame-cycle.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Cycle through a frame array on a fixed interval.
+ *
+ * Returns the index of the active frame, or 0 when `enabled` is false.
+ * The caller resolves `enabled` from its own animation gate so the hook
+ * stays free of context dependencies.
+ */
+export function useFrameCycle(
+  frames: readonly string[],
+  intervalMs: number,
+  enabled: boolean,
+): number {
+  const [frameIndex, setFrameIndex] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || frames.length === 0) return;
+
+    const timer = setInterval(() => {
+      setFrameIndex((v) => (v + 1) % frames.length);
+    }, intervalMs);
+
+    return () => clearInterval(timer);
+  }, [enabled, frames, intervalMs]);
+
+  return enabled ? frameIndex : 0;
+}

--- a/src/cli/components/spinners/use-frame-cycle.ts
+++ b/src/cli/components/spinners/use-frame-cycle.ts
@@ -15,6 +15,7 @@ export function useFrameCycle(
   const [frameIndex, setFrameIndex] = useState(0);
 
   useEffect(() => {
+    setFrameIndex(0);
     if (!enabled || frames.length === 0) return;
 
     const timer = setInterval(() => {


### PR DESCRIPTION
## Summary

- Replaces `<Spinner type="layer" />` (from `ink-spinner`) at the streaming-status row in `InputRich` with a new `StreamingStatusSpinner` that picks one braille animation at random from a small pool on mount.
- Initial pool: `orbit` and `breathe` — frames pre-computed from [gunnargray-dev/unicode-animations](https://github.com/gunnargray-dev/unicode-animations) and inlined (no new dependency).
- Adding another animation later is a single entry in `BRAILLE_ANIMATIONS` plus one key in `STREAMING_STATUS_ANIMATION_KEYS`.
- Extracts the shared frame-cycling logic into a `useFrameCycle` hook so the new spinner and the existing `BlinkingSpinner` share one implementation. `BlinkingSpinner` keeps its unique pulse layer and continues to power the footer's background-subagents indicator unchanged.
- `ink-spinner` stays in `package.json` — `ListenerStatusUI` still uses it for its dots spinner; only the streaming-status site moves off it.

## Files

- `src/cli/components/spinners/animations.ts` — frame data registry (orbit, breathe).
- `src/cli/components/spinners/use-frame-cycle.ts` — shared frame-rotation hook.
- `src/cli/components/spinners/StreamingStatusSpinner.tsx` — random-pick consumer.
- `src/cli/components/BlinkingSpinner.tsx` — refactored to use `useFrameCycle`. Behavior unchanged.
- `src/cli/components/InputRich.tsx` — drops `SpinnerLib`/`ComponentType` imports and the local `Spinner` alias; uses `StreamingStatusSpinner` at the one consumer site.

## Why this design

The orbit/breathe shapes exist as procedural generators upstream, but their outputs are deterministic single-character braille strings — so the right thing to ship is the precomputed 8/17-frame arrays, not the generator. The pool gates by braille-glyph width (each entry must render in 1 terminal cell) so the existing `<Box width={2}>` layout slot stays correct.

`BlinkingSpinner`'s pulse + dim/bright cycle is intentionally not generalized; it's the *footer* indicator's distinguishing feature ("background work alive, not urgent"), and keeping the streaming-status spinner pulse-free preserves the visual hierarchy of "two spinners on screen with different rhythms."

## Test plan

- [ ] Run `bun dev` and start a streaming response — verify the spinner to the left of the agent name rotates a single braille glyph (not the previous `-`, `=`, `≡` cycle).
- [ ] Run multiple streams in one session — confirm the choice between `orbit` and `breathe` varies (random pick per mount).
- [ ] Toggle the animation context off and confirm the spinner freezes on its first frame.
- [ ] Confirm the footer's background-subagents indicator (`BlinkingSpinner` site) still pulses dim/bright with the dots glyph cycling — unchanged behavior.
- [ ] Confirm `ListenerStatusUI` (status bar dots spinner via `ink-spinner`) still works.