### PR TITLE
fix(login): stop aborting OAuth polling on rerender

### DIFF
--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -24,6 +24,11 @@ export function ConstellationLoginView({
   const startedRef = useRef(false);
   const cancelledRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const onCompleteRef = useRef(onComplete);
+  const onAlreadyLoggedInRef = useRef(onAlreadyLoggedIn);
+
+  onCompleteRef.current = onComplete;
+  onAlreadyLoggedInRef.current = onAlreadyLoggedIn;
 
   useInput((input, key) => {
     if (key.escape || (key.ctrl && input === "c")) {
@@ -46,7 +51,7 @@ export function ConstellationLoginView({
           process.env.LETTA_API_KEY || currentSettings.env?.LETTA_API_KEY;
 
         if (hasApiKey) {
-          onAlreadyLoggedIn?.();
+          onAlreadyLoggedInRef.current?.();
           return;
         }
 
@@ -98,7 +103,7 @@ export function ConstellationLoginView({
         setDoneMessage(
           "Signed in to Constellation. Switch to a Constellation agent with /agents.",
         );
-        setTimeout(() => onComplete?.(), 500);
+        setTimeout(() => onCompleteRef.current?.(), 500);
       } catch (err) {
         if (
           cancelledRef.current ||
@@ -115,7 +120,7 @@ export function ConstellationLoginView({
       cancelledRef.current = true;
       abortControllerRef.current?.abort();
     };
-  }, [onAlreadyLoggedIn, onComplete]);
+  }, []);
 
   if (doneMessage) {
     return (


### PR DESCRIPTION
## Summary
- keep the `/login` device-code polling effect stable across normal rerenders of the login view
- store `onComplete` and `onAlreadyLoggedIn` in refs instead of effect dependencies so showing the user code does not trigger cleanup/abort
- preserve the existing `Esc` / `Ctrl+C` cancellation path while allowing successful browser authorization to complete

## Test plan
- [x] `bun run check` passes
- [x] Verified `/login` completes successfully after browser authorization
- [x] Verified `Esc` still cancels the login overlay
- [x] Verified `Ctrl+C` still cancels the login overlay

👾 Generated with [Letta Code](https://letta.com)