### PR TITLE
feat: securely store connection credentials in OS keyring

### DIFF
--- a/src/backend/fake-headless-backend.test.ts
+++ b/src/backend/fake-headless-backend.test.ts
@@ -50,11 +50,21 @@ describe("FakeHeadlessBackend", () => {
       } as ConversationMessageCreateBody),
     );
 
-    const dirs = await readdir(join(storageDir, "conversations"));
-    const firstDir = dirs[0];
-    if (!firstDir)
-      throw new Error("Expected a persisted conversation directory");
-    const conversationDir = join(storageDir, "conversations", firstDir);
+    const conversationsDir = join(storageDir, "conversations");
+    const dirs = await readdir(conversationsDir);
+    let conversationDir: string | undefined;
+    for (const dir of dirs) {
+      const candidateDir = join(conversationsDir, dir);
+      const candidate = JSON.parse(
+        await readFile(join(candidateDir, "conversation.json"), "utf8"),
+      ) as { id?: unknown };
+      if (candidate.id === conversation.id) {
+        conversationDir = candidateDir;
+        break;
+      }
+    }
+    if (!conversationDir)
+      throw new Error("Expected the persisted test conversation directory");
     const manifest = JSON.parse(
       await readFile(join(conversationDir, "manifest.json"), "utf8"),
     );

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -6,6 +6,13 @@ import {
   getChannelDir,
   readChannelConfig,
 } from "./config";
