### PR TITLE
fix(local): use real timestamps for local transcripts

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -51,6 +58,10 @@ async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   return chunks;
 }
 
+function pageItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
+  return Array.isArray(value) ? value : value.getPaginatedItems();
+}
+
 function assistantMessage(input: {
   content: AssistantMessage["content"];
   stopReason: AssistantMessage["stopReason"];
@@ -94,6 +105,165 @@ function lettaStreamFromChunks(
 }
 
 describe("local backend pi transcript", () => {
+  test("uses wall-clock timestamps for new local conversations and messages", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-time-"));
+    const before = Date.now() - 1_000;
+    const executor: HeadlessTurnExecutor = {
+      async execute() {
+        return lettaStreamFromChunks([
+          {
+            message_type: "assistant_message",
+            content: [{ type: "text", text: "ok" }],
+          } as LettaStreamingResponse,
+          {
+            message_type: "stop_reason",
+            stop_reason: "end_turn",
+          } as LettaStreamingResponse,
+        ]);
+      },
+    };
+    const backend = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "hello" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    const after = Date.now() + 1_000;
+    const conversations = (await backend.listConversations({
+      agent_id: agent.id,
+    } as never)) as Array<{ last_message_at?: string | null }>;
+    const messages = pageItems(
+      await backend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    const timestamps = [
+      conversation.created_at,
+      conversations[0]?.last_message_at,
+      messages[0]?.date,
+      messages.at(-1)?.date,
+    ];
+    for (const timestamp of timestamps) {
+      expect(typeof timestamp).toBe("string");
+      const parsed = Date.parse(timestamp ?? "");
+      expect(parsed).toBeGreaterThanOrEqual(before);
+      expect(parsed).toBeLessThanOrEqual(after);
+    }
+  });
+
+  test("repairs legacy synthetic transcript timestamps from manifest and file mtime", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-time-"));
+    const agentId = "agent-local-default";
+    const conversationId = "local-conv-old";
+    const conversationDir = join(
+      storageDir,
+      "conversations",
+      `${conversationId}--${agentId}`,
+    );
+    const createdAt = "2026-05-22T12:00:00.000Z";
+    const activeAt = "2026-05-22T13:00:00.000Z";
+    await mkdir(join(storageDir, "agents"), { recursive: true });
+    await writeFile(
+      join(storageDir, "agents", `${agentId}.json`),
+      `${JSON.stringify({
+        id: agentId,
+        name: "Local",
+        description: null,
+        system: "",
+        tags: [],
+        model: "openai/gpt-5-mini",
+        model_settings: { model: "openai/gpt-5-mini" },
+      })}\n`,
+    );
+    await mkdir(conversationDir, { recursive: true });
+    await writeFile(
+      join(conversationDir, "conversation.json"),
+      `${JSON.stringify({
+        id: conversationId,
+        agent_id: agentId,
+        created_at: "2026-01-01T00:00:01.000Z",
+        updated_at: "2026-01-01T00:00:02.000Z",
+        last_message_at: "2026-01-01T00:00:02.000Z",
+        in_context_message_ids: ["local-ui-msg-1", "local-ui-msg-2"],
+      })}\n`,
+    );
+    await writeFile(
+      join(conversationDir, "manifest.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        message_format: "pi-ai-message-jsonl",
+        provider_stack: "pi-ai",
+        created_at: createdAt,
+      })}\n`,
+    );
+    const messagesPath = join(conversationDir, "messages.jsonl");
+    const transcriptRows = [
+      {
+        id: "local-ui-msg-1",
+        role: "user",
+        content: [{ type: "text", text: "old" }],
+        timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+        metadata: {
+          created_at: "2026-01-01T00:00:01.000Z",
+          updated_at: "2026-01-01T00:00:01.000Z",
+          agent_id: agentId,
+          conversation_id: conversationId,
+        },
+      },
+      {
+        id: "local-ui-msg-2",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        api: "local",
+        provider: "local",
+        model: "local",
+        usage: emptyLocalUsage(),
+        stopReason: "stop",
+        timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+        metadata: {
+          created_at: "2026-01-01T00:00:02.000Z",
+          updated_at: "2026-01-01T00:00:02.000Z",
+          agent_id: agentId,
+          conversation_id: conversationId,
+        },
+      },
+    ].map((message) => JSON.stringify(message));
+    await writeFile(messagesPath, `${transcriptRows.join("\n")}\n`);
+    await utimes(messagesPath, new Date(activeAt), new Date(activeAt));
+
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    const conversations = (await backend.listConversations({
+      agent_id: agentId,
+    } as never)) as Array<{
+      created_at?: string | null;
+      updated_at?: string | null;
+      last_message_at?: string | null;
+    }>;
+    const messages = pageItems(
+      await backend.listConversationMessages(conversationId, {
+        agent_id: agentId,
+        order: "asc",
+      } as never),
+    );
+
+    expect(conversations[0]?.created_at).toBe(createdAt);
+    expect(conversations[0]?.updated_at).toBe(activeAt);
+    expect(conversations[0]?.last_message_at).toBe(activeAt);
+    expect(messages[0]?.date).toBe(createdAt);
+    expect(messages.at(-1)?.date).toBe(activeAt);
+  });
+
   test("reuses cached compiled system prompt across turns until explicit recompile", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-cache-"));
     const systemPrompts: string[] = [];

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -47,6 +47,29 @@ function localMessageConversationId(
     : fallbackConversationId;
 }
 
+function isoFromTimestamp(value: number | undefined): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? new Date(value).toISOString()
+    : undefined;
+}
+
+function localMessageDate(message: LocalMessage, fallbackDate: string): string {
+  return (
+    (typeof message.metadata?.created_at === "string"
+      ? message.metadata.created_at
+      : undefined) ??
+    isoFromTimestamp(message.timestamp) ??
+    fallbackDate
+  );
+}
+
+function offsetIsoTimestamp(value: string, offsetMs: number): string {
+  if (offsetMs === 0) return value;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed + offsetMs).toISOString();
+}
+
 function userContentToStoredContent(
   content: LocalUserMessage["content"],
 ): unknown {
@@ -157,7 +180,7 @@ export function projectLocalMessageToStoredMessages(
     message,
     fallbackConversationId,
   );
-  const date = fallbackDate;
+  const date = localMessageDate(message, fallbackDate);
 
   if (message.metadata?.compaction) {
     return [
@@ -280,15 +303,13 @@ export function projectLocalMessagesToStoredMessages(
 
 export function withProjectedMessageDates(
   messages: StoredMessage[],
-  sourceMessageIndex: number,
+  _sourceMessageIndex: number,
 ): StoredMessage[] {
   return messages.map(
     (message, projectedIndex) =>
       ({
         ...message,
-        date: new Date(
-          Date.UTC(2026, 0, 1, 0, 0, sourceMessageIndex + 1, projectedIndex),
-        ).toISOString(),
+        date: offsetIsoTimestamp(message.date, projectedIndex),
       }) as StoredMessage,
   );
 }

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -146,8 +147,23 @@ function shouldUseDefaultLocalModel(model: unknown): boolean {
   );
 }
 
-function timestampForSequence(sequence: number): string {
-  return new Date(Date.UTC(2026, 0, 1, 0, 0, sequence)).toISOString();
+function currentIsoTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function parseIsoTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isSyntheticLocalTimestamp(value: string | null | undefined): boolean {
+  const parsed = parseIsoTimestamp(value);
+  if (parsed === null) return false;
+  return (
+    parsed >= Date.UTC(2026, 0, 1, 0, 0, 0, 0) &&
+    parsed < Date.UTC(2026, 0, 2, 0, 0, 0, 0)
+  );
 }
 
 function optionalRecordOrNull(
@@ -166,11 +182,11 @@ function conversationModelSettings(
 function createLocalConversationRecord(
   conversationId: string,
   agentId: string,
-  sequence: number,
+  _sequence: number,
   body: Partial<ConversationCreateBody> = {},
 ): StoredConversation {
   const bodyRecord = body as Record<string, unknown>;
-  const now = timestampForSequence(sequence);
+  const now = currentIsoTimestamp();
   const modelSettings = conversationModelSettings(bodyRecord.model_settings);
   return {
     id: conversationId,
@@ -650,6 +666,119 @@ function localMessageDate(message: LocalMessage, fallbackDate: string): string {
   return createdAtForLocalMessage(message) ?? fallbackDate;
 }
 
+interface LocalTranscriptTiming {
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function fileIsoTimestamp(value: number | undefined): string | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? new Date(value).toISOString()
+    : undefined;
+}
+
+function transcriptTimingForConversationDir(
+  conversationDir: string,
+  manifest?: LocalTranscriptManifest,
+): LocalTranscriptTiming {
+  const messagesPath = transcriptMessagesPath(conversationDir);
+  const stats = existsSync(messagesPath) ? statSync(messagesPath) : undefined;
+  const manifestCreatedAt =
+    parseIsoTimestamp(manifest?.created_at) !== null
+      ? manifest?.created_at
+      : undefined;
+  const fileCreatedAt = fileIsoTimestamp(stats?.birthtimeMs);
+  const fileUpdatedAt = fileIsoTimestamp(stats?.mtimeMs);
+  return {
+    createdAt: manifestCreatedAt ?? fileCreatedAt ?? fileUpdatedAt,
+    updatedAt: fileUpdatedAt ?? manifestCreatedAt ?? fileCreatedAt,
+  };
+}
+
+function interpolatedTranscriptTimestamp(
+  timing: LocalTranscriptTiming,
+  index: number,
+  count: number,
+): string | undefined {
+  const start =
+    parseIsoTimestamp(timing.createdAt) ?? parseIsoTimestamp(timing.updatedAt);
+  const end = parseIsoTimestamp(timing.updatedAt) ?? start;
+  if (start === null || end === null) return undefined;
+  if (count <= 1) return new Date(end).toISOString();
+
+  const boundedEnd = Math.max(start, end);
+  const offset = Math.round(((boundedEnd - start) * index) / (count - 1));
+  return new Date(start + offset).toISOString();
+}
+
+function repairSyntheticLocalMessageTimestamps(
+  messages: LocalMessage[],
+  timing: LocalTranscriptTiming,
+): LocalMessage[] {
+  if (
+    !messages.some((message) =>
+      isSyntheticLocalTimestamp(createdAtForLocalMessage(message)),
+    )
+  ) {
+    return messages;
+  }
+
+  return messages.map((message, index) => {
+    const currentCreatedAt = createdAtForLocalMessage(message);
+    if (!isSyntheticLocalTimestamp(currentCreatedAt)) return message;
+
+    const createdAt = interpolatedTranscriptTimestamp(
+      timing,
+      index,
+      messages.length,
+    );
+    if (!createdAt) return message;
+
+    const metadata = message.metadata ?? {};
+    const updatedAt = isSyntheticLocalTimestamp(metadata.updated_at)
+      ? createdAt
+      : (metadata.updated_at ?? createdAt);
+    return {
+      ...message,
+      timestamp: timestampFromIso(createdAt),
+      metadata: {
+        ...metadata,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      },
+    };
+  });
+}
+
+function repairSyntheticConversationTimestamps(
+  conversation: StoredConversation,
+  messages: LocalMessage[],
+  timing: LocalTranscriptTiming,
+): StoredConversation {
+  const firstMessage = messages[0];
+  const lastMessage = messages.at(-1);
+  const firstMessageAt = firstMessage
+    ? createdAtForLocalMessage(firstMessage)
+    : undefined;
+  const lastMessageAt = lastMessage
+    ? createdAtForLocalMessage(lastMessage)
+    : undefined;
+  return {
+    ...conversation,
+    created_at: isSyntheticLocalTimestamp(conversation.created_at)
+      ? (firstMessageAt ?? timing.createdAt ?? conversation.created_at)
+      : conversation.created_at,
+    updated_at: isSyntheticLocalTimestamp(conversation.updated_at)
+      ? (lastMessageAt ?? timing.updatedAt ?? conversation.updated_at)
+      : conversation.updated_at,
+    last_message_at:
+      !conversation.last_message_at ||
+      isSyntheticLocalTimestamp(conversation.last_message_at)
+        ? (lastMessageAt ?? timing.updatedAt ?? conversation.last_message_at)
+        : conversation.last_message_at,
+  };
+}
+
 export class LocalStore {
   private readonly storageDir?: string;
   private readonly strictAgentAccess: boolean;
@@ -984,7 +1113,7 @@ export class LocalStore {
       const updated = updateLocalConversationRecord(
         created,
         body,
-        timestampForSequence(this.messageSeq + this.conversationSeq + 1),
+        currentIsoTimestamp(),
       );
       this.conversations.set(
         this.conversationKey(conversationId, created.agent_id),
@@ -996,7 +1125,7 @@ export class LocalStore {
     const updated = updateLocalConversationRecord(
       current,
       body,
-      timestampForSequence(this.messageSeq + this.conversationSeq + 1),
+      currentIsoTimestamp(),
     );
     this.conversations.set(
       this.conversationKey(conversationId, current.agent_id),
@@ -1773,7 +1902,7 @@ export class LocalStore {
     this.messageSeq += 1;
     return {
       id: `${this.storedMessageIdPrefix}${this.messageSeq}`,
-      date: new Date(Date.UTC(2026, 0, 1, 0, 0, this.messageSeq)).toISOString(),
+      date: currentIsoTimestamp(),
       agent_id: agentId,
       conversation_id: conversation.id,
       ...fields,
@@ -1897,10 +2026,7 @@ export class LocalStore {
         message.id,
       ];
     }
-    const date = localMessageDate(
-      message,
-      new Date(Date.UTC(2026, 0, 1, 0, 0, this.messageSeq + 1)).toISOString(),
-    );
+    const date = localMessageDate(message, currentIsoTimestamp());
     conversation.last_message_at = date;
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
@@ -1952,11 +2078,11 @@ export class LocalStore {
   }
 
   private nextLocalMessageDate(): string {
-    return timestampForSequence(this.localMessageSeq + 1);
+    return currentIsoTimestamp();
   }
 
   private currentLocalMessageDate(): string {
-    return timestampForSequence(this.localMessageSeq);
+    return currentIsoTimestamp();
   }
 
   private loadFromStorage(): void {
@@ -1980,19 +2106,34 @@ export class LocalStore {
     if (existsSync(conversationsDir)) {
       for (const conversationDirName of readdirSync(conversationsDir)) {
         const conversationDir = join(conversationsDir, conversationDirName);
-        const conversation = readJsonFile<StoredConversation>(
+        let conversation = readJsonFile<StoredConversation>(
           join(conversationDir, "conversation.json"),
         );
         if (!conversation?.id || !conversation.agent_id) continue;
 
-        validateLocalTranscriptManifest(conversationDir, this.storageDir);
+        const manifest = validateLocalTranscriptManifest(
+          conversationDir,
+          this.storageDir,
+        );
         const key = this.conversationKey(
           conversation.id,
           conversation.agent_id,
         );
-        const localMessages = readJsonlFile<LocalMessage>(
-          transcriptMessagesPath(conversationDir),
-        ).map(normalizeLocalMessageForPi);
+        const timing = transcriptTimingForConversationDir(
+          conversationDir,
+          manifest,
+        );
+        const localMessages = repairSyntheticLocalMessageTimestamps(
+          readJsonlFile<LocalMessage>(
+            transcriptMessagesPath(conversationDir),
+          ).map(normalizeLocalMessageForPi),
+          timing,
+        );
+        conversation = repairSyntheticConversationTimestamps(
+          conversation,
+          localMessages,
+          timing,
+        );
         const compiledSystemPrompt = readJsonFile<LocalCompiledSystemPrompt>(
           join(conversationDir, "system-prompt.json"),
         );


### PR DESCRIPTION
## Summary
- use wall-clock timestamps for new local conversations, local UI messages, and stored local message chunks instead of deterministic Jan 1 sequence timestamps
- preserve local message metadata timestamps when projecting local UI messages into stored messages
- repair existing synthetic Jan 1 transcript timestamps in memory from the transcript manifest created time and messages file mtime, so existing local `/resume` rows stop showing 20 weeks ago

## Test plan
- [x] `bun run check` passes
- [x] `bun test src/backend/local-backend.test.ts` passes
- [x] added coverage for new wall-clock local timestamps and legacy synthetic timestamp repair

👾 Generated with [Letta Code](https://letta.com)