### PR TITLE
fix(file-index): search live disk for stale index misses

### DIFF
--- a/src/cli/file-index.test.ts
+++ b/src/cli/file-index.test.ts
@@ -14,6 +14,7 @@ import {
   addEntriesToCache,
   refreshFileIndex,
   searchFileIndex,
+  searchFileIndexWithDiskFallback,
   setIndexRoot,
 } from "@/utils/file-index";
 
@@ -100,6 +101,30 @@ describe("build and search", () => {
     expect(paths).toContain("src");
     expect(paths).toContain(join("src", "components"));
     expect(paths).toContain("tests");
+  });
+
+  test("disk fallback finds files created after the last index refresh", async () => {
+    await refreshFileIndex();
+
+    const newFile = join("src", "generated-after-index.ts");
+    writeFileSync(join(TEST_DIR, newFile), "export const generated = true;");
+
+    const staleOnly = searchFileIndex({
+      searchDir: "src",
+      pattern: "generated-after-index",
+      deep: true,
+      maxResults: 10,
+    });
+    expect(staleOnly.map((r) => r.path)).not.toContain(newFile);
+
+    const withFallback = searchFileIndexWithDiskFallback({
+      searchDir: "src",
+      absoluteSearchDir: join(TEST_DIR, "src"),
+      pattern: "generated-after-index",
+      deep: true,
+      maxResults: 10,
+    });
+    expect(withFallback.map((r) => r.path)).toContain(newFile);
   });
 
   test("assigns correct types", async () => {

--- a/src/utils/file-index.ts
+++ b/src/utils/file-index.ts
@@ -11,7 +11,10 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, normalize, relative, sep } from "node:path";
-import { shouldExcludeEntry } from "@/cli/helpers/file-search-config";
+import {
+  shouldExcludeEntry,
+  shouldHardExcludeEntry,
+} from "@/cli/helpers/file-search-config";
 import { debugLog } from "@/utils/debug";
 import { readIntSetting } from "@/utils/letta-settings";
 
@@ -27,6 +30,11 @@ interface SearchFileIndexOptions {
   pattern: string;
   deep: boolean;
   maxResults: number;
+}
+
+interface SearchFileIndexWithDiskOptions extends SearchFileIndexOptions {
+  /** Absolute directory corresponding to `searchDir`. */
+  absoluteSearchDir: string;
 }
 
 interface FileStats {
@@ -62,6 +70,7 @@ const CACHE_VERSION = 2;
  * on large binaries/assets while still content-hashing all normal source files.
  */
 const MAX_CONTENT_HASH_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const MAX_DISK_FALLBACK_VISITED = 25_000;
 
 // Read from ~/.letta/.lettasettings (MAX_ENTRIES), falling back to 50 000.
 // The file is auto-created with comments on first run so users can find it.
@@ -879,4 +888,91 @@ export function searchFileIndex(options: SearchFileIndexOptions): FileMatch[] {
   }
 
   return results;
+}
+
+function searchDiskForMissingFiles(
+  options: SearchFileIndexWithDiskOptions,
+  seen: Set<string>,
+): FileMatch[] {
+  const { absoluteSearchDir, pattern, deep, maxResults } = options;
+  const lowerPattern = pattern.toLowerCase();
+  const results: FileMatch[] = [];
+  const stack: string[] = [absoluteSearchDir];
+  let visited = 0;
+
+  while (stack.length > 0 && results.length < maxResults) {
+    if (visited >= MAX_DISK_FALLBACK_VISITED) break;
+    const dir = stack.pop();
+    if (!dir) break;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+
+    for (const name of entries) {
+      if (results.length >= maxResults) break;
+      if (visited >= MAX_DISK_FALLBACK_VISITED) break;
+      if (shouldHardExcludeEntry(name, indexRoot)) continue;
+
+      const fullPath = join(dir, name);
+      let type: "file" | "dir";
+      try {
+        const stat = statSync(fullPath);
+        type = stat.isDirectory() ? "dir" : "file";
+      } catch {
+        continue;
+      }
+      visited++;
+
+      const relativePath = relative(indexRoot, fullPath);
+      if (relativePath.startsWith("..")) continue;
+      const key = `${type}:${relativePath}`;
+      if (seen.has(key)) {
+        if (deep && type === "dir") stack.push(fullPath);
+        continue;
+      }
+
+      if (
+        pattern.length === 0 ||
+        relativePath.toLowerCase().includes(lowerPattern)
+      ) {
+        results.push({ path: relativePath, type });
+        seen.add(key);
+      }
+
+      if (deep && type === "dir") stack.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Search the in-memory index, then merge a bounded live disk scan for misses.
+ *
+ * The file index is refreshed asynchronously after tool calls, so a file that
+ * was just created can exist on disk before it appears in cachedEntries. This
+ * helper keeps interactive file search correct in that window while preserving
+ * the index as the fast primary path.
+ */
+export function searchFileIndexWithDiskFallback(
+  options: SearchFileIndexWithDiskOptions,
+): FileMatch[] {
+  const indexed = searchFileIndex(options);
+  if (indexed.length >= options.maxResults) return indexed;
+
+  const seen = new Set(indexed.map((entry) => `${entry.type}:${entry.path}`));
+  const missing = searchDiskForMissingFiles(
+    { ...options, maxResults: options.maxResults - indexed.length },
+    seen,
+  );
+
+  if (missing.length > 0) {
+    addEntriesToCache(missing);
+  }
+
+  return [...indexed, ...missing];
 }

--- a/src/websocket/listener/file-commands.ts
+++ b/src/websocket/listener/file-commands.ts
@@ -7,6 +7,7 @@ import {
   getIndexRoot,
   refreshFileIndex,
   searchFileIndex,
+  searchFileIndexWithDiskFallback,
   setIndexRoot,
 } from "@/utils/file-index";
 import { runGrepInFiles } from "./grep-in-files";
@@ -208,12 +209,18 @@ export function createFileCommandSession(params: {
             }
           }
 
-          const files = searchFileIndex({
+          const files = searchFileIndexWithDiskFallback({
             searchDir,
+            absoluteSearchDir: parsed.cwd ?? getIndexRoot(),
             pattern: parsed.query,
             deep: true,
             maxResults: parsed.max_results ?? 5,
-          });
+          }).map((entry) => ({
+            ...entry,
+            path: parsed.cwd
+              ? path.relative(parsed.cwd, path.join(getIndexRoot(), entry.path))
+              : entry.path,
+          }));
           safeSocketSend(
             socket,
             {


### PR DESCRIPTION
Merge bounded live disk search results into file-index lookups so files created by tools are discoverable immediately while the async index refresh catches up.

👾 Generated with [Letta Code](https://letta.com)