### PR TITLE
fix(local): lazy-load transcripts on startup

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -304,6 +304,9 @@ describe("local backend pi transcript", () => {
     const agentId = "agent-local-default";
     const conversationId = "local-conv-tail";
     const conversationDir = join(storageDir, "conversations", "tail");
+    const messageIds = Array.from({ length: 120 }, (_, i) =>
+      i === 119 ? "ui-msg-latest" : `ui-msg-${i}`,
+    );
     await mkdir(join(storageDir, "agents"), { recursive: true });
     await writeFile(
       join(storageDir, "agents", `${agentId}.json`),
@@ -326,7 +329,7 @@ describe("local backend pi transcript", () => {
         created_at: "2026-05-22T12:00:00.000Z",
         updated_at: "2026-05-22T13:00:00.000Z",
         last_message_at: "2026-05-22T13:00:00.000Z",
-        in_context_message_ids: ["ui-msg-latest"],
+        in_context_message_ids: messageIds,
       })}\n`,
     );
     await writeFile(
@@ -341,7 +344,7 @@ describe("local backend pi transcript", () => {
 
     const rows = ["{ definitely not json }"];
     for (let i = 0; i < 120; i += 1) {
-      const id = i === 119 ? "ui-msg-latest" : `ui-msg-${i}`;
+      const id = messageIds[i];
       rows.push(
         JSON.stringify({
           id,
@@ -352,12 +355,20 @@ describe("local backend pi transcript", () => {
               text: `${i === 119 ? "latest" : "older"} ${"x".repeat(2048)}`,
             },
           ],
-          metadata: {
-            created_at: new Date(Date.UTC(2026, 4, 22, 12, i)).toISOString(),
-            updated_at: new Date(Date.UTC(2026, 4, 22, 12, i)).toISOString(),
-            agent_id: agentId,
-            conversation_id: conversationId,
-          },
+          ...(i === 119
+            ? {}
+            : {
+                metadata: {
+                  created_at: new Date(
+                    Date.UTC(2026, 4, 22, 12, i),
+                  ).toISOString(),
+                  updated_at: new Date(
+                    Date.UTC(2026, 4, 22, 12, i),
+                  ).toISOString(),
+                  agent_id: agentId,
+                  conversation_id: conversationId,
+                },
+              }),
         }),
       );
     }
@@ -368,7 +379,7 @@ describe("local backend pi transcript", () => {
 
     const backend = new LocalBackend({ storageDir, memfsEnabled: false });
     const conversation = await backend.retrieveConversation(conversationId);
-    expect(conversation.in_context_message_ids).toEqual(["ui-msg-latest"]);
+    expect(conversation.in_context_message_ids).toEqual(messageIds);
     const messages = pageItems(
       await backend.listConversationMessages(conversationId, {
         agent_id: agentId,
@@ -379,6 +390,16 @@ describe("local backend pi transcript", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0]?.id).toBe("ui-msg-latest");
+    expect(messages[0]?.date).toBe("2026-01-01T00:02:00.000Z");
+
+    const backendForDirectLookup = new LocalBackend({
+      storageDir,
+      memfsEnabled: false,
+    });
+    const latestVariants =
+      await backendForDirectLookup.retrieveMessage("ui-msg-latest");
+    expect(latestVariants[0]?.id).toBe("ui-msg-latest");
+    expect(latestVariants[0]?.date).toBe("2026-01-01T00:02:00.000Z");
   });
 
   test("reuses cached compiled system prompt across turns until explicit recompile", async () => {

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -952,41 +952,15 @@ describe("local backend pi transcript", () => {
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
-    const coalescedMessages = [
-      ...new Map(
-        messages.map((message) => [message.id as string, message]),
-      ).values(),
-    ];
-    expect(messages.length).toBeGreaterThan(coalescedMessages.length);
-    expect(coalescedMessages.map((message) => message.role)).toEqual([
+    expect(messages.map((message) => message.role)).toEqual([
       "user",
       "assistant",
       "toolResult",
       "assistant",
     ]);
-    const finalAssistant = coalescedMessages.at(-1) as { content?: unknown[] };
+    const finalAssistant = messages.at(-1) as { content?: unknown[] };
     expect(finalAssistant.content).toEqual([
       { type: "text", text: "Tool result received." },
-    ]);
-
-    const reloadedBackend = new LocalBackend({
-      storageDir,
-      stream,
-      memfsEnabled: false,
-    });
-    const reloadedMessages = pageItems(
-      await reloadedBackend.listConversationMessages(conversation.id, {
-        agent_id: agent.id,
-        order: "asc",
-      } as never),
-    );
-    expect(reloadedMessages.map((message) => message.message_type)).toEqual([
-      "user_message",
-      "assistant_message",
-      "reasoning_message",
-      "approval_request_message",
-      "tool_return_message",
-      "assistant_message",
     ]);
   });
 

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -952,15 +952,41 @@ describe("local backend pi transcript", () => {
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
-    expect(messages.map((message) => message.role)).toEqual([
+    const coalescedMessages = [
+      ...new Map(
+        messages.map((message) => [message.id as string, message]),
+      ).values(),
+    ];
+    expect(messages.length).toBeGreaterThan(coalescedMessages.length);
+    expect(coalescedMessages.map((message) => message.role)).toEqual([
       "user",
       "assistant",
       "toolResult",
       "assistant",
     ]);
-    const finalAssistant = messages.at(-1) as { content?: unknown[] };
+    const finalAssistant = coalescedMessages.at(-1) as { content?: unknown[] };
     expect(finalAssistant.content).toEqual([
       { type: "text", text: "Tool result received." },
+    ]);
+
+    const reloadedBackend = new LocalBackend({
+      storageDir,
+      stream,
+      memfsEnabled: false,
+    });
+    const reloadedMessages = pageItems(
+      await reloadedBackend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(reloadedMessages.map((message) => message.message_type)).toEqual([
+      "user_message",
+      "assistant_message",
+      "reasoning_message",
+      "approval_request_message",
+      "tool_return_message",
+      "assistant_message",
     ]);
   });
 

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -299,6 +299,88 @@ describe("local backend pi transcript", () => {
     expect(messages.at(-1)?.date).toBe(activeAt);
   });
 
+  test("loads bounded transcript tails without parsing the full jsonl", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-tail-"));
+    const agentId = "agent-local-default";
+    const conversationId = "local-conv-tail";
+    const conversationDir = join(storageDir, "conversations", "tail");
+    await mkdir(join(storageDir, "agents"), { recursive: true });
+    await writeFile(
+      join(storageDir, "agents", `${agentId}.json`),
+      `${JSON.stringify({
+        id: agentId,
+        name: "Local",
+        description: null,
+        system: "",
+        tags: [],
+        model: "openai/gpt-5-mini",
+        model_settings: { model: "openai/gpt-5-mini" },
+      })}\n`,
+    );
+    await mkdir(conversationDir, { recursive: true });
+    await writeFile(
+      join(conversationDir, "conversation.json"),
+      `${JSON.stringify({
+        id: conversationId,
+        agent_id: agentId,
+        created_at: "2026-05-22T12:00:00.000Z",
+        updated_at: "2026-05-22T13:00:00.000Z",
+        last_message_at: "2026-05-22T13:00:00.000Z",
+        in_context_message_ids: ["ui-msg-latest"],
+      })}\n`,
+    );
+    await writeFile(
+      join(conversationDir, "manifest.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        message_format: "pi-ai-message-jsonl",
+        provider_stack: "pi-ai",
+        created_at: "2026-05-22T12:00:00.000Z",
+      })}\n`,
+    );
+
+    const rows = ["{ definitely not json }"];
+    for (let i = 0; i < 120; i += 1) {
+      const id = i === 119 ? "ui-msg-latest" : `ui-msg-${i}`;
+      rows.push(
+        JSON.stringify({
+          id,
+          role: i % 2 === 0 ? "user" : "assistant",
+          content: [
+            {
+              type: "text",
+              text: `${i === 119 ? "latest" : "older"} ${"x".repeat(2048)}`,
+            },
+          ],
+          metadata: {
+            created_at: new Date(Date.UTC(2026, 4, 22, 12, i)).toISOString(),
+            updated_at: new Date(Date.UTC(2026, 4, 22, 12, i)).toISOString(),
+            agent_id: agentId,
+            conversation_id: conversationId,
+          },
+        }),
+      );
+    }
+    await writeFile(
+      join(conversationDir, "messages.jsonl"),
+      `${rows.join("\n")}\n`,
+    );
+
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    const conversation = await backend.retrieveConversation(conversationId);
+    expect(conversation.in_context_message_ids).toEqual(["ui-msg-latest"]);
+    const messages = pageItems(
+      await backend.listConversationMessages(conversationId, {
+        agent_id: agentId,
+        order: "desc",
+        limit: 1,
+      } as never),
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe("ui-msg-latest");
+  });
+
   test("reuses cached compiled system prompt across turns until explicit recompile", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-cache-"));
     const systemPrompts: string[] = [];
@@ -888,11 +970,24 @@ describe("local backend pi transcript", () => {
     );
   });
 
