### PR TITLE
fix(memory): surface no-op memory writes as errors instead of success

### DIFF
--- a/src/tools/impl/memory-apply-patch.ts
+++ b/src/tools/impl/memory-apply-patch.ts
@@ -129,7 +129,10 @@ export async function memory_apply_patch(
 
   const pathspecs = await applyMemoryPatch(memoryDir, input);
   if (pathspecs.length === 0) {
-    return { message: "memory_apply_patch completed with no changed paths." };
+    throw new Error(
+      "memory_apply_patch made no changes: the patch produced no changed paths. " +
+        "Verify the patch targets the intended file(s) and actually modifies content.",
+    );
   }
 
   const commitResult = await commitAndSyncMemoryWrite({
@@ -145,12 +148,13 @@ export async function memory_apply_patch(
     replay: async () => applyMemoryPatch(memoryDir, input),
   });
   if (!commitResult.committed) {
-    return {
-      message:
-        syncMode === "local"
-          ? "memory_apply_patch made no effective changes; skipped commit."
-          : "memory_apply_patch made no effective changes; skipped commit and push.",
-    };
+    throw new Error(
+      syncMode === "local"
+        ? "memory_apply_patch made no effective changes; nothing was committed. " +
+            "The patched content matched what was already on disk."
+        : "memory_apply_patch made no effective changes; nothing was committed or pushed. " +
+            "The patched content matched what was already on disk.",
+    );
   }
 
   if (commitResult.replayed && commitResult.replayNoop) {

--- a/src/tools/impl/memory.ts
+++ b/src/tools/impl/memory.ts
@@ -116,9 +116,10 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
 
   const affectedPaths = await applyMemoryCommand(memoryDir, args);
   if (affectedPaths.length === 0) {
-    return {
-      message: `Memory ${args.command} completed with no changed paths.`,
-    };
+    throw new Error(
+      `Memory ${args.command} made no changes: it produced no changed paths. ` +
+        "Verify the command targets the intended file(s) and actually modifies content.",
+    );
   }
 
   const commitResult = await commitAndSyncMemoryWrite({
@@ -135,12 +136,13 @@ export async function memory(args: MemoryArgs): Promise<MemoryResult> {
       applyMemoryCommand(memoryDir, args, { replaying: true }),
   });
   if (!commitResult.committed) {
-    return {
-      message:
-        syncMode === "local"
-          ? `Memory ${args.command} made no effective changes; skipped commit.`
-          : `Memory ${args.command} made no effective changes; skipped commit and push.`,
-    };
+    throw new Error(
+      syncMode === "local"
+        ? `Memory ${args.command} made no effective changes; nothing was committed. ` +
+            "The resulting content matched what was already on disk."
+        : `Memory ${args.command} made no effective changes; nothing was committed or pushed. ` +
+            "The resulting content matched what was already on disk.",
+    );
   }
 
   // Emit memory_updated push event so web UI auto-refreshes

--- a/src/tools/memory-apply-patch.test.ts
+++ b/src/tools/memory-apply-patch.test.ts
@@ -625,6 +625,42 @@ describe("memory_apply_patch tool", () => {
     expect(rescuedContent).toContain("new");
   });
 
+  test("throws when an update produces no effective changes", async () => {
+    await runScopedMemoryApplyPatch({
+      reason: "seed noop memory",
+      input: [
+        "*** Begin Patch",
+        "*** Add File: system/noop.md",
+        "+---",
+        "+description: Noop block",
+        "+---",
+        "+unchanged",
+        "*** End Patch",
+      ].join("\n"),
+    });
+
+    const headBefore = await runGit(memoryDir, ["rev-parse", "HEAD"]);
+
+    // Replacing a line with the identical text yields no on-disk diff.
+    await expect(
+      runScopedMemoryApplyPatch({
+        reason: "no-op update",
+        input: [
+          "*** Begin Patch",
+          "*** Update File: system/noop.md",
+          "@@",
+          "-unchanged",
+          "+unchanged",
+          "*** End Patch",
+        ].join("\n"),
+      }),
+    ).rejects.toThrow(/made no effective changes/i);
+
+    // No phantom commit should have been created.
+    const headAfter = await runGit(memoryDir, ["rev-parse", "HEAD"]);
+    expect(headAfter).toBe(headBefore);
+  });
+
   test("updates files that omit frontmatter limit", async () => {
     await runScopedMemoryApplyPatch({
       reason: "seed no-limit memory",

--- a/src/tools/memory-tool.test.ts
+++ b/src/tools/memory-tool.test.ts
@@ -529,4 +529,31 @@ describe("memory tool", () => {
       `The memory tool can only be used to modify files in {${memoryDir}} or provided as a relative path`,
     );
   });
+
+  test("throws when a str_replace produces no effective changes", async () => {
+    await runScopedMemory({
+      command: "create",
+      reason: "Seed noop notes",
+      file_path: "reference/history/notes.md",
+      description: "Notes block",
+      file_text: "unchanged value",
+    });
+
+    const headBefore = await runGit(memoryDir, ["rev-parse", "HEAD"]);
+
+    // Replacing a string with itself leaves the file byte-identical.
+    await expect(
+      runScopedMemory({
+        command: "str_replace",
+        reason: "no-op replacement",
+        file_path: "reference/history/notes.md",
+        old_string: "unchanged value",
+        new_string: "unchanged value",
+      }),
+    ).rejects.toThrow(/made no effective changes/i);
+
+    // No phantom commit should have been created.
+    const headAfter = await runGit(memoryDir, ["rev-parse", "HEAD"]);
+    expect(headAfter).toBe(headBefore);
+  });
 });


### PR DESCRIPTION
## Summary
- `memory_apply_patch` and `memory` returned a success-shaped `{ message }` on their no-change branches, but `manager.ts` classifies any non-throwing built-in tool result as `status: "success"`. As a result, no-op memory writes were recorded as successes in the structured `status`, telemetry (`trackToolUsage(..., success=true)`), and post-tool hooks — even though nothing was committed. (Ref: LET-8985)
- Both tools now throw on the true no-op branches (no changed paths / nothing committed), so the manager catch path maps them to `status: "error"` with a descriptive message. Legitimate success branches (replay no-op, replayed, committed) are unchanged.
- The git layer was already correct (`hasStagedMemoryChanges` gates commits), so no phantom commits were ever created — this is an observability/contract fix, not a data fix.

## Test plan
- [x] `bun test src/tools/memory-apply-patch.test.ts` (added: throws when an update produces no effective changes)
- [x] `bun test src/tools/memory-tool.test.ts` (added: throws when a str_replace produces no effective changes)
- [x] `bun run check` — 7/8 pass; the only failure is a pre-existing, unrelated TS error in `src/cli/commands/connect-local-oauth.ts` (present on `origin/main`, untouched here)

👾 Generated with [Letta Code](https://letta.com)