### PR TITLE
docs(skills): add extension authoring guidance

### DIFF
--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: creating-extensions
+description: Creates and edits Letta Code local extensions, including extension tools, slash commands, panels, status values, and capability-gated behavior. Use when the user asks to make an extension, add a tool the agent can call, add a slash command, or add lightweight extension UI outside the dedicated /statusline flow.
+---
+
+# Creating Extensions
+
+Use this skill to create or update trusted global Letta Code extensions in:
+
+```text
+~/.letta/extensions/
+```
+
+Extensions are local runtime capabilities, not TUI-only plugins. Prefer portable APIs and guard optional UI with `letta.capabilities`.
+
+## Choose the right capability
+
+| User wants | Build |
+| --- | --- |
+| Agent/model should autonomously call a local capability | Extension tool |
+| User wants `/foo` to send a prompt or run local UI logic | Extension command |
+| Slash command represents a reusable agent workflow | Skill + thin extension command |
+| Show transient output above input | Panel, usually from a command |
+| Show small persistent state | Status value |
+| Change the bottom statusline appearance | Use `customizing-statusline`, not this skill |
+
+Default to a **tool** when the model should decide when to use the capability. Default to a **command** when the human explicitly invokes it.
+
+## Workflow
+
+1. Inspect `~/.letta/extensions/` for related files.
+2. Preserve unrelated extension code. Prefer a focused new file if merging would be messy.
+3. Choose one capability recipe:
+   - tools: `references/tools.md`
+   - commands: `references/commands.md`
+   - panels/status/capabilities: `references/ui.md`
+4. Write a single-file extension unless the user asks for something larger.
+5. Return disposers for registered commands/tools, timers, subscriptions, and panels that should close on reload.
+6. Do a basic syntax/shape review: valid names, descriptions present, JSON schemas are object schemas, capability guards around optional UI.
+7. Tell the user the absolute file path changed and to run `/reload`.
+
+## Core extension shape
+
+```ts
+export default function activate(letta) {
+  const disposers = [];
+
+  if (letta.capabilities.tools) {
+    disposers.push(letta.tools.register(/* ... */));
+  }
+
+  if (letta.capabilities.commands) {
+    disposers.push(letta.commands.register(/* ... */));
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}
+```
+
+Use `letta.capabilities` for optional behavior:
+
+```ts
+letta.capabilities.tools
+letta.capabilities.commands
+letta.capabilities.ui.panels
+letta.capabilities.ui.statusValues
+letta.capabilities.ui.customStatuslineRenderer
+```
+
+## Rules
+
+- Global trusted code only for now. Do not create project extensions.
+- Do not import Letta Code app internals from extension files.
+- Do not assume extra npm packages are available.
+- Do not do surprising side effects on startup; extensions activate on app start and `/reload`.
+- Keep user-facing output short and intentional.
+- Prefer Node/Bun standard APIs (`node:child_process`, `node:fs`, etc.) for local work.
+- For shell execution, prefer `execFile`/`spawn` over shell strings.
+- Do not use emojis for loading states; use text or spinner-like characters if the user asks for loading UI.
+
+## References
+
+- `references/tools.md` - extension tools the model can call
+- `references/commands.md` - slash commands, command results, and skill-backed commands
+- `references/ui.md` - panels, status values, capability guards

--- a/src/skills/builtin/creating-extensions/references/btw-command.md
+++ b/src/skills/builtin/creating-extensions/references/btw-command.md
@@ -1,11 +1,11 @@
 # `/btw` side-question extension example
 
