### PR TITLE
fix: local conversation model overrides

### DIFF
--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -19,7 +19,9 @@ import {
   type LocalStoreOptions,
 } from "@/backend/local/local-store";
 import { isLocalStateChunkOnly } from "@/backend/local/local-stream-chunks";
+import type { LocalAgentRecord } from "@/backend/local/local-types";
 import { TURN_DID_NOT_COMPLETE } from "@/constants";
+import { isRecord } from "@/utils/type-guards";
 import {
   DeterministicPongExecutor,
   type HeadlessTurnExecutor,
@@ -121,6 +123,29 @@ function localStopReasonChunk(stopReason: string): LettaStreamingResponse {
     message_type: "stop_reason",
     stop_reason: stopReason,
   } as LettaStreamingResponse;
+}
+
+function effectiveAgentForConversation(
+  agent: LocalAgentRecord,
+  conversation: Conversation,
+): LocalAgentRecord {
+  const conversationRecord = conversation as unknown as Record<string, unknown>;
+  const conversationModelSettings = isRecord(conversationRecord.model_settings)
+    ? conversationRecord.model_settings
+    : undefined;
+  return {
+    ...agent,
+    ...(typeof conversationRecord.model === "string"
+      ? { model: conversationRecord.model }
+      : {}),
+    model_settings: {
+      ...agent.model_settings,
+      ...(conversationModelSettings ?? {}),
+      ...(typeof conversationRecord.context_window_limit === "number"
+        ? { context_window_limit: conversationRecord.context_window_limit }
+        : {}),
+    },
+  };
 }
 
 function createReplayStream(
@@ -394,7 +419,13 @@ export class HeadlessBackend implements Backend {
       turnInput.conversationId,
       turnInput.agentId,
     );
-    const agent = this.store.retrieveAgentRecord(turnInput.agentId);
+    const agent = effectiveAgentForConversation(
+      this.store.retrieveAgentRecord(turnInput.agentId),
+      this.store.retrieveConversation(
+        turnInput.conversationId,
+        turnInput.agentId,
+      ),
+    );
     const systemPrompt = await this.resolveSystemPromptForTurn({
       conversationId: turnInput.conversationId,
       agentId: turnInput.agentId,

--- a/src/backend/fake-headless-backend.test.ts
+++ b/src/backend/fake-headless-backend.test.ts
@@ -2,15 +2,38 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ConversationMessageCreateBody } from "@/backend";
+import type {
+  AgentCreateBody,
+  ConversationCreateBody,
+  ConversationMessageCreateBody,
+  ConversationUpdateBody,
+} from "@/backend";
 import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 import { DeterministicToolCallExecutor } from "@/backend/dev/headless-turn-executor";
+import {
+  type ProviderStreamAdapter,
+  ProviderTurnExecutor,
+  type ProviderTurnInput,
+  providerLettaChunk,
+} from "@/backend/dev/provider-turn-executor";
 import { TURN_DID_NOT_COMPLETE } from "@/constants";
 
 async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
   const chunks: unknown[] = [];
   for await (const chunk of stream) chunks.push(chunk);
   return chunks;
+}
+
+class RecordingProviderAdapter implements ProviderStreamAdapter {
+  input: ProviderTurnInput | undefined;
+
+  async *stream(input: ProviderTurnInput) {
+    this.input = input;
+    yield providerLettaChunk({
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    } as never);
+  }
 }
 
 describe("FakeHeadlessBackend", () => {
@@ -65,6 +88,59 @@ describe("FakeHeadlessBackend", () => {
     );
     expect(jsonl).toContain('"content"');
     expect(jsonl).not.toContain('"parts"');
+  });
+
+  test("passes conversation model settings to local provider turns", async () => {
+    const adapter = new RecordingProviderAdapter();
+    const backend = new FakeHeadlessBackend(
+      "agent-fake-headless",
+      new ProviderTurnExecutor(adapter),
+      {
+        strictAgentAccess: false,
+        strictConversationAccess: false,
+      },
+    );
+    const agent = await backend.createAgent({
+      name: "Conversation Override Agent",
+      model: "openai/gpt-5",
+      model_settings: {
+        provider_type: "openai",
+        reasoning: { reasoning_effort: "minimal" },
+        parallel_tool_calls: true,
+      },
+    } as AgentCreateBody);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as ConversationCreateBody);
+    await backend.updateConversation(conversation.id, {
+      model: "openai/gpt-5.5",
+      model_settings: {
+        provider_type: "openai",
+        reasoning: { reasoning_effort: "medium" },
+      },
+      context_window_limit: 500000,
+    } as ConversationUpdateBody);
+
+    await collect(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "use the override" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    expect(adapter.input?.agent.model).toBe("openai/gpt-5.5");
+    expect(adapter.input?.agent.model_settings).toMatchObject({
+      provider_type: "openai",
+      reasoning: { reasoning_effort: "medium" },
+      parallel_tool_calls: true,
+      context_window_limit: 500000,
+    });
+
+    const storedAgent = await backend.retrieveAgent(agent.id);
+    expect(storedAgent.model).toBe("openai/gpt-5");
+    expect(storedAgent.model_settings).toMatchObject({
+      reasoning: { reasoning_effort: "minimal" },
+    });
   });
 
   test("settles orphaned tool calls from an interrupted turn before the next turn", async () => {


### PR DESCRIPTION
## Summary
- Apply conversation-level model/model_settings/context_window_limit when executing local backend turns
- Keep the stored agent defaults unchanged while using an effective per-turn agent config
- Add a regression test that runs through ProviderTurnExecutor and proves stale agent reasoning is overridden by conversation-level GPT-5.5 medium settings before provider adapter execution

## Test plan
- bun test src/backend/fake-headless-backend.test.ts
- bun test src/backend/provider-turn-executor.test.ts src/backend/pi-stream-adapter.test.ts src/backend/local-backend.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/backend/dev/fake-headless-backend.ts src/backend/fake-headless-backend.test.ts
- git diff --check

## Notes
- Full `bun run typecheck` still fails on existing unrelated errors in `src/cli/commands/connect-local-oauth.ts` and `src/web/generate-diff-viewer.ts`.