### PR TITLE
fix(agent): recover TS core busy conflicts

### DIFF
--- a/src/agent/turn-recovery-policy.test.ts
+++ b/src/agent/turn-recovery-policy.test.ts
@@ -66,6 +66,14 @@ describe("isConversationBusyError", () => {
     ).toBe(true);
   });
 
+  test("detects TS core active-run busy error", () => {
+    expect(
+      isConversationBusyError(
+        "Conversation conv-123 is busy with another active run.",
+      ),
+    ).toBe(true);
+  });
+
   test("rejects approval-pending", () => {
     expect(isConversationBusyError("The agent is waiting for approval")).toBe(
       false,
@@ -99,6 +107,14 @@ describe("classifyPreStreamConflict", () => {
   test("conversation busy", () => {
     expect(
       classifyPreStreamConflict("another request is currently being processed"),
+    ).toBe("conversation_busy");
+  });
+
+  test("conversation busy from TS core", () => {
+    expect(
+      classifyPreStreamConflict(
+        "Conversation is busy with another active run.",
+      ),
     ).toBe("conversation_busy");
   });
 
@@ -478,6 +494,22 @@ describe("extractConflictDetail", () => {
     expect(extractConflictDetail(err)).toBe("fallback msg");
   });
 
+  test("nested string: e.error.error", () => {
+    const err = {
+      error: { error: "Conversation is busy with another active run." },
+    };
+    expect(extractConflictDetail(err)).toBe(
+      "Conversation is busy with another active run.",
+    );
+  });
+
+  test("string body: e.error", () => {
+    const err = { error: "Conversation is busy with another active run." };
+    expect(extractConflictDetail(err)).toBe(
+      "Conversation is busy with another active run.",
+    );
+  });
+
   test("flat: e.error.detail", () => {
     const err = {
       error: { detail: "another request is currently being processed" },
@@ -521,6 +553,19 @@ describe("extractConflictDetail", () => {
     expect(isConversationBusyError(detail)).toBe(false);
     expect(getPreStreamErrorAction(detail, 0, 3)).toBe(
       "resolve_approval_pending",
+    );
+  });
+
+  test("end-to-end: TS core busy response retries as conversation busy", () => {
+    const sdkError = {
+      error: {
+        error: "Conversation is busy with another active run.",
+      },
+    };
+    const detail = extractConflictDetail(sdkError);
+    expect(isConversationBusyError(detail)).toBe(true);
+    expect(getPreStreamErrorAction(detail, 0, 3)).toBe(
+      "retry_conversation_busy",
     );
   });
 });

--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -17,7 +17,10 @@ import type { StopReasonType } from "@/types/protocol_v2";
 
 const INVALID_TOOL_CALL_IDS_FRAGMENT = "invalid tool call ids";
 const APPROVAL_PENDING_DETAIL_FRAGMENT = "waiting for approval";
-const CONVERSATION_BUSY_DETAIL_FRAGMENT = "is currently being processed";
+const CONVERSATION_BUSY_DETAIL_FRAGMENTS = [
+  "is currently being processed",
+  "busy with another active run",
+];
 const EMPTY_RESPONSE_DETAIL_FRAGMENT = "empty content in";
 const RETRYABLE_PROVIDER_DETAIL_PATTERNS = [
   "Anthropic API error",
@@ -134,7 +137,10 @@ export function isApprovalPendingError(detail: unknown): boolean {
 /** Conversation is busy (another request is being processed). */
 export function isConversationBusyError(detail: unknown): boolean {
   if (typeof detail !== "string") return false;
-  return detail.toLowerCase().includes(CONVERSATION_BUSY_DETAIL_FRAGMENT);
+  const normalized = detail.toLowerCase();
+  return CONVERSATION_BUSY_DETAIL_FRAGMENTS.some((fragment) =>
+    normalized.includes(fragment),
+  );
 }
 
 /**
@@ -380,6 +386,7 @@ export function getPreStreamErrorAction(
 export function extractConflictDetail(error: unknown): string {
   if (error && typeof error === "object" && "error" in error) {
     const errObj = (error as Record<string, unknown>).error;
+    if (typeof errObj === "string") return errObj;
     if (errObj && typeof errObj === "object") {
       const outer = errObj as Record<string, unknown>;
       // Nested: e.error.error.detail → e.error.error.message
@@ -388,6 +395,8 @@ export function extractConflictDetail(error: unknown): string {
         if (typeof nested.detail === "string") return nested.detail;
         if (typeof nested.message === "string") return nested.message;
       }
+      // String body: e.error.error (e.g. { error: "Conversation is busy..." })
+      if (typeof outer.error === "string") return outer.error;
       // Direct: e.error.detail → e.error.message
       if (typeof outer.detail === "string") return outer.detail;
       if (typeof outer.message === "string") return outer.message;


### PR DESCRIPTION
Prepared by Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974).

## Summary
- Teach the shared turn-recovery policy to recognize the TS core busy response wording: Conversation is busy with another active run.
- Extract string-shaped SDK error bodies from both error and nested error fields before falling back to the generic Error message.
- Add focused coverage that routes the TS core busy response into the existing retry_conversation_busy path.

## Problem
Letta Code already has recovery for 409 conversation-busy responses. That recovery depends on classifying the server error detail as a recoverable busy conflict, then resuming the in-flight run or retrying instead of surfacing the raw conflict.

The TS core conversations router returns a different busy message shape than the older Core wording. It also commonly presents as a string under the error field. The client extractor and classifier did not recognize that combination, so a semantic busy conflict could leak through as an ordinary 409.

## Approach
This keeps the existing recovery behavior and broadens the input normalization only at the shared policy boundary. The change does not add a new retry path. It makes the current headless, TUI, and listener callers see the TS core busy response as the same conversation-busy condition they already handle.

## Before / after
Before: TS core active-run conflicts could be treated as unknown 409s and surface to the user.
After: the same conflict is extracted, classified as conversation_busy, and routed through retry_conversation_busy.

## Risk and limits
Low risk. The new classifier phrase is specific to busy active-run conflicts and should not overlap with pending approval errors. This does not change cancel behavior or non-busy 409s.

## Validation
- bun test src/agent/turn-recovery-policy.test.ts
- bun test src/headless-approval-recovery.test.ts src/websocket/listen-client-concurrency.test.ts
- bun run lint

👾 Generated with [Letta Code](https://letta.com)