### PR TITLE
feat(agents): add login action to Constellation empty state

### DIFF
--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -966,6 +966,15 @@ export function AppView(props: AppViewProps) {
                     backendMode,
                   });
                 }}
+                onLogin={() => {
+                  completeOverlay("resume");
+                  openOverlay(
+                    "login",
+                    "/login",
+                    "Opening login...",
+                    "Login dismissed",
+                  );
+                }}
                 onCancel={closeOverlay}
                 onCreateNewAgent={(name: string, backendMode) => {
                   const overlayCommand = completeOverlay("resume");

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -26,6 +26,7 @@ interface AgentSelectorProps {
   currentAgentId: string;
   onSelect: (agentId: string, backendMode: AgentBackendMode) => void;
   onCancel: () => void;
+  onLogin?: () => void;
   /** Called when user creates a new agent (from New tab or N shortcut) */
   onCreateNewAgent?: (name: string, backendMode: AgentBackendMode) => void;
   /** The command that triggered this selector (e.g., "/agents" or "/resume") */
@@ -158,6 +159,7 @@ export function AgentSelector({
   currentAgentId,
   onSelect,
   onCancel,
+  onLogin,
   onCreateNewAgent,
   command = "/agents",
 }: AgentSelectorProps) {
@@ -683,6 +685,8 @@ export function AgentSelector({
         const selected = constellationPageAgents[constellationSelectedIndex];
         if (selected?.id) {
           onSelect(selected.id, "api");
+        } else if (hasCloudAuth === false) {
+          onLogin?.();
         }
       }
     } else if (key.escape) {
@@ -914,7 +918,13 @@ export function AgentSelector({
       <Text dimColor>
         Connect to Letta Constellation to see hosted agents here.
       </Text>
-      <Text dimColor>Run /login to sign in.</Text>
+      <Box height={1} />
+      <Box flexDirection="column">
+        <Text color={colors.selector.itemHighlighted}>{"> /login"}</Text>
+        <Box paddingLeft={2}>
+          <Text dimColor>Sign in to Letta Constellation</Text>
+        </Box>
+      </Box>
     </Box>
   );
 


### PR DESCRIPTION
## Summary
- surface `/login` as an inline selectable action in the `/agents` Constellation tab when the user is logged out
- allow Enter on the logged-out Constellation empty state to open the login overlay directly from inside `/agents`
- keep the empty-state pattern aligned with the `/model` no-model flow instead of only telling the user to type the command manually

## Test plan
- [x] `bun run check` passes
- [x] Logged-out `/agents` Constellation tab shows an inline `/login` action instead of only text instructions
- [x] Pressing Enter on that state opens the login overlay
- [x] Logged-in Constellation browsing behavior is unchanged

👾 Generated with [Letta Code](https://letta.com)