### PR TITLE
fix(mcp): abort server list timeout

### DIFF
--- a/src/cli/components/McpSelector.tsx
+++ b/src/cli/components/McpSelector.tsx
@@ -15,6 +15,8 @@ import { Text } from "./Text";
 // Horizontal line character (matches approval dialogs)
 const SOLID_LINE = "─";
 export const MCP_SERVERS_LIST_TIMEOUT_MS = 15_000;
+export const MCP_SERVERS_LIST_TIMEOUT_MESSAGE =
+  "Timed out loading MCP servers. The API endpoint may be slow or unavailable; press R to retry.";
 
 interface McpSelectorProps {
   agentId: string;
@@ -24,25 +26,31 @@ interface McpSelectorProps {
 
 type McpServer = StreamableHTTPMcpServer | SseMcpServer | StdioMcpServer;
 
+interface McpServersListClient {
+  mcpServers: {
+    list(options?: {
+      maxRetries?: number;
+      signal?: AbortSignal | null;
+    }): Promise<McpServer[]>;
+  };
+}
+
 const DISPLAY_PAGE_SIZE = 5;
 const TOOLS_DISPLAY_PAGE_SIZE = 8;
 
-export async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  message: string,
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
-  });
+export async function listMcpServersWithTimeout(
+  client: McpServersListClient,
+  timeoutMs = MCP_SERVERS_LIST_TIMEOUT_MS,
+): Promise<McpServer[]> {
+  const signal = AbortSignal.timeout(timeoutMs);
 
   try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
+    return await client.mcpServers.list({ maxRetries: 0, signal });
+  } catch (error) {
+    if (signal.aborted) {
+      throw new Error(MCP_SERVERS_LIST_TIMEOUT_MESSAGE);
     }
+    throw error;
   }
 }
 
@@ -114,11 +122,7 @@ export const McpSelector = memo(function McpSelector({
     setError(null);
     try {
       const client = await getClient();
-      const serverList = await withTimeout(
-        client.mcpServers.list(),
-        MCP_SERVERS_LIST_TIMEOUT_MS,
-        "Timed out loading MCP servers. The API endpoint may be slow or unavailable; press R to retry.",
-      );
+      const serverList = await listMcpServersWithTimeout(client);
       setServers(serverList);
     } catch (err) {
       setError(

--- a/src/cli/components/mcp-selector.test.ts
+++ b/src/cli/components/mcp-selector.test.ts
@@ -1,16 +1,48 @@
 import { describe, expect, test } from "bun:test";
-import { withTimeout } from "./McpSelector";
+import {
+  listMcpServersWithTimeout,
+  MCP_SERVERS_LIST_TIMEOUT_MESSAGE,
+} from "./McpSelector";
 
-describe("withTimeout", () => {
-  test("resolves when the wrapped promise settles before the timeout", async () => {
+describe("listMcpServersWithTimeout", () => {
+  test("passes an abort signal and disables retries", async () => {
+    let capturedOptions:
+      | { maxRetries?: number; signal?: AbortSignal | null }
+      | undefined;
+    const servers: never[] = [];
+
     await expect(
-      withTimeout(Promise.resolve("servers"), 50, "timed out"),
-    ).resolves.toBe("servers");
+      listMcpServersWithTimeout({
+        mcpServers: {
+          list: (options) => {
+            capturedOptions = options;
+            return Promise.resolve(servers);
+          },
+        },
+      }),
+    ).resolves.toBe(servers);
+
+    expect(capturedOptions?.maxRetries).toBe(0);
+    expect(capturedOptions?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  test("rejects with the supplied message when the wrapped promise hangs", async () => {
+  test("rewrites aborts to the retryable MCP list timeout message", async () => {
     await expect(
-      withTimeout(new Promise(() => {}), 1, "MCP list timed out"),
-    ).rejects.toThrow("MCP list timed out");
+      listMcpServersWithTimeout(
+        {
+          mcpServers: {
+            list: (options) =>
+              new Promise((_, reject) => {
+                options?.signal?.addEventListener(
+                  "abort",
+                  () => reject(new Error("raw abort")),
+                  { once: true },
+                );
+              }),
+          },
+        },
+        1,
+      ),
+    ).rejects.toThrow(MCP_SERVERS_LIST_TIMEOUT_MESSAGE);
   });
 });


### PR DESCRIPTION
## Summary
- Replace the MCP selector timeout race with an SDK request abort signal so a stalled server-list request is actually cancelled.
- Disable SDK retries for the overlay list request so the UI returns to the retryable error state after one 15s window.
- Update the regression test to verify the abort signal is passed and timeout aborts surface the existing retryable message.

## Test plan
- [x] bun test ./src/cli/components/mcp-selector.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)