### PR TITLE
feat(hooks): add `quiet` option to suppress hook output

### DIFF
--- a/src/hooks/executor.ts
+++ b/src/hooks/executor.ts
@@ -97,7 +97,6 @@ export async function executeHookCommand(
     return executePromptHook(hook, input, workingDirectory);
   }
 
-  // Default to command hook execution
   if (isCommandHook(hook)) {
     return executeCommandHook(hook, input, workingDirectory);
   }
@@ -126,7 +125,6 @@ export async function executeCommandHook(
   const timeout = hook.timeout ?? DEFAULT_TIMEOUT_MS;
   const inputJson = JSON.stringify(input);
 
-  // Get platform-appropriate shell launchers
   const launchers = buildShellLaunchers(hook.command);
   if (launchers.length === 0) {
     return {
@@ -152,6 +150,7 @@ export async function executeCommandHook(
         timeout,
         hook.command,
         startTime,
+        hook.quiet,
       );
       return result;
     } catch (error) {
@@ -191,6 +190,7 @@ function executeWithLauncher(
   timeout: number,
   command: string,
   startTime: number,
+  quiet?: boolean,
 ): Promise<HookResult> {
   return new Promise<HookResult>((resolve, reject) => {
     let stdout = "";
@@ -218,25 +218,27 @@ function executeWithLauncher(
         const exitLabel = result.timedOut
           ? `${exitColor}timeout\x1b[0m`
           : `${exitColor}exit ${exitCode}\x1b[0m`;
-        console.log(`\x1b[90m[hook:${input.event_type}] ${command}\x1b[0m`);
-        console.log(
-          `\x1b[90m  \u23BF ${exitLabel} (${result.durationMs}ms)\x1b[0m`,
-        );
-        if (result.stdout) {
-          console.log(`\x1b[90m  \u23BF (stdout)\x1b[0m`);
-          const indented = result.stdout
-            .split("\n")
-            .map((line) => `    ${line}`)
-            .join("\n");
-          console.log(`\x1b[90m${indented}\x1b[0m`);
-        }
-        if (result.stderr) {
-          console.log(`\x1b[90m  \u23BF (stderr)\x1b[0m`);
-          const indented = result.stderr
-            .split("\n")
-            .map((line) => `    ${line}`)
-            .join("\n");
-          console.log(`\x1b[90m${indented}\x1b[0m`);
+        if (!quiet) {
+          console.log(`\x1b[90m[hook:${input.event_type}] ${command}\x1b[0m`);
+          console.log(
+            `\x1b[90m  \u23BF ${exitLabel} (${result.durationMs}ms)\x1b[0m`,
+          );
+          if (result.stdout) {
+            console.log(`\x1b[90m  \u23BF (stdout)\x1b[0m`);
+            const indented = result.stdout
+              .split("\n")
+              .map((line) => `    ${line}`)
+              .join("\n");
+            console.log(`\x1b[90m${indented}\x1b[0m`);
+          }
+          if (result.stderr) {
+            console.log(`\x1b[90m  \u23BF (stderr)\x1b[0m`);
+            const indented = result.stderr
+              .split("\n")
+              .map((line) => `    ${line}`)
+              .join("\n");
+            console.log(`\x1b[90m${indented}\x1b[0m`);
+          }
         }
         resolve(result);
       }

--- a/src/hooks/prompt-executor.ts
+++ b/src/hooks/prompt-executor.ts
@@ -197,12 +197,14 @@ export async function executePromptHook(
     const exitColor = shouldBlock ? "\x1b[31m" : "\x1b[32m";
     const exitLabel = `${exitColor}exit ${exitCode}\x1b[0m`;
     const promptLabel = `\x1b[38;2;140;140;249m✦\x1b[90m ${hook.prompt.slice(0, 50)}${hook.prompt.length > 50 ? "..." : ""}`;
-    console.log(`\x1b[90m[hook:${input.event_type}] ${promptLabel}\x1b[0m`);
-    console.log(`\x1b[90m  \u23BF ${exitLabel} (${durationMs}ms)\x1b[0m`);
-    // Show the JSON response as stdout
-    const responseJson = JSON.stringify(parsedResponse);
-    console.log(`\x1b[90m  \u23BF (stdout)\x1b[0m`);
-    console.log(`\x1b[90m    ${responseJson}\x1b[0m`);
+    if (!hook.quiet) {
+      console.log(`\x1b[90m[hook:${input.event_type}] ${promptLabel}\x1b[0m`);
+      console.log(`\x1b[90m  \u23BF ${exitLabel} (${durationMs}ms)\x1b[0m`);
+      // Show the JSON response as stdout
+      const responseJson = JSON.stringify(parsedResponse);
+      console.log(`\x1b[90m  \u23BF (stdout)\x1b[0m`);
+      console.log(`\x1b[90m    ${responseJson}\x1b[0m`);
+    }
 
     return responseToHookResult(parsedResponse, durationMs);
   } catch (error) {
@@ -211,12 +213,14 @@ export async function executePromptHook(
     const timedOut = errorMessage.includes("timed out");
 
     const promptLabel = `\x1b[38;2;140;140;249m✦\x1b[90m ${hook.prompt.slice(0, 50)}${hook.prompt.length > 50 ? "..." : ""}`;
-    console.log(`\x1b[90m[hook:${input.event_type}] ${promptLabel}\x1b[0m`);
-    console.log(
-      `\x1b[90m  \u23BF \x1b[33mexit 1\x1b[0m (${durationMs}ms)\x1b[0m`,
-    );
-    console.log(`\x1b[90m  \u23BF (stderr)\x1b[0m`);
-    console.log(`\x1b[90m    ${errorMessage}\x1b[0m`);
+    if (!hook.quiet) {
+      console.log(`\x1b[90m[hook:${input.event_type}] ${promptLabel}\x1b[0m`);
+      console.log(
+        `\x1b[90m  \u23BF \x1b[33mexit 1\x1b[0m (${durationMs}ms)\x1b[0m`,
+      );
+      console.log(`\x1b[90m  \u23BF (stderr)\x1b[0m`);
+      console.log(`\x1b[90m    ${errorMessage}\x1b[0m`);
+    }
 
     return {
       exitCode: HookExitCode.ERROR,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -37,6 +37,8 @@ export interface CommandHookConfig {
   command: string;
   /** Optional timeout in milliseconds (default: 60000 for command hooks) */
   timeout?: number;
+  /** When true, suppress hook output in the TUI */
+  quiet?: boolean;
 }
 
 /**
@@ -56,6 +58,8 @@ export interface PromptHookConfig {
   model?: string;
   /** Optional timeout in milliseconds (default: 30000 for prompt hooks) */
   timeout?: number;
+  /** When true, suppress hook output in the TUI */
+  quiet?: boolean;
 }
 
 /**


### PR DESCRIPTION
useful for hooks that run very frequently and you don't need to see the output.