### PR TITLE
fix(local): discover Ollama Cloud models dynamically

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -19,16 +19,6 @@ export const LOCAL_KIMI_CODE_PROVIDER_NAME = "lc-kimi-code";
 export const LOCAL_GOOGLE_AI_PROVIDER_NAME = "lc-gemini";
 export const LOCAL_BEDROCK_PROVIDER_NAME = "lc-bedrock";
 
-const OLLAMA_CLOUD_MODELS = [
-  "ollama-cloud/glm-4.7",
-  "ollama-cloud/qwen3-coder:480b",
-  "ollama-cloud/gpt-oss:20b",
-  "ollama-cloud/gpt-oss:120b",
-  "ollama-cloud/kimi-k2.5",
-  "ollama-cloud/minimax-m2.1",
-  "ollama-cloud/deepseek-v3.2",
-] as const;
-
 function hasEnvValue(value: string | undefined): boolean {
   return typeof value === "string" && value.length > 0;
 }
@@ -61,7 +51,6 @@ export interface PiProviderSpec {
   baseUrlEnv?: () => string | undefined;
   fallbackApiKey?: string;
   headers?: () => Record<string, string> | undefined;
-  staticModels?: readonly string[];
   localModelDiscovery?: "ollama" | "openai-compatible";
   envConfigured?: () => boolean;
   createCustomModel?: boolean;
@@ -209,10 +198,10 @@ export const PI_PROVIDER_SPECS = [
     handlePrefixes: ["ollama-cloud/"],
     localProviderNames: [LOCAL_OLLAMA_CLOUD_PROVIDER_NAME],
     defaultModel: "ollama-cloud/gpt-oss:20b",
-    staticModels: OLLAMA_CLOUD_MODELS,
     defaultBaseURL: "https://ollama.com/v1",
     apiKeyEnv: () => process.env.OLLAMA_API_KEY,
     baseUrlEnv: () => process.env.OLLAMA_CLOUD_BASE_URL,
+    localModelDiscovery: "openai-compatible",
     envConfigured: () => hasEnvValue(process.env.OLLAMA_API_KEY),
     createCustomModel: true,
   },
@@ -375,9 +364,6 @@ export function listCatalogModelsForProvider(provider: PiProvider): string[] {
     for (const model of getModels(spec.piProvider)) {
       add(spec.catalogModelHandle(model as Model<Api>));
     }
-  }
-  for (const model of spec.staticModels ?? []) {
-    add(model);
   }
 
   return models;

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -488,6 +488,40 @@ describe("local backend pi transcript", () => {
     expect(handles).not.toContain("lmstudio/google/gemma-3n-e4b");
   });
 
+  test("discovers configured Ollama Cloud models from OpenAI-compatible catalog", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-ollama-cloud-discovery-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "ollama_cloud",
+      providerName: "lc-ollama-cloud",
+      apiKey: "ollama-key",
+      storageDir,
+    });
+    const calls: string[] = [];
+    const captured: { authorization?: string | null } = {};
+    const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      captured.authorization = new Headers(init?.headers).get("Authorization");
+      return new Response(
+        JSON.stringify({ data: [{ id: "rnj-1:8b" }, { id: "glm-5.1" }] }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const handles = (
+      await listLocalModels(storageDir, { fetch: fetchImpl })
+    ).map((model) => model.handle);
+
+    expect(calls).toEqual(["https://ollama.com/v1/models"]);
+    expect(captured.authorization).toBe("Bearer ollama-key");
+    expect(handles).toContain("ollama-cloud/rnj-1:8b");
+    expect(handles).toContain("ollama-cloud/glm-5.1");
+    expect(handles).not.toContain("ollama-cloud/gpt-oss:20b");
+    expect(handles).not.toContain("ollama-cloud/gpt-oss:120b");
+  });
+
   test("uses LM Studio env API key for discovery when stored key is placeholder", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-lmstudio-env-key-"),


### PR DESCRIPTION
## Summary
- Remove the stale hardcoded Ollama Cloud model allowlist from the local provider registry.
- Reuse the existing OpenAI-compatible model discovery path for Ollama Cloud so `/model` reflects the live `https://ollama.com/v1/models` catalog.
- Add a regression test that verifies Ollama Cloud uses dynamic discovery and does not surface stale hardcoded handles.

## Test plan
- [x] `bun test src/backend/local-backend.test.ts`
- [x] Smoke-listed Ollama Cloud models from `https://ollama.com/v1/models` (39 handles returned)
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)