### PR TITLE
fix(startup): backfill command hints

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -218,6 +218,30 @@ function buildStartupCommandHints(options: {
     hasAvailableLocalModels,
   } = options;
 
+  const baseHints = isResumingConversation
+    ? [
+        "→ **/agents**    list all agents",
+        "→ **/resume**    browse all conversations",
+        "→ **/new**       start a new conversation",
+        "→ **/init**      initialize your agent's memory",
+        "→ **/remember**  teach your agent",
+      ]
+    : isPinned
+      ? [
+          "→ **/agents**    list all agents",
+          "→ **/resume**    resume a previous conversation",
+          "→ **/memory**    view your agent's memory",
+          "→ **/init**      initialize your agent's memory",
+          "→ **/remember**  teach your agent",
+        ]
+      : [
+          "→ **/agents**    list all agents",
+          "→ **/resume**    resume a previous conversation",
+          "→ **/pin**       save + name your agent",
+          "→ **/init**      initialize your agent's memory",
+          "→ **/remember**  teach your agent",
+        ];
+
   const onboardingHints: string[] = [];
 
   if (isLocalBackend && !hasAvailableLocalModels) {
@@ -238,37 +262,21 @@ function buildStartupCommandHints(options: {
     onboardingHints.push("→ **/login**     sign in to Constellation");
   }
 
-  if (onboardingHints.length > 0) {
-    return onboardingHints.slice(0, 5);
+  const dedupedHints: string[] = [];
+  const seenHints = new Set<string>();
+
+  for (const hint of [...onboardingHints, ...baseHints]) {
+    if (seenHints.has(hint)) {
+      continue;
+    }
+    seenHints.add(hint);
+    dedupedHints.push(hint);
+    if (dedupedHints.length === 5) {
+      break;
+    }
   }
 
-  if (isResumingConversation) {
-    return [
-      "→ **/agents**    list all agents",
-      "→ **/resume**    browse all conversations",
-      "→ **/new**       start a new conversation",
-      "→ **/init**      initialize your agent's memory",
-      "→ **/remember**  teach your agent",
-    ];
-  }
-
-  if (isPinned) {
-    return [
-      "→ **/agents**    list all agents",
-      "→ **/resume**    resume a previous conversation",
-      "→ **/memory**    view your agent's memory",
-      "→ **/init**      initialize your agent's memory",
-      "→ **/remember**  teach your agent",
-    ];
-  }
-
-  return [
-    "→ **/agents**    list all agents",
-    "→ **/resume**    resume a previous conversation",
-    "→ **/pin**       save + name your agent",
-    "→ **/init**      initialize your agent's memory",
-    "→ **/remember**  teach your agent",
-  ];
+  return dedupedHints;
 }
 
 export function App({
@@ -4349,7 +4357,7 @@ export function App({
       // Build status message based on session type
       const agentName = agentState?.name || "Unnamed Agent";
       const headerMessage = resumedExistingConversation
-        ? `Resuming (empty) conversation with **${agentName}**`
+        ? `Resuming new conversation with **${agentName}**`
         : continueSession
           ? `Starting new conversation with **${agentName}**`
           : "Creating a new agent";


### PR DESCRIPTION
## Summary
- keep startup command hints filled to five items by deduping prioritized onboarding hints and then backfilling from the default hint list
- preserve the contextual onboarding hints while avoiding short hint lists that waste the startup teaching surface
- rename `Resuming (empty) conversation` to `Resuming new conversation`

## Test plan
- [x] `bun run check` passes
- [x] Startup cases with specialized hints still show those hints first
- [x] Startup cases that previously rendered fewer than five hints now backfill from the base list without duplicates
- [x] Empty-conversation resume copy now reads `Resuming new conversation`

👾 Generated with [Letta Code](https://letta.com)