### PR TITLE
fix(mcp): Add timeout for MCP overlay server loading

### DIFF
--- a/src/cli/components/McpSelector.tsx
+++ b/src/cli/components/McpSelector.tsx
@@ -14,6 +14,7 @@ import { Text } from "./Text";
 
 // Horizontal line character (matches approval dialogs)
 const SOLID_LINE = "─";
+export const MCP_SERVERS_LIST_TIMEOUT_MS = 15_000;
 
 interface McpSelectorProps {
   agentId: string;
@@ -25,6 +26,25 @@ type McpServer = StreamableHTTPMcpServer | SseMcpServer | StdioMcpServer;
 
 const DISPLAY_PAGE_SIZE = 5;
 const TOOLS_DISPLAY_PAGE_SIZE = 8;
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
 
 /**
  * Get a display string for the MCP server type
@@ -94,7 +114,11 @@ export const McpSelector = memo(function McpSelector({
     setError(null);
     try {
       const client = await getClient();
-      const serverList = await client.mcpServers.list();
+      const serverList = await withTimeout(
+        client.mcpServers.list(),
+        MCP_SERVERS_LIST_TIMEOUT_MS,
+        "Timed out loading MCP servers. The API endpoint may be slow or unavailable; press R to retry.",
+      );
       setServers(serverList);
     } catch (err) {
       setError(

--- a/src/cli/components/mcp-selector.test.ts
+++ b/src/cli/components/mcp-selector.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { withTimeout } from "./McpSelector";
+
+describe("withTimeout", () => {
+  test("resolves when the wrapped promise settles before the timeout", async () => {
+    await expect(
+      withTimeout(Promise.resolve("servers"), 50, "timed out"),
+    ).resolves.toBe("servers");
+  });
+
+  test("rejects with the supplied message when the wrapped promise hangs", async () => {
+    await expect(
+      withTimeout(new Promise(() => {}), 1, "MCP list timed out"),
+    ).rejects.toThrow("MCP list timed out");
+  });
+});


### PR DESCRIPTION
I am an AI agent submitting a focused fix for #2453.

## Summary
- wraps the `/mcp` overlay's initial `client.mcpServers.list()` call in a 15s timeout
- surfaces a retryable error instead of leaving the TUI in `Loading MCP servers...` indefinitely
- adds regression coverage for the timeout helper

## Why
When `client.mcpServers.list()` stalls, the overlay stays in the loading state forever and users have to Ctrl+C. The overlay already has an error UI with `R refresh` and `Esc cancel`; this change routes the stalled-list case into that existing recovery path.

## Validation
- `bun install`
- `bun test src/cli/components/mcp-selector.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/McpSelector.tsx src/cli/components/mcp-selector.test.ts`
- `git diff --check`
- commit hook also passed layer-boundary, exported-function, filename-casing, lint-staged Biome write, and typecheck checks.