### PR TITLE
feat(extensions): expose host capabilities

### DIFF
--- a/src/cli/extensions/capabilities.ts
+++ b/src/cli/extensions/capabilities.ts
@@ -1,0 +1,11 @@
+import type { ExtensionCapabilities } from "@/extensions/types";
+
+export const TUI_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: true,
+  commands: true,
+  ui: {
+    panels: true,
+    statusValues: true,
+    customStatuslineRenderer: true,
+  },
+};

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -12,7 +12,9 @@ import {
   loadLocalExtensions as loadLocalExtensionsBase,
   resolveLocalExtensionSources,
 } from "@/extensions/extension-host";
+import type { ExtensionCapabilities } from "@/extensions/types";
 import { getAllLettaToolNames, getServerToolName } from "@/tools/manager";
+import { TUI_EXTENSION_CAPABILITIES } from "./capabilities";
 
 function stripSlash(command: string): string {
   return command.startsWith("/") ? command.slice(1) : command;
@@ -33,12 +35,14 @@ function getDefaultReservedToolNames(): Set<string> {
 
 function withDefaultReservations<
   T extends {
+    capabilities?: ExtensionCapabilities;
     reservedCommandIds?: Iterable<string>;
     reservedToolNames?: Iterable<string>;
   },
 >(options: T): T {
   return {
     ...options,
+    capabilities: options.capabilities ?? TUI_EXTENSION_CAPABILITIES,
     reservedCommandIds: [
       ...getDefaultReservedCommandIds(),
       ...(options.reservedCommandIds ?? []),
@@ -82,3 +86,4 @@ export type {
   ResolveLocalExtensionSourcesOptions,
   StatuslineRenderFunction,
 } from "@/extensions/extension-host";
+export { TUI_EXTENSION_CAPABILITIES } from "./capabilities";

--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -1,6 +1,7 @@
 export type {
   ExtensionAgentContext,
   ExtensionBackgroundAgentContext,
+  ExtensionCapabilities,
   ExtensionCapabilityKind,
   ExtensionCapabilityRecord,
   ExtensionCommand,
@@ -30,5 +31,6 @@ export type {
   ExtensionToolRegistration,
   ExtensionToolRunContext,
   ExtensionToolRunResult,
+  ExtensionUiCapabilities,
   ExtensionWorkspaceContext,
 } from "@/extensions/types";

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -1,0 +1,33 @@
+import type { ExtensionCapabilities } from "@/extensions/types";
+
+export const DEFAULT_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: true,
+  commands: true,
+  ui: {
+    panels: true,
+    statusValues: true,
+    customStatuslineRenderer: true,
+  },
+};
+
+export function cloneExtensionCapabilities(
+  capabilities: ExtensionCapabilities,
+): ExtensionCapabilities {
+  return {
+    tools: capabilities.tools,
+    commands: capabilities.commands,
+    ui: {
+      panels: capabilities.ui.panels,
+      statusValues: capabilities.ui.statusValues,
+      customStatuslineRenderer: capabilities.ui.customStatuslineRenderer,
+    },
+  };
+}
+
+export function resolveExtensionCapabilities(
+  capabilities?: ExtensionCapabilities,
+): ExtensionCapabilities {
+  return cloneExtensionCapabilities(
+    capabilities ?? DEFAULT_EXTENSION_CAPABILITIES,
+  );
+}

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -11,9 +11,13 @@ import {
   clearExtensionTools,
   getExtensionToolDefinition,
 } from "@/extensions/tool-registry";
-import type { ExtensionPanelHandle } from "@/extensions/types";
+import type {
+  ExtensionCapabilities,
+  ExtensionPanelHandle,
+} from "@/extensions/types";
 
 type ExtensionTestGlobal = typeof globalThis & {
+  __lettaExtensionCapabilities?: ExtensionCapabilities;
   __lettaExtensionGate?: Promise<void>;
   __lettaExtensionPanel?: ExtensionPanelHandle;
   __lettaExtensionSignal?: AbortSignal;
@@ -24,13 +28,27 @@ function createTempDir(): string {
   return mkdtempSync(path.join(tmpdir(), "letta-extension-host-"));
 }
 
-function createHost(root: string): ExtensionHost {
+function createHost(
+  root: string,
+  capabilities?: ExtensionCapabilities,
+): ExtensionHost {
   return createExtensionHost({
     cacheDirectory: path.join(root, "extension-cache"),
+    ...(capabilities ? { capabilities } : {}),
     getClient: async () => ({}) as unknown as Letta,
     globalExtensionsDirectory: path.join(root, "global-extensions"),
   });
 }
+
+const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: true,
+  commands: false,
+  ui: {
+    panels: false,
+    statusValues: false,
+    customStatuslineRenderer: false,
+  },
+};
 
 describe("extension host", () => {
   afterEach(() => {
@@ -75,6 +93,96 @@ describe("extension host", () => {
 
       unsubscribe();
       host.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("exposes configured capabilities to extensions", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ExtensionTestGlobal;
+    delete testGlobal.__lettaExtensionCapabilities;
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "capabilities.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          globalThis.__lettaExtensionCapabilities = letta.capabilities;
+          if (letta.capabilities.commands) {
+            letta.commands.register({
+              id: "hidden",
+              description: "Should not register",
+              run() { return { type: "handled" }; },
+            });
+          }
+          if (letta.capabilities.ui.panels) {
+            letta.ui.openPanel({ id: "hidden", content: "hidden" });
+          }
+          if (letta.capabilities.tools) {
+            letta.tools.register({
+              name: "visible_tool",
+              description: "Visible tool",
+              run() { return "ok"; },
+            });
+          }
+        }`,
+      );
+
+      const host = createHost(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
+      await host.reload();
+      const snapshot = host.getSnapshot();
+
+      const observedCapabilities = testGlobal.__lettaExtensionCapabilities as
+        | ExtensionCapabilities
+        | undefined;
+      expect(observedCapabilities).toEqual(TOOL_ONLY_EXTENSION_CAPABILITIES);
+      expect(snapshot.capabilities).toEqual(TOOL_ONLY_EXTENSION_CAPABILITIES);
+      expect(Object.keys(snapshot.commands)).toEqual([]);
+      expect(Object.values(snapshot.ui.panels)).toEqual([]);
+      expect(Object.keys(snapshot.tools)).toEqual(["visible_tool"]);
+    } finally {
+      delete testGlobal.__lettaExtensionCapabilities;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("unsupported capabilities no-op even when extensions call the APIs", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "unsupported.ts"),
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hidden",
+            description: "Should not register",
+            run() { return { type: "handled" }; },
+          });
+          letta.ui.openPanel({ id: "hidden", content: "hidden" });
+          letta.ui.setStatus("hidden", "hidden");
+          letta.ui.setStatuslineRenderer(() => "hidden");
+          letta.tools.register({
+            name: "visible_tool",
+            description: "Visible tool",
+            run() { return "ok"; },
+          });
+        }`,
+      );
+
+      const host = createHost(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
+      await host.reload();
+      const snapshot = host.getSnapshot();
+
+      expect(snapshot.errors).toEqual([]);
+      expect(snapshot.commands).toEqual({});
+      expect(snapshot.ui.panels).toEqual({});
+      expect(snapshot.ui.statusValues).toEqual({});
+      expect(snapshot.ui.statuslineRenderer).toBeNull();
+      expect(Object.keys(snapshot.tools)).toEqual(["visible_tool"]);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -21,12 +21,17 @@ import type {
   StatuslineRendererOutput,
 } from "@/cli/display/statusline/types";
 import {
+  cloneExtensionCapabilities,
+  resolveExtensionCapabilities,
+} from "@/extensions/capabilities";
+import {
   getExtensionToolDefinition,
   registerExtensionTool,
   unregisterExtensionTool,
   unregisterExtensionToolsForOwner,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionCapabilities,
   ExtensionCommand,
   ExtensionCommandRegistration,
   ExtensionContext,
@@ -75,6 +80,7 @@ export type LettaExtensionFactory = (
   | Promise<undefined | LettaExtensionDisposer>;
 
 export interface LettaExtensionApi {
+  capabilities: ExtensionCapabilities;
   client: Letta;
   getClient: () => Promise<Letta>;
   getContext: () => ExtensionContext;
@@ -121,6 +127,7 @@ export interface LocalExtensionUiRegistry {
 }
 
 export interface LocalExtensionRegistry {
+  capabilities: ExtensionCapabilities;
   commands: Record<string, ExtensionCommand>;
   diagnostics: ExtensionDiagnostic[];
   disposers: LocalExtensionDisposer[];
@@ -155,6 +162,7 @@ export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
+  capabilities?: ExtensionCapabilities;
   generation?: number;
   onChange?: () => void;
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void;
@@ -173,6 +181,7 @@ export interface CreateExtensionHostOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
+  capabilities?: ExtensionCapabilities;
   reservedCommandIds?: Iterable<string>;
   reservedToolNames?: Iterable<string>;
 }
@@ -209,8 +218,10 @@ export function resolveLocalExtensionSources(
 function createEmptyExtensionRegistry(
   sources: LocalExtensionSource[],
   generation: number,
+  capabilities: ExtensionCapabilities,
 ): LocalExtensionRegistry {
   return {
+    capabilities: cloneExtensionCapabilities(capabilities),
     commands: {},
     diagnostics: [],
     disposers: [],
@@ -298,6 +309,7 @@ function snapshotRegistryForReaders(
   return {
     ...registry,
     commands: { ...registry.commands },
+    capabilities: cloneExtensionCapabilities(registry.capabilities),
     diagnostics: [...registry.diagnostics],
     disposers: [...registry.disposers],
     errors: [...registry.errors],
@@ -656,6 +668,7 @@ function upsertExtensionPanel(
 function createLettaExtensionApi(
   registry: LocalExtensionRegistry,
   owner: ExtensionOwner,
+  capabilities: ExtensionCapabilities,
   getClient: () => Promise<Letta>,
   getContext: () => ExtensionContext,
   onChange: () => void,
@@ -674,6 +687,7 @@ function createLettaExtensionApi(
   };
 
   const unregisterCommand = (id: string) => {
+    if (!capabilities.commands) return;
     validateExtensionCommandId(id);
     if (!guardLive({ id, kind: "command" })) return;
     const existing = registry.commands[id];
@@ -684,6 +698,7 @@ function createLettaExtensionApi(
   };
 
   const clearPanel = (id: string) => {
+    if (!capabilities.ui.panels) return;
     validateExtensionPanelId(id);
     if (!guardLive({ id, kind: "panel" })) return;
     const panelKey = getExtensionPanelKey(owner.id, id);
@@ -695,6 +710,7 @@ function createLettaExtensionApi(
   };
 
   const unregisterTool = (name: string) => {
+    if (!capabilities.tools) return;
     validateExtensionToolName(name);
     if (!guardLive({ id: name, kind: "tool" })) return;
     const existing = registry.tools[name];
@@ -706,12 +722,16 @@ function createLettaExtensionApi(
   };
 
   return {
+    capabilities: cloneExtensionCapabilities(capabilities),
     client: createLazyClient(getClient),
     getClient,
     getContext,
     signal,
     commands: {
       register(command) {
+        if (!capabilities.commands) {
+          return () => undefined;
+        }
         if (!guardLive({ id: command.id, kind: "command" })) {
           return () => undefined;
         }
@@ -739,6 +759,9 @@ function createLettaExtensionApi(
     },
     tools: {
       register(tool) {
+        if (!capabilities.tools) {
+          return () => undefined;
+        }
         if (!guardLive({ id: tool.name, kind: "tool" })) {
           return () => undefined;
         }
@@ -777,12 +800,19 @@ function createLettaExtensionApi(
     ui: {
       clearPanel,
       clearStatus(key) {
+        if (!capabilities.ui.statusValues) return;
         if (!guardLive({ id: key, kind: "status" })) return;
         delete registry.ui.statusValues[key];
         delete registry.ui.statusOwners[key];
         onChange();
       },
       openPanel(panel) {
+        if (!capabilities.ui.panels) {
+          return {
+            close() {},
+            update() {},
+          };
+        }
         if (!guardLive({ id: panel.id, kind: "panel" })) {
           return {
             close() {},
@@ -804,6 +834,7 @@ function createLettaExtensionApi(
         };
       },
       setStatus(key, value) {
+        if (!capabilities.ui.statusValues) return;
         if (!guardLive({ id: key, kind: "status" })) return;
         if (value == null) {
           delete registry.ui.statusValues[key];
@@ -816,6 +847,7 @@ function createLettaExtensionApi(
         onChange();
       },
       setStatuslineRenderer(renderer) {
+        if (!capabilities.ui.customStatuslineRenderer) return;
         if (!guardLive({ id: owner.id, kind: "statusline" })) return;
         registry.ui.statuslineRenderer = toStatuslineRenderer(
           renderer,
@@ -850,10 +882,15 @@ export async function loadLocalExtensions(
     });
   const onChange = options.onChange ?? (() => {});
   const sources = resolveLocalExtensionSources(options);
+  const capabilities = resolveExtensionCapabilities(options.capabilities);
   const generation = options.generation ?? 1;
   const reservedCommandIds = new Set([...(options.reservedCommandIds ?? [])]);
   const reservedToolNames = new Set([...(options.reservedToolNames ?? [])]);
-  const registry = createEmptyExtensionRegistry(sources, generation);
+  const registry = createEmptyExtensionRegistry(
+    sources,
+    generation,
+    capabilities,
+  );
 
   for (const source of sources) {
     for (const extensionPath of source.files) {
@@ -891,6 +928,7 @@ export async function loadLocalExtensions(
           createLettaExtensionApi(
             registry,
             owner,
+            capabilities,
             getConfiguredClient,
             getContext,
             onChange,
@@ -993,9 +1031,11 @@ export function createExtensionHost(
 ): ExtensionHost {
   let generation = 0;
   let disposed = false;
+  const capabilities = resolveExtensionCapabilities(options.capabilities);
   let activeRegistry = createEmptyExtensionRegistry(
     resolveLocalExtensionSources(options),
     generation,
+    capabilities,
   );
   let snapshot = snapshotRegistryForReaders(activeRegistry);
   const listeners = new Set<() => void>();
@@ -1016,6 +1056,7 @@ export function createExtensionHost(
     activeRegistry = createEmptyExtensionRegistry(
       resolveLocalExtensionSources(options),
       loadGeneration,
+      capabilities,
     );
     publish();
 
@@ -1071,6 +1112,7 @@ export function createExtensionHost(
       activeRegistry = createEmptyExtensionRegistry(
         resolveLocalExtensionSources(options),
         generation,
+        capabilities,
       );
       publish();
       listeners.clear();

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -56,6 +56,18 @@ export interface ExtensionBackgroundAgentContext {
   durationMs: number;
 }
 
+export interface ExtensionUiCapabilities {
+  panels: boolean;
+  statusValues: boolean;
+  customStatuslineRenderer: boolean;
+}
+
+export interface ExtensionCapabilities {
+  tools: boolean;
+  commands: boolean;
+  ui: ExtensionUiCapabilities;
+}
+
 export type ExtensionSourceScope = "global" | "project" | "bundled";
 
 export interface ExtensionOwner {


### PR DESCRIPTION
## Summary
- Add `ExtensionCapabilities` and expose `letta.capabilities` to extension activations
- Let extension hosts choose capabilities while keeping TUI defaults enabled through the CLI adapter
- No-op unsupported capability APIs so extensions can gate portable behavior safely

## Test plan
- [x] `bun run check`
- [x] `bun test src/extensions/extension-host.test.ts src/cli/extensions/local-extension-loader.test.ts`
- [x] Manual smoke test for `letta.capabilities`

👾 Generated with [Letta Code](https://letta.com)