-  test("refuses to load versioned transcripts with legacy UI rows and repairs them with migrate-transcripts", async () => {
+  test("refuses to read versioned transcripts with legacy UI rows and repairs them with migrate-transcripts", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-repair-"),
     );
     const conversationDir = join(storageDir, "conversations", "mismatched");
+    await mkdir(join(storageDir, "agents"), { recursive: true });
+    await writeFile(
+      join(storageDir, "agents", "agent-local-default.json"),
+      `${JSON.stringify({
+        id: "agent-local-default",
+        name: "Local",
+        description: null,
+        system: "",
+        tags: [],
+        model: "openai/gpt-5-mini",
+        model_settings: { model: "openai/gpt-5-mini" },
+      })}\n`,
+    );
     await mkdir(conversationDir, { recursive: true });
     await writeFile(
       join(conversationDir, "conversation.json"),
@@ -916,10 +1011,19 @@ describe("local backend pi transcript", () => {
       `${JSON.stringify({ id: "ui-msg-1", role: "user", parts: [{ type: "text", text: "legacy after manifest" }] })}\n`,
     );
 
-    expect(() => new LocalBackend({ storageDir, memfsEnabled: false })).toThrow(
-      LocalTranscriptRepairRequiredError,
-    );
-    expect(() => new LocalBackend({ storageDir, memfsEnabled: false })).toThrow(
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    await expect(
+      backend.listConversationMessages("local-conv-1", {
+        agent_id: "agent-local-default",
+        order: "asc",
+      } as never),
+    ).rejects.toThrow(LocalTranscriptRepairRequiredError);
+    await expect(
+      backend.listConversationMessages("local-conv-1", {
+        agent_id: "agent-local-default",
+        order: "asc",
+      } as never),
+    ).rejects.toThrow(
       `letta local-backend migrate-transcripts --storage-dir "${storageDir}"`,
     );
 

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1445,6 +1445,10 @@ export class LocalStore {
       messages = this.messagesById.get(messageId) ?? [];
     }
     if (messages.length === 0) {
+      this.indexMessageFromTranscriptTail(messageId);
+      messages = this.messagesById.get(messageId) ?? [];
+    }
+    if (messages.length === 0) {
       this.loadConversationContainingMessage(messageId);
       messages = this.messagesById.get(messageId) ?? [];
     }
@@ -2098,11 +2102,19 @@ export class LocalStore {
         metadata.conversationDir,
       );
       const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const conversation = this.conversations.get(key);
+      const sourceStartIndex = tail.reachedStart
+        ? 0
+        : Math.max(
+            0,
+            (conversation?.in_context_message_ids.length ?? 0) -
+              localMessages.length,
+          );
       const projected = this.projectLocalMessages(
         localMessages,
         agentId,
         conversationId,
-        { updateIndex: false },
+        { sourceStartIndex },
       );
       const cursorFound =
         !before || projected.some((message) => message.id === before);
@@ -2173,6 +2185,62 @@ export class LocalStore {
         conversation.agent_id,
       );
       if ((this.messagesById.get(messageId) ?? []).length > 0) return;
+    }
+  }
+
+  private indexMessageFromTranscriptTail(messageId: string): boolean {
+    const sourceMessageId = sourceLocalMessageIdFromStoredMessageId(messageId);
+    for (const conversation of this.conversations.values()) {
+      const key = this.conversationKey(conversation.id, conversation.agent_id);
+      if (this.loadedConversationKeys.has(key)) continue;
+      if (
+        !conversation.in_context_message_ids.includes(sourceMessageId) &&
+        !conversation.in_context_message_ids.includes(messageId)
+      ) {
+        continue;
+      }
+      if (this.indexMessageFromConversationTail(key, conversation, messageId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private indexMessageFromConversationTail(
+    key: string,
+    conversation: StoredConversation,
+    messageId: string,
+  ): boolean {
+    const metadata = this.transcriptMetadataByConversationKey.get(key);
+    if (!metadata || metadata.requiresFullTimestampRepair) return false;
+
+    let maxBytes = 64 * 1024;
+    for (;;) {
+      const tail = readJsonlFileSuffix<LocalMessage>(
+        metadata.messagesPath,
+        maxBytes,
+      );
+      assertNoLegacyUiMessageRows(
+        tail.items,
+        this.storageDir ?? "",
+        metadata.conversationDir,
+      );
+      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const sourceStartIndex = tail.reachedStart
+        ? 0
+        : Math.max(
+            0,
+            conversation.in_context_message_ids.length - localMessages.length,
+          );
+      this.projectLocalMessages(
+        localMessages,
+        conversation.agent_id,
+        conversation.id,
+        { sourceStartIndex },
+      );
+      if ((this.messagesById.get(messageId) ?? []).length > 0) return true;
+      if (tail.reachedStart) return false;
+      maxBytes *= 2;
     }
   }
 

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -506,7 +507,7 @@ function encodePathSegment(value: string): string {
   return Buffer.from(value).toString("base64url");
 }
 
-function jsonl<T>(items: T[]): string {
+function jsonl<T>(items: readonly T[]): string {
   return `${items.map((item) => JSON.stringify(item)).join("\n")}\n`;
 }
 
@@ -521,6 +522,23 @@ function readJsonlFile<T>(path: string): T[] {
     .split("\n")
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as T);
+}
+
+function coalesceLocalMessageSnapshots(
+  messages: readonly LocalMessage[],
+): LocalMessage[] {
+  const coalesced: LocalMessage[] = [];
+  const indexById = new Map<string, number>();
+  for (const message of messages) {
+    const existingIndex = indexById.get(message.id);
+    if (existingIndex === undefined) {
+      indexById.set(message.id, coalesced.length);
+      coalesced.push(message);
+    } else {
+      coalesced[existingIndex] = message;
+    }
+  }
+  return coalesced;
 }
 
 function readJsonlFileSuffix<T>(
@@ -729,6 +747,10 @@ interface LocalConversationTranscriptMetadata {
   requiresFullTimestampRepair: boolean;
 }
 
+type LocalTranscriptPersistOptions =
+  | { mode: "append"; message: LocalMessage }
+  | { mode: "rewrite" };
+
 function fileIsoTimestamp(value: number | undefined): string | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? new Date(value).toISOString()
@@ -858,6 +880,10 @@ export class LocalStore {
     string,
     LocalConversationTranscriptMetadata
   >();
+  private readonly persistedMessageSnapshotsByConversationKey = new Map<
+    string,
+    Map<string, string>
+  >();
   private readonly compiledSystemPromptByConversationKey = new Map<
     string,
     LocalCompiledSystemPrompt
@@ -956,6 +982,7 @@ export class LocalStore {
         this.localMessagesByConversationKey.delete(key);
         this.loadedConversationKeys.delete(key);
         this.transcriptMetadataByConversationKey.delete(key);
+        this.persistedMessageSnapshotsByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
             join(this.storageDir, "conversations", encodePathSegment(key)),
@@ -1242,7 +1269,9 @@ export class LocalStore {
     this.conversations.set(targetKey, forked);
     this.localMessagesByConversationKey.set(targetKey, forkedMessages);
     this.loadedConversationKeys.add(targetKey);
-    this.persistConversationState(forked.id, targetAgentId);
+    this.persistConversationState(forked.id, targetAgentId, {
+      mode: "rewrite",
+    });
     return { id: forked.id };
   }
 
@@ -1505,7 +1534,9 @@ export class LocalStore {
     conversation.last_message_at = date;
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
-    this.persistConversationState(conversation.id, input.agentId);
+    this.persistConversationState(conversation.id, input.agentId, {
+      mode: "rewrite",
+    });
     this.rebuildMessageIndex();
     return {
       numMessagesBefore: previousMessages.length,
@@ -1646,7 +1677,10 @@ export class LocalStore {
       agentId,
       localMessage,
     );
-    this.persistConversationState(conversation.id, agentId);
+    this.persistConversationState(conversation.id, agentId, {
+      mode: "append",
+      message: localMessage,
+    });
   }
 
   private appendAssistantText(
@@ -1959,6 +1993,7 @@ export class LocalStore {
     this.persistConversationState(
       storedChunk.conversation_id,
       storedChunk.agent_id,
+      { mode: "append", message },
     );
   }
 
@@ -2101,7 +2136,9 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const localMessages = coalesceLocalMessageSnapshots(
+        tail.items.map(normalizeLocalMessageForPi),
+      );
       const conversation = this.conversations.get(key);
       const sourceStartIndex = tail.reachedStart
         ? 0
@@ -2225,7 +2262,9 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const localMessages = coalesceLocalMessageSnapshots(
+        tail.items.map(normalizeLocalMessageForPi),
+      );
       const sourceStartIndex = tail.reachedStart
         ? 0
         : Math.max(
@@ -2280,7 +2319,9 @@ export class LocalStore {
       metadata.conversationDir,
     );
     const localMessages = repairSyntheticLocalMessageTimestamps(
-      rawMessages.map(normalizeLocalMessageForPi),
+      coalesceLocalMessageSnapshots(
+        rawMessages.map(normalizeLocalMessageForPi),
+      ),
       metadata.timing,
     );
     const conversation = this.conversations.get(key);
@@ -2296,6 +2337,7 @@ export class LocalStore {
     }
     this.localMessagesByConversationKey.set(key, localMessages);
     this.loadedConversationKeys.add(key);
+    this.resetPersistedMessageSnapshots(key, localMessages);
     for (const message of localMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
@@ -2316,7 +2358,10 @@ export class LocalStore {
     this.localMessagesByConversationKey.set(key, messages);
     this.loadedConversationKeys.add(key);
     this.touchConversationForLocalMessage(conversationId, agentId, message);
-    this.persistConversationState(conversationId, agentId);
+    this.persistConversationState(conversationId, agentId, {
+      mode: "append",
+      message,
+    });
   }
 
   private touchConversationForLocalMessage(
@@ -2504,6 +2549,7 @@ export class LocalStore {
   private persistConversationState(
     conversationId: string,
     agentId: string,
+    transcriptOptions?: LocalTranscriptPersistOptions,
   ): void {
     if (!this.storageDir) return;
     const key = this.conversationKey(conversationId, agentId);
@@ -2523,14 +2569,81 @@ export class LocalStore {
     if (!existsSync(transcriptManifestPath(conversationDir))) {
       writeLocalTranscriptManifest(conversationDir);
     }
-    const messagesPath = transcriptMessagesPath(conversationDir);
-    if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
-      writeFileSync(
-        messagesPath,
-        jsonl(this.localMessagesByConversationKey.get(key) ?? []),
-      );
-    }
+    this.persistConversationTranscript(
+      key,
+      transcriptMessagesPath(conversationDir),
+      transcriptOptions,
+    );
     this.persistCompiledSystemPrompt(conversationId, agentId);
+  }
+
+  private persistConversationTranscript(
+    key: string,
+    messagesPath: string,
+    options?: LocalTranscriptPersistOptions,
+  ): void {
+    const messages = this.localMessagesByConversationKey.get(key) ?? [];
+    if (options?.mode === "rewrite" || !existsSync(messagesPath)) {
+      this.rewriteConversationTranscript(key, messagesPath, messages);
+      return;
+    }
+
+    if (options?.mode === "append") {
+      this.appendConversationTranscriptMessage(
+        key,
+        messagesPath,
+        options.message,
+      );
+      return;
+    }
+
+    if (!this.loadedConversationKeys.has(key)) return;
+  }
+
+  private rewriteConversationTranscript(
+    key: string,
+    messagesPath: string,
+    messages: readonly LocalMessage[],
+  ): void {
+    writeFileSync(messagesPath, jsonl(messages));
+    this.resetPersistedMessageSnapshots(key, messages);
+  }
+
+  private appendConversationTranscriptMessage(
+    key: string,
+    messagesPath: string,
+    message: LocalMessage,
+  ): void {
+    const snapshots = this.persistedMessageSnapshotsByConversationKey.get(key);
+    const snapshot = JSON.stringify(message);
+    if (snapshots?.get(message.id) === snapshot) return;
+    appendFileSync(messagesPath, `${snapshot}\n`);
+    this.persistedMessageSnapshotsForConversation(key).set(
+      message.id,
+      snapshot,
+    );
+  }
+
+  private resetPersistedMessageSnapshots(
+    key: string,
+    messages: readonly LocalMessage[],
+  ): void {
+    const snapshots = new Map<string, string>();
+    for (const message of messages) {
+      snapshots.set(message.id, JSON.stringify(message));
+    }
+    this.persistedMessageSnapshotsByConversationKey.set(key, snapshots);
+  }
+
+  private persistedMessageSnapshotsForConversation(
+    key: string,
+  ): Map<string, string> {
+    let snapshots = this.persistedMessageSnapshotsByConversationKey.get(key);
+    if (!snapshots) {
+      snapshots = new Map<string, string>();
+      this.persistedMessageSnapshotsByConversationKey.set(key, snapshots);
+    }
+    return snapshots;
   }
 
   private persistCompiledSystemPrompt(

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
+  readSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -42,7 +45,6 @@ import {
   isLocalToolCallContent,
   mergeSnapshotContentWithExistingToolCalls,
   projectedMessageLookupKeys,
-  projectLocalMessagesToStoredMessages,
   projectLocalMessageToStoredMessages,
   withProjectedMessageDates,
 } from "./local-message-projection";
@@ -440,6 +442,13 @@ function getIncludedMessageTypes(
   return messageTypes.length > 0 ? new Set(messageTypes) : undefined;
 }
 
+function sourceLocalMessageIdFromStoredMessageId(messageId: string): string {
+  const variantSeparator = messageId.search(/:(assistant|reasoning|tool):/);
+  return variantSeparator >= 0
+    ? messageId.slice(0, variantSeparator)
+    : messageId;
+}
+
 function toStoredOutputFields(chunk: Record<string, unknown>) {
   const { id: _id, date: _date, agent_id, conversation_id, ...fields } = chunk;
   void agent_id;
@@ -514,6 +523,40 @@ function readJsonlFile<T>(path: string): T[] {
     .map((line) => JSON.parse(line) as T);
 }
 
+function readJsonlFileSuffix<T>(
+  path: string,
+  maxBytes: number,
+): { items: T[]; reachedStart: boolean } {
+  if (!existsSync(path)) return { items: [], reachedStart: true };
+  const size = statSync(path).size;
+  if (size === 0) return { items: [], reachedStart: true };
+
+  const bytesToRead = Math.min(size, Math.max(1, maxBytes));
+  const start = size - bytesToRead;
+  const buffer = Buffer.alloc(bytesToRead);
+  const fd = openSync(path, "r");
+  try {
+    readSync(fd, buffer, 0, bytesToRead, start);
+  } finally {
+    closeSync(fd);
+  }
+
+  let text = buffer.toString("utf8");
+  const reachedStart = start === 0;
+  if (!reachedStart) {
+    const firstNewline = text.indexOf("\n");
+    text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+  }
+
+  return {
+    items: text
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as T),
+    reachedStart,
+  };
+}
+
 export const LOCAL_TRANSCRIPT_SCHEMA_VERSION = 1;
 export const LOCAL_TRANSCRIPT_MESSAGE_FORMAT = "pi-ai-message-jsonl";
 export const LOCAL_TRANSCRIPT_PROVIDER_STACK = "pi-ai";
@@ -572,24 +615,35 @@ function transcriptMessagesPath(conversationDir: string): string {
 
 function hasNonEmptyJsonl(path: string): boolean {
   if (!existsSync(path)) return false;
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .some((line) => line.trim().length > 0);
+  const stats = statSync(path);
+  if (stats.size === 0) return false;
+  const bytesToRead = Math.min(stats.size, 4096);
+  const fd = openSync(path, "r");
+  const buffer = Buffer.alloc(bytesToRead);
+  try {
+    readSync(fd, buffer, 0, bytesToRead, 0);
+  } finally {
+    closeSync(fd);
+  }
+  return buffer.toString("utf8").trim().length > 0 || stats.size > bytesToRead;
 }
 
-function hasLegacyUiMessageRows(path: string): boolean {
-  if (!existsSync(path)) return false;
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .some((line) => {
-      const message = JSON.parse(line) as unknown;
-      return (
-        isRecord(message) &&
-        Array.isArray(message.parts) &&
-        (!Object.hasOwn(message, "content") || message.content === null)
-      );
-    });
+function isLegacyUiMessageRow(message: unknown): boolean {
+  return (
+    isRecord(message) &&
+    Array.isArray(message.parts) &&
+    (!Object.hasOwn(message, "content") || message.content === null)
+  );
+}
+
+function assertNoLegacyUiMessageRows(
+  messages: readonly unknown[],
+  storageDir: string,
+  conversationDir: string,
+): void {
+  if (messages.some(isLegacyUiMessageRow)) {
+    throw new LocalTranscriptRepairRequiredError(storageDir, conversationDir);
+  }
 }
 
 function createLocalTranscriptManifest(
@@ -632,9 +686,6 @@ function validateLocalTranscriptManifest(
       `Unsupported local transcript format in ${conversationDir}. Run ${localTranscriptMigrationCommand(storageDir)} or start a new local conversation.`,
     );
   }
-  if (hasLegacyUiMessageRows(transcriptMessagesPath(conversationDir))) {
-    throw new LocalTranscriptRepairRequiredError(storageDir, conversationDir);
-  }
   return manifest;
 }
 
@@ -669,6 +720,13 @@ function localMessageDate(message: LocalMessage, fallbackDate: string): string {
 interface LocalTranscriptTiming {
   createdAt?: string;
   updatedAt?: string;
+}
+
+interface LocalConversationTranscriptMetadata {
+  conversationDir: string;
+  messagesPath: string;
+  timing: LocalTranscriptTiming;
+  requiresFullTimestampRepair: boolean;
 }
 
 function fileIsoTimestamp(value: number | undefined): string | undefined {
@@ -795,6 +853,11 @@ export class LocalStore {
     string,
     LocalMessage[]
   >();
+  private readonly loadedConversationKeys = new Set<string>();
+  private readonly transcriptMetadataByConversationKey = new Map<
+    string,
+    LocalConversationTranscriptMetadata
+  >();
   private readonly compiledSystemPromptByConversationKey = new Map<
     string,
     LocalCompiledSystemPrompt
@@ -891,6 +954,8 @@ export class LocalStore {
       if (conversation.agent_id === agentId) {
         this.conversations.delete(key);
         this.localMessagesByConversationKey.delete(key);
+        this.loadedConversationKeys.delete(key);
+        this.transcriptMetadataByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
             join(this.storageDir, "conversations", encodePathSegment(key)),
@@ -1096,6 +1161,7 @@ export class LocalStore {
     const key = this.conversationKey(conversation.id, agentId);
     this.conversations.set(key, conversation);
     this.localMessagesByConversationKey.set(key, []);
+    this.loadedConversationKeys.add(key);
     this.persistConversationState(conversation.id, agentId);
     return conversation;
   }
@@ -1175,6 +1241,7 @@ export class LocalStore {
     const targetKey = this.conversationKey(forked.id, targetAgentId);
     this.conversations.set(targetKey, forked);
     this.localMessagesByConversationKey.set(targetKey, forkedMessages);
+    this.loadedConversationKeys.add(targetKey);
     this.persistConversationState(forked.id, targetAgentId);
     return { id: forked.id };
   }
@@ -1341,6 +1408,13 @@ export class LocalStore {
       }
       this.ensureConversation(conversationId, agentId);
     }
+    const tailMessages = this.projectTailMessagesForConversation(
+      conversationId,
+      agentId,
+      body,
+    );
+    if (tailMessages) return tailMessages;
+
     const messages = this.projectedMessagesForConversation(
       conversationId,
       agentId,
@@ -1365,8 +1439,15 @@ export class LocalStore {
   }
 
   retrieveMessage(messageId: string): StoredMessage[] {
-    this.rebuildMessageIndex();
-    const messages = this.messagesById.get(messageId) ?? [];
+    let messages = this.messagesById.get(messageId) ?? [];
+    if (messages.length === 0) {
+      this.rebuildMessageIndex();
+      messages = this.messagesById.get(messageId) ?? [];
+    }
+    if (messages.length === 0) {
+      this.loadConversationContainingMessage(messageId);
+      messages = this.messagesById.get(messageId) ?? [];
+    }
     if (messages.length === 0 && this.strictConversationAccess) {
       throw new LocalBackendNotFoundError("Message", messageId);
     }
@@ -1386,7 +1467,10 @@ export class LocalStore {
       input.agentId,
     );
     const key = this.conversationKey(conversation.id, input.agentId);
-    const previousMessages = this.localMessagesByConversationKey.get(key) ?? [];
+    const previousMessages = this.localMessagesForConversation(
+      conversation.id,
+      input.agentId,
+    );
     const id = this.nextLocalMessageId();
     const date = this.currentLocalMessageDate();
     const summaryMessage: LocalMessage = {
@@ -1410,6 +1494,7 @@ export class LocalStore {
       ...(input.remainingMessages ?? []).map(cloneLocalMessage),
     ];
     this.localMessagesByConversationKey.set(key, compactedMessages);
+    this.loadedConversationKeys.add(key);
     conversation.in_context_message_ids = compactedMessages.map(
       (message) => message.id,
     );
@@ -1519,7 +1604,10 @@ export class LocalStore {
     if (message.role !== "assistant") return;
     const conversation = this.ensureConversation(conversationId, agentId);
     const key = this.conversationKey(conversation.id, agentId);
-    const localMessages = this.localMessagesByConversationKey.get(key) ?? [];
+    const localMessages = this.localMessagesForConversation(
+      conversation.id,
+      agentId,
+    );
     const last = localMessages.at(-1);
     const existingAssistant = last?.role === "assistant" ? last : undefined;
     const id = existingAssistant?.id ?? this.nextLocalMessageId();
@@ -1815,7 +1903,10 @@ export class LocalStore {
   ): LocalAssistantMessage {
     const conversation = this.ensureConversation(conversationId, agentId);
     const key = this.conversationKey(conversation.id, agentId);
-    const messages = this.localMessagesByConversationKey.get(key) ?? [];
+    const messages = this.localMessagesForConversation(
+      conversation.id,
+      agentId,
+    );
     const last = messages.at(-1);
     if (last?.role === "assistant") {
       return last;
@@ -1947,28 +2038,29 @@ export class LocalStore {
     return limit === undefined ? items : items.slice(0, limit);
   }
 
-  private projectedMessagesForConversation(
-    conversationId: string,
+  private projectLocalMessages(
+    localMessages: readonly LocalMessage[],
     agentId: string,
+    conversationId: string,
+    options: { sourceStartIndex?: number; updateIndex?: boolean } = {},
   ): StoredMessage[] {
-    const key = this.conversationKey(conversationId, agentId);
-    const conversation = this.conversations.get(key);
-    const resolvedConversationId = conversation?.id ?? conversationId;
-    const localMessages = this.localMessagesByConversationKey.get(key) ?? [];
     const messages: StoredMessage[] = [];
+    const sourceStartIndex = options.sourceStartIndex ?? 0;
     for (let index = 0; index < localMessages.length; index++) {
       const localMessage = localMessages[index];
       if (!localMessage) continue;
+      const sourceIndex = sourceStartIndex + index;
       const projected = withProjectedMessageDates(
         projectLocalMessageToStoredMessages(
           localMessage,
           agentId,
-          resolvedConversationId,
-          new Date(Date.UTC(2026, 0, 1, 0, 0, index + 1)).toISOString(),
+          conversationId,
+          new Date(Date.UTC(2026, 0, 1, 0, 0, sourceIndex + 1)).toISOString(),
         ),
-        index,
+        sourceIndex,
       );
       messages.push(...projected);
+      if (options.updateIndex === false) continue;
       for (const [lookupKey, lookupMessages] of projectedMessageLookupKeys(
         localMessage,
         projected,
@@ -1979,13 +2071,108 @@ export class LocalStore {
     return messages;
   }
 
+  private projectTailMessagesForConversation(
+    conversationId: string,
+    agentId: string,
+    body?: ConversationMessageListBody,
+  ): StoredMessage[] | undefined {
+    const limit = getListLimit(body);
+    if (limit === undefined || getListOrder(body) !== "desc") return undefined;
+    if (getCursor(body, "after")) return undefined;
+
+    const key = this.conversationKey(conversationId, agentId);
+    if (this.loadedConversationKeys.has(key)) return undefined;
+    const metadata = this.transcriptMetadataByConversationKey.get(key);
+    if (!metadata || metadata.requiresFullTimestampRepair) return undefined;
+
+    const before = getCursor(body, "before");
+    let maxBytes = 64 * 1024;
+    for (;;) {
+      const tail = readJsonlFileSuffix<LocalMessage>(
+        metadata.messagesPath,
+        maxBytes,
+      );
+      assertNoLegacyUiMessageRows(
+        tail.items,
+        this.storageDir ?? "",
+        metadata.conversationDir,
+      );
+      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const projected = this.projectLocalMessages(
+        localMessages,
+        agentId,
+        conversationId,
+        { updateIndex: false },
+      );
+      const cursorFound =
+        !before || projected.some((message) => message.id === before);
+      const items = this.applyListOptions(projected, body);
+      if (cursorFound && (items.length >= limit || tail.reachedStart)) {
+        return items;
+      }
+      if (tail.reachedStart) return items;
+      maxBytes *= 2;
+    }
+  }
+
+  private projectedMessagesForConversation(
+    conversationId: string,
+    agentId: string,
+  ): StoredMessage[] {
+    const key = this.conversationKey(conversationId, agentId);
+    const conversation = this.conversations.get(key);
+    const resolvedConversationId = conversation?.id ?? conversationId;
+    const localMessages = this.localMessagesForConversation(
+      resolvedConversationId,
+      agentId,
+    );
+    return this.projectLocalMessages(
+      localMessages,
+      agentId,
+      resolvedConversationId,
+    );
+  }
+
   private rebuildMessageIndex(): void {
     this.messagesById.clear();
     for (const conversation of this.conversations.values()) {
+      const key = this.conversationKey(conversation.id, conversation.agent_id);
+      if (!this.loadedConversationKeys.has(key)) continue;
       this.projectedMessagesForConversation(
         conversation.id,
         conversation.agent_id,
       );
+    }
+  }
+
+  private loadConversationContainingMessage(messageId: string): void {
+    const sourceMessageId = sourceLocalMessageIdFromStoredMessageId(messageId);
+    for (const conversation of this.conversations.values()) {
+      const key = this.conversationKey(conversation.id, conversation.agent_id);
+      if (this.loadedConversationKeys.has(key)) continue;
+      if (
+        !conversation.in_context_message_ids.includes(sourceMessageId) &&
+        !conversation.in_context_message_ids.includes(messageId)
+      ) {
+        continue;
+      }
+      this.loadConversationMessages(
+        key,
+        conversation.id,
+        conversation.agent_id,
+      );
+      if ((this.messagesById.get(messageId) ?? []).length > 0) return;
+    }
+
+    for (const conversation of this.conversations.values()) {
+      const key = this.conversationKey(conversation.id, conversation.agent_id);
+      if (this.loadedConversationKeys.has(key)) continue;
+      this.loadConversationMessages(
+        key,
+        conversation.id,
+        conversation.agent_id,
+      );
+      if ((this.messagesById.get(messageId) ?? []).length > 0) return;
     }
   }
 
@@ -1994,9 +2181,60 @@ export class LocalStore {
     agentId: string,
   ): LocalMessage[] {
     const key = this.conversationKey(conversationId, agentId);
+    if (!this.loadedConversationKeys.has(key)) {
+      this.loadConversationMessages(key, conversationId, agentId);
+    }
     const messages = this.localMessagesByConversationKey.get(key) ?? [];
     this.localMessagesByConversationKey.set(key, messages);
+    this.loadedConversationKeys.add(key);
     return messages;
+  }
+
+  private loadConversationMessages(
+    key: string,
+    conversationId: string,
+    agentId: string,
+  ): void {
+    const metadata = this.transcriptMetadataByConversationKey.get(key);
+    if (!metadata) {
+      this.localMessagesByConversationKey.set(
+        key,
+        this.localMessagesByConversationKey.get(key) ?? [],
+      );
+      this.loadedConversationKeys.add(key);
+      return;
+    }
+
+    const rawMessages = readJsonlFile<LocalMessage>(metadata.messagesPath);
+    assertNoLegacyUiMessageRows(
+      rawMessages,
+      this.storageDir ?? "",
+      metadata.conversationDir,
+    );
+    const localMessages = repairSyntheticLocalMessageTimestamps(
+      rawMessages.map(normalizeLocalMessageForPi),
+      metadata.timing,
+    );
+    const conversation = this.conversations.get(key);
+    if (conversation) {
+      this.conversations.set(
+        key,
+        repairSyntheticConversationTimestamps(
+          conversation,
+          localMessages,
+          metadata.timing,
+        ),
+      );
+    }
+    this.localMessagesByConversationKey.set(key, localMessages);
+    this.loadedConversationKeys.add(key);
+    for (const message of localMessages) {
+      this.localMessageSeq = Math.max(
+        this.localMessageSeq,
+        numericSuffix(message.id, this.localMessageIdPrefix),
+      );
+    }
+    this.projectLocalMessages(localMessages, agentId, conversationId);
   }
 
   private pushLocalMessage(
@@ -2004,10 +2242,11 @@ export class LocalStore {
     agentId: string,
     message: LocalMessage,
   ): void {
-    const key = this.conversationKey(conversationId, agentId);
-    const messages = this.localMessagesByConversationKey.get(key) ?? [];
+    const messages = this.localMessagesForConversation(conversationId, agentId);
     messages.push(message);
+    const key = this.conversationKey(conversationId, agentId);
     this.localMessagesByConversationKey.set(key, messages);
+    this.loadedConversationKeys.add(key);
     this.touchConversationForLocalMessage(conversationId, agentId, message);
     this.persistConversationState(conversationId, agentId);
   }
@@ -2123,28 +2362,26 @@ export class LocalStore {
           conversationDir,
           manifest,
         );
-        const localMessages = repairSyntheticLocalMessageTimestamps(
-          readJsonlFile<LocalMessage>(
-            transcriptMessagesPath(conversationDir),
-          ).map(normalizeLocalMessageForPi),
-          timing,
-        );
+        const requiresFullTimestampRepair =
+          isSyntheticLocalTimestamp(conversation.created_at) ||
+          isSyntheticLocalTimestamp(conversation.updated_at) ||
+          isSyntheticLocalTimestamp(conversation.last_message_at);
         conversation = repairSyntheticConversationTimestamps(
           conversation,
-          localMessages,
+          [],
           timing,
         );
         const compiledSystemPrompt = readJsonFile<LocalCompiledSystemPrompt>(
           join(conversationDir, "system-prompt.json"),
         );
-        const messages = projectLocalMessagesToStoredMessages(
-          localMessages,
-          conversation.agent_id,
-          conversation.id,
-        );
 
         this.conversations.set(key, conversation);
-        this.localMessagesByConversationKey.set(key, localMessages);
+        this.transcriptMetadataByConversationKey.set(key, {
+          conversationDir,
+          messagesPath: transcriptMessagesPath(conversationDir),
+          timing,
+          requiresFullTimestampRepair,
+        });
         if (compiledSystemPrompt?.content) {
           this.compiledSystemPromptByConversationKey.set(
             key,
@@ -2156,17 +2393,10 @@ export class LocalStore {
           numericSuffix(conversation.id, this.conversationIdPrefix),
         );
 
-        for (const localMessage of localMessages) {
+        for (const messageId of conversation.in_context_message_ids ?? []) {
           this.localMessageSeq = Math.max(
             this.localMessageSeq,
-            numericSuffix(localMessage.id, this.localMessageIdPrefix),
-          );
-        }
-        for (const message of messages) {
-          this.messagesById.set(message.id, [message]);
-          this.messageSeq = Math.max(
-            this.messageSeq,
-            numericSuffix(message.id, this.storedMessageIdPrefix),
+            numericSuffix(messageId, this.localMessageIdPrefix),
           );
         }
       }
@@ -2187,14 +2417,14 @@ export class LocalStore {
 
   private projectAgent(record: LocalAgentRecord): AgentState {
     const key = this.conversationKey("default", record.id);
-    const defaultMessages = this.projectedMessagesForConversation(
-      "default",
-      record.id,
-    );
-    const messageIds = defaultMessages.map((message) => message.id);
+    const defaultConversation = this.conversations.get(key);
+    const messageIds = defaultConversation?.in_context_message_ids ?? [];
     const inContextMessageIds =
-      this.conversations.get(key)?.in_context_message_ids ?? messageIds;
-    const lastRunCompletion = defaultMessages.at(-1)?.date ?? null;
+      defaultConversation?.in_context_message_ids ?? messageIds;
+    const lastRunCompletion =
+      defaultConversation?.last_message_at ??
+      defaultConversation?.updated_at ??
+      null;
     return projectLocalAgentState(
       record,
       messageIds,
@@ -2225,10 +2455,13 @@ export class LocalStore {
     if (!existsSync(transcriptManifestPath(conversationDir))) {
       writeLocalTranscriptManifest(conversationDir);
     }
-    writeFileSync(
-      transcriptMessagesPath(conversationDir),
-      jsonl(this.localMessagesByConversationKey.get(key) ?? []),
-    );
+    const messagesPath = transcriptMessagesPath(conversationDir);
+    if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
+      writeFileSync(
+        messagesPath,
+        jsonl(this.localMessagesByConversationKey.get(key) ?? []),
+      );
+    }
     this.persistCompiledSystemPrompt(conversationId, agentId);
   }
 
@@ -2272,6 +2505,7 @@ export class LocalStore {
     );
     this.conversations.set(key, conversation);
     this.localMessagesByConversationKey.set(key, []);
+    this.loadedConversationKeys.add(key);
     this.persistConversationState(conversation.id, resolvedAgentId);
     return conversation;
   }

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -507,7 +506,7 @@ function encodePathSegment(value: string): string {
   return Buffer.from(value).toString("base64url");
 }
 
-function jsonl<T>(items: readonly T[]): string {
+function jsonl<T>(items: T[]): string {
   return `${items.map((item) => JSON.stringify(item)).join("\n")}\n`;
 }
 
@@ -522,23 +521,6 @@ function readJsonlFile<T>(path: string): T[] {
     .split("\n")
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as T);
-}
-
-function coalesceLocalMessageSnapshots(
-  messages: readonly LocalMessage[],
-): LocalMessage[] {
-  const coalesced: LocalMessage[] = [];
-  const indexById = new Map<string, number>();
-  for (const message of messages) {
-    const existingIndex = indexById.get(message.id);
-    if (existingIndex === undefined) {
-      indexById.set(message.id, coalesced.length);
-      coalesced.push(message);
-    } else {
-      coalesced[existingIndex] = message;
-    }
-  }
-  return coalesced;
 }
 
 function readJsonlFileSuffix<T>(
@@ -747,10 +729,6 @@ interface LocalConversationTranscriptMetadata {
   requiresFullTimestampRepair: boolean;
 }
 
-type LocalTranscriptPersistOptions =
-  | { mode: "append"; message: LocalMessage }
-  | { mode: "rewrite" };
-
 function fileIsoTimestamp(value: number | undefined): string | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? new Date(value).toISOString()
@@ -880,10 +858,6 @@ export class LocalStore {
     string,
     LocalConversationTranscriptMetadata
   >();
-  private readonly persistedMessageSnapshotsByConversationKey = new Map<
-    string,
-    Map<string, string>
-  >();
   private readonly compiledSystemPromptByConversationKey = new Map<
     string,
     LocalCompiledSystemPrompt
@@ -982,7 +956,6 @@ export class LocalStore {
         this.localMessagesByConversationKey.delete(key);
         this.loadedConversationKeys.delete(key);
         this.transcriptMetadataByConversationKey.delete(key);
-        this.persistedMessageSnapshotsByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
             join(this.storageDir, "conversations", encodePathSegment(key)),
@@ -1269,9 +1242,7 @@ export class LocalStore {
     this.conversations.set(targetKey, forked);
     this.localMessagesByConversationKey.set(targetKey, forkedMessages);
     this.loadedConversationKeys.add(targetKey);
-    this.persistConversationState(forked.id, targetAgentId, {
-      mode: "rewrite",
-    });
+    this.persistConversationState(forked.id, targetAgentId);
     return { id: forked.id };
   }
 
@@ -1534,9 +1505,7 @@ export class LocalStore {
     conversation.last_message_at = date;
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
-    this.persistConversationState(conversation.id, input.agentId, {
-      mode: "rewrite",
-    });
+    this.persistConversationState(conversation.id, input.agentId);
     this.rebuildMessageIndex();
     return {
       numMessagesBefore: previousMessages.length,
@@ -1677,10 +1646,7 @@ export class LocalStore {
       agentId,
       localMessage,
     );
-    this.persistConversationState(conversation.id, agentId, {
-      mode: "append",
-      message: localMessage,
-    });
+    this.persistConversationState(conversation.id, agentId);
   }
 
   private appendAssistantText(
@@ -1993,7 +1959,6 @@ export class LocalStore {
     this.persistConversationState(
       storedChunk.conversation_id,
       storedChunk.agent_id,
-      { mode: "append", message },
     );
   }
 
@@ -2136,9 +2101,7 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = coalesceLocalMessageSnapshots(
-        tail.items.map(normalizeLocalMessageForPi),
-      );
+      const localMessages = tail.items.map(normalizeLocalMessageForPi);
       const conversation = this.conversations.get(key);
       const sourceStartIndex = tail.reachedStart
         ? 0
@@ -2262,9 +2225,7 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = coalesceLocalMessageSnapshots(
-        tail.items.map(normalizeLocalMessageForPi),
-      );
+      const localMessages = tail.items.map(normalizeLocalMessageForPi);
       const sourceStartIndex = tail.reachedStart
         ? 0
         : Math.max(
@@ -2319,9 +2280,7 @@ export class LocalStore {
       metadata.conversationDir,
     );
     const localMessages = repairSyntheticLocalMessageTimestamps(
-      coalesceLocalMessageSnapshots(
-        rawMessages.map(normalizeLocalMessageForPi),
-      ),
+      rawMessages.map(normalizeLocalMessageForPi),
       metadata.timing,
     );
     const conversation = this.conversations.get(key);
@@ -2337,7 +2296,6 @@ export class LocalStore {
     }
     this.localMessagesByConversationKey.set(key, localMessages);
     this.loadedConversationKeys.add(key);
-    this.resetPersistedMessageSnapshots(key, localMessages);
     for (const message of localMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
@@ -2358,10 +2316,7 @@ export class LocalStore {
     this.localMessagesByConversationKey.set(key, messages);
     this.loadedConversationKeys.add(key);
     this.touchConversationForLocalMessage(conversationId, agentId, message);
-    this.persistConversationState(conversationId, agentId, {
-      mode: "append",
-      message,
-    });
+    this.persistConversationState(conversationId, agentId);
   }
 
   private touchConversationForLocalMessage(
@@ -2549,7 +2504,6 @@ export class LocalStore {
   private persistConversationState(
     conversationId: string,
     agentId: string,
-    transcriptOptions?: LocalTranscriptPersistOptions,
   ): void {
     if (!this.storageDir) return;
     const key = this.conversationKey(conversationId, agentId);
@@ -2569,81 +2523,14 @@ export class LocalStore {
     if (!existsSync(transcriptManifestPath(conversationDir))) {
       writeLocalTranscriptManifest(conversationDir);
     }
-    this.persistConversationTranscript(
-      key,
-      transcriptMessagesPath(conversationDir),
-      transcriptOptions,
-    );
-    this.persistCompiledSystemPrompt(conversationId, agentId);
-  }
-
-  private persistConversationTranscript(
-    key: string,
-    messagesPath: string,
-    options?: LocalTranscriptPersistOptions,
-  ): void {
-    const messages = this.localMessagesByConversationKey.get(key) ?? [];
-    if (options?.mode === "rewrite" || !existsSync(messagesPath)) {
-      this.rewriteConversationTranscript(key, messagesPath, messages);
-      return;
-    }
-
-    if (options?.mode === "append") {
-      this.appendConversationTranscriptMessage(
-        key,
+    const messagesPath = transcriptMessagesPath(conversationDir);
+    if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
+      writeFileSync(
         messagesPath,
-        options.message,
+        jsonl(this.localMessagesByConversationKey.get(key) ?? []),
       );
-      return;
     }
-
-    if (!this.loadedConversationKeys.has(key)) return;
-  }
-
-  private rewriteConversationTranscript(
-    key: string,
-    messagesPath: string,
-    messages: readonly LocalMessage[],
-  ): void {
-    writeFileSync(messagesPath, jsonl(messages));
-    this.resetPersistedMessageSnapshots(key, messages);
-  }
-
-  private appendConversationTranscriptMessage(
-    key: string,
-    messagesPath: string,
-    message: LocalMessage,
-  ): void {
-    const snapshots = this.persistedMessageSnapshotsByConversationKey.get(key);
-    const snapshot = JSON.stringify(message);
-    if (snapshots?.get(message.id) === snapshot) return;
-    appendFileSync(messagesPath, `${snapshot}\n`);
-    this.persistedMessageSnapshotsForConversation(key).set(
-      message.id,
-      snapshot,
-    );
-  }
-
-  private resetPersistedMessageSnapshots(
-    key: string,
-    messages: readonly LocalMessage[],
-  ): void {
-    const snapshots = new Map<string, string>();
-    for (const message of messages) {
-      snapshots.set(message.id, JSON.stringify(message));
-    }
-    this.persistedMessageSnapshotsByConversationKey.set(key, snapshots);
-  }
-
-  private persistedMessageSnapshotsForConversation(
-    key: string,
-  ): Map<string, string> {
-    let snapshots = this.persistedMessageSnapshotsByConversationKey.get(key);
-    if (!snapshots) {
-      snapshots = new Map<string, string>();
-      this.persistedMessageSnapshotsByConversationKey.set(key, snapshots);
-    }
-    return snapshots;
+    this.persistCompiledSystemPrompt(conversationId, agentId);
   }
 
   private persistCompiledSystemPrompt(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1656,20 +1656,13 @@ async function main(): Promise<void> {
           !settings.refreshToken &&
           !apiKey;
         setStartupHasCloudCredentials(Boolean(settings.refreshToken || apiKey));
+        const startupModelsPromise =
+          startupBackendMode === "local" || isSelfHosted
+            ? backend.listModels()
+            : Promise.resolve([]);
         if (startupBackendMode === "local") {
           try {
-            const models = await backend.listModels();
-            setStartupHasAvailableLocalModels(models.length > 0);
-          } catch {
-            setStartupHasAvailableLocalModels(false);
-          }
-        } else {
-          setStartupHasAvailableLocalModels(true);
-        }
-
-        if (startupBackendMode === "local") {
-          try {
-            const models = await backend.listModels();
+            const models = await startupModelsPromise;
             setStartupHasAvailableLocalModels(models.length > 0);
           } catch {
             setStartupHasAvailableLocalModels(false);
@@ -1687,7 +1680,7 @@ async function main(): Promise<void> {
             const { getDefaultModel } = await import("@/agent/model");
             const defaultModel = getDefaultModel();
             setSelfHostedDefaultModel(defaultModel);
-            const modelsList = await backend.listModels();
+            const modelsList = await startupModelsPromise;
             const handles = modelsList
               .map((m) => m.handle)
               .filter((h): h is string => typeof h === "string");


### PR DESCRIPTION
## Summary
- Load local conversation metadata on startup without eagerly parsing every `messages.jsonl` transcript.
- Add bounded tail reads and tail-based direct lookup for recent resume/backfill paths so recent history does not require parsing the whole transcript.
- Share the startup model discovery promise so local boot does not call `listModels()` twice.

## Notes
- This PR intentionally does not change local transcript persistence semantics; it keeps the current snapshot-style transcript format and only optimizes reads/startup. A follow-up PR will align local transcript persistence with pi-tui style append-only session entries.

## Test plan
- [x] `bun test src/backend/local-backend.test.ts src/agent/check-approval-resume-data.test.ts src/backend/fake-headless-backend.test.ts`
- [x] `bun run typecheck`
- [x] pre-commit `tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)