### PR TITLE
fix(channels): keep custom apps on custom channel

### DIFF
--- a/src/websocket/listen-client-channel-accounts.test.ts
+++ b/src/websocket/listen-client-channel-accounts.test.ts
@@ -27,6 +27,63 @@ afterEach(() => {
 });
 
 describe("channel account list responses", () => {
+  test("creates custom app accounts on the built-in custom channel", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_create",
+          request_id: "custom-create-1",
+          channel_id: "custom",
+          account: {
+            account_id: "custom-app-1",
+            display_name: "Webhook.site test",
+            enabled: false,
+            dm_policy: "pairing",
+            config: {
+              url: "https://example.com/webhook",
+              agent_id: "agent-1",
+            },
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_create_response",
+        success: true,
+        channel_id: "custom",
+        account: {
+          channel_id: "custom",
+          account_id: "custom-app-1",
+          display_name: "Webhook.site test",
+          config: {
+            url: "https://example.com/webhook",
+            agent_id: "agent-1",
+          },
+        },
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
   test("return cached account snapshots without waiting for live display-name refresh", async () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -3,10 +3,7 @@ import {
   channelPluginConfigShouldRefreshDisplayName,
   getChannelPluginConfig,
 } from "@/channels/account-config";
-import {
-  removeUserPlugin,
-  scaffoldUserPlugin,
-} from "@/channels/custom/scaffolding";
+import { removeUserPlugin } from "@/channels/custom/scaffolding";
 import { getChannelPluginMetadata } from "@/channels/plugin-registry";
 import type { ChannelRegistryEvent } from "@/channels/registry";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
@@ -525,19 +522,10 @@ export async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_account_create") {
     try {
-      // For the first-party "custom" channel, scaffold a dedicated user plugin
-      // folder so the new app gets its own channel ID (e.g. "my-webhook-app").
-      // The folder must exist before createChannelAccountLive validates the ID.
-      let effectiveChannelId = parsed.channel_id;
-      if (parsed.channel_id === "custom") {
-        const displayName =
-          typeof (parsed.account as Record<string, unknown>).display_name ===
-          "string"
-            ? ((parsed.account as Record<string, unknown>)
-                .display_name as string)
-            : "custom-app";
-        effectiveChannelId = scaffoldUserPlugin(displayName);
-      }
+      // Custom-app model: multiple custom apps are represented as
+      // multiple accounts under the first-party "custom" channel. Do not
+      // scaffold per-app plugin folders/channel IDs here.
+      const effectiveChannelId = parsed.channel_id;
 
       const pluginConfig =
         getChannelPluginConfig(parsed.account as Record<string, unknown>) ?? {};


### PR DESCRIPTION
Create custom apps as accounts under the built-in custom channel instead of scaffolding per-app plugin channel IDs.

👾 Generated with [Letta Code](https://letta.com)