### PR TITLE
docs(skills): optimize extension authoring guidance

### DIFF
--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-extensions
-description: Creates and edits Letta Code local extensions, including extension tools, slash commands, panels, status values, and capability-gated behavior. Use when the user asks to make an extension, add a tool the agent can call, add a slash command, or add lightweight extension UI outside the dedicated /statusline flow.
+description: Creates and edits trusted local Letta Code extensions, including extension tools, slash commands, lifecycle/turn events, scoped conversation helpers, panels, status values, and capability-gated behavior. Use when the user asks to make an extension, add a tool the agent can call, add a slash command, transform turns, react to app events, or add lightweight extension UI outside the dedicated /statusline flow.
 ---
 
 # Creating Extensions
@@ -11,7 +11,7 @@ Use this skill to create or update trusted global Letta Code extensions in:
 ~/.letta/extensions/
 ```
 
-Extensions are local runtime capabilities, not TUI-only plugins. Prefer portable APIs and guard optional UI with `letta.capabilities`.
+Extensions are trusted local apps for Letta Code. They add small composable capabilities through extension APIs, not by importing app internals. Prefer scoped handles (`ctx.conversation`, `ctx.cwd`, `ctx.agent`, `letta.getContext()`) and guard optional UI with `letta.capabilities`.
 
 ## Choose the right capability
 
@@ -20,26 +20,31 @@ Extensions are local runtime capabilities, not TUI-only plugins. Prefer portable
 | Agent/model should autonomously call a local capability | Extension tool |
 | User wants `/foo` to send a prompt or run local UI logic | Extension command |
 | Slash command represents a reusable agent workflow | Skill + thin extension command |
+| Command should work while the main agent is busy | Command with `runWhenBusy: true`, `handled`, panel/status, and usually `ctx.conversation.fork()` |
 | Show transient output above input | Panel, usually from a command |
 | Show small persistent state | Status value |
-| React to app/session lifecycle or turn changes | Event |
+| React to app/session lifecycle or transform outbound turns | Event |
 | Change the bottom statusline appearance | Use `customizing-statusline`, not this skill |
 
-Default to a **tool** when the model should decide when to use the capability. Default to a **command** when the human explicitly invokes it.
+Default to a **tool** when the model should decide when to use the capability. Default to a **command** when the human explicitly invokes it. Compose capabilities when the UX needs it, e.g. command + panel + scoped conversation fork.
 
 ## Workflow
 
 1. Inspect `~/.letta/extensions/` for related files.
 2. Preserve unrelated extension code. Prefer a focused new file if merging would be messy.
-3. Choose one capability recipe:
+3. Choose the extension shape:
+   - simple tool/command/event: read the specific recipe below
+   - multi-capability or stateful extension: also read `references/architecture.md`
+4. Load only the needed recipe:
    - tools: `references/tools.md`
    - commands: `references/commands.md`
    - events: `references/events.md`
    - panels/status/capabilities: `references/ui.md`
-4. Write a single-file extension unless the user asks for something larger.
-5. Return disposers for registered commands/tools, timers, subscriptions, and panels that should close on reload.
-6. Do a basic syntax/shape review: valid names, descriptions present, JSON schemas are object schemas, capability guards around optional UI.
-7. Tell the user the absolute file path changed and to run `/reload`.
+   - busy side-question pattern: `references/btw-command.md`
+5. Write a single-file extension unless the user asks for something larger.
+6. Return disposers for registered commands/tools/events, timers, subscriptions, and panels that should close on reload.
+7. Do a basic review: valid names, descriptions present, schemas are object schemas, optional capabilities guarded, scoped APIs used, cleanup returned.
+8. Tell the user the absolute file path changed and to run `/reload`.
 
 ## Core extension shape
 
@@ -73,19 +78,46 @@ letta.capabilities.ui.statusValues
 letta.capabilities.ui.customStatuslineRenderer
 ```
 
+## Scoped API model
+
+- In commands and events, use `ctx.conversation` for conversation operations:
+  - `ctx.conversation.getHistory()` for recent messages
+  - `ctx.conversation.fork()` for independent/background model work
+  - `forked.sendMessageStream([...])` to stream from a fork
+- In tools, use `ctx.conversation.getHistory()` when the tool needs recent context.
+- Use `letta.client` only for server-specific Letta API calls; do not use it as a substitute for scoped conversation helpers.
+- Do not import `@/backend`, `@/cli`, or other Letta Code internals from extension files.
+
 ## Rules
 
 - Global trusted code only for now. Do not create project extensions.
