### PR TITLE
feat(extensions): bind backend to command context

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -3035,6 +3035,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               agent: { id: agentId, name: agentName },
               args: parsedExtensionCommand.args,
               argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
+              backend: extensionRuntime.getBackendApi(),
               command: parsedExtensionCommand.command,
               conversation: { id: conversationIdRef.current },
               cwd: getCurrentWorkingDirectory(),

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -7,7 +7,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { sendMessageStreamWithBackend } from "@/agent/message";
-import { getBackend } from "@/backend";
+import { type Backend, getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { debugLog } from "@/utils/debug";
 import {
@@ -23,6 +23,7 @@ export interface LocalExtensionRuntime {
   host: ExtensionHost;
   isLoading: boolean;
   registry: ReturnType<ExtensionHost["getSnapshot"]> | null;
+  getBackendApi: () => ExtensionBackendApi;
   getContext: () => ExtensionContext;
   reload: () => Promise<void>;
   updateContext: (context: ExtensionContext) => void;
@@ -38,6 +39,23 @@ function hasLocalExtensionSources(): boolean {
   return resolveLocalExtensionSources().some(
     (source) => source.files.length > 0,
   );
+}
+
+function createExtensionBackendApi(backend: Backend): ExtensionBackendApi {
+  return {
+    forkConversation(conversationId, options) {
+      return backend.forkConversation(conversationId, options);
+    },
+    sendMessageStream(conversationId, messages, options, requestOptions) {
+      return sendMessageStreamWithBackend(
+        backend,
+        conversationId,
+        messages,
+        options,
+        requestOptions,
+      );
+    },
+  };
 }
 
 export function useLocalExtensionRuntime(
@@ -65,14 +83,18 @@ export function useLocalExtensionRuntime(
 
   const getContext = useCallback(() => contextRef.current, []);
 
+  const getBackendApi = useCallback(
+    () => createExtensionBackendApi(getBackend()),
+    [],
+  );
+
   const backend = useMemo<ExtensionBackendApi>(() => {
     return {
       forkConversation(conversationId, options) {
-        return getBackend().forkConversation(conversationId, options);
+        return getBackendApi().forkConversation(conversationId, options);
       },
       sendMessageStream(conversationId, messages, options, requestOptions) {
-        return sendMessageStreamWithBackend(
-          getBackend(),
+        return getBackendApi().sendMessageStream(
           conversationId,
           messages,
           options,
@@ -80,7 +102,7 @@ export function useLocalExtensionRuntime(
         );
       },
     };
-  }, []);
+  }, [getBackendApi]);
 
   const host = useMemo(
     () =>
@@ -166,12 +188,21 @@ export function useLocalExtensionRuntime(
   return useMemo(
     () => ({
       registry,
+      getBackendApi,
       getContext,
       host,
       reload,
       updateContext,
       ...loadState,
     }),
-    [getContext, host, loadState, registry, reload, updateContext],
+    [
+      getBackendApi,
+      getContext,
+      host,
+      loadState,
+      registry,
+      reload,
+      updateContext,
+    ],
   );
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -180,6 +180,7 @@ export interface ExtensionCommandContext {
   command: string;
   args: string;
   argv: string[];
+  backend?: ExtensionBackendApi;
   cwd: string;
   agent: {
     id: string;

--- a/src/skills/builtin/creating-extensions/references/btw-command.md
+++ b/src/skills/builtin/creating-extensions/references/btw-command.md
@@ -56,15 +56,15 @@ export default function activate(letta) {
 
       void (async () => {
         try {
-          if (!letta.backend) {
-            throw new Error("/btw requires letta.backend support");
+          if (!ctx.backend) {
+            throw new Error("/btw requires backend support");
           }
 
-          const forked = await letta.backend.forkConversation(
+          const forked = await ctx.backend.forkConversation(
             ctx.conversation.id || "default",
             { agentId: ctx.agent.id, hidden: true },
           );
-          const stream = await letta.backend.sendMessageStream(
+          const stream = await ctx.backend.sendMessageStream(
             forked.id,
             [
               {

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -95,17 +95,19 @@ export default function activate(letta) {
 
 For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use backend primitives directly, update a panel if available, and return `{ type: "handled" }` quickly.
 
-Use `letta.backend` for conversation operations that should work across local and Constellation backends. Use `letta.client` only for server-specific API calls.
+Use `ctx.backend` for conversation operations that should work across local and Constellation backends. `ctx.backend` is bound to the backend active for that command invocation, so composed flows like fork-then-send stay on the same backend. Use `letta.client` only for server-specific API calls.
 
 Common calls:
 
 ```ts
-const forked = await letta.backend.forkConversation(ctx.conversation.id, {
+if (!ctx.backend) throw new Error("This command requires backend support");
+
+const forked = await ctx.backend.forkConversation(ctx.conversation.id, {
   agentId: ctx.agent.id,
   hidden: true,
 });
 
-const stream = await letta.backend.sendMessageStream(forked.id, [
+const stream = await ctx.backend.sendMessageStream(forked.id, [
   { role: "user", content: input },
 ]);
 ```


### PR DESCRIPTION
## Summary
- Add `ctx.backend` to extension command contexts as an invocation-scoped backend handle
- Keep `letta.backend` available while making command recipes prefer `ctx.backend` for multi-step flows
- Update the `/btw` and busy-safe command docs to use the command-scoped backend

## Test plan
- [x] `bun run check`
- [x] `bun test src/extensions/extension-host.test.ts src/cli/extensions/local-extension-loader.test.ts`
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/creating-extensions`

👾 Generated with [Letta Code](https://letta.com)