### PR TITLE
feat(tui): add first-turn conversation bootstrap

### DIFF
--- a/src/backend/api/search.ts
+++ b/src/backend/api/search.ts
@@ -11,3 +11,9 @@ export async function searchMessages<T>(
 ): Promise<T> {
   return apiRequest<T>("POST", "/v1/messages/search", body);
 }
+
+export async function searchConversations<T>(
+  body: Record<string, unknown>,
+): Promise<T> {
+  return apiRequest<T>("POST", "/v1/conversations/search", body);
+}

--- a/src/backend/conversation-search.ts
+++ b/src/backend/conversation-search.ts
@@ -1,0 +1,109 @@
+import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import { searchConversations } from "./api/search";
+import { type Backend, getBackend } from "./backend";
+
+type SearchMode = "vector" | "fts" | "hybrid";
+
+export type ConversationSearchBody = {
+  query?: unknown;
+  search_mode?: unknown;
+  limit?: unknown;
+  agent_id?: unknown;
+};
+
+export type ConversationSearchResult = {
+  embedded_text: string;
+  conversation: Conversation;
+  rrf_score: number;
+};
+
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+function countMatchedTerms(summary: string, terms: string[]): number {
+  const haystack = summary.toLowerCase();
+  return terms.filter((term) => haystack.includes(term)).length;
+}
+
+async function localSearchConversations(
+  backend: Backend,
+  body: ConversationSearchBody,
+): Promise<ConversationSearchResult[]> {
+  const query = typeof body.query === "string" ? body.query.trim() : "";
+  if (!query) {
+    return [];
+  }
+
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean);
+  if (terms.length === 0) {
+    return [];
+  }
+
+  const limit = typeof body.limit === "number" ? body.limit : 20;
+  const agentId = typeof body.agent_id === "string" ? body.agent_id : undefined;
+  const conversations = pageItems<Conversation>(
+    await backend.listConversations({
+      ...(agentId ? { agent_id: agentId } : {}),
+      limit,
+      order: "desc",
+      order_by: "last_message_at",
+    } as never),
+  );
+
+  return conversations
+    .map((conversation) => {
+      const summary = conversation.summary?.trim() ?? "";
+      if (!summary) {
+        return null;
+      }
+      const matchedTerms = countMatchedTerms(summary, terms);
+      if (matchedTerms === 0) {
+        return null;
+      }
+      return {
+        embedded_text: summary,
+        conversation,
+        rrf_score: matchedTerms / terms.length,
+      } satisfies ConversationSearchResult;
+    })
+    .filter((result): result is ConversationSearchResult => result !== null)
+    .sort((a, b) => b.rrf_score - a.rrf_score)
+    .slice(0, limit);
+}
+
+export async function searchConversationsForBackend(
+  body: ConversationSearchBody,
+  backend: Backend = getBackend(),
+): Promise<ConversationSearchResult[]> {
+  if (backend.capabilities.localModelCatalog) {
+    return localSearchConversations(backend, body);
+  }
+
+  return searchConversations<ConversationSearchResult[]>({
+    ...body,
+    search_mode:
+      body.search_mode === "vector" ||
+      body.search_mode === "fts" ||
+      body.search_mode === "hybrid"
+        ? (body.search_mode as SearchMode)
+        : body.search_mode,
+  } as Record<string, unknown>);
+}

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -124,6 +124,7 @@ import {
   enqueueCommandIoReminder,
   enqueueToolsetChangeReminder,
   resetSharedReminderState,
+  type SharedReminderState,
 } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
