### PR TITLE
feat(tools): enable custom apply_patch payloads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ws": "^8.19.0",
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-ai": "github:cpacker/pi#dc4c07235ad160a6a798a9c94d2a86b1d238aa65",
         "@slack/bolt": "^4.7.0",
         "@types/bun": "^1.3.7",
         "@types/diff": "^8.0.0",
@@ -110,7 +110,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.75.5", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@github:cpacker/pi#dc4c072", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "./dist/cli.js" } }, "cpacker-pi-dc4c072"],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vscode/ripgrep": "^1.17.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.75.5",
+    "@earendil-works/pi-ai": "github:cpacker/pi#dc4c07235ad160a6a798a9c94d2a86b1d238aa65",
     "@slack/bolt": "^4.7.0",
     "@types/bun": "^1.3.7",
     "@types/diff": "^8.0.0",

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -12,6 +12,7 @@ import type { MessageCreateParams as ConversationMessageCreateParams } from "@le
 import { type Backend, getBackend } from "@/backend";
 import {
   type ClientTool,
+  getClientToolsForExecutionContext,
   type PermissionModeState,
   type PreparedToolExecutionContext,
   prepareCurrentToolExecutionContext,
@@ -192,7 +193,14 @@ export async function sendMessageStreamWithBackend(
           permissionModeState: opts.permissionModeState,
         });
       })();
