### PR TITLE
fix(login): allow cancelling the Constellation overlay

### DIFF
--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -1,5 +1,5 @@
 import { hostname } from "node:os";
-import { Box } from "ink";
+import { Box, useInput } from "ink";
 import { useEffect, useRef, useState } from "react";
 import { configureBackendMode } from "@/backend";
 import { Text } from "@/cli/components/Text";
@@ -9,21 +9,34 @@ import { pollForToken, requestDeviceCode } from "./oauth";
 interface ConstellationLoginViewProps {
   onComplete?: () => void;
   onAlreadyLoggedIn?: () => void;
+  onCancel?: () => void;
 }
 
 export function ConstellationLoginView({
   onComplete,
   onAlreadyLoggedIn,
+  onCancel,
 }: ConstellationLoginViewProps) {
   const [error, setError] = useState<string | null>(null);
   const [doneMessage, setDoneMessage] = useState<string | null>(null);
   const [userCode, setUserCode] = useState<string | null>(null);
   const [verificationUri, setVerificationUri] = useState<string | null>(null);
   const startedRef = useRef(false);
+  const cancelledRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === "c")) {
+      cancelledRef.current = true;
+      abortControllerRef.current?.abort();
+      onCancel?.();
+    }
+  });
 
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
+    abortControllerRef.current = new AbortController();
 
     const run = async () => {
       try {
@@ -56,12 +69,17 @@ export function ConstellationLoginView({
 
         const deviceId = settingsManager.getOrCreateDeviceId();
         const deviceName = hostname();
+        const controller = abortControllerRef.current;
+        if (!controller) {
+          return;
+        }
         const tokens = await pollForToken(
           deviceData.device_code,
           deviceData.interval,
           deviceData.expires_in,
           deviceId,
           deviceName,
+          controller.signal,
         );
 
         const now = Date.now();
@@ -82,11 +100,21 @@ export function ConstellationLoginView({
         );
         setTimeout(() => onComplete?.(), 500);
       } catch (err) {
+        if (
+          cancelledRef.current ||
+          (err instanceof Error && err.name === "AbortError")
+        ) {
+          return;
+        }
         setError(err instanceof Error ? err.message : String(err));
       }
     };
 
     void run();
+    return () => {
+      cancelledRef.current = true;
+      abortControllerRef.current?.abort();
+    };
   }, [onAlreadyLoggedIn, onComplete]);
 
   if (doneMessage) {
@@ -119,6 +147,7 @@ export function ConstellationLoginView({
       <Text dimColor>If browser didn't open, visit: {verificationUri}</Text>
       <Text> </Text>
       <Text dimColor>Waiting for you to authorize in the browser...</Text>
+      <Text dimColor>Press Esc to cancel</Text>
     </Box>
   );
 }

--- a/src/auth/oauth-network-errors.test.ts
+++ b/src/auth/oauth-network-errors.test.ts
@@ -87,4 +87,28 @@ describe("OAuth network errors", () => {
       pollForToken("device-code", 0, 60, "device-id"),
     ).rejects.toThrow("User denied authorization");
   });
+
+  test("pollForToken supports cancellation via AbortSignal", async () => {
+    const controller = new AbortController();
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "authorization_pending" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const promise = pollForToken(
+      "device-code",
+      1,
+      60,
+      "device-id",
+      undefined,
+      controller.signal,
+    );
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
 });

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -172,19 +172,51 @@ export async function pollForToken(
   expiresIn: number = 900,
   deviceId: string,
   deviceName?: string,
+  signal?: AbortSignal,
 ): Promise<TokenResponse> {
   const startTime = Date.now();
   const expiresInMs = expiresIn * 1000;
   let pollInterval = interval * 1000;
 
+  const sleep = async (ms: number) => {
+    if (!signal) {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      return;
+    }
+
+    if (signal.aborted) {
+      const error = new Error("OAuth polling cancelled");
+      error.name = "AbortError";
+      throw error;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+
+      const onAbort = () => {
+        clearTimeout(timer);
+        signal.removeEventListener("abort", onAbort);
+        const error = new Error("OAuth polling cancelled");
+        error.name = "AbortError";
+        reject(error);
+      };
+
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
   while (Date.now() - startTime < expiresInMs) {
-    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    await sleep(pollInterval);
 
     try {
       const response = await fetch(
         `${OAUTH_CONFIG.authBaseUrl}/api/oauth/token`,
         {
           method: "POST",
+          signal,
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             grant_type: "urn:ietf:params:oauth:grant-type:device_code",

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -998,6 +998,7 @@ export function AppView(props: AppViewProps) {
                     true,
                   );
                 }}
+                onCancel={closeOverlay}
               />
             )}
 

--- a/src/cli/components/ConstellationLoginOverlay.tsx
+++ b/src/cli/components/ConstellationLoginOverlay.tsx
@@ -4,17 +4,20 @@ import { OverlayShell } from "@/cli/components/OverlayShell";
 interface ConstellationLoginOverlayProps {
   onComplete: () => void;
   onAlreadyLoggedIn: () => void;
+  onCancel: () => void;
 }
 
 export function ConstellationLoginOverlay({
   onComplete,
   onAlreadyLoggedIn,
+  onCancel,
 }: ConstellationLoginOverlayProps) {
   return (
     <OverlayShell command="/login" title="Login to Constellation">
       <ConstellationLoginView
         onComplete={onComplete}
         onAlreadyLoggedIn={onAlreadyLoggedIn}
+        onCancel={onCancel}
       />
     </OverlayShell>
   );


### PR DESCRIPTION
## Summary
- let users cancel the `/login` device-code flow with `Esc` or `Ctrl+C`
- abort OAuth token polling on cancel so the overlay dismisses cleanly and does not leave the terminal stuck
- add a small hint in the login view that `Esc` cancels
- add a focused regression test for `pollForToken` cancellation via `AbortSignal`

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/auth/oauth-network-errors.test.ts` passes
- [x] Verified `/login` can be dismissed with `Esc`
- [x] Verified `/login` can be dismissed with `Ctrl+C`
- [x] Verified terminal input works normally again after cancel

👾 Generated with [Letta Code](https://letta.com)