### PR TITLE
test(cli): cover local backend desktop auth

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -150,6 +150,17 @@ describe("shared CLI arg schema", () => {
       backend: "api",
       args: ["connect", "help"],
     });
+    expect(
+      extractBackendFlag([
+        "remote",
+        "--env-name",
+        "desktop-local",
+        "--backend=local",
+      ]),
+    ).toEqual({
+      backend: "local",
+      args: ["remote", "--env-name", "desktop-local"],
+    });
     expect(() => extractBackendFlag(["--backend"])).toThrow(
       "Missing value for --backend",
     );

--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -287,6 +287,27 @@ describe("listen subcommand auth resolution", () => {
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
 
+  test("uses desktop proxy registration for local backend desktop listener without channels", async () => {
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+    process.env.LETTA_BASE_URL = "http://localhost:54321";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      [],
+    );
+
+    expect(result).toEqual({
+      kind: "remote",
+      serverUrl: "http://localhost:54321",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
   test("rejects self-hosted listener startup without channels", async () => {
     process.env.LETTA_BASE_URL = "http://localhost:8283";
 


### PR DESCRIPTION
Add regression coverage for backend flag extraction and local desktop listener startup so local backend desktop registration stays unauthenticated.

👾 Generated with [Letta Code](https://letta.com)