### PR TITLE
feat(extensions): add extension tools

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -13,6 +13,7 @@ import { INTERRUPTED_BY_USER } from "@/constants";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import {
   executeTool,
+  isExtensionToolParallelSafeForContext,
   prepareCurrentToolExecutionContext,
   type ToolExecutionResult,
   type ToolReturnContent,
@@ -84,8 +85,11 @@ const PARALLEL_SAFE_TOOLS = new Set([
   "Agent",
 ]);
 
-function isParallelSafe(toolName: string): boolean {
-  return PARALLEL_SAFE_TOOLS.has(toolName);
+function isParallelSafe(toolName: string, toolContextId?: string): boolean {
+  return (
+    PARALLEL_SAFE_TOOLS.has(toolName) ||
+    isExtensionToolParallelSafeForContext(toolName, toolContextId)
+  );
 }
 
 /**
@@ -414,7 +418,7 @@ export async function executeApprovalBatch(
 
     const toolName = decision.approval.toolName;
 
-    if (isParallelSafe(toolName)) {
+    if (isParallelSafe(toolName, toolContextId)) {
       parallelIndices.push(i);
     } else {
       // Get resource key for write tools

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -18,6 +18,7 @@ import {
   resolveLocalExtensionSources,
 } from "@/cli/extensions/local-extension-loader";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
+import { clearExtensionTools } from "@/extensions/tool-registry";
 
 function createTempDir(): string {
   return mkdtempSync(path.join(tmpdir(), "letta-extensions-"));
@@ -56,6 +57,10 @@ function createLoadOptions(root: string) {
 }
 
 describe("local extension loader", () => {
+  afterEach(() => {
+    clearExtensionTools();
+  });
+
   test("discovers global extension source", () => {
     const root = createTempDir();
     try {
@@ -498,6 +503,33 @@ describe("local extension loader", () => {
         expect.stringContaining("built-in command"),
         expect.stringContaining("must not start"),
       ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects extension tool names that collide with built-in tools", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const extensionDir = options.globalExtensionsDirectory;
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "tool.ts"),
+        `export default function(letta) {
+          letta.tools.register({
+            name: "Read",
+            description: "Built-in conflict",
+            run() { return "nope"; },
+          });
+        }`,
+      );
+
+      const registry = await loadLocalExtensions(options);
+
+      expect(registry.tools).toEqual({});
+      expect(registry.errors).toHaveLength(1);
+      expect(registry.errors[0]?.error.message).toContain("built-in tool");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -12,6 +12,7 @@ import {
   loadLocalExtensions as loadLocalExtensionsBase,
   resolveLocalExtensionSources,
 } from "@/extensions/extension-host";
+import { getAllLettaToolNames, getServerToolName } from "@/tools/manager";
 
 function stripSlash(command: string): string {
   return command.startsWith("/") ? command.slice(1) : command;
@@ -21,8 +22,20 @@ function getDefaultReservedCommandIds(): Set<string> {
   return new Set(Object.keys(builtinCommands).map(stripSlash));
 }
 
-function withDefaultReservedCommandIds<
-  T extends { reservedCommandIds?: Iterable<string> },
+function getDefaultReservedToolNames(): Set<string> {
+  const reserved = new Set<string>();
+  for (const toolName of getAllLettaToolNames()) {
+    reserved.add(toolName);
+    reserved.add(getServerToolName(toolName));
+  }
+  return reserved;
+}
+
+function withDefaultReservations<
+  T extends {
+    reservedCommandIds?: Iterable<string>;
+    reservedToolNames?: Iterable<string>;
+  },
 >(options: T): T {
   return {
     ...options,
@@ -30,15 +43,19 @@ function withDefaultReservedCommandIds<
       ...getDefaultReservedCommandIds(),
       ...(options.reservedCommandIds ?? []),
     ],
+    reservedToolNames: [
+      ...getDefaultReservedToolNames(),
+      ...(options.reservedToolNames ?? []),
+    ],
   };
 }
 
 export function createExtensionHost(options: CreateExtensionHostOptions) {
-  return createExtensionHostBase(withDefaultReservedCommandIds(options));
+  return createExtensionHostBase(withDefaultReservations(options));
 }
 
 export function loadLocalExtensions(options: LoadLocalExtensionsOptions) {
-  return loadLocalExtensionsBase(withDefaultReservedCommandIds(options));
+  return loadLocalExtensionsBase(withDefaultReservations(options));
 }
 
 export {

--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -23,5 +23,12 @@ export type {
   ExtensionReflectionContext,
   ExtensionSourceScope,
   ExtensionTokenUsageContext,
+  ExtensionTool,
+  ExtensionToolContent,
+  ExtensionToolContentImage,
+  ExtensionToolContentText,
+  ExtensionToolRegistration,
+  ExtensionToolRunContext,
+  ExtensionToolRunResult,
   ExtensionWorkspaceContext,
 } from "@/extensions/types";

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -7,6 +7,10 @@ import {
   createExtensionHost,
   type ExtensionHost,
 } from "@/extensions/extension-host";
+import {
+  clearExtensionTools,
+  getExtensionToolDefinition,
+} from "@/extensions/tool-registry";
 import type { ExtensionPanelHandle } from "@/extensions/types";
 
 type ExtensionTestGlobal = typeof globalThis & {
@@ -29,6 +33,10 @@ function createHost(root: string): ExtensionHost {
 }
 
 describe("extension host", () => {
+  afterEach(() => {
+    clearExtensionTools();
+  });
+
   test("reload publishes snapshots with owner metadata", async () => {
     const root = createTempDir();
     try {
@@ -300,6 +308,54 @@ describe("extension host", () => {
       });
 
       host.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads extension-provided tools with owner metadata", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "tools.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          return letta.tools.register({
+            name: "local_weather",
+            description: "Get local weather",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+            requiresApproval: false,
+            parallelSafe: true,
+            run(ctx) { return "weather for " + ctx.args.city; },
+          });
+        }`,
+      );
+
+      const host = createHost(root);
+      await host.reload();
+      const snapshot = host.getSnapshot();
+
+      expect(snapshot.errors).toEqual([]);
+      expect(snapshot.tools.local_weather).toMatchObject({
+        description: "Get local weather",
+        owner: {
+          generation: 1,
+          id: `global:${extensionPath}`,
+          path: extensionPath,
+        },
+        parallelSafe: true,
+        requiresApproval: false,
+      });
+      expect(getExtensionToolDefinition("local_weather")).toBeDefined();
+
+      host.dispose();
+      expect(getExtensionToolDefinition("local_weather")).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -20,6 +20,12 @@ import type {
   StatuslineRenderer,
   StatuslineRendererOutput,
 } from "@/cli/display/statusline/types";
+import {
+  getExtensionToolDefinition,
+  registerExtensionTool,
+  unregisterExtensionTool,
+  unregisterExtensionToolsForOwner,
+} from "@/extensions/tool-registry";
 import type {
   ExtensionCommand,
   ExtensionCommandRegistration,
@@ -31,6 +37,8 @@ import type {
   ExtensionPanelHandle,
   ExtensionPanelOptions,
   ExtensionPanelUpdate,
+  ExtensionTool,
+  ExtensionToolRegistration,
 } from "@/extensions/types";
 
 export const GLOBAL_EXTENSIONS_DIRECTORY = path.join(
@@ -75,6 +83,10 @@ export interface LettaExtensionApi {
     register: (command: ExtensionCommandRegistration) => LettaExtensionDisposer;
     unregister: (id: string) => void;
   };
+  tools: {
+    register: (tool: ExtensionToolRegistration) => LettaExtensionDisposer;
+    unregister: (name: string) => void;
+  };
   ui: {
     clearPanel: (id: string) => void;
     clearStatus: (key: string) => void;
@@ -118,6 +130,7 @@ export interface LocalExtensionRegistry {
   ownerAbortControllers: Record<string, AbortController>;
   owners: Record<string, ExtensionOwner>;
   sources: LocalExtensionSource[];
+  tools: Record<string, ExtensionTool>;
   ui: LocalExtensionUiRegistry;
 }
 
@@ -146,6 +159,7 @@ export interface LoadLocalExtensionsOptions
   onChange?: () => void;
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void;
   reservedCommandIds?: Iterable<string>;
+  reservedToolNames?: Iterable<string>;
 }
 
 export interface ExtensionHost {
@@ -160,6 +174,7 @@ export interface CreateExtensionHostOptions
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
   reservedCommandIds?: Iterable<string>;
+  reservedToolNames?: Iterable<string>;
 }
 
 function listExtensionFiles(directory: string): string[] {
@@ -205,6 +220,7 @@ function createEmptyExtensionRegistry(
     ownerAbortControllers: {},
     owners: {},
     sources,
+    tools: {},
     ui: {
       panels: {},
       statuslineRenderer: null,
@@ -292,6 +308,7 @@ function snapshotRegistryForReaders(
       ...source,
       files: [...source.files],
     })),
+    tools: { ...registry.tools },
     ui: {
       ...registry.ui,
       panels: { ...registry.ui.panels },
@@ -316,6 +333,14 @@ function removeOwnerCapabilities(
       delete registry.ui.panels[id];
     }
   }
+
+  for (const [name, tool] of Object.entries(registry.tools)) {
+    if (tool.owner?.id === owner.id) {
+      delete registry.tools[name];
+    }
+  }
+
+  unregisterExtensionToolsForOwner(owner);
 
   for (const [key, statusOwner] of Object.entries(registry.ui.statusOwners)) {
     if (statusOwner.id === owner.id) {
@@ -529,6 +554,64 @@ function normalizeExtensionCommand(
   };
 }
 
+function validateExtensionToolName(name: string): void {
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(name)) {
+    throw new Error(
+      "Extension tool name must be 1-64 characters using letters, numbers, underscores, or hyphens",
+    );
+  }
+}
+
+function normalizeExtensionToolParameters(
+  parameters: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!parameters) {
+    return {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    };
+  }
+  if (
+    typeof parameters !== "object" ||
+    parameters === null ||
+    Array.isArray(parameters)
+  ) {
+    throw new Error("Extension tool parameters must be a JSON Schema object");
+  }
+  if (parameters.type !== undefined && parameters.type !== "object") {
+    throw new Error(
+      "Extension tool parameters schema must be an object schema",
+    );
+  }
+  return parameters;
+}
+
+function normalizeExtensionTool(
+  tool: ExtensionToolRegistration,
+  owner: ExtensionOwner,
+): ExtensionTool {
+  validateExtensionToolName(tool.name);
+  if (!tool.description.trim()) {
+    throw new Error(`Extension tool '${tool.name}' must include a description`);
+  }
+  if (typeof tool.run !== "function") {
+    throw new Error(`Extension tool '${tool.name}' must include run()`);
+  }
+
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: normalizeExtensionToolParameters(tool.parameters),
+    owner,
+    path: owner.path,
+    requiresApproval: tool.requiresApproval !== false,
+    parallelSafe: tool.parallelSafe === true,
+    ...(tool.isEnabled ? { isEnabled: tool.isEnabled } : {}),
+    run: tool.run,
+  };
+}
+
 function validateExtensionPanelId(id: string): void {
   if (!id.trim()) {
     throw new Error("Extension panel id must not be empty");
@@ -578,6 +661,7 @@ function createLettaExtensionApi(
   onChange: () => void,
   onDiagnostic: ((diagnostic: ExtensionDiagnostic) => void) | undefined,
   reservedCommandIds: Set<string>,
+  reservedToolNames: Set<string>,
   signal: AbortSignal,
 ): LettaExtensionApi {
   const isLive = () => isOwnerLive(registry, owner);
@@ -606,6 +690,17 @@ function createLettaExtensionApi(
     const existing = registry.ui.panels[panelKey];
     if (existing?.owner?.id === owner.id) {
       delete registry.ui.panels[panelKey];
+      onChange();
+    }
+  };
+
+  const unregisterTool = (name: string) => {
+    validateExtensionToolName(name);
+    if (!guardLive({ id: name, kind: "tool" })) return;
+    const existing = registry.tools[name];
+    if (existing?.owner?.id === owner.id) {
+      delete registry.tools[name];
+      unregisterExtensionTool(name, owner);
       onChange();
     }
   };
@@ -641,6 +736,43 @@ function createLettaExtensionApi(
         return () => unregisterCommand(normalized.id);
       },
       unregister: unregisterCommand,
+    },
+    tools: {
+      register(tool) {
+        if (!guardLive({ id: tool.name, kind: "tool" })) {
+          return () => undefined;
+        }
+
+        const normalized = normalizeExtensionTool(tool, owner);
+        if (reservedToolNames.has(normalized.name)) {
+          throw new Error(
+            `Extension tool '${normalized.name}' conflicts with a built-in tool`,
+          );
+        }
+
+        const existing = registry.tools[normalized.name];
+        const existingGlobal = getExtensionToolDefinition(normalized.name);
+        if ((existing || existingGlobal) && !tool.override) {
+          throw new Error(
+            `Extension tool '${normalized.name}' is already registered by ${existing?.path ?? existingGlobal?.path}`,
+          );
+        }
+
+        registry.tools[normalized.name] = normalized;
+        registerExtensionTool({
+          ...normalized,
+          activationSignal: signal,
+          getContext,
+          isAvailable: () => {
+            if (signal.aborted) return false;
+            return normalized.isEnabled?.(getContext()) ?? true;
+          },
+        });
+        onChange();
+
+        return () => unregisterTool(normalized.name);
+      },
+      unregister: unregisterTool,
     },
     ui: {
       clearPanel,
@@ -720,6 +852,7 @@ export async function loadLocalExtensions(
   const sources = resolveLocalExtensionSources(options);
   const generation = options.generation ?? 1;
   const reservedCommandIds = new Set([...(options.reservedCommandIds ?? [])]);
+  const reservedToolNames = new Set([...(options.reservedToolNames ?? [])]);
   const registry = createEmptyExtensionRegistry(sources, generation);
 
   for (const source of sources) {
@@ -763,6 +896,7 @@ export async function loadLocalExtensions(
             onChange,
             options.onDiagnostic,
             reservedCommandIds,
+            reservedToolNames,
             abortController.signal,
           ),
         );
@@ -839,9 +973,14 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
     }
   }
 
+  for (const owner of Object.values(registry.owners)) {
+    unregisterExtensionToolsForOwner(owner);
+  }
+
   registry.commands = {};
   registry.ownerAbortControllers = {};
   registry.owners = {};
+  registry.tools = {};
   registry.ui.panels = {};
   registry.ui.statusOwners = {};
   registry.ui.statusValues = {};

--- a/src/extensions/tool-registry.ts
+++ b/src/extensions/tool-registry.ts
@@ -1,0 +1,115 @@
+import type {
+  ExtensionOwner,
+  ExtensionTool,
+  ExtensionToolRunContext,
+  ExtensionToolRunResult,
+} from "@/extensions/types";
+
+const EXTENSION_TOOLS_KEY = Symbol.for("@letta/extensionTools");
+
+type GlobalWithExtensionTools = typeof globalThis & {
+  [EXTENSION_TOOLS_KEY]?: Map<string, ExtensionToolDefinition>;
+};
+
+export interface ExtensionToolDefinition extends ExtensionTool {
+  activationSignal: AbortSignal;
+  getContext: ExtensionToolRunContext["getContext"];
+  isAvailable: () => boolean;
+}
+
+function getMutableExtensionToolsRegistry(): Map<
+  string,
+  ExtensionToolDefinition
+> {
+  const global = globalThis as GlobalWithExtensionTools;
+  if (!global[EXTENSION_TOOLS_KEY]) {
+    global[EXTENSION_TOOLS_KEY] = new Map();
+  }
+  return global[EXTENSION_TOOLS_KEY];
+}
+
+export function getAvailableExtensionToolsRegistry(): Map<
+  string,
+  ExtensionToolDefinition
+> {
+  return new Map(
+    Array.from(getMutableExtensionToolsRegistry().entries()).filter(
+      ([, tool]) => {
+        if (tool.activationSignal.aborted) return false;
+        try {
+          return tool.isAvailable();
+        } catch {
+          return false;
+        }
+      },
+    ),
+  );
+}
+
+export function registerExtensionTool(tool: ExtensionToolDefinition): void {
+  getMutableExtensionToolsRegistry().set(tool.name, tool);
+}
+
+export function unregisterExtensionTool(
+  name: string,
+  owner: ExtensionOwner,
+): void {
+  const registry = getMutableExtensionToolsRegistry();
+  const existing = registry.get(name);
+  if (existing?.owner?.id === owner.id) {
+    registry.delete(name);
+  }
+}
+
+export function unregisterExtensionToolsForOwner(owner: ExtensionOwner): void {
+  const registry = getMutableExtensionToolsRegistry();
+  for (const [name, tool] of registry.entries()) {
+    if (tool.owner?.id === owner.id) {
+      registry.delete(name);
+    }
+  }
+}
+
+export function clearExtensionTools(): void {
+  getMutableExtensionToolsRegistry().clear();
+}
+
+export function getExtensionToolDefinition(
+  name: string,
+  registry: Map<
+    string,
+    ExtensionToolDefinition
+  > = getMutableExtensionToolsRegistry(),
+): ExtensionToolDefinition | undefined {
+  return registry.get(name);
+}
+
+export function extensionToolRequiresApproval(
+  name: string,
+  registry: Map<
+    string,
+    ExtensionToolDefinition
+  > = getMutableExtensionToolsRegistry(),
+): boolean | undefined {
+  return registry.get(name)?.requiresApproval;
+}
+
+export function isExtensionToolParallelSafe(
+  name: string,
+  registry: Map<
+    string,
+    ExtensionToolDefinition
+  > = getMutableExtensionToolsRegistry(),
+): boolean {
+  return registry.get(name)?.parallelSafe === true;
+}
+
+export async function runExtensionTool(
+  tool: ExtensionToolDefinition,
+  context: ExtensionToolRunContext,
+): Promise<ExtensionToolRunResult> {
+  if (tool.activationSignal.aborted) {
+    throw new Error(`Extension tool '${tool.name}' is no longer available`);
+  }
+  return tool.run(context);
+}

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -67,6 +67,7 @@ export interface ExtensionOwner {
 
 export type ExtensionCapabilityKind =
   | "command"
+  | "tool"
   | "panel"
   | "status"
   | "statusline";
@@ -197,4 +198,77 @@ export interface ExtensionCommand {
   runWhenBusy: boolean;
   showInTranscript: boolean;
   run: ExtensionCommandRegistration["run"];
+}
+
+export interface ExtensionToolContentText {
+  type: "text";
+  text: string;
+}
+
+export interface ExtensionToolContentImage {
+  type: "image";
+  source: {
+    type: "base64";
+    media_type: string;
+    data: string;
+  };
+}
+
+export type ExtensionToolContent =
+  | ExtensionToolContentText
+  | ExtensionToolContentImage;
+
+export type ExtensionToolRunResult =
+  | string
+  | ExtensionToolContent[]
+  | {
+      content?: string | ExtensionToolContent[];
+      output?: string;
+      stdout?: string[];
+      stderr?: string[];
+      status?: "success" | "error";
+      isError?: boolean;
+      success?: boolean;
+    };
+
+export interface ExtensionToolRunContext {
+  args: Record<string, unknown>;
+  cwd: string;
+  workingDirectory: string;
+  toolCallId: string | null;
+  signal: AbortSignal;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+  permissionMode: string | null;
+  agent: {
+    id: string | null;
+  };
+  conversation: {
+    id: string | null;
+  };
+  getContext: () => ExtensionContext;
+}
+
+export interface ExtensionToolRegistration {
+  name: string;
+  description: string;
+  parameters?: Record<string, unknown>;
+  override?: boolean;
+  requiresApproval?: boolean;
+  parallelSafe?: boolean;
+  isEnabled?: (context: ExtensionContext) => boolean;
+  run: (
+    context: ExtensionToolRunContext,
+  ) => ExtensionToolRunResult | Promise<ExtensionToolRunResult>;
+}
+
+export interface ExtensionTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  owner?: ExtensionOwner;
+  path: string;
+  requiresApproval: boolean;
+  parallelSafe: boolean;
+  isEnabled?: ExtensionToolRegistration["isEnabled"];
+  run: ExtensionToolRegistration["run"];
 }

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -3,6 +3,7 @@
 
 import { resolve } from "node:path";
 import { getCurrentAgentId } from "@/agent/context";
+import { extensionToolRequiresApproval } from "@/extensions/tool-registry";
 import { runPermissionRequestHooks } from "@/hooks";
 import type { PermissionModeState } from "@/tools/manager";
 import { canonicalToolName, isShellToolName } from "./canonical";
@@ -718,6 +719,11 @@ function getDefaultDecision(
   toolName: string,
   toolArgs?: ToolArgs,
 ): PermissionDecision {
+  const extensionRequiresApproval = extensionToolRequiresApproval(toolName);
+  if (extensionRequiresApproval !== undefined) {
+    return extensionRequiresApproval ? "ask" : "allow";
+  }
+
   // Check TOOL_PERMISSIONS to determine if tool requires approval
   // Import is async so we need to do this synchronously - get the permissions from manager
   // For now, use a hardcoded check that matches TOOL_PERMISSIONS configuration

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -19,6 +19,15 @@ import { getActiveChannelIds } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import {
+  type ExtensionToolDefinition,
+  extensionToolRequiresApproval,
+  getAvailableExtensionToolsRegistry,
+  getExtensionToolDefinition,
+  isExtensionToolParallelSafe,
+  runExtensionTool,
+} from "@/extensions/tool-registry";
+import type { ExtensionToolRunContext } from "@/extensions/types";
+import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
   runPreToolUseHooks,
@@ -289,6 +298,22 @@ function filterExternalToolsByClientAllowlist(
   );
 }
 
+function filterExtensionToolsByClientAllowlist(
+  extensionTools: Map<string, ExtensionToolDefinition>,
+  clientToolAllowlist?: string[],
+): Map<string, ExtensionToolDefinition> {
+  if (clientToolAllowlist === undefined) {
+    return new Map(extensionTools);
+  }
+
+  const allowSet = new Set(clientToolAllowlist);
+  return new Map(
+    Array.from(extensionTools.entries()).filter(([name, tool]) =>
+      matchesClientToolAllowlistEntry(allowSet, tool.name, name),
+    ),
+  );
+}
+
 export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
   "AskUserQuestion",
   "Bash",
@@ -522,6 +547,7 @@ type ToolExecutionContextSnapshot = {
   toolRegistry: ToolRegistry;
   externalTools: Map<string, ExternalToolDefinition>;
   externalExecutor?: ExternalToolExecutor;
+  extensionTools: Map<string, ExtensionToolDefinition>;
   workingDirectory: string;
   runtimeContext: RuntimeContextSnapshot;
   permissionModeState: PermissionModeState;
@@ -876,25 +902,43 @@ export async function executeExternalTool(
 /**
  * Get all loaded tools in the format expected by the Letta API's client_tools field.
  * Maps internal tool names to server-facing names for proper tool invocation.
- * Includes both built-in tools and external tools.
+ * Includes built-in, external, and extension tools.
  */
 export function getClientToolsFromRegistry(): ClientTool[] {
   return buildClientToolsFromSnapshot(
     withDynamicMessageChannelCache(toolRegistry),
     getExternalToolsRegistry(),
+    getAvailableExtensionToolsRegistry(),
   );
 }
 
 function buildClientToolsFromSnapshot(
   registry: ToolRegistry,
   externalTools: Map<string, ExternalToolDefinition>,
+  extensionTools: Map<string, ExtensionToolDefinition>,
 ): ClientTool[] {
   const builtInTools = Array.from(registry.entries()).map(([name, tool]) => ({
     name: getServerToolName(name),
     description: tool.schema.description,
     parameters: tool.schema.input_schema,
   }));
-  const externalClientTools = Array.from(externalTools.values()).map(
+  for (const name of externalTools.keys()) {
+    if (extensionTools.has(name)) {
+      debugLog(
+        "tools",
+        "extension tool %s shadows external tool with same name",
+        name,
+      );
+    }
+  }
+  const externalClientTools = Array.from(externalTools.values())
+    .filter((tool) => !extensionTools.has(tool.name))
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    }));
+  const extensionClientTools = Array.from(extensionTools.values()).map(
     (tool) => ({
       name: tool.name,
       description: tool.description,
@@ -902,7 +946,7 @@ function buildClientToolsFromSnapshot(
     }),
   );
 
-  return [...builtInTools, ...externalClientTools];
+  return [...builtInTools, ...externalClientTools, ...extensionClientTools];
 }
 
 function getEffectivePermissionModeState(
@@ -927,6 +971,7 @@ function capturePreparedToolExecutionContext(
     toolRegistry: ToolRegistry;
     externalTools: Map<string, ExternalToolDefinition>;
     externalExecutor?: ExternalToolExecutor;
+    extensionTools: Map<string, ExtensionToolDefinition>;
   },
   options?: {
     clientToolAllowlist?: string[];
@@ -951,6 +996,10 @@ function capturePreparedToolExecutionContext(
       options?.clientToolAllowlist,
     ),
     externalExecutor: snapshot.externalExecutor,
+    extensionTools: filterExtensionToolsByClientAllowlist(
+      snapshot.extensionTools,
+      options?.clientToolAllowlist,
+    ),
     workingDirectory:
       runtimeContext.workingDirectory ?? getCurrentWorkingDirectory(),
     runtimeContext,
@@ -966,6 +1015,7 @@ function capturePreparedToolExecutionContext(
     clientTools: buildClientToolsFromSnapshot(
       executionSnapshot.toolRegistry,
       executionSnapshot.externalTools,
+      executionSnapshot.extensionTools,
     ),
     loadedToolNames: Array.from(executionSnapshot.toolRegistry.keys()),
   };
@@ -985,6 +1035,7 @@ export function captureToolExecutionContext(
       toolRegistry: new Map(toolRegistry),
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
+      extensionTools: getAvailableExtensionToolsRegistry(),
     },
     {
       workingDirectory,
@@ -1011,6 +1062,7 @@ export async function prepareCurrentToolExecutionContext(options?: {
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
+      extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
   );
@@ -1036,6 +1088,7 @@ export async function prepareToolExecutionContextForSpecificTools(
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
+      extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
   );
@@ -1063,6 +1116,7 @@ export async function prepareToolExecutionContextForModel(
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
+      extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
   );
@@ -1074,7 +1128,22 @@ export async function prepareToolExecutionContextForModel(
  * @returns Tool permissions object with requiresApproval flag
  */
 export function getToolPermissions(toolName: string) {
+  const extensionRequiresApproval = extensionToolRequiresApproval(toolName);
+  if (extensionRequiresApproval !== undefined) {
+    return { requiresApproval: extensionRequiresApproval };
+  }
   return TOOL_PERMISSIONS[toolName as ToolName] || { requiresApproval: false };
+}
+
+export function isExtensionToolParallelSafeForContext(
+  toolName: string,
+  contextId?: string,
+): boolean {
+  const context = contextId ? getExecutionContextById(contextId) : undefined;
+  return isExtensionToolParallelSafe(
+    toolName,
+    context?.extensionTools ?? getAvailableExtensionToolsRegistry(),
+  );
 }
 
 /**
@@ -1585,6 +1654,10 @@ function flattenToolResponse(result: unknown): ToolReturnContent {
     return result;
   }
 
+  if (Array.isArray(result) && isMultimodalContent(result)) {
+    return result;
+  }
+
   if (!isRecord(result)) {
     return JSON.stringify(result);
   }
@@ -1655,6 +1728,304 @@ function flattenToolResponse(result: unknown): ToolReturnContent {
   return JSON.stringify(result);
 }
 
+function createLinkedAbortSignal(signals: Array<AbortSignal | undefined>): {
+  cleanup: () => void;
+  signal: AbortSignal;
+} {
+  const activeSignals = signals.filter(
+    (signal): signal is AbortSignal => signal !== undefined,
+  );
+  const controller = new AbortController();
+  const cleanupFns: Array<() => void> = [];
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+    cleanupFns.push(() => signal.removeEventListener("abort", abort));
+  }
+
+  return {
+    cleanup: () => {
+      for (const cleanup of cleanupFns) {
+        cleanup();
+      }
+    },
+    signal: controller.signal,
+  };
+}
+
+function getExtensionToolStatus(result: unknown): "success" | "error" {
+  if (!isRecord(result)) return "success";
+  if (result.status === "error" || result.isError === true) return "error";
+  if (result.success === false) return "error";
+  return "success";
+}
+
+type ToolHookContext = {
+  args: Record<string, unknown>;
+  debugLabel: string;
+  scopedAgentId?: string;
+  toolCallId?: string;
+  toolName: string;
+  workingDirectory: string;
+};
+
+async function collectPostToolHookFeedback(
+  context: ToolHookContext,
+  result: {
+    errorType?: string;
+    failureOutput?: string;
+    output: string;
+    status: "success" | "error";
+  },
+): Promise<string[]> {
+  let postToolUseFeedback: string[] = [];
+  try {
+    const postHookResult = await runPostToolUseHooks(
+      context.toolName,
+      context.args,
+      { status: result.status, output: result.output },
+      context.toolCallId,
+      context.workingDirectory,
+      context.scopedAgentId,
+      undefined,
+      undefined,
+    );
+    postToolUseFeedback = postHookResult.feedback;
+  } catch (error) {
+    debugLog("hooks", `PostToolUse hook error (${context.debugLabel})`, error);
+  }
+
+  let postToolUseFailureFeedback: string[] = [];
+  if (result.status === "error") {
+    try {
+      const failureHookResult = await runPostToolUseFailureHooks(
+        context.toolName,
+        context.args,
+        result.failureOutput ?? result.output,
+        result.errorType ?? "tool_error",
+        context.toolCallId,
+        context.workingDirectory,
+        context.scopedAgentId,
+        undefined,
+        undefined,
+      );
+      postToolUseFailureFeedback = failureHookResult.feedback;
+    } catch (error) {
+      debugLog(
+        "hooks",
+        `PostToolUseFailure hook error (${context.debugLabel})`,
+        error,
+      );
+    }
+  }
+
+  return [...postToolUseFeedback, ...postToolUseFailureFeedback];
+}
+
+function appendHookFeedbackToText(text: string, feedback: string[]): string {
+  if (feedback.length === 0) return text;
+  return `${text}\n\n[Hook feedback]:\n${feedback.join("\n")}`;
+}
+
+function appendHookFeedbackToToolReturn(
+  toolReturn: ToolReturnContent,
+  feedback: string[],
+): ToolReturnContent {
+  if (feedback.length === 0) return toolReturn;
+  const feedbackMessage = `\n\n[Hook feedback]:\n${feedback.join("\n")}`;
+  if (typeof toolReturn === "string") {
+    return toolReturn + feedbackMessage;
+  }
+  return [...toolReturn, { type: "text" as const, text: feedbackMessage }];
+}
+
+async function executeExtensionTool(
+  toolName: string,
+  tool: ExtensionToolDefinition,
+  args: ToolArgs,
+  executionScope: RuntimeContextSnapshot,
+  options: {
+    signal?: AbortSignal;
+    toolCallId?: string;
+    onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+    workingDirectory: string;
+    scopedAgentId?: string;
+  },
+): Promise<ToolExecutionResult> {
+  const startTime = Date.now();
+  const linkedSignal = createLinkedAbortSignal([
+    options.signal,
+    tool.activationSignal,
+  ]);
+  const { signal } = linkedSignal;
+
+  const run = async (): Promise<ToolExecutionResult> => {
+    const preHookResult = await runPreToolUseHooks(
+      toolName,
+      args as Record<string, unknown>,
+      options.toolCallId,
+      options.workingDirectory,
+      options.scopedAgentId,
+    );
+    if (preHookResult.blocked) {
+      const feedback = preHookResult.feedback.join("\n") || "Blocked by hook";
+      return {
+        toolReturn: `Error: Tool execution blocked by hook. ${feedback}`,
+        status: "error",
+      };
+    }
+
+    try {
+      const context: ExtensionToolRunContext = {
+        args: args as Record<string, unknown>,
+        cwd: options.workingDirectory,
+        workingDirectory: options.workingDirectory,
+        toolCallId: options.toolCallId ?? null,
+        signal,
+        ...(options.onOutput
+          ? {
+              onOutput: (chunk: string, stream: "stdout" | "stderr") => {
+                options.onOutput?.(
+                  stripAnsi(
+                    scrubSecretsFromString(chunk, options.scopedAgentId),
+                  ),
+                  stream,
+                );
+              },
+            }
+          : {}),
+        permissionMode: executionScope.permissionMode ?? null,
+        agent: { id: executionScope.agentId ?? null },
+        conversation: { id: executionScope.conversationId ?? null },
+        getContext: tool.getContext,
+      };
+      const result = await runExtensionTool(tool, context);
+      const duration = Date.now() - startTime;
+      const recordResult = isRecord(result) ? result : undefined;
+      const stdout = isStringArray(recordResult?.stdout)
+        ? recordResult.stdout
+        : undefined;
+      const stderr = isStringArray(recordResult?.stderr)
+        ? recordResult.stderr
+        : undefined;
+      const toolStatus = getExtensionToolStatus(result);
+      const flattenedResponse = flattenToolResponse(result);
+      const responseSize =
+        typeof flattenedResponse === "string"
+          ? flattenedResponse.length
+          : JSON.stringify(flattenedResponse).length;
+
+      telemetry.trackToolUsage(
+        toolName,
+        toolStatus === "success",
+        duration,
+        responseSize,
+        toolStatus === "error" ? "tool_error" : undefined,
+        stderr ? stderr.join("\n") : undefined,
+      );
+
+      const hookFeedback = await collectPostToolHookFeedback(
+        {
+          args: args as Record<string, unknown>,
+          debugLabel: "extension tool result path",
+          scopedAgentId: options.scopedAgentId,
+          toolCallId: options.toolCallId,
+          toolName,
+          workingDirectory: options.workingDirectory,
+        },
+        {
+          status: toolStatus,
+          output: getDisplayableToolReturn(flattenedResponse),
+          failureOutput:
+            typeof flattenedResponse === "string"
+              ? flattenedResponse
+              : JSON.stringify(flattenedResponse),
+          errorType: "tool_error",
+        },
+      );
+      const finalToolReturn = appendHookFeedbackToToolReturn(
+        flattenedResponse,
+        hookFeedback,
+      );
+
+      return {
+        toolReturn: finalToolReturn,
+        status: toolStatus,
+        ...(stdout && { stdout }),
+        ...(stderr && { stderr }),
+      };
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      const isAbort =
+        signal.aborted ||
+        (error instanceof Error &&
+          (error.name === "AbortError" ||
+            error.message === "The operation was aborted" ||
+            ("code" in error && error.code === "ABORT_ERR")));
+      const errorType = isAbort
+        ? "abort"
+        : error instanceof Error
+          ? error.name
+          : "unknown";
+      const errorMessage = isAbort
+        ? INTERRUPTED_BY_USER
+        : error instanceof Error
+          ? error.message
+          : String(error);
+
+      telemetry.trackToolUsage(
+        toolName,
+        false,
+        duration,
+        errorMessage.length,
+        errorType,
+        errorMessage,
+      );
+
+      const hookFeedback = await collectPostToolHookFeedback(
+        {
+          args: args as Record<string, unknown>,
+          debugLabel: "extension tool exception path",
+          scopedAgentId: options.scopedAgentId,
+          toolCallId: options.toolCallId,
+          toolName,
+          workingDirectory: options.workingDirectory,
+        },
+        {
+          status: "error",
+          output: errorMessage,
+          failureOutput: errorMessage,
+          errorType,
+        },
+      );
+      const finalErrorMessage = appendHookFeedbackToText(
+        errorMessage,
+        hookFeedback,
+      );
+
+      return {
+        toolReturn: finalErrorMessage,
+        status: "error",
+      };
+    }
+  };
+
+  try {
+    return await runWithRuntimeContext(executionScope, run);
+  } finally {
+    linkedSignal.cleanup();
+  }
+}
+
 /**
  * Executes a tool by name with the provided arguments.
  *
@@ -1692,6 +2063,8 @@ export async function executeTool(
     context?.externalTools ?? getExternalToolsRegistry();
   const activeExternalExecutor =
     context?.externalExecutor ?? getExternalToolExecutor();
+  const activeExtensionTools =
+    context?.extensionTools ?? getAvailableExtensionToolsRegistry();
   const executionScope = context?.runtimeContext
     ? buildExecutionRuntimeContextSnapshot({
         workingDirectory: context.runtimeContext.workingDirectory ?? undefined,
@@ -1706,6 +2079,23 @@ export async function executeTool(
     executionScope.workingDirectory ?? getCurrentWorkingDirectory();
   const scopedAgentId = executionScope.agentId ?? undefined;
 
+  if (activeExtensionTools.has(name)) {
+    const extensionTool = activeExtensionTools.get(name);
+    if (!extensionTool) {
+      return {
+        toolReturn: `Extension tool not found: ${name}`,
+        status: "error",
+      };
+    }
+    return executeExtensionTool(name, extensionTool, args, executionScope, {
+      signal: options?.signal,
+      toolCallId: options?.toolCallId,
+      onOutput: options?.onOutput,
+      workingDirectory,
+      scopedAgentId,
+    });
+  }
+
   // Check if this is an external tool (SDK-executed)
   if (activeExternalTools.has(name)) {
     return executeExternalTool(
@@ -1718,16 +2108,26 @@ export async function executeTool(
 
   const internalName = resolveInternalToolName(name, activeRegistry);
   if (!internalName) {
+    const availableTools = [
+      ...Array.from(activeRegistry.keys()),
+      ...Array.from(activeExternalTools.keys()),
+      ...Array.from(activeExtensionTools.keys()),
+    ];
     return {
-      toolReturn: `Tool not found: ${name}. Available tools: ${Array.from(activeRegistry.keys()).join(", ")}`,
+      toolReturn: `Tool not found: ${name}. Available tools: ${availableTools.join(", ")}`,
       status: "error",
     };
   }
 
   const tool = activeRegistry.get(internalName);
   if (!tool) {
+    const availableTools = [
+      ...Array.from(activeRegistry.keys()),
+      ...Array.from(activeExternalTools.keys()),
+      ...Array.from(activeExtensionTools.keys()),
+    ];
     return {
-      toolReturn: `Tool not found: ${name}. Available tools: ${Array.from(activeRegistry.keys()).join(", ")}`,
+      toolReturn: `Tool not found: ${name}. Available tools: ${availableTools.join(", ")}`,
       status: "error",
     };
   }
@@ -1921,87 +2321,33 @@ export async function executeTool(
         stderr ? stderr.join("\n") : undefined,
       );
 
-      // Run PostToolUse hooks - exit 2 injects stderr into agent context
-      // Note: preceding_reasoning/assistant_message not available here - tracked in accumulator for server tools
-      let postToolUseFeedback: string[] = [];
-      try {
-        const postHookResult = await runPostToolUseHooks(
-          internalName,
-          args as Record<string, unknown>,
-          {
-            status: toolStatus,
-            output: getDisplayableToolReturn(flattenedResponse),
-          },
-          options?.toolCallId,
-          workingDirectory,
+      const hookFeedback = await collectPostToolHookFeedback(
+        {
+          args: args as Record<string, unknown>,
+          debugLabel: "tool result path",
           scopedAgentId,
-          undefined, // precedingReasoning - not available in tool manager context
-          undefined, // precedingAssistantMessage - not available in tool manager context
-        );
-        postToolUseFeedback = postHookResult.feedback;
-      } catch (error) {
-        debugLog("hooks", "PostToolUse hook error (success path)", error);
-      }
-
-      // Run PostToolUseFailure hooks when tool returns error status
-      let postToolUseFailureFeedback: string[] = [];
-      if (toolStatus === "error") {
-        const errorOutput =
-          typeof flattenedResponse === "string"
-            ? flattenedResponse
-            : JSON.stringify(flattenedResponse);
-        try {
-          const failureHookResult = await runPostToolUseFailureHooks(
-            internalName,
-            args as Record<string, unknown>,
-            errorOutput,
-            "tool_error", // error type for returned errors
-            options?.toolCallId,
-            workingDirectory,
-            scopedAgentId,
-            undefined, // precedingReasoning - not available in tool manager context
-            undefined, // precedingAssistantMessage - not available in tool manager context
-          );
-          postToolUseFailureFeedback = failureHookResult.feedback;
-        } catch (error) {
-          debugLog(
-            "hooks",
-            "PostToolUseFailure hook error (tool returned error)",
-            error,
-          );
-        }
-      }
-
-      // Combine feedback from both hook types and inject into tool return
-      const allFeedback = [
-        ...postToolUseFeedback,
-        ...postToolUseFailureFeedback,
-      ];
-      if (allFeedback.length > 0) {
-        const feedbackMessage = `\n\n[Hook feedback]:\n${allFeedback.join("\n")}`;
-        let finalToolReturn: ToolReturnContent;
-        if (typeof flattenedResponse === "string") {
-          finalToolReturn = flattenedResponse + feedbackMessage;
-        } else if (Array.isArray(flattenedResponse)) {
-          // Append feedback as a new text content block
-          finalToolReturn = [
-            ...flattenedResponse,
-            { type: "text" as const, text: feedbackMessage },
-          ];
-        } else {
-          finalToolReturn = flattenedResponse;
-        }
-        return {
-          toolReturn: finalToolReturn,
+          toolCallId: options?.toolCallId,
+          toolName: internalName,
+          workingDirectory,
+        },
+        {
           status: toolStatus,
-          ...(stdout && { stdout }),
-          ...(stderr && { stderr }),
-        };
-      }
+          output: getDisplayableToolReturn(flattenedResponse),
+          failureOutput:
+            typeof flattenedResponse === "string"
+              ? flattenedResponse
+              : JSON.stringify(flattenedResponse),
+          errorType: "tool_error",
+        },
+      );
+      const finalToolReturn = appendHookFeedbackToToolReturn(
+        flattenedResponse,
+        hookFeedback,
+      );
 
       // Return the full response (truncation happens in UI layer only)
       return {
-        toolReturn: flattenedResponse,
+        toolReturn: finalToolReturn,
         status: toolStatus,
         ...(stdout && { stdout }),
         ...(stderr && { stderr }),
@@ -2035,56 +2381,26 @@ export async function executeTool(
         errorMessage,
       );
 
-      // Run PostToolUse hooks for error case - exit 2 injects stderr
-      let postToolUseFeedback: string[] = [];
-      try {
-        const postHookResult = await runPostToolUseHooks(
-          internalName,
-          args as Record<string, unknown>,
-          { status: "error", output: errorMessage },
-          options?.toolCallId,
-          workingDirectory,
+      const hookFeedback = await collectPostToolHookFeedback(
+        {
+          args: args as Record<string, unknown>,
+          debugLabel: "tool exception path",
           scopedAgentId,
-          undefined, // precedingReasoning - not available in tool manager context
-          undefined, // precedingAssistantMessage - not available in tool manager context
-        );
-        postToolUseFeedback = postHookResult.feedback;
-      } catch (error) {
-        debugLog("hooks", "PostToolUse hook error (error path)", error);
-      }
-
-      // Run PostToolUseFailure hooks - exit 2 injects stderr
-      let postToolUseFailureFeedback: string[] = [];
-      try {
-        const failureHookResult = await runPostToolUseFailureHooks(
-          internalName,
-          args as Record<string, unknown>,
-          errorMessage,
+          toolCallId: options?.toolCallId,
+          toolName: internalName,
+          workingDirectory,
+        },
+        {
+          status: "error",
+          output: errorMessage,
+          failureOutput: errorMessage,
           errorType,
-          options?.toolCallId,
-          workingDirectory,
-          scopedAgentId,
-          undefined, // precedingReasoning - not available in tool manager context
-          undefined, // precedingAssistantMessage - not available in tool manager context
-        );
-        postToolUseFailureFeedback = failureHookResult.feedback;
-      } catch (error) {
-        debugLog(
-          "hooks",
-          "PostToolUseFailure hook error (exception path)",
-          error,
-        );
-      }
-
-      // Combine feedback from both hook types
-      const allFeedback = [
-        ...postToolUseFeedback,
-        ...postToolUseFailureFeedback,
-      ];
-      const finalErrorMessage =
-        allFeedback.length > 0
-          ? `${errorMessage}\n\n[Hook feedback]:\n${allFeedback.join("\n")}`
-          : errorMessage;
+        },
+      );
+      const finalErrorMessage = appendHookFeedbackToText(
+        errorMessage,
+        hookFeedback,
+      );
 
       // Don't console.error here - it pollutes the TUI
       // The error message is already returned in toolReturn
@@ -2121,9 +2437,17 @@ export function getAllLettaToolNames(): string[] {
  * @returns Array of tool schemas
  */
 export function getToolSchemas(): ToolSchema[] {
-  return Array.from(withDynamicMessageChannelCache(toolRegistry).values()).map(
-    (tool) => tool.schema,
-  );
+  const builtInSchemas = Array.from(
+    withDynamicMessageChannelCache(toolRegistry).values(),
+  ).map((tool) => tool.schema);
+  const extensionSchemas = Array.from(
+    getAvailableExtensionToolsRegistry().values(),
+  ).map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters as JsonSchema,
+  }));
+  return [...builtInSchemas, ...extensionSchemas];
 }
 
 /**
@@ -2134,8 +2458,27 @@ export function getToolSchemas(): ToolSchema[] {
  */
 export function getToolSchema(name: string): ToolSchema | undefined {
   const internalName = resolveInternalToolName(name);
-  if (!internalName) return undefined;
-  return withDynamicMessageChannelCache(toolRegistry).get(internalName)?.schema;
+  if (internalName) {
+    return withDynamicMessageChannelCache(toolRegistry).get(internalName)
+      ?.schema;
+  }
+  const extensionTool = getExtensionToolDefinition(name);
+  if (extensionTool) {
+    return {
+      name: extensionTool.name,
+      description: extensionTool.description,
+      input_schema: extensionTool.parameters as JsonSchema,
+    };
+  }
+  const externalTool = getExternalToolDefinition(name);
+  if (externalTool) {
+    return {
+      name: externalTool.name,
+      description: externalTool.description,
+      input_schema: externalTool.parameters as JsonSchema,
+    };
+  }
+  return undefined;
 }
 
 export async function refreshDynamicChannelToolsInLoadedRegistry(): Promise<void> {

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -27,6 +27,10 @@ import {
 } from "@/channels/routing";
 import type { ChannelAdapter } from "@/channels/types";
 import {
+  clearExtensionTools,
+  registerExtensionTool,
+} from "@/extensions/tool-registry";
+import {
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
   runWithRuntimeContext,
 } from "@/runtime-context";
@@ -79,6 +83,33 @@ describe("tool execution context snapshot", () => {
     };
   }
 
+  function registerEchoExtensionTool(signal: AbortSignal): void {
+    registerExtensionTool({
+      name: "local_echo",
+      description: "Echo input from a local extension",
+      parameters: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+      owner: {
+        id: "global:/tmp/local-echo.ts",
+        path: "/tmp/local-echo.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/local-echo.ts",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: signal,
+      getContext: () => {
+        throw new Error("context should not be needed for this test");
+      },
+      isAvailable: () => true,
+      run: (ctx) => `echo:${ctx.args.message}`,
+    });
+  }
+
   beforeAll(() => {
     initialTools = getToolNames();
   });
@@ -91,6 +122,7 @@ describe("tool execution context snapshot", () => {
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
     clearExternalTools();
+    clearExtensionTools();
     clearAllRoutes();
     __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
@@ -108,6 +140,7 @@ describe("tool execution context snapshot", () => {
 
   afterAll(async () => {
     clearExternalTools();
+    clearExtensionTools();
     if (initialTools.length > 0) {
       await loadSpecificTools(initialTools);
     } else {
@@ -270,6 +303,83 @@ describe("tool execution context snapshot", () => {
 
     expect(prepared.loadedToolNames).toEqual([]);
     expect(prepared.clientTools).toEqual([]);
+  });
+
+  test("prepares and executes extension tools from turn snapshots", async () => {
+    const controller = new AbortController();
+    registerEchoExtensionTool(controller.signal);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["local_echo"] },
+    );
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "local_echo",
+    ]);
+
+    clearExtensionTools();
+
+    const result = await executeTool(
+      "local_echo",
+      { message: "hi" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("echo:hi");
+  });
+
+  test("extension tools take precedence over external tools with the same name", async () => {
+    registerExternalTools([
+      {
+        name: "local_echo",
+        description: "External tool with duplicate name",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+    const controller = new AbortController();
+    registerEchoExtensionTool(controller.signal);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["local_echo"] },
+    );
+
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "local_echo",
+    ]);
+
+    const result = await executeTool(
+      "local_echo",
+      { message: "hi" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("echo:hi");
+  });
+
+  test("aborted extension activations stop captured tool execution", async () => {
+    const controller = new AbortController();
+    registerEchoExtensionTool(controller.signal);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["local_echo"] },
+    );
+
+    controller.abort();
+
+    const result = await executeTool(
+      "local_echo",
+      { message: "hi" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("error");
+    expect(asText(result.toolReturn)).toBe("Interrupted by user");
   });
 
   test("prepares current tool snapshots with fresh MessageChannel discovery", async () => {


### PR DESCRIPTION
## Summary
- Add `letta.tools.register` support to the extension host with owner-scoped lifecycle cleanup and built-in tool name reservations
- Include extension tools in turn-scoped `client_tools` snapshots and execute them locally through the tool manager
- Wire extension tools into permissions, cancellation, parallel-safe batching, schema lookup, and tests

## Test plan
- [x] `bun run check`
- [x] `bun test src/extensions/extension-host.test.ts src/cli/extensions/local-extension-loader.test.ts src/tools/tool-execution-context.test.ts`
- [x] Manual smoke test with a local extension tool

👾 Generated with [Letta Code](https://letta.com)