### PR TITLE
feat(channels): consolidate channel slash commands

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -133,6 +133,55 @@ Plugins that need Slack/Discord-style auto-routing or rich Desktop management
 remain first-party/bundled work for now. Custom plugins can still expose custom
 `MessageChannel` actions and schema fragments via `messageActions`.
 
+## Slack app manifest notes
+
+The bundled Slack channel runs in Socket Mode. The Slack app must still declare
+the events, scopes, and slash commands that Slack should deliver to Letta Code.
+For `/cancel`, add the `commands` bot scope and a native slash command entry:
+
+```yaml
+features:
+  slash_commands:
+    - command: /cancel
+      url: https://example.com/slack/commands
+      description: Cancel the in-progress Letta agent turn
+      usage_hint: ""
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - chat:write
+      - commands
+      - files:read
+      - files:write
+      - groups:history
+      - im:history
+      - reactions:read
+      - reactions:write
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - message.im
+      - reaction_added
+      - reaction_removed
+  socket_mode_enabled: true
+```
+
+Slack-native slash command payloads do not identify a thread. If `/cancel` is
+sent through Slack's native command UI in a channel, Letta Code can target the
+sole routed thread in that channel; if multiple Letta threads are routed there,
+send `/cancel` as a normal thread message instead so the thread route is
+unambiguous.
+
+The slash command `url` is present because Slack manifests require one; the
+Socket Mode listener receives the command over the app-level WebSocket.
+
 ## First-party vs user plugins
 
 First-party plugins are bundled in `src/channels/<id>/` and registered by the

--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -133,6 +133,23 @@ Plugins that need Slack/Discord-style auto-routing or rich Desktop management
 remain first-party/bundled work for now. Custom plugins can still expose custom
 `MessageChannel` actions and schema fragments via `messageActions`.
 
+## Channel slash commands
+
+Typed slash commands are handled before normal channel ingress so operational
+commands do not get delivered to the agent as regular user messages. The shared
+channel command set is:
+
+- `/status` — show account, listener, route, agent, and conversation state.
+- `/pause` — disable agent replies for the current routed chat.
+- `/resume` — re-enable agent replies for the current routed chat.
+- `/cancel` — abort the in-progress agent turn for the current routed chat.
+- `/chat` — show the Letta web chat link for the current route.
+- `/reflection` — start a memory reflection pass for the current route's agent
+  conversation when MemFS is enabled.
+
+Slack-native slash command payloads currently exist only for `/cancel`; the rest
+are expected to be sent as normal channel messages in the relevant chat/thread.
+
 ## Slack app manifest notes
 
 The bundled Slack channel runs in Socket Mode. The Slack app must still declare

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildChannelAlreadyActiveMessage,
+  buildChannelAlreadyPausedMessage,
+  buildChannelCancelAcceptedMessage,
+  buildChannelCancelNoActiveTurnMessage,
+  buildChannelCancelUnavailableMessage,
   buildChannelHelpMessage,
+  buildChannelNoRouteMessage,
+  buildChannelPausedMessage,
+  buildChannelResumedMessage,
+  buildChannelStatusMessage,
   buildUnsupportedChannelCommandMessage,
   listChannelSlashCommands,
   parseChannelSlashCommand,
@@ -20,14 +29,95 @@ describe("channel slash commands", () => {
     expect(parseChannelSlashCommand("/tmp/file.txt")).toBeNull();
   });
 
