### PR TITLE
feat(extensions): mount lifecycle runtime in headless

### DIFF
--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import {
+  createHeadlessExtensionContext,
+  HEADLESS_EXTENSION_CAPABILITIES,
+} from "@/headless-extension-runtime";
+
+function readHeadlessSource(): string {
+  return readFileSync(
+    fileURLToPath(new URL("./headless.ts", import.meta.url)),
+    "utf-8",
+  );
+}
+
+describe("headless extension lifecycle", () => {
+  test("uses lifecycle-only extension capabilities", () => {
+    expect(HEADLESS_EXTENSION_CAPABILITIES).toEqual({
+      tools: false,
+      commands: false,
+      events: {
+        lifecycle: true,
+      },
+      ui: {
+        panels: false,
+        statusValues: false,
+        customStatuslineRenderer: false,
+      },
+    });
+  });
+
+  test("builds extension context for headless lifecycle events", () => {
+    const context = createHeadlessExtensionContext({
+      agent: {
+        id: "agent-1",
+        name: "Amelia",
+        llm_config: {
+          context_window: 200000,
+          model: "opus",
+          reasoning_effort: "high",
+        },
+      } as AgentState,
+      conversationId: "conversation-1",
+      lastRunId: "run-1",
+      permissionMode: "unrestricted",
+      reflectionSettings: { trigger: "step-count", stepCount: 3 },
+    });
+
+    expect(context.agent).toEqual({ id: "agent-1", name: "Amelia" });
+    expect(context.sessionId).toBe("conversation-1");
+    expect(context.lastRunId).toBe("run-1");
+    expect(context.permissionMode).toBe("unrestricted");
+    expect(context.reflection).toEqual({ mode: "step-count", stepCount: 3 });
+    expect(context.contextWindow.size).toBe(200000);
+  });
+
+  test("loads the runtime before headless modes and emits lifecycle events on exit", () => {
+    const source = readHeadlessSource();
+
+    const runtimeIndex = source.indexOf(
+      "const headlessExtensionRuntime = createHeadlessExtensionRuntime",
+    );
+    const bidirectionalIndex = source.indexOf(
+      "// If input-format is stream-json, use bidirectional mode",
+    );
+    expect(runtimeIndex).toBeGreaterThan(-1);
+    expect(bidirectionalIndex).toBeGreaterThan(runtimeIndex);
+
+    expect(source).toContain("await headlessExtensionRuntime.reload()");
+    expect(source).toContain("await emitHeadlessConversationOpen({");
+    expect(source).toContain("await emitHeadlessConversationClose({");
+    expect(source).toContain("headlessExtensionRuntime.dispose()");
+  });
+});

