### PR TITLE
fix(startup): make session resume backend-aware

### DIFF
--- a/src/agent/agent-id.ts
+++ b/src/agent/agent-id.ts
@@ -1,0 +1,18 @@
+export type AgentBackendMode = "local" | "api";
+
+export function isLocalAgentId(agentId: string): boolean {
+  return agentId.startsWith("agent-local-");
+}
+
+export function isCloudAgentId(agentId: string): boolean {
+  return !isLocalAgentId(agentId);
+}
+
+export function isAgentIdCompatibleWithBackend(
+  agentId: string,
+  backendMode: AgentBackendMode,
+): boolean {
+  return backendMode === "local"
+    ? isLocalAgentId(agentId)
+    : isCloudAgentId(agentId);
+}

--- a/src/agent/resolve-startup-agent-files.test.ts
+++ b/src/agent/resolve-startup-agent-files.test.ts
@@ -9,6 +9,8 @@ const originalHome = process.env.HOME;
 const originalCwd = process.cwd();
 const originalLocalBackendFlag = process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
 const originalLocalBackendDir = process.env.LETTA_LOCAL_BACKEND_DIR;
+const originalBaseUrl = process.env.LETTA_BASE_URL;
+const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
 
 let testHomeDir: string;
 let testProjectDir: string;
@@ -70,6 +72,8 @@ beforeEach(async () => {
   process.env.HOME = testHomeDir;
   delete process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
   delete process.env.LETTA_LOCAL_BACKEND_DIR;
+  delete process.env.LETTA_BASE_URL;
+  delete process.env.LETTA_MEMFS_BASE_URL;
   process.chdir(testProjectDir);
 });
 
