### PR TITLE
feat(statusline): simplify default renderer

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -22,7 +22,7 @@ import {
   DEFAULT_STATUSLINE_RENDERER_ID,
   getBuiltinStatuslineRenderer,
 } from "@/cli/display/statusline/registry";
-import { buildLegacyStatuslineParts } from "@/cli/display/statusline/renderers/Legacy";
+import { buildDefaultStatuslineParts } from "@/cli/display/statusline/renderers/Default";
 import { evaluateLocalExtensionStatuses } from "@/cli/extensions/local-extension-loader";
 import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { bytesToTokens, formatCompact } from "@/cli/helpers/format";
@@ -537,9 +537,9 @@ const StatuslineSlot = memo(function StatuslineSlot({
     return <BlankStatuslineRow rightColumnWidth={rightColumnWidth} />;
   }
 
-  const legacyStatuslineParts = buildLegacyStatuslineParts(statuslineContext);
-  const rightLabel = legacyStatuslineParts.right;
-  const defaultLeftStatusline = legacyStatuslineParts.left;
+  const defaultStatuslineParts = buildDefaultStatuslineParts(statuslineContext);
+  const rightLabel = defaultStatuslineParts.right;
+  const defaultLeftStatusline = defaultStatuslineParts.left;
 
   const leftContent = preemption ? (
     <StatuslinePreemptionView preemption={preemption} />
@@ -1786,7 +1786,7 @@ export function Input({
           glyph: "▶",
         };
       case "unrestricted":
-        // Default mode — show nothing so "Press / for commands" renders instead
+        // Default mode — show nothing so the built-in idle row owns the space.
         return null;
       default:
         return null;

--- a/src/cli/display/statusline/formatting.ts
+++ b/src/cli/display/statusline/formatting.ts
@@ -7,16 +7,3 @@ export function truncateStatuslineText(
   if (maxChars <= 3) return value.slice(0, maxChars);
   return `${value.slice(0, maxChars - 3)}...`;
 }
-
-export function formatStatuslineReasoningEffort(
-  effort: string | null | undefined,
-): string | null {
-  if (effort === "none") return null;
-  if (effort === "xhigh") return "xhigh";
-  if (effort === "max") return "max";
-  if (effort === "minimal") return "minimal";
-  if (effort === "low") return "low";
-  if (effort === "medium") return "medium";
-  if (effort === "high") return "high";
-  return null;
-}

--- a/src/cli/display/statusline/registry.ts
+++ b/src/cli/display/statusline/registry.ts
@@ -1,10 +1,10 @@
-import { legacyStatuslineRenderer } from "@/cli/display/statusline/renderers/Legacy";
+import { defaultStatuslineRenderer } from "@/cli/display/statusline/renderers/Default";
 import type { StatuslineRenderer } from "@/cli/display/statusline/types";
 
-export const DEFAULT_STATUSLINE_RENDERER_ID = "legacy";
+export const DEFAULT_STATUSLINE_RENDERER_ID = "default";
 
 const BUILTIN_STATUSLINE_RENDERERS = [
-  legacyStatuslineRenderer,
+  defaultStatuslineRenderer,
 ] as const satisfies readonly StatuslineRenderer[];
 
 export function getBuiltinStatuslineRenderers(): readonly StatuslineRenderer[] {
@@ -16,6 +16,6 @@ export function getBuiltinStatuslineRenderer(
 ): StatuslineRenderer {
   return (
     BUILTIN_STATUSLINE_RENDERERS.find((renderer) => renderer.id === id) ??
-    legacyStatuslineRenderer
+    defaultStatuslineRenderer
   );
 }

--- a/src/cli/display/statusline/renderers/Default.tsx
+++ b/src/cli/display/statusline/renderers/Default.tsx
@@ -2,62 +2,49 @@ import chalk from "chalk";
 import type { ReactNode } from "react";
 import { colors } from "@/cli/components/colors";
 import { Box, Text } from "@/cli/display/DisplayComponents";
-import {
-  formatStatuslineReasoningEffort,
-  truncateStatuslineText,
-} from "@/cli/display/statusline/formatting";
+import { truncateStatuslineText } from "@/cli/display/statusline/formatting";
 import type {
   StatuslineRenderContext,
   StatuslineRenderer,
 } from "@/cli/display/statusline/types";
-import { shouldHideReasoningForModelDisplay } from "@/cli/helpers/startup-model-display";
 
-interface LegacyStatuslineParts {
+interface DefaultStatuslineParts {
   left: ReactNode;
   right: string;
   rightCore: string;
   rightWidth: number;
 }
 
-export function buildLegacyStatuslineParts(
+export function buildDefaultStatuslineParts(
   context: StatuslineRenderContext,
-): LegacyStatuslineParts {
-  const maxAgentChars = Math.max(
-    10,
-    Math.floor(context.ui.rightColumnWidth * 0.45),
+): DefaultStatuslineParts {
+  const indicatorWidth =
+    (context.ui.isByokProvider ? 2 : 0) +
+    (context.ui.hasTemporaryModelOverride ? 2 : 0);
+  const separatorWidth = 3;
+  const availableTextWidth = Math.max(
+    12,
+    context.ui.rightColumnWidth - separatorWidth - indicatorWidth,
   );
+  const maxAgentChars = Math.max(8, Math.floor(availableTextWidth * 0.4));
   const displayAgentName = truncateStatuslineText(
     context.agent.name || "Unnamed",
     maxAgentChars,
   );
-  const reasoningTag = shouldHideReasoningForModelDisplay(
-    context.model.displayName,
-  )
-    ? null
-    : formatStatuslineReasoningEffort(context.model.reasoningEffort);
-  const byokExtraChars = context.ui.isByokProvider ? 2 : 0;
-  const tempOverrideExtraChars = context.ui.hasTemporaryModelOverride ? 2 : 0;
-
-  const baseReservedChars =
-    displayAgentName.length + byokExtraChars + tempOverrideExtraChars + 4;
-  const modelWithReasoning =
-    (context.model.displayName ?? "unknown") +
-    (reasoningTag ? ` (${reasoningTag})` : "");
-
   const maxModelChars = Math.max(
     8,
-    context.ui.rightColumnWidth - baseReservedChars,
+    availableTextWidth - displayAgentName.length,
   );
   const displayModel = truncateStatuslineText(
-    modelWithReasoning,
+    context.model.displayName ?? "unknown",
     maxModelChars,
   );
+
   const rightWidth =
     displayAgentName.length +
+    separatorWidth +
     displayModel.length +
-    byokExtraChars +
-    tempOverrideExtraChars +
-    3;
+    indicatorWidth;
   const rightPrefixSpaces = Math.max(
     0,
     context.ui.rightColumnWidth - rightWidth,
@@ -65,7 +52,7 @@ export function buildLegacyStatuslineParts(
 
   const rightCoreParts: string[] = [];
   rightCoreParts.push(chalk.hex(colors.footer.agentName)(displayAgentName));
-  rightCoreParts.push(chalk.dim(" ["));
+  rightCoreParts.push(chalk.dim(" · "));
   rightCoreParts.push(chalk.dim(displayModel));
   if (context.ui.isByokProvider) {
     rightCoreParts.push(chalk.dim(" "));
@@ -79,11 +66,6 @@ export function buildLegacyStatuslineParts(
     rightCoreParts.push(chalk.dim(" "));
     rightCoreParts.push(chalk.yellow("▲"));
   }
-  rightCoreParts.push(chalk.dim("]"));
-  if (context.ui.isLocalBackend) {
-    rightCoreParts.push(chalk.dim(" · "));
-    rightCoreParts.push(chalk.hex(colors.status.success)("local"));
-  }
 
   const rightCore = rightCoreParts.join("");
   const right = context.ui.goalStatusText
@@ -91,15 +73,15 @@ export function buildLegacyStatuslineParts(
     : " ".repeat(rightPrefixSpaces) + rightCore;
 
   return {
-    left: <Text dimColor>Press / for commands</Text>,
+    left: <Text> </Text>,
     right,
     rightCore,
     rightWidth,
   };
 }
 
-export function renderLegacyStatusline(context: StatuslineRenderContext) {
-  const parts = buildLegacyStatuslineParts(context);
+export function renderDefaultStatusline(context: StatuslineRenderContext) {
+  const parts = buildDefaultStatuslineParts(context);
 
   return (
     <Box flexDirection="row" marginBottom={1}>
@@ -118,9 +100,9 @@ export function renderLegacyStatusline(context: StatuslineRenderContext) {
   );
 }
 
-export const legacyStatuslineRenderer: StatuslineRenderer = {
-  id: "legacy",
-  label: "Legacy",
-  description: "The existing detailed Letta Code status line.",
-  render: renderLegacyStatusline,
+export const defaultStatuslineRenderer: StatuslineRenderer = {
+  id: "default",
+  label: "Default",
+  description: "The built-in Letta Code statusline.",
+  render: renderDefaultStatusline,
 };

--- a/src/cli/statusline-renderer.test.tsx
+++ b/src/cli/statusline-renderer.test.tsx
@@ -7,7 +7,7 @@ import {
   getBuiltinStatuslineRenderer,
   getBuiltinStatuslineRenderers,
 } from "@/cli/display/statusline/registry";
-import { buildLegacyStatuslineParts } from "@/cli/display/statusline/renderers/Legacy";
+import { buildDefaultStatuslineParts } from "@/cli/display/statusline/renderers/Default";
 import type { StatuslineRenderContext } from "@/cli/display/statusline/types";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
 
@@ -52,16 +52,16 @@ function createStatuslineContext({
 }
 
 describe("statusline renderers", () => {
-  test("default renderer is legacy", () => {
-    expect(DEFAULT_STATUSLINE_RENDERER_ID).toBe("legacy");
-    expect(getBuiltinStatuslineRenderer(undefined).id).toBe("legacy");
-    expect(getBuiltinStatuslineRenderer("missing").id).toBe("legacy");
+  test("default renderer is built in", () => {
+    expect(DEFAULT_STATUSLINE_RENDERER_ID).toBe("default");
+    expect(getBuiltinStatuslineRenderer(undefined).id).toBe("default");
+    expect(getBuiltinStatuslineRenderer("missing").id).toBe("default");
   });
 
-  test("registry exposes the legacy renderer", () => {
+  test("registry exposes the default renderer", () => {
     expect(
       getBuiltinStatuslineRenderers().map((renderer) => renderer.id),
-    ).toEqual(["legacy"]);
+    ).toEqual(["default"]);
   });
 
   test("context exposes broad app state and raw payload", () => {
@@ -81,21 +81,21 @@ describe("statusline renderers", () => {
     expect(context.model.reasoningEffort).toBe("high");
   });
 
-  test("legacy renderer preserves the detailed model label", () => {
-    const output = buildLegacyStatuslineParts(createStatuslineContext());
+  test("default renderer shows compact agent and model label", () => {
+    const output = buildDefaultStatuslineParts(createStatuslineContext());
 
     expect(stripAnsi(String(output.right)).trim()).toBe(
-      "Letta Code [GPT-5.5 (ChatGPT) (high)] · local",
+      "Letta Code · GPT-5.5 (ChatGPT)",
     );
   });
 
-  test("legacy renderer suppresses reasoning for the no-model placeholder", () => {
-    const output = buildLegacyStatuslineParts(
+  test("default renderer omits reasoning and backend labels", () => {
+    const output = buildDefaultStatuslineParts(
       createStatuslineContext({ modelDisplayName: "No model selected" }),
     );
 
     expect(stripAnsi(String(output.right)).trim()).toBe(
-      "Letta Code [No model selected] · local",
+      "Letta Code · No model selected",
     );
   });
 


### PR DESCRIPTION
## Summary
- Replace the legacy built-in statusline renderer with a compact default renderer.
- Show only the right-aligned agent and model label by default.
- Remove the permanent left-side command hint plus reasoning/backend labels from the built-in default.

## Test plan
- [x] bun test src/cli/statusline-renderer.test.tsx src/cli/extensions/local-extension-loader.test.ts src/cli/chdir-command.test.ts src/cli/statusline-payload.test.ts src/settings-manager.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)