### PR TITLE
fix(ws): pull memfs before listing memory

### DIFF
--- a/src/agent/memory-filesystem.ts
+++ b/src/agent/memory-filesystem.ts
@@ -175,14 +175,21 @@ export async function isMemfsEnabledOnServer(
   return enabled;
 }
 
+export interface EnsureLocalMemfsCheckoutOptions {
+  pullOnExistingRepo?: boolean;
+}
+
 /**
  * Ensures the local memfs checkout exists for an already-enabled agent.
  *
  * Unlike applyMemfsFlags(), this helper does not update prompts, tags, tools,
- * or other agent configuration. It only materializes the local git checkout
- * when the repo is missing.
+ * or other agent configuration. It materializes the local git checkout when
+ * missing and can optionally pull an existing remote-backed repo before use.
  */
-export async function ensureLocalMemfsCheckout(agentId: string): Promise<void> {
+export async function ensureLocalMemfsCheckout(
+  agentId: string,
+  options: EnsureLocalMemfsCheckoutOptions = {},
+): Promise<void> {
   if (isLocalBackendEnvEnabled()) {
     const { initializeLocalMemoryRepo } = await import("@/agent/memory-git");
     await initializeLocalMemoryRepo({
@@ -193,8 +200,13 @@ export async function ensureLocalMemfsCheckout(agentId: string): Promise<void> {
     return;
   }
 
-  const { isGitRepo, cloneMemoryRepo } = await import("@/agent/memory-git");
+  const { isGitRepo, cloneMemoryRepo, pullMemory } = await import(
+    "@/agent/memory-git"
+  );
   if (isGitRepo(agentId)) {
+    if (options.pullOnExistingRepo) {
+      await pullMemory(agentId, { throwOnFailure: true });
+    }
     return;
   }
   await cloneMemoryRepo(agentId);

--- a/src/agent/memory-git.ts
+++ b/src/agent/memory-git.ts
@@ -1749,8 +1749,13 @@ export async function cloneMemoryRepo(agentId: string): Promise<void> {
  * Pull latest changes from the server.
  * Called on startup to ensure local state is current.
  */
+export interface PullMemoryOptions {
+  throwOnFailure?: boolean;
+}
+
 export async function pullMemory(
   agentId: string,
+  options: PullMemoryOptions = {},
 ): Promise<{ updated: boolean; summary: string }> {
   const token = await getAuthToken();
   const dir = getMemoryRepoDir(agentId);
@@ -1824,10 +1829,14 @@ export async function pullMemory(
 
       const msg =
         rebaseErr instanceof Error ? rebaseErr.message : String(rebaseErr);
+      const failureSummary = `Pull failed: ${msg}\nHint: verify remote and auth:\n- git -C ${dir} remote -v\n- git -C ${dir} config --get-regexp '^credential\\..*\\.helper$'`;
       debugWarn("memfs-git", `Pull failed: ${msg}`);
+      if (options.throwOnFailure) {
+        throw new Error(failureSummary);
+      }
       return {
         updated: false,
-        summary: `Pull failed: ${msg}\nHint: verify remote and auth:\n- git -C ${dir} remote -v\n- git -C ${dir} config --get-regexp '^credential\\..*\\.helper$'`,
+        summary: failureSummary,
       };
     }
   }

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -7,7 +7,10 @@ import { fileURLToPath } from "node:url";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import WebSocket from "ws";
-import { getMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+import {
+  type EnsureLocalMemfsCheckoutOptions,
+  getMemoryFilesystemRoot,
+} from "@/agent/memory-filesystem";
 import { buildConversationMessagesCreateRequestBody } from "@/agent/message";
 import { models } from "@/agent/model";
 import {
@@ -1450,14 +1453,16 @@ describe("listen-client memory command handling", () => {
   test("bootstraps only the local memfs checkout when memfs is already enabled", async () => {
     const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
     const socket = new MockSocket(WebSocket.OPEN);
-    const ensureLocalMemfsCheckoutMock = mock(async () => {
-      await mkdir(join(tempRoot, ".git"), { recursive: true });
-      await mkdir(join(tempRoot, "system"), { recursive: true });
-      await writeFile(
-        join(tempRoot, "system", "persona.md"),
-        "---\ndescription: Persona\n---\nHello from memory\n",
-      );
-    });
+    const ensureLocalMemfsCheckoutMock = mock(
+      async (_agentId: string, _options?: EnsureLocalMemfsCheckoutOptions) => {
+        await mkdir(join(tempRoot, ".git"), { recursive: true });
+        await mkdir(join(tempRoot, "system"), { recursive: true });
+        await writeFile(
+          join(tempRoot, "system", "persona.md"),
+          "---\ndescription: Persona\n---\nHello from memory\n",
+        );
+      },
+    );
 
     try {
       await __listenClientTestUtils.handleListMemoryCommand(
@@ -1476,6 +1481,10 @@ describe("listen-client memory command handling", () => {
       );
 
       expect(ensureLocalMemfsCheckoutMock).toHaveBeenCalledTimes(1);
+      expect(ensureLocalMemfsCheckoutMock.mock.calls[0]).toEqual([
+        "agent-1",
+        { pullOnExistingRepo: true },
+      ]);
       const messages = socket.sentPayloads.map((payload) =>
         JSON.parse(payload as string),
       );
@@ -1498,6 +1507,112 @@ describe("listen-client memory command handling", () => {
         }),
       ]);
       expect(messages[0].entries[0]?.content).toContain("Hello from memory");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("pulls an existing local memfs checkout before scanning", async () => {
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
+    const socket = new MockSocket(WebSocket.OPEN);
+    const isMemfsEnabledOnServerMock = mock(async () => true);
+    const ensureLocalMemfsCheckoutMock = mock(
+      async (_agentId: string, _options?: EnsureLocalMemfsCheckoutOptions) => {
+        await mkdir(join(tempRoot, "system"), { recursive: true });
+        await writeFile(
+          join(tempRoot, "system", "human.md"),
+          "---\ndescription: Human\n---\nPulled from remote\n",
+        );
+      },
+    );
+
+    try {
+      await mkdir(join(tempRoot, ".git"), { recursive: true });
+
+      await __listenClientTestUtils.handleListMemoryCommand(
+        {
+          type: "list_memory",
+          request_id: "list-memory-pull-1",
+          agent_id: "agent-1",
+          include_references: true,
+        },
+        socket as unknown as WebSocket,
+        {
+          getMemoryFilesystemRoot: () => tempRoot,
+          isMemfsEnabledOnServer: isMemfsEnabledOnServerMock,
+          ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+        },
+      );
+
+      expect(isMemfsEnabledOnServerMock).not.toHaveBeenCalled();
+      expect(ensureLocalMemfsCheckoutMock).toHaveBeenCalledTimes(1);
+      expect(ensureLocalMemfsCheckoutMock.mock.calls[0]).toEqual([
+        "agent-1",
+        { pullOnExistingRepo: true },
+      ]);
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: "list_memory_response",
+        request_id: "list-memory-pull-1",
+        success: true,
+        done: true,
+        total: 1,
+        memfs_enabled: true,
+        memfs_initialized: true,
+      });
+      expect(messages[0].entries).toEqual([
+        expect.objectContaining({
+          relative_path: "system/human.md",
+          is_system: true,
+          description: "Human",
+          references: [],
+        }),
+      ]);
+      expect(messages[0].entries[0]?.content).toContain("Pulled from remote");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("returns a failure response when syncing an existing checkout fails", async () => {
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
+    const socket = new MockSocket(WebSocket.OPEN);
+    const ensureLocalMemfsCheckoutMock = mock(async () => {
+      throw new Error("Pull failed: auth rejected");
+    });
+
+    try {
+      await mkdir(join(tempRoot, ".git"), { recursive: true });
+
+      await __listenClientTestUtils.handleListMemoryCommand(
+        {
+          type: "list_memory",
+          request_id: "list-memory-pull-failed-1",
+          agent_id: "agent-1",
+          include_references: true,
+        },
+        socket as unknown as WebSocket,
+        {
+          getMemoryFilesystemRoot: () => tempRoot,
+          isMemfsEnabledOnServer: async () => true,
+          ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+        },
+      );
+
+      expect(ensureLocalMemfsCheckoutMock).toHaveBeenCalledTimes(1);
+      const message = JSON.parse(socket.sentPayloads[0] as string);
+      expect(message).toMatchObject({
+        type: "list_memory_response",
+        request_id: "list-memory-pull-failed-1",
+        success: false,
+        done: true,
+        total: 0,
+        entries: [],
+        error: "Pull failed: auth rejected",
+      });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/websocket/listener/commands/memory.ts
+++ b/src/websocket/listener/commands/memory.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import type { EnsureLocalMemfsCheckoutOptions } from "@/agent/memory-filesystem";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { ListMemoryCommand } from "@/types/protocol_v2";
 import {
@@ -16,7 +17,10 @@ import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 const WIKI_LINK_REGEX = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 
 export type ListMemoryCommandTestOverrides = {
-  ensureLocalMemfsCheckout?: (agentId: string) => Promise<void>;
+  ensureLocalMemfsCheckout?: (
+    agentId: string,
+    options?: EnsureLocalMemfsCheckoutOptions,
+  ) => Promise<void>;
   getMemoryFilesystemRoot?: (agentId: string) => string;
   isMemfsEnabledOnServer?: (agentId: string) => Promise<boolean>;
 };
@@ -48,7 +52,7 @@ export async function handleListMemoryCommand(
   try {
     const {
       ensureLocalMemfsCheckout: actualEnsureLocalMemfsCheckout,
-      getMemoryFilesystemRoot: actualGetMemoryFilesystemRoot,
+      getScopedMemoryFilesystemRoot: actualGetMemoryFilesystemRoot,
       isMemfsEnabledOnServer: actualIsMemfsEnabledOnServer,
     } = await import("@/agent/memory-filesystem");
     const ensureLocalMemfsCheckout =
@@ -89,10 +93,10 @@ export async function handleListMemoryCommand(
       return true;
     }
 
-    if (!memfsInitialized) {
-      await ensureLocalMemfsCheckout(parsed.agent_id);
-      memfsInitialized = existsSync(join(memoryRoot, ".git"));
-    }
+    await ensureLocalMemfsCheckout(parsed.agent_id, {
+      pullOnExistingRepo: true,
+    });
+    memfsInitialized = existsSync(join(memoryRoot, ".git"));
 
     if (!memfsInitialized) {
       throw new Error(


### PR DESCRIPTION
## Summary
- Problem: Desktop Memory renders data from the listener list_memory path, but existing local MemFS repos were scanned without a fresh pull.
- Approach: extend ensureLocalMemfsCheckout with pullOnExistingRepo, make list_memory await clone or pull before scanning the scoped memory dir, and surface pull failures as list_memory_response errors.
- Risk: list_memory now waits on git sync for remote MemFS repos; local-backend MemFS still initializes local-only repos and does not remote pull.

## Before / after
- Before: an existing .git directory skipped sync, so Desktop could show stale or empty MemFS files.
- After: missing repos clone, existing remote-backed repos pull, and sync failures produce an explicit failed response instead of stale data.

## Validation
- [x] bun test ./src/websocket/listen-client-protocol.test.ts -t "listen-client memory command handling"
- [x] bunx --bun @biomejs/biome@2.2.5 check src/agent/memory-filesystem.ts src/agent/memory-git.ts src/websocket/listener/commands/memory.ts src/websocket/listen-client-protocol.test.ts
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)