### PR TITLE
fix: remove desktop plan-mode protocol wiring

### DIFF
--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -365,7 +365,7 @@ export type QueueItemSource =
  * - message: User or system text to send to the agent
  * - task_notification: Background task completed notification
  * - approval_result: Tool approval/denial result
- * - overlay_action: Plan mode, AskUserQuestion, etc.
+ * - overlay_action: AskUserQuestion or other overlay actions
  */
 export type QueueItemKind =
   | "message"
@@ -441,7 +441,7 @@ export interface QueueBatchDequeuedEvent extends MessageEnvelope {
  * Why the queue cannot dequeue right now.
  * - streaming: Agent turn is actively running/streaming (request, response, or local tool execution)
  * - pending_approvals: Waiting for HITL approval decisions
- * - overlay_open: Plan mode, AskUserQuestion, or other overlay is active
+ * - overlay_open: AskUserQuestion or other overlay is active
  * - command_running: Slash command is executing
  * - interrupt_in_progress: User interrupt (Esc) is being processed
  * - runtime_busy: Generic busy state (e.g., listen-client turn in flight)

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -44,7 +44,6 @@ export interface RuntimeEnvelope {
 export type DevicePermissionMode =
   | "standard"
   | "acceptEdits"
-  | "plan"
   | "memory"
   | "unrestricted";
 
@@ -325,7 +324,6 @@ export interface DeviceStatus {
   is_online: boolean;
   is_processing: boolean;
   current_permission_mode: DevicePermissionMode;
-  plan_mode_enabled: boolean;
   current_working_directory: string | null;
   git_context: GitContext | null;
   letta_code_version: string | null;
@@ -386,7 +384,6 @@ export interface QueueMessage {
 export interface LoopState {
   status: LoopStatus;
   active_run_ids: string[];
-  plan_file_path: string | null;
 }
 
 export interface DeviceStatusUpdateMessage extends RuntimeEnvelope {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -2984,13 +2984,13 @@ describe("listen-client v2 status builders", () => {
     const loopStatus = __listenClientTestUtils.buildLoopStatus(runtime);
     expect(loopStatus.status).toBe("WAITING_ON_INPUT");
     expect(loopStatus.active_run_ids).toEqual([]);
-    expect(loopStatus.plan_file_path).toBeNull();
+    expect("plan_file_path" in loopStatus).toBe(false);
     // queue is now separate from loopStatus — verify via buildQueueSnapshot
     const queueSnapshot = __listenClientTestUtils.buildQueueSnapshot(runtime);
     expect(queueSnapshot).toEqual([]);
   });
 
-  test("buildLoopStatus includes plan file path for scoped plan mode", () => {
+  test("buildLoopStatus does not expose plan file paths", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     __listenClientTestUtils.getOrCreateScopedRuntime(
       listener,
@@ -3006,16 +3006,16 @@ describe("listen-client v2 status builders", () => {
       },
     );
 
-    expect(
-      __listenClientTestUtils.buildLoopStatus(listener, {
-        agent_id: "agent-1",
-        conversation_id: "default",
-      }),
-    ).toEqual({
+    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "default",
+    });
+
+    expect(loopStatus).toEqual({
       status: "WAITING_ON_INPUT",
       active_run_ids: [],
-      plan_file_path: "/tmp/listener-plan.md",
     });
+    expect("plan_file_path" in loopStatus).toBe(false);
   });
 
   test("buildDeviceStatus includes the effective working directory", () => {
@@ -3539,7 +3539,6 @@ describe("listen-client v2 status builders", () => {
     expect(outbound[1].loop_status).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
-      plan_file_path: null,
     });
   });
 
@@ -3679,7 +3678,6 @@ describe("listen-client v2 status builders", () => {
     ).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
-      plan_file_path: null,
     });
   });
 
@@ -4149,72 +4147,7 @@ describe("listen-client capability-gated approval flow", () => {
     }
   });
 
-  test("mode changes reject plan mode when plan mode is disabled", async () => {
-    const originalHome = process.env.HOME;
-    const testHomeDir = await mkdtemp(
-      join(os.tmpdir(), "letta-plan-disabled-"),
-    );
-    await settingsManager.reset();
-    process.env.HOME = testHomeDir;
-    resetRemoteSettingsCache();
-    await settingsManager.initialize();
-
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    listener.socket = socket as unknown as WebSocket;
-
-    const scope = {
-      agent_id: "agent-1",
-      conversation_id: "default",
-    } as const;
-
-    listener.permissionModeByConversation.set(
-      "agent:agent-1::conversation:default",
-      {
-        mode: "standard",
-        planFilePath: null,
-        modeBeforePlan: null,
-      },
-    );
-
-    try {
-      __listenClientTestUtils.handleModeChange(
-        { mode: "plan" },
-        socket as unknown as WebSocket,
-        listener,
-        scope,
-      );
-
-      const outbound = socket.sentPayloads.map((payload) =>
-        JSON.parse(payload as string),
-      );
-      const deviceStatus = outbound.findLast(
-        (payload) => payload.type === "update_device_status",
-      )?.device_status;
-      const loopStatus = outbound.findLast(
-        (payload) => payload.type === "update_loop_status",
-      )?.loop_status;
-      const notice = outbound.findLast(
-        (payload) =>
-          payload.type === "stream_delta" &&
-          payload.delta?.message_type === "loop_error",
-      );
-
-      expect(deviceStatus?.current_permission_mode).toBe("standard");
-      expect(deviceStatus?.plan_mode_enabled).toBe(false);
-      expect(loopStatus?.plan_file_path).toBeNull();
-      expect(notice?.delta?.message).toContain(
-        "Plan mode is disabled in user settings.",
-      );
-    } finally {
-      await settingsManager.reset();
-      await rm(testHomeDir, { recursive: true, force: true });
-      process.env.HOME = originalHome;
-      resetRemoteSettingsCache();
-    }
-  });
-
-  test("mode changes emit fresh loop status plan_file_path on enter exit and re-enter", async () => {
+  test("mode changes reject plan mode in the desktop protocol", async () => {
     const originalHome = process.env.HOME;
     const testHomeDir = await mkdtemp(join(os.tmpdir(), "letta-plan-ws-"));
     await settingsManager.reset();
@@ -4231,53 +4164,44 @@ describe("listen-client capability-gated approval flow", () => {
       agent_id: "agent-1",
       conversation_id: "default",
     } as const;
+    const scopeKey = "agent:agent-1::conversation:default";
+    listener.permissionModeByConversation.set(scopeKey, {
+      mode: "standard",
+      planFilePath: null,
+      modeBeforePlan: null,
+    });
 
     try {
+      const planModePayload = {
+        mode: "plan",
+      } as unknown as Parameters<
+        typeof __listenClientTestUtils.handleModeChange
+      >[0];
+
       __listenClientTestUtils.handleModeChange(
-        { mode: "plan" },
+        planModePayload,
         socket as unknown as WebSocket,
         listener,
         scope,
       );
 
-      const firstPlanPath = (socket.sentPayloads
-        .map((payload) => JSON.parse(payload as string))
-        .findLast((payload) => payload.type === "update_loop_status")
-        ?.loop_status?.plan_file_path ?? null) as string | null;
-
-      expect(firstPlanPath).toBeTruthy();
-
-      __listenClientTestUtils.handleModeChange(
-        { mode: "unrestricted" },
-        socket as unknown as WebSocket,
-        listener,
-        scope,
+      const outbound = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      const notice = outbound.findLast(
+        (payload) =>
+          payload.type === "stream_delta" &&
+          payload.delta?.message_type === "loop_error",
       );
 
-      const afterExitLoopStatus = socket.sentPayloads
-        .map((payload) => JSON.parse(payload as string))
-        .findLast(
-          (payload) =>
-            payload.type === "update_loop_status" &&
-            payload.loop_status?.status === "WAITING_ON_INPUT",
-        );
-
-      expect(afterExitLoopStatus?.loop_status?.plan_file_path).toBeNull();
-
-      __listenClientTestUtils.handleModeChange(
-        { mode: "plan" },
-        socket as unknown as WebSocket,
-        listener,
-        scope,
+      expect(listener.permissionModeByConversation.get(scopeKey)).toEqual({
+        mode: "standard",
+        planFilePath: null,
+        modeBeforePlan: null,
+      });
+      expect(notice?.delta?.message).toContain(
+        "Unsupported permission mode: plan",
       );
-
-      const secondPlanPath = (socket.sentPayloads
-        .map((payload) => JSON.parse(payload as string))
-        .findLast((payload) => payload.type === "update_loop_status")
-        ?.loop_status?.plan_file_path ?? null) as string | null;
-
-      expect(secondPlanPath).toBeTruthy();
-      expect(secondPlanPath).not.toBe(firstPlanPath);
     } finally {
       await settingsManager.reset();
       await rm(testHomeDir, { recursive: true, force: true });

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -4,7 +4,6 @@ import type WebSocket from "ws";
 import { getBackend } from "@/backend";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import { migratePermissionMode } from "@/permissions/mode";
-import { settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type {
   AbortMessageCommand,
@@ -17,7 +16,6 @@ import {
   getIndexRoot,
   setIndexRoot,
 } from "@/utils/file-index";
-import { generatePlanFilePath } from "@/utils/plan-name";
 import {
   rejectPendingApprovalResolvers,
   resolvePendingApprovalResolver,
@@ -74,14 +72,6 @@ function trackListenerError(
   });
 }
 
-function isPlanModeEnabled(): boolean {
-  try {
-    return settingsManager.isPlanModeEnabled();
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Handle mode change request from cloud.
  * Stores the new mode in ListenerRuntime.permissionModeByConversation so
@@ -106,20 +96,11 @@ export function handleModeChange(
       conversationId,
     );
 
-    // Migrate legacy mode values from older clients
-    const incomingMode = migratePermissionMode(msg.mode) ?? msg.mode;
-
-    // Reject plan mode if it's disabled in settings
-    if (incomingMode === "plan" && !isPlanModeEnabled()) {
-      if (current.mode === "plan") {
-        current.mode = "unrestricted";
-        current.planFilePath = null;
-        current.modeBeforePlan = null;
-        persistPermissionModeMapForRuntime(runtime);
-      }
-      emitRuntimeStateUpdates(runtime, scope);
+    // Migrate legacy mode values from older clients.
+    const incomingMode = migratePermissionMode(msg.mode);
+    if (!incomingMode || incomingMode === "plan") {
       emitLoopErrorNotice(socket, runtime, {
-        message: "Plan mode is disabled in user settings.",
+        message: `Unsupported permission mode: ${msg.mode}`,
         stopReason: "error",
         isTerminal: false,
         agentId: scope?.agent_id,
@@ -128,22 +109,9 @@ export function handleModeChange(
       return;
     }
 
-    // Track previous mode so ExitPlanMode can restore it
-    if (incomingMode === "plan" && current.mode !== "plan") {
-      current.modeBeforePlan = current.mode;
-    }
     current.mode = incomingMode;
-
-    // Generate plan file path when entering plan mode
-    if (incomingMode === "plan" && !current.planFilePath) {
-      current.planFilePath = generatePlanFilePath();
-    }
-
-    // Clear plan-related state when leaving plan mode
-    if (incomingMode !== "plan") {
-      current.planFilePath = null;
-      current.modeBeforePlan = null;
-    }
+    current.planFilePath = null;
+    current.modeBeforePlan = null;
 
     persistPermissionModeMapForRuntime(runtime);
 

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -9,7 +9,7 @@ import { getGitContext } from "@/cli/helpers/git-context";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
 import { getSystemPromptDoctorState } from "@/cli/helpers/system-prompt-warning";
 import { experimentManager } from "@/experiments/manager";
-import { permissionMode } from "@/permissions/mode";
+import { type PermissionMode, permissionMode } from "@/permissions/mode";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import { settingsManager } from "@/settings-manager";
 import {
@@ -18,6 +18,7 @@ import {
 } from "@/tools/impl/process_manager";
 import type {
   BackgroundProcessSummary,
+  DevicePermissionMode,
   DeviceStatus,
   DeviceStatusUpdateMessage,
   LoopState,
@@ -62,12 +63,28 @@ import type {
 
 type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
 
-function isPlanModeEnabled(): boolean {
-  try {
-    return settingsManager.isPlanModeEnabled();
-  } catch {
-    return false;
+function coerceDevicePermissionMode(
+  mode: PermissionMode | null | undefined,
+): DevicePermissionMode {
+  switch (mode) {
+    case "standard":
+    case "acceptEdits":
+    case "memory":
+    case "unrestricted":
+      return mode;
+    default:
+      return "standard";
   }
+}
+
+function toDevicePermissionMode(
+  mode: PermissionMode,
+  fallback?: PermissionMode | null,
+): DevicePermissionMode {
+  if (mode === "plan") {
+    return coerceDevicePermissionMode(fallback);
+  }
+  return coerceDevicePermissionMode(mode);
 }
 
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
@@ -386,8 +403,10 @@ export function buildDeviceStatus(
       connection_name: null,
       is_online: false,
       is_processing: false,
-      current_permission_mode: permissionMode.getMode(),
-      plan_mode_enabled: isPlanModeEnabled(),
+      current_permission_mode: toDevicePermissionMode(
+        permissionMode.getMode(),
+        permissionMode.getModeBeforePlan(),
+      ),
       current_working_directory: fallbackCwd,
       git_context: getCachedDeviceGitContext(fallbackCwd),
       letta_code_version: process.env.npm_package_version || null,
@@ -453,8 +472,10 @@ export function buildDeviceStatus(
     connection_name: listener.connectionName,
     is_online: transport ? isListenerTransportOpen(transport) : false,
     is_processing: !!conversationRuntime?.isProcessing,
-    current_permission_mode: conversationPermissionModeState.mode,
-    plan_mode_enabled: isPlanModeEnabled(),
+    current_permission_mode: toDevicePermissionMode(
+      conversationPermissionModeState.mode,
+      conversationPermissionModeState.modeBeforePlan,
+    ),
     current_working_directory: resolvedCwd,
     git_context: getCachedDeviceGitContext(resolvedCwd),
     letta_code_version: process.env.npm_package_version || null,
@@ -497,17 +518,11 @@ export function buildLoopStatus(
     return {
       status: "WAITING_ON_INPUT",
       active_run_ids: [],
-      plan_file_path: null,
     };
   }
   const scope = getScopeForRuntime(runtime, params);
   const scopedAgentId = resolveScopedAgentId(listener, scope);
   const scopedConversationId = resolveScopedConversationId(listener, scope);
-  const conversationPermissionModeState = getConversationPermissionModeState(
-    listener,
-    scopedAgentId,
-    scopedConversationId,
-  );
   const conversationRuntime = getConversationRuntime(
     listener,
     scopedAgentId,
@@ -534,10 +549,6 @@ export function buildLoopStatus(
         : conversationRuntime?.activeRunId
           ? [conversationRuntime.activeRunId]
           : [],
-    plan_file_path:
-      conversationPermissionModeState.mode === "plan"
-        ? conversationPermissionModeState.planFilePath
-        : null,
   };
 }
 

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -79,7 +79,7 @@ export type ProcessQueuedTurn = (
 ) => Promise<void>;
 
 export interface ModeChangePayload {
-  mode: "standard" | "acceptEdits" | "plan" | "memory" | "unrestricted";
+  mode: "standard" | "acceptEdits" | "memory" | "unrestricted";
 }
 
 export interface ChangeCwdMessage {


### PR DESCRIPTION
## Summary
- Follow-up to #2413: remove plan mode from the desktop websocket permission-mode contract.
- Stop advertising plan-mode-specific status fields (`plan_mode_enabled`, `plan_file_path`) to desktop clients.
- Reject stale desktop plan-mode changes while preserving non-plan permission-mode updates.

## Test plan
- [x] `bun test src/websocket/listen-client-protocol.test.ts src/websocket/listener-permission-mode.test.ts src/types/protocol-static-sync.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/types/protocol.ts src/types/protocol_v2.ts src/websocket/listener/types.ts src/websocket/listener/protocol-outbound.ts src/websocket/listener/control-inputs.ts src/websocket/listen-client-protocol.test.ts`
- [x] `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)