### PR TITLE
fix(local): drop bare OpenAI reasoning signatures without encrypted_content

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -171,11 +171,30 @@ function normalizeUserContent(
   const normalized = dropEmptyTextBlocks(content);
   return normalized.length > 0 ? normalized : undefined;
 }
+function hasUnsafeBareReasoningSignature(block: unknown): boolean {
+  if (!isRecord(block)) return false;
+  if (block.type !== "thinking") return false;
+  if (typeof block.thinkingSignature !== "string") return false;
 
+  try {
+    const signature = JSON.parse(block.thinkingSignature) as unknown;
+    return (
+      isRecord(signature) &&
+      signature.type === "reasoning" &&
+      typeof signature.id === "string" &&
+      signature.id.startsWith("rs_") &&
+      !("encrypted_content" in signature)
+    );
+  } catch {
+    return false;
+  }
+}
 function normalizeAssistantContent(
   content: LocalAssistantContent,
 ): LocalAssistantContent | undefined {
-  const normalized = dropEmptyTextBlocks(content);
+  const normalized = dropEmptyTextBlocks(content).filter(
+    (block) => !hasUnsafeBareReasoningSignature(block),
+  );
   return normalized.length > 0 ? normalized : undefined;
 }
 

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -202,6 +202,90 @@ describe("PiStreamAdapter", () => {
     }
   });
 
+  test("drops bare OpenAI reasoning signatures without encrypted_content", async () => {
+    let capturedContext: Context | undefined;
+
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      context: Context,
+    ) => {
+      capturedContext = context;
+      const finalMessage = assistantMessage();
+
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({ stream });
+
+    for await (const _event of adapter.stream({
+      ...input(),
+      uiMessages: [
+        {
+          id: "ui-msg-user",
+          role: "user",
+          content: "hello",
+          timestamp: Date.now(),
+        },
+        {
+          id: "ui-msg-assistant",
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "",
+              thinkingSignature:
+                '{"id":"rs_123","type":"reasoning","summary":[]}',
+            },
+            {
+              type: "toolCall",
+              id: "call-recall",
+              name: "Recall",
+              arguments: { query: "test" },
+            },
+          ],
+          api: "openai-responses",
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: emptyLocalUsage(),
+          stopReason: "toolUse",
+          timestamp: Date.now(),
+        } as never,
+        {
+          id: "ui-msg-tool",
+          role: "toolResult",
+          toolCallId: "call-recall",
+          toolName: "Recall",
+          content: [{ type: "text", text: "result" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+      ],
+    })) {
+      // drain
+    }
+
+    expect(capturedContext).toBeDefined();
+
+    const assistant = capturedContext?.messages.find(
+      (message) => message.role === "assistant",
+    );
+
+    expect(assistant).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call-recall",
+          name: "Recall",
+          arguments: { query: "test" },
+        },
+      ],
+    });
+  });
+
   test("forwards Bedrock provider options and restores AWS env overrides", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-stream-bedrock-"));
     const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;


### PR DESCRIPTION
## Summary

Drop bare OpenAI reasoning signatures from assistant context when they lack `encrypted_content`.

This prevents replaying stale `rs_*` reasoning items into subsequent OpenAI Responses requests, which can fail when `store=false`.

Closes #2378

## Before

Running:

```bash
letta --backend local -p "Reflect on what you learned about me and update memory if useful."
```

could fail with:

```text
404 Item with id 'rs_...' not found.
Items are not persisted when `store` is set to false.
```

The persisted assistant message contained a bare OpenAI reasoning signature:

```json
{
  "type": "thinking",
  "thinking": "",
  "thinkingSignature":
    "{\"id\":\"rs_...\",\"type\":\"reasoning\",\"summary\":[]}"
}
```

which was replayed into a later OpenAI Responses request without `encrypted_content`.

## After

Bare reasoning signatures without `encrypted_content` are filtered from assistant context before provider execution.

The same command now completes successfully:

```text
Done — I updated memory ...
```

Normal thinking blocks and signatures that include `encrypted_content` remain unchanged.

## Changes

* Filter unsafe OpenAI reasoning signatures during assistant content normalization.
* Preserve safe reasoning signatures and non-reasoning thinking blocks.
* Add regression test covering bare reasoning signatures without `encrypted_content`.

## Test plan

```bash
bun test src/backend/pi-stream-adapter.test.ts
bun run check
bun run build
```

Verified against a local repro using:

```bash
letta --backend local -p "Reflect on what you learned about me and update memory if useful."
```