-### Ask a side question in a forked conversation
-
-This example runs while the main agent is busy because it forks the conversation, uses the SDK directly, renders progress in a panel, and returns `{ type: "handled" }` immediately.
+This example runs while the main agent is busy because it forks the conversation, uses the SDK directly, renders progress in a panel when panels are available, and returns `{ type: "handled" }` immediately.
 
 ```ts
 export default function activate(letta) {
+  if (!letta.capabilities.commands) return;
+
   function appendAssistantText(chunk, parts) {
     if (chunk.message_type !== "assistant_message") return;
     const content = chunk.content;
@@ -22,6 +22,11 @@ export default function activate(letta) {
     }
   }
 
+  function openPanelOrNull(content) {
+    if (!letta.capabilities.ui.panels) return null;
+    return letta.ui.openPanel({ id: "btw", content });
+  }
+
   return letta.commands.register({
     id: "btw",
     description: "Ask a side question in a forked conversation",
@@ -31,17 +36,12 @@ export default function activate(letta) {
     run(ctx) {
       const question = ctx.args.trim();
       if (!question) {
-        letta.ui.openPanel({
-          id: "btw",
-          content: ["/btw", "Usage: /btw <question>"],
-        });
+        const panel = openPanelOrNull(["/btw", "Usage: /btw <question>"]);
+        if (panel) setTimeout(() => panel.close(), 5_000);
         return { type: "handled" };
       }
 
-      const panel = letta.ui.openPanel({
-        id: "btw",
-        content: [`/btw ${question}`, "…"],
-      });
+      const panel = openPanelOrNull([`/btw ${question}`, "..."]);
 
       void (async () => {
         try {
@@ -63,21 +63,21 @@ Answer briefly in 1-3 short sentences.`,
           const parts = [];
           for await (const chunk of stream) {
             appendAssistantText(chunk, parts);
-            panel.update({ content: [`/btw ${question}`, parts.join("") || "…"] });
+            panel?.update({ content: [`/btw ${question}`, parts.join("") || "..."] });
           }
 
