### PR TITLE
feat(extensions): expose backend primitives

### DIFF
--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -1,5 +1,10 @@
 export type {
   ExtensionAgentContext,
+  ExtensionBackendApi,
+  ExtensionBackendForkConversationOptions,
+  ExtensionBackendMessage,
+  ExtensionBackendSendMessageOptions,
+  ExtensionBackendSendMessageRequestOptions,
   ExtensionBackgroundAgentContext,
   ExtensionCapabilities,
   ExtensionCapabilityKind,

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -66,14 +66,13 @@ export function useLocalExtensionRuntime(
   const getContext = useCallback(() => contextRef.current, []);
 
   const backend = useMemo<ExtensionBackendApi>(() => {
-    const activeBackend = getBackend();
     return {
       forkConversation(conversationId, options) {
-        return activeBackend.forkConversation(conversationId, options);
+        return getBackend().forkConversation(conversationId, options);
       },
       sendMessageStream(conversationId, messages, options, requestOptions) {
         return sendMessageStreamWithBackend(
-          activeBackend,
+          getBackend(),
           conversationId,
           messages,
           options,

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -6,6 +6,8 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { debugLog } from "@/utils/debug";
 import {
@@ -13,7 +15,7 @@ import {
   type ExtensionHost,
   resolveLocalExtensionSources,
 } from "./local-extension-loader";
-import type { ExtensionContext } from "./types";
+import type { ExtensionBackendApi, ExtensionContext } from "./types";
 
 export interface LocalExtensionRuntime {
   hadStatuslineRenderer: boolean;
@@ -63,13 +65,32 @@ export function useLocalExtensionRuntime(
 
   const getContext = useCallback(() => contextRef.current, []);
 
+  const backend = useMemo<ExtensionBackendApi>(() => {
+    const activeBackend = getBackend();
+    return {
+      forkConversation(conversationId, options) {
+        return activeBackend.forkConversation(conversationId, options);
+      },
+      sendMessageStream(conversationId, messages, options, requestOptions) {
+        return sendMessageStreamWithBackend(
+          activeBackend,
+          conversationId,
+          messages,
+          options,
+          requestOptions,
+        );
+      },
+    };
+  }, []);
+
   const host = useMemo(
     () =>
       createExtensionHost({
+        backend,
         getClient,
         getContext,
       }),
-    [getContext],
+    [backend, getContext],
   );
 
   const registry = useSyncExternalStore(

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -12,11 +12,14 @@ import {
   getExtensionToolDefinition,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionBackendApi,
   ExtensionCapabilities,
   ExtensionPanelHandle,
 } from "@/extensions/types";
 
 type ExtensionTestGlobal = typeof globalThis & {
+  __lettaExtensionBackend?: ExtensionBackendApi;
+  __lettaExtensionForkResult?: { id: string };
   __lettaExtensionCapabilities?: ExtensionCapabilities;
   __lettaExtensionGate?: Promise<void>;
   __lettaExtensionPanel?: ExtensionPanelHandle;
@@ -31,9 +34,11 @@ function createTempDir(): string {
 function createHost(
   root: string,
   capabilities?: ExtensionCapabilities,
+  backend?: ExtensionBackendApi,
 ): ExtensionHost {
   return createExtensionHost({
     cacheDirectory: path.join(root, "extension-cache"),
+    ...(backend ? { backend } : {}),
     ...(capabilities ? { capabilities } : {}),
     getClient: async () => ({}) as unknown as Letta,
     globalExtensionsDirectory: path.join(root, "global-extensions"),
@@ -145,6 +150,55 @@ describe("extension host", () => {
       expect(Object.keys(snapshot.tools)).toEqual(["visible_tool"]);
     } finally {
       delete testGlobal.__lettaExtensionCapabilities;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("exposes configured backend to extensions", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ExtensionTestGlobal;
+    delete testGlobal.__lettaExtensionBackend;
+    delete testGlobal.__lettaExtensionForkResult;
+
+    const backend: ExtensionBackendApi = {
+      forkConversation: async (conversationId, options) => ({
+        id: `${conversationId}:${options?.hidden ? "hidden" : "visible"}`,
+      }),
+      sendMessageStream: async () =>
+        (async function* () {
+          // Empty stream for host plumbing tests.
+        })(),
+    };
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "backend.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default async function(letta) {
+          globalThis.__lettaExtensionBackend = letta.backend;
+          globalThis.__lettaExtensionForkResult = await letta.backend.forkConversation("conv-1", { hidden: true });
+        }`,
+      );
+
+      const host = createHost(root, undefined, backend);
+      await host.reload();
+
+      const observedBackend = testGlobal.__lettaExtensionBackend as
+        | ExtensionBackendApi
+        | undefined;
+      const forkResult = testGlobal.__lettaExtensionForkResult as
+        | { id: string }
+        | undefined;
+      expect(observedBackend).toBe(backend);
+      expect(forkResult).toEqual({
+        id: "conv-1:hidden",
+      });
+      expect(host.getSnapshot().errors).toEqual([]);
+    } finally {
+      delete testGlobal.__lettaExtensionBackend;
+      delete testGlobal.__lettaExtensionForkResult;
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -31,6 +31,7 @@ import {
   unregisterExtensionToolsForOwner,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionBackendApi,
   ExtensionCapabilities,
   ExtensionCommand,
   ExtensionCommandRegistration,
@@ -80,6 +81,7 @@ export type LettaExtensionFactory = (
   | Promise<undefined | LettaExtensionDisposer>;
 
 export interface LettaExtensionApi {
+  backend?: ExtensionBackendApi;
   capabilities: ExtensionCapabilities;
   client: Letta;
   getClient: () => Promise<Letta>;
@@ -162,6 +164,7 @@ export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
+  backend?: ExtensionBackendApi;
   capabilities?: ExtensionCapabilities;
   generation?: number;
   onChange?: () => void;
@@ -181,6 +184,7 @@ export interface CreateExtensionHostOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
+  backend?: ExtensionBackendApi;
   capabilities?: ExtensionCapabilities;
   reservedCommandIds?: Iterable<string>;
   reservedToolNames?: Iterable<string>;
@@ -668,6 +672,7 @@ function upsertExtensionPanel(
 function createLettaExtensionApi(
   registry: LocalExtensionRegistry,
   owner: ExtensionOwner,
+  backend: ExtensionBackendApi | undefined,
   capabilities: ExtensionCapabilities,
   getClient: () => Promise<Letta>,
   getContext: () => ExtensionContext,
@@ -722,6 +727,7 @@ function createLettaExtensionApi(
   };
 
   return {
+    ...(backend ? { backend } : {}),
     capabilities: cloneExtensionCapabilities(capabilities),
     client: createLazyClient(getClient),
     getClient,
@@ -928,6 +934,7 @@ export async function loadLocalExtensions(
           createLettaExtensionApi(
             registry,
             owner,
+            options.backend,
             capabilities,
             getConfiguredClient,
             getContext,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,3 +1,9 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  ApprovalCreate,
+  LettaStreamingResponse,
+} from "@letta-ai/letta-client/resources/agents/messages";
+
 export interface ExtensionWorkspaceContext {
   cwd: string;
   currentDir: string;
@@ -66,6 +72,41 @@ export interface ExtensionCapabilities {
   tools: boolean;
   commands: boolean;
   ui: ExtensionUiCapabilities;
+}
+
+export interface ExtensionBackendForkConversationOptions {
+  agentId?: string;
+  hidden?: boolean;
+}
+
+export type ExtensionBackendMessage = MessageCreate | ApprovalCreate;
+
+export interface ExtensionBackendSendMessageOptions {
+  agentId?: string;
+  background?: boolean;
+  overrideModel?: string;
+  skipImageNormalization?: boolean;
+  streamTokens?: boolean;
+  workingDirectory?: string;
+}
+
+export interface ExtensionBackendSendMessageRequestOptions {
+  headers?: Record<string, string>;
+  maxRetries?: number;
+  signal?: AbortSignal;
+}
+
+export interface ExtensionBackendApi {
+  forkConversation: (
+    conversationId: string,
+    options?: ExtensionBackendForkConversationOptions,
+  ) => Promise<{ id: string }>;
+  sendMessageStream: (
+    conversationId: string,
+    messages: ExtensionBackendMessage[],
+    options?: ExtensionBackendSendMessageOptions,
+    requestOptions?: ExtensionBackendSendMessageRequestOptions,
+  ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }
 
 export type ExtensionSourceScope = "global" | "project" | "bundled";

--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -85,3 +85,4 @@ letta.capabilities.ui.customStatuslineRenderer
 - `references/tools.md` - extension tools the model can call
 - `references/commands.md` - slash commands, command results, and skill-backed commands
 - `references/ui.md` - panels, status values, capability guards
+- `references/btw-command.md` - advanced busy-safe side-question command using backend primitives

--- a/src/skills/builtin/creating-extensions/references/btw-command.md
+++ b/src/skills/builtin/creating-extensions/references/btw-command.md
@@ -1,10 +1,17 @@
 # `/btw` side-question extension example
 
-This example runs while the main agent is busy because it forks the conversation, uses the SDK directly, renders progress in a panel when panels are available, and returns `{ type: "handled" }` immediately.
+This example runs while the main agent is busy because it forks the conversation through the harness backend, streams a response in the fork, renders progress in a panel when panels are available, and returns `{ type: "handled" }` immediately.
 
 ```ts
 export default function activate(letta) {
   if (!letta.capabilities.commands) return;
+
+  function createOtid() {
+    return (
+      globalThis.crypto?.randomUUID?.() ??
+      `btw-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
+  }
 
   function appendAssistantText(chunk, parts) {
     if (chunk.message_type !== "assistant_message") return;
@@ -19,6 +26,10 @@ export default function activate(letta) {
           parts.push(String(part.text));
         }
       }
+      return;
+    }
+    if (content && typeof content === "object" && "text" in content) {
+      parts.push(String(content.text));
     }
   }
 
@@ -45,29 +56,43 @@ export default function activate(letta) {
 
       void (async () => {
         try {
-          const forked = await letta.client.conversations.fork(
-            ctx.conversation.id || "default",
-            { agent_id: ctx.agent.id },
-          );
-          const stream = await letta.client.conversations.messages.create(
-            forked.id,
-            {
-              agent_id: ctx.agent.id,
-              input: `${question}
+          if (!letta.backend) {
+            throw new Error("/btw requires letta.backend support");
+          }
 
-Answer briefly in 1-3 short sentences.`,
-              streaming: true,
+          const forked = await letta.backend.forkConversation(
+            ctx.conversation.id || "default",
+            { agentId: ctx.agent.id, hidden: true },
+          );
+          const stream = await letta.backend.sendMessageStream(
+            forked.id,
+            [
+              {
+                role: "user",
+                content: `${question}\n\nAnswer briefly in 1-3 short sentences.`,
+                otid: createOtid(),
+              },
+            ],
+            {
+              agentId: ctx.agent.id,
+              overrideModel: ctx.model.id ?? undefined,
+              workingDirectory: ctx.cwd,
             },
           );
 
           const parts = [];
           for await (const chunk of stream) {
             appendAssistantText(chunk, parts);
-            panel?.update({ content: [`/btw ${question}`, parts.join("") || "..."] });
+            panel?.update({
+              content: [`/btw ${question}`, parts.join("") || "..."],
+            });
           }
 
           panel?.update({
-            content: [`done /btw ${question}`, parts.join("").trim() || "No response."],
+            content: [
+              `done /btw ${question}`,
+              parts.join("").trim() || "No response.",
+            ],
           });
           if (panel) setTimeout(() => panel.close(), 10_000);
         } catch (error) {

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -91,24 +91,23 @@ export default function activate(letta) {
 }
 ```
 
-## Busy-safe SDK command
+## Busy-safe backend command
 
-For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use the SDK directly, update a panel if available, and return `{ type: "handled" }` quickly.
+For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use backend primitives directly, update a panel if available, and return `{ type: "handled" }` quickly.
 
-Use `letta.client` or `await letta.getClient()` instead of raw `fetch`; SDK initialization is lazy and uses the current backend/auth context.
+Use `letta.backend` for conversation operations that should work across local and Constellation backends. Use `letta.client` only for server-specific API calls.
 
 Common calls:
 
 ```ts
-await letta.client.conversations.fork(ctx.conversation.id || "default", {
-  agent_id: ctx.agent.id,
+const forked = await letta.backend.forkConversation(ctx.conversation.id, {
+  agentId: ctx.agent.id,
+  hidden: true,
 });
 
-await letta.client.conversations.messages.create(conversationId, {
-  agent_id: ctx.agent.id,
-  input,
-  streaming: true,
-});
+const stream = await letta.backend.sendMessageStream(forked.id, [
+  { role: "user", content: input },
+]);
 ```
 
 For a complete side-question example, see `btw-command.md`.


### PR DESCRIPTION
## Summary
- Add an optional `ExtensionBackendApi` with fork and message-stream primitives and expose it to extensions as `letta.backend`
- Wire the TUI extension runtime to resolve the active backend for extension backend calls
- Update extension authoring docs and the `/btw` recipe to use backend primitives instead of the server SDK

## Test plan
- [x] `bun run check`
- [x] `bun test src/extensions/extension-host.test.ts src/cli/extensions/local-extension-loader.test.ts`
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/creating-extensions`

👾 Generated with [Letta Code](https://letta.com)