-  test("lists supported direct commands for channel help", () => {
-    expect(listChannelSlashCommands()).toContainEqual(
-      expect.objectContaining({ name: "help", kind: "direct" }),
-    );
+  test("lists supported commands for channel help", () => {
+    for (const name of ["help", "status", "pause", "resume", "cancel"]) {
+      expect(listChannelSlashCommands()).toContainEqual(
+        expect.objectContaining({ name }),
+      );
+    }
 
     const text = buildChannelHelpMessage("telegram");
     expect(text).toContain("Telegram is connected to Letta Code.");
-    expect(text).toContain("Supported slash commands here: /help.");
+    expect(text).toContain(
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel.",
+    );
+  });
+
+  test("builds channel status for connected and unconnected chats", () => {
+    const msg = {
+      channel: "telegram",
+      chatId: "chat-1",
+      senderId: "user-1",
+      text: "/status",
+      timestamp: Date.now(),
+    };
+
+    expect(
+      buildChannelStatusMessage(msg, {
+        adapterRunning: true,
+        accountConfigured: true,
+        accountEnabled: true,
+        route: {
+          chatId: "chat-1",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enabled: true,
+          createdAt: "2026-05-15T00:00:00.000Z",
+        },
+      }),
+    ).toContain("Route: Connected to a Letta agent conversation.");
+
+    const unconnectedText = buildChannelStatusMessage(msg, {
+      adapterRunning: false,
+      accountConfigured: false,
+      route: null,
+    });
+    expect(unconnectedText).toContain(
+      "No channel account is configured for this receiver.",
+    );
+    expect(unconnectedText).toContain("Listener: stopped.");
+    expect(unconnectedText).toContain("No route is connected");
+  });
+
+  test("builds pause and resume route messages", () => {
+    const route = {
+      accountId: "acct-telegram",
+      chatId: "chat-1",
+      chatType: "direct" as const,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-18T00:00:00.000Z",
+      updatedAt: "2026-05-18T00:00:00.000Z",
+    };
+
+    expect(buildChannelNoRouteMessage("telegram")).toContain(
+      "could not find an existing route",
+    );
+    expect(buildChannelPausedMessage("telegram", route)).toContain(
+      "Telegram paused agent routing",
+    );
+    expect(buildChannelAlreadyPausedMessage("telegram")).toContain(
+      "already paused",
+    );
+    expect(buildChannelResumedMessage("telegram", route)).toContain(
+      "Telegram resumed agent routing",
+    );
+    expect(buildChannelAlreadyActiveMessage("telegram")).toContain(
+      "already active",
+    );
+  });
+
+  test("builds cancel command messages", () => {
+    expect(buildChannelCancelAcceptedMessage("slack")).toBe(
+      "Slack cancelled the in-progress agent turn for this chat.",
+    );
+    expect(buildChannelCancelUnavailableMessage("telegram")).toContain(
+      "not connected to an active Letta Code conversation yet",
+    );
+    expect(buildChannelCancelNoActiveTurnMessage("discord")).toContain(
+      "no in-progress agent turn",
+    );
   });
 
   test("builds a useful unsupported-command response", () => {
@@ -40,7 +130,9 @@ describe("channel slash commands", () => {
     const text = buildUnsupportedChannelCommandMessage("telegram", command);
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
-    expect(text).toContain("Supported slash commands here: /help.");
+    expect(text).toContain(
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel.",
+    );
     expect(text).toContain("without a leading slash");
   });
 });

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -5,6 +5,8 @@ import {
   buildChannelCancelAcceptedMessage,
   buildChannelCancelNoActiveTurnMessage,
   buildChannelCancelUnavailableMessage,
+  buildChannelChatLinkMessage,
+  buildChannelChatUnavailableMessage,
   buildChannelHelpMessage,
   buildChannelNoRouteMessage,
   buildChannelPausedMessage,
@@ -30,7 +32,15 @@ describe("channel slash commands", () => {
   });
 
   test("lists supported commands for channel help", () => {
-    for (const name of ["help", "status", "pause", "resume", "cancel"]) {
+    for (const name of [
+      "help",
+      "status",
+      "pause",
+      "resume",
+      "cancel",
+      "chat",
+      "reflection",
+    ]) {
       expect(listChannelSlashCommands()).toContainEqual(
         expect.objectContaining({ name }),
       );
@@ -39,7 +49,7 @@ describe("channel slash commands", () => {
     const text = buildChannelHelpMessage("telegram");
     expect(text).toContain("Telegram is connected to Letta Code.");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel.",
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /reflection.",
     );
   });
 
@@ -120,6 +130,30 @@ describe("channel slash commands", () => {
     );
   });
 
+  test("builds chat command messages", () => {
+    const route = {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel" as const,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-18T00:00:00.000Z",
+      updatedAt: "2026-05-18T00:00:00.000Z",
+    };
+
+    expect(
+      buildChannelChatLinkMessage(
+        "slack",
+        route,
+        "https://app.letta.com/chat/agent-1?conversation=conv-1",
+      ),
+    ).toContain("Slack chat for this route");
+    expect(buildChannelChatUnavailableMessage("telegram", route)).toContain(
+      "chat UI is not available",
+    );
+  });
+
   test("builds a useful unsupported-command response", () => {
     const command = parseChannelSlashCommand("/compact now");
     expect(command).not.toBeNull();
@@ -131,7 +165,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel.",
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /reflection.",
     );
     expect(text).toContain("without a leading slash");
   });

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -30,7 +30,15 @@ export type ChannelSlashCommandHandlers = {
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
+  chat?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
   pause?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  reflection?: (
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
@@ -77,6 +85,17 @@ const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
     name: "cancel",
     kind: "agent-scoped",
     summary: "Cancel the in-progress agent turn for this chat.",
+  },
+  {
+    name: "chat",
+    kind: "direct",
+    summary: "Show the Letta web chat link for this channel route.",
+  },
+  {
+    name: "reflection",
+    aliases: ["reflect"],
+    kind: "agent-scoped",
+    summary: "Start a memory reflection pass for this conversation.",
   },
 ];
 
@@ -245,6 +264,34 @@ export function buildChannelCancelAcceptedMessage(channelId: string): string {
   return `${displayName} cancelled the in-progress agent turn for this chat.`;
 }
 
+export function buildChannelChatLinkMessage(
+  channelId: string,
+  route: ChannelRoute,
+  chatUrl: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return [
+    `${displayName} chat for this route: ${chatUrl}`,
+    `Agent: ${route.agentId}.`,
+    `Conversation: ${route.conversationId}.`,
+  ].join("\n");
+}
+
+export function buildChannelChatUnavailableMessage(
+  channelId: string,
+  route: ChannelRoute,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} chat UI is not available for local backend agent ${route.agentId}.`;
+}
+
+export function buildChannelReflectionUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cannot start reflection for this chat because the listener is not ready yet. Try again in a moment.`;
+}
+
 async function handleScopedCommand(params: {
   msg: InboundChannelMessage;
   command: ParsedChannelSlashCommand;
@@ -304,6 +351,19 @@ export async function tryHandleChannelSlashCommand(
           command,
           handler: options.handlers?.cancel,
           defaultText: buildChannelCancelAcceptedMessage(msg.channel),
+        });
+      case "chat":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.chat,
+        });
+      case "reflect":
+      case "reflection":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.reflection,
         });
       default:
         return buildUnsupportedChannelCommandMessage(msg.channel, command);

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,5 +1,9 @@
 import { getChannelDisplayName } from "./plugin-registry";
-import type { ChannelAdapter, InboundChannelMessage } from "./types";
+import type {
+  ChannelAdapter,
+  ChannelRoute,
+  InboundChannelMessage,
+} from "./types";
 
 export type ChannelSlashCommandKind = "direct" | "agent-scoped";
 
@@ -16,11 +20,63 @@ export type ChannelSlashCommandDefinition = {
   summary: string;
 };
 
+export type ChannelSlashCommandHandlerResult = {
+  handled: boolean;
+  text?: string;
+};
+
+export type ChannelSlashCommandHandlers = {
+  cancel?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  pause?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  resume?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+};
+
+export type ChannelStatusContext = {
+  adapterRunning: boolean;
+  accountConfigured: boolean;
+  accountEnabled?: boolean;
+  route: ChannelRoute | null;
+};
+
+export type ChannelSlashCommandOptions = {
+  statusContext?: ChannelStatusContext;
+  handlers?: ChannelSlashCommandHandlers;
+};
+
 const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
   {
     name: "help",
     kind: "direct",
     summary: "Show channel usage guidance.",
+  },
+  {
+    name: "status",
+    kind: "direct",
+    summary: "Show this chat's channel connection status.",
+  },
+  {
+    name: "pause",
+    kind: "direct",
+    summary: "Pause agent routing for this chat.",
+  },
+  {
+    name: "resume",
+    kind: "direct",
+    summary: "Resume agent routing for this chat.",
+  },
+  {
+    name: "cancel",
+    kind: "agent-scoped",
+    summary: "Cancel the in-progress agent turn for this chat.",
   },
 ];
 
@@ -61,18 +117,20 @@ export function parseChannelSlashCommand(
   };
 }
 
-export function buildChannelHelpMessage(channelId: string): string {
-  const displayName = channelDisplayName(channelId);
-  const supportedCommands = listChannelSlashCommands()
-    .filter((definition) => definition.kind === "direct")
+function supportedCommandsText(): string {
+  return listChannelSlashCommands()
     .map((definition) => `/${definition.name}`)
     .join(", ");
+}
+
+export function buildChannelHelpMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
 
   return [
     `${displayName} is connected to Letta Code.`,
     "Send a normal message here and the connected agent will reply in this chat.",
     "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
-    `Supported slash commands here: ${supportedCommands}.`,
+    `Supported slash commands here: ${supportedCommandsText()}.`,
     "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
   ].join("\n\n");
 }