-- Do not import Letta Code app internals from extension files.
 - Do not assume extra npm packages are available.
 - Do not do surprising side effects on startup; extensions activate on app start and `/reload`.
 - Keep user-facing output short and intentional.
 - Prefer Node/Bun standard APIs (`node:child_process`, `node:fs`, etc.) for local work.
 - For shell execution, prefer `execFile`/`spawn` over shell strings.
 - Do not use emojis for loading states; use text or spinner-like characters if the user asks for loading UI.
+- For `runWhenBusy: true`, do not return `prompt`; return `handled` and own the UI/background work.
+- Treat `turn_start` as powerful trusted code: keep transforms narrow and unsurprising.
+
+## Pre-flight checklist for complex extensions
+
+Before finishing, verify:
+
+- The extension has one clear owner/file and does not mix unrelated features.
+- Command/tool IDs are valid and do not collide with built-ins.
+- Tool descriptions explain when the model should call them.
+- JSON schemas are object schemas with useful descriptions.
+- Optional UI/event/statusline APIs are capability-guarded.
+- Timers, intervals, event registrations, and panels are cleaned up in a disposer.
+- Busy commands return `{ type: "handled" }` quickly and avoid main-conversation sends.
+- Conversation work uses `ctx.conversation` or forked handles, not app internals.
+- Local shell/file work is scoped to `ctx.cwd` / `ctx.workingDirectory` unless intentionally global.
+- Errors shown to the user are short and actionable.
 
 ## References
 
+- `references/architecture.md` - composition, state, cleanup, scoped conversation, and review checklist for complex extensions
 - `references/tools.md` - extension tools the model can call
 - `references/commands.md` - slash commands, command results, and skill-backed commands
 - `references/events.md` - lifecycle and turn event handlers