@@ -1008,7 +1009,13 @@ export function App({
   // Show exit stats on exit (double Ctrl+C)
   const [showExitStats, setShowExitStats] = useState(false);
 
-  const sharedReminderStateRef = useRef(createSharedReminderState());
+  const sharedReminderStateRef = useRef<SharedReminderState>(
+    (() => {
+      const state = createSharedReminderState();
+      state.pendingConversationBootstrap = !resumedExistingConversation;
+      return state;
+    })(),
+  );
   const _systemPromptRecompileByConversationRef = useRef(
     new Map<string, Promise<void>>(),
   );
@@ -1079,9 +1086,14 @@ export function App({
       return fallback;
     }
   }, [deriveAutoConversationTitle]);
-  const resetBootstrapReminderState = useCallback(() => {
-    resetSharedReminderState(sharedReminderStateRef.current);
-  }, []);
+  const resetBootstrapReminderState = useCallback(
+    (pendingConversationBootstrap = false) => {
+      resetSharedReminderState(sharedReminderStateRef.current);
+      sharedReminderStateRef.current.pendingConversationBootstrap =
+        pendingConversationBootstrap;
+    },
+    [],
+  );
   // Static items (things that are done rendering and can be frozen)
   const [staticItems, setStaticItems] = useState<StaticItem[]>([]);
 

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -266,7 +266,7 @@ type AppViewProps = {
     options?: { notifyOnManualApproval?: boolean },
   ) => Promise<void>;
   refreshDerived: () => void;
-  resetBootstrapReminderState: () => void;
+  resetBootstrapReminderState: (pendingConversationBootstrap?: boolean) => void;
   resetDeferredToolCallCommits: () => void;
   resetTrajectoryBases: () => void;
   restoredInput: string | null;
@@ -1239,7 +1239,7 @@ export function AppView(props: AppViewProps) {
                     buffersRef.current.order = [];
                     buffersRef.current.tokenCount = 0;
                     resetContextHistory(contextTrackerRef.current);
-                    resetBootstrapReminderState();
+                    resetBootstrapReminderState(true);
                     emittedIdsRef.current.clear();
                     resetDeferredToolCallCommits();
                     setStaticItems([]);

--- a/src/cli/app/submit-navigation-commands.ts
+++ b/src/cli/app/submit-navigation-commands.ts
@@ -29,7 +29,7 @@ type NavigationCommandContext = {
     approvals: ApprovalRequest[],
     options?: { notifyOnManualApproval?: boolean },
   ) => Promise<void>;
-  resetBootstrapReminderState: () => void;
+  resetBootstrapReminderState: (pendingConversationBootstrap?: boolean) => void;
   resetDeferredToolCallCommits: () => void;
   resetTrajectoryBases: () => void;
   setCommandRunning: (value: boolean) => void;

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -89,7 +89,7 @@ type ConversationSwitchingContext = {
     approvals: ApprovalRequest[],
     options?: { notifyOnManualApproval?: boolean },
   ) => Promise<void>;
-  resetBootstrapReminderState: () => void;
+  resetBootstrapReminderState: (pendingConversationBootstrap?: boolean) => void;
   resetDeferredToolCallCommits: () => void;
   resetPendingReasoningCycle: () => void;
   resetTrajectoryBases: () => void;
@@ -765,7 +765,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         resetContextHistory(contextTrackerRef.current);
 
         // Ensure bootstrap reminders are re-injected after creating a new agent.
-        resetBootstrapReminderState();
+        resetBootstrapReminderState(true);
 
         const separator = {
           kind: "separator" as const,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -245,7 +245,7 @@ type SubmitHandlerContext = {
     options?: { notifyOnManualApproval?: boolean },
   ) => Promise<void>;
   refreshDerived: () => void;
-  resetBootstrapReminderState: () => void;
+  resetBootstrapReminderState: (pendingConversationBootstrap?: boolean) => void;
   resetDeferredToolCallCommits: () => void;
   resetPendingReasoningCycle: () => void;
   resetTrajectoryBases: () => void;
@@ -1357,7 +1357,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             resetContextHistory(contextTrackerRef.current);
 
             // Ensure bootstrap reminders are re-injected for the new conversation.
-            resetBootstrapReminderState();
+            resetBootstrapReminderState(true);
 
             // Re-run SessionStart hooks for new conversation
             sessionHooksRanRef.current = false;
@@ -1564,7 +1564,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             resetContextHistory(contextTrackerRef.current);
 
             // Ensure bootstrap reminders are re-injected for the new conversation.
-            resetBootstrapReminderState();
+            resetBootstrapReminderState(true);
 
             // Re-run SessionStart hooks for new conversation
             sessionHooksRanRef.current = false;
@@ -3413,6 +3413,8 @@ ${SYSTEM_REMINDER_CLOSE}
           conversationId: conversationIdRef.current,
         },
         state: sharedReminderStateRef.current,
+        conversationBootstrapContent:
+          contentParts as unknown as MessageCreate["content"],
         systemInfoReminderEnabled,
         reflectionSettings,
         skillSources: getSkillSources(),

--- a/src/cli/helpers/conversation-bootstrap.ts
+++ b/src/cli/helpers/conversation-bootstrap.ts
@@ -1,0 +1,192 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import { getBackend } from "@/backend";
+import {
+  type ConversationSearchResult,
+  searchConversationsForBackend,
+} from "@/backend/conversation-search";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
+
+const BOOTSTRAP_RECENT_LIMIT = 5;
+const BOOTSTRAP_RELEVANT_LIMIT = 5;
+const BOOTSTRAP_RELEVANT_FETCH_LIMIT = 12;
+const BOOTSTRAP_RELEVANT_MIN_RRF_SCORE = 0.01;
+const BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE = 0.5;
+
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+export function extractBootstrapQueryText(
+  content: MessageCreate["content"],
+): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  return content
+    .flatMap((item) => {
+      if (item.type !== "text") {
+        return [];
+      }
+      const trimmed = item.text.trim();
+      return trimmed ? [trimmed] : [];
+    })
+    .join("\n\n")
+    .trim();
+}
+
+function formatBootstrapConversationLine(conversation: Conversation): string {
+  return `- ${(conversation.summary || "Unlabelled conversation").trim()} [${conversation.id}]`;
+}
+
+function formatBootstrapReminder(params: {
+  recentConversations: Conversation[];
+  relevantConversations: Conversation[];
+}): string {
+  const { recentConversations, relevantConversations } = params;
+  const lines = [
+    SYSTEM_REMINDER_OPEN,
+    "This is an automated message providing context from prior conversations with this agent.",
+    "The user is starting a brand-new conversation.",
+  ];
+
+  if (recentConversations.length > 0) {
+    lines.push(
+      "",
+      "Recent prior conversations:",
+      ...recentConversations.map(formatBootstrapConversationLine),
+    );
+  }
+
+  if (relevantConversations.length > 0) {
+    lines.push(
+      "",
+      "Relevant prior conversations for the user's first message:",
+      ...relevantConversations.map(formatBootstrapConversationLine),
+    );
+  }
+
+  lines.push(
+    "",
+    "Use this as lightweight context only. Do not treat these summaries as confirmed facts beyond what is written here.",
+    SYSTEM_REMINDER_CLOSE,
+  );
+
+  return lines.join("\n");
+}
+
+function filterBootstrapRelevantConversations(
+  results: ConversationSearchResult[],
+  params: {
+    excludeConversationId?: string;
+    recentIds: Set<string>;
+  },
+): Conversation[] {
+  const { excludeConversationId, recentIds } = params;
+  const dedupedResults: ConversationSearchResult[] = [];
+  const seenConversationIds = new Set<string>();
+
+  for (const result of results) {
+    const conversation = result.conversation;
+    if (conversation.id === excludeConversationId) {
+      continue;
+    }
+
+    if (
+      recentIds.has(conversation.id) ||
+      seenConversationIds.has(conversation.id)
+    ) {
+      continue;
+    }
+
+    seenConversationIds.add(conversation.id);
+    dedupedResults.push(result);
+  }
+
+  if (dedupedResults.length === 0) {
+    return [];
+  }
+
+  const strongestScore = Math.max(
+    ...dedupedResults.map((result) => result.rrf_score),
+  );
+  const minimumAcceptedScore = Math.max(
+    BOOTSTRAP_RELEVANT_MIN_RRF_SCORE,
+    strongestScore * BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE,
+  );
+
+  return dedupedResults
+    .filter((result) => result.rrf_score >= minimumAcceptedScore)
+    .slice(0, BOOTSTRAP_RELEVANT_LIMIT)
+    .map((result) => result.conversation);
+}
+
+export async function buildConversationBootstrapReminder(params: {
+  agentId: string;
+  content: MessageCreate["content"];
+  excludeConversationId?: string;
+}): Promise<string | null> {
+  const { agentId, content, excludeConversationId } = params;
+  const backend = getBackend();
+  const queryText = extractBootstrapQueryText(content);
+
+  const [recentResult, relevantResult] = await Promise.allSettled([
+    backend.listConversations({
+      agent_id: agentId,
+      limit: BOOTSTRAP_RECENT_LIMIT,
+      order: "desc",
+      order_by: "last_message_at",
+    } as never),
+    queryText
+      ? searchConversationsForBackend(
+          {
+            agent_id: agentId,
+            query: queryText,
+            search_mode: "hybrid",
+            limit: BOOTSTRAP_RELEVANT_FETCH_LIMIT,
+          },
+          backend,
+        )
+      : Promise.resolve<ConversationSearchResult[]>([]),
+  ]);
+
+  const recentConversations =
+    recentResult.status === "fulfilled"
+      ? pageItems<Conversation>(recentResult.value).filter(
+          (conversation) => conversation.id !== excludeConversationId,
+        )
+      : [];
+  const recentIds = new Set(
+    recentConversations.map((conversation) => conversation.id),
+  );
+  const relevantConversations =
+    relevantResult.status === "fulfilled"
+      ? filterBootstrapRelevantConversations(relevantResult.value, {
+          excludeConversationId,
+          recentIds,
+        })
+      : [];
+
+  if (recentConversations.length === 0 && relevantConversations.length === 0) {
+    return null;
+  }
+
+  return formatBootstrapReminder({
+    recentConversations,
+    relevantConversations,
+  });
+}

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -16,9 +16,9 @@ const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
   },
   {
     id: "desktop_conversation_bootstrap",
-    label: "desktop conversation bootstrap",
+    label: "conversation bootstrap",
     description:
-      "Desktop-only: inject lightweight prior-conversation context into the first turn of brand-new desktop conversations.",
+      "Inject lightweight prior-conversation context into the first turn of brand-new Letta Code conversations.",
   },
   {
     id: "node",

--- a/src/reminders/catalog.ts
+++ b/src/reminders/catalog.ts
@@ -7,6 +7,7 @@ export type SharedReminderMode =
 
 export type SharedReminderId =
   | "session-context"
+  | "conversation-bootstrap"
   | "agent-info"
   | "secrets-info"
   | "permission-mode"
@@ -33,6 +34,11 @@ export const SHARED_REMINDER_CATALOG: ReadonlyArray<SharedReminderDefinition> =
         "headless-bidirectional",
         "listen",
       ],
