### PR TITLE
fix(memory): use live context usage in Memory Palace

### DIFF
--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -1440,6 +1440,18 @@ export function AppView(props: AppViewProps) {
                   agentName={agentState?.name}
                   onClose={closeOverlay}
                   conversationId={conversationId}
+                  contextUsage={
+                    usedContextTokens > 0
+                      ? {
+                          usedTokens: usedContextTokens,
+                          contextWindow: contextWindowSize ?? 0,
+                          model:
+                            currentModelHandle ??
+                            currentModelDisplay ??
+                            "unknown",
+                        }
+                      : undefined
+                  }
                 />
               ) : (
                 <MemoryTabViewer

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -877,10 +877,20 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           const { generateAndOpenMemoryViewer } = await import(
             "@/web/generate-memory-viewer"
           );
+          const latestContextTokens =
+            contextTrackerRef.current.lastContextTokens;
           generateAndOpenMemoryViewer(agentId, {
             agentName: agentName ?? undefined,
             conversationId:
               conversationId !== "default" ? conversationId : undefined,
+            contextUsage:
+              latestContextTokens > 0
+                ? {
+                    usedTokens: latestContextTokens,
+                    contextWindow: effectiveContextWindowSize ?? 0,
+                    model: llmConfigRef.current?.model ?? "unknown",
+                  }
+                : undefined,
           })
             .then((result) => {
               if (result.opened) {

--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/agent/memory-scanner";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
+import type { ContextUsageSnapshot } from "@/web/context-usage";
 import { generateAndOpenMemoryViewer } from "@/web/generate-memory-viewer";
 import { colors } from "./colors";
 import { Text } from "./Text";
@@ -29,6 +30,7 @@ interface MemfsTreeViewerProps {
   agentName?: string;
   onClose: () => void;
   conversationId?: string;
+  contextUsage?: ContextUsageSnapshot;
 }
 
 /**
@@ -48,6 +50,7 @@ export function MemfsTreeViewer({
   agentName,
   onClose,
   conversationId,
+  contextUsage,
 }: MemfsTreeViewerProps) {
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
@@ -119,7 +122,12 @@ export function MemfsTreeViewer({
     // O: open memory viewer in browser (works in both split and full view)
     if ((input === "o" || input === "O") && hasGitRepo) {
       showStatus("Opening in browser...", 10000);
-      generateAndOpenMemoryViewer(agentId, { agentName })
+      generateAndOpenMemoryViewer(agentId, {
+        agentName,
+        conversationId:
+          conversationId !== "default" ? conversationId : undefined,
+        contextUsage,
+      })
         .then((result) => {
           if (result.opened) {
             showStatus("Opened in browser", 3000);

--- a/src/web/context-usage.test.ts
+++ b/src/web/context-usage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { applyContextUsageSnapshot } from "./context-usage";
+import type { ContextData } from "./types";
+
+function breakdownTotal(context: ContextData): number {
+  return Object.values(context.breakdown).reduce(
+    (sum, tokens) => sum + tokens,
+    0,
+  );
+}
+
+describe("applyContextUsageSnapshot", () => {
+  test("uses the latest payload context tokens over a stale estimate", () => {
+    const context = applyContextUsageSnapshot(
+      {
+        contextWindow: 272_000,
+        usedTokens: 318_000,
+        model: "old-model",
+        breakdown: {
+          system: 18_000,
+          coreMemory: 0,
+          externalMemory: 0,
+          summaryMemory: 0,
+          tools: 0,
+          messages: 300_000,
+        },
+      },
+      {
+        contextWindow: 272_000,
+        usedTokens: 243_000,
+        model: "chatgpt-plus-pro/gpt-5.5",
+      },
+    );
+
+    expect(context?.usedTokens).toBe(243_000);
+    expect(context?.contextWindow).toBe(272_000);
+    expect(context?.model).toBe("chatgpt-plus-pro/gpt-5.5");
+    expect(context ? breakdownTotal(context) : 0).toBe(243_000);
+    expect(context?.breakdown.messages).toBeLessThan(300_000);
+  });
+
+  test("creates context data from a payload snapshot when no estimate exists", () => {
+    const context = applyContextUsageSnapshot(undefined, {
+      contextWindow: 200_000,
+      usedTokens: 123_456,
+      model: "anthropic/claude-sonnet-4-5",
+    });
+
+    expect(context).toEqual({
+      contextWindow: 200_000,
+      usedTokens: 123_456,
+      model: "anthropic/claude-sonnet-4-5",
+      breakdown: {
+        system: 0,
+        coreMemory: 0,
+        externalMemory: 0,
+        summaryMemory: 0,
+        tools: 0,
+        messages: 123_456,
+      },
+    });
+  });
+
+  test("keeps existing context when the payload snapshot is unavailable", () => {
+    const existing: ContextData = {
+      contextWindow: 272_000,
+      usedTokens: 318_000,
+      model: "old-model",
+      breakdown: {
+        system: 18_000,
+        coreMemory: 0,
+        externalMemory: 0,
+        summaryMemory: 0,
+        tools: 0,
+        messages: 300_000,
+      },
+    };
+
+    expect(applyContextUsageSnapshot(existing, undefined)).toBe(existing);
+    expect(
+      applyContextUsageSnapshot(existing, {
+        contextWindow: 272_000,
+        usedTokens: 0,
+        model: "chatgpt-plus-pro/gpt-5.5",
+      }),
+    ).toBe(existing);
+  });
+});

--- a/src/web/context-usage.ts
+++ b/src/web/context-usage.ts
@@ -1,0 +1,99 @@
+import type { ContextData } from "./types";
+
+export interface ContextUsageSnapshot {
+  contextWindow: number;
+  usedTokens: number;
+  model: string;
+}
+
+type BreakdownKey = keyof ContextData["breakdown"];
+
+const BREAKDOWN_KEYS: BreakdownKey[] = [
+  "system",
+  "coreMemory",
+  "externalMemory",
+  "summaryMemory",
+  "tools",
+  "messages",
+];
+
+function emptyBreakdown(): ContextData["breakdown"] {
+  return {
+    system: 0,
+    coreMemory: 0,
+    externalMemory: 0,
+    summaryMemory: 0,
+    tools: 0,
+    messages: 0,
+  };
+}
+
+function nonNegativeInteger(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : 0;
+}
+
+function scaleBreakdownToUsedTokens(
+  breakdown: ContextData["breakdown"] | undefined,
+  usedTokens: number,
+): ContextData["breakdown"] {
+  if (!breakdown) {
+    return { ...emptyBreakdown(), messages: usedTokens };
+  }
+
+  const weights = BREAKDOWN_KEYS.map((key) => ({
+    key,
+    tokens: nonNegativeInteger(breakdown[key]),
+  }));
+  const total = weights.reduce((sum, item) => sum + item.tokens, 0);
+  if (total <= 0) {
+    return { ...emptyBreakdown(), messages: usedTokens };
+  }
+
+  const scaled = emptyBreakdown();
+  const remainders = weights.map((item) => {
+    const exact = (item.tokens / total) * usedTokens;
+    const floor = Math.floor(exact);
+    scaled[item.key] = floor;
+    return { key: item.key, remainder: exact - floor };
+  });
+
+  let remaining =
+    usedTokens - BREAKDOWN_KEYS.reduce((sum, key) => sum + scaled[key], 0);
+  remainders.sort((a, b) => b.remainder - a.remainder);
+  for (const item of remainders) {
+    if (remaining <= 0) break;
+    scaled[item.key] += 1;
+    remaining--;
+  }
+
+  return scaled;
+}
+
+export function applyContextUsageSnapshot(
+  context: ContextData | undefined,
+  snapshot: ContextUsageSnapshot | undefined,
+): ContextData | undefined {
+  const usedTokens = nonNegativeInteger(snapshot?.usedTokens);
+  if (!snapshot || usedTokens <= 0) {
+    return context;
+  }
+
+  const snapshotContextWindow = nonNegativeInteger(snapshot.contextWindow);
+  const contextWindow =
+    snapshotContextWindow > 0
+      ? snapshotContextWindow
+      : nonNegativeInteger(context?.contextWindow);
+  const model =
+    snapshot.model && snapshot.model !== "unknown"
+      ? snapshot.model
+      : context?.model || snapshot.model || "unknown";
+
+  return {
+    contextWindow,
+    usedTokens,
+    model,
+    breakdown: scaleBreakdownToUsedTokens(context?.breakdown, usedTokens),
+  };
+}

--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -20,6 +20,10 @@ import {
 import { getAgentContextOverview } from "@/backend/api/agents";
 import { getClient, getServerUrl } from "@/backend/api/client";
 import { apiRequest } from "@/backend/api/request";
+import {
+  applyContextUsageSnapshot,
+  type ContextUsageSnapshot,
+} from "./context-usage";
 import { collectLocalMemoryContextData } from "./local-memory-context";
 import memoryViewerTemplate from "./memory-viewer-template.txt";
 import type {
@@ -100,6 +104,12 @@ function contextFromOverview(
 export interface GenerateResult {
   filePath: string;
   opened: boolean;
+}
+
+export interface GenerateMemoryViewerOptions {
+  agentName?: string;
+  conversationId?: string;
+  contextUsage?: ContextUsageSnapshot;
 }
 
 // ---------------------------------------------------------------------------
@@ -475,7 +485,7 @@ async function collectMemoryData(
 
 export async function generateAndOpenMemoryViewer(
   agentId: string,
-  options?: { agentName?: string; conversationId?: string },
+  options?: GenerateMemoryViewerOptions,
 ): Promise<GenerateResult> {
   const memoryRoot = getScopedMemoryFilesystemRoot(agentId);
   const repoDir = memoryRoot;
@@ -496,6 +506,8 @@ export async function generateAndOpenMemoryViewer(
   if (options?.agentName) {
     data.agent.name = options.agentName;
   }
+
+  data.context = applyContextUsageSnapshot(data.context, options?.contextUsage);
 
   // 2. Safely embed JSON - escape < to \u003c to prevent </script> injection
   const jsonPayload = JSON.stringify(data).replace(/</g, "\\u003c");


### PR DESCRIPTION
## Summary
- Pass the latest streamed context usage snapshot into Memory Palace generation from both `/palace` and the `/memory` browser opener.
- Apply that snapshot over local backend estimates so the headline usage matches `/context` instead of JSON-size message estimates.
- Rescale the displayed breakdown to the live total and add focused coverage for stale-estimate replacement.

Validation: `bun test src/web/context-usage.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)