### PR TITLE
fix(local): isolate local onboarding sandbox state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1487,7 +1487,6 @@ async function main(): Promise<void> {
       async function checkAndStart() {
         // Load settings
         await settingsManager.loadLocalProjectSettings();
-        const localSettings = settingsManager.getLocalProjectSettings();
         const backend = getBackend();
 
         // For self-hosted servers, pre-fetch available models
@@ -1575,7 +1574,9 @@ async function main(): Promise<void> {
           const localSession = settingsManager.getLocalLastSession(
             process.cwd(),
           );
-          const localAgentId = localSession?.agentId ?? localSettings.lastAgent;
+          const localAgentId =
+            localSession?.agentId ??
+            settingsManager.getLocalLastAgentId(process.cwd());
 
           // Try local LRU first
           if (localAgentId) {
@@ -1878,12 +1879,11 @@ async function main(): Promise<void> {
 
         // Priority 3: LRU from local settings (if not --new or user explicitly requested new from selector)
         if (!resumingAgentId && !shouldCreateNew) {
-          const localProjectSettings =
-            settingsManager.getLocalProjectSettings();
-          if (localProjectSettings?.lastAgent) {
+          const localLastAgentId = settingsManager.getLocalLastAgentId();
+          if (localLastAgentId) {
             try {
-              await backend.retrieveAgent(localProjectSettings.lastAgent);
-              resumingAgentId = localProjectSettings.lastAgent;
+              await backend.retrieveAgent(localLastAgentId);
+              resumingAgentId = localLastAgentId;
             } catch {
               // LRU agent doesn't exist (wrong org, deleted, etc.)
               // Show selector instead of silently creating a new agent

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -7,6 +7,7 @@ import { join, resolve } from "node:path";
 import {
   getLocalBackendStorageDir,
   isLocalBackendEnvEnabled,
+  LOCAL_BACKEND_DIR_ENV,
 } from "./backend/local/paths";
 import type { ExperimentId } from "./experiments/types";
 import type { HooksConfig } from "./hooks/types";
@@ -218,6 +219,14 @@ function normalizeBaseUrl(baseUrl: string): string {
 
 function getLocalBackendSettingsKey(): string {
   return `local:${resolve(getLocalBackendStorageDir())}`;
+}
+
+function shouldSkipLegacyLocalBackendSessionFallback(): boolean {
+  return (
+    isLocalBackendEnvEnabled() &&
+    typeof process.env[LOCAL_BACKEND_DIR_ENV] === "string" &&
+    process.env[LOCAL_BACKEND_DIR_ENV].length > 0
+  );
 }
 
 /**
@@ -1125,6 +1134,10 @@ class SettingsManager {
       return settings.sessionsByServer[serverKey];
     }
 
+    if (shouldSkipLegacyLocalBackendSessionFallback()) {
+      return null;
+    }
+
     // Fall back to legacy lastSession for migration
     if (settings.lastSession) {
       return settings.lastSession;
@@ -1145,6 +1158,10 @@ class SettingsManager {
     // Try server-indexed lookup first
     if (settings.sessionsByServer?.[serverKey]) {
       return settings.sessionsByServer[serverKey].agentId;
+    }
+
+    if (shouldSkipLegacyLocalBackendSessionFallback()) {
+      return null;
     }
 
     // Fall back to legacy for migration
@@ -1193,6 +1210,10 @@ class SettingsManager {
       return localSettings.sessionsByServer[serverKey];
     }
 
+    if (shouldSkipLegacyLocalBackendSessionFallback()) {
+      return null;
+    }
+
     // Fall back to legacy lastSession for migration
     if (localSettings.lastSession) {
       return localSettings.lastSession;
@@ -1214,6 +1235,10 @@ class SettingsManager {
     // Try server-indexed lookup first
     if (localSettings.sessionsByServer?.[serverKey]) {
       return localSettings.sessionsByServer[serverKey].agentId;
+    }
+
+    if (shouldSkipLegacyLocalBackendSessionFallback()) {
+      return null;
     }
 
     // Fall back to legacy for migration


### PR DESCRIPTION
## Summary
- Treat an explicit `LETTA_LOCAL_BACKEND_DIR` override as an isolated local environment for startup session lookup
- Skip legacy unscoped `lastAgent` / `lastSession` migration fallbacks in that mode
- Route startup resume checks through the server-keyed local-session helpers so a fresh local backend dir behaves like a new local user

## Test plan
- [x] `bun run check` passes
- [x] Launch with `LETTA_LOCAL_BACKEND_DIR=/tmp/letta-onboarding-fresh bun run dev -- --backend local`
- [x] Verify startup no longer shows `Unable to locate recently used agent ...` from legacy local state
- [ ] Confirm normal local startup without `LETTA_LOCAL_BACKEND_DIR` still resumes existing local state as before

👾 Generated with [Letta Code](https://letta.com)