### PR TITLE
fix(desktop): show scheduled task messages live

### DIFF
--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import type { DequeuedBatch } from "@/queue/queue-runtime";
+import type { StreamDeltaMessage } from "@/types/protocol_v2";
+import { emitDequeuedUserMessage } from "@/websocket/listener/protocol-outbound";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  ListenerRuntime,
+} from "@/websocket/listener/types";
+
+class MockSocket {
+  readyState = WebSocket.OPEN;
+  bufferedAmount = 0;
+  sentPayloads: string[] = [];
+
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+}
+
+function createRuntime(): {
+  runtime: ConversationRuntime;
+  socket: MockSocket;
+} {
+  const socket = new MockSocket();
+  const listener = {
+    socket: socket as never,
+    transport: socket as never,
+    streamTransport: null,
+    eventSeqCounter: 0,
+    conversationRuntimes: new Map(),
+  } as unknown as ListenerRuntime;
+  const runtime = {
+    listener,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  } as unknown as ConversationRuntime;
+  listener.conversationRuntimes.set("test", runtime);
+  return { runtime, socket };
+}
+
+function parseOnlyStreamDelta(socket: MockSocket): StreamDeltaMessage {
+  expect(socket.sentPayloads).toHaveLength(1);
+  const message = JSON.parse(socket.sentPayloads[0] ?? "{}");
+  expect(message.type).toBe("stream_delta");
+  return message as StreamDeltaMessage;
+}
+
+describe("emitDequeuedUserMessage", () => {
+  test("emits cron_prompt-only turns as visible scheduled task user messages", () => {
+    const { runtime, socket } = createRuntime();
+    const cronText = [
+      "<system-reminder>",
+      'Scheduled task "Daily status" is firing.',
+      "Description: Ask for the current status.",
+      "This is fire #3 (cron: * * * * *).",
+      "",
+      "What changed since the last check-in?",
+      "</system-reminder>",
+    ].join("\n");
+    const incoming = {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: cronText }],
+        },
+      ],
+    } as IncomingMessage;
+    const batch = {
+      batchId: "batch-cron",
+      items: [
+        {
+          id: "item-cron",
+          kind: "cron_prompt",
+          source: "cron",
+          text: cronText,
+          cronTaskId: "task-1",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enqueuedAt: Date.now(),
+        },
+      ],
+      mergedCount: 1,
+      queueLenAfter: 0,
+    } satisfies DequeuedBatch;
+
+    emitDequeuedUserMessage(socket as never, runtime, incoming, batch);
+
+    const message = parseOnlyStreamDelta(socket);
+    expect(message.runtime).toEqual({
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+    });
+    const userDelta = message.delta as {
+      message_type: string;
+      content: unknown;
+    };
+    expect(userDelta.message_type).toBe("user_message");
+    expect(userDelta.content).toEqual([
+      {
+        type: "text",
+        text: [
+          'Scheduled task "Daily status" is firing.',
+          "This is fire #3 (cron: * * * * *).",
+          "",
+          "What changed since the last check-in?",
+        ].join("\n"),
+      },
+    ]);
+    expect(JSON.stringify(userDelta.content)).not.toContain(
+      "<system-reminder>",
+    );
+    expect(JSON.stringify(userDelta.content)).not.toContain("Description:");
+  });
+
+  test("keeps ordinary pure system reminders hidden", () => {
+    const { runtime, socket } = createRuntime();
+    const hiddenReminder =
+      "<system-reminder>Generated device context.</system-reminder>";
+    const incoming = {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [{ role: "user", content: hiddenReminder }],
+    } as IncomingMessage;
+    const batch = {
+      batchId: "batch-user",
+      items: [
+        {
+          id: "item-user",
+          kind: "message",
+          source: "user",
+          content: hiddenReminder,
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enqueuedAt: Date.now(),
+        },
+      ],
+      mergedCount: 1,
+      queueLenAfter: 0,
+    } satisfies DequeuedBatch;
+
+    emitDequeuedUserMessage(socket as never, runtime, incoming, batch);
+
+    expect(socket.sentPayloads).toHaveLength(0);
+  });
+});

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -8,6 +8,7 @@ import { getSubagents } from "@/agent/subagent-state";
 import { getGitContext } from "@/cli/helpers/git-context";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
 import { getSystemPromptDoctorState } from "@/cli/helpers/system-prompt-warning";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
 import { permissionMode } from "@/permissions/mode";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
@@ -768,22 +769,82 @@ export function emitQueueUpdate(
   emitProtocolV2Message(socket, runtime, message, resolvedScope);
 }
 