-          panel.update({
-            content: [`✓ /btw ${question}`, parts.join("").trim() || "No response."],
+          panel?.update({
+            content: [`done /btw ${question}`, parts.join("").trim() || "No response."],
           });
-          setTimeout(() => panel.close(), 10_000);
+          if (panel) setTimeout(() => panel.close(), 10_000);
         } catch (error) {
-          panel.update({
+          panel?.update({
             content: [
-              `✗ /btw ${question}`,
+              `error /btw ${question}`,
               error instanceof Error ? error.message : String(error),
             ],
           });
-          setTimeout(() => panel.close(), 15_000);
+          if (panel) setTimeout(() => panel.close(), 15_000);
         }
       })();
 

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -1,0 +1,114 @@
+# Extension command recipes
+
+Use commands when the human explicitly invokes `/foo`.
+
+## Decide command vs skill vs tool
+
+| Need | Use |
+| --- | --- |
+| `/foo` expands to a prompt | Extension command |
+| `/foo` starts a complex reusable workflow | Skill + thin extension command |
+| Model should call the capability by itself | Extension tool |
+| Command needs transient UI while doing local work | Extension command + panel |
+
+If the command represents a durable agent workflow (for example `/goal`), put the workflow instructions in a skill and keep the command as a small launcher/prompt.
+
+## Command IDs
+
+- Do not include the leading slash. Use `id: "review"`, not `id: "/review"`.
+- Use a lowercase slug with letters, numbers, and hyphens only.
+- Built-in commands like `/reload`, `/model`, `/statusline`, etc. are reserved.
+- Duplicate extension command IDs fail unless `override: true` is intentional.
+
+## Prompt command
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.commands) return;
+
+  return letta.commands.register({
+    id: "review",
+    description: "Review current git changes",
+    args: "[focus]",
+    run(ctx) {
+      const focus = ctx.args.trim();
+      return {
+        type: "prompt",
+        content: focus
+          ? `Review current git changes. Focus on ${focus}.`
+          : "Review current git changes. Focus on correctness issues.",
+        systemReminder: true,
+      };
+    },
+  });
+}
+```
+
+## Output-only command
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.commands) return;
+
+  return letta.commands.register({
+    id: "whereami",
+    description: "Show the active extension command context",
+    run(ctx) {
+      return {
+        type: "output",
+        output: `Agent: ${ctx.agent.name ?? ctx.agent.id}\nCWD: ${ctx.cwd}`,
+      };
+    },
+  });
+}
+```
+
+## Panel command
+
+Use `{ type: "handled" }` when the command owns the UI. Guard panels because they are optional on non-TUI surfaces.
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.commands) return;
+
+  return letta.commands.register({
+    id: "hello-panel",
+    description: "Show a short transient panel",
+    showInTranscript: false,
+    run(ctx) {
+      if (!letta.capabilities.ui.panels) {
+        return { type: "output", output: `hello ${ctx.args || "there"}` };
+      }
+
+      const panel = letta.ui.openPanel({
+        id: "hello-panel",
+        content: [`hello ${ctx.args || "there"}`],
+      });
+      setTimeout(() => panel.close(), 5_000);
+      return { type: "handled" };
+    },
+  });
+}
+```
+
+## Busy-safe SDK command
+
+For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use the SDK directly, update a panel if available, and return `{ type: "handled" }` quickly.
+
+Use `letta.client` or `await letta.getClient()` instead of raw `fetch`; SDK initialization is lazy and uses the current backend/auth context.
+
+Common calls:
+
+```ts
+await letta.client.conversations.fork(ctx.conversation.id || "default", {
+  agent_id: ctx.agent.id,
+});
+
+await letta.client.conversations.messages.create(conversationId, {
+  agent_id: ctx.agent.id,
+  input,
+  streaming: true,
+});
+```
+
+For a complete side-question example, see `btw-command.md`.

--- a/src/skills/builtin/creating-extensions/references/tools.md
+++ b/src/skills/builtin/creating-extensions/references/tools.md
@@ -1,0 +1,115 @@
+# Extension tool recipes
+
+Use tools when the agent/model should call a local capability autonomously.
+
+## Defaults
+
+- Name: lowercase/underscore tool name, e.g. `branch_summary`.
+- Description: explain when the model should use it.
+- Parameters: JSON Schema object. Use `additionalProperties: false` when possible.
+- `requiresApproval: false` only for read-only, low-risk local introspection.
+- `parallelSafe: true` only for read-only tools with no shared mutation or long-lived exclusive resource.
+- Use `ctx.cwd` / `ctx.workingDirectory` as the workspace.
+- Respect `ctx.signal` for long-running work when practical.
+
+## Read-only shell tool
+
+```ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "branch_summary",
+    description: "Summarize the current git branch, working tree status, and recent commits.",
+    parameters: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const [{ stdout: status }, { stdout: log }] = await Promise.all([
+        execFileAsync("git", ["status", "--short", "--branch"], { cwd: ctx.cwd }),
+        execFileAsync("git", ["log", "--oneline", "-5"], { cwd: ctx.cwd }),
+      ]);
+
+      return ["## Branch", status.trim(), "", "## Recent commits", log.trim()].join("\n");
+    },
+  });
+}
+```
+
+## Tool with arguments
+
+```ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "repo_notes_search",
+    description: "Search local repo notes for a query and return matching snippets.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const query = String(ctx.args.query ?? "").trim();
+      if (!query) return { status: "error", content: "query is required" };
+
+      try {
+        const { stdout } = await execFileAsync(
+          "rg",
+          ["--line-number", "--max-count", "20", query, "notes"],
+          { cwd: ctx.cwd },
+        );
+        return stdout.trim() || "No matches.";
+      } catch (error) {
+        if (error && typeof error === "object" && "code" in error && error.code === 1) {
+          return "No matches.";
+        }
+        throw error;
+      }
+    },
+  });
+}
+```
+
+## Mutating or risky tool
+
+Set approval required and avoid `parallelSafe` unless it is truly safe:
+
+```ts
+letta.tools.register({
+  name: "format_file",
+  description: "Format a specific file in the current workspace.",
+  parameters: {
+    type: "object",
+    properties: { path: { type: "string" } },
+    required: ["path"],
+    additionalProperties: false,
+  },
+  requiresApproval: true,
+  parallelSafe: false,
+  async run(ctx) {
+    // mutate only the requested file, with clear output
+    return "formatted";
+  },
+});
+```

--- a/src/skills/builtin/creating-extensions/references/ui.md
+++ b/src/skills/builtin/creating-extensions/references/ui.md
@@ -1,0 +1,65 @@
+# Extension UI recipes
+
+UI capabilities are optional. Always guard UI work with `letta.capabilities.ui.*` when writing portable extensions.
+
+## Capabilities
+
+```ts
+letta.capabilities.ui.panels
+letta.capabilities.ui.statusValues
+letta.capabilities.ui.customStatuslineRenderer
+```
+
+- `panels`: transient text blocks above the input bar.
+- `statusValues`: small named status data that renderers or future surfaces can display.
+- `customStatuslineRenderer`: TUI-only custom bottom-row renderer. Use `customizing-statusline` for statusline work.
+
+## Panels
+
+```ts
+if (letta.capabilities.ui.panels) {
+  const panel = letta.ui.openPanel({
+    id: "my-extension",
+    content: ["Working…"],
+    order: 100,
+  });
+
+  panel.update({ content: ["Done"] });
+  setTimeout(() => panel.close(), 5_000);
+}
+```
+
+Panel content is plain text: a string or string array. Keep it short; use command `output` for longer text.
+
+## Status values
+
+```ts
+if (letta.capabilities.ui.statusValues) {
+  letta.ui.setStatus("branch", "main");
+}
+```
+
+Clear status values in disposers if they are owned by timers or external state:
+
+```ts
+return () => {
+  letta.ui.clearStatus("branch");
+};
+```
+
+## Timers and cleanup
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.ui.statusValues) return;
+
+  const update = () => letta.ui.setStatus("clock", new Date().toLocaleTimeString());
+  update();
+  const timer = setInterval(update, 30_000);
+
+  return () => {
+    clearInterval(timer);
+    letta.ui.clearStatus("clock");
+  };
+}
+```

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -1,157 +1,64 @@
 ---
 name: customizing-commands