@@ -86,6 +90,16 @@ afterEach(async () => {
     delete process.env.LETTA_LOCAL_BACKEND_DIR;
   } else {
     process.env.LETTA_LOCAL_BACKEND_DIR = originalLocalBackendDir;
+  }
+  if (originalBaseUrl === undefined) {
+    delete process.env.LETTA_BASE_URL;
+  } else {
+    process.env.LETTA_BASE_URL = originalBaseUrl;
+  }
+  if (originalMemfsBaseUrl === undefined) {
+    delete process.env.LETTA_MEMFS_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
   }
   await rm(testHomeDir, { recursive: true, force: true });
   await rm(testProjectDir, { recursive: true, force: true });
@@ -115,6 +129,25 @@ describe("startup resolution from settings files", () => {
       action: "resume",
       agentId: "agent-global",
     });
+  });
+
+  test("api startup ignores incompatible local agent stored under api.letta.com", async () => {
+    await writeGlobalSettings({
+      sessionsByServer: {
+        "api.letta.com": {
+          agentId: "agent-local-poisoned",
+          conversationId: "local-conv-poisoned",
+        },
+      },
+      lastAgent: "agent-local-poisoned",
+      lastSession: {
+        agentId: "agent-local-poisoned",
+        conversationId: "local-conv-poisoned",
+      },
+    });
+
+    const target = await resolveFromSettings();
+    expect(target).toEqual({ action: "create" });
   });
 
   test("local session + valid local agent => resume local agent", async () => {
@@ -329,6 +362,8 @@ describe("startup resolution from settings files", () => {
     });
     expect(globalSettings.sessionsByServer?.["api.letta.com"]).toBeUndefined();
     expect(localSettings.sessionsByServer?.["api.letta.com"]).toBeUndefined();
+    expect(globalSettings.lastAgent).toBeNull();
+    expect(globalSettings.lastSession).toBeUndefined();
   });
 
   test("local backend reads the session for the active storage directory", async () => {

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isAgentIdCompatibleWithBackend,
+  isCloudAgentId,
+} from "@/agent/agent-id";
+import {
   buildAgentReference,
   buildAgentTerminalLink,
   buildChatUrl,
@@ -28,6 +32,19 @@ describe("app URL helpers", () => {
   test("isLocalAgentId detects local-backend agents", () => {
     expect(isLocalAgentId("agent-local-abc")).toBe(true);
     expect(isLocalAgentId("agent-abc")).toBe(false);
+  });
+
+  test("cloud/local agent ID helpers are backend-aware", () => {
+    expect(isCloudAgentId("agent-abc")).toBe(true);
+    expect(isCloudAgentId("agent-local-abc")).toBe(false);
+    expect(isAgentIdCompatibleWithBackend("agent-local-abc", "local")).toBe(
+      true,
+    );
+    expect(isAgentIdCompatibleWithBackend("agent-local-abc", "api")).toBe(
+      false,
+    );
+    expect(isAgentIdCompatibleWithBackend("agent-abc", "api")).toBe(true);
+    expect(isAgentIdCompatibleWithBackend("agent-abc", "local")).toBe(false);
   });
 
   test("buildAgentTerminalLink only hyperlinks API-backed agents", () => {

--- a/src/cli/app/session.ts
+++ b/src/cli/app/session.ts
@@ -1,3 +1,4 @@
+import { isAgentIdCompatibleWithBackend } from "@/agent/agent-id";
 import { getCurrentAgentId } from "@/agent/context";
 import { settingsManager } from "@/settings-manager";
 
@@ -11,9 +12,12 @@ export function saveLastSessionBeforeExit(conversationId?: string | null) {
       // persistSession writes session + legacy lastAgent fields
       settingsManager.persistSession(currentAgentId, conversationId);
     } else {
-      // No conversation to save -- still track the agent via legacy fields
+      // No conversation to save — keep project-local lastAgent updated.
+      // Only mirror into global legacy state for cloud/self-hosted agents.
       settingsManager.updateLocalProjectSettings({ lastAgent: currentAgentId });
-      settingsManager.updateSettings({ lastAgent: currentAgentId });
+      if (isAgentIdCompatibleWithBackend(currentAgentId, "api")) {
+        settingsManager.updateSettings({ lastAgent: currentAgentId });
+      }
     }
   } catch {
     // Ignore if no agent context set

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -370,11 +370,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           messageHistory: resumeData.messageHistory,
         };
 
-        settingsManager.setLocalLastSession(
-          { agentId, conversationId },
-          process.cwd(),
-        );
-        settingsManager.setGlobalLastSession({ agentId, conversationId });
+        settingsManager.persistSession(agentId, conversationId, process.cwd());
 
         // Clear current transcript and static items (same pattern as /search)
         buffersRef.current.byId.clear();

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -1332,14 +1332,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               isDefault: false,
             };
 
-            settingsManager.setLocalLastSession(
-              { agentId, conversationId: forked.id },
-              process.cwd(),
-            );
-            settingsManager.setGlobalLastSession({
-              agentId,
-              conversationId: forked.id,
-            });
+            settingsManager.persistSession(agentId, forked.id, process.cwd());
 
             resetContextHistory(contextTrackerRef.current);
             resetBootstrapReminderState();

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,7 +1,9 @@
+import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
+
 const APP_BASE = "https://app.letta.com";
 
 export function isLocalAgentId(agentId: string): boolean {
-  return agentId.startsWith("agent-local-");
+  return isLocalAgentIdShared(agentId);
 }
 
 /**

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -10,6 +10,7 @@ import {
   type QueuedMessage,
   setMessageQueueAdder,
 } from "@/utils/message-queue-bridge";
+import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import type { ApprovalResult } from "./agent/approval-execution";
 import {
   buildFreshDenialApprovals,
@@ -610,6 +611,9 @@ export async function handleHeadlessCommand(
   // Resolve agent (same logic as interactive mode)
   let agent: AgentState | null = null;
   let autoEnableMemfsForFreshAgent = false;
+  const startupBackendMode = backend.capabilities.localModelCatalog
+    ? "local"
+    : "api";
   let specifiedAgentId = values.agent;
   const specifiedAgentName = values.name;
   let specifiedConversationId = values.conversation;
@@ -1136,12 +1140,15 @@ export async function handleHeadlessCommand(
   }
 
   // Priority 4: Try to resume from project settings (.letta/settings.local.json)
-  if (!agent) {
+  if (!agent && startupBackendMode === "local") {
     await settingsManager.loadLocalProjectSettings();
     const localAgentId = settingsManager.getLocalLastAgentId(
       getCurrentWorkingDirectory(),
     );
-    if (localAgentId) {
+    if (
+      localAgentId &&
+      isAgentIdCompatibleWithBackend(localAgentId, startupBackendMode)
+    ) {
       try {
         agent = await backend.retrieveAgent(localAgentId, {
           include: ["agent.tags"],
@@ -1155,9 +1162,12 @@ export async function handleHeadlessCommand(
 
   // Priority 5: Try to reuse global LRU (covers directory-switching case)
   // Do NOT restore global conversation — use default (project-scoped conversations)
-  if (!agent) {
+  if (!agent && startupBackendMode === "api") {
     const globalAgentId = settingsManager.getGlobalLastAgentId();
-    if (globalAgentId) {
+    if (
+      globalAgentId &&
+      isAgentIdCompatibleWithBackend(globalAgentId, startupBackendMode)
+    ) {
       try {
         agent = await backend.retrieveAgent(globalAgentId, {
           include: ["agent.tags"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { ensureFileIndex } from "@/utils/file-index";
+import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import {
   getResumeDataFromBackend,
   type ResumeData,
@@ -1488,6 +1489,9 @@ async function main(): Promise<void> {
         // Load settings
         await settingsManager.loadLocalProjectSettings();
         const backend = getBackend();
+        const startupBackendMode = isExperimentalLocalBackendEnabled()
+          ? "local"
+          : "api";
 
         // For self-hosted servers, pre-fetch available models
         // This is needed so ProfileSelectionInline can show model picker
@@ -1577,41 +1581,36 @@ async function main(): Promise<void> {
           const localAgentId =
             localSession?.agentId ??
             settingsManager.getLocalLastAgentId(process.cwd());
-
-          // Try local LRU first
-          if (localAgentId) {
-            try {
-              const agent = await backend.retrieveAgent(localAgentId, {
-                include: ["agent.tags"],
-              });
-              setResumeAgentId(localAgentId);
-              setResumeAgentName(agent.name ?? null);
-              setLoadingState("selecting_conversation");
-              return;
-            } catch {
-              // Local agent doesn't exist, try global
-              setFailedAgentMessage(
-                `Unable to locate agent ${localAgentId} in .letta/, checking global (~/.letta)`,
-              );
-            }
-          } else {
-            // No recent agent locally, silently fall through to global
-          }
-
-          // Try global LRU
           const globalSession = settingsManager.getGlobalLastSession();
           const globalAgentId = globalSession?.agentId;
-          if (globalAgentId) {
+
+          const preferredResumeAgentId =
+            startupBackendMode === "local"
+              ? localAgentId &&
+                isAgentIdCompatibleWithBackend(localAgentId, "local")
+                ? localAgentId
+                : null
+              : globalAgentId &&
+                  isAgentIdCompatibleWithBackend(globalAgentId, "api")
+                ? globalAgentId
+                : null;
+
+          if (preferredResumeAgentId) {
             try {
-              const agent = await backend.retrieveAgent(globalAgentId, {
-                include: ["agent.tags"],
-              });
-              setResumeAgentId(globalAgentId);
+              const agent = await backend.retrieveAgent(
+                preferredResumeAgentId,
+                {
+                  include: ["agent.tags"],
+                },
+              );
+              setResumeAgentId(preferredResumeAgentId);
               setResumeAgentName(agent.name ?? null);
               setLoadingState("selecting_conversation");
               return;
             } catch {
-              // Global agent also doesn't exist
+              setFailedAgentMessage(
+                `Unable to locate agent ${preferredResumeAgentId}`,
+              );
             }
           }
 
@@ -1648,10 +1647,24 @@ async function main(): Promise<void> {
           return;
         }
 
-        // Step 1: Check local project LRU (session helpers centralize legacy fallback)
-        // Cache the retrieved agent to avoid redundant re-fetch in init()
-        const localAgentId = settingsManager.getLocalLastAgentId(process.cwd());
-        const globalAgentId = settingsManager.getGlobalLastAgentId();
+        // Step 1: Check recent session state for the active backend only.
+        // Cache the retrieved agent to avoid redundant re-fetch in init().
+        const rawLocalAgentId = settingsManager.getLocalLastAgentId(
+          process.cwd(),
+        );
+        const rawGlobalAgentId = settingsManager.getGlobalLastAgentId();
+        const localAgentId =
+          startupBackendMode === "local" &&
+          rawLocalAgentId &&
+          isAgentIdCompatibleWithBackend(rawLocalAgentId, "local")
+            ? rawLocalAgentId
+            : null;
+        const globalAgentId =
+          startupBackendMode === "api" &&
+          rawGlobalAgentId &&
+          isAgentIdCompatibleWithBackend(rawGlobalAgentId, "api")
+            ? rawGlobalAgentId
+            : null;
 
         // Fetch local + global LRU agents in parallel
         let localAgentExists = false;
@@ -1706,7 +1719,8 @@ async function main(): Promise<void> {
           process.cwd(),
         );
         const shouldRepairMissingLocalBackendLru = Boolean(
-          (localAgentId || globalAgentId) &&
+          startupBackendMode === "local" &&
+            (localAgentId || globalAgentId) &&
             !localAgentExists &&
             !globalAgentExists,
         );
@@ -1823,6 +1837,9 @@ async function main(): Promise<void> {
 
       async function init() {
         const backend = getBackend();
+        const startupBackendMode = backend.capabilities.localModelCatalog
+          ? "local"
+          : "api";
 
         // Determine which agent we'll be using (before loading tools)
         let resumingAgentId: string | null = null;
@@ -1877,13 +1894,19 @@ async function main(): Promise<void> {
           }
         }
 
-        // Priority 3: LRU from local settings (if not --new or user explicitly requested new from selector)
+        // Priority 3: LRU from the active backend (if not --new or user explicitly requested new from selector)
         if (!resumingAgentId && !shouldCreateNew) {
-          const localLastAgentId = settingsManager.getLocalLastAgentId();
-          if (localLastAgentId) {
+          const recentAgentId =
+            startupBackendMode === "local"
+              ? settingsManager.getLocalLastAgentId()
+              : settingsManager.getGlobalLastAgentId();
+          if (
+            recentAgentId &&
+            isAgentIdCompatibleWithBackend(recentAgentId, startupBackendMode)
+          ) {
             try {
-              await backend.retrieveAgent(localLastAgentId);
-              resumingAgentId = localLastAgentId;
+              await backend.retrieveAgent(recentAgentId);
+              resumingAgentId = recentAgentId;
             } catch {
               // LRU agent doesn't exist (wrong org, deleted, etc.)
               // Show selector instead of silently creating a new agent
@@ -2076,9 +2099,12 @@ async function main(): Promise<void> {
           await settingsManager.loadLocalProjectSettings();
         }
 
-        // Save agent ID to both project and global settings
+        // Save agent ID to project settings.
+        // Only mirror into global legacy lastAgent for cloud/self-hosted agents.
         settingsManager.updateLocalProjectSettings({ lastAgent: agent.id });
-        settingsManager.updateSettings({ lastAgent: agent.id });
+        if (isAgentIdCompatibleWithBackend(agent.id, "api")) {
+          settingsManager.updateSettings({ lastAgent: agent.id });
+        }
 
         // Set agent context for tools that need it (e.g., Skill tool)
         setAgentContext(agent.id, skillsDirectory, resolvedSkillSources);

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { isCloudAgentId, isLocalAgentId } from "./agent/agent-id";
 import {
   getLocalBackendStorageDir,
   isLocalBackendEnvEnabled,
@@ -219,6 +220,26 @@ function normalizeBaseUrl(baseUrl: string): string {
 
 function getLocalBackendSettingsKey(): string {
   return `local:${resolve(getLocalBackendStorageDir())}`;
+}
+
+function isLocalServerKey(serverKey: string): boolean {
+  return serverKey.startsWith("local:");
+}
+
+function isAgentIdCompatibleWithServerKey(
+  agentId: string,
+  serverKey: string,
+): boolean {
+  return isLocalServerKey(serverKey)
+    ? isLocalAgentId(agentId)
+    : isCloudAgentId(agentId);
+}
+
+function isSessionCompatibleWithServerKey(
+  session: SessionRef,
+  serverKey: string,
+): boolean {
+  return isAgentIdCompatibleWithServerKey(session.agentId, serverKey);
 }
 
 function shouldSkipLegacyLocalBackendSessionFallback(): boolean {
@@ -1130,8 +1151,17 @@ class SettingsManager {
     const serverKey = getCurrentServerKey(settings);
 
     // Try server-indexed lookup first
-    if (settings.sessionsByServer?.[serverKey]) {
-      return settings.sessionsByServer[serverKey];
+    const serverSession = settings.sessionsByServer?.[serverKey];
+    if (serverSession) {
+      if (isSessionCompatibleWithServerKey(serverSession, serverKey)) {
+        return serverSession;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible global session for server %s: %s",
+        serverKey,
+        serverSession.agentId,
+      );
     }
 
     if (shouldSkipLegacyLocalBackendSessionFallback()) {
@@ -1139,7 +1169,10 @@ class SettingsManager {
     }
 
     // Fall back to legacy lastSession for migration
-    if (settings.lastSession) {
+    if (
+      settings.lastSession &&
+      isSessionCompatibleWithServerKey(settings.lastSession, serverKey)
+    ) {
       return settings.lastSession;
     }
 
@@ -1156,8 +1189,17 @@ class SettingsManager {
     const serverKey = getCurrentServerKey(settings);
 
     // Try server-indexed lookup first
-    if (settings.sessionsByServer?.[serverKey]) {
-      return settings.sessionsByServer[serverKey].agentId;
+    const serverSession = settings.sessionsByServer?.[serverKey];
+    if (serverSession) {
+      if (isSessionCompatibleWithServerKey(serverSession, serverKey)) {
+        return serverSession.agentId;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible global agent for server %s: %s",
+        serverKey,
+        serverSession.agentId,
+      );
     }
 
     if (shouldSkipLegacyLocalBackendSessionFallback()) {
@@ -1165,10 +1207,19 @@ class SettingsManager {
     }
 
     // Fall back to legacy for migration
-    if (settings.lastSession) {
+    if (
+      settings.lastSession &&
+      isSessionCompatibleWithServerKey(settings.lastSession, serverKey)
+    ) {
       return settings.lastSession.agentId;
     }
-    return settings.lastAgent;
+    if (
+      settings.lastAgent &&
+      isAgentIdCompatibleWithServerKey(settings.lastAgent, serverKey)
+    ) {
+      return settings.lastAgent;
+    }
+    return null;
   }
 
   /**
@@ -1179,18 +1230,33 @@ class SettingsManager {
     const settings = this.getSettings();
     const serverKey = getCurrentServerKey(settings);
 
+    if (!isSessionCompatibleWithServerKey(session, serverKey)) {
+      debugWarn(
+        "settings",
+        "Skipping incompatible global session write for server %s: %s",
+        serverKey,
+        session.agentId,
+      );
+      return;
+    }
+
     // Update server-indexed storage
     const sessionsByServer = {
       ...settings.sessionsByServer,
       [serverKey]: session,
     };
 
-    // Also update legacy fields for backwards compat with older CLI versions
-    this.updateSettings({
-      sessionsByServer,
-      lastSession: session,
-      lastAgent: session.agentId,
-    });
+    // Keep legacy global fields for cloud/self-hosted agents only.
+    if (isCloudAgentId(session.agentId)) {
+      this.updateSettings({
+        sessionsByServer,
+        lastSession: session,
+        lastAgent: session.agentId,
+      });
+      return;
+    }
+
+    this.updateSettings({ sessionsByServer });
   }
 
   /**
@@ -1206,8 +1272,17 @@ class SettingsManager {
     const localSettings = this.getLocalProjectSettings(workingDirectory);
 
     // Try server-indexed lookup first
-    if (localSettings.sessionsByServer?.[serverKey]) {
-      return localSettings.sessionsByServer[serverKey];
+    const serverSession = localSettings.sessionsByServer?.[serverKey];
+    if (serverSession) {
+      if (isSessionCompatibleWithServerKey(serverSession, serverKey)) {
+        return serverSession;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible local session for server %s: %s",
+        serverKey,
+        serverSession.agentId,
+      );
     }
 
     if (shouldSkipLegacyLocalBackendSessionFallback()) {
@@ -1215,7 +1290,10 @@ class SettingsManager {
     }
 
     // Fall back to legacy lastSession for migration
-    if (localSettings.lastSession) {
+    if (
+      localSettings.lastSession &&
+      isSessionCompatibleWithServerKey(localSettings.lastSession, serverKey)
+    ) {
       return localSettings.lastSession;
     }
 
@@ -1233,8 +1311,17 @@ class SettingsManager {
     const localSettings = this.getLocalProjectSettings(workingDirectory);
 
     // Try server-indexed lookup first
-    if (localSettings.sessionsByServer?.[serverKey]) {
-      return localSettings.sessionsByServer[serverKey].agentId;
+    const serverSession = localSettings.sessionsByServer?.[serverKey];
+    if (serverSession) {
+      if (isSessionCompatibleWithServerKey(serverSession, serverKey)) {
+        return serverSession.agentId;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible local agent for server %s: %s",
+        serverKey,
+        serverSession.agentId,
+      );
     }
 
     if (shouldSkipLegacyLocalBackendSessionFallback()) {
@@ -1242,10 +1329,19 @@ class SettingsManager {
     }
 
     // Fall back to legacy for migration
-    if (localSettings.lastSession) {
+    if (
+      localSettings.lastSession &&
+      isSessionCompatibleWithServerKey(localSettings.lastSession, serverKey)
+    ) {
       return localSettings.lastSession.agentId;
     }
-    return localSettings.lastAgent;
+    if (
+      localSettings.lastAgent &&
+      isAgentIdCompatibleWithServerKey(localSettings.lastAgent, serverKey)
+    ) {
+      return localSettings.lastAgent;
+    }
+    return null;
   }
 
   /**
@@ -1259,6 +1355,16 @@ class SettingsManager {
     const globalSettings = this.getSettings();
     const serverKey = getCurrentServerKey(globalSettings);
     const localSettings = this.getLocalProjectSettings(workingDirectory);
+
+    if (!isSessionCompatibleWithServerKey(session, serverKey)) {
+      debugWarn(
+        "settings",
+        "Skipping incompatible local session write for server %s: %s",
+        serverKey,
+        session.agentId,
+      );
+      return;
+    }
 
     // Update server-indexed storage
     const sessionsByServer = {


### PR DESCRIPTION
## Summary
- make startup resume backend-aware so API mode only resumes cloud sessions and local mode only resumes local sessions
- skip impossible cross-backend agent lookups using shared local/cloud agent ID helpers
- harden settings persistence so local agents cannot be written into cloud session slots (and vice versa)
- route manual dual session writes through `persistSession()` and stop mirroring local agent IDs into global legacy `lastAgent`

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/agent/resolve-startup-agent-files.test.ts src/cli/app-urls.test.ts` passes
- [x] `LETTA_DEBUG=0 bun run dev -- --backend api` no longer attempts to retrieve `agent-local-*` on cloud
- [x] `LETTA_DEBUG=0 bun run dev -- --backend local` still resumes local state correctly

👾 Generated with [Letta Code](https://letta.com)