### PR TITLE
fix(local): reject default conversation renames

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readdir,
   readFile,
+  rm,
   utimes,
   writeFile,
 } from "node:fs/promises";
@@ -194,6 +195,23 @@ describe("local backend pi transcript", () => {
       const parsed = Date.parse(timestamp ?? "");
       expect(parsed).toBeGreaterThanOrEqual(before);
       expect(parsed).toBeLessThanOrEqual(after);
+    }
+  });
+
+  test("rejects updates to the virtual default conversation", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-default-conversation-update-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+
+      expect(() =>
+        backend.updateConversation("default", {
+          summary: "Default rename",
+        } as never),
+      ).toThrow("Default conversation cannot be updated");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
     }
   });
 

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1104,6 +1104,10 @@ export class LocalStore {
     conversationId: string,
     body: ConversationUpdateBody,
   ): Conversation {
+    if (conversationId === "default") {
+      throw new Error("Default conversation cannot be updated");
+    }
+
     const current = this.findConversation(conversationId);
     if (!current) {
       if (this.strictConversationAccess) {

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -396,6 +396,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setConversationOverrideContextWindowLimit,
     setConversationOverrideModelSettings,
     setCurrentPersonalityId,
@@ -2029,7 +2030,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               "",
               "USAGE",
               "  /rename agent [name]      — rename the agent",
-              "  /rename convo [name]      — rename the convo, or auto-generate when omitted",
+              "  /rename convo [name]      — rename a non-default convo, or auto-generate when omitted",
               "  /rename help              — show this help",
             ].join("\n");
             cmd.finish(output, true);
@@ -2074,6 +2075,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 await backend.updateConversation(conversationId, {
                   summary: conversationTitle,
                 });
+                setConversationSummary(conversationTitle);
                 setConversationAutoTitleEligibility(false);
                 cmd.finish(
                   `Conversation title set to "${conversationTitle}"`,
@@ -2083,6 +2085,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 await backend.updateConversation(conversationId, {
                   summary: newValue,
                 });
+                setConversationSummary(newValue);
                 setConversationAutoTitleEligibility(false);
                 cmd.finish(`Conversation renamed to "${newValue}"`, true);
               }


### PR DESCRIPTION
## Summary
- Reject local backend updates to the virtual `default` conversation so `/rename convo` cannot silently mutate hidden default conversation metadata.
- Keep non-default conversation renames reflected in the UI immediately after a successful update.
- Add a regression test covering default conversation update rejection.

## Test plan
- [x] `bun test src/backend/local-backend.test.ts`
- [x] pre-commit `tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)