### PR TITLE
fix(model): preserve context limits across reasoning changes

### DIFF
--- a/src/agent/max-context.test.ts
+++ b/src/agent/max-context.test.ts
@@ -68,6 +68,11 @@ describe("max context command helpers", () => {
       const agent = await backend.createAgent({
         name: "Max Context Agent",
         model: "anthropic/claude-sonnet-4-6",
+        model_settings: {
+          provider_type: "anthropic",
+          effort: "high",
+          parallel_tool_calls: true,
+        },
       } as AgentCreateBody);
 
       await expect(
@@ -113,6 +118,14 @@ describe("max context command helpers", () => {
       expect(resetResult.contextWindow).toBe(200_000);
       expect(resetResult.reset).toBe(true);
 
+      await backend.updateAgent(agent.id, {
+        model_settings: {
+          provider_type: "anthropic",
+          effort: "high",
+          parallel_tool_calls: true,
+        },
+      } as Parameters<typeof backend.updateAgent>[1]);
+
       const conversation = await backend.createConversation({
         agent_id: agent.id,
       } as ConversationCreateBody);
@@ -123,6 +136,10 @@ describe("max context command helpers", () => {
         currentModelId: "sonnet",
       });
       expect(conversationResult.appliedTo).toBe("conversation");
+      expect(conversationResult.conversationModelSettings).toMatchObject({
+        provider_type: "anthropic",
+        effort: "high",
+      });
       expect(
         (
           (await backend.retrieveConversation(conversation.id)) as {

--- a/src/agent/max-context.ts
+++ b/src/agent/max-context.ts
@@ -25,6 +25,7 @@ export type SetMaxContextResult = {
   defaultContextWindow?: number;
   modelLabel?: string;
   updatedAgent?: AgentState;
+  conversationModelSettings?: AgentState["model_settings"] | null;
 };
 
 type ModelContextDefault = {
@@ -56,6 +57,19 @@ function getUpdateArgs(model: (typeof models)[number] | null | undefined) {
   return model?.updateArgs && typeof model.updateArgs === "object"
     ? (model.updateArgs as Record<string, unknown>)
     : undefined;
+}
+
+function nonEmptyModelSettings(
+  value: unknown,
+): AgentState["model_settings"] | null {
+  if (
+    value &&
+    typeof value === "object" &&
+    Object.keys(value as Record<string, unknown>).length > 0
+  ) {
+    return value as AgentState["model_settings"];
+  }
+  return null;
 }
 
 export function formatContextWindowTokens(value: number): string {
@@ -301,9 +315,36 @@ export async function applySetMaxContext(params: {
     };
   }
 
-  await backend.updateConversation(params.conversationId, {
-    context_window_limit: contextWindow,
-  } as Parameters<typeof backend.updateConversation>[1]);
+  const updatedConversation = await backend.updateConversation(
+    params.conversationId,
+    {
+      context_window_limit: contextWindow,
+    } as Parameters<typeof backend.updateConversation>[1],
+  );
+  const updatedConversationRecord = updatedConversation as unknown as Record<
+    string,
+    unknown
+  >;
+  const conversationModel =
+    typeof updatedConversationRecord.model === "string"
+      ? updatedConversationRecord.model
+      : typeof conversationRecord.model === "string"
+        ? conversationRecord.model
+        : null;
+  const conversationModelSettings =
+    nonEmptyModelSettings(updatedConversationRecord.model_settings) ??
+    nonEmptyModelSettings(conversationRecord.model_settings);
+  const agentModelHandle =
+    typeof agent.model === "string" && agent.model.length > 0
+      ? agent.model
+      : buildModelHandleFromConfig(
+          agent.llm_config as ModelConfigSnapshot | null,
+        );
+  const inheritedModelSettings =
+    conversationModelSettings ??
+    (conversationModel === null || conversationModel === agentModelHandle
+      ? (agent.model_settings ?? null)
+      : null);
   return {
     contextWindow,
     reset,
@@ -311,6 +352,7 @@ export async function applySetMaxContext(params: {
     appliedTo: "conversation",
     defaultContextWindow: modelDefault.contextWindow,
     modelLabel: modelDefault.modelLabel,
+    conversationModelSettings: inheritedModelSettings,
   };
 }
 

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -4,6 +4,7 @@ import {
   getModelInfo,
   getModelInfoForLlmConfig,
   getReasoningTierOptionsForHandle,
+  shouldPreserveContextWindowForModelSelection,
 } from "@/agent/model";
 
 describe("getModelInfo", () => {
@@ -279,5 +280,69 @@ describe("getReasoningTierOptionsForHandle", () => {
       "anthropic/claude-haiku-4-5",
     );
     expect(options).toEqual([]);
+  });
+});
+
+describe("shouldPreserveContextWindowForModelSelection", () => {
+  test("preserves manual context when switching reasoning tiers on the same preset", () => {
+    expect(
+      shouldPreserveContextWindowForModelSelection({
+        currentModelHandle: "openai/gpt-5.5",
+        currentModelId: "gpt-5.5-high",
+        currentLlmConfig: {
+          model: "gpt-5.5",
+          model_endpoint_type: "openai",
+          context_window: 500000,
+        },
+        selectedModelHandle: "openai/gpt-5.5",
+        selectedContextWindow: 272000,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not preserve context when selecting a different context-window preset", () => {
+    expect(
+      shouldPreserveContextWindowForModelSelection({
+        currentModelHandle: "anthropic/claude-sonnet-4-6",
+        currentModelId: "sonnet",
+        currentLlmConfig: {
+          model: "claude-sonnet-4-6",
+          model_endpoint_type: "anthropic",
+          context_window: 500000,
+        },
+        selectedModelHandle: "anthropic/claude-sonnet-4-6",
+        selectedContextWindow: 9500000,
+      }),
+    ).toBe(false);
+  });
+
+  test("normalizes ChatGPT OAuth llm_config handles before comparison", () => {
+    expect(
+      shouldPreserveContextWindowForModelSelection({
+        currentModelId: "gpt-5.5-plus-pro-high",
+        currentLlmConfig: {
+          model: "gpt-5.5",
+          model_endpoint_type: "chatgpt_oauth",
+          context_window: 500000,
+        },
+        selectedModelHandle: "chatgpt-plus-pro/gpt-5.5",
+        selectedContextWindow: 272000,
+      }),
+    ).toBe(true);
+  });
+
+  test("derives current preset from llm config when no current model id is available", () => {
+    expect(
+      shouldPreserveContextWindowForModelSelection({
+        currentLlmConfig: {
+          model: "gpt-5.5",
+          model_endpoint_type: "openai",
+          reasoning_effort: "high",
+          context_window: 500000,
+        },
+        selectedModelHandle: "openai/gpt-5.5",
+        selectedContextWindow: 272000,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -15,6 +15,14 @@ export type ModelReasoningEffort =
   | "xhigh"
   | "max";
 
+type ModelConfigSnapshot = {
+  model?: string | null;
+  model_endpoint_type?: string | null;
+  reasoning_effort?: string | null;
+  enable_reasoner?: boolean | null;
+  context_window?: number | null;
+};
+
 const REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
   "none",
   "minimal",
@@ -212,6 +220,70 @@ export function getModelInfoForLlmConfig(
     return candidates[0] ?? direct ?? null;
   }
   return direct ?? candidates[0] ?? null;
+}
+
+function buildModelHandleFromConfig(
+  config: ModelConfigSnapshot | null | undefined,
+): string | null {
+  if (!config) return null;
+  if (config.model_endpoint_type && config.model) {
+    return `${config.model_endpoint_type}/${config.model}`;
+  }
+  return config.model ?? null;
+}
+
+export function normalizeModelHandleForRegistry(
+  modelHandle: string | null | undefined,
+): string | null {
+  if (!modelHandle) return null;
+  const [provider, ...modelParts] = modelHandle.split("/");
+  if (provider === "chatgpt_oauth" && modelParts.length > 0) {
+    return `${OPENAI_CODEX_PROVIDER_NAME}/${modelParts.join("/")}`;
+  }
+  return modelHandle;
+}
+
+export function shouldPreserveContextWindowForModelSelection(input: {
+  currentModelHandle?: string | null;
+  currentModelId?: string | null;
+  currentLlmConfig?: ModelConfigSnapshot | null;
+  selectedModelHandle: string;
+  selectedContextWindow?: number;
+}): boolean {
+  const currentRegistryModelHandle = normalizeModelHandleForRegistry(
+    input.currentModelHandle ??
+      buildModelHandleFromConfig(input.currentLlmConfig),
+  );
+  const selectedRegistryModelHandle = normalizeModelHandleForRegistry(
+    input.selectedModelHandle,
+  );
+
+  if (
+    selectedRegistryModelHandle === null ||
+    selectedRegistryModelHandle !== currentRegistryModelHandle
+  ) {
+    return false;
+  }
+
+  const currentModelInfo = input.currentModelId
+    ? getModelInfo(input.currentModelId)
+    : currentRegistryModelHandle
+      ? getModelInfoForLlmConfig(
+          currentRegistryModelHandle,
+          input.currentLlmConfig,
+        )
+      : null;
+  const currentPresetContextWindow = (
+    currentModelInfo?.updateArgs as { context_window?: unknown } | undefined
+  )?.context_window;
+
+  return (
+    typeof input.selectedContextWindow !== "number" ||
+    (typeof currentPresetContextWindow === "number" &&
+      input.selectedContextWindow === currentPresetContextWindow) ||
+    (typeof currentPresetContextWindow !== "number" &&
+      input.selectedContextWindow === input.currentLlmConfig?.context_window)
+  );
 }
 
 /**

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3000,8 +3000,21 @@ export function App({
           return;
         }
 
+        const hasConversationModelSettings =
+          conversationModelSettings !== undefined &&
+          conversationModelSettings !== null &&
+          Object.keys(conversationModelSettings as Record<string, unknown>)
+            .length > 0;
+        const resolvedConversationModelSettings = hasConversationModelSettings
+          ? conversationModelSettings
+          : conversationModel === undefined ||
+              conversationModel === null ||
+              conversationModel === agentModelHandle
+            ? (agentState.model_settings ?? null)
+            : null;
+
         const reasoningEffort = deriveReasoningEffort(
-          conversationModelSettings,
+          resolvedConversationModelSettings,
           agentState.llm_config,
         );
 
@@ -3026,7 +3039,7 @@ export function App({
             : conversationContextWindowLimit;
 
         setHasConversationModelOverride(true);
-        setConversationOverrideModelSettings(conversationModelSettings ?? null);
+        setConversationOverrideModelSettings(resolvedConversationModelSettings);
         setConversationOverrideContextWindowLimit(
           resolvedConversationContextWindowLimit,
         );
@@ -3965,6 +3978,7 @@ export function App({
     contextTrackerRef,
     conversationIdRef,
     currentModelHandle,
+    currentModelId,
     currentToolset,
     isAgentBusy,
     llmConfig,

--- a/src/cli/app/submit-diagnostics-commands.ts
+++ b/src/cli/app/submit-diagnostics-commands.ts
@@ -175,6 +175,9 @@ export async function handleDiagnosticsCommand(
         setConversationOverrideContextWindowLimit(null);
       } else {
         setHasConversationModelOverride(true);
+        setConversationOverrideModelSettings(
+          result.conversationModelSettings ?? null,
+        );
         setConversationOverrideContextWindowLimit(result.contextWindow);
       }
 

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -8,7 +8,10 @@ import {
   type SetStateAction,
   useCallback,
 } from "react";
-import type { ModelReasoningEffort } from "@/agent/model";
+import {
+  type ModelReasoningEffort,
+  shouldPreserveContextWindowForModelSelection,
+} from "@/agent/model";
 import {
   applyPersonalityToMemory,
   getPersonalityBlockValues,
@@ -70,6 +73,7 @@ type ConfigurationHandlersContext = {
   contextTrackerRef: MutableRefObject<ContextTracker>;
   conversationIdRef: MutableRefObject<string>;
   currentModelHandle: string | null;
+  currentModelId: string | null;
   currentToolset: ToolsetName | null;
   isAgentBusy: () => boolean;
   llmConfig: LlmConfig | null;
@@ -114,6 +118,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
     contextTrackerRef,
     conversationIdRef,
     currentModelHandle,
+    currentModelId,
     currentToolset,
     isAgentBusy,
     llmConfig,
@@ -299,6 +304,22 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           return;
         }
 
+        const currentLlmConfig = llmConfigRef.current;
+        const shouldPreserveContextWindow =
+          shouldPreserveContextWindowForModelSelection({
+            currentModelHandle,
+            currentModelId,
+            currentLlmConfig,
+            selectedModelHandle: modelHandle,
+            selectedContextWindow,
+          });
+        const modelUpdateArgsForRequest = model.updateArgs
+          ? { ...(model.updateArgs as Record<string, unknown>) }
+          : undefined;
+        if (shouldPreserveContextWindow && modelUpdateArgsForRequest) {
+          delete modelUpdateArgsForRequest.context_window;
+        }
+
         await withCommandLock(async () => {
           const cmd =
             resolveOverlayCommand() ??
@@ -326,7 +347,8 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             updatedAgent = await updateAgentLLMConfig(
               agentIdRef.current,
               modelHandle,
-              model.updateArgs,
+              modelUpdateArgsForRequest,
+              { preserveContextWindow: shouldPreserveContextWindow },
             );
             conversationModelSettings = updatedAgent?.model_settings;
           } else {
@@ -336,8 +358,8 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             const updatedConversation = await updateConversationLLMConfig(
               conversationIdRef.current,
               modelHandle,
-              model.updateArgs,
-              { preserveContextWindow: false },
+              modelUpdateArgsForRequest,
+              { preserveContextWindow: shouldPreserveContextWindow },
             );
             conversationModelSettings = (
               updatedConversation as {
@@ -376,15 +398,17 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             );
           }
 
-          const presetContextWindow = (
-            model.updateArgs as { context_window?: unknown } | undefined
-          )?.context_window;
+          const presetContextWindow = modelUpdateArgsForRequest?.context_window;
+          const preservedContextWindow = llmConfigRef.current?.context_window;
           const resolvedContextWindow =
             typeof conversationContextWindowLimit === "number"
               ? conversationContextWindowLimit
-              : typeof presetContextWindow === "number"
-                ? presetContextWindow
-                : undefined;
+              : shouldPreserveContextWindow &&
+                  typeof preservedContextWindow === "number"
+                ? preservedContextWindow
+                : typeof presetContextWindow === "number"
+                  ? presetContextWindow
+                  : undefined;
           if (!isDefaultConversation) {
             setConversationOverrideContextWindowLimit(
               typeof resolvedContextWindow === "number"
@@ -504,6 +528,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
       commandRunner,
       consumeOverlayCommand,
       currentModelHandle,
+      currentModelId,
       currentToolset,
       isAgentBusy,
       maybeRecordToolsetChangeReminder,

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -139,6 +139,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
               {
                 reasoning_effort: desired.effort,
               },
+              { preserveContextWindow: true },
             );
           } else {
             const { updateConversationLLMConfig } = await import(

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import {
+  __testSetBackend,
+  type AgentCreateBody,
+  type ConversationCreateBody,
+} from "@/backend";
+import { LocalBackend } from "@/backend/local";
+import { settingsManager } from "@/settings-manager";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
 
 /**
@@ -18,6 +29,20 @@ function readModelToolsetCommandSource(): string {
   );
   return readFileSync(commandPath, "utf-8");
 }
+
+class MockSocket {
+  readyState = WebSocket.OPEN;
+  sentPayloads: string[] = [];
+
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+}
+
+afterEach(async () => {
+  __testSetBackend(null);
+  await settingsManager.reset();
+});
 
 describe("listen-client model update status message", () => {
   test("emits only model name when toolset did not change", () => {
@@ -196,8 +221,80 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
 
     // Conversation-scoped update for non-default
     expect(source).toContain("updateConversationLLMConfig(");
-    expect(source).toContain("preserveContextWindow: false");
+    expect(source).toContain(
+      "preserveContextWindow: shouldPreserveContextWindow",
+    );
     expect(source).toContain('appliedTo = "conversation"');
+  });
+
+  test("preserves conversation context limit for same-handle desktop model updates", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "ws-model-context-"));
+    const previousHome = process.env.HOME;
+    try {
+      process.env.HOME = storageDir;
+      await settingsManager.reset();
+      await settingsManager.initialize();
+
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Desktop Model Agent",
+        model: "openai/gpt-5.5",
+        context_window_limit: 500000,
+        model_settings: {
+          provider_type: "openai",
+          reasoning: { reasoning_effort: "high" },
+          parallel_tool_calls: true,
+        },
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await backend.updateConversation(conversation.id, {
+        context_window_limit: 500000,
+      } as Parameters<typeof backend.updateConversation>[1]);
+
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const scopedRuntime =
+        __listenClientTestUtils.getOrCreateConversationRuntime(
+          listener,
+          agent.id,
+          conversation.id,
+        );
+      const model = __listenClientTestUtils.resolveModelForUpdate({
+        model_id: "gpt-5.5-medium",
+      });
+      if (!model) throw new Error("Expected gpt-5.5-medium model fixture");
+
+      const response = await __listenClientTestUtils.applyModelUpdateForRuntime(
+        {
+          socket: new MockSocket() as unknown as WebSocket,
+          listener,
+          scopedRuntime,
+          requestId: "model-update-context-1",
+          model,
+        },
+      );
+
+      expect(response.success).toBe(true);
+      expect(
+        (
+          (await backend.retrieveConversation(conversation.id)) as {
+            context_window_limit?: number;
+          }
+        ).context_window_limit,
+      ).toBe(500000);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -1,10 +1,15 @@
 import type WebSocket from "ws";
 import { getAvailableModelHandles } from "@/agent/available-models";
-import { getModelInfo, models } from "@/agent/model";
+import {
+  getModelInfo,
+  models,
+  shouldPreserveContextWindowForModelSelection,
+} from "@/agent/model";
 import {
   updateAgentLLMConfig,
   updateConversationLLMConfig,
 } from "@/agent/modify";
+import { getBackend } from "@/backend";
 import {
   buildByokProviderAliases,
   listProviders,
@@ -56,6 +61,89 @@ type ModelToolsetCommandContext = {
   runDetachedListenerTask: RunDetachedListenerTask;
   getOrCreateScopedRuntime: GetOrCreateScopedRuntime;
 };
+
+type ModelScopeSnapshot = {
+  modelHandle: string | null;
+  llmConfig: {
+    model?: string | null;
+    model_endpoint_type?: string | null;
+    context_window?: number | null;
+  } | null;
+};
+
+function buildModelHandleFromConfig(
+  config: ModelScopeSnapshot["llmConfig"],
+): string | null {
+  if (!config) return null;
+  if (config.model_endpoint_type && config.model) {
+    return `${config.model_endpoint_type}/${config.model}`;
+  }
+  return config.model ?? null;
+}
+
+function withContextWindow(
+  baseConfig: ModelScopeSnapshot["llmConfig"],
+  contextWindow?: number,
+): ModelScopeSnapshot["llmConfig"] {
+  return {
+    ...(baseConfig ?? {}),
+    ...(typeof contextWindow === "number"
+      ? { context_window: contextWindow }
+      : {}),
+  };
+}
+
+async function getCurrentModelScopeSnapshot(params: {
+  agentId: string;
+  conversationId: string;
+}): Promise<ModelScopeSnapshot> {
+  const backend = getBackend();
+  const agent = await backend.retrieveAgent(params.agentId);
+  const agentRecord = agent as unknown as Record<string, unknown>;
+  const agentModelHandle =
+    typeof agent.model === "string" && agent.model.length > 0
+      ? agent.model
+      : buildModelHandleFromConfig(
+          agent.llm_config as ModelScopeSnapshot["llmConfig"],
+        );
+  const agentContextWindow =
+    typeof agentRecord.context_window_limit === "number"
+      ? agentRecord.context_window_limit
+      : typeof agent.llm_config?.context_window === "number"
+        ? agent.llm_config.context_window
+        : undefined;
+
+  if (params.conversationId === "default") {
+    return {
+      modelHandle: agentModelHandle,
+      llmConfig: withContextWindow(
+        agent.llm_config as ModelScopeSnapshot["llmConfig"],
+        agentContextWindow,
+      ),
+    };
+  }
+
+  const conversation = await backend.retrieveConversation(
+    params.conversationId,
+  );
+  const conversationRecord = conversation as unknown as Record<string, unknown>;
+  const conversationModel =
+    typeof conversationRecord.model === "string"
+      ? conversationRecord.model
+      : null;
+  const conversationContextWindow =
+    typeof conversationRecord.context_window_limit === "number"
+      ? conversationRecord.context_window_limit
+      : undefined;
+
+  return {
+    modelHandle: conversationModel ?? agentModelHandle,
+    llmConfig: withContextWindow(
+      agent.llm_config as ModelScopeSnapshot["llmConfig"],
+      conversationContextWindow ?? agentContextWindow,
+    ),
+  };
+}
 
 export function resolveModelForUpdate(payload: {
   model_id?: string;
@@ -207,10 +295,29 @@ export async function applyModelUpdateForRuntime(params: {
 
   const isDefaultConversation = conversationId === "default";
 
-  const updateArgs = {
+  const updateArgs: Record<string, unknown> = {
     ...(model.updateArgs ?? {}),
     parallel_tool_calls: true,
   };
+  const selectedContextWindow =
+    typeof updateArgs.context_window === "number"
+      ? updateArgs.context_window
+      : undefined;
+  const currentModelScope = await getCurrentModelScopeSnapshot({
+    agentId,
+    conversationId,
+  });
+  const shouldPreserveContextWindow =
+    shouldPreserveContextWindowForModelSelection({
+      currentModelHandle: currentModelScope.modelHandle,
+      currentLlmConfig: currentModelScope.llmConfig,
+      selectedModelHandle: model.handle,
+      selectedContextWindow,
+    });
+  const updateArgsForRequest = { ...updateArgs };
+  if (shouldPreserveContextWindow) {
+    delete updateArgsForRequest.context_window;
+  }
 
   let modelSettings: Record<string, unknown> | null = null;
   let appliedTo: "agent" | "conversation";
@@ -219,7 +326,8 @@ export async function applyModelUpdateForRuntime(params: {
     const updatedAgent = await updateAgentLLMConfig(
       agentId,
       model.handle,
-      updateArgs,
+      updateArgsForRequest,
+      { preserveContextWindow: shouldPreserveContextWindow },
     );
     modelSettings =
       (updatedAgent.model_settings as
@@ -231,8 +339,8 @@ export async function applyModelUpdateForRuntime(params: {
     const updatedConversation = await updateConversationLLMConfig(
       conversationId,
       model.handle,
-      updateArgs,
-      { preserveContextWindow: false },
+      updateArgsForRequest,
+      { preserveContextWindow: shouldPreserveContextWindow },
     );
     modelSettings =
       ((


### PR DESCRIPTION
## Summary
- Preserve explicit context-window overrides when changing reasoning tiers on the same model, including desktop websocket model updates.
- Keep context-only conversation overrides from making reasoning appear cleared by inheriting the active model settings locally.
- Continue applying explicit context-window preset changes when users choose a different context-window variant.

## Test plan
- [x] bun run check
- [x] bun test src/agent/model-tier-selection.test.ts src/agent/max-context.test.ts src/websocket/listen-model-update.test.ts

👾 Generated with [Letta Code](https://letta.com)