### PR TITLE
fix(local): report registered model context windows

### DIFF
--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -39,7 +39,30 @@ export interface RegisteredPiProvider {
   path?: string;
 }
 
+type PiProviderRegistryListener = () => void;
+
 const registeredProviders = new Map<string, RegisteredPiProvider>();
+const registryListeners = new Set<PiProviderRegistryListener>();
+
+function notifyRegistryListeners(): void {
+  for (const listener of [...registryListeners]) {
+    try {
+      listener();
+    } catch {
+      // Registry listeners are observers; a UI refresh failure should not make
+      // extension provider registration fail.
+    }
+  }
+}
+
+export function subscribePiProviderRegistry(
+  listener: PiProviderRegistryListener,
+): () => void {
+  registryListeners.add(listener);
+  return () => {
+    registryListeners.delete(listener);
+  };
+}
 
 function cloneHeaders(
   headers: Record<string, string> | undefined,
@@ -188,6 +211,7 @@ export function registerPiProvider(
     ...(owner?.path ? { path: owner.path } : {}),
   };
   registeredProviders.set(providerName, registered);
+  notifyRegistryListeners();
   return getRegisteredPiProvider(providerName) as RegisteredPiProvider;
 }
 
@@ -199,18 +223,24 @@ export function unregisterPiProvider(
   if (!existing) return;
   if (ownerId && existing.ownerId && existing.ownerId !== ownerId) return;
   registeredProviders.delete(providerName);
+  notifyRegistryListeners();
 }
 
 export function unregisterPiProvidersForOwner(ownerId: string): void {
+  let changed = false;
   for (const [providerName, provider] of registeredProviders.entries()) {
     if (provider.ownerId === ownerId) {
       registeredProviders.delete(providerName);
+      changed = true;
     }
   }
+  if (changed) notifyRegistryListeners();
 }
 
 export function clearRegisteredPiProviders(): void {
+  if (registeredProviders.size === 0) return;
   registeredProviders.clear();
+  notifyRegistryListeners();
 }
 
 export function getRegisteredPiProvider(

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -546,6 +546,105 @@ describe("local backend pi transcript", () => {
     );
   });
 
