### PR TITLE
fix(local-backend): settle orphaned tool calls before starting a new turn

### DIFF
--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -19,6 +19,7 @@ import {
   type LocalStoreOptions,
 } from "@/backend/local/local-store";
 import { isLocalStateChunkOnly } from "@/backend/local/local-stream-chunks";
+import { TURN_DID_NOT_COMPLETE } from "@/constants";
 import {
   DeterministicPongExecutor,
   type HeadlessTurnExecutor,
@@ -357,6 +358,15 @@ export class HeadlessBackend implements Backend {
     conversationId: string,
     body: ConversationMessageCreateBody | ConversationMessageStreamBody,
   ) {
+    // Settle any tool calls left without results from a prior interrupted turn.
+    // If the process was killed or the stream errored out before cancelConversation
+    // was called, orphaned tool_use blocks remain in the history. Anthropic rejects
+    // any subsequent turn that includes them, so we add synthetic error results here
+    // before assembling the context for the new turn.
+    this.store.settleInterruptedToolCalls(conversationId, {
+      reason: TURN_DID_NOT_COMPLETE,
+    });
+
     const turnInput = this.store.appendTurnInput(conversationId, body);
     const run = this.startRun(
       turnInput.conversationId,

--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -363,9 +363,19 @@ export class HeadlessBackend implements Backend {
     // was called, orphaned tool_use blocks remain in the history. Anthropic rejects
     // any subsequent turn that includes them, so we add synthetic error results here
     // before assembling the context for the new turn.
-    this.store.settleInterruptedToolCalls(conversationId, {
-      reason: TURN_DID_NOT_COMPLETE,
-    });
+    //
+    // Skip when the incoming turn is an approval — that means the previous turn
+    // ended with requires_approval and the tool call is intentionally pending,
+    // waiting for the user's approval response in this very turn.
+    const messages = (body as { messages?: unknown[] }).messages ?? [];
+    const isApprovalTurn = messages.some(
+      (m) => (m as { type?: string }).type === "approval",
+    );
+    if (!isApprovalTurn) {
+      this.store.settleInterruptedToolCalls(conversationId, {
+        reason: TURN_DID_NOT_COMPLETE,
+      });
+    }
 
     const turnInput = this.store.appendTurnInput(conversationId, body);
     const run = this.startRun(

--- a/src/backend/fake-headless-backend.test.ts
+++ b/src/backend/fake-headless-backend.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { ConversationMessageCreateBody } from "@/backend";
 import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 import { DeterministicToolCallExecutor } from "@/backend/dev/headless-turn-executor";
+import { TURN_DID_NOT_COMPLETE } from "@/constants";
 
 async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   const chunks: unknown[] = [];
@@ -64,6 +65,82 @@ describe("FakeHeadlessBackend", () => {
     );
     expect(jsonl).toContain('"content"');
     expect(jsonl).not.toContain('"parts"');
+  });
+
+  test("settles orphaned tool calls from an interrupted turn before the next turn", async () => {
+    // Simulate what happens when a turn is interrupted (crash / unhandled error)
+    // before cancelConversation is called: a tool_use block is stored in the
+    // conversation history but its tool_result never arrives. The next turn must
+    // add a synthetic error result so the provider doesn't reject the context.
+    const backend = new FakeHeadlessBackend(
+      "agent-fake-headless",
+      new DeterministicToolCallExecutor(),
+      { strictAgentAccess: false, strictConversationAccess: false },
+    );
+    const conversation = await backend.createConversation({
+      agent_id: "agent-fake-headless",
+    });
+
+    // Run a turn that ends with a tool call (requires_approval), then do NOT
+    // send a tool result — leave the tool call orphaned.
+    await collect(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: "agent-fake-headless",
+        messages: [{ role: "user", content: "use a tool" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    // Inspect the raw local messages before the next turn: there should be one
+    // tool call with no corresponding result.
+    const storeBefore = (
+      backend as unknown as {
+        store: { listLocalMessages: (id: string) => unknown[] };
+      }
+    ).store.listLocalMessages(conversation.id);
+    const messagesBefore = storeBefore as Array<{
+      role: string;
+      content?: Array<{ type: string; id?: string }>;
+      toolCallId?: string;
+    }>;
+    const orphanedCallIds = messagesBefore
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => m.content ?? [])
+      .filter((c) => c.type === "toolCall")
+      .map((c) => c.id ?? "");
+    const existingResultIds = messagesBefore
+      .filter((m) => m.role === "toolResult")
+      .map((m) => m.toolCallId ?? "");
+    const unsettled = orphanedCallIds.filter(
+      (id) => !existingResultIds.includes(id),
+    );
+    expect(unsettled.length).toBe(1); // one orphaned tool call before the next turn
+
+    // Start the next turn — executeConversationTurn should settle the orphan first.
+    await collect(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: "agent-fake-headless",
+        messages: [{ role: "user", content: "second turn" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    // Now the orphaned tool call should have a synthetic error result.
+    const storeAfter = (
+      backend as unknown as {
+        store: { listLocalMessages: (id: string) => unknown[] };
+      }
+    ).store.listLocalMessages(conversation.id);
+    const messagesAfter = storeAfter as Array<{
+      role: string;
+      content?: Array<{ type: string; text?: string }>;
+      toolCallId?: string;
+    }>;
+    const settledResult = messagesAfter.find(
+      (m) =>
+        m.role === "toolResult" &&
+        unsettled.includes(m.toolCallId ?? "") &&
+        m.content?.some((c) => c.text === TURN_DID_NOT_COMPLETE),
+    );
+    expect(settledResult).toBeDefined();
   });
 
   test("keeps approval turns open when a tool call is emitted", async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,13 @@ export const DEFAULT_AGENT_NAME = "Letta Code";
 export const INTERRUPTED_BY_USER = "Interrupted by user";
 
 /**
+ * Synthetic tool result injected when a turn ended without completing all tool calls
+ * (e.g. process crash or unhandled stream error). Settled automatically at the start
+ * of the next turn so the conversation history stays valid for the provider.
+ */
+export const TURN_DID_NOT_COMPLETE = "Turn did not complete";
+
+/**
  * XML tag used to wrap system reminder content injected into messages
  */
 export const SYSTEM_REMINDER_TAG = "system-reminder";


### PR DESCRIPTION
## Summary

- When a local backend turn is interrupted without `cancelConversation` being called (process crash, unhandled stream error), `tool_use` blocks are stored in the history without matching `tool_result` entries
- On the next turn, Anthropic rejects the assembled context with `400 "tool_use without tool_result"` — surfaced as "Tried to reflect, but got lost in the palace"
- Fix: call `settleInterruptedToolCalls` at the start of `executeConversationTurn`, before the history is assembled, so any orphaned tool calls get synthetic error results first
- Adds `TURN_DID_NOT_COMPLETE` constant to distinguish auto-settled results from user-cancelled ones

## Test plan

- [ ] New test in `fake-headless-backend.test.ts`: runs a turn ending with a tool call, does NOT send a result (simulating a crash), then starts a second turn and asserts the orphaned call was settled with `TURN_DID_NOT_COMPLETE` before the second turn ran
- [ ] All 7 checks pass

👾 Generated with [Letta Code](https://letta.com)