--- a/src/headless-extension-runtime.ts
+++ b/src/headless-extension-runtime.ts
@@ -1,0 +1,196 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import { getModelInfo } from "@/agent/model";
+import type { SessionStats } from "@/agent/stats";
+import type { Backend } from "@/backend";
+import { getClient } from "@/backend/api/client";
+import type { ReflectionSettings } from "@/cli/helpers/memory-reminder";
+import {
+  createExtensionRuntime,
+  type ExtensionRuntime,
+} from "@/extensions/extension-runtime";
+import type {
+  ExtensionBackendApi,
+  ExtensionCapabilities,
+  ExtensionContext,
+  ExtensionConversationOpenReason,
+} from "@/extensions/types";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { settingsManager } from "@/settings-manager";
+import { telemetry } from "@/telemetry";
+import { getVersion } from "@/version";
+
+export const HEADLESS_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: false,
+  commands: false,
+  events: {
+    lifecycle: true,
+  },
+  ui: {
+    panels: false,
+    statusValues: false,
+    customStatuslineRenderer: false,
+  },
+};
+
+function createHeadlessExtensionBackendApi(
+  backend: Backend,
+): ExtensionBackendApi {
+  return {
+    forkConversation(conversationId, options) {
+      return backend.forkConversation(conversationId, options);
+    },
+    sendMessageStream(conversationId, messages, options, requestOptions) {
+      return sendMessageStreamWithBackend(
+        backend,
+        conversationId,
+        messages,
+        options,
+        requestOptions,
+      );
+    },
+  };
+}
+
+function isHeadlessMemfsEnabled(agentId: string): boolean {
+  try {
+    return settingsManager.isMemfsEnabled(agentId);
+  } catch {
+    return false;
+  }
+}
+
+export function createHeadlessExtensionContext(options: {
+  agent: AgentState;
+  conversationId: string;
+  lastRunId?: string | null;
+  permissionMode?: string | null;
+  reflectionSettings?: ReflectionSettings;
+  sessionStats?: SessionStats | null;
+}): ExtensionContext {
+  const cwd = getCurrentWorkingDirectory();
+  const modelId = options.agent.llm_config?.model ?? null;
+  const modelInfo = modelId ? getModelInfo(modelId) : null;
+  const stats = options.sessionStats?.getSnapshot();
+  const contextWindowSize =
+    typeof options.agent.llm_config?.context_window === "number"
+      ? options.agent.llm_config.context_window
+      : 0;
+  const contextTokens = stats?.usage.contextTokens ?? null;
+  const usedPercentage =
+    contextWindowSize > 0 && typeof contextTokens === "number"
+      ? Math.max(
+          0,
+          Math.min(100, Math.round((contextTokens / contextWindowSize) * 100)),
+        )
+      : null;
+  const memfsEnabled = isHeadlessMemfsEnabled(options.agent.id);
+
+  return {
+    app: { version: getVersion() },
+    workspace: {
+      cwd,
+      currentDir: cwd,
+      projectDir: cwd,
+    },
+    cwd,
+    sessionId: options.conversationId,
+    lastRunId: options.lastRunId ?? null,
+    agent: {
+      id: options.agent.id,
+      name: options.agent.name ?? null,
+    },
+    model: {
+      id: modelId,
+      displayName: modelInfo?.label ?? modelId,
+      provider: modelInfo?.handle.split("/")[0] ?? null,
+      reasoningEffort:
+        typeof options.agent.llm_config?.reasoning_effort === "string"
+          ? options.agent.llm_config.reasoning_effort
+          : null,
+    },
+    toolset: null,
+    systemPromptId: null,
+    permissionMode: options.permissionMode ?? null,
+    networkPhase: null,
+    terminalWidth: process.stdout.columns ?? null,
+    contextWindow: {
+      size: contextWindowSize,
+      totalInputTokens: stats?.usage.promptTokens ?? 0,
+      totalOutputTokens: stats?.usage.completionTokens ?? 0,
+      usedPercentage,
+      remainingPercentage:
+        usedPercentage === null ? null : Math.max(0, 100 - usedPercentage),
+      currentUsage: null,
+    },
+    cost: {
+      totalDurationMs: stats?.totalWallMs ?? 0,
+      totalApiDurationMs: stats?.totalApiMs ?? 0,
+      totalCostUsd: null,
+      totalLinesAdded: null,
+      totalLinesRemoved: null,
+    },
+    reflection: {
+      mode: options.reflectionSettings?.trigger ?? null,
+      stepCount: options.reflectionSettings?.stepCount ?? 0,
+    },
+    memfs: {
+      enabled: memfsEnabled,
+      memoryDir: memfsEnabled
+        ? getScopedMemoryFilesystemRoot(options.agent.id)
+        : null,
+    },
+    backgroundAgents: [],
+  };
+}
+
+export function createHeadlessExtensionRuntime(options: {
+  agent: AgentState;
+  backend: Backend;
+  conversationId: string;
+  permissionMode?: string | null;
+  reflectionSettings?: ReflectionSettings;
+  sessionStats?: SessionStats | null;
+}): ExtensionRuntime {
+  return createExtensionRuntime({
+    capabilities: HEADLESS_EXTENSION_CAPABILITIES,
+    getBackendApi: () => createHeadlessExtensionBackendApi(options.backend),
+    getClient,
+    initialContext: createHeadlessExtensionContext(options),
+  });
+}
+
+export async function emitHeadlessConversationOpen(options: {
+  agent: AgentState;
+  conversationId: string;
+  reason: ExtensionConversationOpenReason;
+  runtime: ExtensionRuntime;
+}): Promise<void> {
+  if (!options.runtime.getSnapshot().hasExtensionSources) return;
+
+  await options.runtime.emitEvent("conversation_open", {
+    agentId: options.agent.id,
+    agentName: options.agent.name ?? null,
+    conversationId: options.conversationId,
+    reason: options.reason,
+  });
+}
+
+export async function emitHeadlessConversationClose(options: {
+  agent: AgentState;
+  conversationId: string;
+  durationMs: number | null;
+  runtime: ExtensionRuntime;
+}): Promise<void> {
+  if (!options.runtime.getSnapshot().hasExtensionSources) return;
+
+  await options.runtime.emitEvent("conversation_close", {
+    agentId: options.agent.id,
+    conversationId: options.conversationId,
+    durationMs: options.durationMs,
+    messageCount: telemetry.getMessageCount(),
+    reason: "quit",
+    toolCallCount: telemetry.getToolCallCount(),
+  });
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -92,6 +92,14 @@ import {
   validateRegistryHandleOrThrow,
 } from "./cli/startup-flag-validation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
+import type { ExtensionRuntime } from "./extensions/extension-runtime";
+import type { ExtensionConversationOpenReason } from "./extensions/types";
+import {
+  createHeadlessExtensionContext,
+  createHeadlessExtensionRuntime,
+  emitHeadlessConversationClose,
+  emitHeadlessConversationOpen,
+} from "./headless-extension-runtime";
 import { computeDiffPreviews } from "./helpers/diff-preview";
 import { formatPermissionDenial } from "./permissions/format-denial";
 import { QueueRuntime } from "./queue/queue-runtime";
@@ -1286,6 +1294,7 @@ export async function handleHeadlessCommand(
 
   // Determine which conversation to use
   let conversationId: string;
+  let conversationOpenReason: ExtensionConversationOpenReason = "startup";
   let effectiveReflectionSettings: ReflectionSettings;
 
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
@@ -1521,6 +1530,7 @@ export async function handleHeadlessCommand(
       // "default" is the agent's primary message history (no explicit conversation)
       // Don't validate - just use it directly
       conversationId = "default";
+      conversationOpenReason = "resume";
     } else {
       // User specified an explicit conversation to resume - validate it exists
       try {
@@ -1530,6 +1540,7 @@ export async function handleHeadlessCommand(
         );
         await backend.retrieveConversation(specifiedConversationId);
         conversationId = specifiedConversationId;
+        conversationOpenReason = "resume";
       } catch {
         console.error(
           `Error: Conversation ${specifiedConversationId} not found`,
@@ -1554,10 +1565,12 @@ export async function handleHeadlessCommand(
     }
     const conversation = await backend.createConversation(createParams);
     conversationId = conversation.id;
+    conversationOpenReason = "new";
   } else if (isSubagent) {
     // Freshly created subagents have no concurrency risk — use the default
     // conversation so it's easy to inspect in the ADE.
     conversationId = "default";
+    conversationOpenReason = "startup";
   } else {
     // Default for headless: always create a new conversation to avoid
     // 409 "conversation busy" races (e.g., parent agent calling letta -p).
@@ -1568,6 +1581,7 @@ export async function handleHeadlessCommand(
       isolated_block_labels: isolatedBlockLabels,
     });
     conversationId = conversation.id;
+    conversationOpenReason = "new";
   }
   markMilestone("HEADLESS_CONVERSATION_READY");
 
@@ -1622,6 +1636,32 @@ export async function handleHeadlessCommand(
       initialToolContext.preparedToolContext.effectiveModel;
   }
 
+  const sessionStats = new SessionStats();
+  const headlessPermissionMode = yoloMode
+    ? "unrestricted"
+    : typeof permissionModeValue === "string"
+      ? permissionModeValue
+      : null;
+  const headlessExtensionRuntime = createHeadlessExtensionRuntime({
+    agent,
+    backend,
+    conversationId,
+    permissionMode: headlessPermissionMode,
+    reflectionSettings: effectiveReflectionSettings,
+    sessionStats,
+  });
+  await headlessExtensionRuntime.reload();
+  try {
+    await emitHeadlessConversationOpen({
+      agent,
+      conversationId,
+      reason: conversationOpenReason,
+      runtime: headlessExtensionRuntime,
+    });
+  } catch {
+    // Extension lifecycle events should not block headless startup.
+  }
+
   // If input-format is stream-json, use bidirectional mode
   if (isBidirectionalMode) {
     await runBidirectionalMode(
@@ -1633,6 +1673,7 @@ export async function handleHeadlessCommand(
       resolvedSkillSources,
       systemInfoReminderEnabled,
       effectiveReflectionSettings,
+      headlessExtensionRuntime,
     );
     return;
   }
@@ -1640,20 +1681,44 @@ export async function handleHeadlessCommand(
   // Create buffers to accumulate stream (pass agent.id for server-side tool hooks)
   const buffers = createBuffers(agent.id);
 
-  // Initialize session stats
-  const sessionStats = new SessionStats();
   telemetry.setSessionStatsGetter(() => sessionStats.getSnapshot());
 
   // Use agent.id as session_id for all stream-json messages
   const sessionId = agent.id;
+  let headlessConversationClosed = false;
+  let lastKnownRunId: string | null = null;
   const exitHeadless = async (
     code: number,
     exitReason: string,
   ): Promise<never> => {
     try {
+      if (!headlessConversationClosed) {
+        headlessConversationClosed = true;
+        headlessExtensionRuntime.updateContext(
+          createHeadlessExtensionContext({
+            agent,
+            conversationId,
+            lastRunId: lastKnownRunId,
+            permissionMode: headlessPermissionMode,
+            reflectionSettings: effectiveReflectionSettings,
+            sessionStats,
+          }),
+        );
+        try {
+          await emitHeadlessConversationClose({
+            agent,
+            conversationId,
+            durationMs: sessionStats.getSnapshot().totalWallMs,
+            runtime: headlessExtensionRuntime,
+          });
+        } catch {
+          // Extension lifecycle events should not block headless shutdown.
+        }
+      }
       telemetry.trackSessionEnd(sessionStats.getSnapshot(), exitReason);
       await telemetry.flush();
     } finally {
+      headlessExtensionRuntime.dispose();
       telemetry.setSessionStatsGetter(undefined);
     }
     return await flushAndExit(code);
@@ -1922,7 +1987,6 @@ ${SYSTEM_REMINDER_CLOSE}
   }
 
   // Track lastRunId outside the while loop so it's available in catch block
-  let lastKnownRunId: string | null = null;
   let llmApiErrorRetries = 0;
   let emptyResponseRetries = 0;
   let conversationBusyRetries = 0;
@@ -2979,17 +3043,36 @@ async function runBidirectionalMode(
   skillSources: SkillSource[],
   systemInfoReminderEnabled: boolean,
   reflectionSettings: ReflectionSettings,
+  headlessExtensionRuntime: ExtensionRuntime,
 ): Promise<void> {
   const sessionId = agent.id;
   const backend = getBackend();
   const telemetryModelId = agent.llm_config?.model ?? "unknown";
   const readline = await import("node:readline");
+  let headlessConversationClosed = false;
   const exitBidirectional = async (
     code: number,
     exitReason: string,
   ): Promise<never> => {
-    telemetry.trackSessionEnd(undefined, exitReason);
-    await telemetry.flush();
+    try {
+      if (!headlessConversationClosed) {
+        headlessConversationClosed = true;
+        try {
+          await emitHeadlessConversationClose({
+            agent,
+            conversationId,
+            durationMs: null,
+            runtime: headlessExtensionRuntime,
+          });
+        } catch {
+          // Extension lifecycle events should not block headless shutdown.
+        }
+      }
+      telemetry.trackSessionEnd(undefined, exitReason);
+      await telemetry.flush();
+    } finally {
+      headlessExtensionRuntime.dispose();
+    }
     return await flushAndExit(code);
   };
 


### PR DESCRIPTION
## Summary
- mount the shared extension runtime in headless mode with lifecycle-only capabilities and tools/commands/UI disabled
- emit `conversation_open` and `conversation_close` from one-shot and bidirectional headless paths
- add headless lifecycle coverage for capabilities, context construction, and runtime wiring

## Test plan
- [x] `bun test src/headless-extension-lifecycle.test.ts src/extensions/extension-runtime.test.ts src/extensions/extension-host.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)