### PR TITLE
refactor(extensions): extract shared runtime

### DIFF
--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -13,6 +13,8 @@ import {
   loadLocalExtensions as loadLocalExtensionsBase,
   resolveLocalExtensionSources,
 } from "@/extensions/extension-host";
+import type { CreateExtensionRuntimeOptions } from "@/extensions/extension-runtime";
+import { createExtensionRuntime as createExtensionRuntimeBase } from "@/extensions/extension-runtime";
 import type { ExtensionCapabilities } from "@/extensions/types";
 import { getAllLettaToolNames, getServerToolName } from "@/tools/manager";
 import { TUI_EXTENSION_CAPABILITIES } from "./capabilities";
@@ -59,6 +61,10 @@ export function createExtensionHost(options: CreateExtensionHostOptions) {
   return createExtensionHostBase(withDefaultReservations(options));
 }
 
+export function createExtensionRuntime(options: CreateExtensionRuntimeOptions) {
+  return createExtensionRuntimeBase(withDefaultReservations(options));
+}
+
 export function loadLocalExtensions(options: LoadLocalExtensionsOptions) {
   return loadLocalExtensionsBase(withDefaultReservations(options));
 }
@@ -88,4 +94,10 @@ export type {
   ResolveLocalExtensionSourcesOptions,
   StatuslineRenderFunction,
 } from "@/extensions/extension-host";
