### PR TITLE
chore: enforce telemetry/ layer boundary

### DIFF
--- a/scripts/check-layer-boundaries.js
+++ b/scripts/check-layer-boundaries.js
@@ -7,6 +7,7 @@
  *   backend/            must not import from  cli/  or  websocket/
  *   providers/          must not import from  agent/  or  cli/
  *   websocket/listener/ must not import from  backend/api/client  or  backend/api/conversations
+ *   telemetry/          must not import from  cli/  agent/  websocket/  or  tools/
  *
  * These are currently violation-free. Adding a rule here means you must
  * also ensure no existing code violates it.
@@ -55,6 +56,12 @@ const RULES = [
     forbidden: ["backend/api/conversations"],
     description:
       "cli/app/ uses the getBackend() abstraction for conversation operations — it must not import the raw conversations module directly",
+  },
+  {
+    layer: "telemetry",
+    forbidden: ["cli", "agent", "websocket", "tools"],
+    description:
+      "telemetry/ is a leaf observer — it must not import from cli/, agent/, websocket/, or tools/ (only backend/api/ for submitting data is permitted)",
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds `telemetry/` to the architectural boundary rules in `scripts/check-layer-boundaries.js`.

`telemetry/` is a leaf observer — it may call `backend/api/` to submit data but must not import from `cli/`, `agent/`, `websocket/`, or `tools/`. Currently 0 violations; this rule prevents future drift.

## Test plan
- [x] `bun run check` passes
- [x] 0 violations confirmed before adding rule

👾 Generated with [Letta Code](https://letta.com)