### PR TITLE
feat(extensions): add extension slash commands and busy-safe panels

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3770,6 +3770,7 @@ export function App({
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
+    extensionRuntime,
     firstUserQueryRef,
     flushPendingReasoningEffort: () => flushPendingReasoningEffort(),
     generateConversationTitle,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -42,6 +42,17 @@ import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
+import {
+  buildExtensionCommandPrompt,
+  parseExtensionCommandArgv,
+  parseExtensionSlashCommand,
+  runExtensionCommandWithTimeout,
+} from "@/cli/extensions/command-runtime";
+import type {
+  ExtensionCommand,
+  ExtensionCommandContext,
+} from "@/cli/extensions/types";
+import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import {
@@ -186,6 +197,7 @@ type SubmitHandlerContext = {
   currentModelProvider: string | null;
   effectiveContextWindowSize: number | undefined;
   emittedIdsRef: MutableRefObject<Set<string>>;
+  extensionRuntime: LocalExtensionRuntime;
   firstUserQueryRef: MutableRefObject<string | null>;
   flushPendingReasoningEffort: () => Promise<void>;
   generateConversationTitle: () => Promise<string | null>;
@@ -324,6 +336,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
+    extensionRuntime,
     firstUserQueryRef,
     flushPendingReasoningEffort,
     generateConversationTitle,
@@ -693,6 +706,14 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               "Reloading settings and restarting TUI effects...",
             );
             cmd.finish("Reloading...", true);
+            try {
+              const { refreshCustomCommands } = await import(
+                "@/cli/commands/custom.js"
+              );
+              refreshCustomCommands();
+            } catch {
+              // Best-effort: the TUI reload below will still refresh extension state.
+            }
             // Defer the reload to let the command UI render first
             setTimeout(
               () =>
@@ -2960,6 +2981,82 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
         // === END custom command handling ===
+
+        const parsedExtensionCommand = parseExtensionSlashCommand(trimmed);
+        const matchedExtensionCommand: ExtensionCommand | undefined =
+          parsedExtensionCommand
+            ? extensionRuntime.registry?.commands[
+                parsedExtensionCommand.command
+              ]
+            : undefined;
+
+        if (parsedExtensionCommand && matchedExtensionCommand) {
+          const cmd = commandRunner.start(
+            trimmed,
+            `Running /${matchedExtensionCommand.id}...`,
+          );
+          setCommandRunning(true);
+
+          try {
+            const extensionContext = extensionRuntime.getContext();
+            const commandContext: ExtensionCommandContext = {
+              agent: { id: agentId, name: agentName },
+              args: parsedExtensionCommand.args,
+              argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
+              command: parsedExtensionCommand.command,
+              conversation: { id: conversationIdRef.current },
+              cwd: getCurrentWorkingDirectory(),
+              getContext: extensionRuntime.getContext,
+              model: {
+                id:
+                  currentModelId ??
+                  llmConfigRef.current?.model ??
+                  extensionContext.model.id,
+                displayName: extensionContext.model.displayName,
+              },
+              permissionMode: extensionContext.permissionMode,
+              rawInput: trimmed,
+            };
+            const result = await runExtensionCommandWithTimeout(
+              matchedExtensionCommand,
+              commandContext,
+            );
+
+            if (result.type === "prompt") {
+              const approvalCheck =
+                await checkPendingApprovalsForSlashCommand();
+              if (approvalCheck.blocked) {
+                cmd.fail(
+                  `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
+                );
+                return { submitted: false };
+              }
+
+              cmd.finish(`Running /${matchedExtensionCommand.id}...`, true);
+              await processConversationWithQueuedApprovals([
+                {
+                  type: "message",
+                  role: "user",
+                  content: buildTextParts(buildExtensionCommandPrompt(result)),
+                  otid: randomUUID(),
+                },
+              ]);
+            } else if (result.type === "output") {
+              cmd.finish(result.output, result.success ?? true);
+            } else {
+              cmd.finish("Handled.", true, true);
+            }
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(
+              `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
+            );
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
 
         // Check if this is a known command before treating it as a slash command
         const { commands, executeCommand } = await import(

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -167,6 +167,11 @@ type ModelSelectorOptions = {
   forceRefresh?: boolean;
 };
 
+async function hasCustomCommand(commandName: string): Promise<boolean> {
+  const { findCustomCommand } = await import("@/cli/commands/custom.js");
+  return Boolean(await findCustomCommand(commandName));
+}
+
 type SubmitHandlerContext = {
   abortControllerRef: MutableRefObject<AbortController | null>;
   agentDescription: string | null;
@@ -565,13 +570,18 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       const queueBypassExtensionCommand = parsedExtensionCommand
         ? extensionRuntime.registry?.commands[parsedExtensionCommand.command]
         : undefined;
+      const isExtensionCommandShadowedByCustom =
+        isAgentBusy() && queueBypassExtensionCommand?.runWhenBusy === true
+          ? await hasCustomCommand(parsedExtensionCommand?.command ?? "")
+          : false;
       // Interactive/non-state slash commands bypass queueing so menus stay responsive
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
         (isInteractiveCommand(userTextForInput) ||
           isNonStateCommand(userTextForInput) ||
-          queueBypassExtensionCommand?.runWhenBusy === true);
+          (queueBypassExtensionCommand?.runWhenBusy === true &&
+            !isExtensionCommandShadowedByCustom));
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
@@ -3045,6 +3055,13 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
 
             if (result.type === "prompt") {
+              if (!showInTranscript) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt with showInTranscript: false. Hidden extension commands must return output or handled and own their UI.`,
+                );
+                return { submitted: true };
+              }
+
               if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
                 getFeedbackCommand().fail(
                   `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
@@ -3071,7 +3088,10 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 },
               ]);
             } else if (result.type === "output") {
-              cmd?.finish(result.output, result.success ?? true);
+              getFeedbackCommand().finish(
+                result.output,
+                result.success ?? true,
+              );
             } else {
               cmd?.finish("Handled.", true, true);
             }

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -559,12 +559,19 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       }
 
       const isSlashCommand = userTextForInput.startsWith("/");
+      const parsedExtensionCommand = isSlashCommand
+        ? parseExtensionSlashCommand(userTextForInput.trim())
+        : null;
+      const queueBypassExtensionCommand = parsedExtensionCommand
+        ? extensionRuntime.registry?.commands[parsedExtensionCommand.command]
+        : undefined;
       // Interactive/non-state slash commands bypass queueing so menus stay responsive
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
         (isInteractiveCommand(userTextForInput) ||
-          isNonStateCommand(userTextForInput));
+          isNonStateCommand(userTextForInput) ||
+          queueBypassExtensionCommand?.runWhenBusy === true);
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
@@ -711,8 +718,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 "@/cli/commands/custom.js"
               );
               refreshCustomCommands();
-            } catch {
-              // Best-effort: the TUI reload below will still refresh extension state.
+            } catch (error) {
+              debugLog(
+                "commands",
+                "refreshCustomCommands failed during /reload: %s",
+                error instanceof Error ? error.message : String(error),
+              );
             }
             // Defer the reload to let the command UI render first
             setTimeout(
@@ -2982,7 +2993,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         }
         // === END custom command handling ===
 
-        const parsedExtensionCommand = parseExtensionSlashCommand(trimmed);
         const matchedExtensionCommand: ExtensionCommand | undefined =
           parsedExtensionCommand
             ? extensionRuntime.registry?.commands[
@@ -2991,11 +3001,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             : undefined;
 
         if (parsedExtensionCommand && matchedExtensionCommand) {
-          const cmd = commandRunner.start(
-            trimmed,
-            `Running /${matchedExtensionCommand.id}...`,
-          );
-          setCommandRunning(true);
+          const showInTranscript = matchedExtensionCommand.showInTranscript;
+          const shouldLockCommand = !matchedExtensionCommand.runWhenBusy;
+          const cmd = showInTranscript
+            ? commandRunner.start(
+                trimmed,
+                `Running /${matchedExtensionCommand.id}...`,
+              )
+            : null;
+          const getFeedbackCommand = () =>
+            cmd ??
+            commandRunner.start(
+              trimmed,
+              `Running /${matchedExtensionCommand.id}...`,
+            );
+          if (shouldLockCommand) {
+            setCommandRunning(true);
+          }
 
           try {
             const extensionContext = extensionRuntime.getContext();
@@ -3023,16 +3045,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             );
 
             if (result.type === "prompt") {
+              if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
+                );
+                return { submitted: true };
+              }
+
               const approvalCheck =
                 await checkPendingApprovalsForSlashCommand();
               if (approvalCheck.blocked) {
-                cmd.fail(
+                getFeedbackCommand().fail(
                   `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
                 );
                 return { submitted: false };
               }
 
-              cmd.finish(`Running /${matchedExtensionCommand.id}...`, true);
+              cmd?.finish(`Running /${matchedExtensionCommand.id}...`, true);
               await processConversationWithQueuedApprovals([
                 {
                   type: "message",
@@ -3042,17 +3071,19 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 },
               ]);
             } else if (result.type === "output") {
-              cmd.finish(result.output, result.success ?? true);
+              cmd?.finish(result.output, result.success ?? true);
             } else {
-              cmd.finish("Handled.", true, true);
+              cmd?.finish("Handled.", true, true);
             }
           } catch (error) {
             const errorDetails = formatErrorDetails(error, agentId);
-            cmd.fail(
+            getFeedbackCommand().fail(
               `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
             );
           } finally {
-            setCommandRunning(false);
+            if (shouldLockCommand) {
+              setCommandRunning(false);
+            }
           }
 
           return { submitted: true };
@@ -3520,6 +3551,7 @@ ${SYSTEM_REMINDER_CLOSE}
       conversationId,
       currentModelHandle,
       currentModelId,
+      extensionRuntime,
       effectiveContextWindowSize,
       commandRunner,
       handleExit,

--- a/src/cli/components/ExtensionPanelRow.tsx
+++ b/src/cli/components/ExtensionPanelRow.tsx
@@ -1,0 +1,35 @@
+import { Box } from "ink";
+import type { ExtensionPanel } from "@/cli/extensions/types";
+import { truncateText } from "@/cli/helpers/truncate-text";
+import { Text } from "./Text";
+
+function visiblePanels(
+  panels: Record<string, ExtensionPanel>,
+): ExtensionPanel[] {
+  return Object.values(panels).sort(
+    (a, b) => b.order - a.order || b.updatedAt - a.updatedAt,
+  );
+}
+
+export function ExtensionPanelRow({
+  panels,
+  terminalWidth,
+}: {
+  panels?: Record<string, ExtensionPanel>;
+  terminalWidth: number;
+}) {
+  const rowWidth = Math.max(0, terminalWidth - 1);
+  if (rowWidth === 0) return null;
+
+  const lines = visiblePanels(panels ?? {}).flatMap((panel) => panel.content);
+  if (lines.length === 0) return null;
+
+  return (
+    <Box width={rowWidth} flexDirection="column">
+      {lines.map((line, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: panel content is caller-owned text
+        <Text key={index}>{truncateText(line || " ", rowWidth)}</Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/cli/components/ExtensionPanelRow.tsx
+++ b/src/cli/components/ExtensionPanelRow.tsx
@@ -3,11 +3,13 @@ import type { ExtensionPanel } from "@/cli/extensions/types";
 import { truncateText } from "@/cli/helpers/truncate-text";
 import { Text } from "./Text";
 
+const MAX_EXTENSION_PANEL_LINES = 8;
+
 function visiblePanels(
   panels: Record<string, ExtensionPanel>,
 ): ExtensionPanel[] {
   return Object.values(panels).sort(
-    (a, b) => b.order - a.order || b.updatedAt - a.updatedAt,
+    (a, b) => a.order - b.order || b.updatedAt - a.updatedAt,
   );
 }
 
@@ -21,7 +23,9 @@ export function ExtensionPanelRow({
   const rowWidth = Math.max(0, terminalWidth - 1);
   if (rowWidth === 0) return null;
 
-  const lines = visiblePanels(panels ?? {}).flatMap((panel) => panel.content);
+  const lines = visiblePanels(panels ?? {})
+    .flatMap((panel) => panel.content)
+    .slice(0, MAX_EXTENSION_PANEL_LINES);
   if (lines.length === 0) return null;
 
   return (

--- a/src/cli/components/InputAssist.tsx
+++ b/src/cli/components/InputAssist.tsx
@@ -1,6 +1,7 @@
 import { Box } from "ink";
 import { useEffect } from "react";
 import type { ModelReasoningEffort } from "@/agent/model";
+import type { ExtensionCommand } from "@/cli/extensions/types";
 import { AgentInfoBar } from "./AgentInfoBar";
 import { FileAutocomplete } from "./FileAutocomplete";
 import { SlashCommandAutocomplete } from "./SlashCommandAutocomplete";
@@ -19,6 +20,7 @@ interface InputAssistProps {
   serverUrl?: string;
   workingDirectory?: string;
   conversationId?: string;
+  extensionCommands?: Record<string, ExtensionCommand>;
 }
 
 /**
@@ -41,6 +43,7 @@ export function InputAssist({
   serverUrl,
   workingDirectory,
   conversationId,
+  extensionCommands,
 }: InputAssistProps) {
   const showFileAutocomplete = currentInput.includes("@");
   const showCommandAutocomplete =
@@ -81,6 +84,7 @@ export function InputAssist({
           onActiveChange={onAutocompleteActiveChange}
           agentId={agentId}
           workingDirectory={workingDirectory}
+          extensionCommands={extensionCommands}
         />
         <AgentInfoBar
           agentId={agentId}

--- a/src/cli/components/InputAssist.tsx
+++ b/src/cli/components/InputAssist.tsx
@@ -1,10 +1,10 @@
 import { Box } from "ink";
 import { useEffect } from "react";
 import type { ModelReasoningEffort } from "@/agent/model";
-import type { ExtensionCommand } from "@/cli/extensions/types";
 import { AgentInfoBar } from "./AgentInfoBar";
 import { FileAutocomplete } from "./FileAutocomplete";
 import { SlashCommandAutocomplete } from "./SlashCommandAutocomplete";
+import type { ExtensionCommandAutocompleteItem } from "./types/autocomplete";
 
 interface InputAssistProps {
   currentInput: string;
@@ -20,7 +20,7 @@ interface InputAssistProps {
   serverUrl?: string;
   workingDirectory?: string;
   conversationId?: string;
-  extensionCommands?: Record<string, ExtensionCommand>;
+  extensionCommands?: Record<string, ExtensionCommandAutocompleteItem>;
 }
 
 /**

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -47,6 +47,7 @@ import { settingsManager } from "@/settings-manager";
 import { debugLog } from "@/utils/debug";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
 import { colors } from "./colors";
+import { ExtensionPanelRow } from "./ExtensionPanelRow";
 import { InputAssist } from "./InputAssist";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { ProductStatusRow } from "./ProductStatusRow";
@@ -1948,6 +1949,13 @@ export function Input({
 
         {interactionEnabled ? (
           <Box flexDirection="column">
+            {!suppressDividers && (
+              <ExtensionPanelRow
+                panels={extensionRuntime.registry?.ui.panels}
+                terminalWidth={terminalWidth}
+              />
+            )}
+
             {!suppressDividers && (
               <ProductStatusRow
                 goalStatusText={goalStatusText}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -2025,6 +2025,7 @@ export function Input({
                 serverUrl={serverUrl}
                 workingDirectory={process.cwd()}
                 conversationId={conversationId}
+                extensionCommands={extensionRuntime.registry?.commands}
               />
             )}
 

--- a/src/cli/components/SlashCommandAutocomplete.tsx
+++ b/src/cli/components/SlashCommandAutocomplete.tsx
@@ -52,6 +52,7 @@ export function SlashCommandAutocomplete({
   onActiveChange,
   agentId,
   workingDirectory = process.cwd(),
+  extensionCommands = {},
 }: AutocompleteProps) {
   const columns = useTerminalWidth();
   const [customCommands, setCustomCommands] = useState<CommandMatch[]>([]);
@@ -138,19 +139,37 @@ export function SlashCommandAutocomplete({
       }
     }
 
+    const extensionCommandMatches: CommandMatch[] = Object.values(
+      extensionCommands,
+    ).map((command) => ({
+      cmd: `/${command.id}`,
+      desc: `${command.description}${command.args ? ` ${command.args}` : ""} (extension)`,
+      order: command.order,
+    }));
+
     const reservedCommands = new Set([
       ...builtins.map((cmd) => cmd.cmd),
+      ...extensionCommandMatches.map((cmd) => cmd.cmd),
       ...customCommands.map((cmd) => cmd.cmd),
     ]);
     const visibleSkillCommands = skillCommands.filter(
       (cmd) => !reservedCommands.has(cmd.cmd),
     );
 
-    // Merge with custom commands and sort by order
-    return [...builtins, ...customCommands, ...visibleSkillCommands].sort(
-      (a, b) => (a.order ?? 100) - (b.order ?? 100),
-    );
-  }, [agentId, workingDirectory, customCommands, skillCommands]);
+    // Merge command sources and sort by order.
+    return [
+      ...builtins,
+      ...extensionCommandMatches,
+      ...customCommands,
+      ...visibleSkillCommands,
+    ].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+  }, [
+    agentId,
+    workingDirectory,
+    extensionCommands,
+    customCommands,
+    skillCommands,
+  ]);
 
   const queryInfo = useMemo(
     () => extractSearchQuery(currentInput, cursorPosition),

--- a/src/cli/components/types/autocomplete.ts
+++ b/src/cli/components/types/autocomplete.ts
@@ -1,8 +1,13 @@
-import type { ExtensionCommand } from "@/cli/extensions/types";
-
 /**
  * Shared types for autocomplete components
  */
+
+export interface ExtensionCommandAutocompleteItem {
+  id: string;
+  description: string;
+  args?: string;
+  order: number;
+}
 
 /**
  * Base props shared by all autocomplete components
@@ -23,7 +28,7 @@ export interface AutocompleteProps {
   /** Working directory for local pin status checking */
   workingDirectory?: string;
   /** Slash commands registered by trusted local extensions */
-  extensionCommands?: Record<string, ExtensionCommand>;
+  extensionCommands?: Record<string, ExtensionCommandAutocompleteItem>;
 }
 
 /**

--- a/src/cli/components/types/autocomplete.ts
+++ b/src/cli/components/types/autocomplete.ts
@@ -1,3 +1,5 @@
+import type { ExtensionCommand } from "@/cli/extensions/types";
+
 /**
  * Shared types for autocomplete components
  */
@@ -20,6 +22,8 @@ export interface AutocompleteProps {
   agentId?: string;
   /** Working directory for local pin status checking */
   workingDirectory?: string;
+  /** Slash commands registered by trusted local extensions */
+  extensionCommands?: Record<string, ExtensionCommand>;
 }
 
 /**

--- a/src/cli/display/statusline/context.ts
+++ b/src/cli/display/statusline/context.ts
@@ -51,7 +51,16 @@ export function buildStatuslineRenderContext({
       totalOutputTokens: payload.context_window.total_output_tokens,
       usedPercentage: payload.context_window.used_percentage,
       remainingPercentage: payload.context_window.remaining_percentage,
-      currentUsage: payload.context_window.current_usage,
+      currentUsage: payload.context_window.current_usage
+        ? {
+            inputTokens: payload.context_window.current_usage.input_tokens,
+            outputTokens: payload.context_window.current_usage.output_tokens,
+            cacheCreationInputTokens:
+              payload.context_window.current_usage.cache_creation_input_tokens,
+            cacheReadInputTokens:
+              payload.context_window.current_usage.cache_read_input_tokens,
+          }
+        : null,
     },
     cost: {
       totalDurationMs: payload.cost.total_duration_ms,
@@ -60,9 +69,21 @@ export function buildStatuslineRenderContext({
       totalLinesAdded: payload.cost.total_lines_added,
       totalLinesRemoved: payload.cost.total_lines_removed,
     },
-    reflection: payload.reflection,
-    memfs: payload.memfs,
-    backgroundAgents: backgroundAgents ?? payload.background_agents,
+    reflection: {
+      mode: payload.reflection.mode,
+      stepCount: payload.reflection.step_count,
+    },
+    memfs: {
+      enabled: payload.memfs.enabled,
+      memoryDir: payload.memfs.memory_dir,
+    },
+    backgroundAgents: (backgroundAgents ?? payload.background_agents).map(
+      (agent) => ({
+        type: agent.type,
+        status: agent.status,
+        durationMs: agent.duration_ms,
+      }),
+    ),
     ui,
   };
 }

--- a/src/cli/display/statusline/types.ts
+++ b/src/cli/display/statusline/types.ts
@@ -13,59 +13,10 @@ export interface StatuslineUiContext {
   rightColumnWidth: number;
 }
 
-export interface StatuslineModelContext {
-  id: string | null;
-  displayName: string | null;
-  provider: string | null;
-  reasoningEffort: string | null;
-}
-
-export interface StatuslineWorkspaceContext {
-  cwd: string;
-  currentDir: string;
-  projectDir: string;
-}
-
-export interface StatuslineContextWindowContext {
-  size: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  usedPercentage: number | null;
-  remainingPercentage: number | null;
-  currentUsage: StatusLinePayload["context_window"]["current_usage"];
-}
-
-export interface StatuslineCostContext {
-  totalDurationMs: number;
-  totalApiDurationMs: number;
-  totalCostUsd: number | null;
-  totalLinesAdded: number | null;
-  totalLinesRemoved: number | null;
-}
-
 export interface StatuslineRenderContext extends ExtensionContext {
   rawPayload: StatusLinePayload;
   components: typeof DisplayComponents;
   statuses: Record<string, string>;
-  app: {
-    version: string;
-  };
-  workspace: StatuslineWorkspaceContext;
-  cwd: string;
-  sessionId: string | null;
-  lastRunId: string | null;
-  agent: StatusLinePayload["agent"];
-  model: StatuslineModelContext;
-  toolset: string | null;
-  systemPromptId: string | null;
-  permissionMode: string | null;
-  networkPhase: StatusLinePayload["network_phase"];
-  terminalWidth: number | null;
-  contextWindow: StatuslineContextWindowContext;
-  cost: StatuslineCostContext;
-  reflection: StatusLinePayload["reflection"];
-  memfs: StatusLinePayload["memfs"];
-  backgroundAgents: StatusLinePayload["background_agents"];
   ui: StatuslineUiContext;
 }
 

--- a/src/cli/display/statusline/types.ts
+++ b/src/cli/display/statusline/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type * as DisplayComponents from "@/cli/display/DisplayComponents";
+import type { ExtensionContext } from "@/cli/extensions/types";
 import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
 
 export interface StatuslineUiContext {
@@ -42,7 +43,7 @@ export interface StatuslineCostContext {
   totalLinesRemoved: number | null;
 }
 
-export interface StatuslineRenderContext {
+export interface StatuslineRenderContext extends ExtensionContext {
   rawPayload: StatusLinePayload;
   components: typeof DisplayComponents;
   statuses: Record<string, string>;

--- a/src/cli/extensions/command-runtime.test.ts
+++ b/src/cli/extensions/command-runtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildExtensionCommandPrompt,
+  normalizeExtensionCommandResult,
+  parseExtensionCommandArgv,
+  parseExtensionSlashCommand,
+} from "@/cli/extensions/command-runtime";
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
+
+describe("extension command runtime", () => {
+  test("parses slash command input", () => {
+    expect(parseExtensionSlashCommand("/review current diff")).toEqual({
+      command: "review",
+      args: "current diff",
+    });
+    expect(parseExtensionSlashCommand("review current diff")).toBeNull();
+  });
+
+  test("splits extension command argv", () => {
+    expect(parseExtensionCommandArgv('one "two words" three\\ four')).toEqual([
+      "one",
+      "two words",
+      "three four",
+    ]);
+  });
+
+  test("normalizes declarative command results", () => {
+    expect(
+      normalizeExtensionCommandResult({ type: "output", output: "done" }),
+    ).toEqual({ type: "output", output: "done" });
+    expect(() => normalizeExtensionCommandResult({ type: "prompt" })).toThrow(
+      "prompt result requires content",
+    );
+  });
+
+  test("wraps prompt results as system reminders by default", () => {
+    expect(buildExtensionCommandPrompt({ content: "Review this" })).toBe(
+      `${SYSTEM_REMINDER_OPEN}\nReview this\n${SYSTEM_REMINDER_CLOSE}`,
+    );
+    expect(
+      buildExtensionCommandPrompt({
+        content: "Review this",
+        systemReminder: false,
+      }),
+    ).toBe("Review this");
+  });
+});

--- a/src/cli/extensions/command-runtime.test.ts
+++ b/src/cli/extensions/command-runtime.test.ts
@@ -14,6 +14,8 @@ describe("extension command runtime", () => {
       args: "current diff",
     });
     expect(parseExtensionSlashCommand("review current diff")).toBeNull();
+    expect(parseExtensionSlashCommand("/")).toBeNull();
+    expect(parseExtensionSlashCommand("//bad")).toBeNull();
   });
 
   test("splits extension command argv", () => {

--- a/src/cli/extensions/command-runtime.ts
+++ b/src/cli/extensions/command-runtime.ts
@@ -14,8 +14,10 @@ export function parseExtensionSlashCommand(trimmed: string): {
   if (!trimmed.startsWith("/")) return null;
   const commandToken = trimmed.split(/\s+/, 1)[0];
   if (!commandToken || commandToken === "/") return null;
+  const command = commandToken.slice(1);
+  if (!command || command.includes("/")) return null;
   return {
-    command: commandToken.slice(1),
+    command,
     args: trimmed.slice(commandToken.length).trim(),
   };
 }

--- a/src/cli/extensions/command-runtime.ts
+++ b/src/cli/extensions/command-runtime.ts
@@ -1,0 +1,159 @@
+import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
+import type {
+  ExtensionCommand,
+  ExtensionCommandContext,
+  ExtensionCommandResult,
+} from "./types";
+
+const EXTENSION_COMMAND_TIMEOUT_MS = 30_000;
+
+export function parseExtensionSlashCommand(trimmed: string): {
+  command: string;
+  args: string;
+} | null {
+  if (!trimmed.startsWith("/")) return null;
+  const commandToken = trimmed.split(/\s+/, 1)[0];
+  if (!commandToken || commandToken === "/") return null;
+  return {
+    command: commandToken.slice(1),
+    args: trimmed.slice(commandToken.length).trim(),
+  };
+}
+
+export function parseExtensionCommandArgv(args: string): string[] {
+  const argv: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      argv.push(current);
+      current = "";
+    }
+  };
+
+  for (const char of args) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushCurrent();
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping) current += "\\";
+  pushCurrent();
+  return argv;
+}
+
+export function normalizeExtensionCommandResult(
+  result: unknown,
+): ExtensionCommandResult {
+  if (!result || typeof result !== "object" || !("type" in result)) {
+    throw new Error(
+      "Extension command must return { type: 'prompt' | 'output' | 'handled' }",
+    );
+  }
+
+  const typed = result as {
+    content?: unknown;
+    output?: unknown;
+    success?: unknown;
+    systemReminder?: unknown;
+    type?: unknown;
+  };
+  if (typed.type === "prompt") {
+    if (typeof typed.content !== "string") {
+      throw new Error("Extension command prompt result requires content");
+    }
+    return {
+      type: "prompt",
+      content: typed.content,
+      ...(typeof typed.systemReminder === "boolean"
+        ? { systemReminder: typed.systemReminder }
+        : {}),
+    };
+  }
+  if (typed.type === "output") {
+    if (typeof typed.output !== "string") {
+      throw new Error("Extension command output result requires output");
+    }
+    return {
+      type: "output",
+      output: typed.output,
+      ...(typeof typed.success === "boolean" ? { success: typed.success } : {}),
+    };
+  }
+  if (typed.type === "handled") {
+    return { type: "handled" };
+  }
+
+  throw new Error(
+    `Unknown extension command result type: ${String(typed.type)}`,
+  );
+}
+
+export function buildExtensionCommandPrompt(result: {
+  content: string;
+  systemReminder?: boolean;
+}): string {
+  if (result.systemReminder === false) {
+    return result.content;
+  }
+  return `${SYSTEM_REMINDER_OPEN}\n${result.content}\n${SYSTEM_REMINDER_CLOSE}`;
+}
+
+export async function runExtensionCommandWithTimeout(
+  command: ExtensionCommand,
+  context: ExtensionCommandContext,
+): Promise<ExtensionCommandResult> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return normalizeExtensionCommandResult(
+      await Promise.race([
+        Promise.resolve(command.run(context)),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Extension command timed out after ${EXTENSION_COMMAND_TIMEOUT_MS}ms`,
+                ),
+              ),
+            EXTENSION_COMMAND_TIMEOUT_MS,
+          );
+        }),
+      ]),
+    );
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type Letta from "@letta-ai/letta-client";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
 import type { StatuslineRenderContext } from "@/cli/display/statusline/types";
 import {
@@ -47,6 +48,7 @@ function createStatuslineContext(): StatuslineRenderContext {
 function createLoadOptions(root: string) {
   return {
     cacheDirectory: path.join(root, "extension-cache"),
+    getClient: async () => ({ marker: "test-client" }) as unknown as Letta,
     getContext: createStatuslineContext,
     globalExtensionsDirectory: path.join(root, "global-extensions"),
   };
@@ -272,6 +274,49 @@ describe("local extension loader", () => {
 
       disposeLocalExtensions(registry);
       expect(registry.commands).toEqual({});
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("passes the configured SDK client to extensions", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "client.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "client-check",
+            description: "Check client availability",
+            run() {
+              return { type: "output", output: letta.client.marker };
+            },
+          });
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      await expect(
+        Promise.resolve(
+          registry.commands["client-check"]?.run({
+            agent: { id: "agent-1", name: "Amelia" },
+            args: "",
+            argv: [],
+            command: "client-check",
+            conversation: { id: "conversation-1" },
+            cwd: "/tmp/project",
+            getContext: createStatuslineContext,
+            model: { id: "model-1", displayName: "Sonnet" },
+            permissionMode: "standard",
+            rawInput: "/client-check",
+          }),
+        ),
+      ).resolves.toEqual({ type: "output", output: "test-client" });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -48,7 +48,8 @@ function createStatuslineContext(): StatuslineRenderContext {
 function createLoadOptions(root: string) {
   return {
     cacheDirectory: path.join(root, "extension-cache"),
-    getClient: async () => ({ marker: "test-client" }) as unknown as Letta,
+    getClient: async () =>
+      ({ getMarker: () => "test-client" }) as unknown as Letta,
     getContext: createStatuslineContext,
     globalExtensionsDirectory: path.join(root, "global-extensions"),
   };
@@ -104,6 +105,35 @@ describe("local extension loader", () => {
 
       expect(registry.loadedPaths).toEqual([]);
       expect(registry.errors).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("does not initialize SDK client until an extension uses it", async () => {
+    const root = createTempDir();
+    try {
+      const options = {
+        ...createLoadOptions(root),
+        getClient: async () => {
+          throw new Error("client should be lazy");
+        },
+      };
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "status.ts"),
+        `export default function(letta) {
+          letta.ui.setStatus("mode", "fast");
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      expect(
+        evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
+      ).toEqual({ mode: "fast" });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -314,8 +344,8 @@ describe("local extension loader", () => {
           letta.commands.register({
             id: "client-check",
             description: "Check client availability",
-            run() {
-              return { type: "output", output: letta.client.marker };
+            async run() {
+              return { type: "output", output: await letta.client.getMarker() };
             },
           });
         }`,

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -90,6 +90,25 @@ describe("local extension loader", () => {
     }
   });
 
+  test("does not initialize SDK client when no extension files exist", async () => {
+    const root = createTempDir();
+    try {
+      const options = {
+        ...createLoadOptions(root),
+        getClient: async () => {
+          throw new Error("client should not initialize without extensions");
+        },
+      };
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.loadedPaths).toEqual([]);
+      expect(registry.errors).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("loads extensions that register statuses and statusline renderers", async () => {
     const root = createTempDir();
     try {
@@ -240,6 +259,8 @@ describe("local extension loader", () => {
             description: "Review a GitHub PR",
             args: "<url-or-number>",
             order: 250,
+            runWhenBusy: true,
+            showInTranscript: false,
             run(ctx) {
               return { type: "prompt", content: "Review this PR: " + ctx.args };
             },
@@ -255,6 +276,8 @@ describe("local extension loader", () => {
       );
       expect(registry.commands["review-pr"]?.args).toBe("<url-or-number>");
       expect(registry.commands["review-pr"]?.order).toBe(250);
+      expect(registry.commands["review-pr"]?.runWhenBusy).toBe(true);
+      expect(registry.commands["review-pr"]?.showInTranscript).toBe(false);
       await expect(
         Promise.resolve(
           registry.commands["review-pr"]?.run({
@@ -317,6 +340,69 @@ describe("local extension loader", () => {
           }),
         ),
       ).resolves.toEqual({ type: "output", output: "test-client" });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("lets extensions manage UI panels", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "panel.ts"),
+        `export default function(letta) {
+          const panel = letta.ui.openPanel({
+            id: "btw",
+            content: ["┌ /btw question ┐", "│ …             │", "└───────────────┘"],
+          });
+          panel.update({ content: "answer" });
+          return () => panel.close();
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      expect(Object.values(registry.ui.panels)[0]).toMatchObject({
+        content: ["answer"],
+        id: "btw",
+      });
+
+      disposeLocalExtensions(registry);
+      expect(registry.ui.panels).toEqual({});
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("scopes panel ids by extension path", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "a.ts"),
+        `export default function(letta) {
+          letta.ui.openPanel({ id: "status", content: "from a" });
+        }`,
+      );
+      writeFileSync(
+        path.join(extensionDir, "b.ts"),
+        `export default function(letta) {
+          letta.ui.openPanel({ id: "status", content: "from b" });
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      expect(
+        Object.values(registry.ui.panels).map((panel) => panel.content),
+      ).toEqual([["from a"], ["from b"]]);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -223,6 +223,125 @@ describe("local extension loader", () => {
     }
   });
 
+  test("loads extension-provided slash commands", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      const extensionPath = path.join(extensionDir, "commands.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          return letta.commands.register({
+            id: "review-pr",
+            description: "Review a GitHub PR",
+            args: "<url-or-number>",
+            order: 250,
+            run(ctx) {
+              return { type: "prompt", content: "Review this PR: " + ctx.args };
+            },
+          });
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.errors).toEqual([]);
+      expect(registry.commands["review-pr"]?.description).toBe(
+        "Review a GitHub PR",
+      );
+      expect(registry.commands["review-pr"]?.args).toBe("<url-or-number>");
+      expect(registry.commands["review-pr"]?.order).toBe(250);
+      await expect(
+        Promise.resolve(
+          registry.commands["review-pr"]?.run({
+            agent: { id: "agent-1", name: "Amelia" },
+            args: "123",
+            argv: ["123"],
+            command: "review-pr",
+            conversation: { id: "conversation-1" },
+            cwd: "/tmp/project",
+            getContext: createStatuslineContext,
+            model: { id: "model-1", displayName: "Sonnet" },
+            permissionMode: "standard",
+            rawInput: "/review-pr 123",
+          }),
+        ),
+      ).resolves.toEqual({ type: "prompt", content: "Review this PR: 123" });
+
+      disposeLocalExtensions(registry);
+      expect(registry.commands).toEqual({});
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects extension command id collisions", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "a.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "dupe",
+            description: "First command",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(extensionDir, "b.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "dupe",
+            description: "Second command",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(extensionDir, "c.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "reload",
+            description: "Built-in conflict",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(extensionDir, "d.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "/bad",
+            description: "Invalid id",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(Object.keys(registry.commands)).toEqual(["dupe"]);
+      expect(registry.errors.map((entry) => entry.path).sort()).toEqual([
+        path.join(extensionDir, "b.ts"),
+        path.join(extensionDir, "c.ts"),
+        path.join(extensionDir, "d.ts"),
+      ]);
+      expect(registry.errors.map((entry) => entry.error.message)).toEqual([
+        expect.stringContaining("already registered"),
+        expect.stringContaining("built-in command"),
+        expect.stringContaining("must not start"),
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("runs extension disposers", async () => {
     const root = createTempDir();
     try {

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -13,6 +13,7 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import type Letta from "@letta-ai/letta-client";
 import * as ts from "typescript";
 import { commands as builtinCommands } from "@/cli/commands/registry";
 import type {
@@ -60,6 +61,7 @@ export type LettaExtensionFactory = (
   | Promise<undefined | LettaExtensionDisposer>;
 
 export interface LettaExtensionApi {
+  client: Letta;
   getContext: () => ExtensionContext;
   commands: {
     register: (command: ExtensionCommandRegistration) => LettaExtensionDisposer;
@@ -118,6 +120,7 @@ export interface ResolveLocalExtensionSourcesOptions {
 export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
+  getClient: () => Promise<Letta>;
   onChange?: () => void;
   reservedCommandIds?: Iterable<string>;
 }
@@ -326,6 +329,7 @@ function normalizeExtensionCommand(
 function createLettaExtensionApi(
   registry: LocalExtensionRegistry,
   extensionPath: string,
+  client: Letta,
   getContext: () => ExtensionContext,
   onChange: () => void,
   reservedCommandIds: Set<string>,
@@ -340,6 +344,7 @@ function createLettaExtensionApi(
   };
 
   return {
+    client,
     getContext,
     commands: {
       register(command) {
@@ -396,9 +401,10 @@ function getExtensionFactory(module: LocalExtensionModule): unknown {
 }
 
 export async function loadLocalExtensions(
-  options: LoadLocalExtensionsOptions = {},
+  options: LoadLocalExtensionsOptions,
 ): Promise<LocalExtensionRegistry> {
   const cacheDirectory = options.cacheDirectory ?? EXTENSION_CACHE_DIRECTORY;
+  const client = await options.getClient();
   const getContext =
     options.getContext ??
     (() => {
@@ -444,6 +450,7 @@ export async function loadLocalExtensions(
         createLettaExtensionApi(
           registry,
           extensionPath,
+          client,
           getContext,
           onChange,
           reservedCommandIds,

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -14,11 +14,17 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import * as ts from "typescript";
+import { commands as builtinCommands } from "@/cli/commands/registry";
 import type {
   StatuslineRenderContext,
   StatuslineRenderer,
   StatuslineRendererOutput,
 } from "@/cli/display/statusline/types";
+import type {
+  ExtensionCommand,
+  ExtensionCommandRegistration,
+  ExtensionContext,
+} from "@/cli/extensions/types";
 
 export const GLOBAL_EXTENSIONS_DIRECTORY = path.join(
   homedir(),
@@ -39,12 +45,6 @@ export type StatuslineRenderFunction = (
   context: StatuslineRenderContext,
 ) => StatuslineRendererOutput;
 
-// First extension surface is statusline rendering, so the shared extension
-// context is currently the statusline render context. When we add non-UI
-// surfaces like commands, split this into a generic ExtensionContext base and
-// let StatuslineRenderContext extend it.
-export type ExtensionContext = StatuslineRenderContext;
-
 export type ExtensionStatusValue =
   | string
   | null
@@ -61,6 +61,10 @@ export type LettaExtensionFactory = (
 
 export interface LettaExtensionApi {
   getContext: () => ExtensionContext;
+  commands: {
+    register: (command: ExtensionCommandRegistration) => LettaExtensionDisposer;
+    unregister: (id: string) => void;
+  };
   ui: {
     clearStatus: (key: string) => void;
     setStatus: (key: string, value: ExtensionStatusValue | undefined) => void;
@@ -86,6 +90,7 @@ export interface LocalExtensionUiRegistry {
 }
 
 export interface LocalExtensionRegistry {
+  commands: Record<string, ExtensionCommand>;
   disposers: LocalExtensionDisposer[];
   errors: LocalExtensionLoadError[];
   loadedPaths: string[];
@@ -114,6 +119,7 @@ export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   onChange?: () => void;
+  reservedCommandIds?: Iterable<string>;
 }
 
 function listExtensionFiles(directory: string): string[] {
@@ -274,14 +280,90 @@ function toStatuslineRenderer(
   return renderer;
 }
 
+function stripSlash(command: string): string {
+  return command.startsWith("/") ? command.slice(1) : command;
+}
+
+function getDefaultReservedCommandIds(): Set<string> {
+  return new Set(Object.keys(builtinCommands).map(stripSlash));
+}
+
+function validateExtensionCommandId(id: string): void {
+  if (id.startsWith("/")) {
+    throw new Error("Extension command id must not start with '/'");
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    throw new Error(
+      "Extension command id must be a lowercase slug using letters, numbers, and hyphens",
+    );
+  }
+}
+
+function normalizeExtensionCommand(
+  command: ExtensionCommandRegistration,
+  extensionPath: string,
+): ExtensionCommand {
+  validateExtensionCommandId(command.id);
+  if (!command.description.trim()) {
+    throw new Error(
+      `Extension command '${command.id}' must include a description`,
+    );
+  }
+  if (typeof command.run !== "function") {
+    throw new Error(`Extension command '${command.id}' must include run()`);
+  }
+
+  return {
+    id: command.id,
+    description: command.description,
+    ...(command.args ? { args: command.args } : {}),
+    order: command.order ?? 250,
+    path: extensionPath,
+    run: command.run,
+  };
+}
+
 function createLettaExtensionApi(
   registry: LocalExtensionRegistry,
   extensionPath: string,
   getContext: () => ExtensionContext,
   onChange: () => void,
+  reservedCommandIds: Set<string>,
 ): LettaExtensionApi {
+  const unregisterCommand = (id: string) => {
+    validateExtensionCommandId(id);
+    const existing = registry.commands[id];
+    if (existing?.path === extensionPath) {
+      delete registry.commands[id];
+      onChange();
+    }
+  };
+
   return {
     getContext,
+    commands: {
+      register(command) {
+        const normalized = normalizeExtensionCommand(command, extensionPath);
+        if (reservedCommandIds.has(normalized.id)) {
+          throw new Error(
+            `Extension command '${normalized.id}' conflicts with a built-in command`,
+          );
+        }
+
+        const existing = registry.commands[normalized.id];
+        if (existing && !command.override) {
+          throw new Error(
+            `Extension command '${normalized.id}' is already registered by ${existing.path}`,
+          );
+        }
+
+        registry.commands[normalized.id] = normalized;
+        onChange();
+
+        return () => unregisterCommand(normalized.id);
+      },
+      unregister: unregisterCommand,
+    },
     ui: {
       clearStatus(key) {
         delete registry.ui.statusValues[key];
@@ -324,7 +406,12 @@ export async function loadLocalExtensions(
     });
   const onChange = options.onChange ?? (() => {});
   const sources = resolveLocalExtensionSources(options);
+  const reservedCommandIds = new Set([
+    ...getDefaultReservedCommandIds(),
+    ...(options.reservedCommandIds ?? []),
+  ]);
   const registry: LocalExtensionRegistry = {
+    commands: {},
     disposers: [],
     errors: [],
     loadedPaths: [],
@@ -354,7 +441,13 @@ export async function loadLocalExtensions(
       }
 
       const dispose = await (factory as LettaExtensionFactory)(
-        createLettaExtensionApi(registry, extensionPath, getContext, onChange),
+        createLettaExtensionApi(
+          registry,
+          extensionPath,
+          getContext,
+          onChange,
+          reservedCommandIds,
+        ),
       );
       if (typeof dispose === "function") {
         registry.disposers.push({ dispose, path: extensionPath });
@@ -408,6 +501,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
     }
   }
 
+  registry.commands = {};
   registry.ui.statusValues = {};
   registry.ui.statuslineRenderer = null;
 }

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -25,6 +25,11 @@ import type {
   ExtensionCommand,
   ExtensionCommandRegistration,
   ExtensionContext,
+  ExtensionPanel,
+  ExtensionPanelContent,
+  ExtensionPanelHandle,
+  ExtensionPanelOptions,
+  ExtensionPanelUpdate,
 } from "@/cli/extensions/types";
 
 export const GLOBAL_EXTENSIONS_DIRECTORY = path.join(
@@ -68,7 +73,9 @@ export interface LettaExtensionApi {
     unregister: (id: string) => void;
   };
   ui: {
+    clearPanel: (id: string) => void;
     clearStatus: (key: string) => void;
+    openPanel: (panel: ExtensionPanelOptions) => ExtensionPanelHandle;
     setStatus: (key: string, value: ExtensionStatusValue | undefined) => void;
     setStatuslineRenderer: (
       renderer: StatuslineRenderer | StatuslineRenderFunction,
@@ -87,6 +94,7 @@ export interface LocalExtensionLoadError {
 }
 
 export interface LocalExtensionUiRegistry {
+  panels: Record<string, ExtensionPanel>;
   statuslineRenderer: StatuslineRenderer | null;
   statusValues: Record<string, ExtensionStatusValue>;
 }
@@ -322,7 +330,49 @@ function normalizeExtensionCommand(
     ...(command.args ? { args: command.args } : {}),
     order: command.order ?? 250,
     path: extensionPath,
+    runWhenBusy: command.runWhenBusy === true,
+    showInTranscript: command.showInTranscript !== false,
     run: command.run,
+  };
+}
+
+function validateExtensionPanelId(id: string): void {
+  if (!id.trim()) {
+    throw new Error("Extension panel id must not be empty");
+  }
+}
+
+function getExtensionPanelKey(extensionPath: string, id: string): string {
+  return JSON.stringify([extensionPath, id]);
+}
+
+function normalizePanelContent(
+  content: ExtensionPanelContent | undefined,
+): string[] {
+  if (content == null) return [];
+  return Array.isArray(content)
+    ? content.map(String)
+    : String(content).split("\n");
+}
+
+function upsertExtensionPanel(
+  registry: LocalExtensionRegistry,
+  extensionPath: string,
+  id: string,
+  update: ExtensionPanelUpdate,
+): void {
+  validateExtensionPanelId(id);
+  const panelKey = getExtensionPanelKey(extensionPath, id);
+  const existing = registry.ui.panels[panelKey];
+  registry.ui.panels[panelKey] = {
+    content:
+      update.content === undefined
+        ? (existing?.content ?? [])
+        : normalizePanelContent(update.content),
+    id,
+    order: update.order ?? existing?.order ?? 100,
+    path: extensionPath,
+    updatedAt: Date.now(),
   };
 }
 
@@ -339,6 +389,16 @@ function createLettaExtensionApi(
     const existing = registry.commands[id];
     if (existing?.path === extensionPath) {
       delete registry.commands[id];
+      onChange();
+    }
+  };
+
+  const clearPanel = (id: string) => {
+    validateExtensionPanelId(id);
+    const panelKey = getExtensionPanelKey(extensionPath, id);
+    const existing = registry.ui.panels[panelKey];
+    if (existing?.path === extensionPath) {
+      delete registry.ui.panels[panelKey];
       onChange();
     }
   };
@@ -370,9 +430,23 @@ function createLettaExtensionApi(
       unregister: unregisterCommand,
     },
     ui: {
+      clearPanel,
       clearStatus(key) {
         delete registry.ui.statusValues[key];
         onChange();
+      },
+      openPanel(panel) {
+        upsertExtensionPanel(registry, extensionPath, panel.id, panel);
+        onChange();
+        return {
+          close() {
+            clearPanel(panel.id);
+          },
+          update(update) {
+            upsertExtensionPanel(registry, extensionPath, panel.id, update);
+            onChange();
+          },
+        };
       },
       setStatus(key, value) {
         if (value == null) {
@@ -404,7 +478,11 @@ export async function loadLocalExtensions(
   options: LoadLocalExtensionsOptions,
 ): Promise<LocalExtensionRegistry> {
   const cacheDirectory = options.cacheDirectory ?? EXTENSION_CACHE_DIRECTORY;
-  const client = await options.getClient();
+  let clientPromise: Promise<Letta> | null = null;
+  const getConfiguredClient = () => {
+    clientPromise ??= options.getClient();
+    return clientPromise;
+  };
   const getContext =
     options.getContext ??
     (() => {
@@ -423,6 +501,7 @@ export async function loadLocalExtensions(
     loadedPaths: [],
     sources,
     ui: {
+      panels: {},
       statuslineRenderer: null,
       statusValues: {},
     },
@@ -446,6 +525,7 @@ export async function loadLocalExtensions(
         );
       }
 
+      const client = await getConfiguredClient();
       const dispose = await (factory as LettaExtensionFactory)(
         createLettaExtensionApi(
           registry,
@@ -509,6 +589,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
   }
 
   registry.commands = {};
+  registry.ui.panels = {};
   registry.ui.statusValues = {};
   registry.ui.statuslineRenderer = null;
 }

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -67,6 +67,7 @@ export type LettaExtensionFactory = (
 
 export interface LettaExtensionApi {
   client: Letta;
+  getClient: () => Promise<Letta>;
   getContext: () => ExtensionContext;
   commands: {
     register: (command: ExtensionCommandRegistration) => LettaExtensionDisposer;
@@ -291,6 +292,36 @@ function toStatuslineRenderer(
   return renderer;
 }
 
+function createLazyClient(getClient: () => Promise<Letta>): Letta {
+  const createProxy = (path: PropertyKey[] = []): unknown =>
+    new Proxy(function lazyLettaClientProxy() {}, {
+      apply(_target, _thisArg, args) {
+        return getClient().then((client) => {
+          let owner: unknown = client;
+          let value: unknown = client;
+          for (const property of path) {
+            owner = value;
+            value = (value as Record<PropertyKey, unknown>)[property];
+          }
+          if (typeof value !== "function") {
+            throw new TypeError(
+              `letta.client.${path.map(String).join(".")} is not callable`,
+            );
+          }
+          return value.apply(owner, args);
+        });
+      },
+      get(_target, property) {
+        // Keep the proxy from being treated as a Promise when code does
+        // `await letta.client` or Promise.resolve(letta.client).
+        if (property === "then") return undefined;
+        return createProxy([...path, property]);
+      },
+    });
+
+  return createProxy() as Letta;
+}
+
 function stripSlash(command: string): string {
   return command.startsWith("/") ? command.slice(1) : command;
 }
@@ -379,7 +410,7 @@ function upsertExtensionPanel(
 function createLettaExtensionApi(
   registry: LocalExtensionRegistry,
   extensionPath: string,
-  client: Letta,
+  getClient: () => Promise<Letta>,
   getContext: () => ExtensionContext,
   onChange: () => void,
   reservedCommandIds: Set<string>,
@@ -404,7 +435,8 @@ function createLettaExtensionApi(
   };
 
   return {
-    client,
+    client: createLazyClient(getClient),
+    getClient,
     getContext,
     commands: {
       register(command) {
@@ -525,12 +557,11 @@ export async function loadLocalExtensions(
         );
       }
 
-      const client = await getConfiguredClient();
       const dispose = await (factory as LettaExtensionFactory)(
         createLettaExtensionApi(
           registry,
           extensionPath,
-          client,
+          getConfiguredClient,
           getContext,
           onChange,
           reservedCommandIds,

--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -1,0 +1,99 @@
+import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
+
+export interface ExtensionWorkspaceContext {
+  cwd: string;
+  currentDir: string;
+  projectDir: string;
+}
+
+export interface ExtensionModelContext {
+  id: string | null;
+  displayName: string | null;
+  provider: string | null;
+  reasoningEffort: string | null;
+}
+
+export interface ExtensionContextWindowContext {
+  size: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  usedPercentage: number | null;
+  remainingPercentage: number | null;
+  currentUsage: StatusLinePayload["context_window"]["current_usage"];
+}
+
+export interface ExtensionCostContext {
+  totalDurationMs: number;
+  totalApiDurationMs: number;
+  totalCostUsd: number | null;
+  totalLinesAdded: number | null;
+  totalLinesRemoved: number | null;
+}
+
+export interface ExtensionContext {
+  app: {
+    version: string;
+  };
+  workspace: ExtensionWorkspaceContext;
+  cwd: string;
+  sessionId: string | null;
+  lastRunId: string | null;
+  agent: StatusLinePayload["agent"];
+  model: ExtensionModelContext;
+  toolset: string | null;
+  systemPromptId: string | null;
+  permissionMode: string | null;
+  networkPhase: StatusLinePayload["network_phase"];
+  terminalWidth: number | null;
+  contextWindow: ExtensionContextWindowContext;
+  cost: ExtensionCostContext;
+  reflection: StatusLinePayload["reflection"];
+  memfs: StatusLinePayload["memfs"];
+  backgroundAgents: StatusLinePayload["background_agents"];
+}
+
+export interface ExtensionCommandContext {
+  rawInput: string;
+  command: string;
+  args: string;
+  argv: string[];
+  cwd: string;
+  agent: {
+    id: string;
+    name: string | null;
+  };
+  conversation: {
+    id: string;
+  };
+  model: {
+    id: string | null;
+    displayName: string | null;
+  };
+  permissionMode: string | null;
+  getContext: () => ExtensionContext;
+}
+
+export type ExtensionCommandResult =
+  | { type: "prompt"; content: string; systemReminder?: boolean }
+  | { type: "output"; output: string; success?: boolean }
+  | { type: "handled" };
+
+export interface ExtensionCommandRegistration {
+  id: string;
+  description: string;
+  args?: string;
+  order?: number;
+  override?: boolean;
+  run: (
+    context: ExtensionCommandContext,
+  ) => ExtensionCommandResult | Promise<ExtensionCommandResult>;
+}
+
+export interface ExtensionCommand {
+  id: string;
+  description: string;
+  args?: string;
+  order: number;
+  path: string;
+  run: ExtensionCommandRegistration["run"];
+}

--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -1,5 +1,3 @@
-import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
-
 export interface ExtensionWorkspaceContext {
   cwd: string;
   currentDir: string;
@@ -13,13 +11,20 @@ export interface ExtensionModelContext {
   reasoningEffort: string | null;
 }
 
+export interface ExtensionTokenUsageContext {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
+}
+
 export interface ExtensionContextWindowContext {
   size: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   usedPercentage: number | null;
   remainingPercentage: number | null;
-  currentUsage: StatusLinePayload["context_window"]["current_usage"];
+  currentUsage: ExtensionTokenUsageContext | null;
 }
 
 export interface ExtensionCostContext {
@@ -30,6 +35,27 @@ export interface ExtensionCostContext {
   totalLinesRemoved: number | null;
 }
 
+export interface ExtensionAgentContext {
+  id: string | null;
+  name: string | null;
+}
+
+export interface ExtensionReflectionContext {
+  mode: "off" | "step-count" | "compaction-event" | null;
+  stepCount: number;
+}
+
+export interface ExtensionMemfsContext {
+  enabled: boolean;
+  memoryDir: string | null;
+}
+
+export interface ExtensionBackgroundAgentContext {
+  type: string;
+  status: string;
+  durationMs: number;
+}
+
 export interface ExtensionContext {
   app: {
     version: string;
@@ -38,18 +64,18 @@ export interface ExtensionContext {
   cwd: string;
   sessionId: string | null;
   lastRunId: string | null;
-  agent: StatusLinePayload["agent"];
+  agent: ExtensionAgentContext;
   model: ExtensionModelContext;
   toolset: string | null;
   systemPromptId: string | null;
   permissionMode: string | null;
-  networkPhase: StatusLinePayload["network_phase"];
+  networkPhase: "upload" | "download" | "error" | null;
   terminalWidth: number | null;
   contextWindow: ExtensionContextWindowContext;
   cost: ExtensionCostContext;
-  reflection: StatusLinePayload["reflection"];
-  memfs: StatusLinePayload["memfs"];
-  backgroundAgents: StatusLinePayload["background_agents"];
+  reflection: ExtensionReflectionContext;
+  memfs: ExtensionMemfsContext;
+  backgroundAgents: ExtensionBackgroundAgentContext[];
 }
 
 export interface ExtensionCommandContext {
@@ -78,12 +104,40 @@ export type ExtensionCommandResult =
   | { type: "output"; output: string; success?: boolean }
   | { type: "handled" };
 
+export type ExtensionPanelContent = string | string[];
+
+export interface ExtensionPanelOptions {
+  content?: ExtensionPanelContent;
+  id: string;
+  order?: number;
+}
+
+export interface ExtensionPanelUpdate {
+  content?: ExtensionPanelContent;
+  order?: number;
+}
+
+export interface ExtensionPanel {
+  content: string[];
+  id: string;
+  order: number;
+  path: string;
+  updatedAt: number;
+}
+
+export interface ExtensionPanelHandle {
+  close: () => void;
+  update: (update: ExtensionPanelUpdate) => void;
+}
+
 export interface ExtensionCommandRegistration {
   id: string;
   description: string;
   args?: string;
   order?: number;
   override?: boolean;
+  runWhenBusy?: boolean;
+  showInTranscript?: boolean;
   run: (
     context: ExtensionCommandContext,
   ) => ExtensionCommandResult | Promise<ExtensionCommandResult>;
@@ -95,5 +149,7 @@ export interface ExtensionCommand {
   args?: string;
   order: number;
   path: string;
+  runWhenBusy: boolean;
+  showInTranscript: boolean;
   run: ExtensionCommandRegistration["run"];
 }

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -2,17 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { debugLog } from "@/utils/debug";
 import {
   disposeLocalExtensions,
-  type ExtensionContext,
   type LocalExtensionRegistry,
   loadLocalExtensions,
   resolveLocalExtensionSources,
 } from "./local-extension-loader";
+import type { ExtensionContext } from "./types";
 
 export interface LocalExtensionRuntime {
   hadStatuslineRenderer: boolean;
   hasExtensionSources: boolean;
   isLoading: boolean;
   registry: LocalExtensionRegistry | null;
+  getContext: () => ExtensionContext;
   reload: () => Promise<void>;
   updateContext: (context: ExtensionContext) => void;
 }
@@ -54,6 +55,8 @@ export function useLocalExtensionRuntime(
   const updateContext = useCallback((context: ExtensionContext) => {
     contextRef.current = context;
   }, []);
+
+  const getContext = useCallback(() => contextRef.current, []);
 
   useEffect(() => {
     contextRef.current = initialContext;
@@ -137,7 +140,7 @@ export function useLocalExtensionRuntime(
   }, [reload]);
 
   return useMemo(
-    () => ({ registry, reload, updateContext, ...loadState }),
-    [loadState, registry, reload, updateContext],
+    () => ({ registry, getContext, reload, updateContext, ...loadState }),
+    [getContext, loadState, registry, reload, updateContext],
   );
 }

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -47,7 +47,7 @@ export function useLocalExtensionRuntime(
     };
   });
   const loadStateRef = useRef(loadState);
-  const [, bumpVersion] = useState(0);
+  const [renderVersion, bumpRenderVersion] = useState(0);
 
   useEffect(() => {
     loadStateRef.current = loadState;
@@ -85,7 +85,7 @@ export function useLocalExtensionRuntime(
       getContext: () => contextRef.current,
       onChange: () => {
         if (mountedRef.current) {
-          bumpVersion((version) => version + 1);
+          bumpRenderVersion((version) => version + 1);
         }
       },
     });
@@ -141,8 +141,17 @@ export function useLocalExtensionRuntime(
     };
   }, [reload]);
 
-  return useMemo(
-    () => ({ registry, getContext, reload, updateContext, ...loadState }),
-    [getContext, loadState, registry, reload, updateContext],
-  );
+  return useMemo(() => {
+    // Extension UI registries are mutated in place by trusted extension code.
+    // Keep renderVersion private but include it here so onChange invalidates
+    // the memoized runtime object and downstream components re-render.
+    void renderVersion;
+    return {
+      registry,
+      getContext,
+      reload,
+      updateContext,
+      ...loadState,
+    };
+  }, [getContext, loadState, registry, reload, updateContext, renderVersion]);
 }

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -25,6 +25,20 @@ interface LocalExtensionLoadState {
   isLoading: boolean;
 }
 
+function snapshotRegistryForRender(
+  registry: LocalExtensionRegistry,
+): LocalExtensionRegistry {
+  return {
+    ...registry,
+    commands: { ...registry.commands },
+    ui: {
+      ...registry.ui,
+      panels: { ...registry.ui.panels },
+      statusValues: { ...registry.ui.statusValues },
+    },
+  };
+}
+
 function hasLocalExtensionSources(): boolean {
   return resolveLocalExtensionSources().some(
     (source) => source.files.length > 0,
@@ -47,7 +61,6 @@ export function useLocalExtensionRuntime(
     };
   });
   const loadStateRef = useRef(loadState);
-  const [renderVersion, bumpRenderVersion] = useState(0);
 
   useEffect(() => {
     loadStateRef.current = loadState;
@@ -84,8 +97,8 @@ export function useLocalExtensionRuntime(
       getClient,
       getContext: () => contextRef.current,
       onChange: () => {
-        if (mountedRef.current) {
-          bumpRenderVersion((version) => version + 1);
+        if (mountedRef.current && registryRef.current) {
+          setRegistry(snapshotRegistryForRender(registryRef.current));
         }
       },
     });
@@ -120,7 +133,7 @@ export function useLocalExtensionRuntime(
     );
 
     registryRef.current = nextRegistry;
-    setRegistry(nextRegistry);
+    setRegistry(snapshotRegistryForRender(nextRegistry));
     setLoadState({
       hadStatuslineRenderer: nextHadStatuslineRenderer,
       hasExtensionSources: nextHasExtensionSources,
@@ -141,17 +154,8 @@ export function useLocalExtensionRuntime(
     };
   }, [reload]);
 
-  return useMemo(() => {
-    // Extension UI registries are mutated in place by trusted extension code.
-    // Keep renderVersion private but include it here so onChange invalidates
-    // the memoized runtime object and downstream components re-render.
-    void renderVersion;
-    return {
-      registry,
-      getContext,
-      reload,
-      updateContext,
-      ...loadState,
-    };
-  }, [getContext, loadState, registry, reload, updateContext, renderVersion]);
+  return useMemo(
+    () => ({ registry, getContext, reload, updateContext, ...loadState }),
+    [getContext, loadState, registry, reload, updateContext],
+  );
 }

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getClient } from "@/backend/api/client";
 import { debugLog } from "@/utils/debug";
 import {
   disposeLocalExtensions,
@@ -80,6 +81,7 @@ export function useLocalExtensionRuntime(
     }
 
     const nextRegistry = await loadLocalExtensions({
+      getClient,
       getContext: () => contextRef.current,
       onChange: () => {
         if (mountedRef.current) {

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -79,6 +79,16 @@ type ExtensionCommandContext = {
 
 Use `ctx.args` for the raw argument string and `ctx.argv` for simple quote-aware splitting.
 
+## Letta SDK client
+
+Extensions also receive the configured Letta SDK client:
+
+```ts
+letta.client
+```
+
+Use it for advanced workflows that need the full Letta API, such as forking conversations, reading agent state, or sending messages. This is the same authenticated client context the app uses.
+
 ### Results
 
 Command handlers return declarative results. The app owns transcript rendering, approval checks, and sending prompts.
@@ -149,10 +159,67 @@ export default function activate(letta) {
 }
 ```
 
+### Ask a side question in a forked conversation
+
+This example intentionally returns normal command output rather than opening a custom side panel.
+
+```ts
+export default function activate(letta) {
+  function appendAssistantText(chunk, parts) {
+    if (chunk.message_type !== "assistant_message") return;
+    const content = chunk.content;
+    if (typeof content === "string") {
+      parts.push(content);
+    } else if (Array.isArray(content)) {
+      for (const part of content) {
+        if (part && typeof part === "object" && "text" in part) {
+          parts.push(String(part.text));
+        }
+      }
+    }
+  }
+
+  return letta.commands.register({
+    id: "btw",
+    description: "Ask a side question in a forked conversation",
+    args: "<question>",
+    async run(ctx) {
+      if (!ctx.args.trim()) {
+        return {
+          type: "output",
+          output: "Usage: /btw <question>",
+          success: false,
+        };
+      }
+
+      const forked = await letta.client.conversations.fork(ctx.conversation.id, {
+        agent_id: ctx.agent.id,
+      });
+      const stream = await letta.client.conversations.messages.create(forked.id, {
+        agent_id: ctx.agent.id,
+        input: ctx.args,
+        streaming: true,
+      });
+
+      const parts = [];
+      for await (const chunk of stream) {
+        appendAssistantText(chunk, parts);
+      }
+
+      return {
+        type: "output",
+        output: parts.join("").trim() || "No response.",
+      };
+    },
+  });
+}
+```
+
 ## Constraints
 
 - Global trusted code only for now. Do not create project extensions.
-- Do not expose app internals, React setters, backend clients, or command runner objects.
+- Do not use app internals, React setters, or command runner objects.
+- Prefer `letta.client` over raw `fetch` when using the Letta API.
 - Keep command handlers fast. Async handlers are allowed, but they should return prompt/output/handled results rather than mutating app state.
 - Do not register built-in command IDs.
 - Do not do surprising side effects on startup; extension files execute when Letta Code starts or `/reload` runs.

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customizing-commands
-description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, or prompt-oriented command behavior.
+description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, SDK-backed command, or panel-rendered command behavior.
 ---
 
 # Customizing Commands
@@ -57,6 +57,26 @@ export default function activate(letta) {
 - Use a lowercase slug with letters, numbers, and hyphens only.
 - Built-in commands like `/reload`, `/model`, `/statusline`, etc. are reserved.
 - Duplicate extension command IDs fail unless the command explicitly uses `override: true`.
+- Prefer specific names for shared commands (`github-review`, `btw-code`) to avoid collisions with other extensions.
+
+Command resolution order is: built-in/special commands, custom command files, extension commands, then remaining registry/skill commands. Extension commands cannot replace built-ins, and custom command files with the same name win over extensions.
+
+### Command metadata
+
+```ts
+letta.commands.register({
+  id: "btw",
+  description: "Ask a side question",
+  runWhenBusy: true,
+  showInTranscript: false,
+  run(ctx) {
+    return { type: "handled" };
+  },
+});
+```
+
+- `runWhenBusy`: allows the command to run while the main agent is streaming/executing. Busy-safe commands must use their own SDK calls and should not return `prompt` while the agent is running.
+- `showInTranscript`: defaults to `true`. Set `false` for commands that render their own UI panel and should not add a command row to the transcript.
 
 ### Command context
 
@@ -88,6 +108,45 @@ letta.client
 ```
 
 Use it for advanced workflows that need the full Letta API, such as forking conversations, reading agent state, or sending messages. This is the same authenticated client context the app uses.
+
+API reference:
+
+- Letta API docs: https://docs.letta.com/api-reference/overview
+- TypeScript SDK package: https://www.npmjs.com/package/@letta-ai/letta-client
+
+Guidance:
+
+- Prefer `letta.client` over raw `fetch`; it already has the current backend URL, auth, and app headers.
+- Verify SDK method and parameter names before guessing. The generated SDK follows API field names, so request params are often snake_case (`agent_id`), not camelCase (`agentId`).
+- For the default conversation, pass `"default"` plus `{ agent_id: ctx.agent.id }` when the endpoint requires agent-direct mode.
+- Common conversation calls:
+  - `await letta.client.conversations.fork(conversationId, { agent_id: ctx.agent.id })`
+  - `await letta.client.conversations.messages.create(conversationId, { agent_id: ctx.agent.id, input, streaming: true })`
+- Streaming message calls return an async iterable of chunks. Extract assistant text from `assistant_message` chunks; chunk content may be a string or an array of text parts.
+
+## UI panels
+
+Commands can write raw lines into the space above the input bar:
+
+```ts
+const panel = letta.ui.openPanel({
+  id: "btw",
+  content: [`/btw ${question}`, "…"],
+});
+
+panel.update({ content: [`/btw ${question}`, "Caren"] });
+setTimeout(() => panel.close(), 10_000);
+```
+
+Panels are intentionally minimal: `id`, `content`, and optional `order`. `content` may be a string (split on newlines) or an array of strings. Core only reserves the slot above the input bar and truncates lines to terminal width; the extension owns visual formatting such as borders, spacing, wrapping, and right alignment.
+
+Guidance:
+
+- Keep panel output short. If you need long-form output, prefer command `output` or a normal `prompt` flow.
+- Panels persist until `panel.close()`, `letta.ui.clearPanel(id)`, the same `id` is overwritten, or `/reload` disposes extensions.
+- For transient results, close the panel after a short timeout.
+- If formatting depends on terminal size, use `ctx.getContext().terminalWidth` inside a command or `letta.getContext().terminalWidth` outside a command. Terminal sizes are columns, not pixels.
+- Avoid unexplained magic widths. If you cap width for aesthetics, name the constant, e.g. `PANEL_MAX_COLUMNS`.
 
 ### Results
 
@@ -161,65 +220,14 @@ export default function activate(letta) {
 
 ### Ask a side question in a forked conversation
 
-This example intentionally returns normal command output rather than opening a custom side panel.
-
-```ts
-export default function activate(letta) {
-  function appendAssistantText(chunk, parts) {
-    if (chunk.message_type !== "assistant_message") return;
-    const content = chunk.content;
-    if (typeof content === "string") {
-      parts.push(content);
-    } else if (Array.isArray(content)) {
-      for (const part of content) {
-        if (part && typeof part === "object" && "text" in part) {
-          parts.push(String(part.text));
-        }
-      }
-    }
-  }
-
-  return letta.commands.register({
-    id: "btw",
-    description: "Ask a side question in a forked conversation",
-    args: "<question>",
-    async run(ctx) {
-      if (!ctx.args.trim()) {
-        return {
-          type: "output",
-          output: "Usage: /btw <question>",
-          success: false,
-        };
-      }
-
-      const forked = await letta.client.conversations.fork(ctx.conversation.id, {
-        agent_id: ctx.agent.id,
-      });
-      const stream = await letta.client.conversations.messages.create(forked.id, {
-        agent_id: ctx.agent.id,
-        input: ctx.args,
-        streaming: true,
-      });
-
-      const parts = [];
-      for await (const chunk of stream) {
-        appendAssistantText(chunk, parts);
-      }
-
-      return {
-        type: "output",
-        output: parts.join("").trim() || "No response.",
-      };
-    },
-  });
-}
-```
+For a fuller `/btw` recipe using `runWhenBusy`, `showInTranscript: false`, `letta.client.conversations.fork(...)`, streaming, and `letta.ui.openPanel(...)`, see [`reference/btw-command.md`](reference/btw-command.md).
 
 ## Constraints
 
 - Global trusted code only for now. Do not create project extensions.
 - Do not use app internals, React setters, or command runner objects.
 - Prefer `letta.client` over raw `fetch` when using the Letta API.
-- Keep command handlers fast. Async handlers are allowed, but they should return prompt/output/handled results rather than mutating app state.
+- Keep command handlers fast. For long-running SDK work, start an async task, update a panel, and return `{ type: "handled" }` immediately.
+- If a command uses `runWhenBusy`, do not return `prompt` while the agent is running. Use `letta.client` and panels instead.
 - Do not register built-in command IDs.
 - Do not do surprising side effects on startup; extension files execute when Letta Code starts or `/reload` runs.

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: customizing-commands
+description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, or prompt-oriented command behavior.
+---
+
+# Customizing Commands
+
+Use this skill to create or update global Letta Code slash commands provided by local extensions.
+
+Extension files live here:
+
+```text
+~/.letta/extensions/
+```
+
+Use a focused file name like:
+
+```text
+~/.letta/extensions/commands.ts
+~/.letta/extensions/review.ts
+```
+
+## Workflow
+
+1. Inspect `~/.letta/extensions/` for existing command extensions.
+2. Preserve unrelated extension code. If adding a new command to an existing command file is clean, edit it; otherwise create a focused new file.
+3. Register commands with `letta.commands.register()`.
+4. Return the unregister function, or return a disposer that calls it.
+5. Tell the user exactly which file changed and ask them to run `/reload`.
+6. After reload, the command should appear in slash-command autocomplete and execute from the input.
+
+## API
+
+```ts
+export default function activate(letta) {
+  const unregister = letta.commands.register({
+    id: "review",
+    description: "Review current git changes",
+    args: "[focus]",
+    order: 250,
+    async run(ctx) {
+      return {
+        type: "prompt",
+        content: "Review the current git diff. Focus only on correctness issues.",
+        systemReminder: true,
+      };
+    },
+  });
+
+  return unregister;
+}
+```
+
+### Command IDs
+
+- Do not include the leading slash. Use `id: "review"`, not `id: "/review"`.
+- Use a lowercase slug with letters, numbers, and hyphens only.
+- Built-in commands like `/reload`, `/model`, `/statusline`, etc. are reserved.
+- Duplicate extension command IDs fail unless the command explicitly uses `override: true`.
+
+### Command context
+
+`run(ctx)` receives:
+
+```ts
+type ExtensionCommandContext = {
+  rawInput: string;
+  command: string;
+  args: string;
+  argv: string[];
+  cwd: string;
+  agent: { id: string; name: string | null };
+  conversation: { id: string };
+  model: { id: string | null; displayName: string | null };
+  permissionMode: string | null;
+  getContext(): ExtensionContext;
+};
+```
+
+Use `ctx.args` for the raw argument string and `ctx.argv` for simple quote-aware splitting.
+
+### Results
+
+Command handlers return declarative results. The app owns transcript rendering, approval checks, and sending prompts.
+
+```ts
+type ExtensionCommandResult =
+  | { type: "prompt"; content: string; systemReminder?: boolean }
+  | { type: "output"; output: string; success?: boolean }
+  | { type: "handled" };
+```
+
+- `prompt`: sends content to the agent. By default content is wrapped as a system reminder; set `systemReminder: false` to send it as a normal user prompt.
+- `output`: finishes the command row with text and does not contact the agent.
+- `handled`: finishes the command row without sending a prompt.
+
+## Examples
+
+### Review current changes
+
+```ts
+export default function activate(letta) {
+  return letta.commands.register({
+    id: "review",
+    description: "Review current git changes",
+    async run() {
+      return {
+        type: "prompt",
+        content: "Review the current git diff. Focus only on correctness issues.",
+        systemReminder: true,
+      };
+    },
+  });
+}
+```
+
+### Review a PR argument
+
+```ts
+export default function activate(letta) {
+  return letta.commands.register({
+    id: "review-pr",
+    description: "Review a GitHub PR",
+    args: "<url-or-number>",
+    async run(ctx) {
+      return {
+        type: "prompt",
+        content: `Review this PR: ${ctx.args}`,
+      };
+    },
+  });
+}
+```
+
+### Show local output only
+
+```ts
+export default function activate(letta) {
+  return letta.commands.register({
+    id: "whoami",
+    description: "Show current command context",
+    run(ctx) {
+      return {
+        type: "output",
+        output: `Agent: ${ctx.agent.name ?? ctx.agent.id}\nCWD: ${ctx.cwd}`,
+      };
+    },
+  });
+}
+```
+
+## Constraints
+
+- Global trusted code only for now. Do not create project extensions.
+- Do not expose app internals, React setters, backend clients, or command runner objects.
+- Keep command handlers fast. Async handlers are allowed, but they should return prompt/output/handled results rather than mutating app state.
+- Do not register built-in command IDs.
+- Do not do surprising side effects on startup; extension files execute when Letta Code starts or `/reload` runs.

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -76,7 +76,7 @@ letta.commands.register({
 ```
 
 - `runWhenBusy`: allows the command to run while the main agent is streaming/executing. Busy-safe commands must use their own SDK calls and should not return `prompt` while the agent is running.
-- `showInTranscript`: defaults to `true`. Set `false` for commands that render their own UI panel and should not add a command row to the transcript.
+- `showInTranscript`: defaults to `true`. Set `false` for commands that render their own UI panel and should not add a command row to the transcript. Hidden commands cannot return `prompt`; return `handled` when the extension owns the UI. `output` results are still surfaced by the app.
 
 ### Command context
 
@@ -105,9 +105,10 @@ Extensions also receive the configured Letta SDK client:
 
 ```ts
 letta.client
+await letta.getClient()
 ```
 
-Use it for advanced workflows that need the full Letta API, such as forking conversations, reading agent state, or sending messages. This is the same authenticated client context the app uses.
+Use it for advanced workflows that need the full Letta API, such as forking conversations, reading agent state, or sending messages. This is the same authenticated client context the app uses. SDK initialization is lazy: `letta.client` initializes on first method call, and `letta.getClient()` initializes when awaited.
 
 API reference:
 
@@ -116,7 +117,7 @@ API reference:
 
 Guidance:
 
-- Prefer `letta.client` over raw `fetch`; it already has the current backend URL, auth, and app headers.
+- Prefer `letta.client` or `await letta.getClient()` over raw `fetch`; they already have the current backend URL, auth, and app headers.
 - Verify SDK method and parameter names before guessing. The generated SDK follows API field names, so request params are often snake_case (`agent_id`), not camelCase (`agentId`).
 - For the default conversation, pass `"default"` plus `{ agent_id: ctx.agent.id }` when the endpoint requires agent-direct mode.
 - Common conversation calls:
@@ -138,7 +139,7 @@ panel.update({ content: [`/btw ${question}`, "Caren"] });
 setTimeout(() => panel.close(), 10_000);
 ```
 
-Panels are intentionally minimal: `id`, `content`, and optional `order`. `content` may be a string (split on newlines) or an array of strings. Core only reserves the slot above the input bar and truncates lines to terminal width; the extension owns visual formatting such as borders, spacing, wrapping, and right alignment.
+Panels are intentionally minimal: `id`, `content`, and optional `order`. `content` may be a string (split on newlines) or an array of strings. Core only reserves the slot above the input bar, sorts lower `order` values first, renders up to 8 panel lines, and truncates lines to terminal width; the extension owns visual formatting such as borders, spacing, wrapping, and right alignment.
 
 Guidance:
 
@@ -226,8 +227,9 @@ For a fuller `/btw` recipe using `runWhenBusy`, `showInTranscript: false`, `lett
 
 - Global trusted code only for now. Do not create project extensions.
 - Do not use app internals, React setters, or command runner objects.
-- Prefer `letta.client` over raw `fetch` when using the Letta API.
+- Prefer `letta.client` or `await letta.getClient()` over raw `fetch` when using the Letta API.
 - Keep command handlers fast. For long-running SDK work, start an async task, update a panel, and return `{ type: "handled" }` immediately.
 - If a command uses `runWhenBusy`, do not return `prompt` while the agent is running. Use `letta.client` and panels instead.
+- If a command uses `showInTranscript: false`, do not return `prompt`; hidden commands should usually return `handled` and own their panel side effects.
 - Do not register built-in command IDs.
 - Do not do surprising side effects on startup; extension files execute when Letta Code starts or `/reload` runs.

--- a/src/skills/builtin/customizing-commands/reference/btw-command.md
+++ b/src/skills/builtin/customizing-commands/reference/btw-command.md
@@ -1,0 +1,90 @@
+# `/btw` side-question extension example
+
+### Ask a side question in a forked conversation
+
+This example runs while the main agent is busy because it forks the conversation, uses the SDK directly, renders progress in a panel, and returns `{ type: "handled" }` immediately.
+
+```ts
+export default function activate(letta) {
+  function appendAssistantText(chunk, parts) {
+    if (chunk.message_type !== "assistant_message") return;
+    const content = chunk.content;
+    if (typeof content === "string") {
+      parts.push(content);
+      return;
+    }
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (part && typeof part === "object" && "text" in part) {
+          parts.push(String(part.text));
+        }
+      }
+    }
+  }
+
+  return letta.commands.register({
+    id: "btw",
+    description: "Ask a side question in a forked conversation",
+    args: "<question>",
+    runWhenBusy: true,
+    showInTranscript: false,
+    run(ctx) {
+      const question = ctx.args.trim();
+      if (!question) {
+        letta.ui.openPanel({
+          id: "btw",
+          content: ["/btw", "Usage: /btw <question>"],
+        });
+        return { type: "handled" };
+      }
+
+      const panel = letta.ui.openPanel({
+        id: "btw",
+        content: [`/btw ${question}`, "…"],
+      });
+
+      void (async () => {
+        try {
+          const forked = await letta.client.conversations.fork(
+            ctx.conversation.id || "default",
+            { agent_id: ctx.agent.id },
+          );
+          const stream = await letta.client.conversations.messages.create(
+            forked.id,
+            {
+              agent_id: ctx.agent.id,
+              input: `${question}
+
+Answer briefly in 1-3 short sentences.`,
+              streaming: true,
+            },
+          );
+
+          const parts = [];
+          for await (const chunk of stream) {
+            appendAssistantText(chunk, parts);
+            panel.update({ content: [`/btw ${question}`, parts.join("") || "…"] });
+          }
+
+          panel.update({
+            content: [`✓ /btw ${question}`, parts.join("").trim() || "No response."],
+          });
+          setTimeout(() => panel.close(), 10_000);
+        } catch (error) {
+          panel.update({
+            content: [
+              `✗ /btw ${question}`,
+              error instanceof Error ? error.message : String(error),
+            ],
+          });
+          setTimeout(() => panel.close(), 15_000);
+        }
+      })();
+
+      return { type: "handled" };
+    },
+  });
+}
+```
+
+Add custom borders, right alignment, wrapping, or history only if the user asks for that polish.


### PR DESCRIPTION
## Summary
- Add trusted local extension slash command registration, autocomplete, command execution, and SDK client access.
- Add busy-safe command metadata plus a raw panel slot above the input bar for extension-owned side UI.
- Document the command API, SDK guidance, and a fuller /btw reference example.

## Test plan
- [x] bun run check
- [x] bun test src/cli/extensions/local-extension-loader.test.ts src/cli/extensions/command-runtime.test.ts
- [x] bun test (full local suite run; unrelated existing environment/test failures remain, including startup/headless/local input tests)

👾 Generated with [Letta Code](https://letta.com)