### PR TITLE
fix: resolve CLI hang/crash when using --new-agent with --conv default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1878,7 +1878,7 @@ async function main(): Promise<void> {
         // Conversation ID is unique, so we can derive the agent from it
         // (except for "default" which requires --agent flag, validated above)
         // =====================================================================
-        if (specifiedConversationId) {
+        if (specifiedConversationId && !forceNew) {
           if (specifiedConversationId === "default") {
             // "default" requires --agent (validated in flag preprocessing above)
             // Use the specified agent directly, skip conversation validation
@@ -2635,7 +2635,7 @@ async function main(): Promise<void> {
           );
         }
 
-        if (specifiedConversationId) {
+        if (specifiedConversationId && specifiedConversationId !== "default") {
           // Use the explicitly specified conversation ID
           // User explicitly requested this conversation, so error if it doesn't exist
           conversationIdToUse = specifiedConversationId;

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -176,6 +176,17 @@ describe("Startup Flow - Smoke", () => {
     expect(result.stderr).not.toContain("No recent session found");
   });
 
+  test("--new-agent --conv default headless parses and reaches credential check", async () => {
+    const result = await runCli(
+      ["--new-agent", "--conv", "default", "-p", "Say OK"],
+      {
+        expectExit: 1,
+      },
+    );
+    expect(result.stderr).toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("No recent session found");
+  });
+
   test("--toolset auto is accepted", async () => {
     const result = await runCli(
       ["--new-agent", "--toolset", "auto", "-p", "Say OK"],


### PR DESCRIPTION
Closes #2510 

### Problem
When launching the Letta Code CLI in interactive (TUI) mode using the `--new-agent --conv default` flags, the terminal hangs indefinitely on the welcome/loading screen. 
Under the hood, the application crashes silently due to an unhandled exception during the initial startup validation:
`Error during initialization: Unreachable: --conv default requires --agent`

### Root Cause
1. **Startup Flag Preprocessing**: The validator `validateConversationDefaultRequiresAgent` correctly permits `--conv default` to be passed without `--agent` if `--new-agent` (`forceNew`) is active, as a new agent will be created.
2. **TUI Startup Flow**: Inside the loading state initializer (`checkAndStart`) in `src/index.ts`, the logic attempted to resolve the specified conversation ID immediately on mount. If the specified conversation ID was `"default"`, it checked for `specifiedAgentId`. Because the new agent had not yet been created, `specifiedAgentId` was `null`, throwing the unreachable error and halting the CLI.

### Solution
1. **Bypass Pre-resolution on Agent Creation**: Updated the startup check in `src/index.ts` to skip the immediate conversation resolution/validation block when `forceNew` is active, allowing the flow to proceed to agent creation.
2. **Fall Through to Default Block**: Modified the check in `src/index.ts` so that `specifiedConversationId === "default"` falls through to the default conversation block instead of forcing `setResumedExistingConversation(true)`. This prevents the UI from incorrectly treating the brand-new agent's default conversation as a resumed session, ensuring that startup greetings/bootstrap prompts render properly.
3. **Tests Added**: Added a headless CLI validation smoke test verifying the flag combination reaches the credential check without error in `src/startup-flow.test.ts`.