### PR TITLE
feat(tui): add rotating empty-composer prompt hints

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -279,6 +279,23 @@ function buildStartupCommandHints(options: {
   return dedupedHints;
 }
 
+function hasConversationContent(lines: Line[]): boolean {
+  return lines.some((line) => {
+    switch (line.kind) {
+      case "user":
+      case "assistant":
+      case "reasoning":
+      case "tool_call":
+      case "error":
+      case "command":
+      case "bash_command":
+        return true;
+      default:
+        return false;
+    }
+  });
+}
+
 export function App({
   agentId: initialAgentId,
   agentState: initialAgentState,
@@ -4426,6 +4443,13 @@ export function App({
   const inputVisible = !showExitStats;
   const inputEnabled =
     !showExitStats && pendingApprovals.length === 0 && !anySelectorOpen;
+  const showInspirationalPromptHints =
+    loadingState === "ready" &&
+    !hasConversationContent(lines) &&
+    !streaming &&
+    queueDisplay.length === 0 &&
+    pendingApprovals.length === 0 &&
+    !anySelectorOpen;
   const currentApprovalPreviewCommitted = currentApproval?.toolCallId
     ? eagerCommittedPreviewsRef.current.has(currentApproval.toolCallId)
     : false;
@@ -4479,6 +4503,7 @@ export function App({
       emittedIdsRef={emittedIdsRef}
       feedbackPrefill={feedbackPrefill}
       footerUpdateText={footerUpdateText}
+      showInspirationalPromptHints={showInspirationalPromptHints}
       handleAgentSelect={handleAgentSelect}
       handleApproveAlways={handleApproveAlways}
       handleApproveCurrent={handleApproveCurrent}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -153,6 +153,7 @@ type AppViewProps = {
 
   feedbackPrefill: string;
   footerUpdateText: string | null;
+  showInspirationalPromptHints: boolean;
   handleAgentSelect: (
     targetAgentId: string,
     opts?: {
@@ -344,6 +345,7 @@ export function AppView(props: AppViewProps) {
     handleCtrlD,
     feedbackPrefill,
     footerUpdateText,
+    showInspirationalPromptHints,
     handleAgentSelect,
     handleApproveAlways,
     handleApproveCurrent,
@@ -705,6 +707,7 @@ export function AppView(props: AppViewProps) {
                 statusLineRight={statusLine.rightText || undefined}
                 statusLinePrompt={statusLine.prompt}
                 footerNotification={footerUpdateText}
+                showInspirationalPromptHints={showInspirationalPromptHints}
               />
             </Box>
 

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -53,6 +53,14 @@ import { Text } from "./Text";
 // Window for double-escape to clear input
 const ESC_CLEAR_WINDOW_MS = 2500;
 const FOOTER_WIDTH_STREAMING_DELTA = 2;
+const EMPTY_COMPOSER_PROMPT_ROTATION_MS = 6000;
+const EMPTY_COMPOSER_PROMPT_HINTS = [
+  'Try "help me understand this codebase"',
+  'Try "help me organize my desktop"',
+  'Try "debug this error"',
+  'Try "explain what this function does"',
+  'Try "review this pull request"',
+];
 
 function truncateEnd(value: string, maxChars: number): string {
   if (maxChars <= 0) return "";
@@ -1047,6 +1055,7 @@ export function Input({
   statusLinePrompt,
   onCycleReasoningEffort,
   footerNotification,
+  showInspirationalPromptHints = false,
 }: {
   visible?: boolean;
   streaming: boolean;
@@ -1096,6 +1105,7 @@ export function Input({
   statusLinePrompt?: string;
   onCycleReasoningEffort?: () => void;
   footerNotification?: string | null;
+  showInspirationalPromptHints?: boolean;
 }) {
   const [value, setValue] = useState("");
   const [escapePressed, setEscapePressed] = useState(false);
@@ -1106,6 +1116,8 @@ export function Input({
   const [currentMode, setCurrentMode] = useState<PermissionMode>(
     externalMode || permissionMode.getMode(),
   );
+  const [emptyPromptHintIndex, setEmptyPromptHintIndex] = useState(0);
+  const [emptyPromptHintReady, setEmptyPromptHintReady] = useState(false);
   const [isAutocompleteActive, setIsAutocompleteActive] = useState(false);
   const [cursorPos, setCursorPos] = useState<number | undefined>(undefined);
   const [currentCursorPosition, setCurrentCursorPosition] = useState(0);
@@ -1245,6 +1257,47 @@ export function Input({
       onRestoredInputConsumed?.();
     }
   }, [restoredInput, value, onRestoredInputConsumed]);
+
+  useEffect(() => {
+    if (!showInspirationalPromptHints || value !== "") {
+      setEmptyPromptHintIndex(0);
+      setEmptyPromptHintReady(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setEmptyPromptHintReady(true);
+    }, EMPTY_COMPOSER_PROMPT_ROTATION_MS);
+
+    return () => clearTimeout(timer);
+  }, [showInspirationalPromptHints, value]);
+
+  useEffect(() => {
+    if (
+      !showInspirationalPromptHints ||
+      value !== "" ||
+      !emptyPromptHintReady
+    ) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setEmptyPromptHintIndex(
+        (prev) => (prev + 1) % EMPTY_COMPOSER_PROMPT_HINTS.length,
+      );
+    }, EMPTY_COMPOSER_PROMPT_ROTATION_MS);
+
+    return () => clearInterval(timer);
+  }, [showInspirationalPromptHints, value, emptyPromptHintReady]);
+
+  const inspirationalPlaceholder = showInspirationalPromptHints
+    ? (EMPTY_COMPOSER_PROMPT_HINTS[emptyPromptHintIndex] ?? undefined)
+    : undefined;
+  const showInspirationalPlaceholder =
+    showInspirationalPromptHints &&
+    emptyPromptHintReady &&
+    value === "" &&
+    !!inspirationalPlaceholder;
 
   const handleBangAtEmpty = useCallback(() => {
     if (isBashMode) return false;
@@ -1889,6 +1942,11 @@ export function Input({
                   value={value}
                   onChange={setValue}
                   onSubmit={handleSubmit}
+                  placeholder={
+                    showInspirationalPlaceholder
+                      ? inspirationalPlaceholder
+                      : undefined
+                  }
                   cursorPosition={cursorPos}
                   onCursorMove={setCurrentCursorPosition}
                   focus={interactionEnabled && !onEscapeCancel}
@@ -1981,6 +2039,7 @@ export function Input({
     contentWidth,
     value,
     handleSubmit,
+    showInspirationalPlaceholder,
     cursorPos,
     onEscapeCancel,
     handleBangAtEmpty,
@@ -2020,6 +2079,7 @@ export function Input({
     queueMode,
     deferModeSupported,
     isLocalBackend,
+    inspirationalPlaceholder,
   ]);
 
   // If not visible, render nothing but keep component mounted to preserve state


### PR DESCRIPTION
## Summary
- show rotating inspirational sample prompts in the empty composer for truly fresh conversations
- delay the first hint, rotate on a calm interval, and hide the hint immediately once the user starts typing or real conversation content appears
- keep the startup status/welcome chrome from suppressing the hints by gating on actual conversation content instead of any rendered transcript item

## Test plan
- [x] `bun run check` passes
- [x] Fresh empty conversation shows muted rotating sample prompts in the composer
- [x] Startup status text does not prevent the hints from appearing
- [x] Typing hides the hint immediately
- [x] Existing conversations do not show the rotating hints

👾 Generated with [Letta Code](https://letta.com)