### PR TITLE
fix(desktop): allow tutorial agent creation

### DIFF
--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -860,6 +860,7 @@ export function isCreateAgentCommand(
     typeof c.request_id === "string" &&
     (c.personality === "memo" ||
       c.personality === "blank" ||
+      c.personality === "tutorial" ||
       c.personality === "linus" ||
       c.personality === "kawaii") &&
     (c.model === undefined || typeof c.model === "string") &&


### PR DESCRIPTION
Allow the desktop listener create_agent command to accept the tutorial personality so Tutor creation returns a response instead of being ignored.