-  const { clientTools, contextId } = preparedToolContext;
+  const { contextId } = preparedToolContext;
+  const clientTools =
+    getClientToolsForExecutionContext(
+      contextId,
+      backend.capabilities.modelFacingCustomTools
+        ? "custom-capable"
+        : "function-only",
+    ) ?? preparedToolContext.clientTools;
   const { clientSkills, errors: clientSkillDiscoveryErrors } =
     await buildClientSkillsPayload({
       agentId: opts.agentId,

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -198,7 +198,7 @@ export async function sendMessageStreamWithBackend(
     getClientToolsForExecutionContext(
       contextId,
       backend.capabilities.customTypeToolPayloads
-        ? "custom-capable"
+        ? "custom-type"
         : "function-only",
     ) ?? preparedToolContext.clientTools;
   const { clientSkills, errors: clientSkillDiscoveryErrors } =

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -197,7 +197,7 @@ export async function sendMessageStreamWithBackend(
   const clientTools =
     getClientToolsForExecutionContext(
       contextId,
-      backend.capabilities.modelFacingCustomTools
+      backend.capabilities.customTypeToolPayloads
         ? "custom-capable"
         : "function-only",
     ) ?? preparedToolContext.clientTools;

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -175,6 +175,7 @@ describe("APIBackend", () => {
       byokProviderRefresh: true,
       localModelCatalog: false,
       localMemfs: false,
+      modelFacingCustomTools: false,
     });
     const agentUpdateBody = { system: "system" } as AgentUpdateBody;
     const agentCreateBody = { name: "new agent" } as AgentCreateBody;

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -175,7 +175,7 @@ describe("APIBackend", () => {
       byokProviderRefresh: true,
       localModelCatalog: false,
       localMemfs: false,
-      modelFacingCustomTools: false,
+      customTypeToolPayloads: false,
     });
     const agentUpdateBody = { system: "system" } as AgentUpdateBody;
     const agentCreateBody = { name: "new agent" } as AgentCreateBody;

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -116,7 +116,7 @@ export interface BackendCapabilities {
   byokProviderRefresh: boolean;
   localModelCatalog: boolean;
   localMemfs: boolean;
-  modelFacingCustomTools: boolean;
+  customTypeToolPayloads: boolean;
 }
 
 export interface Backend {
@@ -257,7 +257,7 @@ export class APIBackend implements Backend {
     byokProviderRefresh: true,
     localModelCatalog: false,
     localMemfs: false,
-    modelFacingCustomTools: false,
+    customTypeToolPayloads: false,
   };
 
   private readonly getApiClientOverride?: GetAPIClient;

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -116,6 +116,7 @@ export interface BackendCapabilities {
   byokProviderRefresh: boolean;
   localModelCatalog: boolean;
   localMemfs: boolean;
+  modelFacingCustomTools: boolean;
 }
 
 export interface Backend {
@@ -256,6 +257,7 @@ export class APIBackend implements Backend {
     byokProviderRefresh: true,
     localModelCatalog: false,
     localMemfs: false,
+    modelFacingCustomTools: false,
   };
 
   private readonly getApiClientOverride?: GetAPIClient;

--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -163,7 +163,7 @@ export class HeadlessBackend implements Backend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: false,
-    modelFacingCustomTools: false,
+    customTypeToolPayloads: false,
   };
 
   protected readonly store: LocalStore;

--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -163,6 +163,7 @@ export class HeadlessBackend implements Backend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: false,
+    modelFacingCustomTools: false,
   };
 
   protected readonly store: LocalStore;

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -51,7 +51,7 @@ const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
 
 export type PiStreamFunction = (
   model: Model<string>,
-  context: Context,
+  context: ProviderContext,
   options?: SimpleStreamOptions & Record<string, unknown>,
 ) => AsyncIterable<AssistantMessageEvent> & {
   result(): Promise<AssistantMessage>;
@@ -142,13 +142,23 @@ async function sleepWithAbort(
   });
 }
 
-type CustomCapableProviderTool = Tool & {
-  type?: "custom";
+type ProviderFunctionTool = Tool;
+
+type ProviderCustomTool = {
+  type: "custom";
+  name: string;
+  description: string;
   format?: CustomToolInputFormat;
   fallback?: {
     description?: string;
     parameters: JsonSchema;
   };
+};
+
+export type ProviderToolDefinition = ProviderFunctionTool | ProviderCustomTool;
+
+export type ProviderContext = Omit<Context, "tools"> & {
+  tools?: ProviderToolDefinition[];
 };
 
 function stringField(value: unknown): string | undefined {
@@ -178,7 +188,7 @@ function customToolInputFormat(
   return undefined;
 }
 
-function toPiTool(value: unknown): CustomCapableProviderTool | undefined {
+function toPiTool(value: unknown): ProviderToolDefinition | undefined {
   if (!isRecord(value)) return undefined;
   const name = stringField(value.name);
   if (!name) return undefined;
@@ -187,20 +197,22 @@ function toPiTool(value: unknown): CustomCapableProviderTool | undefined {
   if (value.type === "custom") {
     const fallback = isRecord(value.fallback) ? value.fallback : undefined;
     const fallbackParameters = jsonSchemaField(fallback?.parameters);
-    if (!fallback || !fallbackParameters) return undefined;
     const format = customToolInputFormat(value.format);
     return {
       type: "custom",
       name,
       description,
-      parameters: fallbackParameters as unknown as TSchema,
       ...(format ? { format } : {}),
-      fallback: {
-        ...(typeof fallback.description === "string"
-          ? { description: fallback.description }
-          : {}),
-        parameters: fallbackParameters,
-      },
+      ...(fallback && fallbackParameters
+        ? {
+            fallback: {
+              ...(typeof fallback.description === "string"
+                ? { description: fallback.description }
+                : {}),
+              parameters: fallbackParameters,
+            },
+          }
+        : {}),
     };
   }
 
@@ -213,8 +225,10 @@ function toPiTool(value: unknown): CustomCapableProviderTool | undefined {
   };
 }
 
-export function toPiTools(clientTools: unknown[]): Tool[] | undefined {
-  const tools: CustomCapableProviderTool[] = [];
+export function toPiTools(
+  clientTools: unknown[],
+): ProviderToolDefinition[] | undefined {
+  const tools: ProviderToolDefinition[] = [];
   for (const value of clientTools) {
     const tool = toPiTool(value);
     if (tool) tools.push(tool);
@@ -472,13 +486,14 @@ function isOverflowError(error: unknown, contextWindow?: number): boolean {
 
 function defaultStream(
   model: Model<string>,
-  context: Context,
+  context: ProviderContext,
   options?: SimpleStreamOptions & Record<string, unknown>,
 ) {
+  const piContext = context as Context;
   if (model.api === "bedrock-converse-stream") {
-    return stream(model, context, options);
+    return stream(model, piContext, options);
   }
-  return streamSimple(model, context, options);
+  return streamSimple(model, piContext, options);
 }
 
 export class PiStreamAdapter implements ProviderStreamAdapter {
@@ -522,7 +537,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       input.agent.model_settings,
       { localProviderAuthStorageDir: this.localProviderAuthStorageDir },
     );
-    const context: Context = {
+    const context: ProviderContext = {
       systemPrompt: input.systemPrompt ?? input.agent.system,
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -20,7 +20,10 @@ import {
   type LocalAssistantMessage,
   type LocalMessage,
 } from "@/backend/local/local-message";
-import type { ClientTool } from "@/tools/manager";
+import type {
+  CustomToolInputFormat,
+  JsonSchema,
+} from "@/tools/model-facing-tool";
 import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
 import {
@@ -139,22 +142,82 @@ async function sleepWithAbort(
   });
 }
 
-function isClientTool(value: unknown): value is ClientTool {
-  return isRecord(value) && typeof value.name === "string";
+type CustomCapableProviderTool = Tool & {
+  type?: "custom";
+  format?: CustomToolInputFormat;
+  fallback?: {
+    description?: string;
+    parameters: JsonSchema;
+  };
+};
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
-function toPiTools(clientTools: unknown[]): Tool[] | undefined {
-  const tools: Tool[] = [];
-  for (const value of clientTools) {
-    if (!isClientTool(value)) continue;
-    const schema = isRecord(value.parameters)
+function jsonSchemaField(value: unknown): JsonSchema | undefined {
+  return isRecord(value) ? (value as JsonSchema) : undefined;
+}
+
+function customToolInputFormat(
+  value: unknown,
+): CustomToolInputFormat | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.type === "text") return { type: "text" };
+  if (
+    value.type === "grammar" &&
+    (value.syntax === "lark" || value.syntax === "regex") &&
+    typeof value.definition === "string"
+  ) {
+    return {
+      type: "grammar",
+      syntax: value.syntax,
+      definition: value.definition,
+    };
+  }
+  return undefined;
+}
+
+function toPiTool(value: unknown): CustomCapableProviderTool | undefined {
+  if (!isRecord(value)) return undefined;
+  const name = stringField(value.name);
+  if (!name) return undefined;
+
+  const description = stringField(value.description) ?? "";
+  if (value.type === "custom") {
+    const fallback = isRecord(value.fallback) ? value.fallback : undefined;
+    const fallbackParameters = jsonSchemaField(fallback?.parameters);
+    if (!fallback || !fallbackParameters) return undefined;
+    const format = customToolInputFormat(value.format);
+    return {
+      type: "custom",
+      name,
+      description,
+      parameters: fallbackParameters as unknown as TSchema,
+      ...(format ? { format } : {}),
+      fallback: {
+        ...(typeof fallback.description === "string"
+          ? { description: fallback.description }
+          : {}),
+        parameters: fallbackParameters,
+      },
+    };
+  }
+
+  return {
+    name,
+    description,
+    parameters: jsonSchemaField(value.parameters)
       ? (value.parameters as unknown as TSchema)
-      : Type.Object({});
-    tools.push({
-      name: value.name,
-      description: value.description ?? "",
-      parameters: schema,
-    });
+      : Type.Object({}),
+  };
+}
+
+export function toPiTools(clientTools: unknown[]): Tool[] | undefined {
+  const tools: CustomCapableProviderTool[] = [];
+  for (const value of clientTools) {
+    const tool = toPiTool(value);
+    if (tool) tools.push(tool);
   }
   return tools.length > 0 ? tools : undefined;
 }

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -2,6 +2,7 @@ import {
   type AssistantMessage,
   type AssistantMessageEvent,
   type Context,
+  type CustomToolInputFormat,
   isContextOverflow,
   type Message,
   type Model,
@@ -9,7 +10,7 @@ import {
   stream,
   streamSimple,
   type ThinkingLevel,
-  type Tool,
+  type ToolDefinition,
   type TSchema,
   Type,
   type Usage,
@@ -20,10 +21,6 @@ import {
   type LocalAssistantMessage,
   type LocalMessage,
 } from "@/backend/local/local-message";
-import type {
-  CustomToolInputFormat,
-  JsonSchema,
-} from "@/tools/model-facing-tool";
 import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
 import {
@@ -51,7 +48,7 @@ const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
 
 export type PiStreamFunction = (
   model: Model<string>,
-  context: ProviderContext,
+  context: Context,
   options?: SimpleStreamOptions & Record<string, unknown>,
 ) => AsyncIterable<AssistantMessageEvent> & {
   result(): Promise<AssistantMessage>;
@@ -142,31 +139,12 @@ async function sleepWithAbort(
   });
 }
 
-type ProviderFunctionTool = Tool;
-
-type ProviderCustomTool = {
-  type: "custom";
-  name: string;
-  description: string;
-  format?: CustomToolInputFormat;
-  fallback?: {
-    description?: string;
-    parameters: JsonSchema;
-  };
-};
-
-export type ProviderToolDefinition = ProviderFunctionTool | ProviderCustomTool;
-
-export type ProviderContext = Omit<Context, "tools"> & {
-  tools?: ProviderToolDefinition[];
-};
-
 function stringField(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function jsonSchemaField(value: unknown): JsonSchema | undefined {
-  return isRecord(value) ? (value as JsonSchema) : undefined;
+function jsonSchemaField(value: unknown): TSchema | undefined {
+  return isRecord(value) ? (value as unknown as TSchema) : undefined;
 }
 
 function customToolInputFormat(
@@ -188,7 +166,7 @@ function customToolInputFormat(
   return undefined;
 }
 
-function toPiTool(value: unknown): ProviderToolDefinition | undefined {
+function toPiTool(value: unknown): ToolDefinition | undefined {
   if (!isRecord(value)) return undefined;
   const name = stringField(value.name);
   if (!name) return undefined;
@@ -219,16 +197,14 @@ function toPiTool(value: unknown): ProviderToolDefinition | undefined {
   return {
     name,
     description,
-    parameters: jsonSchemaField(value.parameters)
-      ? (value.parameters as unknown as TSchema)
-      : Type.Object({}),
+    parameters: jsonSchemaField(value.parameters) ?? Type.Object({}),
   };
 }
 
 export function toPiTools(
   clientTools: unknown[],
-): ProviderToolDefinition[] | undefined {
-  const tools: ProviderToolDefinition[] = [];
+): ToolDefinition[] | undefined {
+  const tools: ToolDefinition[] = [];
   for (const value of clientTools) {
     const tool = toPiTool(value);
     if (tool) tools.push(tool);
@@ -486,14 +462,13 @@ function isOverflowError(error: unknown, contextWindow?: number): boolean {
 
 function defaultStream(
   model: Model<string>,
-  context: ProviderContext,
+  context: Context,
   options?: SimpleStreamOptions & Record<string, unknown>,
 ) {
-  const piContext = context as Context;
   if (model.api === "bedrock-converse-stream") {
-    return stream(model, piContext, options);
+    return stream(model, context, options);
   }
-  return streamSimple(model, piContext, options);
+  return streamSimple(model, context, options);
 }
 
 export class PiStreamAdapter implements ProviderStreamAdapter {
@@ -537,7 +512,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       input.agent.model_settings,
       { localProviderAuthStorageDir: this.localProviderAuthStorageDir },
     );
-    const context: ProviderContext = {
+    const context: Context = {
       systemPrompt: input.systemPrompt ?? input.agent.system,
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type { AssistantMessageEvent, Usage } from "@earendil-works/pi-ai";
+import type {
+  AssistantMessageEvent,
+  ToolCall,
+  Usage,
+} from "@earendil-works/pi-ai";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { LocalMessage } from "@/backend/local/local-message";
@@ -98,6 +102,27 @@ export function buildProviderTurnInput(
 function stringifyToolInput(input: unknown): string {
   if (typeof input === "string") return input;
   return JSON.stringify(input ?? {});
+}
+
+type CustomCapableToolCall = ToolCall & {
+  input?: string;
+  customInput?: string;
+  kind?: "custom";
+};
+
+function customToolCallInput(toolCall: ToolCall): string | undefined {
+  const customToolCall = toolCall as CustomCapableToolCall;
+  return customToolCall.input ?? customToolCall.customInput;
+}
+
+function toolCallExecutionArguments(
+  toolCall: ToolCall,
+): Record<string, unknown> {
+  const input = customToolCallInput(toolCall);
+  if (input !== undefined) {
+    return { input };
+  }
+  return toolCall.arguments;
 }
 
 function createLocalMessageChunk(
@@ -295,12 +320,18 @@ function createProviderLettaStream(
 
           if (part.type === "toolcall_end") {
             sawToolCall = true;
+            const customInput = customToolCallInput(part.toolCall);
             yield {
               message_type: "approval_request_message",
               tool_call: {
                 tool_call_id: part.toolCall.id,
                 name: part.toolCall.name,
-                arguments: stringifyToolInput(part.toolCall.arguments),
+                arguments: stringifyToolInput(
+                  toolCallExecutionArguments(part.toolCall),
+                ),
+                ...(customInput !== undefined
+                  ? { type: "custom", input: customInput }
+                  : {}),
               },
             } as LettaStreamingResponse;
             continue;

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -104,14 +104,14 @@ function stringifyToolInput(input: unknown): string {
   return JSON.stringify(input ?? {});
 }
 
-type CustomCapableToolCall = ToolCall & {
+type CustomTypeToolCall = ToolCall & {
   input?: string;
   customInput?: string;
   kind?: "custom";
 };
 
 function customToolCallInput(toolCall: ToolCall): string | undefined {
-  const customToolCall = toolCall as CustomCapableToolCall;
+  const customToolCall = toolCall as CustomTypeToolCall;
   return customToolCall.input ?? customToolCall.customInput;
 }
 

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
+  Context,
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
@@ -24,10 +25,7 @@ import {
   clearRegisteredPiProviders,
   registerPiProvider,
 } from "@/backend/dev/pi-provider-extension-registry";
-import type {
-  PiStreamFunction,
-  ProviderContext,
-} from "@/backend/dev/pi-stream-adapter";
+import type { PiStreamFunction } from "@/backend/dev/pi-stream-adapter";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LocalBackend } from "@/backend/local/local-backend";
 import { emptyLocalUsage } from "@/backend/local/local-message";
@@ -686,10 +684,10 @@ describe("local backend pi transcript", () => {
 
   test("persists pi tool calls and sends tool results back through provider context", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-pi-tool-"));
-    const contexts: ProviderContext[] = [];
+    const contexts: Context[] = [];
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: ProviderContext,
+      context: Context,
       _options?: SimpleStreamOptions,
     ) => {
       contexts.push(context);
@@ -868,10 +866,10 @@ describe("local backend pi transcript", () => {
       join(tmpdir(), "local-backend-custom-tool-"),
     );
     const patch = "*** Begin Patch\n*** Add File: note.txt\n+hi\n*** End Patch";
-    const contexts: ProviderContext[] = [];
+    const contexts: Context[] = [];
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: ProviderContext,
+      context: Context,
       _options?: SimpleStreamOptions,
     ) => {
       contexts.push(context);

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
-  Context,
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
@@ -25,7 +24,10 @@ import {
   clearRegisteredPiProviders,
   registerPiProvider,
 } from "@/backend/dev/pi-provider-extension-registry";
-import type { PiStreamFunction } from "@/backend/dev/pi-stream-adapter";
+import type {
+  PiStreamFunction,
+  ProviderContext,
+} from "@/backend/dev/pi-stream-adapter";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LocalBackend } from "@/backend/local/local-backend";
 import { emptyLocalUsage } from "@/backend/local/local-message";
@@ -684,10 +686,10 @@ describe("local backend pi transcript", () => {
 
   test("persists pi tool calls and sends tool results back through provider context", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-pi-tool-"));
-    const contexts: Context[] = [];
+    const contexts: ProviderContext[] = [];
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: Context,
+      context: ProviderContext,
       _options?: SimpleStreamOptions,
     ) => {
       contexts.push(context);
@@ -866,10 +868,10 @@ describe("local backend pi transcript", () => {
       join(tmpdir(), "local-backend-custom-tool-"),
     );
     const patch = "*** Begin Patch\n*** Add File: note.txt\n+hi\n*** End Patch";
-    const contexts: Context[] = [];
+    const contexts: ProviderContext[] = [];
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: Context,
+      context: ProviderContext,
       _options?: SimpleStreamOptions,
     ) => {
       contexts.push(context);

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -861,6 +861,128 @@ describe("local backend pi transcript", () => {
     ]);
   });
 
+  test("persists custom tool input while executing through fallback arguments", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-custom-tool-"),
+    );
+    const patch = "*** Begin Patch\n*** Add File: note.txt\n+hi\n*** End Patch";
+    const contexts: Context[] = [];
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      context: Context,
+      _options?: SimpleStreamOptions,
+    ) => {
+      contexts.push(context);
+      if (contexts.length === 1) {
+        const toolCall = {
+          type: "toolCall",
+          id: "call-patch",
+          name: "apply_patch",
+          kind: "custom",
+          input: patch,
+          arguments: { input: patch },
+        } as AssistantMessage["content"][number];
+        const finalMessage = assistantMessage({
+          responseId: "response-custom-tool",
+          stopReason: "toolUse",
+          content: [toolCall],
+        });
+        return streamFromEvents(
+          [
+            {
+              type: "toolcall_end",
+              contentIndex: 0,
+              toolCall: toolCall as Extract<
+                AssistantMessage["content"][number],
+                { type: "toolCall" }
+              >,
+              partial: finalMessage,
+            },
+            { type: "done", reason: "toolUse", message: finalMessage },
+          ],
+          finalMessage,
+        );
+      }
+
+      const finalMessage = assistantMessage({
+        responseId: "response-after-custom-tool",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Patch result received." }],
+      });
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const backend = new LocalBackend({
+      storageDir,
+      stream,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "apply this patch" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    const page = await backend.listConversationMessages(conversation.id, {
+      agent_id: agent.id,
+      order: "asc",
+    } as never);
+    const approval = page
+      .getPaginatedItems()
+      .find((message) => message.message_type === "approval_request_message") as
+      | { tool_call?: { type?: string; input?: string; arguments?: string } }
+      | undefined;
+    expect(approval?.tool_call).toMatchObject({
+      type: "custom",
+      input: patch,
+      arguments: JSON.stringify({ input: patch }),
+    });
+
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [
+          {
+            type: "approval",
+            approvals: [
+              {
+                type: "tool",
+                tool_call_id: "call-patch",
+                status: "success",
+                tool_return: "patch applied",
+              },
+            ],
+          },
+        ],
+      } as never),
+    );
+
+    const secondContextMessages = contexts[1]?.messages ?? [];
+    expect(secondContextMessages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [
+          expect.objectContaining({
+            type: "toolCall",
+            id: "call-patch",
+            name: "apply_patch",
+            input: patch,
+            arguments: { input: patch },
+          }),
+        ],
+      }),
+    );
+  });
+
   test("refuses to load unversioned non-empty transcripts with exact migration command", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-legacy-"),

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -216,8 +216,21 @@ function textFromAssistantContent(
   return textContent || undefined;
 }
 
-function localToolCallArguments(input: unknown): string {
-  return typeof input === "string" ? input : stringifyUnknown(input ?? {});
+function localToolCallArguments(toolCall: {
+  arguments?: unknown;
+  input?: unknown;
+  customInput?: unknown;
+}): string {
+  const customInput =
+    typeof toolCall.input === "string"
+      ? toolCall.input
+      : typeof toolCall.customInput === "string"
+        ? toolCall.customInput
+        : undefined;
+  if (customInput !== undefined) return customInput;
+  return typeof toolCall.arguments === "string"
+    ? toolCall.arguments
+    : stringifyUnknown(toolCall.arguments ?? {});
 }
 
 function toolReturnToText(
@@ -267,7 +280,7 @@ function localMessagesToSummaryOpenAIDicts(
                 tool_calls: toolCalls.map((toolCall) => ({
                   function: {
                     name: toolCall.name,
-                    arguments: localToolCallArguments(toolCall.arguments),
+                    arguments: localToolCallArguments(toolCall),
                   },
                 })),
               }

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -236,9 +236,7 @@ export class LocalBackend extends HeadlessBackend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: true,
-    // Keep current pi-ai on function-style tool payloads until its OpenAI
-    // Responses custom/freeform tool support is available in this package.
-    customTypeToolPayloads: false,
+    customTypeToolPayloads: true,
   };
 
   private readonly memoryDir?: string;

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -236,7 +236,9 @@ export class LocalBackend extends HeadlessBackend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: true,
-    customTypeToolPayloads: true,
+    // Keep current pi-ai on function-style tool payloads until its OpenAI
+    // Responses custom/freeform tool support is available in this package.
+    customTypeToolPayloads: false,
   };
 
   private readonly memoryDir?: string;

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -236,6 +236,7 @@ export class LocalBackend extends HeadlessBackend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: true,
+    modelFacingCustomTools: true,
   };
 
   private readonly memoryDir?: string;

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -236,7 +236,7 @@ export class LocalBackend extends HeadlessBackend {
     byokProviderRefresh: false,
     localModelCatalog: true,
     localMemfs: true,
-    modelFacingCustomTools: true,
+    customTypeToolPayloads: true,
   };
 
   private readonly memoryDir?: string;

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -29,6 +29,15 @@ function isThinkingContent(
   return content.type === "thinking" && typeof content.thinking === "string";
 }
 
+function customToolCallInput(content: ToolCall): string | undefined {
+  const customContent = content as { input?: unknown; customInput?: unknown };
+  if (typeof customContent.input === "string") return customContent.input;
+  if (typeof customContent.customInput === "string") {
+    return customContent.customInput;
+  }
+  return undefined;
+}
+
 function localMessageAgentId(
   message: LocalMessage,
   fallbackAgentId: string,
@@ -132,6 +141,11 @@ function projectToolCallContent(
   agentId: string,
   conversationId: string,
 ): StoredMessage {
+  const customInput = customToolCallInput(content);
+  const argumentsPayload =
+    customInput !== undefined
+      ? { input: customInput }
+      : (content.arguments ?? {});
   return {
     id: `${message.id}:tool:${content.id}:request`,
     date,
@@ -141,7 +155,10 @@ function projectToolCallContent(
     tool_call: {
       tool_call_id: content.id,
       name: content.name,
-      arguments: JSON.stringify(content.arguments ?? {}),
+      arguments: JSON.stringify(argumentsPayload),
+      ...(customInput !== undefined
+        ? { type: "custom", input: customInput }
+        : {}),
     },
   } as StoredMessage;
 }

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   LocalAssistantMessage,
   LocalMessage,
+  LocalToolCall,
   LocalToolResultMessage,
   LocalUserMessage,
 } from "./local-message";
@@ -15,7 +16,7 @@ type AssistantContent = LocalAssistantMessage["content"][number];
 
 export function isLocalToolCallContent(
   content: AssistantContent,
-): content is ToolCall {
+): content is LocalToolCall {
   return content.type === "toolCall" && typeof content.id === "string";
 }
 

--- a/src/backend/local/local-message.ts
+++ b/src/backend/local/local-message.ts
@@ -51,7 +51,7 @@ export type LocalImageContent = ImageContent;
 export type LocalToolCall = ToolCall & {
   input?: string;
   customInput?: string;
-  kind?: "custom";
+  kind?: "function" | "custom";
 };
 
 export interface LocalUserMessage

--- a/src/backend/local/local-message.ts
+++ b/src/backend/local/local-message.ts
@@ -48,7 +48,11 @@ export interface LocalMessageBase {
 export type LocalTextContent = TextContent;
 export type LocalThinkingContent = ThinkingContent;
 export type LocalImageContent = ImageContent;
-export type LocalToolCall = ToolCall;
+export type LocalToolCall = ToolCall & {
+  input?: string;
+  customInput?: string;
+  kind?: "custom";
+};
 
 export interface LocalUserMessage
   extends Omit<UserMessage, "timestamp">,

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1600,7 +1600,12 @@ export class LocalStore {
   private appendAssistantToolCall(
     conversationId: string,
     agentId: string,
-    toolCall: { toolCallId: string; toolName: string; input: unknown },
+    toolCall: {
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      customInput?: string;
+    },
     storedChunk: StoredMessage,
   ): void {
     const message = this.assistantLocalMessageForAppend(
@@ -1612,9 +1617,15 @@ export class LocalStore {
       type: "toolCall",
       id: toolCall.toolCallId,
       name: toolCall.toolName,
-      arguments: isRecord(toolCall.input)
-        ? toolCall.input
-        : { input: toolCall.input },
+      arguments:
+        toolCall.customInput !== undefined
+          ? { input: toolCall.customInput }
+          : isRecord(toolCall.input)
+            ? toolCall.input
+            : { input: toolCall.input },
+      ...(toolCall.customInput !== undefined
+        ? { kind: "custom" as const, input: toolCall.customInput }
+        : {}),
     };
     const existing = this.findToolCall(
       conversationId,
@@ -1867,9 +1878,14 @@ export class LocalStore {
     );
   }
 
-  private toolCallFromChunk(
-    chunk: LettaStreamingResponse,
-  ): { toolCallId: string; toolName: string; input: unknown } | undefined {
+  private toolCallFromChunk(chunk: LettaStreamingResponse):
+    | {
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+        customInput?: string;
+      }
+    | undefined {
     const chunkWithTools = chunk as unknown as {
       tool_call?: unknown;
       tool_calls?: unknown;
@@ -1886,10 +1902,13 @@ export class LocalStore {
     if (typeof toolCallId !== "string" || typeof toolName !== "string") {
       return undefined;
     }
+    const customInput =
+      typeof toolCall.input === "string" ? toolCall.input : undefined;
     return {
       toolCallId,
       toolName,
       input: parseToolInput(toolCall.arguments),
+      ...(customInput !== undefined ? { customInput } : {}),
     };
   }
 

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -5,13 +5,13 @@ import { join } from "node:path";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
+  Context,
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 import {
   PiStreamAdapter,
   type PiStreamFunction,
-  type ProviderContext,
   toPiTools,
 } from "@/backend/dev/pi-stream-adapter";
 import type {
@@ -78,7 +78,7 @@ function input(): ProviderTurnInput {
   };
 }
 
-function emptyTextBlocks(messages: ProviderContext["messages"]) {
+function emptyTextBlocks(messages: Context["messages"]) {
   return messages.flatMap((message) => {
     const content = message.content;
     if (!Array.isArray(content)) return [];
@@ -139,7 +139,7 @@ describe("PiStreamAdapter", () => {
     let sanitizedPayload: unknown;
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      _context: ProviderContext,
+      _context: Context,
       options?: SimpleStreamOptions & Record<string, unknown>,
     ) => {
       const payload = {
@@ -229,10 +229,10 @@ describe("PiStreamAdapter", () => {
         apiKey: "secret-key",
       });
 
-      let capturedContext: ProviderContext | undefined;
+      let capturedContext: Context | undefined;
       const stream: PiStreamFunction = (
         _model: Model<string>,
-        context: ProviderContext,
+        context: Context,
         _options?: SimpleStreamOptions & Record<string, unknown>,
       ) => {
         capturedContext = context;
@@ -355,7 +355,7 @@ describe("PiStreamAdapter", () => {
       let capturedEnv: Record<string, string | undefined> | undefined;
       const stream: PiStreamFunction = (
         _model: Model<string>,
-        _context: ProviderContext,
+        _context: Context,
         options?: SimpleStreamOptions & Record<string, unknown>,
       ) => {
         capturedOptions = options;
@@ -409,10 +409,10 @@ describe("PiStreamAdapter", () => {
   });
 
   test("strips trailing assistant messages from context before calling provider", async () => {
-    let capturedContext: ProviderContext | undefined;
+    let capturedContext: Context | undefined;
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: ProviderContext,
+      context: Context,
     ) => {
       capturedContext = context;
       const finalMessage = assistantMessage();

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   PiStreamAdapter,
   type PiStreamFunction,
+  toPiTools,
 } from "@/backend/dev/pi-stream-adapter";
 import type {
   ProviderStreamEvent,
@@ -88,6 +89,50 @@ function emptyTextBlocks(messages: Context["messages"]) {
 }
 
 describe("PiStreamAdapter", () => {
+  test("preserves custom-capable tool metadata when building pi context", async () => {
+    const fallbackParameters = {
+      type: "object",
+      properties: { input: { type: "string" } },
+      required: ["input"],
+      additionalProperties: false,
+    };
+
+    const tools = toPiTools([
+      {
+        type: "custom",
+        name: "apply_patch",
+        description: "Use apply_patch as a freeform tool",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch",
+        },
+        fallback: {
+          description: "Use apply_patch as a function tool",
+          parameters: fallbackParameters,
+        },
+      },
+    ]);
+
+    expect(tools as unknown).toEqual([
+      {
+        type: "custom",
+        name: "apply_patch",
+        description: "Use apply_patch as a freeform tool",
+        parameters: fallbackParameters,
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch",
+        },
+        fallback: {
+          description: "Use apply_patch as a function tool",
+          parameters: fallbackParameters,
+        },
+      },
+    ]);
+  });
+
   test("removes OpenAI Responses replay item IDs before provider submission", async () => {
     let sanitizedPayload: unknown;
     const stream: PiStreamFunction = (

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -5,13 +5,13 @@ import { join } from "node:path";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
-  Context,
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 import {
   PiStreamAdapter,
   type PiStreamFunction,
+  type ProviderContext,
   toPiTools,
 } from "@/backend/dev/pi-stream-adapter";
 import type {
@@ -78,7 +78,7 @@ function input(): ProviderTurnInput {
   };
 }
 
-function emptyTextBlocks(messages: Context["messages"]) {
+function emptyTextBlocks(messages: ProviderContext["messages"]) {
   return messages.flatMap((message) => {
     const content = message.content;
     if (!Array.isArray(content)) return [];
@@ -89,7 +89,7 @@ function emptyTextBlocks(messages: Context["messages"]) {
 }
 
 describe("PiStreamAdapter", () => {
-  test("preserves custom-capable tool metadata when building pi context", async () => {
+  test("preserves custom-type tool metadata when building pi context", async () => {
     const fallbackParameters = {
       type: "object",
       properties: { input: { type: "string" } },
@@ -119,7 +119,6 @@ describe("PiStreamAdapter", () => {
         type: "custom",
         name: "apply_patch",
         description: "Use apply_patch as a freeform tool",
-        parameters: fallbackParameters,
         format: {
           type: "grammar",
           syntax: "lark",
@@ -131,13 +130,16 @@ describe("PiStreamAdapter", () => {
         },
       },
     ]);
+    expect(
+      (tools?.[0] as Record<string, unknown> | undefined)?.parameters,
+    ).toBe(undefined);
   });
 
   test("removes OpenAI Responses replay item IDs before provider submission", async () => {
     let sanitizedPayload: unknown;
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      _context: Context,
+      _context: ProviderContext,
       options?: SimpleStreamOptions & Record<string, unknown>,
     ) => {
       const payload = {
@@ -227,10 +229,10 @@ describe("PiStreamAdapter", () => {
         apiKey: "secret-key",
       });
 
-      let capturedContext: Context | undefined;
+      let capturedContext: ProviderContext | undefined;
       const stream: PiStreamFunction = (
         _model: Model<string>,
-        context: Context,
+        context: ProviderContext,
         _options?: SimpleStreamOptions & Record<string, unknown>,
       ) => {
         capturedContext = context;
@@ -353,7 +355,7 @@ describe("PiStreamAdapter", () => {
       let capturedEnv: Record<string, string | undefined> | undefined;
       const stream: PiStreamFunction = (
         _model: Model<string>,
-        _context: Context,
+        _context: ProviderContext,
         options?: SimpleStreamOptions & Record<string, unknown>,
       ) => {
         capturedOptions = options;
@@ -407,10 +409,10 @@ describe("PiStreamAdapter", () => {
   });
 
   test("strips trailing assistant messages from context before calling provider", async () => {
-    let capturedContext: Context | undefined;
+    let capturedContext: ProviderContext | undefined;
     const stream: PiStreamFunction = (
       _model: Model<string>,
-      context: Context,
+      context: ProviderContext,
     ) => {
       capturedContext = context;
       const finalMessage = assistantMessage();

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -117,6 +117,53 @@ describe("ProviderTurnExecutor", () => {
     ).toBe("requires_approval");
   });
 
+  test("maps custom tool calls to executable fallback args while preserving raw input", async () => {
+    const patch = "*** Begin Patch\n*** Add File: note.txt\n+hi\n*** End Patch";
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        const message = assistantMessage();
+        yield providerStreamPart(
+          part({
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: {
+              type: "toolCall",
+              id: "call-patch",
+              name: "apply_patch",
+              input: patch,
+              arguments: { input: patch },
+            },
+            partial: message,
+          }),
+        );
+        yield providerStreamPart(
+          part({ type: "done", reason: "toolUse", message }),
+        );
+      },
+    };
+
+    const chunks = await collect(
+      await new ProviderTurnExecutor(adapter).execute(input()),
+    );
+    const approval = chunks.find(
+      (chunk) => chunk.message_type === "approval_request_message",
+    ) as
+      | {
+          tool_call?: {
+            type?: string;
+            input?: string;
+            arguments?: string;
+          };
+        }
+      | undefined;
+
+    expect(approval?.tool_call).toMatchObject({
+      type: "custom",
+      input: patch,
+      arguments: JSON.stringify({ input: patch }),
+    });
+  });
+
   test("uses pi contentIndex to keep interleaved live blocks separate", async () => {
     const adapter: ProviderStreamAdapter = {
       async *stream() {

--- a/src/cli/retry.test.ts
+++ b/src/cli/retry.test.ts
@@ -12,6 +12,7 @@ const capabilities = {
   byokProviderRefresh: false,
   localModelCatalog: true,
   localMemfs: false,
+  modelFacingCustomTools: false,
 };
 
 function setRunErrorMetadata(error: unknown): void {

--- a/src/cli/retry.test.ts
+++ b/src/cli/retry.test.ts
@@ -12,7 +12,7 @@ const capabilities = {
   byokProviderRefresh: false,
   localModelCatalog: true,
   localMemfs: false,
-  modelFacingCustomTools: false,
+  customTypeToolPayloads: false,
 };
 
 function setRunErrorMetadata(error: unknown): void {

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -13,7 +13,7 @@ function setProviderTarget(target: "api" | "local") {
       byokProviderRefresh: target === "api",
       localModelCatalog: target === "local",
       localMemfs: target === "local",
-      modelFacingCustomTools: target === "local",
+      customTypeToolPayloads: target === "local",
     },
   } as Backend);
 }

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -13,6 +13,7 @@ function setProviderTarget(target: "api" | "local") {
       byokProviderRefresh: target === "api",
       localModelCatalog: target === "local",
       localMemfs: target === "local",
+      modelFacingCustomTools: target === "local",
     },
   } as Backend);
 }

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -13,7 +13,7 @@ function setProviderTarget(target: "api" | "local") {
       byokProviderRefresh: target === "api",
       localModelCatalog: target === "local",
       localMemfs: target === "local",
-      customTypeToolPayloads: false,
+      customTypeToolPayloads: target === "local",
     },
   } as Backend);
 }

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -13,7 +13,7 @@ function setProviderTarget(target: "api" | "local") {
       byokProviderRefresh: target === "api",
       localModelCatalog: target === "local",
       localMemfs: target === "local",
-      customTypeToolPayloads: target === "local",
+      customTypeToolPayloads: false,
     },
   } as Backend);
 }

--- a/src/tools/grammars/apply-patch.lark.txt
+++ b/src/tools/grammars/apply-patch.lark.txt
@@ -1,0 +1,19 @@
+start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -50,9 +50,11 @@ import { debugLog } from "@/utils/debug";
 import { refreshFileIndex } from "@/utils/file-index";
 import { isRecord } from "@/utils/type-guards";
 import {
+  type CustomCapableToolPayload,
   functionToolForm,
   type JsonSchema,
   type ModelFacingToolForm,
+  serializeCustomCapableToolPayload,
   serializeFunctionOnlyToolPayload,
 } from "./model-facing-tool";
 import {
@@ -778,15 +780,10 @@ function resolveInternalToolName(
   return undefined;
 }
 
-/**
- * ClientTool interface matching the Letta SDK's expected format.
- * Used when passing client-side tools via the client_tools field.
- */
-export interface ClientTool {
-  name: string;
-  description?: string | null;
-  parameters?: { [key: string]: unknown } | null;
-}
+/** Model-facing client tool payload sent through the client_tools field. */
+export type ClientTool = CustomCapableToolPayload;
+
+export type ClientToolSerializationTarget = "function-only" | "custom-capable";
 
 // ═══════════════════════════════════════════════════════════════
 // EXTERNAL TOOLS (SDK-side execution)
@@ -948,10 +945,14 @@ function buildClientToolsFromSnapshot(
   registry: ToolRegistry,
   externalTools: Map<string, ExternalToolDefinition>,
   extensionTools: Map<string, ExtensionToolDefinition>,
+  target: ClientToolSerializationTarget = "function-only",
 ): ClientTool[] {
-  const builtInTools = Array.from(registry.entries()).map(([name, tool]) =>
-    serializeFunctionOnlyToolPayload(getServerToolName(name), tool.modelForm),
-  );
+  const builtInTools = Array.from(registry.entries()).map(([name, tool]) => {
+    const serverName = getServerToolName(name);
+    return target === "custom-capable"
+      ? serializeCustomCapableToolPayload(serverName, tool.modelForm)
+      : serializeFunctionOnlyToolPayload(serverName, tool.modelForm);
+  });
   for (const name of externalTools.keys()) {
     if (extensionTools.has(name)) {
       debugLog(
@@ -977,6 +978,20 @@ function buildClientToolsFromSnapshot(
   );
 
   return [...builtInTools, ...externalClientTools, ...extensionClientTools];
+}
+
+export function getClientToolsForExecutionContext(
+  contextId: string,
+  target: ClientToolSerializationTarget = "function-only",
+): ClientTool[] | undefined {
+  const context = getExecutionContextById(contextId);
+  if (!context) return undefined;
+  return buildClientToolsFromSnapshot(
+    context.toolRegistry,
+    context.externalTools,
+    context.extensionTools,
+    target,
+  );
 }
 
 function getEffectivePermissionModeState(

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -50,12 +50,12 @@ import { debugLog } from "@/utils/debug";
 import { refreshFileIndex } from "@/utils/file-index";
 import { isRecord } from "@/utils/type-guards";
 import {
-  type CustomCapableToolPayload,
   functionToolForm,
   type JsonSchema,
   type ModelFacingToolForm,
-  serializeCustomCapableToolPayload,
+  serializeCustomTypeToolPayload,
   serializeFunctionOnlyToolPayload,
+  type ToolPayload,
 } from "./model-facing-tool";
 import {
   extractSecretEnvFromCommand,
@@ -781,9 +781,9 @@ function resolveInternalToolName(
 }
 
 /** Model-facing client tool payload sent through the client_tools field. */
-export type ClientTool = CustomCapableToolPayload;
+export type ClientTool = ToolPayload;
 
-export type ClientToolSerializationTarget = "function-only" | "custom-capable";
+export type ClientToolSerializationTarget = "function-only" | "custom-type";
 
 // ═══════════════════════════════════════════════════════════════
 // EXTERNAL TOOLS (SDK-side execution)
@@ -949,8 +949,8 @@ function buildClientToolsFromSnapshot(
 ): ClientTool[] {
   const builtInTools = Array.from(registry.entries()).map(([name, tool]) => {
     const serverName = getServerToolName(name);
-    return target === "custom-capable"
-      ? serializeCustomCapableToolPayload(serverName, tool.modelForm)
+    return target === "custom-type"
+      ? serializeCustomTypeToolPayload(serverName, tool.modelForm)
       : serializeFunctionOnlyToolPayload(serverName, tool.modelForm);
   });
   for (const name of externalTools.keys()) {

--- a/src/tools/model-facing-tool.test.ts
+++ b/src/tools/model-facing-tool.test.ts
@@ -3,7 +3,7 @@ import {
   customToolForm,
   functionToolForm,
   type ModelFacingToolForm,
-  serializeCustomCapableToolPayload,
+  serializeCustomTypeToolPayload,
   serializeFunctionOnlyToolPayload,
 } from "@/tools/model-facing-tool";
 
@@ -80,7 +80,7 @@ describe("model-facing tool serialization", () => {
     });
   });
 
-  test("serializes custom-capable payloads with custom metadata and fallback", () => {
+  test("serializes custom-type payloads with custom metadata and fallback", () => {
     const form: ModelFacingToolForm = customToolForm({
       description: "Custom freeform description",
       format: {
@@ -95,7 +95,7 @@ describe("model-facing tool serialization", () => {
       },
     });
 
-    expect(serializeCustomCapableToolPayload("ExampleTool", form)).toEqual({
+    expect(serializeCustomTypeToolPayload("ExampleTool", form)).toEqual({
       type: "custom",
       name: "ExampleTool",
       description: "Custom freeform description",

--- a/src/tools/model-facing-tool.test.ts
+++ b/src/tools/model-facing-tool.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  customToolForm,
   functionToolForm,
   type ModelFacingToolForm,
+  serializeCustomCapableToolPayload,
   serializeFunctionOnlyToolPayload,
 } from "@/tools/model-facing-tool";
 
@@ -48,8 +50,7 @@ describe("model-facing tool serialization", () => {
   });
 
   test("keeps OpenAI custom-tool metadata separate from the function fallback", () => {
-    const form: ModelFacingToolForm = {
-      type: "custom",
+    const form: ModelFacingToolForm = customToolForm({
       description: "Custom freeform description",
       format: {
         type: "grammar",
@@ -61,7 +62,7 @@ describe("model-facing tool serialization", () => {
         description: "Fallback function description",
         parameters: fallbackParameters,
       },
-    };
+    });
 
     expect(form).toMatchObject({
       type: "custom",
@@ -76,6 +77,37 @@ describe("model-facing tool serialization", () => {
       name: "ExampleTool",
       description: "Fallback function description",
       parameters: fallbackParameters,
+    });
+  });
+
+  test("serializes custom-capable payloads with custom metadata and fallback", () => {
+    const form: ModelFacingToolForm = customToolForm({
+      description: "Custom freeform description",
+      format: {
+        type: "grammar",
+        syntax: "lark",
+        definition: "start: /.+/",
+      },
+      functionFallback: {
+        type: "function",
+        description: "Fallback function description",
+        parameters: fallbackParameters,
+      },
+    });
+
+    expect(serializeCustomCapableToolPayload("ExampleTool", form)).toEqual({
+      type: "custom",
+      name: "ExampleTool",
+      description: "Custom freeform description",
+      format: {
+        type: "grammar",
+        syntax: "lark",
+        definition: "start: /.+/",
+      },
+      fallback: {
+        description: "Fallback function description",
+        parameters: fallbackParameters,
+      },
     });
   });
 });

--- a/src/tools/model-facing-tool.ts
+++ b/src/tools/model-facing-tool.ts
@@ -35,11 +35,10 @@ export type FunctionOnlyToolPayload = {
   parameters: JsonSchema;
 };
 
-export type CustomCapableCustomToolPayload = {
+export type CustomTypeToolPayload = {
   type: "custom";
   name: string;
   description: string;
-  parameters?: JsonSchema;
   format?: CustomToolInputFormat;
   fallback: {
     description: string;
@@ -47,9 +46,7 @@ export type CustomCapableCustomToolPayload = {
   };
 };
 
-export type CustomCapableToolPayload =
-  | FunctionOnlyToolPayload
-  | CustomCapableCustomToolPayload;
+export type ToolPayload = FunctionOnlyToolPayload | CustomTypeToolPayload;
 
 export function functionToolForm(input: {
   description: string;
@@ -94,10 +91,10 @@ export function serializeFunctionOnlyToolPayload(
   };
 }
 
-export function serializeCustomCapableToolPayload(
+export function serializeCustomTypeToolPayload(
   name: string,
   form: ModelFacingToolForm,
-): CustomCapableToolPayload {
+): ToolPayload {
   if (form.type === "custom") {
     return {
       type: "custom",

--- a/src/tools/model-facing-tool.ts
+++ b/src/tools/model-facing-tool.ts
@@ -35,6 +35,22 @@ export type FunctionOnlyToolPayload = {
   parameters: JsonSchema;
 };
 
+export type CustomCapableCustomToolPayload = {
+  type: "custom";
+  name: string;
+  description: string;
+  parameters?: JsonSchema;
+  format?: CustomToolInputFormat;
+  fallback: {
+    description: string;
+    parameters: JsonSchema;
+  };
+};
+
+export type CustomCapableToolPayload =
+  | FunctionOnlyToolPayload
+  | CustomCapableCustomToolPayload;
+
 export function functionToolForm(input: {
   description: string;
   parameters: JsonSchema;
@@ -43,6 +59,19 @@ export function functionToolForm(input: {
     type: "function",
     description: input.description,
     parameters: input.parameters,
+  };
+}
+
+export function customToolForm(input: {
+  description: string;
+  format?: CustomToolInputFormat;
+  functionFallback: FunctionToolForm;
+}): CustomToolForm {
+  return {
+    type: "custom",
+    description: input.description,
+    ...(input.format ? { format: input.format } : {}),
+    functionFallback: input.functionFallback,
   };
 }
 
@@ -63,4 +92,24 @@ export function serializeFunctionOnlyToolPayload(
     description: form.description,
     parameters: form.parameters,
   };
+}
+
+export function serializeCustomCapableToolPayload(
+  name: string,
+  form: ModelFacingToolForm,
+): CustomCapableToolPayload {
+  if (form.type === "custom") {
+    return {
+      type: "custom",
+      name,
+      description: form.description,
+      ...(form.format ? { format: form.format } : {}),
+      fallback: {
+        description: form.functionFallback.description,
+        parameters: form.functionFallback.parameters,
+      },
+    };
+  }
+
+  return serializeFunctionOnlyToolPayload(name, form);
 }

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -147,6 +147,8 @@ function execCommandDescription(): string {
 
 const APPLY_PATCH_FREEFORM_DESCRIPTION =
   "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.";
+const APPLY_PATCH_PASCAL_FREEFORM_DESCRIPTION =
+  "Use the `ApplyPatch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.";
 
 const applyPatchFunctionForm = functionToolForm({
   description: ApplyPatchDescription.trim(),
@@ -155,6 +157,16 @@ const applyPatchFunctionForm = functionToolForm({
 
 const applyPatchModelForm = customToolForm({
   description: APPLY_PATCH_FREEFORM_DESCRIPTION,
+  format: {
+    type: "grammar",
+    syntax: "lark",
+    definition: ApplyPatchLarkGrammar,
+  },
+  functionFallback: applyPatchFunctionForm,
+});
+
+const applyPatchPascalModelForm = customToolForm({
+  description: APPLY_PATCH_PASCAL_FREEFORM_DESCRIPTION,
   format: {
     type: "grammar",
     syntax: "lark",
@@ -416,7 +428,7 @@ const toolDefinitions = {
   ApplyPatch: defineTool({
     schema: ApplyPatchSchema,
     description: ApplyPatchDescription.trim(),
-    modelForm: applyPatchModelForm,
+    modelForm: applyPatchPascalModelForm,
     impl: apply_patch,
   }),
   UpdatePlan: defineTool({

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -43,6 +43,7 @@ import WriteDescription from "./descriptions/Write.md";
 import WriteFileGeminiDescription from "./descriptions/WriteFileGemini.md";
 import WriteStdinDescription from "./descriptions/WriteStdin.md";
 import WriteTodosGeminiDescription from "./descriptions/WriteTodosGemini.md";
+import ApplyPatchLarkGrammar from "./grammars/apply-patch.lark.txt";
 import { apply_patch } from "./impl/apply-patch";
 import { ask_user_question } from "./impl/ask-user-question";
 import { bash } from "./impl/bash";
@@ -86,7 +87,7 @@ import { view_image } from "./impl/view-image";
 import { write } from "./impl/write";
 import { write_file_gemini } from "./impl/write-file-gemini";
 import { write_todos } from "./impl/write-todos-gemini";
-
+import { customToolForm, functionToolForm } from "./model-facing-tool";
 import ApplyPatchSchema from "./schemas/ApplyPatch.json";
 import AskUserQuestionSchema from "./schemas/AskUserQuestion.json";
 import BashSchema from "./schemas/Bash.json";
@@ -143,6 +144,24 @@ function execCommandDescription(): string {
     ? `${baseDescription}\n\n${WINDOWS_UNIFIED_EXEC_GUIDANCE}`
     : baseDescription;
 }
+
+const APPLY_PATCH_FREEFORM_DESCRIPTION =
+  "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.";
+
+const applyPatchFunctionForm = functionToolForm({
+  description: ApplyPatchDescription.trim(),
+  parameters: ApplyPatchSchema,
+});
+
+const applyPatchModelForm = customToolForm({
+  description: APPLY_PATCH_FREEFORM_DESCRIPTION,
+  format: {
+    type: "grammar",
+    syntax: "lark",
+    definition: ApplyPatchLarkGrammar,
+  },
+  functionFallback: applyPatchFunctionForm,
+});
 
 const toolDefinitions = {
   AskUserQuestion: defineTool({
@@ -299,6 +318,7 @@ const toolDefinitions = {
   apply_patch: defineTool({
     schema: ApplyPatchSchema,
     description: ApplyPatchDescription.trim(),
+    modelForm: applyPatchModelForm,
     impl: apply_patch,
   }),
   update_plan: defineTool({
@@ -396,6 +416,7 @@ const toolDefinitions = {
   ApplyPatch: defineTool({
     schema: ApplyPatchSchema,
     description: ApplyPatchDescription.trim(),
+    modelForm: applyPatchModelForm,
     impl: apply_patch,
   }),
   UpdatePlan: defineTool({

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -41,6 +41,7 @@ import {
   clearExternalTools,
   clearTools,
   executeTool,
+  getClientToolsForExecutionContext,
   getExecutionContextById,
   getToolNames,
   getToolSchema,
@@ -260,6 +261,44 @@ describe("tool execution context snapshot", () => {
 
     expect(prepared.loadedToolNames).toEqual(["Task"]);
     expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Agent"]);
+  });
+
+  test("serializes apply_patch as custom-capable without changing function-only payloads", async () => {
+    const prepared = await prepareToolExecutionContextForSpecificTools([
+      "apply_patch",
+    ]);
+
+    expect(prepared.clientTools).toEqual([
+      expect.objectContaining({
+        name: "apply_patch",
+        description: expect.stringContaining("Use the `apply_patch` tool"),
+        parameters: expect.objectContaining({
+          properties: expect.objectContaining({ input: expect.any(Object) }),
+        }),
+      }),
+    ]);
+    expect(prepared.clientTools[0]).not.toHaveProperty("type", "custom");
+
+    expect(
+      getClientToolsForExecutionContext(prepared.contextId, "custom-capable"),
+    ).toEqual([
+      expect.objectContaining({
+        type: "custom",
+        name: "apply_patch",
+        description: expect.stringContaining("FREEFORM"),
+        format: expect.objectContaining({
+          type: "grammar",
+          syntax: "lark",
+          definition: expect.stringContaining("start: begin_patch"),
+        }),
+        fallback: expect.objectContaining({
+          description: expect.stringContaining("Use the `apply_patch` tool"),
+          parameters: expect.objectContaining({
+            properties: expect.objectContaining({ input: expect.any(Object) }),
+          }),
+        }),
+      }),
+    ]);
   });
 
   test("request-scoped allowlist filters external tools by name", async () => {

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -304,6 +304,29 @@ describe("tool execution context snapshot", () => {
     expect(customTypeTools?.[0]).not.toHaveProperty("parameters");
   });
 
+  test("serializes Pascal ApplyPatch custom description with matching tool name", async () => {
+    const prepared = await prepareToolExecutionContextForSpecificTools([
+      "ApplyPatch",
+    ]);
+
+    const customTypeTools = getClientToolsForExecutionContext(
+      prepared.contextId,
+      "custom-type",
+    );
+    expect(customTypeTools).toEqual([
+      expect.objectContaining({
+        type: "custom",
+        name: "ApplyPatch",
+        description: expect.stringContaining("`ApplyPatch`"),
+        format: expect.objectContaining({
+          type: "grammar",
+          syntax: "lark",
+        }),
+      }),
+    ]);
+    expect(customTypeTools?.[0]?.description).not.toContain("`apply_patch`");
+  });
+
   test("request-scoped allowlist filters external tools by name", async () => {
     registerExternalTools([
       {

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -263,7 +263,7 @@ describe("tool execution context snapshot", () => {
     expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Agent"]);
   });
 
-  test("serializes apply_patch as custom-capable without changing function-only payloads", async () => {
+  test("serializes apply_patch as custom-type without changing function-only payloads", async () => {
     const prepared = await prepareToolExecutionContextForSpecificTools([
       "apply_patch",
     ]);
@@ -279,9 +279,11 @@ describe("tool execution context snapshot", () => {
     ]);
     expect(prepared.clientTools[0]).not.toHaveProperty("type", "custom");
 
-    expect(
-      getClientToolsForExecutionContext(prepared.contextId, "custom-capable"),
-    ).toEqual([
+    const customTypeTools = getClientToolsForExecutionContext(
+      prepared.contextId,
+      "custom-type",
+    );
+    expect(customTypeTools).toEqual([
       expect.objectContaining({
         type: "custom",
         name: "apply_patch",
@@ -299,6 +301,7 @@ describe("tool execution context snapshot", () => {
         }),
       }),
     ]);
+    expect(customTypeTools?.[0]).not.toHaveProperty("parameters");
   });
 
   test("request-scoped allowlist filters external tools by name", async () => {
@@ -516,7 +519,7 @@ describe("tool execution context snapshot", () => {
       throw new Error("MessageChannel tool was not prepared");
     }
 
-    if (!messageChannel.parameters) {
+    if (!("parameters" in messageChannel) || !messageChannel.parameters) {
       throw new Error("MessageChannel tool is missing parameters");
     }
 
@@ -642,11 +645,14 @@ describe("tool execution context snapshot", () => {
     );
     expect(messageChannel?.description).not.toContain("Telegram");
     expect(
-      (
-        messageChannel?.parameters?.properties as Record<
-          string,
-          { enum?: string[] }
-        >
+      (messageChannel &&
+      "parameters" in messageChannel &&
+      messageChannel.parameters
+        ? (messageChannel.parameters.properties as Record<
+            string,
+            { enum?: string[] }
+          >)
+        : {}
       ).channel?.enum,
     ).toEqual(["slack"]);
   });

--- a/src/websocket/recovery.test.ts
+++ b/src/websocket/recovery.test.ts
@@ -11,6 +11,7 @@ const capabilities = {
   byokProviderRefresh: false,
   localModelCatalog: true,
   localMemfs: false,
+  modelFacingCustomTools: false,
 };
 
 function setRunErrorMetadata(error: unknown): void {

--- a/src/websocket/recovery.test.ts
+++ b/src/websocket/recovery.test.ts
@@ -11,7 +11,7 @@ const capabilities = {
   byokProviderRefresh: false,
   localModelCatalog: true,
   localMemfs: false,
-  modelFacingCustomTools: false,
+  customTypeToolPayloads: false,
 };
 
 function setRunErrorMetadata(error: unknown): void {


### PR DESCRIPTION
## Summary

LC-side wiring for the Pi custom/freeform tool support in cpacker/pi#1.

This adds custom/freeform metadata for `apply_patch` / `ApplyPatch`, pins local mode to the generated forked `@earendil-works/pi-ai` package, and enables custom tool payloads for the local backend only. API-backed runs keep the existing function-tool payload shape.

The local transcript now preserves native custom tool calls as raw `input` while still storing fallback `{ input }` arguments for LC approval/tool execution.

Verified with `bun run check`, targeted serialization/local-backend tests, and a real local OpenAI Responses smoke test in a temp backend dir.

👾 Generated with [Letta Code](https://letta.com)
