### PR TITLE
refactor(tools): add generic model-facing tool forms

### DIFF
--- a/src/tools/define-tool.ts
+++ b/src/tools/define-tool.ts
@@ -1,0 +1,38 @@
+import {
+  functionToolForm,
+  type JsonSchema,
+  type ModelFacingToolForm,
+} from "./model-facing-tool";
+
+export type ToolArgs = Record<string, unknown>;
+export type ToolRunner = (args: ToolArgs) => Promise<unknown>;
+export type TypedToolImplementation<
+  TArgs extends object = ToolArgs,
+  TResult = unknown,
+> = (args: TArgs) => Promise<TResult>;
+
+export interface ToolAssets {
+  schema: JsonSchema;
+  description: string;
+  modelForm: ModelFacingToolForm;
+  impl: ToolRunner;
+}
+
+export function defineTool<TArgs extends object, TResult>(input: {
+  schema: JsonSchema;
+  description: string;
+  modelForm?: ModelFacingToolForm;
+  impl: TypedToolImplementation<TArgs, TResult>;
+}): ToolAssets {
+  return {
+    schema: input.schema,
+    description: input.description,
+    modelForm:
+      input.modelForm ??
+      functionToolForm({
+        description: input.description,
+        parameters: input.schema,
+      }),
+    impl: (args) => input.impl(args as TArgs),
+  };
+}

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -53,7 +53,7 @@ import {
   functionToolForm,
   type JsonSchema,
   type ModelFacingToolForm,
-  serializeFunctionToolPayload,
+  serializeFunctionOnlyToolPayload,
 } from "./model-facing-tool";
 import {
   extractSecretEnvFromCommand,
@@ -151,8 +151,8 @@ function resolvedModelForm(
   if (base.type === "custom") {
     return {
       ...base,
-      fallback: {
-        ...base.fallback,
+      functionFallback: {
+        ...base.functionFallback,
         description,
         parameters: inputSchema,
       },
@@ -950,7 +950,7 @@ function buildClientToolsFromSnapshot(
   extensionTools: Map<string, ExtensionToolDefinition>,
 ): ClientTool[] {
   const builtInTools = Array.from(registry.entries()).map(([name, tool]) =>
-    serializeFunctionToolPayload(getServerToolName(name), tool.modelForm),
+    serializeFunctionOnlyToolPayload(getServerToolName(name), tool.modelForm),
   );
   for (const name of externalTools.keys()) {
     if (extensionTools.has(name)) {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -50,6 +50,12 @@ import { debugLog } from "@/utils/debug";
 import { refreshFileIndex } from "@/utils/file-index";
 import { isRecord } from "@/utils/type-guards";
 import {
+  functionToolForm,
+  type JsonSchema,
+  type ModelFacingToolForm,
+  serializeFunctionToolPayload,
+} from "./model-facing-tool";
+import {
   extractSecretEnvFromCommand,
   scrubSecretsFromString,
 } from "./secret-substitution";
@@ -137,6 +143,28 @@ async function resolveBackendSpecificToolDescription(
   return description;
 }
 
+function resolvedModelForm(
+  base: ModelFacingToolForm,
+  description: string,
+  inputSchema: JsonSchema,
+): ModelFacingToolForm {
+  if (base.type === "custom") {
+    return {
+      ...base,
+      fallback: {
+        ...base.fallback,
+        description,
+        parameters: inputSchema,
+      },
+    };
+  }
+
+  return functionToolForm({
+    description,
+    parameters: inputSchema,
+  });
+}
+
 function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
   const nextRegistry = new Map(registry);
   const existing = nextRegistry.get("MessageChannel");
@@ -169,9 +197,11 @@ function withDynamicMessageChannelCache(registry: ToolRegistry): ToolRegistry {
       description: cachedMessageChannel.description,
       input_schema: cachedMessageChannel.schema as JsonSchema,
     },
-    fn:
-      existing?.fn ??
-      (TOOL_DEFINITIONS.MessageChannel.impl as ToolDefinition["fn"]),
+    modelForm: functionToolForm({
+      description: cachedMessageChannel.description,
+      parameters: cachedMessageChannel.schema as JsonSchema,
+    }),
+    fn: existing?.fn ?? TOOL_DEFINITIONS.MessageChannel.impl,
   });
   return nextRegistry;
 }
@@ -468,12 +498,6 @@ const TOOL_PERMISSIONS: Record<ToolName, { requiresApproval: boolean }> = {
   ReadManyFiles: { requiresApproval: false },
 };
 
-interface JsonSchema {
-  properties?: Record<string, JsonSchema>;
-  required?: string[];
-  [key: string]: unknown;
-}
-
 type ToolArgs = Record<string, unknown>;
 
 interface ToolSchema {
@@ -484,6 +508,7 @@ interface ToolSchema {
 
 interface ToolDefinition {
   schema: ToolSchema;
+  modelForm: ModelFacingToolForm;
   fn: (args: ToolArgs) => Promise<unknown>;
 }
 
@@ -924,11 +949,9 @@ function buildClientToolsFromSnapshot(
   externalTools: Map<string, ExternalToolDefinition>,
   extensionTools: Map<string, ExtensionToolDefinition>,
 ): ClientTool[] {
-  const builtInTools = Array.from(registry.entries()).map(([name, tool]) => ({
-    name: getServerToolName(name),
-    description: tool.schema.description,
-    parameters: tool.schema.input_schema,
-  }));
+  const builtInTools = Array.from(registry.entries()).map(([name, tool]) =>
+    serializeFunctionToolPayload(getServerToolName(name), tool.modelForm),
+  );
   for (const name of externalTools.keys()) {
     if (extensionTools.has(name)) {
       debugLog(
@@ -1264,6 +1287,7 @@ function maybeApplyLspReadOverride(registry: ToolRegistry): void {
       description: lspDefinition.description,
       input_schema: lspDefinition.schema,
     },
+    modelForm: lspDefinition.modelForm,
     fn: lspDefinition.impl,
   });
 }
@@ -1319,6 +1343,11 @@ async function buildSpecificToolRegistry(
 
     newRegistry.set(internalName, {
       schema: toolSchema,
+      modelForm: resolvedModelForm(
+        definition.modelForm,
+        resolvedTool.description,
+        resolvedTool.input_schema as JsonSchema,
+      ),
       fn: definition.impl,
     });
   }
@@ -1448,6 +1477,11 @@ async function buildRegistryForModel(
 
       newRegistry.set(name, {
         schema: toolSchema,
+        modelForm: resolvedModelForm(
+          definition.modelForm,
+          resolvedTool.description,
+          resolvedTool.input_schema as JsonSchema,
+        ),
         fn: definition.impl,
       });
     } catch (error) {
@@ -2524,6 +2558,10 @@ export async function refreshDynamicChannelToolsInLoadedRegistry(): Promise<void
       description: resolvedTool.description,
       input_schema: resolvedTool.input_schema as JsonSchema,
     },
+    modelForm: functionToolForm({
+      description: resolvedTool.description,
+      parameters: resolvedTool.input_schema as JsonSchema,
+    }),
     fn: definition.impl,
   });
 }

--- a/src/tools/model-facing-tool.test.ts
+++ b/src/tools/model-facing-tool.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import {
+  functionToolForm,
+  type ModelFacingToolForm,
+  serializeFunctionToolPayload,
+  serializeProviderRuntimeToolPayload,
+} from "@/tools/model-facing-tool";
+
+const fallbackParameters = {
+  type: "object",
+  properties: {
+    input: { type: "string" },
+  },
+  required: ["input"],
+  additionalProperties: false,
+};
+
+describe("model-facing tool serialization", () => {
+  test("serializes function tools without changing their schema", () => {
+    const form = functionToolForm({
+      description: "Function description",
+      parameters: fallbackParameters,
+    });
+
+    expect(serializeFunctionToolPayload("ExampleTool", form)).toEqual({
+      name: "ExampleTool",
+      description: "Function description",
+      parameters: fallbackParameters,
+    });
+    expect(serializeProviderRuntimeToolPayload("ExampleTool", form)).toEqual({
+      name: "ExampleTool",
+      description: "Function description",
+      parameters: fallbackParameters,
+    });
+  });
+
+  test("downgrades custom tools to their function fallback for function-only payloads", () => {
+    const form: ModelFacingToolForm = {
+      type: "custom",
+      description: "Custom freeform description",
+      format: { type: "text" },
+      fallback: {
+        type: "function",
+        description: "Fallback function description",
+        parameters: fallbackParameters,
+      },
+    };
+
+    expect(serializeFunctionToolPayload("ExampleTool", form)).toEqual({
+      name: "ExampleTool",
+      description: "Fallback function description",
+      parameters: fallbackParameters,
+    });
+  });
+
+  test("preserves custom metadata only for provider-runtime payloads", () => {
+    const form: ModelFacingToolForm = {
+      type: "custom",
+      description: "Custom freeform description",
+      format: {
+        type: "grammar",
+        syntax: "lark",
+        definition: "start: /.+/",
+      },
+      fallback: {
+        type: "function",
+        description: "Fallback function description",
+        parameters: fallbackParameters,
+        inputField: "input",
+      },
+    };
+
+    expect(serializeProviderRuntimeToolPayload("ExampleTool", form)).toEqual({
+      type: "custom",
+      name: "ExampleTool",
+      description: "Custom freeform description",
+      format: {
+        type: "grammar",
+        syntax: "lark",
+        definition: "start: /.+/",
+      },
+      fallback: {
+        description: "Fallback function description",
+        parameters: fallbackParameters,
+        inputField: "input",
+      },
+    });
+  });
+});

--- a/src/tools/model-facing-tool.test.ts
+++ b/src/tools/model-facing-tool.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   functionToolForm,
   type ModelFacingToolForm,
-  serializeFunctionToolPayload,
-  serializeProviderRuntimeToolPayload,
+  serializeFunctionOnlyToolPayload,
 } from "@/tools/model-facing-tool";
 
 const fallbackParameters = {
@@ -22,12 +21,7 @@ describe("model-facing tool serialization", () => {
       parameters: fallbackParameters,
     });
 
-    expect(serializeFunctionToolPayload("ExampleTool", form)).toEqual({
-      name: "ExampleTool",
-      description: "Function description",
-      parameters: fallbackParameters,
-    });
-    expect(serializeProviderRuntimeToolPayload("ExampleTool", form)).toEqual({
+    expect(serializeFunctionOnlyToolPayload("ExampleTool", form)).toEqual({
       name: "ExampleTool",
       description: "Function description",
       parameters: fallbackParameters,
@@ -39,21 +33,21 @@ describe("model-facing tool serialization", () => {
       type: "custom",
       description: "Custom freeform description",
       format: { type: "text" },
-      fallback: {
+      functionFallback: {
         type: "function",
         description: "Fallback function description",
         parameters: fallbackParameters,
       },
     };
 
-    expect(serializeFunctionToolPayload("ExampleTool", form)).toEqual({
+    expect(serializeFunctionOnlyToolPayload("ExampleTool", form)).toEqual({
       name: "ExampleTool",
       description: "Fallback function description",
       parameters: fallbackParameters,
     });
   });
 
-  test("preserves custom metadata only for provider-runtime payloads", () => {
+  test("keeps OpenAI custom-tool metadata separate from the function fallback", () => {
     const form: ModelFacingToolForm = {
       type: "custom",
       description: "Custom freeform description",
@@ -62,28 +56,26 @@ describe("model-facing tool serialization", () => {
         syntax: "lark",
         definition: "start: /.+/",
       },
-      fallback: {
+      functionFallback: {
         type: "function",
         description: "Fallback function description",
         parameters: fallbackParameters,
-        inputField: "input",
       },
     };
 
-    expect(serializeProviderRuntimeToolPayload("ExampleTool", form)).toEqual({
+    expect(form).toMatchObject({
       type: "custom",
-      name: "ExampleTool",
       description: "Custom freeform description",
       format: {
         type: "grammar",
         syntax: "lark",
         definition: "start: /.+/",
       },
-      fallback: {
-        description: "Fallback function description",
-        parameters: fallbackParameters,
-        inputField: "input",
-      },
+    });
+    expect(serializeFunctionOnlyToolPayload("ExampleTool", form)).toEqual({
+      name: "ExampleTool",
+      description: "Fallback function description",
+      parameters: fallbackParameters,
     });
   });
 });

--- a/src/tools/model-facing-tool.ts
+++ b/src/tools/model-facing-tool.ts
@@ -22,34 +22,18 @@ export type CustomToolForm = {
   type: "custom";
   description: string;
   format?: CustomToolInputFormat;
-  fallback: FunctionToolForm & {
-    inputField?: string;
-  };
+  // Internal fallback for backends that only accept JSON-schema function tools.
+  // This is not part of OpenAI Responses custom tool payloads.
+  functionFallback: FunctionToolForm;
 };
 
 export type ModelFacingToolForm = FunctionToolForm | CustomToolForm;
 
-export type FunctionToolPayload = {
+export type FunctionOnlyToolPayload = {
   name: string;
   description: string;
   parameters: JsonSchema;
 };
-
-export type ProviderRuntimeCustomToolPayload = {
-  type: "custom";
-  name: string;
-  description: string;
-  format?: CustomToolInputFormat;
-  fallback: {
-    description?: string;
-    parameters: JsonSchema;
-    inputField?: string;
-  };
-};
-
-export type ProviderRuntimeToolPayload =
-  | FunctionToolPayload
-  | ProviderRuntimeCustomToolPayload;
 
 export function functionToolForm(input: {
   description: string;
@@ -62,15 +46,15 @@ export function functionToolForm(input: {
   };
 }
 
-export function serializeFunctionToolPayload(
+export function serializeFunctionOnlyToolPayload(
   name: string,
   form: ModelFacingToolForm,
-): FunctionToolPayload {
+): FunctionOnlyToolPayload {
   if (form.type === "custom") {
     return {
       name,
-      description: form.fallback.description,
-      parameters: form.fallback.parameters,
+      description: form.functionFallback.description,
+      parameters: form.functionFallback.parameters,
     };
   }
 
@@ -79,27 +63,4 @@ export function serializeFunctionToolPayload(
     description: form.description,
     parameters: form.parameters,
   };
-}
-
-export function serializeProviderRuntimeToolPayload(
-  name: string,
-  form: ModelFacingToolForm,
-): ProviderRuntimeToolPayload {
-  if (form.type === "custom") {
-    return {
-      type: "custom",
-      name,
-      description: form.description,
-      ...(form.format ? { format: form.format } : {}),
-      fallback: {
-        description: form.fallback.description,
-        parameters: form.fallback.parameters,
-        ...(form.fallback.inputField
-          ? { inputField: form.fallback.inputField }
-          : {}),
-      },
-    };
-  }
-
-  return serializeFunctionToolPayload(name, form);
 }

--- a/src/tools/model-facing-tool.ts
+++ b/src/tools/model-facing-tool.ts
@@ -1,0 +1,105 @@
+export interface JsonSchema {
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+export type FunctionToolForm = {
+  type: "function";
+  description: string;
+  parameters: JsonSchema;
+};
+
+export type CustomToolInputFormat =
+  | { type: "text" }
+  | {
+      type: "grammar";
+      syntax: "lark" | "regex";
+      definition: string;
+    };
+
+export type CustomToolForm = {
+  type: "custom";
+  description: string;
+  format?: CustomToolInputFormat;
+  fallback: FunctionToolForm & {
+    inputField?: string;
+  };
+};
+
+export type ModelFacingToolForm = FunctionToolForm | CustomToolForm;
+
+export type FunctionToolPayload = {
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+};
+
+export type ProviderRuntimeCustomToolPayload = {
+  type: "custom";
+  name: string;
+  description: string;
+  format?: CustomToolInputFormat;
+  fallback: {
+    description?: string;
+    parameters: JsonSchema;
+    inputField?: string;
+  };
+};
+
+export type ProviderRuntimeToolPayload =
+  | FunctionToolPayload
+  | ProviderRuntimeCustomToolPayload;
+
+export function functionToolForm(input: {
+  description: string;
+  parameters: JsonSchema;
+}): FunctionToolForm {
+  return {
+    type: "function",
+    description: input.description,
+    parameters: input.parameters,
+  };
+}
+
+export function serializeFunctionToolPayload(
+  name: string,
+  form: ModelFacingToolForm,
+): FunctionToolPayload {
+  if (form.type === "custom") {
+    return {
+      name,
+      description: form.fallback.description,
+      parameters: form.fallback.parameters,
+    };
+  }
+
+  return {
+    name,
+    description: form.description,
+    parameters: form.parameters,
+  };
+}
+
+export function serializeProviderRuntimeToolPayload(
+  name: string,
+  form: ModelFacingToolForm,
+): ProviderRuntimeToolPayload {
+  if (form.type === "custom") {
+    return {
+      type: "custom",
+      name,
+      description: form.description,
+      ...(form.format ? { format: form.format } : {}),
+      fallback: {
+        description: form.fallback.description,
+        parameters: form.fallback.parameters,
+        ...(form.fallback.inputField
+          ? { inputField: form.fallback.inputField }
+          : {}),
+      },
+    };
+  }
+
+  return serializeFunctionToolPayload(name, form);
+}

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -1,3 +1,4 @@
+import { defineTool, type ToolAssets } from "./define-tool";
 import ApplyPatchDescription from "./descriptions/ApplyPatch.md";
 import AskUserQuestionDescription from "./descriptions/AskUserQuestion.md";
 import BashDescription from "./descriptions/Bash.md";
@@ -143,334 +144,326 @@ function execCommandDescription(): string {
     : baseDescription;
 }
 
-type ToolImplementation = (args: Record<string, unknown>) => Promise<unknown>;
-
-interface ToolAssets {
-  schema: Record<string, unknown>;
-  description: string;
-  impl: ToolImplementation;
-}
-
 const toolDefinitions = {
-  AskUserQuestion: {
+  AskUserQuestion: defineTool({
     schema: AskUserQuestionSchema,
     description: AskUserQuestionDescription.trim(),
-    impl: ask_user_question as unknown as ToolImplementation,
-  },
-  Bash: {
+    impl: ask_user_question,
+  }),
+  Bash: defineTool({
     schema: BashSchema,
     description: BashDescription.trim(),
-    impl: bash as unknown as ToolImplementation,
-  },
-  BashOutput: {
+    impl: bash,
+  }),
+  BashOutput: defineTool({
     schema: BashOutputSchema,
     description: BashOutputDescription.trim(),
-    impl: bash_output as unknown as ToolImplementation,
-  },
-  CreateWorktree: {
+    impl: bash_output,
+  }),
+  CreateWorktree: defineTool({
     schema: CreateWorktreeSchema,
     description: CreateWorktreeDescription.trim(),
-    impl: create_worktree as unknown as ToolImplementation,
-  },
-  Edit: {
+    impl: create_worktree,
+  }),
+  Edit: defineTool({
     schema: EditSchema,
     description: EditDescription.trim(),
-    impl: edit as unknown as ToolImplementation,
-  },
-  Glob: {
+    impl: edit,
+  }),
+  Glob: defineTool({
     schema: GlobSchema,
     description: GlobDescription.trim(),
-    impl: glob as unknown as ToolImplementation,
-  },
-  Grep: {
+    impl: glob,
+  }),
+  Grep: defineTool({
     schema: GrepSchema,
     description: GrepDescription.trim(),
-    impl: grep as unknown as ToolImplementation,
-  },
-  KillBash: {
+    impl: grep,
+  }),
+  KillBash: defineTool({
     schema: KillBashSchema,
     description: KillBashDescription.trim(),
-    impl: kill_bash as unknown as ToolImplementation,
-  },
-  TaskOutput: {
+    impl: kill_bash,
+  }),
+  TaskOutput: defineTool({
     schema: TaskOutputSchema,
     description: TaskOutputDescription.trim(),
-    impl: task_output as unknown as ToolImplementation,
-  },
-  TaskStop: {
+    impl: task_output,
+  }),
+  TaskStop: defineTool({
     schema: TaskStopSchema,
     description: TaskStopDescription.trim(),
-    impl: task_stop as unknown as ToolImplementation,
-  },
-  LS: {
+    impl: task_stop,
+  }),
+  LS: defineTool({
     schema: LSSchema,
     description: LSDescription.trim(),
-    impl: ls as unknown as ToolImplementation,
-  },
-  memory: {
+    impl: ls,
+  }),
+  memory: defineTool({
     schema: MemorySchema,
     description: MemoryDescription.trim(),
-    impl: memory as unknown as ToolImplementation,
-  },
-  memory_apply_patch: {
+    impl: memory,
+  }),
+  memory_apply_patch: defineTool({
     schema: MemoryApplyPatchSchema,
     description: MemoryApplyPatchDescription.trim(),
-    impl: memory_apply_patch as unknown as ToolImplementation,
-  },
-  MessageChannel: {
+    impl: memory_apply_patch,
+  }),
+  MessageChannel: defineTool({
     schema: MessageChannelSchema,
     description: MessageChannelDescription.trim(),
-    impl: message_channel as unknown as ToolImplementation,
-  },
-  MultiEdit: {
+    impl: message_channel,
+  }),
+  MultiEdit: defineTool({
     schema: MultiEditSchema,
     description: MultiEditDescription.trim(),
-    impl: multi_edit as unknown as ToolImplementation,
-  },
-  Read: {
+    impl: multi_edit,
+  }),
+  Read: defineTool({
     schema: ReadSchema,
     description: ReadDescription.trim(),
-    impl: read as unknown as ToolImplementation,
-  },
-  view_image: {
+    impl: read,
+  }),
+  view_image: defineTool({
     schema: ViewImageSchema,
     description: ViewImageDescription.trim(),
-    impl: view_image as unknown as ToolImplementation,
-  },
-  ViewImage: {
+    impl: view_image,
+  }),
+  ViewImage: defineTool({
     schema: ViewImageSchema,
     description: ViewImageDescription.trim(),
-    impl: view_image as unknown as ToolImplementation,
-  },
+    impl: view_image,
+  }),
   // LSP-enhanced Read - used when LETTA_ENABLE_LSP is set
-  ReadLSP: {
+  ReadLSP: defineTool({
     schema: ReadLSPSchema,
     description: ReadLSPDescription.trim(),
-    impl: read_lsp as unknown as ToolImplementation,
-  },
-  Skill: {
+    impl: read_lsp,
+  }),
+  Skill: defineTool({
     schema: SkillSchema,
     description: SkillDescription.trim(),
-    impl: skill as unknown as ToolImplementation,
-  },
-  Task: {
+    impl: skill,
+  }),
+  Task: defineTool({
     schema: TaskSchema,
     description: TaskDescription.trim(),
-    impl: task as unknown as ToolImplementation,
-  },
-  TodoWrite: {
+    impl: task,
+  }),
+  TodoWrite: defineTool({
     schema: TodoWriteSchema,
     description: TodoWriteDescription.trim(),
-    impl: todo_write as unknown as ToolImplementation,
-  },
-  Write: {
+    impl: todo_write,
+  }),
+  Write: defineTool({
     schema: WriteSchema,
     description: WriteDescription.trim(),
-    impl: write as unknown as ToolImplementation,
-  },
-  shell_command: {
+    impl: write,
+  }),
+  shell_command: defineTool({
     schema: ShellCommandSchema,
     description: ShellCommandDescription.trim(),
-    impl: shell_command as unknown as ToolImplementation,
-  },
-  exec_command: {
+    impl: shell_command,
+  }),
+  exec_command: defineTool({
     schema: ExecCommandSchema,
     description: execCommandDescription(),
-    impl: exec_command as unknown as ToolImplementation,
-  },
-  write_stdin: {
+    impl: exec_command,
+  }),
+  write_stdin: defineTool({
     schema: WriteStdinSchema,
     description: WriteStdinDescription.trim(),
-    impl: write_stdin as unknown as ToolImplementation,
-  },
-  shell: {
+    impl: write_stdin,
+  }),
+  shell: defineTool({
     schema: ShellSchema,
     description: ShellDescription.trim(),
-    impl: shell as unknown as ToolImplementation,
-  },
-  read_file: {
+    impl: shell,
+  }),
+  read_file: defineTool({
     schema: ReadFileCodexSchema,
     description: ReadFileCodexDescription.trim(),
-    impl: read_file as unknown as ToolImplementation,
-  },
-  list_dir: {
+    impl: read_file,
+  }),
+  list_dir: defineTool({
     schema: ListDirCodexSchema,
     description: ListDirCodexDescription.trim(),
-    impl: list_dir as unknown as ToolImplementation,
-  },
-  grep_files: {
+    impl: list_dir,
+  }),
+  grep_files: defineTool({
     schema: GrepFilesSchema,
     description: GrepFilesDescription.trim(),
-    impl: grep_files as unknown as ToolImplementation,
-  },
-  apply_patch: {
+    impl: grep_files,
+  }),
+  apply_patch: defineTool({
     schema: ApplyPatchSchema,
     description: ApplyPatchDescription.trim(),
-    impl: apply_patch as unknown as ToolImplementation,
-  },
-  update_plan: {
+    impl: apply_patch,
+  }),
+  update_plan: defineTool({
     schema: UpdatePlanSchema,
     description: UpdatePlanDescription.trim(),
-    impl: update_plan as unknown as ToolImplementation,
-  },
-  get_goal: {
+    impl: update_plan,
+  }),
+  get_goal: defineTool({
     schema: GetGoalSchema,
     description: GetGoalDescription.trim(),
-    impl: get_goal as unknown as ToolImplementation,
-  },
-  create_goal: {
+    impl: get_goal,
+  }),
+  create_goal: defineTool({
     schema: CreateGoalSchema,
     description: CreateGoalDescription.trim(),
-    impl: create_goal as unknown as ToolImplementation,
-  },
-  update_goal: {
+    impl: create_goal,
+  }),
+  update_goal: defineTool({
     schema: UpdateGoalSchema,
     description: UpdateGoalDescription.trim(),
-    impl: update_goal as unknown as ToolImplementation,
-  },
+    impl: update_goal,
+  }),
   // Gemini toolset
-  glob_gemini: {
+  glob_gemini: defineTool({
     schema: GlobGeminiSchema,
     description: GlobGeminiDescription.trim(),
-    impl: glob_gemini as unknown as ToolImplementation,
-  },
-  list_directory: {
+    impl: glob_gemini,
+  }),
+  list_directory: defineTool({
     schema: ListDirectoryGeminiSchema,
     description: ListDirectoryGeminiDescription.trim(),
-    impl: list_directory as unknown as ToolImplementation,
-  },
-  read_file_gemini: {
+    impl: list_directory,
+  }),
+  read_file_gemini: defineTool({
     schema: ReadFileGeminiSchema,
     description: ReadFileGeminiDescription.trim(),
-    impl: read_file_gemini as unknown as ToolImplementation,
-  },
-  read_many_files: {
+    impl: read_file_gemini,
+  }),
+  read_many_files: defineTool({
     schema: ReadManyFilesGeminiSchema,
     description: ReadManyFilesGeminiDescription.trim(),
-    impl: read_many_files as unknown as ToolImplementation,
-  },
-  replace: {
+    impl: read_many_files,
+  }),
+  replace: defineTool({
     schema: ReplaceGeminiSchema,
     description: ReplaceGeminiDescription.trim(),
-    impl: replace as unknown as ToolImplementation,
-  },
-  run_shell_command: {
+    impl: replace,
+  }),
+  run_shell_command: defineTool({
     schema: RunShellCommandGeminiSchema,
     description: RunShellCommandGeminiDescription.trim(),
-    impl: run_shell_command as unknown as ToolImplementation,
-  },
-  search_file_content: {
+    impl: run_shell_command,
+  }),
+  search_file_content: defineTool({
     schema: SearchFileContentGeminiSchema,
     description: SearchFileContentGeminiDescription.trim(),
-    impl: search_file_content as unknown as ToolImplementation,
-  },
-  write_todos: {
+    impl: search_file_content,
+  }),
+  write_todos: defineTool({
     schema: WriteTodosGeminiSchema,
     description: WriteTodosGeminiDescription.trim(),
-    impl: write_todos as unknown as ToolImplementation,
-  },
-  write_file_gemini: {
+    impl: write_todos,
+  }),
+  write_file_gemini: defineTool({
     schema: WriteFileGeminiSchema,
     description: WriteFileGeminiDescription.trim(),
-    impl: write_file_gemini as unknown as ToolImplementation,
-  },
+    impl: write_file_gemini,
+  }),
   // Codex-2 toolset (PascalCase aliases for OpenAI tools)
-  ShellCommand: {
+  ShellCommand: defineTool({
     schema: ShellCommandSchema,
     description: ShellCommandDescription.trim(),
-    impl: shell_command as unknown as ToolImplementation,
-  },
-  Shell: {
+    impl: shell_command,
+  }),
+  Shell: defineTool({
     schema: ShellSchema,
     description: ShellDescription.trim(),
-    impl: shell as unknown as ToolImplementation,
-  },
-  ReadFile: {
+    impl: shell,
+  }),
+  ReadFile: defineTool({
     schema: ReadFileCodexSchema,
     description: ReadFileCodexDescription.trim(),
-    impl: read_file as unknown as ToolImplementation,
-  },
-  ListDir: {
+    impl: read_file,
+  }),
+  ListDir: defineTool({
     schema: ListDirCodexSchema,
     description: ListDirCodexDescription.trim(),
-    impl: list_dir as unknown as ToolImplementation,
-  },
-  GrepFiles: {
+    impl: list_dir,
+  }),
+  GrepFiles: defineTool({
     schema: GrepFilesSchema,
     description: GrepFilesDescription.trim(),
-    impl: grep_files as unknown as ToolImplementation,
-  },
-  ApplyPatch: {
+    impl: grep_files,
+  }),
+  ApplyPatch: defineTool({
     schema: ApplyPatchSchema,
     description: ApplyPatchDescription.trim(),
-    impl: apply_patch as unknown as ToolImplementation,
-  },
-  UpdatePlan: {
+    impl: apply_patch,
+  }),
+  UpdatePlan: defineTool({
     schema: UpdatePlanSchema,
     description: UpdatePlanDescription.trim(),
-    impl: update_plan as unknown as ToolImplementation,
-  },
-  GetGoal: {
+    impl: update_plan,
+  }),
+  GetGoal: defineTool({
     schema: GetGoalSchema,
     description: GetGoalDescription.trim(),
-    impl: get_goal as unknown as ToolImplementation,
-  },
-  CreateGoal: {
+    impl: get_goal,
+  }),
+  CreateGoal: defineTool({
     schema: CreateGoalSchema,
     description: CreateGoalDescription.trim(),
-    impl: create_goal as unknown as ToolImplementation,
-  },
-  UpdateGoal: {
+    impl: create_goal,
+  }),
+  UpdateGoal: defineTool({
     schema: UpdateGoalSchema,
     description: UpdateGoalDescription.trim(),
-    impl: update_goal as unknown as ToolImplementation,
-  },
+    impl: update_goal,
+  }),
   // Gemini-2 toolset (PascalCase aliases for Gemini tools)
-  RunShellCommand: {
+  RunShellCommand: defineTool({
     schema: RunShellCommandGeminiSchema,
     description: RunShellCommandGeminiDescription.trim(),
-    impl: run_shell_command as unknown as ToolImplementation,
-  },
-  ReadFileGemini: {
+    impl: run_shell_command,
+  }),
+  ReadFileGemini: defineTool({
     schema: ReadFileGeminiSchema,
     description: ReadFileGeminiDescription.trim(),
-    impl: read_file_gemini as unknown as ToolImplementation,
-  },
-  ListDirectory: {
+    impl: read_file_gemini,
+  }),
+  ListDirectory: defineTool({
     schema: ListDirectoryGeminiSchema,
     description: ListDirectoryGeminiDescription.trim(),
-    impl: list_directory as unknown as ToolImplementation,
-  },
-  GlobGemini: {
+    impl: list_directory,
+  }),
+  GlobGemini: defineTool({
     schema: GlobGeminiSchema,
     description: GlobGeminiDescription.trim(),
-    impl: glob_gemini as unknown as ToolImplementation,
-  },
-  SearchFileContent: {
+    impl: glob_gemini,
+  }),
+  SearchFileContent: defineTool({
     schema: SearchFileContentGeminiSchema,
     description: SearchFileContentGeminiDescription.trim(),
-    impl: search_file_content as unknown as ToolImplementation,
-  },
-  Replace: {
+    impl: search_file_content,
+  }),
+  Replace: defineTool({
     schema: ReplaceGeminiSchema,
     description: ReplaceGeminiDescription.trim(),
-    impl: replace as unknown as ToolImplementation,
-  },
-  WriteFileGemini: {
+    impl: replace,
+  }),
+  WriteFileGemini: defineTool({
     schema: WriteFileGeminiSchema,
     description: WriteFileGeminiDescription.trim(),
-    impl: write_file_gemini as unknown as ToolImplementation,
-  },
-  WriteTodos: {
+    impl: write_file_gemini,
+  }),
+  WriteTodos: defineTool({
     schema: WriteTodosGeminiSchema,
     description: WriteTodosGeminiDescription.trim(),
-    impl: write_todos as unknown as ToolImplementation,
-  },
-  ReadManyFiles: {
+    impl: write_todos,
+  }),
+  ReadManyFiles: defineTool({
     schema: ReadManyFilesGeminiSchema,
     description: ReadManyFilesGeminiDescription.trim(),
-    impl: read_many_files as unknown as ToolImplementation,
-  },
+    impl: read_many_files,
+  }),
 } as const satisfies Record<string, ToolAssets>;
 
 export type ToolName = keyof typeof toolDefinitions;


### PR DESCRIPTION
## Summary
- Add backend-agnostic model-facing tool form metadata, including function/custom forms and explicit function-only fallback serialization.
- Wrap built-in tool definitions with `defineTool()` so implementations stay typed without the old `as unknown as ToolImplementation` casts.
- Thread `modelForm` through the loaded tool registry while preserving current Letta API `client_tools` function-only payload behavior.
- Verified with `bun run check` and `env -u LETTA_LOCAL_BACKEND_EXPERIMENTAL -u MEMORY_DIR -u LETTA_MEMORY_DIR bun test src/tools`.

👾 Generated with [Letta Code](https://letta.com)
