### PR TITLE
fix(startup): infer backend from explicit agent id

### DIFF
--- a/src/cli/startup-backend-mode.test.ts
+++ b/src/cli/startup-backend-mode.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { inferBackendModeFromAgentId } from "@/cli/startup-backend-mode";
+
+describe("startup backend mode inference", () => {
+  test("local agent IDs use the local backend", () => {
+    expect(inferBackendModeFromAgentId("agent-local-abc")).toBe("local");
+  });
+
+  test("cloud agent IDs use the API backend", () => {
+    expect(inferBackendModeFromAgentId("agent-abc")).toBe("api");
+  });
+
+  test("missing agent IDs do not infer a backend", () => {
+    expect(inferBackendModeFromAgentId(null)).toBeUndefined();
+    expect(inferBackendModeFromAgentId(undefined)).toBeUndefined();
+  });
+});

--- a/src/cli/startup-backend-mode.ts
+++ b/src/cli/startup-backend-mode.ts
@@ -1,0 +1,8 @@
+import { isLocalAgentId } from "@/agent/agent-id";
+
+export function inferBackendModeFromAgentId(
+  agentId?: string | null,
+): "api" | "local" | undefined {
+  if (!agentId) return undefined;
+  return isLocalAgentId(agentId) ? "local" : "api";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { formatErrorDetails } from "./cli/helpers/error-formatter";
 import type { ApprovalRequest } from "./cli/helpers/stream";
 import { initTerminalTheme } from "./cli/helpers/terminal-theme";
 import { ProfileSelectionInline } from "./cli/profile-selection";
+import { inferBackendModeFromAgentId } from "./cli/startup-backend-mode";
 import {
   validateConversationDefaultRequiresAgent,
   validateFlagConflicts,
@@ -730,6 +731,11 @@ async function main(): Promise<void> {
   }
 
   const specifiedAgentName = values.name ?? null;
+  const inferredBackendModeFromAgentId =
+    inferBackendModeFromAgentId(specifiedAgentId);
+  if (!explicitBackendMode && inferredBackendModeFromAgentId) {
+    configureBackendMode(inferredBackendModeFromAgentId);
+  }
   const specifiedModel = values.model ?? undefined;
   const systemPromptPreset = values.system ?? undefined;
   const systemCustom = values["system-custom"] ?? undefined;
@@ -771,6 +777,7 @@ async function main(): Promise<void> {
 
   if (
     !explicitBackendMode &&
+    !inferredBackendModeFromAgentId &&
     settings.preferredBackendMode === "local" &&
     baseURL === LETTA_CLOUD_API_URL
   ) {
@@ -783,6 +790,7 @@ async function main(): Promise<void> {
   // none exist, startup falls through to local default-agent creation.
   if (
     !explicitBackendMode &&
+    !inferredBackendModeFromAgentId &&
     !isHeadless &&
     baseURL === LETTA_CLOUD_API_URL &&
     !settings.refreshToken &&


### PR DESCRIPTION
## Summary
- infer startup backend mode from explicit `--agent` IDs before applying saved backend preferences
- route `agent-local-*` resume commands to the local backend instead of Constellation
- preserve explicit `--backend api|local` as the highest-priority override

## Test plan
- [x] `bun run check` passes
- [x] `LETTA_DEBUG=0 bun run dev -- --agent agent-local-3c0b11d3-8bcf-41e4-9fa8-38cf2cb16788` resumes locally in manual testing
- [x] added unit coverage for backend inference from agent ID prefixes

👾 Generated with [Letta Code](https://letta.com)