### PR TITLE
fix(local): re-project agent state on post-boot provider register

### DIFF
--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -41,6 +41,28 @@ export interface RegisteredPiProvider {
 
 const registeredProviders = new Map<string, RegisteredPiProvider>();
 
+type RegistryListener = () => void;
+const registryListeners = new Set<RegistryListener>();
+
+function notifyPiProviderRegistry(): void {
+  for (const listener of [...registryListeners]) {
+    try {
+      listener();
+    } catch {
+      // ignore listener errors so one bad listener can't block the rest
+    }
+  }
+}
+
+export function subscribePiProviderRegistry(
+  listener: RegistryListener,
+): () => void {
+  registryListeners.add(listener);
+  return () => {
+    registryListeners.delete(listener);
+  };
+}
+
 function cloneHeaders(
   headers: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
@@ -188,6 +210,7 @@ export function registerPiProvider(
     ...(owner?.path ? { path: owner.path } : {}),
   };
   registeredProviders.set(providerName, registered);
+  notifyPiProviderRegistry();
   return getRegisteredPiProvider(providerName) as RegisteredPiProvider;
 }
 
@@ -199,18 +222,24 @@ export function unregisterPiProvider(
   if (!existing) return;
   if (ownerId && existing.ownerId && existing.ownerId !== ownerId) return;
   registeredProviders.delete(providerName);
+  notifyPiProviderRegistry();
 }
 
 export function unregisterPiProvidersForOwner(ownerId: string): void {
+  let mutated = false;
   for (const [providerName, provider] of registeredProviders.entries()) {
     if (provider.ownerId === ownerId) {
       registeredProviders.delete(providerName);
+      mutated = true;
     }
   }
+  if (mutated) notifyPiProviderRegistry();
 }
 
 export function clearRegisteredPiProviders(): void {
+  const hadProviders = registeredProviders.size > 0;
   registeredProviders.clear();
+  if (hadProviders) notifyPiProviderRegistry();
 }
 
 export function getRegisteredPiProvider(

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -24,6 +24,11 @@ import type {
   ConversationMessageStreamBody,
   ConversationUpdateBody,
 } from "@/backend/backend";
+import {
+  getRegisteredPiProvider,
+  resolveRegisteredPiProviderFromModelHandle,
+  stripRegisteredProviderHandlePrefix,
+} from "@/backend/dev/pi-provider-extension-registry";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import { isRecord } from "@/utils/type-guards";
 import type { LocalCompactionStats } from "./compaction";
@@ -292,6 +297,18 @@ function normalizeAgentRecord(
   };
 }
 
+function registeredModelContextWindow(modelHandle: string): number | undefined {
+  const providerName = resolveRegisteredPiProviderFromModelHandle(modelHandle);
+  if (!providerName) return undefined;
+  const provider = getRegisteredPiProvider(providerName);
+  const modelId = stripRegisteredProviderHandlePrefix(
+    modelHandle,
+    providerName,
+  );
+  if (!provider?.config.models || !modelId) return undefined;
+  return provider.config.models.find((m) => m.id === modelId)?.contextWindow;
+}
+
 export function projectLocalAgentState(
   record: LocalAgentRecord,
   messageIds: string[] = [],
@@ -340,7 +357,7 @@ export function projectLocalAgentState(
       context_window:
         typeof record.model_settings.context_window_limit === "number"
           ? record.model_settings.context_window_limit
-          : 128000,
+          : (registeredModelContextWindow(record.model) ?? 128000),
       ...(reasoningEffort && { reasoning_effort: reasoningEffort }),
       ...(enableReasoner !== undefined && { enable_reasoner: enableReasoner }),
       ...((typeof record.model_settings.max_tokens === "number" ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   isExperimentalLocalBackendEnabled,
 } from "./backend";
 import { getBillingTier } from "./backend/api/metadata";
+import { subscribePiProviderRegistry } from "./backend/dev/pi-provider-extension-registry";
 import {
   isLocalBackendNoMemfsEnvEnabled,
   LOCAL_BACKEND_NO_MEMFS_ENV,
@@ -1989,6 +1990,29 @@ async function main(): Promise<void> {
       },
       [],
     );
+
+    // Re-project agent state when an extension registers a Pi provider after
+    // boot. The initial projection at load time runs before the extension's
+    // async activate() finishes, so resolvedContextWindow can be stale.
+    useEffect(() => {
+      if (!agentId || loadingState !== "ready") return;
+      const unsubscribe = subscribePiProviderRegistry(() => {
+        const backend = getBackend();
+        backend
+          .retrieveAgent(agentId, {
+            include: ["agent.secrets", "agent.tools", "agent.tags"],
+          })
+          .then((agent) => {
+            setAgentState(agent);
+          })
+          .catch((err) => {
+            if (isDebugEnabled()) {
+              console.error("re-project agent state failed:", err);
+            }
+          });
+      });
+      return unsubscribe;
+    }, [agentId, loadingState]);
 
     useEffect(() => {
       if (loadingState !== "assembling") {


### PR DESCRIPTION
## Summary

Follow-up to `fix(local): honor registered provider contextWindow in llm_config shim` (already on this branch).

Extensions that register Pi providers via the async `activate()` hook finish *after* the initial `projectLocalAgentState()` runs, so the projected `context_window` is computed before `registeredModelContextWindow()` has any registered provider to consult — UI falls back to the 128K default even when the registered model declares 262K.

This adds:

1. `subscribePiProviderRegistry(listener)` in `pi-provider-extension-registry.ts`, with `notifyPiProviderRegistry()` fired from `register`/`unregister`/`unregisterForOwner`/`clear` (guarded so no-op iterations don't notify).
2. A `useEffect` in `LoadingApp` that subscribes once `loadingState === "ready"` and re-runs `retrieveAgent` → `setAgentState` on every registry mutation, so the projected `context_window` re-resolves.

Refs https://github.com/letta-ai/letta-code/issues/2572.

## Status

Works on `/reload` paths (verified: UI flips from 128K to 262K once `omlx-provider.ts` finishes registering `lmstudio`).

**Cold boot is still broken** — even though `subscribePiProviderRegistry` fires correctly, a teardown immediately after the extension's second `activate()` empties the registry, so the re-projection sees no providers and falls back to 128K again. Two suspected culprits, neither investigated here:

- `omlx-provider.ts` activates twice on cold boot (same `scope:path` owner id, ~40ms apart) — unclear whether multiple sources resolve the same path or whether load-then-reload is the normal cold-boot sequence.
- `disposeLocalExtensions()` in `extension-host.ts` clears providers for every owner during the second activate's teardown phase, regardless of ownership.

Leaving cold-boot diagnosis to @cpacker (handoff comment incoming on #2572).