### PR TITLE
fix(providers): send LM Studio server provider type

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -8,6 +8,8 @@ export const LOCAL_OPENROUTER_PROVIDER_NAME = "lc-openrouter";
 export const LOCAL_OLLAMA_PROVIDER_NAME = "lc-ollama";
 export const LOCAL_OLLAMA_CLOUD_PROVIDER_NAME = "lc-ollama-cloud";
 export const LOCAL_LMSTUDIO_PROVIDER_NAME = "lc-lmstudio";
+export const LMSTUDIO_OPENAI_PROVIDER_TYPE = "lmstudio_openai";
+export const LEGACY_LMSTUDIO_PROVIDER_TYPE = "lmstudio";
 export const LOCAL_LLAMA_CPP_PROVIDER_NAME = "lc-llama-cpp";
 export const LOCAL_ZAI_PROVIDER_NAME = "lc-zai";
 export const LOCAL_ZAI_CODING_PROVIDER_NAME = "lc-zai-coding";
@@ -216,7 +218,10 @@ export const PI_PROVIDER_SPECS = [
   },
   {
     id: "lmstudio",
-    providerTypes: ["lmstudio"],
+    providerTypes: [
+      LMSTUDIO_OPENAI_PROVIDER_TYPE,
+      LEGACY_LMSTUDIO_PROVIDER_TYPE,
+    ],
     handlePrefixes: ["lmstudio/"],
     localProviderNames: [LOCAL_LMSTUDIO_PROVIDER_NAME],
     defaultModel: "lmstudio/google/gemma-3n-e4b",

--- a/src/backend/local-provider-timeout.test.ts
+++ b/src/backend/local-provider-timeout.test.ts
@@ -47,7 +47,7 @@ describe("local provider timeout", () => {
     try {
       await createOrUpdateLocalProvider({
         storageDir,
-        providerType: "lmstudio",
+        providerType: "lmstudio_openai",
         providerName: "lc-lmstudio",
         apiKey: "not-needed",
         baseURL: "http://127.0.0.1:1234/v1",
@@ -55,6 +55,7 @@ describe("local provider timeout", () => {
       });
       const stored = await getLocalProviderByName("lc-lmstudio", storageDir);
       expect(stored).toMatchObject({
+        provider_type: "lmstudio_openai",
         base_url: "http://127.0.0.1:1234/v1",
         timeout: 600_000,
       });

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -154,6 +154,16 @@ describe("pi model factory", () => {
     }
   });
 
+  test("resolves server LM Studio provider type to local runtime provider", async () => {
+    const resolved = await resolvePiModelForAgent(undefined, {
+      provider_type: "lmstudio_openai",
+    });
+
+    expect(resolved.provider).toBe("lmstudio");
+    expect(resolved.model.provider).toBe("lmstudio");
+    expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+  });
+
   test("normalizes local OpenAI-compatible provider base URLs for runtime", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-llama-cpp-base-url-"));
     try {

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -66,6 +66,7 @@ describe("connect provider normalization", () => {
 
     expect(defaultConnectApiKey(ollama)).toBe("not-needed");
     expect(defaultConnectApiKey(lmstudio)).toBe("not-needed");
+    expect(lmstudio.byokProvider.providerType).toBe("lmstudio_openai");
     expect(defaultConnectApiKey(llamaCpp)).toBe("not-needed");
     expect(llamaCpp.canonical).toBe("llama-cpp");
   });

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -116,8 +116,12 @@ describe("connect subcommand", () => {
     );
 
     expect(exitCode).toBe(0);
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "lmstudio_openai",
+      "not-needed",
+    );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
-      "lmstudio",
+      "lmstudio_openai",
       "lc-lmstudio",
       "not-needed",
       undefined,

--- a/src/providers/byok-provider-aliases.test.ts
+++ b/src/providers/byok-provider-aliases.test.ts
@@ -24,6 +24,7 @@ describe("buildByokProviderAliases", () => {
     expect(aliases["lc-gemini"]).toBe("google_ai");
     expect(aliases["lc-minimax"]).toBe("minimax");
     expect(aliases["lc-openrouter"]).toBe("openrouter");
+    expect(aliases["lc-lmstudio"]).toBe("lmstudio");
     expect(aliases["lc-llama-cpp"]).toBe("llama.cpp");
     expect(aliases["lc-bedrock"]).toBe("bedrock");
     expect(aliases["chatgpt-plus-pro"]).toBe("chatgpt-plus-pro");
@@ -39,6 +40,16 @@ describe("buildByokProviderAliases", () => {
     // Built-ins still present
     expect(aliases["lc-openai"]).toBe("openai");
     expect(aliases["lc-anthropic"]).toBe("anthropic");
+  });
+
+  test("maps connected LM Studio provider types to the LM Studio handle", () => {
+    const aliases = buildByokProviderAliases([
+      { name: "lmstudio-server", provider_type: "lmstudio_openai" },
+      { name: "lmstudio-legacy", provider_type: "lmstudio" },
+    ]);
+
+    expect(aliases["lmstudio-server"]).toBe("lmstudio");
+    expect(aliases["lmstudio-legacy"]).toBe("lmstudio");
   });
 
   test("handles unknown provider types gracefully", () => {

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -15,7 +15,10 @@ import {
   updateProvider as updateProviderRequest,
 } from "@/backend/api/providers";
 import { getBackend } from "@/backend/backend";
-import { PROVIDER_TYPE_TO_BASE_PROVIDER } from "@/backend/dev/pi-provider-registry";
+import {
+  LMSTUDIO_OPENAI_PROVIDER_TYPE,
+  PROVIDER_TYPE_TO_BASE_PROVIDER,
+} from "@/backend/dev/pi-provider-registry";
 import {
   createOrUpdateLocalProvider,
   deleteLocalProvider,
@@ -143,7 +146,7 @@ export const BYOK_PROVIDERS = [
     id: "lmstudio",
     displayName: "LM Studio (local)",
     description: "Connect local LM Studio at http://127.0.0.1:1234/v1",
-    providerType: "lmstudio",
+    providerType: LMSTUDIO_OPENAI_PROVIDER_TYPE,
     providerName: "lc-lmstudio",
     requiresApiKey: false,
     defaultApiKey: "not-needed",

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -15,6 +15,13 @@ function providerById(id: string): ByokProvider {
 }
 
 describe("ProviderSelector local provider API keys", () => {
+  test("keeps LM Studio UI identity while using server provider type", () => {
+    const lmstudio = providerById("lmstudio");
+
+    expect(lmstudio.providerName).toBe("lc-lmstudio");
+    expect(lmstudio.providerType).toBe("lmstudio_openai");
+  });
+
   test("uses default key placeholders for API-key optional local providers", () => {
     expect(defaultProviderApiKey(providerById("ollama"))).toBe("not-needed");
     expect(defaultProviderApiKey(providerById("lmstudio"))).toBe("not-needed");


### PR DESCRIPTION
## Summary
- Send `lmstudio_openai` for the built-in LM Studio provider when the CLI creates or validates the provider.
- Keep the CLI-facing provider id, provider name, and model handle prefix as `lmstudio` / `lc-lmstudio` / `lmstudio/`.
- Continue accepting legacy `lmstudio` provider_type values for local records and model alias resolution.

## Test plan
- [x] `bun test src/cli/subcommands/connect.test.ts src/cli/connect-normalize.test.ts src/tests/cli/provider-selector-local-provider.test.ts src/providers/byok-provider-aliases.test.ts src/backend/pi-model-factory.test.ts src/backend/local-provider-timeout.test.ts`
- [x] `bun run typecheck`
- [ ] `bunx --bun @biomejs/biome@2.2.5 check src/backend/dev/pi-provider-registry.ts src/providers/byok-providers.ts src/cli/subcommands/connect.test.ts src/cli/connect-normalize.test.ts src/tests/cli/provider-selector-local-provider.test.ts src/providers/byok-provider-aliases.test.ts src/backend/local-provider-timeout.test.ts src/backend/pi-model-factory.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)