### PR TITLE
fix(channels): remove unnecessary escapes in reminder text

### DIFF
--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -49,7 +49,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const lines = [
     SYSTEM_REMINDER_OPEN,
     `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
-    `If you should reply to the external user, use MessageChannel with action=\"send\", channel=\"${escapedChannel}\", and chat_id=\"${escapedChatId}\". Put the user-visible reply in message.`,
+    `If you should reply to the external user, use MessageChannel with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
     "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
     "Do not produce a plain text assistant response as the user-visible reply.",
     "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",


### PR DESCRIPTION
## Summary
- remove unnecessary escaped quotes from the channel reminder template literal
- clears the Biome `noUselessEscapeInString` warning on main

## Test plan
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/channels/xml.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)