-description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, SDK-backed command, or panel-rendered command behavior.
+description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, SDK-backed command, or command-driven panel behavior.
 ---
 
 # Customizing Commands
 
-Use this skill to create or update global Letta Code slash commands provided by local extensions.
+Use this as the command-specific entrypoint for local extension slash commands. For broader extension work, recipes live in `../creating-extensions/references/commands.md`, `../creating-extensions/references/ui.md`, and `../creating-extensions/references/btw-command.md`.
 
-Extension files live here:
+Extension files live in:
 
 ```text
 ~/.letta/extensions/
 ```
 
-Use a focused file name like:
+Use a focused file name, e.g. `~/.letta/extensions/review.ts` or `~/.letta/extensions/commands.ts`.
 
-```text
-~/.letta/extensions/commands.ts
-~/.letta/extensions/review.ts
-```
+## First decide whether a command is right
+
+| User wants | Build |
+| --- | --- |
+| `/foo` sends a prompt or shows local output | Extension command |
+| `/foo` starts a reusable agent workflow | Skill + thin extension command |
+| Agent/model should autonomously call the capability | Extension tool, not a command |
+| Command shows transient progress/results | Extension command + panel |
+
+If the command is a durable workflow like `/goal`, put the workflow instructions in a skill and keep the extension command as a small launcher/prompt.
 
 ## Workflow
 
-1. Inspect `~/.letta/extensions/` for existing command extensions.
-2. Preserve unrelated extension code. If adding a new command to an existing command file is clean, edit it; otherwise create a focused new file.
-3. Register commands with `letta.commands.register()`.
-4. Return the unregister function, or return a disposer that calls it.
-5. Tell the user exactly which file changed and ask them to run `/reload`.
-6. After reload, the command should appear in slash-command autocomplete and execute from the input.
+1. Inspect `~/.letta/extensions/` for related command files.
+2. Preserve unrelated extension code; create a focused new file if merging is messy.
+3. Register with `letta.commands.register()` and guard with `letta.capabilities.commands`.
+4. Return the unregister function, or a disposer that calls it plus any timer/panel cleanup.
+5. Tell the user the exact file path changed and to run `/reload`.
 
-## API
+## Default prompt command
 
 ```ts
 export default function activate(letta) {
-  const unregister = letta.commands.register({
+  if (!letta.capabilities.commands) return;
+
+  return letta.commands.register({
     id: "review",
     description: "Review current git changes",
     args: "[focus]",
-    order: 250,
-    async run(ctx) {
+    run(ctx) {
+      const focus = ctx.args.trim();
       return {
         type: "prompt",
-        content: "Review the current git diff. Focus only on correctness issues.",
+        content: focus
+          ? `Review current git changes. Focus on ${focus}.`
+          : "Review current git changes. Focus on correctness issues.",
         systemReminder: true,
       };
     },
   });
-
-  return unregister;
 }
 ```
 
