### PR TITLE
fix(cron): support comma-separated values and range-step syntax in field validation

### DIFF
--- a/src/cron/parse-interval.test.ts
+++ b/src/cron/parse-interval.test.ts
@@ -155,11 +155,35 @@ describe("isValidCron", () => {
     expect(isValidCron("0-59 * * * *")).toBe(true);
   });
 
+  test("valid comma-separated values", () => {
+    expect(isValidCron("1,5,9 * * * *")).toBe(true);
+    expect(isValidCron("0 1,5,9 * * *")).toBe(true);
+    expect(isValidCron("1,5,9,13,17,21 * * * *")).toBe(true);
+    expect(isValidCron("0 0 * * 1,3,5")).toBe(true);
+  });
+
+  test("valid range with step", () => {
+    expect(isValidCron("1-21/4 * * * *")).toBe(true);
+    expect(isValidCron("0 0-23/2 * * *")).toBe(true);
+  });
+
+  test("valid comma-separated with ranges and steps", () => {
+    // Comma-separated items that include ranges
+    expect(isValidCron("1-5,10-15 * * * *")).toBe(true);
+    // Comma-separated items that include steps
+    expect(isValidCron("*/5,*/15 * * * *")).toBe(true);
+    // Mixed: exact, range, step
+    expect(isValidCron("0,10-20,30-59/5 * * * *")).toBe(true);
+  });
+
   test("invalid expressions", () => {
     expect(isValidCron("")).toBe(false);
     expect(isValidCron("* * *")).toBe(false); // too few fields
     expect(isValidCron("* * * * * *")).toBe(false); // too many fields
     expect(isValidCron("abc * * * *")).toBe(false);
+    expect(isValidCron("1, * * * *")).toBe(false); // trailing comma
+    expect(isValidCron(",5 * * * *")).toBe(false); // leading comma
+    expect(isValidCron(", * * * *")).toBe(false); // lone comma
   });
 });
 
@@ -257,6 +281,35 @@ describe("cronMatchesTime", () => {
     const date = new Date("2026-03-26T14:30:00");
     expect(cronMatchesTime("30 14 * * *", date, null)).toBe(true);
     expect(cronMatchesTime("30 14 * * *", date, undefined)).toBe(true);
+  });
+
+  test("comma-separated values match", () => {
+    const date = new Date("2026-03-26T14:30:00");
+    // minute 30 is in the list 0,15,30,45
+    expect(cronMatchesTime("0,15,30,45 * * * *", date)).toBe(true);
+    // minute 30 is NOT in the list 1,5,9
+    expect(cronMatchesTime("1,5,9 * * * *", date)).toBe(false);
+    // comma-separated day-of-week: Thursday is 4
+    expect(cronMatchesTime("30 14 * * 1,3,5", date)).toBe(false); // not Mon/Wed/Fri
+    expect(cronMatchesTime("30 14 * * 1,4,5", date)).toBe(true); // Thu is in list
+  });
+
+  test("range with step matches", () => {
+    const date = new Date("2026-03-26T14:30:00");
+    // 1-21/4 → 1,5,9,13,17,21 → 30 is NOT in this set
+    expect(cronMatchesTime("1-21/4 * * * *", date)).toBe(false);
+    // 0-59/15 → 0,15,30,45 → 30 IS in this set
+    expect(cronMatchesTime("0-59/15 * * * *", date)).toBe(true);
+    // Range with step for hour: 14 is in 0-23/2 → 0,2,4,...,14,...,22
+    expect(cronMatchesTime("* 0-23/2 * * *", date)).toBe(true);
+  });
+
+  test("comma-separated with ranges", () => {
+    const date = new Date("2026-03-26T14:30:00");
+    // 10-20,30-40 → minute 30 is in 30-40 range
+    expect(cronMatchesTime("10-20,30-40 * * * *", date)).toBe(true);
+    // 1-5,10-15 → minute 30 is NOT in either range
+    expect(cronMatchesTime("1-5,10-15 * * * *", date)).toBe(false);
   });
 });
 

--- a/src/cron/parse-interval.ts
+++ b/src/cron/parse-interval.ts
@@ -182,16 +182,24 @@ function dateToCron(d: Date): string {
 
 // ── Cron validation ─────────────────────────────────────────────────
 
-const CRON_FIELD_RE = /^(\*|\d+)([/-]\d+)?$/;
+/** Matches a single cron sub-field (no commas): *, N, star/N, N-M, N-M/S */
+const CRON_SUBFIELD_RE = /^(\*|\d+)(-\d+)?(\/\d+)?$/;
 
 /**
- * Validate a 5-field cron expression. Very basic — checks field count and
- * each field matches `*`, `N`, `*​/N`, or `N-N` patterns.
+ * Validate a 5-field cron expression. Checks field count and each field
+ * supports wildcards, exact values, steps, ranges, range-steps, and
+ * comma-separated combinations of the above.
  */
 export function isValidCron(expr: string): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
-  return fields.every((f) => CRON_FIELD_RE.test(f));
+  return fields.every((f) => {
+    // Split on commas and validate each sub-field individually
+    const subFields = f.split(",");
+    // Reject empty sub-fields (trailing/leading/double commas)
+    if (subFields.some((s) => s === "")) return false;
+    return subFields.every((s) => CRON_SUBFIELD_RE.test(s));
+  });
 }
 
 // ── Cron evaluation ─────────────────────────────────────────────────
