### PR TITLE
feat(cron): log schedule runs to disk

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -118,6 +118,7 @@ import {
   handleMissedOneShot,
   isProcessAlive,
   readCronFile,
+  safeAppendCronRunLogForTask,
   shouldFireTask,
   updateTask,
 } from "@/cron";
@@ -1457,6 +1458,13 @@ export function App({
                 t.fire_count = 1;
               });
             }
+
+            safeAppendCronRunLogForTask(freshTask, {
+              status: "ok",
+              runAtMs: now.getTime(),
+              scheduledFor: freshTask.scheduled_for,
+              firedAt: nowIso,
+            });
 
             debugLog("cron", `TUI shadow scheduler fired task ${taskId}`);
           };

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -7,6 +7,7 @@
  *   letta cron add --prompt <text> --cron <expr> [--agent <id>]
  *   letta cron list [--agent <id>] [--conversation <id>]
  *   letta cron get <id>
+ *   letta cron runs --id <id>
  *   letta cron delete <id>
  *   letta cron delete --all [--agent <id>]
  */
@@ -16,11 +17,13 @@ import {
   addTask,
   deleteAllTasks,
   deleteTask,
+  getCronRunLogPath,
   getTask,
   isValidCron,
   listTasks,
   parseAt,
   parseEvery,
+  readCronRunLogEntriesPage,
 } from "@/cron";
 
 // ── Usage ───────────────────────────────────────────────────────────
@@ -34,6 +37,7 @@ Usage:
   letta cron add --prompt <text> --cron <expr> [options]
   letta cron list [options]
   letta cron get <id>
+  letta cron runs --id <id> [--limit <n>]
   letta cron delete <id>
   letta cron delete --all [--agent <id>]
 
