### PR TITLE
fix(listener): launch channel reflections after turns

### DIFF
--- a/src/websocket/listener/turn-reflection.test.ts
+++ b/src/websocket/listener/turn-reflection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createContextTracker } from "@/cli/helpers/context-tracker";
+import { REFLECTION_STATE_SCHEMA_VERSION } from "@/cli/helpers/reflection-transcript";
+import { createSharedReminderState } from "@/reminders/state";
+import { __listenerTurnTestUtils } from "@/websocket/listener/turn";
+
+describe("post-turn channel reflection", () => {
+  test("launches step-count reflection after a channel turn reaches the transcript threshold", async () => {
+    const launches: string[] = [];
+
+    const didLaunch =
+      await __listenerTurnTestUtils.maybeLaunchPostTurnChannelReflection({
+        hasChannelTurnSources: true,
+        agentId: "agent-1",
+        conversationId: "conv-slack-thread",
+        memfsEnabled: true,
+        reflectionSettings: { trigger: "step-count", stepCount: 3 },
+        reminderState: createSharedReminderState(),
+        contextTracker: createContextTracker(),
+        getTranscriptState: mock(async () => ({
+          schema_version: REFLECTION_STATE_SCHEMA_VERSION,
+          total_completed_turns: 3,
+          reflected_completed_turns: 0,
+          turns_since_last_successful_reflection: 3,
+        })),
+        launch: mock(async (trigger) => {
+          launches.push(trigger);
+          return true;
+        }),
+      });
+
+    expect(didLaunch).toBe(true);
+    expect(launches).toEqual(["step-count"]);
+  });
+
+  test("launches compaction reflection after a channel turn marks compaction complete", async () => {
+    const reminderState = createSharedReminderState();
+    const contextTracker = createContextTracker();
+    contextTracker.pendingReflectionTrigger = true;
+    const launches: string[] = [];
+
+    const didLaunch =
+      await __listenerTurnTestUtils.maybeLaunchPostTurnChannelReflection({
+        hasChannelTurnSources: true,
+        agentId: "agent-1",
+        conversationId: "conv-slack-thread",
+        memfsEnabled: true,
+        reflectionSettings: { trigger: "compaction-event", stepCount: 25 },
+        reminderState,
+        contextTracker,
+        launch: mock(async (trigger) => {
+          launches.push(trigger);
+          return true;
+        }),
+      });
+
+    expect(didLaunch).toBe(true);
+    expect(launches).toEqual(["compaction-event"]);
+    expect(contextTracker.pendingReflectionTrigger).toBe(false);
+    expect(reminderState.pendingReflectionTrigger).toBe(false);
+  });
+
+  test("ignores non-channel turns so interactive behavior stays unchanged", async () => {
+    const launch = mock(async () => true);
+
+    const didLaunch =
+      await __listenerTurnTestUtils.maybeLaunchPostTurnChannelReflection({
+        hasChannelTurnSources: false,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        memfsEnabled: true,
+        reflectionSettings: { trigger: "step-count", stepCount: 1 },
+        reminderState: createSharedReminderState(),
+        contextTracker: createContextTracker(),
+        getTranscriptState: mock(async () => ({
+          schema_version: REFLECTION_STATE_SCHEMA_VERSION,
+          total_completed_turns: 1,
+          reflected_completed_turns: 0,
+          turns_since_last_successful_reflection: 1,
+        })),
+        launch,
+      });
+
+    expect(didLaunch).toBe(false);
+    expect(launch).not.toHaveBeenCalled();
+  });
+});

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -31,10 +31,13 @@ import {
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
 import { createBuffers, toLines } from "@/cli/helpers/accumulator";
+import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import {
   getReflectionSettings,
+  type ReflectionSettings,
   type ReflectionTrigger,
+  shouldFireStepCountTrigger,
 } from "@/cli/helpers/memory-reminder";
 import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
 import {
@@ -43,6 +46,7 @@ import {
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
   finalizeAutoReflectionPayload,
+  getReflectionTranscriptState,
 } from "@/cli/helpers/reflection-transcript";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
 import {
@@ -50,7 +54,10 @@ import {
   prependReminderPartsToContent,
 } from "@/reminders/engine";
 import { buildListenReminderContext } from "@/reminders/listen-context";
-import { syncReminderStateFromContextTracker } from "@/reminders/state";
+import {
+  type SharedReminderState,
+  syncReminderStateFromContextTracker,
+} from "@/reminders/state";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
@@ -144,6 +151,7 @@ function trackListenerUserInput(
 
 export const __listenerTurnTestUtils = {
   trackListenerUserInput,
+  maybeLaunchPostTurnChannelReflection,
 };
 
 function hasActiveReflectionSubagent(
@@ -319,6 +327,63 @@ function buildMaybeLaunchReflectionSubagent(params: {
       return false;
     }
   };
+}
+
+type PostTurnReflectionLauncher = (
+  triggerSource: Exclude<ReflectionTrigger, "off">,
+) => Promise<boolean>;
+
+async function maybeLaunchPostTurnChannelReflection(params: {
+  hasChannelTurnSources: boolean;
+  agentId?: string | null;
+  conversationId: string;
+  memfsEnabled: boolean;
+  reflectionSettings: ReflectionSettings;
+  reminderState: SharedReminderState;
+  contextTracker: ContextTracker;
+  launch: PostTurnReflectionLauncher;
+  getTranscriptState?: typeof getReflectionTranscriptState;
+}): Promise<boolean> {
+  if (
+    !params.hasChannelTurnSources ||
+    !params.agentId ||
+    !params.memfsEnabled
+  ) {
+    return false;
+  }
+
+  switch (params.reflectionSettings.trigger) {
+    case "off":
+      return false;
+    case "compaction-event": {
+      syncReminderStateFromContextTracker(
+        params.reminderState,
+        params.contextTracker,
+      );
+      if (!params.reminderState.pendingReflectionTrigger) {
+        return false;
+      }
+      params.reminderState.pendingReflectionTrigger = false;
+      return params.launch("compaction-event");
+    }
+    case "step-count": {
+      const readTranscriptState =
+        params.getTranscriptState ?? getReflectionTranscriptState;
+      const transcriptState = await readTranscriptState(
+        params.agentId,
+        params.conversationId,
+      );
+      if (
+        !shouldFireStepCountTrigger(
+          transcriptState.turns_since_last_successful_reflection,
+          params.reflectionSettings,
+        )
+      ) {
+        return false;
+      }
+      return params.launch("step-count");
+    }
+  }
 }
 
 function finalizeInterruptedTurn(
@@ -789,6 +854,40 @@ export async function handleIncomingMessage(
               transcriptError instanceof Error
                 ? transcriptError.message
                 : String(transcriptError)
+            }`,
+          );
+        }
+        try {
+          const reflectionSettings = getReflectionSettings(
+            agentId || undefined,
+            turnWorkingDirectory,
+          );
+          await maybeLaunchPostTurnChannelReflection({
+            hasChannelTurnSources: (msg.channelTurnSources?.length ?? 0) > 0,
+            agentId,
+            conversationId,
+            memfsEnabled: Boolean(
+              agentId && settingsManager.isMemfsEnabled(agentId),
+            ),
+            reflectionSettings,
+            reminderState: runtime.reminderState,
+            contextTracker: runtime.contextTracker,
+            launch: buildMaybeLaunchReflectionSubagent({
+              runtime,
+              socket,
+              agentId: agentId || "",
+              conversationId,
+              workingDirectory: turnWorkingDirectory,
+              cachedAgent,
+            }),
+          });
+        } catch (reflectionError) {
+          debugWarn(
+            "memory",
+            `Failed to evaluate post-turn channel reflection: ${
+              reflectionError instanceof Error
+                ? reflectionError.message
+                : String(reflectionError)
             }`,
           );
         }


### PR DESCRIPTION
## Summary
- Launches automatic reflection after successful channel-originated turns, once the transcript delta has been appended.
- Handles both step-count and compaction-event triggers so Slack threads do not need another message before dreaming.
- Keeps the new post-turn path scoped to channel turns so normal interactive reflection behavior is unchanged.

## Test plan
- [x] `bun test src/websocket/listener/turn-reflection.test.ts`
- [x] `bun test src/cli/memory-reminder.test.ts src/websocket/listen-reflection-runtime.test.ts src/websocket/listener-reconnect-reminders.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)