### PR TITLE
fix(local): persist LM Studio env API key

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -4,6 +4,7 @@ import {
   getLocalChatGPTApiKey,
   getLocalProviderRecordByName,
   type LocalProviderRecord,
+  localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
 import {
   type LocalProviderTimeout,
@@ -123,12 +124,6 @@ function localProviderRecord(
   return null;
 }
 
-function apiKeyFromRecord(
-  record: LocalProviderRecord | null,
-): string | undefined {
-  return record?.auth.type === "api" ? record.auth.key : undefined;
-}
-
 function localProviderConnection(
   providerNames: readonly string[],
   envValue: string | undefined,
@@ -142,7 +137,7 @@ function localProviderConnection(
 } {
   const record = localProviderRecord(providerNames, storageDir);
   return {
-    apiKey: apiKeyFromRecord(record) ?? envValue,
+    apiKey: localProviderApiKeyFromRecord(record) ?? envValue,
     baseURL: record?.base_url,
     timeout: resolveLocalProviderTimeout({
       configuredTimeout: record?.timeout,
@@ -172,11 +167,12 @@ export function resolveZaiConnection(options: {
     options.storageDir,
   );
   const regularKey =
-    apiKeyFromRecord(regularRecord) ??
+    localProviderApiKeyFromRecord(regularRecord) ??
     process.env.ZAI_API_KEY ??
     process.env.ZHIPU_API_KEY;
   const codingKey =
-    apiKeyFromRecord(codingRecord) ?? process.env.ZAI_CODING_API_KEY;
+    localProviderApiKeyFromRecord(codingRecord) ??
+    process.env.ZAI_CODING_API_KEY;
   const regularConnection: ZaiConnection = {
     providerName: "zai",
     baseURL:

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -62,6 +62,33 @@ function pageItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
   return Array.isArray(value) ? value : value.getPaginatedItems();
 }
 
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 function assistantMessage(input: {
   content: AssistantMessage["content"];
   stopReason: AssistantMessage["stopReason"];
@@ -459,6 +486,36 @@ describe("local backend pi transcript", () => {
     expect(calls).toEqual(["http://127.0.0.1:1234/v1/models"]);
     expect(handles).toContain("lmstudio/openai/gpt-oss-20b");
     expect(handles).not.toContain("lmstudio/google/gemma-3n-e4b");
+  });
+
+  test("uses LM Studio env API key for discovery when stored key is placeholder", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-lmstudio-env-key-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "lmstudio",
+      providerName: "lc-lmstudio",
+      apiKey: "not-needed",
+      baseURL: "http://localhost:8000/v1",
+      storageDir,
+    });
+    const captured: { authorization?: string | null } = {};
+    const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
+      captured.authorization = new Headers(init?.headers).get("Authorization");
+      return new Response(JSON.stringify({ data: [{ id: "secure-model" }] }), {
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await withEnv({ LMSTUDIO_API_KEY: "1234" }, async () => {
+      const handles = (
+        await listLocalModels(storageDir, { fetch: fetchImpl })
+      ).map((model) => model.handle);
+
+      expect(handles).toContain("lmstudio/secure-model");
+    });
+
+    expect(captured.authorization).toBe("Bearer 1234");
   });
 
   test("discovers configured llama.cpp models from OpenAI-compatible catalog", async () => {

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -13,6 +13,7 @@ import {
 import {
   type LocalProviderRecord,
   listLocalProviderRecords,
+  localProviderApiKeyFromRecord,
 } from "./local-provider-auth-store";
 
 export interface LocalModelConfig {
@@ -179,12 +180,6 @@ function providerRecordFor(
   return records.find((record) => names.includes(record.name));
 }
 
-function apiKeyFromRecord(
-  record: LocalProviderRecord | undefined,
-): string | undefined {
-  return record?.auth.type === "api" ? record.auth.key : undefined;
-}
-
 function isDiscoverableLocalProvider(provider: PiProvider): boolean {
   return getPiProviderSpec(provider).localModelDiscovery !== undefined;
 }
@@ -202,7 +197,7 @@ async function discoverModelIdsForProvider(
   const baseURL =
     record?.base_url ?? spec.baseUrlEnv?.() ?? spec.defaultBaseURL;
   if (!baseURL) return [];
-  const apiKey = apiKeyFromRecord(record) ?? spec.apiKeyEnv?.();
+  const apiKey = localProviderApiKeyFromRecord(record) ?? spec.apiKeyEnv?.();
   const input = {
     baseURL,
     apiKey,

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -54,6 +54,8 @@ export interface LocalProviderOAuthAuth {
 
 export type LocalProviderAuth = LocalProviderApiAuth | LocalProviderOAuthAuth;
 
+export const LOCAL_PROVIDER_NO_API_KEY = "not-needed";
+
 export interface LocalProviderRecord {
   id: string;
   name: string;
@@ -128,6 +130,15 @@ function providerResponse(record: LocalProviderRecord): ProviderResponse {
     ...(record.access_key ? { access_key: record.access_key } : {}),
     ...(record.region ? { region: record.region } : {}),
   };
+}
+
+export function localProviderApiKeyFromRecord(
+  record: LocalProviderRecord | null | undefined,
+): string | undefined {
+  if (record?.auth.type !== "api") return undefined;
+  return record.auth.key === LOCAL_PROVIDER_NO_API_KEY
+    ? undefined
+    : record.auth.key;
 }
 
 export function listLocalProviderRecords(
@@ -273,7 +284,7 @@ export function getLocalProviderApiKeyByName(
   storageDir?: string,
 ): string | undefined {
   const record = getLocalProviderRecordByName(providerName, storageDir);
-  return record?.auth.type === "api" ? record.auth.key : undefined;
+  return localProviderApiKeyFromRecord(record);
 }
 
 export function getLocalProviderApiKeyByType(
@@ -281,7 +292,7 @@ export function getLocalProviderApiKeyByType(
   storageDir?: string,
 ): string | undefined {
   const record = getLocalProviderRecordByType(providerType, storageDir);
-  return record?.auth.type === "api" ? record.auth.key : undefined;
+  return localProviderApiKeyFromRecord(record);
 }
 
 export function getLocalChatGPTOAuth(

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -177,6 +177,31 @@ describe("pi model factory", () => {
     }
   });
 
+  test("does not let local no-key placeholders mask LM Studio env API keys", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-lmstudio-env-key-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "lmstudio",
+        providerName: "lc-lmstudio",
+        apiKey: "not-needed",
+        baseURL: "http://localhost:8000/v1",
+      });
+
+      await withEnv({ LMSTUDIO_API_KEY: "1234" }, async () => {
+        const resolved = await resolvePiModelForAgent(
+          "lmstudio/local-model",
+          { provider_type: "lmstudio" },
+          { localProviderAuthStorageDir: storageDir },
+        );
+
+        expect(resolved.apiKey).toBe("1234");
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("restores process env overrides", () => {
     const originalRegion = process.env.AWS_REGION;
     delete process.env.AWS_PROFILE;

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -653,7 +653,7 @@ export function ProviderSelector({
             {apiKeyInput
               ? maskApiKey(apiKeyInput)
               : hasDefaultApiKey
-                ? "(press Enter for no key)"
+                ? "(press Enter for default key)"
                 : "(enter key)"}
           </Text>
           <Text
@@ -670,7 +670,7 @@ export function ProviderSelector({
           <Text dimColor>
             {"  "}
             {hasDefaultApiKey && !hasTypedApiKey && validationState === "idle"
-              ? "Enter to validate without a key · Esc cancel"
+              ? "Enter to validate with default key · Esc cancel"
               : footerText}
           </Text>
         </Box>

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -8,6 +8,33 @@ import {
   resolveConnectProvider,
 } from "@/cli/commands/connect-normalize";
 
+function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => T,
+): T {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe("connect provider normalization", () => {
   test("normalizes codex alias to chatgpt provider", () => {
     const resolved = resolveConnectProvider("codex");
@@ -57,16 +84,36 @@ describe("connect provider normalization", () => {
   });
 
   test("supports API-key optional local providers", () => {
-    const ollama = resolveConnectProvider("ollama");
-    const lmstudio = resolveConnectProvider("lmstudio");
-    const llamaCpp = resolveConnectProvider("llama.cpp");
-    if (!ollama || !lmstudio || !llamaCpp) {
-      throw new Error("Expected local providers to resolve");
-    }
+    withEnv(
+      {
+        OLLAMA_LOCAL_API_KEY: undefined,
+        LMSTUDIO_API_KEY: undefined,
+        LLAMA_CPP_API_KEY: undefined,
+      },
+      () => {
+        const ollama = resolveConnectProvider("ollama");
+        const lmstudio = resolveConnectProvider("lmstudio");
+        const llamaCpp = resolveConnectProvider("llama.cpp");
+        if (!ollama || !lmstudio || !llamaCpp) {
+          throw new Error("Expected local providers to resolve");
+        }
 
-    expect(defaultConnectApiKey(ollama)).toBe("not-needed");
-    expect(defaultConnectApiKey(lmstudio)).toBe("not-needed");
-    expect(defaultConnectApiKey(llamaCpp)).toBe("not-needed");
-    expect(llamaCpp.canonical).toBe("llama-cpp");
+        expect(defaultConnectApiKey(ollama)).toBe("not-needed");
+        expect(defaultConnectApiKey(lmstudio)).toBe("not-needed");
+        expect(defaultConnectApiKey(llamaCpp)).toBe("not-needed");
+        expect(llamaCpp.canonical).toBe("llama-cpp");
+      },
+    );
+  });
+
+  test("uses environment keys before API-key optional defaults", () => {
+    withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
+      const lmstudio = resolveConnectProvider("lmstudio");
+      if (!lmstudio) {
+        throw new Error("Expected lmstudio provider to resolve");
+      }
+
+      expect(defaultConnectApiKey(lmstudio)).toBe("1234");
+    });
   });
 });

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -25,6 +25,33 @@ function createIoDeps() {
   };
 }
 
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe("connect subcommand", () => {
   test("runs OAuth flow for codex alias", async () => {
     const { stdout, deps } = createIoDeps();
@@ -86,7 +113,9 @@ describe("connect subcommand", () => {
   test("connects API-key optional local providers without prompting", async () => {
     const { deps } = createIoDeps();
 
-    const exitCode = await runConnectSubcommand(["ollama"], deps);
+    const exitCode = await withEnv({ OLLAMA_LOCAL_API_KEY: undefined }, () =>
+      runConnectSubcommand(["ollama"], deps),
+    );
 
     expect(exitCode).toBe(0);
     expect(deps.promptSecret).not.toHaveBeenCalled();
@@ -104,15 +133,17 @@ describe("connect subcommand", () => {
   test("passes local provider base URL and timeout options", async () => {
     const { deps } = createIoDeps();
 
-    const exitCode = await runConnectSubcommand(
-      [
-        "lmstudio",
-        "--base-url",
-        "http://127.0.0.1:1234/v1",
-        "--timeout",
-        "600s",
-      ],
-      deps,
+    const exitCode = await withEnv({ LMSTUDIO_API_KEY: undefined }, () =>
+      runConnectSubcommand(
+        [
+          "lmstudio",
+          "--base-url",
+          "http://127.0.0.1:1234/v1",
+          "--timeout",
+          "600s",
+        ],
+        deps,
+      ),
     );
 
     expect(exitCode).toBe(0);
@@ -133,9 +164,11 @@ describe("connect subcommand", () => {
   test("connects llama.cpp local provider alias", async () => {
     const { deps } = createIoDeps();
 
-    const exitCode = await runConnectSubcommand(
-      ["llama.cpp", "--base-url", "http://localhost:8080/v1"],
-      deps,
+    const exitCode = await withEnv({ LLAMA_CPP_API_KEY: undefined }, () =>
+      runConnectSubcommand(
+        ["llama.cpp", "--base-url", "http://localhost:8080/v1"],
+        deps,
+      ),
     );
 
     expect(exitCode).toBe(0);
@@ -147,6 +180,29 @@ describe("connect subcommand", () => {
       undefined,
       undefined,
       { baseURL: "http://localhost:8080/v1" },
+    );
+  });
+
+  test("uses LM Studio environment API key when no key is provided", async () => {
+    const { deps } = createIoDeps();
+
+    const exitCode = await withEnv({ LMSTUDIO_API_KEY: "1234" }, () =>
+      runConnectSubcommand(
+        ["lmstudio", "--base-url", "http://localhost:8000/v1"],
+        deps,
+      ),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith("lmstudio", "1234");
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "lmstudio",
+      "lc-lmstudio",
+      "1234",
+      undefined,
+      undefined,
+      undefined,
+      { baseURL: "http://localhost:8000/v1" },
     );
   });
 

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -15,12 +15,17 @@ import {
   updateProvider as updateProviderRequest,
 } from "@/backend/api/providers";
 import { getBackend } from "@/backend/backend";
-import { PROVIDER_TYPE_TO_BASE_PROVIDER } from "@/backend/dev/pi-provider-registry";
+import {
+  getPiProviderSpec,
+  PROVIDER_TYPE_TO_BASE_PROVIDER,
+  resolveProviderFromProviderType,
+} from "@/backend/dev/pi-provider-registry";
 import {
   createOrUpdateLocalProvider,
   deleteLocalProvider,
   getLocalProviderByName,
   isLocalProviderTypeSupported,
+  LOCAL_PROVIDER_NO_API_KEY,
   listLocalProviders,
   removeLocalProviderByName,
   updateLocalProvider,
@@ -130,7 +135,7 @@ export const BYOK_PROVIDERS = [
     providerType: "ollama",
     providerName: "lc-ollama",
     requiresApiKey: false,
-    defaultApiKey: "not-needed",
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
   },
   {
     id: "ollama-cloud",
@@ -146,7 +151,7 @@ export const BYOK_PROVIDERS = [
     providerType: "lmstudio",
     providerName: "lc-lmstudio",
     requiresApiKey: false,
-    defaultApiKey: "not-needed",
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
   },
   {
     id: "llama-cpp",
@@ -155,7 +160,7 @@ export const BYOK_PROVIDERS = [
     providerType: "llama_cpp",
     providerName: "lc-llama-cpp",
     requiresApiKey: false,
-    defaultApiKey: "not-needed",
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
   },
   {
     id: "bedrock",
@@ -194,11 +199,24 @@ export const BYOK_PROVIDERS = [
 export type ByokProviderId = (typeof BYOK_PROVIDERS)[number]["id"];
 export type ByokProvider = (typeof BYOK_PROVIDERS)[number];
 
+function providerEnvApiKey(provider: ByokProvider): string | undefined {
+  const piProvider = resolveProviderFromProviderType(provider.providerType);
+  if (!piProvider) return undefined;
+
+  const apiKey = getPiProviderSpec(piProvider).apiKeyEnv?.();
+  return apiKey && apiKey.length > 0 ? apiKey : undefined;
+}
+
 export function defaultProviderApiKey(
   provider: ByokProvider,
 ): string | undefined {
   if ("requiresApiKey" in provider && provider.requiresApiKey === false) {
-    return "defaultApiKey" in provider ? provider.defaultApiKey : "not-needed";
+    return (
+      providerEnvApiKey(provider) ??
+      ("defaultApiKey" in provider
+        ? provider.defaultApiKey
+        : LOCAL_PROVIDER_NO_API_KEY)
+    );
   }
   return undefined;
 }

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -6,6 +6,33 @@ import {
   defaultProviderApiKey,
 } from "@/providers/byok-providers";
 
+function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => T,
+): T {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 function providerById(id: string): ByokProvider {
   const provider = BYOK_PROVIDERS.find((candidate) => candidate.id === id);
   if (!provider) {
@@ -16,19 +43,52 @@ function providerById(id: string): ByokProvider {
 
 describe("ProviderSelector local provider API keys", () => {
   test("uses default key placeholders for API-key optional local providers", () => {
-    expect(defaultProviderApiKey(providerById("ollama"))).toBe("not-needed");
-    expect(defaultProviderApiKey(providerById("lmstudio"))).toBe("not-needed");
-    expect(defaultProviderApiKey(providerById("llama-cpp"))).toBe("not-needed");
+    withEnv(
+      {
+        OLLAMA_LOCAL_API_KEY: undefined,
+        LMSTUDIO_API_KEY: undefined,
+        LLAMA_CPP_API_KEY: undefined,
+      },
+      () => {
+        expect(defaultProviderApiKey(providerById("ollama"))).toBe(
+          "not-needed",
+        );
+        expect(defaultProviderApiKey(providerById("lmstudio"))).toBe(
+          "not-needed",
+        );
+        expect(defaultProviderApiKey(providerById("llama-cpp"))).toBe(
+          "not-needed",
+        );
+      },
+    );
   });
 
   test("allows blank input only when the selected provider has a default key", () => {
-    expect(providerApiKeyFromInput(providerById("lmstudio"), "")).toBe(
-      "not-needed",
+    withEnv(
+      {
+        OLLAMA_LOCAL_API_KEY: undefined,
+        LMSTUDIO_API_KEY: undefined,
+      },
+      () => {
+        expect(providerApiKeyFromInput(providerById("lmstudio"), "")).toBe(
+          "not-needed",
+        );
+        expect(providerApiKeyFromInput(providerById("ollama"), "   ")).toBe(
+          "not-needed",
+        );
+        expect(providerApiKeyFromInput(providerById("openai"), "")).toBe(
+          undefined,
+        );
+      },
     );
-    expect(providerApiKeyFromInput(providerById("ollama"), "   ")).toBe(
-      "not-needed",
-    );
-    expect(providerApiKeyFromInput(providerById("openai"), "")).toBe(undefined);
+  });
+
+  test("uses environment keys before local provider placeholders", () => {
+    withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
+      expect(providerApiKeyFromInput(providerById("lmstudio"), "")).toBe(
+        "1234",
+      );
+    });
   });
 
   test("uses explicitly typed keys over local provider defaults", () => {


### PR DESCRIPTION
## Summary
- Use optional local provider env vars (for example `LMSTUDIO_API_KEY`) before falling back to the `not-needed` placeholder during connect flows.
- Treat stored `not-needed` local provider auth as no stored API key so runtime/model discovery can still use env keys for existing configs.
- Update LM Studio/local provider tests to cover connect persistence, discovery auth headers, and runtime resolution.

Closes #2475

## Test plan
- [x] `bun run check`
- [x] `bun test src/cli/subcommands/connect.test.ts src/cli/connect-normalize.test.ts src/tests/cli/provider-selector-local-provider.test.ts src/backend/pi-model-factory.test.ts src/backend/local-backend.test.ts`
- [x] Isolated smoke: `LETTA_LOCAL_BACKEND_DIR=$(mktemp -d) LMSTUDIO_API_KEY=1234 bun run dev --backend local connect lmstudio --base-url http://localhost:8000/v1`

👾 Generated with [Letta Code](https://letta.com)