### PR TITLE
feat(cli): drive streaming spinner width from context usage tier

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -874,6 +874,11 @@ export function App({
   // Live, approximate token counter (resets each turn)
   const [tokenCount, setTokenCount] = useState(0);
 
+  // Live total context tokens (history + system + output). Mirrors
+  // `contextTrackerRef.current.lastContextTokens` into reactive state so
+  // UI can react during streaming — the ref itself doesn't trigger renders.
+  const [usedContextTokens, setUsedContextTokens] = useState(0);
+
   // Trajectory token/time bases (accumulated across runs)
   const [trajectoryTokenBase, setTrajectoryTokenBase] = useState(0);
   const [trajectoryElapsedBaseMs, setTrajectoryElapsedBaseMs] = useState(0);
@@ -2252,6 +2257,7 @@ export function App({
   const refreshDerived = useCallback(() => {
     const b = buffersRef.current;
     setTokenCount(b.tokenCount);
+    setUsedContextTokens(contextTrackerRef.current.lastContextTokens);
     const newLines = toLines(b);
     setLines(newLines);
     commitEligibleLines(b);
@@ -4588,6 +4594,8 @@ export function App({
       stubDescriptions={stubDescriptions}
       thinkingMessage={thinkingMessage}
       trajectoryTokenDisplay={trajectoryTokenDisplay}
+      usedContextTokens={usedContextTokens}
+      contextWindowSize={effectiveContextWindowSize}
       uiPermissionMode={uiPermissionMode}
       uiRalphActive={uiRalphActive}
       updateAgentName={updateAgentName}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -305,6 +305,8 @@ type AppViewProps = {
   stubDescriptions: Map<string, string>;
   thinkingMessage: string;
   trajectoryTokenDisplay: number;
+  usedContextTokens: number;
+  contextWindowSize: number | null | undefined;
   uiPermissionMode: PermissionMode;
   uiRalphActive: boolean;
   updateAgentName: (name: string) => void;
@@ -443,6 +445,8 @@ export function AppView(props: AppViewProps) {
     stubDescriptions,
     thinkingMessage,
     trajectoryTokenDisplay,
+    usedContextTokens,
+    contextWindowSize,
     uiPermissionMode,
     uiRalphActive,
     updateAgentName,
@@ -700,6 +704,8 @@ export function AppView(props: AppViewProps) {
                 visible={inputVisible}
                 streaming={streaming}
                 tokenCount={trajectoryTokenDisplay}
+                usedContextTokens={usedContextTokens}
+                contextWindowSize={contextWindowSize}
                 elapsedBaseMs={liveTrajectoryElapsedBaseMs}
                 thinkingMessage={thinkingMessage}
                 includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -781,6 +781,19 @@ const StreamingStatus = memo(function StreamingStatus({
   const contextTier = contextTierFromRatio(contextRatio);
   const spinnerColumnWidth = spinnerWidthForTier(contextTier) + 1;
 
+  // Bump a counter on each false→true streaming edge so the spinner
+  // remounts (via key={}) and re-picks from its tier pool. Without this
+  // the useState initializer can persist a pick across messages when
+  // the JSX shape and tier value are unchanged between streams.
+  const [streamSeed, setStreamSeed] = useState(0);
+  const prevStreamingRef = useRef(false);
+  useEffect(() => {
+    if (streaming && !prevStreamingRef.current) {
+      setStreamSeed((s) => s + 1);
+    }
+    prevStreamingRef.current = streaming;
+  }, [streaming]);
+
   const [shimmerOffset, setShimmerOffset] = useState(-3);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [tipMessage, setTipMessage] = useState("");
@@ -933,7 +946,7 @@ const StreamingStatus = memo(function StreamingStatus({
         <Box width={spinnerColumnWidth} flexShrink={0}>
           <Text color={colors.status.processing}>
             {animate ? (
-              <StreamingStatusSpinner tier={contextTier} />
+              <StreamingStatusSpinner key={streamSeed} tier={contextTier} />
             ) : (
               CLI_GLYPHS.bullet
             )}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -946,7 +946,10 @@ const StreamingStatus = memo(function StreamingStatus({
         <Box width={spinnerColumnWidth} flexShrink={0}>
           <Text color={colors.status.processing}>
             {animate ? (
-              <StreamingStatusSpinner key={streamSeed} tier={contextTier} />
+              <StreamingStatusSpinner
+                tier={contextTier}
+                streamSeed={streamSeed}
+              />
             ) : (
               CLI_GLYPHS.bullet
             )}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -44,6 +44,10 @@ import { InputAssist } from "./InputAssist";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { QueuedMessages } from "./QueuedMessages";
 import { ShimmerText } from "./ShimmerText";
+import {
+  contextTierFromRatio,
+  spinnerWidthForTier,
+} from "./spinners/animations.js";
 import { StreamingStatusSpinner } from "./spinners/StreamingStatusSpinner.js";
 import { Text } from "./Text";
 
@@ -711,6 +715,8 @@ const StreamingStatus = memo(function StreamingStatus({
   streaming,
   visible,
   tokenCount,
+  usedContextTokens,
+  contextWindowSize,
   elapsedBaseMs,
   thinkingMessage,
   includeSystemPromptUpgradeTip,
@@ -723,6 +729,8 @@ const StreamingStatus = memo(function StreamingStatus({
   streaming: boolean;
   visible: boolean;
   tokenCount: number;
+  usedContextTokens: number;
+  contextWindowSize: number | null | undefined;
   elapsedBaseMs: number;
   thinkingMessage: string;
   includeSystemPromptUpgradeTip: boolean;
@@ -763,6 +771,15 @@ const StreamingStatus = memo(function StreamingStatus({
   }, []);
 
   const animate = shouldAnimate && !isResizing;
+
+  // Context-usage tier drives both the spinner animation and its column
+  // width — wider as the conversation fills up.
+  const contextRatio =
+    contextWindowSize && contextWindowSize > 0
+      ? usedContextTokens / contextWindowSize
+      : 0;
+  const contextTier = contextTierFromRatio(contextRatio);
+  const spinnerColumnWidth = spinnerWidthForTier(contextTier) + 1;
 
   const [shimmerOffset, setShimmerOffset] = useState(-3);
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -842,7 +859,10 @@ const StreamingStatus = memo(function StreamingStatus({
   // Avoid painting into the terminal's last column; some terminals will soft-wrap
   // padded Ink rows at the edge which breaks Ink's line-clearing accounting and
   // leaves duplicate status rows behind during streaming/resizes.
-  const statusContentWidth = Math.max(0, terminalWidth - 3);
+  const statusContentWidth = Math.max(
+    0,
+    terminalWidth - 1 - spinnerColumnWidth,
+  );
   const minMessageWidth = 12;
   const statusHintParts = useMemo(() => {
     const parts: string[] = [];
@@ -910,9 +930,13 @@ const StreamingStatus = memo(function StreamingStatus({
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row">
-        <Box width={2} flexShrink={0}>
+        <Box width={spinnerColumnWidth} flexShrink={0}>
           <Text color={colors.status.processing}>
-            {animate ? <StreamingStatusSpinner /> : CLI_GLYPHS.bullet}
+            {animate ? (
+              <StreamingStatusSpinner tier={contextTier} />
+            ) : (
+              CLI_GLYPHS.bullet
+            )}
           </Text>
         </Box>
         <Box width={statusContentWidth} flexShrink={0} flexDirection="row">
@@ -933,7 +957,7 @@ const StreamingStatus = memo(function StreamingStatus({
         </Box>
       </Box>
       <Box flexDirection="row">
-        <Box width={2} flexShrink={0} />
+        <Box width={spinnerColumnWidth} flexShrink={0} />
         <Box width={statusContentWidth} flexShrink={0}>
           <Text color={colors.subagent.hint} wrap="truncate-end">
             {tipLineText}
@@ -956,6 +980,8 @@ export function Input({
   visible = true,
   streaming,
   tokenCount,
+  usedContextTokens = 0,
+  contextWindowSize,
   elapsedBaseMs = 0,
   thinkingMessage,
   includeSystemPromptUpgradeTip = true,
@@ -1004,6 +1030,8 @@ export function Input({
   visible?: boolean;
   streaming: boolean;
   tokenCount: number;
+  usedContextTokens?: number;
+  contextWindowSize?: number | null;
   elapsedBaseMs?: number;
   thinkingMessage: string;
   includeSystemPromptUpgradeTip?: boolean;
@@ -2028,6 +2056,8 @@ export function Input({
         streaming={streaming}
         visible={visible}
         tokenCount={tokenCount}
+        usedContextTokens={usedContextTokens}
+        contextWindowSize={contextWindowSize}
         elapsedBaseMs={elapsedBaseMs}
         thinkingMessage={thinkingMessage}
         includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}

--- a/src/cli/components/spinners/StreamingStatusSpinner.tsx
+++ b/src/cli/components/spinners/StreamingStatusSpinner.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import stringWidth from "string-width";
 import { colors } from "@/cli/components/colors.js";
 import { Text } from "@/cli/components/Text";
@@ -6,6 +6,7 @@ import { useAnimation } from "@/cli/contexts/AnimationContext.js";
 import {
   BRAILLE_ANIMATIONS,
   type BrailleAnimationKey,
+  CONTEXT_TIER_ANIMATIONS,
   STREAMING_STATUS_ANIMATION_KEYS,
 } from "./animations.js";
 import { useFrameCycle } from "./use-frame-cycle.js";
@@ -13,44 +14,83 @@ import { useFrameCycle } from "./use-frame-cycle.js";
 interface StreamingStatusSpinnerProps {
   color?: string;
   /**
-   * Override the randomly-picked animation. Primarily for tests; leave
-   * unset in production so streams get a random pick on mount.
+   * Explicit animation override. Wins over `tier`. Used by tests and for
+   * temporary local hardcodes.
    */
   animation?: BrailleAnimationKey;
+  /**
+   * Context-usage tier (0–3). When set, the spinner picks one animation
+   * at random from `CONTEXT_TIER_ANIMATIONS[tier]` and re-picks on tier
+   * change. Ignored if `animation` is provided.
+   */
+  tier?: number;
   /** Target cell width; the frame is centered and space-padded. */
   width?: number;
   marginRight?: number;
 }
 
-function pickRandomAnimationKey(): BrailleAnimationKey {
-  const pool = STREAMING_STATUS_ANIMATION_KEYS;
+function pickFromPool(
+  pool: readonly BrailleAnimationKey[],
+): BrailleAnimationKey {
+  if (pool.length === 0) return "orbit";
   const idx = Math.floor(Math.random() * pool.length);
   return pool[idx] ?? pool[0] ?? "orbit";
+}
+
+function resolveInitialKey(
+  animation: BrailleAnimationKey | undefined,
+  tier: number | undefined,
+): BrailleAnimationKey {
+  if (animation) return animation;
+  if (tier !== undefined) {
+    const clamped = Math.max(
+      0,
+      Math.min(CONTEXT_TIER_ANIMATIONS.length - 1, tier),
+    );
+    return pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? []);
+  }
+  return pickFromPool(STREAMING_STATUS_ANIMATION_KEYS);
 }
 
 /**
  * Spinner for the streaming-status row of the chat input.
  *
- * On mount, picks one animation at random from
- * {@link STREAMING_STATUS_ANIMATION_KEYS} and cycles its frames via
- * {@link useFrameCycle}. Honors the global `AnimationContext` — when
- * animations are disabled, the first frame is held static.
+ * Selection priority:
+ *   1. `animation` prop (explicit override)
+ *   2. `tier` prop — random pick from the tier's pool, re-picked when
+ *      the tier changes (so a single stream can grow as context fills)
+ *   3. Random from the unconstrained 1-cell pool on mount
  *
- * Replaces the previous `<Spinner type="layer" />` from `ink-spinner`
- * at the streaming-status site; that dependency is retained for other
- * call sites (e.g. `ListenerStatusUI`).
+ * Honors the global `AnimationContext` — when animations are disabled,
+ * the first frame is held static.
  */
 export const StreamingStatusSpinner = memo(
   ({
     color = colors.status.processing,
     animation,
+    tier,
     width = 1,
     marginRight = 0,
   }: StreamingStatusSpinnerProps) => {
     const { shouldAnimate } = useAnimation();
-    const [animationKey] = useState<BrailleAnimationKey>(
-      () => animation ?? pickRandomAnimationKey(),
+    const [animationKey, setAnimationKey] = useState<BrailleAnimationKey>(() =>
+      resolveInitialKey(animation, tier),
     );
+
+    useEffect(() => {
+      if (animation) {
+        setAnimationKey(animation);
+        return;
+      }
+      if (tier !== undefined) {
+        const clamped = Math.max(
+          0,
+          Math.min(CONTEXT_TIER_ANIMATIONS.length - 1, tier),
+        );
+        setAnimationKey(pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? []));
+      }
+    }, [animation, tier]);
+
     const { frames, intervalMs } = BRAILLE_ANIMATIONS[animationKey];
 
     const frameIndex = useFrameCycle(frames, intervalMs, shouldAnimate);

--- a/src/cli/components/spinners/StreamingStatusSpinner.tsx
+++ b/src/cli/components/spinners/StreamingStatusSpinner.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from "react";
+import { memo } from "react";
 import stringWidth from "string-width";
 import { colors } from "@/cli/components/colors.js";
 import { Text } from "@/cli/components/Text";
@@ -14,16 +14,23 @@ import { useFrameCycle } from "./use-frame-cycle.js";
 interface StreamingStatusSpinnerProps {
   color?: string;
   /**
-   * Explicit animation override. Wins over `tier`. Used by tests and for
+   * Explicit animation override. Wins over `tier`. Used by tests and
    * temporary local hardcodes.
    */
   animation?: BrailleAnimationKey;
   /**
    * Context-usage tier (0–3). When set, the spinner picks one animation
-   * at random from `CONTEXT_TIER_ANIMATIONS[tier]` and re-picks on tier
-   * change. Ignored if `animation` is provided.
+   * from `CONTEXT_TIER_ANIMATIONS[tier]`. Ignored if `animation` is
+   * provided.
    */
   tier?: number;
+  /**
+   * Monotonically increasing integer that selects which animation in
+   * the pool. The parent bumps it on each new stream so consecutive
+   * streams rotate through the pool deterministically (round-robin).
+   * Stable within a stream → stable animation within a stream.
+   */
+  streamSeed?: number;
   /** Target cell width; the frame is centered and space-padded. */
   width?: number;
   marginRight?: number;
@@ -31,15 +38,17 @@ interface StreamingStatusSpinnerProps {
 
 function pickFromPool(
   pool: readonly BrailleAnimationKey[],
+  seed: number,
 ): BrailleAnimationKey {
   if (pool.length === 0) return "orbit";
-  const idx = Math.floor(Math.random() * pool.length);
+  const idx = ((seed % pool.length) + pool.length) % pool.length;
   return pool[idx] ?? pool[0] ?? "orbit";
 }
 
-function resolveInitialKey(
+function resolveAnimationKey(
   animation: BrailleAnimationKey | undefined,
   tier: number | undefined,
+  seed: number,
 ): BrailleAnimationKey {
   if (animation) return animation;
   if (tier !== undefined) {
@@ -47,9 +56,9 @@ function resolveInitialKey(
       0,
       Math.min(CONTEXT_TIER_ANIMATIONS.length - 1, tier),
     );
-    return pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? []);
+    return pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? [], seed);
   }
-  return pickFromPool(STREAMING_STATUS_ANIMATION_KEYS);
+  return pickFromPool(STREAMING_STATUS_ANIMATION_KEYS, seed);
 }
 
 /**
@@ -57,9 +66,11 @@ function resolveInitialKey(
  *
  * Selection priority:
  *   1. `animation` prop (explicit override)
- *   2. `tier` prop — random pick from the tier's pool, re-picked when
- *      the tier changes (so a single stream can grow as context fills)
- *   3. Random from the unconstrained 1-cell pool on mount
+ *   2. `tier` + `streamSeed` — `pool[streamSeed % pool.length]`. The
+ *      parent increments `streamSeed` on each new stream so consecutive
+ *      streams rotate through the tier's pool; mid-stream tier crossings
+ *      pick from the new tier's pool at the same seed.
+ *   3. Random-ish from the unconstrained 1-cell pool using the seed.
  *
  * Honors the global `AnimationContext` — when animations are disabled,
  * the first frame is held static.
@@ -69,28 +80,12 @@ export const StreamingStatusSpinner = memo(
     color = colors.status.processing,
     animation,
     tier,
+    streamSeed = 0,
     width = 1,
     marginRight = 0,
   }: StreamingStatusSpinnerProps) => {
     const { shouldAnimate } = useAnimation();
-    const [animationKey, setAnimationKey] = useState<BrailleAnimationKey>(() =>
-      resolveInitialKey(animation, tier),
-    );
-
-    useEffect(() => {
-      if (animation) {
-        setAnimationKey(animation);
-        return;
-      }
-      if (tier !== undefined) {
-        const clamped = Math.max(
-          0,
-          Math.min(CONTEXT_TIER_ANIMATIONS.length - 1, tier),
-        );
-        setAnimationKey(pickFromPool(CONTEXT_TIER_ANIMATIONS[clamped] ?? []));
-      }
-    }, [animation, tier]);
-
+    const animationKey = resolveAnimationKey(animation, tier, streamSeed);
     const { frames, intervalMs } = BRAILLE_ANIMATIONS[animationKey];
 
     const frameIndex = useFrameCycle(frames, intervalMs, shouldAnimate);

--- a/src/cli/components/spinners/animations.ts
+++ b/src/cli/components/spinners/animations.ts
@@ -2,25 +2,29 @@
  * Braille spinner animations available to {@link StreamingStatusSpinner}.
  *
  * Frames are pre-computed from the procedural generators in
- * `gunnargray-dev/unicode-animations`. Each entry below renders as a
- * single braille character (1 terminal cell) so animations can be swapped
- * without disturbing surrounding layout — keep new entries to a 2x4 dot
- * grid (W=2 in the upstream generator) for the same width guarantee.
+ * `gunnargray-dev/unicode-animations`. The `cellWidth` field is the
+ * number of terminal cells each frame occupies (2 dot-columns per cell);
+ * the consumer reads this to size its layout slot.
  *
  * To add a new animation:
  *   1. Define a {@link BrailleAnimation} entry below.
- *   2. Append its key to {@link STREAMING_STATUS_ANIMATION_KEYS}.
+ *   2. Add it to {@link BRAILLE_ANIMATIONS}.
+ *   3. Optionally include it in {@link STREAMING_STATUS_ANIMATION_KEYS}
+ *      (the unconstrained random pool) or in
+ *      {@link CONTEXT_TIER_ANIMATIONS} (the context-tier router).
  */
 
 export type BrailleAnimation = {
   readonly frames: readonly string[];
   readonly intervalMs: number;
+  readonly cellWidth: number;
 };
 
 /** 2-dot "comet" rotating clockwise around a 2x4 ring. */
 const ORBIT: BrailleAnimation = {
   frames: ["⠃", "⠉", "⠘", "⠰", "⢠", "⣀", "⡄", "⠆"],
   intervalMs: 100,
+  cellWidth: 1,
 };
 
 /** Cell fills from a single dot to all 8, holds, then deflates back. */
@@ -45,20 +49,116 @@ const BREATHE: BrailleAnimation = {
     "⠀",
   ],
   intervalMs: 100,
+  cellWidth: 1,
+};
+
+/** 4-cell tail traversing a serpentine path through a 4x4 grid. */
+const SNAKE: BrailleAnimation = {
+  frames: [
+    "⣁⡀",
+    "⣉⠀",
+    "⡉⠁",
+    "⠉⠉",
+    "⠈⠙",
+    "⠀⠛",
+    "⠐⠚",
+    "⠒⠒",
+    "⠖⠂",
+    "⠶⠀",
+    "⠦⠄",
+    "⠤⠤",
+    "⠠⢤",
+    "⠀⣤",
+    "⢀⣠",
+    "⣀⣀",
+  ],
+  intervalMs: 80,
+  cellWidth: 2,
+};
+
+/** Concentric rings expanding outward from the center of a 6x4 grid. */
+const PULSE: BrailleAnimation = {
+  frames: ["⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈"],
+  intervalMs: 180,
+  cellWidth: 3,
+};
+
+/** Diagonal sweep across an 8x4 grid. */
+const CASCADE: BrailleAnimation = {
+  frames: [
+    "⠀⠀⠀⠀",
+    "⠀⠀⠀⠀",
+    "⠁⠀⠀⠀",
+    "⠋⠀⠀⠀",
+    "⠞⠁⠀⠀",
+    "⡴⠋⠀⠀",
+    "⣠⠞⠁⠀",
+    "⢀⡴⠋⠀",
+    "⠀⣠⠞⠁",
+    "⠀⢀⡴⠋",
+    "⠀⠀⣠⠞",
+    "⠀⠀⢀⡴",
+    "⠀⠀⠀⣠",
+    "⠀⠀⠀⢀",
+  ],
+  intervalMs: 60,
+  cellWidth: 4,
 };
 
 export const BRAILLE_ANIMATIONS = {
   orbit: ORBIT,
   breathe: BREATHE,
+  snake: SNAKE,
+  pulse: PULSE,
+  cascade: CASCADE,
 } as const satisfies Readonly<Record<string, BrailleAnimation>>;
 
 export type BrailleAnimationKey = keyof typeof BRAILLE_ANIMATIONS;
 
 /**
- * Pool that {@link StreamingStatusSpinner} picks from at random on mount.
- * Order is irrelevant — picks are uniform across this list.
+ * Unconstrained random pool used when no tier is specified. Keep this
+ * list to 1-cell-wide animations so the spinner is a true drop-in.
  */
 export const STREAMING_STATUS_ANIMATION_KEYS: readonly BrailleAnimationKey[] = [
   "orbit",
   "breathe",
 ];
+
+/**
+ * Tier 0 — 0–25% context used. Width 1.
+ * Tier 1 — 25–50%. Width 2.
+ * Tier 2 — 50–75%. Width 3.
+ * Tier 3 — 75–100%. Width 4.
+ *
+ * Each tier is a pool; the spinner picks one entry at random when the
+ * tier becomes active and holds that choice until the tier changes.
+ */
+export const CONTEXT_TIER_ANIMATIONS: readonly (readonly BrailleAnimationKey[])[] =
+  [["orbit", "breathe"], ["snake"], ["pulse"], ["cascade"]];
+
+export const CONTEXT_TIER_COUNT = CONTEXT_TIER_ANIMATIONS.length;
+
+/**
+ * Map a context-usage ratio (0..1) to a tier index in
+ * {@link CONTEXT_TIER_ANIMATIONS}. Anything outside [0, 1] clamps.
+ */
+export function contextTierFromRatio(ratio: number): number {
+  if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+  if (ratio >= 0.75) return 3;
+  if (ratio >= 0.5) return 2;
+  if (ratio >= 0.25) return 1;
+  return 0;
+}
+
+/**
+ * Cell width reserved for the spinner at a given tier. The consumer
+ * uses this to size its layout slot so animations render without
+ * truncation.
+ */
+export function spinnerWidthForTier(tier: number): number {
+  const clamped = Math.max(0, Math.min(CONTEXT_TIER_COUNT - 1, tier));
+  const pool = CONTEXT_TIER_ANIMATIONS[clamped];
+  const firstKey = pool?.[0];
+  if (!firstKey) return 1;
+  return BRAILLE_ANIMATIONS[firstKey].cellWidth;
+}

--- a/src/cli/components/spinners/animations.ts
+++ b/src/cli/components/spinners/animations.ts
@@ -27,24 +27,28 @@ const ORBIT: BrailleAnimation = {
   cellWidth: 1,
 };
 
-/** Cell fills from a single dot to all 8, holds, then deflates back. */
+/**
+ * Center-outward bloom: middle cells fill first (rows 1-2), then corner cells
+ * (rows 0 and 3); on exit, corners drain first and the middle dots collapse
+ * back to the center. Fully time-symmetric (exhale = inhale reversed).
+ */
 const BREATHE: BrailleAnimation = {
   frames: [
     "⠀",
     "⠂",
-    "⠌",
-    "⡑",
-    "⢕",
-    "⢝",
-    "⣫",
-    "⣟",
+    "⠢",
+    "⠲",
+    "⠶",
+    "⠷",
+    "⢷",
+    "⢿",
     "⣿",
-    "⣟",
-    "⣫",
-    "⢝",
-    "⢕",
-    "⡑",
-    "⠌",
+    "⢿",
+    "⢷",
+    "⠷",
+    "⠶",
+    "⠲",
+    "⠢",
     "⠂",
     "⠀",
   ],
@@ -52,12 +56,19 @@ const BREATHE: BrailleAnimation = {
   cellWidth: 1,
 };
 
-/** 4-cell tail traversing a serpentine path through a 4x4 grid. */
+/**
+ * 4-cell tail traversing a continuous 60-cell loop through a 4x4 grid:
+ *   phase 1 - row zigzag down
+ *   phase 2 - column zigzag up
+ *   phase 3 - row zigzag up (inverted phase 1)
+ *   phase 4 - column zigzag down (inverted phase 2)
+ * End connects back to start via an adjacent step — no jumps.
+ */
 const SNAKE: BrailleAnimation = {
   frames: [
-    "⣁⡀",
-    "⣉⠀",
-    "⡉⠁",
+    "⡇⠀",
+    "⠏⠀",
+    "⠋⠁",
     "⠉⠉",
     "⠈⠙",
     "⠀⠛",
@@ -71,6 +82,50 @@ const SNAKE: BrailleAnimation = {
     "⠀⣤",
     "⢀⣠",
     "⣀⣀",
+    "⣄⡀",
+    "⣆⠀",
+    "⡇⠀",
+    "⠏⠀",
+    "⠛⠀",
+    "⠹⠀",
+    "⢸⠀",
+    "⢰⡀",
+    "⢠⡄",
+    "⢀⡆",
+    "⠀⡇",
+    "⠀⠏",
+    "⠀⠛",
+    "⠀⠹",
+    "⠀⢸",
+    "⠀⣰",
+    "⢀⣠",
+    "⣀⣀",
+    "⣄⡀",
+    "⣤⠀",
+    "⡤⠄",
+    "⠤⠤",
+    "⠠⠴",
+    "⠀⠶",
+    "⠐⠲",
+    "⠒⠒",
+    "⠓⠂",
+    "⠛⠀",
+    "⠋⠁",
+    "⠉⠉",
+    "⠈⠙",
+    "⠀⠹",
+    "⠀⢸",
+    "⠀⣰",
+    "⠀⣤",
+    "⠀⣆",
+    "⠀⡇",
+    "⠈⠇",
+    "⠘⠃",
+    "⠸⠁",
+    "⢸⠀",
+    "⣰⠀",
+    "⣤⠀",
+    "⣆⠀",
   ],
   intervalMs: 80,
   cellWidth: 2,
@@ -220,44 +275,43 @@ const DIAGSWIPE: BrailleAnimation = {
   cellWidth: 2,
 };
 
-/** Two-phase checkerboard pattern across a 6x4 grid. */
+/**
+ * Two-dot-wide diagonal stripes flowing continuously downward-right.
+ * Pattern: `floor((r + c + offset) / 2) % 2 === 0`. Period of 4 — each
+ * frame shifts the pattern by one dot along the (1,1) diagonal.
+ */
 const CHECKERBOARD: BrailleAnimation = {
-  frames: ["⢕⢕⢕", "⡪⡪⡪", "⢊⠔⡡", "⡡⢊⠔"],
-  intervalMs: 250,
+  frames: ["⢋⡴⢋", "⣡⠞⣡", "⡴⢋⡴", "⠞⣡⠞"],
+  intervalMs: 80,
   cellWidth: 3,
 };
 
-/** Each column fills bottom-up, then the whole row empties. */
+/**
+ * Sine-wave bars traveling continuously across a 6x4 grid. Each column is a
+ * histogram bar whose height oscillates with a sine wave; columns are phase-
+ * shifted by a half-period each, so a wave appears to travel left-to-right
+ * with no reset/empty frame in the cycle.
+ */
 const COLUMNS: BrailleAnimation = {
   frames: [
-    "⡀⠀⠀",
-    "⡄⠀⠀",
-    "⡆⠀⠀",
-    "⡇⠀⠀",
-    "⣇⠀⠀",
-    "⣧⠀⠀",
-    "⣷⠀⠀",
-    "⣿⠀⠀",
-    "⣿⡀⠀",
-    "⣿⡄⠀",
-    "⣿⡆⠀",
-    "⣿⡇⠀",
-    "⣿⣇⠀",
-    "⣿⣧⠀",
-    "⣿⣷⠀",
-    "⣿⣿⠀",
-    "⣿⣿⡀",
-    "⣿⣿⡄",
-    "⣿⣿⡆",
-    "⣿⣿⡇",
-    "⣿⣿⣇",
-    "⣿⣿⣧",
-    "⣿⣿⣷",
-    "⣿⣿⣿",
-    "⣿⣿⣿",
-    "⠀⠀⠀",
+    "⣄⢀⣴",
+    "⣆⠀⣰",
+    "⣦⡀⣠",
+    "⣷⡀⢀",
+    "⣷⣄⢀",
+    "⣿⣆⠀",
+    "⣾⣦⡀",
+    "⣾⣷⡀",
+    "⣴⣷⣄",
+    "⣰⣿⣆",
+    "⣠⣾⣦",
+    "⢀⣾⣷",
+    "⢀⣴⣷",
+    "⠀⣰⣿",
+    "⡀⣠⣾",
+    "⡀⢀⣾",
   ],
-  intervalMs: 60,
+  intervalMs: 100,
   cellWidth: 3,
 };
 

--- a/src/cli/components/spinners/animations.ts
+++ b/src/cli/components/spinners/animations.ts
@@ -83,6 +83,252 @@ const PULSE: BrailleAnimation = {
   cellWidth: 3,
 };
 
+/**
+ * "Grains" falling and piling into a single braille cell. Sourced from
+ * `cli-spinners.sand` (not the procedural unicode-animations registry).
+ */
+const SAND: BrailleAnimation = {
+  frames: [
+    "⠁",
+    "⠂",
+    "⠄",
+    "⡀",
+    "⡈",
+    "⡐",
+    "⡠",
+    "⣀",
+    "⣁",
+    "⣂",
+    "⣄",
+    "⣌",
+    "⣔",
+    "⣤",
+    "⣥",
+    "⣦",
+    "⣮",
+    "⣶",
+    "⣷",
+    "⣿",
+    "⡿",
+    "⠿",
+    "⢟",
+    "⠟",
+    "⡛",
+    "⠛",
+    "⠫",
+    "⢋",
+    "⠋",
+    "⠍",
+    "⡉",
+    "⠉",
+    "⠑",
+    "⠡",
+    "⢁",
+  ],
+  intervalMs: 80,
+  cellWidth: 1,
+};
+
+/**
+ * Long looping "wagon wheel" cycle from cli-spinners.dots12.
+ * 56 frames distributed across two adjacent braille cells.
+ */
+const DOTS12: BrailleAnimation = {
+  frames: [
+    "⢀⠀",
+    "⡀⠀",
+    "⠄⠀",
+    "⢂⠀",
+    "⡂⠀",
+    "⠅⠀",
+    "⢃⠀",
+    "⡃⠀",
+    "⠍⠀",
+    "⢋⠀",
+    "⡋⠀",
+    "⠍⠁",
+    "⢋⠁",
+    "⡋⠁",
+    "⠍⠉",
+    "⠋⠉",
+    "⠋⠉",
+    "⠉⠙",
+    "⠉⠙",
+    "⠉⠩",
+    "⠈⢙",
+    "⠈⡙",
+    "⢈⠩",
+    "⡀⢙",
+    "⠄⡙",
+    "⢂⠩",
+    "⡂⢘",
+    "⠅⡘",
+    "⢃⠨",
+    "⡃⢐",
+    "⠍⡐",
+    "⢋⠠",
+    "⡋⢀",
+    "⠍⡁",
+    "⢋⠁",
+    "⡋⠁",
+    "⠍⠉",
+    "⠋⠉",
+    "⠋⠉",
+    "⠉⠙",
+    "⠉⠙",
+    "⠉⠩",
+    "⠈⢙",
+    "⠈⡙",
+    "⠈⠩",
+    "⠀⢙",
+    "⠀⡙",
+    "⠀⠩",
+    "⠀⢘",
+    "⠀⡘",
+    "⠀⠨",
+    "⠀⢐",
+    "⠀⡐",
+    "⠀⠠",
+    "⠀⢀",
+    "⠀⡀",
+  ],
+  intervalMs: 80,
+  cellWidth: 2,
+};
+
+/** Diagonal wipe across a 4x4 grid that fills and unfills. */
+const DIAGSWIPE: BrailleAnimation = {
+  frames: [
+    "⠁⠀",
+    "⠋⠀",
+    "⠟⠁",
+    "⡿⠋",
+    "⣿⠟",
+    "⣿⡿",
+    "⣿⣿",
+    "⣿⣿",
+    "⣾⣿",
+    "⣴⣿",
+    "⣠⣾",
+    "⢀⣴",
+    "⠀⣠",
+    "⠀⢀",
+    "⠀⠀",
+    "⠀⠀",
+  ],
+  intervalMs: 60,
+  cellWidth: 2,
+};
+
+/** Two-phase checkerboard pattern across a 6x4 grid. */
+const CHECKERBOARD: BrailleAnimation = {
+  frames: ["⢕⢕⢕", "⡪⡪⡪", "⢊⠔⡡", "⡡⢊⠔"],
+  intervalMs: 250,
+  cellWidth: 3,
+};
+
+/** Each column fills bottom-up, then the whole row empties. */
+const COLUMNS: BrailleAnimation = {
+  frames: [
+    "⡀⠀⠀",
+    "⡄⠀⠀",
+    "⡆⠀⠀",
+    "⡇⠀⠀",
+    "⣇⠀⠀",
+    "⣧⠀⠀",
+    "⣷⠀⠀",
+    "⣿⠀⠀",
+    "⣿⡀⠀",
+    "⣿⡄⠀",
+    "⣿⡆⠀",
+    "⣿⡇⠀",
+    "⣿⣇⠀",
+    "⣿⣧⠀",
+    "⣿⣷⠀",
+    "⣿⣿⠀",
+    "⣿⣿⡀",
+    "⣿⣿⡄",
+    "⣿⣿⡆",
+    "⣿⣿⡇",
+    "⣿⣿⣇",
+    "⣿⣿⣧",
+    "⣿⣿⣷",
+    "⣿⣿⣿",
+    "⣿⣿⣿",
+    "⠀⠀⠀",
+  ],
+  intervalMs: 60,
+  cellWidth: 3,
+};
+
+/** Sine wave traveling across an 8x4 grid, with sparkle scatter. */
+const WAVEROWS: BrailleAnimation = {
+  frames: [
+    "⠖⠉⠉⠑",
+    "⡠⠖⠉⠉",
+    "⣠⡠⠖⠉",
+    "⣄⣠⡠⠖",
+    "⠢⣄⣠⡠",
+    "⠙⠢⣄⣠",
+    "⠉⠙⠢⣄",
+    "⠊⠉⠙⠢",
+    "⠜⠊⠉⠙",
+    "⡤⠜⠊⠉",
+    "⣀⡤⠜⠊",
+    "⢤⣀⡤⠜",
+    "⠣⢤⣀⡤",
+    "⠑⠣⢤⣀",
+    "⠉⠑⠣⢤",
+    "⠋⠉⠑⠣",
+  ],
+  intervalMs: 90,
+  cellWidth: 4,
+};
+
+/** Falling-drop pattern across 4 cells; cycles every 6 frames. */
+const RAIN: BrailleAnimation = {
+  frames: [
+    "⢁⠂⠔⠈",
+    "⠂⠌⡠⠐",
+    "⠄⡐⢀⠡",
+    "⡈⠠⠀⢂",
+    "⠐⢀⠁⠄",
+    "⠠⠁⠊⡀",
+    "⢁⠂⠔⠈",
+    "⠂⠌⡠⠐",
+    "⠄⡐⢀⠡",
+    "⡈⠠⠀⢂",
+    "⠐⢀⠁⠄",
+    "⠠⠁⠊⡀",
+  ],
+  intervalMs: 100,
+  cellWidth: 4,
+};
+
+/** Two interleaved sine helices crossing the grid. */
+const HELIX: BrailleAnimation = {
+  frames: [
+    "⢌⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+    "⢎⣉⢎⣉",
+    "⣉⡱⣉⡱",
+    "⣉⢎⣉⢎",
+    "⡱⣉⡱⣉",
+  ],
+  intervalMs: 80,
+  cellWidth: 4,
+};
+
 /** Diagonal sweep across an 8x4 grid. */
 const CASCADE: BrailleAnimation = {
   frames: [
@@ -108,9 +354,17 @@ const CASCADE: BrailleAnimation = {
 export const BRAILLE_ANIMATIONS = {
   orbit: ORBIT,
   breathe: BREATHE,
+  sand: SAND,
   snake: SNAKE,
+  dots12: DOTS12,
+  diagswipe: DIAGSWIPE,
   pulse: PULSE,
+  checkerboard: CHECKERBOARD,
+  columns: COLUMNS,
   cascade: CASCADE,
+  waverows: WAVEROWS,
+  rain: RAIN,
+  helix: HELIX,
 } as const satisfies Readonly<Record<string, BrailleAnimation>>;
 
 export type BrailleAnimationKey = keyof typeof BRAILLE_ANIMATIONS;
@@ -122,6 +376,7 @@ export type BrailleAnimationKey = keyof typeof BRAILLE_ANIMATIONS;
 export const STREAMING_STATUS_ANIMATION_KEYS: readonly BrailleAnimationKey[] = [
   "orbit",
   "breathe",
+  "sand",
 ];
 
 /**
@@ -134,7 +389,12 @@ export const STREAMING_STATUS_ANIMATION_KEYS: readonly BrailleAnimationKey[] = [
  * tier becomes active and holds that choice until the tier changes.
  */
 export const CONTEXT_TIER_ANIMATIONS: readonly (readonly BrailleAnimationKey[])[] =
-  [["orbit", "breathe"], ["snake"], ["pulse"], ["cascade"]];
+  [
+    ["orbit", "breathe", "sand"],
+    ["snake", "dots12", "diagswipe"],
+    ["pulse", "checkerboard", "columns"],
+    ["cascade", "waverows", "rain", "helix"],
+  ];
 
 export const CONTEXT_TIER_COUNT = CONTEXT_TIER_ANIMATIONS.length;
 

--- a/src/cli/components/spinners/use-frame-cycle.ts
+++ b/src/cli/components/spinners/use-frame-cycle.ts
@@ -15,6 +15,7 @@ export function useFrameCycle(
   const [frameIndex, setFrameIndex] = useState(0);
 
   useEffect(() => {
+    setFrameIndex(0);
     if (!enabled || frames.length === 0) return;
 
     const timer = setInterval(() => {


### PR DESCRIPTION
**Stacked on top of #2399** — targets `feat/streaming-status-spinner-pool`.

## Summary

Make the streaming-status spinner widen as the conversation fills toward the context window, with each tier picking from a width-appropriate pool of braille animations. Selection within a tier is a deterministic round-robin (`pool[streamSeed % pool.length]`), so consecutive streams cycle through every option in the pool before any repeat.

| Context used | Tier | Width | Animation pool |
|---|---|---|---|
| 0–25% | 0 | 1 cell | `orbit`, `breathe`, `sand` |
| 25–50% | 1 | 2 cells | `snake`, `dots12`, `diagswipe` |
| 50–75% | 2 | 3 cells | `pulse`, `checkerboard`, `columns` |
| 75–100% | 3 | 4 cells | `cascade`, `waverows`, `rain`, `helix` |

13 animations total. `sand` and `dots12` come from `cli-spinners`; the others are pre-computed from `gunnargray-dev/unicode-animations` generators (no upstream dependency — frames are inlined as static data). The Box width wrapping the spinner is driven by the same tier so the second status row (the tip line) stays vertically aligned at every tier.

## Plumbing

`contextTrackerRef.current.lastContextTokens` lives in a ref and doesn't trigger React renders. To get reactive updates during streaming, the value is mirrored into a `useState` (`usedContextTokens`) updated inside `refreshDerived` — the same per-chunk path that already updates `tokenCount`.

Data flow: `AppCoordinator` → `AppView` → `Input` (InputRich) → `StreamingStatus` → `StreamingStatusSpinner`. Both `usedContextTokens` and `effectiveContextWindowSize` are threaded through; tier derivation happens in `StreamingStatus`.

## Pool selection

Each new stream increments a `streamSeed` counter (tracked in `StreamingStatus`, bumped on every false→true `streaming` edge). The spinner derives its animation from `pool[streamSeed % pool.length]`. This gives:
- Guaranteed variety — every entry in the pool is shown before any repeat (round-robin, not random).
- No fiber unmount/remount per turn — the spinner stays mounted and just re-renders with a new derived key when `streamSeed` or `tier` changes.
- Reproducible debugging — given a streamSeed and a tier, the chosen animation is deterministic.

Mid-stream tier crossings still pick from the new tier's pool at the same seed; `useFrameCycle` resets the frame index when the frames array changes, so the swap is clean.

## Animation redesigns

Four entries in the registry were re-authored after eye-testing the upstream `unicode-animations` outputs at terminal size:

| Animation | Before | After |
|---|---|---|
| `breathe` (tier 0) | 17-frame diffuse build + symmetric reverse exit. Dots shimmered in non-monotonic order as the cell filled/emptied. | 17-frame center-outward bloom. Middle ring (rows 1-2) fills first, then outer ring; corners drain first on exit and the middle dots collapse last. Time-symmetric. |
| `snake` (tier 1) | 16-frame row-zigzag with a visible jump from `(3,0)` back to `(0,0)` at the loop wrap. | 60-frame 4-phase cycle: row-zigzag down → col-zigzag up → row-zigzag up (inverted) → col-zigzag down (inverted). Returns to start via an adjacent step; no jumps anywhere. |
| `checkerboard` (tier 2) | 4-frame mixed-modulo pattern; the rhythm broke between frames 1 and 2 because the upstream generator switched from mod-2 to mod-3 mid-cycle. | 4-frame diagonal stripe flow shifting one dot per frame along the (1,1) diagonal. Continuous diagonal motion; interval dropped from 250ms to 80ms so the flow reads as motion rather than as a held pattern. |
| `columns` (tier 2) | 26-frame column-by-column fill that ended with an all-empty "reset" frame. | 16-frame sine-wave histogram — three bars each oscillating with a phase lag, creating a continuous traveling wave. No reset frame. |

`rain`, `pulse`, `cascade`, `waverows`, `helix`, `orbit`, `sand`, `dots12`, `diagswipe` are unchanged from their upstream-derived defaults.

## Files

- `src/cli/components/spinners/animations.ts` — 13-entry registry with `cellWidth` per entry; tier pool definitions; `contextTierFromRatio` and `spinnerWidthForTier` helpers.
- `src/cli/components/spinners/use-frame-cycle.ts` — resets frame index when frames change so mid-stream animation swaps don't render a stale index.
- `src/cli/components/spinners/StreamingStatusSpinner.tsx` — accepts `tier` and `streamSeed` props; pure derivation, no `useState`/`useEffect` for animation selection.
- `src/cli/components/InputRich.tsx` — receives + threads new props; computes tier; widens both Box slots (spinner column + tip-row spacer); adjusts `statusContentWidth = terminalWidth - 1 - spinnerColumnWidth`. Tracks `streamSeed` via a `useRef` + `useEffect` on `streaming` rising edge.
- `src/cli/app/AppCoordinator.tsx` — `useState` for `usedContextTokens`; `setUsedContextTokens(...)` in `refreshDerived`; passes both new props to AppView.
- `src/cli/app/AppView.tsx` — adds props to `AppViewProps`, threads them to `<Input>`.

## Performance

Tier derivation is one division + three comparisons per chunk inside the existing per-chunk re-render path — effectively free. The spinner is wrapped in `memo` and only re-renders on tier crossings (≤3 per stream) plus its own frame-cycle ticks. No new intervals, no new subscriptions. The mod-based pool selection replaced an earlier `Math.random()` + key-remount approach, eliminating the unmount/remount cost on each new stream.

## Layout reflow

Tier transitions widen the spinner column by 1 cell at a time, which shifts the agent name + thinking message right by the same amount. Reflow happens at most 3 times per stream (forward only during normal use; compaction can trigger backward shifts). The second status row stays aligned because both rows share the same `spinnerColumnWidth` constant.

## Test plan

- [ ] Start a fresh stream — confirm the spinner is a 1-cell tier-0 animation (orbit/breathe/sand).
- [ ] Run multiple turns in succession — confirm the tier-0 spinner *choice* varies between streams (round-robin: orbit → breathe → sand → orbit → …).
- [ ] Push the conversation into a long context — confirm spinner widens at ~25%/50%/75% milestones to tier-appropriate animations (snake/dots12/diagswipe → pulse/checkerboard/columns → cascade/waverows/rain/helix).
- [ ] Trigger `/compact` mid-conversation — confirm spinner shrinks back to a lower tier after compaction completes.
- [ ] With animations disabled via the global `AnimationContext`, confirm static `CLI_GLYPHS.bullet` renders and the column width still respects the current tier.
- [ ] Confirm the second row (the tip line) stays indented to match the spinner column at every tier.