### PR TITLE
feat(connect): allow cancelling OAuth flow with Esc

### DIFF
--- a/src/auth/openai-oauth.ts
+++ b/src/auth/openai-oauth.ts
@@ -213,8 +213,41 @@ export async function generatePKCE(): Promise<{
 export function startLocalOAuthServer(
   expectedState: string,
   port = OPENAI_OAUTH_CONFIG.defaultPort,
+  signal?: AbortSignal,
 ): Promise<{ result: OAuthCallbackResult; server: http.Server }> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      const error = new Error("OAuth callback server cancelled");
+      error.name = "AbortError";
+      reject(error);
+      return;
+    }
+
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      callback();
+    };
+
+    const onAbort = () => {
+      server.close();
+      finish(() => {
+        const error = new Error("OAuth callback server cancelled");
+        error.name = "AbortError";
+        reject(error);
+      });
+    };
+
     const server = http.createServer((req, res) => {
       const url = new URL(req.url || "", `http://localhost:${port}`);
 
@@ -234,9 +267,11 @@ export function startLocalOAuthServer(
               detail: errorDescription || undefined,
             }),
           );
-          reject(
-            new Error(`OAuth error: ${error} - ${errorDescription || ""}`),
-          );
+          finish(() => {
+            reject(
+              new Error(`OAuth error: ${error} - ${errorDescription || ""}`),
+            );
+          });
           return;
         }
 
@@ -249,7 +284,9 @@ export function startLocalOAuthServer(
               message: "Missing authorization code or state parameter.",
             }),
           );
-          reject(new Error("Missing authorization code or state parameter"));
+          finish(() => {
+            reject(new Error("Missing authorization code or state parameter"));
+          });
           return;
         }
 
@@ -263,11 +300,13 @@ export function startLocalOAuthServer(
                 "State mismatch - the authorization may have been tampered with.",
             }),
           );
-          reject(
-            new Error(
-              "State mismatch - the authorization may have been tampered with",
-            ),
-          );
+          finish(() => {
+            reject(
+              new Error(
+                "State mismatch - the authorization may have been tampered with",
+              ),
+            );
+          });
           return;
         }
 
@@ -282,7 +321,9 @@ export function startLocalOAuthServer(
           }),
         );
 
