### PR TITLE
fix(startup): clear no-model placeholder after connect

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -322,6 +322,13 @@ export function App({
     prefetchAvailableModelHandles();
   }, []);
 
+  const [hasAvailableLocalModels, setHasAvailableLocalModels] = useState(
+    startupHasAvailableLocalModels,
+  );
+  const markLocalModelsAvailable = useCallback(() => {
+    setHasAvailableLocalModels(true);
+  }, []);
+
   // Track current agent (can change when swapping)
   const [agentId, setAgentId] = useState(initialAgentId);
   const [agentState, setAgentState] = useState(initialAgentState);
@@ -831,7 +838,7 @@ export function App({
     deriveReasoningEffort(effectiveModelSettings, llmConfig);
   const startupModelDisplayOverride = getStartupModelDisplayOverride({
     isLocalBackend: isLocalBackendEnabled(),
-    startupHasAvailableLocalModels,
+    startupHasAvailableLocalModels: hasAvailableLocalModels,
   });
 
   // Use tier-aware resolution so the display matches the agent's reasoning effort
@@ -3787,6 +3794,7 @@ export function App({
     setHasConversationModelOverride,
     setLines,
     setLlmConfig,
+    markLocalModelsAvailable,
     setModelSelectorOptions,
     setNeedsEagerApprovalCheck,
     setPinDialogLocal,
@@ -3958,6 +3966,7 @@ export function App({
     setConversationOverrideModelSettings,
     setCurrentModelHandle,
     setCurrentModelId,
+    setHasAvailableLocalModels,
     setCurrentPersonalityId,
     setCurrentSystemPromptId,
     setCurrentToolset,
@@ -4540,6 +4549,7 @@ export function App({
       liveItems={liveItems}
       liveTrajectoryElapsedBaseMs={liveTrajectoryElapsedBaseMs}
       loadingState={loadingState}
+      markLocalModelsAvailable={markLocalModelsAvailable}
       maybeCarryOverActiveConversationModel={
         maybeCarryOverActiveConversationModel
       }

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -230,6 +230,7 @@ type AppViewProps = {
   liveItems: Line[];
   liveTrajectoryElapsedBaseMs: number;
   loadingState: AppLoadingState;
+  markLocalModelsAvailable: () => void;
   maybeCarryOverActiveConversationModel: (
     targetConversationId: string,
   ) => Promise<void>;
@@ -382,6 +383,7 @@ export function AppView(props: AppViewProps) {
     liveItems,
     liveTrajectoryElapsedBaseMs,
     loadingState,
+    markLocalModelsAvailable,
     maybeCarryOverActiveConversationModel,
     modelReasoningPrompt,
     modelSelectorOptions,
@@ -893,6 +895,7 @@ export function AppView(props: AppViewProps) {
                         refreshDerived,
                         setCommandRunning,
                         onCodexConnected: () => {
+                          markLocalModelsAvailable();
                           setModelSelectorOptions({
                             filterProvider: "chatgpt-plus-pro",
                             forceRefresh: true,

--- a/src/cli/app/submit-connection-commands.ts
+++ b/src/cli/app/submit-connection-commands.ts
@@ -20,6 +20,7 @@ type ConnectionCommandContext = {
   buffersRef: MutableRefObject<Buffers>;
   commandRunner: AppCommandRunner;
   conversationIdRef: MutableRefObject<string>;
+  markLocalModelsAvailable: () => void;
   refreshDerived: () => void;
   setCommandRunning: (value: boolean) => void;
   setModelSelectorOptions: Dispatch<SetStateAction<ModelSelectorOptions>>;
@@ -41,6 +42,7 @@ export async function handleConnectionCommand(
     buffersRef,
     commandRunner,
     conversationIdRef,
+    markLocalModelsAvailable,
     refreshDerived,
     setCommandRunning,
     setModelSelectorOptions,
@@ -147,6 +149,7 @@ export async function handleConnectionCommand(
           refreshDerived,
           setCommandRunning,
           onCodexConnected: () => {
+            markLocalModelsAvailable();
             setModelSelectorOptions({
               filterProvider: "chatgpt-plus-pro",
               forceRefresh: true,

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -88,6 +88,7 @@ type ConfigurationHandlersContext = {
   >;
   setCurrentModelHandle: Dispatch<SetStateAction<string | null>>;
   setCurrentModelId: Dispatch<SetStateAction<string | null>>;
+  setHasAvailableLocalModels: Dispatch<SetStateAction<boolean>>;
   setCurrentPersonalityId: Dispatch<SetStateAction<PersonalityId | null>>;
   setCurrentSystemPromptId: Dispatch<SetStateAction<string | null>>;
   setCurrentToolset: Dispatch<SetStateAction<ToolsetName | null>>;
@@ -125,6 +126,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
     setConversationOverrideModelSettings,
     setCurrentModelHandle,
     setCurrentModelId,
+    setHasAvailableLocalModels,
     setCurrentPersonalityId,
     setCurrentSystemPromptId,
     setCurrentToolset,
@@ -421,6 +423,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           // Reset context token tracking since different models have different tokenizers
           resetContextHistory(contextTrackerRef.current);
           setCurrentModelHandle(modelHandle);
+          setHasAvailableLocalModels(true);
 
           const persistedToolsetPreference =
             settingsManager.getToolsetPreference(agentId);

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -265,6 +265,7 @@ type SubmitHandlerContext = {
   setHasConversationModelOverride: (value: boolean) => void;
   setLines: Dispatch<SetStateAction<Line[]>>;
   setLlmConfig: Dispatch<SetStateAction<LlmConfig | null>>;
+  markLocalModelsAvailable: () => void;
   setModelSelectorOptions: Dispatch<SetStateAction<ModelSelectorOptions>>;
   setNeedsEagerApprovalCheck: Dispatch<SetStateAction<boolean>>;
   setPinDialogLocal: Dispatch<SetStateAction<boolean>>;
@@ -389,6 +390,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     setHasConversationModelOverride,
     setLines,
     setLlmConfig,
+    markLocalModelsAvailable,
     setModelSelectorOptions,
     setNeedsEagerApprovalCheck,
     setPinDialogLocal,
@@ -920,6 +922,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             refreshDerived,
             openOverlay,
             setCommandRunning,
+            markLocalModelsAvailable,
             setModelSelectorOptions,
           },
         );


### PR DESCRIPTION
## Summary
- clear the synthetic `No model selected` placeholder as soon as local models become available during the session
- mark local models as available immediately after successful ChatGPT OAuth connect so the indicator updates without waiting for a restart
- keep clearing the placeholder after successful `/model` selections as well, including the case where the user manually re-selects GPT-5.5
- preserve the startup no-model placeholder when the backend still truly has no available local models

## Test plan
- [x] `bun run check` passes
- [x] Verified `/connect` with ChatGPT OAuth clears the `No model selected` indicator immediately
- [x] Verified `/model` selecting GPT-5.5 also clears the placeholder immediately
- [ ] Verify fresh no-model startup still shows the placeholder before any provider/model is available

👾 Generated with [Letta Code](https://letta.com)