--- a/src/skills/builtin/creating-extensions/references/architecture.md
+++ b/src/skills/builtin/creating-extensions/references/architecture.md
@@ -1,0 +1,138 @@
+# Extension architecture patterns
+
+Use this reference for non-trivial extensions: multiple capabilities, local state, timers, background model work, or UI.
+
+## Mental model
+
+An extension is trusted local code that registers capabilities during activation and cleans them up on reload/shutdown. Keep the public surface small:
+
+- activation registers commands/tools/events/UI
+- command/tool/event handlers receive scoped context
+- state is local and explicit
+- cleanup is returned from activation
+
+Do not import Letta Code internals. If the extension API does not expose a capability yet, avoid reaching around it.
+
+## Capability composition patterns
+
+### Tool + command
+
+Use a tool for autonomous model use and a command for explicit human invocation. Keep shared local helper functions inside the same file.
+
+```ts
+function summarizeBranch(cwd) {
+  // local implementation
+}
+
+export default function activate(letta) {
+  const disposers = [];
+
+  if (letta.capabilities.tools) {
+    disposers.push(letta.tools.register({
+      name: "branch_summary",
+      description: "Summarize the current git branch when repository state matters.",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      requiresApproval: false,
+      async run(ctx) {
+        return summarizeBranch(ctx.cwd);
+      },
+    }));
+  }
+
+  if (letta.capabilities.commands) {
+    disposers.push(letta.commands.register({
+      id: "branch-summary",
+      description: "Show current branch summary",
+      async run(ctx) {
+        return { type: "output", output: await summarizeBranch(ctx.cwd) };
+      },
+    }));
+  }
+
+  return () => disposers.reverse().forEach((dispose) => dispose());
+}
+```
+
+### Command + panel + background conversation
+
+Use this for side questions, long local work, or busy-safe commands. For commands with `runWhenBusy: true`, return `{ type: "handled" }` quickly and update a panel/status asynchronously. If model output is needed while the main agent is busy, fork first:
+
+```ts
+const forked = await ctx.conversation.fork({ hidden: true });
+const stream = await forked.sendMessageStream([
+  { role: "user", content: prompt },
+]);
+```
+
+Do not call `ctx.conversation.sendMessageStream()` on the active conversation from a busy command; direct sends can conflict with the active run.
+
+### Event + status value
+
+Use lifecycle events to maintain small status values such as active conversation state. Guard both event and status capabilities.
+
+```ts
+if (letta.capabilities.events.lifecycle && letta.capabilities.ui.statusValues) {
+  disposers.push(letta.events.on("conversation_open", (event) => {
+    letta.ui.setStatus("conversation", event.reason);
+  }));
+}
+```
+
+### `turn_start` transform
+
+Use `turn_start` only when the extension needs to inspect or transform the outbound user-message turn. Keep transforms local and predictable. Prefer appending/prepending focused context or replacing explicit shortcuts over broad rewrites.
+
+## Local state
+
+For small persistent state, use a clearly named file under `~/.letta/extensions/`, for example:
+
+```text
+~/.letta/extensions/my-extension.state.json
+```
+
+Use atomic-ish writes when practical: write the full JSON file from an in-memory object after each change. Validate parsed state and fall back gracefully if the file is missing or malformed.
+
+Keep state separate from source code. Do not store secrets in plain JSON; use existing secret/provider mechanisms when credentials are needed.
+
+## Timers and subscriptions
+
+Timers are okay for active-session behavior, but they only run while the extension host is alive. Always clear them:
+
+```ts
+const timer = setInterval(update, 30_000);
+return () => clearInterval(timer);
+```
+
+For long async loops, check `letta.signal.aborted` or `ctx.signal.aborted` and stop quietly.
+
+## Scoped conversation handles
+
+Commands and events receive `ctx.conversation`:
+
+```ts
+ctx.conversation.id                 // string | null
+ctx.conversation.getHistory(opts)   // recent messages
+ctx.conversation.fork(opts)         // returns a scoped handle
+ctx.conversation.sendMessageStream(messages, opts)
+```
+
+A forked handle keeps the same agent/backend defaults and targets the forked conversation. Use forked handles for background model work. Use `getHistory({ limit, order, includeErrors })` when local logic needs conversation context.
+
+Tools currently receive `ctx.conversation.getHistory()` but not fork/send helpers. If a tool needs model-side follow-up, return information for the model to act on instead of starting a hidden run from the tool.
+
+## Error handling
+
+- Catch expected local errors and return short user-facing text.
+- Let unexpected errors throw when diagnostics are better than hiding the failure.
+- For panel workflows, update the panel with a concise error and close it after a delay.
+- For tools, return `{ status: "error", content: "..." }` or throw depending on whether the model can recover.
+
+## Final review checklist
+
+- Capability guards are present for commands/tools/events/UI.
+- Activation does not do heavy work unless the feature needs startup state.
+- All disposers/timers/subscriptions are cleaned up.
+- `runWhenBusy: true` commands return `handled`, not `prompt`.
+- Background model work uses a forked conversation.
+- Local filesystem and shell work uses scoped paths and `execFile`/`spawn`.
+- Extension output is concise and actionable.

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -2,6 +2,8 @@
 
 Use commands when the human explicitly invokes `/foo`.
 
+For complex command-driven extensions with panels, timers, local state, or background model work, also read `architecture.md`.
+
 ## Decide command vs skill vs tool
 
 | Need | Use |
@@ -10,6 +12,7 @@ Use commands when the human explicitly invokes `/foo`.
 | `/foo` starts a complex reusable workflow | Skill + thin extension command |
 | Model should call the capability by itself | Extension tool |
 | Command needs transient UI while doing local work | Extension command + panel |
+| Command needs model output while the main agent is busy | `runWhenBusy: true` command + forked `ctx.conversation` |
 
 If the command represents a durable agent workflow (for example `/goal`), put the workflow instructions in a skill and keep the command as a small launcher/prompt.
 
@@ -21,6 +24,8 @@ If the command represents a durable agent workflow (for example `/goal`), put th
 - Duplicate extension command IDs fail unless `override: true` is intentional.
 
 ## Prompt command
+
+Use `prompt` for normal slash shortcuts that should become the next agent turn. Prompt commands are not busy-safe.
 
 ```ts
 export default function activate(letta) {
@@ -45,6 +50,8 @@ export default function activate(letta) {
 ```
 
 ## Output-only command