@@ -82,31 +140,179 @@ export function buildUnsupportedChannelCommandMessage(
   command: ParsedChannelSlashCommand,
 ): string {
   const displayName = channelDisplayName(channelId);
-  const supportedCommands = listChannelSlashCommands()
-    .filter((definition) => definition.kind === "direct")
-    .map((definition) => `/${definition.name}`)
-    .join(", ");
 
   return [
     `${displayName} received ${command.raw}, but that slash command is not supported in channels yet.`,
-    `Supported slash commands here: ${supportedCommands}.`,
+    `Supported slash commands here: ${supportedCommandsText()}.`,
     "Send normal messages without a leading slash to talk to the connected agent.",
   ].join("\n\n");
+}
+
+export function buildChannelStatusMessage(
+  msg: InboundChannelMessage,
+  context: ChannelStatusContext,
+): string {
+  const displayName = channelDisplayName(msg.channel);
+  const route = context.route;
+  const routeStatus = route
+    ? "Connected to a Letta agent conversation."
+    : "No route is connected for this chat yet.";
+  const accountStatus = !context.accountConfigured
+    ? "No channel account is configured for this receiver."
+    : context.accountEnabled === false
+      ? "Channel account is configured but disabled."
+      : "Channel account is configured and enabled.";
+
+  const lines = [
+    `${displayName} status`,
+    accountStatus,
+    `Listener: ${context.adapterRunning ? "running" : "stopped"}.`,
+    `Route: ${routeStatus}`,
+  ];
+
+  if (route) {
+    lines.push(`Agent: ${route.agentId}.`);
+    lines.push(`Conversation: ${route.conversationId}.`);
+    if (route.threadId) {
+      lines.push(`Thread: ${route.threadId}.`);
+    }
+  } else {
+    lines.push(
+      "Send a normal non-command message here to get pairing or connection instructions.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export function buildChannelNoRouteMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return [
+    `${displayName} could not find an existing route for this chat.`,
+    "Send a normal message first and follow the pairing instructions, then try again.",
+  ].join("\n\n");
+}
+
+export function buildChannelPausedMessage(
+  channelId: string,
+  route: ChannelRoute,
+): string {
+  const displayName = channelDisplayName(channelId);
+  const conversation = route.conversationId
+    ? ` Conversation: ${route.conversationId}.`
+    : "";
+  return `${displayName} paused agent routing for this chat.${conversation} Send /resume here to turn replies back on.`;
+}
+
+export function buildChannelAlreadyPausedMessage(channelId: string): string {
+  return `${channelDisplayName(channelId)} agent routing is already paused for this chat. Send /resume here to turn replies back on.`;
+}
+
+export function buildChannelResumedMessage(
+  channelId: string,
+  route: ChannelRoute,
+): string {
+  const displayName = channelDisplayName(channelId);
+  const conversation = route.conversationId
+    ? ` Conversation: ${route.conversationId}.`
+    : "";
+  return `${displayName} resumed agent routing for this chat.${conversation} Normal messages here will go to the connected agent again.`;
+}
+
+export function buildChannelAlreadyActiveMessage(channelId: string): string {
+  return `${channelDisplayName(channelId)} agent routing is already active for this chat.`;
+}
+
+export function buildChannelCancelUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return [
+    `${displayName} received /cancel, but this chat is not connected to an active Letta Code conversation yet.`,
+    "Send a normal message first to connect this chat to an agent.",
+  ].join("\n\n");
+}
+
+export function buildChannelCancelNoActiveTurnMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} received /cancel, but there is no in-progress agent turn to cancel for this chat.`;
+}
+
+export function buildChannelCancelAcceptedMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cancelled the in-progress agent turn for this chat.`;
+}
+
+async function handleScopedCommand(params: {
+  msg: InboundChannelMessage;
+  command: ParsedChannelSlashCommand;
+  handler:
+    | ((
+        command: ParsedChannelSlashCommand,
+        msg: InboundChannelMessage,
+      ) => Promise<ChannelSlashCommandHandlerResult>)
+    | undefined;
+  defaultText?: string;
+}): Promise<string | null> {
+  const result = await params.handler?.(params.command, params.msg);
+  if (!result?.handled) {
+    return null;
+  }
+  return result.text ?? params.defaultText ?? null;
 }
 
 export async function tryHandleChannelSlashCommand(
   adapter: ChannelAdapter,
   msg: InboundChannelMessage,
+  options: ChannelSlashCommandOptions = {},
 ): Promise<boolean> {
   const command = parseChannelSlashCommand(msg.text);
   if (!command) {
     return false;
   }
 
-  const text =
-    command.name === "help"
-      ? buildChannelHelpMessage(msg.channel)
-      : buildUnsupportedChannelCommandMessage(msg.channel, command);
+  const text = await (async () => {
+    switch (command.name) {
+      case "help":
+        return buildChannelHelpMessage(msg.channel);
+      case "status":
+        return buildChannelStatusMessage(
+          msg,
+          options.statusContext ?? {
+            adapterRunning: adapter.isRunning(),
+            accountConfigured: false,
+            route: null,
+          },
+        );
+      case "pause":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.pause,
+        });
+      case "resume":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.resume,
+        });
+      case "cancel":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.cancel,
+          defaultText: buildChannelCancelAcceptedMessage(msg.channel),
+        });
+      default:
+        return buildUnsupportedChannelCommandMessage(msg.channel, command);
+    }
+  })();
+
+  if (text === null) {
+    return false;
+  }
 
   await adapter.sendDirectReply(
     msg.chatId,

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -584,6 +584,133 @@ describe("ChannelRegistry", () => {
       "Slack cancelled the in-progress agent turn for this chat.",
     );
   });
+
+  test("/chat replies with the web chat link for the routed conversation", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("telegram", {
+      accountId: "acct-telegram",
+      chatId: "123",
+      chatType: "direct",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "/chat",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(replies[0]?.text).toContain(
+      "https://app.letta.com/chat/agent-1?conversation=conv-1",
+    );
+    expect(replies[0]?.text).toContain("Conversation: conv-1.");
+  });
+
+  test("/reflection invokes the channel reflection handler for the routed conversation", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const reflections: unknown[] = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReflectionHandler(async (params) => {
+      reflections.push(params);
+      return { handled: true, text: "Started a reflection pass." };
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/reflection",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(reflections).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies[0]?.text).toBe("Started a reflection pass.");
+  });
 });
 
 describe("buildSlackConversationSummary", () => {

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -1094,6 +1094,62 @@ describe("pending channel control requests", () => {
     ]);
   });
 