-        resolve({ result: { code, state }, server });
+        finish(() => {
+          resolve({ result: { code, state }, server });
+        });
       } else {
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Not found");
@@ -291,27 +332,37 @@ export function startLocalOAuthServer(
 
     server.on("error", (err: NodeJS.ErrnoException) => {
       if (err.code === "EADDRINUSE") {
-        reject(
-          new Error(
-            `Port ${port} is already in use. Please close any application using this port and try again.`,
-          ),
-        );
+        finish(() => {
+          reject(
+            new Error(
+              `Port ${port} is already in use. Please close any application using this port and try again.`,
+            ),
+          );
+        });
       } else {
-        reject(err);
+        finish(() => {
+          reject(err);
+        });
       }
     });
+
+    if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
 
     server.listen(port, "127.0.0.1", () => {
       // Server started successfully, waiting for callback
     });
 
     // Timeout after 5 minutes
-    setTimeout(
+    timeout = setTimeout(
       () => {
         server.close();
-        reject(
-          new Error("OAuth timeout - no callback received within 5 minutes"),
-        );
+        finish(() => {
+          reject(
+            new Error("OAuth timeout - no callback received within 5 minutes"),
+          );
+        });
       },
       5 * 60 * 1000,
     );

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4447,11 +4447,13 @@ export function App({
   const inputVisible = !showExitStats;
   const inputEnabled =
     !showExitStats && pendingApprovals.length === 0 && !anySelectorOpen;
-  const onEscapeCommandCancel = isActiveConnectOperationCancellable()
-    ? () => {
-        cancelActiveConnectOperation();
-      }
-    : undefined;
+  const onEscapeCommandCancel = useCallback(() => {
+    if (isActiveConnectOperationCancellable()) {
+      cancelActiveConnectOperation();
+      return true;
+    }
+    return false;
+  }, []);
   const showInspirationalPromptHints =
     loadingState === "ready" &&
     !hasConversationContent(lines) &&

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -40,6 +40,10 @@ import { getBackend, isLocalBackendEnabled } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { getBillingTier } from "@/backend/api/metadata";
 import {
+  cancelActiveConnectOperation,
+  isActiveConnectOperationCancellable,
+} from "@/cli/commands/connect-command-state";
+import {
   type CommandFinishedEvent,
   type CommandHandle,
   createCommandRunner,
@@ -4443,6 +4447,11 @@ export function App({
   const inputVisible = !showExitStats;
   const inputEnabled =
     !showExitStats && pendingApprovals.length === 0 && !anySelectorOpen;
+  const onEscapeCommandCancel = isActiveConnectOperationCancellable()
+    ? () => {
+        cancelActiveConnectOperation();
+      }
+    : undefined;
   const showInspirationalPromptHints =
     loadingState === "ready" &&
     !hasConversationContent(lines) &&
@@ -4504,6 +4513,7 @@ export function App({
       feedbackPrefill={feedbackPrefill}
       footerUpdateText={footerUpdateText}
       showInspirationalPromptHints={showInspirationalPromptHints}
+      onEscapeCommandCancel={onEscapeCommandCancel}
       handleAgentSelect={handleAgentSelect}
       handleApproveAlways={handleApproveAlways}
       handleApproveCurrent={handleApproveCurrent}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -154,6 +154,7 @@ type AppViewProps = {
   feedbackPrefill: string;
   footerUpdateText: string | null;
   showInspirationalPromptHints: boolean;
+  onEscapeCommandCancel?: () => void;
   handleAgentSelect: (
     targetAgentId: string,
     opts?: {
@@ -346,6 +347,7 @@ export function AppView(props: AppViewProps) {
     feedbackPrefill,
     footerUpdateText,
     showInspirationalPromptHints,
+    onEscapeCommandCancel,
     handleAgentSelect,
     handleApproveAlways,
     handleApproveCurrent,
@@ -693,6 +695,7 @@ export function AppView(props: AppViewProps) {
                 onEscapeCancel={
                   profileConfirmPending ? handleProfileEscapeCancel : undefined
                 }
+                onEscapeCommandCancel={onEscapeCommandCancel}
                 inputDisabled={btwState.status === "complete"}
                 goalLoopActive={uiGoalLoopActive}
                 onGoalLoopExit={handleGoalLoopExit}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -154,7 +154,7 @@ type AppViewProps = {
   feedbackPrefill: string;
   footerUpdateText: string | null;
   showInspirationalPromptHints: boolean;
-  onEscapeCommandCancel?: () => void;
+  onEscapeCommandCancel?: () => boolean;
   handleAgentSelect: (
     targetAgentId: string,
     opts?: {

--- a/src/cli/commands/connect-command-state.ts
+++ b/src/cli/commands/connect-command-state.ts
@@ -1,0 +1,19 @@
+let activeConnectAbortController: AbortController | null = null;
+
+export function setActiveConnectAbortController(
+  controller: AbortController | null,
+): void {
+  activeConnectAbortController = controller;
+}
+
+export function isActiveConnectOperationCancellable(): boolean {
+  return activeConnectAbortController !== null;
+}
+
+export function cancelActiveConnectOperation(): boolean {
+  if (!activeConnectAbortController) {
+    return false;
+  }
+  activeConnectAbortController.abort();
+  return true;
+}

--- a/src/cli/commands/connect-oauth-core.ts
+++ b/src/cli/commands/connect-oauth-core.ts
@@ -36,6 +36,7 @@ interface OAuthFlowDeps {
   startCallbackServer: (
     expectedState: string,
     port?: number,
+    signal?: AbortSignal,
   ) => Promise<OAuthCodeServerResult>;
   exchangeTokens: (
     code: string,
@@ -72,6 +73,7 @@ const DEFAULT_DEPS: OAuthFlowDeps = {
 export interface ChatGPTOAuthFlowCallbacks {
   onStatus: (message: string) => void | Promise<void>;
   openBrowser?: (authorizationUrl: string) => Promise<void>;
+  signal?: AbortSignal;
 }
 
 export async function openOAuthBrowser(
@@ -125,6 +127,7 @@ export async function runChatGPTOAuthConnectFlow(
     const serverPromise = mergedDeps.startCallbackServer(
       state,
       OPENAI_OAUTH_CONFIG.defaultPort,
+      callbacks.signal,
     );
 
     await browserOpener(authorizationUrl);
@@ -133,6 +136,7 @@ export async function runChatGPTOAuthConnectFlow(
       "Waiting for authorization...\n\n" +
         "Please complete the sign-in process in your browser.\n" +
         "The page will redirect automatically when done.\n\n" +
+        "Press Esc to cancel.\n\n" +
         `If needed, visit:\n${authorizationUrl}`,
     );
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -6,6 +6,7 @@ import {
   type LocalProviderTimeout,
   parseLocalProviderTimeout,
 } from "@/backend/local/local-provider-timeout";
+import { setActiveConnectAbortController } from "@/cli/commands/connect-command-state";
 import type { Buffers, Line } from "@/cli/helpers/accumulator";
 import {
   checkProviderApiKey,
@@ -356,6 +357,8 @@ async function handleConnectChatGPT(
   }
 
   ctx.setCommandRunning(true);
+  const abortController = new AbortController();
+  setActiveConnectAbortController(abortController);
   const cmdId = addCommandResult(
     ctx.buffersRef,
     ctx.refreshDerived,
@@ -367,6 +370,7 @@ async function handleConnectChatGPT(
 
   try {
     await runChatGPTOAuthConnectFlow({
+      signal: abortController.signal,
       onStatus: (status) =>
         updateCommandResult(
           ctx.buffersRef,
@@ -395,16 +399,20 @@ async function handleConnectChatGPT(
       setTimeout(() => ctx.onCodexConnected?.(), 500);
     }
   } catch (error) {
+    const isCancelled = error instanceof Error && error.name === "AbortError";
     updateCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
       cmdId,
       msg,
-      `✗ Failed to connect: ${getErrorMessage(error)}`,
+      isCancelled
+        ? "Cancelled ChatGPT connection."
+        : `✗ Failed to connect: ${getErrorMessage(error)}`,
       false,
       "finished",
     );
   } finally {
+    setActiveConnectAbortController(null);
     ctx.setCommandRunning(false);
   }
 }

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1094,7 +1094,7 @@ export function Input({
   messageQueue?: QueuedMessage[];
   onQueueEdit?: () => string;
   onEscapeCancel?: () => void;
-  onEscapeCommandCancel?: () => void;
+  onEscapeCommandCancel?: () => boolean;
   inputDisabled?: boolean;
   goalLoopActive?: boolean;
   onGoalLoopExit?: () => void;
@@ -1371,6 +1371,29 @@ export function Input({
     }
   }, [interactionEnabled]);
 
+  const interactionEnabledRef = useRef(interactionEnabled);
+  useEffect(() => {
+    interactionEnabledRef.current = interactionEnabled;
+  }, [interactionEnabled]);
+
+  const onEscapeCommandCancelRef = useRef(onEscapeCommandCancel);
+  useEffect(() => {
+    onEscapeCommandCancelRef.current = onEscapeCommandCancel;
+  }, [onEscapeCommandCancel]);
+
+  useEffect(() => {
+    const handleRawInput = (data: Buffer | string) => {
+      if (!interactionEnabledRef.current) return;
+      if (data.toString("utf8") !== "\u001b") return;
+      onEscapeCommandCancelRef.current?.();
+    };
+
+    stdin.on("data", handleRawInput);
+    return () => {
+      stdin.off("data", handleRawInput);
+    };
+  }, []);
+
   // Get server URL (same logic as client.ts)
   const settings = settingsManager.getSettings();
   const serverUrl =
@@ -1422,8 +1445,7 @@ export function Input({
         return;
       }
 
-      if (onEscapeCommandCancel) {
-        onEscapeCommandCancel();
+      if (onEscapeCommandCancel?.()) {
         return;
       }
 

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1043,6 +1043,7 @@ export function Input({
   messageQueue,
   onQueueEdit,
   onEscapeCancel,
+  onEscapeCommandCancel,
   inputDisabled = false,
   goalLoopActive = false,
   onGoalLoopExit,
@@ -1093,6 +1094,7 @@ export function Input({
   messageQueue?: QueuedMessage[];
   onQueueEdit?: () => string;
   onEscapeCancel?: () => void;
+  onEscapeCommandCancel?: () => void;
   inputDisabled?: boolean;
   goalLoopActive?: boolean;
   onGoalLoopExit?: () => void;
@@ -1417,6 +1419,11 @@ export function Input({
         onInterrupt();
         // Don't load queued messages into input - let the dequeue effect
         // in App.tsx process them automatically after the interrupt completes.
+        return;
+      }
+
+      if (onEscapeCommandCancel) {
+        onEscapeCommandCancel();
         return;
       }
 


### PR DESCRIPTION
## Summary
- pressing Esc while `/connect chatgpt` (or `/connect codex`) is waiting for browser authorization now cancels the flow cleanly
- the local OAuth callback server is aborted so no background work hangs around
- the command finishes with `Cancelled ChatGPT connection.` instead of leaving the user stuck
- the waiting state now shows `Press Esc to cancel.` so the user knows the option exists

## Test plan
- [x] `bun run check` passes
- [ ] Run `/connect chatgpt`, see "Press Esc to cancel." in the waiting message, press Esc, see cancellation message
- [ ] Verify the local OAuth server is cleaned up after cancellation (port freed)
- [ ] Verify completing the OAuth flow normally still works end-to-end

👾 Generated with [Letta Code](https://letta.com)