+  test("uses extension-registered context windows for local agent state", async () => {
+    registerPiProvider("lmstudio", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gemma-4-26B-A4B-it-oQ6",
+          name: "Gemma 4 VLM",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-registered-context-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "lmstudio",
+      providerName: "lc-lmstudio",
+      apiKey: "not-needed",
+      baseURL: "http://127.0.0.1:1234/v1",
+      storageDir,
+    });
+
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+
+    expect(agent.model).toBe("lmstudio/gemma-4-26B-A4B-it-oQ6");
+    expect(
+      (agent as { llm_config?: { context_window?: number } }).llm_config
+        ?.context_window,
+    ).toBe(256000);
+    expect(
+      (agent as { llm_config?: { max_tokens?: number } }).llm_config
+        ?.max_tokens,
+    ).toBe(8192);
+  });
+
+  test("projects legacy local 128k defaults through registered model metadata", async () => {
+    registerPiProvider("lmstudio", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gemma-4-26B-A4B-it-oQ6",
+          name: "Gemma 4 VLM",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-legacy-context-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "lmstudio",
+      providerName: "lc-lmstudio",
+      apiKey: "not-needed",
+      baseURL: "http://127.0.0.1:1234/v1",
+      storageDir,
+    });
+    await mkdir(join(storageDir, "agents"), { recursive: true });
+    await writeFile(
+      join(storageDir, "agents", "agent-local-default.json"),
+      JSON.stringify(
+        {
+          id: "agent-local-default",
+          name: "Letta Code",
+          description: null,
+          system: "",
+          tags: [],
+          model: "lmstudio/gemma-4-26B-A4B-it-oQ6",
+          model_settings: {
+            provider_type: "lmstudio",
+            context_window_limit: 128000,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    const agent = await backend.retrieveAgent("agent-local-default");
+
+    expect(
+      (agent as { llm_config?: { context_window?: number } }).llm_config
+        ?.context_window,
+    ).toBe(256000);
+  });
+
   test("discovers configured Ollama Cloud models from OpenAI-compatible catalog", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-ollama-cloud-discovery-"),

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -45,7 +45,11 @@ import {
   summarizeLocalMessagesSlidingWindow,
 } from "./compaction";
 import type { LocalMessage } from "./local-message";
-import { listLocalModels, resolveLocalModelConfig } from "./local-model-config";
+import {
+  listLocalModels,
+  localModelSettingsForHandle,
+  resolveLocalModelConfig,
+} from "./local-model-config";
 import type {
   LocalAgentRecord,
   LocalStoreOptions,
@@ -254,6 +258,7 @@ export class LocalBackend extends HeadlessBackend {
       defaultAgentName: "Letta Code",
       defaultAgentModel: modelConfig.handle,
       defaultAgentModelSettings: modelConfig.modelSettings,
+      modelSettingsForModel: localModelSettingsForHandle,
       conversationIdPrefix: "local-conv-",
       storedMessageIdPrefix: "letta-msg-",
       localMessageIdPrefix: "ui-msg-",

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -2,7 +2,12 @@ import {
   DEFAULT_PI_PROVIDER,
   type PiProvider,
 } from "@/backend/dev/pi-model-factory";
-import { listRegisteredPiProviders } from "@/backend/dev/pi-provider-extension-registry";
+import {
+  getRegisteredPiProvider,
+  listRegisteredPiProviders,
+  resolveRegisteredPiProviderFromModelHandle,
+  stripRegisteredProviderHandlePrefix,
+} from "@/backend/dev/pi-provider-extension-registry";
 import {
   getPiProviderSpec,
   isPiProvider,
@@ -11,6 +16,8 @@ import {
   localModelHandle,
   localProviderType,
   resolveLocalModel,
+  resolveProviderFromModelHandle,
+  stripProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-registry";
 import {
   type LocalProviderRecord,
@@ -235,14 +242,64 @@ export function resolveLocalProvider(storageDir?: string): PiProvider {
 
 export { localModelHandle, localProviderType, resolveLocalModel };
 
+function registeredModelSettingsForProviderModel(
+  provider: PiProvider | string,
+  modelId: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!modelId) return undefined;
+  const registeredProvider = getRegisteredPiProvider(provider);
+  const registeredModel = registeredProvider?.config.models?.find(
+    (model) => model.id === modelId,
+  );
+  if (!registeredModel) return undefined;
+  return {
+    provider_type: isPiProviderForLocalModelHandle(provider)
+      ? localProviderType(provider)
+      : provider,
+    context_window_limit: registeredModel.contextWindow,
+    max_tokens: registeredModel.maxTokens,
+  };
+}
+
+export function localModelSettingsForHandle(
+  handle: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!handle) return undefined;
+  const registeredProvider = resolveRegisteredPiProviderFromModelHandle(handle);
+  if (registeredProvider) {
+    return registeredModelSettingsForProviderModel(
+      registeredProvider,
+      stripRegisteredProviderHandlePrefix(handle, registeredProvider),
+    );
+  }
+
+  const provider = resolveProviderFromModelHandle(handle);
+  if (!provider) return undefined;
+  return registeredModelSettingsForProviderModel(
+    provider,
+    stripProviderHandlePrefix(handle, provider),
+  );
+}
+
 export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
   const provider = resolveLocalProvider(storageDir);
-  const model = resolveLocalModel(provider);
+  const registeredModel = getRegisteredPiProvider(provider)?.config.models?.[0];
+  const model = registeredModel?.id ?? resolveLocalModel(provider);
+  const handle = registeredModel
+    ? `${provider}/${registeredModel.id}`
+    : localModelHandle(provider, model);
+  const registeredModelSettings = registeredModelSettingsForProviderModel(
+    provider,
+    registeredModel?.id,
+  );
   return {
     provider,
     model,
-    handle: localModelHandle(provider, model),
-    modelSettings: { provider_type: localProviderType(provider) },
+    handle,
+    modelSettings: {
+      provider_type: localProviderType(provider),
+      ...(registeredModelSettings ?? {}),
+    },
   };
 }
 

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -62,6 +62,7 @@ type StoredConversation = Conversation & {
 
 const DEFAULT_LOCAL_AGENT_NAME = "Letta Code";
 const DEFAULT_LOCAL_MODEL = "local/default";
+const LEGACY_LOCAL_CONTEXT_WINDOW_LIMIT = 128000;
 const DEFAULT_LOCAL_CONVERSATION_ID_PREFIX = "local-conv-";
 const DEFAULT_LOCAL_STORED_MESSAGE_ID_PREFIX = "letta-msg-";
 const DEFAULT_LOCAL_UI_MESSAGE_ID_PREFIX = "ui-msg-";
@@ -115,9 +116,7 @@ function createDefaultAgentRecord(
     system: "",
     tags: [],
     model: defaultAgentModel,
-    model_settings: {
-      context_window_limit: 128000,
-    },
+    model_settings: {},
   };
 }
 
@@ -466,6 +465,9 @@ export interface LocalStoreOptions {
   defaultAgentName?: string;
   defaultAgentModel?: string;
   defaultAgentModelSettings?: Record<string, unknown>;
+  modelSettingsForModel?: (
+    model: string,
+  ) => Record<string, unknown> | undefined;
   conversationIdPrefix?: string;
   storedMessageIdPrefix?: string;
   localMessageIdPrefix?: string;
@@ -786,6 +788,9 @@ export class LocalStore {
   private readonly defaultAgentName: string;
   private readonly defaultAgentModel: string;
   private readonly defaultAgentModelSettings: Record<string, unknown>;
+  private readonly modelSettingsForModel?: (
+    model: string,
+  ) => Record<string, unknown> | undefined;
   private readonly conversationIdPrefix: string;
   private readonly storedMessageIdPrefix: string;
   private readonly localMessageIdPrefix: string;
@@ -818,6 +823,7 @@ export class LocalStore {
     this.defaultAgentModelSettings = {
       ...(options.defaultAgentModelSettings ?? {}),
     };
+    this.modelSettingsForModel = options.modelSettingsForModel;
     this.conversationIdPrefix =
       options.conversationIdPrefix ?? DEFAULT_LOCAL_CONVERSATION_ID_PREFIX;
     this.storedMessageIdPrefix =
@@ -1043,6 +1049,40 @@ export class LocalStore {
       model_settings: {
         ...this.defaultAgentModelSettings,
         ...agent.model_settings,
+      },
+    };
+  }
+
+  private modelSettingsDefaultsForModel(
+    model: string,
+  ): Record<string, unknown> | undefined {
+    return (
+      this.modelSettingsForModel?.(model) ??
+      (model === this.defaultAgentModel
+        ? this.defaultAgentModelSettings
+        : undefined)
+    );
+  }
+
+  private projectableAgentRecord(record: LocalAgentRecord): LocalAgentRecord {
+    const defaults = this.modelSettingsDefaultsForModel(record.model);
+    if (!defaults || Object.keys(defaults).length === 0) return record;
+
+    const contextWindowLimit = record.model_settings.context_window_limit;
+    const defaultContextWindowLimit = defaults.context_window_limit;
+    const shouldReplaceLegacyContextWindow =
+      contextWindowLimit === LEGACY_LOCAL_CONTEXT_WINDOW_LIMIT &&
+      typeof defaultContextWindowLimit === "number" &&
+      defaultContextWindowLimit > LEGACY_LOCAL_CONTEXT_WINDOW_LIMIT;
+
+    return {
+      ...record,
+      model_settings: {
+        ...defaults,
+        ...record.model_settings,
+        ...(shouldReplaceLegacyContextWindow
+          ? { context_window_limit: defaultContextWindowLimit }
+          : {}),
       },
     };
   }
@@ -2196,7 +2236,7 @@ export class LocalStore {
       this.conversations.get(key)?.in_context_message_ids ?? messageIds;
     const lastRunCompletion = defaultMessages.at(-1)?.date ?? null;
     return projectLocalAgentState(
-      record,
+      this.projectableAgentRecord(record),
       messageIds,
       inContextMessageIds,
       lastRunCompletion,

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -10,6 +10,9 @@ import {
 import {
   clearRegisteredPiProviders,
   registerPiProvider,
+  subscribePiProviderRegistry,
+  unregisterPiProvider,
+  unregisterPiProvidersForOwner,
 } from "@/backend/dev/pi-provider-extension-registry";
 import {
   createOrUpdateLocalProvider,
@@ -36,6 +39,61 @@ async function withEnv<T>(
 describe("pi model factory", () => {
   afterEach(() => {
     clearRegisteredPiProviders();
+  });
+
+  test("notifies subscribers when extension provider registry changes", () => {
+    const changes: string[] = [];
+    const unsubscribe = subscribePiProviderRegistry(() => {
+      changes.push("changed");
+    });
+    const config = {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions" as const,
+      models: [
+        {
+          id: "gemma-4",
+          name: "Gemma 4",
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    };
+
+    try {
+      clearRegisteredPiProviders();
+      expect(changes).toEqual([]);
+
+      registerPiProvider("lmstudio", config, { id: "owner-1" });
+      expect(changes).toHaveLength(1);
+
+      unregisterPiProvider("lmstudio", "other-owner");
+      expect(changes).toHaveLength(1);
+
+      unregisterPiProvider("lmstudio", "owner-1");
+      expect(changes).toHaveLength(2);
+
+      registerPiProvider("lmstudio", config, { id: "owner-1" });
+      registerPiProvider("ollama", config, { id: "owner-2" });
+      expect(changes).toHaveLength(4);
+
+      unregisterPiProvidersForOwner("owner-1");
+      expect(changes).toHaveLength(5);
+
+      unregisterPiProvidersForOwner("missing-owner");
+      expect(changes).toHaveLength(5);
+
+      clearRegisteredPiProviders();
+      expect(changes).toHaveLength(6);
+
+      clearRegisteredPiProviders();
+      expect(changes).toHaveLength(6);
+    } finally {
+      unsubscribe();
+    }
   });
 
   test("uses KIMI_API_KEY for Kimi For Coding", async () => {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -40,6 +40,7 @@ import {
 import { getBackend, isLocalBackendEnabled } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { getBillingTier } from "@/backend/api/metadata";
+import { subscribePiProviderRegistry } from "@/backend/dev/pi-provider-extension-registry";
 import {
   cancelActiveConnectOperation,
   isActiveConnectOperationCancellable,
@@ -3029,6 +3030,98 @@ export function App({
     }
     return undefined;
   }, [loadingState, agentId, initialAgentState]);
+
+  // Extension provider metadata can arrive after the first local AgentState
+  // projection on cold boot. Re-project the active local agent when the provider
+  // registry changes so statusline context windows reflect registered models.
+  useEffect(() => {
+    if (
+      !isLocalBackend ||
+      loadingState !== "ready" ||
+      !agentId ||
+      agentId === "loading"
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let refreshQueued = false;
+
+    const refreshAgentFromRegisteredProviderMetadata = () => {
+      if (refreshQueued) return;
+      refreshQueued = true;
+
+      queueMicrotask(() => {
+        refreshQueued = false;
+        const currentAgentId = agentIdRef.current;
+        if (cancelled || !currentAgentId || currentAgentId === "loading") {
+          return;
+        }
+
+        void getBackend()
+          .retrieveAgent(currentAgentId)
+          .then((agent) => {
+            if (cancelled || agentIdRef.current !== agent.id) return;
+            setAgentState(agent);
+            setAgentDescription(agent.description ?? null);
+            setAgentLastRunAt(
+              (agent as { last_run_completion?: string | null })
+                .last_run_completion ?? null,
+            );
+
+            if (
+              conversationIdRef.current === "default" &&
+              !hasConversationModelOverrideRef.current
+            ) {
+              const agentModelHandle = getPreferredAgentModelHandle(agent);
+              setLlmConfig(agent.llm_config);
+              setCurrentModelHandle(agentModelHandle ?? null);
+              const modelInfo = getModelInfoForLlmConfig(
+                agentModelHandle || "",
+                {
+                  ...(agent.llm_config as unknown as {
+                    reasoning_effort?: string | null;
+                    enable_reasoner?: boolean | null;
+                  }),
+                  context_window:
+                    (
+                      agent as unknown as {
+                        context_window_limit?: number | null;
+                      }
+                    ).context_window_limit ?? null,
+                },
+              );
+              setCurrentModelId(modelInfo?.id ?? (agentModelHandle || null));
+            }
+          })
+          .catch((error) => {
+            debugLog(
+              "agent-config",
+              "Failed to refresh local agent after provider registry change: %O",
+              error,
+            );
+          });
+      });
+    };
+
+    if (!extensionRuntime.isLoading) {
+      refreshAgentFromRegisteredProviderMetadata();
+    }
+
+    const unsubscribe = subscribePiProviderRegistry(
+      refreshAgentFromRegisteredProviderMetadata,
+    );
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [
+    agentId,
+    extensionRuntime.isLoading,
+    hasConversationModelOverrideRef,
+    isLocalBackend,
+    loadingState,
+  ]);
 
   // Keep effective model state in sync with the active conversation override.
   // biome-ignore lint/correctness/useExhaustiveDependencies: ref.current is intentionally read dynamically

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type Letta from "@letta-ai/letta-client";
 import * as ts from "typescript";
+import { clearAvailableModelsCache } from "@/agent/available-models";
 import type { PiProviderRegistration } from "@/backend/dev/pi-provider-extension-registry";
 import {
   registerPiProvider,
@@ -392,6 +393,7 @@ function removeOwnerCapabilities(
   owner: ExtensionOwner,
 ): void {
   unregisterPiProvidersForOwner(owner.id);
+  clearAvailableModelsCache();
 
   for (const [id, command] of Object.entries(registry.commands)) {
     if (command.owner?.id === owner.id) {
@@ -871,6 +873,7 @@ function createLettaExtensionApi(
     if (!capabilities.providers) return;
     if (!guardLive({ id: name, kind: "provider" })) return;
     unregisterPiProvider(name, owner.id);
+    clearAvailableModelsCache();
     onChange();
   };
 
@@ -888,6 +891,7 @@ function createLettaExtensionApi(
       id: owner.id,
       path: owner.path,
     });
+    clearAvailableModelsCache();
     onChange();
     return () => unregisterProvider(name);
   };
@@ -1312,6 +1316,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
     unregisterPiProvidersForOwner(owner.id);
     unregisterExtensionToolsForOwner(owner);
   }
+  clearAvailableModelsCache();
 
   registry.commands = {};
   registry.events = {};


### PR DESCRIPTION
## Summary
- Thread extension-registered local model `contextWindow` / `maxTokens` metadata into local agent state so statusline and `/context` reporting do not get stuck on the legacy 128k fallback.
- Stop stamping new local default agents with an unconditional 128k context limit; use registered model metadata when available and keep 128k only as compatibility fallback.
- Clear the available-model cache when extension providers are registered/unregistered so `/model` and model switching see fresh provider metadata.

## Test plan
- [x] `bun test src/backend/local-backend.test.ts src/extensions/extension-host.test.ts src/backend/pi-model-factory.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)