### PR TITLE
fix(bootstrap): tighten conversation relevance filtering

### DIFF
--- a/src/cli/helpers/conversation-bootstrap.test.ts
+++ b/src/cli/helpers/conversation-bootstrap.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { ConversationSearchResult } from "@/backend/conversation-search";
+import {
+  filterBootstrapRelevantConversations,
+  selectBootstrapRecentConversations,
+} from "@/cli/helpers/conversation-bootstrap";
+
+function conversation(id: string): Conversation {
+  return { id, summary: `Conversation ${id}` } as Conversation;
+}
+
+function result(id: string, score: number): ConversationSearchResult {
+  return {
+    embedded_text: `Description ${id}`,
+    conversation: conversation(id),
+    rrf_score: score,
+  };
+}
+
+describe("filterBootstrapRelevantConversations", () => {
+  test("rejects weak single-channel RRF matches", () => {
+    expect(
+      filterBootstrapRelevantConversations(
+        [result("one", 0.0164), result("two", 0.014)],
+        {},
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps only high-confidence results near the strongest score", () => {
+    expect(
+      filterBootstrapRelevantConversations(
+        [result("one", 0.033), result("two", 0.026), result("three", 0.018)],
+        {},
+      ).map((item) => item.conversation.id),
+    ).toEqual(["one", "two"]);
+  });
+
+  test("dedupes and excludes the active conversation before scoring", () => {
+    expect(
+      filterBootstrapRelevantConversations(
+        [result("current", 0.04), result("one", 0.033), result("one", 0.032)],
+        { excludeConversationId: "current" },
+      ).map((item) => item.conversation.id),
+    ).toEqual(["one"]);
+  });
+});
+
+describe("selectBootstrapRecentConversations", () => {
+  test("backfills recent conversations after removing relevant duplicates", () => {
+    const recent = Array.from({ length: 10 }, (_, index) =>
+      conversation(`conv-${index + 1}`),
+    );
+
+    expect(
+      selectBootstrapRecentConversations(recent, {
+        excludeConversationId: "conv-4",
+        relevantConversationIds: new Set(["conv-1", "conv-2", "conv-3"]),
+      }).map((item) => item.id),
+    ).toEqual(["conv-5", "conv-6", "conv-7", "conv-8", "conv-9"]);
+  });
+});

--- a/src/cli/helpers/conversation-bootstrap.ts
+++ b/src/cli/helpers/conversation-bootstrap.ts
@@ -9,9 +9,14 @@ import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 
 const BOOTSTRAP_RECENT_LIMIT = 5;
 const BOOTSTRAP_RELEVANT_LIMIT = 5;
+const BOOTSTRAP_RECENT_FETCH_LIMIT =
+  BOOTSTRAP_RECENT_LIMIT + BOOTSTRAP_RELEVANT_LIMIT;
 const BOOTSTRAP_RELEVANT_FETCH_LIMIT = 12;
-const BOOTSTRAP_RELEVANT_MIN_RRF_SCORE = 0.01;
-const BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE = 0.5;
+// The remote hybrid search uses RRF with k=60, so a rank-1 result from only
+// one retrieval channel scores ~0.016. Require a stronger score so weak
+// vector-only nearest neighbors do not get injected as bootstrap context.
+const BOOTSTRAP_RELEVANT_MIN_RRF_SCORE = 0.025;
+const BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE = 0.75;
 
 function pageItems<T>(page: unknown): T[] {
   if (Array.isArray(page)) return page as T[];
@@ -101,7 +106,7 @@ function formatBootstrapReminder(params: {
   return lines.join("\n");
 }
 
-function filterBootstrapRelevantConversations(
+export function filterBootstrapRelevantConversations(
   results: ConversationSearchResult[],
   params: {
     excludeConversationId?: string;
@@ -142,6 +147,20 @@ function filterBootstrapRelevantConversations(
     .slice(0, BOOTSTRAP_RELEVANT_LIMIT);
 }
 
+export function selectBootstrapRecentConversations(
+  conversations: Conversation[],
+  params: {
+    excludeConversationId?: string;
+    relevantConversationIds: Set<string>;
+  },
+): Conversation[] {
+  const { excludeConversationId, relevantConversationIds } = params;
+  return conversations
+    .filter((conversation) => conversation.id !== excludeConversationId)
+    .filter((conversation) => !relevantConversationIds.has(conversation.id))
+    .slice(0, BOOTSTRAP_RECENT_LIMIT);
+}
+
 export async function buildConversationBootstrapReminder(params: {
   agentId: string;
   content: MessageCreate["content"];
@@ -154,7 +173,7 @@ export async function buildConversationBootstrapReminder(params: {
   const [recentResult, relevantResult] = await Promise.allSettled([
     backend.listConversations({
       agent_id: agentId,
-      limit: BOOTSTRAP_RECENT_LIMIT,
+      limit: BOOTSTRAP_RECENT_FETCH_LIMIT,
       order: "desc",
       order_by: "last_message_at",
     } as never),
@@ -174,9 +193,7 @@ export async function buildConversationBootstrapReminder(params: {
 
   const recentConversations =
     recentResult.status === "fulfilled"
-      ? pageItems<Conversation>(recentResult.value).filter(
-          (conversation) => conversation.id !== excludeConversationId,
-        )
+      ? pageItems<Conversation>(recentResult.value)
       : [];
   const relevantConversations =
     relevantResult.status === "fulfilled"
@@ -187,8 +204,12 @@ export async function buildConversationBootstrapReminder(params: {
   const relevantConversationIds = new Set(
     relevantConversations.map((result) => result.conversation.id),
   );
-  const nonDuplicatedRecentConversations = recentConversations.filter(
-    (conversation) => !relevantConversationIds.has(conversation.id),
+  const nonDuplicatedRecentConversations = selectBootstrapRecentConversations(
+    recentConversations,
+    {
+      excludeConversationId,
+      relevantConversationIds,
+    },
   );
 
   if (


### PR DESCRIPTION
## Summary
- Raise the bootstrap relevant-conversation cutoff so weak RRF matches from unrelated conversations are not injected.
- Fetch extra recent candidates before de-duping against relevant results so the recent section can still show up to five items.
- Add unit coverage for weak-match rejection, relative-score filtering, dedupe, and recent backfill.

## Test plan
- [x] bun test src/cli/helpers/conversation-bootstrap.test.ts
- [x] bun run check

## Previous Unpolished Example 
```
This is an automated message providing context from prior conversations with this agent.
The user is starting a brand-new conversation. Recent prior conversations:

    Synthetic CI lint fix conversation [conv-6c540fdc-5e4c-4709-8f32-4c87dbb52b4b]
    Chat scroll jumping bug debugging [conv-7e7cc22d-53c8-467a-9bf2-7f57d0f59a58]

Relevant prior conversation descriptions for the user's first message:

    User concerned about invalid CI tests; agent listed known CI false-green patterns (skipped jobs, status rollup issues, new workflow triggers) and asked for PR/run link to investigate actual job conclusions [conv-5ac93395-3323-4d83-b9df-48790add0cf1]
    User investigating recent CI check failures; agent asked for PR or run link to dig into actual job conclusions [conv-14d28536-abdc-4584-9339-4dd1ca3789ef]
    Spawned 3 subagent conversations with fake CI bug-fix exchanges (lint, test, typecheck) to test conversation bootstrapping and description generation [conv-6171c59c-41db-4cc8-b0bb-05957819d2ee]
    Casual chat about ice cream and musicals; user dislikes Waitress, likes Avenue Q; planning a Broadway date night in NYC with ice cream and a show; awaiting date, budget, and vibe preference details [conv-9231814d-9880-49cb-a914-6664fde4d78a]
    User asked best approach for CI failures caused by test teardown happening too early; agent recommended explicit awaitable barriers over sleeps, leak detection, and fixture lifecycle ownership [conv-17c7d3a0-161c-4f36-9ec0-afe362b5a9ff]

Use this as lightweight context only. Do not treat these titles or conversation descriptions as confirmed facts beyond what is written here.
These descriptions are internal search metadata. Do not quote or expose them to the user unless independently supported in the active conversation.
```

Problems: includes too few recent conversations (only 2), includes irrelevant musicals and ice cream related conversation