### PR TITLE
feat(statusline): route setup through skill

### DIFF
--- a/src/cli/app/command-routing.ts
+++ b/src/cli/app/command-routing.ts
@@ -40,7 +40,6 @@ const NON_STATE_COMMANDS = new Set([
   "/feedback",
   "/export",
   "/download",
-  "/statusline",
   "/reasoning-tab",
   "/secret",
   "/palace", // read-only memory viewer

--- a/src/cli/app/submit-diagnostics-commands.ts
+++ b/src/cli/app/submit-diagnostics-commands.ts
@@ -66,20 +66,6 @@ export async function handleDiagnosticsCommand(
     setLlmConfig,
   } = ctx;
 
-  if (trimmed === "/statusline" || trimmed.startsWith("/statusline ")) {
-    const cmd = commandRunner.start(trimmed, "Checking statusline setup...");
-    cmd.finish(
-      [
-        "Statusline customization now uses local extensions.",
-        "Create a global extension at ~/.letta/extensions/statusline.tsx and register a renderer with letta.ui.setStatuslineRenderer().",
-        "Legacy shell command statusline config is no longer executed.",
-      ].join("\n"),
-      true,
-      true,
-    );
-    return { submitted: true };
-  }
-
   if (trimmed === "/usage") {
     const cmd = commandRunner.start(trimmed, "Fetching usage statistics...");
 

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -931,6 +931,61 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
+        if (trimmed === "/statusline" || trimmed.startsWith("/statusline ")) {
+          const args = trimmed.slice("/statusline".length).trim();
+          const cmd = commandRunner.start(
+            msg,
+            args
+              ? `Starting statusline setup for: ${args}`
+              : "Starting statusline setup...",
+          );
+
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              "Pending approval(s). Resolve approvals before running /statusline.",
+            );
+            return { submitted: false };
+          }
+
+          setCommandRunning(true);
+          try {
+            const { loadRenderedSkillContent, wrapSkillContent } = await import(
+              "@/tools/impl/skill"
+            );
+            const skillContent = await loadRenderedSkillContent(
+              "customizing-statusline",
+              {
+                agentId,
+                args,
+                allowDisabledModelInvocation: true,
+              },
+            );
+            const request = args
+              ? `The user ran \`/statusline ${args}\`. Use the loaded skill to help them create, edit, or migrate their Letta Code statusline extension.`
+              : "The user ran `/statusline` without arguments. Use the loaded skill's bare `/statusline` behavior.";
+
+            cmd.finish("Running statusline setup...", true);
+            await processConversationWithQueuedApprovals([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(
+                  `${wrapSkillContent("customizing-statusline", skillContent)}\n\n${SYSTEM_REMINDER_OPEN}\n${request}\n${SYSTEM_REMINDER_CLOSE}`,
+                ),
+                otid: randomUUID(),
+              },
+            ]);
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to run statusline setup: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+
         const diagnosticsCommandResult = await handleDiagnosticsCommand(
           trimmed,
           {

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -417,11 +417,12 @@ export const commands: Record<string, Command> = {
     },
   },
   "/statusline": {
-    desc: "Show local extension statusline setup info",
+    desc: "Customize the bottom statusline",
+    args: "[request]",
     order: 36.5,
     handler: () => {
       // Handled specially in App.tsx
-      return "Checking statusline setup...";
+      return "Starting statusline setup...";
     },
   },
   "/title": {

--- a/src/skills/builtin/customizing-statusline/SKILL.md
+++ b/src/skills/builtin/customizing-statusline/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: customizing-statusline
+description: Creates, edits, and migrates Letta Code statusline extensions. Use when handling the /statusline command or continuing work started by /statusline.
+---
+
+# Customizing Statusline
+
+Use this skill to create or update the global Letta Code statusline extension:
+
+```text
+~/.letta/extensions/statusline.tsx
+```
+
+The statusline is a full-row idle renderer. Host UI can still temporarily preempt it for safety confirmations and transient hints.
+
+## Statusline ownership model
+
+```text
+safety preemption
+else transient host hint
+else custom statusline extension
+else built-in default statusline
+```
+
+A custom statusline owns the whole idle row. Do not preserve legacy left/right split semantics in the new API.
+
+## Workflow
+
+1. Check whether `~/.letta/extensions/statusline.tsx` exists.
+2. If it exists, read it before editing and preserve unrelated code.
+3. If it does not exist, start from the built-in default template or synthesize a focused starter for the user's request.
+4. If the user asks to migrate, import a `.sh` file, or match a shell prompt, read `references/migration.md`.
+5. If API details or concrete patterns are needed, read `references/api.md` and `references/examples.md`.
+6. Edit `~/.letta/extensions/statusline.tsx`.
+7. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
+
+## Bare `/statusline` behavior
+
+If the user ran `/statusline` without a specific request:
+
+- If a custom statusline file exists, summarize what it appears to do and ask what they want to change.
+- If no custom file exists, explain that Letta is using the built-in default statusline and offer focused next steps:
+  1. start from the default Letta statusline
+  2. add project info like git branch, worktree, or PR
+  3. migrate an existing legacy statusline `.sh` file
+  4. match shell prompt / PS1
+  5. describe a custom statusline in their own words
+
+Keep this conversational. Do not build a menu UI unless the product command explicitly asks for one.
+
+## Rules
+
+- Global-only for now. Do not create project extensions.
+- Keep the extension single-file for MVP.
+- Do not assume extra npm packages are available.
+- Do not use relative multi-file imports yet.
+- Keep renderers synchronous. Do not shell, fetch, or await inside render.
+- Do async work in setup code, intervals, subscriptions, or status providers.
+- Return a disposer that clears timers/subscriptions.
+- Preserve existing extension code unless the user asks to reset.
+- Do not delete legacy command statusline files or settings unless the user explicitly asks.
+
+## Useful references
+
+- `references/api.md` - extension API, render context, lifecycle rules
+- `references/examples.md` - common statusline patterns
+- `references/migration.md` - legacy command `.sh` and PS1 migration

--- a/src/skills/builtin/customizing-statusline/references/api.md
+++ b/src/skills/builtin/customizing-statusline/references/api.md
@@ -1,0 +1,155 @@
+# Statusline Extension API
+
+Use this reference when creating or editing `~/.letta/extensions/statusline.tsx`.
+
+## Location
+
+```text
+~/.letta/extensions/statusline.tsx
+```
+
+This is a trusted, user-owned global extension file. Project extensions are intentionally unsupported for now.
+
+## Activation
+
+Export a default function or named `activate` function:
+
+```tsx
+export default function activate(letta) {
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    return <Text>{context.agent.name} · {context.model.displayName}</Text>;
+  });
+}
+```
+
+## API
+
+```ts
+letta.getContext(): StatuslineRenderContext
+
+letta.ui.setStatus(key: string, value: string | null | undefined | ((context) => string | null)): void
+letta.ui.clearStatus(key: string): void
+letta.ui.setStatuslineRenderer(renderer: StatuslineRenderer | ((context) => ReactNode | null)): void
+```
+
+`setStatus` stores named string values. Renderers read evaluated values from `context.statuses`.
+
+```tsx
+letta.ui.setStatus("branch", "main");
+
+letta.ui.setStatuslineRenderer((context) => {
+  const { Text } = context.components;
+  return <Text>{context.statuses.branch}</Text>;
+});
+```
+
+## Renderer rules
+
+- Renderer owns the entire idle bottom row.
+- Renderer must be synchronous.
+- Do not run shell commands, network requests, file reads, or awaits inside render.
+- Do async work in setup code or intervals, store results with `setStatus`, then render `context.statuses`.
+- Return `null` only when intentionally rendering nothing.
+
+## Async state pattern
+
+Use Node/Bun APIs directly from the trusted extension file. Do not assume helper methods like `letta.shell` exist.
+
+```tsx
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  const update = async () => {
+    try {
+      const context = letta.getContext();
+      const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+        cwd: context.workspace.currentDir,
+      });
+      letta.ui.setStatus("branch", stdout.trim());
+    } catch {
+      letta.ui.clearStatus("branch");
+    }
+  };
+
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    const branch = context.statuses.branch;
+    return <Text>{branch ? `branch ${branch}` : context.agent.name}</Text>;
+  });
+
+  void update();
+  const timer = setInterval(update, 30_000);
+
+  return () => {
+    clearInterval(timer);
+    letta.ui.clearStatus("branch");
+  };
+}
+```
+
+## Context fields
+
+The app statusline render context source types live near:
+
+```text
+src/cli/display/statusline/types.ts
+src/cli/display/statusline/context.ts
+```
+
+Common fields:
+
+```ts
+context.components      // Display components such as Text, Box, Spacer
+context.statuses        // evaluated extension status strings
+context.app.version
+context.workspace.cwd
+context.workspace.currentDir
+context.workspace.projectDir
+context.agent.name
+context.agent.id
+context.model.id
+context.model.displayName
+context.model.provider
+context.model.reasoningEffort
+context.permissionMode
+context.terminalWidth
+context.contextWindow.usedPercentage
+context.contextWindow.remainingPercentage
+context.cost.totalDurationMs
+context.cost.totalCostUsd
+context.reflection
+context.memfs
+context.backgroundAgents
+context.rawPayload      // compatibility payload for advanced cases
+```
+
+Prefer semantic fields over `rawPayload` unless migrating old command statuslines.
+
+## Full-row layout
+
+New statuslines do not have a host left/right API. To create left/right visual alignment, do it inside the renderer:
+
+```tsx
+return (
+  <Box flexDirection="row">
+    <Box flexGrow={1}>
+      <Text>left content</Text>
+    </Box>
+    <Text>right content</Text>
+  </Box>
+);
+```
+
+## Reload behavior
+
+After editing `~/.letta/extensions/statusline.tsx`, tell the user to run:
+
+```text
+/reload
+```
+
+The runtime tracks extension loading separately from “no custom statusline,” so a custom statusline should not flash back to the built-in default during reload.

--- a/src/skills/builtin/customizing-statusline/references/examples.md
+++ b/src/skills/builtin/customizing-statusline/references/examples.md
@@ -1,0 +1,133 @@
+# Statusline Examples
+
+Use these as patterns, not mandatory templates. Keep the final extension focused on the user's request.
+
+## Agent and model
+
+```tsx
+export default function activate(letta) {
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    return <Text>{context.agent.name ?? "Letta"} · {context.model.displayName ?? "no model"}</Text>;
+  });
+}
+```
+
+## Git branch with fallback
+
+```tsx
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  const update = async () => {
+    try {
+      const context = letta.getContext();
+      const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+        cwd: context.workspace.currentDir,
+      });
+      letta.ui.setStatus("branch", stdout.trim());
+    } catch {
+      letta.ui.clearStatus("branch");
+    }
+  };
+
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    const branch = context.statuses.branch;
+    return <Text>{branch ? `git ${branch}` : context.agent.name}</Text>;
+  });
+
+  void update();
+  const timer = setInterval(update, 30_000);
+  return () => clearInterval(timer);
+}
+```
+
+## Full row with internal right alignment
+
+```tsx
+export default function activate(letta) {
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Box, Text } = context.components;
+    const model = context.model.displayName ?? "no model";
+
+    return (
+      <Box flexDirection="row">
+        <Box flexGrow={1}>
+          <Text dimColor>Press / for commands</Text>
+        </Box>
+        <Text>{context.agent.name ?? "Letta"} · {model}</Text>
+      </Box>
+    );
+  });
+}
+```
+
+## GitHub PR number via `gh`
+
+```tsx
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  const update = async () => {
+    try {
+      const context = letta.getContext();
+      const { stdout } = await execFileAsync(
+        "gh",
+        ["pr", "view", "--json", "number,title", "--jq", "\"#\\(.number) \\(.title)\""],
+        { cwd: context.workspace.currentDir },
+      );
+      const pr = stdout.trim();
+      pr ? letta.ui.setStatus("pr", pr) : letta.ui.clearStatus("pr");
+    } catch {
+      letta.ui.clearStatus("pr");
+    }
+  };
+
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    return <Text>{context.statuses.pr ?? context.model.displayName}</Text>;
+  });
+
+  void update();
+  const timer = setInterval(update, 60_000);
+  return () => clearInterval(timer);
+}
+```
+
+## macOS currently playing track
+
+```tsx
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  const update = async () => {
+    try {
+      const script = 'tell application "Music" to if it is running then artist of current track & " - " & name of current track';
+      const { stdout } = await execFileAsync("osascript", ["-e", script]);
+      const music = stdout.trim();
+      music ? letta.ui.setStatus("music", music) : letta.ui.clearStatus("music");
+    } catch {
+      letta.ui.clearStatus("music");
+    }
+  };
+
+  letta.ui.setStatuslineRenderer((context) => {
+    const { Text } = context.components;
+    return <Text>{context.statuses.music ?? context.agent.name}</Text>;
+  });
+
+  void update();
+  const timer = setInterval(update, 15_000);
+  return () => clearInterval(timer);
+}
+```

--- a/src/skills/builtin/customizing-statusline/references/migration.md
+++ b/src/skills/builtin/customizing-statusline/references/migration.md
@@ -1,0 +1,131 @@
+# Statusline Migration
+
+Use this reference when migrating legacy command statuslines, standalone `.sh` statusline scripts, or shell PS1 prompts.
+
+## Legacy Letta command statusline
+
+Inspect these files for old config:
+
+```text
+~/.letta/settings.json
+<project>/.letta/settings.json
+<project>/.letta/settings.local.json
+```
+
+Look for either shape:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "..."
+  }
+}
+```
+
+```json
+{
+  "statusLine": {
+    "command": "...",
+    "refreshIntervalMs": 30000,
+    "timeout": 5000,
+    "debounceMs": 300,
+    "padding": 0,
+    "prompt": ">"
+  }
+}
+```
+
+When migrating:
+
+- Preserve old config and referenced files unless the user explicitly asks to delete them.
+- If `command` references a `.sh` file, read it before writing the new extension.
+- Translate polling (`refreshIntervalMs`) to `setInterval`.
+- Translate direct command output into cached status plus synchronous rendering.
+- If the command output used `\x1e` to split left/right output, convert it to internal full-row layout with `Box`; do not create a new left/right API.
+- Treat old prompt customization separately. The new statusline controls the bottom row, not necessarily the input prompt.
+
+Old model:
+
+```sh
+echo "$(git branch --show-current)"
+```
+
+New model:
+
+```tsx
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const update = async () => {
+  const context = letta.getContext();
+  const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+    cwd: context.workspace.currentDir,
+  });
+  letta.ui.setStatus("branch", stdout.trim());
+};
+
+letta.ui.setStatuslineRenderer((context) => {
+  const { Text } = context.components;
+  return <Text>{context.statuses.branch ?? ""}</Text>;
+});
+```
+
+## Standalone `.sh` file migration
+
+If the user provides a `.sh` path:
+
+1. Read the script.
+2. Identify commands, expected stdin JSON, environment variables, and output shape.
+3. Port shell commands to async setup/update code.
+4. Store results with `letta.ui.setStatus(key, value)`.
+5. Render cached status synchronously.
+6. Preserve graceful fallbacks for missing tools, not-a-git-repo, no PR, etc.
+
+If a script depends heavily on stdin JSON, use `context.rawPayload` as a temporary migration aid, but prefer semantic context fields for new code.
+
+## Shell PS1 import
+
+If the user asks to match their shell prompt, inspect shell config files in this order:
+
+```text
+~/.zshrc
+~/.bashrc
+~/.bash_profile
+~/.profile
+```
+
+Extract PS1 with:
+
+```js
+/(?:^|\n)\s*(?:export\s+)?PS1\s*=\s*["']([^"']+)["']/m
+```
+
+Map common escapes:
+
+```text
+\u -> username
+\h -> short hostname
+\H -> hostname
+\w -> current working directory
+\W -> basename(current working directory)
+\$ -> prompt character, usually remove if trailing
+\n -> newline
+\t -> HH:MM:SS
+\d -> date like Tue May 23
+\@ -> 12-hour time
+\# -> command number, usually omit unless requested
+\! -> history number, usually omit unless requested
+```
+
+If the imported prompt ends with `$`, `>`, or similar prompt chars, remove that trailing prompt marker. The statusline is not the input prompt.
+
+If no PS1 is found and the user did not provide other instructions, ask for one of:
+
+1. the output of `echo $PS1`
+2. a description of what their prompt shows
+3. the current prompt output as it appears in their terminal
+
+Preserve colors where practical using display components. If the PS1 is too dynamic to port exactly, ask whether to approximate it or port specific commands.


### PR DESCRIPTION
## Summary
- add a bundled `customizing-statusline` skill with API, examples, and migration guidance for local extension statuslines
- route `/statusline` through the skill-driven agent workflow instead of the static setup info response
- treat `/statusline` as a state-changing command so it does not bypass busy-agent command gating

## Test plan
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/customizing-statusline`
- [x] `bun test src/skills/skill-creator-scripts.test.ts src/cli/extensions/local-extension-loader.test.ts src/cli/statusline-renderer.test.tsx`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)