### PR TITLE
fix(experiments): show dismissed message on no-op close

### DIFF
--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -1137,12 +1137,13 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
     async (
       changes: Array<{ experimentId: ExperimentId; enabled: boolean }>,
     ) => {
+      const overlayCommand = consumeOverlayCommand("experiment");
+
       if (changes.length === 0) {
+        overlayCommand?.finish("Experiments dialog dismissed", true);
         setActiveOverlay(null);
         return;
       }
-
-      const overlayCommand = consumeOverlayCommand("experiment");
 
       if (isAgentBusy()) {
         setActiveOverlay(null);


### PR DESCRIPTION
## Summary
- finish the pending `/experiments` overlay command when confirming with no changes
- show `Experiments dialog dismissed` for no-op closes, matching cancel and other menu dismissal behavior

## Test plan
- [x] `bun run check` passes

👾 Generated with [Letta Code](https://letta.com)