### PR TITLE
fix(startup): keep no-model label on local resume

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2610,7 +2610,6 @@ export function App({
             snapshot: {
               continueSession,
               agentState,
-              agentProvenance,
               startupHasAvailableLocalModels,
               terminalWidth: columns,
             },
@@ -2689,7 +2688,6 @@ export function App({
     continueSession,
     columns,
     agentState,
-    agentProvenance,
     resumedExistingConversation,
     releaseNotes,
     startupHasCloudCredentials,
@@ -4337,7 +4335,6 @@ export function App({
           snapshot: {
             continueSession,
             agentState,
-            agentProvenance,
             startupHasAvailableLocalModels,
             terminalWidth: columns,
           },

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -815,7 +815,6 @@ export function App({
   const startupModelDisplayOverride = getStartupModelDisplayOverride({
     isLocalBackend: isLocalBackendEnabled(),
     startupHasAvailableLocalModels,
-    agentProvenance,
   });
 
   // Use tier-aware resolution so the display matches the agent's reasoning effort

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -199,7 +199,6 @@ export type StaticItem =
       snapshot: {
         continueSession: boolean;
         agentState?: AgentState | null;
-        agentProvenance?: AgentProvenance | null;
         startupHasAvailableLocalModels?: boolean;
         terminalWidth: number;
       };

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -73,7 +73,7 @@ export function WelcomeScreen({
   loadingState,
   continueSession,
   agentState,
-  agentProvenance,
+  agentProvenance: _agentProvenance,
   startupHasAvailableLocalModels = true,
 }: {
   loadingState: LoadingState;
@@ -99,7 +99,6 @@ export function WelcomeScreen({
   const startupModelDisplayOverride = getStartupModelDisplayOverride({
     isLocalBackend: isLocalBackendEnabled(),
     startupHasAvailableLocalModels,
-    agentProvenance,
   });
   const model =
     startupModelDisplayOverride ??

--- a/src/cli/components/WelcomeScreen.tsx
+++ b/src/cli/components/WelcomeScreen.tsx
@@ -2,7 +2,6 @@ import { homedir } from "node:os";
 import type { Letta } from "@letta-ai/letta-client";
 import { Box } from "ink";
 import { useEffect, useState } from "react";
-import type { AgentProvenance } from "@/agent/create";
 import { getModelDisplayName } from "@/agent/model";
 import { isLocalBackendEnabled } from "@/backend";
 import { getStartupModelDisplayOverride } from "@/cli/helpers/startup-model-display";
@@ -73,13 +72,11 @@ export function WelcomeScreen({
   loadingState,
   continueSession,
   agentState,
-  agentProvenance: _agentProvenance,
   startupHasAvailableLocalModels = true,
 }: {
   loadingState: LoadingState;
   continueSession?: boolean;
   agentState?: Letta.AgentState | null;
-  agentProvenance?: AgentProvenance | null;
   startupHasAvailableLocalModels?: boolean;
 }) {
   // Keep hook call for potential future responsive behavior

--- a/src/cli/helpers/startup-model-display.test.ts
+++ b/src/cli/helpers/startup-model-display.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getStartupModelDisplayOverride } from "@/cli/helpers/startup-model-display";
+
+describe("getStartupModelDisplayOverride", () => {
+  test("shows no-model label for local startup when no local models are available", () => {
+    expect(
+      getStartupModelDisplayOverride({
+        isLocalBackend: true,
+        startupHasAvailableLocalModels: false,
+      }),
+    ).toBe("No model selected");
+  });
+
+  test("does not override when local models are available", () => {
+    expect(
+      getStartupModelDisplayOverride({
+        isLocalBackend: true,
+        startupHasAvailableLocalModels: true,
+      }),
+    ).toBeNull();
+  });
+
+  test("does not override for non-local backends", () => {
+    expect(
+      getStartupModelDisplayOverride({
+        isLocalBackend: false,
+        startupHasAvailableLocalModels: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/cli/helpers/startup-model-display.ts
+++ b/src/cli/helpers/startup-model-display.ts
@@ -1,20 +1,12 @@
-import type { AgentProvenance } from "@/agent/create";
-
 const STARTUP_NO_MODEL_LABEL = "No model selected";
 
 export function getStartupModelDisplayOverride(options: {
   isLocalBackend: boolean;
   startupHasAvailableLocalModels: boolean;
-  agentProvenance: AgentProvenance | null | undefined;
 }): string | null {
-  const { isLocalBackend, startupHasAvailableLocalModels, agentProvenance } =
-    options;
+  const { isLocalBackend, startupHasAvailableLocalModels } = options;
 
-  if (
-    isLocalBackend &&
-    !startupHasAvailableLocalModels &&
-    agentProvenance?.isNew
-  ) {
+  if (isLocalBackend && !startupHasAvailableLocalModels) {
     return STARTUP_NO_MODEL_LABEL;
   }
 

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -311,7 +311,6 @@ function ProfileSelectionUI({
         loadingState={loading ? "loading_profiles" : "ready"}
         continueSession={false}
         agentState={null}
-        agentProvenance={null}
       />
       <Box height={1} />
 


### PR DESCRIPTION
## Summary
- keep showing `No model selected` for local agents while the local backend still reports zero available models
- stop tying the startup model override to `agentProvenance.isNew`, so the label persists across immediate restarts of the same empty local agent
- add a focused helper test covering local/no-model, local/has-models, and non-local cases

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/cli/helpers/startup-model-display.test.ts` passes
- [ ] Verify a fresh local no-model agent still shows `No model selected`
- [ ] Verify restarting the same local no-model agent still shows `No model selected`
- [ ] Verify once local models become available later, the UI returns to the real model label

👾 Generated with [Letta Code](https://letta.com)