### PR TITLE
feat(experiments): add diffs worktree viewer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "@letta-ai/letta-code",
       "dependencies": {
         "@letta-ai/letta-client": "^1.10.2",
+        "@pierre/diffs": "1.2.2",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "node-pty": "^1.1.0",
@@ -179,6 +180,10 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
+    "@pierre/diffs": ["@pierre/diffs@1.2.2", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ=="],
+
+    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -211,6 +216,8 @@
 
     "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
 
+    "@shikijs/transformers": ["@shikijs/transformers@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/types": "3.23.0" } }, "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ=="],
+
     "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
@@ -227,7 +234,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.15.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw=="],
 
-    "@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
+    "@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA=="],
 
@@ -239,7 +246,7 @@
 
     "@smithy/signature-v4": ["@smithy/signature-v4@5.4.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw=="],
 
-    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -689,6 +696,8 @@
 
     "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
     "madge": ["madge@8.0.0", "", { "dependencies": { "chalk": "^4.1.2", "commander": "^7.2.0", "commondir": "^1.0.1", "debug": "^4.3.4", "dependency-tree": "^11.0.0", "ora": "^5.4.1", "pluralize": "^8.0.0", "pretty-ms": "^7.0.1", "rc": "^1.2.8", "stream-to-array": "^2.3.0", "ts-graphviz": "^2.1.2", "walkdir": "^0.4.1" }, "peerDependencies": { "typescript": "^5.4.4" }, "optionalPeers": ["typescript"], "bin": { "madge": "bin/cli.js" } }, "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -828,6 +837,8 @@
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
 
@@ -1019,107 +1030,63 @@
 
     "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/core/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/core/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-env/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-http/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/credential-provider-http/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
     "@aws-sdk/credential-provider-http/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
-
-    "@aws-sdk/credential-provider-http/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-ini/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/credential-provider-login/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-login/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/credential-provider-process/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-process/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1052.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-sso/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/credential-provider-web-identity/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/credential-provider-web-identity/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/eventstream-handler-node/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/eventstream-handler-node/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/middleware-eventstream/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/middleware-eventstream/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/middleware-websocket/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
     "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
-
-    "@aws-sdk/middleware-websocket/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/nested-clients/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
     "@aws-sdk/nested-clients/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
-
-    "@aws-sdk/nested-clients/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/signature-v4-multi-region/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
-
-    "@aws-sdk/signature-v4-multi-region/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
-
     "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
-    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+    "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
-    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "@aws-sdk/xml-builder/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+    "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
-    "@smithy/node-http-handler/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+    "@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
-    "@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+    "@shikijs/transformers/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
+
+    "@smithy/credential-provider-imds/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/fetch-http-handler/@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
+
+    "@smithy/fetch-http-handler/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/signature-v4/@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
+
+    "@smithy/signature-v4/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1182,6 +1149,18 @@
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@pierre/diffs/shiki/@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@pierre/diffs/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@pierre/diffs/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@letta-ai/letta-client": "^1.10.2",
+    "@pierre/diffs": "1.2.2",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",
     "node-pty": "^1.1.0",

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -492,6 +492,10 @@ export function App({
     agentId: string;
     cmdId: string;
   } | null>(null);
+  const [worktreeDiffSelectorPending, setWorktreeDiffSelectorPending] =
+    useState<{
+      worktrees: import("@/web/worktree-diff-list").WorktreeDiffOption[];
+    } | null>(null);
 
   // If we have approval requests, we should show the approval dialog instead of the input area
   const [pendingApprovals, setPendingApprovals] = useState<ApprovalRequest[]>(
@@ -3827,6 +3831,7 @@ export function App({
     setNeedsEagerApprovalCheck,
     setPinDialogLocal,
     setProfileConfirmPending,
+    setWorktreeDiffSelectorPending,
     setReasoningTabCycleEnabled: _setReasoningTabCycleEnabled,
     setSearchQuery,
     setStaticItems,
@@ -4611,6 +4616,8 @@ export function App({
       resumeKey={resumeKey}
       searchQuery={searchQuery}
       sessionStatsRef={sessionStatsRef}
+      worktreeDiffSelectorPending={worktreeDiffSelectorPending}
+      setWorktreeDiffSelectorPending={setWorktreeDiffSelectorPending}
       setActiveOverlay={setActiveOverlay}
       setBtwState={setBtwState}
       setCommandRunning={setCommandRunning}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -52,6 +52,7 @@ import { ToolsetSelector } from "@/cli/components/ToolsetSelector";
 import { UserMessage } from "@/cli/components/UserMessageRich";
 import { WelcomeScreen } from "@/cli/components/WelcomeScreen";
 import { WindowTitlePicker } from "@/cli/components/WindowTitlePicker";
+import { WorktreeDiffSelector } from "@/cli/components/WorktreeDiffSelector";
 import { AnimationProvider } from "@/cli/contexts/AnimationContext";
 import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
@@ -273,6 +274,14 @@ type AppViewProps = {
   resumeKey: number;
   searchQuery: string;
   sessionStatsRef: RefObject<SessionStats>;
+  worktreeDiffSelectorPending: {
+    worktrees: import("@/web/worktree-diff-list").WorktreeDiffOption[];
+  } | null;
+  setWorktreeDiffSelectorPending: Dispatch<
+    SetStateAction<{
+      worktrees: import("@/web/worktree-diff-list").WorktreeDiffOption[];
+    } | null>
+  >;
   setActiveOverlay: Dispatch<SetStateAction<ActiveOverlay>>;
   setBtwState: Dispatch<SetStateAction<BtwState>>;
   setCommandRunning: (value: boolean) => void;
@@ -421,6 +430,8 @@ export function AppView(props: AppViewProps) {
     resumeKey,
     searchQuery,
     sessionStatsRef,
+    worktreeDiffSelectorPending,
+    setWorktreeDiffSelectorPending,
     setActiveOverlay,
     setBtwState,
     setCommandRunning,
@@ -949,6 +960,51 @@ export function AppView(props: AppViewProps) {
                 onCancel={closeOverlay}
               />
             )}
+
+            {activeOverlay === "worktree-diff" &&
+              worktreeDiffSelectorPending && (
+                <WorktreeDiffSelector
+                  worktrees={worktreeDiffSelectorPending.worktrees}
+                  onSelect={(path) => {
+                    setWorktreeDiffSelectorPending(null);
+                    const overlayCommand = completeOverlay("worktree-diff");
+                    const cmd =
+                      overlayCommand ??
+                      commandRunner.start(
+                        "/experiments",
+                        "Opening worktree diff...",
+                      );
+                    void import("@/web/generate-diff-viewer")
+                      .then(({ generateAndOpenDiffViewer }) =>
+                        generateAndOpenDiffViewer(path),
+                      )
+                      .then((result) => {
+                        const fileSummary = `${result.fileCount} file${result.fileCount === 1 ? "" : "s"}`;
+                        if (result.opened) {
+                          cmd.finish(
+                            `Opened worktree diff (${fileSummary})`,
+                            true,
+                          );
+                        } else {
+                          cmd.finish(
+                            `Open manually: ${result.filePath} (${fileSummary})`,
+                            true,
+                          );
+                        }
+                      })
+                      .catch((err: unknown) => {
+                        cmd.finish(
+                          `Failed to open diff: ${err instanceof Error ? err.message : String(err)}`,
+                          false,
+                        );
+                      });
+                  }}
+                  onCancel={() => {
+                    setWorktreeDiffSelectorPending(null);
+                    closeOverlay();
+                  }}
+                />
+              )}
 
             {/* Toolset Selector - conditionally mounted as overlay */}
             {activeOverlay === "toolset" && (

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -54,6 +54,7 @@ export type AppProps = {
 export type ActiveOverlay =
   | "model"
   | "experiment"
+  | "worktree-diff"
   | "sleeptime"
   | "compaction"
   | "toolset"

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -103,6 +103,7 @@ import {
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from "@/constants";
+import { experimentManager } from "@/experiments/manager";
 import { goalLoopMode } from "@/goal-loop-mode";
 import {
   runPreCompactHooks,
@@ -160,6 +161,10 @@ type ProfileConfirmPending = {
   name: string;
   agentId: string;
   cmdId: string;
+};
+
+type WorktreeDiffSelectorPending = {
+  worktrees: import("@/web/worktree-diff-list").WorktreeDiffOption[];
 };
 
 type ModelSelectorOptions = {
@@ -280,6 +285,9 @@ type SubmitHandlerContext = {
   setProfileConfirmPending: Dispatch<
     SetStateAction<ProfileConfirmPending | null>
   >;
+  setWorktreeDiffSelectorPending: Dispatch<
+    SetStateAction<WorktreeDiffSelectorPending | null>
+  >;
   setReasoningTabCycleEnabled: Dispatch<SetStateAction<boolean>>;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   setStaticItems: Dispatch<SetStateAction<StaticItem[]>>;
@@ -395,6 +403,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     setNeedsEagerApprovalCheck,
     setPinDialogLocal,
     setProfileConfirmPending,
+    setWorktreeDiffSelectorPending,
     setReasoningTabCycleEnabled,
     setSearchQuery,
     setStaticItems,
@@ -687,6 +696,81 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             "Opening experiments selector...",
             "Experiments dialog dismissed",
           );
+          return { submitted: true };
+        }
+
+        const [slashCommand, experimentsSubcommand, ...experimentsArgs] =
+          trimmed.split(/\s+/);
+        if (
+          slashCommand === "/experiments" &&
+          experimentsSubcommand === "diffs"
+        ) {
+          const args = experimentsArgs;
+          if (args.length > 1) {
+            const cmd = commandRunner.start(
+              "/experiments",
+              "Usage: /experiments diffs [path]",
+            );
+            cmd.fail("Usage: /experiments diffs [path]");
+            return { submitted: true };
+          }
+          if (!experimentManager.isEnabled("diffs")) {
+            const cmd = commandRunner.start(
+              "/experiments",
+              "Diffs experiment is disabled.",
+            );
+            cmd.fail("Enable the diffs experiment with /experiments first.");
+            return { submitted: true };
+          }
+
+          if (!args[0]) {
+            const cmd = openOverlay(
+              "worktree-diff",
+              "/experiments diffs",
+              "Loading worktrees...",
+              "Worktree diff selector dismissed",
+            );
+            const { listWorktreeDiffOptions } = await import(
+              "@/web/worktree-diff-list"
+            );
+            listWorktreeDiffOptions()
+              .then((worktrees) => {
+                setWorktreeDiffSelectorPending({ worktrees });
+                cmd.update({ output: "Select a worktree to diff" });
+              })
+              .catch((err: unknown) => {
+                cmd.fail(
+                  `Failed to list worktrees: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              });
+            return { submitted: true };
+          }
+
+          const cmd = commandRunner.start(
+            "/experiments",
+            "Opening worktree diff...",
+          );
+          const { generateAndOpenDiffViewer } = await import(
+            "@/web/generate-diff-viewer"
+          );
+          generateAndOpenDiffViewer(args[0])
+            .then((result) => {
+              const fileSummary = `${result.fileCount} file${result.fileCount === 1 ? "" : "s"}`;
+              if (result.opened) {
+                cmd.finish(`Opened worktree diff (${fileSummary})`, true);
+              } else {
+                cmd.finish(
+                  `Open manually: ${result.filePath} (${fileSummary})`,
+                  true,
+                );
+              }
+            })
+            .catch((err: unknown) => {
+              cmd.finish(
+                `Failed to open diff: ${err instanceof Error ? err.message : String(err)}`,
+                false,
+              );
+            });
           return { submitted: true };
         }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -283,7 +283,6 @@ export const commands: Record<string, Command> = {
   "/experiments": {
     desc: "Toggle experiments",
     order: 27.1,
-    noArgs: true,
     handler: () => {
       // Handled specially in App.tsx to open experiments selector
       return "Opening experiments selector...";

--- a/src/cli/components/WorktreeDiffSelector.tsx
+++ b/src/cli/components/WorktreeDiffSelector.tsx
@@ -1,0 +1,76 @@
+import { Box } from "ink";
+import type { WorktreeDiffOption } from "@/web/worktree-diff-list";
+import { colors } from "./colors";
+import { OverlayShell } from "./OverlayShell";
+import { type SelectableItem, SingleSelectPicker } from "./SingleSelectPicker";
+import { Text } from "./Text";
+
+type WorktreeDiffSelectorProps = {
+  worktrees: WorktreeDiffOption[];
+  onSelect: (path: string) => void;
+  onCancel: () => void;
+};
+
+export function WorktreeDiffSelector({
+  worktrees,
+  onSelect,
+  onCancel,
+}: WorktreeDiffSelectorProps) {
+  const items: SelectableItem[] = worktrees.map((worktree) => ({
+    key: worktree.path,
+    label: worktree.name,
+    description: `${worktree.branch} · ${worktree.fileCount} files · +${worktree.insertions}/-${worktree.deletions}`,
+    isCurrent: worktree.isCurrent,
+    dimLabel: !worktree.hasChanges,
+  }));
+
+  return (
+    <OverlayShell command="/experiments diffs" title="Open Worktree Diff">
+      {items.length === 0 ? (
+        <Text dimColor>No worktrees found.</Text>
+      ) : (
+        <SingleSelectPicker
+          items={items}
+          onSelect={onSelect}
+          onCancel={onCancel}
+          renderItem={(item, _index, isSelected) => {
+            const worktree = worktrees.find((entry) => entry.path === item.key);
+            if (!worktree) return null;
+            return (
+              <Box flexDirection="column" marginBottom={1}>
+                <Box>
+                  <Text
+                    color={
+                      isSelected ? colors.selector.itemHighlighted : undefined
+                    }
+                  >
+                    {isSelected ? "> " : "  "}
+                  </Text>
+                  <Text
+                    bold={isSelected}
+                    dimColor={!worktree.hasChanges}
+                    color={
+                      isSelected ? colors.selector.itemHighlighted : undefined
+                    }
+                  >
+                    {worktree.name}
+                    {worktree.isCurrent ? " (current)" : ""}
+                  </Text>
+                  <Text dimColor>{` · ${worktree.branch}`}</Text>
+                  <Text color={worktree.hasChanges ? "green" : undefined}>
+                    {` · ${worktree.fileCount} files`}
+                  </Text>
+                  <Text color="green">{` +${worktree.insertions}`}</Text>
+                  <Text color="red">{` -${worktree.deletions}`}</Text>
+                </Box>
+                <Box marginLeft={2}>
+                  <Text dimColor>{worktree.path}</Text>
+                </Box>
+              </Box>
+            );
+          }}
+        />
+      )}
+    </OverlayShell>
+  );
+}

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -21,6 +21,12 @@ const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
       "Inject lightweight prior-conversation context into the first turn of brand-new Letta Code conversations.",
   },
   {
+    id: "diffs",
+    label: "diffs",
+    description:
+      "Open browser-based worktree diff previews powered by Diffs from Pierre.",
+  },
+  {
     id: "node",
     label: "node",
     description: "Route API requests through the Letta Node / TS core path.",

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -1,6 +1,7 @@
 export type ExperimentId =
   | "conversation_titles"
   | "desktop_conversation_bootstrap"
+  | "diffs"
   | "node"
   | "tui_cron";
 

--- a/src/web/diff-viewer-template.txt
+++ b/src/web/diff-viewer-template.txt
@@ -1,0 +1,630 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Worktree Diff | Letta Code</title>
+<style>
+:root {
+  color-scheme: light dark;
+  --bg: #f5f3ee;
+  --bg-gradient-1: rgba(121, 85, 255, 0.14);
+  --bg-gradient-2: rgba(255, 152, 102, 0.12);
+  --fg: #1d1b20;
+  --muted: #6d6975;
+  --subtle: #8b8792;
+  --border: rgba(31, 28, 39, 0.12);
+  --border-strong: rgba(31, 28, 39, 0.2);
+  --panel: rgba(255, 255, 255, 0.78);
+  --panel-solid: #fffdf8;
+  --panel-elevated: rgba(255, 255, 255, 0.92);
+  --accent: #7657ff;
+  --accent-2: #ff8159;
+  --good: #22863a;
+  --bad: #c7352f;
+  --shadow: 0 24px 80px rgba(48, 33, 89, 0.13), 0 2px 10px rgba(34, 30, 42, 0.06);
+  --radius: 18px;
+  --hero-offset: 168px;
+  --mono: "SFMono-Regular", "Berkeley Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
+  --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #09090d;
+    --bg-gradient-1: rgba(118, 87, 255, 0.22);
+    --bg-gradient-2: rgba(255, 129, 89, 0.13);
+    --fg: #f4f0ff;
+    --muted: #aaa3b8;
+    --subtle: #7d768a;
+    --border: rgba(239, 234, 255, 0.12);
+    --border-strong: rgba(239, 234, 255, 0.2);
+    --panel: rgba(21, 19, 29, 0.78);
+    --panel-solid: #121019;
+    --panel-elevated: rgba(28, 25, 39, 0.92);
+    --accent: #a896ff;
+    --accent-2: #ff9d79;
+    --good: #63c174;
+    --bad: #ff756d;
+    --shadow: 0 24px 90px rgba(0, 0, 0, 0.45), 0 2px 14px rgba(0, 0, 0, 0.35);
+  }
+}
+* { box-sizing: border-box; }
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--hero-offset) + 24px);
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 14% -8%, var(--bg-gradient-1), transparent 34rem),
+    radial-gradient(circle at 85% 4%, var(--bg-gradient-2), transparent 30rem),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg) 92%, #fff 8%), var(--bg));
+  color: var(--fg);
+  font-family: var(--sans);
+  font-size: 14px;
+}
+a { color: inherit; }
+.top-curtain {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--hero-offset);
+  z-index: 50;
+  background: var(--bg);
+  pointer-events: none;
+}
+.shell {
+  width: min(1600px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 24px 0 56px;
+}
+.hero {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  margin-bottom: 18px;
+  padding: 18px 20px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--panel-solid);
+  box-shadow: var(--shadow);
+}
+.kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.kicker::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 18px var(--accent);
+}
+h1 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 40px);
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+}
+.subtitle {
+  margin: 10px 0 0;
+  max-width: 980px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 10px;
+  min-width: min(500px, 44vw);
+}
+.meta-card,
+.stat-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel-elevated) 86%, transparent);
+  padding: 10px 12px;
+}
+.meta-label,
+.stat-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--subtle);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.meta-value {
+  display: block;
+  overflow: hidden;
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.stat-card {
+  padding: 14px 16px;
+  background: var(--panel);
+  backdrop-filter: blur(18px);
+}
+.stat-value {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+.stat-value.add { color: var(--good); }
+.stat-value.del { color: var(--bad); }
+.layout {
+  display: grid;
+  grid-template-columns: 310px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+.sidebar {
+  position: sticky;
+  top: calc(var(--hero-offset) + 16px);
+  max-height: calc(100vh - var(--hero-offset) - 34px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px) saturate(130%);
+}
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar-title {
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.search {
+  width: calc(100% - 28px);
+  margin: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  outline: none;
+  background: var(--panel-elevated);
+  color: var(--fg);
+  font: 13px var(--sans);
+}
+.search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent); }
+.file-list {
+  max-height: calc(100vh - var(--hero-offset) - 154px);
+  margin: 0;
+  padding: 0 10px 12px;
+  overflow: auto;
+  list-style: none;
+}
+.file-link {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 8px;
+  padding: 10px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  text-decoration: none;
+}
+.file-link:hover,
+.file-link.active {
+  border-color: var(--border-strong);
+  background: var(--panel-elevated);
+}
+.file-name {
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.file-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--subtle);
+  font-size: 12px;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.delta { font-family: var(--mono); }
+.delta.add { color: var(--good); }
+.delta.del { color: var(--bad); }
+.diff-stack { min-width: 0; }
+.diff-file {
+  position: relative;
+  margin: 0 0 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-solid);
+  box-shadow: var(--shadow);
+}
+.diff-anchor {
+  display: block;
+  width: 0;
+  height: 0;
+  visibility: hidden;
+}
+.file-header {
+  position: sticky;
+  top: var(--hero-offset);
+  z-index: 55;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+  border-bottom: 1px solid var(--border);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--accent) 10%, transparent), transparent 42%),
+    var(--panel-solid);
+}
+.file-title {
+  min-width: 0;
+}
+.file-title-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.file-title-main code {
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rename {
+  margin-top: 5px;
+  color: var(--subtle);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.file-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
+}
+.copy-path,
+.collapse {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel-solid);
+  color: var(--fg);
+  cursor: pointer;
+  font: 700 12px var(--sans);
+  padding: 7px 10px;
+}
+.copy-path:hover,
+.collapse:hover { border-color: var(--accent); color: var(--accent); }
+.diff-content {
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: var(--panel-solid);
+  scrollbar-gutter: stable;
+}
+.diff-content::-webkit-scrollbar {
+  height: 12px;
+}
+.diff-content::-webkit-scrollbar-track {
+  background: var(--panel-solid);
+}
+.diff-content::-webkit-scrollbar-thumb {
+  border: 3px solid var(--panel-solid);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+.diff-file.collapsed .diff-content { display: none; }
+.diff-content pre,
+.diff-content code,
+.diff-content [class*="diff"] {
+  font-family: var(--mono);
+}
+
+.notice {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  border-radius: var(--radius);
+  padding: 22px;
+  color: var(--muted);
+  box-shadow: var(--shadow);
+}
+.empty-state {
+  padding: 54px;
+  text-align: center;
+}
+.footer {
+  margin-top: 18px;
+  color: var(--subtle);
+  font-size: 12px;
+  text-align: center;
+}
+@media (max-width: 1100px) {
+  :root { --hero-offset: 0px; }
+  .hero { position: relative; top: 0; grid-template-columns: 1fr; }
+  .meta-grid { min-width: 0; }
+  .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .layout { grid-template-columns: 1fr; }
+  .sidebar { position: relative; top: 0; max-height: none; }
+  .file-list { max-height: 320px; }
+  html { scroll-padding-top: 24px; }
+}
+@media (max-width: 640px) {
+  .shell { width: min(100vw - 20px, 1600px); padding-top: 10px; }
+  .hero, .file-header { grid-template-columns: 1fr; }
+  .meta-grid, .stats { grid-template-columns: 1fr; }
+  .file-header { align-items: flex-start; }
+  .file-actions { width: 100%; flex-wrap: wrap; }
+}
+</style>
+</head>
+<body>
+<div class="top-curtain" aria-hidden="true"></div>
+<div class="shell">
+  <header class="hero">
+    <div>
+      <div class="kicker">Letta Code Experiments</div>
+      <h1>Worktree Diff</h1>
+      <p class="subtitle">A browser diff preview for the current worktree, rendered with Pierre Diffs themes, split layout, word-level highlights, and compact hunk separators.</p>
+    </div>
+    <div class="meta-grid" aria-label="Diff metadata">
+      <div class="meta-card"><span class="meta-label">Repository</span><span class="meta-value" id="repo"></span></div>
+      <div class="meta-card"><span class="meta-label">Worktree</span><span class="meta-value" id="worktree"></span></div>
+      <div class="meta-card"><span class="meta-label">Base</span><span class="meta-value" id="base"></span></div>
+      <div class="meta-card"><span class="meta-label">Generated</span><span class="meta-value" id="generated"></span></div>
+    </div>
+  </header>
+  <section class="stats" id="stats"></section>
+  <main id="app"></main>
+  <div class="footer">Rendered with <strong>@pierre/diffs</strong> via Letta Code.</div>
+</div>
+<script type="application/json" id="payload"><!--LETTA_DIFF_DATA_PLACEHOLDER--></script>
+<script>
+const data = JSON.parse(document.getElementById("payload").textContent);
+const app = document.getElementById("app");
+const stats = document.getElementById("stats");
+const text = (value) => value == null || value === "" ? "—" : String(value);
+const setText = (id, value) => { document.getElementById(id).textContent = text(value); };
+setText("repo", data.repoRoot);
+setText("worktree", data.worktreePath);
+setText("base", data.baseRef || data.baseCommit);
+setText("generated", new Date(data.generatedAt).toLocaleString());
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function fileTypeLabel(type) {
+  return ({
+    "new": "added",
+    "deleted": "deleted",
+    "change": "changed",
+    "rename-pure": "renamed",
+    "rename-changed": "renamed",
+  })[type] || type;
+}
+
+function renderStats() {
+  stats.innerHTML = `
+    <div class="stat-card"><span class="stat-label">Files</span><div class="stat-value">${data.files.length}</div></div>
+    <div class="stat-card"><span class="stat-label">Insertions</span><div class="stat-value add">+${data.insertions}</div></div>
+    <div class="stat-card"><span class="stat-label">Deletions</span><div class="stat-value del">-${data.deletions}</div></div>
+    <div class="stat-card"><span class="stat-label">Changed lines</span><div class="stat-value">${data.insertions + data.deletions}</div></div>
+  `;
+}
+
+function renderFileNav() {
+  return `
+    <aside class="sidebar">
+      <div class="sidebar-header"><div class="sidebar-title">Changed files</div><span class="badge">${data.files.length}</span></div>
+      <input class="search" id="fileSearch" placeholder="Filter files…" autocomplete="off" />
+      <ul class="file-list" id="fileList">
+        ${data.files.map((file, index) => `
+          <li data-file-row data-name="${escapeHtml(file.name.toLowerCase())}">
+            <a class="file-link" href="#file-${index}" data-file-link="${index}" data-file-target="${index}">
+              <span class="file-name">${escapeHtml(file.name)}</span>
+              <span class="file-meta">
+                <span class="badge">${escapeHtml(fileTypeLabel(file.type))}</span>
+                <span class="delta add">+${file.additions}</span>
+                <span class="delta del">-${file.deletions}</span>
+              </span>
+            </a>
+          </li>
+        `).join("")}
+      </ul>
+    </aside>
+  `;
+}
+
+function renderFile(file, index) {
+  const rename = file.prevName && file.prevName !== file.name
+    ? `<div class="rename">${escapeHtml(file.prevName)} → ${escapeHtml(file.name)}</div>`
+    : "";
+  return `
+    <section class="diff-file" data-file-section="${index}">
+      <span class="diff-anchor" id="file-${index}"></span>
+      <div class="file-header">
+        <div class="file-title">
+          <div class="file-title-main">
+            <span class="badge">${escapeHtml(fileTypeLabel(file.type))}</span>
+            <code title="${escapeHtml(file.name)}">${escapeHtml(file.name)}</code>
+          </div>
+          ${rename}
+        </div>
+        <div class="file-actions">
+          <span class="delta add">+${file.additions}</span>
+          <span class="delta del">-${file.deletions}</span>
+          <button class="copy-path" data-copy-path="${escapeHtml(file.name)}">Copy path</button>
+          <button class="collapse" data-collapse="${index}">Collapse</button>
+        </div>
+      </div>
+      <div class="diff-content">${file.html}</div>
+    </section>
+  `;
+}
+
+
+function bindInteractions() {
+  document.getElementById("fileSearch")?.addEventListener("input", (event) => {
+    const query = event.target.value.trim().toLowerCase();
+    for (const row of document.querySelectorAll("[data-file-row]")) {
+      row.style.display = row.dataset.name.includes(query) ? "" : "none";
+    }
+  });
+
+  for (const button of document.querySelectorAll("[data-copy-path]")) {
+    button.addEventListener("click", async () => {
+      const path = button.dataset.copyPath;
+      try {
+        await navigator.clipboard.writeText(path);
+        const original = button.textContent;
+        button.textContent = "Copied";
+        setTimeout(() => { button.textContent = original; }, 1200);
+      } catch {
+        button.textContent = "Copy failed";
+      }
+    });
+  }
+
+  for (const button of document.querySelectorAll("[data-collapse]")) {
+    button.addEventListener("click", () => {
+      const section = document.querySelector(`[data-file-section="${button.dataset.collapse}"]`);
+      section.classList.toggle("collapsed");
+      button.textContent = section.classList.contains("collapsed") ? "Expand" : "Collapse";
+    });
+  }
+
+  const links = [...document.querySelectorAll("[data-file-link]")];
+  const sections = [...document.querySelectorAll("[data-file-section]")];
+
+  function setActive(index) {
+    for (const link of links) {
+      link.classList.toggle("active", link.dataset.fileLink === String(index));
+    }
+  }
+
+  function offsetTop() {
+    const value = getComputedStyle(document.documentElement).getPropertyValue("--hero-offset");
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  // Suppress scroll-spy updates briefly while we programmatically scroll,
+  // otherwise intermediate sections flip the active state mid-animation.
+  let lockUntil = 0;
+
+  function scrollToSection(index) {
+    const section = document.querySelector(`[data-file-section="${index}"]`);
+    if (!section) return;
+    const top =
+      section.getBoundingClientRect().top + window.scrollY - offsetTop() - 12;
+    lockUntil = Date.now() + 700;
+    setActive(index);
+    window.scrollTo({ top, behavior: "smooth" });
+  }
+
+  for (const link of links) {
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      scrollToSection(link.dataset.fileTarget);
+    });
+  }
+
+  function updateActiveFromScroll() {
+    if (Date.now() < lockUntil) return;
+    const threshold = offsetTop() + 24;
+    let activeIndex = sections.length ? sections[0].dataset.fileSection : null;
+    for (const section of sections) {
+      if (section.getBoundingClientRect().top - threshold <= 0) {
+        activeIndex = section.dataset.fileSection;
+      } else {
+        break;
+      }
+    }
+    if (activeIndex != null) setActive(activeIndex);
+  }
+
+  let scrollRaf = 0;
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (scrollRaf) return;
+      scrollRaf = window.requestAnimationFrame(() => {
+        scrollRaf = 0;
+        updateActiveFromScroll();
+      });
+    },
+    { passive: true },
+  );
+  updateActiveFromScroll();
+}
+
+function syncHeroOffset() {
+  const hero = document.querySelector(".hero");
+  if (!hero) return;
+  const offset = Math.ceil(hero.getBoundingClientRect().height) + 12;
+  document.documentElement.style.setProperty("--hero-offset", offset + "px");
+}
+
+renderStats();
+if (!data.files.length) {
+  app.innerHTML = `<div class="notice empty-state"><h2>No diff found</h2><p>This worktree has no committed, unstaged, staged, or untracked changes compared with its base.</p></div>`;
+} else {
+  app.innerHTML = `<div class="layout">${renderFileNav()}<div class="diff-stack">${data.files.map(renderFile).join("")}</div></div>`;
+  bindInteractions();
+}
+
+syncHeroOffset();
+window.addEventListener("resize", syncHeroOffset);
+window.addEventListener("load", syncHeroOffset);
+</script>
+</body>
+</html>

--- a/src/web/generate-diff-viewer.ts
+++ b/src/web/generate-diff-viewer.ts
@@ -1,0 +1,408 @@
+/**
+ * Browser diff viewer for git worktrees.
+ *
+ * Collects a git diff for the current worktree, renders each file with
+ * @pierre/diffs, writes a self-contained HTML file to ~/.letta/viewers/, and
+ * opens it in the user's browser.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { type FileDiffMetadata, parsePatchFiles } from "@pierre/diffs";
+import { preloadFileDiff } from "@pierre/diffs/ssr";
+import diffViewerTemplate from "./diff-viewer-template.txt";
+
+const execFile = promisify(execFileCb);
+
+const VIEWERS_DIR = join(homedir(), ".letta", "viewers");
+const GIT_TIMEOUT_MS = 60_000;
+const GIT_MAX_BUFFER = 50 * 1024 * 1024;
+const MAX_RENDERED_FILES = 100;
+const DIFF_UNSAFE_CSS = `
+:host {
+  --diffs-addition-color-override: #15803d;
+  --diffs-deletion-color-override: #b91c1c;
+  --diffs-bg-addition-override: light-dark(#d1fadf, rgba(22, 163, 74, 0.26));
+  --diffs-bg-deletion-override: light-dark(#ffe0e0, rgba(220, 38, 38, 0.3));
+  --diffs-bg-addition-emphasis-override: light-dark(#86efac, rgba(34, 197, 94, 0.48));
+  --diffs-bg-deletion-emphasis-override: light-dark(#fca5a5, rgba(248, 113, 113, 0.52));
+  --diffs-bg-addition-number-override: light-dark(#bbf7d0, rgba(22, 163, 74, 0.38));
+  --diffs-bg-deletion-number-override: light-dark(#fecaca, rgba(220, 38, 38, 0.42));
+  --diffs-fg-number-addition-override: light-dark(#166534, #86efac);
+  --diffs-fg-number-deletion-override: light-dark(#991b1b, #fca5a5);
+}
+
+[data-line-type="change-addition"] {
+  --diffs-line-bg: light-dark(#d1fadf, rgba(22, 163, 74, 0.26)) !important;
+  background: light-dark(#d1fadf, rgba(22, 163, 74, 0.26)) !important;
+}
+
+[data-line-type="change-deletion"] {
+  --diffs-line-bg: light-dark(#ffe0e0, rgba(220, 38, 38, 0.3)) !important;
+  background: light-dark(#ffe0e0, rgba(220, 38, 38, 0.3)) !important;
+}
+
+[data-additions] [data-line-type="change-addition"] {
+  box-shadow: inset 3px 0 0 #16a34a;
+}
+
+[data-deletions] [data-line-type="change-deletion"] {
+  box-shadow: inset 3px 0 0 #dc2626;
+}
+
+[data-line-type="change-addition"] span {
+  background-color: light-dark(rgba(22, 163, 74, 0.16), rgba(34, 197, 94, 0.22));
+}
+
+[data-line-type="change-deletion"] span {
+  background-color: light-dark(rgba(220, 38, 38, 0.15), rgba(248, 113, 113, 0.24));
+}
+
+[data-line-type="change-addition"] [data-line-number-content]::before {
+  content: "+";
+  margin-right: 0.45ch;
+  color: #16a34a;
+}
+
+[data-line-type="change-deletion"] [data-line-number-content]::before {
+  content: "−";
+  margin-right: 0.45ch;
+  color: #dc2626;
+}
+`;
+
+type GitExecError = Error & {
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+};
+
+export type DiffViewerResult = {
+  filePath: string;
+  opened: boolean;
+  fileCount: number;
+};
+
+type DiffViewerFile = {
+  name: string;
+  prevName?: string;
+  type: FileDiffMetadata["type"];
+  additions: number;
+  deletions: number;
+  html: string;
+};
+
+type DiffViewerPayload = {
+  repoRoot: string;
+  worktreePath: string;
+  baseRef: string;
+  baseCommit: string;
+  generatedAt: string;
+  insertions: number;
+  deletions: number;
+  files: DiffViewerFile[];
+};
+
+type RenderedDiffFiles = {
+  files: DiffViewerFile[];
+  insertions: number;
+  deletions: number;
+};
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFile("git", args, {
+      cwd,
+      maxBuffer: GIT_MAX_BUFFER,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return stdout?.toString() ?? "";
+  } catch (error) {
+    const gitError = error as GitExecError;
+    const stderr = gitError.stderr?.toString().trim();
+    throw new Error(stderr || gitError.message);
+  }
+}
+
+async function runGitOptional(cwd: string, args: string[]): Promise<string> {
+  try {
+    return await runGit(cwd, args);
+  } catch {
+    return "";
+  }
+}
+
+function parseNameStatus(diffNameStatus: string): Set<string> {
+  const paths = new Set<string>();
+  for (const line of diffNameStatus.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    const status = parts[0] ?? "";
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const renamedPath = parts[2];
+      if (renamedPath) paths.add(renamedPath);
+      continue;
+    }
+    const filePath = parts[1];
+    if (filePath) paths.add(filePath);
+  }
+  return paths;
+}
+
+function parseNumstat(numstat: string): {
+  insertions: number;
+  deletions: number;
+} {
+  let insertions = 0;
+  let deletions = 0;
+  for (const line of numstat.split("\n")) {
+    if (!line.trim()) continue;
+    const [added, removed] = line.split("\t");
+    const addedCount = Number(added);
+    const removedCount = Number(removed);
+    if (Number.isFinite(addedCount)) insertions += addedCount;
+    if (Number.isFinite(removedCount)) deletions += removedCount;
+  }
+  return { insertions, deletions };
+}
+
+function getFileKey(file: FileDiffMetadata): string {
+  return file.name || file.prevName || "unknown";
+}
+
+function getFileLineCounts(file: FileDiffMetadata): {
+  additions: number;
+  deletions: number;
+} {
+  let additions = 0;
+  let deletions = 0;
+  for (const hunk of file.hunks) {
+    additions += hunk.additionCount;
+    deletions += hunk.deletionCount;
+  }
+  return { additions, deletions };
+}
+
+async function listUntrackedFiles(repoRoot: string): Promise<string[]> {
+  const output = await runGitOptional(repoRoot, [
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+  ]);
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function buildUntrackedPatch(repoRoot: string): Promise<string> {
+  const files = await listUntrackedFiles(repoRoot);
+  const patches: string[] = [];
+  for (const file of files) {
+    const patch = await runGitOptional(repoRoot, [
+      "diff",
+      "--binary",
+      "--no-index",
+      "--",
+      "/dev/null",
+      file,
+    ]);
+    if (patch.trim()) patches.push(patch);
+  }
+  return patches.join("\n");
+}
+
+async function collectDiff(cwd: string): Promise<{
+  repoRoot: string;
+  baseRef: string;
+  baseCommit: string;
+  patch: string;
+  changedPaths: Set<string>;
+  insertions: number;
+  deletions: number;
+}> {
+  const repoRoot = (await runGit(cwd, ["rev-parse", "--show-toplevel"])).trim();
+  const upstream = (
+    await runGitOptional(cwd, [
+      "rev-parse",
+      "--abbrev-ref",
+      "--symbolic-full-name",
+      "@{upstream}",
+    ])
+  ).trim();
+  const defaultBranch = (
+    await runGitOptional(cwd, [
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      "refs/remotes/origin/HEAD",
+    ])
+  ).trim();
+  const baseRef = upstream || defaultBranch || "HEAD";
+  const baseCommit = (
+    await runGitOptional(cwd, ["merge-base", baseRef, "HEAD"])
+  ).trim();
+  const diffBase = baseCommit || baseRef;
+  const untrackedPatch = await buildUntrackedPatch(repoRoot);
+  const patchParts = await Promise.all([
+    runGitOptional(repoRoot, ["diff", "--binary", diffBase]),
+    untrackedPatch,
+  ]);
+  const patch = patchParts.filter(Boolean).join("\n");
+
+  const [diffNames, diffNumstat] = await Promise.all([
+    runGitOptional(repoRoot, ["diff", "--name-status", diffBase]),
+    runGitOptional(repoRoot, ["diff", "--numstat", diffBase]),
+  ]);
+  const stats = parseNumstat(diffNumstat);
+
+  return {
+    repoRoot,
+    baseRef,
+    baseCommit: diffBase,
+    patch,
+    changedPaths: new Set([
+      ...parseNameStatus(diffNames),
+      ...(await listUntrackedFiles(repoRoot)),
+    ]),
+    insertions: stats.insertions,
+    deletions: stats.deletions,
+  };
+}
+
+async function renderDiffFiles(
+  patch: string,
+  changedPaths: Set<string>,
+): Promise<RenderedDiffFiles> {
+  if (!patch.trim()) return { files: [], insertions: 0, deletions: 0 };
+
+  const parsed = parsePatchFiles(patch);
+  const files = parsed
+    .flatMap((entry) => entry.files)
+    .slice(0, MAX_RENDERED_FILES);
+  const rendered: DiffViewerFile[] = [];
+  let insertions = 0;
+  let deletions = 0;
+  for (const file of files) {
+    const lineCounts = getFileLineCounts(file);
+    insertions += lineCounts.additions;
+    deletions += lineCounts.deletions;
+    const result = await preloadFileDiff({
+      fileDiff: file,
+      options: {
+        diffStyle: "split",
+        diffIndicators: "bars",
+        disableFileHeader: true,
+        hunkSeparators: "line-info-basic",
+        lineDiffType: "word",
+        overflow: "wrap",
+        stickyHeader: false,
+        theme: {
+          light: "pierre-light",
+          dark: "pierre-dark",
+        },
+        unsafeCSS: DIFF_UNSAFE_CSS,
+      },
+    });
+    rendered.push({
+      name: getFileKey(file),
+      prevName: file.prevName,
+      type: file.type,
+      additions: lineCounts.additions,
+      deletions: lineCounts.deletions,
+      html: result.prerenderedHTML,
+    });
+  }
+
+  for (const path of changedPaths) {
+    if (!rendered.some((file) => file.name === path)) {
+      rendered.push({
+        name: path,
+        type: "change",
+        additions: 0,
+        deletions: 0,
+        html: `<div class="notice">Binary or empty diff omitted for ${escapeHtml(path)}.</div>`,
+      });
+    }
+  }
+
+  return { files: rendered, insertions, deletions };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function resolveTargetPath(targetPath?: string): string {
+  if (!targetPath?.trim()) return process.cwd();
+  return isAbsolute(targetPath)
+    ? targetPath
+    : resolve(process.cwd(), targetPath);
+}
+
+function shouldSkipOpen(): boolean {
+  return (
+    Boolean(process.env.TMUX) ||
+    Boolean(process.env.SSH_CONNECTION) ||
+    Boolean(process.env.SSH_TTY)
+  );
+}
+
+export async function generateAndOpenDiffViewer(
+  targetPath?: string,
+): Promise<DiffViewerResult> {
+  const worktreePath = resolveTargetPath(targetPath);
+  const collected = await collectDiff(worktreePath);
+  const rendered = await renderDiffFiles(
+    collected.patch,
+    collected.changedPaths,
+  );
+  const payload: DiffViewerPayload = {
+    repoRoot: collected.repoRoot,
+    worktreePath,
+    baseRef: collected.baseRef,
+    baseCommit: collected.baseCommit,
+    generatedAt: new Date().toISOString(),
+    insertions: rendered.insertions || collected.insertions,
+    deletions: rendered.deletions || collected.deletions,
+    files: rendered.files,
+  };
+
+  const jsonPayload = JSON.stringify(payload).replace(/</g, "\\u003c");
+  const html = diffViewerTemplate.replace(
+    "<!--LETTA_DIFF_DATA_PLACEHOLDER-->",
+    () => jsonPayload,
+  );
+
+  if (!existsSync(VIEWERS_DIR)) {
+    mkdirSync(VIEWERS_DIR, { recursive: true, mode: 0o700 });
+  }
+  try {
+    chmodSync(VIEWERS_DIR, 0o700);
+  } catch {}
+
+  const filePath = join(
+    VIEWERS_DIR,
+    `diff-${encodeURIComponent(worktreePath)}.html`,
+  );
+  writeFileSync(filePath, html);
+  chmodSync(filePath, 0o600);
+
+  const skipOpen = shouldSkipOpen();
+  if (!skipOpen) {
+    try {
+      const { default: openUrl } = await import("open");
+      await openUrl(filePath, { wait: false });
+    } catch {
+      throw new Error(`Could not open browser. Run: open ${filePath}`);
+    }
+  }
+
+  return { filePath, opened: !skipOpen, fileCount: rendered.files.length };
+}

--- a/src/web/html.d.ts
+++ b/src/web/html.d.ts
@@ -7,3 +7,8 @@ declare module "*plan-viewer-template.txt" {
   const content: string;
   export default content;
 }
+
+declare module "*diff-viewer-template.txt" {
+  const content: string;
+  export default content;
+}

--- a/src/web/worktree-diff-list.ts
+++ b/src/web/worktree-diff-list.ts
@@ -1,0 +1,181 @@
+import { execFile as execFileCb } from "node:child_process";
+import { basename } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+const GIT_TIMEOUT_MS = 60_000;
+const GIT_MAX_BUFFER = 10 * 1024 * 1024;
+
+export type WorktreeDiffOption = {
+  path: string;
+  name: string;
+  branch: string;
+  head: string;
+  isCurrent: boolean;
+  fileCount: number;
+  insertions: number;
+  deletions: number;
+  hasChanges: boolean;
+};
+
+type GitExecError = Error & {
+  stderr?: string | Buffer;
+};
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFile("git", args, {
+      cwd,
+      maxBuffer: GIT_MAX_BUFFER,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return stdout?.toString() ?? "";
+  } catch (error) {
+    const gitError = error as GitExecError;
+    const stderr = gitError.stderr?.toString().trim();
+    throw new Error(stderr || gitError.message);
+  }
+}
+
+async function runGitOptional(cwd: string, args: string[]): Promise<string> {
+  try {
+    return await runGit(cwd, args);
+  } catch {
+    return "";
+  }
+}
+
+function parseNumstat(numstat: string): {
+  insertions: number;
+  deletions: number;
+} {
+  let insertions = 0;
+  let deletions = 0;
+  for (const line of numstat.split("\n")) {
+    if (!line.trim()) continue;
+    const [added, removed] = line.split("\t");
+    const addedCount = Number(added);
+    const removedCount = Number(removed);
+    if (Number.isFinite(addedCount)) insertions += addedCount;
+    if (Number.isFinite(removedCount)) deletions += removedCount;
+  }
+  return { insertions, deletions };
+}
+
+function parseWorktreeList(
+  output: string,
+  currentPath: string,
+): WorktreeDiffOption[] {
+  const worktrees: WorktreeDiffOption[] = [];
+  let current: Partial<WorktreeDiffOption> | null = null;
+
+  for (const line of output.split("\n")) {
+    if (!line.trim()) {
+      if (current?.path) {
+        worktrees.push({
+          path: current.path,
+          name: basename(current.path),
+          branch: current.branch ?? "detached",
+          head: current.head ?? "",
+          isCurrent: current.path === currentPath,
+          fileCount: 0,
+          insertions: 0,
+          deletions: 0,
+          hasChanges: false,
+        });
+      }
+      current = null;
+      continue;
+    }
+
+    const [key, ...rest] = line.split(" ");
+    const value = rest.join(" ").trim();
+    if (key === "worktree") {
+      current = { path: value };
+    } else if (current && key === "HEAD") {
+      current.head = value;
+    } else if (current && key === "branch") {
+      current.branch = value.replace(/^refs\/heads\//, "");
+    }
+  }
+
+  if (current?.path) {
+    worktrees.push({
+      path: current.path,
+      name: basename(current.path),
+      branch: current.branch ?? "detached",
+      head: current.head ?? "",
+      isCurrent: current.path === currentPath,
+      fileCount: 0,
+      insertions: 0,
+      deletions: 0,
+      hasChanges: false,
+    });
+  }
+
+  return worktrees;
+}
+
+async function getDiffBase(cwd: string): Promise<string> {
+  const upstream = (
+    await runGitOptional(cwd, [
+      "rev-parse",
+      "--abbrev-ref",
+      "--symbolic-full-name",
+      "@{upstream}",
+    ])
+  ).trim();
+  const defaultBranch = (
+    await runGitOptional(cwd, [
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      "refs/remotes/origin/HEAD",
+    ])
+  ).trim();
+  const baseRef = upstream || defaultBranch || "HEAD";
+  const mergeBase = (
+    await runGitOptional(cwd, ["merge-base", baseRef, "HEAD"])
+  ).trim();
+  return mergeBase || baseRef;
+}
+
+async function summarizeWorktree(
+  worktree: WorktreeDiffOption,
+): Promise<WorktreeDiffOption> {
+  const diffBase = await getDiffBase(worktree.path);
+  const [names, numstat, untracked] = await Promise.all([
+    runGitOptional(worktree.path, ["diff", "--name-only", diffBase]),
+    runGitOptional(worktree.path, ["diff", "--numstat", diffBase]),
+    runGitOptional(worktree.path, [
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+    ]),
+  ]);
+  const changedPaths = new Set(
+    [...names.split("\n"), ...untracked.split("\n")]
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  const stats = parseNumstat(numstat);
+
+  return {
+    ...worktree,
+    fileCount: changedPaths.size,
+    insertions: stats.insertions,
+    deletions: stats.deletions,
+    hasChanges: changedPaths.size > 0,
+  };
+}
+
+export async function listWorktreeDiffOptions(
+  cwd: string = process.cwd(),
+): Promise<WorktreeDiffOption[]> {
+  const currentPath = (
+    await runGit(cwd, ["rev-parse", "--show-toplevel"])
+  ).trim();
+  const output = await runGit(currentPath, ["worktree", "list", "--porcelain"]);
+  const worktrees = parseWorktreeList(output, currentPath);
+  return Promise.all(worktrees.map((worktree) => summarizeWorktree(worktree)));
+}


### PR DESCRIPTION
## Summary
- Adds a new `diffs` experiment that renders a browser-based worktree diff viewer powered by [`@pierre/diffs`](https://diffs.com).
- `/experiments diffs` opens a terminal worktree selector (branch, file count, +/-); selecting one opens its diff. `/experiments diffs <path>` opens a specific worktree directly.
- The generated self-contained HTML viewer uses Pierre light/dark themes, split layout, word-level red/green highlights, a sticky file navigator with scroll-spy, and per-file copy-path / collapse controls.

## Implementation
- `src/web/generate-diff-viewer.ts` — collects committed + working-tree + untracked diffs and renders each file via `@pierre/diffs` SSR.
- `src/web/diff-viewer-template.txt` — self-contained HTML/CSS/JS shell (opaque sticky top bar + dynamic offset so diffs never bleed behind it; click-to-scroll nav).
- `src/web/worktree-diff-list.ts` — enumerates worktrees with diff stats.
- `src/cli/components/WorktreeDiffSelector.tsx` — terminal selector overlay.
- Wires the `worktree-diff` overlay through `use-submit-handler`, `AppView`, `AppCoordinator`, and `types`.

## Test plan
- [ ] `bun run check` passes
- [ ] `/experiments` shows the `diffs` toggle and enabling it works
- [ ] `/experiments diffs` lists worktrees; selecting one opens the viewer
- [ ] `/experiments diffs <path>` opens that worktree directly
- [ ] Viewer: red/green split highlights, file nav click + scroll-spy, sticky bars do not overlap diff content

👾 Generated with [Letta Code](https://letta.com)