### PR TITLE
fix(local): Support reasoning selection for local models

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -274,6 +274,16 @@ describe("getReasoningTierOptionsForHandle", () => {
     }
   });
 
+  test("returns generic reasoning options for discovered Ollama models", () => {
+    const options = getReasoningTierOptionsForHandle("ollama/gpt-oss:20b");
+    expect(options).toEqual([
+      { effort: "none", modelId: "ollama/gpt-oss:20b" },
+      { effort: "low", modelId: "ollama/gpt-oss:20b" },
+      { effort: "medium", modelId: "ollama/gpt-oss:20b" },
+      { effort: "high", modelId: "ollama/gpt-oss:20b" },
+    ]);
+  });
+
   test("returns empty options for models without reasoning tiers", () => {
     const options = getReasoningTierOptionsForHandle(
       "anthropic/claude-haiku-4-5",

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -46,6 +46,15 @@ export function isLocalModelHandle(modelHandle: string): boolean {
   );
 }
 
+export function getLocalModelLabel(modelHandle: string): string {
+  const providerPrefix = LOCAL_MODEL_HANDLE_PREFIXES.find((prefix) =>
+    modelHandle.startsWith(prefix),
+  );
+  return providerPrefix
+    ? modelHandle.slice(providerPrefix.length)
+    : modelHandle;
+}
+
 function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
   return (
     typeof value === "string" &&

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -25,6 +25,27 @@ const REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
   "max",
 ];
 
+const LOCAL_REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
+  "none",
+  "low",
+  "medium",
+  "high",
+];
+
+const LOCAL_MODEL_HANDLE_PREFIXES = [
+  "ollama/",
+  "ollama-cloud/",
+  "lmstudio/",
+  "llama.cpp/",
+  "llama-cpp/",
+];
+
+function isLocalModelHandle(modelHandle: string): boolean {
+  return LOCAL_MODEL_HANDLE_PREFIXES.some((prefix) =>
+    modelHandle.startsWith(prefix),
+  );
+}
+
 function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
   return (
     typeof value === "string" &&
@@ -54,6 +75,13 @@ export function getReasoningTierOptionsForHandle(
     if (!byEffort.has(effort)) {
       byEffort.set(effort, model.id);
     }
+  }
+
+  if (byEffort.size === 0 && isLocalModelHandle(modelHandle)) {
+    return LOCAL_REASONING_EFFORT_ORDER.map((effort) => ({
+      effort,
+      modelId: modelHandle,
+    }));
   }
 
   return REASONING_EFFORT_ORDER.flatMap((effort) => {

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -40,7 +40,7 @@ const LOCAL_MODEL_HANDLE_PREFIXES = [
   "llama-cpp/",
 ];
 
-function isLocalModelHandle(modelHandle: string): boolean {
+export function isLocalModelHandle(modelHandle: string): boolean {
   return LOCAL_MODEL_HANDLE_PREFIXES.some((prefix) =>
     modelHandle.startsWith(prefix),
   );

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -185,6 +185,17 @@ function buildModelSettings(
           ? updateArgs.parallel_tool_calls
           : true,
     };
+    if (updateArgs?.reasoning_effort) {
+      openaiProxySettings.reasoning = {
+        reasoning_effort: updateArgs.reasoning_effort as
+          | "none"
+          | "minimal"
+          | "low"
+          | "medium"
+          | "high"
+          | "xhigh",
+      };
+    }
     if (typeof updateArgs?.strict === "boolean") {
       (openaiProxySettings as Record<string, unknown>).strict =
         updateArgs.strict;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -693,6 +693,7 @@ export function App({
   const [modelReasoningPrompt, setModelReasoningPrompt] = useState<{
     modelLabel: string;
     initialModelId: string;
+    initialEffort?: ModelReasoningEffort;
     options: Array<{ effort: ModelReasoningEffort; modelId: string }>;
   } | null>(null);
   const closeOverlay = useCallback(() => {

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -196,7 +196,11 @@ type AppViewProps = {
   handleModelSelect: (
     modelId: string,
     commandId?: string | null,
-    opts?: { skipReasoningPrompt?: boolean },
+    opts?: {
+      promptReasoning?: boolean;
+      skipReasoningPrompt?: boolean;
+      reasoningEffort?: ModelReasoningEffort;
+    },
   ) => Promise<void>;
   handlePasteError: (message: string) => void;
   handlePermissionModeChange: (mode: PermissionMode) => void;
@@ -715,10 +719,11 @@ export function AppView(props: AppViewProps) {
                   modelLabel={modelReasoningPrompt.modelLabel}
                   options={modelReasoningPrompt.options}
                   initialModelId={modelReasoningPrompt.initialModelId}
-                  onSelect={(selectedModelId) => {
+                  onSelect={(selectedOption) => {
                     setModelReasoningPrompt(null);
-                    void handleModelSelect(selectedModelId, null, {
+                    void handleModelSelect(selectedOption.modelId, null, {
                       skipReasoningPrompt: true,
+                      reasoningEffort: selectedOption.effort,
                     });
                   }}
                   onCancel={() => setModelReasoningPrompt(null)}
@@ -727,7 +732,11 @@ export function AppView(props: AppViewProps) {
                 <ModelSelector
                   currentModelId={currentModelId ?? undefined}
                   currentModelHandle={currentModelHandle}
-                  onSelect={handleModelSelect}
+                  onSelect={(modelId) => {
+                    void handleModelSelect(modelId, null, {
+                      promptReasoning: true,
+                    });
+                  }}
                   onOpenConnect={() => {
                     const overlayCommand = completeOverlay("model");
                     overlayCommand?.finish("Models dialog dismissed", true);

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -100,6 +100,7 @@ type ModelSelectorOptions = {
 type ModelReasoningPrompt = {
   modelLabel: string;
   initialModelId: string;
+  initialEffort?: ModelReasoningEffort;
   options: Array<{ effort: ModelReasoningEffort; modelId: string }>;
 };
 
@@ -719,6 +720,7 @@ export function AppView(props: AppViewProps) {
                   modelLabel={modelReasoningPrompt.modelLabel}
                   options={modelReasoningPrompt.options}
                   initialModelId={modelReasoningPrompt.initialModelId}
+                  initialEffort={modelReasoningPrompt.initialEffort}
                   onSelect={(selectedOption) => {
                     setModelReasoningPrompt(null);
                     void handleModelSelect(selectedOption.modelId, null, {

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -49,6 +49,7 @@ import type {
 type ModelReasoningPrompt = {
   modelLabel: string;
   initialModelId: string;
+  initialEffort?: ModelReasoningEffort;
   options: Array<{ effort: ModelReasoningEffort; modelId: string }>;
 };
 
@@ -287,6 +288,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             setModelReasoningPrompt({
               modelLabel: model.label,
               initialModelId: preferredOption.modelId,
+              initialEffort: preferredOption.effort,
               options: reasoningTierOptions,
             });
             return;

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -142,7 +142,11 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
     async (
       modelId: string,
       commandId?: string | null,
-      opts?: { skipReasoningPrompt?: boolean },
+      opts?: {
+        promptReasoning?: boolean;
+        skipReasoningPrompt?: boolean;
+        reasoningEffort?: ModelReasoningEffort;
+      },
     ) => {
       let overlayCommand = commandId
         ? commandRunner.getHandle(commandId, "/model")
@@ -203,16 +207,31 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             "@/agent/available-models"
           );
           const apiContextWindow = await getModelContextWindow(modelId);
+          const updateArgs: Record<string, unknown> = {
+            ...(apiContextWindow ? { context_window: apiContextWindow } : {}),
+            ...(opts?.reasoningEffort
+              ? { reasoning_effort: opts.reasoningEffort }
+              : {}),
+          };
 
           selectedModel = {
             id: modelId,
             handle: modelId,
             label: modelId.split("/").pop() ?? modelId,
             description: "Custom model",
-            updateArgs: apiContextWindow
-              ? { context_window: apiContextWindow }
-              : undefined,
+            updateArgs:
+              Object.keys(updateArgs).length > 0 ? updateArgs : undefined,
           } as unknown as (typeof models)[number];
+        }
+
+        if (selectedModel && opts?.reasoningEffort) {
+          selectedModel = {
+            ...selectedModel,
+            updateArgs: {
+              ...(selectedModel.updateArgs ?? {}),
+              reasoning_effort: opts.reasoningEffort,
+            },
+          };
         }
 
         if (!selectedModel) {
@@ -250,7 +269,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
 
         if (
           !opts?.skipReasoningPrompt &&
-          activeOverlay === "model" &&
+          (opts?.promptReasoning || activeOverlay === "model") &&
           reasoningTierOptions.length > 1
         ) {
           const selectedEffort = (

--- a/src/cli/app/use-reasoning-cycle.test.ts
+++ b/src/cli/app/use-reasoning-cycle.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { resolveReasoningCycleModelHandle } from "@/cli/app/use-reasoning-cycle";
+
+describe("resolveReasoningCycleModelHandle", () => {
+  test("preserves local model handles from llm_config", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "ollama/gemma4:latest",
+          model_endpoint_type: "openai",
+          context_window: 128000,
+        },
+        null,
+      ),
+    ).toBe("ollama/gemma4:latest");
+  });
+
+  test("uses local agent model before compatibility llm_config endpoint", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "ollama/gemma4:latest",
+          model_endpoint_type: "openai",
+          context_window: 128000,
+        },
+        "ollama/gemma4:latest",
+      ),
+    ).toBe("ollama/gemma4:latest");
+  });
+
+  test("keeps provider-prefixed cloud handles for non-local models", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "gpt-5.4",
+          model_endpoint_type: "openai",
+          context_window: 128000,
+        },
+        null,
+      ),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  test("maps ChatGPT OAuth endpoint type to the model registry provider", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "gpt-5.5",
+          model_endpoint_type: "chatgpt_oauth",
+          context_window: 128000,
+        },
+        null,
+      ),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+});

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -8,7 +8,7 @@ import {
   type SetStateAction,
   useCallback,
 } from "react";
-import type { ModelReasoningEffort } from "@/agent/model";
+import { isLocalModelHandle, type ModelReasoningEffort } from "@/agent/model";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 
@@ -55,6 +55,32 @@ type ReasoningCycleContext = {
   setLlmConfig: Dispatch<SetStateAction<LlmConfig | null>>;
   withCommandLock: (fn: () => Promise<void>) => Promise<void>;
 };
+
+export function resolveReasoningCycleModelHandle(
+  llmConfig: LlmConfig | null | undefined,
+  agentModel: string | null | undefined,
+): string | null {
+  if (agentModel && isLocalModelHandle(agentModel)) {
+    return agentModel;
+  }
+
+  const model = llmConfig?.model;
+  if (!model) return agentModel ?? null;
+
+  if (isLocalModelHandle(model)) {
+    return model;
+  }
+
+  if (llmConfig?.model_endpoint_type) {
+    return `${
+      llmConfig.model_endpoint_type === "chatgpt_oauth"
+        ? OPENAI_CODEX_PROVIDER_NAME
+        : llmConfig.model_endpoint_type
+    }/${model}`;
+  }
+
+  return model;
+}
 
 export function useReasoningCycle(ctx: ReasoningCycleContext) {
   const {
@@ -286,17 +312,12 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
       if (reasoningCycleInFlightRef.current) return;
 
       const current = llmConfigRef.current;
-      // For ChatGPT OAuth sessions, llm_config may report model_endpoint_type as
-      // "chatgpt_oauth" while our code/model registry uses the provider name
-      // "chatgpt-plus-pro" in handles.
-      const modelHandle =
-        current?.model_endpoint_type && current?.model
-          ? `${
-              current.model_endpoint_type === "chatgpt_oauth"
-                ? OPENAI_CODEX_PROVIDER_NAME
-                : current.model_endpoint_type
-            }/${current.model}`
-          : current?.model;
+      const modelHandle = resolveReasoningCycleModelHandle(
+        current,
+        hasConversationModelOverrideRef.current
+          ? null
+          : (agentStateRef.current?.model ?? null),
+      );
       if (!modelHandle) return;
 
       // Derive current effort from effective model settings (conversation override aware)
@@ -306,19 +327,15 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
       const currentEffort =
         deriveReasoningEffort(modelSettingsForEffort, current) ?? "none";
 
-      const { models } = await import("@/agent/model");
-      const tiers = models
-        .filter((m) => m.handle === modelHandle)
-        .map((m) => {
-          const effort = (
-            m.updateArgs as { reasoning_effort?: unknown } | undefined
-          )?.reasoning_effort;
-          return {
-            id: m.id,
-            effort: typeof effort === "string" ? effort : null,
-          };
-        })
-        .filter((m): m is { id: string; effort: string } => Boolean(m.effort));
+      const { getReasoningTierOptionsForHandle } = await import(
+        "@/agent/model"
+      );
+      const tiers = getReasoningTierOptionsForHandle(modelHandle).map(
+        (option) => ({
+          id: option.modelId,
+          effort: option.effort,
+        }),
+      );
 
       // Only enable cycling when there are multiple tiers for the same handle.
       if (tiers.length < 2) return;

--- a/src/cli/components/ModelReasoningSelector.tsx
+++ b/src/cli/components/ModelReasoningSelector.tsx
@@ -17,6 +17,7 @@ interface ModelReasoningSelectorProps {
   modelLabel: string;
   options: ReasoningOption[];
   initialModelId: string;
+  initialEffort?: ModelReasoningEffort;
   onSelect: (option: ReasoningOption) => void;
   onCancel: () => void;
 }
@@ -36,6 +37,7 @@ export function ModelReasoningSelector({
   modelLabel,
   options,
   initialModelId,
+  initialEffort,
   onSelect,
   onCancel,
 }: ModelReasoningSelectorProps) {
@@ -43,19 +45,23 @@ export function ModelReasoningSelector({
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
   const [selectedIndex, setSelectedIndex] = useState(() => {
     const idx = options.findIndex(
-      (option) => option.modelId === initialModelId,
+      (option) =>
+        option.modelId === initialModelId &&
+        (initialEffort === undefined || option.effort === initialEffort),
     );
     return idx >= 0 ? idx : 0;
   });
 
   useEffect(() => {
     const idx = options.findIndex(
-      (option) => option.modelId === initialModelId,
+      (option) =>
+        option.modelId === initialModelId &&
+        (initialEffort === undefined || option.effort === initialEffort),
     );
     if (idx >= 0) {
       setSelectedIndex(idx);
     }
-  }, [options, initialModelId]);
+  }, [options, initialModelId, initialEffort]);
 
   const selectedOption = options[selectedIndex] ?? options[0];
   const effortOptions = useMemo(

--- a/src/cli/components/ModelReasoningSelector.tsx
+++ b/src/cli/components/ModelReasoningSelector.tsx
@@ -17,7 +17,7 @@ interface ModelReasoningSelectorProps {
   modelLabel: string;
   options: ReasoningOption[];
   initialModelId: string;
-  onSelect: (modelId: string) => void;
+  onSelect: (option: ReasoningOption) => void;
   onCancel: () => void;
 }
 
@@ -96,7 +96,7 @@ export function ModelReasoningSelector({
 
     if (key.return) {
       if (selectedOption) {
-        onSelect(selectedOption.modelId);
+        onSelect(selectedOption);
       }
       return;
     }

--- a/src/cli/components/ModelSelector-categories.test.tsx
+++ b/src/cli/components/ModelSelector-categories.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getModelCategories,
+  toSelectorModelForHandle,
   usesBackendModelCatalog,
 } from "@/cli/components/ModelSelector";
 
@@ -80,5 +81,21 @@ describe("getModelCategories", () => {
     expect(usesBackendModelCatalog(false, true)).toBe(true);
     expect(usesBackendModelCatalog(true, false)).toBe(true);
     expect(usesBackendModelCatalog(false, false)).toBe(false);
+  });
+});
+
+describe("toSelectorModelForHandle", () => {
+  test("uses a display label without the local provider prefix", () => {
+    expect(toSelectorModelForHandle("ollama/qwen2.5:7b")).toMatchObject({
+      id: "ollama/qwen2.5:7b",
+      handle: "ollama/qwen2.5:7b",
+      label: "qwen2.5:7b",
+    });
+  });
+
+  test("keeps non-local handles unchanged", () => {
+    expect(toSelectorModelForHandle("openai/gpt-5.5")).toMatchObject({
+      label: "openai/gpt-5.5",
+    });
   });
 });

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -103,6 +103,36 @@ type UiModel = {
   updateArgs?: Record<string, unknown>;
 };
 
+const LOCAL_MODEL_HANDLE_PREFIXES = [
+  "ollama/",
+  "ollama-cloud/",
+  "lmstudio/",
+  "llama.cpp/",
+  "llama-cpp/",
+];
+
+function isLocalModelHandle(handle: string): boolean {
+  return LOCAL_MODEL_HANDLE_PREFIXES.some((prefix) =>
+    handle.startsWith(prefix),
+  );
+}
+
+function localModelLabel(handle: string): string {
+  const providerPrefix = LOCAL_MODEL_HANDLE_PREFIXES.find((prefix) =>
+    handle.startsWith(prefix),
+  );
+  return providerPrefix ? handle.slice(providerPrefix.length) : handle;
+}
+
+export function toSelectorModelForHandle(handle: string): UiModel {
+  return {
+    id: handle,
+    handle,
+    label: isLocalModelHandle(handle) ? localModelLabel(handle) : handle,
+    description: "",
+  };
+}
+
 const API_GATED_MODEL_HANDLES = new Set(["letta/auto", "letta/auto-fast"]);
 
 export function filterModelsByAvailabilityForSelector<
@@ -556,12 +586,7 @@ export function ModelSelector({
           handle,
         });
       } else {
-        resolved.push({
-          id: handle,
-          handle,
-          label: handle,
-          description: "",
-        });
+        resolved.push(toSelectorModelForHandle(handle));
       }
     }
     return resolved;
@@ -580,12 +605,7 @@ export function ModelSelector({
         description: "",
       })),
       "server-recommended": serverRecommendedModels,
-      "server-all": serverAllModels.map((handle) => ({
-        id: handle,
-        handle,
-        label: handle,
-        description: "",
-      })),
+      "server-all": serverAllModels.map(toSelectorModelForHandle),
       all: allLettaModels,
     }),
     [

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -7,7 +7,7 @@ import {
   getAvailableModelsCacheInfo,
   getCachedModelHandles,
 } from "@/agent/available-models";
-import { models } from "@/agent/model";
+import { getLocalModelLabel, models } from "@/agent/model";
 
 import {
   buildByokProviderAliases,
@@ -103,32 +103,11 @@ type UiModel = {
   updateArgs?: Record<string, unknown>;
 };
 
-const LOCAL_MODEL_HANDLE_PREFIXES = [
-  "ollama/",
-  "ollama-cloud/",
-  "lmstudio/",
-  "llama.cpp/",
-  "llama-cpp/",
-];
-
-function isLocalModelHandle(handle: string): boolean {
-  return LOCAL_MODEL_HANDLE_PREFIXES.some((prefix) =>
-    handle.startsWith(prefix),
-  );
-}
-
-function localModelLabel(handle: string): string {
-  const providerPrefix = LOCAL_MODEL_HANDLE_PREFIXES.find((prefix) =>
-    handle.startsWith(prefix),
-  );
-  return providerPrefix ? handle.slice(providerPrefix.length) : handle;
-}
-
 export function toSelectorModelForHandle(handle: string): UiModel {
   return {
     id: handle,
     handle,
-    label: isLocalModelHandle(handle) ? localModelLabel(handle) : handle,
+    label: getLocalModelLabel(handle),
     description: "",
   };
 }

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -6,10 +6,15 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
 import React, { useCallback, useEffect, useState } from "react";
+import {
+  getReasoningTierOptionsForHandle,
+  type ModelReasoningEffort,
+} from "@/agent/model";
 import { getBackend } from "@/backend";
 import { getRecentAgentOptions } from "@/cli/helpers/recent-agent-options";
 import { settingsManager } from "@/settings-manager";
 import { colors } from "./components/colors";
+import { ModelReasoningSelector } from "./components/ModelReasoningSelector";
 import { Text } from "./components/Text";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 
@@ -26,6 +31,7 @@ interface ProfileSelectionResult {
   agentId?: string;
   profileName?: string | null;
   model?: string;
+  reasoningEffort?: ModelReasoningEffort;
 }
 
 const MAX_DISPLAY = 3;
@@ -98,6 +104,12 @@ function ProfileSelectionUI({
   );
   const [modelSelectedIndex, setModelSelectedIndex] = useState(0);
   const [modelSearchQuery, setModelSearchQuery] = useState("");
+  const [modelReasoningPrompt, setModelReasoningPrompt] = useState<{
+    model: string;
+    initialModelId: string;
+    initialEffort?: ModelReasoningEffort;
+    options: Array<{ effort: ModelReasoningEffort; modelId: string }>;
+  } | null>(null);
 
   const loadOptions = useCallback(async () => {
     setInternalLoading(true);
@@ -218,6 +230,10 @@ function ProfileSelectionUI({
   useInput((_input, key) => {
     if (loading) return;
 
+    if (modelReasoningPrompt) {
+      return;
+    }
+
     // Model selection mode
     if (selectingModel && serverModelsForNewAgent) {
       if (key.upArrow) {
@@ -229,6 +245,21 @@ function ProfileSelectionUI({
       } else if (key.return) {
         const selected = filteredModels[modelSelectedIndex];
         if (selected) {
+          const reasoningOptions = getReasoningTierOptionsForHandle(selected);
+          if (reasoningOptions.length > 1) {
+            const preferredOption =
+              reasoningOptions.find((option) => option.effort === "medium") ??
+              reasoningOptions[0];
+            if (preferredOption) {
+              setModelReasoningPrompt({
+                model: selected,
+                initialModelId: preferredOption.modelId,
+                initialEffort: preferredOption.effort,
+                options: reasoningOptions,
+              });
+              return;
+            }
+          }
           onComplete({ type: "new_with_model", model: selected });
         }
       } else if (key.escape || (key.ctrl && _input === "c")) {
@@ -322,7 +353,25 @@ function ProfileSelectionUI({
         </>
       )}
 
-      {loading ? null : selectingModel && serverModelsForNewAgent ? (
+      {loading ? null : modelReasoningPrompt ? (
+        <ModelReasoningSelector
+          modelLabel={
+            modelReasoningPrompt.model.split("/").pop() ??
+            modelReasoningPrompt.model
+          }
+          options={modelReasoningPrompt.options}
+          initialModelId={modelReasoningPrompt.initialModelId}
+          initialEffort={modelReasoningPrompt.initialEffort}
+          onSelect={(selectedOption) => {
+            onComplete({
+              type: "new_with_model",
+              model: selectedOption.modelId,
+              reasoningEffort: selectedOption.effort,
+            });
+          }}
+          onCancel={() => setModelReasoningPrompt(null)}
+        />
+      ) : selectingModel && serverModelsForNewAgent ? (
         // Model selection mode
         <Box flexDirection="column" gap={1}>
           <Text bold color={colors.selector.title}>
@@ -503,7 +552,10 @@ export function ProfileSelectionInline({
   onSelect: (agentId: string) => void;
   onCreateNew: () => void;
   /** Called when user selects a model from serverModelsForNewAgent */
-  onCreateNewWithModel?: (model: string) => void;
+  onCreateNewWithModel?: (
+    model: string,
+    reasoningEffort?: ModelReasoningEffort,
+  ) => void;
   onExit: () => void;
 }) {
   const handleComplete = (result: ProfileSelectionResult) => {
@@ -512,7 +564,7 @@ export function ProfileSelectionInline({
     } else if (result.type === "select" && result.agentId) {
       onSelect(result.agentId);
     } else if (result.type === "new_with_model" && result.model) {
-      onCreateNewWithModel?.(result.model);
+      onCreateNewWithModel?.(result.model, result.reasoningEffort);
     } else {
       onCreateNew();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   getModelPresetUpdateForAgent,
   getModelUpdateArgs,
   getResumeRefreshArgs,
+  type ModelReasoningEffort,
   resolveModel,
 } from "./agent/model";
 import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
@@ -1397,6 +1398,10 @@ async function main(): Promise<void> {
     const [selectedServerModel, setSelectedServerModel] = useState<
       string | null
     >(null);
+    const [
+      selectedServerModelReasoningEffort,
+      setSelectedServerModelReasoningEffort,
+    ] = useState<ModelReasoningEffort | null>(null);
     const [selfHostedDefaultModel, setSelfHostedDefaultModel] = useState<
       string | null
     >(null);
@@ -2101,7 +2106,13 @@ async function main(): Promise<void> {
             : undefined;
           const modelForUpdateArgs =
             personalityOptions?.model ?? effectiveModel;
-          const updateArgs = getModelUpdateArgs(modelForUpdateArgs);
+          const baseUpdateArgs = getModelUpdateArgs(modelForUpdateArgs);
+          const updateArgs = selectedServerModelReasoningEffort
+            ? {
+                ...(baseUpdateArgs ?? {}),
+                reasoning_effort: selectedServerModelReasoningEffort,
+              }
+            : baseUpdateArgs;
           const result = await createAgent({
             ...(personalityOptions ?? {}),
             model: modelForUpdateArgs,
@@ -2576,9 +2587,13 @@ async function main(): Promise<void> {
           setUserRequestedNewAgent(true);
           setLoadingState("assembling");
         },
-        onCreateNewWithModel: (modelHandle: string) => {
+        onCreateNewWithModel: (
+          modelHandle: string,
+          reasoningEffort?: ModelReasoningEffort,
+        ) => {
           setUserRequestedNewAgent(true);
           setSelectedServerModel(modelHandle);
+          setSelectedServerModelReasoningEffort(reasoningEffort ?? null);
           setLoadingState("assembling");
         },
         onExit: () => {


### PR DESCRIPTION
## Summary
- Adds generic reasoning effort options for discovered local model handles like `ollama/*`, so the reasoning selector appears for local models.
- Carries the selected reasoning effort through custom model updates into OpenAI-compatible settings.
- Cleans local model labels in the selector by hiding provider prefixes for local handles.

Validated with `bun test src/agent/model-tier-selection.test.ts src/cli/components/ModelSelector-categories.test.tsx` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)