### PR TITLE
feat(tui): show recent agents when pins are empty

### DIFF
--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getModelDisplayName } from "@/agent/model";
 import { getBackendForMode } from "@/backend/backend";
 import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
+import {
+  getRecentAgentOptions,
+  type RecentAgentOption,
+} from "@/cli/helpers/recent-agent-options";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { DEFAULT_AGENT_NAME } from "@/constants";
 import { settingsManager } from "@/settings-manager";
@@ -46,6 +50,10 @@ interface PinnedAgentData {
   isLocal: boolean;
 }
 
+interface PinnedFallbackData extends RecentAgentOption {
+  isPinnedFallback: true;
+}
+
 const ALL_TABS: { id: TabId; label: string }[] = [
   { id: "pinned", label: "Pinned" },
   { id: "constellation", label: "Constellation" },
@@ -69,6 +77,7 @@ const TAB_EMPTY_STATES: Record<TabId, string> = {
 
 const DISPLAY_PAGE_SIZE = 5;
 const FETCH_PAGE_SIZE = 20;
+const PINNED_FALLBACK_DISPLAY_SIZE = 3;
 
 /**
  * Check if the user has cloud credentials (API key or refresh token).
@@ -175,6 +184,9 @@ export function AgentSelector({
   // Pinned tab state
   const [pinnedAgents, setPinnedAgents] = useState<PinnedAgentData[]>([]);
   const [pinnedLoading, setPinnedLoading] = useState(true);
+  const [pinnedFallbackAgents, setPinnedFallbackAgents] = useState<
+    PinnedFallbackData[]
+  >([]);
   const [pinnedSelectedIndex, setPinnedSelectedIndex] = useState(0);
   const [pinnedPage, setPinnedPage] = useState(0);
 
@@ -225,39 +237,66 @@ export function AgentSelector({
     try {
       const mergedPinned = settingsManager.getMergedPinnedAgents();
 
-      if (mergedPinned.length === 0) {
+      let pinnedData: PinnedAgentData[] = [];
+
+      if (mergedPinned.length > 0) {
+        pinnedData = await Promise.all(
+          mergedPinned.map(async ({ agentId, isLocal }) => {
+            try {
+              // Use the correct backend for this agent's mode
+              if (!isLocal && !hasCloudCredentials()) {
+                return {
+                  agentId,
+                  agent: null,
+                  error: "Not signed in",
+                  isLocal,
+                };
+              }
+              const agentBackend = isLocal
+                ? getBackendForMode("local")
+                : getBackendForMode("api");
+              const agent = await agentBackend.retrieveAgent(agentId, {
+                include: ["agent.blocks"],
+              });
+              return { agentId, agent, error: null, isLocal };
+            } catch {
+              return {
+                agentId,
+                agent: null,
+                error: "Agent not found",
+                isLocal,
+              };
+            }
+          }),
+        );
+      }
+
+      const validPinnedData = pinnedData.filter((p) => p.agent !== null);
+
+      if (validPinnedData.length === 0) {
         setPinnedAgents([]);
+        const recentAgents = await getRecentAgentOptions({
+          includeLocal: true,
+          includeConstellation: hasCloudCredentials(),
+          limit: PINNED_FALLBACK_DISPLAY_SIZE,
+          currentAgentId,
+        });
+        setPinnedFallbackAgents(
+          recentAgents.map((item) => ({ ...item, isPinnedFallback: true })),
+        );
         setPinnedLoading(false);
         return;
       }
 
-      const pinnedData = await Promise.all(
-        mergedPinned.map(async ({ agentId, isLocal }) => {
-          try {
-            // Use the correct backend for this agent's mode
-            if (!isLocal && !hasCloudCredentials()) {
-              return { agentId, agent: null, error: "Not signed in", isLocal };
-            }
-            const agentBackend = isLocal
-              ? getBackendForMode("local")
-              : getBackendForMode("api");
-            const agent = await agentBackend.retrieveAgent(agentId, {
-              include: ["agent.blocks"],
-            });
-            return { agentId, agent, error: null, isLocal };
-          } catch {
-            return { agentId, agent: null, error: "Agent not found", isLocal };
-          }
-        }),
-      );
-
       setPinnedAgents(pinnedData);
+      setPinnedFallbackAgents([]);
     } catch {
       setPinnedAgents([]);
+      setPinnedFallbackAgents([]);
     } finally {
       setPinnedLoading(false);
     }
-  }, []);
+  }, [currentAgentId]);
 
   // Load local agents from disk
   const loadLocalAgents = useCallback(() => {
@@ -408,11 +447,19 @@ export function AgentSelector({
 
   // Pagination calculations - Pinned (filter out 404 agents)
   const validPinnedAgents = pinnedAgents.filter((p) => p.agent !== null);
+  const showingPinnedFallback =
+    validPinnedAgents.length === 0 && pinnedFallbackAgents.length > 0;
   const pinnedTotalPages = Math.ceil(
-    validPinnedAgents.length / DISPLAY_PAGE_SIZE,
+    (showingPinnedFallback
+      ? pinnedFallbackAgents.length
+      : validPinnedAgents.length) / DISPLAY_PAGE_SIZE,
   );
   const pinnedStartIndex = pinnedPage * DISPLAY_PAGE_SIZE;
   const pinnedPageAgents = validPinnedAgents.slice(
+    pinnedStartIndex,
+    pinnedStartIndex + DISPLAY_PAGE_SIZE,
+  );
+  const pinnedFallbackPageAgents = pinnedFallbackAgents.slice(
     pinnedStartIndex,
     pinnedStartIndex + DISPLAY_PAGE_SIZE,
   );
@@ -459,7 +506,9 @@ export function AgentSelector({
     activeTab === "constellation" ? constellationError : null;
   const currentAgents =
     activeTab === "pinned"
-      ? pinnedPageAgents.map((p) => p.agent).filter(Boolean)
+      ? showingPinnedFallback
+        ? pinnedFallbackPageAgents.map((p) => p.agent)
+        : pinnedPageAgents.map((p) => p.agent).filter(Boolean)
       : activeTab === "local"
         ? localPageAgents
         : constellationPageAgents;
@@ -592,10 +641,18 @@ export function AgentSelector({
 
       // Select agent
       if (activeTab === "pinned") {
-        const selected = pinnedPageAgents[pinnedSelectedIndex];
-        if (selected?.agent) {
-          const mode: AgentBackendMode = selected.isLocal ? "local" : "api";
-          onSelect(selected.agentId, mode);
+        if (showingPinnedFallback) {
+          const selected = pinnedFallbackPageAgents[pinnedSelectedIndex];
+          if (selected?.agent) {
+            const mode: AgentBackendMode = selected.isLocal ? "local" : "api";
+            onSelect(selected.agent.id, mode);
+          }
+        } else {
+          const selected = pinnedPageAgents[pinnedSelectedIndex];
+          if (selected?.agent) {
+            const mode: AgentBackendMode = selected.isLocal ? "local" : "api";
+            onSelect(selected.agentId, mode);
+          }
         }
       } else if (activeTab === "local") {
         const selected = localPageAgents[localSelectedIndex];
@@ -666,15 +723,27 @@ export function AgentSelector({
         }
       }
     } else if (activeTab === "pinned" && (input === "p" || input === "P")) {
-      // Unpin from current scope (pinned tab only)
-      const selected = pinnedPageAgents[pinnedSelectedIndex];
-      if (selected) {
-        if (selected.isLocal) {
-          settingsManager.unpinLocal(selected.agentId);
-        } else {
-          settingsManager.unpinGlobal(selected.agentId);
+      if (showingPinnedFallback) {
+        const selected = pinnedFallbackPageAgents[pinnedSelectedIndex];
+        if (selected) {
+          if (selected.isLocal) {
+            settingsManager.pinLocal(selected.agent.id);
+          } else {
+            settingsManager.pinGlobal(selected.agent.id);
+          }
+          loadPinnedAgents();
         }
-        loadPinnedAgents();
+      } else {
+        // Unpin from current scope (pinned tab only)
+        const selected = pinnedPageAgents[pinnedSelectedIndex];
+        if (selected) {
+          if (selected.isLocal) {
+            settingsManager.unpinLocal(selected.agentId);
+          } else {
+            settingsManager.unpinGlobal(selected.agentId);
+          }
+          loadPinnedAgents();
+        }
       }
     } else if (input === "D") {
       // Delete agent - open confirmation
@@ -884,6 +953,7 @@ export function AgentSelector({
         activeTab !== "new" &&
         !currentLoading &&
         ((activeTab === "pinned" && validPinnedAgents.length > 0) ||
+          (activeTab === "pinned" && showingPinnedFallback) ||
           (activeTab === "local" && localAgents.length > 0) ||
           (activeTab === "constellation" &&
             !constellationError &&
@@ -896,7 +966,10 @@ export function AgentSelector({
                   : activeTab === "local"
                     ? `Page ${localPage + 1}/${localTotalPages || 1}`
                     : `Page ${constellationPage + 1}${constellationHasMore ? "+" : `/${constellationTotalPages || 1}`}${constellationLoadingMore ? " (loading...)" : ""}`;
-              const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? " · P unpin" : ""} · Esc cancel`;
+              const pinnedHint = showingPinnedFallback
+                ? " · Shift+P pin"
+                : " · Shift+P unpin";
+              const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? pinnedHint : ""} · Esc cancel`;
 
               return (
                 <Box flexDirection="column">
@@ -927,6 +1000,18 @@ export function AgentSelector({
           }
         />
         <Text dimColor> {TAB_DESCRIPTIONS[activeTab]}</Text>
+        {activeTab === "pinned" && showingPinnedFallback && <Box height={2} />}
+        {activeTab === "pinned" && showingPinnedFallback && (
+          <Text dimColor>
+            {" "}
+            No pinned agents yet, showing recent agents instead.
+          </Text>
+        )}
+        {activeTab === "pinned" && showingPinnedFallback ? (
+          <Box height={1} />
+        ) : (
+          <Box height={2} />
+        )}
       </Box>
 
       {/* Search input - list tabs only */}
@@ -966,7 +1051,9 @@ export function AgentSelector({
 
       {/* Empty state */}
       {!currentLoading &&
-        ((activeTab === "pinned" && validPinnedAgents.length === 0) ||
+        ((activeTab === "pinned" &&
+          validPinnedAgents.length === 0 &&
+          !showingPinnedFallback) ||
           (activeTab === "local" && localAgents.length === 0) ||
           (activeTab === "constellation" &&
             !constellationError &&
@@ -979,8 +1066,19 @@ export function AgentSelector({
         )}
 
       {/* Pinned tab content */}
+      {activeTab === "pinned" && !pinnedLoading && showingPinnedFallback && (
+        <Box flexDirection="column">
+          {pinnedFallbackPageAgents.map((data, index) =>
+            renderAgentItem(data.agent, index, index === pinnedSelectedIndex, {
+              backend: data.isLocal ? "local" : "constellation",
+            }),
+          )}
+        </Box>
+      )}
+
       {activeTab === "pinned" &&
         !pinnedLoading &&
+        !showingPinnedFallback &&
         validPinnedAgents.length > 0 && (
           <Box flexDirection="column">
             {pinnedPageAgents.map((data, index) =>

--- a/src/cli/helpers/recent-agent-options.ts
+++ b/src/cli/helpers/recent-agent-options.ts
@@ -1,0 +1,72 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getClient } from "@/backend/api/client";
+import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
+
+export interface RecentAgentOption {
+  agent: AgentState;
+  isLocal: boolean;
+}
+
+function sortRecentAgents(
+  agents: RecentAgentOption[],
+  currentAgentId?: string,
+): RecentAgentOption[] {
+  return agents.toSorted((a, b) => {
+    if (currentAgentId) {
+      if (a.agent.id === currentAgentId) return -1;
+      if (b.agent.id === currentAgentId) return 1;
+    }
+
+    const aTime = a.agent.last_run_completion
+      ? new Date(a.agent.last_run_completion).getTime()
+      : 0;
+    const bTime = b.agent.last_run_completion
+      ? new Date(b.agent.last_run_completion).getTime()
+      : 0;
+    return bTime - aTime;
+  });
+}
+
+export async function getRecentAgentOptions(options?: {
+  includeLocal?: boolean;
+  includeConstellation?: boolean;
+  limit?: number;
+  currentAgentId?: string;
+}): Promise<RecentAgentOption[]> {
+  const includeLocal = options?.includeLocal !== false;
+  const includeConstellation = options?.includeConstellation !== false;
+  const limit = options?.limit ?? 5;
+
+  const localAgents = includeLocal
+    ? listLocalAgentsFromDisk().map((agent) => ({ agent, isLocal: true }))
+    : [];
+
+  const constellationAgents = includeConstellation
+    ? await (async () => {
+        try {
+          const client = await getClient();
+          const result = await client.agents.list({
+            limit,
+            include: ["agent.blocks"],
+            order: "desc",
+            order_by: "last_run_completion",
+          });
+          return result.items.map((agent) => ({ agent, isLocal: false }));
+        } catch {
+          return [];
+        }
+      })()
+    : [];
+
+  const seen = new Set<string>();
+  const deduped = sortRecentAgents(
+    [...localAgents, ...constellationAgents].filter((item) => {
+      if (seen.has(item.agent.id)) return false;
+      seen.add(item.agent.id);
+      return true;
+    }),
+    options?.currentAgentId,
+  );
+
+  return deduped.slice(0, limit);
+}

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -299,9 +299,7 @@ function ProfileSelectionUI({
 
   const hasLocalDir = settingsManager.hasLocalLettaDir();
   const contextMessage = externalFreshRepoMode
-    ? options.length > 0
-      ? "0 pinned agents available."
-      : "0 pinned agents available."
+    ? `${options.length} pinned agent${options.length !== 1 ? "s" : ""} available.`
     : hasLocalDir
       ? "Existing `.letta` folder detected."
       : `${options.length} agent profile${options.length !== 1 ? "s" : ""} detected.`;

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -7,6 +7,7 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { Box, useInput } from "ink";
 import React, { useCallback, useEffect, useState } from "react";
 import { getBackend } from "@/backend";
+import { getRecentAgentOptions } from "@/cli/helpers/recent-agent-options";
 import { settingsManager } from "@/settings-manager";
 import { colors } from "./components/colors";
 import { Text } from "./components/Text";
@@ -28,6 +29,7 @@ interface ProfileSelectionResult {
 }
 
 const MAX_DISPLAY = 3;
+const RECENT_FALLBACK_DISPLAY = 2;
 const MAX_VISIBLE_MODELS = 8;
 const MODEL_SEARCH_THRESHOLD = 10; // Show search input when more than this many models
 
@@ -136,8 +138,11 @@ function ProfileSelectionUI({
       }
 
       // Fetch agent data
-      const fetchedOptions = await Promise.all(
+      let fetchedOptions = await Promise.all(
         optionsToFetch.map(async (opt) => {
+          if (opt.agent) {
+            return opt;
+          }
           try {
             const agent = await backend.retrieveAgent(opt.agentId, {
               include: ["agent.blocks"],
@@ -149,7 +154,26 @@ function ProfileSelectionUI({
         }),
       );
 
-      setOptions(fetchedOptions.filter((opt) => opt.agent !== null));
+      fetchedOptions = fetchedOptions.filter((opt) => opt.agent !== null);
+
+      // Fresh repo / invalid pins fallback: show recent agents from the active backend(s)
+      if (fetchedOptions.length === 0) {
+        const recentAgents = await getRecentAgentOptions({
+          includeLocal: false,
+          includeConstellation: true,
+          limit: RECENT_FALLBACK_DISPLAY,
+        });
+
+        fetchedOptions = recentAgents.map((recent) => ({
+          name: recent.agent.name,
+          agentId: recent.agent.id,
+          isLocal: recent.isLocal,
+          isLru: false,
+          agent: recent.agent,
+        }));
+      }
+
+      setOptions(fetchedOptions);
     } catch {
       setOptions([]);
     } finally {
@@ -275,7 +299,9 @@ function ProfileSelectionUI({
 
   const hasLocalDir = settingsManager.hasLocalLettaDir();
   const contextMessage = externalFreshRepoMode
-    ? `${options.length} pinned agent${options.length !== 1 ? "s" : ""} available.`
+    ? options.length > 0
+      ? "0 pinned agents available."
+      : "0 pinned agents available."
     : hasLocalDir
       ? "Existing `.letta` folder detected."
       : `${options.length} agent profile${options.length !== 1 ? "s" : ""} detected.`;
@@ -362,9 +388,6 @@ function ProfileSelectionUI({
         // Agent selection mode
         <Box flexDirection="column" gap={1}>
           <Text dimColor>{contextMessage}</Text>
-          {options.length > 0 && (
-            <Text bold>Which agent would you like to use?</Text>
-          )}
 
           <Box flexDirection="column" gap={1}>
             {displayOptions.map((option, index) => {
@@ -444,7 +467,7 @@ function ProfileSelectionUI({
             </Box>
           </Box>
 
-          <Box>
+          <Box marginLeft={2}>
             <Text dimColor>↑↓ navigate · Enter select · Esc exit</Text>
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
- fall back to a small list of recent agents in startup selection when there are no usable pinned or LRU agents
- make the `/agents` pinned tab show recent agents when pins are empty or all pinned agents are invalid
- allow recent-agent fallback rows in the pinned tab to be pinned with `Shift+P`
- keep the copy and spacing focused on pinning as the primary concept while making the empty state useful

## Test plan
- [x] `bun run check` passes
- [x] Logged-in startup with no local agents and no usable pinned/LRU agents shows recent Constellation agents instead of create-new only
- [x] `/agents` pinned tab with no usable pins shows 3 recent agents instead of a dead empty state
- [x] `Enter` selects a recent fallback agent and `Shift+P` pins it
- [x] Spacing/copy for pinned fallback state matches the intended quickstart layout

👾 Generated with [Letta Code](https://letta.com)