### PR TITLE
fix(startup): skip cloud recents when logged out

### DIFF
--- a/src/cli/helpers/recent-agent-options-credentials.test.ts
+++ b/src/cli/helpers/recent-agent-options-credentials.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { shouldIncludeConstellationRecentAgents } from "@/cli/helpers/recent-agent-options";
+
+describe("shouldIncludeConstellationRecentAgents", () => {
+  test("returns false when constellation fetch is disabled", () => {
+    expect(
+      shouldIncludeConstellationRecentAgents(false, {
+        refreshToken: "refresh-token",
+        env: {},
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when no cloud credentials exist", () => {
+    expect(
+      shouldIncludeConstellationRecentAgents(true, {
+        refreshToken: undefined,
+        env: {},
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when a refresh token exists", () => {
+    expect(
+      shouldIncludeConstellationRecentAgents(true, {
+        refreshToken: "refresh-token",
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true when an API key exists", () => {
+    expect(
+      shouldIncludeConstellationRecentAgents(true, {
+        refreshToken: undefined,
+        env: { LETTA_API_KEY: "sk-test" },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/cli/helpers/recent-agent-options.ts
+++ b/src/cli/helpers/recent-agent-options.ts
@@ -1,6 +1,8 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getClient } from "@/backend/api/client";
 import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
+import type { Settings } from "@/settings-manager";
+import { settingsManager } from "@/settings-manager";
 
 export interface RecentAgentOption {
   agent: AgentState;
@@ -27,6 +29,16 @@ function sortRecentAgents(
   });
 }
 
+export function shouldIncludeConstellationRecentAgents(
+  includeConstellation: boolean,
+  settings: Pick<Settings, "refreshToken" | "env">,
+): boolean {
+  return Boolean(
+    includeConstellation &&
+      (settings.refreshToken || settings.env?.LETTA_API_KEY),
+  );
+}
+
 export async function getRecentAgentOptions(options?: {
   includeLocal?: boolean;
   includeConstellation?: boolean;
@@ -36,12 +48,19 @@ export async function getRecentAgentOptions(options?: {
   const includeLocal = options?.includeLocal !== false;
   const includeConstellation = options?.includeConstellation !== false;
   const limit = options?.limit ?? 5;
+  const settings = includeConstellation
+    ? await settingsManager.getSettingsWithSecureTokens()
+    : null;
+  const shouldIncludeConstellation =
+    settings !== null
+      ? shouldIncludeConstellationRecentAgents(includeConstellation, settings)
+      : false;
 
   const localAgents = includeLocal
     ? listLocalAgentsFromDisk().map((agent) => ({ agent, isLocal: true }))
     : [];
 
-  const constellationAgents = includeConstellation
+  const constellationAgents = shouldIncludeConstellation
     ? await (async () => {
         try {
           const client = await getClient();


### PR DESCRIPTION
## Summary
- skip the constellation recent-agent path entirely when there are no saved cloud credentials
- prevent `getClient()` from being touched in the logged-out local-first startup case, which removes the noisy missing-credential console output
- keep the cloud recent-agent fallback intact for signed-in users by gating it behind a small shared credential check helper
- add a focused helper test covering disabled, logged-out, refresh-token, and API-key cases

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/cli/helpers/recent-agent-options-credentials.test.ts` passes
- [ ] Verify fresh logged-out local-first startup no longer prints `Missing LETTA_API_KEY` / `getClient() called without credentials`
- [ ] Verify signed-in users still get constellation recent-agent fallback behavior when pins are empty

👾 Generated with [Letta Code](https://letta.com)