+
+Use `output` for local results that do not need the model.
 
 ```ts
 export default function activate(letta) {
@@ -93,20 +100,20 @@ export default function activate(letta) {
 
 ## Busy-safe conversation command
 
-For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use the scoped conversation handle directly, update a panel if available, and return `{ type: "handled" }` quickly.
+For commands with `runWhenBusy: true`, do not return `prompt` while the agent is running. Use the scoped conversation handle directly, update a panel/status if available, and return `{ type: "handled" }` quickly.
 
-Use `ctx.conversation` for scoped conversation operations that should work across local and Constellation backends. The handle is bound to the active conversation and backend for that command invocation, so composed flows like fork-then-send stay on the same backend. Use `letta.client` only for server-specific API calls.
+Use `ctx.conversation` for conversation operations that should work across local and Constellation backends. The handle is bound to the active conversation and backend for that command invocation, so composed flows like fork-then-send stay on the same backend. Use `letta.client` only for server-specific API calls.
 
-Common calls:
+Common pattern:
 
 ```ts
-const forked = await ctx.conversation.fork({
-  hidden: true,
-});
+const forked = await ctx.conversation.fork({ hidden: true });
 
 const stream = await forked.sendMessageStream([
   { role: "user", content: input },
 ]);
 ```
+
+Do not send directly to the active conversation from a busy command; fork first unless the user explicitly asked to affect the main conversation later.
 
 For a complete side-question example, see `btw-command.md`.

--- a/src/skills/builtin/creating-extensions/references/events.md
+++ b/src/skills/builtin/creating-extensions/references/events.md
@@ -1,6 +1,6 @@
 # Extension event recipes
 
-Use events when trusted local code should react to app/session changes without the human explicitly invoking a command.
+Use events when trusted local code should react to app/session changes or transform outbound turns without the human explicitly invoking a command. For event-driven extensions with state, timers, panels, or background model work, also read `architecture.md`.
 
 This is the first slice of the hooks-v2 direction. The long-term goal is for typed extension events to replace settings-based hooks. Existing hooks still own blocking decisions and model feedback injection until each event has a typed return contract.
 
@@ -139,7 +139,7 @@ Handlers also receive:
 }
 ```
 
-`ctx.conversation` is bound when the event is dispatched. Use it for scoped conversation calls made while handling that event.
+`ctx.conversation` is bound when the event is dispatched. Use it for scoped conversation calls made while handling that event. If an event needs background model work, prefer `ctx.conversation.fork()` and send to the fork. Do not send to the active conversation from `turn_start`; that event is already in the path of sending a turn.
 
 Respect `ctx.signal` for long-running async work. It is aborted on `/reload` and app shutdown.
 

--- a/src/skills/builtin/creating-extensions/references/tools.md
+++ b/src/skills/builtin/creating-extensions/references/tools.md
@@ -2,6 +2,8 @@
 
 Use tools when the agent/model should call a local capability autonomously.
 
+For tools that are part of a larger extension with commands, UI, local state, or events, also read `architecture.md`.
+
 ## Defaults
 
 - Name: lowercase/underscore tool name, e.g. `branch_summary`.
@@ -12,6 +14,7 @@ Use tools when the agent/model should call a local capability autonomously.
 - Use `ctx.cwd` / `ctx.workingDirectory` as the workspace.
 - Use `await ctx.conversation.getHistory()` when a tool needs recent conversation context. It returns the most recent messages in chronological order by default.
 - Respect `ctx.signal` for long-running work when practical.
+- Tools should return information for the model to use; they should not start hidden model runs.
 
 ## Read-only shell tool
 

--- a/src/skills/builtin/creating-extensions/references/ui.md
+++ b/src/skills/builtin/creating-extensions/references/ui.md
@@ -2,6 +2,8 @@
 
 UI capabilities are optional. Always guard UI work with `letta.capabilities.ui.*` when writing portable extensions.
 
+For UI that belongs to a larger command/event extension, also read `architecture.md` for cleanup and composition patterns.
+
 ## Capabilities
 
 ```ts
@@ -31,6 +33,8 @@ if (letta.capabilities.ui.panels) {
 
 Panel content is plain text: a string or string array. Keep it short; use command `output` for longer text.
 
+Close panels when they are transient, and close/replace long-lived panels from the activation disposer if reload should remove them.
+
 ## Status values
 
 ```ts
