### PR TITLE
feat(tui): clarify local vs constellation status

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -36,7 +36,7 @@ import {
   getSnapshot as getSubagentSnapshot,
   subscribe as subscribeToSubagents,
 } from "@/agent/subagent-state";
-import { getBackend } from "@/backend";
+import { getBackend, isLocalBackendEnabled } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { getBillingTier } from "@/backend/api/metadata";
 import {
@@ -766,6 +766,7 @@ export function App({
   }, [agentState?.name, conversationSummary, projectDirectory]);
 
   const currentModelProvider = llmConfig?.provider_name ?? null;
+  const isLocalBackend = isLocalBackendEnabled();
   const currentReasoningEffort: ModelReasoningEffort | null =
     currentModelLabel?.startsWith("letta/auto")
       ? null
@@ -4396,6 +4397,7 @@ export function App({
       currentModelHandle={currentModelHandle}
       currentModelId={currentModelId}
       currentModelProvider={currentModelProvider}
+      isLocalBackend={isLocalBackend}
       currentPersonalityId={currentPersonalityId}
       currentReasoningEffort={currentReasoningEffort}
       currentSystemPromptId={currentSystemPromptId}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -137,6 +137,7 @@ type AppViewProps = {
   currentModelHandle: string | null;
   currentModelId: string | null;
   currentModelProvider: string | null;
+  isLocalBackend: boolean;
   currentPersonalityId: PersonalityId | null;
   currentReasoningEffort: ModelReasoningEffort | null;
   currentSystemPromptId: string | null;
@@ -325,6 +326,7 @@ export function AppView(props: AppViewProps) {
     currentModelHandle,
     currentModelId,
     currentModelProvider,
+    isLocalBackend,
     currentPersonalityId,
     currentReasoningEffort,
     currentSystemPromptId,
@@ -678,6 +680,7 @@ export function AppView(props: AppViewProps) {
                 agentName={agentName}
                 currentModel={currentModelDisplay}
                 currentModelProvider={currentModelProvider}
+                isLocalBackend={isLocalBackend}
                 hasTemporaryModelOverride={hasTemporaryModelOverride}
                 currentReasoningEffort={currentReasoningEffort}
                 messageQueue={queueDisplay}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -443,6 +443,7 @@ const InputFooter = memo(function InputFooter({
   currentReasoningEffort,
   isOpenAICodexProvider,
   isByokProvider,
+  isLocalBackend = false,
   hasTemporaryModelOverride,
   hideFooter,
   rightColumnWidth,
@@ -466,6 +467,7 @@ const InputFooter = memo(function InputFooter({
   currentReasoningEffort?: ModelReasoningEffort | null;
   isOpenAICodexProvider: boolean;
   isByokProvider: boolean;
+  isLocalBackend?: boolean;
   hasTemporaryModelOverride?: boolean;
   hideFooter: boolean;
   rightColumnWidth: number;
@@ -584,12 +586,17 @@ const InputFooter = memo(function InputFooter({
       parts.push(chalk.yellow("▲"));
     }
     parts.push(chalk.dim("]"));
+    if (isLocalBackend) {
+      parts.push(chalk.dim(" · "));
+      parts.push(chalk.hex(colors.status.success)("local"));
+    }
     return parts.join("");
   }, [
     displayAgentName,
     displayModel,
     isByokProvider,
     isOpenAICodexProvider,
+    isLocalBackend,
     hasTemporaryModelOverride,
   ]);
 
@@ -1019,6 +1026,7 @@ export function Input({
   agentName,
   currentModel,
   currentModelProvider,
+  isLocalBackend = false,
   hasTemporaryModelOverride = false,
   currentReasoningEffort,
   messageQueue,
@@ -1067,6 +1075,7 @@ export function Input({
   agentName?: string | null;
   currentModel?: string | null;
   currentModelProvider?: string | null;
+  isLocalBackend?: boolean;
   hasTemporaryModelOverride?: boolean;
   currentReasoningEffort?: ModelReasoningEffort | null;
   messageQueue?: QueuedMessage[];
@@ -1942,6 +1951,7 @@ export function Input({
                   currentModelProvider?.startsWith("lc-") ||
                   currentModelProvider === OPENAI_CODEX_PROVIDER_NAME
                 }
+                isLocalBackend={isLocalBackend}
                 hasTemporaryModelOverride={hasTemporaryModelOverride}
                 hideFooter={hideFooter}
                 rightColumnWidth={footerRightColumnWidth}
@@ -2009,6 +2019,7 @@ export function Input({
     suppressDividers,
     queueMode,
     deferModeSupported,
+    isLocalBackend,
   ]);
 
   // If not visible, render nothing but keep component mounted to preserve state

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -114,9 +114,7 @@ export function WelcomeScreen({
       ? "Local"
       : authMethod === "url"
         ? process.env.LETTA_BASE_URL || "Custom URL"
-        : authMethod === "api-key"
-          ? "API key auth"
-          : "OAuth";
+        : "Constellation";
 
   // Check if memfs (context repositories) is enabled for this agent
   const memfsEnabled = agentState?.id


### PR DESCRIPTION
## Summary
- replace the startup hosted auth label with `Constellation` while keeping `Local` for local mode and custom URLs unchanged
- append a subtle green ` · local` to the persistent bottom-right footer only in local mode
- keep the status bar quiet by not adding any extra label in Constellation mode

## Test plan
- [x] `bun run check` passes
- [ ] Verify startup shows `<model> · Local` in local mode
- [ ] Verify startup shows `<model> · Constellation` in hosted mode
- [ ] Verify the persistent footer appends `· local` only in local mode
- [ ] Verify Constellation mode footer remains unchanged

👾 Generated with [Letta Code](https://letta.com)