-### Command IDs
-
-- Do not include the leading slash. Use `id: "review"`, not `id: "/review"`.
-- Use a lowercase slug with letters, numbers, and hyphens only.
-- Built-in commands like `/reload`, `/model`, `/statusline`, etc. are reserved.
-- Duplicate extension command IDs fail unless the command explicitly uses `override: true`.
-- Prefer specific names for shared commands (`github-review`, `btw-code`) to avoid collisions with other extensions.
-
-Command resolution order is: built-in/special commands, custom command files, extension commands, then remaining registry/skill commands. Extension commands cannot replace built-ins, and custom command files with the same name win over extensions.
-
-### Command metadata
-
-```ts
-letta.commands.register({
-  id: "btw",
-  description: "Ask a side question",
-  runWhenBusy: true,
-  showInTranscript: false,
-  run(ctx) {
-    return { type: "handled" };
-  },
-});
-```
-
-- `runWhenBusy`: allows the command to run while the main agent is streaming/executing. Busy-safe commands must use their own SDK calls and should not return `prompt` while the agent is running.
-- `showInTranscript`: defaults to `true`. Set `false` for commands that render their own UI panel and should not add a command row to the transcript. Hidden commands cannot return `prompt`; return `handled` when the extension owns the UI. `output` results are still surfaced by the app.
-
-### Command context
-
-`run(ctx)` receives:
-
-```ts
-type ExtensionCommandContext = {
-  rawInput: string;
-  command: string;
-  args: string;
-  argv: string[];
-  cwd: string;
-  agent: { id: string; name: string | null };
-  conversation: { id: string };
-  model: { id: string | null; displayName: string | null };
-  permissionMode: string | null;
-  getContext(): ExtensionContext;
-};
-```
-
-Use `ctx.args` for the raw argument string and `ctx.argv` for simple quote-aware splitting.
-
-## Letta SDK client
-
-Extensions also receive the configured Letta SDK client:
-
-```ts
-letta.client
-await letta.getClient()
-```
-
-Use it for advanced workflows that need the full Letta API, such as forking conversations, reading agent state, or sending messages. This is the same authenticated client context the app uses. SDK initialization is lazy: `letta.client` initializes on first method call, and `letta.getClient()` initializes when awaited.
-
-API reference:
-
-- Letta API docs: https://docs.letta.com/api-reference/overview
-- TypeScript SDK package: https://www.npmjs.com/package/@letta-ai/letta-client
-
-Guidance:
-
-- Prefer `letta.client` or `await letta.getClient()` over raw `fetch`; they already have the current backend URL, auth, and app headers.
-- Verify SDK method and parameter names before guessing. The generated SDK follows API field names, so request params are often snake_case (`agent_id`), not camelCase (`agentId`).
-- For the default conversation, pass `"default"` plus `{ agent_id: ctx.agent.id }` when the endpoint requires agent-direct mode.
-- Common conversation calls:
-  - `await letta.client.conversations.fork(conversationId, { agent_id: ctx.agent.id })`
-  - `await letta.client.conversations.messages.create(conversationId, { agent_id: ctx.agent.id, input, streaming: true })`
-- Streaming message calls return an async iterable of chunks. Extract assistant text from `assistant_message` chunks; chunk content may be a string or an array of text parts.
-
-## UI panels
-
-Commands can write raw lines into the space above the input bar:
-
-```ts
-const panel = letta.ui.openPanel({
-  id: "btw",
-  content: [`/btw ${question}`, "…"],
-});
-
-panel.update({ content: [`/btw ${question}`, "Caren"] });
-setTimeout(() => panel.close(), 10_000);
-```
-
-Panels are intentionally minimal: `id`, `content`, and optional `order`. `content` may be a string (split on newlines) or an array of strings. Core only reserves the slot above the input bar, sorts lower `order` values first, renders up to 8 panel lines, and truncates lines to terminal width; the extension owns visual formatting such as borders, spacing, wrapping, and right alignment.
-
-Guidance:
-
-- Keep panel output short. If you need long-form output, prefer command `output` or a normal `prompt` flow.
-- Panels persist until `panel.close()`, `letta.ui.clearPanel(id)`, the same `id` is overwritten, or `/reload` disposes extensions.
-- For transient results, close the panel after a short timeout.
-- If formatting depends on terminal size, use `ctx.getContext().terminalWidth` inside a command or `letta.getContext().terminalWidth` outside a command. Terminal sizes are columns, not pixels.
-- Avoid unexplained magic widths. If you cap width for aesthetics, name the constant, e.g. `PANEL_MAX_COLUMNS`.
-
-### Results
-
-Command handlers return declarative results. The app owns transcript rendering, approval checks, and sending prompts.
+## Command result types
 
 ```ts
 type ExtensionCommandResult =
@@ -160,76 +67,22 @@ type ExtensionCommandResult =
   | { type: "handled" };
 ```
 
