### PR TITLE
feat(extensions): expose conversation history to tools

### DIFF
--- a/src/cli/extensions/types.ts
+++ b/src/cli/extensions/types.ts
@@ -17,6 +17,7 @@ export type {
   ExtensionContextWindowContext,
   ExtensionConversationCloseEvent,
   ExtensionConversationCloseReason,
+  ExtensionConversationHistoryOptions,
   ExtensionConversationOpenEvent,
   ExtensionConversationOpenReason,
   ExtensionCostContext,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -2,6 +2,7 @@ import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agen
 import type {
   ApprovalCreate,
   LettaStreamingResponse,
+  Message,
 } from "@letta-ai/letta-client/resources/agents/messages";
 
 export interface ExtensionWorkspaceContext {
@@ -362,6 +363,15 @@ export type ExtensionToolRunResult =
       success?: boolean;
     };
 
+export interface ExtensionConversationHistoryOptions {
+  /** Maximum number of recent messages to return. Defaults to 100. */
+  limit?: number;
+  /** Return chronological (asc, default) or newest-first (desc) messages. */
+  order?: "asc" | "desc";
+  /** Include error messages and error statuses. Defaults to true. */
+  includeErrors?: boolean;
+}
+
 export interface ExtensionToolRunContext {
   args: Record<string, unknown>;
   cwd: string;
@@ -375,6 +385,9 @@ export interface ExtensionToolRunContext {
   };
   conversation: {
     id: string | null;
+    getHistory: (
+      options?: ExtensionConversationHistoryOptions,
+    ) => Promise<Message[]>;
   };
   getContext: () => ExtensionContext;
 }

--- a/src/skills/builtin/creating-extensions/references/tools.md
+++ b/src/skills/builtin/creating-extensions/references/tools.md
@@ -10,6 +10,7 @@ Use tools when the agent/model should call a local capability autonomously.
 - `requiresApproval: false` only for read-only, low-risk local introspection.
 - `parallelSafe: true` only for read-only tools with no shared mutation or long-lived exclusive resource.
 - Use `ctx.cwd` / `ctx.workingDirectory` as the workspace.
+- Use `await ctx.conversation.getHistory()` when a tool needs recent conversation context. It returns the most recent messages in chronological order by default.
 - Respect `ctx.signal` for long-running work when practical.
 
 ## Read-only shell tool

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1,5 +1,6 @@
 import * as nodeFs from "node:fs/promises";
 import * as nodePath from "node:path";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import stripAnsi from "strip-ansi";
 import { getDisplayableToolReturn } from "@/agent/approval-execution";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@/agent/context";
 import { getModelInfo } from "@/agent/model";
 import { getAllSubagentConfigs } from "@/agent/subagents";
+import type { ConversationMessageListBody } from "@/backend";
 import {
   buildDynamicMessageChannelToolDefinition,
   getCachedDynamicMessageChannelToolDefinition,
@@ -26,7 +28,10 @@ import {
   isExtensionToolParallelSafe,
   runExtensionTool,
 } from "@/extensions/tool-registry";
-import type { ExtensionToolRunContext } from "@/extensions/types";
+import type {
+  ExtensionConversationHistoryOptions,
+  ExtensionToolRunContext,
+} from "@/extensions/types";
 import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
@@ -1775,6 +1780,43 @@ function getExtensionToolStatus(result: unknown): "success" | "error" {
   return "success";
 }
 
+const DEFAULT_EXTENSION_CONVERSATION_HISTORY_LIMIT = 100;
+const MAX_EXTENSION_CONVERSATION_HISTORY_LIMIT = 500;
+
+function normalizeExtensionConversationHistoryLimit(limit?: number): number {
+  if (limit === undefined) return DEFAULT_EXTENSION_CONVERSATION_HISTORY_LIMIT;
+  if (!Number.isFinite(limit))
+    return DEFAULT_EXTENSION_CONVERSATION_HISTORY_LIMIT;
+  return Math.min(
+    Math.max(1, Math.trunc(limit)),
+    MAX_EXTENSION_CONVERSATION_HISTORY_LIMIT,
+  );
+}
+
+async function loadExtensionConversationHistory(
+  executionScope: RuntimeContextSnapshot,
+  options?: ExtensionConversationHistoryOptions,
+): Promise<Message[]> {
+  const conversationId = executionScope.conversationId ?? "default";
+  const agentId = executionScope.agentId ?? null;
+  if (!executionScope.conversationId && !agentId) {
+    return [];
+  }
+
+  const { getBackend } = await import("@/backend");
+  const page = await getBackend().listConversationMessages(conversationId, {
+    limit: normalizeExtensionConversationHistoryLimit(options?.limit),
+    order: "desc",
+    include_err: options?.includeErrors ?? true,
+    ...(conversationId === "default" && agentId ? { agent_id: agentId } : {}),
+  } as ConversationMessageListBody);
+  const messages = page.getPaginatedItems() as Message[];
+  if (options?.order === "desc") {
+    return messages;
+  }
+  return [...messages].reverse();
+}
+
 type ToolHookContext = {
   args: Record<string, unknown>;
   debugLabel: string;
@@ -1911,7 +1953,11 @@ async function executeExtensionTool(
           : {}),
         permissionMode: executionScope.permissionMode ?? null,
         agent: { id: executionScope.agentId ?? null },
-        conversation: { id: executionScope.conversationId ?? null },
+        conversation: {
+          id: executionScope.conversationId ?? null,
+          getHistory: (historyOptions) =>
+            loadExtensionConversationHistory(executionScope, historyOptions),
+        },
         getContext: tool.getContext,
       };
       const result = await runExtensionTool(tool, context);

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -9,7 +9,8 @@ import {
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { __testSetBackend } from "@/backend";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { __testSetBackend, type Backend } from "@/backend";
 import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 import {
   __testOverrideLoadChannelAccounts,
@@ -329,6 +330,79 @@ describe("tool execution context snapshot", () => {
 
     expect(result.status).toBe("success");
     expect(asText(result.toolReturn)).toBe("echo:hi");
+  });
+
+  test("exposes recent conversation history to extension tools", async () => {
+    const newestFirstMessages = [
+      {
+        id: "msg-2",
+        date: "2026-05-27T00:00:02.000Z",
+        message_type: "assistant_message",
+        content: "hello",
+      },
+      {
+        id: "msg-1",
+        date: "2026-05-27T00:00:01.000Z",
+        message_type: "user_message",
+        content: "hi",
+      },
+    ] as unknown as Message[];
+    const listCalls: Array<{ body: unknown; conversationId: string }> = [];
+    __testSetBackend({
+      listConversationMessages: async (
+        conversationId: string,
+        body: unknown,
+      ) => {
+        listCalls.push({ conversationId, body });
+        return {
+          getPaginatedItems: () => newestFirstMessages,
+        };
+      },
+    } as unknown as Backend);
+
+    const controller = new AbortController();
+    registerExtensionTool({
+      name: "history_echo",
+      description: "Echo conversation history ids",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/history-echo.ts",
+        path: "/tmp/history-echo.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/history-echo.ts",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      getContext: () => {
+        throw new Error("context should not be needed for this test");
+      },
+      isAvailable: () => true,
+      run: async (ctx) => {
+        const history = await ctx.conversation.getHistory({ limit: 2 });
+        return history.map((message) => message.id).join(",");
+      },
+    });
+
+    const result = await runWithRuntimeContext(
+      { agentId: "agent-1", conversationId: "default" },
+      () => executeTool("history_echo", {}),
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("msg-1,msg-2");
+    expect(listCalls).toEqual([
+      {
+        conversationId: "default",
+        body: {
+          agent_id: "agent-1",
+          include_err: true,
+          limit: 2,
+          order: "desc",
+        },
+      },
+    ]);
   });
 
   test("extension tools take precedence over external tools with the same name", async () => {


### PR DESCRIPTION
## Summary
- Add `ctx.conversation.getHistory()` for extension tools to inspect recent scoped conversation messages.
- Thread history loading through the turn execution context with default chronological results and bounded limits.
- Document the API and cover it with a tool execution context test.

Closes #2539

## Test plan
- [x] `bun test src/tools/tool-execution-context.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)