+import {
+  deleteChannelSecret,
+  getActiveChannelCredentialsStoreMode,
+  getCachedChannelCredentialsStoreMode,
+  getChannelSecret,
+  setChannelSecret,
+} from "./credential-store";
 import type {
   ChannelAccount,
   ChannelDefaultPermissionMode,
@@ -52,6 +59,13 @@ interface ChannelAccountStore {
 export const LEGACY_CHANNEL_ACCOUNT_ID = "__legacy_migrated__";
 
 const stores = new Map<string, ChannelAccountStore>();
+const CHANNEL_SECRET_REFS_KEY = "__letta_secret_refs";
+const SECRET_PRESENT_PLACEHOLDER = "__letta_channel_secret_present__";
+const pendingSecretWrites: Promise<unknown>[] = [];
+
+type ChannelAccountWithSecretRefs = ChannelAccount & {
+  [CHANNEL_SECRET_REFS_KEY]?: Record<string, true>;
+};
 
 let loadAccountsOverride:
   | ((channelId: string) => ChannelAccount[] | null)
@@ -59,6 +73,130 @@ let loadAccountsOverride:
 let saveAccountsOverride:
   | ((channelId: string, accounts: ChannelAccount[]) => void)
   | null = null;
+
+function isSecretPlaceholder(value: unknown): boolean {
+  return value === SECRET_PRESENT_PLACEHOLDER;
+}
+
+function getSecretFieldPaths(account: ChannelAccount): string[] {
+  if (isSlackChannelAccount(account)) {
+    return ["botToken", "appToken"];
+  }
+  if (isTelegramChannelAccount(account) || isDiscordChannelAccount(account)) {
+    return ["token"];
+  }
+  if (
+    isCustomChannelAccount(account) ||
+    !isFirstPartyChannelId(account.channel)
+  ) {
+    return ["config.bot_token", "config.auth"];
+  }
+  return [];
+}
+
+function getSecretValueFromAccount(
+  account: ChannelAccount,
+  fieldPath: string,
+): unknown {
+  if (fieldPath.startsWith("config.")) {
+    const key = fieldPath.slice("config.".length);
+    return (account as CustomChannelAccount).config?.[key];
+  }
+  return (account as unknown as Record<string, unknown>)[fieldPath];
+}
+
+function setSecretValueOnAccount(
+  account: ChannelAccount,
+  fieldPath: string,
+  value: string,
+): void {
+  if (fieldPath.startsWith("config.")) {
+    const key = fieldPath.slice("config.".length);
+    const customAccount = account as CustomChannelAccount;
+    customAccount.config = { ...(customAccount.config ?? {}), [key]: value };
+    return;
+  }
+  (account as unknown as Record<string, unknown>)[fieldPath] = value;
+}
+
+function deleteSecretValueFromAccount(
+  account: ChannelAccount,
+  fieldPath: string,
+): void {
+  if (fieldPath.startsWith("config.")) {
+    const key = fieldPath.slice("config.".length);
+    delete (account as CustomChannelAccount).config?.[key];
+    return;
+  }
+  delete (account as unknown as Record<string, unknown>)[fieldPath];
+}
+
+function getSecretRefs(account: ChannelAccount): Record<string, true> {
+  return {
+    ...((account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY] ??
+      {}),
+  };
+}
+
+function markSecretRef(account: ChannelAccount, fieldPath: string): void {
+  (account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY] = {
+    ...getSecretRefs(account),
+    [fieldPath]: true,
+  };
+}
+
+function unmarkSecretRef(account: ChannelAccount, fieldPath: string): void {
+  const refs = getSecretRefs(account);
+  delete refs[fieldPath];
+  if (Object.keys(refs).length === 0) {
+    delete (account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY];
+    return;
+  }
+  (account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY] = refs;
+}
+
+function applySecretPlaceholders(account: ChannelAccount): void {
+  const refs = getSecretRefs(account);
+  for (const fieldPath of Object.keys(refs)) {
+    const current = getSecretValueFromAccount(account, fieldPath);
+    if (typeof current !== "string" || current.length === 0) {
+      setSecretValueOnAccount(account, fieldPath, SECRET_PRESENT_PLACEHOLDER);
+    }
+  }
+}
+
+function queueSecretWrite(promise: Promise<unknown>): void {
+  pendingSecretWrites.push(
+    promise.catch((error) => {
+      console.warn("Failed to persist channel secret:", error);
+      throw error;
+    }),
+  );
+}
+
+function prepareAccountForStorage(account: ChannelAccount): ChannelAccount {
+  const cloned = cloneAccount(account) as ChannelAccountWithSecretRefs;
+  if (getCachedChannelCredentialsStoreMode() !== "keyring") {
+    delete cloned[CHANNEL_SECRET_REFS_KEY];
+    return cloned;
+  }
+
+  delete cloned[CHANNEL_SECRET_REFS_KEY];
+  for (const fieldPath of getSecretFieldPaths(cloned)) {
+    const value = getSecretValueFromAccount(cloned, fieldPath);
+    if (typeof value === "string" && value.trim().length > 0) {
+      markSecretRef(cloned, fieldPath);
+      if (!isSecretPlaceholder(value)) {
+        queueSecretWrite(
+          setChannelSecret(cloned.channel, cloned.accountId, fieldPath, value),
+        );
+      }
+      deleteSecretValueFromAccount(cloned, fieldPath);
+    }
+  }
+
+  return cloned;
+}
 
 function cloneAccount<T extends ChannelAccount>(account: T): T {
   const cloned = {
@@ -299,9 +437,11 @@ export function loadChannelAccounts(channelId: string): void {
       const text = readFileSync(path, "utf-8");
       const parsed = JSON.parse(text) as Partial<ChannelAccountStore>;
       stores.set(channelId, {
-        accounts: (parsed.accounts ?? []).map((account) =>
-          normalizeLoadedAccount(account),
-        ),
+        accounts: (parsed.accounts ?? []).map((account) => {
+          const normalized = normalizeLoadedAccount(account);
+          applySecretPlaceholders(normalized);
+          return normalized;
+        }),
       });
       return;
     } catch {
@@ -333,7 +473,7 @@ export function loadChannelAccounts(channelId: string): void {
 function saveChannelAccounts(channelId: string): void {
   const store = getStore(channelId);
   const writeAccounts = store.accounts.map((account) => {
-    const cloned = cloneAccount(account);
+    const cloned = prepareAccountForStorage(account);
     // Canonicalize: convert camelCase keys to snake_case for storage
     for (const [snakeKey, camelKey] of Object.entries(SNAKE_TO_CAMEL)) {
       const value = (cloned as unknown as Record<string, unknown>)[camelKey];
@@ -364,8 +504,71 @@ function saveChannelAccounts(channelId: string): void {
   );
 }
 
+export async function flushPendingChannelSecretWrites(): Promise<void> {
+  while (pendingSecretWrites.length > 0) {
+    const writes = pendingSecretWrites.splice(0, pendingSecretWrites.length);
+    await Promise.all(writes);
+  }
+}
+
+export async function hydrateChannelAccountSecrets(
+  channelId: string,
+): Promise<void> {
+  const mode = await getActiveChannelCredentialsStoreMode();
+  const store = getStore(channelId);
+  if (mode !== "keyring") {
+    return;
+  }
+
+  let migratedPlaintextSecrets = false;
+  let removedMissingSecretRefs = false;
+
+  for (const account of store.accounts) {
+    for (const fieldPath of getSecretFieldPaths(account)) {
+      const currentValue = getSecretValueFromAccount(account, fieldPath);
+      if (typeof currentValue === "string" && currentValue.trim().length > 0) {
+        markSecretRef(account, fieldPath);
+        if (!isSecretPlaceholder(currentValue)) {
+          await setChannelSecret(
+            account.channel,
+            account.accountId,
+            fieldPath,
+            currentValue,
+          );
+          migratedPlaintextSecrets = true;
+        } else {
+          const storedValue = await getChannelSecret(
+            account.channel,
+            account.accountId,
+            fieldPath,
+          );
+          if (storedValue) {
+            setSecretValueOnAccount(account, fieldPath, storedValue);
+          } else {
+            unmarkSecretRef(account, fieldPath);
+            setSecretValueOnAccount(account, fieldPath, "");
+            removedMissingSecretRefs = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (migratedPlaintextSecrets || removedMissingSecretRefs) {
+    saveChannelAccounts(channelId);
+    await flushPendingChannelSecretWrites();
+  }
+}
+
 export function listChannelAccounts(channelId: string): ChannelAccount[] {
   return getStore(channelId).accounts.map((account) => cloneAccount(account));
+}
+
+export async function listChannelAccountsWithSecrets(
+  channelId: string,
+): Promise<ChannelAccount[]> {
+  await hydrateChannelAccountSecrets(channelId);
+  return listChannelAccounts(channelId);
 }
 
 export function getChannelAccount(
@@ -376,6 +579,14 @@ export function getChannelAccount(
     (entry) => entry.accountId === accountId,
   );
   return account ? cloneAccount(account) : null;
+}
+
+export async function getChannelAccountWithSecrets(
+  channelId: string,
+  accountId: string,
+): Promise<ChannelAccount | null> {
+  await hydrateChannelAccountSecrets(channelId);
+  return getChannelAccount(channelId, accountId);
 }
 
 export function upsertChannelAccount(
@@ -396,6 +607,16 @@ export function upsertChannelAccount(
   return cloneAccount(next);
 }
 
+export async function upsertChannelAccountWithSecrets(
+  channelId: string,
+  account: ChannelAccount,
+): Promise<ChannelAccount> {
+  await getActiveChannelCredentialsStoreMode();
+  const next = upsertChannelAccount(channelId, account);
+  await flushPendingChannelSecretWrites();
+  return next;
+}
+
 export function removeChannelAccount(
   channelId: string,
   accountId: string,
@@ -410,6 +631,22 @@ export function removeChannelAccount(
   store.accounts = nextAccounts;
   saveChannelAccounts(channelId);
   return true;
+}
+
+export async function removeChannelAccountWithSecrets(
+  channelId: string,
+  accountId: string,
+): Promise<boolean> {
+  await hydrateChannelAccountSecrets(channelId);
+  const account = getChannelAccount(channelId, accountId);
+  if (account && getCachedChannelCredentialsStoreMode() === "keyring") {
+    await Promise.all(
+      getSecretFieldPaths(account).map((fieldPath) =>
+        deleteChannelSecret(channelId, accountId, fieldPath),
+      ),
+    );
+  }
+  return removeChannelAccount(channelId, accountId);
 }
 
 export function clearChannelAccountStores(): void {

--- a/src/channels/credential-store.test.ts
+++ b/src/channels/credential-store.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearChannelAccountStores,
+  flushPendingChannelSecretWrites,
+  getChannelAccountWithSecrets,
+  hydrateChannelAccountSecrets,
+  removeChannelAccountWithSecrets,
+  upsertChannelAccountWithSecrets,
+} from "@/channels/accounts";
+import { __testOverrideChannelsRoot } from "@/channels/config";
+import {
+  __setActiveChannelCredentialsStoreModeForTests,
+  __setChannelCredentialsStoreModeForTests,
+  __setChannelKeychainAvailableForTests,
+  __setChannelSecretStoreOverrideForTests,
+  buildChannelSecretName,
+  getActiveChannelCredentialsStoreMode,
+} from "@/channels/credential-store";
+import type { SlackChannelAccount } from "@/channels/types";
+
+function readAccountsFile(root: string, channelId: string): unknown {
+  return JSON.parse(
+    readFileSync(join(root, channelId, "accounts.json"), "utf-8"),
+  );
+}
+
+function makeSlackAccount(): SlackChannelAccount {
+  return {
+    channel: "slack",
+    accountId: "slack-account",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-secret",
+    appToken: "xapp-secret",
+    agentId: "agent-1",
+    defaultPermissionMode: "acceptEdits",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    createdAt: "2026-05-26T00:00:00.000Z",
+    updatedAt: "2026-05-26T00:00:00.000Z",
+  };
+}
+
+describe("channel credential storage", () => {
+  let channelsRoot: string;
+  let secrets: Map<string, string>;
+
+  beforeEach(() => {
+    channelsRoot = mkdtempSync(join(tmpdir(), "letta-channel-secrets-"));
+    secrets = new Map<string, string>();
+    clearChannelAccountStores();
+    __testOverrideChannelsRoot(channelsRoot);
+    __setChannelCredentialsStoreModeForTests(null);
+    __setActiveChannelCredentialsStoreModeForTests(null);
+    __setChannelKeychainAvailableForTests(null);
+    __setChannelSecretStoreOverrideForTests({
+      get: async (name) => secrets.get(name) ?? null,
+      set: async (name, value) => {
+        secrets.set(name, value);
+      },
+      delete: async (name) => secrets.delete(name),
+    });
+  });
+
+  afterEach(() => {
+    clearChannelAccountStores();
+    __testOverrideChannelsRoot(null);
+    __setChannelCredentialsStoreModeForTests(null);
+    __setActiveChannelCredentialsStoreModeForTests(null);
+    __setChannelKeychainAvailableForTests(null);
+    __setChannelSecretStoreOverrideForTests(null);
+    rmSync(channelsRoot, { recursive: true, force: true });
+  });
+
+  test("keyring mode stores Slack tokens outside accounts.json and hydrates them", async () => {
+    __setActiveChannelCredentialsStoreModeForTests("keyring");
+
+    await upsertChannelAccountWithSecrets("slack", makeSlackAccount());
+    await flushPendingChannelSecretWrites();
+
+    expect(
+      secrets.get(buildChannelSecretName("slack", "slack-account", "botToken")),
+    ).toBe("xoxb-secret");
+    expect(
+      secrets.get(buildChannelSecretName("slack", "slack-account", "appToken")),
+    ).toBe("xapp-secret");
+
+    const persisted = readAccountsFile(channelsRoot, "slack") as {
+      accounts: Array<Record<string, unknown>>;
+    };
+    expect(JSON.stringify(persisted)).not.toContain("xoxb-secret");
+    expect(JSON.stringify(persisted)).not.toContain("xapp-secret");
+    expect(persisted.accounts[0]).toMatchObject({
+      __letta_secret_refs: {
+        botToken: true,
+        appToken: true,
+      },
+    });
+
+    clearChannelAccountStores();
+    const hydrated = (await getChannelAccountWithSecrets(
+      "slack",
+      "slack-account",
+    )) as SlackChannelAccount | null;
+
+    expect(hydrated?.botToken).toBe("xoxb-secret");
+    expect(hydrated?.appToken).toBe("xapp-secret");
+  });
+
+  test("keyring mode migrates existing plaintext tokens out of accounts.json", async () => {
+    __setActiveChannelCredentialsStoreModeForTests("keyring");
+    mkdirSync(join(channelsRoot, "slack"), { recursive: true });
+    writeFileSync(
+      join(channelsRoot, "slack", "accounts.json"),
+      `${JSON.stringify({ accounts: [makeSlackAccount()] }, null, 2)}\n`,
+    );
+
+    await hydrateChannelAccountSecrets("slack");
+
+    expect(
+      secrets.get(buildChannelSecretName("slack", "slack-account", "botToken")),
+    ).toBe("xoxb-secret");
+    expect(
+      secrets.get(buildChannelSecretName("slack", "slack-account", "appToken")),
+    ).toBe("xapp-secret");
+
+    const persistedText = readFileSync(
+      join(channelsRoot, "slack", "accounts.json"),
+      "utf-8",
+    );
+    expect(persistedText).not.toContain("xoxb-secret");
+    expect(persistedText).not.toContain("xapp-secret");
+    expect(persistedText).toContain("__letta_secret_refs");
+  });
+
+  test("deleting an account removes keyring secrets", async () => {
+    __setActiveChannelCredentialsStoreModeForTests("keyring");
+
+    await upsertChannelAccountWithSecrets("slack", makeSlackAccount());
+    await flushPendingChannelSecretWrites();
+
+    expect(
+      await removeChannelAccountWithSecrets("slack", "slack-account"),
+    ).toBe(true);
+    expect(
+      secrets.has(buildChannelSecretName("slack", "slack-account", "botToken")),
+    ).toBe(false);
+    expect(
+      secrets.has(buildChannelSecretName("slack", "slack-account", "appToken")),
+    ).toBe(false);
+  });
+
+  test("auto falls back to file mode when keyring is unavailable", async () => {
+    __setChannelCredentialsStoreModeForTests("auto");
+    __setChannelKeychainAvailableForTests(false);
+
+    expect(await getActiveChannelCredentialsStoreMode()).toBe("file");
+  });
+
+  test("explicit keyring mode errors when keyring is unavailable", async () => {
+    __setChannelCredentialsStoreModeForTests("keyring");
+    __setChannelKeychainAvailableForTests(false);
+
+    await expect(getActiveChannelCredentialsStoreMode()).rejects.toThrow(
+      "OS secure storage is unavailable",
+    );
+  });
+
+  test("file mode preserves plaintext accounts.json compatibility", async () => {
+    __setActiveChannelCredentialsStoreModeForTests("file");
+
+    await upsertChannelAccountWithSecrets("slack", makeSlackAccount());
+
+    const persistedText = readFileSync(
+      join(channelsRoot, "slack", "accounts.json"),
+      "utf-8",
+    );
+    expect(persistedText).toContain("xoxb-secret");
+    expect(persistedText).toContain("xapp-secret");
+    expect(persistedText).not.toContain("__letta_secret_refs");
+    expect(existsSync(join(channelsRoot, "slack", "accounts.json"))).toBe(true);
+  });
+});

--- a/src/channels/credential-store.ts
+++ b/src/channels/credential-store.ts
@@ -1,0 +1,166 @@
+import { settingsManager } from "@/settings-manager";
+import {
+  deleteSecretValue,
+  getSecretValue,
+  isKeychainAvailable,
+  setSecretValue,
+} from "@/utils/secrets";
+
+export type ChannelCredentialsStoreMode = "file" | "keyring" | "auto";
+export type ActiveChannelCredentialsStoreMode = "file" | "keyring";
+
+const CHANNEL_CREDENTIALS_STORE_ENV = "LETTA_CHANNEL_CREDENTIALS_STORE";
+const CHANNEL_SECRET_PREFIX = "channel";
+
+let activeModeCache: ActiveChannelCredentialsStoreMode | null = null;
+let requestedModeOverrideForTests: ChannelCredentialsStoreMode | null = null;
+let activeModeOverrideForTests: ActiveChannelCredentialsStoreMode | null = null;
+let keychainAvailableOverrideForTests: boolean | null = null;
+let channelSecretStoreOverrideForTests: {
+  get: (name: string) => Promise<string | null>;
+  set: (name: string, value: string) => Promise<void>;
+  delete: (name: string) => Promise<boolean>;
+} | null = null;
+
+function parseStoreMode(value: unknown): ChannelCredentialsStoreMode | null {
+  return value === "file" || value === "keyring" || value === "auto"
+    ? value
+    : null;
+}
+
+export function getRequestedChannelCredentialsStoreMode(): ChannelCredentialsStoreMode {
+  if (requestedModeOverrideForTests) {
+    return requestedModeOverrideForTests;
+  }
+
+  const envMode = parseStoreMode(process.env[CHANNEL_CREDENTIALS_STORE_ENV]);
+  if (envMode) {
+    return envMode;
+  }
+
+  try {
+    return (
+      parseStoreMode(settingsManager.getSettings().channelCredentialsStore) ??
+      "auto"
+    );
+  } catch {
+    return "auto";
+  }
+}
+
+export async function getActiveChannelCredentialsStoreMode(): Promise<ActiveChannelCredentialsStoreMode> {
+  if (activeModeOverrideForTests) {
+    activeModeCache = activeModeOverrideForTests;
+    return activeModeOverrideForTests;
+  }
+
+  if (activeModeCache) {
+    return activeModeCache;
+  }
+
+  const requestedMode = getRequestedChannelCredentialsStoreMode();
+  if (requestedMode === "file") {
+    activeModeCache = "file";
+    return activeModeCache;
+  }
+
+  const keychainAvailable =
+    keychainAvailableOverrideForTests ?? (await isKeychainAvailable());
+  if (keychainAvailable) {
+    activeModeCache = "keyring";
+    return activeModeCache;
+  }
+
+  if (requestedMode === "keyring") {
+    throw new Error(
+      "Channel credential store is set to keyring, but OS secure storage is unavailable.",
+    );
+  }
+
+  activeModeCache = "file";
+  return activeModeCache;
+}
+
+export function getCachedChannelCredentialsStoreMode(): ActiveChannelCredentialsStoreMode | null {
+  return activeModeCache;
+}
+
+export function buildChannelSecretName(
+  channelId: string,
+  accountId: string,
+  field: string,
+): string {
+  return [CHANNEL_SECRET_PREFIX, channelId, accountId, field].join(":");
+}
+
+export async function getChannelSecret(
+  channelId: string,
+  accountId: string,
+  field: string,
+): Promise<string | null> {
+  const name = buildChannelSecretName(channelId, accountId, field);
+  if (channelSecretStoreOverrideForTests) {
+    return channelSecretStoreOverrideForTests.get(name);
+  }
+
+  return getSecretValue(name, `${channelId}/${accountId}/${field}`);
+}
+
+export async function setChannelSecret(
+  channelId: string,
+  accountId: string,
+  field: string,
+  value: string,
+): Promise<void> {
+  const name = buildChannelSecretName(channelId, accountId, field);
+  if (channelSecretStoreOverrideForTests) {
+    await channelSecretStoreOverrideForTests.set(name, value);
+    return;
+  }
+
+  await setSecretValue(name, value);
+}
+
+export async function deleteChannelSecret(
+  channelId: string,
+  accountId: string,
+  field: string,
+): Promise<boolean> {
+  const name = buildChannelSecretName(channelId, accountId, field);
+  if (channelSecretStoreOverrideForTests) {
+    return channelSecretStoreOverrideForTests.delete(name);
+  }
+
+  return deleteSecretValue(name);
+}
+
+export function __setChannelCredentialsStoreModeForTests(
+  mode: ChannelCredentialsStoreMode | null,
+): void {
+  requestedModeOverrideForTests = mode;
+  activeModeCache = null;
+}
+
+export function __resetChannelCredentialsStoreModeCacheForTests(): void {
+  activeModeCache = null;
+}
+
+export function __setActiveChannelCredentialsStoreModeForTests(
+  mode: ActiveChannelCredentialsStoreMode | null,
+): void {
+  activeModeOverrideForTests = mode;
+  activeModeCache = null;
+}
+
+export function __setChannelKeychainAvailableForTests(
+  available: boolean | null,
+): void {
+  keychainAvailableOverrideForTests = available;
+  activeModeCache = null;
+}
+
+export function __setChannelSecretStoreOverrideForTests(
+  override: typeof channelSecretStoreOverrideForTests,
+): void {
+  channelSecretStoreOverrideForTests = override;
+}

--- a/src/channels/discord/setup.ts
+++ b/src/channels/discord/setup.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
-import { upsertChannelAccount } from "@/channels/accounts";
+import { upsertChannelAccountWithSecrets } from "@/channels/accounts";
 import type {
   DiscordChannelAccount,
   DiscordChannelMode,
@@ -187,7 +187,7 @@ export async function runDiscordSetup(): Promise<boolean> {
       updatedAt: now,
     };
 
-    upsertChannelAccount("discord", account);
+    await upsertChannelAccountWithSecrets("discord", account);
     console.log("\n✓ Discord bot configured!");
     console.log("Config written to: ~/.letta/channels/discord/accounts.json\n");
     console.log("Next steps:");

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -16,9 +16,11 @@ import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import type { ApprovalResponseBody } from "@/types/protocol_v2";
 import {
   getChannelAccount,
+  getChannelAccountWithSecrets,
+  hydrateChannelAccountSecrets,
   LEGACY_CHANNEL_ACCOUNT_ID,
   listChannelAccounts,
-  loadChannelAccounts,
+  listChannelAccountsWithSecrets,
 } from "./accounts";
 import {
   buildChannelAlreadyActiveMessage,
@@ -55,6 +57,7 @@ import {
 } from "./pending-control-requests";
 import {
   getChannelDisplayName,
+  getSupportedChannelIds,
   isFirstPartyChannelPlugin,
   loadChannelPlugin,
 } from "./plugin-registry";
@@ -794,8 +797,7 @@ export class ChannelRegistry {
   }
 
   async startChannel(channelId: string): Promise<boolean> {
-    loadChannelAccounts(channelId);
-    const accounts = listChannelAccounts(channelId).filter(
+    const accounts = (await listChannelAccountsWithSecrets(channelId)).filter(
       (account) => account.enabled,
     );
     if (accounts.length === 0) {
@@ -817,8 +819,7 @@ export class ChannelRegistry {
     options?: ChannelStartupOptions,
   ): Promise<boolean> {
     logChannelStartup(options?.logger, `starting ${channelId}/${accountId}`);
-    loadChannelAccounts(channelId);
-    const account = getChannelAccount(channelId, accountId);
+    const account = await getChannelAccountWithSecrets(channelId, accountId);
     if (!account) {
       logChannelStartup(
         options?.logger,
@@ -1998,12 +1999,23 @@ export async function initializeChannels(
   );
   logChannelStartup(options?.logger, `root: ${getChannelsRoot()}`);
 
+  // Eagerly hydrate/migrate channel account secrets at channel subsystem
+  // startup. This converts existing plaintext token fields in accounts.json to
+  // keyring-backed refs when the active credential store is `keyring` (or
+  // `auto` with keyring available), while preserving file-mode compatibility.
+  for (const channelId of new Set([
+    ...getSupportedChannelIds(),
+    ...channelNames,
+  ])) {
+    await hydrateChannelAccountSecrets(channelId);
+  }
+
   for (const channelId of channelNames) {
     logChannelStartup(
       options?.logger,
       `loading ${channelId} accounts from ${getChannelAccountsPath(channelId)}`,
     );
-    loadChannelAccounts(channelId);
+    await hydrateChannelAccountSecrets(channelId);
     const accounts = listChannelAccounts(channelId);
     const enabledAccountIds = accounts
       .filter((account) => account.enabled)

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -9,10 +9,13 @@ import {
 } from "./account-config";
 import {
   getChannelAccount,
+  getChannelAccountWithSecrets,
   LEGACY_CHANNEL_ACCOUNT_ID,
   listChannelAccounts,
-  removeChannelAccount,
+  listChannelAccountsWithSecrets,
+  removeChannelAccountWithSecrets,
   upsertChannelAccount,
+  upsertChannelAccountWithSecrets,
 } from "./accounts";
 import { resolveDiscordAccountDisplayName } from "./discord/adapter";
 import {
@@ -290,6 +293,28 @@ function getSelectedChannelAccount(
   }
 
   const accounts = listChannelAccounts(channelId);
+  if (accounts.length === 0) {
+    return null;
+  }
+  if (accounts.length === 1) {
+    return accounts[0] ?? null;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple accounts. Specify account_id.`,
+  );
+}
+
+async function getSelectedChannelAccountWithSecrets(
+  channelId: string,
+  accountId?: string,
+): Promise<ChannelAccount | null> {
+  const normalizedAccountId = accountId?.trim();
+  if (normalizedAccountId) {
+    return getChannelAccountWithSecrets(channelId, normalizedAccountId);
+  }
+
+  const accounts = await listChannelAccountsWithSecrets(channelId);
   if (accounts.length === 0) {
     return null;
   }
@@ -939,6 +964,15 @@ export function getChannelConfigSnapshot(
   };
 }
 
+export async function getChannelConfigSnapshotWithSecrets(
+  channelId: string,
+  accountId?: string,
+): Promise<ChannelConfigSnapshot | null> {
+  assertSupportedChannelId(channelId);
+  await getSelectedChannelAccountWithSecrets(channelId, accountId);
+  return getChannelConfigSnapshot(channelId, accountId);
+}
+
 export async function setChannelConfigLive(
   channelId: string,
   patch: ChannelConfigPatch,
@@ -946,11 +980,14 @@ export async function setChannelConfigLive(
 ): Promise<ChannelConfigSnapshot> {
   assertSupportedChannelId(channelId);
   const normalizedPatch = normalizeChannelConfigPatch(channelId, patch);
-  const existing = getSelectedChannelAccount(channelId, accountId);
+  const existing = await getSelectedChannelAccountWithSecrets(
+    channelId,
+    accountId,
+  );
   let targetAccountId = existing?.accountId;
   let shouldRefreshDisplayName = false;
   if (existing) {
-    updateChannelAccountLive(channelId, existing.accountId, {
+    await updateChannelAccountLiveWithSecrets(channelId, existing.accountId, {
       enabled: existing.enabled,
       token: normalizedPatch.token,
       botToken: normalizedPatch.botToken,
@@ -981,7 +1018,7 @@ export async function setChannelConfigLive(
       normalizedPatch,
     );
   } else {
-    const created = createChannelAccountLive(
+    const created = await createChannelAccountLiveWithSecrets(
       channelId,
       {
         enabled: false,
@@ -1029,7 +1066,8 @@ export async function setChannelConfigLive(
   }
 
   if (
-    (getChannelAccount(channelId, targetAccountId)?.enabled ?? false) === true
+    ((await getChannelAccountWithSecrets(channelId, targetAccountId))
+      ?.enabled ?? false) === true
   ) {
     await ensureChannelRegistry().startChannelAccount(
       channelId,
@@ -1037,7 +1075,10 @@ export async function setChannelConfigLive(
     );
   }
 
-  const snapshot = getChannelConfigSnapshot(channelId, targetAccountId);
+  const snapshot = await getChannelConfigSnapshotWithSecrets(
+    channelId,
+    targetAccountId,
+  );
   if (!snapshot) {
     throw new Error(`Failed to write ${channelId} channel config`);
   }
@@ -1051,7 +1092,10 @@ export async function startChannelLive(
 ): Promise<ChannelSummary> {
   assertSupportedChannelId(channelId);
 
-  const existing = getSelectedChannelAccount(channelId, accountId);
+  const existing = await getSelectedChannelAccountWithSecrets(
+    channelId,
+    accountId,
+  );
   if (!existing) {
     throw new Error(
       `Channel "${channelId}" is not configured. Configure it first.`,
@@ -1079,7 +1123,7 @@ export async function startChannelLive(
   }
 
   if (!existing.enabled) {
-    upsertChannelAccount(channelId, {
+    await upsertChannelAccountWithSecrets(channelId, {
       ...existing,
       enabled: true,
       updatedAt: new Date().toISOString(),
@@ -1110,14 +1154,17 @@ export async function stopChannelLive(
 ): Promise<ChannelSummary> {
   assertSupportedChannelId(channelId);
 
-  const existing = getSelectedChannelAccount(channelId, accountId);
+  const existing = await getSelectedChannelAccountWithSecrets(
+    channelId,
+    accountId,
+  );
   if (!existing) {
     throw new Error(
       `Channel "${channelId}" is not configured. Configure it first.`,
     );
   }
 
-  upsertChannelAccount(channelId, {
+  await upsertChannelAccountWithSecrets(channelId, {
     ...existing,
     enabled: false,
     updatedAt: new Date().toISOString(),
@@ -1142,12 +1189,30 @@ export function listChannelAccountSnapshots(
   return listChannelAccounts(channelId).map(toAccountSnapshot);
 }
 
+export async function listChannelAccountSnapshotsWithSecrets(
+  channelId: string,
+): Promise<ChannelAccountSnapshot[]> {
+  assertSupportedChannelId(channelId);
+  return (await listChannelAccountsWithSecrets(channelId)).map(
+    toAccountSnapshot,
+  );
+}
+
 export function getChannelAccountSnapshot(
   channelId: string,
   accountId: string,
 ): ChannelAccountSnapshot | null {
   assertSupportedChannelId(channelId);
   const account = getChannelAccount(channelId, accountId);
+  return account ? toAccountSnapshot(account) : null;
+}
+
+export async function getChannelAccountSnapshotWithSecrets(
+  channelId: string,
+  accountId: string,
+): Promise<ChannelAccountSnapshot | null> {
+  assertSupportedChannelId(channelId);
+  const account = await getChannelAccountWithSecrets(channelId, accountId);
   return account ? toAccountSnapshot(account) : null;
 }
 
@@ -1166,6 +1231,27 @@ export function createChannelAccountLive(
   }
 
   const created = upsertChannelAccount(
+    channelId,
+    createAccountFromPatch(channelId, accountId, patch),
+  );
+  return toAccountSnapshot(created);
+}
+
+export async function createChannelAccountLiveWithSecrets(
+  channelId: string,
+  patch: ChannelAccountPatch,
+  options?: { accountId?: string },
+): Promise<ChannelAccountSnapshot> {
+  assertSupportedChannelId(channelId);
+  const accountId = options?.accountId?.trim() || randomUUID();
+  const existing = await getChannelAccountWithSecrets(channelId, accountId);
+  if (existing) {
+    throw new Error(
+      `Channel account "${accountId}" already exists for ${channelId}.`,
+    );
+  }
+
+  const created = await upsertChannelAccountWithSecrets(
     channelId,
     createAccountFromPatch(channelId, accountId, patch),
   );
@@ -1220,6 +1306,54 @@ export function updateChannelAccountLive(
           "Failed to save routes",
         )}. Account changes were rolled back.`,
       );
+    }
+  }
+
+  return toAccountSnapshot(updated);
+}
+
+export async function updateChannelAccountLiveWithSecrets(
+  channelId: string,
+  accountId: string,
+  patch: ChannelAccountPatch,
+): Promise<ChannelAccountSnapshot> {
+  assertSupportedChannelId(channelId);
+  const existing = await getChannelAccountWithSecrets(channelId, accountId);
+  if (!existing) {
+    throw new Error(
+      `Channel account "${accountId}" was not found for ${channelId}.`,
+    );
+  }
+
+  const nextAccount = mergeAccountPatch(existing, patch);
+  const shouldResetRoutes =
+    (isSlackChannelAccount(existing) || isDiscordChannelAccount(existing)) &&
+    (isSlackChannelAccount(nextAccount) ||
+      isDiscordChannelAccount(nextAccount)) &&
+    typeof nextAccount.agentId === "string" &&
+    nextAccount.agentId !== existing.agentId;
+
+  const updated = await upsertChannelAccountWithSecrets(channelId, nextAccount);
+
+  if (shouldResetRoutes) {
+    try {
+      loadRoutes(channelId);
+      removeRoutesForAccount(channelId, accountId);
+    } catch (error) {
+      try {
+        await upsertChannelAccountWithSecrets(channelId, existing);
+      } catch (rollbackError) {
+        throw new Error(
+          `Failed to reset channel routes after updating account: ${getErrorMessage(
+            error,
+            "route reset failed",
+          )}; rollback also failed: ${getErrorMessage(
+            rollbackError,
+            "rollback failed",
+          )}`,
+        );
+      }
+      throw error;
     }
   }
 
@@ -1350,7 +1484,7 @@ export async function startChannelAccountLive(
   accountId: string,
 ): Promise<ChannelAccountSnapshot> {
   assertSupportedChannelId(channelId);
-  const existing = getChannelAccount(channelId, accountId);
+  const existing = await getChannelAccountWithSecrets(channelId, accountId);
   if (!existing) {
     throw new Error(
       `Channel account "${accountId}" was not found for ${channelId}.`,
@@ -1378,7 +1512,7 @@ export async function startChannelAccountLive(
   }
 
   if (!existing.enabled) {
-    upsertChannelAccount(channelId, {
+    await upsertChannelAccountWithSecrets(channelId, {
       ...existing,
       enabled: true,
       updatedAt: new Date().toISOString(),
@@ -1402,7 +1536,7 @@ export async function stopChannelAccountLive(
   accountId: string,
 ): Promise<ChannelAccountSnapshot> {
   assertSupportedChannelId(channelId);
-  const existing = getChannelAccount(channelId, accountId);
+  const existing = await getChannelAccountWithSecrets(channelId, accountId);
   if (!existing) {
     throw new Error(
       `Channel account "${accountId}" was not found for ${channelId}.`,
@@ -1410,7 +1544,7 @@ export async function stopChannelAccountLive(
   }
 
   const next = existing.enabled
-    ? upsertChannelAccount(channelId, {
+    ? await upsertChannelAccountWithSecrets(channelId, {
         ...existing,
         enabled: false,
         updatedAt: new Date().toISOString(),
@@ -1427,7 +1561,7 @@ export async function removeChannelAccountLive(
   accountId: string,
 ): Promise<boolean> {
   assertSupportedChannelId(channelId);
-  const existing = getChannelAccount(channelId, accountId);
+  const existing = await getChannelAccountWithSecrets(channelId, accountId);
   if (!existing) {
     return false;
   }
@@ -1439,7 +1573,7 @@ export async function removeChannelAccountLive(
   removeRoutesForAccount(channelId, accountId);
   removeChannelTargetsForAccount(channelId, accountId);
   removePairingStateForAccount(channelId, accountId);
-  const removed = removeChannelAccount(channelId, accountId);
+  const removed = await removeChannelAccountWithSecrets(channelId, accountId);
   await refreshLoadedMessageChannelTool();
   return removed;
 }

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
-import { upsertChannelAccount } from "@/channels/accounts";
+import { upsertChannelAccountWithSecrets } from "@/channels/accounts";
 import {
   DEFAULT_SLACK_PERMISSION_MODE,
   type DmPolicy,
@@ -106,7 +106,7 @@ export async function runSlackSetup(): Promise<boolean> {
       updatedAt: now,
     };
 
-    upsertChannelAccount("slack", account);
+    await upsertChannelAccountWithSecrets("slack", account);
     console.log("\n✓ Slack app configured!");
     console.log("Config written to: ~/.letta/channels/slack/accounts.json\n");
     console.log("Next steps:");

--- a/src/channels/telegram/setup.ts
+++ b/src/channels/telegram/setup.ts
@@ -13,7 +13,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline/promises";
-import { upsertChannelAccount } from "@/channels/accounts";
+import { upsertChannelAccountWithSecrets } from "@/channels/accounts";
 import type { DmPolicy, TelegramChannelAccount } from "@/channels/types";
 import { validateTelegramToken } from "./adapter";
 import { ensureTelegramRuntimeInstalled } from "./runtime";
@@ -125,7 +125,7 @@ export async function runTelegramSetup(): Promise<boolean> {
       updatedAt: now,
     };
 
-    upsertChannelAccount("telegram", account);
+    await upsertChannelAccountWithSecrets("telegram", account);
     console.log("\n✓ Telegram bot configured!");
     console.log(
       "Config written to: ~/.letta/channels/telegram/accounts.json\n",

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -57,17 +57,6 @@ export async function runLocalOAuthConnectFlow(
       void Promise.resolve(callbacks.onStatus(status));
       void browserOpener(info.url);
     },
-    onDeviceCode: (info) => {
-      const status = [
-        `Open this URL to authenticate ${oauthProvider.name}:`,
-        "",
-        info.verificationUri,
-        "",
-        `Enter code: ${info.userCode}`,
-      ].join("\n");
-      void Promise.resolve(callbacks.onStatus(status));
-      void browserOpener(info.verificationUri);
-    },
     onPrompt: (prompt) =>
       callbacks.onPrompt?.(prompt) ?? defaultPrompt(oauthProvider.name, prompt),
     onProgress: (message) => {

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -16,6 +16,11 @@ export interface LocalOAuthConnectCallbacks {
   signal?: AbortSignal;
 }
 
+interface OAuthDeviceCodeInfo {
+  verificationUri: string;
+  userCode: string;
+}
+
 function localOAuthProviderId(provider: ByokProvider): string {
   const providerId = provider.oauthProviderId;
   if (!providerId) {
@@ -45,7 +50,7 @@ export async function runLocalOAuthConnectFlow(
   const browserOpener = callbacks.openBrowser ?? openOAuthBrowser;
   await callbacks.onStatus(`Starting ${oauthProvider.name} login...`);
 
-  const credentials = await oauthProvider.login({
+  const loginCallbacks = {
     signal: callbacks.signal,
     onAuth: (info) => {
       const status = [
@@ -68,7 +73,23 @@ export async function runLocalOAuthConnectFlow(
         `${oauthProvider.name} requires selection: ${prompt.message}`,
       );
     },
-  });
+  } as Parameters<typeof oauthProvider.login>[0] & {
+    onDeviceCode?: (info: OAuthDeviceCodeInfo) => void;
+  };
+
+  loginCallbacks.onDeviceCode = (info) => {
+    const status = [
+      `Open this URL to authenticate ${oauthProvider.name}:`,
+      "",
+      info.verificationUri,
+      "",
+      `Enter code: ${info.userCode}`,
+    ].join("\n");
+    void Promise.resolve(callbacks.onStatus(status));
+    void browserOpener(info.verificationUri);
+  };
+
+  const credentials = await oauthProvider.login(loginCallbacks);
 
   setLocalOAuthProvider({
     providerName: provider.providerName,

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -80,6 +80,7 @@ export interface Settings {
   autoSwapOnQuotaLimit: boolean; // Auto-switch to temporary Auto model override on quota-limit errors
   includeWorktreeTool: boolean; // Include CreateWorktree in toolsets when true
   preferredBackendMode?: "api" | "local"; // Startup backend preference when no explicit --backend is provided
+  channelCredentialsStore?: "file" | "keyring" | "auto"; // Where channel/connection tokens are persisted
   recentModels: string[]; // Recently used model IDs (most recent first, max 5)
   memoryReminderInterval: number | null | "compaction" | "auto-compaction"; // DEPRECATED: use reflection* fields
   reflectionTrigger: "off" | "step-count" | "compaction-event";

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -37,7 +37,7 @@ function isDuplicateKeychainItemError(error: unknown): boolean {
   );
 }
 
-async function getSecretValue(
+export async function getSecretValue(
   name: string,
   label: string,
 ): Promise<string | null> {
@@ -67,7 +67,10 @@ async function getSecretValue(
   }
 }
 
-async function setSecretValue(name: string, value: string): Promise<void> {
+export async function setSecretValue(
+  name: string,
+  value: string,
+): Promise<void> {
   if (!secretsAvailable) {
     throw new Error("Secrets API unavailable");
   }
@@ -100,6 +103,22 @@ async function setSecretValue(name: string, value: string): Promise<void> {
     name,
     value,
   });
+}
+
+export async function deleteSecretValue(name: string): Promise<boolean> {
+  if (!secretsAvailable) {
+    return false;
+  }
+
+  try {
+    return await secrets.delete({
+      service: SERVICE_NAME,
+      name,
+    });
+  } catch (error) {
+    console.warn(`Failed to delete secret ${name}: ${error}`);
+    return false;
+  }
 }
 
 /**

--- a/src/websocket/listen-client-channel-accounts.test.ts
+++ b/src/websocket/listen-client-channel-accounts.test.ts
@@ -27,6 +27,63 @@ afterEach(() => {
 });
 
 describe("channel account list responses", () => {
+  test("creates custom app accounts on the built-in custom channel", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => []);
+    __testOverrideSaveChannelAccounts(() => {});
+
+    const socket = new MockSocket(WebSocket.OPEN);
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+
+    try {
+      await __listenClientTestUtils.handleChannelsProtocolCommand(
+        {
+          type: "channel_account_create",
+          request_id: "custom-create-1",
+          channel_id: "custom",
+          account: {
+            account_id: "custom-app-1",
+            display_name: "Webhook.site test",
+            enabled: false,
+            dm_policy: "pairing",
+            config: {
+              url: "https://example.com/webhook",
+              agent_id: "agent-1",
+            },
+          },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {
+          onStatusChange: undefined,
+          connectionId: "conn-test",
+        },
+        async () => {},
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+
+      expect(messages[0]).toMatchObject({
+        type: "channel_account_create_response",
+        success: true,
+        channel_id: "custom",
+        account: {
+          channel_id: "custom",
+          account_id: "custom-app-1",
+          display_name: "Webhook.site test",
+          config: {
+            url: "https://example.com/webhook",
+            agent_id: "agent-1",
+          },
+        },
+      });
+    } finally {
+      __listenClientTestUtils.stopRuntime(runtime, true);
+    }
+  });
+
   test("return cached account snapshots without waiting for live display-name refresh", async () => {
     const socket = new MockSocket(WebSocket.OPEN);
     const runtime = __listenClientTestUtils.createListenerRuntime();

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -2205,7 +2205,7 @@ describe("listen-client channels command handling", () => {
 
     __listenClientTestUtils.setChannelsServiceLoaderForTests(async () => ({
       ...actualChannelsService,
-      createChannelAccountLive: () => ({
+      createChannelAccountLiveWithSecrets: async () => ({
         channelId: "telegram" as const,
         accountId: "bot-1",
         displayName: "@docsbot",

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -3,10 +3,7 @@ import {
   channelPluginConfigShouldRefreshDisplayName,
   getChannelPluginConfig,
 } from "@/channels/account-config";
-import {
-  removeUserPlugin,
-  scaffoldUserPlugin,
-} from "@/channels/custom/scaffolding";
+import { removeUserPlugin } from "@/channels/custom/scaffolding";
 import { getChannelPluginMetadata } from "@/channels/plugin-registry";
 import type { ChannelRegistryEvent } from "@/channels/registry";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
@@ -525,19 +522,10 @@ export async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_account_create") {
     try {
-      // For the first-party "custom" channel, scaffold a dedicated user plugin
-      // folder so the new app gets its own channel ID (e.g. "my-webhook-app").
-      // The folder must exist before createChannelAccountLive validates the ID.
-      let effectiveChannelId = parsed.channel_id;
-      if (parsed.channel_id === "custom") {
-        const displayName =
-          typeof (parsed.account as Record<string, unknown>).display_name ===
-          "string"
-            ? ((parsed.account as Record<string, unknown>)
-                .display_name as string)
-            : "custom-app";
-        effectiveChannelId = scaffoldUserPlugin(displayName);
-      }
+      // Custom-app model: multiple custom apps are represented as
+      // multiple accounts under the first-party "custom" channel. Do not
+      // scaffold per-app plugin folders/channel IDs here.
+      const effectiveChannelId = parsed.channel_id;
 
       const pluginConfig =
         getChannelPluginConfig(parsed.account as Record<string, unknown>) ?? {};

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -254,7 +254,7 @@ export async function handleChannelsProtocolCommand(
     bindChannelPairing,
     bindChannelAccountLive,
     bindChannelTarget,
-    createChannelAccountLive,
+    createChannelAccountLiveWithSecrets,
     refreshChannelAccountDisplayNameLive,
     getChannelConfigSnapshot,
     listChannelAccountSnapshots,
@@ -270,7 +270,7 @@ export async function handleChannelsProtocolCommand(
     stopChannelAccountLive,
     stopChannelLive,
     unbindChannelAccountLive,
-    updateChannelAccountLive,
+    updateChannelAccountLiveWithSecrets,
     updateChannelRouteLive,
   } = await loadChannelsService();
 
@@ -529,7 +529,7 @@ export async function handleChannelsProtocolCommand(
 
       const pluginConfig =
         getChannelPluginConfig(parsed.account as Record<string, unknown>) ?? {};
-      const created = createChannelAccountLive(
+      const created = await createChannelAccountLiveWithSecrets(
         effectiveChannelId,
         {
           displayName:
@@ -600,7 +600,7 @@ export async function handleChannelsProtocolCommand(
     try {
       const pluginConfig =
         getChannelPluginConfig(parsed.patch as Record<string, unknown>) ?? {};
-      const updated = updateChannelAccountLive(
+      const updated = await updateChannelAccountLiveWithSecrets(
         parsed.channel_id,
         parsed.account_id,
         {


### PR DESCRIPTION
## Summary

- Add Codex-style `file | keyring | auto` storage modes for channel/connection credentials.
- Store Slack, Telegram, Discord, and custom app tokens in OS secure storage when keyring mode is active.
- Migrate existing plaintext token values from `~/.letta/channels/*/accounts.json` into keyring on channel startup.
- Preserve backwards-compatible file-backed behavior when keyring is unavailable or explicitly disabled.
- Route Desktop/WebSocket account create/update/start flows through the new secure credential hydration path.

## Test plan

- `bun run typecheck`
- `LETTA_CHANNEL_CREDENTIALS_STORE=file bun test src/channels/credential-store.test.ts src/channels/service.test.ts src/channels/discord-service.test.ts src/channels/whatsapp-service.test.ts src/channels/registry.test.ts src/websocket/listen-client-channel-accounts.test.ts`