### PR TITLE
feat(statusline): add local extension runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "ink-link": "^5.0.0",
         "node-pty": "^1.1.0",
         "open": "^10.2.0",
+        "react": "18.2.0",
         "sharp": "^0.34.5",
         "shiki": "^4.0.2",
         "strip-ansi": "^7.2.0",
@@ -33,7 +34,6 @@
         "madge": "^8.0.0",
         "minimatch": "^10.0.3",
         "picomatch": "^2.3.1",
-        "react": "18.2.0",
         "typescript": "^5.0.0",
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ink-link": "^5.0.0",
     "node-pty": "^1.1.0",
     "open": "^10.2.0",
+    "react": "18.2.0",
     "sharp": "^0.34.5",
     "shiki": "^4.0.2",
     "strip-ansi": "^7.2.0",
@@ -66,7 +67,6 @@
     "madge": "^8.0.0",
     "minimatch": "^10.0.3",
     "picomatch": "^2.3.1",
-    "react": "18.2.0",
     "typescript": "^5.0.0"
   },
   "scripts": {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -49,6 +49,8 @@ import {
   createCommandRunner,
 } from "@/cli/commands/runner";
 import type { BtwState } from "@/cli/components/BtwPane";
+import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
+import { useLocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import {
   appendStreamingOutput,
   type Buffers,
@@ -2152,6 +2154,12 @@ export function App({
     turnCount: sharedReminderStateRef.current.turnCount,
     reflectionMode: reflectionSettings.trigger,
     reflectionStepCount: reflectionSettings.stepCount,
+    memfsEnabled:
+      agentId !== "loading" ? settingsManager.isMemfsEnabled(agentId) : false,
+    memfsDirectory:
+      agentId !== "loading" && settingsManager.isMemfsEnabled(agentId)
+        ? getScopedMemoryFilesystemRoot(agentId)
+        : null,
     permissionMode: uiPermissionMode,
     networkPhase,
     terminalWidth: chromeColumns,
@@ -2162,6 +2170,36 @@ export function App({
     })),
     triggerVersion: statusLineTriggerVersion,
   });
+  const extensionContext = useMemo(
+    () =>
+      buildStatuslineRenderContext({
+        payload: statusLine.payload,
+        ui: {
+          currentModelProvider: currentModelProvider ?? null,
+          goalStatusText: null,
+          hasTemporaryModelOverride: Boolean(hasTemporaryModelOverride),
+          isByokProvider: Boolean(
+            currentModelProvider?.startsWith("lc-") ||
+              currentModelProvider === OPENAI_CODEX_PROVIDER_NAME,
+          ),
+          isLocalBackend,
+          isOpenAICodexProvider:
+            currentModelProvider === OPENAI_CODEX_PROVIDER_NAME,
+          rightColumnWidth: Math.max(
+            28,
+            Math.min(72, Math.floor(chromeColumns * 0.45)),
+          ),
+        },
+      }),
+    [
+      chromeColumns,
+      currentModelProvider,
+      hasTemporaryModelOverride,
+      isLocalBackend,
+      statusLine.payload,
+    ],
+  );
+  const extensionRuntime = useLocalExtensionRuntime(extensionContext);
 
   const previousStreamingForStatusLineRef = useRef(streaming);
   useEffect(() => {
@@ -4614,6 +4652,7 @@ export function App({
       staticItems={staticItems}
       staticRenderEpoch={staticRenderEpoch}
       statusLine={statusLine}
+      extensionRuntime={extensionRuntime}
       streaming={streaming}
       stubDescriptions={stubDescriptions}
       thinkingMessage={thinkingMessage}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -53,6 +53,7 @@ import { UserMessage } from "@/cli/components/UserMessageRich";
 import { WelcomeScreen } from "@/cli/components/WelcomeScreen";
 import { WindowTitlePicker } from "@/cli/components/WindowTitlePicker";
 import { AnimationProvider } from "@/cli/contexts/AnimationContext";
+import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { backfillBuffers } from "@/cli/helpers/backfill";
 import {
@@ -295,6 +296,7 @@ type AppViewProps = {
   staticItems: StaticItem[];
   staticRenderEpoch: number;
   statusLine: StatusLineState;
+  extensionRuntime: LocalExtensionRuntime;
   streaming: boolean;
   stubDescriptions: Map<string, string>;
   thinkingMessage: string;
@@ -434,6 +436,7 @@ export function AppView(props: AppViewProps) {
     staticItems,
     staticRenderEpoch,
     statusLine,
+    extensionRuntime,
     streaming,
     stubDescriptions,
     thinkingMessage,
@@ -716,6 +719,7 @@ export function AppView(props: AppViewProps) {
                 statusLineText={statusLine.text || undefined}
                 statusLineRight={statusLine.rightText || undefined}
                 statusLinePayload={statusLine.payload}
+                extensionRuntime={extensionRuntime}
                 statusLinePrompt={statusLine.prompt}
                 footerNotification={footerUpdateText}
                 showInspirationalPromptHints={showInspirationalPromptHints}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -24,6 +24,8 @@ import {
   getBuiltinStatuslineRenderer,
 } from "@/cli/display/statusline/registry";
 import { buildLegacyStatuslineParts } from "@/cli/display/statusline/renderers/Legacy";
+import { evaluateLocalExtensionStatuses } from "@/cli/extensions/local-extension-loader";
+import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { bytesToTokens, formatCompact } from "@/cli/helpers/format";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import { formatGoalStatusIndicator } from "@/cli/helpers/goal-command";
@@ -43,6 +45,7 @@ import type { PermissionMode } from "@/permissions/mode";
 import { permissionMode } from "@/permissions/mode";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import { settingsManager } from "@/settings-manager";
+import { debugLog } from "@/utils/debug";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
 import { colors } from "./colors";
 import { InputAssist } from "./InputAssist";
@@ -61,7 +64,7 @@ import { Text } from "./Text";
 const ESC_CLEAR_WINDOW_MS = 2500;
 const FOOTER_WIDTH_STREAMING_DELTA = 2;
 const EMPTY_COMPOSER_PROMPT_ROTATION_MS = 6000;
-const STATUSLINE_TRANSIENT_HINT_MS = 4000;
+const STATUSLINE_TRANSIENT_HINT_MS = 3000;
 const EMPTY_COMPOSER_PROMPT_HINTS = [
   'Try "help me understand this codebase"',
   'Try "help me organize my desktop"',
@@ -484,6 +487,25 @@ type StatuslineTransientHint =
       deferModeSupported: boolean;
     };
 
+function isStatuslineTransientHintRelevant(
+  hint: StatuslineTransientHint,
+  state: {
+    isBashMode: boolean;
+    queuedUserMessageCount: number;
+  },
+): boolean {
+  switch (hint.type) {
+    case "bash-mode":
+      return state.isBashMode;
+    case "queued-message-hint":
+    case "queue-mode-changed":
+      return state.queuedUserMessageCount > 0;
+    case "message":
+    case "permission-mode":
+      return true;
+  }
+}
+
 function getStatuslinePreemption({
   ctrlCPressed,
   escapePressed,
@@ -627,10 +649,8 @@ function StatuslineTransientHintView({
   }
 }
 
-function DefaultOrExtensionStatusline({
+function DefaultStatuslineLeftContent({
   defaultLeftStatusline,
-  statusLineActive,
-  statusLineText,
   isBashMode,
   modeName,
   modeColor,
@@ -638,29 +658,12 @@ function DefaultOrExtensionStatusline({
   showExitHint,
 }: {
   defaultLeftStatusline: ReactNode;
-  statusLineActive: boolean;
-  statusLineText?: string;
   isBashMode: boolean;
   modeName: string | null;
   modeColor: string | null;
   modeGlyph?: string | null;
   showExitHint: boolean;
 }) {
-  if (statusLineActive) {
-    if (!statusLineText) {
-      return <Text> </Text>;
-    }
-
-    return (
-      <StatusLineContent
-        text={statusLineText}
-        modeName={null}
-        modeColor={null}
-        showExitHint={false}
-      />
-    );
-  }
-
   if (isBashMode) {
     return <StatuslineBashModeHint />;
   }
@@ -679,9 +682,31 @@ function DefaultOrExtensionStatusline({
   return defaultLeftStatusline;
 }
 
+function BlankStatuslineRow({
+  rightColumnWidth,
+}: {
+  rightColumnWidth: number;
+}) {
+  return (
+    <Box flexDirection="row" marginBottom={1}>
+      <Box flexGrow={1} paddingRight={1}>
+        <Text> </Text>
+      </Box>
+      <Box
+        flexDirection="column"
+        alignItems="flex-end"
+        width={rightColumnWidth}
+        flexShrink={0}
+      >
+        <Text>{" ".repeat(rightColumnWidth)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
 /**
- * Bottom statusline slot. The default/custom statusline owns this row in the
- * idle/base state, while host-owned input states can preempt it.
+ * Bottom statusline slot. Safety states and transient host hints may preempt the
+ * row; otherwise custom extensions own the idle row before the built-in default.
  */
 const StatuslineSlot = memo(function StatuslineSlot({
   ctrlCPressed,
@@ -702,6 +727,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
   statusLineText,
   statusLineRight,
   statusLinePayload,
+  extensionRuntime,
   transientHint,
 }: {
   ctrlCPressed: boolean;
@@ -722,6 +748,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
   statusLineText?: string;
   statusLineRight?: string;
   statusLinePayload: StatusLinePayload;
+  extensionRuntime: LocalExtensionRuntime;
   transientHint?: StatuslineTransientHint | null;
 }) {
   const hideFooterContent = hideFooter;
@@ -731,7 +758,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
     escapePressed,
   });
 
-  const statuslineContext = buildStatuslineRenderContext({
+  const baseStatuslineContext = buildStatuslineRenderContext({
     payload: statusLinePayload,
     ui: {
       currentModelProvider: currentModelProvider ?? null,
@@ -743,11 +770,45 @@ const StatuslineSlot = memo(function StatuslineSlot({
       rightColumnWidth,
     },
   });
-  const statuslineRenderer = getBuiltinStatuslineRenderer(
+  const statuslineContext = {
+    ...baseStatuslineContext,
+    statuses: evaluateLocalExtensionStatuses(
+      extensionRuntime.registry,
+      baseStatuslineContext,
+    ),
+  };
+  extensionRuntime.updateContext(statuslineContext);
+
+  const builtInStatuslineRenderer = getBuiltinStatuslineRenderer(
     DEFAULT_STATUSLINE_RENDERER_ID,
   );
-  const renderedDefaultStatusline =
-    statuslineRenderer.render(statuslineContext);
+  const localStatuslineRenderer =
+    extensionRuntime.registry?.ui.statuslineRenderer ?? null;
+  const idleSlotAvailable =
+    !hideFooterContent && !preemption && !transientHint && !statusLineActive;
+
+  if (idleSlotAvailable && localStatuslineRenderer) {
+    try {
+      return localStatuslineRenderer.render(statuslineContext);
+    } catch (error) {
+      debugLog(
+        "extensions",
+        "statusline renderer %s failed: %s",
+        localStatuslineRenderer.id,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  if (
+    idleSlotAvailable &&
+    extensionRuntime.isLoading &&
+    (extensionRuntime.hasExtensionSources ||
+      extensionRuntime.hadStatuslineRenderer)
+  ) {
+    return <BlankStatuslineRow rightColumnWidth={rightColumnWidth} />;
+  }
+
   const legacyStatuslineParts = buildLegacyStatuslineParts(statuslineContext);
   const rightLabel = legacyStatuslineParts.right;
   const defaultLeftStatusline = legacyStatuslineParts.left;
@@ -756,11 +817,20 @@ const StatuslineSlot = memo(function StatuslineSlot({
     <StatuslinePreemptionView preemption={preemption} />
   ) : transientHint ? (
     <StatuslineTransientHintView hint={transientHint} />
+  ) : statusLineActive ? (
+    statusLineText ? (
+      <StatusLineContent
+        text={statusLineText}
+        modeName={null}
+        modeColor={null}
+        showExitHint={false}
+      />
+    ) : (
+      <Text> </Text>
+    )
   ) : (
-    <DefaultOrExtensionStatusline
+    <DefaultStatuslineLeftContent
       defaultLeftStatusline={defaultLeftStatusline}
-      statusLineActive={statusLineActive}
-      statusLineText={statusLineText}
       isBashMode={isBashMode}
       modeName={modeName}
       modeColor={modeColor}
@@ -768,6 +838,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
       showExitHint={showExitHint}
     />
   );
+  const shouldBlankRightColumn = Boolean(preemption || transientHint);
 
   const shouldRenderDefaultStatusline = shouldRenderDefaultStatuslineRenderer({
     hideFooterContent,
@@ -780,7 +851,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
   });
 
   if (shouldRenderDefaultStatusline) {
-    return renderedDefaultStatusline;
+    return builtInStatuslineRenderer.render(statuslineContext);
   }
 
   return (
@@ -797,6 +868,8 @@ const StatuslineSlot = memo(function StatuslineSlot({
         flexShrink={0}
       >
         {hideFooterContent ? (
+          <Text>{" ".repeat(rightColumnWidth)}</Text>
+        ) : shouldBlankRightColumn ? (
           <Text>{" ".repeat(rightColumnWidth)}</Text>
         ) : statusLineRight ? (
           statusLineRight.split("\n").map((line, i) => (
@@ -1142,6 +1215,7 @@ export function Input({
   statusLineText,
   statusLineRight,
   statusLinePayload,
+  extensionRuntime,
   statusLinePrompt,
   onCycleReasoningEffort,
   footerNotification,
@@ -1196,6 +1270,7 @@ export function Input({
   statusLineText?: string;
   statusLineRight?: string;
   statusLinePayload: StatusLinePayload;
+  extensionRuntime: LocalExtensionRuntime;
   statusLinePrompt?: string;
   onCycleReasoningEffort?: () => void;
   footerNotification?: string | null;
@@ -1275,6 +1350,14 @@ export function Input({
   const interactionEnabled = visible && inputEnabled && !inputDisabled;
   const reserveInputSpace = !collapseInputWhenDisabled;
 
+  const clearStatuslineTransientHint = useCallback(() => {
+    if (statuslineTransientHintTimerRef.current) {
+      clearTimeout(statuslineTransientHintTimerRef.current);
+      statuslineTransientHintTimerRef.current = null;
+    }
+    setStatuslineTransientHint(null);
+  }, []);
+
   const showStatuslineTransientHint = useCallback(
     (hint: StatuslineTransientHint) => {
       if (statuslineTransientHintTimerRef.current) {
@@ -1288,6 +1371,7 @@ export function Input({
     },
     [],
   );
+
   const hideFooter = !interactionEnabled || value.startsWith("/");
   const inputRowLines = useMemo(() => {
     return Math.max(1, getVisualLines(value, contentWidth).length);
@@ -2071,6 +2155,23 @@ export function Input({
   const queuedUserMessageCount =
     messageQueue?.filter((message) => message.kind === "user").length ?? 0;
 
+  useEffect(() => {
+    if (!statuslineTransientHint) return;
+    if (
+      !isStatuslineTransientHintRelevant(statuslineTransientHint, {
+        isBashMode,
+        queuedUserMessageCount,
+      })
+    ) {
+      clearStatuslineTransientHint();
+    }
+  }, [
+    statuslineTransientHint,
+    isBashMode,
+    queuedUserMessageCount,
+    clearStatuslineTransientHint,
+  ]);
+
   const previousQueuedUserMessageCountRef = useRef(queuedUserMessageCount);
   useEffect(() => {
     const previousCount = previousQueuedUserMessageCountRef.current;
@@ -2243,6 +2344,7 @@ export function Input({
                 statusLineText={statusLineText}
                 statusLineRight={statusLineRight}
                 statusLinePayload={statusLinePayload}
+                extensionRuntime={extensionRuntime}
                 transientHint={statuslineTransientHint}
               />
             )}
@@ -2293,6 +2395,7 @@ export function Input({
     statusLineText,
     statusLineRight,
     statusLinePayload,
+    extensionRuntime,
 
     goalStatusText,
     promptChar,

--- a/src/cli/display/statusline/context.ts
+++ b/src/cli/display/statusline/context.ts
@@ -6,17 +6,22 @@ import type {
 import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
 
 export interface BuildStatuslineRenderContextInput {
+  backgroundAgents?: StatusLinePayload["background_agents"];
   payload: StatusLinePayload;
+  statuses?: Record<string, string>;
   ui: StatuslineUiContext;
 }
 
 export function buildStatuslineRenderContext({
+  backgroundAgents,
   payload,
+  statuses = {},
   ui,
 }: BuildStatuslineRenderContextInput): StatuslineRenderContext {
   return {
     rawPayload: payload,
     components: DisplayComponents,
+    statuses,
     app: {
       version: payload.version,
     },
@@ -57,7 +62,7 @@ export function buildStatuslineRenderContext({
     },
     reflection: payload.reflection,
     memfs: payload.memfs,
-    backgroundAgents: payload.background_agents,
+    backgroundAgents: backgroundAgents ?? payload.background_agents,
     ui,
   };
 }

--- a/src/cli/display/statusline/types.ts
+++ b/src/cli/display/statusline/types.ts
@@ -45,6 +45,7 @@ export interface StatuslineCostContext {
 export interface StatuslineRenderContext {
   rawPayload: StatusLinePayload;
   components: typeof DisplayComponents;
+  statuses: Record<string, string>;
   app: {
     version: string;
   };

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
+import type { StatuslineRenderContext } from "@/cli/display/statusline/types";
+import {
+  disposeLocalExtensions,
+  evaluateLocalExtensionStatuses,
+  loadLocalExtensions,
+  resolveLocalExtensionSources,
+} from "@/cli/extensions/local-extension-loader";
+import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "letta-extensions-"));
+}
+
+function createStatuslineContext(): StatuslineRenderContext {
+  return buildStatuslineRenderContext({
+    payload: buildStatusLinePayload({
+      agentName: "Letta Code",
+      currentDirectory: "/tmp/project",
+      modelDisplayName: "Sonnet 4.6",
+      projectDirectory: "/tmp/project",
+      toolset: "default",
+    }),
+    statuses: { mode: "fast" },
+    ui: {
+      currentModelProvider: "anthropic",
+      goalStatusText: null,
+      hasTemporaryModelOverride: false,
+      isByokProvider: false,
+      isLocalBackend: true,
+      isOpenAICodexProvider: false,
+      rightColumnWidth: 80,
+    },
+  });
+}
+
+function createLoadOptions(root: string) {
+  return {
+    cacheDirectory: path.join(root, "extension-cache"),
+    getContext: createStatuslineContext,
+    globalExtensionsDirectory: path.join(root, "global-extensions"),
+  };
+}
+
+describe("local extension loader", () => {
+  test("discovers global extension source", () => {
+    const root = createTempDir();
+    try {
+      const { globalExtensionsDirectory: globalExtensions } =
+        createLoadOptions(root);
+      mkdirSync(globalExtensions, { recursive: true });
+      writeFileSync(
+        path.join(globalExtensions, "a.ts"),
+        "export default () => {};",
+      );
+      writeFileSync(
+        path.join(globalExtensions, "b.tsx"),
+        "export default () => {};",
+      );
+
+      expect(
+        resolveLocalExtensionSources({
+          globalExtensionsDirectory: globalExtensions,
+        }),
+      ).toEqual([
+        {
+          files: [
+            path.join(globalExtensions, "a.ts"),
+            path.join(globalExtensions, "b.tsx"),
+          ],
+          root: globalExtensions,
+          scope: "global",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads extensions that register statuses and statusline renderers", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      const extensionPath = path.join(extensionDir, "statusline.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          letta.ui.setStatus("mode", "fast");
+          letta.ui.setStatus("agent", (ctx) => ctx.agent.name);
+          letta.ui.setStatuslineRenderer((ctx) => "first:" + ctx.statuses.mode);
+        }`,
+      );
+
+      const firstRegistry = await loadLocalExtensions(options);
+      expect(firstRegistry.errors).toEqual([]);
+      expect(firstRegistry.loadedPaths).toEqual([extensionPath]);
+      expect(
+        evaluateLocalExtensionStatuses(
+          firstRegistry,
+          createStatuslineContext(),
+        ),
+      ).toEqual({ agent: "Letta Code", mode: "fast" });
+      expect(
+        firstRegistry.ui.statuslineRenderer?.render({
+          ...createStatuslineContext(),
+          statuses: evaluateLocalExtensionStatuses(
+            firstRegistry,
+            createStatuslineContext(),
+          ),
+        }),
+      ).toBe("first:fast");
+
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          letta.ui.setStatus("mode", "slow");
+          letta.ui.setStatuslineRenderer((ctx) => "second:" + ctx.statuses.mode);
+        }`,
+      );
+
+      const secondRegistry = await loadLocalExtensions(options);
+      expect(secondRegistry.errors).toEqual([]);
+      expect(
+        evaluateLocalExtensionStatuses(
+          secondRegistry,
+          createStatuslineContext(),
+        ),
+      ).toEqual({ mode: "slow" });
+      expect(
+        secondRegistry.ui.statuslineRenderer?.render({
+          ...createStatuslineContext(),
+          statuses: evaluateLocalExtensionStatuses(
+            secondRegistry,
+            createStatuslineContext(),
+          ),
+        }),
+      ).toBe("second:slow");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("captures extension load errors without blocking other extensions", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "broken.ts"),
+        "export const nope = 1;",
+      );
+      writeFileSync(
+        path.join(extensionDir, "working.ts"),
+        `export default function(letta) {
+          letta.ui.setStatus("ok", "true");
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.loadedPaths).toEqual([
+        path.join(extensionDir, "working.ts"),
+      ]);
+      expect(
+        evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
+      ).toEqual({ ok: "true" });
+      expect(registry.errors).toHaveLength(1);
+      expect(registry.errors[0]?.path).toBe(
+        path.join(extensionDir, "broken.ts"),
+      );
+      expect(registry.errors[0]?.error.message).toContain(
+        "Extension must export",
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("runs extension disposers", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "status.ts"),
+        `export default function(letta) {
+          letta.ui.setStatus("mode", "fast");
+          letta.ui.setStatuslineRenderer(() => "statusline");
+          return () => letta.ui.clearStatus("mode");
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+      expect(registry.disposers).toHaveLength(1);
+      expect(
+        evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
+      ).toEqual({ mode: "fast" });
+      expect(registry.ui.statuslineRenderer).not.toBeNull();
+
+      disposeLocalExtensions(registry);
+
+      expect(registry.disposers).toEqual([]);
+      expect(
+        evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
+      ).toEqual({});
+      expect(registry.ui.statuslineRenderer).toBeNull();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
@@ -142,6 +148,39 @@ describe("local extension loader", () => {
           ),
         }),
       ).toBe("second:slow");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("transpiles TypeScript and TSX extensions to importable mjs cache files", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      const extensionPath = path.join(extensionDir, "statusline.tsx");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta: any) {
+          const Label = letta.getContext().components.Text;
+          letta.ui.setStatuslineRenderer((ctx: any) => <Label>{ctx.agent.name}</Label>);
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      expect(registry.loadedPaths).toEqual([extensionPath]);
+      const cacheFiles = readdirSync(options.cacheDirectory).filter((entry) =>
+        entry.startsWith(".letta-extension-statusline-"),
+      );
+      expect(cacheFiles).toHaveLength(1);
+      expect(cacheFiles[0]?.endsWith(".mjs")).toBe(true);
+      const output = registry.ui.statuslineRenderer?.render(
+        createStatuslineContext(),
+      );
+      expect(output).toMatchObject({ props: { children: "Letta Code" } });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -1,0 +1,363 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type {
+  StatuslineRenderContext,
+  StatuslineRenderer,
+  StatuslineRendererOutput,
+} from "@/cli/display/statusline/types";
+
+export const GLOBAL_EXTENSIONS_DIRECTORY = path.join(
+  homedir(),
+  ".letta",
+  "extensions",
+);
+export const EXTENSION_CACHE_DIRECTORY = path.join(
+  homedir(),
+  ".letta",
+  "extension-cache",
+);
+
+const EXTENSION_FILE_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
+const requireFromRuntime = createRequire(import.meta.url);
+
+export type StatuslineRenderFunction = (
+  context: StatuslineRenderContext,
+) => StatuslineRendererOutput;
+
+// First extension surface is statusline rendering, so the shared extension
+// context is currently the statusline render context. When we add non-UI
+// surfaces like commands, split this into a generic ExtensionContext base and
+// let StatuslineRenderContext extend it.
+export type ExtensionContext = StatuslineRenderContext;
+
+export type ExtensionStatusValue =
+  | string
+  | null
+  | ((context: ExtensionContext) => string | null);
+
+export type LettaExtensionDisposer = () => void;
+
+export type LettaExtensionFactory = (
+  letta: LettaExtensionApi,
+) =>
+  | undefined
+  | LettaExtensionDisposer
+  | Promise<undefined | LettaExtensionDisposer>;
+
+export interface LettaExtensionApi {
+  getContext: () => ExtensionContext;
+  ui: {
+    clearStatus: (key: string) => void;
+    setStatus: (key: string, value: ExtensionStatusValue | undefined) => void;
+    setStatuslineRenderer: (
+      renderer: StatuslineRenderer | StatuslineRenderFunction,
+    ) => void;
+  };
+}
+
+export interface LocalExtensionDisposer {
+  dispose: LettaExtensionDisposer;
+  path: string;
+}
+
+export interface LocalExtensionLoadError {
+  error: Error;
+  path: string;
+}
+
+export interface LocalExtensionUiRegistry {
+  statuslineRenderer: StatuslineRenderer | null;
+  statusValues: Record<string, ExtensionStatusValue>;
+}
+
+export interface LocalExtensionRegistry {
+  disposers: LocalExtensionDisposer[];
+  errors: LocalExtensionLoadError[];
+  loadedPaths: string[];
+  sources: LocalExtensionSource[];
+  ui: LocalExtensionUiRegistry;
+}
+
+export interface LocalExtensionSource {
+  files: string[];
+  root: string;
+  scope: "global" | "project";
+  trusted: boolean;
+}
+
+interface LocalExtensionModule {
+  activate?: unknown;
+  default?: unknown;
+}
+
+export interface ResolveLocalExtensionSourcesOptions {
+  cacheDirectory?: string;
+  globalExtensionsDirectory?: string;
+}
+
+export interface LoadLocalExtensionsOptions
+  extends ResolveLocalExtensionSourcesOptions {
+  getContext?: () => ExtensionContext;
+  onChange?: () => void;
+}
+
+function listExtensionFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => {
+      if (!entry.isFile()) return false;
+      if (entry.name.startsWith(".")) return false;
+      return EXTENSION_FILE_EXTENSIONS.has(path.extname(entry.name));
+    })
+    .map((entry) => path.join(directory, entry.name))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveLocalExtensionSources(
+  options: ResolveLocalExtensionSourcesOptions = {},
+): LocalExtensionSource[] {
+  const globalExtensionsDirectory =
+    options.globalExtensionsDirectory ?? GLOBAL_EXTENSIONS_DIRECTORY;
+
+  return [
+    {
+      files: listExtensionFiles(globalExtensionsDirectory),
+      root: globalExtensionsDirectory,
+      scope: "global",
+      trusted: true,
+    },
+  ];
+}
+
+function getRuntimePackageDirectory(packageName: string): string {
+  return path.dirname(
+    requireFromRuntime.resolve(path.join(packageName, "package.json")),
+  );
+}
+
+function ensureRuntimeDependencySymlink(
+  cacheDirectory: string,
+  packageName: string,
+): void {
+  const nodeModulesDirectory = path.join(cacheDirectory, "node_modules");
+  const linkPath = path.join(nodeModulesDirectory, packageName);
+  if (existsSync(linkPath)) return;
+
+  mkdirSync(nodeModulesDirectory, { recursive: true });
+  symlinkSync(
+    getRuntimePackageDirectory(packageName),
+    linkPath,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+}
+
+function ensureExtensionCache(cacheDirectory: string): void {
+  mkdirSync(cacheDirectory, { recursive: true });
+  ensureRuntimeDependencySymlink(cacheDirectory, "react");
+}
+
+function createImportableExtensionPath(
+  extensionPath: string,
+  cacheDirectory: string,
+): string {
+  ensureExtensionCache(cacheDirectory);
+
+  const source = readFileSync(extensionPath, "utf8");
+  const hash = createHash("sha256").update(source).digest("hex").slice(0, 16);
+  const extension = path.extname(extensionPath);
+  const baseName = path
+    .basename(extensionPath, extension)
+    .replace(/[^a-zA-Z0-9_-]/g, "-");
+  const importPath = path.join(
+    cacheDirectory,
+    `.letta-extension-${baseName}-${hash}${extension}`,
+  );
+
+  if (!existsSync(importPath)) {
+    writeFileSync(importPath, source, "utf8");
+  }
+
+  try {
+    for (const entry of readdirSync(cacheDirectory)) {
+      if (
+        entry.startsWith(`.letta-extension-${baseName}-`) &&
+        entry.endsWith(extension) &&
+        entry !== path.basename(importPath)
+      ) {
+        unlinkSync(path.join(cacheDirectory, entry));
+      }
+    }
+  } catch {
+    // Best-effort cache cleanup only.
+  }
+
+  return importPath;
+}
+
+function toStatuslineRenderer(
+  renderer: StatuslineRenderer | StatuslineRenderFunction,
+  extensionPath: string,
+): StatuslineRenderer {
+  if (typeof renderer === "function") {
+    return {
+      id: `local:${extensionPath}`,
+      label: path.basename(extensionPath),
+      description: extensionPath,
+      render: renderer,
+    };
+  }
+
+  return renderer;
+}
+
+function createLettaExtensionApi(
+  registry: LocalExtensionRegistry,
+  extensionPath: string,
+  getContext: () => ExtensionContext,
+  onChange: () => void,
+): LettaExtensionApi {
+  return {
+    getContext,
+    ui: {
+      clearStatus(key) {
+        delete registry.ui.statusValues[key];
+        onChange();
+      },
+      setStatus(key, value) {
+        if (value == null) {
+          delete registry.ui.statusValues[key];
+          onChange();
+          return;
+        }
+        registry.ui.statusValues[key] = value;
+        onChange();
+      },
+      setStatuslineRenderer(renderer) {
+        registry.ui.statuslineRenderer = toStatuslineRenderer(
+          renderer,
+          extensionPath,
+        );
+        onChange();
+      },
+    },
+  };
+}
+
+function getExtensionFactory(module: LocalExtensionModule): unknown {
+  return typeof module.default === "function"
+    ? module.default
+    : module.activate;
+}
+
+export async function loadLocalExtensions(
+  options: LoadLocalExtensionsOptions = {},
+): Promise<LocalExtensionRegistry> {
+  const cacheDirectory = options.cacheDirectory ?? EXTENSION_CACHE_DIRECTORY;
+  const getContext =
+    options.getContext ??
+    (() => {
+      throw new Error("Extension context is not available yet");
+    });
+  const onChange = options.onChange ?? (() => {});
+  const sources = resolveLocalExtensionSources(options);
+  const registry: LocalExtensionRegistry = {
+    disposers: [],
+    errors: [],
+    loadedPaths: [],
+    sources,
+    ui: {
+      statuslineRenderer: null,
+      statusValues: {},
+    },
+  };
+
+  for (const extensionPath of sources.flatMap((source) => source.files)) {
+    try {
+      const mtimeMs = statSync(extensionPath).mtimeMs;
+      const importPath = createImportableExtensionPath(
+        extensionPath,
+        cacheDirectory,
+      );
+      const module = (await import(
+        `${pathToFileURL(importPath).href}?extension=${mtimeMs}`
+      )) as LocalExtensionModule;
+      const factory = getExtensionFactory(module);
+
+      if (typeof factory !== "function") {
+        throw new Error(
+          "Extension must export a default function or activate() function",
+        );
+      }
+
+      const dispose = await (factory as LettaExtensionFactory)(
+        createLettaExtensionApi(registry, extensionPath, getContext, onChange),
+      );
+      if (typeof dispose === "function") {
+        registry.disposers.push({ dispose, path: extensionPath });
+      }
+      registry.loadedPaths.push(extensionPath);
+    } catch (error) {
+      registry.errors.push({
+        error: error instanceof Error ? error : new Error(String(error)),
+        path: extensionPath,
+      });
+    }
+  }
+
+  return registry;
+}
+
+export function evaluateLocalExtensionStatuses(
+  registry: LocalExtensionRegistry | null,
+  context: ExtensionContext,
+): Record<string, string> {
+  if (!registry) return {};
+
+  const statuses: Record<string, string> = {};
+  for (const [key, value] of Object.entries(registry.ui.statusValues)) {
+    try {
+      const nextValue = typeof value === "function" ? value(context) : value;
+      if (nextValue != null) {
+        statuses[key] = nextValue;
+      }
+    } catch {
+      // Status providers run during render; failed providers are skipped so the
+      // extension cannot crash the TUI.
+    }
+  }
+
+  return statuses;
+}
+
+export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
+  const disposers = [...registry.disposers].reverse();
+  registry.disposers = [];
+
+  for (const { dispose, path: extensionPath } of disposers) {
+    try {
+      dispose();
+    } catch (error) {
+      registry.errors.push({
+        error: error instanceof Error ? error : new Error(String(error)),
+        path: extensionPath,
+      });
+    }
+  }
+
+  registry.ui.statusValues = {};
+  registry.ui.statuslineRenderer = null;
+}

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -13,6 +13,7 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import * as ts from "typescript";
 import type {
   StatuslineRenderContext,
   StatuslineRenderer,
@@ -31,6 +32,7 @@ export const EXTENSION_CACHE_DIRECTORY = path.join(
 );
 
 const EXTENSION_FILE_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
+const TYPESCRIPT_EXTENSION_FILE_EXTENSIONS = new Set([".ts", ".tsx"]);
 const requireFromRuntime = createRequire(import.meta.url);
 
 export type StatuslineRenderFunction = (
@@ -170,6 +172,54 @@ function ensureExtensionCache(cacheDirectory: string): void {
   ensureRuntimeDependencySymlink(cacheDirectory, "react");
 }
 
+function formatTranspileDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+  if (!diagnostic.file || diagnostic.start == null) {
+    return message;
+  }
+
+  const position = diagnostic.file.getLineAndCharacterOfPosition(
+    diagnostic.start,
+  );
+  return `${diagnostic.file.fileName}:${position.line + 1}:${position.character + 1} ${message}`;
+}
+
+function transpileTypeScriptExtension(
+  extensionPath: string,
+  source: string,
+): string {
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: extensionPath,
+    reportDiagnostics: true,
+  });
+
+  const errors = result.diagnostics?.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors?.length) {
+    throw new Error(errors.map(formatTranspileDiagnostic).join("\n"));
+  }
+
+  return result.outputText;
+}
+
+function prepareExtensionForImport(
+  extensionPath: string,
+  source: string,
+): string {
+  const extension = path.extname(extensionPath);
+  if (TYPESCRIPT_EXTENSION_FILE_EXTENSIONS.has(extension)) {
+    return transpileTypeScriptExtension(extensionPath, source);
+  }
+
+  return source;
+}
+
 function createImportableExtensionPath(
   extensionPath: string,
   cacheDirectory: string,
@@ -179,23 +229,23 @@ function createImportableExtensionPath(
   const source = readFileSync(extensionPath, "utf8");
   const hash = createHash("sha256").update(source).digest("hex").slice(0, 16);
   const extension = path.extname(extensionPath);
+  const importableSource = prepareExtensionForImport(extensionPath, source);
   const baseName = path
     .basename(extensionPath, extension)
     .replace(/[^a-zA-Z0-9_-]/g, "-");
   const importPath = path.join(
     cacheDirectory,
-    `.letta-extension-${baseName}-${hash}${extension}`,
+    `.letta-extension-${baseName}-${hash}.mjs`,
   );
 
   if (!existsSync(importPath)) {
-    writeFileSync(importPath, source, "utf8");
+    writeFileSync(importPath, importableSource, "utf8");
   }
 
   try {
     for (const entry of readdirSync(cacheDirectory)) {
       if (
         entry.startsWith(`.letta-extension-${baseName}-`) &&
-        entry.endsWith(extension) &&
         entry !== path.basename(importPath)
       ) {
         unlinkSync(path.join(cacheDirectory, entry));

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { debugLog } from "@/utils/debug";
+import {
+  disposeLocalExtensions,
+  type ExtensionContext,
+  type LocalExtensionRegistry,
+  loadLocalExtensions,
+  resolveLocalExtensionSources,
+} from "./local-extension-loader";
+
+export interface LocalExtensionRuntime {
+  hadStatuslineRenderer: boolean;
+  hasExtensionSources: boolean;
+  isLoading: boolean;
+  registry: LocalExtensionRegistry | null;
+  reload: () => Promise<void>;
+  updateContext: (context: ExtensionContext) => void;
+}
+
+interface LocalExtensionLoadState {
+  hadStatuslineRenderer: boolean;
+  hasExtensionSources: boolean;
+  isLoading: boolean;
+}
+
+function hasLocalExtensionSources(): boolean {
+  return resolveLocalExtensionSources().some(
+    (source) => source.files.length > 0,
+  );
+}
+
+export function useLocalExtensionRuntime(
+  initialContext: ExtensionContext,
+): LocalExtensionRuntime {
+  const contextRef = useRef(initialContext);
+  const mountedRef = useRef(false);
+  const registryRef = useRef<LocalExtensionRegistry | null>(null);
+  const [registry, setRegistry] = useState<LocalExtensionRegistry | null>(null);
+  const [loadState, setLoadState] = useState<LocalExtensionLoadState>(() => {
+    const hasExtensionSources = hasLocalExtensionSources();
+    return {
+      hadStatuslineRenderer: false,
+      hasExtensionSources,
+      isLoading: hasExtensionSources,
+    };
+  });
+  const loadStateRef = useRef(loadState);
+  const [, bumpVersion] = useState(0);
+
+  useEffect(() => {
+    loadStateRef.current = loadState;
+  }, [loadState]);
+
+  const updateContext = useCallback((context: ExtensionContext) => {
+    contextRef.current = context;
+  }, []);
+
+  useEffect(() => {
+    contextRef.current = initialContext;
+  }, [initialContext]);
+
+  const reload = useCallback(async () => {
+    const previousHadStatuslineRenderer =
+      Boolean(registryRef.current?.ui.statuslineRenderer) ||
+      loadStateRef.current.hadStatuslineRenderer;
+    const hasExtensionSources = hasLocalExtensionSources();
+    setLoadState({
+      hadStatuslineRenderer: previousHadStatuslineRenderer,
+      hasExtensionSources,
+      isLoading: true,
+    });
+
+    if (registryRef.current) {
+      disposeLocalExtensions(registryRef.current);
+      registryRef.current = null;
+      setRegistry(null);
+    }
+
+    const nextRegistry = await loadLocalExtensions({
+      getContext: () => contextRef.current,
+      onChange: () => {
+        if (mountedRef.current) {
+          bumpVersion((version) => version + 1);
+        }
+      },
+    });
+
+    debugLog(
+      "extensions",
+      "loaded %s extension(s) from %s source(s); renderer=%s",
+      nextRegistry.loadedPaths.length,
+      nextRegistry.sources.length,
+      nextRegistry.ui.statuslineRenderer?.id ?? "(none)",
+    );
+
+    for (const loadError of nextRegistry.errors) {
+      debugLog(
+        "extensions",
+        "failed to load %s: %s",
+        loadError.path,
+        loadError.error.message,
+      );
+    }
+
+    if (!mountedRef.current) {
+      disposeLocalExtensions(nextRegistry);
+      return;
+    }
+
+    const nextHasExtensionSources = nextRegistry.sources.some(
+      (source) => source.files.length > 0,
+    );
+    const nextHadStatuslineRenderer = Boolean(
+      nextRegistry.ui.statuslineRenderer,
+    );
+
+    registryRef.current = nextRegistry;
+    setRegistry(nextRegistry);
+    setLoadState({
+      hadStatuslineRenderer: nextHadStatuslineRenderer,
+      hasExtensionSources: nextHasExtensionSources,
+      isLoading: false,
+    });
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void reload();
+
+    return () => {
+      mountedRef.current = false;
+      if (registryRef.current) {
+        disposeLocalExtensions(registryRef.current);
+        registryRef.current = null;
+      }
+    };
+  }, [reload]);
+
+  return useMemo(
+    () => ({ registry, reload, updateContext, ...loadState }),
+    [loadState, registry, reload, updateContext],
+  );
+}

--- a/src/cli/statusline-renderer.test.tsx
+++ b/src/cli/statusline-renderer.test.tsx
@@ -76,6 +76,7 @@ describe("statusline renderers", () => {
     expect(context.components.Box).toBeDefined();
     expect(context.components.Text).toBeDefined();
     expect(context.components.Spacer).toBeDefined();
+    expect(context.statuses).toEqual({});
     expect(context.agent.name).toBe("Letta Code");
     expect(context.model.displayName).toBe("GPT-5.5 (ChatGPT)");
     expect(context.model.provider).toBe("chatgpt-plus-pro");
@@ -98,6 +99,24 @@ describe("statusline renderers", () => {
     expect(stripAnsi(String(output.right)).trim()).toBe(
       "Letta Code [No model selected] · local",
     );
+  });
+
+  test("default renderer does not override safety preemptions", () => {
+    expect(
+      shouldRenderDefaultStatuslineRenderer({
+        ...DEFAULT_STATUSLINE_ACTIVATION,
+        preemptionActive: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("default renderer does not override transient host hints", () => {
+    expect(
+      shouldRenderDefaultStatuslineRenderer({
+        ...DEFAULT_STATUSLINE_ACTIVATION,
+        transientHintActive: true,
+      }),
+    ).toBe(false);
   });
 
   test("default renderer does not override command-provided right text", () => {


### PR DESCRIPTION
## Summary
- Add a global local extension loader/runtime for ~/.letta/extensions files, with status values and full-row custom statusline renderers.
- Move extension runtime ownership to AppCoordinator and thread it through to the input statusline slot.
- Preserve host-owned safety/transient hint preemption while letting custom renderers own idle space, including reload loading behavior to avoid default flashes.

## Test plan
- [x] bun test src/cli/statusline-renderer.test.tsx src/cli/extensions/local-extension-loader.test.ts src/cli/chdir-command.test.ts src/cli/statusline-config.test.ts src/cli/statusline-controller.test.ts src/cli/statusline-help.test.ts src/cli/statusline-runtime.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)