### PR TITLE
feat(startup): make new-user local flow drop into chat

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -100,7 +100,6 @@ import {
   useTerminalWidth,
 } from "@/cli/hooks/use-terminal-width";
 import { useSuspend } from "@/cli/hooks/useSuspend/use-suspend.ts";
-import { DEFAULT_AGENT_NAME } from "@/constants";
 import {
   getTask,
   handleMissedOneShot,
@@ -205,14 +204,42 @@ function buildStartupCommandHints(options: {
   isResumingConversation: boolean;
   isPinned: boolean;
   isLocalBackend: boolean;
-  agentName: string | null | undefined;
+  hasMessages: boolean;
+  hasCloudCredentials: boolean;
+  hasAvailableLocalModels: boolean;
 }): string[] {
-  const { isResumingConversation, isPinned, isLocalBackend, agentName } =
-    options;
-  const isDefaultNamedAgent =
-    !agentName ||
-    agentName === DEFAULT_AGENT_NAME ||
-    agentName === "Unnamed Agent";
+  const {
+    isResumingConversation,
+    isPinned,
+    isLocalBackend,
+    hasMessages,
+    hasCloudCredentials,
+    hasAvailableLocalModels,
+  } = options;
+
+  const onboardingHints: string[] = [];
+
+  if (isLocalBackend && !hasAvailableLocalModels) {
+    onboardingHints.push(
+      "→ **/model**     switch models",
+      "→ **/connect**   configure your llm api keys",
+    );
+  }
+
+  if (!hasMessages) {
+    onboardingHints.push(
+      "→ **/rename**    name your agent",
+      "→ **/init**      initialize your agent's memory",
+    );
+  }
+
+  if (!hasCloudCredentials) {
+    onboardingHints.push("→ **/login**     sign in to Constellation");
+  }
+
+  if (onboardingHints.length > 0) {
+    return onboardingHints.slice(0, 5);
+  }
 
   if (isResumingConversation) {
     return [
@@ -221,16 +248,6 @@ function buildStartupCommandHints(options: {
       "→ **/new**       start a new conversation",
       "→ **/init**      initialize your agent's memory",
       "→ **/remember**  teach your agent",
-    ];
-  }
-
-  if (isLocalBackend && !isPinned && isDefaultNamedAgent) {
-    return [
-      "→ **/model**     switch models",
-      "→ **/connect**   configure your llm api keys",
-      "→ **/rename**    name your agent",
-      "→ **/init**      initialize your agent's memory",
-      "→ **/login**     sign in to Constellation",
     ];
   }
 
@@ -267,6 +284,8 @@ export function App({
   reasoningTabCycleEnabled: initialReasoningTabCycleEnabled = false,
   showCompactions = false,
   agentProvenance = null,
+  startupHasCloudCredentials = false,
+  startupHasAvailableLocalModels = true,
   releaseNotes = null,
   updateNotification = null,
   systemInfoReminderEnabled = true,
@@ -2610,7 +2629,9 @@ export function App({
         isResumingConversation,
         isPinned,
         isLocalBackend: isLocalBackendEnabled(),
-        agentName,
+        hasMessages: messageHistory.length > 0,
+        hasCloudCredentials: startupHasCloudCredentials,
+        hasAvailableLocalModels: startupHasAvailableLocalModels,
       });
 
       // Build status lines with optional release notes above header
@@ -2651,6 +2672,8 @@ export function App({
     agentProvenance,
     resumedExistingConversation,
     releaseNotes,
+    startupHasCloudCredentials,
+    startupHasAvailableLocalModels,
     messageHistory,
   ]);
 
@@ -4321,7 +4344,9 @@ export function App({
         isResumingConversation: resumedExistingConversation,
         isPinned,
         isLocalBackend: isLocalBackendEnabled(),
-        agentName,
+        hasMessages: messageHistory.length > 0,
+        hasCloudCredentials: startupHasCloudCredentials,
+        hasAvailableLocalModels: startupHasAvailableLocalModels,
       });
 
       // Build status lines with optional release notes above header
@@ -4362,6 +4387,8 @@ export function App({
     agentState,
     refreshDerived,
     releaseNotes,
+    startupHasCloudCredentials,
+    startupHasAvailableLocalModels,
   ]);
 
   const liveTrajectorySnapshot =

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -42,6 +42,8 @@ export type AppProps = {
   reasoningTabCycleEnabled?: boolean;
   showCompactions?: boolean;
   agentProvenance?: AgentProvenance | null;
+  startupHasCloudCredentials?: boolean;
+  startupHasAvailableLocalModels?: boolean;
   releaseNotes?: string | null; // Markdown release notes to display above header
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -41,7 +41,7 @@ describe("local-first setup wiring", () => {
     expect(source.slice(start, end)).toContain('preferredBackendMode: "api"');
   });
 
-  test("startup shows setup for new users while honoring saved local preference", () => {
+  test("startup auto-enters local mode for credentialless new users while honoring saved local preference", () => {
     const source = readSource("../index.ts");
     const start = source.indexOf('settings.preferredBackendMode === "local"');
     const end = source.indexOf('configureBackendMode("local")', start);
@@ -56,11 +56,30 @@ describe("local-first setup wiring", () => {
     expect(segment).not.toContain("!apiKey");
     expect(segment).not.toContain("!settings.refreshToken");
 
-    const setupStart = source.indexOf("!settings.refreshToken");
-    const setupEnd = source.indexOf("return main().catch", setupStart);
+    const setupStart = source.indexOf(
+      "Local-first new-user flow: if the user has no Letta Cloud credentials",
+    );
+    const setupEnd = source.indexOf(
+      "await settingsManager.flush();",
+      setupStart,
+    );
     expect(setupStart).toBeGreaterThan(-1);
     expect(setupEnd).toBeGreaterThan(setupStart);
-    expect(source.slice(setupStart, setupEnd)).toContain("await runSetup()");
+    const setupSegment = source.slice(
+      setupStart,
+      setupEnd + "await settingsManager.flush();".length,
+    );
+    expect(setupSegment).toContain("!explicitBackendMode");
+    expect(setupSegment).toContain("!isHeadless");
+    expect(setupSegment).toContain("!settings.refreshToken");
+    expect(setupSegment).toContain("!apiKey");
+    expect(setupSegment).toContain('configureBackendMode("local")');
+    expect(setupSegment).toContain(
+      'settingsManager.updateSettings({ preferredBackendMode: "local" })',
+    );
+    expect(setupSegment).toContain("await settingsManager.flush();");
+    expect(source).toContain("isCredentiallessLocalStartup");
+    expect(source).toContain(".filter((entry) => entry.isLocal)");
   });
 
   test("backend and setup subcommands expose default backend controls", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -777,6 +777,22 @@ async function main(): Promise<void> {
     configureBackendMode("local");
   }
 
+  // Local-first new-user flow: if the user has no Letta Cloud credentials and
+  // did not explicitly request a backend, start in local mode immediately so
+  // they can type right away. Existing local agents will be resumed below; if
+  // none exist, startup falls through to local default-agent creation.
+  if (
+    !explicitBackendMode &&
+    !isHeadless &&
+    baseURL === LETTA_CLOUD_API_URL &&
+    !settings.refreshToken &&
+    !apiKey
+  ) {
+    configureBackendMode("local");
+    settingsManager.updateSettings({ preferredBackendMode: "local" });
+    await settingsManager.flush();
+  }
+
   const startupBackend = getBackend();
   const localNoMemfsRequested = Boolean(
     startupBackend.capabilities.localMemfs &&
@@ -1297,7 +1313,7 @@ async function main(): Promise<void> {
   markMilestone("REACT_IMPORT_START");
   const React = await import("react");
   const { render } = await import("ink");
-  const { useState, useEffect, useCallback } = React;
+  const { useState, useEffect, useCallback, useRef } = React;
   const AppModule = await import("@/cli/App");
   const App = AppModule.App;
 
@@ -1353,6 +1369,11 @@ async function main(): Promise<void> {
     const [selectedGlobalAgentId, setSelectedGlobalAgentId] = useState<
       string | null
     >(null);
+    const startupCreatedAgentRef = useRef<AgentState | null>(null);
+    const [startupHasCloudCredentials, setStartupHasCloudCredentials] =
+      useState(Boolean(settings.refreshToken || apiKey));
+    const [startupHasAvailableLocalModels, setStartupHasAvailableLocalModels] =
+      useState(true);
     // Cache agent object from Phase 1 validation to avoid redundant re-fetch in Phase 2
     const [validatedAgent, setValidatedAgent] = useState<AgentState | null>(
       preResolvedAgent ?? null,
@@ -1501,6 +1522,22 @@ async function main(): Promise<void> {
           settings.env?.LETTA_BASE_URL ||
           LETTA_CLOUD_API_URL;
         const isSelfHosted = !baseURL.includes("api.letta.com");
+        const isCredentiallessLocalStartup =
+          startupBackendMode === "local" &&
+          !isSelfHosted &&
+          !settings.refreshToken &&
+          !apiKey;
+        setStartupHasCloudCredentials(Boolean(settings.refreshToken || apiKey));
+        if (startupBackendMode === "local") {
+          try {
+            const models = await backend.listModels();
+            setStartupHasAvailableLocalModels(models.length > 0);
+          } catch {
+            setStartupHasAvailableLocalModels(false);
+          }
+        } else {
+          setStartupHasAvailableLocalModels(true);
+        }
 
         // Track whether we need model picker (for skipping ensureDefaultAgents)
         let needsModelPicker = false;
@@ -1715,18 +1752,17 @@ async function main(): Promise<void> {
         }
 
         // Step 3: Resolve startup target using pure decision logic
-        const mergedPinned = settingsManager.getMergedPinnedAgents(
-          process.cwd(),
-        );
-        const shouldRepairMissingLocalBackendLru = Boolean(
+        const mergedPinned = isCredentiallessLocalStartup
+          ? settingsManager
+              .getMergedPinnedAgents(process.cwd())
+              .filter((entry) => entry.isLocal)
+          : settingsManager.getMergedPinnedAgents(process.cwd());
+        const fallbackSession =
           startupBackendMode === "local" &&
-            (localAgentId || globalAgentId) &&
-            !localAgentExists &&
-            !globalAgentExists,
-        );
-        const fallbackSession = shouldRepairMissingLocalBackendLru
-          ? await getLocalBackendStartupFallbackSession(backend)
-          : null;
+          !localAgentExists &&
+          !globalAgentExists
+            ? await getLocalBackendStartupFallbackSession(backend)
+            : null;
         const { resolveStartupTarget } = await import(
           "@/agent/resolve-startup-agent"
         );
@@ -1765,6 +1801,9 @@ async function main(): Promise<void> {
                 preferredModel: model,
               });
               if (defaultAgent) {
+                startupCreatedAgentRef.current = defaultAgent;
+                setAgentProvenance({ isNew: true, blocks: [] });
+                setValidatedAgent(defaultAgent);
                 setSelectedGlobalAgentId(defaultAgent.id);
                 setLoadingState("assembling");
                 return;
@@ -1847,8 +1886,17 @@ async function main(): Promise<void> {
         // (validatedAgent React state may not be committed yet).
         let resolvedAgent: AgentState | null = null;
 
+        // Fresh local-first startup may create the default agent during the
+        // initial resolution phase. Carry it across explicitly instead of
+        // depending on selectedGlobalAgentId state having committed in time.
+        if (startupCreatedAgentRef.current) {
+          resolvedAgent = startupCreatedAgentRef.current;
+          resumingAgentId = startupCreatedAgentRef.current.id;
+          startupCreatedAgentRef.current = null;
+        }
+
         // Priority 1: --agent flag
-        if (agentIdArg) {
+        if (!resumingAgentId && agentIdArg) {
           // Use cached agent from name resolution if available
           if (validatedAgent && validatedAgent.id === agentIdArg) {
             resumingAgentId = agentIdArg;
@@ -2549,6 +2597,8 @@ async function main(): Promise<void> {
         reasoningTabCycleEnabled: settings.reasoningTabCycleEnabled === true,
         showCompactions: settings.showCompactions,
         agentProvenance,
+        startupHasCloudCredentials,
+        startupHasAvailableLocalModels,
         releaseNotes,
         systemInfoReminderEnabled: !noSystemInfoReminderFlag,
       });
@@ -2569,6 +2619,8 @@ async function main(): Promise<void> {
       reasoningTabCycleEnabled: settings.reasoningTabCycleEnabled === true,
       showCompactions: settings.showCompactions,
       agentProvenance,
+      startupHasCloudCredentials,
+      startupHasAvailableLocalModels,
       releaseNotes,
       updateNotification,
       systemInfoReminderEnabled: !noSystemInfoReminderFlag,


### PR DESCRIPTION
## Summary
- start credentialless interactive users in local mode instead of showing the setup menu
- resume any existing local agent before creating a new one, and carry startup-created agents cleanly into the assembled session
- ignore global pinned metadata during credentialless local startup so a fresh local backend does not bounce into the selector
- show startup hints from onboarding conditions instead of pin state: missing local models shows `/model` and `/connect`, empty conversations show `/rename` and `/init`, and missing cloud login shows `/login`

## Test plan
- [x] `bun run check` passes
- [x] Verified fresh local startup drops directly into a ready-to-type chat instead of the setup menu
- [x] Verified reopening the same empty local conversation still shows the onboarding hints
- [x] Verified a fresh local backend no longer shows the `0 pinned agents available` selector state
- [ ] Follow-up PR: fix misleading `GPT-5.5 · Local` startup model label when no local model is actually configured

👾 Generated with [Letta Code](https://letta.com)