-export function isSystemReminderPart(part: unknown): boolean {
-  if (!part || typeof part !== "object") return false;
-  if (!("type" in part) || (part as { type: string }).type !== "text") {
-    return false;
-  }
-  if (
-    !("text" in part) ||
-    typeof (part as { text: string }).text !== "string"
-  ) {
-    return false;
-  }
-  const trimmed = (part as { text: string }).text.trim();
+function isTextContentPart(
+  part: unknown,
+): part is { type: "text"; text: string } {
   return (
-    trimmed.startsWith("<system-reminder>") &&
-    trimmed.endsWith("</system-reminder>")
+    !!part &&
+    typeof part === "object" &&
+    "type" in part &&
+    (part as { type: unknown }).type === "text" &&
+    "text" in part &&
+    typeof (part as { text: unknown }).text === "string"
   );
+}
+
+export function isSystemReminderPart(part: unknown): boolean {
+  if (!isTextContentPart(part)) return false;
+  const trimmed = part.text.trim();
+  return (
+    trimmed.startsWith(SYSTEM_REMINDER_OPEN) &&
+    trimmed.endsWith(SYSTEM_REMINDER_CLOSE)
+  );
+}
+
+function unwrapSystemReminderText(text: string): string | null {
+  const trimmed = text.trim();
+  if (
+    trimmed.startsWith(SYSTEM_REMINDER_OPEN) &&
+    trimmed.endsWith(SYSTEM_REMINDER_CLOSE)
+  ) {
+    return trimmed
+      .slice(SYSTEM_REMINDER_OPEN.length, -SYSTEM_REMINDER_CLOSE.length)
+      .trim();
+  }
+  return null;
+}
+
+function formatCronPromptForDisplay(text: string): string {
+  const unwrapped = unwrapSystemReminderText(text) ?? text.trim();
+  const lines = unwrapped.split(/\r?\n/);
+  if (lines[1]?.startsWith("Description: ")) {
+    lines.splice(1, 1);
+  }
+  return lines.join("\n").trim();
+}
+
+function getCronPromptDisplayForText(
+  text: string,
+  batch: DequeuedBatch,
+): string | null {
+  for (const item of batch.items) {
+    if (item.kind !== "cron_prompt") {
+      continue;
+    }
+    if (text === item.text || text.trim() === item.text.trim()) {
+      return formatCronPromptForDisplay(item.text);
+    }
+  }
+  return null;
+}
+
+function replaceCronPromptsForDisplay(
+  text: string,
+  batch: DequeuedBatch,
+): string {
+  let displayText = text;
+  for (const item of batch.items) {
+    if (item.kind !== "cron_prompt") {
+      continue;
+    }
+    const display = formatCronPromptForDisplay(item.text);
+    if (displayText.trim() === item.text.trim()) {
+      displayText = display;
+      continue;
+    }
+    displayText = displayText.split(item.text).join(display);
+  }
+  return displayText;
 }
 
 export function emitDequeuedUserMessage(
@@ -802,9 +863,19 @@ export function emitDequeuedUserMessage(
   let content: MessageCreate["content"];
 
   if (typeof rawContent === "string") {
-    content = rawContent.replace(SYSTEM_REMINDER_RE, "").trim();
+    content = replaceCronPromptsForDisplay(rawContent, batch)
+      .replace(SYSTEM_REMINDER_RE, "")
+      .trim();
   } else if (Array.isArray(rawContent)) {
-    content = rawContent.filter((part) => !isSystemReminderPart(part));
+    content = rawContent.flatMap((part) => {
+      if (isTextContentPart(part)) {
+        const cronDisplay = getCronPromptDisplayForText(part.text, batch);
+        if (cronDisplay !== null) {
+          return [{ ...part, text: cronDisplay }];
+        }
+      }
+      return isSystemReminderPart(part) ? [] : [part];
+    }) as MessageCreate["content"];
   } else {
     return;
   }


### PR DESCRIPTION
## Problem

LET-8716 reports that scheduled task runs do not appear in Letta Code Desktop until the app is restarted. The scheduled task itself fires and persisted history/backfill can recover it later, but the live LCD chat timeline misses the user-row echo for the scheduled prompt.

The live listener path was treating scheduled-task prompts like ordinary hidden device context. Cron prompts are intentionally wrapped in system-reminder tags before they are sent into the agent, and the live websocket echo strips pure system-reminder content before rendering user messages. That meant a cron_prompt-only turn had no visible content to emit even though the agent run continued.

## Approach

This changes the listener outbound formatting for dequeued user messages so cron_prompt queue items are handled as a special visible scheduled-task case before generic system-reminder stripping runs.

For scheduled tasks, the live user-message echo now:

- unwraps the system-reminder tags
- keeps the scheduled-task header, fire count, cron/one-off line, and prompt
- drops the internal description line to match the cleaner TUI display
- still hides ordinary pure system-reminder rows that are not cron_prompt queue items

## Before / after

Before: when a schedule fired in LCD, the live websocket echo stripped the whole scheduled-task prompt and emitted no visible user row, so the message appeared only after restart/backfill.

After: the same cron_prompt dequeued turn emits a visible user_message stream delta immediately, while normal generated device-context reminders remain hidden from chat.

## Risk

Low to medium. The change is scoped to the listener live user-message echo and only changes behavior for dequeued batches that include cron_prompt items. Ordinary system-reminder-only content continues to be suppressed, and the agent still receives the full wrapped scheduled-task prompt internally.

## Validation

- bun test src/websocket/listener/protocol-outbound.test.ts
- bun test ./src/websocket/listen-client-concurrency.test.ts --timeout 30000
- bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/protocol-outbound.ts src/websocket/listener/protocol-outbound.test.ts
- bun run typecheck

👾 Generated with [Letta Code](https://letta.com)