@@ -328,6 +336,11 @@ export function cronMatchesTime(
 }
 
 function fieldMatches(field: string, value: number): boolean {
+  // Comma-separated: any sub-field matching is enough
+  if (field.includes(",")) {
+    return field.split(",").some((sub) => fieldMatches(sub, value));
+  }
+
   if (field === "*") return true;
 
   // Step: */N
@@ -337,7 +350,19 @@ function fieldMatches(field: string, value: number): boolean {
     return value % step === 0;
   }
 
-  // Range: N-N
+  // Range with step: N-M/S
+  if (field.includes("-") && field.includes("/")) {
+    const [range, stepStr] = field.split("/");
+    const step = Number.parseInt(stepStr ?? "", 10);
+    if (step <= 0 || !Number.isFinite(step)) return false;
+    const [startStr, endStr] = (range ?? "").split("-");
+    const start = Number.parseInt(startStr ?? "", 10);
+    const end = Number.parseInt(endStr ?? "", 10);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
+    return value >= start && value <= end && (value - start) % step === 0;
+  }
+
+  // Range: N-M
   if (field.includes("-")) {
     const [startStr, endStr] = field.split("-");
     const start = Number.parseInt(startStr ?? "", 10);


### PR DESCRIPTION
## Bug

The `CRON_FIELD_RE` regex in `src/cron/parse-interval.ts` only matched a limited subset of standard cron field syntax:

```js
// Before
const CRON_FIELD_RE = /^(\*|\d+)([/-]\d+)?$/;
```

This regex only accepted: `*`, single integers (`5`), `*/4` (step), and `5-20` (range). It **rejected** standard cron comma syntax like `1,5,9` and range+step like `1-21/4`.

Two functions were affected:
1. **`isValidCron()`** — used `CRON_FIELD_RE` to validate each of 5 cron fields, so comma-separated and range-step expressions were incorrectly rejected
2. **`fieldMatches()`** — did not handle comma-separated values or `N-M/S` range-step patterns, so `cronMatchesTime()` could not match them

## Fix

### `isValidCron()` — New regex + comma splitting

```js
// After
const CRON_SUBFIELD_RE = /^(\*|\d+)(-\d+)?(\/\d+)?$/;
```

The new regex properly separates the range (`-N`) and step (`/N`) components so that `N-M/S` is accepted. `isValidCron()` now splits each field on commas and validates each sub-field individually, rejecting empty sub-fields (trailing/leading/double commas).

### `fieldMatches()` — Comma and range-step support

- Added comma splitting at the top of the function: if the field contains `,`, split and recursively check each sub-field (any match is sufficient)
- Added `N-M/S` range-step handling: checks that the value is within the range AND aligned with the step offset

## Supported cron field syntax after this fix

| Pattern | Description | Example |
|---------|-------------|---------|
| `*` | Wildcard | `*` |
| `N` | Exact value | `5` |
| `*/N` | Step | `*/15` |
| `N-M` | Range | `1-5` |
| `N-M/S` | Range with step | `1-21/4` |
| `N,M,K` | Comma-separated | `1,5,9` |
| Mixed | Combinations | `0,10-20,30-59/5` |

## Test coverage

Added 8 new test cases covering:
- **isValidCron**: comma-separated values, range+step, mixed comma-separated with ranges/steps, invalid comma patterns (trailing, leading, lone comma)
- **cronMatchesTime**: comma-separated matching, range+step matching, comma-separated with ranges

All 83 tests in `src/cron/` pass (42 in `parse-interval.test.ts`, 28 in `cron-file.test.ts`, 13 in `scheduler.test.ts`).

## Test plan

- [x] Run `bun test src/cron/` — all 83 tests pass
- [x] Verify comma-separated cron expressions are accepted by `isValidCron`
- [x] Verify range+step expressions are accepted by `isValidCron`
- [x] Verify `cronMatchesTime` correctly matches/does not match comma and range-step fields
- [x] Verify invalid patterns (trailing/leading commas) are still rejected

👾 Generated with [Letta Code](https://letta.com)