-- `prompt`: sends content to the agent. By default content is wrapped as a system reminder; set `systemReminder: false` to send it as a normal user prompt.
-- `output`: finishes the command row with text and does not contact the agent.
-- `handled`: finishes the command row without sending a prompt.
+- `prompt`: sends content to the agent. Use for normal slash shortcuts.
+- `output`: prints local text and does not contact the agent.
+- `handled`: command handled its own side effects/UI; common for panel commands.
 
-## Examples
+## Rules
 
-### Review current changes
-
-```ts
-export default function activate(letta) {
-  return letta.commands.register({
-    id: "review",
-    description: "Review current git changes",
-    async run() {
-      return {
-        type: "prompt",
-        content: "Review the current git diff. Focus only on correctness issues.",
-        systemReminder: true,
-      };
-    },
-  });
-}
-```
-
-### Review a PR argument
-
-```ts
-export default function activate(letta) {
-  return letta.commands.register({
-    id: "review-pr",
-    description: "Review a GitHub PR",
-    args: "<url-or-number>",
-    async run(ctx) {
-      return {
-        type: "prompt",
-        content: `Review this PR: ${ctx.args}`,
-      };
-    },
-  });
-}
-```
-
-### Show local output only
-
-```ts
-export default function activate(letta) {
-  return letta.commands.register({
-    id: "whoami",
-    description: "Show current command context",
-    run(ctx) {
-      return {
-        type: "output",
-        output: `Agent: ${ctx.agent.name ?? ctx.agent.id}\nCWD: ${ctx.cwd}`,
-      };
-    },
-  });
-}
-```
-
-### Ask a side question in a forked conversation
-
-For a fuller `/btw` recipe using `runWhenBusy`, `showInTranscript: false`, `letta.client.conversations.fork(...)`, streaming, and `letta.ui.openPanel(...)`, see [`reference/btw-command.md`](reference/btw-command.md).
-
-## Constraints
-
-- Global trusted code only for now. Do not create project extensions.
-- Do not use app internals, React setters, or command runner objects.
-- Prefer `letta.client` or `await letta.getClient()` over raw `fetch` when using the Letta API.
-- Keep command handlers fast. For long-running SDK work, start an async task, update a panel, and return `{ type: "handled" }` immediately.
-- If a command uses `runWhenBusy`, do not return `prompt` while the agent is running. Use `letta.client` and panels instead.
-- If a command uses `showInTranscript: false`, do not return `prompt`; hidden commands should usually return `handled` and own their panel side effects.
+- Command IDs omit the slash: `id: "review"`, not `"/review"`.
+- Use lowercase slugs with letters, numbers, and hyphens.
 - Do not register built-in command IDs.
-- Do not do surprising side effects on startup; extension files execute when Letta Code starts or `/reload` runs.
+- `runWhenBusy: true` commands must not return `prompt` while the main agent is busy; use SDK calls/panels and return `handled`.
+- `showInTranscript: false` commands should usually return `handled`, not `prompt`.
+- Do not import Letta Code app internals.
+- Do not do surprising side effects on startup; extensions activate on app start and `/reload`.
+
+## More recipes
+
+- Simple output command, panel command, SDK command: `../creating-extensions/references/commands.md`
+- Panel/status UI patterns: `../creating-extensions/references/ui.md`
+- Complete `/btw` side-question recipe: `../creating-extensions/references/btw-command.md`

--- a/src/skills/builtin/customizing-statusline/SKILL.md
+++ b/src/skills/builtin/customizing-statusline/SKILL.md
@@ -31,8 +31,9 @@ A custom statusline owns the whole idle row. Do not preserve legacy left/right s
 3. If it does not exist, start from the built-in default template or synthesize a focused starter for the user's request.
 4. If the user asks to migrate, import a `.sh` file, or match a shell prompt, read `references/migration.md`.
 5. If API details or concrete patterns are needed, read `references/api.md` and `references/examples.md`.