@@ -39,7 +43,7 @@ if (letta.capabilities.ui.statusValues) {
 }
 ```
 
-Clear status values in disposers if they are owned by timers or external state:
+Clear status values in disposers if they are owned by timers, events, or external state:
 
 ```ts
 return () => {

--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: customizing-commands
-description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, SDK-backed command, or command-driven panel behavior.
+description: Creates, edits, and enables Letta Code extension-provided slash commands. Use when the user asks to add a custom /command, slash command, command shortcut, scoped conversation-backed command, or command-driven panel behavior.
 ---
 
 # Customizing Commands
 
-Use this as the command-specific entrypoint for local extension slash commands. For broader extension work, recipes live in `../creating-extensions/references/commands.md`, `../creating-extensions/references/ui.md`, and `../creating-extensions/references/btw-command.md`.
+Use this as the command-specific entrypoint for local extension slash commands. For broader extension work, recipes live in `../creating-extensions/references/commands.md`, `../creating-extensions/references/architecture.md`, `../creating-extensions/references/ui.md`, and `../creating-extensions/references/btw-command.md`.
 
 Extension files live in:
 
@@ -23,6 +23,7 @@ Use a focused file name, e.g. `~/.letta/extensions/review.ts` or `~/.letta/exten
 | `/foo` starts a reusable agent workflow | Skill + thin extension command |
 | Agent/model should autonomously call the capability | Extension tool, not a command |
 | Command shows transient progress/results | Extension command + panel |
+| Command needs model output while the main agent is busy | `runWhenBusy: true` command + forked `ctx.conversation` |
 
 If the command is a durable workflow like `/goal`, put the workflow instructions in a skill and keep the extension command as a small launcher/prompt.
 
@@ -76,13 +77,14 @@ type ExtensionCommandResult =
 - Command IDs omit the slash: `id: "review"`, not `"/review"`.
 - Use lowercase slugs with letters, numbers, and hyphens.
 - Do not register built-in command IDs.
-- `runWhenBusy: true` commands must not return `prompt` while the main agent is busy; use SDK calls/panels and return `handled`.
+- `runWhenBusy: true` commands must not return `prompt` while the main agent is busy; use scoped conversation helpers/panels and return `handled`.
 - `showInTranscript: false` commands should usually return `handled`, not `prompt`.
 - Do not import Letta Code app internals.
 - Do not do surprising side effects on startup; extensions activate on app start and `/reload`.
 
 ## More recipes
 
-- Simple output command, panel command, SDK command: `../creating-extensions/references/commands.md`
+- Simple output command, panel command, busy-safe conversation command: `../creating-extensions/references/commands.md`
+- Complex command architecture, state, cleanup: `../creating-extensions/references/architecture.md`
 - Panel/status UI patterns: `../creating-extensions/references/ui.md`
 - Complete `/btw` side-question recipe: `../creating-extensions/references/btw-command.md`

--- a/src/skills/builtin/customizing-statusline/SKILL.md
+++ b/src/skills/builtin/customizing-statusline/SKILL.md
@@ -31,9 +31,10 @@ A custom statusline owns the whole idle row. Do not preserve legacy left/right s
 3. If it does not exist, start from the built-in default template or synthesize a focused starter for the user's request.
 4. If the user asks to migrate, import a `.sh` file, or match a shell prompt, read `references/migration.md`.
 5. If API details or concrete patterns are needed, read `references/api.md` and `references/examples.md`.
-6. Guard statusline-specific behavior with `letta.capabilities.ui.customStatuslineRenderer` when writing new files.
-7. Edit `~/.letta/extensions/statusline.tsx`.
-8. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
+6. If the request combines statusline work with commands, tools, events, panels, or stateful extension behavior, also use `creating-extensions` and its `references/architecture.md`.
+7. Guard statusline-specific behavior with `letta.capabilities.ui.customStatuslineRenderer` when writing new files.
+8. Edit `~/.letta/extensions/statusline.tsx`.
+9. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
 
 ## Bare `/statusline` behavior
 


### PR DESCRIPTION
## Summary
- expand the creating-extensions skill around the trusted local app/scoped API mental model
- add an architecture reference for complex extensions covering composition, state, cleanup, scoped conversation handles, and busy-safe patterns
- align command/statusline skills with scoped conversation helpers and broader extension composition guidance

## Test plan
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)