### PR TITLE
fix: default resume pending approval detection

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -57,6 +57,14 @@ function makeUserMessage(id = "msg-last"): Message {
   } as Message;
 }
 
+function makeSummaryMessage(id = "msg-summary"): Message {
+  return {
+    id,
+    date: new Date().toISOString(),
+    message_type: "summary_message",
+  } as Message;
+}
+
 function datedMessage(
   id: string,
   messageType: MessageType,
@@ -164,6 +172,33 @@ describe("getResumeData", () => {
     expect(messagesRetrieve).toHaveBeenCalledWith("msg-live");
     expect(messagesRetrieve).toHaveBeenCalledTimes(1);
     expect(agentsList).toHaveBeenCalledTimes(0);
+    expect(resume.pendingApprovals).toHaveLength(1);
+    expect(resume.pendingApprovals[0]?.toolCallId).toBe("tool-1");
+  });
+
+  test("default conversation resume uses agent message_ids when in-context ids are absent", async () => {
+    const agentsList = mock(async () => ({
+      getPaginatedItems: () => [makeSummaryMessage("msg-summary-latest")],
+    }));
+    const messagesRetrieve = mock(async () => [
+      makeApprovalMessage("msg-pending-approval"),
+    ]);
+
+    installBackend({
+      listAgentMessages: agentsList,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeDataFromBackend(
+      makeAgent({
+        message_ids: ["msg-pending-approval"],
+      }),
+      "default",
+    );
+
+    expect(messagesRetrieve).toHaveBeenCalledWith("msg-pending-approval");
+    expect(messagesRetrieve).toHaveBeenCalledTimes(1);
+    expect(agentsList).toHaveBeenCalledTimes(1);
     expect(resume.pendingApprovals).toHaveLength(1);
     expect(resume.pendingApprovals[0]?.toolCallId).toBe("tool-1");
   });

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -509,10 +509,12 @@ export async function getResumeDataFromBackend(
       };
     } else {
       // For the default conversation, use the agent's in-context message IDs as
-      // the primary anchor, mirroring the explicit-conversation path. Fall back
-      // to the default-conversation message stream only when that anchor is not
-      // available, and keep using the stream for backfill/history.
-      inContextMessageIds = agentWithInContext.in_context_message_ids;
+      // the primary anchor, mirroring the explicit-conversation path. Hosted
+      // AgentState exposes this as message_ids; local compatibility shims may
+      // expose in_context_message_ids. Fall back to the message stream only when
+      // neither anchor is available, and keep using the stream for backfill/history.
+      inContextMessageIds =
+        agentWithInContext.in_context_message_ids ?? agent.message_ids;
       const lastInContextId = inContextMessageIds?.at(-1);
       let defaultConversationMessages: Message[] = [];
       if ((includeMessageHistory && isBackfillEnabled()) || !lastInContextId) {


### PR DESCRIPTION
## Summary
- use `agent.message_ids` as the hosted default-conversation in-context anchor when `agent.in_context_message_ids` is absent
- keep local compatibility by preferring `in_context_message_ids` when present
- add a regression test where the default feed latest message is a compaction summary but the in-context tail is a pending approval

## Test plan
- `bun test src/agent/check-approval-resume-data.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/agent/check-approval.ts src/agent/check-approval-resume-data.test.ts`

## Notes
- `bun run typecheck` currently fails on unrelated existing errors in `src/cli/commands/connect-local-oauth.ts` (`onDeviceCode` is not in `OAuthLoginCallbacks`, and `info` has implicit any).