-6. Edit `~/.letta/extensions/statusline.tsx`.
-7. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
+6. Guard statusline-specific behavior with `letta.capabilities.ui.customStatuslineRenderer` when writing new files.
+7. Edit `~/.letta/extensions/statusline.tsx`.
+8. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
 
 ## Bare `/statusline` behavior
 
@@ -56,6 +57,8 @@ Keep this conversational. Do not build a menu UI unless the product command expl
 - Do not use relative multi-file imports yet.
 - Keep renderers synchronous. Do not shell, fetch, or await inside render.
 - Do async work in setup code, intervals, subscriptions, or status providers.
+- Use `letta.ui.setStatus` for data and `setStatuslineRenderer` for drawing that data.
+- Guard optional APIs with `letta.capabilities.ui.statusValues` and `letta.capabilities.ui.customStatuslineRenderer` in new files.
 - Return a disposer that clears timers/subscriptions.
 - Preserve existing extension code unless the user asks to reset.
 - Do not delete legacy command statusline files or settings unless the user explicitly asks.

--- a/src/skills/builtin/customizing-statusline/references/api.md
+++ b/src/skills/builtin/customizing-statusline/references/api.md
@@ -16,6 +16,8 @@ Export a default function or named `activate` function:
 
 ```tsx
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   letta.ui.setStatuslineRenderer((context) => {
     const { Text } = context.components;
     return <Text>{context.agent.name} · {context.model.displayName}</Text>;
@@ -27,6 +29,9 @@ export default function activate(letta) {
 
 ```ts
 letta.getContext(): StatuslineRenderContext
+
+letta.capabilities.ui.statusValues: boolean
+letta.capabilities.ui.customStatuslineRenderer: boolean
 
 letta.ui.setStatus(key: string, value: string | null | undefined | ((context) => string | null)): void
 letta.ui.clearStatus(key: string): void
@@ -63,15 +68,21 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   const update = async () => {
     try {
       const context = letta.getContext();
       const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
         cwd: context.workspace.currentDir,
       });
-      letta.ui.setStatus("branch", stdout.trim());
+      if (letta.capabilities.ui.statusValues) {
+        letta.ui.setStatus("branch", stdout.trim());
+      }
     } catch {
-      letta.ui.clearStatus("branch");
+      if (letta.capabilities.ui.statusValues) {
+        letta.ui.clearStatus("branch");
+      }
     }
   };
 
@@ -86,7 +97,9 @@ export default function activate(letta) {
 
   return () => {
     clearInterval(timer);
-    letta.ui.clearStatus("branch");
+    if (letta.capabilities.ui.statusValues) {
+      letta.ui.clearStatus("branch");
+    }
   };
 }
 ```

--- a/src/skills/builtin/customizing-statusline/references/examples.md
+++ b/src/skills/builtin/customizing-statusline/references/examples.md
@@ -6,6 +6,8 @@ Use these as patterns, not mandatory templates. Keep the final extension focused
 
 ```tsx
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   letta.ui.setStatuslineRenderer((context) => {
     const { Text } = context.components;
     return <Text>{context.agent.name ?? "Letta"} · {context.model.displayName ?? "no model"}</Text>;
@@ -22,6 +24,8 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   const update = async () => {
     try {
       const context = letta.getContext();
@@ -50,6 +54,8 @@ export default function activate(letta) {
 
 ```tsx
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   letta.ui.setStatuslineRenderer((context) => {
     const { Box, Text } = context.components;
     const model = context.model.displayName ?? "no model";
@@ -75,6 +81,8 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   const update = async () => {
     try {
       const context = letta.getContext();
@@ -110,6 +118,8 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
   const update = async () => {
     try {
       const script = 'tell application "Music" to if it is running then artist of current track & " - " & name of current track';


### PR DESCRIPTION
## Summary
- Add a generic `creating-extensions` skill with focused recipes for tools, commands, panels/status, and advanced SDK commands
- Slim `customizing-commands` into a command-specific entrypoint with guidance for command vs tool vs skill-backed workflows
- Keep `customizing-statusline` separate and update its guidance/examples for capability-gated statusline APIs

## Test plan
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/creating-extensions`
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/customizing-commands`
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/customizing-statusline`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)