+  test("/reflection bypasses pending channel control prompts", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+    registry.setMessageHandler(() => {});
+
+    const approvalResponses: unknown[] = [];
+    registry.setApprovalResponseHandler(async (params) => {
+      approvalResponses.push(params);
+      return true;
+    });
+    const reflections: unknown[] = [];
+    registry.setReflectionHandler(async (params) => {
+      reflections.push(params);
+      return { handled: true, text: "Started a reflection pass." };
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    await registry.registerPendingControlRequest(
+      createPendingControlRequestEvent(),
+    );
+
+    await adapter.onMessage?.(createInboundMessage("/reflection"));
+
+    expect(approvalResponses).toHaveLength(0);
+    expect(reflections).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Started a reflection pass.",
+        replyToMessageId: "1712800000.000200",
+      },
+    ]);
+  });
+
   test("freeform multi-question channel replies approve instead of reprompting", async () => {
     const replies: Array<{
       chatId: string;

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -217,6 +217,373 @@ describe("ChannelRegistry", () => {
       "Telegram received /compact now, but that slash command is not supported in channels yet.",
     );
   });
+
+  test("/status replies with route status instead of being delivered to the agent", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "telegram",
+        accountId: "acct-telegram",
+        enabled: true,
+        token: "test-token",
+        dmPolicy: "open",
+        allowedUsers: [],
+        binding: { agentId: null, conversationId: null },
+        createdAt: "2026-05-13T00:00:00.000Z",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+      },
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+
+    addRoute("telegram", {
+      accountId: "acct-telegram",
+      chatId: "123",
+      chatType: "direct",
+      threadId: null,
+      agentId: "agent-status",
+      conversationId: "conv-status",
+      enabled: true,
+      createdAt: "2026-05-15T00:00:00.000Z",
+    });
+
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      senderName: "Alice",
+      text: "/status",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({
+      chatId: "123",
+      replyToMessageId: "77",
+    });
+    expect(replies[0]?.text).toContain("Telegram status");
+    expect(replies[0]?.text).toContain(
+      "Route: Connected to a Letta agent conversation.",
+    );
+    expect(replies[0]?.text).toContain("Agent: agent-status.");
+    expect(replies[0]?.text).toContain("Conversation: conv-status.");
+  });
+
+  test("/pause and /resume update the current route without agent delivery", async () => {
+    addRoute("telegram", {
+      accountId: "acct-telegram",
+      chatId: "123",
+      chatType: "direct",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-18T00:00:00.000Z",
+      updatedAt: "2026-05-18T00:00:00.000Z",
+    });
+
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      senderName: "Alice",
+      text: "/pause",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(replies.at(-1)).toMatchObject({
+      chatId: "123",
+      replyToMessageId: "77",
+    });
+    expect(replies.at(-1)?.text).toContain("paused agent routing");
+    expect(getRoute("telegram", "123", "acct-telegram")).toBeNull();
+
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      senderName: "Alice",
+      text: "/resume",
+      timestamp: Date.now(),
+      messageId: "78",
+      chatType: "direct",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(replies.at(-1)).toMatchObject({
+      chatId: "123",
+      replyToMessageId: "78",
+    });
+    expect(replies.at(-1)?.text).toContain("resumed agent routing");
+    expect(getRoute("telegram", "123", "acct-telegram")?.conversationId).toBe(
+      "conv-1",
+    );
+  });
+
+  test("/cancel invokes the channel cancel handler for the routed chat", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    const cancellations: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Slack cancelled the in-progress agent turn for this chat.",
+        replyToMessageId: "1712800000.000200",
+      },
+    ]);
+  });
+
+  test("/cancel reports when the routed chat has no active turn", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    registry.setMessageHandler(() => {});
+    registry.setCancelHandler(async () => false);
+    registry.setReady();
+    registry.registerAdapter({
+      id: "telegram:acct-telegram",
+      channelId: "telegram",
+      accountId: "acct-telegram",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("telegram", {
+      accountId: "acct-telegram",
+      chatId: "123",
+      chatType: "direct",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("telegram", "acct-telegram");
+    await adapter?.onMessage?.({
+      channel: "telegram",
+      accountId: "acct-telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "77",
+      chatType: "direct",
+    });
+
+    expect(replies[0]?.text).toBe(
+      "Telegram received /cancel, but there is no in-progress agent turn to cancel for this chat.",
+    );
+  });
+
+  test("/cancel can target the sole Slack thread route when native commands omit thread metadata", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const cancellations: unknown[] = [];
+    const registry = new ChannelRegistry();
+    registry.setMessageHandler(() => {});
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/cancel",
+      timestamp: Date.now(),
+      messageId: "trigger-1",
+      threadId: null,
+      chatType: "channel",
+    });
+
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies[0]?.text).toBe(
+      "Slack cancelled the in-progress agent turn for this chat.",
+    );
+  });
 });
 
 describe("buildSlackConversationSummary", () => {
@@ -542,6 +909,62 @@ describe("pending channel control requests", () => {
         },
       },
     });
