### PR TITLE
fix(tui): use correct backend for cross-backend agent operations

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -474,6 +474,14 @@ export function getBackend(): Backend {
   return backend;
 }
 
+/**
+ * Get a backend instance for a specific mode without switching the global backend.
+ * Useful for cross-backend operations like retrieving pinned agents from the other backend.
+ */
+export function getBackendForMode(mode: BackendMode): Backend {
+  return createBackendForMode(mode);
+}
+
 export function configureBackendMode(mode: BackendMode): void {
   configuredBackendMode = mode;
   process.env[LOCAL_BACKEND_EXPERIMENTAL_ENV] = mode === "local" ? "1" : "0";

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -533,6 +533,10 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         overlayCommand ?? commandRunner.start("/agents", "Switching agent...");
       cmd.update({ output: "Switching agent...", phase: "running" });
 
+      // Track previous backend mode for rollback on failure
+      const previousBackendMode = isLocalBackendEnabled() ? "local" : "api";
+      let didSwitchBackend = false;
+
       try {
         // Switch backend if the target agent belongs to a different backend
         if (opts?.backendMode) {
@@ -540,6 +544,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           const targetIsLocal = opts.backendMode === "local";
           if (currentIsLocal !== targetIsLocal) {
             configureBackendMode(opts.backendMode);
+            didSwitchBackend = true;
           }
         }
 
@@ -629,6 +634,10 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
         setStaticItems([separator]);
         cmd.finish(successOutput, true);
       } catch (error) {
+        // Rollback backend mode if we switched before the failure
+        if (didSwitchBackend) {
+          configureBackendMode(previousBackendMode);
+        }
         const errorDetails = formatErrorDetails(error, agentId);
         cmd.fail(`Failed: ${errorDetails}`);
       } finally {

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -1,8 +1,8 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getModelDisplayName } from "@/agent/model";
-import { type Backend, getBackend } from "@/backend";
+import { getBackendForMode } from "@/backend/backend";
 import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { DEFAULT_AGENT_NAME } from "@/constants";
@@ -32,7 +32,12 @@ type TabId = "pinned" | "local" | "constellation" | "new";
 
 type ViewState =
   | { type: "list" }
-  | { type: "deleteConfirm"; agent: AgentState; agentId: string };
+  | {
+      type: "deleteConfirm";
+      agent: AgentState;
+      agentId: string;
+      isLocal: boolean;
+    };
 
 interface PinnedAgentData {
   agentId: string;
@@ -140,12 +145,6 @@ export function AgentSelector({
   command = "/agents",
 }: AgentSelectorProps) {
   const terminalWidth = useTerminalWidth();
-  const backendRef = useRef<Backend | null>(null);
-  const selectorBackend = useCallback(() => {
-    const backend = backendRef.current ?? getBackend();
-    backendRef.current = backend;
-    return backend;
-  }, []);
 
   // Tab state
   // Eagerly check for local agents (synchronous disk read) to determine tab visibility
@@ -231,12 +230,14 @@ export function AgentSelector({
         return;
       }
 
-      const backend = selectorBackend();
-
       const pinnedData = await Promise.all(
         mergedPinned.map(async ({ agentId, isLocal }) => {
           try {
-            const agent = await backend.retrieveAgent(agentId, {
+            // Use the correct backend for this agent's mode
+            const agentBackend = isLocal
+              ? getBackendForMode("local")
+              : getBackendForMode("api");
+            const agent = await agentBackend.retrieveAgent(agentId, {
               include: ["agent.blocks"],
             });
             return { agentId, agent, error: null, isLocal };
@@ -252,7 +253,7 @@ export function AgentSelector({
     } finally {
       setPinnedLoading(false);
     }
-  }, [selectorBackend]);
+  }, []);
 
   // Load local agents from disk
   const loadLocalAgents = useCallback(() => {
@@ -473,14 +474,17 @@ export function AgentSelector({
   // Handle agent deletion
   const handleDeleteAgent = useCallback(async () => {
     if (viewState.type !== "deleteConfirm") return;
-    const { agent, agentId } = viewState;
+    const { agent, agentId, isLocal } = viewState;
     const expectedName = agent.name || agentId.slice(0, 12);
 
     if (deleteConfirmInput !== expectedName) return;
 
     setDeleteLoading(true);
     try {
-      const backend = selectorBackend();
+      // Use the correct backend for this agent's mode
+      const backend = isLocal
+        ? getBackendForMode("local")
+        : getBackendForMode("api");
       await backend.deleteAgent(agentId);
 
       // Reset state and refresh tabs
@@ -495,7 +499,7 @@ export function AgentSelector({
     } finally {
       setDeleteLoading(false);
     }
-  }, [viewState, deleteConfirmInput, loadPinnedAgents, selectorBackend]);
+  }, [viewState, deleteConfirmInput, loadPinnedAgents]);
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel
@@ -662,20 +666,24 @@ export function AgentSelector({
       // Delete agent - open confirmation
       let selectedAgent: AgentState | null = null;
       let selectedAgentId: string | null = null;
+      let selectedIsLocal = false;
 
       if (activeTab === "pinned") {
         const selected = pinnedPageAgents[pinnedSelectedIndex];
         if (selected?.agent) {
           selectedAgent = selected.agent;
           selectedAgentId = selected.agentId;
+          selectedIsLocal = selected.isLocal;
         }
       } else if (activeTab === "local") {
         selectedAgent = localPageAgents[localSelectedIndex] ?? null;
         selectedAgentId = selectedAgent?.id ?? null;
+        selectedIsLocal = true;
       } else {
         selectedAgent =
           constellationPageAgents[constellationSelectedIndex] ?? null;
         selectedAgentId = selectedAgent?.id ?? null;
+        selectedIsLocal = false;
       }
 
       if (selectedAgent && selectedAgentId) {
@@ -683,6 +691,7 @@ export function AgentSelector({
           type: "deleteConfirm",
           agent: selectedAgent,
           agentId: selectedAgentId,
+          isLocal: selectedIsLocal,
         });
         setDeleteConfirmInput("");
       }


### PR DESCRIPTION
## Summary
- Export `getBackendForMode()` to get a backend instance for a specific mode without switching the global backend
- Fix pinned agent retrieval to use the correct backend based on `isLocal` flag (so pinned local agents show correctly when in API mode)
- Fix agent deletion to use the correct backend based on `isLocal` flag
- Add rollback of backend mode if `retrieveAgent` fails during agent switch (so you do not get stranded on the wrong backend)

Addresses review comments from #2419 that were left after merge.

## Test plan
- [x] `bun run check` passes
- [ ] Manual test: pin a local agent, switch to API mode, open agent picker — pinned local agent should show correctly
- [ ] Manual test: delete a pinned local agent while in API mode — should delete from local backend
- [ ] Manual test: switch to an agent on a different backend, then cause retrieveAgent to fail — backend should roll back to previous mode

👾 Generated with [Letta Code](https://letta.com)