### PR TITLE
ci: cap build job test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
     if: needs.classify.outputs.run_heavy_ci == 'true'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -169,6 +170,7 @@ jobs:
         uses: t1m0thyj/unlock-keyring@v1
 
       - name: Run tests (extended timeout)
+        timeout-minutes: 15
         # Unit tests must pass for fork PRs (no secrets). Keep API-dependent tests
         # in a separate gated step.
         run: node scripts/run-unit-tests.cjs


### PR DESCRIPTION
## Summary
- Add a 30 minute timeout to the cross-platform build matrix job
- Add a 15 minute timeout to the unit test step so hung tests fail promptly instead of running for hours

## Test plan
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)