@@ -72,6 +76,9 @@ const CRON_OPTIONS = {
   agent: { type: "string" },
   conversation: { type: "string" },
   all: { type: "boolean" },
+  id: { type: "string" },
+  limit: { type: "string" },
+  "run-id": { type: "string" },
 } as const;
 
 function parseCronArgs(argv: string[]) {
@@ -256,6 +263,34 @@ function handleGet(positionals: string[]): number {
   return 0;
 }
 
+function handleRuns(
+  values: ReturnType<typeof parseCronArgs>["values"],
+): number {
+  const id = values.id;
+  if (!id || typeof id !== "string") {
+    console.error("Error: --id is required. Usage: letta cron runs --id <id>");
+    return 1;
+  }
+
+  const limitRaw = Number.parseInt(String(values.limit ?? "50"), 10);
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
+  const runId = values["run-id"];
+
+  try {
+    const logPath = getCronRunLogPath(id);
+    const page = readCronRunLogEntriesPage(logPath, {
+      jobId: id,
+      limit,
+      ...(typeof runId === "string" && runId.trim() ? { runId } : {}),
+    });
+    console.log(JSON.stringify(page, null, 2));
+    return 0;
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
 function handleDelete(
   values: ReturnType<typeof parseCronArgs>["values"],
   positionals: string[],
@@ -314,6 +349,8 @@ export async function runCronSubcommand(argv: string[]): Promise<number> {
       return handleList(parsed.values);
     case "get":
       return handleGet(parsed.positionals);
+    case "runs":
+      return handleRuns(parsed.values);
     case "delete":
       return handleDelete(parsed.values, parsed.positionals);
     default:

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -95,7 +95,7 @@ function getLettaDir(): string {
   return join(process.env.HOME ?? process.env.USERPROFILE ?? "~", ".letta");
 }
 
-function getCronFilePath(): string {
+export function getCronFilePath(): string {
   return join(getLettaDir(), CRON_FILE_NAME);
 }
 

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -32,7 +32,20 @@ export {
   parseAt,
   parseEvery,
 } from "./parse-interval";
-
+export {
+  appendCronRunLog,
+  appendCronRunLogForTask,
+  type CronRunLogEntry,
+  type CronRunLogPage,
+  type CronRunLogStatus,
+  DEFAULT_CRON_RUN_LOG_KEEP_LINES,
+  DEFAULT_CRON_RUN_LOG_MAX_BYTES,
+  getCronRunLogPath,
+  readCronRunLogEntries,
+  readCronRunLogEntriesPage,
+  resolveCronRunLogPath,
+  safeAppendCronRunLogForTask,
+} from "./run-log";
 export {
   handleMissedOneShot,
   shouldFireTask,

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  appendCronRunLog,
+  DEFAULT_CRON_RUN_LOG_KEEP_LINES,
+  DEFAULT_CRON_RUN_LOG_MAX_BYTES,
+  getCronRunLogPath,
+  readCronRunLogEntries,
+  readCronRunLogEntriesPage,
+  resolveCronRunLogPath,
+} from "@/cron/run-log";
+
+const TEST_DIR = path.join(import.meta.dir, "__run_log_test_tmp__");
+const origHome = process.env.LETTA_HOME;
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.LETTA_HOME = TEST_DIR;
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  if (origHome) process.env.LETTA_HOME = origHome;
+  else delete process.env.LETTA_HOME;
+});
+
+describe("cron run log", () => {
+  test("exports reference retention defaults", () => {
+    expect(DEFAULT_CRON_RUN_LOG_MAX_BYTES).toBe(2_000_000);
+    expect(DEFAULT_CRON_RUN_LOG_KEEP_LINES).toBe(2_000);
+  });
+
+  test("resolves crons.json to sibling runs/<jobId>.jsonl", () => {
+    const storePath = path.join(os.tmpdir(), "letta", "crons.json");
+    const logPath = resolveCronRunLogPath({ storePath, jobId: "job-1" });
+    expect(
+      logPath.endsWith(path.join(os.tmpdir(), "letta", "runs", "job-1.jsonl")),
+    ).toBe(true);
+  });
+
+  test("resolves current LETTA_HOME run log path", () => {
+    expect(getCronRunLogPath("job-1")).toBe(
+      path.join(TEST_DIR, "runs", "job-1.jsonl"),
+    );
+  });
+
+  test("rejects unsafe job ids", () => {
+    const storePath = path.join(os.tmpdir(), "letta", "crons.json");
+    expect(() =>
+      resolveCronRunLogPath({ storePath, jobId: "../job-1" }),
+    ).toThrow(/invalid cron run log job id/i);
+    expect(() =>
+      resolveCronRunLogPath({ storePath, jobId: "nested/job-1" }),
+    ).toThrow(/invalid cron run log job id/i);
+    expect(() =>
+      resolveCronRunLogPath({ storePath, jobId: "..\\job-1" }),
+    ).toThrow(/invalid cron run log job id/i);
+  });
+
+  test("appends JSONL and prunes by line count", () => {
+    const logPath = getCronRunLogPath("job-1");
+    for (let i = 0; i < 10; i++) {
+      appendCronRunLog(
+        logPath,
+        {
+          ts: 1000 + i,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+        },
+        { maxBytes: 1, keepLines: 3 },
+      );
+    }
+
+    const lines = readFileSync(logPath, "utf-8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[2] ?? "{}")).toMatchObject({ ts: 1009 });
+  });
+
+  test("reads entries and ignores invalid lines", () => {
+    const logPath = getCronRunLogPath("job-1");
+    appendCronRunLog(logPath, {
+      ts: 1000,
+      jobId: "job-1",
+      action: "finished",
+      status: "ok",
+      queueItemId: "q-1",
+    });
+    appendCronRunLog(logPath, {
+      ts: 2000,
+      jobId: "job-1",
+      action: "finished",
+      status: "error",
+      error: "boom",
+      runId: "run-2",
+    });
+    appendCronRunLog(logPath, {
+      ts: 3000,
+      jobId: "job-2",
+      action: "finished",
+      status: "skipped",
+    });
+    appendFileSync(logPath, "not-json\n");
+    appendFileSync(logPath, '{"ts":4000,"jobId":"job-1","action":"started"}\n');
+
+    const entries = readCronRunLogEntries(logPath, {
+      jobId: "job-1",
+      limit: 10,
+    });
+    expect(entries.map((entry) => entry.ts)).toEqual([1000, 2000]);
+    expect(entries[0]?.queueItemId).toBe("q-1");
+    expect(entries[1]?.error).toBe("boom");
+  });
+
+  test("reads newest page first and filters by run id", () => {
+    const logPath = getCronRunLogPath("job-1");
+    appendCronRunLog(logPath, {
+      ts: 1000,
+      jobId: "job-1",
+      action: "finished",
+      status: "ok",
+      runId: "run-1",
+    });
+    appendCronRunLog(logPath, {
+      ts: 2000,
+      jobId: "job-1",
+      action: "finished",
+      status: "error",
+      runId: "run-2",
+    });
+
+    expect(readCronRunLogEntriesPage(logPath, { limit: 1 })).toMatchObject({
+      total: 2,
+      hasMore: true,
+      nextOffset: 1,
+      entries: [{ ts: 2000 }],
+    });
+    expect(
+      readCronRunLogEntriesPage(logPath, { runId: "run-1" }).entries,
+    ).toEqual([expect.objectContaining({ runId: "run-1", ts: 1000 })]);
+  });
+});

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,0 +1,260 @@
+/**
+ * Per-task cron run history backed by JSONL files next to crons.json.
+ *
+ * This mirrors the reference shape: job state stays in one JSON file, while
+ * each job/task gets an append-only `runs/<id>.jsonl` history file.
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { type CronTask, getCronFilePath } from "./cron-file";
+
+export type CronRunLogStatus = "ok" | "error" | "skipped";
+
+export interface CronRunLogEntry {
+  ts: number;
+  jobId: string;
+  action: "finished";
+  status?: CronRunLogStatus;
+  error?: string;
+  summary?: string;
+  agentId?: string;
+  conversationId?: string;
+  runId?: string;
+  runAtMs?: number;
+  queueItemId?: string;
+  scheduledFor?: string | null;
+  firedAt?: string;
+}
+
+export interface CronRunLogPage {
+  entries: CronRunLogEntry[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}
+
+export const DEFAULT_CRON_RUN_LOG_MAX_BYTES = 2_000_000;
+export const DEFAULT_CRON_RUN_LOG_KEEP_LINES = 2_000;
+
+function assertSafeCronRunLogJobId(jobId: string): string {
+  const trimmed = jobId.trim();
+  if (!trimmed) {
+    throw new Error("invalid cron run log job id");
+  }
+  if (
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed.includes("\0")
+  ) {
+    throw new Error("invalid cron run log job id");
+  }
+  return trimmed;
+}
+
+export function resolveCronRunLogPath(params: {
+  storePath: string;
+  jobId: string;
+}): string {
+  const storePath = path.resolve(params.storePath);
+  const runsDir = path.resolve(path.dirname(storePath), "runs");
+  const safeJobId = assertSafeCronRunLogJobId(params.jobId);
+  const resolvedPath = path.resolve(runsDir, `${safeJobId}.jsonl`);
+  if (!resolvedPath.startsWith(`${runsDir}${path.sep}`)) {
+    throw new Error("invalid cron run log job id");
+  }
+  return resolvedPath;
+}
+
+export function getCronRunLogPath(jobId: string): string {
+  return resolveCronRunLogPath({ storePath: getCronFilePath(), jobId });
+}
+
+function setSecureDirMode(dirPath: string): void {
+  try {
+    chmodSync(dirPath, 0o700);
+  } catch {
+    // Best effort on platforms/filesystems that do not support chmod.
+  }
+}
+
+function setSecureFileMode(filePath: string): void {
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // Best effort on platforms/filesystems that do not support chmod.
+  }
+}
+
+function pruneIfNeeded(
+  filePath: string,
+  opts: { maxBytes: number; keepLines: number },
+): void {
+  let size = 0;
+  try {
+    size = statSync(filePath).size;
+  } catch {
+    return;
+  }
+  if (size <= opts.maxBytes) {
+    return;
+  }
+
+  const raw = readFileSync(filePath, "utf-8");
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
+  writeFileSync(filePath, `${kept.join("\n")}\n`, { mode: 0o600 });
+  setSecureFileMode(filePath);
+}
+
+export function appendCronRunLog(
+  filePath: string,
+  entry: CronRunLogEntry,
+  opts?: { maxBytes?: number; keepLines?: number },
+): void {
+  const resolved = path.resolve(filePath);
+  const runDir = path.dirname(resolved);
+  if (!existsSync(runDir)) {
+    mkdirSync(runDir, { recursive: true, mode: 0o700 });
+  }
+  setSecureDirMode(runDir);
+  appendFileSync(resolved, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+  setSecureFileMode(resolved);
+  pruneIfNeeded(resolved, {
+    maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
+    keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,
+  });
+}
+
+function parseAllRunLogEntries(raw: string, jobId?: string): CronRunLogEntry[] {
+  if (!raw.trim()) {
+    return [];
+  }
+  const entries: CronRunLogEntry[] = [];
+  for (const rawLine of raw.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(line) as Partial<CronRunLogEntry> | null;
+      if (!obj || typeof obj !== "object") {
+        continue;
+      }
+      if (obj.action !== "finished") {
+        continue;
+      }
+      if (typeof obj.jobId !== "string" || obj.jobId.trim().length === 0) {
+        continue;
+      }
+      if (typeof obj.ts !== "number" || !Number.isFinite(obj.ts)) {
+        continue;
+      }
+      if (jobId && obj.jobId !== jobId) {
+        continue;
+      }
+      entries.push({
+        ts: obj.ts,
+        jobId: obj.jobId,
+        action: "finished",
+        status: obj.status,
+        error: obj.error,
+        summary: obj.summary,
+        agentId: obj.agentId,
+        conversationId: obj.conversationId,
+        runId: obj.runId,
+        runAtMs: obj.runAtMs,
+        queueItemId: obj.queueItemId,
+        scheduledFor: obj.scheduledFor,
+        firedAt: obj.firedAt,
+      });
+    } catch {
+      // Ignore invalid lines.
+    }
+  }
+  return entries;
+}
+
+export function readCronRunLogEntries(
+  filePath: string,
+  opts?: { limit?: number; jobId?: string },
+): CronRunLogEntry[] {
+  const limit = Math.max(1, Math.min(5000, Math.floor(opts?.limit ?? 200)));
+  let raw = "";
+  try {
+    raw = readFileSync(path.resolve(filePath), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseAllRunLogEntries(raw, opts?.jobId).slice(-limit);
+}
+
+export function readCronRunLogEntriesPage(
+  filePath: string,
+  opts?: { limit?: number; offset?: number; jobId?: string; runId?: string },
+): CronRunLogPage {
+  const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? 50)));
+  const offset = Math.max(0, Math.floor(opts?.offset ?? 0));
+  const entries = readCronRunLogEntries(filePath, {
+    limit: 5000,
+    jobId: opts?.jobId,
+  })
+    .filter((entry) => !opts?.runId || entry.runId === opts.runId)
+    .toSorted((a, b) => b.ts - a.ts);
+  const pageEntries = entries.slice(offset, offset + limit);
+  const nextOffset = offset + pageEntries.length;
+  return {
+    entries: pageEntries,
+    total: entries.length,
+    offset,
+    limit,
+    hasMore: nextOffset < entries.length,
+    nextOffset: nextOffset < entries.length ? nextOffset : null,
+  };
+}
+
+export function appendCronRunLogForTask(
+  task: CronTask,
+  entry: Omit<
+    CronRunLogEntry,
+    "action" | "agentId" | "conversationId" | "jobId" | "ts"
+  > & {
+    ts?: number;
+  },
+): void {
+  appendCronRunLog(getCronRunLogPath(task.id), {
+    ts: entry.ts ?? Date.now(),
+    jobId: task.id,
+    action: "finished",
+    agentId: task.agent_id,
+    conversationId: task.conversation_id,
+    ...entry,
+  });
+}
+
+export function safeAppendCronRunLogForTask(
+  task: CronTask,
+  entry: Parameters<typeof appendCronRunLogForTask>[1],
+): void {
+  try {
+    appendCronRunLogForTask(task, entry);
+  } catch (err) {
+    console.error(
+      `[Cron] Error writing run log for task ${task.id}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -9,6 +9,8 @@ import {
   updateTask,
 } from "@/cron/cron-file";
 import { cronMatchesTime } from "@/cron/parse-interval";
+import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
+import { handleMissedOneShot } from "@/cron/scheduler";
 
 // ── Test setup ──────────────────────────────────────────────────────
 
@@ -155,6 +157,31 @@ describe("task lifecycle", () => {
     );
     // jitter_offset_ms should be a number (may be 0 or negative for :00/:30)
     expect(typeof task.jitter_offset_ms).toBe("number");
+  });
+
+  test("missed one-shot writes a skipped run log", () => {
+    const scheduledFor = new Date(Date.now() - 10 * 60 * 1000);
+    const { task } = addTask(
+      makeInput({
+        recurring: false,
+        scheduled_for: scheduledFor,
+      }),
+    );
+
+    expect(handleMissedOneShot(task, new Date())).toBe(true);
+
+    const entries = readCronRunLogEntries(getCronRunLogPath(task.id), {
+      jobId: task.id,
+      limit: 10,
+    });
+    expect(entries).toEqual([
+      expect.objectContaining({
+        jobId: task.id,
+        status: "skipped",
+        summary: "missed",
+        scheduledFor: scheduledFor.toISOString(),
+      }),
+    ]);
   });
 });
 

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -36,6 +36,7 @@ import {
   verifySchedulerLease,
 } from "./cron-file";
 import { cronMatchesTime } from "./parse-interval";
+import { safeAppendCronRunLogForTask } from "./run-log";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -140,7 +141,7 @@ function fireCronTask(
 
   const text = wrapCronPrompt(task);
 
-  conversationRuntime.queueRuntime.enqueue({
+  const queuedItem = conversationRuntime.queueRuntime.enqueue({
     kind: "cron_prompt",
     source: "cron" as import("@/types/protocol").QueueItemSource,
     text,
@@ -148,6 +149,16 @@ function fireCronTask(
     agentId: task.agent_id,
     conversationId: task.conversation_id,
   } as Omit<CronPromptQueueItem, "id" | "enqueuedAt">);
+
+  if (!queuedItem) {
+    safeAppendCronRunLogForTask(task, {
+      status: "error",
+      error: "queue buffer limit",
+      runAtMs: now.getTime(),
+      scheduledFor: task.scheduled_for,
+    });
+    return;
+  }
 
   scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
 
@@ -167,6 +178,14 @@ function fireCronTask(
       t.fire_count = 1;
     });
   }
+
+  safeAppendCronRunLogForTask(task, {
+    status: "ok",
+    runAtMs: now.getTime(),
+    queueItemId: queuedItem.id,
+    scheduledFor: task.scheduled_for,
+    firedAt: nowIso,
+  });
 }
 
 /** Returns true if the task was marked as missed (caller should skip firing). */
@@ -179,6 +198,12 @@ export function handleMissedOneShot(task: CronTask, now: Date): boolean {
     updateTask(task.id, (t) => {
       t.status = "missed";
       t.missed_at = now.toISOString();
+    });
+    safeAppendCronRunLogForTask(task, {
+      status: "skipped",
+      summary: "missed",
+      runAtMs: now.getTime(),
+      scheduledFor: task.scheduled_for,
     });
     return true;
   }
@@ -237,6 +262,12 @@ function tick(
           fireCronTask(freshTask, now, socket, opts, processQueuedTurn);
         } catch (err) {
           console.error(`[Cron] Error firing task ${taskId}:`, err);
+          safeAppendCronRunLogForTask(freshTask, {
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+            runAtMs: now.getTime(),
+            scheduledFor: freshTask.scheduled_for,
+          });
         }
       };
 


### PR DESCRIPTION
## Summary
- Add JSONL cron run history files under `~/.letta/runs/<task-id>.jsonl`, while keeping `crons.json` as the task/state file.
- Record scheduler fire attempts from the WS listener and TUI shadow scheduler, plus missed one-shot schedules, as `ok`, `error`, or `skipped` entries.
- Add `letta cron runs --id <id>` with `--limit` and `--run-id` filters to inspect the history.

## Reference alignment
- Mirrors the OpenClaw storage shape: definitions/state stay in one JSON file, and per-job run history lives in sibling JSONL files under `runs/`.
- Keeps existing Letta Code scheduling semantics intact; this is audit logging around the current enqueue/missed paths, not a new scheduler design.

## Validation
- `bun test src/cron/run-log.test.ts src/cron/scheduler.test.ts src/cron/cron-file.test.ts`
- `bun run check`

## Notes
- The log records scheduler/enqueue/missed status. It does not yet attach final assistant result text or a message permalink because the current cron path enqueues work asynchronously.
- Run logs prune locally using the reference defaults: 2,000,000 bytes and 2,000 lines per task file.

👾 Generated with [Letta Code](https://letta.com)