### PR TITLE
feat(protocol): expose conversation cwd map

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -337,9 +337,17 @@ export interface DeviceStatus {
   pending_control_requests: PendingControlRequest[];
   experiments: ExperimentSnapshot[];
   memory_directory: string | null;
-  /** Persisted per-conversation CWD overrides, keyed by listener scope key. */
+  /**
+   * Persisted CWD overrides keyed by listener scope key.
+   *
+   * Key format:
+   * - `conversation:<conversation_id>` for conversation-scoped overrides
+   * - `agent:<agent_id>::conversation:default` for an agent's default conversation scope
+   *
+   * Example: `conversation:conv_123` or `agent:agent_123::conversation:default`
+   */
   cwd_map?: Record<string, string>;
-  /** Listener boot CWD used when a conversation has no entry in cwd_map. */
+  /** Listener boot CWD used when a conversation has no matching formatted key in `cwd_map`. */
   boot_working_directory?: string | null;
   should_doctor?: boolean;
   reflection_settings: ReflectionSettingsSnapshot | null;

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -337,6 +337,10 @@ export interface DeviceStatus {
   pending_control_requests: PendingControlRequest[];
   experiments: ExperimentSnapshot[];
   memory_directory: string | null;
+  /** Persisted per-conversation CWD overrides, keyed by listener scope key. */
+  cwd_map?: Record<string, string>;
+  /** Listener boot CWD used when a conversation has no entry in cwd_map. */
+  boot_working_directory?: string | null;
   should_doctor?: boolean;
   reflection_settings: ReflectionSettingsSnapshot | null;
   /** Remote slash command IDs this letta-code version can handle via `execute_command`. */
@@ -1065,6 +1069,23 @@ export interface CreateAgentCommand {
   pin_global?: boolean;
 }
 
+export interface RetrieveCwdMapCommand {
+  type: "retrieve_cwd_map";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+}
+
+export interface RetrieveCwdMapResponseMessage {
+  type: "retrieve_cwd_map_response";
+  request_id: string;
+  success: boolean;
+  /** Persisted per-conversation CWD overrides, keyed by listener scope key. */
+  cwd_map: Record<string, string>;
+  /** Listener boot CWD used when a conversation has no entry in cwd_map. */
+  boot_working_directory: string | null;
+  error?: string;
+}
+
 export interface GetReflectionSettingsCommand {
   type: "get_reflection_settings";
   /** Echoed back in the response for request correlation. */
@@ -1758,6 +1779,7 @@ export type WsProtocolCommand =
   | SkillEnableCommand
   | SkillDisableCommand
   | CreateAgentCommand
+  | RetrieveCwdMapCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
   | GetExperimentsCommand
@@ -1825,6 +1847,7 @@ export type WsProtocolMessage =
   | ChannelPairingsUpdatedMessage
   | ChannelRoutesUpdatedMessage
   | ChannelTargetsUpdatedMessage
+  | RetrieveCwdMapResponseMessage
   | SecretListResponse
   | SecretApplyResponse
   | RemoveQueueItemResponse;

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1069,14 +1069,14 @@ export interface CreateAgentCommand {
   pin_global?: boolean;
 }
 
-export interface RetrieveCwdMapCommand {
-  type: "retrieve_cwd_map";
+export interface GetCwdMapCommand {
+  type: "get_cwd_map";
   /** Echoed back in the response for request correlation. */
   request_id: string;
 }
 
-export interface RetrieveCwdMapResponseMessage {
-  type: "retrieve_cwd_map_response";
+export interface GetCwdMapResponseMessage {
+  type: "get_cwd_map_response";
   request_id: string;
   success: boolean;
   /** Persisted per-conversation CWD overrides, keyed by listener scope key. */

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1787,7 +1787,7 @@ export type WsProtocolCommand =
   | SkillEnableCommand
   | SkillDisableCommand
   | CreateAgentCommand
-  | RetrieveCwdMapCommand
+  | GetCwdMapCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
   | GetExperimentsCommand
@@ -1855,7 +1855,7 @@ export type WsProtocolMessage =
   | ChannelPairingsUpdatedMessage
   | ChannelRoutesUpdatedMessage
   | ChannelTargetsUpdatedMessage
-  | RetrieveCwdMapResponseMessage
+  | GetCwdMapResponseMessage
   | SecretListResponse
   | SecretApplyResponse
   | RemoveQueueItemResponse;

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -530,6 +530,22 @@ export function createListenerMessageHandler(
         return;
       }
 
+      if (parsed.type === "retrieve_cwd_map") {
+        safeSocketSend(
+          socket,
+          {
+            type: "retrieve_cwd_map_response",
+            request_id: parsed.request_id,
+            success: true,
+            cwd_map: Object.fromEntries(runtime.workingDirectoryByConversation),
+            boot_working_directory: runtime.bootWorkingDirectory,
+          },
+          "retrieve_cwd_map_response_failed",
+          "retrieve_cwd_map_response",
+        );
+        return;
+      }
+
       if (
         handleSettingsProtocolCommand(parsed, {
           socket,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -540,8 +540,8 @@ export function createListenerMessageHandler(
             cwd_map: Object.fromEntries(runtime.workingDirectoryByConversation),
             boot_working_directory: runtime.bootWorkingDirectory,
           },
-          "retrieve_cwd_map_response_failed",
           "retrieve_cwd_map_response",
+          "retrieve_cwd_map",
         );
         return;
       }

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -530,18 +530,18 @@ export function createListenerMessageHandler(
         return;
       }
 
-      if (parsed.type === "retrieve_cwd_map") {
+      if (parsed.type === "get_cwd_map") {
         safeSocketSend(
           socket,
           {
-            type: "retrieve_cwd_map_response",
+            type: "get_cwd_map_response",
             request_id: parsed.request_id,
             success: true,
             cwd_map: Object.fromEntries(runtime.workingDirectoryByConversation),
             boot_working_directory: runtime.bootWorkingDirectory,
           },
-          "retrieve_cwd_map_response",
-          "retrieve_cwd_map",
+          "get_cwd_map_response",
+          "get_cwd_map",
         );
         return;
       }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -51,6 +51,7 @@ import type {
   ReadFileCommand,
   ReadMemoryFileCommand,
   RemoveQueueItemCommand,
+  RetrieveCwdMapCommand,
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
@@ -642,6 +643,14 @@ export function isEnableMemfsCommand(
     typeof c.request_id === "string" &&
     typeof c.agent_id === "string"
   );
+}
+
+export function isRetrieveCwdMapCommand(
+  value: unknown,
+): value is RetrieveCwdMapCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as { type?: unknown; request_id?: unknown };
+  return c.type === "retrieve_cwd_map" && typeof c.request_id === "string";
 }
 
 export function isListModelsCommand(
@@ -1604,6 +1613,7 @@ export function parseServerMessage(
       isSkillEnableCommand(parsed) ||
       isSkillDisableCommand(parsed) ||
       isCreateAgentCommand(parsed) ||
+      isRetrieveCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -37,6 +37,7 @@ import type {
   EnableMemfsCommand,
   ExecuteCommandCommand,
   FileOpsCommand,
+  GetCwdMapCommand,
   GetExperimentsCommand,
   GetReflectionSettingsCommand,
   GetTreeCommand,
@@ -51,7 +52,6 @@ import type {
   ReadFileCommand,
   ReadMemoryFileCommand,
   RemoveQueueItemCommand,
-  RetrieveCwdMapCommand,
   RuntimeScope,
   SearchBranchesCommand,
   SearchFilesCommand,
@@ -645,12 +645,10 @@ export function isEnableMemfsCommand(
   );
 }
 
-export function isRetrieveCwdMapCommand(
-  value: unknown,
-): value is RetrieveCwdMapCommand {
+export function isGetCwdMapCommand(value: unknown): value is GetCwdMapCommand {
   if (!value || typeof value !== "object") return false;
   const c = value as { type?: unknown; request_id?: unknown };
-  return c.type === "retrieve_cwd_map" && typeof c.request_id === "string";
+  return c.type === "get_cwd_map" && typeof c.request_id === "string";
 }
 
 export function isListModelsCommand(
@@ -1613,7 +1611,7 @@ export function parseServerMessage(
       isSkillEnableCommand(parsed) ||
       isSkillDisableCommand(parsed) ||
       isCreateAgentCommand(parsed) ||
-      isRetrieveCwdMapCommand(parsed) ||
+      isGetCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -399,6 +399,8 @@ export function buildDeviceStatus(
       pending_control_requests: [],
       experiments: experimentManager.list(),
       memory_directory: null,
+      cwd_map: {},
+      boot_working_directory: fallbackCwd,
       should_doctor: false,
       reflection_settings: null,
       supported_commands: [...SUPPORTED_REMOTE_COMMANDS],
@@ -473,6 +475,8 @@ export function buildDeviceStatus(
     memory_directory: scopedAgentId
       ? getMemoryFilesystemRoot(scopedAgentId)
       : null,
+    cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
+    boot_working_directory: listener.bootWorkingDirectory,
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
     supported_commands: [...SUPPORTED_REMOTE_COMMANDS],
     reflection_settings: scopedAgentId

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -475,8 +475,12 @@ export function buildDeviceStatus(
     memory_directory: scopedAgentId
       ? getMemoryFilesystemRoot(scopedAgentId)
       : null,
-    cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
-    boot_working_directory: listener.bootWorkingDirectory,
+    ...(!scope
+      ? {
+          cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
+          boot_working_directory: listener.bootWorkingDirectory,
+        }
+      : {}),
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
     supported_commands: [...SUPPORTED_REMOTE_COMMANDS],
     reflection_settings: scopedAgentId


### PR DESCRIPTION
Expose persisted per-conversation working directory state over the device protocol so clients can group chats by project.

👾 Generated with [Letta Code](https://letta.com)