### PR TITLE
feat(local): mirror pi providers in connect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
@@ -17,7 +16,7 @@
         "ws": "^8.19.0",
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.75.5",
         "@slack/bolt": "^4.7.0",
         "@types/bun": "^1.3.7",
         "@types/diff": "^8.0.0",
@@ -56,59 +55,43 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1046.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.9", "@aws-sdk/credential-provider-node": "^3.972.40", "@aws-sdk/eventstream-handler-node": "^3.972.15", "@aws-sdk/middleware-eventstream": "^3.972.11", "@aws-sdk/middleware-host-header": "^3.972.11", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.12", "@aws-sdk/middleware-user-agent": "^3.972.39", "@aws-sdk/middleware-websocket": "^3.972.17", "@aws-sdk/region-config-resolver": "^3.972.14", "@aws-sdk/token-providers": "3.1046.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@aws-sdk/util-user-agent-browser": "^3.972.11", "@aws-sdk/util-user-agent-node": "^3.973.25", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-MT+nf7bna9gEohYFqUbPivR/XFPq7K8PmvgZY0h+kC/4k9SYDjQjsuA+sGH2AaZwJmMGXhmL4FpWRsYMc5gOQw=="],
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.974.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.23", "@smithy/core": "^3.24.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.25", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w=="],
 
-    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.35", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WkFQ8BedszVomhh/Zzs8WwnE/XBmTqZjoQVB8u/4zH6kZCjouXZpPpb93gD8m0EZmzAl7dxHE/y+yDpuKzNCMw=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw=="],
 
-    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-ylx0ZJTU+2eNcvXQ69VNR3TVSYa/ibpvdK717/NxqR9aXRMn2QRWZaiI8aa5yY/fOWZ5mknSmxGaVxxtdwv3EA=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/credential-provider-env": "^3.972.35", "@aws-sdk/credential-provider-http": "^3.972.37", "@aws-sdk/credential-provider-login": "^3.972.39", "@aws-sdk/credential-provider-process": "^3.972.35", "@aws-sdk/credential-provider-sso": "^3.972.39", "@aws-sdk/credential-provider-web-identity": "^3.972.39", "@aws-sdk/nested-clients": "^3.997.7", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/credential-provider-imds": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QhRSrdkk+Gq0AFIylpiI0N6lcJqFYV9Jtr4Luz5FpYOYbjJSfyTG6iLhnK/UPIgN1Jnon8WAmSC//16XYGvwkA=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/credential-provider-env": "^3.972.39", "@aws-sdk/credential-provider-http": "^3.972.41", "@aws-sdk/credential-provider-login": "^3.972.43", "@aws-sdk/credential-provider-process": "^3.972.39", "@aws-sdk/credential-provider-sso": "^3.972.43", "@aws-sdk/credential-provider-web-identity": "^3.972.43", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/nested-clients": "^3.997.7", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1hU0NtC04QbFIuoBuF4aQ2A97GsSE5/A0ZJpDijwexsBREIQ4KPRYl3v/FfKCPBYsaTeGjkOFx5nLhWHY24LOw=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.40", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.35", "@aws-sdk/credential-provider-http": "^3.972.37", "@aws-sdk/credential-provider-ini": "^3.972.39", "@aws-sdk/credential-provider-process": "^3.972.35", "@aws-sdk/credential-provider-sso": "^3.972.39", "@aws-sdk/credential-provider-web-identity": "^3.972.39", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/credential-provider-imds": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-ZgrQaGkpyTlVSCCsffzijVg+KgftTAWYvI5Otc36J/4jNiHb+7MmBiJIR0a5AHLvifC92PiYHt5pijP0dswd1w=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.44", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.39", "@aws-sdk/credential-provider-http": "^3.972.41", "@aws-sdk/credential-provider-ini": "^3.972.43", "@aws-sdk/credential-provider-process": "^3.972.39", "@aws-sdk/credential-provider-sso": "^3.972.43", "@aws-sdk/credential-provider-web-identity": "^3.972.43", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/credential-provider-imds": "^4.3.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ=="],
 
-    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.35", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hNj1rAwZWT1vfz54BwH8FUWxZuqStrM25Q5LEIwn2erHPMRVAjLlpZqEbCEEqS99eEEOhdeetnS0WeNa3iYeEQ=="],
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/nested-clients": "^3.997.7", "@aws-sdk/token-providers": "3.1046.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-mwIPNPldyCZkvHozb6E0X/vuQLN1UCjcA6MwUf1gaO7EwghCmuNZXatq0L3zptKFvPC4Nds7+WFUkifI1XmbSw=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/token-providers": "3.1052.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/nested-clients": "^3.997.7", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-b9HT8CnpyPVn1hU14Q7ihjwSPlRzToYmRYJxRd5jNHEZ43lrIhoLaTT8JmfQQt5j5M8rTX1iN1X8mvu0SM1dXA=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw=="],
 
-    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Al7z1qKPUIRILnB3Ggd1Tz88wjSkQjDErajR7YY33mquTbeN0gTDtJtclNtyhQMWr7ZRpQk0v5/xop4fjT0sug=="],
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.17", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ=="],
 
-    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-A0Z45YInBwsAabF8jf9hEQjXDuq4gFHNNqxCYuk8iREFZ7hw0NZ6+7FFlYa11gJ+i6y79C4J6giQ7fa1EDRYxw=="],
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A=="],
 
-    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg=="],
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.21", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA=="],
 
-    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.11", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.13", "@aws-sdk/signature-v4-multi-region": "^3.996.28", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA=="],
 
-    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.12", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.28", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/signature-v4": "^5.4.2", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q=="],
 
-    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.39", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg=="],
-
-    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.17", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0PRAeIunuJRAweM/YWATe0jCHx4BMzSuwry461/TgcwMc8mNShwTdXiG6eEQBD7u+nNPC8Inp9KXjSB6D7uNYg=="],
-
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.7", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.9", "@aws-sdk/middleware-host-header": "^3.972.11", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.12", "@aws-sdk/middleware-user-agent": "^3.972.39", "@aws-sdk/region-config-resolver": "^3.972.14", "@aws-sdk/signature-v4-multi-region": "^3.996.26", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@aws-sdk/util-user-agent-browser": "^3.972.11", "@aws-sdk/util-user-agent-node": "^3.973.25", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA=="],
-
-    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA=="],
-
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.26", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag=="],
-
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1046.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.9", "@aws-sdk/nested-clients": "^3.997.7", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
-    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg=="],
-
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
-    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA=="],
-
-    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.25", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.39", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw=="],
-
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.23", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.25", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
@@ -126,7 +109,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.75.5", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -252,7 +235,7 @@
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
-    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA=="],
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
 
     "@smithy/signature-v4": ["@smithy/signature-v4@5.4.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw=="],
 
@@ -261,8 +244,6 @@
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
-
-    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@ts-graphviz/adapter": ["@ts-graphviz/adapter@2.0.6", "", { "dependencies": { "@ts-graphviz/common": "^2.1.5" } }, "sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q=="],
 
@@ -356,8 +337,6 @@
 
     "ast-module-types": ["ast-module-types@6.0.2", "", {}, "sha512-6KuK/7nZ/2Qh7sGuVEiwxjCxzTY2Pdb5mTo5z1e6/J8BA0tvjR7G8vQJKrQMTqwmnA3UPEyKIFX4YUS1DO1Hvw=="],
 
