### PR TITLE
Regenerate conversation descriptions after compaction

### DIFF
--- a/src/agent/conversation-description.test.ts
+++ b/src/agent/conversation-description.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeConversationDescription } from "@/agent/conversation-description";
+
+describe("normalizeConversationDescription", () => {
+  test("returns null for empty and slash-command-shaped values", () => {
+    expect(normalizeConversationDescription("")).toBeNull();
+    expect(normalizeConversationDescription("   ")).toBeNull();
+    expect(normalizeConversationDescription("/compact all")).toBeNull();
+  });
+
+  test("collapses whitespace and strips surrounding quotes", () => {
+    expect(
+      normalizeConversationDescription(
+        '  "Discussed   conversation   description metadata"  ',
+      ),
+    ).toBe("Discussed conversation description metadata");
+  });
+
+  test("trims to forty words", () => {
+    const words = Array.from({ length: 45 }, (_, index) => `word${index}`);
+
+    expect(normalizeConversationDescription(words.join(" "))).toBe(
+      words.slice(0, 40).join(" "),
+    );
+  });
+});

--- a/src/agent/conversation-description.ts
+++ b/src/agent/conversation-description.ts
@@ -1,0 +1,187 @@
+import type Letta from "@letta-ai/letta-client";
+import { getBackend } from "@/backend";
+import { getClient } from "@/backend/api/client";
+import {
+  forkConversation,
+  updateConversationDescription,
+} from "@/backend/api/conversations";
+import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
+import { experimentManager } from "@/experiments/manager";
+import { isDebugEnabled } from "@/utils/debug";
+
+const CONVERSATION_DESCRIPTION_MAX_WORDS = 40;
+
+/**
+ * Hard timeout on the fork-and-generate flow. Description generation is
+ * best-effort and should never block the main conversation path indefinitely.
+ */
+const CONVERSATION_DESCRIPTION_TIMEOUT_MS = 30_000;
+
+const CONVERSATION_DESCRIPTION_SYSTEM_PROMPT = `You generate short internal conversation descriptions.
+
+Output ONLY a concise description of the conversation above.
+Rules:
+- up to 40 words
+- capture the concrete topic, the user's goal, and any meaningful constraints or decisions
+- no quotes, markdown, bullets, prefixes, or trailing punctuation
+- never call any tools — reply with plain text only
+- ignore setup noise like tool chatter, system reminders, approvals, and boilerplate unless the conversation is explicitly about them`;
+
+const CONVERSATION_DESCRIPTION_USER_PROMPT =
+  "Based on the conversation above, output a concise internal description for search and bootstrap context. Reply with ONLY the description text — no quotes, no tools, no preamble.";
+
+function trimToWordLimit(value: string, maxWords: number): string {
+  const words = value.split(/\s+/).filter(Boolean);
+  if (words.length <= maxWords) {
+    return value;
+  }
+  return words.slice(0, maxWords).join(" ");
+}
+
+export function normalizeConversationDescription(value: string): string | null {
+  let normalized = value.replace(/\s+/g, " ").trim();
+
+  if (
+    (normalized.startsWith('"') && normalized.endsWith('"')) ||
+    (normalized.startsWith("'") && normalized.endsWith("'"))
+  ) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  if (!normalized || normalized.startsWith("/")) {
+    return null;
+  }
+
+  return trimToWordLimit(normalized, CONVERSATION_DESCRIPTION_MAX_WORDS);
+}
+
+/**
+ * Extract plain-text content from an assistant_message chunk's `content`
+ * field, which may be a raw string or an array of structured content parts.
+ */
+function extractAssistantText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    let collected = "";
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof (part as { text?: unknown }).text === "string"
+      ) {
+        collected += (part as { text: string }).text;
+      }
+    }
+    return collected;
+  }
+  return "";
+}
+
+export async function generateConversationDescriptionFromFork(
+  client: Letta,
+  conversationId: string,
+): Promise<string | null> {
+  let forkId: string | null = null;
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(
+    () => abortController.abort(),
+    CONVERSATION_DESCRIPTION_TIMEOUT_MS,
+  );
+
+  try {
+    const fork = await forkConversation(conversationId, { hidden: true });
+    forkId = fork.id;
+
+    const stream = await client.conversations.messages.create(
+      forkId,
+      {
+        messages: [
+          {
+            role: "user",
+            content: CONVERSATION_DESCRIPTION_USER_PROMPT,
+          },
+        ],
+        override_model: DEFAULT_SUMMARIZATION_MODEL,
+        override_system: CONVERSATION_DESCRIPTION_SYSTEM_PROMPT,
+        max_steps: 1,
+        streaming: true,
+        stream_tokens: false,
+        include_pings: false,
+      },
+      { signal: abortController.signal },
+    );
+
+    let descriptionText = "";
+    for await (const chunk of stream) {
+      if (
+        chunk &&
+        typeof chunk === "object" &&
+        "message_type" in chunk &&
+        (chunk as { message_type?: string }).message_type ===
+          "assistant_message"
+      ) {
+        descriptionText += extractAssistantText(
+          (chunk as { content?: unknown }).content,
+        );
+      }
+    }
+
+    return normalizeConversationDescription(descriptionText);
+  } catch (err) {
+    if (isDebugEnabled()) {
+      console.error(
+        "[DEBUG] generateConversationDescriptionFromFork failed:",
+        err,
+      );
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+    if (forkId) {
+      void client.conversations.delete(forkId).catch((err) => {
+        if (isDebugEnabled()) {
+          console.error(
+            "[DEBUG] failed to delete description-fork conversation:",
+            err,
+          );
+        }
+      });
+    }
+  }
+}
+
+export async function regenerateConversationDescription(
+  conversationId: string | null | undefined,
+): Promise<boolean> {
+  if (!experimentManager.isEnabled("desktop_conversation_bootstrap")) {
+    return false;
+  }
+  if (getBackend().capabilities.localModelCatalog) {
+    return false;
+  }
+  if (!conversationId || conversationId === "default") {
+    return false;
+  }
+
+  try {
+    const client = await getClient();
+    const description = await generateConversationDescriptionFromFork(
+      client,
+      conversationId,
+    );
+    if (!description) {
+      return false;
+    }
+
+    await updateConversationDescription(conversationId, { description });
+    return true;
+  } catch (err) {
+    if (isDebugEnabled()) {
+      console.error("[DEBUG] regenerateConversationDescription failed:", err);
+    }
+    return false;
+  }
+}

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -18,6 +18,7 @@ import type { ApprovalResult } from "@/agent/approval-execution";
 import { prefetchAvailableModelHandles } from "@/agent/available-models";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { setCurrentAgentId } from "@/agent/context";
+import { regenerateConversationDescription } from "@/agent/conversation-description";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import {
   getModelInfoForLlmConfig,
@@ -38,7 +39,6 @@ import {
 } from "@/agent/subagent-state";
 import { getBackend, isLocalBackendEnabled } from "@/backend";
 import { getClient } from "@/backend/api/client";
-import { updateConversationDescription } from "@/backend/api/conversations";
 import { getBillingTier } from "@/backend/api/metadata";
 import {
   cancelActiveConnectOperation,
@@ -71,7 +71,6 @@ import {
   resetContextHistory,
 } from "@/cli/helpers/context-tracker";
 import {
-  generateConversationDescriptionFromFork,
   generateConversationTitleFromFork,
   normalizeConversationTitle,
 } from "@/cli/helpers/conversation-title";
@@ -1225,48 +1224,43 @@ export function App({
       return fallback;
     }
   }, [deriveAutoConversationTitle]);
-  const generateConversationDescription = useCallback(async () => {
-    if (!experimentManager.isEnabled("desktop_conversation_bootstrap")) {
-      return;
-    }
-    if (
-      !shouldAutoGenerateConversationDescriptionRef.current ||
-      isAutoConversationDescriptionInFlightRef.current
-    ) {
-      return;
-    }
-    if (getBackend().capabilities.localModelCatalog) {
-      return;
-    }
-
-    const conversationId = conversationIdRef.current;
-    if (!conversationId || conversationId === "default") {
-      return;
-    }
-
-    isAutoConversationDescriptionInFlightRef.current = true;
-    try {
-      const client = await getClient();
-      const description = await generateConversationDescriptionFromFork(
-        client,
-        conversationId,
-      );
-      if (!description) {
+  const generateConversationDescription = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (!experimentManager.isEnabled("desktop_conversation_bootstrap")) {
+        return;
+      }
+      if (
+        (!options?.force &&
+          !shouldAutoGenerateConversationDescriptionRef.current) ||
+        isAutoConversationDescriptionInFlightRef.current
+      ) {
+        return;
+      }
+      if (getBackend().capabilities.localModelCatalog) {
         return;
       }
 
-      await updateConversationDescription(conversationId, {
-        description,
-      });
-      shouldAutoGenerateConversationDescriptionRef.current = false;
-    } catch (err) {
-      if (isDebugEnabled()) {
-        console.error("[DEBUG] generateConversationDescription failed:", err);
+      const conversationId = conversationIdRef.current;
+      if (!conversationId || conversationId === "default") {
+        return;
       }
-    } finally {
-      isAutoConversationDescriptionInFlightRef.current = false;
-    }
-  }, []);
+
+      isAutoConversationDescriptionInFlightRef.current = true;
+      try {
+        const updated = await regenerateConversationDescription(conversationId);
+        if (updated) {
+          shouldAutoGenerateConversationDescriptionRef.current = false;
+        }
+      } catch (err) {
+        if (isDebugEnabled()) {
+          console.error("[DEBUG] generateConversationDescription failed:", err);
+        }
+      } finally {
+        isAutoConversationDescriptionInFlightRef.current = false;
+      }
+    },
+    [],
+  );
   const resetBootstrapReminderState = useCallback(
     (pendingConversationBootstrap = false) => {
       resetSharedReminderState(sharedReminderStateRef.current);
@@ -3899,6 +3893,7 @@ export function App({
     extensionRuntime,
     firstUserQueryRef,
     flushPendingReasoningEffort: () => flushPendingReasoningEffort(),
+    generateConversationDescription,
     generateConversationTitle,
     handleAgentSelect,
     handleBtwCommand,

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -198,7 +198,9 @@ type ConversationLoopContext = {
   currentModelId: string | null;
   emptyResponseRetriesRef: MutableRefObject<number>;
   executingToolCallIdsRef: MutableRefObject<string[]>;
-  generateConversationDescription: () => Promise<void>;
+  generateConversationDescription: (options?: {
+    force?: boolean;
+  }) => Promise<void>;
   extensionRuntime: LocalExtensionRuntime;
   generateConversationTitle: () => Promise<string | null>;
   hasConversationModelOverrideRef: MutableRefObject<boolean>;
@@ -1685,7 +1687,15 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               }
             }
 
-            void generateConversationDescription();
+            if (
+              contextTrackerRef.current
+                .pendingConversationDescriptionRegeneration
+            ) {
+              contextTrackerRef.current.pendingConversationDescriptionRegeneration = false;
+              void generateConversationDescription({ force: true });
+            } else {
+              void generateConversationDescription();
+            }
 
             const trajectorySnapshot = sessionStatsRef.current.endTrajectory();
             setTrajectoryTokenBase(0);

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -212,6 +212,9 @@ type SubmitHandlerContext = {
   extensionRuntime: LocalExtensionRuntime;
   firstUserQueryRef: MutableRefObject<string | null>;
   flushPendingReasoningEffort: () => Promise<void>;
+  generateConversationDescription: (options?: {
+    force?: boolean;
+  }) => Promise<void>;
   generateConversationTitle: () => Promise<string | null>;
   handleAgentSelect: (
     targetAgentId: string,
@@ -354,6 +357,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     extensionRuntime,
     firstUserQueryRef,
     flushPendingReasoningEffort,
+    generateConversationDescription,
     generateConversationTitle,
     handleAgentSelect,
     handleBtwCommand,
@@ -1983,6 +1987,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Manual /compact bypasses stream compaction events, so trigger
             // post-compaction reflection reminder/auto-launch on the next user turn.
             contextTrackerRef.current.pendingReflectionTrigger = true;
+            void generateConversationDescription({ force: true });
           } catch (error) {
             const apiError = error as {
               status?: number;

--- a/src/cli/context-tracker.test.ts
+++ b/src/cli/context-tracker.test.ts
@@ -13,6 +13,7 @@ describe("contextTracker", () => {
     ];
     tracker.pendingCompaction = true;
     tracker.pendingReflectionTrigger = true;
+    tracker.pendingConversationDescriptionRegeneration = true;
     tracker.currentTurnId = 9;
 
     resetContextHistory(tracker);
@@ -21,6 +22,7 @@ describe("contextTracker", () => {
     expect(tracker.contextTokensHistory).toEqual([]);
     expect(tracker.pendingCompaction).toBe(false);
     expect(tracker.pendingReflectionTrigger).toBe(false);
+    expect(tracker.pendingConversationDescriptionRegeneration).toBe(false);
     expect(tracker.currentTurnId).toBe(9);
   });
 });

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -600,6 +600,7 @@ function markCompactionCompleted(ctx?: ContextTracker): void {
   if (!ctx) return;
   ctx.pendingCompaction = true;
   ctx.pendingReflectionTrigger = true;
+  ctx.pendingConversationDescriptionRegeneration = true;
 }
 
 function resolveLineIdForKind(

--- a/src/cli/helpers/context-tracker-accumulator.test.ts
+++ b/src/cli/helpers/context-tracker-accumulator.test.ts
@@ -122,6 +122,7 @@ describe("accumulator usage statistics", () => {
     );
 
     expect(tracker.pendingReflectionTrigger).toBe(false);
+    expect(tracker.pendingConversationDescriptionRegeneration).toBe(false);
     expect(buffers.byId.get("evt-compaction-1")).toMatchObject({
       kind: "event",
       eventType: "compaction",
@@ -140,6 +141,7 @@ describe("accumulator usage statistics", () => {
 
     expect(tracker.pendingCompaction).toBe(true);
     expect(tracker.pendingReflectionTrigger).toBe(true);
+    expect(tracker.pendingConversationDescriptionRegeneration).toBe(true);
     expect(buffers.byId.get("evt-compaction-1")).toMatchObject({
       kind: "event",
       eventType: "compaction",
@@ -227,6 +229,7 @@ describe("accumulator usage statistics", () => {
 
     expect(tracker.pendingCompaction).toBe(true);
     expect(tracker.pendingReflectionTrigger).toBe(true);
+    expect(tracker.pendingConversationDescriptionRegeneration).toBe(true);
   });
 
   test("accumulates assistant messages when otid is missing but id is present", () => {

--- a/src/cli/helpers/context-tracker.ts
+++ b/src/cli/helpers/context-tracker.ts
@@ -18,6 +18,8 @@ export type ContextTracker = {
   pendingCompaction: boolean;
   /** Set when compaction happens; consumed by the next user message to trigger memory reminder/spawn */
   pendingReflectionTrigger: boolean;
+  /** Set when compaction completes; consumed to refresh conversation search metadata */
+  pendingConversationDescriptionRegeneration: boolean;
 };
 
 export function createContextTracker(): ContextTracker {
@@ -27,6 +29,7 @@ export function createContextTracker(): ContextTracker {
     currentTurnId: 0, // simple in-memory counter for now
     pendingCompaction: false,
     pendingReflectionTrigger: false,
+    pendingConversationDescriptionRegeneration: false,
   };
 }
 
@@ -36,4 +39,5 @@ export function resetContextHistory(ct: ContextTracker): void {
   ct.contextTokensHistory = [];
   ct.pendingCompaction = false;
   ct.pendingReflectionTrigger = false;
+  ct.pendingConversationDescriptionRegeneration = false;
 }

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -7,7 +7,6 @@ import { isDebugEnabled } from "@/utils/debug";
  * Maximum characters allowed for an auto-generated conversation title.
  */
 export const CONVERSATION_TITLE_MAX_LENGTH = 100;
-const CONVERSATION_DESCRIPTION_MAX_WORDS = 40;
 
 /**
  * Hard timeout on the fork-and-generate flow. Title generation is best-effort
@@ -38,19 +37,6 @@ Rules:
 const CONVERSATION_TITLE_USER_PROMPT =
   "Based on the conversation above, output a short title (2-7 words) describing the topic. Reply with ONLY the title text — no quotes, no tools, no preamble.";
 
-const CONVERSATION_DESCRIPTION_SYSTEM_PROMPT = `You generate short internal conversation descriptions.
-
-Output ONLY a concise description of the conversation above.
-Rules:
-- up to 40 words
-- capture the concrete topic, the user's goal, and any meaningful constraints or decisions
-- no quotes, markdown, bullets, prefixes, or trailing punctuation
-- never call any tools — reply with plain text only
-- ignore setup noise like tool chatter, system reminders, approvals, and boilerplate unless the conversation is explicitly about them`;
-
-const CONVERSATION_DESCRIPTION_USER_PROMPT =
-  "Based on the conversation above, output a concise internal description for search and bootstrap context. Reply with ONLY the description text — no quotes, no tools, no preamble.";
-
 /**
  * Strip whitespace, surrounding quotes, and clamp to {@link CONVERSATION_TITLE_MAX_LENGTH}.
  * Returns null when the input doesn't yield a usable title (empty, slash command, etc.).
@@ -71,31 +57,6 @@ export function normalizeConversationTitle(value: string): string | null {
   }
 
   return normalized.slice(0, CONVERSATION_TITLE_MAX_LENGTH);
-}
-
-function trimToWordLimit(value: string, maxWords: number): string {
-  const words = value.split(/\s+/).filter(Boolean);
-  if (words.length <= maxWords) {
-    return value;
-  }
-  return words.slice(0, maxWords).join(" ");
-}
-
-export function normalizeConversationDescription(value: string): string | null {
-  let normalized = value.replace(/\s+/g, " ").trim();
-
-  if (
-    (normalized.startsWith('"') && normalized.endsWith('"')) ||
-    (normalized.startsWith("'") && normalized.endsWith("'"))
-  ) {
-    normalized = normalized.slice(1, -1).trim();
-  }
-
-  if (!normalized || normalized.startsWith("/")) {
-    return null;
-  }
-
-  return trimToWordLimit(normalized, CONVERSATION_DESCRIPTION_MAX_WORDS);
 }
 
 /**
@@ -202,79 +163,6 @@ export async function generateConversationTitleFromFork(
         if (isDebugEnabled()) {
           console.error(
             "[DEBUG] failed to delete title-fork conversation:",
-            err,
-          );
-        }
-      });
-    }
-  }
-}
-
-export async function generateConversationDescriptionFromFork(
-  client: Letta,
-  conversationId: string,
-): Promise<string | null> {
-  let forkId: string | null = null;
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(
-    () => abortController.abort(),
-    CONVERSATION_TITLE_TIMEOUT_MS,
-  );
-
-  try {
-    const fork = await forkConversation(conversationId, { hidden: true });
-    forkId = fork.id;
-
-    const stream = await client.conversations.messages.create(
-      forkId,
-      {
-        messages: [
-          {
-            role: "user",
-            content: CONVERSATION_DESCRIPTION_USER_PROMPT,
-          },
-        ],
-        override_model: DEFAULT_SUMMARIZATION_MODEL,
-        override_system: CONVERSATION_DESCRIPTION_SYSTEM_PROMPT,
-        max_steps: 1,
-        streaming: true,
-        stream_tokens: false,
-        include_pings: false,
-      },
-      { signal: abortController.signal },
-    );
-
-    let descriptionText = "";
-    for await (const chunk of stream) {
-      if (
-        chunk &&
-        typeof chunk === "object" &&
-        "message_type" in chunk &&
-        (chunk as { message_type?: string }).message_type ===
-          "assistant_message"
-      ) {
-        descriptionText += extractAssistantText(
-          (chunk as { content?: unknown }).content,
-        );
-      }
-    }
-
-    return normalizeConversationDescription(descriptionText);
-  } catch (err) {
-    if (isDebugEnabled()) {
-      console.error(
-        "[DEBUG] generateConversationDescriptionFromFork failed:",
-        err,
-      );
-    }
-    return null;
-  } finally {
-    clearTimeout(timeoutId);
-    if (forkId) {
-      void client.conversations.delete(forkId).catch((err) => {
-        if (isDebugEnabled()) {
-          console.error(
-            "[DEBUG] failed to delete description-fork conversation:",
             err,
           );
         }

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import { regenerateConversationDescription } from "@/agent/conversation-description";
 import {
   applySetMaxContext,
   formatSetMaxContextResult,
@@ -290,6 +291,7 @@ async function handleCompactCommand(
     );
 
     conversationRuntime.contextTracker.pendingReflectionTrigger = true;
+    void regenerateConversationDescription(conversationRuntime.conversationId);
 
     return [
       `Compaction completed${modeDisplay}. Message buffer length reduced from ${result.num_messages_before} to ${result.num_messages_after}.`,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -16,6 +16,7 @@ import {
   setConversationId,
   setCurrentAgentId,
 } from "@/agent/context";
+import { regenerateConversationDescription } from "@/agent/conversation-description";
 import { getMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import {
   getStreamToolContextId,
@@ -890,6 +891,10 @@ export async function handleIncomingMessage(
                 : String(reflectionError)
             }`,
           );
+        }
+        if (runtime.contextTracker.pendingConversationDescriptionRegeneration) {
+          runtime.contextTracker.pendingConversationDescriptionRegeneration = false;
+          void regenerateConversationDescription(conversationId);
         }
         runtime.lastStopReason = "end_turn";
         runtime.isProcessing = false;


### PR DESCRIPTION
## Summary
- move conversation description generation into a shared helper used by TUI and listener flows
- force-refresh conversation descriptions after successful manual `/compact`
- refresh descriptions after streamed/automatic compaction completes by consuming a context-tracker flag

## Testing
- `bun test src/agent/conversation-description.test.ts src/cli/context-tracker.test.ts src/cli/helpers/context-tracker-accumulator.test.ts`
- `bun test src/websocket/listen-client-protocol.test.ts src/websocket/listener/turn-reflection.test.ts src/websocket/listener-reconnect-reminders.test.ts`
- `bun run check`

## Example
before compaction
<img width="745" height="175" alt="image" src="https://github.com/user-attachments/assets/dbf68554-e8f7-4160-9039-f68f0028f4cd" />
after more messages and compaction
<img width="1729" height="120" alt="image" src="https://github.com/user-attachments/assets/60d398c6-84ad-4a0b-b148-fc680c61a8a0" />
