### PR TITLE
fix(startup): hide default model label when local has no models

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -72,6 +72,7 @@ import {
   toQueuedMsg,
 } from "@/cli/helpers/queued-message-parts";
 import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
+import { getStartupModelDisplayOverride } from "@/cli/helpers/startup-model-display";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import {
   collectFinishedTaskToolCalls,
@@ -803,10 +804,16 @@ export function App({
     : agentState?.model_settings;
   const derivedReasoningEffort: ModelReasoningEffort | null =
     deriveReasoningEffort(effectiveModelSettings, llmConfig);
+  const startupModelDisplayOverride = getStartupModelDisplayOverride({
+    isLocalBackend: isLocalBackendEnabled(),
+    startupHasAvailableLocalModels,
+    agentProvenance,
+  });
 
   // Use tier-aware resolution so the display matches the agent's reasoning effort
   // (e.g. "GPT-5.3-Codex" not just "GPT-5" for the first match).
   const currentModelDisplay = useMemo(() => {
+    if (startupModelDisplayOverride) return startupModelDisplayOverride;
     if (!currentModelLabel) return null;
     const info = getModelInfoForLlmConfig(currentModelLabel, {
       reasoning_effort: derivedReasoningEffort ?? null,
@@ -823,7 +830,12 @@ export function App({
       currentModelLabel.split("/").pop() ??
       null
     );
-  }, [currentModelLabel, derivedReasoningEffort, llmConfig]);
+  }, [
+    currentModelLabel,
+    derivedReasoningEffort,
+    llmConfig,
+    startupModelDisplayOverride,
+  ]);
 
   // Set terminal title from window title config
   useEffect(() => {
@@ -2592,6 +2604,7 @@ export function App({
               continueSession,
               agentState,
               agentProvenance,
+              startupHasAvailableLocalModels,
               terminalWidth: columns,
             },
           },
@@ -4318,6 +4331,7 @@ export function App({
             continueSession,
             agentState,
             agentProvenance,
+            startupHasAvailableLocalModels,
             terminalWidth: columns,
           },
         },

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -200,6 +200,7 @@ export type StaticItem =
         continueSession: boolean;
         agentState?: AgentState | null;
         agentProvenance?: AgentProvenance | null;
+        startupHasAvailableLocalModels?: boolean;
         terminalWidth: number;
       };
     }

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import type { AgentProvenance } from "@/agent/create";
 import { getModelDisplayName } from "@/agent/model";
 import { isLocalBackendEnabled } from "@/backend";
+import { getStartupModelDisplayOverride } from "@/cli/helpers/startup-model-display";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { settingsManager } from "@/settings-manager";
 import { getVersion } from "@/version";
@@ -72,12 +73,14 @@ export function WelcomeScreen({
   loadingState,
   continueSession,
   agentState,
-  agentProvenance: _agentProvenance,
+  agentProvenance,
+  startupHasAvailableLocalModels = true,
 }: {
   loadingState: LoadingState;
   continueSession?: boolean;
   agentState?: Letta.AgentState | null;
   agentProvenance?: AgentProvenance | null;
+  startupHasAvailableLocalModels?: boolean;
 }) {
   // Keep hook call for potential future responsive behavior
   useTerminalWidth();
@@ -93,9 +96,16 @@ export function WelcomeScreen({
     llmConfig?.model_endpoint_type && llmConfig?.model
       ? `${llmConfig.model_endpoint_type}/${llmConfig.model}`
       : (llmConfig?.model ?? null);
-  const model = fullModel
-    ? (getModelDisplayName(fullModel) ?? fullModel.split("/").pop())
-    : undefined;
+  const startupModelDisplayOverride = getStartupModelDisplayOverride({
+    isLocalBackend: isLocalBackendEnabled(),
+    startupHasAvailableLocalModels,
+    agentProvenance,
+  });
+  const model =
+    startupModelDisplayOverride ??
+    (fullModel
+      ? (getModelDisplayName(fullModel) ?? fullModel.split("/").pop())
+      : undefined);
 
   // Get auth method - use sync check for env vars, async only for keychain
   const initialAuth = getInitialAuthMethod();

--- a/src/cli/helpers/startup-model-display.ts
+++ b/src/cli/helpers/startup-model-display.ts
@@ -1,0 +1,22 @@
+import type { AgentProvenance } from "@/agent/create";
+
+const STARTUP_NO_MODEL_LABEL = "No model selected";
+
+export function getStartupModelDisplayOverride(options: {
+  isLocalBackend: boolean;
+  startupHasAvailableLocalModels: boolean;
+  agentProvenance: AgentProvenance | null | undefined;
+}): string | null {
+  const { isLocalBackend, startupHasAvailableLocalModels, agentProvenance } =
+    options;
+
+  if (
+    isLocalBackend &&
+    !startupHasAvailableLocalModels &&
+    agentProvenance?.isNew
+  ) {
+    return STARTUP_NO_MODEL_LABEL;
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1539,6 +1539,17 @@ async function main(): Promise<void> {
           setStartupHasAvailableLocalModels(true);
         }
 
+        if (startupBackendMode === "local") {
+          try {
+            const models = await backend.listModels();
+            setStartupHasAvailableLocalModels(models.length > 0);
+          } catch {
+            setStartupHasAvailableLocalModels(false);
+          }
+        } else {
+          setStartupHasAvailableLocalModels(true);
+        }
+
         // Track whether we need model picker (for skipping ensureDefaultAgents)
         let needsModelPicker = false;
 


### PR DESCRIPTION
## Summary
- show `No model selected` in the startup header and footer when a new local agent is created before any local models are available
- keep the override UI-only so agent creation can continue using the existing backend defaults under the hood
- scope the override narrowly to the startup-created local no-model case so real model labels still appear once models become available later
- centralize the override in a shared helper used by both the welcome screen and app coordinator display paths

## Test plan
- [x] `bun run check` passes
- [x] Verified fresh local no-model startup shows `No model selected · Local` instead of `GPT-5.5 · Local`
- [x] Verified footer/status uses the same `No model selected` label in that startup case
- [ ] Verify that after models become available later, the UI returns to showing the real model label on restart

👾 Generated with [Letta Code](https://letta.com)