-    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
-
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
@@ -367,8 +346,6 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
-    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -444,7 +421,7 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -457,8 +434,6 @@
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
-
-    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -546,7 +521,7 @@
 
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
-    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
@@ -585,8 +560,6 @@
     "get-own-enumerable-property-symbols": ["get-own-enumerable-property-symbols@3.0.2", "", {}, "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 
@@ -641,8 +614,6 @@
     "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
 
     "ink-text-input": ["ink-text-input@5.0.1", "", { "dependencies": { "chalk": "^5.2.0", "type-fest": "^3.6.1" }, "peerDependencies": { "ink": "^4.0.0", "react": "^18.0.0" } }, "sha512-crnsYJalG4EhneOFnr/q+Kzw1RgmXI2KsBaLFE6mpiIKxAtJLUnvygOF2IUKO8z4nwkSkveGRBMd81RoYdRSag=="],
-
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -716,7 +687,7 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+    "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
     "madge": ["madge@8.0.0", "", { "dependencies": { "chalk": "^4.1.2", "commander": "^7.2.0", "commondir": "^1.0.1", "debug": "^4.3.4", "dependency-tree": "^11.0.0", "ora": "^5.4.1", "pluralize": "^8.0.0", "pretty-ms": "^7.0.1", "rc": "^1.2.8", "stream-to-array": "^2.3.0", "ts-graphviz": "^2.1.2", "walkdir": "^0.4.1" }, "peerDependencies": { "typescript": "^5.4.4" }, "optionalPeers": ["typescript"], "bin": { "madge": "bin/cli.js" } }, "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw=="],
 
@@ -768,8 +739,6 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
-
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
@@ -805,10 +774,6 @@
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
-
-    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
-
-    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
@@ -849,8 +814,6 @@
     "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -926,12 +889,6 @@
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
-    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
-
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1004,8 +961,6 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
-
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
@@ -1062,6 +1017,110 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/core/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/core/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-env/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-http/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-ini/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-login/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-login/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-node/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-process/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-process/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1052.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-sso/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/credential-provider-web-identity/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/credential-provider-web-identity/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/eventstream-handler-node/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/middleware-eventstream/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
+
+    "@aws-sdk/middleware-websocket/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/nested-clients/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/nested-clients/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/signature-v4-multi-region/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/signature-v4-multi-region/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/token-providers/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@aws-sdk/xml-builder/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/node-http-handler/@smithy/core": ["@smithy/core@3.24.4", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw=="],
+
+    "@smithy/node-http-handler/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
@@ -1106,8 +1165,6 @@
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
-    "path-scurry/lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
-
     "precinct/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "sass-lookup/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
@@ -1127,8 +1184,6 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "listr2/cli-truncate/string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=22.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vscode/ripgrep": "^1.17.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.75.5",
     "@slack/bolt": "^4.7.0",
     "@types/bun": "^1.3.7",
     "@types/diff": "^8.0.0",

--- a/src/backend/api/providers.ts
+++ b/src/backend/api/providers.ts
@@ -6,6 +6,7 @@ export interface ProviderResponse {
   name: string;
   provider_type: string;
   provider_category?: "base" | "byok" | null;
+  auth_type?: "api" | "oauth";
   api_key?: string;
   base_url?: string;
   timeout?: number | false;

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,7 +1,11 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModel, getModels } from "@earendil-works/pi-ai";
 import {
-  getLocalChatGPTApiKey,
+  getOAuthProvider,
+  type OAuthCredentials,
+} from "@earendil-works/pi-ai/oauth";
+import {
+  getLocalOAuthApiKey,
   getLocalProviderRecordByName,
   type LocalProviderRecord,
   localProviderApiKeyFromRecord,
@@ -211,12 +215,18 @@ export function resolveZaiConnection(options: {
 function getCatalogModel(
   provider: PiProvider,
   modelId: string,
+  oauthCredentials?: OAuthCredentials,
 ): Model<Api> | undefined {
   const spec = getPiProviderSpec(provider);
   if (!spec.piProvider) return undefined;
-  return getModels(spec.piProvider).find((model) => model.id === modelId) as
-    | Model<Api>
-    | undefined;
+  const model = getModels(spec.piProvider).find(
+    (model) => model.id === modelId,
+  ) as Model<Api> | undefined;
+  if (!model || !oauthCredentials) return model;
+
+  const oauthProvider = getOAuthProvider(spec.piProvider);
+  return (oauthProvider?.modifyModels?.([model], oauthCredentials)[0] ??
+    model) as Model<Api>;
 }
 
 function customOpenAICompatibleModel(input: {
@@ -355,6 +365,7 @@ export async function resolvePiModelForAgent(
   const headers = spec.headers?.();
   let providerOptions: Record<string, unknown> | undefined;
   let envOverrides: Record<string, string | undefined> | undefined;
+  let oauthCredentials: OAuthCredentials | undefined;
 
   if (provider === "zai") {
     const zai = resolveZaiConnection({
@@ -373,11 +384,17 @@ export async function resolvePiModelForAgent(
     baseURL = zai.baseURL;
   }
 
-  if (provider === "openai-codex") {
+  if (connection.record?.auth.type === "oauth" && spec.piProvider) {
+    const oauth = await getLocalOAuthApiKey({
+      providerId: spec.piProvider,
+      providerNames: spec.localProviderNames,
+      storageDir,
+    });
     connection = {
       ...connection,
-      apiKey: await getLocalChatGPTApiKey(storageDir),
+      apiKey: oauth?.apiKey,
     };
+    oauthCredentials = oauth?.credentials;
   }
 
   if (provider === "amazon-bedrock") {
@@ -388,7 +405,7 @@ export async function resolvePiModelForAgent(
 
   const contextWindow = numericSetting(modelSettings.context_window_limit);
   const maxTokens = numericSetting(modelSettings.max_tokens);
-  const catalogModel = getCatalogModel(provider, modelId);
+  const catalogModel = getCatalogModel(provider, modelId, oauthCredentials);
   const model = spec.createCustomModel
     ? customOpenAICompatibleModel({
         provider,

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -22,7 +22,7 @@ import {
   stripProviderHandlePrefix,
 } from "./pi-provider-registry";
 
-export const DEFAULT_PI_PROVIDER = "openai-responses" satisfies PiProvider;
+export const DEFAULT_PI_PROVIDER = "openai" satisfies PiProvider;
 export type { PiProvider } from "./pi-provider-registry";
 
 export interface PiModelSettings {
@@ -88,7 +88,6 @@ export function resolvePiProvider(
   provider = process.env.LETTA_CODE_DEV_PI_PROVIDER ??
     inferDefaultProviderFromStandardKeys(),
 ): PiProvider {
-  if (provider === "openai") return "openai-responses";
   if (isPiProvider(provider)) return provider;
   throw new Error(
     `Unknown pi provider "${provider}". Expected ${expectedPiProviderList()}.`,
@@ -158,12 +157,12 @@ export function resolveZaiConnection(options: {
   storageDir?: string;
   preferredProviderType?: "zai" | "zai_coding";
 }): ZaiConnection {
-  const regularRecord = getLocalProviderRecordByName(
-    LOCAL_ZAI_PROVIDER_NAME,
+  const regularRecord = localProviderRecord(
+    ["zai", LOCAL_ZAI_PROVIDER_NAME],
     options.storageDir,
   );
-  const codingRecord = getLocalProviderRecordByName(
-    LOCAL_ZAI_CODING_PROVIDER_NAME,
+  const codingRecord = localProviderRecord(
+    ["zai_coding", LOCAL_ZAI_CODING_PROVIDER_NAME],
     options.storageDir,
   );
   const regularKey =
@@ -374,14 +373,14 @@ export async function resolvePiModelForAgent(
     baseURL = zai.baseURL;
   }
 
-  if (provider === "chatgpt-oauth") {
+  if (provider === "openai-codex") {
     connection = {
       ...connection,
       apiKey: await getLocalChatGPTApiKey(storageDir),
     };
   }
 
-  if (provider === "bedrock") {
+  if (provider === "amazon-bedrock") {
     const bedrock = bedrockLocalProviderOptions(connection.record);
     providerOptions = bedrock.providerOptions;
     envOverrides = bedrock.envOverrides;

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -154,7 +154,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     providerTypes: ["openai-codex", "chatgpt_oauth"],
     handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
     localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
-    defaultModel: "openai-codex/gpt-5.1-codex-max",
+    defaultModel: "openai-codex/gpt-5.5",
   },
 };
 

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -1,5 +1,5 @@
 import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
-import { getModels } from "@earendil-works/pi-ai";
+import { getEnvApiKey, getModels, getProviders } from "@earendil-works/pi-ai";
 
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
 export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
@@ -19,25 +19,13 @@ export const LOCAL_KIMI_CODE_PROVIDER_NAME = "lc-kimi-code";
 export const LOCAL_GOOGLE_AI_PROVIDER_NAME = "lc-gemini";
 export const LOCAL_BEDROCK_PROVIDER_NAME = "lc-bedrock";
 
-function hasEnvValue(value: string | undefined): boolean {
-  return typeof value === "string" && value.length > 0;
-}
-
-export type PiProvider =
-  | "openai-responses"
-  | "anthropic"
-  | "openrouter"
-  | "zai"
-  | "minimax"
-  | "moonshot"
-  | "kimi-coding"
-  | "google-ai"
+export type LocalEndpointProvider =
   | "ollama"
   | "ollama-cloud"
   | "lmstudio"
-  | "llama-cpp"
-  | "bedrock"
-  | "chatgpt-oauth";
+  | "llama-cpp";
+
+export type PiProvider = KnownProvider | LocalEndpointProvider;
 
 export interface PiProviderSpec {
   id: PiProvider;
@@ -57,130 +45,171 @@ export interface PiProviderSpec {
   catalogModelHandle?: (model: Model<Api>) => string | undefined;
 }
 
+interface PiProviderOverride {
+  providerTypes?: readonly string[];
+  handlePrefixes?: readonly string[];
+  localProviderNames?: readonly string[];
+  defaultModel?: string;
+  defaultBaseURL?: string;
+  apiKeyEnv?: () => string | undefined;
+  baseUrlEnv?: () => string | undefined;
+  fallbackApiKey?: string;
+  headers?: () => Record<string, string> | undefined;
+  localModelDiscovery?: "ollama" | "openai-compatible";
+  envConfigured?: () => boolean;
+  createCustomModel?: boolean;
+  catalogModelHandle?: (model: Model<Api>) => string | undefined;
+}
+
+function hasEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
 const prefixedCatalogModelHandle = (prefix: string) => (model: Model<Api>) =>
   `${prefix}${model.id}`;
 
-export const PI_PROVIDER_SPECS = [
-  {
-    id: "openai-responses",
-    piProvider: "openai",
+const PI_PROVIDER_ALIASES: Record<string, PiProvider> = {
+  "openai-responses": "openai",
+  "google-ai": "google",
+  bedrock: "amazon-bedrock",
+  "chatgpt-oauth": "openai-codex",
+  moonshot: "moonshotai",
+  "kimi-code": "kimi-coding",
+};
+
+const PI_PROVIDER_OVERRIDES: Partial<
+  Record<KnownProvider, PiProviderOverride>
+> = {
+  openai: {
     providerTypes: ["openai", "openai-responses"],
     handlePrefixes: ["openai/", "openai-responses/"],
-    localProviderNames: [LOCAL_OPENAI_PROVIDER_NAME],
+    localProviderNames: ["openai", LOCAL_OPENAI_PROVIDER_NAME],
     defaultModel: "openai/gpt-5.5",
-    apiKeyEnv: () => process.env.OPENAI_API_KEY,
-    envConfigured: () => hasEnvValue(process.env.OPENAI_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("openai/"),
   },
-  {
-    id: "anthropic",
-    piProvider: "anthropic",
-    providerTypes: ["anthropic"],
-    handlePrefixes: ["anthropic/"],
-    localProviderNames: [LOCAL_ANTHROPIC_PROVIDER_NAME],
+  anthropic: {
+    localProviderNames: ["anthropic", LOCAL_ANTHROPIC_PROVIDER_NAME],
     defaultModel: "anthropic/claude-sonnet-4-6",
-    apiKeyEnv: () => process.env.ANTHROPIC_API_KEY,
-    envConfigured: () => hasEnvValue(process.env.ANTHROPIC_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("anthropic/"),
   },
-  {
-    id: "openrouter",
-    piProvider: "openrouter",
-    providerTypes: ["openrouter"],
-    handlePrefixes: ["openrouter/"],
-    localProviderNames: [LOCAL_OPENROUTER_PROVIDER_NAME],
+  openrouter: {
+    localProviderNames: ["openrouter", LOCAL_OPENROUTER_PROVIDER_NAME],
     defaultModel: "openrouter/deepseek/deepseek-v4-pro",
-    apiKeyEnv: () => process.env.OPENROUTER_API_KEY,
     baseUrlEnv: () => process.env.OPENROUTER_BASE_URL,
     headers: () => ({ "X-Title": "Letta Code" }),
-    envConfigured: () => hasEnvValue(process.env.OPENROUTER_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("openrouter/"),
   },
-  {
-    id: "zai",
-    piProvider: "zai",
+  zai: {
     providerTypes: ["zai", "zai_coding"],
-    handlePrefixes: ["zai/"],
     localProviderNames: [
+      "zai",
+      "zai_coding",
       LOCAL_ZAI_PROVIDER_NAME,
       LOCAL_ZAI_CODING_PROVIDER_NAME,
     ],
     defaultModel: "zai/glm-5.1",
     envConfigured: () =>
-      hasEnvValue(process.env.ZAI_API_KEY) ||
+      getEnvApiKey("zai") !== undefined ||
       hasEnvValue(process.env.ZHIPU_API_KEY) ||
       hasEnvValue(process.env.ZAI_CODING_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("zai/"),
   },
-  {
-    id: "minimax",
-    piProvider: "minimax",
-    providerTypes: ["minimax"],
-    handlePrefixes: ["minimax/"],
-    localProviderNames: [LOCAL_MINIMAX_PROVIDER_NAME],
+  minimax: {
+    localProviderNames: ["minimax", LOCAL_MINIMAX_PROVIDER_NAME],
     defaultModel: "minimax/MiniMax-M2.7",
-    apiKeyEnv: () => process.env.MINIMAX_API_KEY,
     baseUrlEnv: () => process.env.MINIMAX_BASE_URL,
-    envConfigured: () => hasEnvValue(process.env.MINIMAX_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("minimax/"),
   },
-  {
-    id: "moonshot",
-    piProvider: "moonshotai",
-    providerTypes: ["moonshot"],
-    handlePrefixes: ["moonshot/"],
-    localProviderNames: [LOCAL_MOONSHOT_PROVIDER_NAME],
-    defaultModel: "moonshot/kimi-k2.5",
-    apiKeyEnv: () => process.env.MOONSHOT_API_KEY,
+  moonshotai: {
+    providerTypes: ["moonshotai", "moonshot"],
+    handlePrefixes: ["moonshotai/", "moonshot/"],
+    localProviderNames: ["moonshotai", LOCAL_MOONSHOT_PROVIDER_NAME],
+    defaultModel: "moonshotai/kimi-k2.5",
     baseUrlEnv: () => process.env.MOONSHOT_BASE_URL,
-    envConfigured: () => hasEnvValue(process.env.MOONSHOT_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("moonshot/"),
   },
-  {
-    id: "kimi-coding",
-    piProvider: "kimi-coding",
-    providerTypes: ["moonshot_coding"],
-    handlePrefixes: ["moonshot_coding/"],
-    localProviderNames: [LOCAL_KIMI_CODE_PROVIDER_NAME],
-    defaultModel: "moonshot_coding/kimi-for-coding",
-    apiKeyEnv: () => process.env.KIMI_API_KEY,
-    envConfigured: () => hasEnvValue(process.env.KIMI_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("moonshot_coding/"),
+  "kimi-coding": {
+    providerTypes: ["kimi-coding", "moonshot_coding"],
+    handlePrefixes: ["kimi-coding/", "moonshot_coding/"],
+    localProviderNames: ["kimi-coding", LOCAL_KIMI_CODE_PROVIDER_NAME],
+    defaultModel: "kimi-coding/kimi-for-coding",
   },
-  {
-    id: "google-ai",
-    piProvider: "google",
-    providerTypes: ["google_ai"],
-    handlePrefixes: ["google_ai/"],
-    localProviderNames: [LOCAL_GOOGLE_AI_PROVIDER_NAME],
-    defaultModel: "google_ai/gemini-3.1-pro-preview",
+  google: {
+    providerTypes: ["google", "google_ai"],
+    handlePrefixes: ["google/", "google_ai/"],
+    localProviderNames: ["google", LOCAL_GOOGLE_AI_PROVIDER_NAME],
+    defaultModel: "google/gemini-3.1-pro-preview",
     apiKeyEnv: () =>
-      process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? process.env.GEMINI_API_KEY,
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? getEnvApiKey("google"),
     baseUrlEnv: () => process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
     envConfigured: () =>
       hasEnvValue(process.env.GOOGLE_GENERATIVE_AI_API_KEY) ||
-      hasEnvValue(process.env.GEMINI_API_KEY),
-    catalogModelHandle: prefixedCatalogModelHandle("google_ai/"),
+      getEnvApiKey("google") !== undefined,
   },
-  {
-    id: "bedrock",
-    piProvider: "amazon-bedrock",
-    providerTypes: ["bedrock"],
-    handlePrefixes: ["bedrock/"],
-    localProviderNames: [LOCAL_BEDROCK_PROVIDER_NAME],
-    defaultModel: "bedrock/us.anthropic.claude-sonnet-4-6",
-    envConfigured: () =>
-      (hasEnvValue(process.env.AWS_ACCESS_KEY_ID) &&
-        hasEnvValue(process.env.AWS_SECRET_ACCESS_KEY)) ||
-      hasEnvValue(process.env.AWS_PROFILE) ||
-      hasEnvValue(process.env.AWS_BEARER_TOKEN_BEDROCK),
-    catalogModelHandle: prefixedCatalogModelHandle("bedrock/"),
+  "amazon-bedrock": {
+    providerTypes: ["amazon-bedrock", "bedrock"],
+    handlePrefixes: ["amazon-bedrock/", "bedrock/"],
+    localProviderNames: ["amazon-bedrock", LOCAL_BEDROCK_PROVIDER_NAME],
+    defaultModel: "amazon-bedrock/us.anthropic.claude-sonnet-4-6",
   },
+  "openai-codex": {
+    providerTypes: ["openai-codex", "chatgpt_oauth"],
+    handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
+    localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
+    defaultModel: "openai-codex/gpt-5.1-codex-max",
+  },
+};
+
+function defaultModelForProvider(
+  provider: KnownProvider,
+  handlePrefix: string,
+): string {
+  const model = getModels(provider)[0] as Model<Api> | undefined;
+  return model ? `${handlePrefix}${model.id}` : `${handlePrefix}model`;
+}
+
+function makePiProviderSpec(provider: KnownProvider): PiProviderSpec {
+  const override = PI_PROVIDER_OVERRIDES[provider] ?? {};
+  const handlePrefixes = unique(override.handlePrefixes ?? [`${provider}/`]);
+  const providerTypes = unique(override.providerTypes ?? [provider]);
+  const localProviderNames = unique(override.localProviderNames ?? [provider]);
+  const primaryHandlePrefix = handlePrefixes[0] ?? `${provider}/`;
+  return {
+    id: provider,
+    piProvider: provider,
+    providerTypes,
+    handlePrefixes,
+    localProviderNames,
+    defaultModel:
+      override.defaultModel ??
+      defaultModelForProvider(provider, primaryHandlePrefix),
+    ...(override.defaultBaseURL
+      ? { defaultBaseURL: override.defaultBaseURL }
+      : {}),
+    apiKeyEnv: override.apiKeyEnv ?? (() => getEnvApiKey(provider)),
+    ...(override.baseUrlEnv ? { baseUrlEnv: override.baseUrlEnv } : {}),
+    ...(override.fallbackApiKey
+      ? { fallbackApiKey: override.fallbackApiKey }
+      : {}),
+    ...(override.headers ? { headers: override.headers } : {}),
+    ...(override.localModelDiscovery
+      ? { localModelDiscovery: override.localModelDiscovery }
+      : {}),
+    envConfigured:
+      override.envConfigured ?? (() => getEnvApiKey(provider) !== undefined),
+    ...(override.createCustomModel !== undefined
+      ? { createCustomModel: override.createCustomModel }
+      : {}),
+    catalogModelHandle:
+      override.catalogModelHandle ??
+      prefixedCatalogModelHandle(primaryHandlePrefix),
+  };
+}
+
+const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
   {
     id: "ollama",
     providerTypes: ["ollama"],
     handlePrefixes: ["ollama/"],
-    localProviderNames: [LOCAL_OLLAMA_PROVIDER_NAME],
+    localProviderNames: ["ollama", LOCAL_OLLAMA_PROVIDER_NAME],
     defaultModel: "ollama/llama2",
     defaultBaseURL: "http://localhost:11434/v1",
     apiKeyEnv: () => process.env.OLLAMA_LOCAL_API_KEY,
@@ -196,7 +225,7 @@ export const PI_PROVIDER_SPECS = [
     id: "ollama-cloud",
     providerTypes: ["ollama_cloud"],
     handlePrefixes: ["ollama-cloud/"],
-    localProviderNames: [LOCAL_OLLAMA_CLOUD_PROVIDER_NAME],
+    localProviderNames: ["ollama-cloud", LOCAL_OLLAMA_CLOUD_PROVIDER_NAME],
     defaultModel: "ollama-cloud/gpt-oss:20b",
     defaultBaseURL: "https://ollama.com/v1",
     apiKeyEnv: () => process.env.OLLAMA_API_KEY,
@@ -212,7 +241,7 @@ export const PI_PROVIDER_SPECS = [
       LEGACY_LMSTUDIO_PROVIDER_TYPE,
     ],
     handlePrefixes: ["lmstudio/"],
-    localProviderNames: [LOCAL_LMSTUDIO_PROVIDER_NAME],
+    localProviderNames: ["lmstudio", LOCAL_LMSTUDIO_PROVIDER_NAME],
     defaultModel: "lmstudio/google/gemma-3n-e4b",
     defaultBaseURL: "http://127.0.0.1:1234/v1",
     apiKeyEnv: () => process.env.LMSTUDIO_API_KEY,
@@ -228,7 +257,7 @@ export const PI_PROVIDER_SPECS = [
     id: "llama-cpp",
     providerTypes: ["llama_cpp", "llama.cpp"],
     handlePrefixes: ["llama.cpp/", "llama-cpp/"],
-    localProviderNames: [LOCAL_LLAMA_CPP_PROVIDER_NAME],
+    localProviderNames: ["llama-cpp", LOCAL_LLAMA_CPP_PROVIDER_NAME],
     defaultModel: "llama.cpp/model",
     defaultBaseURL: "http://localhost:8080/v1",
     apiKeyEnv: () => process.env.LLAMA_CPP_API_KEY,
@@ -242,16 +271,12 @@ export const PI_PROVIDER_SPECS = [
       hasEnvValue(process.env.LLAMACPP_BASE_URL),
     createCustomModel: true,
   },
-  {
-    id: "chatgpt-oauth",
-    piProvider: "openai-codex",
-    providerTypes: ["chatgpt_oauth"],
-    handlePrefixes: ["chatgpt-plus-pro/"],
-    localProviderNames: [LOCAL_CHATGPT_PROVIDER_NAME],
-    defaultModel: "chatgpt-plus-pro/gpt-5.1-codex-max",
-    catalogModelHandle: prefixedCatalogModelHandle("chatgpt-plus-pro/"),
-  },
-] as const satisfies readonly PiProviderSpec[];
+];
+
+export const PI_PROVIDER_SPECS: readonly PiProviderSpec[] = [
+  ...getProviders().map(makePiProviderSpec),
+  ...LOCAL_ENDPOINT_PROVIDER_SPECS,
+];
 
 export const SUPPORTED_LOCAL_PROVIDER_TYPES: ReadonlySet<string> = new Set(
   PI_PROVIDER_SPECS.flatMap((provider) => provider.providerTypes),
@@ -270,8 +295,16 @@ export const PROVIDER_TYPE_TO_BASE_PROVIDER = Object.fromEntries(
   ),
 ) as Record<string, string>;
 
+function canonicalProvider(provider: string): PiProvider | undefined {
+  if (KNOWN_PI_PROVIDERS.has(provider as PiProvider)) {
+    return provider as PiProvider;
+  }
+  return PI_PROVIDER_ALIASES[provider];
+}
+
 export function getPiProviderSpec(provider: PiProvider): PiProviderSpec {
-  const spec = PI_PROVIDER_SPECS.find((entry) => entry.id === provider);
+  const canonical = canonicalProvider(provider) ?? provider;
+  const spec = PI_PROVIDER_SPECS.find((entry) => entry.id === canonical);
   if (!spec) {
     throw new Error(`Unknown pi provider "${provider}".`);
   }
@@ -279,7 +312,7 @@ export function getPiProviderSpec(provider: PiProvider): PiProviderSpec {
 }
 
 export function isPiProvider(provider: string): provider is PiProvider {
-  return KNOWN_PI_PROVIDERS.has(provider as PiProvider);
+  return canonicalProvider(provider) !== undefined;
 }
 
 export function expectedPiProviderList(): string {
@@ -300,7 +333,7 @@ export function resolveProviderFromProviderType(
 ): PiProvider | undefined {
   if (typeof providerType !== "string") return undefined;
   return PI_PROVIDER_SPECS.find((provider) =>
-    (provider.providerTypes as readonly string[]).includes(providerType),
+    provider.providerTypes.includes(providerType),
   )?.id;
 }
 
@@ -315,7 +348,7 @@ export function stripProviderHandlePrefix(
 }
 
 export function localProviderType(provider: PiProvider): string {
-  return getPiProviderSpec(provider).providerTypes[0] ?? "openai";
+  return getPiProviderSpec(provider).providerTypes[0] ?? provider;
 }
 
 export function localModelHandle(provider: PiProvider, model: string): string {

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -50,6 +50,7 @@ export interface LocalProviderOAuthAuth {
   idToken?: string;
   expires: number;
   accountId?: string;
+  [key: string]: unknown;
 }
 
 export type LocalProviderAuth = LocalProviderApiAuth | LocalProviderOAuthAuth;
@@ -125,6 +126,7 @@ function providerResponse(record: LocalProviderRecord): ProviderResponse {
     name: record.name,
     provider_type: record.provider_type,
     provider_category: record.provider_category,
+    auth_type: record.auth.type,
     ...(record.base_url ? { base_url: record.base_url } : {}),
     ...(record.timeout !== undefined ? { timeout: record.timeout } : {}),
     ...(record.access_key ? { access_key: record.access_key } : {}),
@@ -309,83 +311,148 @@ export function setLocalChatGPTOAuth(
   auth: LocalProviderOAuthAuth,
   storageDir?: string,
 ): void {
-  const file = readAuthFile(storageDir);
-  const now = new Date().toISOString();
-  const existing = file.providers[LOCAL_CHATGPT_PROVIDER_NAME];
-  file.providers[LOCAL_CHATGPT_PROVIDER_NAME] = {
-    id: existing?.id ?? providerId(LOCAL_CHATGPT_PROVIDER_NAME),
-    name: LOCAL_CHATGPT_PROVIDER_NAME,
-    provider_type: "chatgpt_oauth",
-    provider_category: "byok",
+  setLocalOAuthProvider({
+    providerName: LOCAL_CHATGPT_PROVIDER_NAME,
+    providerType: "chatgpt_oauth",
     auth,
+    storageDir,
+  });
+}
+
+export function setLocalOAuthProvider(input: {
+  providerName: string;
+  providerType: string;
+  auth: LocalProviderOAuthAuth;
+  storageDir?: string;
+}): void {
+  if (!isLocalProviderTypeSupported(input.providerType)) {
+    throw new Error(
+      `Provider type "${input.providerType}" is not supported in local mode yet.`,
+    );
+  }
+
+  const file = readAuthFile(input.storageDir);
+  const now = new Date().toISOString();
+  const existing = file.providers[input.providerName];
+  file.providers[input.providerName] = {
+    id: existing?.id ?? providerId(input.providerName),
+    name: input.providerName,
+    provider_type: input.providerType,
+    provider_category: "byok",
+    auth: input.auth,
     created_at: existing?.created_at ?? now,
     updated_at: now,
   };
-  writeAuthFile(file, storageDir);
+  writeAuthFile(file, input.storageDir);
 }
 
 function toPiOAuthCredentials(auth: LocalProviderOAuthAuth): OAuthCredentials {
+  const { type: _type, ...credentials } = auth;
   return {
+    ...credentials,
     access: auth.access,
     refresh: auth.refresh ?? "",
     expires: auth.expires,
-    ...(auth.accountId ? { accountId: auth.accountId } : {}),
-    ...(auth.idToken ? { idToken: auth.idToken } : {}),
   };
 }
 
-function toLocalChatGPTOAuth(
+function toLocalOAuthAuth(
   credentials: OAuthCredentials,
-  previous: LocalProviderOAuthAuth,
+  previous?: LocalProviderOAuthAuth,
 ): LocalProviderOAuthAuth {
-  const refresh = credentials.refresh || previous.refresh;
+  const refresh = credentials.refresh || previous?.refresh;
   return {
     type: "oauth",
     access: credentials.access,
     expires: credentials.expires,
     ...(refresh ? { refresh } : {}),
-    ...(typeof credentials.accountId === "string"
-      ? { accountId: credentials.accountId }
-      : previous.accountId
-        ? { accountId: previous.accountId }
-        : {}),
-    ...(typeof credentials.idToken === "string"
-      ? { idToken: credentials.idToken }
-      : previous.idToken
-        ? { idToken: previous.idToken }
-        : {}),
+    ...Object.fromEntries(
+      Object.entries(credentials).filter(
+        ([key, value]) =>
+          !["access", "refresh", "expires"].includes(key) &&
+          value !== undefined,
+      ),
+    ),
   };
 }
 
-function localChatGPTOAuthEquals(
+function localOAuthAuthEquals(
   left: LocalProviderOAuthAuth,
   right: LocalProviderOAuthAuth,
 ): boolean {
-  return (
-    left.access === right.access &&
-    left.refresh === right.refresh &&
-    left.idToken === right.idToken &&
-    left.expires === right.expires &&
-    left.accountId === right.accountId
-  );
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function localOAuthAuthFromCredentials(
+  credentials: OAuthCredentials,
+): LocalProviderOAuthAuth {
+  return toLocalOAuthAuth(credentials);
+}
+
+function localOAuthRecord(
+  providerNames: readonly string[],
+  storageDir?: string,
+): LocalProviderRecord | undefined {
+  for (const providerName of providerNames) {
+    const record = getLocalProviderRecordByName(providerName, storageDir);
+    if (record?.auth.type === "oauth") return record;
+  }
+  return undefined;
+}
+
+export function getLocalOAuthCredentials(
+  providerNames: readonly string[],
+  storageDir?: string,
+): OAuthCredentials | undefined {
+  const record = localOAuthRecord(providerNames, storageDir);
+  return record
+    ? toPiOAuthCredentials(record.auth as LocalProviderOAuthAuth)
+    : undefined;
+}
+
+export async function getLocalOAuthApiKey(input: {
+  providerId: string;
+  providerNames: readonly string[];
+  storageDir?: string;
+}): Promise<
+  | {
+      apiKey: string;
+      credentials: OAuthCredentials;
+    }
+  | undefined
+> {
+  const record = localOAuthRecord(input.providerNames, input.storageDir);
+  if (!record || record.auth.type !== "oauth") return undefined;
+
+  const result = await getOAuthApiKey(input.providerId, {
+    [input.providerId]: toPiOAuthCredentials(record.auth),
+  });
+  if (!result) return undefined;
+
+  const nextAuth = toLocalOAuthAuth(result.newCredentials, record.auth);
+  if (!localOAuthAuthEquals(nextAuth, record.auth)) {
+    setLocalOAuthProvider({
+      providerName: record.name,
+      providerType: record.provider_type,
+      auth: nextAuth,
+      storageDir: input.storageDir,
+    });
+  }
+  return {
+    apiKey: result.apiKey,
+    credentials: result.newCredentials,
+  };
 }
 
 export async function getLocalChatGPTApiKey(
   storageDir?: string,
 ): Promise<string | undefined> {
-  const auth = getLocalChatGPTOAuth(storageDir);
-  if (!auth) return undefined;
-
-  const result = await getOAuthApiKey("openai-codex", {
-    "openai-codex": toPiOAuthCredentials(auth),
+  const result = await getLocalOAuthApiKey({
+    providerId: "openai-codex",
+    providerNames: [LOCAL_CHATGPT_PROVIDER_NAME, "openai-codex"],
+    storageDir,
   });
-  if (!result) return undefined;
-
-  const nextAuth = toLocalChatGPTOAuth(result.newCredentials, auth);
-  if (!localChatGPTOAuthEquals(nextAuth, auth)) {
-    setLocalChatGPTOAuth(nextAuth, storageDir);
-  }
-  return result.apiKey;
+  return result?.apiKey;
 }
 
 function parseChatGPTOAuth(value: string): LocalProviderOAuthAuth {

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -117,7 +117,7 @@ describe("pi model factory", () => {
       { provider_type: "bedrock" },
     );
 
-    expect(resolved.provider).toBe("bedrock");
+    expect(resolved.provider).toBe("amazon-bedrock");
     expect(resolved.model.id).toBe("us.anthropic.claude-opus-4-7");
     expect(resolved.model.reasoning).toBe(true);
   });

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { getModels } from "@earendil-works/pi-ai";
 import {
   applyPiEnvOverrides,
   resolvePiModelForAgent,
 } from "@/backend/dev/pi-model-factory";
-import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+import {
+  createOrUpdateLocalProvider,
+  localOAuthAuthFromCredentials,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
 
 function envValue(key: string): string | undefined {
   return process.env[key];
@@ -56,6 +61,9 @@ describe("pi model factory", () => {
   test("resolves ChatGPT OAuth through pi OAuth credentials", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-chatgpt-oauth-"));
     try {
+      const model = getModels("openai-codex")[0];
+      if (!model) throw new Error("Expected ChatGPT subscription models");
+
       await createOrUpdateLocalProvider({
         storageDir,
         providerType: "chatgpt_oauth",
@@ -70,12 +78,72 @@ describe("pi model factory", () => {
       });
 
       const resolved = await resolvePiModelForAgent(
-        "chatgpt-plus-pro/gpt-5.1-codex-max",
+        `chatgpt-plus-pro/${model.id}`,
         { provider_type: "chatgpt_oauth" },
         { localProviderAuthStorageDir: storageDir },
       );
 
       expect(resolved.apiKey).toBe("chatgpt-access-token");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves generic local OAuth credentials through pi OAuth providers", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-anthropic-oauth-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "anthropic",
+        providerType: "anthropic",
+        auth: localOAuthAuthFromCredentials({
+          access: "sk-ant-oat-local",
+          refresh: "anthropic-refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "anthropic/claude-sonnet-4-6",
+        { provider_type: "anthropic" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.apiKey).toBe("sk-ant-oat-local");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("applies pi OAuth model modifications for GitHub Copilot", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-copilot-oauth-"));
+    try {
+      const model = getModels("github-copilot")[0];
+      if (!model) throw new Error("Expected GitHub Copilot models");
+
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "github-copilot",
+        providerType: "github-copilot",
+        auth: localOAuthAuthFromCredentials({
+          access: "tid=1;exp=1;proxy-ep=proxy.enterprise.githubcopilot.com;",
+          refresh: "copilot-refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        `github-copilot/${model.id}`,
+        { provider_type: "github-copilot" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.apiKey).toBe(
+        "tid=1;exp=1;proxy-ep=proxy.enterprise.githubcopilot.com;",
+      );
+      expect(resolved.model.baseUrl).toBe(
+        "https://api.enterprise.githubcopilot.com",
+      );
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -890,7 +890,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "connect" && (
               <ProviderSelector
                 onCancel={closeOverlay}
-                onStartOAuth={async (_provider, target) => {
+                onStartOAuth={async (provider, target) => {
                   const overlayCommand = completeOverlay("connect");
                   const cmd =
                     overlayCommand ??
@@ -921,7 +921,7 @@ export function AppView(props: AppViewProps) {
                           );
                         },
                       },
-                      "/connect chatgpt",
+                      `/connect ${provider.id === "openai-codex-oauth" ? "chatgpt" : provider.id}`,
                     );
                   } finally {
                     setActiveConnectCommandId(null);

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -890,7 +890,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "connect" && (
               <ProviderSelector
                 onCancel={closeOverlay}
-                onStartOAuth={async () => {
+                onStartOAuth={async (_provider, target) => {
                   const overlayCommand = completeOverlay("connect");
                   const cmd =
                     overlayCommand ??
@@ -906,6 +906,7 @@ export function AppView(props: AppViewProps) {
                         buffersRef,
                         refreshDerived,
                         setCommandRunning,
+                        target,
                         onCodexConnected: () => {
                           markLocalModelsAvailable();
                           setModelSelectorOptions({

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -1,0 +1,91 @@
+import {
+  getOAuthProvider,
+  type OAuthPrompt,
+} from "@earendil-works/pi-ai/oauth";
+import {
+  localOAuthAuthFromCredentials,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
+import type { ByokProvider } from "@/providers/byok-providers";
+import { openOAuthBrowser } from "./connect-oauth-core";
+
+export interface LocalOAuthConnectCallbacks {
+  onStatus: (message: string) => void | Promise<void>;
+  onPrompt?: (prompt: OAuthPrompt) => Promise<string>;
+  openBrowser?: (authorizationUrl: string) => Promise<void>;
+  signal?: AbortSignal;
+}
+
+function localOAuthProviderId(provider: ByokProvider): string {
+  const providerId = provider.oauthProviderId;
+  if (!providerId) {
+    throw new Error(`${provider.displayName} is missing an OAuth provider id.`);
+  }
+  return providerId;
+}
+
+async function defaultPrompt(
+  providerName: string,
+  prompt: OAuthPrompt,
+): Promise<string> {
+  if (prompt.allowEmpty) return "";
+  throw new Error(`${providerName} requires input: ${prompt.message}`);
+}
+
+export async function runLocalOAuthConnectFlow(
+  provider: ByokProvider,
+  callbacks: LocalOAuthConnectCallbacks,
+): Promise<{ providerName: string }> {
+  const providerId = localOAuthProviderId(provider);
+  const oauthProvider = getOAuthProvider(providerId);
+  if (!oauthProvider) {
+    throw new Error(`Unknown OAuth provider: ${providerId}`);
+  }
+
+  const browserOpener = callbacks.openBrowser ?? openOAuthBrowser;
+  await callbacks.onStatus(`Starting ${oauthProvider.name} login...`);
+
+  const credentials = await oauthProvider.login({
+    signal: callbacks.signal,
+    onAuth: (info) => {
+      const status = [
+        `Open this URL to authenticate ${oauthProvider.name}:`,
+        "",
+        info.url,
+        ...(info.instructions ? ["", info.instructions] : []),
+      ].join("\n");
+      void Promise.resolve(callbacks.onStatus(status));
+      void browserOpener(info.url);
+    },
+    onDeviceCode: (info) => {
+      const status = [
+        `Open this URL to authenticate ${oauthProvider.name}:`,
+        "",
+        info.verificationUri,
+        "",
+        `Enter code: ${info.userCode}`,
+      ].join("\n");
+      void Promise.resolve(callbacks.onStatus(status));
+      void browserOpener(info.verificationUri);
+    },
+    onPrompt: (prompt) =>
+      callbacks.onPrompt?.(prompt) ?? defaultPrompt(oauthProvider.name, prompt),
+    onProgress: (message) => {
+      void Promise.resolve(callbacks.onStatus(message));
+    },
+    onSelect: async (prompt) => {
+      if (prompt.options.length === 1) return prompt.options[0]?.id;
+      throw new Error(
+        `${oauthProvider.name} requires selection: ${prompt.message}`,
+      );
+    },
+  });
+
+  setLocalOAuthProvider({
+    providerName: provider.providerName,
+    providerType: provider.providerType,
+    auth: localOAuthAuthFromCredentials(credentials),
+  });
+
+  return { providerName: provider.providerName };
+}

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -31,6 +31,7 @@ const LOCAL_ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
 
 function providerMatches(provider: ByokProvider, token: string): boolean {
   if (provider.id === token) return true;
+  if (provider.oauthProviderId === token) return true;
   if (provider.providerType === token) return true;
   if (provider.providerName === token) return true;
   return false;
@@ -40,7 +41,9 @@ function findChatGPTProvider(
   target: ProviderStorageTarget,
 ): ByokProvider | undefined {
   return getProviderConfigs(target).find(
-    (provider) => provider.providerType === "chatgpt_oauth",
+    (provider) =>
+      provider.oauthProviderId === "openai-codex" ||
+      provider.providerType === "chatgpt_oauth",
   );
 }
 

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -2,70 +2,46 @@ import {
   type ByokProvider,
   type ByokProviderId,
   defaultProviderApiKey,
+  defaultProviderStorageTarget,
   getProviderConfig,
+  getProviderConfigs,
+  type ProviderStorageTarget,
 } from "@/providers/byok-providers";
 
-export type ConnectProviderCanonical =
-  | "chatgpt"
-  | "anthropic"
-  | "openai"
-  | "zai"
-  | "zai-coding"
-  | "minimax"
-  | "moonshot"
-  | "kimi-code"
-  | "gemini"
-  | "openrouter"
-  | "ollama"
-  | "ollama-cloud"
-  | "lmstudio"
-  | "llama-cpp"
-  | "bedrock";
+export type ConnectProviderCanonical = string;
 
 const ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
   chatgpt: "chatgpt",
   codex: "chatgpt",
-  anthropic: "anthropic",
-  openai: "openai",
-  zai: "zai",
-  "zai-coding": "zai-coding",
-  minimax: "minimax",
-  moonshot: "moonshot",
-  "kimi-code": "kimi-code",
-  gemini: "gemini",
-  openrouter: "openrouter",
+  "openai-codex": "chatgpt",
   ollama: "ollama",
   "ollama-cloud": "ollama-cloud",
   lmstudio: "lmstudio",
   "llama-cpp": "llama-cpp",
   "llama.cpp": "llama-cpp",
   llamacpp: "llama-cpp",
-  bedrock: "bedrock",
 };
 
-const CANONICAL_ORDER: ConnectProviderCanonical[] = [
-  "chatgpt",
-  "anthropic",
-  "openai",
-  "zai",
-  "zai-coding",
-  "minimax",
-  "moonshot",
-  "kimi-code",
-  "gemini",
-  "openrouter",
-  "ollama",
-  "ollama-cloud",
-  "lmstudio",
-  "llama-cpp",
-  "bedrock",
-];
+const LOCAL_ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
+  gemini: "google",
+  "kimi-code": "kimi-coding",
+  moonshot: "moonshotai",
+  bedrock: "amazon-bedrock",
+};
 
-function canonicalToByokId(
-  canonical: ConnectProviderCanonical,
-): ByokProviderId {
-  if (canonical === "chatgpt") return "codex";
-  return canonical;
+function providerMatches(provider: ByokProvider, token: string): boolean {
+  if (provider.id === token) return true;
+  if (provider.providerType === token) return true;
+  if (provider.providerName === token) return true;
+  return false;
+}
+
+function findChatGPTProvider(
+  target: ProviderStorageTarget,
+): ByokProvider | undefined {
+  return getProviderConfigs(target).find(
+    (provider) => provider.providerType === "chatgpt_oauth",
+  );
 }
 
 export interface ResolvedConnectProvider {
@@ -73,10 +49,12 @@ export interface ResolvedConnectProvider {
   canonical: ConnectProviderCanonical;
   byokId: ByokProviderId;
   byokProvider: ByokProvider;
+  target: ProviderStorageTarget;
 }
 
 export function resolveConnectProvider(
   providerToken: string | undefined,
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
 ): ResolvedConnectProvider | null {
   if (!providerToken) {
     return null;
@@ -87,13 +65,16 @@ export function resolveConnectProvider(
     return null;
   }
 
-  const canonical = ALIAS_TO_CANONICAL[rawInput];
-  if (!canonical) {
-    return null;
-  }
-
-  const byokId = canonicalToByokId(canonical);
-  const byokProvider = getProviderConfig(byokId);
+  const canonical =
+    ALIAS_TO_CANONICAL[rawInput] ??
+    (target === "local" ? LOCAL_ALIAS_TO_CANONICAL[rawInput] : undefined) ??
+    rawInput;
+  const byokProvider =
+    canonical === "chatgpt"
+      ? findChatGPTProvider(target)
+      : (getProviderConfigs(target).find((provider) =>
+          providerMatches(provider, canonical),
+        ) ?? getProviderConfig(canonical, target));
   if (!byokProvider) {
     return null;
   }
@@ -101,34 +82,46 @@ export function resolveConnectProvider(
   return {
     rawInput,
     canonical,
-    byokId,
+    byokId: byokProvider.id,
     byokProvider,
+    target,
   };
 }
 
-export function listConnectProvidersForHelp(): string[] {
-  return CANONICAL_ORDER.map((provider) => {
-    if (provider === "chatgpt") {
-      return "chatgpt (alias: codex)";
-    }
-    return provider;
-  });
+export function listConnectProvidersForHelp(
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
+): string[] {
+  const providers = getProviderConfigs(target).map((provider) => provider.id);
+  if (providers.includes("codex") || providers.includes("openai-codex-oauth")) {
+    return [
+      "chatgpt (alias: codex)",
+      ...providers.filter(
+        (provider) => provider !== "codex" && provider !== "openai-codex-oauth",
+      ),
+    ];
+  }
+  return providers;
 }
 
-export function listConnectProviderTokens(): string[] {
-  return [...CANONICAL_ORDER, "codex"];
+export function listConnectProviderTokens(
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
+): string[] {
+  return [...listConnectProvidersForHelp(target), "codex"];
 }
 
 export function isConnectOAuthProvider(
   provider: ResolvedConnectProvider,
 ): boolean {
-  return provider.canonical === "chatgpt";
+  return provider.byokProvider.isOAuth === true;
 }
 
 export function isConnectBedrockProvider(
   provider: ResolvedConnectProvider,
 ): boolean {
-  return provider.canonical === "bedrock";
+  return (
+    provider.byokProvider.providerType === "bedrock" ||
+    provider.byokProvider.providerType === "amazon-bedrock"
+  );
 }
 
 export function isConnectApiKeyProvider(
@@ -148,5 +141,5 @@ export function defaultConnectApiKey(
 export function isConnectZaiBaseProvider(
   provider: ResolvedConnectProvider,
 ): boolean {
-  return provider.canonical === "zai";
+  return provider.byokProvider.providerType === "zai";
 }

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -25,6 +25,7 @@ import {
   removeOpenAICodexProvider,
 } from "@/providers/openai-codex-provider";
 import { getErrorMessage } from "@/utils/error";
+import { runLocalOAuthConnectFlow } from "./connect-local-oauth";
 import {
   defaultConnectApiKey,
   isConnectApiKeyProvider,
@@ -432,6 +433,86 @@ async function handleConnectChatGPT(
   }
 }
 
+async function handleConnectLocalOAuthProvider(
+  ctx: ConnectCommandContext,
+  msg: string,
+  provider: ResolvedConnectProvider,
+): Promise<void> {
+  const existingProvider = await getProviderByName(
+    provider.byokProvider.providerName,
+    { target: "local" },
+  );
+  if (existingProvider?.auth_type === "oauth") {
+    addCommandResult(
+      ctx.buffersRef,
+      ctx.refreshDerived,
+      msg,
+      `Already connected to ${provider.byokProvider.displayName}. Disconnect first if you want to re-authenticate.`,
+      false,
+    );
+    return;
+  }
+
+  ctx.setCommandRunning(true);
+  const abortController = new AbortController();
+  setActiveConnectAbortController(abortController);
+  const cmdId = addCommandResult(
+    ctx.buffersRef,
+    ctx.refreshDerived,
+    msg,
+    `Starting ${provider.byokProvider.displayName} login...`,
+    true,
+    "running",
+  );
+
+  try {
+    await runLocalOAuthConnectFlow(provider.byokProvider, {
+      signal: abortController.signal,
+      onStatus: (status) =>
+        updateCommandResult(
+          ctx.buffersRef,
+          ctx.refreshDerived,
+          cmdId,
+          msg,
+          status,
+          true,
+          "running",
+        ),
+    });
+
+    updateCommandResult(
+      ctx.buffersRef,
+      ctx.refreshDerived,
+      cmdId,
+      msg,
+      `✓ Successfully connected to ${provider.byokProvider.displayName}!\n\n` +
+        `Provider '${provider.byokProvider.providerName}' saved in local storage.`,
+      true,
+      "finished",
+    );
+
+    if (provider.byokProvider.oauthProviderId === "openai-codex") {
+      setTimeout(() => ctx.onCodexConnected?.(), 500);
+    }
+  } catch (error) {
+    const isCancelled = error instanceof Error && error.name === "AbortError";
+    updateCommandResult(
+      ctx.buffersRef,
+      ctx.refreshDerived,
+      cmdId,
+      msg,
+      isCancelled
+        ? `Cancelled ${provider.byokProvider.displayName} connection.`
+        : `✗ Failed to connect ${provider.byokProvider.displayName}: ${getErrorMessage(error)}`,
+      false,
+      "finished",
+    );
+  } finally {
+    setActiveConnectAbortController(null);
+    ctx.setCommandRunning(false);
+  }
+}
+
 async function handleConnectApiKeyProvider(
   ctx: ConnectCommandContext,
   msg: string,
@@ -673,7 +754,11 @@ export async function handleConnect(
   }
 
   if (isConnectOAuthProvider(provider)) {
-    await handleConnectChatGPT(ctx, msg);
+    if (provider.target === "local") {
+      await handleConnectLocalOAuthProvider(ctx, msg, provider);
+    } else {
+      await handleConnectChatGPT(ctx, msg);
+    }
     return;
   }
 
@@ -798,9 +883,15 @@ async function handleDisconnectByokProvider(
   provider: ResolvedConnectProvider,
 ): Promise<void> {
   const existing = await getProviderByName(provider.byokProvider.providerName, {
-    target: ctx.target,
+    target: provider.target,
   });
-  if (!existing) {
+  const authMatches =
+    provider.target !== "local" || !existing?.auth_type
+      ? true
+      : provider.byokProvider.isOAuth
+        ? existing.auth_type === "oauth"
+        : existing.auth_type !== "oauth";
+  if (!existing || !authMatches) {
     addCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
@@ -823,7 +914,7 @@ async function handleDisconnectByokProvider(
   ctx.setCommandRunning(true);
   try {
     await removeProviderByName(provider.byokProvider.providerName, {
-      target: ctx.target,
+      target: provider.target,
     });
     updateCommandResult(
       ctx.buffersRef,
@@ -831,7 +922,7 @@ async function handleDisconnectByokProvider(
       cmdId,
       msg,
       `✓ Disconnected from ${provider.byokProvider.displayName}.\n\n` +
-        `Provider '${provider.byokProvider.providerName}' removed from ${providerStorageTargetLabel(ctx.target)}.`,
+        `Provider '${provider.byokProvider.providerName}' removed from ${providerStorageTargetLabel(provider.target)}.`,
       true,
       "finished",
     );
@@ -971,7 +1062,11 @@ export async function handleDisconnect(
   }
 
   if (isConnectOAuthProvider(provider)) {
-    await handleDisconnectChatGPT(ctx, msg);
+    if (provider.target === "local") {
+      await handleDisconnectByokProvider(ctx, msg, provider);
+    } else {
+      await handleDisconnectChatGPT(ctx, msg);
+    }
     return;
   }
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -12,10 +12,12 @@ import {
   checkProviderApiKey,
   createOrUpdateProvider,
   getProviderByName,
+  type ProviderStorageTarget,
   providerStorageTargetLabel,
   removeProviderByName,
 } from "@/providers/byok-providers";
 import {
+  createOrUpdateOpenAICodexProvider,
   deleteOpenAICodexProvider,
   getOpenAICodexProvider,
   listProviders,
@@ -56,6 +58,7 @@ export interface ConnectCommandContext {
   buffersRef: { current: Buffers };
   refreshDerived: () => void;
   setCommandRunning: (running: boolean) => void;
+  target?: ProviderStorageTarget;
   onCodexConnected?: () => void;
 }
 
@@ -133,11 +136,14 @@ function formatConnectUsage(): string {
   ].join("\n");
 }
 
-function formatUnknownProviderError(provider: string): string {
+function formatUnknownProviderError(
+  provider: string,
+  target?: ProviderStorageTarget,
+): string {
   return [
     `Error: Unknown provider "${provider}"`,
     "",
-    `Available providers: ${listConnectProviderTokens().join(", ")}`,
+    `Available providers: ${listConnectProviderTokens(target).join(", ")}`,
     "Usage: /connect <provider> [options]",
   ].join("\n");
 }
@@ -344,7 +350,9 @@ async function handleConnectChatGPT(
   ctx: ConnectCommandContext,
   msg: string,
 ): Promise<void> {
-  const existingProvider = await isChatGPTOAuthConnected();
+  const existingProvider = await isChatGPTOAuthConnected({
+    getProvider: () => getOpenAICodexProvider({ target: ctx.target }),
+  });
   if (existingProvider) {
     addCommandResult(
       ctx.buffersRef,
@@ -369,19 +377,26 @@ async function handleConnectChatGPT(
   );
 
   try {
-    await runChatGPTOAuthConnectFlow({
-      signal: abortController.signal,
-      onStatus: (status) =>
-        updateCommandResult(
-          ctx.buffersRef,
-          ctx.refreshDerived,
-          cmdId,
-          msg,
-          status,
-          true,
-          "running",
-        ),
-    });
+    await runChatGPTOAuthConnectFlow(
+      {
+        signal: abortController.signal,
+        onStatus: (status) =>
+          updateCommandResult(
+            ctx.buffersRef,
+            ctx.refreshDerived,
+            cmdId,
+            msg,
+            status,
+            true,
+            "running",
+          ),
+      },
+      {
+        getProvider: () => getOpenAICodexProvider({ target: ctx.target }),
+        createOrUpdateProvider: (config) =>
+          createOrUpdateOpenAICodexProvider(config, { target: ctx.target }),
+      },
+    );
 
     updateCommandResult(
       ctx.buffersRef,
@@ -389,7 +404,7 @@ async function handleConnectChatGPT(
       cmdId,
       msg,
       `✓ Successfully connected to ChatGPT!\n\n` +
-        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' saved in ${providerStorageTargetLabel()}.\n` +
+        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' saved in ${providerStorageTargetLabel(ctx.target)}.\n` +
         "Your ChatGPT Plus/Pro subscription is now linked.",
       true,
       "finished",
@@ -436,7 +451,14 @@ async function handleConnectApiKeyProvider(
   ctx.setCommandRunning(true);
 
   try {
-    await checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+    await checkProviderApiKey(
+      provider.byokProvider.providerType,
+      apiKey,
+      undefined,
+      undefined,
+      undefined,
+      { target: ctx.target },
+    );
 
     updateCommandResult(
       ctx.buffersRef,
@@ -457,12 +479,18 @@ async function handleConnectApiKeyProvider(
         undefined,
         undefined,
         options,
+        { target: ctx.target },
       );
     } else {
       await createOrUpdateProvider(
         provider.byokProvider.providerType,
         provider.byokProvider.providerName,
         apiKey,
+        undefined,
+        undefined,
+        undefined,
+        {},
+        { target: ctx.target },
       );
     }
 
@@ -472,7 +500,7 @@ async function handleConnectApiKeyProvider(
       cmdId,
       msg,
       `✓ Successfully connected to ${provider.byokProvider.displayName}!\n\n` +
-        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel()}.` +
+        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel(ctx.target)}.` +
         providerOptionsSummary(options),
       true,
       "finished",
@@ -565,6 +593,7 @@ async function handleConnectBedrock(
       method === "iam" ? parsed.accessKey : undefined,
       parsed.region,
       method === "profile" ? parsed.profile : undefined,
+      { target: ctx.target },
     );
 
     updateCommandResult(
@@ -584,6 +613,8 @@ async function handleConnectBedrock(
       method === "iam" ? parsed.accessKey : undefined,
       parsed.region,
       method === "profile" ? parsed.profile : undefined,
+      {},
+      { target: ctx.target },
     );
 
     updateCommandResult(
@@ -592,7 +623,7 @@ async function handleConnectBedrock(
       cmdId,
       msg,
       `✓ Successfully connected to ${provider.byokProvider.displayName}!\n\n` +
-        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel()}.`,
+        `Provider '${provider.byokProvider.providerName}' saved in ${providerStorageTargetLabel(ctx.target)}.`,
       true,
       "finished",
     );
@@ -629,13 +660,13 @@ export async function handleConnect(
     return;
   }
 
-  const provider = resolveConnectProvider(providerToken);
+  const provider = resolveConnectProvider(providerToken, ctx.target);
   if (!provider) {
     addCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      formatUnknownProviderError(providerToken),
+      formatUnknownProviderError(providerToken, ctx.target),
       false,
     );
     return;
@@ -710,7 +741,9 @@ async function handleDisconnectChatGPT(
   ctx: ConnectCommandContext,
   msg: string,
 ): Promise<void> {
-  const existingProvider = await getOpenAICodexProvider();
+  const existingProvider = await getOpenAICodexProvider({
+    target: ctx.target,
+  });
   if (!existingProvider) {
     addCommandResult(
       ctx.buffersRef,
@@ -733,14 +766,14 @@ async function handleDisconnectChatGPT(
 
   ctx.setCommandRunning(true);
   try {
-    await removeOpenAICodexProvider();
+    await removeOpenAICodexProvider({ target: ctx.target });
     updateCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
       cmdId,
       msg,
       `✓ Disconnected from ChatGPT OAuth.\n\n` +
-        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' removed from ${providerStorageTargetLabel()}.`,
+        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' removed from ${providerStorageTargetLabel(ctx.target)}.`,
       true,
       "finished",
     );
@@ -764,7 +797,9 @@ async function handleDisconnectByokProvider(
   msg: string,
   provider: ResolvedConnectProvider,
 ): Promise<void> {
-  const existing = await getProviderByName(provider.byokProvider.providerName);
+  const existing = await getProviderByName(provider.byokProvider.providerName, {
+    target: ctx.target,
+  });
   if (!existing) {
     addCommandResult(
       ctx.buffersRef,
@@ -787,14 +822,16 @@ async function handleDisconnectByokProvider(
 
   ctx.setCommandRunning(true);
   try {
-    await removeProviderByName(provider.byokProvider.providerName);
+    await removeProviderByName(provider.byokProvider.providerName, {
+      target: ctx.target,
+    });
     updateCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
       cmdId,
       msg,
       `✓ Disconnected from ${provider.byokProvider.displayName}.\n\n` +
-        `Provider '${provider.byokProvider.providerName}' removed from ${providerStorageTargetLabel()}.`,
+        `Provider '${provider.byokProvider.providerName}' removed from ${providerStorageTargetLabel(ctx.target)}.`,
       true,
       "finished",
     );
@@ -831,7 +868,7 @@ async function handleDisconnectClaude(
   ctx.setCommandRunning(true);
 
   try {
-    const providers = await listProviders();
+    const providers = await listProviders({ target: ctx.target });
     const claudeProvider = providers.find(
       (provider) => provider.name === CLAUDE_PROVIDER_NAME,
     );
@@ -859,7 +896,7 @@ async function handleDisconnectClaude(
       "running",
     );
 
-    await deleteOpenAICodexProvider(claudeProvider.id);
+    await deleteOpenAICodexProvider(claudeProvider.id, { target: ctx.target });
 
     updateCommandResult(
       ctx.buffersRef,
@@ -921,7 +958,7 @@ export async function handleDisconnect(
     return;
   }
 
-  const provider = resolveConnectProvider(providerToken);
+  const provider = resolveConnectProvider(providerToken, ctx.target);
   if (!provider) {
     addCommandResult(
       ctx.buffersRef,

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -22,7 +22,7 @@ import { colors } from "./colors";
 import { Text } from "./Text";
 
 const SOLID_LINE = "─";
-const VISIBLE_PROVIDERS = 12;
+const VISIBLE_PROVIDERS = 8;
 
 type ViewState =
   | { type: "list" }
@@ -61,11 +61,10 @@ export function hasConstellationProviderStoreCredentials(
   );
 }
 
-export function shouldShowConstellationLoginPrompt(
-  target: ProviderStorageTarget,
+export function shouldShowProviderStoreTabs(
   hasConstellationCredentials: boolean | null,
 ): boolean {
-  return target === "api" && hasConstellationCredentials === false;
+  return hasConstellationCredentials === true;
 }
 
 export function filterProviderConfigs(
@@ -134,13 +133,10 @@ export function ProviderSelector({
     () => filterProviderConfigs(providers, searchQuery),
     [providers, searchQuery],
   );
-  const showConstellationLoginPrompt = shouldShowConstellationLoginPrompt(
-    selectedTarget,
+  const showProviderStoreTabs = shouldShowProviderStoreTabs(
     hasConstellationCredentials,
   );
-  const selectableProviders = showConstellationLoginPrompt
-    ? []
-    : filteredProviders;
+  const selectableProviders = filteredProviders;
   const providerStartIndex = useMemo(() => {
     if (selectedIndex < VISIBLE_PROVIDERS) return 0;
     return Math.min(
@@ -156,7 +152,6 @@ export function ProviderSelector({
       ),
     [selectableProviders, providerStartIndex],
   );
-  const providersAbove = providerStartIndex;
   const providersBelow = Math.max(
     0,
     selectableProviders.length - providerStartIndex - VISIBLE_PROVIDERS,
@@ -192,14 +187,8 @@ export function ProviderSelector({
 
   // Load connected providers on mount and when switching targets.
   useEffect(() => {
-    if (showConstellationLoginPrompt) {
-      setConnectedProviders(new Map());
+    if (selectedTarget === "api" && !showProviderStoreTabs) {
       setIsLoading(false);
-      return;
-    }
-
-    if (selectedTarget === "api" && hasConstellationCredentials === null) {
-      setIsLoading(true);
       return;
     }
 
@@ -219,11 +208,16 @@ export function ProviderSelector({
         }
       }
     })();
-  }, [
-    selectedTarget,
-    hasConstellationCredentials,
-    showConstellationLoginPrompt,
-  ]);
+  }, [selectedTarget, showProviderStoreTabs]);
+
+  useEffect(() => {
+    if (!showProviderStoreTabs && selectedTarget !== "local") {
+      setSelectedTarget("local");
+      setSelectedIndex(0);
+      setSearchQuery("");
+      setViewState({ type: "list" });
+    }
+  }, [selectedTarget, showProviderStoreTabs]);
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -242,11 +236,12 @@ export function ProviderSelector({
   }, [selectedIndex, selectableProviders.length]);
 
   const switchTarget = useCallback(() => {
+    if (!showProviderStoreTabs) return;
     setSelectedTarget((target) => (target === "local" ? "api" : "local"));
     setSelectedIndex(0);
     setSearchQuery("");
     setViewState({ type: "list" });
-  }, []);
+  }, [showProviderStoreTabs]);
 
   // Check if a provider is connected
   const isConnected = useCallback(
@@ -584,7 +579,10 @@ export function ProviderSelector({
         } else {
           onCancel();
         }
-      } else if (key.leftArrow || key.rightArrow || key.tab) {
+      } else if (
+        showProviderStoreTabs &&
+        (key.leftArrow || key.rightArrow || key.tab)
+      ) {
         switchTarget();
       } else if (key.backspace || key.delete) {
         if (searchQuery) {
@@ -606,10 +604,12 @@ export function ProviderSelector({
         }
       } else if (
         input &&
-        !showConstellationLoginPrompt &&
         !key.ctrl &&
         !key.meta &&
         !key.return &&
+        !key.tab &&
+        !key.leftArrow &&
+        !key.rightArrow &&
         !key.upArrow &&
         !key.downArrow
       ) {
@@ -775,63 +775,54 @@ export function ProviderSelector({
           Connect your LLM API keys
         </Text>
         <Text dimColor>Change models with /model after connecting</Text>
-        <Box marginTop={1} flexDirection="row">
-          <Text dimColor>{"  "}</Text>
-          <Text
-            bold={selectedTarget === "local"}
-            color={
-              selectedTarget === "local" ? colors.selector.title : undefined
-            }
-            dimColor={selectedTarget !== "local"}
-          >
-            {selectedTarget === "local" ? "[ Local ]" : "  Local  "}
-          </Text>
-          <Text dimColor>{"  "}</Text>
-          <Text
-            bold={selectedTarget === "api"}
-            color={selectedTarget === "api" ? colors.selector.title : undefined}
-            dimColor={selectedTarget !== "api"}
-          >
-            {selectedTarget === "api"
-              ? "[ Constellation ]"
-              : "  Constellation  "}
-          </Text>
-        </Box>
-        <Text dimColor>
-          {selectedTarget === "local"
-            ? "  Local providers are stored on this machine and affect local agents only."
-            : "  Constellation providers are stored in Letta and affect Constellation agents."}
-        </Text>
-        {!showConstellationLoginPrompt && (
-          <Text>
-            <Text dimColor>{"  Filter: "}</Text>
-            {searchQuery ? (
-              <Text>{searchQuery}</Text>
-            ) : (
-              <Text dimColor>(type to filter)</Text>
-            )}
-          </Text>
+        {showProviderStoreTabs && (
+          <Box marginTop={1} flexDirection="row">
+            <Text>{"  "}</Text>
+            <Text
+              bold={selectedTarget === "local"}
+              color={
+                selectedTarget === "local"
+                  ? colors.selector.title
+                  : colors.command.running
+              }
+            >
+              {selectedTarget === "local" ? "[ Local ]" : "  Local  "}
+            </Text>
+            <Text>{"  "}</Text>
+            <Text
+              bold={selectedTarget === "api"}
+              color={
+                selectedTarget === "api"
+                  ? colors.selector.title
+                  : colors.command.running
+              }
+            >
+              {selectedTarget === "api"
+                ? "[ Constellation ]"
+                : "  Constellation  "}
+            </Text>
+          </Box>
         )}
+        {!showProviderStoreTabs && <Box height={1} />}
+        <Text>
+          <Text dimColor>{"  Filter: "}</Text>
+          {searchQuery ? (
+            <Text>{searchQuery}</Text>
+          ) : (
+            <Text dimColor>(type to filter)</Text>
+          )}
+        </Text>
       </Box>
 
       {isLoading ? (
         <Box>
           <Text dimColor>{"  "}Loading providers...</Text>
         </Box>
-      ) : showConstellationLoginPrompt ? (
-        <Box flexDirection="column">
-          <Text dimColor>{"  "}Use /login to log into Constellation.</Text>
-        </Box>
       ) : (
         <Box flexDirection="column">
           {selectableProviders.length === 0 && searchQuery ? (
             <Text dimColor>{"  "}No providers match your filter.</Text>
           ) : null}
-          {providersAbove > 0 && (
-            <Text dimColor>
-              {"  "}↑ {providersAbove} more above
-            </Text>
-          )}
           {visibleProviders.map((provider, index) => {
             const actualIndex = providerStartIndex + index;
             const isSelected = actualIndex === selectedIndex;
@@ -882,11 +873,13 @@ export function ProviderSelector({
       {!isLoading && (
         <Box marginTop={1}>
           <Text dimColor>
-            {showConstellationLoginPrompt
-              ? "  Tab/←→ switch tab · Esc cancel"
-              : searchQuery
+            {searchQuery
+              ? showProviderStoreTabs
                 ? "  Enter select · ↑↓ navigate · Backspace edit filter · Tab/←→ switch tab · Esc clear"
-                : "  Enter select · ↑↓ navigate · type filter · Tab/←→ switch tab · Esc cancel"}
+                : "  Enter select · ↑↓ navigate · Backspace edit filter · Esc clear"
+              : showProviderStoreTabs
+                ? "  Enter select · ↑↓ navigate · type filter · Tab/←→ switch tab · Esc cancel"
+                : "  Enter select · ↑↓ navigate · type filter · Esc cancel"}
           </Text>
         </Box>
       )}

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -15,6 +15,7 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import { type Settings, settingsManager } from "@/settings-manager";
 import { type AwsProfile, parseAwsCredentials } from "@/utils/aws-credentials";
 import { debugLog } from "@/utils/debug";
 import { colors } from "./colors";
@@ -49,6 +50,48 @@ export function providerApiKeyFromInput(
   return input.trim() || defaultProviderApiKey(provider);
 }
 
+export function hasConstellationProviderStoreCredentials(
+  settings: Pick<Settings, "env" | "refreshToken">,
+  env: { LETTA_API_KEY?: string } = {
+    LETTA_API_KEY: process.env.LETTA_API_KEY,
+  },
+): boolean {
+  return Boolean(
+    env.LETTA_API_KEY || settings.env?.LETTA_API_KEY || settings.refreshToken,
+  );
+}
+
+export function shouldShowConstellationLoginPrompt(
+  target: ProviderStorageTarget,
+  hasConstellationCredentials: boolean | null,
+): boolean {
+  return target === "api" && hasConstellationCredentials === false;
+}
+
+export function filterProviderConfigs(
+  providers: readonly ByokProvider[],
+  query: string,
+): ByokProvider[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return [...providers];
+
+  return providers.filter((provider) => {
+    const searchable = [
+      provider.id,
+      provider.displayName,
+      provider.description,
+      provider.providerType,
+      provider.providerName,
+      provider.oauthProviderId,
+      ...(provider.providerNames ?? []),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return searchable.includes(normalized);
+  });
+}
+
 export function ProviderSelector({
   onCancel,
   onStartOAuth,
@@ -60,12 +103,15 @@ export function ProviderSelector({
   const [selectedTarget, setSelectedTarget] = useState<ProviderStorageTarget>(
     defaultProviderStorageTarget(),
   );
+  const [hasConstellationCredentials, setHasConstellationCredentials] =
+    useState<boolean | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [connectedProviders, setConnectedProviders] = useState<
     Map<string, ProviderResponse>
   >(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [viewState, setViewState] = useState<ViewState>({ type: "list" });
+  const [searchQuery, setSearchQuery] = useState("");
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [validationState, setValidationState] =
     useState<ValidationState>("idle");
@@ -84,25 +130,36 @@ export function ProviderSelector({
     () => getProviderConfigs(selectedTarget),
     [selectedTarget],
   );
+  const filteredProviders = useMemo(
+    () => filterProviderConfigs(providers, searchQuery),
+    [providers, searchQuery],
+  );
+  const showConstellationLoginPrompt = shouldShowConstellationLoginPrompt(
+    selectedTarget,
+    hasConstellationCredentials,
+  );
+  const selectableProviders = showConstellationLoginPrompt
+    ? []
+    : filteredProviders;
   const providerStartIndex = useMemo(() => {
     if (selectedIndex < VISIBLE_PROVIDERS) return 0;
     return Math.min(
       selectedIndex - VISIBLE_PROVIDERS + 1,
-      Math.max(0, providers.length - VISIBLE_PROVIDERS),
+      Math.max(0, selectableProviders.length - VISIBLE_PROVIDERS),
     );
-  }, [selectedIndex, providers.length]);
+  }, [selectedIndex, selectableProviders.length]);
   const visibleProviders = useMemo(
     () =>
-      providers.slice(
+      selectableProviders.slice(
         providerStartIndex,
         providerStartIndex + VISIBLE_PROVIDERS,
       ),
-    [providers, providerStartIndex],
+    [selectableProviders, providerStartIndex],
   );
   const providersAbove = providerStartIndex;
   const providersBelow = Math.max(
     0,
-    providers.length - providerStartIndex - VISIBLE_PROVIDERS,
+    selectableProviders.length - providerStartIndex - VISIBLE_PROVIDERS,
   );
 
   const mountedRef = useRef(true);
@@ -113,8 +170,39 @@ export function ProviderSelector({
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    settingsManager
+      .getSettingsWithSecureTokens()
+      .then((settings) => {
+        if (cancelled || !mountedRef.current) return;
+        setHasConstellationCredentials(
+          hasConstellationProviderStoreCredentials(settings),
+        );
+      })
+      .catch(() => {
+        if (cancelled || !mountedRef.current) return;
+        setHasConstellationCredentials(Boolean(process.env.LETTA_API_KEY));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Load connected providers on mount and when switching targets.
   useEffect(() => {
+    if (showConstellationLoginPrompt) {
+      setConnectedProviders(new Map());
+      setIsLoading(false);
+      return;
+    }
+
+    if (selectedTarget === "api" && hasConstellationCredentials === null) {
+      setIsLoading(true);
+      return;
+    }
+
     setIsLoading(true);
     (async () => {
       try {
@@ -131,7 +219,11 @@ export function ProviderSelector({
         }
       }
     })();
-  }, [selectedTarget]);
+  }, [
+    selectedTarget,
+    hasConstellationCredentials,
+    showConstellationLoginPrompt,
+  ]);
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -139,14 +231,20 @@ export function ProviderSelector({
   }, []);
 
   useEffect(() => {
-    if (selectedIndex >= providers.length && providers.length > 0) {
-      setSelectedIndex(providers.length - 1);
+    if (selectableProviders.length === 0) {
+      if (selectedIndex !== 0) setSelectedIndex(0);
+      return;
     }
-  }, [selectedIndex, providers.length]);
+
+    if (selectedIndex >= selectableProviders.length) {
+      setSelectedIndex(selectableProviders.length - 1);
+    }
+  }, [selectedIndex, selectableProviders.length]);
 
   const switchTarget = useCallback(() => {
     setSelectedTarget((target) => (target === "local" ? "api" : "local"));
     setSelectedIndex(0);
+    setSearchQuery("");
     setViewState({ type: "list" });
   }, []);
 
@@ -480,18 +578,43 @@ export function ProviderSelector({
       if (isLoading) return;
 
       if (key.escape) {
-        onCancel();
+        if (searchQuery) {
+          setSearchQuery("");
+          setSelectedIndex(0);
+        } else {
+          onCancel();
+        }
       } else if (key.leftArrow || key.rightArrow || key.tab) {
         switchTarget();
+      } else if (key.backspace || key.delete) {
+        if (searchQuery) {
+          setSearchQuery((prev) => prev.slice(0, -1));
+          setSelectedIndex(0);
+        }
       } else if (key.upArrow) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
-        setSelectedIndex((prev) => Math.min(providers.length - 1, prev + 1));
+        setSelectedIndex((prev) =>
+          selectableProviders.length === 0
+            ? 0
+            : Math.min(selectableProviders.length - 1, prev + 1),
+        );
       } else if (key.return) {
-        const provider = providers[selectedIndex];
+        const provider = selectableProviders[selectedIndex];
         if (provider) {
           handleSelectProvider(provider);
         }
+      } else if (
+        input &&
+        !showConstellationLoginPrompt &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.return &&
+        !key.upArrow &&
+        !key.downArrow
+      ) {
+        setSearchQuery((prev) => prev + input);
+        setSelectedIndex(0);
       }
     } else if (viewState.type === "input") {
       if (key.escape) {
@@ -683,14 +806,31 @@ export function ProviderSelector({
             ? "  Local providers are stored on this machine and affect local agents only."
             : "  Constellation providers are stored in Letta and affect Constellation agents."}
         </Text>
+        {!showConstellationLoginPrompt && (
+          <Text>
+            <Text dimColor>{"  Filter: "}</Text>
+            {searchQuery ? (
+              <Text>{searchQuery}</Text>
+            ) : (
+              <Text dimColor>(type to filter)</Text>
+            )}
+          </Text>
+        )}
       </Box>
 
       {isLoading ? (
         <Box>
           <Text dimColor>{"  "}Loading providers...</Text>
         </Box>
+      ) : showConstellationLoginPrompt ? (
+        <Box flexDirection="column">
+          <Text dimColor>{"  "}Use /login to log into Constellation.</Text>
+        </Box>
       ) : (
         <Box flexDirection="column">
+          {selectableProviders.length === 0 && searchQuery ? (
+            <Text dimColor>{"  "}No providers match your filter.</Text>
+          ) : null}
           {providersAbove > 0 && (
             <Text dimColor>
               {"  "}↑ {providersAbove} more above
@@ -737,7 +877,7 @@ export function ProviderSelector({
             <Text dimColor>
               {"  "}↓ {providersBelow} more below
             </Text>
-          ) : providers.length > VISIBLE_PROVIDERS ? (
+          ) : selectableProviders.length > VISIBLE_PROVIDERS ? (
             <Text> </Text>
           ) : null}
         </Box>
@@ -746,7 +886,11 @@ export function ProviderSelector({
       {!isLoading && (
         <Box marginTop={1}>
           <Text dimColor>
-            {"  "}Enter select · ↑↓ navigate · Tab/←→ switch tab · Esc cancel
+            {showConstellationLoginPrompt
+              ? "  Tab/←→ switch tab · Esc cancel"
+              : searchQuery
+                ? "  Enter select · ↑↓ navigate · Backspace edit filter · Tab/←→ switch tab · Esc clear"
+                : "  Enter select · ↑↓ navigate · type filter · Tab/←→ switch tab · Esc cancel"}
           </Text>
         </Box>
       )}

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -154,17 +154,31 @@ export function ProviderSelector({
   const isConnected = useCallback(
     (provider: ByokProvider) => {
       const providerNames = provider.providerNames ?? [provider.providerName];
-      return providerNames.some((name) => connectedProviders.has(name));
+      return providerNames.some((name) => {
+        const connected = connectedProviders.get(name);
+        if (!connected) return false;
+        if (selectedTarget !== "local" || !connected.auth_type) return true;
+        return provider.isOAuth
+          ? connected.auth_type === "oauth"
+          : connected.auth_type !== "oauth";
+      });
     },
-    [connectedProviders],
+    [connectedProviders, selectedTarget],
   );
 
   const getConnectedProviderName = useCallback(
     (provider: ByokProvider): string | undefined => {
       const providerNames = provider.providerNames ?? [provider.providerName];
-      return providerNames.find((name) => connectedProviders.has(name));
+      return providerNames.find((name) => {
+        const connected = connectedProviders.get(name);
+        if (!connected) return false;
+        if (selectedTarget !== "local" || !connected.auth_type) return true;
+        return provider.isOAuth
+          ? connected.auth_type === "oauth"
+          : connected.auth_type !== "oauth";
+      });
     },
-    [connectedProviders],
+    [connectedProviders, selectedTarget],
   );
 
   // Get provider ID if connected

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -3,14 +3,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import {
   type AuthMethod,
-  BYOK_PROVIDERS,
   type ByokProvider,
   checkProviderApiKey,
   createOrUpdateProvider,
   defaultProviderApiKey,
+  defaultProviderStorageTarget,
   getConnectedProviders,
+  getProviderConfigs,
   type ProviderField,
   type ProviderResponse,
+  type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
 import { type AwsProfile, parseAwsCredentials } from "@/utils/aws-credentials";
@@ -32,8 +34,11 @@ type ValidationState = "idle" | "validating" | "valid" | "invalid" | "saving";
 
 interface ProviderSelectorProps {
   onCancel: () => void;
-  /** Called when ChatGPT/Codex OAuth flow should start */
-  onStartOAuth?: () => void;
+  /** Called when an OAuth flow should start */
+  onStartOAuth?: (
+    provider: ByokProvider,
+    target: ProviderStorageTarget,
+  ) => void;
 }
 
 export function providerApiKeyFromInput(
@@ -51,6 +56,9 @@ export function ProviderSelector({
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
 
   // State
+  const [selectedTarget, setSelectedTarget] = useState<ProviderStorageTarget>(
+    defaultProviderStorageTarget(),
+  );
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [connectedProviders, setConnectedProviders] = useState<
     Map<string, ProviderResponse>
@@ -71,6 +79,7 @@ export function ProviderSelector({
   const [awsProfiles, setAwsProfiles] = useState<AwsProfile[]>([]);
   const [profileIndex, setProfileIndex] = useState(0);
   const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
+  const providers = getProviderConfigs(selectedTarget);
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -80,11 +89,14 @@ export function ProviderSelector({
     };
   }, []);
 
-  // Load connected providers on mount
+  // Load connected providers on mount and when switching targets.
   useEffect(() => {
+    setIsLoading(true);
     (async () => {
       try {
-        const providers = await getConnectedProviders();
+        const providers = await getConnectedProviders({
+          target: selectedTarget,
+        });
         if (mountedRef.current) {
           setConnectedProviders(providers);
           setIsLoading(false);
@@ -95,12 +107,32 @@ export function ProviderSelector({
         }
       }
     })();
+  }, [selectedTarget]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+    setViewState({ type: "list" });
+  }, []);
+
+  const switchTarget = useCallback(() => {
+    setSelectedTarget((target) => (target === "local" ? "api" : "local"));
+    setSelectedIndex(0);
+    setViewState({ type: "list" });
   }, []);
 
   // Check if a provider is connected
   const isConnected = useCallback(
     (provider: ByokProvider) => {
-      return connectedProviders.has(provider.providerName);
+      const providerNames = provider.providerNames ?? [provider.providerName];
+      return providerNames.some((name) => connectedProviders.has(name));
+    },
+    [connectedProviders],
+  );
+
+  const getConnectedProviderName = useCallback(
+    (provider: ByokProvider): string | undefined => {
+      const providerNames = provider.providerNames ?? [provider.providerName];
+      return providerNames.find((name) => connectedProviders.has(name));
     },
     [connectedProviders],
   );
@@ -108,9 +140,12 @@ export function ProviderSelector({
   // Get provider ID if connected
   const getProviderId = useCallback(
     (provider: ByokProvider): string | undefined => {
-      return connectedProviders.get(provider.providerName)?.id;
+      const providerName = getConnectedProviderName(provider);
+      return providerName
+        ? connectedProviders.get(providerName)?.id
+        : undefined;
     },
-    [connectedProviders],
+    [connectedProviders, getConnectedProviderName],
   );
 
   // Handle selecting a provider from the list
@@ -119,7 +154,7 @@ export function ProviderSelector({
       if ("isOAuth" in provider && provider.isOAuth) {
         // OAuth provider - trigger OAuth flow
         if (onStartOAuth) {
-          onStartOAuth();
+          onStartOAuth(provider, selectedTarget);
         }
         return;
       }
@@ -151,7 +186,7 @@ export function ProviderSelector({
         setValidationError(null);
       }
     },
-    [isConnected, getProviderId, onStartOAuth],
+    [isConnected, getProviderId, onStartOAuth, selectedTarget],
   );
 
   // Handle selecting an auth method
@@ -232,9 +267,16 @@ export function ProviderSelector({
           provider.providerType,
           provider.providerName,
           apiKey,
+          undefined,
+          undefined,
+          undefined,
+          {},
+          { target: selectedTarget },
         );
         // Refresh connected providers
-        const providers = await getConnectedProviders();
+        const providers = await getConnectedProviders({
+          target: selectedTarget,
+        });
         if (mountedRef.current) {
           setConnectedProviders(providers);
           setViewState({ type: "list" });
@@ -257,7 +299,14 @@ export function ProviderSelector({
     setValidationError(null);
 
     try {
-      await checkProviderApiKey(provider.providerType, apiKey);
+      await checkProviderApiKey(
+        provider.providerType,
+        apiKey,
+        undefined,
+        undefined,
+        undefined,
+        { target: selectedTarget },
+      );
       if (mountedRef.current) {
         setValidationState("valid");
       }
@@ -269,7 +318,7 @@ export function ProviderSelector({
         );
       }
     }
-  }, [viewState, apiKeyInput, validationState]);
+  }, [viewState, apiKeyInput, validationState, selectedTarget]);
 
   // Handle multi-field validation and saving (for providers like Bedrock)
   const handleMultiFieldValidateAndSave = useCallback(async () => {
@@ -302,9 +351,13 @@ export function ProviderSelector({
           accessKey,
           region,
           profile,
+          {},
+          { target: selectedTarget },
         );
         // Refresh connected providers
-        const providers = await getConnectedProviders();
+        const providers = await getConnectedProviders({
+          target: selectedTarget,
+        });
         if (mountedRef.current) {
           setConnectedProviders(providers);
           setViewState({ type: "list" });
@@ -333,6 +386,7 @@ export function ProviderSelector({
         accessKey,
         region,
         profile,
+        { target: selectedTarget },
       );
       if (mountedRef.current) {
         setValidationState("valid");
@@ -345,7 +399,7 @@ export function ProviderSelector({
         );
       }
     }
-  }, [viewState, fieldValues, validationState]);
+  }, [viewState, fieldValues, validationState, selectedTarget]);
 
   // Handle disconnect
   const handleDisconnect = useCallback(async () => {
@@ -353,9 +407,14 @@ export function ProviderSelector({
 
     const { provider } = viewState;
     try {
-      await removeProviderByName(provider.providerName);
+      await removeProviderByName(
+        getConnectedProviderName(provider) ?? provider.providerName,
+        {
+          target: selectedTarget,
+        },
+      );
       // Refresh connected providers
-      const providers = await getConnectedProviders();
+      const providers = await getConnectedProviders({ target: selectedTarget });
       if (mountedRef.current) {
         setConnectedProviders(providers);
         setViewState({ type: "list" });
@@ -363,7 +422,7 @@ export function ProviderSelector({
     } catch {
       // Silently fail, stay on options view
     }
-  }, [viewState]);
+  }, [viewState, selectedTarget, getConnectedProviderName]);
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel
@@ -378,14 +437,14 @@ export function ProviderSelector({
 
       if (key.escape) {
         onCancel();
+      } else if (key.leftArrow || key.rightArrow || key.tab) {
+        switchTarget();
       } else if (key.upArrow) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
-        setSelectedIndex((prev) =>
-          Math.min(BYOK_PROVIDERS.length - 1, prev + 1),
-        );
+        setSelectedIndex((prev) => Math.min(providers.length - 1, prev + 1));
       } else if (key.return) {
-        const provider = BYOK_PROVIDERS[selectedIndex];
+        const provider = providers[selectedIndex];
         if (provider) {
           handleSelectProvider(provider);
         }
@@ -549,6 +608,37 @@ export function ProviderSelector({
           Connect your LLM API keys
         </Text>
         <Text dimColor>Change models with /model after connecting</Text>
+        <Box marginTop={1} flexDirection="row">
+          <Text dimColor>{"  "}</Text>
+          <Text
+            bold={selectedTarget === "local"}
+            color={
+              selectedTarget === "local"
+                ? colors.selector.itemHighlighted
+                : undefined
+            }
+          >
+            {selectedTarget === "local" ? "[ Local ]" : "  Local  "}
+          </Text>
+          <Text dimColor>{"  "}</Text>
+          <Text
+            bold={selectedTarget === "api"}
+            color={
+              selectedTarget === "api"
+                ? colors.selector.itemHighlighted
+                : undefined
+            }
+          >
+            {selectedTarget === "api"
+              ? "[ Constellation ]"
+              : "  Constellation  "}
+          </Text>
+        </Box>
+        <Text dimColor>
+          {selectedTarget === "local"
+            ? "  Local providers are stored on this machine and affect local agents only."
+            : "  Constellation providers are stored in Letta and affect Constellation agents."}
+        </Text>
       </Box>
 
       {isLoading ? (
@@ -557,7 +647,7 @@ export function ProviderSelector({
         </Box>
       ) : (
         <Box flexDirection="column">
-          {BYOK_PROVIDERS.map((provider, index) => {
+          {providers.map((provider, index) => {
             const isSelected = index === selectedIndex;
             const connected = isConnected(provider);
 
@@ -598,7 +688,9 @@ export function ProviderSelector({
 
       {!isLoading && (
         <Box marginTop={1}>
-          <Text dimColor>{"  "}Enter select · ↑↓ navigate · Esc cancel</Text>
+          <Text dimColor>
+            {"  "}Enter select · ↑↓ navigate · Tab/←→ switch tab · Esc cancel
+          </Text>
         </Box>
       )}
     </>

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -779,6 +779,9 @@ export function ProviderSelector({
           <Text dimColor>{"  "}</Text>
           <Text
             bold={selectedTarget === "local"}
+            color={
+              selectedTarget === "local" ? colors.selector.title : undefined
+            }
             dimColor={selectedTarget !== "local"}
           >
             {selectedTarget === "local" ? "[ Local ]" : "  Local  "}
@@ -786,6 +789,7 @@ export function ProviderSelector({
           <Text dimColor>{"  "}</Text>
           <Text
             bold={selectedTarget === "api"}
+            color={selectedTarget === "api" ? colors.selector.title : undefined}
             dimColor={selectedTarget !== "api"}
           >
             {selectedTarget === "api"

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -779,22 +779,14 @@ export function ProviderSelector({
           <Text dimColor>{"  "}</Text>
           <Text
             bold={selectedTarget === "local"}
-            color={
-              selectedTarget === "local"
-                ? colors.selector.itemHighlighted
-                : undefined
-            }
+            dimColor={selectedTarget !== "local"}
           >
             {selectedTarget === "local" ? "[ Local ]" : "  Local  "}
           </Text>
           <Text dimColor>{"  "}</Text>
           <Text
             bold={selectedTarget === "api"}
-            color={
-              selectedTarget === "api"
-                ? colors.selector.itemHighlighted
-                : undefined
-            }
+            dimColor={selectedTarget !== "api"}
           >
             {selectedTarget === "api"
               ? "[ Constellation ]"

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -1,5 +1,5 @@
 import { Box, useInput } from "ink";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import {
   type AuthMethod,
@@ -21,6 +21,7 @@ import { colors } from "./colors";
 import { Text } from "./Text";
 
 const SOLID_LINE = "─";
+const VISIBLE_PROVIDERS = 12;
 
 type ViewState =
   | { type: "list" }
@@ -79,7 +80,30 @@ export function ProviderSelector({
   const [awsProfiles, setAwsProfiles] = useState<AwsProfile[]>([]);
   const [profileIndex, setProfileIndex] = useState(0);
   const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
-  const providers = getProviderConfigs(selectedTarget);
+  const providers = useMemo(
+    () => getProviderConfigs(selectedTarget),
+    [selectedTarget],
+  );
+  const providerStartIndex = useMemo(() => {
+    if (selectedIndex < VISIBLE_PROVIDERS) return 0;
+    return Math.min(
+      selectedIndex - VISIBLE_PROVIDERS + 1,
+      Math.max(0, providers.length - VISIBLE_PROVIDERS),
+    );
+  }, [selectedIndex, providers.length]);
+  const visibleProviders = useMemo(
+    () =>
+      providers.slice(
+        providerStartIndex,
+        providerStartIndex + VISIBLE_PROVIDERS,
+      ),
+    [providers, providerStartIndex],
+  );
+  const providersAbove = providerStartIndex;
+  const providersBelow = Math.max(
+    0,
+    providers.length - providerStartIndex - VISIBLE_PROVIDERS,
+  );
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -113,6 +137,12 @@ export function ProviderSelector({
     setSelectedIndex(0);
     setViewState({ type: "list" });
   }, []);
+
+  useEffect(() => {
+    if (selectedIndex >= providers.length && providers.length > 0) {
+      setSelectedIndex(providers.length - 1);
+    }
+  }, [selectedIndex, providers.length]);
 
   const switchTarget = useCallback(() => {
     setSelectedTarget((target) => (target === "local" ? "api" : "local"));
@@ -647,8 +677,14 @@ export function ProviderSelector({
         </Box>
       ) : (
         <Box flexDirection="column">
-          {providers.map((provider, index) => {
-            const isSelected = index === selectedIndex;
+          {providersAbove > 0 && (
+            <Text dimColor>
+              {"  "}↑ {providersAbove} more above
+            </Text>
+          )}
+          {visibleProviders.map((provider, index) => {
+            const actualIndex = providerStartIndex + index;
+            const isSelected = actualIndex === selectedIndex;
             const connected = isConnected(provider);
 
             return (
@@ -683,6 +719,13 @@ export function ProviderSelector({
               </Box>
             );
           })}
+          {providersBelow > 0 ? (
+            <Text dimColor>
+              {"  "}↓ {providersBelow} more below
+            </Text>
+          ) : providers.length > VISIBLE_PROVIDERS ? (
+            <Text> </Text>
+          ) : null}
         </Box>
       )}
 

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -79,6 +79,13 @@ describe("connect provider normalization", () => {
     expect(resolveConnectProvider("unknown-provider", "api")).toBeNull();
   });
 
+  test("does not resolve local-only providers for the API provider store", () => {
+    expect(resolveConnectProvider("ollama", "api")).toBeNull();
+    expect(resolveConnectProvider("ollama-cloud", "api")).toBeNull();
+    expect(resolveConnectProvider("lmstudio", "api")).toBeNull();
+    expect(resolveConnectProvider("llama.cpp", "api")).toBeNull();
+  });
+
   test("help list contains chatgpt alias", () => {
     expect(listConnectProvidersForHelp("api")).toContain(
       "chatgpt (alias: codex)",
@@ -93,9 +100,9 @@ describe("connect provider normalization", () => {
         LLAMA_CPP_API_KEY: undefined,
       },
       () => {
-        const ollama = resolveConnectProvider("ollama", "api");
-        const lmstudio = resolveConnectProvider("lmstudio", "api");
-        const llamaCpp = resolveConnectProvider("llama.cpp", "api");
+        const ollama = resolveConnectProvider("ollama", "local");
+        const lmstudio = resolveConnectProvider("lmstudio", "local");
+        const llamaCpp = resolveConnectProvider("llama.cpp", "local");
         if (!ollama || !lmstudio || !llamaCpp) {
           throw new Error("Expected local providers to resolve");
         }
@@ -111,7 +118,7 @@ describe("connect provider normalization", () => {
 
   test("uses environment keys before API-key optional defaults", () => {
     withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
-      const lmstudio = resolveConnectProvider("lmstudio", "api");
+      const lmstudio = resolveConnectProvider("lmstudio", "local");
       if (!lmstudio) {
         throw new Error("Expected lmstudio provider to resolve");
       }

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -116,6 +116,20 @@ describe("connect provider normalization", () => {
     );
   });
 
+  test("resolves local subscription providers from the pi OAuth catalog", () => {
+    const anthropicOAuth = resolveConnectProvider("anthropic-oauth", "local");
+    const githubCopilot = resolveConnectProvider("github-copilot", "local");
+
+    if (!anthropicOAuth || !githubCopilot) {
+      throw new Error("Expected local OAuth providers to resolve");
+    }
+
+    expect(isConnectOAuthProvider(anthropicOAuth)).toBe(true);
+    expect(anthropicOAuth.byokProvider.oauthProviderId).toBe("anthropic");
+    expect(isConnectOAuthProvider(githubCopilot)).toBe(true);
+    expect(githubCopilot.byokProvider.oauthProviderId).toBe("github-copilot");
+  });
+
   test("uses environment keys before API-key optional defaults", () => {
     withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
       const lmstudio = resolveConnectProvider("lmstudio", "local");

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -37,7 +37,7 @@ function withEnv<T>(
 
 describe("connect provider normalization", () => {
   test("normalizes codex alias to chatgpt provider", () => {
-    const resolved = resolveConnectProvider("codex");
+    const resolved = resolveConnectProvider("codex", "api");
 
     expect(resolved).not.toBeNull();
     if (!resolved) {
@@ -50,8 +50,8 @@ describe("connect provider normalization", () => {
   });
 
   test("resolves standard api-key providers", () => {
-    const anthropic = resolveConnectProvider("anthropic");
-    const openrouter = resolveConnectProvider("openrouter");
+    const anthropic = resolveConnectProvider("anthropic", "api");
+    const openrouter = resolveConnectProvider("openrouter", "api");
 
     if (!anthropic || !openrouter) {
       throw new Error("Expected anthropic and openrouter providers to resolve");
@@ -65,7 +65,7 @@ describe("connect provider normalization", () => {
   });
 
   test("resolves bedrock as non-api-key provider", () => {
-    const bedrock = resolveConnectProvider("bedrock");
+    const bedrock = resolveConnectProvider("bedrock", "api");
     if (!bedrock) {
       throw new Error("Expected bedrock provider to resolve");
     }
@@ -76,11 +76,13 @@ describe("connect provider normalization", () => {
   });
 
   test("returns null for unknown provider", () => {
-    expect(resolveConnectProvider("unknown-provider")).toBeNull();
+    expect(resolveConnectProvider("unknown-provider", "api")).toBeNull();
   });
 
   test("help list contains chatgpt alias", () => {
-    expect(listConnectProvidersForHelp()).toContain("chatgpt (alias: codex)");
+    expect(listConnectProvidersForHelp("api")).toContain(
+      "chatgpt (alias: codex)",
+    );
   });
 
   test("supports API-key optional local providers", () => {
@@ -91,9 +93,9 @@ describe("connect provider normalization", () => {
         LLAMA_CPP_API_KEY: undefined,
       },
       () => {
-        const ollama = resolveConnectProvider("ollama");
-        const lmstudio = resolveConnectProvider("lmstudio");
-        const llamaCpp = resolveConnectProvider("llama.cpp");
+        const ollama = resolveConnectProvider("ollama", "api");
+        const lmstudio = resolveConnectProvider("lmstudio", "api");
+        const llamaCpp = resolveConnectProvider("llama.cpp", "api");
         if (!ollama || !lmstudio || !llamaCpp) {
           throw new Error("Expected local providers to resolve");
         }
@@ -109,7 +111,7 @@ describe("connect provider normalization", () => {
 
   test("uses environment keys before API-key optional defaults", () => {
     withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
-      const lmstudio = resolveConnectProvider("lmstudio");
+      const lmstudio = resolveConnectProvider("lmstudio", "api");
       if (!lmstudio) {
         throw new Error("Expected lmstudio provider to resolve");
       }

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { __testSetBackend, type Backend } from "@/backend";
 import { runConnectSubcommand } from "@/cli/subcommands/connect";
+
+function setProviderTarget(target: "api" | "local") {
+  __testSetBackend({
+    capabilities: {
+      remoteMemfs: target === "api",
+      serverSideToolManagement: target === "api",
+      serverSecrets: target === "api",
+      agentFileImportExport: target === "api",
+      promptRecompile: target === "api",
+      byokProviderRefresh: target === "api",
+      localModelCatalog: target === "local",
+      localMemfs: target === "local",
+    },
+  } as Backend);
+}
 
 function createIoDeps() {
   const stdout: string[] = [];
@@ -53,6 +69,14 @@ async function withEnv<T>(
 }
 
 describe("connect subcommand", () => {
+  beforeEach(() => {
+    setProviderTarget("api");
+  });
+
+  afterEach(() => {
+    setProviderTarget("api");
+  });
+
   test("runs OAuth flow for codex alias", async () => {
     const { stdout, deps } = createIoDeps();
 
@@ -112,6 +136,7 @@ describe("connect subcommand", () => {
 
   test("connects API-key optional local providers without prompting", async () => {
     const { deps } = createIoDeps();
+    setProviderTarget("local");
 
     const exitCode = await withEnv({ OLLAMA_LOCAL_API_KEY: undefined }, () =>
       runConnectSubcommand(["ollama"], deps),
@@ -125,13 +150,14 @@ describe("connect subcommand", () => {
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "ollama",
-      "lc-ollama",
+      "ollama",
       "not-needed",
     );
   });
 
   test("passes local provider base URL and timeout options", async () => {
     const { deps } = createIoDeps();
+    setProviderTarget("local");
 
     const exitCode = await withEnv({ LMSTUDIO_API_KEY: undefined }, () =>
       runConnectSubcommand(
@@ -153,7 +179,7 @@ describe("connect subcommand", () => {
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "lmstudio_openai",
-      "lc-lmstudio",
+      "lmstudio",
       "not-needed",
       undefined,
       undefined,
@@ -167,6 +193,7 @@ describe("connect subcommand", () => {
 
   test("connects llama.cpp local provider alias", async () => {
     const { deps } = createIoDeps();
+    setProviderTarget("local");
 
     const exitCode = await withEnv({ LLAMA_CPP_API_KEY: undefined }, () =>
       runConnectSubcommand(
@@ -178,7 +205,7 @@ describe("connect subcommand", () => {
     expect(exitCode).toBe(0);
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "llama_cpp",
-      "lc-llama-cpp",
+      "llama-cpp",
       "not-needed",
       undefined,
       undefined,
@@ -189,6 +216,7 @@ describe("connect subcommand", () => {
 
   test("uses LM Studio environment API key when no key is provided", async () => {
     const { deps } = createIoDeps();
+    setProviderTarget("local");
 
     const exitCode = await withEnv({ LMSTUDIO_API_KEY: "1234" }, () =>
       runConnectSubcommand(
@@ -204,7 +232,7 @@ describe("connect subcommand", () => {
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "lmstudio_openai",
-      "lc-lmstudio",
+      "lmstudio",
       "1234",
       undefined,
       undefined,

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -3,6 +3,10 @@ import { Writable } from "node:stream";
 import { parseArgs } from "node:util";
 import { parseLocalProviderTimeout } from "@/backend/local/local-provider-timeout";
 import {
+  type LocalOAuthConnectCallbacks,
+  runLocalOAuthConnectFlow,
+} from "@/cli/commands/connect-local-oauth";
+import {
   defaultConnectApiKey,
   isConnectApiKeyProvider,
   isConnectBedrockProvider,
@@ -65,6 +69,10 @@ interface ConnectSubcommandDeps {
   runChatGPTOAuthConnectFlow: (
     callbacks: ChatGPTOAuthFlowCallbacks,
   ) => Promise<unknown>;
+  runLocalOAuthConnectFlow: (
+    provider: Parameters<typeof runLocalOAuthConnectFlow>[0],
+    callbacks: LocalOAuthConnectCallbacks,
+  ) => Promise<unknown>;
   providerStorageTargetLabel: () => string;
 }
 
@@ -87,6 +95,7 @@ const DEFAULT_DEPS: ConnectSubcommandDeps = {
   createOrUpdateProvider,
   isChatGPTOAuthConnected,
   runChatGPTOAuthConnectFlow,
+  runLocalOAuthConnectFlow,
   providerStorageTargetLabel,
 };
 
@@ -214,23 +223,47 @@ export async function runConnectSubcommand(
 
   if (isConnectOAuthProvider(provider)) {
     try {
-      await io.ensureSettingsReady();
+      if (provider.target !== "local") {
+        await io.ensureSettingsReady();
 
-      if (await io.isChatGPTOAuthConnected()) {
-        io.stdout(
-          "Already connected to ChatGPT via OAuth. Disconnect first if you want to re-authenticate.",
-        );
+        if (await io.isChatGPTOAuthConnected()) {
+          io.stdout(
+            "Already connected to ChatGPT via OAuth. Disconnect first if you want to re-authenticate.",
+          );
+          return 0;
+        }
+
+        await io.runChatGPTOAuthConnectFlow({
+          onStatus: (status) => io.stdout(status),
+        });
+
+        io.stdout("Successfully connected to ChatGPT OAuth.");
         return 0;
       }
 
-      await io.runChatGPTOAuthConnectFlow({
+      await io.runLocalOAuthConnectFlow(provider.byokProvider, {
         onStatus: (status) => io.stdout(status),
+        onPrompt: async (prompt) => {
+          if (prompt.allowEmpty && !io.isTTY()) return "";
+          if (!io.isTTY()) {
+            throw new Error(
+              `${provider.byokProvider.displayName} requires input: ${prompt.message}`,
+            );
+          }
+          return io.promptSecret(
+            `${prompt.message}${prompt.placeholder ? ` (${prompt.placeholder})` : ""}: `,
+          );
+        },
       });
 
-      io.stdout("Successfully connected to ChatGPT OAuth.");
+      io.stdout(
+        `Successfully connected to ${provider.byokProvider.displayName}.`,
+      );
       return 0;
     } catch (error) {
-      io.stderr(`Failed to connect ChatGPT OAuth: ${getErrorMessage(error)}`);
+      io.stderr(
+        `Failed to connect ${provider.byokProvider.displayName}: ${getErrorMessage(error)}`,
+      );
       return 1;
     }
   }

--- a/src/providers/byok-provider-aliases.test.ts
+++ b/src/providers/byok-provider-aliases.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("buildByokProviderAliases", () => {
   test("derives default aliases from all built-in BYOK_PROVIDERS", () => {
-    const aliases = buildByokProviderAliases();
+    const aliases = buildByokProviderAliases([], "api");
 
     // Every built-in provider with a known providerType should have an alias
     for (const bp of BYOK_PROVIDERS) {
@@ -16,24 +16,25 @@ describe("buildByokProviderAliases", () => {
   });
 
   test("includes all built-in lc-* providers (not just a partial set)", () => {
-    const aliases = buildByokProviderAliases();
+    const aliases = buildByokProviderAliases([], "api");
 
     expect(aliases["lc-anthropic"]).toBe("anthropic");
     expect(aliases["lc-openai"]).toBe("openai");
     expect(aliases["lc-zai"]).toBe("zai");
-    expect(aliases["lc-gemini"]).toBe("google_ai");
+    expect(aliases["lc-gemini"]).toBe("google");
     expect(aliases["lc-minimax"]).toBe("minimax");
     expect(aliases["lc-openrouter"]).toBe("openrouter");
     expect(aliases["lc-lmstudio"]).toBe("lmstudio");
     expect(aliases["lc-llama-cpp"]).toBe("llama.cpp");
-    expect(aliases["lc-bedrock"]).toBe("bedrock");
-    expect(aliases["chatgpt-plus-pro"]).toBe("chatgpt-plus-pro");
+    expect(aliases["lc-bedrock"]).toBe("amazon-bedrock");
+    expect(aliases["chatgpt-plus-pro"]).toBe("openai-codex");
   });
 
   test("layers connected providers on top of built-in aliases", () => {
-    const aliases = buildByokProviderAliases([
-      { name: "openai-sarah", provider_type: "openai" },
-    ]);
+    const aliases = buildByokProviderAliases(
+      [{ name: "openai-sarah", provider_type: "openai" }],
+      "api",
+    );
 
     // Custom provider mapped
     expect(aliases["openai-sarah"]).toBe("openai");
@@ -43,19 +44,23 @@ describe("buildByokProviderAliases", () => {
   });
 
   test("maps connected LM Studio provider types to the LM Studio handle", () => {
-    const aliases = buildByokProviderAliases([
-      { name: "lmstudio-server", provider_type: "lmstudio_openai" },
-      { name: "lmstudio-legacy", provider_type: "lmstudio" },
-    ]);
+    const aliases = buildByokProviderAliases(
+      [
+        { name: "lmstudio-server", provider_type: "lmstudio_openai" },
+        { name: "lmstudio-legacy", provider_type: "lmstudio" },
+      ],
+      "api",
+    );
 
     expect(aliases["lmstudio-server"]).toBe("lmstudio");
     expect(aliases["lmstudio-legacy"]).toBe("lmstudio");
   });
 
   test("handles unknown provider types gracefully", () => {
-    const aliases = buildByokProviderAliases([
-      { name: "unknown-provider", provider_type: "some_new_type" },
-    ]);
+    const aliases = buildByokProviderAliases(
+      [{ name: "unknown-provider", provider_type: "some_new_type" }],
+      "api",
+    );
 
     // Unknown type doesn't get an alias
     expect(aliases["unknown-provider"]).toBeUndefined();
@@ -64,9 +69,10 @@ describe("buildByokProviderAliases", () => {
   });
 
   test("connected provider can override a built-in alias", () => {
-    const aliases = buildByokProviderAliases([
-      { name: "lc-anthropic", provider_type: "anthropic" },
-    ]);
+    const aliases = buildByokProviderAliases(
+      [{ name: "lc-anthropic", provider_type: "anthropic" }],
+      "api",
+    );
 
     // Still maps correctly (same value)
     expect(aliases["lc-anthropic"]).toBe("anthropic");
@@ -74,7 +80,7 @@ describe("buildByokProviderAliases", () => {
 });
 
 describe("isByokHandleForSelector", () => {
-  const defaultAliases = buildByokProviderAliases();
+  const defaultAliases = buildByokProviderAliases([], "api");
 
   test("matches chatgpt-plus-pro/ prefix", () => {
     expect(
@@ -89,9 +95,10 @@ describe("isByokHandleForSelector", () => {
   });
 
   test("matches known BYOK provider names via aliases", () => {
-    const aliases = buildByokProviderAliases([
-      { name: "openai-sarah", provider_type: "openai" },
-    ]);
+    const aliases = buildByokProviderAliases(
+      [{ name: "openai-sarah", provider_type: "openai" }],
+      "api",
+    );
 
     expect(isByokHandleForSelector("openai-sarah/gpt-5-fast", aliases)).toBe(
       true,

--- a/src/providers/byok-provider-aliases.test.ts
+++ b/src/providers/byok-provider-aliases.test.ts
@@ -24,10 +24,27 @@ describe("buildByokProviderAliases", () => {
     expect(aliases["lc-gemini"]).toBe("google");
     expect(aliases["lc-minimax"]).toBe("minimax");
     expect(aliases["lc-openrouter"]).toBe("openrouter");
-    expect(aliases["lc-lmstudio"]).toBe("lmstudio");
-    expect(aliases["lc-llama-cpp"]).toBe("llama.cpp");
     expect(aliases["lc-bedrock"]).toBe("amazon-bedrock");
     expect(aliases["chatgpt-plus-pro"]).toBe("openai-codex");
+  });
+
+  test("includes local endpoint aliases only for the local provider store", () => {
+    const apiAliases = buildByokProviderAliases([], "api");
+    const localAliases = buildByokProviderAliases([], "local");
+
+    expect(apiAliases["lc-ollama"]).toBeUndefined();
+    expect(apiAliases["lc-ollama-cloud"]).toBeUndefined();
+    expect(apiAliases["lc-lmstudio"]).toBeUndefined();
+    expect(apiAliases["lc-llama-cpp"]).toBeUndefined();
+
+    expect(localAliases.ollama).toBe("ollama");
+    expect(localAliases["lc-ollama"]).toBe("ollama");
+    expect(localAliases["ollama-cloud"]).toBe("ollama-cloud");
+    expect(localAliases["lc-ollama-cloud"]).toBe("ollama-cloud");
+    expect(localAliases.lmstudio).toBe("lmstudio");
+    expect(localAliases["lc-lmstudio"]).toBe("lmstudio");
+    expect(localAliases["llama-cpp"]).toBe("llama.cpp");
+    expect(localAliases["lc-llama-cpp"]).toBe("llama.cpp");
   });
 
   test("layers connected providers on top of built-in aliases", () => {

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -3,6 +3,8 @@
  * Unified module for managing custom LLM provider connections
  */
 
+import { getProviders } from "@earendil-works/pi-ai";
+import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import {
   checkProviderApiKey as checkProviderApiKeyRequest,
   createOrUpdateProvider as createOrUpdateProviderRequest,
@@ -18,6 +20,7 @@ import { getBackend } from "@/backend/backend";
 import {
   getPiProviderSpec,
   LMSTUDIO_OPENAI_PROVIDER_TYPE,
+  PI_PROVIDER_SPECS,
   PROVIDER_TYPE_TO_BASE_PROVIDER,
   resolveProviderFromProviderType,
 } from "@/backend/dev/pi-provider-registry";
@@ -35,9 +38,15 @@ import type { LocalProviderTimeout } from "@/backend/local/local-provider-timeou
 
 export type { ProviderResponse } from "@/backend/api/providers";
 
+export type ProviderStorageTarget = "api" | "local";
+
 export interface ProviderConnectionOptions {
   baseURL?: string;
   timeout?: LocalProviderTimeout;
+}
+
+export interface ProviderOperationOptions {
+  target?: ProviderStorageTarget;
 }
 
 // Field definition for multi-field providers (like Bedrock)
@@ -56,8 +65,50 @@ export interface AuthMethod {
   fields: ProviderField[];
 }
 
-// Provider configuration for the /connect UI
-export const BYOK_PROVIDERS = [
+export interface ByokProvider {
+  id: string;
+  displayName: string;
+  description: string;
+  providerType: string;
+  providerName: string;
+  providerNames?: readonly string[];
+  isOAuth?: boolean;
+  requiresApiKey?: boolean;
+  defaultApiKey?: string;
+  fields?: ProviderField[];
+  authMethods?: AuthMethod[];
+}
+
+export type ByokProviderId = string;
+
+const BEDROCK_AUTH_METHODS: AuthMethod[] = [
+  {
+    id: "iam",
+    label: "AWS Access Keys",
+    description: "Enter access key and secret key manually",
+    fields: [
+      {
+        key: "accessKey",
+        label: "AWS Access Key ID",
+        placeholder: "AKIA...",
+      },
+      { key: "apiKey", label: "AWS Secret Access Key", secret: true },
+      { key: "region", label: "AWS Region", placeholder: "us-east-1" },
+    ],
+  },
+  {
+    id: "profile",
+    label: "AWS Profile",
+    description: "Load credentials from ~/.aws/credentials",
+    fields: [
+      { key: "profile", label: "Profile Name", placeholder: "default" },
+      { key: "region", label: "AWS Region", placeholder: "us-east-1" },
+    ],
+  },
+];
+
+// Provider configuration for the Constellation / Letta API provider store.
+export const CONSTELLATION_BYOK_PROVIDERS: readonly ByokProvider[] = [
   {
     id: "codex",
     displayName: "ChatGPT / Codex plan",
@@ -169,36 +220,179 @@ export const BYOK_PROVIDERS = [
     description: "Connect to Claude on Amazon Bedrock",
     providerType: "bedrock",
     providerName: "lc-bedrock",
-    authMethods: [
-      {
-        id: "iam",
-        label: "AWS Access Keys",
-        description: "Enter access key and secret key manually",
-        fields: [
-          {
-            key: "accessKey",
-            label: "AWS Access Key ID",
-            placeholder: "AKIA...",
-          },
-          { key: "apiKey", label: "AWS Secret Access Key", secret: true },
-          { key: "region", label: "AWS Region", placeholder: "us-east-1" },
-        ],
-      },
-      {
-        id: "profile",
-        label: "AWS Profile",
-        description: "Load credentials from ~/.aws/credentials",
-        fields: [
-          { key: "profile", label: "Profile Name", placeholder: "default" },
-          { key: "region", label: "AWS Region", placeholder: "us-east-1" },
-        ],
-      },
-    ] as AuthMethod[],
+    authMethods: BEDROCK_AUTH_METHODS,
   },
-] as const;
+];
 
-export type ByokProviderId = (typeof BYOK_PROVIDERS)[number]["id"];
-export type ByokProvider = (typeof BYOK_PROVIDERS)[number];
+// Backwards-compatible export for code/tests that mean the API provider list.
+export const BYOK_PROVIDERS = CONSTELLATION_BYOK_PROVIDERS;
+
+const LOCAL_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  anthropic: "Anthropic",
+  "amazon-bedrock": "Amazon Bedrock",
+  "azure-openai-responses": "Azure OpenAI Responses",
+  cerebras: "Cerebras",
+  "cloudflare-ai-gateway": "Cloudflare AI Gateway",
+  "cloudflare-workers-ai": "Cloudflare Workers AI",
+  deepseek: "DeepSeek",
+  fireworks: "Fireworks",
+  google: "Google Gemini",
+  "google-vertex": "Google Vertex AI",
+  groq: "Groq",
+  "github-copilot": "GitHub Copilot",
+  huggingface: "Hugging Face",
+  "kimi-coding": "Kimi For Coding",
+  mistral: "Mistral",
+  minimax: "MiniMax",
+  "minimax-cn": "MiniMax (China)",
+  moonshotai: "Moonshot AI",
+  "moonshotai-cn": "Moonshot AI (China)",
+  opencode: "OpenCode Zen",
+  "opencode-go": "OpenCode Go",
+  openai: "OpenAI",
+  "openai-codex": "ChatGPT Plus/Pro",
+  openrouter: "OpenRouter",
+  together: "Together AI",
+  "vercel-ai-gateway": "Vercel AI Gateway",
+  xai: "xAI",
+  xiaomi: "Xiaomi MiMo",
+  "xiaomi-token-plan-cn": "Xiaomi MiMo Token Plan (China)",
+  "xiaomi-token-plan-ams": "Xiaomi MiMo Token Plan (Amsterdam)",
+  "xiaomi-token-plan-sgp": "Xiaomi MiMo Token Plan (Singapore)",
+  zai: "ZAI",
+};
+
+const LOCAL_EXTRA_PROVIDER_CONFIGS: readonly ByokProvider[] = [
+  {
+    id: "zai-coding",
+    displayName: "zAI Coding Plan",
+    description: "Connect a zAI Coding plan key",
+    providerType: "zai_coding",
+    providerName: "zai_coding",
+    providerNames: ["zai_coding", "lc-zai-coding"],
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama (local)",
+    description: "Connect local Ollama at http://localhost:11434/v1",
+    providerType: "ollama",
+    providerName: "ollama",
+    providerNames: ["ollama", "lc-ollama"],
+    requiresApiKey: false,
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+  },
+  {
+    id: "ollama-cloud",
+    displayName: "Ollama Cloud",
+    description: "Connect an Ollama Cloud API key",
+    providerType: "ollama_cloud",
+    providerName: "ollama-cloud",
+    providerNames: ["ollama-cloud", "lc-ollama-cloud"],
+  },
+  {
+    id: "lmstudio",
+    displayName: "LM Studio (local)",
+    description: "Connect local LM Studio at http://127.0.0.1:1234/v1",
+    providerType: LMSTUDIO_OPENAI_PROVIDER_TYPE,
+    providerName: "lmstudio",
+    providerNames: ["lmstudio", "lc-lmstudio"],
+    requiresApiKey: false,
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+  },
+  {
+    id: "llama-cpp",
+    displayName: "llama.cpp (local)",
+    description: "Connect local llama.cpp at http://localhost:8080/v1",
+    providerType: "llama_cpp",
+    providerName: "llama-cpp",
+    providerNames: ["llama-cpp", "lc-llama-cpp"],
+    requiresApiKey: false,
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+  },
+];
+
+function humanizeProviderId(provider: string): string {
+  return provider
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function displayNameForLocalProvider(provider: string): string {
+  return LOCAL_PROVIDER_DISPLAY_NAMES[provider] ?? humanizeProviderId(provider);
+}
+
+function localProviderDescription(provider: string): string {
+  return `Connect a ${displayNameForLocalProvider(provider)} API key`;
+}
+
+function byokProviderFromPiSpec(provider: string): ByokProvider | undefined {
+  const spec = PI_PROVIDER_SPECS.find((candidate) => candidate.id === provider);
+  if (!spec) return undefined;
+  return {
+    id: provider,
+    displayName: displayNameForLocalProvider(provider),
+    description: localProviderDescription(provider),
+    providerType: spec.providerTypes[0] ?? provider,
+    providerName: spec.localProviderNames[0] ?? provider,
+    providerNames: spec.localProviderNames,
+    ...(provider === "amazon-bedrock"
+      ? { authMethods: BEDROCK_AUTH_METHODS }
+      : {}),
+  };
+}
+
+function localOAuthProviderConfigs(): ByokProvider[] {
+  return getOAuthProviders()
+    .filter((provider) => provider.id === "openai-codex")
+    .map((provider) => {
+      const spec = PI_PROVIDER_SPECS.find(
+        (candidate) => candidate.piProvider === provider.id,
+      );
+      return {
+        id: `${provider.id}-oauth`,
+        displayName: provider.name,
+        description: "Connect a subscription account",
+        providerType:
+          provider.id === "openai-codex"
+            ? "chatgpt_oauth"
+            : (spec?.providerTypes[0] ?? provider.id),
+        providerName:
+          provider.id === "openai-codex"
+            ? "chatgpt-plus-pro"
+            : (spec?.localProviderNames[0] ?? provider.id),
+        providerNames:
+          provider.id === "openai-codex"
+            ? ["chatgpt-plus-pro", "openai-codex"]
+            : spec?.localProviderNames,
+        isOAuth: true,
+      };
+    });
+}
+
+const API_KEY_PROVIDER_EXCLUSIONS = new Set(["openai-codex"]);
+
+export function getProviderConfigs(
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
+): readonly ByokProvider[] {
+  if (target === "api") return CONSTELLATION_BYOK_PROVIDERS;
+
+  const byId = new Map<string, ByokProvider>();
+  for (const provider of localOAuthProviderConfigs()) {
+    byId.set(provider.id, provider);
+  }
+  for (const provider of getProviders()) {
+    if (API_KEY_PROVIDER_EXCLUSIONS.has(provider)) continue;
+    const config = byokProviderFromPiSpec(provider);
+    if (config) byId.set(config.id, config);
+  }
+  for (const provider of LOCAL_EXTRA_PROVIDER_CONFIGS) {
+    byId.set(provider.id, provider);
+  }
+  return [...byId.values()].sort((left, right) =>
+    left.displayName.localeCompare(right.displayName),
+  );
+}
 
 function providerEnvApiKey(provider: ByokProvider): string | undefined {
   const piProvider = resolveProviderFromProviderType(provider.providerType);
@@ -211,13 +405,8 @@ function providerEnvApiKey(provider: ByokProvider): string | undefined {
 export function defaultProviderApiKey(
   provider: ByokProvider,
 ): string | undefined {
-  if ("requiresApiKey" in provider && provider.requiresApiKey === false) {
-    return (
-      providerEnvApiKey(provider) ??
-      ("defaultApiKey" in provider
-        ? provider.defaultApiKey
-        : LOCAL_PROVIDER_NO_API_KEY)
-    );
+  if (provider.requiresApiKey === false) {
+    return providerEnvApiKey(provider) ?? provider.defaultApiKey;
   }
   return undefined;
 }
@@ -226,8 +415,20 @@ export function isLocalProviderStoreEnabled(): boolean {
   return getBackend().capabilities.localModelCatalog;
 }
 
-export function providerStorageTargetLabel(): string {
-  return isLocalProviderStoreEnabled() ? "local storage" : "Letta";
+export function defaultProviderStorageTarget(): ProviderStorageTarget {
+  return isLocalProviderStoreEnabled() ? "local" : "api";
+}
+
+function useLocalProviderStore(
+  target = defaultProviderStorageTarget(),
+): boolean {
+  return target === "local";
+}
+
+export function providerStorageTargetLabel(
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
+): string {
+  return target === "local" ? "local storage" : "Letta";
 }
 
 function assertLocalProviderSupported(providerType: string): void {
@@ -242,27 +443,31 @@ function assertLocalProviderSupported(providerType: string): void {
 // These are used by both the TUI ModelSelector and the WS list_models handler
 // to categorize model handles as BYOK vs Letta API.
 
-/** Prefixes that always indicate a BYOK handle (ChatGPT OAuth + lc-* providers) */
-export const STATIC_BYOK_PROVIDER_PREFIXES = ["chatgpt-plus-pro/", "lc-"];
+/** Prefixes that always indicate a BYOK handle (subscription aliases + lc-* providers) */
+export const STATIC_BYOK_PROVIDER_PREFIXES = [
+  "chatgpt-plus-pro/",
+  "openai-codex/",
+  "lc-",
+];
 
 export { PROVIDER_TYPE_TO_BASE_PROVIDER };
 
 /**
  * Build a mapping of BYOK provider names → base provider strings.
  *
- * Default aliases are derived from BYOK_PROVIDERS metadata so all built-in
- * providers are always covered. Connected providers (from API) are layered on
- * top to support custom provider names (e.g., "openai-sarah" → "openai").
+ * Default aliases are derived from both Constellation and local provider
+ * metadata so all built-in providers are covered. Connected providers are
+ * layered on top to support custom provider names.
  */
 export function buildByokProviderAliases(
   connectedProviders: Array<
     Pick<ProviderResponse, "name" | "provider_type">
   > = [],
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
 ): Record<string, string> {
   const aliases: Record<string, string> = {};
 
-  // Seed from built-in BYOK_PROVIDERS so every known provider has an alias
-  for (const bp of BYOK_PROVIDERS) {
+  for (const bp of getProviderConfigs(target)) {
     const base = PROVIDER_TYPE_TO_BASE_PROVIDER[bp.providerType];
     if (base) {
       aliases[bp.providerName] = base;
@@ -282,8 +487,8 @@ export function buildByokProviderAliases(
 
 /**
  * Check whether a model handle belongs to a BYOK provider.
- * Matches static prefixes (chatgpt-plus-pro/, lc-*) and any provider
- * name present in the alias map.
+ * Matches static prefixes (subscription aliases + lc-* providers) and any
+ * provider name present in the alias map.
  */
 export function isByokHandleForSelector(
   handle: string,
@@ -303,22 +508,24 @@ export function isByokHandleForSelector(
 }
 
 /**
- * List all BYOK providers for the current user
+ * List all BYOK providers for the target store.
  */
-export async function listProviders(): Promise<ProviderResponse[]> {
-  if (isLocalProviderStoreEnabled()) {
+export async function listProviders(
+  options: ProviderOperationOptions = {},
+): Promise<ProviderResponse[]> {
+  if (useLocalProviderStore(options.target)) {
     return listLocalProviders();
   }
   return listApiProviders();
 }
 
 /**
- * Get a map of connected providers by name
+ * Get a map of connected providers by name.
  */
-export async function getConnectedProviders(): Promise<
-  Map<string, ProviderResponse>
-> {
-  const providers = await listProviders();
+export async function getConnectedProviders(
+  options: ProviderOperationOptions = {},
+): Promise<Map<string, ProviderResponse>> {
+  const providers = await listProviders(options);
   const map = new Map<string, ProviderResponse>();
   for (const provider of providers) {
     map.set(provider.name, provider);
@@ -327,30 +534,32 @@ export async function getConnectedProviders(): Promise<
 }
 
 /**
- * Check if a specific BYOK provider is connected
+ * Check if a specific BYOK provider is connected.
  */
 export async function isProviderConnected(
   providerName: string,
+  options: ProviderOperationOptions = {},
 ): Promise<boolean> {
-  const providers = await listProviders();
+  const providers = await listProviders(options);
   return providers.some((p) => p.name === providerName);
 }
 
 /**
- * Get a provider by name
+ * Get a provider by name.
  */
 export async function getProviderByName(
   providerName: string,
+  options: ProviderOperationOptions = {},
 ): Promise<ProviderResponse | null> {
-  if (isLocalProviderStoreEnabled()) {
+  if (useLocalProviderStore(options.target)) {
     return getLocalProviderByName(providerName);
   }
   return getProviderByNameRequest(providerName);
 }
 
 /**
- * Validate an API key with the provider's check endpoint
- * Returns true if valid, throws error if invalid
+ * Validate an API key with the provider's check endpoint.
+ * Returns true if valid, throws error if invalid.
  */
 export async function checkProviderApiKey(
   providerType: string,
@@ -358,8 +567,9 @@ export async function checkProviderApiKey(
   accessKey?: string,
   region?: string,
   profile?: string,
+  options: ProviderOperationOptions = {},
 ): Promise<void> {
-  if (isLocalProviderStoreEnabled()) {
+  if (useLocalProviderStore(options.target)) {
     assertLocalProviderSupported(providerType);
     return;
   }
@@ -373,7 +583,7 @@ export async function checkProviderApiKey(
 }
 
 /**
- * Create a new BYOK provider
+ * Create a new BYOK provider.
  */
 export async function createProvider(
   providerType: string,
@@ -383,8 +593,9 @@ export async function createProvider(
   region?: string,
   profile?: string,
   options: ProviderConnectionOptions = {},
+  operationOptions: ProviderOperationOptions = {},
 ): Promise<ProviderResponse> {
-  if (isLocalProviderStoreEnabled()) {
+  if (useLocalProviderStore(operationOptions.target)) {
     return createOrUpdateLocalProvider({
       providerType,
       providerName,
@@ -407,7 +618,7 @@ export async function createProvider(
 }
 
 /**
- * Update an existing provider's API key
+ * Update an existing provider's API key.
  */
 export async function updateProvider(
   providerId: string,
@@ -415,16 +626,19 @@ export async function updateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  storageDirOrOptions?: string | ProviderOperationOptions,
   options: ProviderConnectionOptions = {},
 ): Promise<ProviderResponse> {
-  if (isLocalProviderStoreEnabled()) {
+  const operationOptions =
+    typeof storageDirOrOptions === "object" ? storageDirOrOptions : {};
+  if (useLocalProviderStore(operationOptions.target)) {
     return updateLocalProvider(
       providerId,
       apiKey,
       accessKey,
       region,
       profile,
-      undefined,
+      typeof storageDirOrOptions === "string" ? storageDirOrOptions : undefined,
       options,
     );
   }
@@ -432,10 +646,13 @@ export async function updateProvider(
 }
 
 /**
- * Delete a provider by ID
+ * Delete a provider by ID.
  */
-export async function deleteProvider(providerId: string): Promise<void> {
-  if (isLocalProviderStoreEnabled()) {
+export async function deleteProvider(
+  providerId: string,
+  options: ProviderOperationOptions = {},
+): Promise<void> {
+  if (useLocalProviderStore(options.target)) {
     await deleteLocalProvider(providerId);
     return;
   }
@@ -443,8 +660,8 @@ export async function deleteProvider(providerId: string): Promise<void> {
 }
 
 /**
- * Create or update a BYOK provider
- * If provider exists, updates the API key; otherwise creates new
+ * Create or update a BYOK provider.
+ * If provider exists, updates the API key; otherwise creates new.
  */
 export async function createOrUpdateProvider(
   providerType: string,
@@ -454,8 +671,9 @@ export async function createOrUpdateProvider(
   region?: string,
   profile?: string,
   options: ProviderConnectionOptions = {},
+  operationOptions: ProviderOperationOptions = {},
 ): Promise<ProviderResponse> {
-  if (isLocalProviderStoreEnabled()) {
+  if (useLocalProviderStore(operationOptions.target)) {
     return createOrUpdateLocalProvider({
       providerType,
       providerName,
@@ -478,12 +696,13 @@ export async function createOrUpdateProvider(
 }
 
 /**
- * Remove a provider by name
+ * Remove a provider by name.
  */
 export async function removeProviderByName(
   providerName: string,
+  options: ProviderOperationOptions = {},
 ): Promise<void> {
-  if (isLocalProviderStoreEnabled()) {
+  if (useLocalProviderStore(options.target)) {
     await removeLocalProviderByName(providerName);
     return;
   }
@@ -491,10 +710,11 @@ export async function removeProviderByName(
 }
 
 /**
- * Get provider config by ID
+ * Get provider config by ID for a target.
  */
 export function getProviderConfig(
   id: ByokProviderId,
+  target: ProviderStorageTarget = defaultProviderStorageTarget(),
 ): ByokProvider | undefined {
-  return BYOK_PROVIDERS.find((p) => p.id === id);
+  return getProviderConfigs(target).find((p) => p.id === id);
 }

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -73,6 +73,7 @@ export interface ByokProvider {
   providerName: string;
   providerNames?: readonly string[];
   isOAuth?: boolean;
+  oauthProviderId?: string;
   requiresApiKey?: boolean;
   defaultApiKey?: string;
   fields?: ProviderField[];
@@ -308,35 +309,53 @@ function byokProviderFromPiSpec(provider: string): ByokProvider | undefined {
   };
 }
 
-function localOAuthProviderConfigs(): ByokProvider[] {
-  return getOAuthProviders()
-    .filter((provider) => provider.id === "openai-codex")
-    .map((provider) => {
-      const spec = PI_PROVIDER_SPECS.find(
-        (candidate) => candidate.piProvider === provider.id,
-      );
-      return {
-        id: `${provider.id}-oauth`,
-        displayName: provider.name,
-        description: "Connect a subscription account",
-        providerType:
-          provider.id === "openai-codex"
-            ? "chatgpt_oauth"
-            : (spec?.providerTypes[0] ?? provider.id),
-        providerName:
-          provider.id === "openai-codex"
-            ? "chatgpt-plus-pro"
-            : (spec?.localProviderNames[0] ?? provider.id),
-        providerNames:
-          provider.id === "openai-codex"
-            ? ["chatgpt-plus-pro", "openai-codex"]
-            : spec?.localProviderNames,
-        isOAuth: true,
-      };
-    });
+// Pi TUI exposes Anthropic in both subscription and API-key login flows.
+// Other OAuth providers are subscription-only in the Pi TUI.
+const PI_TUI_API_KEY_OAUTH_PROVIDER_IDS = new Set(["anthropic"]);
+
+function localOAuthConfigId(providerId: string): string {
+  if (providerId === "openai-codex") return "openai-codex-oauth";
+  if (PI_TUI_API_KEY_OAUTH_PROVIDER_IDS.has(providerId)) {
+    return `${providerId}-oauth`;
+  }
+  return providerId;
 }
 
-const API_KEY_PROVIDER_EXCLUSIONS = new Set(["openai-codex"]);
+function localOAuthProviderConfigs(): ByokProvider[] {
+  return getOAuthProviders().map((provider) => {
+    const spec = PI_PROVIDER_SPECS.find(
+      (candidate) => candidate.piProvider === provider.id,
+    );
+    const providerName =
+      provider.id === "openai-codex"
+        ? "chatgpt-plus-pro"
+        : (spec?.localProviderNames[0] ?? provider.id);
+    return {
+      id: localOAuthConfigId(provider.id),
+      displayName: provider.name,
+      description: "Connect a subscription account",
+      providerType: spec?.providerTypes[0] ?? provider.id,
+      providerName,
+      providerNames:
+        provider.id === "openai-codex"
+          ? [providerName, "openai-codex"]
+          : spec?.localProviderNames,
+      isOAuth: true,
+      oauthProviderId: provider.id,
+    };
+  });
+}
+
+function localApiKeyProviderIds(): string[] {
+  const oauthProviderIds = new Set(
+    getOAuthProviders().map((provider) => provider.id),
+  );
+  return getProviders().filter(
+    (provider) =>
+      !oauthProviderIds.has(provider) ||
+      PI_TUI_API_KEY_OAUTH_PROVIDER_IDS.has(provider),
+  );
+}
 
 export function getProviderConfigs(
   target: ProviderStorageTarget = defaultProviderStorageTarget(),
@@ -347,8 +366,7 @@ export function getProviderConfigs(
   for (const provider of localOAuthProviderConfigs()) {
     byId.set(provider.id, provider);
   }
-  for (const provider of getProviders()) {
-    if (API_KEY_PROVIDER_EXCLUSIONS.has(provider)) continue;
+  for (const provider of localApiKeyProviderIds()) {
     const config = byokProviderFromPiSpec(provider);
     if (config) byId.set(config.id, config);
   }

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -181,40 +181,6 @@ export const CONSTELLATION_BYOK_PROVIDERS: readonly ByokProvider[] = [
     providerName: "lc-openrouter",
   },
   {
-    id: "ollama",
-    displayName: "Ollama (local)",
-    description: "Connect local Ollama at http://localhost:11434/v1",
-    providerType: "ollama",
-    providerName: "lc-ollama",
-    requiresApiKey: false,
-    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
-  },
-  {
-    id: "ollama-cloud",
-    displayName: "Ollama Cloud",
-    description: "Connect an Ollama Cloud API key",
-    providerType: "ollama_cloud",
-    providerName: "lc-ollama-cloud",
-  },
-  {
-    id: "lmstudio",
-    displayName: "LM Studio (local)",
-    description: "Connect local LM Studio at http://127.0.0.1:1234/v1",
-    providerType: LMSTUDIO_OPENAI_PROVIDER_TYPE,
-    providerName: "lc-lmstudio",
-    requiresApiKey: false,
-    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
-  },
-  {
-    id: "llama-cpp",
-    displayName: "llama.cpp (local)",
-    description: "Connect local llama.cpp at http://localhost:8080/v1",
-    providerType: "llama_cpp",
-    providerName: "lc-llama-cpp",
-    requiresApiKey: false,
-    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
-  },
-  {
     id: "bedrock",
     displayName: "AWS Bedrock",
     description: "Connect to Claude on Amazon Bedrock",
@@ -470,7 +436,12 @@ export function buildByokProviderAliases(
   for (const bp of getProviderConfigs(target)) {
     const base = PROVIDER_TYPE_TO_BASE_PROVIDER[bp.providerType];
     if (base) {
-      aliases[bp.providerName] = base;
+      for (const providerName of [
+        bp.providerName,
+        ...(bp.providerNames ?? []),
+      ]) {
+        aliases[providerName] = base;
+      }
     }
   }
 

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getProviders } from "@earendil-works/pi-ai";
+import { resolveProviderFromProviderType } from "@/backend/dev/pi-provider-registry";
+import { listLocalModels } from "@/backend/local/local-model-config";
+import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+import { getProviderConfigs } from "@/providers/byok-providers";
+
+describe("local pi provider catalog", () => {
+  test("local /connect configs cover every upstream pi-ai provider", () => {
+    const coveredProviders = new Set(
+      getProviderConfigs("local")
+        .map((provider) =>
+          resolveProviderFromProviderType(provider.providerType),
+        )
+        .filter((provider) => provider !== undefined),
+    );
+
+    for (const provider of getProviders()) {
+      expect(coveredProviders.has(provider)).toBe(true);
+    }
+  });
+
+  test("local model listing uses the upstream pi-ai catalog for generic providers", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-pi-provider-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "deepseek",
+        providerName: "deepseek",
+        apiKey: "deepseek-key",
+      });
+
+      const handles = (await listLocalModels(storageDir)).map(
+        (model) => model.handle,
+      );
+
+      expect(handles).toContain("deepseek/deepseek-v4-flash");
+      expect(handles).toContain("deepseek/deepseek-v4-pro");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getProviders } from "@earendil-works/pi-ai";
-import { resolveProviderFromProviderType } from "@/backend/dev/pi-provider-registry";
+import { getModels, getProviders } from "@earendil-works/pi-ai";
+import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import {
+  PI_PROVIDER_SPECS,
+  resolveProviderFromProviderType,
+} from "@/backend/dev/pi-provider-registry";
 import { listLocalModels } from "@/backend/local/local-model-config";
 import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
 import { getProviderConfigs } from "@/providers/byok-providers";
@@ -32,6 +36,40 @@ describe("local pi provider catalog", () => {
     for (const provider of getProviders()) {
       expect(coveredProviders.has(provider)).toBe(true);
     }
+  });
+
+  test("local /connect configs cover every upstream pi-ai OAuth provider", () => {
+    const localOAuthProviderIds = new Set(
+      getProviderConfigs("local")
+        .filter((provider) => provider.isOAuth)
+        .map((provider) => provider.oauthProviderId),
+    );
+
+    for (const provider of getOAuthProviders()) {
+      expect(localOAuthProviderIds.has(provider.id)).toBe(true);
+    }
+  });
+
+  test("local provider defaults point at current pi-ai catalog models", () => {
+    for (const spec of PI_PROVIDER_SPECS) {
+      if (!spec.piProvider) continue;
+      const modelId = spec.defaultModel.split("/").slice(1).join("/");
+      expect(
+        getModels(spec.piProvider).some((model) => model.id === modelId),
+      ).toBe(true);
+    }
+  });
+
+  test("local /connect API-key providers mirror Pi TUI OAuth split", () => {
+    const localApiKeyProviderIds = new Set(
+      getProviderConfigs("local")
+        .filter((provider) => !provider.isOAuth)
+        .map((provider) => provider.id),
+    );
+
+    expect(localApiKeyProviderIds.has("anthropic")).toBe(true);
+    expect(localApiKeyProviderIds.has("openai-codex")).toBe(false);
+    expect(localApiKeyProviderIds.has("github-copilot")).toBe(false);
   });
 
   test("local model listing uses the upstream pi-ai catalog for generic providers", async () => {

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -9,6 +9,17 @@ import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth
 import { getProviderConfigs } from "@/providers/byok-providers";
 
 describe("local pi provider catalog", () => {
+  test("Constellation /connect configs exclude local-only providers", () => {
+    const apiProviderIds = new Set(
+      getProviderConfigs("api").map((provider) => provider.id),
+    );
+
+    expect(apiProviderIds.has("ollama")).toBe(false);
+    expect(apiProviderIds.has("ollama-cloud")).toBe(false);
+    expect(apiProviderIds.has("lmstudio")).toBe(false);
+    expect(apiProviderIds.has("llama-cpp")).toBe(false);
+  });
+
   test("local /connect configs cover every upstream pi-ai provider", () => {
     const coveredProviders = new Set(
       getProviderConfigs("local")

--- a/src/providers/openai-codex-provider.ts
+++ b/src/providers/openai-codex-provider.ts
@@ -10,6 +10,7 @@ import {
   deleteProvider,
   getProviderByName,
   listProviders,
+  type ProviderOperationOptions,
   type ProviderResponse,
   updateProvider,
 } from "./byok-providers";
@@ -52,8 +53,10 @@ function encodeOAuthConfig(config: ChatGPTOAuthConfig): string {
 /**
  * Get the chatgpt-plus-pro provider if it exists
  */
-export async function getOpenAICodexProvider(): Promise<ProviderResponse | null> {
-  return getProviderByName(OPENAI_CODEX_PROVIDER_NAME);
+export async function getOpenAICodexProvider(
+  options: ProviderOperationOptions = {},
+): Promise<ProviderResponse | null> {
+  return getProviderByName(OPENAI_CODEX_PROVIDER_NAME, options);
 }
 
 /**
@@ -62,11 +65,17 @@ export async function getOpenAICodexProvider(): Promise<ProviderResponse | null>
  */
 export async function createOpenAICodexProvider(
   config: ChatGPTOAuthConfig,
+  options: ProviderOperationOptions = {},
 ): Promise<ProviderResponse> {
   return createProvider(
     CHATGPT_OAUTH_PROVIDER_TYPE,
     OPENAI_CODEX_PROVIDER_NAME,
     encodeOAuthConfig(config),
+    undefined,
+    undefined,
+    undefined,
+    {},
+    options,
   );
 }
 
@@ -77,8 +86,16 @@ export async function createOpenAICodexProvider(
 export async function updateOpenAICodexProvider(
   providerId: string,
   config: ChatGPTOAuthConfig,
+  options: ProviderOperationOptions = {},
 ): Promise<ProviderResponse> {
-  return updateProvider(providerId, encodeOAuthConfig(config));
+  return updateProvider(
+    providerId,
+    encodeOAuthConfig(config),
+    undefined,
+    undefined,
+    undefined,
+    options,
+  );
 }
 
 /**
@@ -86,8 +103,9 @@ export async function updateOpenAICodexProvider(
  */
 export async function deleteOpenAICodexProvider(
   providerId: string,
+  options: ProviderOperationOptions = {},
 ): Promise<void> {
-  await deleteProvider(providerId);
+  await deleteProvider(providerId, options);
 }
 
 /**
@@ -103,23 +121,26 @@ export async function deleteOpenAICodexProvider(
  */
 export async function createOrUpdateOpenAICodexProvider(
   config: ChatGPTOAuthConfig,
+  options: ProviderOperationOptions = {},
 ): Promise<ProviderResponse> {
-  const existing = await getOpenAICodexProvider();
+  const existing = await getOpenAICodexProvider(options);
 
   if (existing) {
-    return updateOpenAICodexProvider(existing.id, config);
+    return updateOpenAICodexProvider(existing.id, config, options);
   }
 
-  return createOpenAICodexProvider(config);
+  return createOpenAICodexProvider(config, options);
 }
 
 /**
  * Remove the ChatGPT OAuth provider (called on /disconnect)
  */
-export async function removeOpenAICodexProvider(): Promise<void> {
-  const existing = await getOpenAICodexProvider();
+export async function removeOpenAICodexProvider(
+  options: ProviderOperationOptions = {},
+): Promise<void> {
+  const existing = await getOpenAICodexProvider(options);
   if (existing) {
-    await deleteOpenAICodexProvider(existing.id);
+    await deleteOpenAICodexProvider(existing.id, options);
   }
 }
 

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { providerApiKeyFromInput } from "@/cli/components/ProviderSelector";
 import {
-  BYOK_PROVIDERS,
   type ByokProvider,
   defaultProviderApiKey,
+  getProviderConfigs,
 } from "@/providers/byok-providers";
 
 function withEnv<T>(
@@ -34,7 +34,9 @@ function withEnv<T>(
 }
 
 function providerById(id: string): ByokProvider {
-  const provider = BYOK_PROVIDERS.find((candidate) => candidate.id === id);
+  const provider = getProviderConfigs("local").find(
+    (candidate) => candidate.id === id,
+  );
   if (!provider) {
     throw new Error(`Expected provider ${id} to exist`);
   }
@@ -45,7 +47,7 @@ describe("ProviderSelector local provider API keys", () => {
   test("keeps LM Studio UI identity while using server provider type", () => {
     const lmstudio = providerById("lmstudio");
 
-    expect(lmstudio.providerName).toBe("lc-lmstudio");
+    expect(lmstudio.providerNames).toContain("lc-lmstudio");
     expect(lmstudio.providerType).toBe("lmstudio_openai");
   });
 

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -3,7 +3,7 @@ import {
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
   providerApiKeyFromInput,
-  shouldShowConstellationLoginPrompt,
+  shouldShowProviderStoreTabs,
 } from "@/cli/components/ProviderSelector";
 import {
   type ByokProvider,
@@ -113,15 +113,15 @@ describe("ProviderSelector local provider API keys", () => {
 });
 
 describe("ProviderSelector Constellation auth gating", () => {
-  test("requires Constellation credentials before showing API provider rows", () => {
+  test("requires Constellation credentials before showing provider-store tabs", () => {
     const loggedOut = hasConstellationProviderStoreCredentials(
       { env: {}, refreshToken: undefined },
       {},
     );
 
     expect(loggedOut).toBe(false);
-    expect(shouldShowConstellationLoginPrompt("api", loggedOut)).toBe(true);
-    expect(shouldShowConstellationLoginPrompt("local", loggedOut)).toBe(false);
+    expect(shouldShowProviderStoreTabs(loggedOut)).toBe(false);
+    expect(shouldShowProviderStoreTabs(null)).toBe(false);
   });
 
   test("accepts env, stored API key, or refresh token as Constellation auth", () => {
@@ -143,6 +143,7 @@ describe("ProviderSelector Constellation auth gating", () => {
         {},
       ),
     ).toBe(true);
+    expect(shouldShowProviderStoreTabs(true)).toBe(true);
   });
 });
 

--- a/src/tests/cli/provider-selector-local-provider.test.ts
+++ b/src/tests/cli/provider-selector-local-provider.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { providerApiKeyFromInput } from "@/cli/components/ProviderSelector";
+import {
+  filterProviderConfigs,
+  hasConstellationProviderStoreCredentials,
+  providerApiKeyFromInput,
+  shouldShowConstellationLoginPrompt,
+} from "@/cli/components/ProviderSelector";
 import {
   type ByokProvider,
   defaultProviderApiKey,
@@ -103,6 +108,64 @@ describe("ProviderSelector local provider API keys", () => {
   test("uses explicitly typed keys over local provider defaults", () => {
     expect(providerApiKeyFromInput(providerById("lmstudio"), " lm-key ")).toBe(
       "lm-key",
+    );
+  });
+});
+
+describe("ProviderSelector Constellation auth gating", () => {
+  test("requires Constellation credentials before showing API provider rows", () => {
+    const loggedOut = hasConstellationProviderStoreCredentials(
+      { env: {}, refreshToken: undefined },
+      {},
+    );
+
+    expect(loggedOut).toBe(false);
+    expect(shouldShowConstellationLoginPrompt("api", loggedOut)).toBe(true);
+    expect(shouldShowConstellationLoginPrompt("local", loggedOut)).toBe(false);
+  });
+
+  test("accepts env, stored API key, or refresh token as Constellation auth", () => {
+    expect(
+      hasConstellationProviderStoreCredentials(
+        { env: {}, refreshToken: undefined },
+        { LETTA_API_KEY: "env-key" },
+      ),
+    ).toBe(true);
+    expect(
+      hasConstellationProviderStoreCredentials(
+        { env: { LETTA_API_KEY: "stored-key" }, refreshToken: undefined },
+        {},
+      ),
+    ).toBe(true);
+    expect(
+      hasConstellationProviderStoreCredentials(
+        { env: {}, refreshToken: "refresh-token" },
+        {},
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("ProviderSelector provider filtering", () => {
+  test("matches local providers by display name and description", () => {
+    const providers = getProviderConfigs("local");
+
+    expect(
+      filterProviderConfigs(providers, "copilot").map((p) => p.id),
+    ).toEqual(["github-copilot"]);
+    expect(
+      filterProviderConfigs(providers, "subscription").map((p) => p.id),
+    ).toEqual(["anthropic-oauth", "openai-codex-oauth", "github-copilot"]);
+  });
+
+  test("matches provider aliases and restores all providers for blank query", () => {
+    const providers = getProviderConfigs("local");
+
+    expect(
+      filterProviderConfigs(providers, "lc-lmstudio").map((p) => p.id),
+    ).toEqual(["lmstudio"]);
+    expect(filterProviderConfigs(providers, "   ").length).toBe(
+      providers.length,
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add Local / Constellation tabs to `/connect` so unified TUI sessions choose the provider store explicitly.
- Generate the Local provider list from upstream `pi-ai` providers, while keeping compatibility aliases and non-Pi local endpoints.
- Update local model/provider resolution so generic Pi providers are usable and add guardrail coverage that every upstream Pi provider appears in Local `/connect`.

## Test plan
- [x] `bun test src/providers/local-pi-provider-catalog.test.ts src/backend/local-backend.test.ts src/backend/pi-model-factory.test.ts`
- [x] `bun test src/cli/connect-normalize.test.ts src/providers/byok-provider-aliases.test.ts src/tests/cli/provider-selector-local-provider.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)