### PR TITLE
fix: repair agent guide symlinks

### DIFF
--- a/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
+++ b/.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc
@@ -1,1 +1,1 @@
-../../CLAUDE.md
+../../AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` as a symlink to `AGENTS.md` for compatibility with tools that still look for Claude-style agent instructions.
- Retargets the Cursor rule symlink to `AGENTS.md` so the file indexer no longer follows a broken `CLAUDE.md` path.

## Test plan
- [x] `stat CLAUDE.md`
- [x] `stat .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc`
- [x] `LETTA_DEBUG=1 bun --loader=.md:text --loader=.mdx:text --loader=.txt:text -e 'import { refreshFileIndex } from "./src/utils/file-index.ts"; await refreshFileIndex();'`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)