### PR TITLE
fix(permissions): share CLI permission overrides across bundled entrypoints

### DIFF
--- a/src/permissions/cli-permissions-instance.ts
+++ b/src/permissions/cli-permissions-instance.ts
@@ -1,6 +1,24 @@
 /**
  * Singleton instance of CliPermissions.
+ *
+ * Keep this on globalThis instead of as a module-local singleton. The bundled
+ * CLI can contain more than one copy of this module when multiple entrypoint
+ * graphs are included (interactive + headless). CLI startup may set flags like
+ * --disable-memory-guard through one copy while permission checks read from
+ * another; a global symbol makes those copies share the same state.
  */
 import { CliPermissions } from "./cli";
 
-export const cliPermissions = new CliPermissions();
+const CLI_PERMISSIONS_KEY = Symbol.for("@letta/cliPermissions");
+
+type GlobalWithCliPermissions = typeof globalThis & {
+  [CLI_PERMISSIONS_KEY]?: CliPermissions;
+};
+
+function getCliPermissions(): CliPermissions {
+  const state = globalThis as GlobalWithCliPermissions;
+  state[CLI_PERMISSIONS_KEY] ??= new CliPermissions();
+  return state[CLI_PERMISSIONS_KEY];
+}
+
+export const cliPermissions = getCliPermissions();

--- a/src/permissions/permissions-cli.test.ts
+++ b/src/permissions/permissions-cli.test.ts
@@ -67,6 +67,13 @@ test("tracks disable-memory-guard CLI override", () => {
   expect(cliPermissions.isMemoryGuardDisabled()).toBe(true);
 });
 
+test("stores singleton on global symbol for bundled duplicate modules", () => {
+  const key = Symbol.for("@letta/cliPermissions");
+  const globals = globalThis as unknown as Record<symbol, unknown>;
+
+  expect(globals[key]).toBe(cliPermissions);
+});
+
 test("clear resets disable-memory-guard CLI override", () => {
   cliPermissions.setMemoryGuardDisabled(true);
   cliPermissions.clear();


### PR DESCRIPTION
## Summary
- Store the CLI permissions singleton on `globalThis` via a stable symbol so duplicated bundled module copies share flag state.
- Fixes `--disable-memory-guard` being parsed by interactive startup but ignored by the cross-agent guard when the bundle contains duplicate permission modules.
- Adds a regression assertion that the exported singleton is installed on the global symbol.

## Test plan
- [x] `bun test src/permissions/permissions-cli.test.ts src/permissions/cross-agent-guard.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint src/permissions/cli-permissions-instance.ts src/permissions/permissions-cli.test.ts`
- [x] `bun run build`

👾 Generated with [Letta Code](https://letta.com)