+    },
+    {
+      id: "conversation-bootstrap",
+      description: "First-turn prior-conversation bootstrap context",
+      modes: ["interactive"],
     },
     {
       id: "agent-info",

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -1,6 +1,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { SkillSource } from "@/agent/skills";
 import { buildAgentInfo } from "@/cli/helpers/agent-info";
+import { buildConversationBootstrapReminder } from "@/cli/helpers/conversation-bootstrap";
 import {
   buildCompactionMemoryReminder,
   buildMemoryReminder,
@@ -12,6 +13,7 @@ import {
   type SessionContextSource,
 } from "@/cli/helpers/session-context";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
+import { experimentManager } from "@/experiments/manager";
 import { permissionMode } from "@/permissions/mode";
 import { settingsManager } from "@/settings-manager";
 import { debugLog } from "@/utils/debug";
@@ -43,6 +45,7 @@ export interface SharedReminderContext {
   maybeLaunchReflectionSubagent?: (
     triggerSource: ReflectionTriggerSource,
   ) => Promise<boolean>;
+  conversationBootstrapContent?: MessageCreate["content"];
   /** Explicit working directory (overrides process.cwd() in session context). */
   workingDirectory?: string;
   /** Source of the session context (varies intro text). */
@@ -138,6 +141,33 @@ async function buildSessionContextReminder(
   context.state.hasSentSessionContext = true;
   context.state.pendingSessionContextReason = undefined;
   return reminder || null;
+}
+
+async function buildConversationBootstrapReminderPart(
+  context: SharedReminderContext,
+): Promise<string | null> {
+  if (
+    !context.state.pendingConversationBootstrap ||
+    context.state.hasSentConversationBootstrap ||
+    !experimentManager.isEnabled("desktop_conversation_bootstrap") ||
+    !context.conversationBootstrapContent
+  ) {
+    return null;
+  }
+
+  context.state.hasSentConversationBootstrap = true;
+  context.state.pendingConversationBootstrap = false;
+
+  const conversationId = context.agent.conversationId;
+  if (!conversationId) {
+    return null;
+  }
+
+  return buildConversationBootstrapReminder({
+    agentId: context.agent.id,
+    content: context.conversationBootstrapContent,
+    excludeConversationId: conversationId,
+  });
 }
 
 async function buildPlanModeReminder(
@@ -365,6 +395,7 @@ export const sharedReminderProviders: Record<
   SharedReminderProvider
 > = {
   "agent-info": buildAgentInfoReminder,
+  "conversation-bootstrap": buildConversationBootstrapReminderPart,
   "secrets-info": buildSecretsInfoReminder,
   "session-context": buildSessionContextReminder,
   "permission-mode": buildPermissionModeReminder,

--- a/src/reminders/state.ts
+++ b/src/reminders/state.ts
@@ -24,6 +24,8 @@ export type SessionContextReason = "initial_attach" | "cwd_changed";
 export interface SharedReminderState {
   hasSentAgentInfo: boolean;
   hasSentSessionContext: boolean;
+  hasSentConversationBootstrap: boolean;
+  pendingConversationBootstrap: boolean;
   hasSentSecretsInfo: boolean;
   lastNotifiedPermissionMode: PermissionMode | null;
   turnCount: number;
@@ -38,6 +40,8 @@ export function createSharedReminderState(): SharedReminderState {
   return {
     hasSentAgentInfo: false,
     hasSentSessionContext: false,
+    hasSentConversationBootstrap: false,
+    pendingConversationBootstrap: false,
     hasSentSecretsInfo: false,
     lastNotifiedPermissionMode: null,
     turnCount: 0,


### PR DESCRIPTION
## Summary
- add first-turn prior-conversation bootstrap context to brand-new TUI conversations through the shared reminder pipeline
- call `/v1/conversations/search` through a thin REST helper plus a local summary-based fallback, instead of waiting on generated SDK support
- reuse the existing bootstrap experiment and broaden its surfaced label/description so the toggle is not desktop-branded in the TUI

## Test plan
- [x] `bun run check`


## Example
```
This is an automated message providing context from prior conversations with this agent.
The user is starting a brand-new conversation. Recent prior conversations:

    New conversation bootstrapping with context injection [conv-d4f682d1-e957-4556-9bd9-6cc68d027289]
    Fixing failing CI tests [conv-a24d403c-19a2-4897-a58d-437d3273b927]
    Fixing failing CI tests [conv-d75337f3-5b41-4fad-a3d5-2a2ca4a1c4bf]
    Testing out the agent [conv-15f478a1-2eca-4ffe-8707-c5b769b82dec]
    Fixing CI issues [conv-cf04a5ca-80ba-4c94-8394-ccb52b84fff2]

Relevant prior conversations for the user's first message:

    Fixing CI issues [conv-f817d6ed-2174-461b-9f83-9e7571513505]
    CI issues: fixing failing checks [conv-0c8a601d-3056-459f-9a68-00e79eddbdae]
    CI issues: Prettier lint failure on README.md [conv-316ffbad-bdba-43a1-ad05-b131d40477b1]
    CI issues: tagged release workflow and process [conv-8a21fda6-45ee-438f-9c0a-3cee706b6f18]
    CI issues: PR 11446 conversations index already exists [conv-c990e542-aa77-4817-9dc8-17ca2a9d0737]

Use this as lightweight context only. Do not treat these summaries
```
<img width="554" height="309" alt="image" src="https://github.com/user-attachments/assets/2ad04c7e-86d1-45d5-bf0a-fa1f63462c8b" />
