### PR TITLE
feat(tui): add synthetic no-model onboarding reply

### DIFF
--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -29,6 +29,7 @@ import {
   refreshInputOtidsForNewRequest,
   shouldAttemptApprovalRecovery,
 } from "@/agent/approval-recovery";
+import { getAvailableModelHandles } from "@/agent/available-models";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { getStreamToolContextId, sendMessageStream } from "@/agent/message";
 import { getModelInfo, getModelInfoForLlmConfig } from "@/agent/model";
@@ -63,6 +64,10 @@ import {
 } from "@/cli/helpers/error-formatter";
 import { parsePatchOperations } from "@/cli/helpers/format-args-display";
 import { buildGoalBudgetLimitPrompt } from "@/cli/helpers/goal-command";
+import {
+  buildLocalNoModelResponse,
+  splitSyntheticAssistantResponse,
+} from "@/cli/helpers/local-no-model-response";
 import {
   buildQueuedContentParts,
   buildQueuedUserText,
@@ -132,6 +137,10 @@ import type {
 } from "./types";
 
 type NetworkPhase = "error" | "upload" | "download" | null;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 type ConversationLoopContext = {
   abortControllerRef: MutableRefObject<AbortController | null>;
@@ -313,6 +322,100 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     userCancelledRef,
     waitingForQueueCancelRef,
   } = ctx;
+
+  const maybeStreamSyntheticNoModelResponse = useCallback(
+    async (
+      currentInput: Array<MessageCreate | ApprovalCreate>,
+      allowReentry: boolean,
+      hasApprovalInput: boolean,
+    ): Promise<boolean> => {
+      const backend = getBackend();
+      if (
+        !backend.capabilities.localModelCatalog ||
+        allowReentry ||
+        hasApprovalInput
+      ) {
+        return false;
+      }
+
+      const hasUserMessage = currentInput.some(
+        (item) => item.type === "message" && item.role === "user",
+      );
+      if (!hasUserMessage) {
+        return false;
+      }
+
+      const availableModels = await getAvailableModelHandles({
+        forceRefresh: true,
+      });
+      if (availableModels.handles.size > 0) {
+        return false;
+      }
+
+      const currentSettings =
+        await settingsManager.getSettingsWithSecureTokens();
+      const hasCloudAuth = Boolean(
+        process.env.LETTA_API_KEY ||
+          currentSettings.refreshToken ||
+          currentSettings.env?.LETTA_API_KEY,
+      );
+
+      setThinkingMessage(getRandomThinkingVerb());
+      await sleep(250);
+
+      const lineId = uid("assistant");
+      buffersRef.current.byId.set(lineId, {
+        kind: "assistant",
+        id: lineId,
+        text: "",
+        phase: "streaming",
+      });
+      buffersRef.current.order.push(lineId);
+      refreshDerived();
+
+      const chunks = splitSyntheticAssistantResponse(
+        buildLocalNoModelResponse(hasCloudAuth),
+      );
+      for (const chunk of chunks) {
+        if (abortControllerRef.current?.signal.aborted) {
+          break;
+        }
+
+        const currentLine = buffersRef.current.byId.get(lineId);
+        if (!currentLine || currentLine.kind !== "assistant") {
+          break;
+        }
+
+        buffersRef.current.byId.set(lineId, {
+          ...currentLine,
+          text: currentLine.text + chunk,
+        });
+        buffersRef.current.tokenCount += Buffer.byteLength(chunk, "utf8");
+        refreshDerived();
+        await sleep(chunk === "\n" ? 70 : 120);
+      }
+
+      const finalLine = buffersRef.current.byId.get(lineId);
+      if (finalLine && finalLine.kind === "assistant") {
+        buffersRef.current.byId.set(lineId, {
+          ...finalLine,
+          phase: "finished",
+        });
+      }
+      setNetworkPhase(null);
+      setStreaming(false);
+      refreshDerived();
+      return true;
+    },
+    [
+      abortControllerRef,
+      buffersRef,
+      refreshDerived,
+      setNetworkPhase,
+      setStreaming,
+      setThinkingMessage,
+    ],
+  );
 
   // Core streaming function - iterative loop that processes conversation turns
   // biome-ignore lint/correctness/useExhaustiveDependencies: blanket suppression — this callback has ~16 omitted deps (refs, stable functions, etc.). Refs are safe (read .current dynamically), but the blanket ignore also hides any genuinely missing reactive deps. If stale-closure bugs appear in processConversation, audit the dep array here first.
@@ -524,6 +627,16 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         openTrajectorySegment();
         setNetworkPhase("upload");
         abortControllerRef.current = new AbortController();
+
+        if (
+          await maybeStreamSyntheticNoModelResponse(
+            currentInput,
+            allowReentry,
+            hasApprovalInput,
+          )
+        ) {
+          return;
+        }
 
         // Recover interrupted message only after explicit user interrupt:
         // if cache contains ONLY user messages, prepend them.
@@ -2789,6 +2902,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       resetTrajectoryBases,
       setUiPermissionMode,
       prepareScopedToolExecutionContext,
+      maybeStreamSyntheticNoModelResponse,
     ],
   );
 

