### PR TITLE
fix(startup): hide reasoning for no-model placeholder

### DIFF
--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from "react";
 import stringWidth from "string-width";
 import type { ModelReasoningEffort } from "@/agent/model";
 import { buildAppUrl, buildChatUrl } from "@/cli/helpers/app-urls";
+import { shouldHideReasoningForModelDisplay } from "@/cli/helpers/startup-model-display";
 import { truncateText } from "@/cli/helpers/truncate-text";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { DEFAULT_AGENT_NAME } from "@/constants";
@@ -61,7 +62,9 @@ export const AgentInfoBar = memo(function AgentInfoBar({
       ? buildChatUrl(agentId, { conversationId })
       : "";
   const showBottomBar = agentId && agentId !== "loading";
-  const reasoningLabel = formatReasoningLabel(currentReasoningEffort);
+  const reasoningLabel = shouldHideReasoningForModelDisplay(currentModel)
+    ? null
+    : formatReasoningLabel(currentReasoningEffort);
   const modelLine = currentModel
     ? `${currentModel}${reasoningLabel ? ` (${reasoningLabel})` : ""}`
     : null;

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -27,6 +27,7 @@ import { buildChatUrl } from "@/cli/helpers/app-urls.js";
 import { bytesToTokens, formatCompact } from "@/cli/helpers/format";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import { formatGoalStatusIndicator } from "@/cli/helpers/goal-command";
+import { shouldHideReasoningForModelDisplay } from "@/cli/helpers/startup-model-display";
 import { getRandomThinkingTip } from "@/cli/helpers/thinking-messages";
 import {
   ELAPSED_DISPLAY_THRESHOLD_MS,
@@ -528,7 +529,9 @@ const InputFooter = memo(function InputFooter({
 
   const maxAgentChars = Math.max(10, Math.floor(rightColumnWidth * 0.45));
   const displayAgentName = truncateEnd(agentName || "Unnamed", maxAgentChars);
-  const reasoningTag = getReasoningEffortTag(currentReasoningEffort);
+  const reasoningTag = shouldHideReasoningForModelDisplay(currentModel)
+    ? null
+    : getReasoningEffortTag(currentReasoningEffort);
   const byokExtraChars = isByokProvider ? 2 : 0; // " ▲"
   const tempOverrideExtraChars = hasTemporaryModelOverride ? 2 : 0; // " ▲"
 

--- a/src/cli/helpers/startup-model-display.test.ts
+++ b/src/cli/helpers/startup-model-display.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { getStartupModelDisplayOverride } from "@/cli/helpers/startup-model-display";
+import {
+  getStartupModelDisplayOverride,
+  shouldHideReasoningForModelDisplay,
+} from "@/cli/helpers/startup-model-display";
 
 describe("getStartupModelDisplayOverride", () => {
   test("shows no-model label for local startup when no local models are available", () => {
@@ -27,5 +30,11 @@ describe("getStartupModelDisplayOverride", () => {
         startupHasAvailableLocalModels: false,
       }),
     ).toBeNull();
+  });
+
+  test("suppresses reasoning suffix for the no-model placeholder", () => {
+    expect(shouldHideReasoningForModelDisplay("No model selected")).toBe(true);
+    expect(shouldHideReasoningForModelDisplay("GPT-5.5")).toBe(false);
+    expect(shouldHideReasoningForModelDisplay(null)).toBe(false);
   });
 });

--- a/src/cli/helpers/startup-model-display.ts
+++ b/src/cli/helpers/startup-model-display.ts
@@ -1,5 +1,11 @@
 const STARTUP_NO_MODEL_LABEL = "No model selected";
 
+export function shouldHideReasoningForModelDisplay(
+  modelDisplay: string | null | undefined,
+): boolean {
+  return modelDisplay === STARTUP_NO_MODEL_LABEL;
+}
+
 export function getStartupModelDisplayOverride(options: {
   isLocalBackend: boolean;
   startupHasAvailableLocalModels: boolean;


### PR DESCRIPTION
## Summary
- suppress reasoning suffixes like `(high)` when the UI is showing the synthetic `No model selected` placeholder
- apply the suppression in the shared footer/info-bar display paths so the placeholder stays consistent across startup and resumed local no-model sessions
- keep real reasoning labels unchanged for actual model names
- extend the startup-model-display helper test to cover the no-model reasoning suppression behavior

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/cli/helpers/startup-model-display.test.ts` passes
- [ ] Verify fresh local no-model startup shows `No model selected` without a reasoning suffix
- [ ] Verify resumed local no-model sessions also avoid the reasoning suffix
- [ ] Verify real models still show reasoning labels normally

👾 Generated with [Letta Code](https://letta.com)