### PR TITLE
feat(hooks): allow hooks to rewrite tool input

### DIFF
--- a/src/hooks/executor.ts
+++ b/src/hooks/executor.ts
@@ -354,6 +354,7 @@ export async function executeHooks(
   const feedback: string[] = [];
   let blocked = false;
   let errored = false;
+  let updatedInput: Record<string, unknown> | undefined;
 
   for (const hook of hooks) {
     const result = await executeHookCommand(hook, input, workingDirectory);
@@ -362,12 +363,30 @@ export async function executeHooks(
     // Collect feedback from stdout when hook succeeds (exit 0)
     // Only for UserPromptSubmit and SessionStart hooks
     if (result.exitCode === HookExitCode.ALLOW) {
-      if (
-        result.stdout?.trim() &&
-        (input.event_type === "UserPromptSubmit" ||
-          input.event_type === "SessionStart")
-      ) {
-        feedback.push(result.stdout.trim());
+      if (result.stdout?.trim()) {
+        // Try to parse updatedInput from hook output (PreToolUse rewrite protocol)
+        if (input.event_type === "PreToolUse" && !updatedInput) {
+          try {
+            const json = JSON.parse(result.stdout.trim());
+            const rewritten = json?.hookSpecificOutput?.updatedInput;
+            if (
+              rewritten &&
+              typeof rewritten === "object" &&
+              !Array.isArray(rewritten)
+            ) {
+              updatedInput = rewritten as Record<string, unknown>;
+            }
+          } catch {
+            // Not JSON or no updatedInput — ignore
+          }
+        }
+
+        if (
+          input.event_type === "UserPromptSubmit" ||
+          input.event_type === "SessionStart"
+        ) {
+          feedback.push(result.stdout.trim());
+        }
       }
       continue;
     }
@@ -398,6 +417,7 @@ export async function executeHooks(
     errored,
     feedback,
     results,
+    ...(updatedInput && { updatedInput }),
   };
 }
 

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -216,6 +216,8 @@ export interface HookExecutionResult {
   feedback: string[];
   /** Individual results from each hook */
   results: HookResult[];
+  /** Rewritten tool input from a hook (PreToolUse updatedInput protocol) */
+  updatedInput?: Record<string, unknown>;
 }
 
 // ============================================================================

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2171,6 +2171,14 @@ export async function executeTool(
       };
     }
 
+    // Apply rewritten tool input from PreToolUse hooks (e.g. rtk command rewrite)
+    if (preHookResult.updatedInput) {
+      args = {
+        ...(args as Record<string, unknown>),
+        ...preHookResult.updatedInput,
+      };
+    }
+
     try {
       // Inject options for tools that support them without altering schemas
       let enhancedArgs = args;


### PR DESCRIPTION
Allows usage of scripts that rewrite tool calls like [rtk's](https://github.com/rtk-ai/rtk) [rtk-rewrite.sh](https://github.com/rtk-ai/rtk/blob/develop/hooks/claude/rtk-rewrite.sh) in PreToolUse hooks.