### PR TITLE
fix(agents): use explicit colors for backend toggle in New tab

### DIFF
--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -1140,21 +1140,19 @@ export function AgentSelector({
                 color={
                   newAgentBackendMode === "api"
                     ? colors.selector.itemHighlighted
-                    : undefined
+                    : colors.selector.title
                 }
-                dimColor={newAgentBackendMode !== "api"}
               >
                 Constellation
               </Text>
-              <Text dimColor> · </Text>
+              <Text color={colors.selector.title}> · </Text>
               <Text
                 bold={newAgentBackendMode === "local"}
                 color={
                   newAgentBackendMode === "local"
                     ? colors.selector.itemHighlighted
-                    : undefined
+                    : colors.selector.title
                 }
-                dimColor={newAgentBackendMode !== "local"}
               >
                 Local
               </Text>


### PR DESCRIPTION
## Summary

When pressing Ctrl+B in the `/agents` New tab to switch between Constellation and Local, the newly-active label rendered as muted purple instead of the bright purple that Constellation shows by default.

**Root cause:** The inactive state used `dimColor={true}` with no explicit `color` prop. On re-render, Ink could bleed the dim ANSI modifier onto the newly-active label, making it render with the right hue but dimmed.

**Fix:** Drop `dimColor` entirely and use explicit colors for both states throughout:
- Active: `colors.selector.itemHighlighted` (`#8C8CF9`, bright purple)
- Inactive: `colors.selector.title` (`#BEBEEE`, muted)
- Separator: `colors.selector.title` (explicit, no dimColor)

Both Constellation and Local now use identical rendering logic when active, so they look the same whichever is selected.

## Test plan
- [ ] Open `/agents` → New tab → verify Constellation shows bright purple
- [ ] Press Ctrl+B → verify Local shows the same bright purple

👾 Generated with [Letta Code](https://letta.com)