### PR TITLE
fix(codex): align shell tools with unified exec

### DIFF
--- a/src/agent/approval-execution.ts
+++ b/src/agent/approval-execution.ts
@@ -121,6 +121,8 @@ const GLOBAL_LOCK_TOOLS = new Set([
   // Memory tool (file + git side effects)
   "memory",
   "shell_command",
+  "exec_command",
+  "write_stdin",
   "shell",
   "ShellCommand",
   "Shell",

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -112,7 +112,6 @@ function withStartupTimeout<T>(
     timer = setTimeout(() => {
       reject(new Error(`${label} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
-    timer.unref?.();
 
     promise.then(
       (value) => {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2236,8 +2236,6 @@ export function App({
 
         if (t === "exec_command") {
           command = typeof args.cmd === "string" ? args.cmd : "(no command)";
-          description =
-            typeof args.justification === "string" ? args.justification : "";
         } else if (t === "write_stdin") {
           const sessionId =
             typeof args.session_id === "string" ||

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -635,12 +635,19 @@ export function App({
           return args.file_path || undefined;
         }
         if (isShellTool(approval.toolName)) {
-          const cmd =
-            typeof args.command === "string"
-              ? args.command
-              : Array.isArray(args.command)
-                ? args.command.join(" ")
-                : "";
+          const cmd = (() => {
+            if (typeof args.cmd === "string") return args.cmd;
+            if (typeof args.command === "string") return args.command;
+            if (Array.isArray(args.command)) return args.command.join(" ");
+            if (
+              approval.toolName === "write_stdin" &&
+              (typeof args.session_id === "string" ||
+                typeof args.session_id === "number")
+            ) {
+              return `write_stdin ${String(args.session_id)}`;
+            }
+            return "";
+          })();
           return cmd.length > 50 ? `${cmd.slice(0, 50)}...` : cmd || undefined;
         }
         if (isPatchTool(approval.toolName)) {
@@ -2227,7 +2234,22 @@ export function App({
         let command = "(no command)";
         let description = "";
 
-        if (t === "shell") {
+        if (t === "exec_command") {
+          command = typeof args.cmd === "string" ? args.cmd : "(no command)";
+          description =
+            typeof args.justification === "string" ? args.justification : "";
+        } else if (t === "write_stdin") {
+          const sessionId =
+            typeof args.session_id === "string" ||
+            typeof args.session_id === "number"
+              ? String(args.session_id)
+              : "unknown";
+          command = `write_stdin ${sessionId}`;
+          description =
+            typeof args.chars === "string" && args.chars.length > 0
+              ? "Write input to running shell session"
+              : "Poll running shell session";
+        } else if (t === "shell") {
           const cmdVal = args.command;
           command = Array.isArray(cmdVal)
             ? cmdVal.join(" ")

--- a/src/cli/components/ApprovalPreview.tsx
+++ b/src/cli/components/ApprovalPreview.tsx
@@ -116,7 +116,6 @@ export const ApprovalPreview = memo(
         let description = "";
         if (toolName === "exec_command") {
           command = typeof args.cmd === "string" ? args.cmd : "";
-          description = args.justification || "";
         } else if (toolName === "write_stdin") {
           const sessionId =
             typeof args.session_id === "string" ||

--- a/src/cli/components/ApprovalPreview.tsx
+++ b/src/cli/components/ApprovalPreview.tsx
@@ -2,6 +2,7 @@ import { Box } from "ink";
 import { memo } from "react";
 import type { AdvancedDiffSuccess } from "@/cli/helpers/diff";
 import { parsePatchOperations } from "@/cli/helpers/format-args-display";
+import { isShellTool } from "@/cli/helpers/tool-name-mapping";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { AdvancedDiffRenderer } from "./AdvancedDiffRenderer";
 import { colors } from "./colors";
@@ -108,21 +109,34 @@ export const ApprovalPreview = memo(
     const dottedLine = DOTTED_LINE.repeat(Math.max(columns, 10));
 
     // Bash/Shell: Use BashPreview component
-    if (
-      toolName === "Bash" ||
-      toolName === "shell" ||
-      toolName === "Shell" ||
-      toolName === "shell_command"
-    ) {
+    if (isShellTool(toolName)) {
       try {
         const args = JSON.parse(toolArgs);
-        const command =
-          typeof args.command === "string"
-            ? args.command
-            : Array.isArray(args.command)
-              ? args.command.join(" ")
-              : "";
-        const description = args.description || args.justification || "";
+        let command = "";
+        let description = "";
+        if (toolName === "exec_command") {
+          command = typeof args.cmd === "string" ? args.cmd : "";
+          description = args.justification || "";
+        } else if (toolName === "write_stdin") {
+          const sessionId =
+            typeof args.session_id === "string" ||
+            typeof args.session_id === "number"
+              ? String(args.session_id)
+              : "unknown";
+          command = `write_stdin ${sessionId}`;
+          description =
+            typeof args.chars === "string" && args.chars.length > 0
+              ? "Write input to running shell session"
+              : "Poll running shell session";
+        } else {
+          command =
+            typeof args.command === "string"
+              ? args.command
+              : Array.isArray(args.command)
+                ? args.command.join(" ")
+                : "";
+          description = args.description || args.justification || "";
+        }
 
         return (
           <Box flexDirection="column">

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -91,8 +91,6 @@ function getBashInfo(approval: ApprovalRequest): BashInfo | null {
 
     if (t === "exec_command") {
       command = typeof args.cmd === "string" ? args.cmd : "(no command)";
-      description =
-        typeof args.justification === "string" ? args.justification : "";
     } else if (t === "write_stdin") {
       const sessionId =
         typeof args.session_id === "string" ||

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -89,7 +89,22 @@ function getBashInfo(approval: ApprovalRequest): BashInfo | null {
     let command = "";
     let description = "";
 
-    if (t === "shell") {
+    if (t === "exec_command") {
+      command = typeof args.cmd === "string" ? args.cmd : "(no command)";
+      description =
+        typeof args.justification === "string" ? args.justification : "";
+    } else if (t === "write_stdin") {
+      const sessionId =
+        typeof args.session_id === "string" ||
+        typeof args.session_id === "number"
+          ? String(args.session_id)
+          : "unknown";
+      command = `write_stdin ${sessionId}`;
+      description =
+        typeof args.chars === "string" && args.chars.length > 0
+          ? "Write input to running shell session"
+          : "Poll running shell session";
+    } else if (t === "shell") {
       // Shell tool uses command array and justification
       const cmdVal = args.command;
       command = Array.isArray(cmdVal)

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -1028,18 +1028,23 @@ export const ToolCallMessage = memo(
           {isShellOutputTool(rawName) &&
             line.phase === "finished" &&
             line.resultText &&
-            line.resultOk !== false && (
-              <CollapsedOutputDisplay
-                output={formatUnifiedExecOutputForTui(
-                  extractMessageFromResult(line.resultText),
-                )}
-                maxChars={300}
-                expanded={
-                  expandedToolCallId != null && expandedToolCallId === line.id
-                }
-                isLast={lastShellToolCallId === line.id}
-              />
-            )}
+            line.resultOk !== false &&
+            (() => {
+              const output = formatUnifiedExecOutputForTui(
+                extractMessageFromResult(line.resultText),
+                { hideEmptyCompletion: rawName === "write_stdin" },
+              );
+              return output ? (
+                <CollapsedOutputDisplay
+                  output={output}
+                  maxChars={300}
+                  expanded={
+                    expandedToolCallId != null && expandedToolCallId === line.id
+                  }
+                  isLast={lastShellToolCallId === line.id}
+                />
+              ) : null;
+            })()}
 
           {/* Tool result for non-shell tools or shell tool errors */}
           {(() => {

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -23,6 +23,7 @@ import {
   isTaskTool,
   isTodoTool,
 } from "@/cli/helpers/tool-name-mapping.js";
+import { formatUnifiedExecOutputForTui } from "@/cli/helpers/unified-exec-output.js";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import { clipToolReturn } from "@/tools/manager.js";
 import { isRecord } from "@/utils/type-guards";
@@ -1013,7 +1014,9 @@ export const ToolCallMessage = memo(
             line.resultText &&
             line.resultOk !== false && (
               <CollapsedOutputDisplay
-                output={extractMessageFromResult(line.resultText)}
+                output={formatUnifiedExecOutputForTui(
+                  extractMessageFromResult(line.resultText),
+                )}
                 maxChars={300}
                 expanded={
                   expandedToolCallId != null && expandedToolCallId === line.id

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -128,6 +128,7 @@ type ToolCallLine = {
   toolCallId?: string;
   name?: string;
   argsText?: string;
+  unifiedExecCommandDisplay?: string;
   resultText?: string;
   resultOk?: boolean;
   phase: "streaming" | "ready" | "running" | "finished";
@@ -238,7 +239,9 @@ export const ToolCallMessage = memo(
             return { formatted: null, parseable: true };
           }
           try {
-            const formatted = formatArgsDisplay(argsText, rawName);
+            const formatted = formatArgsDisplay(argsText, rawName, {
+              unifiedExecCommandDisplay: line.unifiedExecCommandDisplay,
+            });
             return { formatted, parseable: true };
           } catch {
             return { formatted: null, parseable: false };
@@ -257,7 +260,10 @@ export const ToolCallMessage = memo(
           args = "(…)";
         } else {
           const formattedArgs =
-            formatted ?? formatArgsDisplay(argsText, rawName);
+            formatted ??
+            formatArgsDisplay(argsText, rawName, {
+              unifiedExecCommandDisplay: line.unifiedExecCommandDisplay,
+            });
           if (formattedArgs.shellSemantic) {
             shellSemanticKind = formattedArgs.shellSemantic.kind;
             displayName = formattedArgs.shellSemantic.label;

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -270,6 +270,8 @@ export const ToolCallMessage = memo(
             if (formattedArgs.shellSemantic.kind === "run") {
               shellCommand = formattedArgs.shellSemantic.rawCommand;
             }
+          } else if (formattedArgs.displayName) {
+            displayName = formattedArgs.displayName;
           }
           // Normalize newlines to spaces to prevent forced line breaks
           const normalizedDisplay = formattedArgs.display.replace(/\n/g, " ");

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -286,7 +286,9 @@ export const ToolCallMessage = memo(
       ) {
         try {
           const parsedArgs = JSON.parse(argsText);
-          if (typeof parsedArgs.command === "string") {
+          if (typeof parsedArgs.cmd === "string") {
+            shellCommand = parsedArgs.cmd;
+          } else if (typeof parsedArgs.command === "string") {
             shellCommand = parsedArgs.command;
           } else if (Array.isArray(parsedArgs.command)) {
             shellCommand = parsedArgs.command.join(" ");

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -241,6 +241,10 @@ export const ToolCallMessage = memo(
           try {
             const formatted = formatArgsDisplay(argsText, rawName, {
               unifiedExecCommandDisplay: line.unifiedExecCommandDisplay,
+              suppressUnifiedExecInteractionLabel:
+                rawName === "write_stdin" &&
+                line.phase === "finished" &&
+                line.resultOk === false,
             });
             return { formatted, parseable: true };
           } catch {
@@ -263,6 +267,10 @@ export const ToolCallMessage = memo(
             formatted ??
             formatArgsDisplay(argsText, rawName, {
               unifiedExecCommandDisplay: line.unifiedExecCommandDisplay,
+              suppressUnifiedExecInteractionLabel:
+                rawName === "write_stdin" &&
+                line.phase === "finished" &&
+                line.resultOk === false,
             });
           if (formattedArgs.shellSemantic) {
             shellSemanticKind = formattedArgs.shellSemantic.kind;

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -79,4 +79,21 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
       rawCommand: "git status --short",
     });
   });
+
+  test("summarizes Codex write_stdin without raw polling args", () => {
+    const args = JSON.stringify({
+      session_id: 8,
+      chars: "hello from stdin\n",
+      yield_time_ms: 1000,
+      max_output_tokens: 2000,
+    });
+
+    const formatted = formatArgsDisplay(args, "write_stdin");
+    expect(formatted.display).toBe("write_stdin 8");
+    expect(formatted.shellSemantic).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: "write_stdin 8",
+    });
+  });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -89,9 +89,8 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     });
 
     const formatted = formatArgsDisplay(args, "write_stdin");
-    expect(formatted.display).toBe(
-      "Interacted with background terminal (session 8)",
-    );
+    expect(formatted.displayName).toBe("Interacted with background terminal");
+    expect(formatted.display).toBe(" (session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
@@ -106,9 +105,8 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     const formatted = formatArgsDisplay(args, "write_stdin", {
       unifiedExecCommandDisplay: "python3 repl.py",
     });
-    expect(formatted.display).toBe(
-      "Interacted with background terminal · python3 repl.py",
-    );
+    expect(formatted.displayName).toBe("Interacted with background terminal");
+    expect(formatted.display).toBe(" · python3 repl.py");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
@@ -120,9 +118,8 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     });
 
     const formatted = formatArgsDisplay(args, "write_stdin");
-    expect(formatted.display).toBe(
-      "Waited for background terminal (session 8)",
-    );
+    expect(formatted.displayName).toBe("Waited for background terminal");
+    expect(formatted.display).toBe(" (session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -90,7 +90,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
 
     const formatted = formatArgsDisplay(args, "write_stdin");
     expect(formatted.displayName).toBe("Interacted with background terminal");
-    expect(formatted.display).toBe(" (session 8)");
+    expect(formatted.display).toBe("(session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
@@ -106,7 +106,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
       unifiedExecCommandDisplay: "python3 repl.py",
     });
     expect(formatted.displayName).toBe("Interacted with background terminal");
-    expect(formatted.display).toBe(" · python3 repl.py");
+    expect(formatted.display).toBe("· python3 repl.py");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
@@ -119,7 +119,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
 
     const formatted = formatArgsDisplay(args, "write_stdin");
     expect(formatted.displayName).toBe("Waited for background terminal");
-    expect(formatted.display).toBe(" (session 8)");
+    expect(formatted.display).toBe("(session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
@@ -134,6 +134,6 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
       suppressUnifiedExecInteractionLabel: true,
     });
     expect(formatted.displayName).toBeUndefined();
-    expect(formatted.display).toBe(" · cat");
+    expect(formatted.display).toBe("· cat");
   });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -122,4 +122,18 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     expect(formatted.display).toBe(" (session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });
+
+  test("does not label failed write_stdin as a terminal interaction", () => {
+    const args = JSON.stringify({
+      session_id: 8,
+      chars: "hello from stdin\n",
+    });
+
+    const formatted = formatArgsDisplay(args, "write_stdin", {
+      unifiedExecCommandDisplay: "cat",
+      suppressUnifiedExecInteractionLabel: true,
+    });
+    expect(formatted.displayName).toBeUndefined();
+    expect(formatted.display).toBe(" · cat");
+  });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -92,11 +92,24 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     expect(formatted.display).toBe(
       "Interacted with background terminal (session 8)",
     );
-    expect(formatted.shellSemantic).toMatchObject({
-      kind: "run",
-      label: "Run",
-      rawCommand: "Interacted with background terminal (session 8)",
+    expect(formatted.shellSemantic).toBeUndefined();
+  });
+
+  test("summarizes Codex write_stdin with original command display when available", () => {
+    const args = JSON.stringify({
+      session_id: 8,
+      chars: "hello from stdin\n",
+      yield_time_ms: 1000,
+      max_output_tokens: 2000,
     });
+
+    const formatted = formatArgsDisplay(args, "write_stdin", {
+      unifiedExecCommandDisplay: "python3 repl.py",
+    });
+    expect(formatted.display).toBe(
+      "Interacted with background terminal · python3 repl.py",
+    );
+    expect(formatted.shellSemantic).toBeUndefined();
   });
 
   test("summarizes Codex write_stdin polling with Codex-like language", () => {
@@ -110,10 +123,6 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     expect(formatted.display).toBe(
       "Waited for background terminal (session 8)",
     );
-    expect(formatted.shellSemantic).toMatchObject({
-      kind: "run",
-      label: "Run",
-      rawCommand: "Waited for background terminal (session 8)",
-    });
+    expect(formatted.shellSemantic).toBeUndefined();
   });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -89,11 +89,31 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     });
 
     const formatted = formatArgsDisplay(args, "write_stdin");
-    expect(formatted.display).toBe("write_stdin 8");
+    expect(formatted.display).toBe(
+      "Interacted with background terminal (session 8)",
+    );
     expect(formatted.shellSemantic).toMatchObject({
       kind: "run",
       label: "Run",
-      rawCommand: "write_stdin 8",
+      rawCommand: "Interacted with background terminal (session 8)",
+    });
+  });
+
+  test("summarizes Codex write_stdin polling with Codex-like language", () => {
+    const args = JSON.stringify({
+      session_id: 8,
+      yield_time_ms: 1000,
+      max_output_tokens: 2000,
+    });
+
+    const formatted = formatArgsDisplay(args, "write_stdin");
+    expect(formatted.display).toBe(
+      "Waited for background terminal (session 8)",
+    );
+    expect(formatted.shellSemantic).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: "Waited for background terminal (session 8)",
     });
   });
 });

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -65,4 +65,18 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
       rawCommand: "git status --short",
     });
   });
+
+  test("uses cmd for Codex unified exec shell display", () => {
+    const args = JSON.stringify({
+      cmd: "git status --short",
+    });
+
+    const formatted = formatArgsDisplay(args, "exec_command");
+    expect(formatted.display).toBe("git status --short");
+    expect(formatted.shellSemantic).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: "git status --short",
+    });
+  });
 });

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -19,6 +19,7 @@ import { MAX_CONTEXT_HISTORY } from "./context-tracker";
 import { findLastSafeSplitPoint } from "./markdown-split";
 import { trimFinishedReasoningText } from "./reasoning-text";
 import { isShellOutputTool } from "./tool-name-mapping";
+import { extractUnifiedExecRunningSessionId } from "./unified-exec-output";
 
 type CompactionSummaryMessageChunk = {
   message_type: "summary_message";
@@ -169,6 +170,7 @@ export type Line =
       toolCallId?: string;
       name?: string;
       argsText?: string;
+      unifiedExecCommandDisplay?: string;
       // from the tool return object
       resultText?: string;
       resultOk?: boolean;
@@ -278,6 +280,10 @@ export type Buffers = {
   splitCounters: Map<string, number>; // tracks split count per original otid
   // Track server-side tool calls for hook triggering (toolCallId -> info)
   serverToolCalls: Map<string, ServerToolCallInfo>;
+  // Maps Codex unified exec session IDs to the original command that created
+  // them. This lets write_stdin render Codex-like "background terminal"
+  // labels without reaching into the ephemeral tool runtime session map.
+  unifiedExecSessionCommands: Map<string, string>;
   // Track if this run has pending approvals (used to gate server tool phases)
   approvalsPending: boolean;
   // Agent ID for passing to hooks (needed for server-side tools like memory)
@@ -311,9 +317,58 @@ export function createBuffers(agentId?: string): Buffers {
     tokenStreamingEnabled: false,
     splitCounters: new Map(),
     serverToolCalls: new Map(),
+    unifiedExecSessionCommands: new Map(),
     approvalsPending: false,
     agentId,
   };
+}
+
+function parseToolArgsText(
+  argsText: string | undefined,
+): Record<string, unknown> | null {
+  if (!argsText?.trim()) return null;
+  try {
+    const parsed = JSON.parse(argsText);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractExecCommandDisplay(
+  argsText: string | undefined,
+): string | null {
+  const parsed = parseToolArgsText(argsText);
+  const cmd = parsed?.cmd;
+  return typeof cmd === "string" && cmd.trim() ? cmd : null;
+}
+
+function extractWriteStdinSessionId(
+  argsText: string | undefined,
+): string | null {
+  const parsed = parseToolArgsText(argsText);
+  const sessionId = parsed?.session_id;
+  if (typeof sessionId === "string" && sessionId.trim()) return sessionId;
+  if (typeof sessionId === "number" && Number.isFinite(sessionId)) {
+    return String(sessionId);
+  }
+  return null;
+}
+
+function annotateWriteStdinCommandDisplay(
+  b: Buffers,
+  line: ToolCallLine,
+): ToolCallLine {
+  if (line.name !== "write_stdin") return line;
+  const sessionId = extractWriteStdinSessionId(line.argsText);
+  if (!sessionId) return line;
+  const commandDisplay = b.unifiedExecSessionCommands.get(sessionId);
+  if (!commandDisplay || line.unifiedExecCommandDisplay === commandDisplay) {
+    return line;
+  }
+  const updatedLine = { ...line, unifiedExecCommandDisplay: commandDisplay };
+  b.byId.set(line.id, updatedLine);
+  return updatedLine;
 }
 
 // Guarantees that there's only one line per ID
@@ -1050,8 +1105,8 @@ export function onChunk(
           ...line,
           argsText: (line.argsText || "") + argsText,
         };
-        line = updatedLine;
-        b.byId.set(id, updatedLine);
+        line = annotateWriteStdinCommandDisplay(b, updatedLine);
+        b.byId.set(id, line);
         // Count tool call arguments as LLM output tokens
         b.tokenCount += Buffer.byteLength(argsText, "utf8");
       }
@@ -1137,11 +1192,13 @@ export function onChunk(
           : undefined;
         if (!id) continue;
 
-        const line = ensure<ToolCallLine>(b, id, () => ({
+        let line = ensure<ToolCallLine>(b, id, () => ({
           kind: "tool_call",
           id,
           phase: "finished",
         }));
+
+        line = annotateWriteStdinCommandDisplay(b, line);
 
         // Immutable update: create new object with result
         const updatedLine = {
@@ -1151,6 +1208,16 @@ export function onChunk(
           resultOk: status === "success",
         };
         b.byId.set(id, updatedLine);
+
+        if (updatedLine.name === "exec_command") {
+          const sessionId = extractUnifiedExecRunningSessionId(resultText);
+          const commandDisplay = extractExecCommandDisplay(
+            updatedLine.argsText,
+          );
+          if (sessionId && commandDisplay) {
+            b.unifiedExecSessionCommands.set(sessionId, commandDisplay);
+          }
+        }
 
         // Trigger PostToolUse hook for server-side tools (fire-and-forget)
         if (toolCallId) {

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -370,8 +370,8 @@ export function formatArgsDisplay(
               typeof parsed.chars === "string" && parsed.chars.length > 0;
             const commandDisplay = options?.unifiedExecCommandDisplay?.trim();
             const suffix = commandDisplay
-              ? ` · ${commandDisplay}`
-              : ` (session ${sessionId})`;
+              ? `· ${commandDisplay}`
+              : `(session ${sessionId})`;
             if (options?.suppressUnifiedExecInteractionLabel) {
               return { display: suffix, parsed };
             }

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -364,8 +364,8 @@ export function formatArgsDisplay(
             const isWrite =
               typeof parsed.chars === "string" && parsed.chars.length > 0;
             display = isWrite
-              ? `write_stdin ${sessionId}`
-              : `poll session ${sessionId}`;
+              ? `Interacted with background terminal (session ${sessionId})`
+              : `Waited for background terminal (session ${sessionId})`;
             shellSemantic = {
               kind: "run",
               label: "Run",

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -210,6 +210,9 @@ export function parsePatchOperations(input: string): PatchOperation[] {
 export function formatArgsDisplay(
   argsJson: string,
   toolName?: string,
+  options?: {
+    unifiedExecCommandDisplay?: string;
+  },
 ): {
   display: string;
   parsed: Record<string, unknown>;
@@ -363,16 +366,14 @@ export function formatArgsDisplay(
                 : "unknown";
             const isWrite =
               typeof parsed.chars === "string" && parsed.chars.length > 0;
+            const commandDisplay = options?.unifiedExecCommandDisplay?.trim();
+            const suffix = commandDisplay
+              ? ` · ${commandDisplay}`
+              : ` (session ${sessionId})`;
             display = isWrite
-              ? `Interacted with background terminal (session ${sessionId})`
-              : `Waited for background terminal (session ${sessionId})`;
-            shellSemantic = {
-              kind: "run",
-              label: "Run",
-              summary: display,
-              rawCommand: display,
-            } satisfies ShellSemanticDisplay;
-            return { display, parsed, shellSemantic };
+              ? `Interacted with background terminal${suffix}`
+              : `Waited for background terminal${suffix}`;
+            return { display, parsed };
           }
 
           // Plan tools: only show compact plan item count.

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -215,6 +215,7 @@ export function formatArgsDisplay(
   },
 ): {
   display: string;
+  displayName?: string;
   parsed: Record<string, unknown>;
   shellSemantic?: ShellSemanticDisplay;
 } {
@@ -370,10 +371,13 @@ export function formatArgsDisplay(
             const suffix = commandDisplay
               ? ` · ${commandDisplay}`
               : ` (session ${sessionId})`;
-            display = isWrite
-              ? `Interacted with background terminal${suffix}`
-              : `Waited for background terminal${suffix}`;
-            return { display, parsed };
+            return {
+              display: suffix,
+              displayName: isWrite
+                ? "Interacted with background terminal"
+                : "Waited for background terminal",
+              parsed,
+            };
           }
 
           // Plan tools: only show compact plan item count.

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -212,6 +212,7 @@ export function formatArgsDisplay(
   toolName?: string,
   options?: {
     unifiedExecCommandDisplay?: string;
+    suppressUnifiedExecInteractionLabel?: boolean;
   },
 ): {
   display: string;
@@ -371,6 +372,9 @@ export function formatArgsDisplay(
             const suffix = commandDisplay
               ? ` · ${commandDisplay}`
               : ` (session ${sessionId})`;
+            if (options?.suppressUnifiedExecInteractionLabel) {
+              return { display: suffix, parsed };
+            }
             return {
               display: suffix,
               displayName: isWrite

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -365,13 +365,14 @@ export function formatArgsDisplay(
           }
 
           // Shell/Bash tools: show just the command
-          if (isShellTool(toolName) && parsed.command) {
+          if (isShellTool(toolName) && (parsed.command || parsed.cmd)) {
+            const commandValue = parsed.cmd ?? parsed.command;
             shellSemantic = summarizeShellDisplay(
-              Array.isArray(parsed.command)
-                ? parsed.command.filter(
+              Array.isArray(commandValue)
+                ? commandValue.filter(
                     (part): part is string => typeof part === "string",
                   )
-                : String(parsed.command),
+                : String(commandValue),
             );
             display = shellSemantic.summary;
             return { display, parsed, shellSemantic };

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -352,6 +352,29 @@ export function formatArgsDisplay(
             return { display, parsed };
           }
 
+          // write_stdin is part of Codex unified exec: keep it on the shell
+          // rendering path, but don't dump raw polling/truncation args in the
+          // transcript header.
+          if (toolName.toLowerCase() === "write_stdin") {
+            const sessionId =
+              typeof parsed.session_id === "string" ||
+              typeof parsed.session_id === "number"
+                ? String(parsed.session_id)
+                : "unknown";
+            const isWrite =
+              typeof parsed.chars === "string" && parsed.chars.length > 0;
+            display = isWrite
+              ? `write_stdin ${sessionId}`
+              : `poll session ${sessionId}`;
+            shellSemantic = {
+              kind: "run",
+              label: "Run",
+              summary: display,
+              rawCommand: display,
+            } satisfies ShellSemanticDisplay;
+            return { display, parsed, shellSemantic };
+          }
+
           // Plan tools: only show compact plan item count.
           if (isPlanTool(toolName) && Array.isArray(parsed.plan)) {
             display = formatItemCount(parsed.plan.length);

--- a/src/cli/helpers/tool-name-mapping.ts
+++ b/src/cli/helpers/tool-name-mapping.ts
@@ -28,6 +28,7 @@ export function getDisplayToolName(rawName: string): string {
 
   // Codex toolset (snake_case)
   if (rawName === "update_plan") return "Planning";
+  if (rawName === "exec_command" || rawName === "write_stdin") return "Bash";
   if (rawName === "shell_command" || rawName === "shell") return "Bash";
   if (rawName === "read_file") return "Read";
   if (rawName === "list_dir") return "LS";
@@ -206,6 +207,8 @@ export function isShellTool(name: string): boolean {
     n === "shell" ||
     n === "shell_command" ||
     n === "shellcommand" ||
+    n === "exec_command" ||
+    n === "write_stdin" ||
     n === "run_shell_command" ||
     n === "runshellcommand"
   );

--- a/src/cli/helpers/unified-exec-accumulator.test.ts
+++ b/src/cli/helpers/unified-exec-accumulator.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { createBuffers, onChunk } from "@/cli/helpers/accumulator";
+
+describe("unified exec accumulator metadata", () => {
+  test("carries original exec command display into write_stdin lines", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "exec-call",
+        name: "exec_command",
+        arguments: JSON.stringify({ cmd: "python3 repl.py", tty: true }),
+      },
+    } as never);
+
+    onChunk(buffers, {
+      message_type: "tool_return_message",
+      tool_call_id: "exec-call",
+      status: "success",
+      tool_return: [
+        "Chunk ID: abc123",
+        "Wall time: 0.1000 seconds",
+        "Process running with session ID 8",
+        "Original token count: 1",
+        "Output:",
+        "ready",
+      ].join("\n"),
+    } as never);
+
+    onChunk(buffers, {
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "stdin-call",
+        name: "write_stdin",
+        arguments: JSON.stringify({ session_id: 8, chars: "2 + 2\n" }),
+      },
+    } as never);
+
+    const line = buffers.byId.get("stdin-call");
+    expect(line).toMatchObject({
+      kind: "tool_call",
+      name: "write_stdin",
+      unifiedExecCommandDisplay: "python3 repl.py",
+    });
+  });
+});

--- a/src/cli/helpers/unified-exec-output.ts
+++ b/src/cli/helpers/unified-exec-output.ts
@@ -64,7 +64,7 @@ export function formatUnifiedExecOutputForTui(
   }
 
   const sessionStatus = parsed.sessionId
-    ? `Process running with session ID ${parsed.sessionId}`
+    ? "Process running in background"
     : null;
 
   if (output.length > 0) {

--- a/src/cli/helpers/unified-exec-output.ts
+++ b/src/cli/helpers/unified-exec-output.ts
@@ -37,6 +37,12 @@ function parseUnifiedExecOutput(text: string): ParsedUnifiedExecOutput | null {
   };
 }
 
+export function extractUnifiedExecRunningSessionId(
+  text: string,
+): string | null {
+  return parseUnifiedExecOutput(text)?.sessionId ?? null;
+}
+
 /**
  * Codex unified exec returns model-facing metadata before the actual command
  * output. The TUI shell renderer should stay focused on what the command

--- a/src/cli/helpers/unified-exec-output.ts
+++ b/src/cli/helpers/unified-exec-output.ts
@@ -1,0 +1,70 @@
+type ParsedUnifiedExecOutput = {
+  output: string;
+  exitCode?: number;
+  sessionId?: string;
+};
+
+function parseUnifiedExecOutput(text: string): ParsedUnifiedExecOutput | null {
+  const lines = text.split("\n");
+  const outputIndex = lines.indexOf("Output:");
+  if (outputIndex < 0) {
+    return null;
+  }
+
+  const metadataLines = lines.slice(0, outputIndex);
+  if (!metadataLines.some((line) => line.startsWith("Wall time: "))) {
+    return null;
+  }
+
+  const exitLine = metadataLines.find((line) =>
+    line.startsWith("Process exited with code "),
+  );
+  const sessionLine = metadataLines.find((line) =>
+    line.startsWith("Process running with session ID "),
+  );
+  const exitCode = exitLine
+    ? Number(exitLine.replace("Process exited with code ", ""))
+    : undefined;
+  const sessionId = sessionLine?.replace(
+    "Process running with session ID ",
+    "",
+  );
+
+  return {
+    output: lines.slice(outputIndex + 1).join("\n"),
+    ...(Number.isFinite(exitCode) ? { exitCode } : {}),
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+/**
+ * Codex unified exec returns model-facing metadata before the actual command
+ * output. The TUI shell renderer should stay focused on what the command
+ * printed, while preserving non-zero exits and empty running sessions.
+ */
+export function formatUnifiedExecOutputForTui(text: string): string {
+  const parsed = parseUnifiedExecOutput(text);
+  if (!parsed) {
+    return text;
+  }
+
+  const output = parsed.output.replace(/\n+$/, "");
+  const prefix: string[] = [];
+  if (parsed.exitCode !== undefined && parsed.exitCode !== 0) {
+    prefix.push(`Exit code: ${parsed.exitCode}`);
+  }
+
+  if (output.length > 0) {
+    return prefix.length > 0 ? `${prefix.join("\n")}\n${output}` : output;
+  }
+
+  if (parsed.sessionId) {
+    return `Process running with session ID ${parsed.sessionId}`;
+  }
+
+  if (prefix.length > 0) {
+    return prefix.join("\n");
+  }
+
+  return "(Command completed with no output)";
+}

--- a/src/cli/helpers/unified-exec-output.ts
+++ b/src/cli/helpers/unified-exec-output.ts
@@ -48,7 +48,10 @@ export function extractUnifiedExecRunningSessionId(
  * output. The TUI shell renderer should stay focused on what the command
  * printed, while preserving non-zero exits and running session status.
  */
-export function formatUnifiedExecOutputForTui(text: string): string {
+export function formatUnifiedExecOutputForTui(
+  text: string,
+  options?: { hideEmptyCompletion?: boolean },
+): string {
   const parsed = parseUnifiedExecOutput(text);
   if (!parsed) {
     return text;
@@ -74,6 +77,10 @@ export function formatUnifiedExecOutputForTui(text: string): string {
 
   if (prefix.length > 0) {
     return prefix.join("\n");
+  }
+
+  if (options?.hideEmptyCompletion) {
+    return "";
   }
 
   return "(Command completed with no output)";

--- a/src/cli/helpers/unified-exec-output.ts
+++ b/src/cli/helpers/unified-exec-output.ts
@@ -40,7 +40,7 @@ function parseUnifiedExecOutput(text: string): ParsedUnifiedExecOutput | null {
 /**
  * Codex unified exec returns model-facing metadata before the actual command
  * output. The TUI shell renderer should stay focused on what the command
- * printed, while preserving non-zero exits and empty running sessions.
+ * printed, while preserving non-zero exits and running session status.
  */
 export function formatUnifiedExecOutputForTui(text: string): string {
   const parsed = parseUnifiedExecOutput(text);
@@ -54,12 +54,16 @@ export function formatUnifiedExecOutputForTui(text: string): string {
     prefix.push(`Exit code: ${parsed.exitCode}`);
   }
 
+  const sessionStatus = parsed.sessionId
+    ? `Process running with session ID ${parsed.sessionId}`
+    : null;
+
   if (output.length > 0) {
-    return prefix.length > 0 ? `${prefix.join("\n")}\n${output}` : output;
+    return [...prefix, output, sessionStatus].filter(Boolean).join("\n");
   }
 
-  if (parsed.sessionId) {
-    return `Process running with session ID ${parsed.sessionId}`;
+  if (sessionStatus) {
+    return sessionStatus;
   }
 
   if (prefix.length > 0) {

--- a/src/cli/unified-exec-output.test.ts
+++ b/src/cli/unified-exec-output.test.ts
@@ -65,6 +65,21 @@ describe("formatUnifiedExecOutputForTui", () => {
     expect(formatUnifiedExecOutputForTui("plain output")).toBe("plain output");
   });
 
+  test("can hide empty completion output for background polls", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process exited with code 0",
+      "Original token count: 0",
+      "Output:",
+      "",
+    ].join("\n");
+
+    expect(
+      formatUnifiedExecOutputForTui(text, { hideEmptyCompletion: true }),
+    ).toBe("");
+  });
+
   test("extracts running session IDs from unified exec output", () => {
     const text = [
       "Chunk ID: abc123",

--- a/src/cli/unified-exec-output.test.ts
+++ b/src/cli/unified-exec-output.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { formatUnifiedExecOutputForTui } from "@/cli/helpers/unified-exec-output";
+import {
+  extractUnifiedExecRunningSessionId,
+  formatUnifiedExecOutputForTui,
+} from "@/cli/helpers/unified-exec-output";
 
 describe("formatUnifiedExecOutputForTui", () => {
   test("shows command output without Codex metadata", () => {
@@ -60,5 +63,19 @@ describe("formatUnifiedExecOutputForTui", () => {
 
   test("leaves non-unified output unchanged", () => {
     expect(formatUnifiedExecOutputForTui("plain output")).toBe("plain output");
+  });
+
+  test("extracts running session IDs from unified exec output", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process running with session ID 4",
+      "Original token count: 1",
+      "Output:",
+      "ready",
+    ].join("\n");
+
+    expect(extractUnifiedExecRunningSessionId(text)).toBe("4");
+    expect(extractUnifiedExecRunningSessionId("plain output")).toBeNull();
   });
 });

--- a/src/cli/unified-exec-output.test.ts
+++ b/src/cli/unified-exec-output.test.ts
@@ -43,6 +43,21 @@ describe("formatUnifiedExecOutputForTui", () => {
     );
   });
 
+  test("keeps running session status when output is present", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process running with session ID 4",
+      "Original token count: 1",
+      "Output:",
+      "ready",
+    ].join("\n");
+
+    expect(formatUnifiedExecOutputForTui(text)).toBe(
+      "ready\nProcess running with session ID 4",
+    );
+  });
+
   test("leaves non-unified output unchanged", () => {
     expect(formatUnifiedExecOutputForTui("plain output")).toBe("plain output");
   });

--- a/src/cli/unified-exec-output.test.ts
+++ b/src/cli/unified-exec-output.test.ts
@@ -42,7 +42,7 @@ describe("formatUnifiedExecOutputForTui", () => {
     ].join("\n");
 
     expect(formatUnifiedExecOutputForTui(text)).toBe(
-      "Process running with session ID 4",
+      "Process running in background",
     );
   });
 
@@ -57,7 +57,7 @@ describe("formatUnifiedExecOutputForTui", () => {
     ].join("\n");
 
     expect(formatUnifiedExecOutputForTui(text)).toBe(
-      "ready\nProcess running with session ID 4",
+      "ready\nProcess running in background",
     );
   });
 

--- a/src/cli/unified-exec-output.test.ts
+++ b/src/cli/unified-exec-output.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { formatUnifiedExecOutputForTui } from "@/cli/helpers/unified-exec-output";
+
+describe("formatUnifiedExecOutputForTui", () => {
+  test("shows command output without Codex metadata", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process exited with code 0",
+      "Original token count: 1",
+      "Output:",
+      "hello",
+    ].join("\n");
+
+    expect(formatUnifiedExecOutputForTui(text)).toBe("hello");
+  });
+
+  test("preserves non-zero exit codes", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process exited with code 7",
+      "Original token count: 1",
+      "Output:",
+      "bad",
+    ].join("\n");
+
+    expect(formatUnifiedExecOutputForTui(text)).toBe("Exit code: 7\nbad");
+  });
+
+  test("shows running session when no output has arrived yet", () => {
+    const text = [
+      "Chunk ID: abc123",
+      "Wall time: 0.1234 seconds",
+      "Process running with session ID 4",
+      "Original token count: 0",
+      "Output:",
+      "",
+    ].join("\n");
+
+    expect(formatUnifiedExecOutputForTui(text)).toBe(
+      "Process running with session ID 4",
+    );
+  });
+
+  test("leaves non-unified output unchanged", () => {
+    expect(formatUnifiedExecOutputForTui("plain output")).toBe("plain output");
+  });
+});

--- a/src/permissions/analyzer.ts
+++ b/src/permissions/analyzer.ts
@@ -133,11 +133,13 @@ export function analyzeApprovalContext(
 
     case "Bash":
       return analyzeBashApproval(
-        typeof toolArgs.command === "string"
-          ? toolArgs.command
-          : Array.isArray(toolArgs.command)
-            ? toolArgs.command.join(" ")
-            : "",
+        typeof toolArgs.cmd === "string"
+          ? toolArgs.cmd
+          : typeof toolArgs.command === "string"
+            ? toolArgs.command
+            : Array.isArray(toolArgs.command)
+              ? toolArgs.command.join(" ")
+              : "",
         workingDirectory,
       );
 

--- a/src/permissions/canonical.ts
+++ b/src/permissions/canonical.ts
@@ -4,6 +4,8 @@ const SHELL_TOOL_NAMES = new Set([
   "Shell",
   "shell_command",
   "ShellCommand",
+  "exec_command",
+  "write_stdin",
   "run_shell_command",
   "RunShellCommand",
 ]);

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -58,6 +58,8 @@ const READ_ONLY_SHELL_TOOLS = new Set([
   "Shell",
   "shell_command",
   "ShellCommand",
+  "exec_command",
+  "write_stdin",
   "run_shell_command",
   "RunShellCommand",
 ]);
@@ -617,23 +619,30 @@ function buildPermissionQuery(
     case "Bash": {
       // Bash: "Bash(command with args)"
       const command =
-        typeof toolArgs.command === "string"
-          ? toolArgs.command
-          : Array.isArray(toolArgs.command)
-            ? toolArgs.command.join(" ")
-            : "";
+        typeof toolArgs.cmd === "string"
+          ? toolArgs.cmd
+          : typeof toolArgs.command === "string"
+            ? toolArgs.command
+            : Array.isArray(toolArgs.command)
+              ? toolArgs.command.join(" ")
+              : "";
       return `Bash(${command})`;
     }
     case "shell":
-    case "shell_command": {
+    case "shell_command":
+    case "exec_command": {
       const command =
-        typeof toolArgs.command === "string"
-          ? toolArgs.command
-          : Array.isArray(toolArgs.command)
-            ? toolArgs.command.join(" ")
-            : "";
+        typeof toolArgs.cmd === "string"
+          ? toolArgs.cmd
+          : typeof toolArgs.command === "string"
+            ? toolArgs.command
+            : Array.isArray(toolArgs.command)
+              ? toolArgs.command.join(" ")
+              : "";
       return `Bash(${command})`;
     }
+    case "write_stdin":
+      return "Bash(write_stdin)";
     case "run_shell_command":
     case "RunShellCommand": {
       if (engine === "v1") {
@@ -656,6 +665,10 @@ function buildPermissionQuery(
 }
 
 function extractShellCommand(toolArgs: ToolArgs): string | string[] | null {
+  const cmd = toolArgs.cmd;
+  if (typeof cmd === "string") {
+    return cmd;
+  }
   const command = toolArgs.command;
   if (typeof command === "string" || Array.isArray(command)) {
     return command;
@@ -739,6 +752,7 @@ function getDefaultDecision(
     "read_file",
     "list_dir",
     "grep_files",
+    "write_stdin",
     "update_plan",
     // Codex toolset (PascalCase) - tools that don't require approval
     "ReadFile",

--- a/src/permissions/cross-agent-guard.test.ts
+++ b/src/permissions/cross-agent-guard.test.ts
@@ -258,7 +258,7 @@ describe("extractTargetAgentPaths", () => {
     ).toEqual(new Set([OTHER]));
   });
 
-  test("shell tool aliases (run_shell_command, shell_command) work", () => {
+  test("shell tool aliases (run_shell_command, shell_command, exec_command) work", () => {
     expect(
       extractTargetAgentPaths(
         "run_shell_command",
@@ -270,6 +270,13 @@ describe("extractTargetAgentPaths", () => {
       extractTargetAgentPaths(
         "shell_command",
         { command: `ls ${otherMemory()}` },
+        "/tmp",
+      ).agentIds,
+    ).toEqual(new Set([OTHER]));
+    expect(
+      extractTargetAgentPaths(
+        "exec_command",
+        { cmd: `ls ${otherMemory()}` },
         "/tmp",
       ).agentIds,
     ).toEqual(new Set([OTHER]));

--- a/src/permissions/cross-agent-guard.ts
+++ b/src/permissions/cross-agent-guard.ts
@@ -217,6 +217,8 @@ function extractMultiEditPaths(toolArgs: ToolArgs): string[] {
 }
 
 function extractShellCommand(toolArgs: ToolArgs): string | null {
+  const cmd = toolArgs.cmd;
+  if (typeof cmd === "string") return cmd;
   const command = toolArgs.command;
   if (typeof command === "string") return command;
   if (Array.isArray(command)) {

--- a/src/permissions/mode.ts
+++ b/src/permissions/mode.ts
@@ -254,6 +254,8 @@ class PermissionModeManager {
           "Shell",
           "shell_command",
           "ShellCommand",
+          "exec_command",
+          "write_stdin",
           "run_shell_command",
           "RunShellCommand",
           "run_shell_command_gemini",
@@ -311,7 +313,19 @@ class PermissionModeManager {
         }
 
         if (shellTools.includes(toolName)) {
-          const command = toolArgs?.command as string | string[] | undefined;
+          if (toolName === "write_stdin") {
+            return toolArgs?.chars
+              ? {
+                  decision: "deny",
+                  reason:
+                    "Memory mode does not allow writing stdin to shell sessions.",
+                }
+              : { decision: "allow" };
+          }
+
+          const command =
+            (toolArgs?.cmd as string | undefined) ??
+            (toolArgs?.command as string | string[] | undefined);
           if (
             command &&
             isReadOnlyShellCommand(command, { allowExternalPaths: true })

--- a/src/permissions/permissions-analyzer.test.ts
+++ b/src/permissions/permissions-analyzer.test.ts
@@ -760,6 +760,16 @@ test("run_shell_command is analyzed as Bash", () => {
   expect(context.recommendedRule).toBe("Bash(curl:*)");
 });
 
+test("exec_command is analyzed as Bash using cmd", () => {
+  const context = analyzeApprovalContext(
+    "exec_command",
+    { cmd: "curl -s http://localhost:4321/intro" },
+    "/Users/test/project",
+  );
+
+  expect(context.recommendedRule).toBe("Bash(curl:*)");
+});
+
 // ============================================================================
 // gh CLI approval tests
 // ============================================================================

--- a/src/permissions/permissions-cli.test.ts
+++ b/src/permissions/permissions-cli.test.ts
@@ -460,3 +460,30 @@ test("ShellCommand auto-allows captured read-only inspection scripts", () => {
     expect(result.reason).toBe("Read-only shell command");
   }
 });
+
+test("exec_command uses cmd for Bash permission matching", () => {
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+  };
+
+  const readOnly = checkPermission(
+    "exec_command",
+    { cmd: "git status --short" },
+    permissions,
+    "/Users/test/project",
+  );
+  expect(readOnly.decision).toBe("allow");
+  expect(readOnly.reason).toBe("Read-only shell command");
+
+  cliPermissions.setAllowedTools("Bash(npm run test:*)");
+  const allowed = checkPermission(
+    "exec_command",
+    { cmd: "npm run test:unit" },
+    permissions,
+    "/Users/test/project",
+  );
+  expect(allowed.decision).toBe("allow");
+  expect(allowed.matchedRule).toBe("Bash(npm run test:*) (CLI)");
+});

--- a/src/permissions/permissions-mode.test.ts
+++ b/src/permissions/permissions-mode.test.ts
@@ -460,6 +460,49 @@ test("memory mode - allows Bash redirection inside MEMORY_DIR", () => {
   }
 });
 
+test("memory mode - applies shell scoping to exec_command cmd", () => {
+  permissionMode.setMode("memory");
+  const originalMemoryDir = process.env.MEMORY_DIR;
+  process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+  try {
+    const result = checkPermission(
+      "exec_command",
+      { cmd: 'echo "test content" > "$MEMORY_DIR/system/test.md"' },
+      { allow: [], deny: [], ask: [] },
+      "/Users/test/.letta/agents/agent-1/memory",
+    );
+
+    expect(result.decision).toBe("allow");
+    expect(result.matchedRule).toBe("memory mode");
+  } finally {
+    if (originalMemoryDir === undefined) delete process.env.MEMORY_DIR;
+    else process.env.MEMORY_DIR = originalMemoryDir;
+  }
+});
+
+test("memory mode - allows write_stdin polls but denies stdin writes", () => {
+  permissionMode.setMode("memory");
+
+  const pollResult = checkPermission(
+    "write_stdin",
+    { session_id: 1, chars: "" },
+    { allow: [], deny: [], ask: [] },
+    "/Users/test/project",
+  );
+  expect(pollResult.decision).toBe("allow");
+  expect(pollResult.matchedRule).toBe("memory mode");
+
+  const writeResult = checkPermission(
+    "write_stdin",
+    { session_id: 1, chars: "echo pwn\n" },
+    { allow: [], deny: [], ask: [] },
+    "/Users/test/project",
+  );
+  expect(writeResult.decision).toBe("deny");
+  expect(writeResult.matchedRule).toBe("memory mode");
+});
+
 test("memory mode - denies Bash redirection outside MEMORY_DIR", () => {
   permissionMode.setMode("memory");
   const originalMemoryDir = process.env.MEMORY_DIR;

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -23,18 +23,32 @@ describe("Codex unified exec toolset", () => {
     expect(properties).not.toContain("additional_permissions");
   });
 
-  test("keeps unified exec tool descriptions aligned with Codex", () => {
+  test("keeps unified exec tool descriptions aligned with Codex plus LC commit attribution", () => {
+    const execCommandDescription = [
+      "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+      "",
+      "# Git commits",
+      "",
+      "When creating a git commit on behalf of the user, end the commit message with:",
+      "",
+      "👾 Generated with [Letta Code](https://letta.com)",
+      "",
+      "Co-Authored-By: Letta Code <noreply@letta.com>",
+      "",
+      "Use a quoted multiline commit message so the footer is included verbatim.",
+    ].join("\n");
+
     expect(TOOL_DEFINITIONS.exec_command.description).toBe(
       process.platform === "win32"
         ? [
-            "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+            execCommandDescription,
             "",
             "Windows safety rules:",
             "- Do not compose destructive filesystem commands across shells. Do not enumerate paths in PowerShell and then pass them to `cmd /c`, batch builtins, or another shell for deletion or moving. Use one shell end-to-end, prefer native PowerShell cmdlets such as `Remove-Item` / `Move-Item` with `-LiteralPath`, and avoid string-built shell commands for file operations.",
             "- Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.",
             "- When using `Start-Process` to launch a background helper or service, pass `-WindowStyle Hidden` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control.",
           ].join("\n")
-        : "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+        : execCommandDescription,
     );
     expect(TOOL_DEFINITIONS.write_stdin.description).toBe(
       "Writes characters to an existing unified exec session and returns recent output.",

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, test } from "bun:test";
+import ShellDescription from "@/tools/descriptions/Shell.md";
 import { OPENAI_DEFAULT_TOOLS, OPENAI_PASCAL_TOOLS } from "@/tools/manager";
 import ExecCommandSchema from "@/tools/schemas/ExecCommand.json";
 import { TOOL_DEFINITIONS } from "@/tools/tool-definitions";
+
+function extractCommitGuidance(description: string): string {
+  const start = description.indexOf("# Committing changes with git");
+  const end = description.indexOf("# Creating pull requests", start);
+  if (start === -1 || end === -1) {
+    throw new Error("Expected shell description to include commit guidance");
+  }
+  return description.slice(start, end).trim();
+}
 
 describe("Codex unified exec toolset", () => {
   test("uses Codex exec_command/write_stdin instead of shell_command", () => {
@@ -23,19 +33,11 @@ describe("Codex unified exec toolset", () => {
     expect(properties).not.toContain("additional_permissions");
   });
 
-  test("keeps unified exec tool descriptions aligned with Codex plus LC commit attribution", () => {
+  test("keeps unified exec tool descriptions aligned with Codex plus LC commit guidance", () => {
     const execCommandDescription = [
       "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
       "",
-      "# Git commits",
-      "",
-      "When creating a git commit on behalf of the user, end the commit message with:",
-      "",
-      "👾 Generated with [Letta Code](https://letta.com)",
-      "",
-      "Co-Authored-By: Letta Code <noreply@letta.com>",
-      "",
-      "Use a quoted multiline commit message so the footer is included verbatim.",
+      extractCommitGuidance(ShellDescription),
     ].join("\n");
 
     expect(TOOL_DEFINITIONS.exec_command.description).toBe(

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_DEFAULT_TOOLS, OPENAI_PASCAL_TOOLS } from "@/tools/manager";
 import ExecCommandSchema from "@/tools/schemas/ExecCommand.json";
+import { TOOL_DEFINITIONS } from "@/tools/tool-definitions";
 
 describe("Codex unified exec toolset", () => {
   test("uses Codex exec_command/write_stdin instead of shell_command", () => {
@@ -20,5 +21,23 @@ describe("Codex unified exec toolset", () => {
     expect(properties).not.toContain("justification");
     expect(properties).not.toContain("prefix_rule");
     expect(properties).not.toContain("additional_permissions");
+  });
+
+  test("keeps unified exec tool descriptions aligned with Codex", () => {
+    expect(TOOL_DEFINITIONS.exec_command.description).toBe(
+      process.platform === "win32"
+        ? [
+            "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+            "",
+            "Windows safety rules:",
+            "- Do not compose destructive filesystem commands across shells. Do not enumerate paths in PowerShell and then pass them to `cmd /c`, batch builtins, or another shell for deletion or moving. Use one shell end-to-end, prefer native PowerShell cmdlets such as `Remove-Item` / `Move-Item` with `-LiteralPath`, and avoid string-built shell commands for file operations.",
+            "- Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.",
+            "- When using `Start-Process` to launch a background helper or service, pass `-WindowStyle Hidden` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control.",
+          ].join("\n")
+        : "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+    );
+    expect(TOOL_DEFINITIONS.write_stdin.description).toBe(
+      "Writes characters to an existing unified exec session and returns recent output.",
+    );
   });
 });

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { OPENAI_DEFAULT_TOOLS, OPENAI_PASCAL_TOOLS } from "@/tools/manager";
+
+describe("Codex unified exec toolset", () => {
+  test("uses Codex exec_command/write_stdin instead of shell_command", () => {
+    expect(OPENAI_DEFAULT_TOOLS).toContain("exec_command");
+    expect(OPENAI_DEFAULT_TOOLS).toContain("write_stdin");
+    expect(OPENAI_DEFAULT_TOOLS).not.toContain("shell_command");
+
+    expect(OPENAI_PASCAL_TOOLS).toContain("exec_command");
+    expect(OPENAI_PASCAL_TOOLS).toContain("write_stdin");
+    expect(OPENAI_PASCAL_TOOLS).not.toContain("ShellCommand");
+  });
+});

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { OPENAI_DEFAULT_TOOLS, OPENAI_PASCAL_TOOLS } from "@/tools/manager";
+import ExecCommandSchema from "@/tools/schemas/ExecCommand.json";
 
 describe("Codex unified exec toolset", () => {
   test("uses Codex exec_command/write_stdin instead of shell_command", () => {
@@ -10,5 +11,14 @@ describe("Codex unified exec toolset", () => {
     expect(OPENAI_PASCAL_TOOLS).toContain("exec_command");
     expect(OPENAI_PASCAL_TOOLS).toContain("write_stdin");
     expect(OPENAI_PASCAL_TOOLS).not.toContain("ShellCommand");
+  });
+
+  test("documents LC-specific omission of upstream sandbox fields", () => {
+    const properties = Object.keys(ExecCommandSchema.properties);
+
+    expect(properties).not.toContain("sandbox_permissions");
+    expect(properties).not.toContain("justification");
+    expect(properties).not.toContain("prefix_rule");
+    expect(properties).not.toContain("additional_permissions");
   });
 });

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,1 +1,3 @@
 Runs a command in a PTY, returning output or a session ID for ongoing interaction.
+
+Letta Code intentionally omits upstream Codex sandbox-escalation fields (`sandbox_permissions`, `justification`, `prefix_rule`, and `additional_permissions`) because this harness does not implement Codex sandbox overrides or permission profiles. Normal Letta Code approval rules still apply.

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,3 +1,1 @@
 Runs a command in a PTY, returning output or a session ID for ongoing interaction.
-
-Letta Code intentionally omits upstream Codex sandbox-escalation fields (`sandbox_permissions`, `justification`, `prefix_rule`, and `additional_permissions`) because this harness does not implement Codex sandbox overrides or permission profiles. Normal Letta Code approval rules still apply.

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,1 +1,11 @@
 Runs a command in a PTY, returning output or a session ID for ongoing interaction.
+
+# Git commits
+
+When creating a git commit on behalf of the user, end the commit message with:
+
+👾 Generated with [Letta Code](https://letta.com)
+
+Co-Authored-By: Letta Code <noreply@letta.com>
+
+Use a quoted multiline commit message so the footer is included verbatim.

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,11 +1,50 @@
 Runs a command in a PTY, returning output or a session ID for ongoing interaction.
 
-# Git commits
+# Committing changes with git
 
-When creating a git commit on behalf of the user, end the commit message with:
+Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:
+
+Git Safety Protocol:
+- NEVER update the git config
+- NEVER run destructive/irreversible git commands (like push --force, hard reset, etc) unless the user explicitly requests them 
+- NEVER skip hooks (--no-verify, --no-gpg-sign, etc) unless the user explicitly requests it
+- NEVER run force push to main/master, warn the user if they request it
+- CRITICAL: Always create NEW commits rather than amending, unless the user explicitly requests a git amend. When a pre-commit hook fails, the commit did NOT happen  -- so --amend would modify the PREVIOUS commit, which may result in destroying work or losing previous changes. Instead, after hook failure, fix the issue, re-stage, and create a NEW commit
+- When staging files, prefer adding specific files by name rather than using "git add -A" or "git add .", which can accidentally include sensitive files (.env, credentials) or large binaries
+- NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTANT to only commit when explicitly asked, otherwise the user will feel that you are being too proactive.
+
+1. Run the following shell commands in parallel:
+  - Run a git status command to see all untracked files. IMPORTANT: Never use the -uall flag as it can cause memory issues on large repos.
+  - Run a git diff command to see both staged and unstaged changes that will be committed.
+  - Run a git log command to see recent commit messages, so that you can follow this repository's commit message style.
+2. Analyze all staged changes (both previously staged and newly added) and draft a commit message:
+  - Summarize the nature of the changes (eg. new feature, enhancement to an existing feature, bug fix, refactoring, test, docs, etc.). Ensure the message accurately reflects the changes and their purpose (i.e. "add" means a wholly new feature, "update" means an enhancement to an existing feature, "fix" means a bug fix, etc.).
+  - Do not commit files that likely contain secrets (.env, credentials.json, etc). Warn the user if they specifically request to commit those files
+  - Draft a concise (1-2 sentences) commit message that focuses on the "why" rather than the "what"
+  - Ensure it accurately reflects the changes and their purpose
+3. Run the following commands:
+   - Add relevant untracked files to the staging area.
+   - Create the commit with a message ending with:
+   👾 Generated with [Letta Code](https://letta.com)
+
+   Co-Authored-By: Letta Code <noreply@letta.com>
+   - Run git status after the commit completes to verify success.
+   Note: git status depends on the commit completing, so run it sequentially after the commit.
+4. If the commit fails due to pre-commit hook: fix the issue and create a NEW commit
+
+Important notes:
+- NEVER run additional commands to read or explore code, besides git commands
+- DO NOT push to the remote repository unless the user explicitly asks you to do so
+- IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
+- IMPORTANT: Do not use --no-edit with git rebase commands, as the --no-edit flag is not a valid option for git rebase.
+- If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
+- In order to ensure good formatting, ALWAYS pass the commit message as a single-quoted string with embedded newlines, a la this example:
+<example>
+git commit -m 'Commit message here.
 
 👾 Generated with [Letta Code](https://letta.com)
 
-Co-Authored-By: Letta Code <noreply@letta.com>
+Co-Authored-By: Letta Code <noreply@letta.com>'
+</example>
 
-Use a quoted multiline commit message so the footer is included verbatim.
+Use single quotes (not double quotes) and do NOT wrap the message in `$(...)` or backticks — single-quoting preserves the message verbatim (including `$VAR`, backticks, and other special characters) without needing escapes.

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,0 +1,1 @@
+Runs a command in a PTY, returning output or a session ID for ongoing interaction.

--- a/src/tools/descriptions/WriteStdin.md
+++ b/src/tools/descriptions/WriteStdin.md
@@ -1,0 +1,1 @@
+Writes characters to an existing unified exec session and returns recent output.

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -69,6 +69,32 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
 
     expect(second.output).toContain("Process exited with code 0");
     expect(second.output).toContain("Output:\ndone");
+
+    await expect(
+      write_stdin({
+        session_id: Number(match?.[1]),
+        chars: "",
+      }),
+    ).rejects.toThrow("Unknown process id");
+  });
+
+  test("empty write_stdin polls wait like Codex background terminal polls", async () => {
+    const first = await exec_command({
+      cmd: "printf start; sleep 0.8; printf done",
+      yield_time_ms: 250,
+    });
+
+    const match = first.output.match(/Process running with session ID (\d+)/);
+    expect(match?.[1]).toBeDefined();
+
+    const second = await write_stdin({
+      session_id: Number(match?.[1]),
+      chars: "",
+      yield_time_ms: 100,
+    });
+
+    expect(second.output).toContain("Process exited with code 0");
+    expect(second.output).toContain("Output:\ndone");
   });
 
   test("write_stdin sends input to tty-enabled sessions", async () => {
@@ -91,6 +117,16 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     expect(second.output).toContain("Output:\nhello");
   });
 
+  test("tty-enabled sessions allocate a terminal device", async () => {
+    const result = await exec_command({
+      cmd: "test -t 0 && printf tty || printf pipe",
+      tty: true,
+    });
+
+    expect(result.output).toContain("Process exited with code 0");
+    expect(result.output).toContain("Output:\ntty");
+  });
+
   test("non-tty sessions close stdin like Codex pipe mode", async () => {
     const result = await exec_command({
       cmd: "cat",
@@ -100,6 +136,25 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     expect(result.output).toContain("Process exited with code 0");
     expect(result.output).not.toContain("Process running with session ID");
     expect(result.output).toContain("Output:\n");
+  });
+
+  test("write_stdin reports Codex stdin-closed error for non-tty sessions", async () => {
+    const first = await exec_command({
+      cmd: "sleep 2",
+      yield_time_ms: 250,
+    });
+
+    const match = first.output.match(/Process running with session ID (\d+)/);
+    expect(match?.[1]).toBeDefined();
+
+    await expect(
+      write_stdin({
+        session_id: Number(match?.[1]),
+        chars: "hello\n",
+      }),
+    ).rejects.toThrow(
+      "stdin is closed for this session; rerun exec_command with tty=true to keep stdin open",
+    );
   });
 
   test("preserves non-zero exit code in model-facing output", async () => {

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -91,6 +91,17 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     expect(second.output).toContain("Output:\nhello");
   });
 
+  test("non-tty sessions close stdin like Codex pipe mode", async () => {
+    const result = await exec_command({
+      cmd: "cat",
+      yield_time_ms: 1000,
+    });
+
+    expect(result.output).toContain("Process exited with code 0");
+    expect(result.output).not.toContain("Process running with session ID");
+    expect(result.output).toContain("Output:\n");
+  });
+
   test("preserves non-zero exit code in model-facing output", async () => {
     const result = await exec_command({
       cmd: "printf 'bad'; exit 7",

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -100,4 +100,24 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     expect(result.output).toContain("Process exited with code 7");
     expect(result.output).toContain("Output:\nbad");
   });
+
+  test("streams stdout and stderr with distinct stream labels", async () => {
+    const chunks: Array<{ chunk: string; stream: "stdout" | "stderr" }> = [];
+
+    await exec_command({
+      cmd: "printf out; printf err >&2",
+      onOutput: (chunk, stream) => chunks.push({ chunk, stream }),
+    });
+
+    expect(
+      chunks.some(
+        (entry) => entry.stream === "stdout" && entry.chunk.includes("out"),
+      ),
+    ).toBe(true);
+    expect(
+      chunks.some(
+        (entry) => entry.stream === "stderr" && entry.chunk.includes("err"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -53,8 +53,8 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
 
   test("returns session id for running command and write_stdin polls it", async () => {
     const first = await exec_command({
-      cmd: "printf start; sleep 0.2; printf done",
-      yield_time_ms: 50,
+      cmd: "printf start; sleep 0.5; printf done",
+      yield_time_ms: 250,
     });
 
     const match = first.output.match(/Process running with session ID (\d+)/);
@@ -64,7 +64,7 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     const second = await write_stdin({
       session_id: Number(match?.[1]),
       chars: "",
-      yield_time_ms: 500,
+      yield_time_ms: 1000,
     });
 
     expect(second.output).toContain("Process exited with code 0");
@@ -94,7 +94,6 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
   test("preserves non-zero exit code in model-facing output", async () => {
     const result = await exec_command({
       cmd: "printf 'bad'; exit 7",
-      yield_time_ms: 50,
     });
 
     expect(result.output).toContain("Process exited with code 7");

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import {
+  __clearExecSessionsForTests,
+  exec_command,
+  write_stdin,
+} from "@/tools/impl/exec-command";
+import {
+  __resetBackgroundRetentionConfigForTests,
+  backgroundProcesses,
+} from "@/tools/impl/process_manager";
+
+const isWindows = process.platform === "win32";
+
+describe.skipIf(isWindows)("Codex unified exec tools", () => {
+  beforeEach(() => {
+    __resetBackgroundRetentionConfigForTests();
+  });
+
+  afterEach(() => {
+    const outputFiles = Array.from(backgroundProcesses.values())
+      .map((proc) => proc.outputFile)
+      .filter((filePath): filePath is string => Boolean(filePath));
+
+    for (const proc of backgroundProcesses.values()) {
+      try {
+        proc.process.kill("SIGTERM");
+      } catch {
+        // Ignore cleanup failures for already-exited processes.
+      }
+    }
+    backgroundProcesses.clear();
+    __clearExecSessionsForTests();
+    __resetBackgroundRetentionConfigForTests();
+
+    for (const outputFile of outputFiles) {
+      if (fs.existsSync(outputFile)) {
+        fs.unlinkSync(outputFile);
+      }
+    }
+  });
+
+  test("formats completed command output like Codex unified exec", async () => {
+    const result = await exec_command({ cmd: "printf 'hello'" });
+
+    expect(result.output).toMatch(/Chunk ID: [0-9a-f]{6}/);
+    expect(result.output).toContain("Wall time:");
+    expect(result.output).toContain("Process exited with code 0");
+    expect(result.output).toContain("Original token count:");
+    expect(result.output).toContain("Output:\nhello");
+    expect(result.output).not.toContain("Process running with session ID");
+  });
+
+  test("returns session id for running command and write_stdin polls it", async () => {
+    const first = await exec_command({
+      cmd: "printf start; sleep 0.2; printf done",
+      yield_time_ms: 50,
+    });
+
+    const match = first.output.match(/Process running with session ID (\d+)/);
+    expect(match?.[1]).toBeDefined();
+    expect(first.output).toContain("Output:\nstart");
+
+    const second = await write_stdin({
+      session_id: Number(match?.[1]),
+      chars: "",
+      yield_time_ms: 500,
+    });
+
+    expect(second.output).toContain("Process exited with code 0");
+    expect(second.output).toContain("Output:\ndone");
+  });
+
+  test("write_stdin sends input to tty-enabled sessions", async () => {
+    const first = await exec_command({
+      cmd: "cat",
+      tty: true,
+      yield_time_ms: 50,
+    });
+
+    const match = first.output.match(/Process running with session ID (\d+)/);
+    expect(match?.[1]).toBeDefined();
+
+    const second = await write_stdin({
+      session_id: Number(match?.[1]),
+      chars: "hello\n",
+      yield_time_ms: 200,
+    });
+
+    expect(second.output).toContain("Process running with session ID");
+    expect(second.output).toContain("Output:\nhello");
+  });
+
+  test("preserves non-zero exit code in model-facing output", async () => {
+    const result = await exec_command({
+      cmd: "printf 'bad'; exit 7",
+      yield_time_ms: 50,
+    });
+
+    expect(result.output).toContain("Process exited with code 7");
+    expect(result.output).toContain("Output:\nbad");
+  });
+});

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -33,9 +33,11 @@ interface ExecCommandArgs {
   yield_time_ms?: number;
   max_output_tokens?: number;
   login?: boolean;
-  sandbox_permissions?: "use_default" | "require_escalated" | string;
-  justification?: string;
-  prefix_rule?: string[];
+  // Upstream Codex also exposes sandbox-escalation fields here:
+  // sandbox_permissions, justification, prefix_rule, additional_permissions.
+  // Letta Code intentionally omits them from the model-facing schema because
+  // this harness has no Codex sandbox override / permission-profile layer;
+  // the regular Letta Code approval system still gates command execution.
   signal?: AbortSignal;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
   secretEnv?: Record<string, string>;

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -16,12 +16,16 @@ import {
   buildPowerShellCommand,
   buildShellLaunchers,
 } from "./shell-launchers.js";
-import { LIMITS, truncateByChars } from "./truncation.js";
+import { truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
 const DEFAULT_EXEC_YIELD_TIME_MS = 10_000;
 const DEFAULT_WRITE_STDIN_YIELD_TIME_MS = 250;
+const MIN_YIELD_TIME_MS = 250;
+const MIN_EMPTY_WRITE_STDIN_YIELD_TIME_MS = 5_000;
 const MAX_YIELD_TIME_MS = 30_000;
+const MAX_EMPTY_WRITE_STDIN_YIELD_TIME_MS = 300_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 const MAX_SESSION_OUTPUT_CHARS = 1_000_000;
 const EXEC_SESSION_CLEANUP_MS = 5 * 60 * 1000;
 
@@ -74,6 +78,48 @@ type ProcessLauncher = {
   write(input: string): void;
 };
 
+type NodePtyExitEvent = { exitCode?: number; signal?: number };
+
+type NodePtyProcess = {
+  pid: number;
+  write: (data: string) => void;
+  kill: (signal?: string) => void;
+  onData: (listener: (data: string) => void) => void;
+  onExit: (listener: (event: NodePtyExitEvent) => void) => void;
+};
+
+type NodePtyModule = {
+  spawn: (
+    file: string,
+    args: string[],
+    options: {
+      name: string;
+      cols: number;
+      rows: number;
+      cwd: string;
+      env: Record<string, string>;
+    },
+  ) => NodePtyProcess;
+};
+
+const NODE_PTY_BRIDGE_SCRIPT = String.raw`
+const pty = require("node-pty");
+const config = JSON.parse(process.argv[1]);
+const child = pty.spawn(config.executable, config.args, {
+  name: "xterm-256color",
+  cols: 80,
+  rows: 24,
+  cwd: config.cwd,
+  env: process.env,
+});
+child.onData((data) => process.stdout.write(data));
+child.onExit(({ exitCode }) => process.exit(typeof exitCode === "number" ? exitCode : 1));
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (data) => child.write(data));
+process.on("SIGTERM", () => child.kill("SIGTERM"));
+process.on("SIGINT", () => child.kill("SIGINT"));
+`;
+
 type ExecOutputChunk = {
   text: string;
   stream: "stdout" | "stderr";
@@ -89,7 +135,24 @@ function sleep(ms: number): Promise<void> {
 
 function clampYieldTime(value: number | undefined, fallback: number): number {
   const time = Number.isFinite(value) ? Number(value) : fallback;
-  return Math.max(0, Math.min(time, MAX_YIELD_TIME_MS));
+  return Math.max(MIN_YIELD_TIME_MS, Math.min(time, MAX_YIELD_TIME_MS));
+}
+
+function clampWriteStdinYieldTime(
+  value: number | undefined,
+  input: string,
+): number {
+  const time = Math.max(
+    MIN_YIELD_TIME_MS,
+    Number.isFinite(value) ? Number(value) : DEFAULT_WRITE_STDIN_YIELD_TIME_MS,
+  );
+  if (input.length === 0) {
+    return Math.max(
+      MIN_EMPTY_WRITE_STDIN_YIELD_TIME_MS,
+      Math.min(time, MAX_EMPTY_WRITE_STDIN_YIELD_TIME_MS),
+    );
+  }
+  return Math.min(time, MAX_YIELD_TIME_MS);
 }
 
 function estimateTokenCount(text: string): number {
@@ -97,10 +160,11 @@ function estimateTokenCount(text: string): number {
 }
 
 function maxCharsForTokens(maxOutputTokens?: number): number {
-  if (!maxOutputTokens || maxOutputTokens <= 0) {
-    return LIMITS.BASH_OUTPUT_CHARS;
-  }
-  return Math.max(1, maxOutputTokens * 4);
+  const maxTokens =
+    maxOutputTokens && maxOutputTokens > 0
+      ? maxOutputTokens
+      : DEFAULT_MAX_OUTPUT_TOKENS;
+  return Math.max(1, maxTokens * 4);
 }
 
 function truncateOutput(text: string, maxOutputTokens?: number): string {
@@ -198,6 +262,14 @@ function scheduleExecSessionCleanup(sessionId: string): void {
   }
 }
 
+function releaseExecSession(session: ExecSession): void {
+  if (session.cleanupTimer) {
+    clearTimeout(session.cleanupTimer);
+    session.cleanupTimer = undefined;
+  }
+  execSessions.delete(session.id);
+}
+
 function formatExecOutput(params: {
   chunkId: string;
   wallTimeMs: number;
@@ -291,6 +363,54 @@ function buildExecLaunchers(args: ExecCommandArgs): string[][] {
   });
 }
 
+function buildPtyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const ptyEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) {
+      ptyEnv[key] = value;
+    }
+  }
+  ptyEnv.TERM = ptyEnv.TERM || "xterm-256color";
+  ptyEnv.COLORTERM = ptyEnv.COLORTERM || "truecolor";
+  return ptyEnv;
+}
+
+function createSessionOutputAppender(params: {
+  session: ExecSession;
+  outputFile: string;
+}): (text: string, stream: "stdout" | "stderr") => void {
+  return (text: string, stream: "stdout" | "stderr") => {
+    appendSessionOutput(params.session, text, stream);
+    const bgProcess = backgroundProcesses.get(params.session.id);
+    if (bgProcess) {
+      appendBackgroundProcessOutput(bgProcess, stream, text);
+    }
+    appendToOutputFile(params.outputFile, text);
+  };
+}
+
+function markSessionFailed(session: ExecSession): void {
+  session.status = "failed";
+  const bgProcess = backgroundProcesses.get(session.id);
+  if (bgProcess) {
+    bgProcess.status = "failed";
+    scheduleBackgroundProcessCleanup(session.id);
+  }
+  scheduleExecSessionCleanup(session.id);
+}
+
+function markSessionClosed(session: ExecSession, code: number | null): void {
+  session.status = code === 0 ? "completed" : "failed";
+  session.exitCode = code;
+  const bgProcess = backgroundProcesses.get(session.id);
+  if (bgProcess) {
+    bgProcess.status = session.status;
+    bgProcess.exitCode = code;
+    scheduleBackgroundProcessCleanup(session.id);
+  }
+  scheduleExecSessionCleanup(session.id);
+}
+
 function spawnPipeProcess(params: {
   launcher: string[];
   cwd: string;
@@ -308,18 +428,11 @@ function spawnPipeProcess(params: {
     cwd: params.cwd,
     env: params.env,
     shell: false,
-    stdio: [params.session.tty ? "pipe" : "ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
     detached: process.platform !== "win32",
   });
 
-  const appendOutput = (text: string, stream: "stdout" | "stderr") => {
-    appendSessionOutput(params.session, text, stream);
-    const bgProcess = backgroundProcesses.get(params.session.id);
-    if (bgProcess) {
-      appendBackgroundProcessOutput(bgProcess, stream, text);
-    }
-    appendToOutputFile(params.outputFile, text);
-  };
+  const appendOutput = createSessionOutputAppender(params);
 
   childProcess.stdout?.on("data", (chunk: Buffer) => {
     appendOutput(chunk.toString("utf8"), "stdout");
@@ -329,26 +442,12 @@ function spawnPipeProcess(params: {
   });
 
   childProcess.on("error", (error) => {
-    params.session.status = "failed";
     appendOutput(error.message, "stderr");
-    const bgProcess = backgroundProcesses.get(params.session.id);
-    if (bgProcess) {
-      bgProcess.status = "failed";
-      scheduleBackgroundProcessCleanup(params.session.id);
-    }
-    scheduleExecSessionCleanup(params.session.id);
+    markSessionFailed(params.session);
   });
 
   childProcess.on("close", (code) => {
-    params.session.status = code === 0 ? "completed" : "failed";
-    params.session.exitCode = code;
-    const bgProcess = backgroundProcesses.get(params.session.id);
-    if (bgProcess) {
-      bgProcess.status = params.session.status;
-      bgProcess.exitCode = code;
-      scheduleBackgroundProcessCleanup(params.session.id);
-    }
-    scheduleExecSessionCleanup(params.session.id);
+    markSessionClosed(params.session, code);
   });
 
   return {
@@ -365,6 +464,102 @@ function spawnPipeProcess(params: {
     },
     write(input: string) {
       childProcess.stdin?.write(input);
+    },
+  };
+}
+
+function spawnPtyProcess(params: {
+  launcher: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  session: ExecSession;
+  outputFile: string;
+}): ProcessLauncher {
+  const [executable, ...args] = params.launcher;
+  if (!executable) {
+    throw new Error("Executable is required");
+  }
+
+  noteExpectedWorktreeForLauncher(params.launcher, params.cwd);
+  const appendOutput = createSessionOutputAppender(params);
+  const ptyEnv = buildPtyEnv(params.env);
+
+  if (typeof Bun !== "undefined") {
+    // node-pty's native handles do not integrate reliably when loaded into
+    // Bun's event loop. Local Bun dev/tests run the PTY inside a tiny Node
+    // bridge; the distributed CLI runs under Node and uses node-pty directly.
+    const childProcess: ChildProcess = spawn(
+      "node",
+      [
+        "-e",
+        NODE_PTY_BRIDGE_SCRIPT,
+        JSON.stringify({ executable, args, cwd: params.cwd }),
+      ],
+      {
+        cwd: params.cwd,
+        env: ptyEnv,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        detached: process.platform !== "win32",
+      },
+    );
+
+    childProcess.stdout?.on("data", (chunk: Buffer) => {
+      appendOutput(chunk.toString("utf8"), "stdout");
+    });
+    childProcess.stderr?.on("data", (chunk: Buffer) => {
+      appendOutput(chunk.toString("utf8"), "stderr");
+    });
+    childProcess.on("error", (error) => {
+      appendOutput(error.message, "stderr");
+      markSessionFailed(params.session);
+    });
+    childProcess.on("close", (code) => {
+      markSessionClosed(params.session, code);
+    });
+
+    return {
+      kill(signal?: string | number) {
+        if (childProcess.pid && process.platform !== "win32") {
+          try {
+            process.kill(-childProcess.pid, signal as NodeJS.Signals);
+            return;
+          } catch {
+            // Fall back to killing the bridge directly below.
+          }
+        }
+        childProcess.kill(signal as NodeJS.Signals);
+      },
+      write(input: string) {
+        childProcess.stdin?.write(input);
+      },
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pty = require("node-pty") as NodePtyModule;
+  const ptyProcess = pty.spawn(executable, args, {
+    name: "xterm-256color",
+    cols: 80,
+    rows: 24,
+    cwd: params.cwd,
+    env: ptyEnv,
+  });
+
+  ptyProcess.onData((data) => appendOutput(data, "stdout"));
+  ptyProcess.onExit(({ exitCode }) => {
+    markSessionClosed(
+      params.session,
+      typeof exitCode === "number" ? exitCode : null,
+    );
+  });
+
+  return {
+    kill(signal?: string | number) {
+      ptyProcess.kill(typeof signal === "string" ? signal : undefined);
+    },
+    write(input: string) {
+      ptyProcess.write(input);
     },
   };
 }
@@ -437,7 +632,8 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
 
   let processLauncher: ProcessLauncher;
   try {
-    processLauncher = spawnPipeProcess({
+    const spawnProcess = session.tty ? spawnPtyProcess : spawnPipeProcess;
+    processLauncher = spawnProcess({
       launcher,
       cwd,
       env,
@@ -497,16 +693,22 @@ export async function exec_command(
     onOutput: args.onOutput,
   });
 
+  const sessionId = session.status === "running" ? session.id : null;
+  const formattedOutput = formatExecOutput({
+    chunkId: generateChunkId(),
+    wallTimeMs,
+    exitCode: session.exitCode,
+    sessionId,
+    output,
+    originalTokenCount: estimateTokenCount(output),
+    maxOutputTokens: args.max_output_tokens,
+  });
+  if (sessionId === null) {
+    releaseExecSession(session);
+  }
+
   return {
-    output: formatExecOutput({
-      chunkId: generateChunkId(),
-      wallTimeMs,
-      exitCode: session.exitCode,
-      sessionId: session.status === "running" ? session.id : null,
-      output,
-      originalTokenCount: estimateTokenCount(output),
-      maxOutputTokens: args.max_output_tokens,
-    }),
+    output: formattedOutput,
   };
 }
 
@@ -518,13 +720,13 @@ export async function write_stdin(
   const session = execSessions.get(sessionId);
   const backgroundProcess = backgroundProcesses.get(sessionId);
   if (!session || !backgroundProcess) {
-    throw new Error(`Unknown unified exec session ID: ${sessionId}`);
+    throw new Error(`Unknown process id ${sessionId}`);
   }
 
   const chars = args.chars ?? "";
   if (chars && !session.tty) {
     throw new Error(
-      "stdin is only available for exec_command sessions started with tty=true",
+      "stdin is closed for this session; rerun exec_command with tty=true to keep stdin open",
     );
   }
   if (chars) {
@@ -533,10 +735,7 @@ export async function write_stdin(
   }
 
   const startOffset = session.readOffset;
-  const yieldTimeMs = clampYieldTime(
-    args.yield_time_ms,
-    DEFAULT_WRITE_STDIN_YIELD_TIME_MS,
-  );
+  const yieldTimeMs = clampWriteStdinYieldTime(args.yield_time_ms, chars);
   const { output, wallTimeMs } = await waitForSessionOutput({
     session,
     startOffset,
@@ -544,16 +743,22 @@ export async function write_stdin(
     onOutput: args.onOutput,
   });
 
+  const nextSessionId = session.status === "running" ? session.id : null;
+  const formattedOutput = formatExecOutput({
+    chunkId: generateChunkId(),
+    wallTimeMs,
+    exitCode: session.exitCode,
+    sessionId: nextSessionId,
+    output,
+    originalTokenCount: estimateTokenCount(output),
+    maxOutputTokens: args.max_output_tokens,
+  });
+  if (nextSessionId === null) {
+    releaseExecSession(session);
+  }
+
   return {
-    output: formatExecOutput({
-      chunkId: generateChunkId(),
-      wallTimeMs,
-      exitCode: session.exitCode,
-      sessionId: session.status === "running" ? session.id : null,
-      output,
-      originalTokenCount: estimateTokenCount(output),
-      maxOutputTokens: args.max_output_tokens,
-    }),
+    output: formattedOutput,
   };
 }
 

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -308,7 +308,7 @@ function spawnPipeProcess(params: {
     cwd: params.cwd,
     env: params.env,
     shell: false,
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: [params.session.tty ? "pipe" : "ignore", "pipe", "pipe"],
     detached: process.platform !== "win32",
   });
 

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -1,0 +1,500 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
+import {
+  appendBackgroundProcessOutput,
+  appendToOutputFile,
+  assertBackgroundProcessCapacity,
+  backgroundProcesses,
+  createBackgroundOutputFile,
+  getNextExecSessionId,
+  scheduleBackgroundProcessCleanup,
+} from "./process_manager.js";
+import { resolveShellWorkdir } from "./shell.js";
+import { getShellEnv } from "./shell-env.js";
+import {
+  buildPowerShellCommand,
+  buildShellLaunchers,
+} from "./shell-launchers.js";
+import { LIMITS, truncateByChars } from "./truncation.js";
+import { validateRequiredParams } from "./validation.js";
+
+const DEFAULT_EXEC_YIELD_TIME_MS = 10_000;
+const DEFAULT_WRITE_STDIN_YIELD_TIME_MS = 250;
+const MAX_YIELD_TIME_MS = 30_000;
+const MAX_SESSION_OUTPUT_CHARS = 1_000_000;
+const EXEC_SESSION_CLEANUP_MS = 5 * 60 * 1000;
+
+interface ExecCommandArgs {
+  cmd: string;
+  workdir?: string;
+  shell?: string;
+  tty?: boolean;
+  yield_time_ms?: number;
+  max_output_tokens?: number;
+  login?: boolean;
+  sandbox_permissions?: "use_default" | "require_escalated" | string;
+  justification?: string;
+  prefix_rule?: string[];
+  signal?: AbortSignal;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+  secretEnv?: Record<string, string>;
+}
+
+interface WriteStdinArgs {
+  session_id: number | string;
+  chars?: string;
+  yield_time_ms?: number;
+  max_output_tokens?: number;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+}
+
+interface ExecCommandResult {
+  output: string;
+}
+
+type ExecSessionStatus = "running" | "completed" | "failed";
+
+interface ExecSession {
+  id: string;
+  command: string;
+  output: string;
+  readOffset: number;
+  status: ExecSessionStatus;
+  exitCode: number | null;
+  tty: boolean;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+
+type ProcessLauncher = {
+  kill(signal?: string | number): unknown;
+  write(input: string): void;
+};
+
+const execSessions = new Map<string, ExecSession>();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function clampYieldTime(value: number | undefined, fallback: number): number {
+  const time = Number.isFinite(value) ? Number(value) : fallback;
+  return Math.max(0, Math.min(time, MAX_YIELD_TIME_MS));
+}
+
+function estimateTokenCount(text: string): number {
+  return Math.ceil(Buffer.byteLength(text, "utf8") / 4);
+}
+
+function maxCharsForTokens(maxOutputTokens?: number): number {
+  if (!maxOutputTokens || maxOutputTokens <= 0) {
+    return LIMITS.BASH_OUTPUT_CHARS;
+  }
+  return Math.max(1, maxOutputTokens * 4);
+}
+
+function truncateOutput(text: string, maxOutputTokens?: number): string {
+  return truncateByChars(
+    text,
+    maxCharsForTokens(maxOutputTokens),
+    "exec_command",
+    {
+      workingDirectory: getCurrentWorkingDirectory(),
+      toolName: "exec_command",
+    },
+  ).content;
+}
+
+function appendSessionOutput(session: ExecSession, text: string): void {
+  session.output += text;
+  if (session.output.length <= MAX_SESSION_OUTPUT_CHARS) {
+    return;
+  }
+
+  const removedChars = session.output.length - MAX_SESSION_OUTPUT_CHARS;
+  session.output = session.output.slice(removedChars);
+  session.readOffset = Math.max(0, session.readOffset - removedChars);
+}
+
+function scheduleExecSessionCleanup(sessionId: string): void {
+  const session = execSessions.get(sessionId);
+  if (!session || session.status === "running") {
+    return;
+  }
+  if (session.cleanupTimer) {
+    clearTimeout(session.cleanupTimer);
+  }
+  session.cleanupTimer = setTimeout(() => {
+    const current = execSessions.get(sessionId);
+    if (current === session && current.status !== "running") {
+      execSessions.delete(sessionId);
+    }
+  }, EXEC_SESSION_CLEANUP_MS);
+  if (
+    typeof session.cleanupTimer === "object" &&
+    "unref" in session.cleanupTimer
+  ) {
+    session.cleanupTimer.unref();
+  }
+}
+
+function formatExecOutput(params: {
+  chunkId: string;
+  wallTimeMs: number;
+  exitCode: number | null;
+  sessionId: string | null;
+  output: string;
+  originalTokenCount: number;
+  maxOutputTokens?: number;
+}): string {
+  const sections = [
+    `Chunk ID: ${params.chunkId}`,
+    `Wall time: ${(params.wallTimeMs / 1000).toFixed(4)} seconds`,
+  ];
+
+  if (params.exitCode !== null) {
+    sections.push(`Process exited with code ${params.exitCode}`);
+  }
+  if (params.sessionId !== null) {
+    sections.push(`Process running with session ID ${params.sessionId}`);
+  }
+
+  sections.push(`Original token count: ${params.originalTokenCount}`);
+  sections.push("Output:");
+  sections.push(truncateOutput(params.output, params.maxOutputTokens));
+  return sections.join("\n");
+}
+
+function generateChunkId(): string {
+  return Array.from({ length: 6 }, () =>
+    Math.floor(Math.random() * 16).toString(16),
+  ).join("");
+}
+
+function shellCommandFlag(shellName: string, login: boolean): string {
+  if (!login) return "-c";
+  const normalized = shellName.replace(/\\/g, "/").toLowerCase();
+  if (normalized.includes("bash") || normalized.includes("zsh")) {
+    return "-lc";
+  }
+  return "-c";
+}
+
+function isPowerShell(shell: string): boolean {
+  const normalized = shell.replace(/\\/g, "/").toLowerCase();
+  return normalized.includes("powershell") || normalized.includes("pwsh");
+}
+
+function isCmd(shell: string): boolean {
+  const normalized = shell.replace(/\\/g, "/").toLowerCase();
+  return normalized.endsWith("cmd.exe") || normalized.endsWith("/cmd");
+}
+
+function buildExplicitShellLauncher(
+  shell: string,
+  cmd: string,
+  login: boolean,
+  envAliases?: string[],
+): string[] {
+  if (process.platform === "win32") {
+    if (isPowerShell(shell)) {
+      return [
+        shell,
+        "-NoProfile",
+        "-Command",
+        buildPowerShellCommand(cmd, envAliases),
+      ];
+    }
+    if (isCmd(shell)) {
+      return [shell, "/d", "/s", "/c", cmd];
+    }
+  }
+  return [shell, shellCommandFlag(shell, login), cmd];
+}
+
+function buildExecLaunchers(args: ExecCommandArgs): string[][] {
+  const login = args.login ?? true;
+  const envAliases = args.secretEnv ? Object.keys(args.secretEnv) : undefined;
+  if (args.shell?.trim()) {
+    return [
+      buildExplicitShellLauncher(
+        args.shell.trim(),
+        args.cmd,
+        login,
+        envAliases,
+      ),
+    ];
+  }
+  return buildShellLaunchers(args.cmd, {
+    login,
+    powershellEnvAliases: envAliases,
+  });
+}
+
+function spawnPipeProcess(params: {
+  launcher: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  session: ExecSession;
+  outputFile: string;
+}): ProcessLauncher {
+  const [executable, ...args] = params.launcher;
+  if (!executable) {
+    throw new Error("Executable is required");
+  }
+
+  noteExpectedWorktreeForLauncher(params.launcher, params.cwd);
+  const childProcess: ChildProcess = spawn(executable, args, {
+    cwd: params.cwd,
+    env: params.env,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+
+  const appendOutput = (text: string, stream: "stdout" | "stderr") => {
+    appendSessionOutput(params.session, text);
+    const bgProcess = backgroundProcesses.get(params.session.id);
+    if (bgProcess) {
+      appendBackgroundProcessOutput(bgProcess, stream, text);
+    }
+    appendToOutputFile(params.outputFile, text);
+  };
+
+  childProcess.stdout?.on("data", (chunk: Buffer) => {
+    appendOutput(chunk.toString("utf8"), "stdout");
+  });
+  childProcess.stderr?.on("data", (chunk: Buffer) => {
+    appendOutput(chunk.toString("utf8"), "stderr");
+  });
+
+  childProcess.on("error", (error) => {
+    params.session.status = "failed";
+    appendOutput(error.message, "stderr");
+    const bgProcess = backgroundProcesses.get(params.session.id);
+    if (bgProcess) {
+      bgProcess.status = "failed";
+      scheduleBackgroundProcessCleanup(params.session.id);
+    }
+    scheduleExecSessionCleanup(params.session.id);
+  });
+
+  childProcess.on("close", (code) => {
+    params.session.status = code === 0 ? "completed" : "failed";
+    params.session.exitCode = code;
+    const bgProcess = backgroundProcesses.get(params.session.id);
+    if (bgProcess) {
+      bgProcess.status = params.session.status;
+      bgProcess.exitCode = code;
+      scheduleBackgroundProcessCleanup(params.session.id);
+    }
+    scheduleExecSessionCleanup(params.session.id);
+  });
+
+  return {
+    kill(signal?: string | number) {
+      if (childProcess.pid && process.platform !== "win32") {
+        try {
+          process.kill(-childProcess.pid, signal as NodeJS.Signals);
+          return;
+        } catch {
+          // Fall back to killing the child directly below.
+        }
+      }
+      childProcess.kill(signal as NodeJS.Signals);
+    },
+    write(input: string) {
+      childProcess.stdin?.write(input);
+    },
+  };
+}
+
+async function waitForSessionOutput(params: {
+  session: ExecSession;
+  startOffset: number;
+  yieldTimeMs: number;
+  onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
+}): Promise<{ output: string; wallTimeMs: number }> {
+  const startTime = Date.now();
+  const deadline = startTime + params.yieldTimeMs;
+  let emittedOffset = params.startOffset;
+
+  while (Date.now() < deadline && params.session.status === "running") {
+    if (params.onOutput && params.session.output.length > emittedOffset) {
+      params.onOutput(params.session.output.slice(emittedOffset), "stdout");
+      emittedOffset = params.session.output.length;
+    }
+    await sleep(25);
+  }
+
+  if (params.onOutput && params.session.output.length > emittedOffset) {
+    params.onOutput(params.session.output.slice(emittedOffset), "stdout");
+  }
+
+  const endOffset = params.session.output.length;
+  const output = params.session.output.slice(params.startOffset, endOffset);
+  params.session.readOffset = endOffset;
+
+  return { output, wallTimeMs: Date.now() - startTime };
+}
+
+async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
+  assertBackgroundProcessCapacity();
+
+  const id = getNextExecSessionId();
+  const outputFile = createBackgroundOutputFile(`exec_${id}`);
+  const cwd = resolveShellWorkdir(args.workdir);
+  const env = { ...getShellEnv(), ...(args.secretEnv ?? {}) };
+  const launchers = buildExecLaunchers(args);
+  const launcher = launchers[0];
+  if (!launcher) {
+    throw new Error("Command must be a non-empty string");
+  }
+
+  const session: ExecSession = {
+    id,
+    command: args.cmd,
+    output: "",
+    readOffset: 0,
+    status: "running",
+    exitCode: null,
+    tty: args.tty ?? false,
+  };
+  execSessions.set(id, session);
+
+  let processLauncher: ProcessLauncher;
+  try {
+    processLauncher = spawnPipeProcess({
+      launcher,
+      cwd,
+      env,
+      session,
+      outputFile,
+    });
+  } catch (error) {
+    execSessions.delete(id);
+    throw error;
+  }
+
+  backgroundProcesses.set(id, {
+    process: processLauncher,
+    command: args.cmd,
+    stdout: [],
+    stderr: [],
+    status: session.status,
+    exitCode: session.exitCode,
+    lastReadIndex: { stdout: 0, stderr: 0 },
+    startTime: new Date(),
+    outputFile,
+    totalStdoutLines: 0,
+    totalStderrLines: 0,
+  });
+  if (session.status !== "running") {
+    scheduleBackgroundProcessCleanup(id);
+  }
+
+  args.signal?.addEventListener(
+    "abort",
+    () => {
+      processLauncher.kill("SIGTERM");
+    },
+    { once: true },
+  );
+
+  return session;
+}
+
+export async function exec_command(
+  args: ExecCommandArgs,
+): Promise<ExecCommandResult> {
+  validateRequiredParams(args, ["cmd"], "exec_command");
+  if (!args.cmd || typeof args.cmd !== "string") {
+    throw new Error("cmd must be a non-empty string");
+  }
+
+  const session = await startExecSession(args);
+  const yieldTimeMs = clampYieldTime(
+    args.yield_time_ms,
+    DEFAULT_EXEC_YIELD_TIME_MS,
+  );
+  const { output, wallTimeMs } = await waitForSessionOutput({
+    session,
+    startOffset: 0,
+    yieldTimeMs,
+    onOutput: args.onOutput,
+  });
+
+  return {
+    output: formatExecOutput({
+      chunkId: generateChunkId(),
+      wallTimeMs,
+      exitCode: session.exitCode,
+      sessionId: session.status === "running" ? session.id : null,
+      output,
+      originalTokenCount: estimateTokenCount(output),
+      maxOutputTokens: args.max_output_tokens,
+    }),
+  };
+}
+
+export async function write_stdin(
+  args: WriteStdinArgs,
+): Promise<ExecCommandResult> {
+  validateRequiredParams(args, ["session_id"], "write_stdin");
+  const sessionId = String(args.session_id);
+  const session = execSessions.get(sessionId);
+  const backgroundProcess = backgroundProcesses.get(sessionId);
+  if (!session || !backgroundProcess) {
+    throw new Error(`Unknown unified exec session ID: ${sessionId}`);
+  }
+
+  const chars = args.chars ?? "";
+  if (chars && !session.tty) {
+    throw new Error(
+      "stdin is only available for exec_command sessions started with tty=true",
+    );
+  }
+  if (chars) {
+    (backgroundProcess.process as ProcessLauncher).write(chars);
+    await sleep(100);
+  }
+
+  const startOffset = session.readOffset;
+  const yieldTimeMs = clampYieldTime(
+    args.yield_time_ms,
+    DEFAULT_WRITE_STDIN_YIELD_TIME_MS,
+  );
+  const { output, wallTimeMs } = await waitForSessionOutput({
+    session,
+    startOffset,
+    yieldTimeMs,
+    onOutput: args.onOutput,
+  });
+
+  return {
+    output: formatExecOutput({
+      chunkId: generateChunkId(),
+      wallTimeMs,
+      exitCode: session.exitCode,
+      sessionId: session.status === "running" ? session.id : null,
+      output,
+      originalTokenCount: estimateTokenCount(output),
+      maxOutputTokens: args.max_output_tokens,
+    }),
+  };
+}
+
+export function __clearExecSessionsForTests(): void {
+  for (const session of execSessions.values()) {
+    if (session.cleanupTimer) {
+      clearTimeout(session.cleanupTimer);
+    }
+  }
+  execSessions.clear();
+}
+
+export function __getExecSessionForTests(
+  sessionId: string,
+): ExecSession | undefined {
+  return execSessions.get(sessionId);
+}

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -59,6 +59,7 @@ interface ExecSession {
   id: string;
   command: string;
   output: string;
+  chunks: ExecOutputChunk[];
   readOffset: number;
   status: ExecSessionStatus;
   exitCode: number | null;
@@ -69,6 +70,13 @@ interface ExecSession {
 type ProcessLauncher = {
   kill(signal?: string | number): unknown;
   write(input: string): void;
+};
+
+type ExecOutputChunk = {
+  text: string;
+  stream: "stdout" | "stderr";
+  start: number;
+  end: number;
 };
 
 const execSessions = new Map<string, ExecSession>();
@@ -105,8 +113,16 @@ function truncateOutput(text: string, maxOutputTokens?: number): string {
   ).content;
 }
 
-function appendSessionOutput(session: ExecSession, text: string): void {
+function appendSessionOutput(
+  session: ExecSession,
+  text: string,
+  stream: "stdout" | "stderr",
+): void {
+  const start = session.output.length;
   session.output += text;
+  const end = session.output.length;
+  session.chunks.push({ text, stream, start, end });
+
   if (session.output.length <= MAX_SESSION_OUTPUT_CHARS) {
     return;
   }
@@ -114,6 +130,48 @@ function appendSessionOutput(session: ExecSession, text: string): void {
   const removedChars = session.output.length - MAX_SESSION_OUTPUT_CHARS;
   session.output = session.output.slice(removedChars);
   session.readOffset = Math.max(0, session.readOffset - removedChars);
+  session.chunks = session.chunks
+    .map((chunk) => ({
+      ...chunk,
+      start: chunk.start - removedChars,
+      end: chunk.end - removedChars,
+    }))
+    .filter((chunk) => chunk.end > 0)
+    .map((chunk) => {
+      if (chunk.start >= 0) {
+        return chunk;
+      }
+      return {
+        ...chunk,
+        text: chunk.text.slice(-chunk.end),
+        start: 0,
+      };
+    });
+}
+
+function getSessionOutputChunks(
+  session: ExecSession,
+  startOffset: number,
+  endOffset: number,
+): ExecOutputChunk[] {
+  const chunks: ExecOutputChunk[] = [];
+  for (const chunk of session.chunks) {
+    if (chunk.end <= startOffset || chunk.start >= endOffset) {
+      continue;
+    }
+    const sliceStart = Math.max(0, startOffset - chunk.start);
+    const sliceEnd = Math.min(chunk.text.length, endOffset - chunk.start);
+    const text = chunk.text.slice(sliceStart, sliceEnd);
+    if (text) {
+      chunks.push({
+        text,
+        stream: chunk.stream,
+        start: Math.max(chunk.start, startOffset),
+        end: Math.min(chunk.end, endOffset),
+      });
+    }
+  }
+  return chunks;
 }
 
 function scheduleExecSessionCleanup(sessionId: string): void {
@@ -253,7 +311,7 @@ function spawnPipeProcess(params: {
   });
 
   const appendOutput = (text: string, stream: "stdout" | "stderr") => {
-    appendSessionOutput(params.session, text);
+    appendSessionOutput(params.session, text, stream);
     const bgProcess = backgroundProcesses.get(params.session.id);
     if (bgProcess) {
       appendBackgroundProcessOutput(bgProcess, stream, text);
@@ -321,14 +379,26 @@ async function waitForSessionOutput(params: {
 
   while (Date.now() < deadline && params.session.status === "running") {
     if (params.onOutput && params.session.output.length > emittedOffset) {
-      params.onOutput(params.session.output.slice(emittedOffset), "stdout");
+      for (const chunk of getSessionOutputChunks(
+        params.session,
+        emittedOffset,
+        params.session.output.length,
+      )) {
+        params.onOutput(chunk.text, chunk.stream);
+      }
       emittedOffset = params.session.output.length;
     }
     await sleep(25);
   }
 
   if (params.onOutput && params.session.output.length > emittedOffset) {
-    params.onOutput(params.session.output.slice(emittedOffset), "stdout");
+    for (const chunk of getSessionOutputChunks(
+      params.session,
+      emittedOffset,
+      params.session.output.length,
+    )) {
+      params.onOutput(chunk.text, chunk.stream);
+    }
   }
 
   const endOffset = params.session.output.length;
@@ -355,6 +425,7 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
     id,
     command: args.cmd,
     output: "",
+    chunks: [],
     readOffset: 0,
     status: "running",
     exitCode: null,

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -102,7 +102,7 @@ type NodePtyModule = {
   ) => NodePtyProcess;
 };
 
-const NODE_PTY_BRIDGE_SCRIPT = String.raw`
+const NODE_PTY_BRIDGE_SCRIPT = `
 const pty = require("node-pty");
 const config = JSON.parse(process.argv[1]);
 const child = pty.spawn(config.executable, config.args, {

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -1,7 +1,11 @@
 type TimerHandle = ReturnType<typeof setTimeout>;
 
+export interface BackgroundProcessHandle {
+  kill(signal?: string | number): unknown;
+}
+
 export interface BackgroundProcess {
-  process: import("child_process").ChildProcess;
+  process: BackgroundProcessHandle;
   command: string;
   stdout: string[];
   stderr: string[];
@@ -33,6 +37,11 @@ export const backgroundTasks = new Map<string, BackgroundTask>();
 let bashIdCounter = 1;
 export function getNextBashId() {
   return `bash_${bashIdCounter++}`;
+}
+
+let execSessionIdCounter = 1;
+export function getNextExecSessionId() {
+  return String(execSessionIdCounter++);
 }
 
 let taskIdCounter = 1;

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -178,6 +178,8 @@ const STREAMING_SHELL_TOOLS = new Set([
   "Bash",
   "BashOutput",
   "TaskOutput",
+  "exec_command",
+  "write_stdin",
   "shell_command",
   "ShellCommand",
   "shell",
@@ -332,7 +334,8 @@ export const ANTHROPIC_DEFAULT_TOOLS: ToolName[] = [
 ];
 
 export const OPENAI_DEFAULT_TOOLS: ToolName[] = [
-  "shell_command",
+  "exec_command",
+  "write_stdin",
   // TODO(codex-parity): add once request_user_input tool exists in raw codex path.
   // "request_user_input",
   "apply_patch",
@@ -368,7 +371,8 @@ export const OPENAI_PASCAL_TOOLS: ToolName[] = [
   "TaskStop",
   "Skill",
   // Standard Codex tools
-  "ShellCommand",
+  "exec_command",
+  "write_stdin",
   "ViewImage",
   "ApplyPatch",
   "UpdatePlan",
@@ -419,6 +423,8 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   TodoWrite: { requiresApproval: false },
   Write: { requiresApproval: true },
   shell_command: { requiresApproval: true },
+  exec_command: { requiresApproval: true },
+  write_stdin: { requiresApproval: false },
   shell: { requiresApproval: true },
   read_file: { requiresApproval: false },
   list_dir: { requiresApproval: false },
@@ -2174,7 +2180,7 @@ export async function executeTool(
         // Inject secrets as environment variables instead of substituting into
         // the command string. This prevents shell metacharacters in secrets
         // (e.g. $$, backticks, quotes) from being interpreted by the shell.
-        const command = enhancedArgs.command;
+        const command = enhancedArgs.command ?? enhancedArgs.cmd;
         const secretEnv =
           typeof command === "string" ||
           (Array.isArray(command) &&

--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "cmd": {
+      "type": "string",
+      "description": "Shell command to execute."
+    },
+    "justification": {
+      "type": "string",
+      "description": "Only set if sandbox_permissions is \"require_escalated\". Request approval from the user to run this command outside the sandbox. Phrased as a simple question that summarizes the purpose of the command as it relates to the task at hand - e.g. 'Do you want to fetch and pull the latest version of this git branch?'"
+    },
+    "login": {
+      "type": "boolean",
+      "description": "Whether to run the shell with -l/-i semantics. Defaults to true."
+    },
+    "max_output_tokens": {
+      "type": "number",
+      "description": "Maximum number of tokens to return. Excess output will be truncated."
+    },
+    "prefix_rule": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Only specify when sandbox_permissions is `require_escalated`. Suggest a prefix command pattern that will allow you to fulfill similar requests from the user in the future. Should be a short but reasonable prefix, e.g. [\"git\", \"pull\"] or [\"uv\", \"run\"] or [\"pytest\"]."
+    },
+    "sandbox_permissions": {
+      "type": "string",
+      "description": "Sandbox permissions for the command. Set to \"require_escalated\" to request running without sandbox restrictions; defaults to \"use_default\"."
+    },
+    "shell": {
+      "type": "string",
+      "description": "Shell binary to launch. Defaults to the user's default shell."
+    },
+    "tty": {
+      "type": "boolean",
+      "description": "Whether to allocate a TTY for the command. Defaults to false (plain pipes); set to true to open a PTY and access TTY process."
+    },
+    "workdir": {
+      "type": "string",
+      "description": "Optional working directory to run the command in; defaults to the turn cwd."
+    },
+    "yield_time_ms": {
+      "type": "number",
+      "description": "How long to wait (in milliseconds) for output before yielding."
+    }
+  },
+  "required": ["cmd"],
+  "additionalProperties": false
+}

--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -6,10 +6,6 @@
       "type": "string",
       "description": "Shell command to execute."
     },
-    "justification": {
-      "type": "string",
-      "description": "Only set if sandbox_permissions is \"require_escalated\". Request approval from the user to run this command outside the sandbox. Phrased as a simple question that summarizes the purpose of the command as it relates to the task at hand - e.g. 'Do you want to fetch and pull the latest version of this git branch?'"
-    },
     "login": {
       "type": "boolean",
       "description": "Whether to run the shell with -l/-i semantics. Defaults to true."
@@ -17,17 +13,6 @@
     "max_output_tokens": {
       "type": "number",
       "description": "Maximum number of tokens to return. Excess output will be truncated."
-    },
-    "prefix_rule": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "Only specify when sandbox_permissions is `require_escalated`. Suggest a prefix command pattern that will allow you to fulfill similar requests from the user in the future. Should be a short but reasonable prefix, e.g. [\"git\", \"pull\"] or [\"uv\", \"run\"] or [\"pytest\"]."
-    },
-    "sandbox_permissions": {
-      "type": "string",
-      "description": "Sandbox permissions for the command. Set to \"require_escalated\" to request running without sandbox restrictions; defaults to \"use_default\"."
     },
     "shell": {
       "type": "string",

--- a/src/tools/schemas/WriteStdin.json
+++ b/src/tools/schemas/WriteStdin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "chars": {
+      "type": "string",
+      "description": "Bytes to write to stdin (may be empty to poll)."
+    },
+    "max_output_tokens": {
+      "type": "number",
+      "description": "Maximum number of tokens to return. Excess output will be truncated."
+    },
+    "session_id": {
+      "type": "number",
+      "description": "Identifier of the running unified exec session."
+    },
+    "yield_time_ms": {
+      "type": "number",
+      "description": "How long to wait (in milliseconds) for output before yielding."
+    }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -85,6 +85,7 @@ import { view_image } from "./impl/view-image";
 import { write } from "./impl/write";
 import { write_file_gemini } from "./impl/write-file-gemini";
 import { write_todos } from "./impl/write-todos-gemini";
+
 import ApplyPatchSchema from "./schemas/ApplyPatch.json";
 import AskUserQuestionSchema from "./schemas/AskUserQuestion.json";
 import BashSchema from "./schemas/Bash.json";
@@ -129,6 +130,18 @@ import WriteSchema from "./schemas/Write.json";
 import WriteFileGeminiSchema from "./schemas/WriteFileGemini.json";
 import WriteStdinSchema from "./schemas/WriteStdin.json";
 import WriteTodosGeminiSchema from "./schemas/WriteTodosGemini.json";
+
+const WINDOWS_UNIFIED_EXEC_GUIDANCE = `Windows safety rules:
+- Do not compose destructive filesystem commands across shells. Do not enumerate paths in PowerShell and then pass them to \`cmd /c\`, batch builtins, or another shell for deletion or moving. Use one shell end-to-end, prefer native PowerShell cmdlets such as \`Remove-Item\` / \`Move-Item\` with \`-LiteralPath\`, and avoid string-built shell commands for file operations.
+- Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.
+- When using \`Start-Process\` to launch a background helper or service, pass \`-WindowStyle Hidden\` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control.`;
+
+function execCommandDescription(): string {
+  const baseDescription = ExecCommandDescription.trim();
+  return process.platform === "win32"
+    ? `${baseDescription}\n\n${WINDOWS_UNIFIED_EXEC_GUIDANCE}`
+    : baseDescription;
+}
 
 type ToolImplementation = (args: Record<string, unknown>) => Promise<unknown>;
 
@@ -262,7 +275,7 @@ const toolDefinitions = {
   },
   exec_command: {
     schema: ExecCommandSchema,
-    description: ExecCommandDescription.trim(),
+    description: execCommandDescription(),
     impl: exec_command as unknown as ToolImplementation,
   },
   write_stdin: {

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -5,6 +5,7 @@ import BashOutputDescription from "./descriptions/BashOutput.md";
 import CreateGoalDescription from "./descriptions/CreateGoal.md";
 import CreateWorktreeDescription from "./descriptions/CreateWorktree.md";
 import EditDescription from "./descriptions/Edit.md";
+import ExecCommandDescription from "./descriptions/ExecCommand.md";
 import GetGoalDescription from "./descriptions/GetGoal.md";
 import GlobDescription from "./descriptions/Glob.md";
 // Gemini toolset
@@ -39,6 +40,7 @@ import UpdatePlanDescription from "./descriptions/UpdatePlan.md";
 import ViewImageDescription from "./descriptions/ViewImage.md";
 import WriteDescription from "./descriptions/Write.md";
 import WriteFileGeminiDescription from "./descriptions/WriteFileGemini.md";
+import WriteStdinDescription from "./descriptions/WriteStdin.md";
 import WriteTodosGeminiDescription from "./descriptions/WriteTodosGemini.md";
 import { apply_patch } from "./impl/apply-patch";
 import { ask_user_question } from "./impl/ask-user-question";
@@ -47,6 +49,7 @@ import { bash_output } from "./impl/bash-output";
 import { create_goal } from "./impl/create-goal";
 import { create_worktree } from "./impl/create-worktree";
 import { edit } from "./impl/edit";
+import { exec_command, write_stdin } from "./impl/exec-command";
 import { get_goal } from "./impl/get-goal";
 import { glob } from "./impl/glob";
 // Gemini toolset
@@ -89,6 +92,7 @@ import BashOutputSchema from "./schemas/BashOutput.json";
 import CreateGoalSchema from "./schemas/CreateGoal.json";
 import CreateWorktreeSchema from "./schemas/CreateWorktree.json";
 import EditSchema from "./schemas/Edit.json";
+import ExecCommandSchema from "./schemas/ExecCommand.json";
 import GetGoalSchema from "./schemas/GetGoal.json";
 import GlobSchema from "./schemas/Glob.json";
 // Gemini toolset
@@ -123,6 +127,7 @@ import UpdatePlanSchema from "./schemas/UpdatePlan.json";
 import ViewImageSchema from "./schemas/ViewImage.json";
 import WriteSchema from "./schemas/Write.json";
 import WriteFileGeminiSchema from "./schemas/WriteFileGemini.json";
+import WriteStdinSchema from "./schemas/WriteStdin.json";
 import WriteTodosGeminiSchema from "./schemas/WriteTodosGemini.json";
 
 type ToolImplementation = (args: Record<string, unknown>) => Promise<unknown>;
@@ -254,6 +259,16 @@ const toolDefinitions = {
     schema: ShellCommandSchema,
     description: ShellCommandDescription.trim(),
     impl: shell_command as unknown as ToolImplementation,
+  },
+  exec_command: {
+    schema: ExecCommandSchema,
+    description: ExecCommandDescription.trim(),
+    impl: exec_command as unknown as ToolImplementation,
+  },
+  write_stdin: {
+    schema: WriteStdinSchema,
+    description: WriteStdinDescription.trim(),
+    impl: write_stdin as unknown as ToolImplementation,
   },
   shell: {
     schema: ShellSchema,


### PR DESCRIPTION
## Summary
- Adds Codex unified exec tools (`exec_command`, `write_stdin`) to the Codex toolset, using the upstream `cmd`/`session_id` payload shape while intentionally omitting unsupported Codex sandbox override fields from the schema.
- Implements a session-backed command runtime for unified exec: Codex-style result envelopes, bounded yielding, stdout/stderr streaming labels, output truncation defaults, background process retention, cleanup, and Codex-like stdin/session lifecycle handling.
- Backs `tty=true` sessions with a real PTY (`node-pty` under Node; a Node bridge for Bun dev/tests), while non-tty sessions use closed stdin pipe mode like Codex.
- Matches Codex `write_stdin` behavior more closely: empty polls wait like background-terminal polls, completed sessions are released after the final response, and non-tty stdin writes use Codex’s stdin-closed error.
- Updates approval, permission, cross-agent guard, memory-mode, secret-env, and tool execution wiring so shell analysis and execution use `cmd` and `session_id` correctly.
- Polishes CLI/TUI rendering for unified exec: approval/previews show the command, completed results hide Codex metadata in the transcript, running sessions remain visible, stderr styling is preserved, failed stdin writes do not render as successful terminal interactions, and successful `write_stdin` calls mirror Codex background-terminal wording with the original command when available.
- Fixes a Windows Telegram test/CI hang by keeping the Telegram startup timeout timer refed so a stuck polling start can actually reject.
- Adds regression coverage for runtime behavior, schema/toolset exposure, intentional schema drift, permission analysis, transcript formatting, memory-mode scoping, non-tty stdin closure, real PTY allocation, session release, and the Telegram startup timeout path.

## Validation
- `bun run check`
- `bun test src/tools/exec-command.test.ts src/tools/codex-unified-exec-toolset.test.ts src/cli/helpers/unified-exec-accumulator.test.ts src/cli/unified-exec-output.test.ts src/cli/format-args-display.test.ts src/cli/tool-name-mapping.test.ts src/permissions/permissions-cli.test.ts src/permissions/permissions-analyzer.test.ts src/permissions/cross-agent-guard.test.ts src/permissions/permissions-mode.test.ts src/channels/telegram-adapter.test.ts`

👾 Generated with [Letta Code](https://letta.com)
