### PR TITLE
fix(local): retry empty provider responses after tool results

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -94,6 +94,29 @@ class PiProviderError extends Error {
   }
 }
 
+class EmptyPiResponseError extends Error {
+  readonly isRetryable = true;
+
+  constructor() {
+    super("Received empty content in local provider response.");
+    this.name = "EmptyPiResponseError";
+  }
+}
+
+function hasAssistantOutputContent(message: AssistantMessage): boolean {
+  return message.content.some((block) => {
+    if (block.type === "toolCall") return true;
+    if (block.type === "text") return block.text.trim().length > 0;
+    return false;
+  });
+}
+
+function assertAssistantHasOutputContent(message: AssistantMessage): void {
+  if (!hasAssistantOutputContent(message)) {
+    throw new EmptyPiResponseError();
+  }
+}
+
 async function sleepWithAbort(
   delayMs: number,
   abortSignal: AbortSignal | undefined,
@@ -384,6 +407,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         }
         if (part.type === "done") {
+          assertAssistantHasOutputContent(part.message);
           finalMessage = part.message;
           yield providerLocalMessage(
             toLocalAssistantMessage(part.message, input),
@@ -394,6 +418,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       if (streamError) throw streamError;
       finalMessage ??= await result.result();
+      assertAssistantHasOutputContent(finalMessage);
       if (
         finalMessage.stopReason === "error" ||
         finalMessage.stopReason === "aborted"

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -416,6 +416,18 @@ describe("local backend pi transcript", () => {
         );
       }
 
+      if (contexts.length === 2) {
+        const emptyMessage = assistantMessage({
+          responseId: "response-empty-after-tool",
+          stopReason: "stop",
+          content: [],
+        });
+        return streamFromEvents(
+          [{ type: "done", reason: "stop", message: emptyMessage }],
+          emptyMessage,
+        );
+      }
+
       const finalMessage = assistantMessage({
         responseId: "response-final",
         stopReason: "stop",
@@ -475,7 +487,7 @@ describe("local backend pi transcript", () => {
       "approval_request_message",
     ]);
 
-    await drain(
+    const continuationChunks = await collect(
       await backend.createConversationMessageStream(conversation.id, {
         agent_id: agent.id,
         messages: [
@@ -494,13 +506,40 @@ describe("local backend pi transcript", () => {
       } as never),
     );
 
-    expect(contexts).toHaveLength(2);
+    expect(
+      continuationChunks.some((chunk) => {
+        const event = chunk as { message_type?: string; event_type?: string };
+        return (
+          event.message_type === "event_message" && event.event_type === "retry"
+        );
+      }),
+    ).toBe(true);
+
+    expect(contexts).toHaveLength(3);
     const secondContextMessages = contexts[1]?.messages ?? [];
     expect(secondContextMessages.at(-1)).toMatchObject({
       role: "toolResult",
       toolCallId: "call-readme",
       content: [{ type: "text", text: "README contents" }],
     });
+
+    const conversationDir = await firstConversationDir(storageDir);
+    const messages = (
+      await readFile(join(conversationDir, "messages.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    const finalAssistant = messages.at(-1) as { content?: unknown[] };
+    expect(finalAssistant.content).toEqual([
+      { type: "text", text: "Tool result received." },
+    ]);
   });
 
   test("refuses to load unversioned non-empty transcripts with exact migration command", async () => {

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -256,4 +256,49 @@ describe("PiStreamAdapter", () => {
     ).toContain("WebSocket closed 1006 Connection ended");
     expect(events.some((event) => event.type === "local-message")).toBe(true);
   });
+
+  test("retries empty local provider responses before persisting model output", async () => {
+    let calls = 0;
+    const stream: PiStreamFunction = () => {
+      calls += 1;
+      if (calls === 1) {
+        const empty = { ...assistantMessage(), content: [] };
+        return streamFromEvents(
+          [{ type: "done", reason: "stop", message: empty }],
+          empty,
+        );
+      }
+
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({ stream });
+    const events: ProviderStreamEvent[] = [];
+    for await (const event of adapter.stream(input())) {
+      events.push(event);
+    }
+
+    expect(calls).toBe(2);
+    expect(
+      events.some((event) => {
+        if (event.type !== "letta-chunk") return false;
+        const chunk = event.chunk as {
+          message_type?: string;
+          event_type?: string;
+        };
+        return (
+          chunk.message_type === "event_message" && chunk.event_type === "retry"
+        );
+      }),
+    ).toBe(true);
+    const localMessages = events.filter(
+      (event) => event.type === "local-message",
+    );
+    expect(localMessages).toHaveLength(1);
+    expect(JSON.stringify(localMessages[0])).toContain("ok");
+  });
 });


### PR DESCRIPTION
## Summary
- Treat empty local provider assistant responses as retryable before they are persisted.
- Prevent tool-result continuations from ending as invisible blank assistant turns when local/Ollama providers return no text or tool call.
- Add regression coverage for empty local provider retries and the post-tool-result continuation path.

Validated with `bun test src/backend/pi-stream-adapter.test.ts src/backend/local-backend.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)