### PR TITLE
refactor(agent): inject backend into message streaming

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -9,7 +9,7 @@ import type {
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
-import { getBackend } from "@/backend";
+import { type Backend, getBackend } from "@/backend";
 import {
   type ClientTool,
   type PermissionModeState,
@@ -94,6 +94,12 @@ export type SendMessageStreamOptions = {
   actingUserId?: string;
 };
 
+export type SendMessageStreamRequestOptions = {
+  maxRetries?: number;
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+};
+
 export function buildConversationMessagesCreateRequestBody(
   conversationId: string,
   messages: Array<MessageCreate | ApprovalCreate>,
@@ -141,17 +147,35 @@ export async function sendMessageStream(
   opts: SendMessageStreamOptions = { streamTokens: true, background: true },
   // Disable SDK retries by default - state management happens outside the stream,
   // so retries would violate idempotency and create race conditions
-  requestOptions: {
-    maxRetries?: number;
-    signal?: AbortSignal;
-    headers?: Record<string, string>;
-  } = {
+  requestOptions: SendMessageStreamRequestOptions = {
+    maxRetries: 0,
+  },
+): Promise<Stream<LettaStreamingResponse>> {
+  return sendMessageStreamWithBackend(
+    getBackend(),
+    conversationId,
+    messages,
+    opts,
+    requestOptions,
+  );
+}
+
+/**
+ * Send a message through an explicit backend instance. Use this when a caller
+ * composes several backend operations and needs fork/send to stay on the same
+ * backend without reaching back through the global backend singleton.
+ */
+export async function sendMessageStreamWithBackend(
+  backend: Backend,
+  conversationId: string,
+  messages: Array<MessageCreate | ApprovalCreate>,
+  opts: SendMessageStreamOptions = { streamTokens: true, background: true },
+  requestOptions: SendMessageStreamRequestOptions = {
     maxRetries: 0,
   },
 ): Promise<Stream<LettaStreamingResponse>> {
   const requestStartTime = isTimingsEnabled() ? performance.now() : undefined;
   const requestStartedAtMs = Date.now();
-  const backend = getBackend();
   const normalizedMessages = opts.skipImageNormalization
     ? messages
     : await normalizeMessageImageParts(messages);

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -24,7 +24,7 @@ import {
 import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { createAgent } from "@/agent/create";
 import { selectDefaultAgentModel } from "@/agent/defaults";
-import { sendMessageStream } from "@/agent/message";
+import { sendMessageStreamWithBackend } from "@/agent/message";
 import {
   configureBackendMode,
   getBackend,
@@ -188,8 +188,10 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       try {
         const isDefault = conversationIdRef.current === "default";
 
+        const backend = getBackend();
+
         // Fork the conversation
-        const forked = await getBackend().forkConversation(
+        const forked = await backend.forkConversation(
           conversationIdRef.current,
           {
             ...(isDefault ? { agentId } : {}),
@@ -211,17 +213,22 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           },
         ];
         let approvalRecoveryRetries = 0;
-        let stream: Awaited<ReturnType<typeof sendMessageStream>>;
+        let stream: Awaited<ReturnType<typeof sendMessageStreamWithBackend>>;
 
         while (true) {
           try {
             const preparedToolContext = await prepareScopedToolExecutionContext(
               tempModelOverrideRef.current ?? undefined,
             );
-            stream = await sendMessageStream(forked.id, currentInput, {
-              overrideModel: tempModelOverrideRef.current ?? undefined,
-              preparedToolContext: preparedToolContext.preparedToolContext,
-            });
+            stream = await sendMessageStreamWithBackend(
+              backend,
+              forked.id,
+              currentInput,
+              {
+                overrideModel: tempModelOverrideRef.current ?? undefined,
+                preparedToolContext: preparedToolContext.preparedToolContext,
+              },
+            );
             break;
           } catch (preStreamError) {
             debugLog(


### PR DESCRIPTION
## Summary
- Add `sendMessageStreamWithBackend` so turn streaming can use an explicit backend instance
- Keep `sendMessageStream` as the existing global-backend wrapper
- Route built-in `/btw` fork/send through the same explicit backend instance

## Test plan
- [x] `bun run check`
- [x] `bun test src/agent/message-client-skills.test.ts src/tools/tool-execution-context.test.ts`

👾 Generated with [Letta Code](https://letta.com)