### PR TITLE
fix(tui): simplify logout flow

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -1030,8 +1030,17 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
-        // Special handling for /logout command - clear credentials and exit
+        // Special handling for /logout command
         if (trimmed === "/logout") {
+          if (isAgentBusy()) {
+            const cmd = commandRunner.start(
+              "/logout",
+              "Cannot log out while the agent is running.",
+            );
+            cmd.fail("Wait for the current turn to finish and try again.");
+            return { submitted: true };
+          }
+
           const cmd = commandRunner.start(msg.trim(), "Logging out...");
 
           setCommandRunning(true);
@@ -1040,6 +1049,24 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             const { settingsManager } = await import("@/settings-manager");
             const currentSettings =
               await settingsManager.getSettingsWithSecureTokens();
+            const hasEnvApiKey = Boolean(process.env.LETTA_API_KEY);
+            const hasStoredCloudAuth = Boolean(
+              currentSettings.refreshToken ||
+                currentSettings.env?.LETTA_API_KEY,
+            );
+
+            if (!hasEnvApiKey && !hasStoredCloudAuth) {
+              cmd.finish(
+                "Already logged out. Run /login to sign into Constellation.",
+                true,
+              );
+              return { submitted: true };
+            }
+
+            const currentAgentId = agentIdRef.current;
+            const currentConversationId =
+              conversationIdRef.current ?? "default";
+            const currentAgentIsLocal = isLocalAgentId(currentAgentId);
 
             // Revoke refresh token on server if we have one
             if (currentSettings.refreshToken) {
@@ -1050,12 +1077,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Clear all credentials including secrets
             await settingsManager.logout();
 
-            cmd.finish(
-              buildLogoutSuccessMessage(Boolean(process.env.LETTA_API_KEY)),
-              true,
-            );
+            // Logged out while already using a local agent → stay in place.
+            if (currentAgentIsLocal) {
+              const localAgentLabel = agentName ?? currentAgentId;
+              const baseMessage = `Logged out successfully. You're still using your local agent ${localAgentLabel}.`;
+              cmd.finish(
+                hasEnvApiKey
+                  ? `${baseMessage}\n\n${buildLogoutSuccessMessage(true)}`
+                  : baseMessage,
+                true,
+              );
+              refreshDerived();
+              return { submitted: true };
+            }
 
-            saveLastSessionBeforeExit(conversationIdRef.current);
+            cmd.finish(buildLogoutSuccessMessage(hasEnvApiKey), true);
+
+            saveLastSessionBeforeExit(currentConversationId);
 
             // Track session end explicitly (before exit) with stats
             const stats = sessionStatsRef.current.getSnapshot();
@@ -1086,7 +1124,8 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Flush telemetry before exit
             await telemetry.flush();
 
-            // Exit after a brief delay to show the message
+            // No valid local session to return to after logging out of cloud.
+            // Exit after a brief delay to show the message.
             setTimeout(() => process.exit(0), 500);
           } catch (error) {
             let errorOutput = formatErrorDetails(error, agentId);

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -1384,6 +1384,52 @@ class SettingsManager {
   }
 
   /**
+   * Get the last session for the currently configured local backend storage dir,
+   * regardless of the active runtime backend mode.
+   *
+   * This is useful when switching from cloud -> local (e.g. /logout), where we
+   * need to resume the user's last local session even though the current server
+   * key still points at the cloud backend.
+   */
+  getLastLocalBackendSession(
+    workingDirectory: string = process.cwd(),
+  ): SessionRef | null {
+    const localServerKey = getLocalBackendSettingsKey();
+    const localSettings = this.getLocalProjectSettings(workingDirectory);
+    const localProjectSession =
+      localSettings.sessionsByServer?.[localServerKey];
+    if (localProjectSession) {
+      if (
+        isSessionCompatibleWithServerKey(localProjectSession, localServerKey)
+      ) {
+        return localProjectSession;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible explicit local backend session for server %s: %s",
+        localServerKey,
+        localProjectSession.agentId,
+      );
+    }
+
+    const globalSettings = this.getSettings();
+    const globalSession = globalSettings.sessionsByServer?.[localServerKey];
+    if (globalSession) {
+      if (isSessionCompatibleWithServerKey(globalSession, localServerKey)) {
+        return globalSession;
+      }
+      debugWarn(
+        "settings",
+        "Ignoring incompatible explicit global local-backend session for server %s: %s",
+        localServerKey,
+        globalSession.agentId,
+      );
+    }
+
+    return null;
+  }
+
+  /**
    * Get the effective last session (local overrides global).
    * Returns null if no session is available anywhere.
    */
@@ -2280,10 +2326,6 @@ class SettingsManager {
         this.markDirty("refreshToken", "tokenExpiresAt", "deviceId", "env");
         await this.persistSettings();
       }
-
-      console.log(
-        "Successfully logged out and cleared all authentication data",
-      );
     } catch (error) {
       trackBoundaryError({
         errorType: "settings_logout_failed",

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -1384,52 +1384,6 @@ class SettingsManager {
   }
 
   /**
-   * Get the last session for the currently configured local backend storage dir,
-   * regardless of the active runtime backend mode.
-   *
-   * This is useful when switching from cloud -> local (e.g. /logout), where we
-   * need to resume the user's last local session even though the current server
-   * key still points at the cloud backend.
-   */
-  getLastLocalBackendSession(
-    workingDirectory: string = process.cwd(),
-  ): SessionRef | null {
-    const localServerKey = getLocalBackendSettingsKey();
-    const localSettings = this.getLocalProjectSettings(workingDirectory);
-    const localProjectSession =
-      localSettings.sessionsByServer?.[localServerKey];
-    if (localProjectSession) {
-      if (
-        isSessionCompatibleWithServerKey(localProjectSession, localServerKey)
-      ) {
-        return localProjectSession;
-      }
-      debugWarn(
-        "settings",
-        "Ignoring incompatible explicit local backend session for server %s: %s",
-        localServerKey,
-        localProjectSession.agentId,
-      );
-    }
-
-    const globalSettings = this.getSettings();
-    const globalSession = globalSettings.sessionsByServer?.[localServerKey];
-    if (globalSession) {
-      if (isSessionCompatibleWithServerKey(globalSession, localServerKey)) {
-        return globalSession;
-      }
-      debugWarn(
-        "settings",
-        "Ignoring incompatible explicit global local-backend session for server %s: %s",
-        localServerKey,
-        globalSession.agentId,
-      );
-    }
-
-    return null;
-  }
-
-  /**
    * Get the effective last session (local overrides global).
    * Returns null if no session is available anywhere.
    */


### PR DESCRIPTION
## Summary
- keep users in their current local session when they log out from local mode
- make cloud logout clear auth and exit instead of switching in-place to a local session with confusing transcript backfill
- block `/logout` while the agent is running
- refine already-logged-out copy to point users to `/login`
- remove the extra low-level logout success log line so the command result owns user-facing messaging

## Test plan
- [x] `bun run check` passes
- [x] Local agent + `/logout` keeps the session open and shows the local-session confirmation message
- [x] Cloud agent + `/logout` logs out and exits cleanly
- [x] `/logout` while already logged out shows: `Already logged out. Run /login to sign into Constellation.`
- [x] `/logout` while busy is blocked

👾 Generated with [Letta Code](https://letta.com)