### PR TITLE
fix(bootstrap): calibrate conversation relevance threshold

### DIFF
--- a/src/cli/helpers/conversation-bootstrap.test.ts
+++ b/src/cli/helpers/conversation-bootstrap.test.ts
@@ -22,7 +22,7 @@ describe("filterBootstrapRelevantConversations", () => {
   test("rejects weak single-channel RRF matches", () => {
     expect(
       filterBootstrapRelevantConversations(
-        [result("one", 0.0164), result("two", 0.014)],
+        [result("one", 0.0082), result("two", 0.008)],
         {},
       ),
     ).toEqual([]);
@@ -31,10 +31,37 @@ describe("filterBootstrapRelevantConversations", () => {
   test("keeps only high-confidence results near the strongest score", () => {
     expect(
       filterBootstrapRelevantConversations(
-        [result("one", 0.033), result("two", 0.026), result("three", 0.018)],
+        [
+          result("one", 0.016393),
+          result("two", 0.015388),
+          result("three", 0.015038),
+        ],
         {},
       ).map((item) => item.conversation.id),
     ).toEqual(["one", "two"]);
+  });
+
+  test("keeps prod-like CI matches while dropping the weaker tail", () => {
+    expect(
+      filterBootstrapRelevantConversations(
+        [
+          result("ci-rank-1", 0.016393),
+          result("ci-rank-2", 0.016001),
+          result("ci-rank-3", 0.015757),
+          result("ci-rank-4", 0.015749),
+          result("ci-rank-5", 0.015388),
+          result("weak-tail-1", 0.015038),
+          result("weak-tail-2", 0.014939),
+        ],
+        {},
+      ).map((item) => item.conversation.id),
+    ).toEqual([
+      "ci-rank-1",
+      "ci-rank-2",
+      "ci-rank-3",
+      "ci-rank-4",
+      "ci-rank-5",
+    ]);
   });
 
   test("dedupes and excludes the active conversation before scoring", () => {

--- a/src/cli/helpers/conversation-bootstrap.ts
+++ b/src/cli/helpers/conversation-bootstrap.ts
@@ -12,11 +12,12 @@ const BOOTSTRAP_RELEVANT_LIMIT = 5;
 const BOOTSTRAP_RECENT_FETCH_LIMIT =
   BOOTSTRAP_RECENT_LIMIT + BOOTSTRAP_RELEVANT_LIMIT;
 const BOOTSTRAP_RELEVANT_FETCH_LIMIT = 12;
-// The remote hybrid search uses RRF with k=60, so a rank-1 result from only
-// one retrieval channel scores ~0.016. Require a stronger score so weak
-// vector-only nearest neighbors do not get injected as bootstrap context.
-const BOOTSTRAP_RELEVANT_MIN_RRF_SCORE = 0.025;
-const BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE = 0.75;
+// The remote hybrid search uses weighted RRF with k=60 and 0.5 weights per
+// channel. A rank-1 result from only one channel scores ~0.008, while a rank-1
+// result from both vector + FTS scores ~0.016. Require hybrid agreement, then
+// keep only the strongest cluster so weak tail matches do not get injected.
+const BOOTSTRAP_RELEVANT_MIN_RRF_SCORE = 0.012;
+const BOOTSTRAP_RELEVANT_MIN_RELATIVE_SCORE = 0.93;
 
 function pageItems<T>(page: unknown): T[] {
   if (Array.isArray(page)) return page as T[];


### PR DESCRIPTION
## Summary
- calibrate the bootstrap relevance threshold to weighted-RRF scores observed from a real CI-checks query
- lower the absolute floor from the impossible 0.025 cutoff to 0.012 while keeping a strict 0.93 relative cluster cutoff
- update unit coverage with prod-like score distribution to keep CI matches and drop weaker tail results

## Test plan
- [x] live read-only query against `/v1/conversations/search` for the CI-checks prompt
- [x] `bun test src/cli/helpers/conversation-bootstrap.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)

## Better tuned
```
This is an automated message providing context from prior conversations with this agent.
The user is starting a brand-new conversation. Recent prior conversations:

    Async programming problem debugging [conv-6bd0ad2a-defc-4cc6-93a9-bacc631d1cd2]
    CI check failure investigation [conv-3a703314-3875-45cb-af81-6c8484cbc04e]
    Unlabelled conversation [conv-acc3192c-3d3b-4c6f-b74e-9f8f8a4df0f8]
    New conversation bootstrapping with context injection [conv-d4f682d1-e957-4556-9bd9-6cc68d027289]
    AWS IAM and Organizations setup [conv-ec9a71a8-ed3f-4d95-b6a8-3fe590b544f6]

Relevant prior conversation descriptions for the user's first message:

    User asked about the difference between multithreading and multiprocessing; explained thread vs process memory sharing, GIL limitations, and I/O-bound vs CPU-bound use cases [conv-8120c034-b27b-44d2-a564-7555b30adc60]
    User asked about combining multithreading with multiprocessing; explained hybrid pattern of process pools with internal thread pools, GIL limitations, and tradeoffs [conv-d811200c-fb27-4b5d-afa9-a662a246db3e]
    User asked about multi-threaded programming; no specific details provided yet [conv-6f15b15d-6a7b-4a62-a362-6cca9f904176]

Use this as lightweight context only. Do not treat these titles or conversation descriptions as confirmed facts beyond what is written here.
These descriptions are internal search metadata. Do not quote or expose them to the user unless independently supported in the active conversation.
```