### PR TITLE
feat(local): allow extensions to register pi providers

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -441,8 +441,8 @@ export async function resolvePiModelForAgent(
         timeout: resolveLocalProviderTimeout({ providerIds: [provider] }),
       };
   let baseURL =
-    registeredProvider?.config.baseUrl ??
     connection.baseURL ??
+    registeredProvider?.config.baseUrl ??
     spec?.baseUrlEnv?.() ??
     spec?.defaultBaseURL;
   let headers = mergeHeaders(

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -15,6 +15,14 @@ import {
   resolveLocalProviderTimeout,
 } from "@/backend/local/local-provider-timeout";
 import {
+  getRegisteredPiProvider,
+  type PiProviderModelRegistration,
+  type PiProviderRegistration,
+  resolveRegisteredPiProviderApiKey,
+  resolveRegisteredPiProviderFromModelHandle,
+  stripRegisteredProviderHandlePrefix,
+} from "./pi-provider-extension-registry";
+import {
   expectedPiProviderList,
   getPiProviderSpec,
   isPiProvider,
@@ -93,6 +101,7 @@ export function resolvePiProvider(
     inferDefaultProviderFromStandardKeys(),
 ): PiProvider {
   if (isPiProvider(provider)) return provider;
+  if (getRegisteredPiProvider(provider)) return provider as PiProvider;
   throw new Error(
     `Unknown pi provider "${provider}". Expected ${expectedPiProviderList()}.`,
   );
@@ -103,6 +112,9 @@ export function resolvePiProviderFromAgent(
   modelSettings: PiModelSettings = {},
 ): PiProvider {
   return (
+    (resolveRegisteredPiProviderFromModelHandle(model) as
+      | PiProvider
+      | undefined) ??
     resolveProviderFromModelHandle(model) ??
     resolveProviderFromProviderType(modelSettings.provider_type) ??
     resolvePiProvider()
@@ -284,6 +296,61 @@ function withOverrides(
   };
 }
 
+function mergeHeaders(
+  ...headers: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  const merged: Record<string, string> = {};
+  for (const header of headers) {
+    if (!header) continue;
+    Object.assign(merged, header);
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function withAuthHeader(
+  headers: Record<string, string> | undefined,
+  apiKey: string | undefined,
+  authHeader: boolean | undefined,
+): Record<string, string> | undefined {
+  if (!authHeader || !apiKey) return headers;
+  return {
+    ...headers,
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+function registeredModelToPiModel(input: {
+  providerName: string;
+  config: PiProviderRegistration;
+  model: PiProviderModelRegistration;
+  baseURL?: string;
+  headers?: Record<string, string>;
+}): Model<Api> {
+  const api = input.model.api ?? input.config.api;
+  if (!api) {
+    throw new Error(
+      `Provider "${input.providerName}" model "${input.model.id}" is missing an api`,
+    );
+  }
+  return {
+    id: input.model.id,
+    name: input.model.name,
+    api,
+    provider: input.providerName,
+    baseUrl: input.model.baseUrl ?? input.baseURL ?? "",
+    reasoning: input.model.reasoning,
+    ...(input.model.thinkingLevelMap
+      ? { thinkingLevelMap: input.model.thinkingLevelMap }
+      : {}),
+    input: input.model.input,
+    cost: input.model.cost,
+    contextWindow: input.model.contextWindow,
+    maxTokens: input.model.maxTokens,
+    ...(input.headers ? { headers: input.headers } : {}),
+    ...(input.model.compat ? { compat: input.model.compat } : {}),
+  } as Model<Api>;
+}
+
 function numericSetting(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
@@ -342,11 +409,16 @@ export async function resolvePiModelForAgent(
   const provider = options.provider
     ? resolvePiProvider(options.provider)
     : resolvePiProviderFromAgent(modelHandle, modelSettings);
-  const spec = getPiProviderSpec(provider);
+  const registeredProvider = getRegisteredPiProvider(provider);
+  const spec = isPiProvider(provider) ? getPiProviderSpec(provider) : undefined;
   const modelId =
     options.model ??
-    resolvePiModelFromAgent(modelHandle, provider) ??
-    resolvePiModelFromAgent(spec.defaultModel, provider) ??
+    (registeredProvider
+      ? stripRegisteredProviderHandlePrefix(modelHandle, provider)
+      : undefined) ??
+    (spec ? resolvePiModelFromAgent(modelHandle, spec.id) : undefined) ??
+    registeredProvider?.config.models?.[0]?.id ??
+    (spec ? resolvePiModelFromAgent(spec.defaultModel, spec.id) : undefined) ??
     process.env.LETTA_CODE_DEV_PI_MODEL ??
     "";
   const storageDir = options.localProviderAuthStorageDir;
@@ -355,14 +427,28 @@ export async function resolvePiModelForAgent(
       ? modelSettings.provider_type
       : options.preferredProviderType;
 
-  let connection = localProviderConnection(
-    spec.localProviderNames,
-    spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
-    storageDir,
+  const registeredApiKey = resolveRegisteredPiProviderApiKey(
+    registeredProvider?.config.apiKey,
   );
+  let connection = spec
+    ? localProviderConnection(
+        spec.localProviderNames,
+        registeredApiKey ?? spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
+        storageDir,
+      )
+    : {
+        apiKey: registeredApiKey,
+        timeout: resolveLocalProviderTimeout({ providerIds: [provider] }),
+      };
   let baseURL =
-    connection.baseURL ?? spec.baseUrlEnv?.() ?? spec.defaultBaseURL;
-  const headers = spec.headers?.();
+    registeredProvider?.config.baseUrl ??
+    connection.baseURL ??
+    spec?.baseUrlEnv?.() ??
+    spec?.defaultBaseURL;
+  let headers = mergeHeaders(
+    spec?.headers?.(),
+    registeredProvider?.config.headers,
+  );
   let providerOptions: Record<string, unknown> | undefined;
   let envOverrides: Record<string, string | undefined> | undefined;
   let oauthCredentials: OAuthCredentials | undefined;
@@ -384,7 +470,7 @@ export async function resolvePiModelForAgent(
     baseURL = zai.baseURL;
   }
 
-  if (connection.record?.auth.type === "oauth" && spec.piProvider) {
+  if (connection.record?.auth.type === "oauth" && spec?.piProvider) {
     const oauth = await getLocalOAuthApiKey({
       providerId: spec.piProvider,
       providerNames: spec.localProviderNames,
@@ -405,43 +491,81 @@ export async function resolvePiModelForAgent(
 
   const contextWindow = numericSetting(modelSettings.context_window_limit);
   const maxTokens = numericSetting(modelSettings.max_tokens);
-  const catalogModel = getCatalogModel(provider, modelId, oauthCredentials);
-  const model = spec.createCustomModel
-    ? customOpenAICompatibleModel({
-        provider,
-        modelId,
-        baseURL:
-          normalizeLocalOpenAICompatibleBaseURL(provider, baseURL) ??
-          spec.defaultBaseURL ??
-          "",
+  headers = withAuthHeader(
+    headers,
+    connection.apiKey,
+    registeredProvider?.config.authHeader,
+  );
+
+  const registeredModels = registeredProvider?.config.models;
+  const registeredModel = registeredModels?.find(
+    (model) => model.id === modelId,
+  );
+  if (registeredModels && !registeredModel) {
+    throw new Error(
+      `Unknown model "${modelId}" for registered provider "${provider}".`,
+    );
+  }
+
+  const normalizedBaseURL = spec
+    ? (normalizeLocalOpenAICompatibleBaseURL(spec.id, baseURL) ?? baseURL)
+    : baseURL;
+  let model: Model<Api>;
+  if (registeredModel && registeredProvider) {
+    model = withOverrides(
+      registeredModelToPiModel({
+        providerName: provider,
+        config: registeredProvider.config,
+        model: registeredModel,
+        baseURL: normalizedBaseURL,
+        headers: mergeHeaders(headers, registeredModel.headers),
+      }),
+      {
         contextWindow,
         maxTokens,
-      })
-    : catalogModel
-      ? withOverrides(catalogModel, {
-          baseURL,
-          headers,
-          contextWindow,
-          maxTokens,
-        })
-      : (() => {
-          const fallback = getModel(
-            spec.piProvider ?? "openai",
-            modelId as never,
-          ) as Model<Api> | undefined;
-          if (!fallback) {
-            throw new Error(
-              `Unknown model "${modelId}" for provider "${provider}". ` +
-                "Check the model handle or update the model catalog.",
-            );
-          }
-          return withOverrides(fallback, {
-            baseURL,
-            headers,
-            contextWindow,
-            maxTokens,
-          });
-        })();
+      },
+    );
+  } else if (!spec) {
+    throw new Error(
+      `Unknown model "${modelId}" for provider "${provider}". ` +
+        "Register the provider with models before using it.",
+    );
+  } else if (spec.createCustomModel) {
+    model = customOpenAICompatibleModel({
+      provider: spec.id,
+      modelId,
+      baseURL: normalizedBaseURL ?? spec.defaultBaseURL ?? "",
+      contextWindow,
+      maxTokens,
+    });
+  } else {
+    const catalogModel = getCatalogModel(spec.id, modelId, oauthCredentials);
+    if (catalogModel) {
+      model = withOverrides(catalogModel, {
+        baseURL,
+        headers,
+        contextWindow,
+        maxTokens,
+      });
+    } else {
+      const fallback = getModel(
+        spec.piProvider ?? "openai",
+        modelId as never,
+      ) as Model<Api> | undefined;
+      if (!fallback) {
+        throw new Error(
+          `Unknown model "${modelId}" for provider "${provider}". ` +
+            "Check the model handle or update the model catalog.",
+        );
+      }
+      model = withOverrides(fallback, {
+        baseURL,
+        headers,
+        contextWindow,
+        maxTokens,
+      });
+    }
+  }
 
   return {
     provider,

--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -1,0 +1,257 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+export type PiProviderInputType = "text" | "image";
+
+export interface PiProviderModelRegistration {
+  id: string;
+  name: string;
+  api?: Api;
+  baseUrl?: string;
+  reasoning: boolean;
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  input: PiProviderInputType[];
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+  headers?: Record<string, string>;
+  compat?: Model<Api>["compat"];
+}
+
+export interface PiProviderRegistration {
+  name?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  api?: Api;
+  headers?: Record<string, string>;
+  authHeader?: boolean;
+  models?: PiProviderModelRegistration[];
+}
+
+export interface RegisteredPiProvider {
+  providerName: string;
+  config: PiProviderRegistration;
+  ownerId?: string;
+  path?: string;
+}
+
+const registeredProviders = new Map<string, RegisteredPiProvider>();
+
+function cloneHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return headers ? { ...headers } : undefined;
+}
+
+function cloneModel(
+  model: PiProviderModelRegistration,
+): PiProviderModelRegistration {
+  return {
+    ...model,
+    input: [...model.input],
+    cost: { ...model.cost },
+    ...(model.headers ? { headers: { ...model.headers } } : {}),
+    ...(model.compat ? { compat: { ...model.compat } } : {}),
+    ...(model.thinkingLevelMap
+      ? { thinkingLevelMap: { ...model.thinkingLevelMap } }
+      : {}),
+  };
+}
+
+function cloneConfig(config: PiProviderRegistration): PiProviderRegistration {
+  return {
+    ...config,
+    ...(config.headers ? { headers: cloneHeaders(config.headers) } : {}),
+    ...(config.models ? { models: config.models.map(cloneModel) } : {}),
+  };
+}
+
+function validateProviderName(providerName: string): void {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(providerName)) {
+    throw new Error(
+      "Provider name must start with a letter or number and contain only letters, numbers, dots, underscores, or hyphens",
+    );
+  }
+}
+
+function validateFiniteNonNegative(value: unknown, label: string): void {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a finite non-negative number`);
+  }
+}
+
+function validatePositiveInteger(value: unknown, label: string): void {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    !Number.isInteger(value)
+  ) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}
+
+function validateInput(input: unknown, label: string): void {
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error(`${label}.input must be a non-empty array`);
+  }
+  for (const item of input) {
+    if (item !== "text" && item !== "image") {
+      throw new Error(`${label}.input can only contain "text" or "image"`);
+    }
+  }
+}
+
+function validateHeaders(headers: unknown, label: string): void {
+  if (headers === undefined) return;
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    throw new Error(`${label} must be an object of string headers`);
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (!key || typeof value !== "string") {
+      throw new Error(`${label} must be an object of string headers`);
+    }
+  }
+}
+
+function validateModel(
+  providerName: string,
+  config: PiProviderRegistration,
+  model: PiProviderModelRegistration,
+): void {
+  const label = `Provider ${providerName}, model ${model.id || "<unknown>"}`;
+  if (!model.id || typeof model.id !== "string") {
+    throw new Error(`${label}: id is required`);
+  }
+  if (!model.name || typeof model.name !== "string") {
+    throw new Error(`${label}: name is required`);
+  }
+  if (!model.api && !config.api) {
+    throw new Error(`${label}: api is required at provider or model level`);
+  }
+  if (typeof model.reasoning !== "boolean") {
+    throw new Error(`${label}: reasoning must be boolean`);
+  }
+  validateInput(model.input, label);
+  validateFiniteNonNegative(model.cost?.input, `${label}.cost.input`);
+  validateFiniteNonNegative(model.cost?.output, `${label}.cost.output`);
+  validateFiniteNonNegative(model.cost?.cacheRead, `${label}.cost.cacheRead`);
+  validateFiniteNonNegative(model.cost?.cacheWrite, `${label}.cost.cacheWrite`);
+  validatePositiveInteger(model.contextWindow, `${label}.contextWindow`);
+  validatePositiveInteger(model.maxTokens, `${label}.maxTokens`);
+  validateHeaders(model.headers, `${label}.headers`);
+}
+
+function validateProviderConfig(
+  providerName: string,
+  config: PiProviderRegistration,
+): void {
+  validateProviderName(providerName);
+  validateHeaders(config.headers, `Provider ${providerName}.headers`);
+  if (
+    config.authHeader !== undefined &&
+    typeof config.authHeader !== "boolean"
+  ) {
+    throw new Error(`Provider ${providerName}.authHeader must be boolean`);
+  }
+  if (config.models !== undefined) {
+    if (!Array.isArray(config.models)) {
+      throw new Error(`Provider ${providerName}.models must be an array`);
+    }
+    const ids = new Set<string>();
+    for (const model of config.models) {
+      validateModel(providerName, config, model);
+      if (ids.has(model.id)) {
+        throw new Error(
+          `Provider ${providerName}: duplicate model id "${model.id}"`,
+        );
+      }
+      ids.add(model.id);
+    }
+  }
+}
+
+export function registerPiProvider(
+  providerName: string,
+  config: PiProviderRegistration,
+  owner?: { id?: string; path?: string },
+): RegisteredPiProvider {
+  validateProviderConfig(providerName, config);
+  const registered: RegisteredPiProvider = {
+    providerName,
+    config: cloneConfig(config),
+    ...(owner?.id ? { ownerId: owner.id } : {}),
+    ...(owner?.path ? { path: owner.path } : {}),
+  };
+  registeredProviders.set(providerName, registered);
+  return getRegisteredPiProvider(providerName) as RegisteredPiProvider;
+}
+
+export function unregisterPiProvider(
+  providerName: string,
+  ownerId?: string,
+): void {
+  const existing = registeredProviders.get(providerName);
+  if (!existing) return;
+  if (ownerId && existing.ownerId && existing.ownerId !== ownerId) return;
+  registeredProviders.delete(providerName);
+}
+
+export function unregisterPiProvidersForOwner(ownerId: string): void {
+  for (const [providerName, provider] of registeredProviders.entries()) {
+    if (provider.ownerId === ownerId) {
+      registeredProviders.delete(providerName);
+    }
+  }
+}
+
+export function clearRegisteredPiProviders(): void {
+  registeredProviders.clear();
+}
+
+export function getRegisteredPiProvider(
+  providerName: string,
+): RegisteredPiProvider | undefined {
+  const provider = registeredProviders.get(providerName);
+  if (!provider) return undefined;
+  return {
+    ...provider,
+    config: cloneConfig(provider.config),
+  };
+}
+
+export function listRegisteredPiProviders(): RegisteredPiProvider[] {
+  return [...registeredProviders.values()].map((provider) => ({
+    ...provider,
+    config: cloneConfig(provider.config),
+  }));
+}
+
+export function resolveRegisteredPiProviderFromModelHandle(
+  model: string | undefined,
+): string | undefined {
+  if (!model) return undefined;
+  return [...registeredProviders.keys()].find((providerName) =>
+    model.startsWith(`${providerName}/`),
+  );
+}
+
+export function stripRegisteredProviderHandlePrefix(
+  model: string | undefined,
+  providerName: string,
+): string | undefined {
+  if (!model) return undefined;
+  const prefix = `${providerName}/`;
+  return model.startsWith(prefix) ? model.slice(prefix.length) : model;
+}
+
+export function resolveRegisteredPiProviderApiKey(
+  apiKey: string | undefined,
+): string | undefined {
+  if (!apiKey) return undefined;
+  return process.env[apiKey] ?? apiKey;
+}

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {
   mkdir,
@@ -21,6 +21,10 @@ import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ConversationMessageCreateBody } from "@/backend";
 import type { HeadlessTurnExecutor } from "@/backend/dev/headless-turn-executor";
+import {
+  clearRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-extension-registry";
 import type { PiStreamFunction } from "@/backend/dev/pi-stream-adapter";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LocalBackend } from "@/backend/local/local-backend";
@@ -132,6 +136,10 @@ function lettaStreamFromChunks(
 }
 
 describe("local backend pi transcript", () => {
+  afterEach(() => {
+    clearRegisteredPiProviders();
+  });
+
   test("uses wall-clock timestamps for new local conversations and messages", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-time-"));
     const before = Date.now() - 1_000;
@@ -486,6 +494,56 @@ describe("local backend pi transcript", () => {
     expect(calls).toEqual(["http://127.0.0.1:1234/v1/models"]);
     expect(handles).toContain("lmstudio/openai/gpt-oss-20b");
     expect(handles).not.toContain("lmstudio/google/gemma-3n-e4b");
+  });
+
+  test("lists extension-registered local provider models with context windows", async () => {
+    registerPiProvider("lmstudio", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gemma-4-26B-A4B-it-oQ6",
+          name: "Gemma 4 VLM",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-registered-provider-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "lmstudio",
+      providerName: "lc-lmstudio",
+      apiKey: "not-needed",
+      baseURL: "http://127.0.0.1:1234/v1",
+      storageDir,
+    });
+    const calls: string[] = [];
+    const fetchImpl = (async (input: unknown) => {
+      calls.push(typeof input === "string" ? input : String(input));
+      return new Response(
+        JSON.stringify({ data: [{ id: "heuristic-only-model" }] }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const models = await listLocalModels(storageDir, { fetch: fetchImpl });
+
+    expect(calls).toEqual([]);
+    expect(models).toContainEqual({
+      handle: "lmstudio/gemma-4-26B-A4B-it-oQ6",
+      max_context_window: 256000,
+      model: "lmstudio/gemma-4-26B-A4B-it-oQ6",
+      model_endpoint_type: "lmstudio",
+    });
+    expect(models.map((model) => model.handle)).not.toContain(
+      "lmstudio/heuristic-only-model",
+    );
   });
 
   test("discovers configured Ollama Cloud models from OpenAI-compatible catalog", async () => {

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -2,8 +2,10 @@ import {
   DEFAULT_PI_PROVIDER,
   type PiProvider,
 } from "@/backend/dev/pi-model-factory";
+import { listRegisteredPiProviders } from "@/backend/dev/pi-provider-extension-registry";
 import {
   getPiProviderSpec,
+  isPiProvider,
   listCatalogModelsForProvider,
   listConfiguredPiProviders,
   localModelHandle,
@@ -25,6 +27,7 @@ export interface LocalModelConfig {
 
 interface LocalModelListEntry {
   handle: string;
+  max_context_window?: number;
   model: string;
   model_endpoint_type: string;
 }
@@ -184,6 +187,12 @@ function isDiscoverableLocalProvider(provider: PiProvider): boolean {
   return getPiProviderSpec(provider).localModelDiscovery !== undefined;
 }
 
+function isPiProviderForLocalModelHandle(
+  provider: PiProvider | string,
+): provider is PiProvider {
+  return isPiProvider(provider);
+}
+
 async function discoverModelIdsForProvider(
   provider: PiProvider,
   records: readonly LocalProviderRecord[],
@@ -245,15 +254,51 @@ export async function listLocalModels(
   const providerNames = localProviderNamesFromRecords(records);
   const configured = resolveLocalModelConfig(storageDir);
   const models: LocalModelListEntry[] = [];
-  const addModel = (provider: PiProvider, model: string) => {
-    const handle = localModelHandle(provider, model);
+  const registeredProviders = listRegisteredPiProviders();
+  const registeredProvidersWithModels = new Set(
+    registeredProviders
+      .filter((provider) => provider.config.models !== undefined)
+      .map((provider) => provider.providerName),
+  );
+  const addModel = (
+    provider: PiProvider | string,
+    model: string,
+    options: {
+      handle?: string;
+      maxContextWindow?: number;
+      modelEndpointType?: string;
+    } = {},
+  ) => {
+    const handle =
+      options.handle ??
+      (typeof provider === "string" &&
+      !isPiProviderForLocalModelHandle(provider)
+        ? `${provider}/${model}`
+        : localModelHandle(provider as PiProvider, model));
     if (models.some((entry) => entry.handle === handle)) return;
     models.push({
       handle,
+      ...(options.maxContextWindow
+        ? { max_context_window: options.maxContextWindow }
+        : {}),
       model: handle,
-      model_endpoint_type: localProviderType(provider),
+      model_endpoint_type:
+        options.modelEndpointType ??
+        (isPiProviderForLocalModelHandle(provider)
+          ? localProviderType(provider)
+          : provider),
     });
   };
+
+  for (const provider of registeredProviders) {
+    for (const model of provider.config.models ?? []) {
+      addModel(provider.providerName, model.id, {
+        handle: `${provider.providerName}/${model.id}`,
+        maxContextWindow: model.contextWindow,
+        modelEndpointType: provider.providerName,
+      });
+    }
+  }
 
   // Only add the configured model if its provider is actually reachable
   // (has keys/env configured). Otherwise we'd show models the user can't use.
@@ -262,6 +307,7 @@ export async function listLocalModels(
   ).includes(configured.provider);
   if (
     !isDiscoverableLocalProvider(configured.provider) &&
+    !registeredProvidersWithModels.has(configured.provider) &&
     configuredProviderIsConfigured
   ) {
     addModel(configured.provider, configured.model);
@@ -273,6 +319,7 @@ export async function listLocalModels(
       LOCAL_MODEL_DISCOVERY_TIMEOUT_MS,
   };
   for (const provider of listConfiguredPiProviders(providerNames)) {
+    if (registeredProvidersWithModels.has(provider)) continue;
     if (isDiscoverableLocalProvider(provider)) {
       try {
         for (const model of await discoverModelIdsForProvider(

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -275,6 +275,47 @@ describe("pi model factory", () => {
     });
   });
 
+  test("local provider connection base URL overrides extension default", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-lmstudio-extension-url-"),
+    );
+    try {
+      registerPiProvider("lmstudio", {
+        baseUrl: "http://localhost:8000/v1",
+        apiKey: "not-needed",
+        api: "openai-completions",
+        models: [
+          {
+            id: "gemma-4-26B-A4B-it-oQ6",
+            name: "Gemma 4 VLM",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 256000,
+            maxTokens: 8192,
+          },
+        ],
+      });
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "lmstudio",
+        providerName: "lc-lmstudio",
+        apiKey: "not-needed",
+        baseURL: "http://127.0.0.1:1234/v1",
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "lmstudio/gemma-4-26B-A4B-it-oQ6",
+        { provider_type: "lmstudio_openai" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("normalizes local OpenAI-compatible provider base URLs for runtime", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-llama-cpp-base-url-"));
     try {

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,10 @@ import {
   applyPiEnvOverrides,
   resolvePiModelForAgent,
 } from "@/backend/dev/pi-model-factory";
+import {
+  clearRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-extension-registry";
 import {
   createOrUpdateLocalProvider,
   localOAuthAuthFromCredentials,
@@ -30,6 +34,10 @@ async function withEnv<T>(
 }
 
 describe("pi model factory", () => {
+  afterEach(() => {
+    clearRegisteredPiProviders();
+  });
+
   test("uses KIMI_API_KEY for Kimi For Coding", async () => {
     await withEnv(
       { KIMI_API_KEY: "kimi-key", MOONSHOT_API_KEY: undefined },
@@ -230,6 +238,41 @@ describe("pi model factory", () => {
     expect(resolved.provider).toBe("lmstudio");
     expect(resolved.model.provider).toBe("lmstudio");
     expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+  });
+
+  test("uses extension-registered provider capabilities for local OpenAI-compatible models", async () => {
+    registerPiProvider("lmstudio", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gemma-4-26B-A4B-it-oQ6",
+          name: "Gemma 4 VLM",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+
+    const resolved = await resolvePiModelForAgent(
+      "lmstudio/gemma-4-26B-A4B-it-oQ6",
+      { provider_type: "lmstudio_openai" },
+    );
+
+    expect(resolved.provider).toBe("lmstudio");
+    expect(resolved.model).toMatchObject({
+      id: "gemma-4-26B-A4B-it-oQ6",
+      provider: "lmstudio",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 256000,
+      maxTokens: 8192,
+    });
   });
 
   test("normalizes local OpenAI-compatible provider base URLs for runtime", async () => {

--- a/src/cli/extensions/capabilities.ts
+++ b/src/cli/extensions/capabilities.ts
@@ -6,6 +6,7 @@ export const TUI_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   events: {
     lifecycle: true,
   },
+  providers: true,
   ui: {
     panels: true,
     statusValues: true,

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -6,6 +6,7 @@ export const DEFAULT_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   events: {
     lifecycle: true,
   },
+  providers: true,
   ui: {
     panels: true,
     statusValues: true,
@@ -22,6 +23,7 @@ export function cloneExtensionCapabilities(
     events: {
       lifecycle: capabilities.events.lifecycle,
     },
+    providers: capabilities.providers,
     ui: {
       panels: capabilities.ui.panels,
       statusValues: capabilities.ui.statusValues,

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
 import {
+  clearRegisteredPiProviders,
+  getRegisteredPiProvider,
+} from "@/backend/dev/pi-provider-extension-registry";
+import {
   createExtensionHost,
   type ExtensionHost,
 } from "@/extensions/extension-host";
@@ -96,6 +100,7 @@ const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   tools: true,
   commands: false,
   events: { lifecycle: false },
+  providers: false,
   ui: {
     panels: false,
     statusValues: false,
@@ -106,6 +111,7 @@ const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 describe("extension host", () => {
   afterEach(() => {
     clearExtensionTools();
+    clearRegisteredPiProviders();
   });
 
   test("reload publishes snapshots with owner metadata", async () => {
@@ -247,6 +253,51 @@ describe("extension host", () => {
     } finally {
       delete testGlobal.__lettaExtensionBackend;
       delete testGlobal.__lettaExtensionForkResult;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("lets extensions register pi providers for local backend", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "provider.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          letta.registerProvider("lmstudio", {
+            baseUrl: "http://localhost:8000/v1",
+            apiKey: "not-needed",
+            api: "openai-completions",
+            models: [{
+              id: "gemma-4-26B-A4B-it-oQ6",
+              name: "Gemma 4 VLM",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 256000,
+              maxTokens: 8192,
+            }],
+          });
+        }`,
+      );
+
+      const host = createHost(root);
+      await host.reload();
+
+      expect(
+        getRegisteredPiProvider("lmstudio")?.config.models?.[0],
+      ).toMatchObject({
+        id: "gemma-4-26B-A4B-it-oQ6",
+        input: ["text", "image"],
+        contextWindow: 256000,
+        reasoning: true,
+      });
+
+      host.dispose();
+      expect(getRegisteredPiProvider("lmstudio")).toBeUndefined();
+    } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -15,6 +15,12 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type Letta from "@letta-ai/letta-client";
 import * as ts from "typescript";
+import type { PiProviderRegistration } from "@/backend/dev/pi-provider-extension-registry";
+import {
+  registerPiProvider,
+  unregisterPiProvider,
+  unregisterPiProvidersForOwner,
+} from "@/backend/dev/pi-provider-extension-registry";
 import type {
   StatuslineRenderContext,
   StatuslineRenderer,
@@ -93,12 +99,24 @@ export interface LettaExtensionApi {
   getClient: () => Promise<Letta>;
   getContext: () => ExtensionContext;
   signal: AbortSignal;
+  registerProvider: (
+    name: string,
+    config: PiProviderRegistration,
+  ) => LettaExtensionDisposer;
+  unregisterProvider: (name: string) => void;
   commands: {
     register: (command: ExtensionCommandRegistration) => LettaExtensionDisposer;
     unregister: (id: string) => void;
   };
   tools: {
     register: (tool: ExtensionToolRegistration) => LettaExtensionDisposer;
+    unregister: (name: string) => void;
+  };
+  providers: {
+    register: (
+      name: string,
+      config: PiProviderRegistration,
+    ) => LettaExtensionDisposer;
     unregister: (name: string) => void;
   };
   events: {
@@ -371,6 +389,8 @@ function removeOwnerCapabilities(
   registry: LocalExtensionRegistry,
   owner: ExtensionOwner,
 ): void {
+  unregisterPiProvidersForOwner(owner.id);
+
   for (const [id, command] of Object.entries(registry.commands)) {
     if (command.owner?.id === owner.id) {
       delete registry.commands[id];
@@ -805,6 +825,31 @@ function createLettaExtensionApi(
     }
   };
 
+  const unregisterProvider = (name: string) => {
+    if (!capabilities.providers) return;
+    if (!guardLive({ id: name, kind: "provider" })) return;
+    unregisterPiProvider(name, owner.id);
+    onChange();
+  };
+
+  const registerProviderForOwner = (
+    name: string,
+    config: PiProviderRegistration,
+  ): LettaExtensionDisposer => {
+    if (!capabilities.providers) {
+      return () => undefined;
+    }
+    if (!guardLive({ id: name, kind: "provider" })) {
+      return () => undefined;
+    }
+    registerPiProvider(name, config, {
+      id: owner.id,
+      path: owner.path,
+    });
+    onChange();
+    return () => unregisterProvider(name);
+  };
+
   const onEvent = <TName extends ExtensionEventName>(
     name: TName,
     handler: ExtensionEventHandler<TName>,
@@ -841,6 +886,8 @@ function createLettaExtensionApi(
     getClient,
     getContext,
     signal,
+    registerProvider: registerProviderForOwner,
+    unregisterProvider,
     commands: {
       register(command) {
         if (!capabilities.commands) {
@@ -910,6 +957,12 @@ function createLettaExtensionApi(
         return () => unregisterTool(normalized.name);
       },
       unregister: unregisterTool,
+    },
+    providers: {
+      register(name, config) {
+        return registerProviderForOwner(name, config);
+      },
+      unregister: unregisterProvider,
     },
     events: {
       off: unregisterEvent,
@@ -1182,6 +1235,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
   }
 
   for (const owner of Object.values(registry.owners)) {
+    unregisterPiProvidersForOwner(owner.id);
     unregisterExtensionToolsForOwner(owner);
   }
 

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -76,6 +76,7 @@ export interface ExtensionCapabilities {
   tools: boolean;
   commands: boolean;
   events: ExtensionEventCapabilities;
+  providers: boolean;
   ui: ExtensionUiCapabilities;
 }
 
@@ -196,6 +197,7 @@ export interface ExtensionEventEmissionResult {
 export type ExtensionCapabilityKind =
   | "command"
   | "event"
+  | "provider"
   | "tool"
   | "panel"
   | "status"

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -42,6 +42,7 @@ describe("headless extension runtime", () => {
       events: {
         lifecycle: true,
       },
+      providers: true,
       ui: {
         panels: false,
         statusValues: false,

--- a/src/headless-extension-runtime.ts
+++ b/src/headless-extension-runtime.ts
@@ -27,6 +27,7 @@ export const HEADLESS_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   events: {
     lifecycle: true,
   },
+  providers: true,
   ui: {
     panels: false,
     statusValues: false,


### PR DESCRIPTION
## Summary
- Add a pi-mono-style `letta.registerProvider()` / `letta.providers.register()` extension API for registering pi provider model contracts.
- Make local backend pi model resolution consume registered model capabilities (`input`, `reasoning`, `contextWindow`, `maxTokens`, headers/base URL) before falling back to heuristic custom OpenAI-compatible models.
- Surface registered local provider models and context windows through local model listing so `/model` and context-window defaults can use extension metadata.

## Fixes
- Fixes #2541

## Test plan
- [x] `bun test src/backend/pi-model-factory.test.ts src/backend/local-backend.test.ts src/extensions/extension-host.test.ts src/headless-extension-lifecycle.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)