### PR TITLE
fix: hide reflection error detail behind LETTA_DEBUG flag

### DIFF
--- a/src/cli/helpers/memory-subagent-completion.ts
+++ b/src/cli/helpers/memory-subagent-completion.ts
@@ -1,4 +1,5 @@
 import { recompileAgentSystemPrompt } from "@/agent/modify";
+import { isDebugEnabled } from "@/utils/debug";
 import {
   estimateSystemTokens,
   setSystemPromptDoctorState,
@@ -81,10 +82,11 @@ export async function handleMemorySubagentCompletion(
   }
 
   if (!success) {
-    const normalizedError = error || "Unknown error";
     if (subagentType === "reflection") {
-      return `Tried to reflect, but got lost in the palace: ${normalizedError}`;
+      const detail = isDebugEnabled() ? `: ${error || "Unknown error"}` : "";
+      return `Tried to reflect, but got lost in the palace${detail}`;
     }
+    const normalizedError = error || "Unknown error";
     return `Memory initialization failed: ${normalizedError}`;
   }
 


### PR DESCRIPTION
## Summary

- The full JSON error payload from a failed reflection turn is not actionable to end users
- Gate it behind `LETTA_DEBUG`: show only the friendly message at `LETTA_DEBUG=0`, append the full error at `LETTA_DEBUG=1`
- Memory init failures are unchanged (keep full error — rarer, more diagnostic value)

## Before / After

**LETTA_DEBUG=0 (default production):**
```
• Tried to reflect, but got lost in the palace
```

**LETTA_DEBUG=1 (dev mode):**
```
• Tried to reflect, but got lost in the palace: {"error":{"message":"400 {\"type\":\"error\"...
```

## Test plan
- [ ] Checks pass
- [ ] Manually verify message shows without detail at `LETTA_DEBUG=0`
- [ ] Manually verify full error appended at `LETTA_DEBUG=1`

👾 Generated with [Letta Code](https://letta.com)