### PR TITLE
feat(cli): rename max context command

### DIFF
--- a/src/agent/max-context.test.ts
+++ b/src/agent/max-context.test.ts
@@ -36,6 +36,9 @@ describe("max context command helpers", () => {
     expect(() => parseSetMaxContextArgs("10000 --force")).toThrow(
       "Unknown option: --force",
     );
+    expect(() => parseSetMaxContextArgs("10000 20000")).toThrow(
+      "Usage: /context-limit [tokens] [--override]",
+    );
   });
 
   test("resolves model.json default context windows", () => {

--- a/src/agent/max-context.ts
+++ b/src/agent/max-context.ts
@@ -92,7 +92,7 @@ export function parseSetMaxContextArgs(
   }
 
   if (values.length > 1) {
-    throw new Error("Usage: /set-max-context [tokens] [--override]");
+    throw new Error("Usage: /context-limit [tokens] [--override]");
   }
 
   if (values.length === 0) {

--- a/src/cli/app/submit-diagnostics-commands.ts
+++ b/src/cli/app/submit-diagnostics-commands.ts
@@ -361,11 +361,21 @@ export async function handleDiagnosticsCommand(
     return { submitted: true };
   }
 
-  if (
-    trimmed === "/set-max-context" ||
-    trimmed.startsWith("/set-max-context ")
-  ) {
-    const args = trimmed.slice("/set-max-context".length).trim();
+  const contextLimitCommand = (() => {
+    if (trimmed === "/context-limit" || trimmed.startsWith("/context-limit ")) {
+      return "/context-limit";
+    }
+    if (
+      trimmed === "/set-max-context" ||
+      trimmed.startsWith("/set-max-context ")
+    ) {
+      return "/set-max-context";
+    }
+    return null;
+  })();
+
+  if (contextLimitCommand) {
+    const args = trimmed.slice(contextLimitCommand.length).trim();
     const cmd = commandRunner.start(trimmed, "Setting max context window...");
     setCommandRunning(true);
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -140,6 +140,15 @@ export const commands: Record<string, Command> = {
       return "Opening compaction settings...";
     },
   },
+  "/context-limit": {
+    desc: "Set or reset the max context window",
+    args: "[tokens] [--override]",
+    order: 15.7,
+    handler: () => {
+      // Handled specially in App.tsx
+      return "Setting max context window...";
+    },
+  },
   "/memfs": {
     desc: "Manage filesystem-backed memory (/memfs [enable|disable|sync|reset])",
     args: "[enable|disable|sync|reset]",
@@ -600,7 +609,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/set-max-context": {
-    desc: "Set or reset the max context window",
+    desc: "Alias for /context-limit",
     args: "[tokens] [--override]",
     hidden: true,
     handler: () => {

--- a/src/cli/context-limit-command.test.ts
+++ b/src/cli/context-limit-command.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { commands, executeCommand } from "@/cli/commands/registry";
+
+describe("/context-limit command registration", () => {
+  test("advertises the canonical command and hides the legacy alias", () => {
+    expect(commands["/context-limit"]).toMatchObject({
+      desc: "Set or reset the max context window",
+      args: "[tokens] [--override]",
+    });
+    expect(commands["/context-limit"]?.hidden).not.toBe(true);
+
+    expect(commands["/set-max-context"]).toMatchObject({
+      desc: "Alias for /context-limit",
+      args: "[tokens] [--override]",
+      hidden: true,
+    });
+
+    const discoverableCommands = Object.entries(commands)
+      .filter(([, command]) => !command.hidden)
+      .map(([name]) => name);
+
+    expect(discoverableCommands).toContain("/context-limit");
+    expect(discoverableCommands).not.toContain("/set-max-context");
+  });
+
+  test("executes canonical and legacy registry entries", async () => {
+    await expect(
+      executeCommand("/context-limit 10000 --override"),
+    ).resolves.toMatchObject({
+      success: true,
+      output: "Setting max context window...",
+    });
+
+    await expect(
+      executeCommand("/set-max-context 10000 --override"),
+    ).resolves.toMatchObject({
+      success: true,
+      output: "Setting max context window...",
+    });
+  });
+});

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -936,9 +936,9 @@ describe("listen-client parseServerMessage", () => {
     expect(setExperiment?.type).toBe("set_experiment");
   });
 
-  test("advertises and parses remote context-limit execute_command", () => {
+  test("advertises context-limit and parses the legacy set-max-context alias", () => {
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("context-limit");
-    expect(SUPPORTED_REMOTE_COMMANDS).toContain("set-max-context");
+    expect(SUPPORTED_REMOTE_COMMANDS).not.toContain("set-max-context");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("goal");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("compact");
 

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -936,7 +936,8 @@ describe("listen-client parseServerMessage", () => {
     expect(setExperiment?.type).toBe("set_experiment");
   });
 
-  test("advertises and parses remote set-max-context execute_command", () => {
+  test("advertises and parses remote context-limit execute_command", () => {
+    expect(SUPPORTED_REMOTE_COMMANDS).toContain("context-limit");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("set-max-context");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("goal");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("compact");
@@ -945,8 +946,8 @@ describe("listen-client parseServerMessage", () => {
       Buffer.from(
         JSON.stringify({
           type: "execute_command",
-          command_id: "set-max-context",
-          request_id: "set-max-context-1",
+          command_id: "context-limit",
+          request_id: "context-limit-1",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
           args: "10000 --override",
         }),
@@ -955,8 +956,26 @@ describe("listen-client parseServerMessage", () => {
 
     expect(command).toMatchObject({
       type: "execute_command",
-      command_id: "set-max-context",
+      command_id: "context-limit",
       args: "10000 --override",
+    });
+
+    const legacyCommand = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "execute_command",
+          command_id: "set-max-context",
+          request_id: "set-max-context-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          args: "12000 --override",
+        }),
+      ),
+    );
+
+    expect(legacyCommand).toMatchObject({
+      type: "execute_command",
+      command_id: "set-max-context",
+      args: "12000 --override",
     });
   });
 
@@ -1081,7 +1100,7 @@ describe("listen-client parseServerMessage", () => {
     }
   });
 
-  test("runs remote set-max-context execute_command", async () => {
+  test("runs remote context-limit and legacy set-max-context execute_command", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "ws-max-context-"));
     try {
       const backend = new LocalBackend({
@@ -1104,8 +1123,8 @@ describe("listen-client parseServerMessage", () => {
       await handleExecuteCommand(
         {
           type: "execute_command",
-          command_id: "set-max-context",
-          request_id: "set-max-context-run-1",
+          command_id: "context-limit",
+          request_id: "context-limit-run-1",
           runtime: { agent_id: agent.id, conversation_id: "default" },
           args: "10000 --override",
         },
@@ -1123,6 +1142,30 @@ describe("listen-client parseServerMessage", () => {
       ).toBe(10_000);
       expect(socket.sentPayloads.join("\n")).toContain(
         "Agent max context set to 10,000 tokens with override.",
+      );
+
+      await handleExecuteCommand(
+        {
+          type: "execute_command",
+          command_id: "set-max-context",
+          request_id: "set-max-context-run-1",
+          runtime: { agent_id: agent.id, conversation_id: "default" },
+          args: "12000 --override",
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {},
+      );
+
+      expect(
+        (
+          (await backend.retrieveAgent(agent.id)) as {
+            llm_config?: { context_window?: number };
+          }
+        ).llm_config?.context_window,
+      ).toBe(12_000);
+      expect(socket.sentPayloads.join("\n")).toContain(
+        "Agent max context set to 12,000 tokens with override.",
       );
     } finally {
       await rm(storageDir, { recursive: true, force: true });

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -129,6 +129,7 @@ export async function handleExecuteCommand(
         output = await handleCompactCommand(conversationRuntime, trimmedArgs);
         break;
 
+      case "context-limit":
       case "set-max-context":
         output = await handleSetMaxContextCommand(
           conversationRuntime,
@@ -760,14 +761,14 @@ async function handleGoalCommand(
   return resultPrefix;
 }
 
-/** /set-max-context — Set or reset the active scope's max context window. */
+/** /context-limit — Set or reset the active scope's max context window. */
 async function handleSetMaxContextCommand(
   conversationRuntime: ConversationRuntime,
   args: string | undefined,
 ): Promise<string> {
   const agentId = conversationRuntime.agentId;
   if (!agentId) {
-    throw new Error("No agent ID available for /set-max-context command");
+    throw new Error("No agent ID available for /context-limit command");
   }
 
   const result = await applySetMaxContext({

--- a/src/websocket/listener/listener-constants.ts
+++ b/src/websocket/listener/listener-constants.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "remember",
   "goal",
   "compact",
+  "context-limit",
   "set-max-context",
   "channels",
   "toolset",

--- a/src/websocket/listener/listener-constants.ts
+++ b/src/websocket/listener/listener-constants.ts
@@ -13,7 +13,6 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "goal",
   "compact",
   "context-limit",
-  "set-max-context",
   "channels",
   "toolset",
   // /secret opens the EditSecretsDialog and routes reads/writes through the


### PR DESCRIPTION
## Problem
- The max context command was exposed as `/set-max-context`, but the canonical user-facing name should be `/context-limit`.

## Approach
- Register `/context-limit` as the visible CLI slash command.
- Keep `/set-max-context` as a hidden CLI alias and accepted remote `execute_command` alias.
- Add `context-limit` to remote supported commands so app command discovery and allowlists can enable it.
- Update usage text to `/context-limit` without changing max-context scoping semantics.

## Before / after behavior
- Before: `/set-max-context` worked; `/context-limit` was absent from CLI discovery and remote supported commands.
- After: `/context-limit` works and appears in CLI discovery and remote supported commands; `/set-max-context` still works as a legacy alias.

## Legacy alias behavior
- CLI registry keeps `/set-max-context` hidden but executable.
- Remote command dispatch accepts both `context-limit` and `set-max-context` command IDs.

## Risk / limits
- Low-risk routing and registration change.
- Existing max-context semantics are unchanged: the default conversation updates agent defaults, while non-default conversations update the conversation-scoped context limit.

## Validation
- `bunx --bun @biomejs/biome@2.2.5 check --write src/agent/max-context.ts src/agent/max-context.test.ts src/cli/app/submit-diagnostics-commands.ts src/cli/commands/registry.ts src/cli/context-limit-command.test.ts src/websocket/listen-client-protocol.test.ts src/websocket/listener/commands.ts src/websocket/listener/listener-constants.ts`
- `bun test src/agent/max-context.test.ts src/cli/context-limit-command.test.ts src/websocket/listen-client-protocol.test.ts`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)