### PR TITLE
feat(tui): add local and constellation agent tabs

### DIFF
--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -64,6 +64,7 @@ export {
   LocalBackendNotFoundError,
   LocalStore,
   type LocalStoreOptions,
+  projectLocalAgentState,
   type StoredMessage,
   type StoredTurnInput,
 } from "./local-store";

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -275,7 +275,7 @@ function normalizeAgentRecord(
   };
 }
 
-function projectAgentState(
+export function projectLocalAgentState(
   record: LocalAgentRecord,
   messageIds: string[] = [],
   inContextMessageIds: string[] = messageIds,
@@ -2057,7 +2057,7 @@ export class LocalStore {
     const inContextMessageIds =
       this.conversations.get(key)?.in_context_message_ids ?? messageIds;
     const lastRunCompletion = defaultMessages.at(-1)?.date ?? null;
-    return projectAgentState(
+    return projectLocalAgentState(
       record,
       messageIds,
       inContextMessageIds,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3978,7 +3978,10 @@ export function App({
       // Process the queued action
       if (action.type === "switch_agent") {
         // Call handleAgentSelect - it will see isAgentBusy() as false now
-        handleAgentSelect(action.agentId, { commandId: action.commandId });
+        handleAgentSelect(action.agentId, {
+          commandId: action.commandId,
+          backendMode: action.backendMode,
+        });
       } else if (action.type === "switch_model") {
         // Call handleModelSelect - it will see isAgentBusy() as false now
         handleModelSelect(action.modelId, action.commandId);

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -168,6 +168,7 @@ type AppViewProps = {
       profileName?: string;
       conversationId?: string;
       commandId?: string;
+      backendMode?: import("@/cli/components/AgentSelector").AgentBackendMode;
     },
   ) => Promise<void>;
   handleApproveAlways: (
@@ -983,10 +984,11 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "resume" && (
               <AgentSelector
                 currentAgentId={agentId}
-                onSelect={async (id) => {
+                onSelect={async (id, backendMode) => {
                   const overlayCommand = completeOverlay("resume");
                   await handleAgentSelect(id, {
                     commandId: overlayCommand?.id,
+                    backendMode,
                   });
                 }}
                 onCancel={closeOverlay}

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -77,7 +77,12 @@ export type ActiveOverlay =
   | null;
 
 export type QueuedOverlayAction =
-  | { type: "switch_agent"; agentId: string; commandId?: string }
+  | {
+      type: "switch_agent";
+      agentId: string;
+      commandId?: string;
+      backendMode?: "local" | "api";
+    }
   | { type: "switch_model"; modelId: string; commandId?: string }
   | {
       type: "set_experiment";

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -25,7 +25,11 @@ import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { createAgent } from "@/agent/create";
 import { selectDefaultAgentModel } from "@/agent/defaults";
 import { sendMessageStream } from "@/agent/message";
-import { getBackend } from "@/backend";
+import {
+  configureBackendMode,
+  getBackend,
+  isLocalBackendEnabled,
+} from "@/backend";
 import { getServerUrl } from "@/backend/api/client";
 import type { BtwState } from "@/cli/components/BtwPane";
 import {
@@ -476,6 +480,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         profileName?: string;
         conversationId?: string;
         commandId?: string;
+        backendMode?: "local" | "api";
       },
     ) => {
       const overlayCommand = opts?.commandId
@@ -515,6 +520,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           type: "switch_agent",
           agentId: targetAgentId,
           commandId: cmd.id,
+          backendMode: opts?.backendMode,
         });
         return;
       }
@@ -528,6 +534,15 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       cmd.update({ output: "Switching agent...", phase: "running" });
 
       try {
+        // Switch backend if the target agent belongs to a different backend
+        if (opts?.backendMode) {
+          const currentIsLocal = isLocalBackendEnabled();
+          const targetIsLocal = opts.backendMode === "local";
+          if (currentIsLocal !== targetIsLocal) {
+            configureBackendMode(opts.backendMode);
+          }
+        }
+
         // Fetch new agent
         const agent = await getBackend().retrieveAgent(targetAgentId);
 

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -1,8 +1,9 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getModelDisplayName } from "@/agent/model";
 import { type Backend, getBackend } from "@/backend";
+import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { DEFAULT_AGENT_NAME } from "@/constants";
 import { settingsManager } from "@/settings-manager";
@@ -14,9 +15,12 @@ import { validateAgentName } from "./PinDialog";
 import { TabBar } from "./TabBar";
 import { Text } from "./Text";
 
+/** Backend mode to switch to when selecting an agent */
+export type AgentBackendMode = "local" | "api";
+
 interface AgentSelectorProps {
   currentAgentId: string;
-  onSelect: (agentId: string) => void;
+  onSelect: (agentId: string, backendMode: AgentBackendMode) => void;
   onCancel: () => void;
   /** Called when user creates a new agent (from New tab or N shortcut) */
   onCreateNewAgent?: (name: string) => void;
@@ -24,7 +28,7 @@ interface AgentSelectorProps {
   command?: string;
 }
 
-type TabId = "pinned" | "letta-code" | "all" | "new";
+type TabId = "pinned" | "local" | "constellation" | "new";
 
 type ViewState =
   | { type: "list" }
@@ -37,29 +41,39 @@ interface PinnedAgentData {
   isLocal: boolean;
 }
 
-const TABS: { id: TabId; label: string }[] = [
+const ALL_TABS: { id: TabId; label: string }[] = [
   { id: "pinned", label: "Pinned" },
-  { id: "letta-code", label: "Letta Code" },
-  { id: "all", label: "All" },
+  { id: "constellation", label: "Constellation" },
+  { id: "local", label: "Local" },
   { id: "new", label: "New" },
 ];
 
 const TAB_DESCRIPTIONS: Record<TabId, string> = {
   pinned: "Save agents for easy access by pinning them with /pin",
-  "letta-code": "Displaying agents created inside of Letta Code",
-  all: "Displaying all available agents",
+  local: "Local agents from this device",
+  constellation: "Hosted agents from Letta Constellation",
   new: "Create a brand new agent",
 };
 
 const TAB_EMPTY_STATES: Record<TabId, string> = {
   pinned: "No pinned agents, use /pin to save",
-  "letta-code": "No agents with tag 'origin:letta-code'",
-  all: "No agents found",
+  local: "No local agents found",
+  constellation: "No agents found",
   new: "",
 };
 
 const DISPLAY_PAGE_SIZE = 5;
 const FETCH_PAGE_SIZE = 20;
+
+/**
+ * Check if the user has cloud credentials (API key or refresh token).
+ * Used to determine whether the Constellation tab can fetch agents.
+ */
+async function hasCloudCredentials(): Promise<boolean> {
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
+  return Boolean(apiKey || settings.refreshToken);
+}
 
 /**
  * Format a relative time string from a date
@@ -134,7 +148,29 @@ export function AgentSelector({
   }, []);
 
   // Tab state
+  // Eagerly check for local agents (synchronous disk read) to determine tab visibility
+  const [hasLocalAgents, setHasLocalAgents] = useState(() => {
+    try {
+      return listLocalAgentsFromDisk().length > 0;
+    } catch {
+      return false;
+    }
+  });
+
+  // Compute visible tabs — Local tab only shown when there are local agents
+  const visibleTabs = useMemo(
+    () => ALL_TABS.filter((t) => t.id !== "local" || hasLocalAgents),
+    [hasLocalAgents],
+  );
+
   const [activeTab, setActiveTab] = useState<TabId>("pinned");
+
+  // If active tab is no longer visible (e.g. local tab hidden after deleting all local agents), fall back
+  useEffect(() => {
+    if (activeTab === "local" && !hasLocalAgents) {
+      setActiveTab("constellation");
+    }
+  }, [activeTab, hasLocalAgents]);
 
   // Pinned tab state
   const [pinnedAgents, setPinnedAgents] = useState<PinnedAgentData[]>([]);
@@ -142,29 +178,33 @@ export function AgentSelector({
   const [pinnedSelectedIndex, setPinnedSelectedIndex] = useState(0);
   const [pinnedPage, setPinnedPage] = useState(0);
 
-  // Letta Code tab state (cached separately)
-  const [lettaCodeAgents, setLettaCodeAgents] = useState<AgentState[]>([]);
-  const [lettaCodeCursor, setLettaCodeCursor] = useState<string | null>(null);
-  const [lettaCodeLoading, setLettaCodeLoading] = useState(false);
-  const [lettaCodeLoadingMore, setLettaCodeLoadingMore] = useState(false);
-  const [lettaCodeHasMore, setLettaCodeHasMore] = useState(true);
-  const [lettaCodeSelectedIndex, setLettaCodeSelectedIndex] = useState(0);
-  const [lettaCodePage, setLettaCodePage] = useState(0);
-  const [lettaCodeError, setLettaCodeError] = useState<string | null>(null);
-  const [lettaCodeLoaded, setLettaCodeLoaded] = useState(false);
-  const [lettaCodeQuery, setLettaCodeQuery] = useState<string>(""); // Query used to load current data
+  // Local tab state (reads from disk, no API calls)
+  const [localAgents, setLocalAgents] = useState<AgentState[]>([]);
+  const [localLoading, setLocalLoading] = useState(false);
+  const [localSelectedIndex, setLocalSelectedIndex] = useState(0);
+  const [localPage, setLocalPage] = useState(0);
+  const [localLoaded, setLocalLoaded] = useState(false);
 
-  // All tab state (cached separately)
-  const [allAgents, setAllAgents] = useState<AgentState[]>([]);
-  const [allCursor, setAllCursor] = useState<string | null>(null);
-  const [allLoading, setAllLoading] = useState(false);
-  const [allLoadingMore, setAllLoadingMore] = useState(false);
-  const [allHasMore, setAllHasMore] = useState(true);
-  const [allSelectedIndex, setAllSelectedIndex] = useState(0);
-  const [allPage, setAllPage] = useState(0);
-  const [allError, setAllError] = useState<string | null>(null);
-  const [allLoaded, setAllLoaded] = useState(false);
-  const [allQuery, setAllQuery] = useState<string>(""); // Query used to load current data
+  // Constellation tab state (fetches from API)
+  const [constellationAgents, setConstellationAgents] = useState<AgentState[]>(
+    [],
+  );
+  const [constellationCursor, setConstellationCursor] = useState<string | null>(
+    null,
+  );
+  const [constellationLoading, setConstellationLoading] = useState(false);
+  const [constellationLoadingMore, setConstellationLoadingMore] =
+    useState(false);
+  const [constellationHasMore, setConstellationHasMore] = useState(true);
+  const [constellationSelectedIndex, setConstellationSelectedIndex] =
+    useState(0);
+  const [constellationPage, setConstellationPage] = useState(0);
+  const [constellationError, setConstellationError] = useState<string | null>(
+    null,
+  );
+  const [constellationLoaded, setConstellationLoaded] = useState(false);
+  const [constellationQuery, setConstellationQuery] = useState<string>("");
+  const [hasCloudAuth, setHasCloudAuth] = useState<boolean | null>(null);
 
   // Search state (shared across list tabs)
   const [searchInput, setSearchInput] = useState("");
@@ -214,18 +254,32 @@ export function AgentSelector({
     }
   }, [selectorBackend]);
 
-  // Fetch agents for list tabs (Letta Code / All)
-  const fetchListAgents = useCallback(
-    async (
-      filterLettaCode: boolean,
-      afterCursor?: string | null,
-      query?: string,
-    ) => {
-      const backend = selectorBackend();
+  // Load local agents from disk
+  const loadLocalAgents = useCallback(() => {
+    setLocalLoading(true);
+    try {
+      const agents = listLocalAgentsFromDisk();
+      setLocalAgents(agents);
+      setHasLocalAgents(agents.length > 0);
+      setLocalPage(0);
+      setLocalSelectedIndex(0);
+      setLocalLoaded(true);
+    } catch {
+      setLocalAgents([]);
+      setHasLocalAgents(false);
+    } finally {
+      setLocalLoading(false);
+    }
+  }, []);
 
-      const agentList = await backend.listAgents({
+  // Fetch Constellation agents from cloud API directly (not via getBackend, which may be local)
+  const fetchConstellationAgents = useCallback(
+    async (afterCursor?: string | null, query?: string) => {
+      const { getClient } = await import("@/backend/api/client");
+      const client = await getClient();
+
+      const agentList = await client.agents.list({
         limit: FETCH_PAGE_SIZE,
-        ...(filterLettaCode && { tags: ["origin:letta-code"] }),
         include: ["agent.blocks"],
         order: "desc",
         order_by: "last_run_completion",
@@ -240,54 +294,67 @@ export function AgentSelector({
 
       return { agents: agentList.items, nextCursor: cursor };
     },
-    [selectorBackend],
+    [],
   );
 
-  // Load Letta Code agents
-  const loadLettaCodeAgents = useCallback(
+  // Load Constellation agents
+  const loadConstellationAgents = useCallback(
     async (query?: string) => {
-      setLettaCodeLoading(true);
-      setLettaCodeError(null);
+      setConstellationLoading(true);
+      setConstellationError(null);
       try {
-        const result = await fetchListAgents(true, null, query);
-        setLettaCodeAgents(result.agents);
-        setLettaCodeCursor(result.nextCursor);
-        setLettaCodeHasMore(result.nextCursor !== null);
-        setLettaCodePage(0);
-        setLettaCodeSelectedIndex(0);
-        setLettaCodeLoaded(true);
-        setLettaCodeQuery(query || ""); // Track query used for this load
+        const result = await fetchConstellationAgents(null, query);
+        setConstellationAgents(result.agents);
+        setConstellationCursor(result.nextCursor);
+        setConstellationHasMore(result.nextCursor !== null);
+        setConstellationPage(0);
+        setConstellationSelectedIndex(0);
+        setConstellationLoaded(true);
+        setConstellationQuery(query || "");
       } catch (err) {
-        setLettaCodeError(err instanceof Error ? err.message : String(err));
+        setConstellationError(err instanceof Error ? err.message : String(err));
       } finally {
-        setLettaCodeLoading(false);
+        setConstellationLoading(false);
       }
     },
-    [fetchListAgents],
+    [fetchConstellationAgents],
   );
 
-  // Load All agents
-  const loadAllAgents = useCallback(
-    async (query?: string) => {
-      setAllLoading(true);
-      setAllError(null);
-      try {
-        const result = await fetchListAgents(false, null, query);
-        setAllAgents(result.agents);
-        setAllCursor(result.nextCursor);
-        setAllHasMore(result.nextCursor !== null);
-        setAllPage(0);
-        setAllSelectedIndex(0);
-        setAllLoaded(true);
-        setAllQuery(query || ""); // Track query used for this load
-      } catch (err) {
-        setAllError(err instanceof Error ? err.message : String(err));
-      } finally {
-        setAllLoading(false);
-      }
-    },
-    [fetchListAgents],
-  );
+  // Fetch more Constellation agents (pagination)
+  const fetchMoreConstellationAgents = useCallback(async () => {
+    if (
+      constellationLoadingMore ||
+      !constellationHasMore ||
+      !constellationCursor
+    )
+      return;
+
+    setConstellationLoadingMore(true);
+    try {
+      const result = await fetchConstellationAgents(
+        constellationCursor,
+        activeQuery || undefined,
+      );
+      setConstellationAgents((prev) => [...prev, ...result.agents]);
+      setConstellationCursor(result.nextCursor);
+      setConstellationHasMore(result.nextCursor !== null);
+    } catch {
+      // Silently fail on pagination errors
+    } finally {
+      setConstellationLoadingMore(false);
+    }
+  }, [
+    constellationLoadingMore,
+    constellationHasMore,
+    constellationCursor,
+    fetchConstellationAgents,
+    activeQuery,
+  ]);
+
+  // Check cloud auth on mount
+  useEffect(() => {
+    hasCloudCredentials().then(setHasCloudAuth);
+  }, []);
 
   // Load pinned agents on mount
   useEffect(() => {
@@ -296,84 +363,33 @@ export function AgentSelector({
 
   // Load tab data when switching tabs (only if not already loaded)
   useEffect(() => {
-    if (activeTab === "letta-code" && !lettaCodeLoaded && !lettaCodeLoading) {
-      loadLettaCodeAgents();
-    } else if (activeTab === "all" && !allLoaded && !allLoading) {
-      loadAllAgents();
+    if (activeTab === "local" && !localLoaded && !localLoading) {
+      loadLocalAgents();
+    } else if (
+      activeTab === "constellation" &&
+      !constellationLoaded &&
+      !constellationLoading &&
+      hasCloudAuth
+    ) {
+      loadConstellationAgents();
     }
   }, [
     activeTab,
-    lettaCodeLoaded,
-    lettaCodeLoading,
-    loadLettaCodeAgents,
-    allLoaded,
-    allLoading,
-    loadAllAgents,
+    localLoaded,
+    localLoading,
+    loadLocalAgents,
+    constellationLoaded,
+    constellationLoading,
+    loadConstellationAgents,
+    hasCloudAuth,
   ]);
 
   // Reload current tab when search query changes (only if query differs from cached)
   useEffect(() => {
-    if (activeTab === "letta-code" && activeQuery !== lettaCodeQuery) {
-      loadLettaCodeAgents(activeQuery || undefined);
-    } else if (activeTab === "all" && activeQuery !== allQuery) {
-      loadAllAgents(activeQuery || undefined);
+    if (activeTab === "constellation" && activeQuery !== constellationQuery) {
+      loadConstellationAgents(activeQuery || undefined);
     }
-  }, [
-    activeQuery,
-    activeTab,
-    lettaCodeQuery,
-    allQuery,
-    loadLettaCodeAgents,
-    loadAllAgents,
-  ]);
-
-  // Fetch more Letta Code agents
-  const fetchMoreLettaCodeAgents = useCallback(async () => {
-    if (lettaCodeLoadingMore || !lettaCodeHasMore || !lettaCodeCursor) return;
-
-    setLettaCodeLoadingMore(true);
-    try {
-      const result = await fetchListAgents(
-        true,
-        lettaCodeCursor,
-        activeQuery || undefined,
-      );
-      setLettaCodeAgents((prev) => [...prev, ...result.agents]);
-      setLettaCodeCursor(result.nextCursor);
-      setLettaCodeHasMore(result.nextCursor !== null);
-    } catch {
-      // Silently fail on pagination errors
-    } finally {
-      setLettaCodeLoadingMore(false);
-    }
-  }, [
-    lettaCodeLoadingMore,
-    lettaCodeHasMore,
-    lettaCodeCursor,
-    fetchListAgents,
-    activeQuery,
-  ]);
-
-  // Fetch more All agents
-  const fetchMoreAllAgents = useCallback(async () => {
-    if (allLoadingMore || !allHasMore || !allCursor) return;
-
-    setAllLoadingMore(true);
-    try {
-      const result = await fetchListAgents(
-        false,
-        allCursor,
-        activeQuery || undefined,
-      );
-      setAllAgents((prev) => [...prev, ...result.agents]);
-      setAllCursor(result.nextCursor);
-      setAllHasMore(result.nextCursor !== null);
-    } catch {
-      // Silently fail on pagination errors
-    } finally {
-      setAllLoadingMore(false);
-    }
-  }, [allLoadingMore, allHasMore, allCursor, fetchListAgents, activeQuery]);
+  }, [activeQuery, activeTab, constellationQuery, loadConstellationAgents]);
 
   // Pagination calculations - Pinned (filter out 404 agents)
   const validPinnedAgents = pinnedAgents.filter((p) => p.agent !== null);
@@ -386,52 +402,58 @@ export function AgentSelector({
     pinnedStartIndex + DISPLAY_PAGE_SIZE,
   );
 
-  // Pagination calculations - Letta Code
-  const lettaCodeTotalPages = Math.ceil(
-    lettaCodeAgents.length / DISPLAY_PAGE_SIZE,
+  // Pagination calculations - Local (current agent pinned to top)
+  const sortedLocalAgents = useMemo(
+    () =>
+      localAgents.toSorted((a, b) => {
+        if (a.id === currentAgentId) return -1;
+        if (b.id === currentAgentId) return 1;
+        return 0;
+      }),
+    [localAgents, currentAgentId],
   );
-  const lettaCodeStartIndex = lettaCodePage * DISPLAY_PAGE_SIZE;
-  const lettaCodePageAgents = lettaCodeAgents.slice(
-    lettaCodeStartIndex,
-    lettaCodeStartIndex + DISPLAY_PAGE_SIZE,
+  const localTotalPages = Math.ceil(
+    sortedLocalAgents.length / DISPLAY_PAGE_SIZE,
   );
-  const lettaCodeCanGoNext =
-    lettaCodePage < lettaCodeTotalPages - 1 || lettaCodeHasMore;
+  const localStartIndex = localPage * DISPLAY_PAGE_SIZE;
+  const localPageAgents = sortedLocalAgents.slice(
+    localStartIndex,
+    localStartIndex + DISPLAY_PAGE_SIZE,
+  );
 
-  // Pagination calculations - All
-  const allTotalPages = Math.ceil(allAgents.length / DISPLAY_PAGE_SIZE);
-  const allStartIndex = allPage * DISPLAY_PAGE_SIZE;
-  const allPageAgents = allAgents.slice(
-    allStartIndex,
-    allStartIndex + DISPLAY_PAGE_SIZE,
+  // Pagination calculations - Constellation
+  const constellationTotalPages = Math.ceil(
+    constellationAgents.length / DISPLAY_PAGE_SIZE,
   );
-  const allCanGoNext = allPage < allTotalPages - 1 || allHasMore;
+  const constellationStartIndex = constellationPage * DISPLAY_PAGE_SIZE;
+  const constellationPageAgents = constellationAgents.slice(
+    constellationStartIndex,
+    constellationStartIndex + DISPLAY_PAGE_SIZE,
+  );
+  const constellationCanGoNext =
+    constellationPage < constellationTotalPages - 1 || constellationHasMore;
 
   // Current tab's state (computed)
   const currentLoading =
     activeTab === "pinned"
       ? pinnedLoading
-      : activeTab === "letta-code"
-        ? lettaCodeLoading
-        : allLoading;
+      : activeTab === "local"
+        ? localLoading
+        : constellationLoading;
   const currentError =
-    activeTab === "letta-code"
-      ? lettaCodeError
-      : activeTab === "all"
-        ? allError
-        : null;
+    activeTab === "constellation" ? constellationError : null;
   const currentAgents =
     activeTab === "pinned"
       ? pinnedPageAgents.map((p) => p.agent).filter(Boolean)
-      : activeTab === "letta-code"
-        ? lettaCodePageAgents
-        : allPageAgents;
+      : activeTab === "local"
+        ? localPageAgents
+        : constellationPageAgents;
   const setCurrentSelectedIndex =
     activeTab === "pinned"
       ? setPinnedSelectedIndex
-      : activeTab === "letta-code"
-        ? setLettaCodeSelectedIndex
-        : setAllSelectedIndex;
+      : activeTab === "local"
+        ? setLocalSelectedIndex
+        : setConstellationSelectedIndex;
 
   // Submit search
   const submitSearch = useCallback(() => {
@@ -466,8 +488,8 @@ export function AgentSelector({
       setDeleteConfirmInput("");
       // Reload pinned and invalidate cached tabs
       loadPinnedAgents();
-      setLettaCodeLoaded(false);
-      setAllLoaded(false);
+      setLocalLoaded(false);
+      setConstellationLoaded(false);
     } catch {
       // Stay on confirmation screen on error
     } finally {
@@ -508,9 +530,9 @@ export function AgentSelector({
 
     // Tab key cycles through tabs
     if (key.tab) {
-      const currentIndex = TABS.findIndex((t) => t.id === activeTab);
-      const nextIndex = (currentIndex + 1) % TABS.length;
-      setActiveTab(TABS[nextIndex]?.id ?? "pinned");
+      const currentIndex = visibleTabs.findIndex((t) => t.id === activeTab);
+      const nextIndex = (currentIndex + 1) % visibleTabs.length;
+      setActiveTab(visibleTabs[nextIndex]?.id ?? "pinned");
       return;
     }
 
@@ -554,17 +576,18 @@ export function AgentSelector({
       if (activeTab === "pinned") {
         const selected = pinnedPageAgents[pinnedSelectedIndex];
         if (selected?.agent) {
-          onSelect(selected.agentId);
+          const mode: AgentBackendMode = selected.isLocal ? "local" : "api";
+          onSelect(selected.agentId, mode);
         }
-      } else if (activeTab === "letta-code") {
-        const selected = lettaCodePageAgents[lettaCodeSelectedIndex];
+      } else if (activeTab === "local") {
+        const selected = localPageAgents[localSelectedIndex];
         if (selected?.id) {
-          onSelect(selected.id);
+          onSelect(selected.id, "local");
         }
-      } else {
-        const selected = allPageAgents[allSelectedIndex];
+      } else if (activeTab === "constellation") {
+        const selected = constellationPageAgents[constellationSelectedIndex];
         if (selected?.id) {
-          onSelect(selected.id);
+          onSelect(selected.id, "api");
         }
       }
     } else if (key.escape) {
@@ -585,15 +608,15 @@ export function AgentSelector({
           setPinnedPage((prev) => prev - 1);
           setPinnedSelectedIndex(0);
         }
-      } else if (activeTab === "letta-code") {
-        if (lettaCodePage > 0) {
-          setLettaCodePage((prev) => prev - 1);
-          setLettaCodeSelectedIndex(0);
+      } else if (activeTab === "local") {
+        if (localPage > 0) {
+          setLocalPage((prev) => prev - 1);
+          setLocalSelectedIndex(0);
         }
       } else {
-        if (allPage > 0) {
-          setAllPage((prev) => prev - 1);
-          setAllSelectedIndex(0);
+        if (constellationPage > 0) {
+          setConstellationPage((prev) => prev - 1);
+          setConstellationSelectedIndex(0);
         }
       }
     } else if (key.rightArrow) {
@@ -603,29 +626,25 @@ export function AgentSelector({
           setPinnedPage((prev) => prev + 1);
           setPinnedSelectedIndex(0);
         }
-      } else if (activeTab === "letta-code" && lettaCodeCanGoNext) {
-        const nextPageIndex = lettaCodePage + 1;
+      } else if (activeTab === "local") {
+        if (localPage < localTotalPages - 1) {
+          setLocalPage((prev) => prev + 1);
+          setLocalSelectedIndex(0);
+        }
+      } else if (activeTab === "constellation" && constellationCanGoNext) {
+        const nextPageIndex = constellationPage + 1;
         const nextStartIndex = nextPageIndex * DISPLAY_PAGE_SIZE;
 
-        if (nextStartIndex >= lettaCodeAgents.length && lettaCodeHasMore) {
-          fetchMoreLettaCodeAgents();
+        if (
+          nextStartIndex >= constellationAgents.length &&
+          constellationHasMore
+        ) {
+          fetchMoreConstellationAgents();
         }
 
-        if (nextStartIndex < lettaCodeAgents.length) {
-          setLettaCodePage(nextPageIndex);
-          setLettaCodeSelectedIndex(0);
-        }
-      } else if (activeTab === "all" && allCanGoNext) {
-        const nextPageIndex = allPage + 1;
-        const nextStartIndex = nextPageIndex * DISPLAY_PAGE_SIZE;
-
-        if (nextStartIndex >= allAgents.length && allHasMore) {
-          fetchMoreAllAgents();
-        }
-
-        if (nextStartIndex < allAgents.length) {
-          setAllPage(nextPageIndex);
-          setAllSelectedIndex(0);
+        if (nextStartIndex < constellationAgents.length) {
+          setConstellationPage(nextPageIndex);
+          setConstellationSelectedIndex(0);
         }
       }
     } else if (activeTab === "pinned" && (input === "p" || input === "P")) {
@@ -650,11 +669,12 @@ export function AgentSelector({
           selectedAgent = selected.agent;
           selectedAgentId = selected.agentId;
         }
-      } else if (activeTab === "letta-code") {
-        selectedAgent = lettaCodePageAgents[lettaCodeSelectedIndex] ?? null;
+      } else if (activeTab === "local") {
+        selectedAgent = localPageAgents[localSelectedIndex] ?? null;
         selectedAgentId = selectedAgent?.id ?? null;
       } else {
-        selectedAgent = allPageAgents[allSelectedIndex] ?? null;
+        selectedAgent =
+          constellationPageAgents[constellationSelectedIndex] ?? null;
         selectedAgentId = selectedAgent?.id ?? null;
       }
 
@@ -680,7 +700,7 @@ export function AgentSelector({
     agent: AgentState,
     _index: number,
     isSelected: boolean,
-    extra?: { isLocal?: boolean },
+    extra?: { isLocal?: boolean; backend?: "local" | "constellation" },
   ) => {
     const isCurrent = agent.id === currentAgentId;
     const relativeTime = formatRelativeTime(agent.last_run_completion);
@@ -691,6 +711,10 @@ export function AgentSelector({
     const fixedChars = 2 + 3 + (isCurrent ? 10 : 0);
     const availableForId = Math.max(15, terminalWidth - nameLen - fixedChars);
     const displayId = truncateAgentId(agent.id, availableForId);
+
+    const backendLabel = extra?.backend
+      ? `${extra.backend === "local" ? "Local" : "Constellation"} · `
+      : "";
 
     return (
       <Box key={agent.id} flexDirection="column" marginBottom={1}>
@@ -711,7 +735,7 @@ export function AgentSelector({
             {" · "}
             {extra?.isLocal !== undefined
               ? `${extra.isLocal ? "project" : "global"} · `
-              : ""}
+              : backendLabel}
             {displayId}
           </Text>
           {isCurrent && (
@@ -772,6 +796,16 @@ export function AgentSelector({
     );
   };
 
+  // Render Constellation upsell (shown when not logged in)
+  const renderConstellationUpsell = () => (
+    <Box flexDirection="column" paddingLeft={2}>
+      <Text dimColor>
+        Connect to Letta Constellation to see hosted agents here.
+      </Text>
+      <Text dimColor>Run /login to sign in.</Text>
+    </Box>
+  );
+
   // Render delete confirmation view
   const renderDeleteConfirm = () => {
     if (viewState.type !== "deleteConfirm") return null;
@@ -827,18 +861,18 @@ export function AgentSelector({
         activeTab !== "new" &&
         !currentLoading &&
         ((activeTab === "pinned" && validPinnedAgents.length > 0) ||
-          (activeTab === "letta-code" &&
-            !lettaCodeError &&
-            lettaCodeAgents.length > 0) ||
-          (activeTab === "all" && !allError && allAgents.length > 0))
+          (activeTab === "local" && localAgents.length > 0) ||
+          (activeTab === "constellation" &&
+            !constellationError &&
+            constellationAgents.length > 0))
           ? (() => {
               const footerWidth = Math.max(0, terminalWidth - 2);
               const pageText =
                 activeTab === "pinned"
                   ? `Page ${pinnedPage + 1}/${pinnedTotalPages || 1}`
-                  : activeTab === "letta-code"
-                    ? `Page ${lettaCodePage + 1}${lettaCodeHasMore ? "+" : `/${lettaCodeTotalPages || 1}`}${lettaCodeLoadingMore ? " (loading...)" : ""}`
-                    : `Page ${allPage + 1}${allHasMore ? "+" : `/${allTotalPages || 1}`}${allLoadingMore ? " (loading...)" : ""}`;
+                  : activeTab === "local"
+                    ? `Page ${localPage + 1}/${localTotalPages || 1}`
+                    : `Page ${constellationPage + 1}${constellationHasMore ? "+" : `/${constellationTotalPages || 1}`}${constellationLoadingMore ? " (loading...)" : ""}`;
               const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? " · P unpin" : ""} · Esc cancel`;
 
               return (
@@ -863,9 +897,11 @@ export function AgentSelector({
     >
       <Box flexDirection="column" paddingLeft={1} marginBottom={1}>
         <TabBar
-          tabs={TABS.map((t) => t.id)}
+          tabs={visibleTabs.map((t) => t.id)}
           activeTab={activeTab}
-          getLabel={(tabId) => TABS.find((t) => t.id === tabId)?.label ?? tabId}
+          getLabel={(tabId) =>
+            visibleTabs.find((t) => t.id === tabId)?.label ?? tabId
+          }
         />
         <Text dimColor> {TAB_DESCRIPTIONS[activeTab]}</Text>
       </Box>
@@ -899,13 +935,20 @@ export function AgentSelector({
         </Box>
       )}
 
+      {/* Constellation upsell when not logged in */}
+      {activeTab === "constellation" &&
+        !currentLoading &&
+        hasCloudAuth === false &&
+        renderConstellationUpsell()}
+
       {/* Empty state */}
       {!currentLoading &&
         ((activeTab === "pinned" && validPinnedAgents.length === 0) ||
-          (activeTab === "letta-code" &&
-            !lettaCodeError &&
-            lettaCodeAgents.length === 0) ||
-          (activeTab === "all" && !allError && allAgents.length === 0)) && (
+          (activeTab === "local" && localAgents.length === 0) ||
+          (activeTab === "constellation" &&
+            !constellationError &&
+            hasCloudAuth &&
+            constellationAgents.length === 0)) && (
           <Box flexDirection="column">
             <Text dimColor>{TAB_EMPTY_STATES[activeTab]}</Text>
             <Text dimColor>Press ESC to cancel</Text>
@@ -923,26 +966,32 @@ export function AgentSelector({
           </Box>
         )}
 
-      {/* Letta Code tab content */}
-      {activeTab === "letta-code" &&
-        !lettaCodeLoading &&
-        !lettaCodeError &&
-        lettaCodeAgents.length > 0 && (
-          <Box flexDirection="column">
-            {lettaCodePageAgents.map((agent, index) =>
-              renderAgentItem(agent, index, index === lettaCodeSelectedIndex),
-            )}
-          </Box>
-        )}
+      {/* Local tab content */}
+      {activeTab === "local" && !localLoading && localAgents.length > 0 && (
+        <Box flexDirection="column">
+          {localPageAgents.map((agent, index) =>
+            renderAgentItem(agent, index, index === localSelectedIndex, {
+              backend: "local",
+            }),
+          )}
+        </Box>
+      )}
 
-      {/* All tab content */}
-      {activeTab === "all" &&
-        !allLoading &&
-        !allError &&
-        allAgents.length > 0 && (
+      {/* Constellation tab content */}
+      {activeTab === "constellation" &&
+        !constellationLoading &&
+        !constellationError &&
+        constellationAgents.length > 0 && (
           <Box flexDirection="column">
-            {allPageAgents.map((agent, index) =>
-              renderAgentItem(agent, index, index === allSelectedIndex),
+            {constellationPageAgents.map((agent, index) =>
+              renderAgentItem(
+                agent,
+                index,
+                index === constellationSelectedIndex,
+                {
+                  backend: "constellation",
+                },
+              ),
             )}
           </Box>
         )}

--- a/src/cli/helpers/local-agent-listing.ts
+++ b/src/cli/helpers/local-agent-listing.ts
@@ -8,6 +8,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { projectLocalAgentState } from "@/backend/local";
 import type { LocalAgentRecord } from "@/backend/local/local-types";
 import { getLocalBackendStorageDir } from "@/backend/local/paths";
 
@@ -30,7 +31,15 @@ export function listLocalAgentsFromDisk(): AgentState[] {
       const raw = readFileSync(filePath, "utf8");
       const record = JSON.parse(raw) as LocalAgentRecord;
       const mtime = statSync(filePath).mtimeMs;
-      agents.push({ agent: projectLocalAgent(record, mtime), mtime });
+      agents.push({
+        agent: projectLocalAgentState(
+          record,
+          [],
+          [],
+          new Date(mtime).toISOString(),
+        ),
+        mtime,
+      });
     } catch {
       // Skip malformed agent files
     }
@@ -40,39 +49,4 @@ export function listLocalAgentsFromDisk(): AgentState[] {
   agents.sort((a, b) => b.mtime - a.mtime);
 
   return agents.map((a) => a.agent);
-}
-
-/**
- * Project a LocalAgentRecord to an AgentState (subset of fields needed for display).
- * Mirrors projectAgentState from local-store.ts but simplified for listing.
- */
-function projectLocalAgent(
-  record: LocalAgentRecord,
-  mtimeMs?: number,
-): AgentState {
-  return {
-    id: record.id,
-    name: record.name,
-    description: record.description,
-    system: record.system,
-    tools: [],
-    tags: record.tags,
-    model: record.model,
-    model_settings: record.model_settings,
-    ...(record.compaction_settings !== undefined
-      ? { compaction_settings: record.compaction_settings }
-      : {}),
-    llm_config: {
-      model: record.model,
-      model_endpoint_type: "openai",
-      model_endpoint: "https://example.invalid/v1",
-      context_window:
-        typeof record.model_settings.context_window_limit === "number"
-          ? record.model_settings.context_window_limit
-          : 128000,
-    },
-    ...(mtimeMs
-      ? { last_run_completion: new Date(mtimeMs).toISOString() }
-      : {}),
-  } as unknown as AgentState;
 }

--- a/src/cli/helpers/local-agent-listing.ts
+++ b/src/cli/helpers/local-agent-listing.ts
@@ -1,0 +1,78 @@
+/**
+ * Lightweight local agent listing — reads agent JSON files from disk
+ * without requiring the full LocalBackend or LocalStore to be instantiated.
+ *
+ * Used by the AgentSelector to show local agents regardless of current backend mode.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type { LocalAgentRecord } from "@/backend/local/local-types";
+import { getLocalBackendStorageDir } from "@/backend/local/paths";
+
+/**
+ * Read all local agent records from disk and project them to AgentState.
+ * Returns an empty array if the local backend directory doesn't exist yet.
+ */
+export function listLocalAgentsFromDisk(): AgentState[] {
+  const storageDir = getLocalBackendStorageDir();
+  const agentsDir = join(storageDir, "agents");
+
+  if (!existsSync(agentsDir)) return [];
+
+  const files = readdirSync(agentsDir).filter((f) => f.endsWith(".json"));
+
+  const agents: { agent: AgentState; mtime: number }[] = [];
+  for (const file of files) {
+    try {
+      const filePath = join(agentsDir, file);
+      const raw = readFileSync(filePath, "utf8");
+      const record = JSON.parse(raw) as LocalAgentRecord;
+      const mtime = statSync(filePath).mtimeMs;
+      agents.push({ agent: projectLocalAgent(record, mtime), mtime });
+    } catch {
+      // Skip malformed agent files
+    }
+  }
+
+  // Sort by file mtime descending (most recently modified first)
+  agents.sort((a, b) => b.mtime - a.mtime);
+
+  return agents.map((a) => a.agent);
+}
+
+/**
+ * Project a LocalAgentRecord to an AgentState (subset of fields needed for display).
+ * Mirrors projectAgentState from local-store.ts but simplified for listing.
+ */
+function projectLocalAgent(
+  record: LocalAgentRecord,
+  mtimeMs?: number,
+): AgentState {
+  return {
+    id: record.id,
+    name: record.name,
+    description: record.description,
+    system: record.system,
+    tools: [],
+    tags: record.tags,
+    model: record.model,
+    model_settings: record.model_settings,
+    ...(record.compaction_settings !== undefined
+      ? { compaction_settings: record.compaction_settings }
+      : {}),
+    llm_config: {
+      model: record.model,
+      model_endpoint_type: "openai",
+      model_endpoint: "https://example.invalid/v1",
+      context_window:
+        typeof record.model_settings.context_window_limit === "number"
+          ? record.model_settings.context_window_limit
+          : 128000,
+    },
+    ...(mtimeMs
+      ? { last_run_completion: new Date(mtimeMs).toISOString() }
+      : {}),
+  } as unknown as AgentState;
+}


### PR DESCRIPTION
## Summary
- add separate Constellation and Local tabs to `/agents`, with Constellation shown before Local
- fetch Constellation agents directly from the cloud API, read Local agents from disk, and switch backends when selecting across modes
- improve Local agent UX by hiding the Local tab when empty, using file mtimes for recency, and pinning the current agent to the top

## Test plan
- [x] run `bun run check`
- [ ] open `/agents` while logged into Constellation and verify the Constellation tab shows cloud agents only
- [ ] verify Local tab appears only when local agents exist and lists the current local agent first
- [ ] switch between a Constellation agent and a Local agent from the picker and confirm backend switching works
- [ ] verify logged-out Constellation state shows the upsell copy

👾 Generated with [Letta Code](https://letta.com)