+export type {
+  CreateExtensionRuntimeOptions,
+  ExtensionRuntime,
+  ExtensionRuntimeLoadState,
+  ExtensionRuntimeSnapshot,
+} from "@/extensions/extension-runtime";
 export { TUI_EXTENSION_CAPABILITIES } from "./capabilities";

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -1,19 +1,11 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { sendMessageStreamWithBackend } from "@/agent/message";
 import { type Backend, getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
-import { debugLog } from "@/utils/debug";
 import {
-  createExtensionHost,
-  type ExtensionHost,
-  resolveLocalExtensionSources,
+  createExtensionRuntime,
+  type ExtensionRuntime,
+  type ExtensionRuntimeSnapshot,
 } from "./local-extension-loader";
 import type {
   ExtensionBackendApi,
@@ -24,31 +16,19 @@ import type {
 } from "./types";
 
 export interface LocalExtensionRuntime {
-  hadStatuslineRenderer: boolean;
-  hasExtensionSources: boolean;
-  host: ExtensionHost;
-  isLoading: boolean;
-  registry: ReturnType<ExtensionHost["getSnapshot"]> | null;
-  getBackendApi: () => ExtensionBackendApi;
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
   ) => Promise<ExtensionEventEmissionResult>;
+  getBackendApi: () => ExtensionBackendApi | undefined;
   getContext: () => ExtensionContext;
-  reload: () => Promise<void>;
-  updateContext: (context: ExtensionContext) => void;
-}
-
-interface LocalExtensionLoadState {
   hadStatuslineRenderer: boolean;
   hasExtensionSources: boolean;
+  host: ExtensionRuntime["host"];
   isLoading: boolean;
-}
-
-function hasLocalExtensionSources(): boolean {
-  return resolveLocalExtensionSources().some(
-    (source) => source.files.length > 0,
-  );
+  registry: ExtensionRuntimeSnapshot["registry"];
+  reload: () => Promise<void>;
+  updateContext: (context: ExtensionContext) => void;
 }
 
 function createExtensionBackendApi(backend: Backend): ExtensionBackendApi {
@@ -71,158 +51,48 @@ function createExtensionBackendApi(backend: Backend): ExtensionBackendApi {
 export function useLocalExtensionRuntime(
   initialContext: ExtensionContext,
 ): LocalExtensionRuntime {
-  const contextRef = useRef(initialContext);
-  const mountedRef = useRef(false);
-  const [loadState, setLoadState] = useState<LocalExtensionLoadState>(() => {
-    const hasExtensionSources = hasLocalExtensionSources();
-    return {
-      hadStatuslineRenderer: false,
-      hasExtensionSources,
-      isLoading: hasExtensionSources,
-    };
-  });
-  const loadStateRef = useRef(loadState);
-
-  useEffect(() => {
-    loadStateRef.current = loadState;
-  }, [loadState]);
-
-  const updateContext = useCallback((context: ExtensionContext) => {
-    contextRef.current = context;
-  }, []);
-
-  const getContext = useCallback(() => contextRef.current, []);
-
-  const getBackendApi = useCallback(
-    () => createExtensionBackendApi(getBackend()),
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the runtime is process-local; context updates are pushed through updateContext below.
+  const runtime = useMemo(
+    () =>
+      createExtensionRuntime({
+        getBackendApi: () => createExtensionBackendApi(getBackend()),
+        getClient,
+        initialContext,
+      }),
     [],
   );
 
-  const backend = useMemo<ExtensionBackendApi>(() => {
-    return {
-      forkConversation(conversationId, options) {
-        return getBackendApi().forkConversation(conversationId, options);
-      },
-      sendMessageStream(conversationId, messages, options, requestOptions) {
-        return getBackendApi().sendMessageStream(
-          conversationId,
-          messages,
-          options,
-          requestOptions,
-        );
-      },
-    };
-  }, [getBackendApi]);
-
-  const host = useMemo(
-    () =>
-      createExtensionHost({
-        backend,
-        getClient,
-        getContext,
-      }),
-    [backend, getContext],
-  );
-
-  const registry = useSyncExternalStore(
-    host.subscribe,
-    host.getSnapshot,
-    host.getSnapshot,
-  );
-
-  const emitEvent = useCallback(
-    <TName extends ExtensionEventName>(
-      name: TName,
-      event: ExtensionEventMap[TName],
-    ) => host.emitEvent(name, event),
-    [host],
+  const snapshot = useSyncExternalStore(
+    runtime.subscribe,
+    runtime.getSnapshot,
+    runtime.getSnapshot,
   );
 
   useEffect(() => {
-    contextRef.current = initialContext;
-  }, [initialContext]);
-
-  const reload = useCallback(async () => {
-    const previousSnapshot = host.getSnapshot();
-    const previousHadStatuslineRenderer =
-      Boolean(previousSnapshot.ui.statuslineRenderer) ||
-      loadStateRef.current.hadStatuslineRenderer;
-    const hasExtensionSources = hasLocalExtensionSources();
-    setLoadState({
-      hadStatuslineRenderer: previousHadStatuslineRenderer,
-      hasExtensionSources,
-      isLoading: true,
-    });
-
-    await host.reload();
-    const nextRegistry = host.getSnapshot();
-
-    debugLog(
-      "extensions",
-      "loaded %s extension(s) from %s source(s); renderer=%s",
-      nextRegistry.loadedPaths.length,
-      nextRegistry.sources.length,
-      nextRegistry.ui.statuslineRenderer?.id ?? "(none)",
-    );
-
-    for (const loadError of nextRegistry.errors) {
-      debugLog(
-        "extensions",
-        "failed to load %s: %s",
-        loadError.path,
-        loadError.error.message,
-      );
-    }
-
-    if (!mountedRef.current) {
-      host.dispose();
-      return;
-    }
-
-    const nextHasExtensionSources = nextRegistry.sources.some(
-      (source) => source.files.length > 0,
-    );
-    const nextHadStatuslineRenderer = Boolean(
-      nextRegistry.ui.statuslineRenderer,
-    );
-
-    setLoadState({
-      hadStatuslineRenderer: nextHadStatuslineRenderer,
-      hasExtensionSources: nextHasExtensionSources,
-      isLoading: false,
-    });
-  }, [host]);
+    runtime.updateContext(initialContext);
+  }, [initialContext, runtime]);
 
   useEffect(() => {
-    mountedRef.current = true;
-    void reload();
+    void runtime.reload();
 
     return () => {
-      mountedRef.current = false;
-      host.dispose();
+      runtime.dispose();
     };
-  }, [host, reload]);
+  }, [runtime]);
 
   return useMemo(
     () => ({
-      registry,
-      getBackendApi,
-      emitEvent,
-      getContext,
-      host,
-      reload,
-      updateContext,
-      ...loadState,
+      emitEvent: runtime.emitEvent,
+      getBackendApi: runtime.getBackendApi,
+      getContext: runtime.getContext,
+      hadStatuslineRenderer: snapshot.hadStatuslineRenderer,
+      hasExtensionSources: snapshot.hasExtensionSources,
+      host: runtime.host,
+      isLoading: snapshot.isLoading,
+      registry: snapshot.registry,
+      reload: runtime.reload,
+      updateContext: runtime.updateContext,
     }),
-    [
-      emitEvent,
-      getBackendApi,
-      getContext,
-      host,
-      loadState,
-      registry,
-      reload,
-      updateContext,
-    ],
+    [runtime, snapshot],
   );
 }

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -305,7 +305,7 @@ describe("extension host", () => {
         `export default function(letta) {
           letta.events.on("conversation_open", (event, ctx) => {
             globalThis.__lettaExtensionEvents.push(
-              event.reason + ":" + event.agentId + ":" + ctx.context.agent.name,
+              event.reason + ":" + event.agentId + ":" + ctx.context.agent.name + ":" + Boolean(ctx.backend),
             );
             letta.ui.setStatus("lifecycle", event.reason);
           });
@@ -315,7 +315,11 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
+      const backend: ExtensionBackendApi = {
+        forkConversation: async () => ({ id: "forked" }),
+        sendMessageStream: async () => (async function* () {})(),
+      };
+      const host = createHost(root, undefined, backend);
       await host.reload();
       expect(host.getSnapshot().events.conversation_open).toHaveLength(2);
 
@@ -333,7 +337,7 @@ describe("extension host", () => {
       });
       expect(result.diagnostics).toHaveLength(1);
       expect(testGlobal.__lettaExtensionEvents).toEqual([
-        "startup:agent-1:Amelia",
+        "startup:agent-1:Amelia:true",
       ]);
       expect(snapshot.ui.statusValues.lifecycle).toBe("startup");
       expect(snapshot.errors.at(-1)).toMatchObject({

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -199,6 +199,7 @@ export interface ExtensionHost {
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
+    backend?: ExtensionBackendApi,
   ) => Promise<ExtensionEventEmissionResult>;
   getSnapshot: () => LocalExtensionRegistry;
   reload: () => Promise<void>;
@@ -1113,6 +1114,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
   name: TName,
   event: ExtensionEventMap[TName],
   getContext: () => ExtensionContext,
+  backend?: ExtensionBackendApi,
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
 ): Promise<ExtensionEventEmissionResult> {
   if (!registry) {
@@ -1132,6 +1134,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
     try {
       const context = getContext();
       const eventContext: ExtensionEventContext = {
+        ...(backend ? { backend } : {}),
         context,
         getContext,
         signal: signal ?? new AbortController().signal,
@@ -1290,7 +1293,7 @@ export function createExtensionHost(
       publish();
       listeners.clear();
     },
-    async emitEvent(name, payload) {
+    async emitEvent(name, payload, backend) {
       if (disposed) {
         return { diagnostics: [], handlerCount: 0, name };
       }
@@ -1299,6 +1302,7 @@ export function createExtensionHost(
         name,
         payload,
         getContext,
+        backend ?? options.backend,
       );
       if (result.diagnostics.length > 0) {
         publish();

--- a/src/extensions/extension-runtime.test.ts
+++ b/src/extensions/extension-runtime.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type Letta from "@letta-ai/letta-client";
+import { createExtensionRuntime } from "@/extensions/extension-runtime";
+import type { ExtensionBackendApi, ExtensionContext } from "@/extensions/types";
+
+type ExtensionRuntimeTestGlobal = typeof globalThis & {
+  __lettaRuntimeEvents?: string[];
+};
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "letta-extension-runtime-"));
+}
+
+function createExtensionContext(agentName = "Amelia"): ExtensionContext {
+  return {
+    app: { version: "test" },
+    backgroundAgents: [],
+    contextWindow: {
+      currentUsage: null,
+      remainingPercentage: null,
+      size: 200000,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      usedPercentage: null,
+    },
+    cost: {
+      totalApiDurationMs: 0,
+      totalCostUsd: null,
+      totalDurationMs: 0,
+      totalLinesAdded: null,
+      totalLinesRemoved: null,
+    },
+    cwd: "/tmp/project",
+    lastRunId: null,
+    memfs: { enabled: false, memoryDir: null },
+    model: {
+      displayName: "Sonnet",
+      id: "model-1",
+      provider: "anthropic",
+      reasoningEffort: null,
+    },
+    networkPhase: null,
+    permissionMode: "standard",
+    reflection: { mode: null, stepCount: 0 },
+    sessionId: "conversation-1",
+    systemPromptId: null,
+    terminalWidth: 80,
+    toolset: "default",
+    agent: { id: "agent-1", name: agentName },
+    workspace: {
+      cwd: "/tmp/project",
+      currentDir: "/tmp/project",
+      projectDir: "/tmp/project",
+    },
+  };
+}
+
+describe("extension runtime", () => {
+  test("loads extensions and dispatches events with fresh context and backend", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ExtensionRuntimeTestGlobal;
+    testGlobal.__lettaRuntimeEvents = [];
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "events.ts"),
+        `export default function(letta) {
+          letta.events.on("conversation_open", async (event, ctx) => {
+            const fork = await ctx.backend.forkConversation(event.conversationId, { hidden: true });
+            globalThis.__lettaRuntimeEvents.push(
+              event.reason + ":" + ctx.context.agent.name + ":" + fork.id,
+            );
+          });
+        }`,
+      );
+
+      const backend: ExtensionBackendApi = {
+        forkConversation: async () => ({ id: "forked-conversation" }),
+        sendMessageStream: async () => (async function* () {})(),
+      };
+      const runtime = createExtensionRuntime({
+        cacheDirectory: path.join(root, "extension-cache"),
+        getBackendApi: () => backend,
+        getClient: async () => ({}) as unknown as Letta,
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        hasExtensionSources: true,
+        isLoading: true,
+      });
+      expect(runtime.getSnapshot()).toBe(runtime.getSnapshot());
+
+      await runtime.reload();
+      runtime.updateContext(createExtensionContext("Updated Agent"));
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        hasExtensionSources: true,
+        isLoading: false,
+      });
+      expect(runtime.getSnapshot().registry.loadedPaths).toHaveLength(1);
+
+      await runtime.emitEvent("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Updated Agent",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+
+      expect(testGlobal.__lettaRuntimeEvents).toEqual([
+        "startup:Updated Agent:forked-conversation",
+      ]);
+
+      runtime.dispose();
+    } finally {
+      delete testGlobal.__lettaRuntimeEvents;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/extensions/extension-runtime.ts
+++ b/src/extensions/extension-runtime.ts
@@ -1,0 +1,203 @@
+import type Letta from "@letta-ai/letta-client";
+import {
+  type CreateExtensionHostOptions,
+  createExtensionHost,
+  type ExtensionHost,
+  resolveLocalExtensionSources,
+} from "@/extensions/extension-host";
+import type {
+  ExtensionBackendApi,
+  ExtensionContext,
+  ExtensionEventEmissionResult,
+  ExtensionEventMap,
+  ExtensionEventName,
+} from "@/extensions/types";
+import { debugLog } from "@/utils/debug";
+
+export interface ExtensionRuntimeLoadState {
+  hadStatuslineRenderer: boolean;
+  hasExtensionSources: boolean;
+  isLoading: boolean;
+}
+
+export interface ExtensionRuntimeSnapshot extends ExtensionRuntimeLoadState {
+  registry: ReturnType<ExtensionHost["getSnapshot"]>;
+}
+
+export interface CreateExtensionRuntimeOptions
+  extends Omit<CreateExtensionHostOptions, "backend" | "getContext"> {
+  getBackendApi?: () => ExtensionBackendApi | undefined;
+  getClient: () => Promise<Letta>;
+  initialContext: ExtensionContext;
+}
+
+export interface ExtensionRuntime {
+  dispose: () => void;
+  emitEvent: <TName extends ExtensionEventName>(
+    name: TName,
+    event: ExtensionEventMap[TName],
+  ) => Promise<ExtensionEventEmissionResult>;
+  getBackendApi: () => ExtensionBackendApi | undefined;
+  getContext: () => ExtensionContext;
+  getSnapshot: () => ExtensionRuntimeSnapshot;
+  host: ExtensionHost;
+  reload: () => Promise<void>;
+  subscribe: (listener: () => void) => () => void;
+  updateContext: (context: ExtensionContext) => void;
+}
+
+function hasExtensionSources(
+  options: Pick<
+    CreateExtensionRuntimeOptions,
+    "cacheDirectory" | "globalExtensionsDirectory"
+  >,
+): boolean {
+  return resolveLocalExtensionSources(options).some(
+    (source) => source.files.length > 0,
+  );
+}
+
+function createActivationBackendApi(
+  getBackendApi: () => ExtensionBackendApi | undefined,
+): ExtensionBackendApi {
+  const requireBackend = () => {
+    const backend = getBackendApi();
+    if (!backend) {
+      throw new Error("Extension backend is not available");
+    }
+    return backend;
+  };
+
+  return {
+    forkConversation(conversationId, options) {
+      return requireBackend().forkConversation(conversationId, options);
+    },
+    sendMessageStream(conversationId, messages, options, requestOptions) {
+      return requireBackend().sendMessageStream(
+        conversationId,
+        messages,
+        options,
+        requestOptions,
+      );
+    },
+  };
+}
+
+export function createExtensionRuntime(
+  options: CreateExtensionRuntimeOptions,
+): ExtensionRuntime {
+  const {
+    getBackendApi: resolveBackendApi,
+    initialContext,
+    ...hostOptions
+  } = options;
+  let context = initialContext;
+  let disposed = false;
+  const initialHasExtensionSources = hasExtensionSources(hostOptions);
+  let loadState: ExtensionRuntimeLoadState = {
+    hadStatuslineRenderer: false,
+    hasExtensionSources: initialHasExtensionSources,
+    isLoading: initialHasExtensionSources,
+  };
+  const listeners = new Set<() => void>();
+
+  const getBackendApi = () => resolveBackendApi?.();
+  const getContext = () => context;
+  const backend = resolveBackendApi
+    ? createActivationBackendApi(getBackendApi)
+    : undefined;
+
+  const host = createExtensionHost({
+    ...hostOptions,
+    ...(backend ? { backend } : {}),
+    getContext,
+  });
+
+  const buildSnapshot = (): ExtensionRuntimeSnapshot => ({
+    registry: host.getSnapshot(),
+    ...loadState,
+  });
+  let snapshot = buildSnapshot();
+
+  const publish = () => {
+    snapshot = buildSnapshot();
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const unsubscribeHost = host.subscribe(publish);
+
+  const getSnapshot = () => snapshot;
+
+  const reload = async () => {
+    if (disposed) return;
+
+    const previousSnapshot = host.getSnapshot();
+    const previousHadStatuslineRenderer =
+      Boolean(previousSnapshot.ui.statuslineRenderer) ||
+      loadState.hadStatuslineRenderer;
+    loadState = {
+      hadStatuslineRenderer: previousHadStatuslineRenderer,
+      hasExtensionSources: hasExtensionSources(hostOptions),
+      isLoading: true,
+    };
+    publish();
+
+    await host.reload();
+    if (disposed) return;
+
+    const nextRegistry = host.getSnapshot();
+    debugLog(
+      "extensions",
+      "loaded %s extension(s) from %s source(s); renderer=%s",
+      nextRegistry.loadedPaths.length,
+      nextRegistry.sources.length,
+      nextRegistry.ui.statuslineRenderer?.id ?? "(none)",
+    );
+
+    for (const loadError of nextRegistry.errors) {
+      debugLog(
+        "extensions",
+        "failed to load %s: %s",
+        loadError.path,
+        loadError.error.message,
+      );
+    }
+
+    loadState = {
+      hadStatuslineRenderer: Boolean(nextRegistry.ui.statuslineRenderer),
+      hasExtensionSources: nextRegistry.sources.some(
+        (source) => source.files.length > 0,
+      ),
+      isLoading: false,
+    };
+    publish();
+  };
+
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      host.dispose();
+      unsubscribeHost();
+      listeners.clear();
+    },
+    emitEvent(name, event) {
+      return host.emitEvent(name, event, getBackendApi());
+    },
+    getBackendApi,
+    getContext,
+    getSnapshot,
+    host,
+    reload,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    updateContext(nextContext) {
+      context = nextContext;
+    },
+  };
+}

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -165,6 +165,7 @@ export interface ExtensionEventResultMap {
 }
 
 export interface ExtensionEventContext {
+  backend?: ExtensionBackendApi;
   context: ExtensionContext;
   getContext: () => ExtensionContext;
   signal: AbortSignal;

--- a/src/skills/builtin/creating-extensions/references/events.md
+++ b/src/skills/builtin/creating-extensions/references/events.md
@@ -83,11 +83,14 @@ Handlers also receive:
 
 ```ts
 {
+  backend?: letta.backend;
   context: letta.getContext();
   getContext: () => letta.getContext();
   signal: AbortSignal;
 }
 ```
+
+`ctx.backend` is bound when the event is dispatched. Use it for backend calls made while handling that event.
 
 Respect `ctx.signal` for long-running async work. It is aborted on `/reload` and app shutdown.
 


### PR DESCRIPTION
## Summary
- add a surface-independent `createExtensionRuntime` that owns extension host creation, reload/dispose, snapshots, context updates, and event dispatch
- simplify the TUI `useLocalExtensionRuntime` hook to wrap the shared runtime while preserving current behavior
- pass a dispatch-scoped backend handle through extension event context as `ctx.backend`

## Test plan
- [x] `bun test src/extensions/extension-runtime.test.ts src/extensions/extension-host.test.ts src/cli/extensions/local-extension-loader.test.ts`
- [x] `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/creating-extensions`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)