+  });
+
+  test("/cancel bypasses pending channel control prompts", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+    registry.setMessageHandler(() => {});
+
+    const approvalResponses: unknown[] = [];
+    registry.setApprovalResponseHandler(async (params) => {
+      approvalResponses.push(params);
+      return true;
+    });
+    const cancellations: unknown[] = [];
+    registry.setCancelHandler(async (params) => {
+      cancellations.push(params);
+      return true;
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    await registry.registerPendingControlRequest(
+      createPendingControlRequestEvent(),
+    );
+
+    await adapter.onMessage?.(createInboundMessage("/cancel"));
+
+    expect(approvalResponses).toHaveLength(0);
+    expect(cancellations).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Slack cancelled the in-progress agent turn for this chat.",
+        replyToMessageId: "1712800000.000200",
+      },
+    ]);
   });
 
   test("freeform multi-question channel replies approve instead of reprompting", async () => {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -784,7 +784,7 @@ export class ChannelRegistry {
     msg: InboundChannelMessage,
   ): Promise<boolean> {
     const slashCommand = parseChannelSlashCommand(msg.text);
-    if (slashCommand?.name === "cancel") {
+    if (slashCommand) {
       return false;
     }
 

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,7 +19,17 @@ import {
   listChannelAccounts,
   loadChannelAccounts,
 } from "./accounts";
-import { tryHandleChannelSlashCommand } from "./commands";
+import {
+  buildChannelAlreadyActiveMessage,
+  buildChannelAlreadyPausedMessage,
+  buildChannelCancelNoActiveTurnMessage,
+  buildChannelCancelUnavailableMessage,
+  buildChannelNoRouteMessage,
+  buildChannelPausedMessage,
+  buildChannelResumedMessage,
+  parseChannelSlashCommand,
+  tryHandleChannelSlashCommand,
+} from "./commands";
 import { isDiscordGuildChannelAllowed } from "./discord/channel-gating";
 import {
   formatChannelControlRequestPrompt,
@@ -250,6 +260,13 @@ export type ChannelApprovalResponseHandler = (params: {
   response: ApprovalResponseBody;
 }) => Promise<boolean>;
 
+export type ChannelCancelHandler = (params: {
+  runtime: {
+    agent_id: string;
+    conversation_id: string;
+  };
+}) => Promise<boolean>;
+
 type PendingChannelControlRequest = {
   event: ChannelControlRequestEvent;
   deliveredThisProcess: boolean;
@@ -289,6 +306,7 @@ export class ChannelRegistry {
   private messageHandler: ChannelMessageHandler | null = null;
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private approvalResponseHandler: ChannelApprovalResponseHandler | null = null;
+  private cancelHandler: ChannelCancelHandler | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
   private readonly pendingControlRequestsById = new Map<
     string,
@@ -419,6 +437,10 @@ export class ChannelRegistry {
     handler: ChannelApprovalResponseHandler | null,
   ): void {
     this.approvalResponseHandler = handler;
+  }
+
+  setCancelHandler(handler: ChannelCancelHandler | null): void {
+    this.cancelHandler = handler;
   }
 
   setEventHandler(
@@ -711,6 +733,7 @@ export class ChannelRegistry {
     this.messageHandler = null;
     this.eventHandler = null;
     this.approvalResponseHandler = null;
+    this.cancelHandler = null;
   }
 
   /**
@@ -727,6 +750,7 @@ export class ChannelRegistry {
     this.messageHandler = null;
     this.eventHandler = null;
     this.approvalResponseHandler = null;
+    this.cancelHandler = null;
     this.pendingControlRequestsById.clear();
     this.pendingControlRequestIdByScope.clear();
     instance = null;
@@ -738,6 +762,11 @@ export class ChannelRegistry {
     adapter: ChannelAdapter,
     msg: InboundChannelMessage,
   ): Promise<boolean> {
+    const slashCommand = parseChannelSlashCommand(msg.text);
+    if (slashCommand?.name === "cancel") {
+      return false;
+    }
+
     const scopeKey = getChannelApprovalScopeKey({
       channel: msg.channel,
       accountId: msg.accountId,
@@ -797,6 +826,141 @@ export class ChannelRegistry {
     return true;
   }
 
+  private findRawRouteForMessage(
+    msg: InboundChannelMessage,
+  ): ChannelRoute | null {
+    const route =
+      getRouteRaw(msg.channel, msg.chatId, msg.accountId, msg.threadId) ??
+      (msg.threadId
+        ? getRouteRaw(msg.channel, msg.chatId, msg.accountId, null)
+        : undefined);
+    return route ?? null;
+  }
+
+  private loadAndFindRawRouteForMessage(
+    msg: InboundChannelMessage,
+  ): ChannelRoute | null {
+    const route = this.findRawRouteForMessage(msg);
+    if (route) {
+      return route;
+    }
+    loadRoutes(msg.channel);
+    return this.findRawRouteForMessage(msg);
+  }
+
+  private async handlePauseResumeSlashCommand(
+    commandName: "pause" | "resume",
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.loadAndFindRawRouteForMessage(msg);
+    if (!route) {
+      return {
+        handled: true,
+        text: buildChannelNoRouteMessage(msg.channel),
+      };
+    }
+
+    if (commandName === "pause") {
+      if (route.enabled === false) {
+        return {
+          handled: true,
+          text: buildChannelAlreadyPausedMessage(msg.channel),
+        };
+      }
+      const updatedRoute: ChannelRoute = {
+        ...route,
+        enabled: false,
+        updatedAt: new Date().toISOString(),
+      };
+      addRoute(msg.channel, updatedRoute);
+      return {
+        handled: true,
+        text: buildChannelPausedMessage(msg.channel, updatedRoute),
+      };
+    }
+
+    if (route.enabled !== false) {
+      return {
+        handled: true,
+        text: buildChannelAlreadyActiveMessage(msg.channel),
+      };
+    }
+    const updatedRoute: ChannelRoute = {
+      ...route,
+      enabled: true,
+      updatedAt: new Date().toISOString(),
+    };
+    addRoute(msg.channel, updatedRoute);
+    return {
+      handled: true,
+      text: buildChannelResumedMessage(msg.channel, updatedRoute),
+    };
+  }
+
+  private async handleCancelSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.getCancelRoute(msg);
+    if (!route?.enabled || !this.cancelHandler) {
+      return {
+        handled: true,
+        text: buildChannelCancelUnavailableMessage(msg.channel),
+      };
+    }
+
+    const cancelled = await this.cancelHandler({
+      runtime: {
+        agent_id: route.agentId,
+        conversation_id: route.conversationId,
+      },
+    });
+
+    if (!cancelled) {
+      return {
+        handled: true,
+        text: buildChannelCancelNoActiveTurnMessage(msg.channel),
+      };
+    }
+
+    return { handled: true };
+  }
+
+  private getCancelRoute(msg: InboundChannelMessage): ChannelRoute | null {
+    let route = this.getRoute(
+      msg.channel,
+      msg.chatId,
+      msg.accountId,
+      msg.threadId,
+    );
+    if (route) {
+      return route;
+    }
+
+    loadRoutes(msg.channel);
+    route = this.getRoute(msg.channel, msg.chatId, msg.accountId, msg.threadId);
+    if (route) {
+      return route;
+    }
+
+    if (
+      msg.channel !== "slack" ||
+      msg.chatType !== "channel" ||
+      msg.threadId != null
+    ) {
+      return null;
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const matches = getRoutesForChannel(msg.channel, accountId).filter(
+      (candidate) =>
+        candidate.chatId === msg.chatId &&
+        candidate.chatType === "channel" &&
+        candidate.enabled,
+    );
+
+    return matches.length === 1 ? (matches[0] ?? null) : null;
+  }
+
   private async handleInboundMessage(
     msg: InboundChannelMessage,
   ): Promise<void> {
@@ -807,11 +971,46 @@ export class ChannelRegistry {
       return;
     }
 
-    if (await tryHandleChannelSlashCommand(adapter, msg)) {
+    const config = getChannelAccount(msg.channel, accountId);
+
+    const getStatusRoute = (): ChannelRoute | null => {
+      let statusRoute = getRouteFromStore(
+        msg.channel,
+        msg.chatId,
+        accountId,
+        msg.threadId,
+      );
+      if (!statusRoute) {
+        loadRoutes(msg.channel);
+        statusRoute = getRouteFromStore(
+          msg.channel,
+          msg.chatId,
+          accountId,
+          msg.threadId,
+        );
+      }
+      return statusRoute;
+    };
+
+    if (
+      await tryHandleChannelSlashCommand(adapter, msg, {
+        statusContext: {
+          adapterRunning: adapter.isRunning(),
+          accountConfigured: !!config,
+          accountEnabled: config?.enabled,
+          route: getStatusRoute(),
+        },
+        handlers: {
+          cancel: async (_command, commandMsg) =>
+            this.handleCancelSlashCommand(commandMsg),
+          pause: async () => this.handlePauseResumeSlashCommand("pause", msg),
+          resume: async () => this.handlePauseResumeSlashCommand("resume", msg),
+        },
+      })
+    ) {
       return;
     }
 
-    const config = getChannelAccount(msg.channel, accountId);
     if (!config) return;
 
     if (msg.channel === "slack" && isSlackChannelAccount(config)) {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -12,6 +12,7 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import { getClient } from "@/backend/api/client";
+import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import type { ApprovalResponseBody } from "@/types/protocol_v2";
 import {
   getChannelAccount,
@@ -24,8 +25,11 @@ import {
   buildChannelAlreadyPausedMessage,
   buildChannelCancelNoActiveTurnMessage,
   buildChannelCancelUnavailableMessage,
+  buildChannelChatLinkMessage,
+  buildChannelChatUnavailableMessage,
   buildChannelNoRouteMessage,
   buildChannelPausedMessage,
+  buildChannelReflectionUnavailableMessage,
   buildChannelResumedMessage,
   parseChannelSlashCommand,
   tryHandleChannelSlashCommand,
@@ -267,6 +271,16 @@ export type ChannelCancelHandler = (params: {
   };
 }) => Promise<boolean>;
 
+export type ChannelReflectionHandler = (params: {
+  runtime: {
+    agent_id: string;
+    conversation_id: string;
+  };
+}) => Promise<{
+  handled: boolean;
+  text?: string;
+}>;
+
 type PendingChannelControlRequest = {
   event: ChannelControlRequestEvent;
   deliveredThisProcess: boolean;
@@ -307,6 +321,7 @@ export class ChannelRegistry {
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
   private approvalResponseHandler: ChannelApprovalResponseHandler | null = null;
   private cancelHandler: ChannelCancelHandler | null = null;
+  private reflectionHandler: ChannelReflectionHandler | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
   private readonly pendingControlRequestsById = new Map<
     string,
@@ -441,6 +456,10 @@ export class ChannelRegistry {
 
   setCancelHandler(handler: ChannelCancelHandler | null): void {
     this.cancelHandler = handler;
+  }
+
+  setReflectionHandler(handler: ChannelReflectionHandler | null): void {
+    this.reflectionHandler = handler;
   }
 
   setEventHandler(
@@ -734,6 +753,7 @@ export class ChannelRegistry {
     this.eventHandler = null;
     this.approvalResponseHandler = null;
     this.cancelHandler = null;
+    this.reflectionHandler = null;
   }
 
   /**
@@ -751,6 +771,7 @@ export class ChannelRegistry {
     this.eventHandler = null;
     this.approvalResponseHandler = null;
     this.cancelHandler = null;
+    this.reflectionHandler = null;
     this.pendingControlRequestsById.clear();
     this.pendingControlRequestIdByScope.clear();
     instance = null;
@@ -925,6 +946,62 @@ export class ChannelRegistry {
     return { handled: true };
   }
 
+  private async handleChatSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.loadAndFindRawRouteForMessage(msg);
+    if (!route) {
+      return {
+        handled: true,
+        text: buildChannelNoRouteMessage(msg.channel),
+      };
+    }
+
+    if (isLocalAgentId(route.agentId)) {
+      return {
+        handled: true,
+        text: buildChannelChatUnavailableMessage(msg.channel, route),
+      };
+    }
+
+    return {
+      handled: true,
+      text: buildChannelChatLinkMessage(
+        msg.channel,
+        route,
+        buildChatUrl(route.agentId, {
+          conversationId: route.conversationId,
+        }),
+      ),
+    };
+  }
+
+  private async handleReflectionSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.loadAndFindRawRouteForMessage(msg);
+    if (!route?.enabled) {
+      return {
+        handled: true,
+        text: buildChannelNoRouteMessage(msg.channel),
+      };
+    }
+
+    if (!this.reflectionHandler) {
+      return {
+        handled: true,
+        text: buildChannelReflectionUnavailableMessage(msg.channel),
+      };
+    }
+
+    return this.reflectionHandler({
+      runtime: {
+        agent_id: route.agentId,
+        conversation_id: route.conversationId,
+      },
+    });
+  }
+
   private getCancelRoute(msg: InboundChannelMessage): ChannelRoute | null {
     let route = this.getRoute(
       msg.channel,
@@ -1003,7 +1080,11 @@ export class ChannelRegistry {
         handlers: {
           cancel: async (_command, commandMsg) =>
             this.handleCancelSlashCommand(commandMsg),
+          chat: async (_command, commandMsg) =>
+            this.handleChatSlashCommand(commandMsg),
           pause: async () => this.handlePauseResumeSlashCommand("pause", msg),
+          reflection: async (_command, commandMsg) =>
+            this.handleReflectionSlashCommand(commandMsg),
           resume: async () => this.handlePauseResumeSlashCommand("resume", msg),
         },
       })

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -37,6 +37,19 @@ type SlackEventHandler = (args: {
   };
 }) => Promise<void>;
 
+type SlackCommandHandler = (args: {
+  command: {
+    command?: string;
+    text?: string;
+    user_id?: string;
+    user_name?: string;
+    channel_id?: string;
+    channel_name?: string;
+    trigger_id?: string;
+  };
+  ack: () => Promise<void>;
+}) => Promise<void>;
+
 class FakeSlackApp {
   static instances: FakeSlackApp[] = [];
 
@@ -82,6 +95,7 @@ class FakeSlackApp {
 
   messageHandler: SlackMessageHandler | null = null;
   eventHandlers = new Map<string, SlackEventHandler>();
+  commandHandlers = new Map<string, SlackCommandHandler>();
   errorHandler: ((error: Error) => Promise<void>) | null = null;
   readonly init = mock(async () => {});
   readonly start = mock(async () => {});
@@ -97,6 +111,10 @@ class FakeSlackApp {
 
   event(name: string, handler: SlackEventHandler): void {
     this.eventHandlers.set(name, handler);
+  }
+
+  command(name: string, handler: SlackCommandHandler): void {
+    this.commandHandlers.set(name, handler);
   }
 
   error(handler: (error: Error) => Promise<void>): void {
@@ -272,6 +290,59 @@ test("slack adapter start does not re-run bolt init", async () => {
   expect(app).toBeDefined();
   expect(app?.init).not.toHaveBeenCalled();
   expect(app?.start).toHaveBeenCalledTimes(1);
+});
+
+test("slack adapter forwards native /cancel command as channel slash input", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const messages: unknown[] = [];
+  adapter.onMessage = async (message) => {
+    messages.push(message);
+  };
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.commandHandlers.get("/cancel");
+  if (!handler) {
+    throw new Error("Expected /cancel command handler");
+  }
+
+  const ack = mock(async () => {});
+  await handler({
+    command: {
+      command: "/cancel",
+      text: "",
+      user_id: "U123",
+      user_name: "Alice",
+      channel_id: "C123",
+      channel_name: "eng",
+      trigger_id: "trigger-1",
+    },
+    ack,
+  });
+
+  expect(ack).toHaveBeenCalledTimes(1);
+  expect(messages).toHaveLength(1);
+  expect(messages[0]).toMatchObject({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    senderId: "U123",
+    senderName: "Alice",
+    chatLabel: "eng",
+    text: "/cancel",
+    messageId: "trigger-1",
+    threadId: null,
+    chatType: "channel",
+  });
 });
 
 test("resolveSlackAccountDisplayName prefers the Slack bot profile display name", async () => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -79,6 +79,16 @@ type SlackReactionEvent = {
   event_ts?: string;
 };
 
+type SlackCommandPayload = {
+  command?: string;
+  text?: string;
+  user_id?: string;
+  user_name?: string;
+  channel_id?: string;
+  channel_name?: string;
+  trigger_id?: string;
+};
+
 type Constructor = abstract new (...args: never[]) => unknown;
 
 function isConstructorFunction<T extends Constructor>(
@@ -1112,6 +1122,51 @@ export function createSlackAdapter(
         });
       } catch (error) {
         console.error("[Slack] Error handling channel mention:", error);
+      }
+    });
+
+    instance.command("/cancel", async ({ command, ack }) => {
+      await ack();
+
+      if (!adapter.onMessage) {
+        return;
+      }
+
+      const payload = command as SlackCommandPayload;
+      if (
+        !isNonEmptyString(payload.channel_id) ||
+        !isNonEmptyString(payload.user_id)
+      ) {
+        return;
+      }
+
+      const commandText = isNonEmptyString(payload.text)
+        ? `/cancel ${payload.text.trim()}`
+        : "/cancel";
+
+      const inbound: InboundChannelMessage = {
+        channel: "slack",
+        accountId: config.accountId,
+        chatId: payload.channel_id,
+        senderId: payload.user_id,
+        senderName: firstNonEmptyString(payload.user_name, payload.user_id),
+        chatLabel: firstNonEmptyString(
+          payload.channel_name,
+          payload.channel_id,
+        ),
+        text: commandText,
+        timestamp: Date.now(),
+        messageId: firstNonEmptyString(payload.trigger_id, payload.command),
+        threadId: null,
+        chatType: resolveSlackChatType(payload.channel_id),
+        isMention: false,
+        raw: command,
+      };
+
+      try {
+        await adapter.onMessage(inbound);
+      } catch (error) {
+        console.error("[Slack] Error handling /cancel command:", error);
       }
     });
 

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -31,9 +31,12 @@ export async function runSlackSetup(): Promise<boolean> {
     console.log(
       "  4. Enable App Home messages and subscribe to app_mention + message.channels + message.groups + message.im + reaction_added + reaction_removed\n",
     );
+    console.log(
+      "  5. Add the /cancel slash command if you want Slack-native cancellation\n",
+    );
     console.log("Recommended bot token scopes:");
     console.log(
-      "  app_mentions:read, channels:history, chat:write, groups:history, im:history, users:read",
+      "  app_mentions:read, channels:history, chat:write, commands, groups:history, im:history, users:read",
     );
     console.log("  reactions:read, reactions:write, files:read, files:write\n");
 

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -17,7 +17,12 @@ import {
 } from "@/channels/accounts";
 import { clearDynamicMessageChannelToolCache } from "@/channels/message-tool";
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
-import { setRouteInMemory } from "@/channels/routing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  setRouteInMemory,
+} from "@/channels/routing";
 import type { ChannelAdapter } from "@/channels/types";
 import { runWithRuntimeContext } from "@/runtime-context";
 import {
@@ -77,6 +82,9 @@ describe("tool execution context snapshot", () => {
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
     clearExternalTools();
+    clearAllRoutes();
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
     clearChannelAccountStores();
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
@@ -411,6 +419,8 @@ describe("tool execution context snapshot", () => {
 
   test("does not leak MessageChannel into conversations that only share an agent-level Slack account", async () => {
     installChannelAccountTestOverrides();
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
     await loadSpecificTools(["Read"]);
 
     const registry = new ChannelRegistry();
@@ -447,6 +457,8 @@ describe("tool execution context snapshot", () => {
 
   test("includes MessageChannel in scoped snapshots when the conversation has a Slack route", async () => {
     installChannelAccountTestOverrides();
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
     await loadSpecificTools(["Read"]);
 
     const registry = new ChannelRegistry();

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -404,7 +404,7 @@ export async function handleAbortMessageInput(
   listener: ListenerRuntime,
   params: {
     command: AbortMessageCommand;
-    socket: WebSocket;
+    socket: ListenerTransport;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];
       connectionId?: string;

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -439,6 +439,20 @@ export async function wireChannelIngress(
     }),
   );
 
+  registry.setCancelHandler(async ({ runtime }) =>
+    handleAbortMessageInput(listener, {
+      command: {
+        type: "abort_message",
+        runtime,
+        request_id: `channel-cancel-${crypto.randomUUID()}`,
+        run_id: null,
+      },
+      socket,
+      opts,
+      processQueuedTurn,
+    }),
+  );
+
   registry.setReady();
 }
 

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -1,12 +1,22 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import WebSocket from "ws";
+import { getMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import {
   getSubagents,
   subscribe as subscribeToSubagentState,
   subscribeToStreamEvents as subscribeToSubagentStreamEvents,
 } from "@/agent/subagent-state";
+import { getBackend } from "@/backend";
 import { getChannelRegistry } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
+import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
+import { isReflectionSubagentActive } from "@/cli/helpers/reflection-gate";
+import {
+  buildAutoReflectionPayload,
+  buildParentMemorySnapshot,
+  buildReflectionSubagentPrompt,
+  finalizeAutoReflectionPayload,
+} from "@/cli/helpers/reflection-transcript";
 import {
   startScheduler as startCronScheduler,
   stopScheduler as stopCronScheduler,
@@ -80,6 +90,13 @@ import {
   scheduleListenerWarmupsAfterSync,
 } from "./warmup";
 import { stopAllWorktreeWatchers } from "./worktree-watcher";
+
+function escapeTaskNotificationSummary(summary: string): string {
+  return summary
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
 
 function trackListenerError(
   errorType: string,
@@ -452,6 +469,143 @@ export async function wireChannelIngress(
       processQueuedTurn,
     }),
   );
+
+  registry.setReflectionHandler(async ({ runtime }) => {
+    const agentId = runtime.agent_id;
+    const conversationId = runtime.conversation_id;
+
+    if (!settingsManager.isMemfsEnabled(agentId)) {
+      return {
+        handled: true,
+        text: "Reflection needs the memory filesystem to be enabled for this agent. Use /remember for a lightweight memory update instead.",
+      };
+    }
+
+    if (isReflectionSubagentActive(getSubagents(), agentId, conversationId)) {
+      return {
+        handled: true,
+        text: "A reflection agent is already running for this conversation.",
+      };
+    }
+
+    try {
+      let systemPrompt: string | undefined;
+      try {
+        const agent = await getBackend().retrieveAgent(agentId);
+        systemPrompt = agent.system ?? undefined;
+      } catch {
+        // Non-fatal — the reflection payload can omit the system prompt.
+      }
+
+      const autoPayload = await buildAutoReflectionPayload(
+        agentId,
+        conversationId,
+        systemPrompt,
+      );
+      if (!autoPayload) {
+        return {
+          handled: true,
+          text: "No new transcript content to reflect on for this conversation.",
+        };
+      }
+
+      const memoryDir = getMemoryFilesystemRoot(agentId);
+      const parentMemory = await buildParentMemorySnapshot(memoryDir);
+      const reflectionPrompt = buildReflectionSubagentPrompt({
+        memoryDir,
+        parentMemory,
+      });
+
+      const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
+        await import("@/tools/impl/task");
+      const { subagentId } = spawnBackgroundSubagentTask({
+        subagentType: "reflection",
+        prompt: reflectionPrompt,
+        description: "Reflecting on channel conversation",
+        silentCompletion: true,
+        transcriptPath: autoPayload.payloadPath,
+        parentScope: { agentId, conversationId },
+        onComplete: async ({ success, error, agentId: reflectionAgentId }) => {
+          telemetry.trackReflectionEnd("manual", success, {
+            subagentId: reflectionAgentId ?? undefined,
+            conversationId,
+            error,
+          });
+          await finalizeAutoReflectionPayload(
+            agentId,
+            conversationId,
+            autoPayload.payloadPath,
+            autoPayload.endSnapshotLine,
+            success,
+          );
+
+          const completionMessage = await handleMemorySubagentCompletion(
+            {
+              agentId,
+              conversationId,
+              subagentType: "reflection",
+              success,
+              error,
+            },
+            {
+              recompileByConversation:
+                listener.systemPromptRecompileByConversation,
+              recompileQueuedByConversation:
+                listener.queuedSystemPromptRecompileByConversation,
+              logRecompileFailure: (message) =>
+                isDebugEnabled() && console.warn(message),
+            },
+          );
+
+          const conversationRuntime = getOrCreateConversationRuntime(
+            listener,
+            agentId,
+            conversationId,
+          );
+          const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
+            completionMessage,
+          )}</summary></task-notification>`;
+          emitStreamDelta(
+            socket,
+            conversationRuntime,
+            {
+              type: "message",
+              id: `user-msg-${crypto.randomUUID()}`,
+              date: new Date().toISOString(),
+              message_type: "user_message",
+              content: [{ type: "text", text: notificationXml }],
+            } as import("@/types/protocol_v2").StreamDelta,
+            {
+              agent_id: agentId,
+              conversation_id: conversationId,
+            },
+          );
+        },
+      });
+
+      const reflectionAgentId = await waitForBackgroundSubagentAgentId(
+        subagentId,
+        1000,
+      );
+      telemetry.trackReflectionStart("manual", {
+        subagentId: reflectionAgentId ?? undefined,
+        conversationId,
+        startMessageId: autoPayload.startMessageId,
+        endMessageId: autoPayload.endMessageId,
+      });
+
+      return {
+        handled: true,
+        text: "Started a reflection pass for this conversation.",
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        handled: true,
+        text: `Failed to start reflection: ${message}`,
+      };
+    }
+  });
 
   registry.setReady();
 }


### PR DESCRIPTION
## Summary

Consolidates the channel slash-command work into one branch:

- Supersedes #2286 by adding /status for channel chats.
- Supersedes #2299 by adding /pause and /resume for channel route control.
- Supersedes #2327 by adding /cancel through the existing listener abort path, including Slack-native /cancel payload handling.
- Adds channel-tailored /chat and /reflection commands for routed channel conversations.

## Problem

The separate slash-command PRs all touched the same shared channel router, registry ingress path, and registry tests. Keeping them split caused repeat merge conflicts and made it too easy for the router API to drift in incompatible directions.

Channel users also need a practical command set without switching back to the TUI: inspect connection status, pause or resume route delivery, cancel an in-progress turn, jump to the Letta web chat, and manually trigger memory reflection.

## Approach

The shared channel command router now advertises /help, /status, /pause, /resume, /cancel, /chat, and /reflection. Parsing and user-facing copy stay in src/channels/commands.ts, while stateful operations stay in ChannelRegistry handlers.

/status reads account and route state. /pause and /resume update the persisted route enabled flag. /cancel calls the listener's existing abort-message path and still bypasses pending channel control prompts so it can act as an escape hatch. /chat returns the app.letta.com chat URL for the current routed agent/conversation when the route is cloud-backed. /reflection starts the same memory reflection subagent flow used by the listener, scoped to the routed agent conversation, when MemFS is enabled.

Slack-native /cancel command payloads are converted into normal inbound channel messages, with a sole-thread fallback for Slack's missing thread metadata. The other commands are typed as normal messages in the relevant channel chat/thread for now.

I dropped the stale Discord import-only changes from the pause/resume PR and moved old test additions onto the current colocated test paths.

## Before / after

Before: channel slash support was limited to /help on main, while /status, /pause, /resume, and /cancel lived on separate conflicting branches.

After: one shared implementation handles the consolidated channel command set across channel ingress: /status, /pause, /resume, /cancel, /chat, and /reflection.

## Limits and follow-up

This PR intentionally does not add /ade or /migrate. It also does not add /heartbeat, /reset, /setconv, /approve, or /disapprove.

Slack-native slash command payloads still cannot identify a specific thread. If a Slack channel has multiple routed Letta threads, users should send /cancel as a normal message in the target thread instead.

## Validation

- USER_CWD="$PWD" bun test src/channels/commands.test.ts src/channels/registry.test.ts src/channels/slack-adapter.test.ts src/tools/tool-execution-context.test.ts
- bun run typecheck
- bun run lint
- git diff --check

👾 Generated with [Letta Code](https://letta.com)
