### PR TITLE
fix: relax routed Telegram reply reminder

### DIFF
--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -64,7 +64,7 @@ describe("formatChannelNotification", () => {
       "Plain assistant text is not delivered to the user.",
     );
     expect(reminder).toContain(
-      'If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+      'If you should reply to the external user, use MessageChannel with action="send", channel="telegram", and chat_id="12345"',
     );
     expect(reminder).toContain(
       "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
@@ -90,7 +90,7 @@ describe("formatChannelNotification", () => {
     const xml = buildChannelNotificationXml(msg);
 
     expect(reminder).toContain(
-      'If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="telegram", and chat_id="12345"',
+      'If you should reply to the external user, use MessageChannel with action="send", channel="telegram", and chat_id="12345"',
     );
     expect(reminder).not.toContain('accountId="account-1"');
     expect(xml).toContain('account_id="account-1"');

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -49,7 +49,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const lines = [
     SYSTEM_REMINDER_OPEN,
     `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
-    `If you should reply to the external user, your final action for this turn must be exactly one MessageChannel call with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
+    `If you should reply to the external user, use MessageChannel with action=\"send\", channel=\"${escapedChannel}\", and chat_id=\"${escapedChatId}\". Put the user-visible reply in message.`,
     "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
     "Do not produce a plain text assistant response as the user-visible reply.",
     "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",


### PR DESCRIPTION
## Summary
- remove the routed Telegram reminder text that said the final action must be exactly one MessageChannel send
- keep the reminder focused on using MessageChannel with the correct channel and chat_id
- update the XML reminder tests to match the relaxed wording

## Test plan
- [x] bun test src/channels/xml.test.ts

👾 Generated with [Letta Code](https://letta.com)