### PR TITLE
fix(statusline): widen default renderer label

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -537,7 +537,10 @@ const StatuslineSlot = memo(function StatuslineSlot({
     return <BlankStatuslineRow rightColumnWidth={rightColumnWidth} />;
   }
 
-  const defaultStatuslineParts = buildDefaultStatuslineParts(statuslineContext);
+  const defaultStatuslineParts = buildDefaultStatuslineParts(
+    statuslineContext,
+    rightColumnWidth,
+  );
   const rightLabel = defaultStatuslineParts.right;
   const defaultLeftStatusline = defaultStatuslineParts.left;
 

--- a/src/cli/display/statusline/renderers/Default.tsx
+++ b/src/cli/display/statusline/renderers/Default.tsx
@@ -15,8 +15,16 @@ interface DefaultStatuslineParts {
   rightWidth: number;
 }
 
+export function getDefaultStatuslineRightColumnWidth(
+  context: StatuslineRenderContext,
+): number {
+  const terminalWidth = context.terminalWidth ?? context.ui.rightColumnWidth;
+  return Math.max(context.ui.rightColumnWidth, terminalWidth - 4);
+}
+
 export function buildDefaultStatuslineParts(
   context: StatuslineRenderContext,
+  rightColumnWidth = getDefaultStatuslineRightColumnWidth(context),
 ): DefaultStatuslineParts {
   const indicatorWidth =
     (context.ui.isByokProvider ? 2 : 0) +
@@ -24,7 +32,7 @@ export function buildDefaultStatuslineParts(
   const separatorWidth = 3;
   const availableTextWidth = Math.max(
     12,
-    context.ui.rightColumnWidth - separatorWidth - indicatorWidth,
+    rightColumnWidth - separatorWidth - indicatorWidth,
   );
   const maxAgentChars = Math.max(8, Math.floor(availableTextWidth * 0.4));
   const displayAgentName = truncateStatuslineText(
@@ -45,10 +53,7 @@ export function buildDefaultStatuslineParts(
     separatorWidth +
     displayModel.length +
     indicatorWidth;
-  const rightPrefixSpaces = Math.max(
-    0,
-    context.ui.rightColumnWidth - rightWidth,
-  );
+  const rightPrefixSpaces = Math.max(0, rightColumnWidth - rightWidth);
 
   const rightCoreParts: string[] = [];
   rightCoreParts.push(chalk.hex(colors.footer.agentName)(displayAgentName));
@@ -81,7 +86,8 @@ export function buildDefaultStatuslineParts(
 }
 
 export function renderDefaultStatusline(context: StatuslineRenderContext) {
-  const parts = buildDefaultStatuslineParts(context);
+  const rightColumnWidth = getDefaultStatuslineRightColumnWidth(context);
+  const parts = buildDefaultStatuslineParts(context, rightColumnWidth);
 
   return (
     <Box flexDirection="row" marginBottom={1}>
@@ -91,7 +97,7 @@ export function renderDefaultStatusline(context: StatuslineRenderContext) {
       <Box
         flexDirection="column"
         alignItems="flex-end"
-        width={context.ui.rightColumnWidth}
+        width={rightColumnWidth}
         flexShrink={0}
       >
         <Text>{parts.right}</Text>

--- a/src/cli/statusline-renderer.test.tsx
+++ b/src/cli/statusline-renderer.test.tsx
@@ -7,7 +7,10 @@ import {
   getBuiltinStatuslineRenderer,
   getBuiltinStatuslineRenderers,
 } from "@/cli/display/statusline/registry";
-import { buildDefaultStatuslineParts } from "@/cli/display/statusline/renderers/Default";
+import {
+  buildDefaultStatuslineParts,
+  getDefaultStatuslineRightColumnWidth,
+} from "@/cli/display/statusline/renderers/Default";
 import type { StatuslineRenderContext } from "@/cli/display/statusline/types";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
 
@@ -23,11 +26,15 @@ function createStatuslineContext({
   agentName = "Letta Code",
   modelDisplayName = "GPT-5.5 (ChatGPT)",
   reasoningEffort = "high",
+  rightColumnWidth = 80,
+  terminalWidth = 120,
   toolset = "letta-code",
 }: {
   agentName?: string;
   modelDisplayName?: string;
   reasoningEffort?: string;
+  rightColumnWidth?: number;
+  terminalWidth?: number;
   toolset?: string;
 } = {}): StatuslineRenderContext {
   return buildStatuslineRenderContext({
@@ -37,6 +44,7 @@ function createStatuslineContext({
       modelDisplayName,
       projectDirectory: "/tmp/project",
       reasoningEffort,
+      terminalWidth,
       toolset,
     }),
     ui: {
@@ -46,7 +54,7 @@ function createStatuslineContext({
       isByokProvider: false,
       isLocalBackend: true,
       isOpenAICodexProvider: false,
-      rightColumnWidth: 80,
+      rightColumnWidth,
     },
   });
 }
@@ -97,6 +105,20 @@ describe("statusline renderers", () => {
     expect(stripAnsi(String(output.right)).trim()).toBe(
       "Letta Code · No model selected",
     );
+  });
+
+  test("default renderer uses idle row width for long agent names", () => {
+    const context = createStatuslineContext({
+      agentName: "A Very Long Agent Name",
+      modelDisplayName: "Claude",
+      rightColumnWidth: 36,
+      terminalWidth: 80,
+    });
+
+    expect(getDefaultStatuslineRightColumnWidth(context)).toBe(76);
+    expect(
+      stripAnsi(String(buildDefaultStatuslineParts(context).right)),
+    ).toContain("A Very Long Agent Name");
   });
 
   test("default renderer does not override safety preemptions", () => {


### PR DESCRIPTION
## Summary
- Let the built-in default statusline use the idle row width instead of the narrow shared right-column budget.
- Keep host-mode fallback rows on the existing narrower right column so bash/permission hints still have left-side room.
- Add coverage for long agent names staying visible on an 80-column terminal.

## Test plan
- [x] bun test src/cli/statusline-renderer.test.tsx src/cli/extensions/local-extension-loader.test.ts src/cli/chdir-command.test.ts src/cli/statusline-payload.test.ts src/settings-manager.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)