--- a/src/cli/helpers/local-no-model-response.ts
+++ b/src/cli/helpers/local-no-model-response.ts
@@ -1,0 +1,67 @@
+const LOCAL_NO_MODEL_WITHOUT_CLOUD_AUTH = [
+  "It looks like we're in local mode, but we don't have any models available yet.",
+  "",
+  "to get set up, you can either:",
+  "- run `/connect` to add a provider from inside letta code",
+  "- export a provider key in your env and restart `letta`, for example `export OPENAI_API_KEY=...`",
+  "- or run `/login` if you'd rather use models hosted on Constellation",
+  "",
+  "once one of those is set up, send your message again and we can get started.",
+].join("\n");
+
+const LOCAL_NO_MODEL_WITH_CLOUD_AUTH = [
+  "It looks like we're in local mode, but we don't have any models available yet.",
+  "",
+  "to get set up, you can either:",
+  "- run `/connect` to add a provider from inside letta code",
+  "- export a provider key in your env and restart `letta`, for example `export OPENAI_API_KEY=...`",
+  "",
+  "if you'd rather use models hosted on Constellation instead, switch back to OAuth mode and try again.",
+  "",
+  "once a model is available, send your message again and we can get started.",
+].join("\n");
+
+export function buildLocalNoModelResponse(hasCloudAuth: boolean): string {
+  return hasCloudAuth
+    ? LOCAL_NO_MODEL_WITH_CLOUD_AUTH
+    : LOCAL_NO_MODEL_WITHOUT_CLOUD_AUTH;
+}
+
+export function splitSyntheticAssistantResponse(text: string): string[] {
+  const chunks: string[] = [];
+  const lines = text.split(/(\n)/);
+
+  for (const line of lines) {
+    if (line === "") {
+      continue;
+    }
+    if (line === "\n") {
+      chunks.push(line);
+      continue;
+    }
+
+    const parts = line.match(/\S+\s*|\s+/g) ?? [line];
+    let current = "";
+    for (const part of parts) {
+      current += part;
+      const trimmed = current.trimEnd();
+      const shouldFlush =
+        trimmed.endsWith(",") ||
+        trimmed.endsWith(".") ||
+        trimmed.endsWith(":") ||
+        trimmed.endsWith("?") ||
+        trimmed.endsWith("!") ||
+        current.length >= 28;
+      if (shouldFlush) {
+        chunks.push(current);
+        current = "";
+      }
+    }
+
+    if (current) {
+      chunks.push(current);
+    }
+  }
+
+  return chunks.length > 0 ? chunks : [text];
+}

--- a/src/cli/local-no-model-response.test.ts
+++ b/src/cli/local-no-model-response.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLocalNoModelResponse,
+  splitSyntheticAssistantResponse,
+} from "@/cli/helpers/local-no-model-response";
+
+describe("local no-model synthetic response", () => {
+  test("logged-out copy includes /login guidance", () => {
+    const message = buildLocalNoModelResponse(false);
+    expect(message).toContain("/connect");
+    expect(message).toContain("export OPENAI_API_KEY=...");
+    expect(message).toContain("/login");
+  });
+
+  test("logged-in copy omits /login guidance", () => {
+    const message = buildLocalNoModelResponse(true);
+    expect(message).toContain("/connect");
+    expect(message).toContain("models hosted on Constellation");
+    expect(message).not.toContain("/login");
+  });
+
+  test("synthetic streaming chunks preserve line breaks", () => {
+    expect(splitSyntheticAssistantResponse("hi\n\nthere")).toEqual([
+      "hi",
+      "\n",
+      "\n",
+      "there",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- intercept normal local-mode prompts before any backend message is created when no models are available
- stream a synthetic assistant onboarding reply instead of throwing a dry no-model error
- tailor the copy based on whether cloud auth exists
- keep the synthetic response UI-only so it does not persist as a real conversation message

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/cli/local-no-model-response.test.ts` passes
- [x] In local mode with no models configured, sending a normal prompt shows the synthetic onboarding reply
- [x] The synthetic reply clears the bottom calculating state when finished
- [x] The synthetic reply is not persisted as a real conversation message

👾 Generated with [Letta Code](https://letta.com)