### PR TITLE
fix(mcp): repair legacy server refresh

### DIFF
--- a/src/cli/components/McpSelector.tsx
+++ b/src/cli/components/McpSelector.tsx
@@ -7,6 +7,7 @@ import type { Tool } from "@letta-ai/letta-client/resources/tools";
 import { Box, useInput } from "ink";
 import { memo, useCallback, useEffect, useState } from "react";
 import { getClient } from "@/backend/api/client";
+import { buildLegacyMcpServerRepair } from "@/cli/helpers/mcp-server-repair";
 import { truncateText } from "@/cli/helpers/truncate-text";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { colors } from "./colors";
@@ -176,7 +177,23 @@ export const McpSelector = memo(function McpSelector({
       await client.mcpServers.refresh(viewingServer.id, { agent_id: agentId });
 
       // Reload tools list
-      const toolsList = await client.mcpServers.tools.list(viewingServer.id);
+      let toolsList = await client.mcpServers.tools.list(viewingServer.id);
+
+      if (toolsList.length === 0 && viewingServer.mcp_server_type !== "stdio") {
+        const repair = buildLegacyMcpServerRepair(viewingServer);
+        if (repair) {
+          const repairedServer = await client.mcpServers.update(
+            viewingServer.id,
+            repair,
+          );
+          setViewingServer(repairedServer);
+          await client.mcpServers.refresh(viewingServer.id, {
+            agent_id: agentId,
+          });
+          toolsList = await client.mcpServers.tools.list(viewingServer.id);
+        }
+      }
+
       setTools(toolsList);
 
       // Refresh agent's current tools

--- a/src/cli/helpers/mcp-server-repair.test.ts
+++ b/src/cli/helpers/mcp-server-repair.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { buildLegacyMcpServerRepair } from "@/cli/helpers/mcp-server-repair";
+
+describe("buildLegacyMcpServerRepair", () => {
+  test("builds a nested config repair for authless streamable HTTP servers", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        id: "mcp_server-test",
+        server_name: "dragonnet",
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+        custom_headers: null,
+      }),
+    ).toEqual({
+      server_name: "dragonnet",
+      config: {
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+      },
+    });
+  });
+
+  test("builds a nested config repair for authless SSE servers", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        id: "mcp_server-test",
+        server_name: "legacy-sse",
+        mcp_server_type: "sse",
+        server_url: "https://example.com/sse",
+      }),
+    ).toEqual({
+      server_name: "legacy-sse",
+      config: {
+        mcp_server_type: "sse",
+        server_url: "https://example.com/sse",
+      },
+    });
+  });
+
+  test("skips repairs when visible auth could be dropped", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "secure",
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+        auth_header: "Authorization",
+      }),
+    ).toBeNull();
+
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "secure",
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+        auth_token: "redacted-token",
+      }),
+    ).toBeNull();
+
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "secure",
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+        custom_headers: { Authorization: "Bearer redacted" },
+      }),
+    ).toBeNull();
+  });
+
+  test("allows empty custom headers", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "empty-headers",
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+        custom_headers: {},
+      }),
+    ).toEqual({
+      server_name: "empty-headers",
+      config: {
+        mcp_server_type: "streamable_http",
+        server_url: "https://example.com/mcp",
+      },
+    });
+  });
+
+  test("skips repairs without a usable URL", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "missing-url",
+        mcp_server_type: "streamable_http",
+        server_url: "",
+      }),
+    ).toBeNull();
+
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "blank-url",
+        mcp_server_type: "streamable_http",
+        server_url: "   ",
+      }),
+    ).toBeNull();
+  });
+
+  test("skips stdio servers", () => {
+    expect(
+      buildLegacyMcpServerRepair({
+        server_name: "stdio-server",
+        mcp_server_type: "stdio",
+        command: "node",
+        args: ["server.js"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/cli/helpers/mcp-server-repair.ts
+++ b/src/cli/helpers/mcp-server-repair.ts
@@ -1,0 +1,63 @@
+import type {
+  SseMcpServer,
+  StdioMcpServer,
+  StreamableHTTPMcpServer,
+  UpdateSseMcpServer,
+  UpdateStreamableHTTPMcpServer,
+} from "@letta-ai/letta-client/resources/mcp-servers/mcp-servers";
+
+type RepairableMcpServer = SseMcpServer | StreamableHTTPMcpServer;
+type McpServer = RepairableMcpServer | StdioMcpServer;
+
+type RepairConfig = UpdateSseMcpServer | UpdateStreamableHTTPMcpServer;
+
+interface McpServerRepair {
+  server_name: string;
+  config: RepairConfig;
+}
+
+function hasCustomHeaders(server: RepairableMcpServer): boolean {
+  return (
+    !!server.custom_headers && Object.keys(server.custom_headers).length > 0
+  );
+}
+
+function hasVisibleAuth(server: RepairableMcpServer): boolean {
+  return (
+    !!server.auth_header || !!server.auth_token || hasCustomHeaders(server)
+  );
+}
+
+export function buildLegacyMcpServerRepair(
+  server: McpServer,
+): McpServerRepair | null {
+  if (server.mcp_server_type === "sse") {
+    if (!server.server_url.trim() || hasVisibleAuth(server)) {
+      return null;
+    }
+
+    return {
+      server_name: server.server_name,
+      config: {
+        mcp_server_type: "sse",
+        server_url: server.server_url,
+      },
+    };
+  }
+
+  if (server.mcp_server_type === "streamable_http") {
+    if (!server.server_url.trim() || hasVisibleAuth(server)) {
+      return null;
+    }
+
+    return {
+      server_name: server.server_name,
+      config: {
+        mcp_server_type: "streamable_http",
+        server_url: server.server_url,
+      },
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Repair legacy MCP server configs from `/mcp` manual refresh when the first refresh still returns zero tools
- Retry once with a minimal nested HTTP/SSE config patch before reloading tools
- Skip stdio, unusable URLs, and servers with visible auth/custom headers to avoid unsafe rewrites

## Context

This is a defensive Letta Code workaround for legacy/flattened MCP server rows while the server-side normalization issue is tracked in letta-ai/letta#3353.

## Validation

- `bun test src/cli/helpers/mcp-server-repair.test.ts` — PASS
- `bun run check` — PASS

## Risks

- The authoritative fix should still live server-side so all clients benefit.
- The CLI repair sends only `mcp_server_type` and `server_url` to avoid clearing auth/header fields, and only runs after a zero-tool manual refresh.
