### PR TITLE
feat(local): persist v2 session transcripts

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -950,7 +950,7 @@ describe("local backend pi transcript", () => {
       await readFile(join(dir, "manifest.json"), "utf8"),
     );
     expect(manifest).toMatchObject({
-      schema_version: 1,
+      schema_version: 2,
       message_format: "pi-session-entry-jsonl",
       provider_stack: "pi-ai",
     });
@@ -1272,6 +1272,8 @@ describe("local backend pi transcript", () => {
     expect(manifest.migrated_from).toBe(
       "versioned-pi-transcript-with-legacy-ui-message-rows",
     );
+    expect(manifest.schema_version).toBe(2);
+    expect(manifest.message_format).toBe("pi-session-entry-jsonl");
     const convertedEntries = (
       await readFile(join(conversationDir, "messages.jsonl"), "utf8")
     )
@@ -1333,6 +1335,8 @@ describe("local backend pi transcript", () => {
       await readFile(join(conversationDir, "manifest.json"), "utf8"),
     );
     expect(manifest.provider_stack).toBe("pi-ai");
+    expect(manifest.schema_version).toBe(2);
+    expect(manifest.message_format).toBe("pi-session-entry-jsonl");
     const convertedEntries = (
       await readFile(join(conversationDir, "messages.jsonl"), "utf8")
     )

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -42,7 +42,12 @@ async function firstConversationDir(storageDir: string): Promise<string> {
   expect(entries.length).toBeGreaterThan(0);
   for (const entry of entries) {
     const dir = join(storageDir, "conversations", entry);
-    const raw = await readFile(join(dir, "messages.jsonl"), "utf8");
+    let raw: string;
+    try {
+      raw = await readFile(join(dir, "messages.jsonl"), "utf8");
+    } catch {
+      continue;
+    }
     const rows = raw
       .split("\n")
       .filter((line) => line.trim().length > 0)
@@ -553,6 +558,62 @@ describe("local backend pi transcript", () => {
     await backend.compactConversationMessages(conversation.id, {
       agent_id: agent.id,
     } as never);
+
+    const conversationDir = await firstConversationDir(storageDir);
+    const entriesAfterCompaction = (
+      await readFile(join(conversationDir, "messages.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(entriesAfterCompaction.map((entry) => entry.type)).toEqual([
+      "session",
+      "message",
+      "message",
+      "compaction",
+    ]);
+    const messageEntries = entriesAfterCompaction.filter(
+      (entry) => entry.type === "message",
+    );
+    expect(
+      messageEntries.map(
+        (entry) => (entry.message as Record<string, unknown> | undefined)?.id,
+      ),
+    ).toEqual(["ui-msg-1", "ui-msg-2"]);
+    expect(
+      messageEntries.every(
+        (entry) => entry.id !== (entry.message as Record<string, unknown>).id,
+      ),
+    ).toBe(true);
+    const compactionEntry = entriesAfterCompaction.at(-1) as Record<
+      string,
+      unknown
+    >;
+    expect(compactionEntry).toMatchObject({
+      type: "compaction",
+      parentId: messageEntries.at(-1)?.id,
+      summary: "Compacted summary.",
+    });
+    expect(
+      (compactionEntry.message as Record<string, unknown> | undefined)?.id,
+    ).toBe("ui-msg-3");
+
+    const reloadedAfterCompaction = new LocalBackend({
+      storageDir,
+      executor,
+      complete,
+      memfsEnabled: false,
+    });
+    const activeAfterCompaction = pageItems(
+      await reloadedAfterCompaction.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(activeAfterCompaction.map((message) => message.id)).toEqual([
+      "ui-msg-3",
+    ]);
+
     await drain(
       await backend.createConversationMessageStream(conversation.id, {
         agent_id: agent.id,

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -43,7 +43,17 @@ async function firstConversationDir(storageDir: string): Promise<string> {
   for (const entry of entries) {
     const dir = join(storageDir, "conversations", entry);
     const raw = await readFile(join(dir, "messages.jsonl"), "utf8");
-    if (raw.trim().length > 0) return dir;
+    const rows = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    if (
+      rows.some(
+        (row) => row.type === "message" || Object.hasOwn(row, "content"),
+      )
+    ) {
+      return dir;
+    }
   }
   const firstEntry = entries[0];
   if (!firstEntry)
@@ -880,13 +890,17 @@ describe("local backend pi transcript", () => {
     );
     expect(manifest).toMatchObject({
       schema_version: 1,
-      message_format: "pi-ai-message-jsonl",
+      message_format: "pi-session-entry-jsonl",
       provider_stack: "pi-ai",
     });
-    const messages = (await readFile(join(dir, "messages.jsonl"), "utf8"))
+    const entries = (await readFile(join(dir, "messages.jsonl"), "utf8"))
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(entries[0]).toMatchObject({ type: "session", version: 3 });
+    const messages = entries
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message as Record<string, unknown>);
     expect(messages.every((message) => "content" in message)).toBe(true);
     expect(JSON.stringify(messages)).not.toContain('"parts"');
 
@@ -1063,12 +1077,16 @@ describe("local backend pi transcript", () => {
     });
 
     const conversationDir = await firstConversationDir(storageDir);
-    const messages = (
+    const entries = (
       await readFile(join(conversationDir, "messages.jsonl"), "utf8")
     )
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(entries[0]).toMatchObject({ type: "session", version: 3 });
+    const messages = entries
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message as Record<string, unknown>);
     expect(messages.map((message) => message.role)).toEqual([
       "user",
       "assistant",
@@ -1078,6 +1096,26 @@ describe("local backend pi transcript", () => {
     const finalAssistant = messages.at(-1) as { content?: unknown[] };
     expect(finalAssistant.content).toEqual([
       { type: "text", text: "Tool result received." },
+    ]);
+
+    const reloadedBackend = new LocalBackend({
+      storageDir,
+      stream,
+      memfsEnabled: false,
+    });
+    const reloadedMessages = pageItems(
+      await reloadedBackend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(reloadedMessages.map((message) => message.message_type)).toEqual([
+      "user_message",
+      "assistant_message",
+      "reasoning_message",
+      "approval_request_message",
+      "tool_return_message",
+      "assistant_message",
     ]);
   });
 
@@ -1173,9 +1211,15 @@ describe("local backend pi transcript", () => {
     expect(manifest.migrated_from).toBe(
       "versioned-pi-transcript-with-legacy-ui-message-rows",
     );
-    const converted = JSON.parse(
-      (await readFile(join(conversationDir, "messages.jsonl"), "utf8")).trim(),
-    );
+    const convertedEntries = (
+      await readFile(join(conversationDir, "messages.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(convertedEntries[0]).toMatchObject({ type: "session" });
+    const converted = convertedEntries.find((entry) => entry.type === "message")
+      ?.message as Record<string, unknown>;
     expect(converted).toMatchObject({
       id: "ui-msg-1",
       role: "user",
@@ -1228,12 +1272,16 @@ describe("local backend pi transcript", () => {
       await readFile(join(conversationDir, "manifest.json"), "utf8"),
     );
     expect(manifest.provider_stack).toBe("pi-ai");
-    const converted = (
+    const convertedEntries = (
       await readFile(join(conversationDir, "messages.jsonl"), "utf8")
     )
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { role: string });
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(convertedEntries[0]).toMatchObject({ type: "session" });
+    const converted = convertedEntries
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message as { role: string });
     expect(converted.map((message) => message.role)).toEqual([
       "user",
       "assistant",

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -560,17 +560,22 @@ function readJsonlFileSuffix<T>(
   };
 }
 
-export const LOCAL_TRANSCRIPT_SCHEMA_VERSION = 1;
+export const LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION = 1;
+export const LOCAL_TRANSCRIPT_SCHEMA_VERSION = 2;
 export const LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT = "pi-ai-message-jsonl";
 export const LOCAL_TRANSCRIPT_MESSAGE_FORMAT = "pi-session-entry-jsonl";
 export const LOCAL_TRANSCRIPT_PROVIDER_STACK = "pi-ai";
+
+type LocalTranscriptSchemaVersion =
+  | typeof LOCAL_TRANSCRIPT_SCHEMA_VERSION
+  | typeof LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION;
 
 type LocalTranscriptMessageFormat =
   | typeof LOCAL_TRANSCRIPT_MESSAGE_FORMAT
   | typeof LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
 
 export interface LocalTranscriptManifest {
-  schema_version: typeof LOCAL_TRANSCRIPT_SCHEMA_VERSION;
+  schema_version: LocalTranscriptSchemaVersion;
   message_format: LocalTranscriptMessageFormat;
   provider_stack: typeof LOCAL_TRANSCRIPT_PROVIDER_STACK;
   created_at: string;
@@ -868,10 +873,14 @@ function validateLocalTranscriptManifest(
     }
     return undefined;
   }
+  const isCurrentFormat =
+    manifest.schema_version === LOCAL_TRANSCRIPT_SCHEMA_VERSION &&
+    manifest.message_format === LOCAL_TRANSCRIPT_MESSAGE_FORMAT;
+  const isLegacyFormat =
+    manifest.schema_version === LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION &&
+    manifest.message_format === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
   if (
-    manifest.schema_version !== LOCAL_TRANSCRIPT_SCHEMA_VERSION ||
-    (manifest.message_format !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT &&
-      manifest.message_format !== LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) ||
+    (!isCurrentFormat && !isLegacyFormat) ||
     manifest.provider_stack !== LOCAL_TRANSCRIPT_PROVIDER_STACK
   ) {
     throw new Error(

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -508,7 +509,7 @@ function encodePathSegment(value: string): string {
   return Buffer.from(value).toString("base64url");
 }
 
-function jsonl<T>(items: T[]): string {
+function jsonl<T>(items: readonly T[]): string {
   return `${items.map((item) => JSON.stringify(item)).join("\n")}\n`;
 }
 
@@ -560,12 +561,17 @@ function readJsonlFileSuffix<T>(
 }
 
 export const LOCAL_TRANSCRIPT_SCHEMA_VERSION = 1;
-export const LOCAL_TRANSCRIPT_MESSAGE_FORMAT = "pi-ai-message-jsonl";
+export const LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT = "pi-ai-message-jsonl";
+export const LOCAL_TRANSCRIPT_MESSAGE_FORMAT = "pi-session-entry-jsonl";
 export const LOCAL_TRANSCRIPT_PROVIDER_STACK = "pi-ai";
+
+type LocalTranscriptMessageFormat =
+  | typeof LOCAL_TRANSCRIPT_MESSAGE_FORMAT
+  | typeof LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
 
 export interface LocalTranscriptManifest {
   schema_version: typeof LOCAL_TRANSCRIPT_SCHEMA_VERSION;
-  message_format: typeof LOCAL_TRANSCRIPT_MESSAGE_FORMAT;
+  message_format: LocalTranscriptMessageFormat;
   provider_stack: typeof LOCAL_TRANSCRIPT_PROVIDER_STACK;
   created_at: string;
   migrated_from?: string;
@@ -648,6 +654,85 @@ function assertNoLegacyUiMessageRows(
   }
 }
 
+interface LocalTranscriptSessionHeader {
+  type: "session";
+  version: 3;
+  id: string;
+  timestamp: string;
+  cwd: string;
+}
+
+interface LocalTranscriptSessionMessageEntry {
+  type: "message";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  message: LocalMessage;
+}
+
+type LocalTranscriptSessionEntry =
+  | LocalTranscriptSessionHeader
+  | LocalTranscriptSessionMessageEntry;
+
+function isLocalTranscriptSessionMessageEntry(
+  value: unknown,
+): value is LocalTranscriptSessionMessageEntry {
+  return (
+    isRecord(value) &&
+    value.type === "message" &&
+    typeof value.id === "string" &&
+    (value.parentId === null || typeof value.parentId === "string") &&
+    typeof value.timestamp === "string" &&
+    isRecord(value.message) &&
+    typeof value.message.id === "string"
+  );
+}
+
+function createLocalTranscriptSessionHeader(
+  conversation: StoredConversation,
+): LocalTranscriptSessionHeader {
+  return {
+    type: "session",
+    version: 3,
+    id: conversation.id,
+    timestamp: conversation.created_at ?? currentIsoTimestamp(),
+    cwd: process.cwd(),
+  };
+}
+
+function localTranscriptSessionEntries(
+  conversation: StoredConversation,
+  messages: readonly LocalMessage[],
+): LocalTranscriptSessionEntry[] {
+  let parentId: string | null = null;
+  return [
+    createLocalTranscriptSessionHeader(conversation),
+    ...messages.map((message) => {
+      const entry: LocalTranscriptSessionMessageEntry = {
+        type: "message",
+        id: message.id,
+        parentId,
+        timestamp: localMessageDate(message, currentIsoTimestamp()),
+        message,
+      };
+      parentId = entry.id;
+      return entry;
+    }),
+  ];
+}
+
+function localMessagesFromTranscriptRows(
+  rows: readonly unknown[],
+  messageFormat: LocalTranscriptMessageFormat,
+): LocalMessage[] {
+  if (messageFormat === LOCAL_TRANSCRIPT_MESSAGE_FORMAT) {
+    return rows
+      .filter(isLocalTranscriptSessionMessageEntry)
+      .map((entry) => entry.message);
+  }
+  return rows as LocalMessage[];
+}
+
 function createLocalTranscriptManifest(
   input: {
     migratedFrom?: string;
@@ -681,7 +766,8 @@ function validateLocalTranscriptManifest(
   }
   if (
     manifest.schema_version !== LOCAL_TRANSCRIPT_SCHEMA_VERSION ||
-    manifest.message_format !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT ||
+    (manifest.message_format !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT &&
+      manifest.message_format !== LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) ||
     manifest.provider_stack !== LOCAL_TRANSCRIPT_PROVIDER_STACK
   ) {
     throw new Error(
@@ -727,8 +813,14 @@ interface LocalTranscriptTiming {
 interface LocalConversationTranscriptMetadata {
   conversationDir: string;
   messagesPath: string;
+  messageFormat: LocalTranscriptMessageFormat;
   timing: LocalTranscriptTiming;
   requiresFullTimestampRepair: boolean;
+}
+
+interface LocalTranscriptPersistOptions {
+  transcript?: "append" | "rewrite" | "skip";
+  message?: LocalMessage;
 }
 
 function fileIsoTimestamp(value: number | undefined): string | undefined {
@@ -863,6 +955,14 @@ export class LocalStore {
     string,
     LocalConversationTranscriptMetadata
   >();
+  private readonly persistedSessionMessageIdsByConversationKey = new Map<
+    string,
+    Set<string>
+  >();
+  private readonly lastSessionEntryIdByConversationKey = new Map<
+    string,
+    string | null
+  >();
   private readonly compiledSystemPromptByConversationKey = new Map<
     string,
     LocalCompiledSystemPrompt
@@ -962,6 +1062,8 @@ export class LocalStore {
         this.localMessagesByConversationKey.delete(key);
         this.loadedConversationKeys.delete(key);
         this.transcriptMetadataByConversationKey.delete(key);
+        this.persistedSessionMessageIdsByConversationKey.delete(key);
+        this.lastSessionEntryIdByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
             join(this.storageDir, "conversations", encodePathSegment(key)),
@@ -1286,7 +1388,9 @@ export class LocalStore {
     this.conversations.set(targetKey, forked);
     this.localMessagesByConversationKey.set(targetKey, forkedMessages);
     this.loadedConversationKeys.add(targetKey);
-    this.persistConversationState(forked.id, targetAgentId);
+    this.persistConversationState(forked.id, targetAgentId, {
+      transcript: "rewrite",
+    });
     return { id: forked.id };
   }
 
@@ -1347,7 +1451,11 @@ export class LocalStore {
     }
 
     const messageType = (chunk as { message_type?: unknown })?.message_type;
-    if (typeof messageType !== "string" || messageType === "stop_reason") {
+    if (messageType === "stop_reason") {
+      this.persistPendingAssistantMessage(conversationId, agentId);
+      return chunk;
+    }
+    if (typeof messageType !== "string") {
       return chunk;
     }
 
@@ -1549,7 +1657,9 @@ export class LocalStore {
     conversation.last_message_at = date;
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
-    this.persistConversationState(conversation.id, input.agentId);
+    this.persistConversationState(conversation.id, input.agentId, {
+      transcript: "rewrite",
+    });
     this.rebuildMessageIndex();
     return {
       numMessagesBefore: previousMessages.length,
@@ -1690,7 +1800,10 @@ export class LocalStore {
       agentId,
       localMessage,
     );
-    this.persistConversationState(conversation.id, agentId);
+    this.persistConversationState(conversation.id, agentId, {
+      transcript: "append",
+      message: localMessage,
+    });
   }
 
   private appendAssistantText(
@@ -2003,6 +2116,9 @@ export class LocalStore {
     this.persistConversationState(
       storedChunk.conversation_id,
       storedChunk.agent_id,
+      {
+        transcript: "skip",
+      },
     );
   }
 
@@ -2136,26 +2252,30 @@ export class LocalStore {
     const before = getCursor(body, "before");
     let maxBytes = 64 * 1024;
     for (;;) {
-      const tail = readJsonlFileSuffix<LocalMessage>(
+      const tail = readJsonlFileSuffix<unknown>(
         metadata.messagesPath,
         maxBytes,
       );
-      assertNoLegacyUiMessageRows(
+      const localMessages = localMessagesFromTranscriptRows(
         tail.items,
+        metadata.messageFormat,
+      );
+      assertNoLegacyUiMessageRows(
+        localMessages,
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const normalizedMessages = localMessages.map(normalizeLocalMessageForPi);
       const conversation = this.conversations.get(key);
       const sourceStartIndex = tail.reachedStart
         ? 0
         : Math.max(
             0,
             (conversation?.in_context_message_ids.length ?? 0) -
-              localMessages.length,
+              normalizedMessages.length,
           );
       const projected = this.projectLocalMessages(
-        localMessages,
+        normalizedMessages,
         agentId,
         conversationId,
         { sourceStartIndex },
@@ -2260,24 +2380,29 @@ export class LocalStore {
 
     let maxBytes = 64 * 1024;
     for (;;) {
-      const tail = readJsonlFileSuffix<LocalMessage>(
+      const tail = readJsonlFileSuffix<unknown>(
         metadata.messagesPath,
         maxBytes,
       );
-      assertNoLegacyUiMessageRows(
+      const localMessages = localMessagesFromTranscriptRows(
         tail.items,
+        metadata.messageFormat,
+      );
+      assertNoLegacyUiMessageRows(
+        localMessages,
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const localMessages = tail.items.map(normalizeLocalMessageForPi);
+      const normalizedMessages = localMessages.map(normalizeLocalMessageForPi);
       const sourceStartIndex = tail.reachedStart
         ? 0
         : Math.max(
             0,
-            conversation.in_context_message_ids.length - localMessages.length,
+            conversation.in_context_message_ids.length -
+              normalizedMessages.length,
           );
       this.projectLocalMessages(
-        localMessages,
+        normalizedMessages,
         conversation.agent_id,
         conversation.id,
         { sourceStartIndex },
@@ -2317,7 +2442,11 @@ export class LocalStore {
       return;
     }
 
-    const rawMessages = readJsonlFile<LocalMessage>(metadata.messagesPath);
+    const rawRows = readJsonlFile<unknown>(metadata.messagesPath);
+    const rawMessages = localMessagesFromTranscriptRows(
+      rawRows,
+      metadata.messageFormat,
+    );
     assertNoLegacyUiMessageRows(
       rawMessages,
       this.storageDir ?? "",
@@ -2340,6 +2469,7 @@ export class LocalStore {
     }
     this.localMessagesByConversationKey.set(key, localMessages);
     this.loadedConversationKeys.add(key);
+    this.resetPersistedSessionState(key, metadata.messageFormat, localMessages);
     for (const message of localMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
@@ -2360,7 +2490,28 @@ export class LocalStore {
     this.localMessagesByConversationKey.set(key, messages);
     this.loadedConversationKeys.add(key);
     this.touchConversationForLocalMessage(conversationId, agentId, message);
-    this.persistConversationState(conversationId, agentId);
+    this.persistConversationState(conversationId, agentId, {
+      transcript: "append",
+      message,
+    });
+  }
+
+  private persistPendingAssistantMessage(
+    conversationId: string,
+    agentId: string,
+  ): void {
+    const messages = this.localMessagesForConversation(conversationId, agentId);
+    const last = messages.at(-1);
+    if (last?.role !== "assistant") {
+      this.persistConversationState(conversationId, agentId, {
+        transcript: "skip",
+      });
+      return;
+    }
+    this.persistConversationState(conversationId, agentId, {
+      transcript: "append",
+      message: last,
+    });
   }
 
   private touchConversationForLocalMessage(
@@ -2491,6 +2642,8 @@ export class LocalStore {
         this.transcriptMetadataByConversationKey.set(key, {
           conversationDir,
           messagesPath: transcriptMessagesPath(conversationDir),
+          messageFormat:
+            manifest?.message_format ?? LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
           timing,
           requiresFullTimestampRepair,
         });
@@ -2548,6 +2701,7 @@ export class LocalStore {
   private persistConversationState(
     conversationId: string,
     agentId: string,
+    options: LocalTranscriptPersistOptions = {},
   ): void {
     if (!this.storageDir) return;
     const key = this.conversationKey(conversationId, agentId);
@@ -2568,13 +2722,115 @@ export class LocalStore {
       writeLocalTranscriptManifest(conversationDir);
     }
     const messagesPath = transcriptMessagesPath(conversationDir);
-    if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
-      writeFileSync(
+    const metadata = this.transcriptMetadataByConversationKey.get(key);
+    const messageFormat =
+      metadata?.messageFormat ?? LOCAL_TRANSCRIPT_MESSAGE_FORMAT;
+    this.persistConversationTranscript(
+      key,
+      conversation,
+      messagesPath,
+      messageFormat,
+      options,
+    );
+    this.persistCompiledSystemPrompt(conversationId, agentId);
+  }
+
+  private persistConversationTranscript(
+    key: string,
+    conversation: StoredConversation,
+    messagesPath: string,
+    messageFormat: LocalTranscriptMessageFormat,
+    options: LocalTranscriptPersistOptions,
+  ): void {
+    if (options.transcript === "skip") return;
+    const messages = this.localMessagesByConversationKey.get(key) ?? [];
+    if (messageFormat === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) {
+      if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
+        writeFileSync(messagesPath, jsonl(messages));
+      }
+      return;
+    }
+
+    if (
+      options.transcript === "append" &&
+      options.message &&
+      existsSync(messagesPath)
+    ) {
+      this.appendConversationSessionEntry(key, messagesPath, options.message);
+      return;
+    }
+
+    if (
+      options.transcript === "rewrite" ||
+      this.loadedConversationKeys.has(key) ||
+      !existsSync(messagesPath)
+    ) {
+      this.rewriteConversationSessionTranscript(
+        key,
+        conversation,
         messagesPath,
-        jsonl(this.localMessagesByConversationKey.get(key) ?? []),
+        messages,
       );
     }
-    this.persistCompiledSystemPrompt(conversationId, agentId);
+  }
+
+  private rewriteConversationSessionTranscript(
+    key: string,
+    conversation: StoredConversation,
+    messagesPath: string,
+    messages: readonly LocalMessage[],
+  ): void {
+    writeFileSync(
+      messagesPath,
+      jsonl(localTranscriptSessionEntries(conversation, messages)),
+    );
+    this.resetPersistedSessionState(
+      key,
+      LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
+      messages,
+    );
+  }
+
+  private appendConversationSessionEntry(
+    key: string,
+    messagesPath: string,
+    message: LocalMessage,
+  ): void {
+    let persistedIds =
+      this.persistedSessionMessageIdsByConversationKey.get(key);
+    if (!persistedIds) {
+      persistedIds = new Set<string>();
+      this.persistedSessionMessageIdsByConversationKey.set(key, persistedIds);
+    }
+    if (persistedIds.has(message.id)) return;
+
+    const parentId = this.lastSessionEntryIdByConversationKey.get(key) ?? null;
+    const entry: LocalTranscriptSessionMessageEntry = {
+      type: "message",
+      id: message.id,
+      parentId,
+      timestamp: localMessageDate(message, currentIsoTimestamp()),
+      message,
+    };
+    appendFileSync(messagesPath, `${JSON.stringify(entry)}\n`);
+    persistedIds.add(message.id);
+    this.lastSessionEntryIdByConversationKey.set(key, entry.id);
+  }
+
+  private resetPersistedSessionState(
+    key: string,
+    messageFormat: LocalTranscriptMessageFormat,
+    messages: readonly LocalMessage[],
+  ): void {
+    if (messageFormat !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT) return;
+    this.persistedSessionMessageIdsByConversationKey.set(
+      key,
+      new Set(messages.map((message) => message.id)),
+    );
+    this.lastSessionEntryIdByConversationKey.set(
+      key,
+      messages.at(-1)?.id ?? null,
+    );
   }
 
   private persistCompiledSystemPrompt(

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -662,17 +662,44 @@ interface LocalTranscriptSessionHeader {
   cwd: string;
 }
 
-interface LocalTranscriptSessionMessageEntry {
-  type: "message";
+interface LocalTranscriptEntryBase {
   id: string;
   parentId: string | null;
   timestamp: string;
+}
+
+interface LocalTranscriptSessionMessageEntry extends LocalTranscriptEntryBase {
+  type: "message";
   message: LocalMessage;
+}
+
+interface LocalTranscriptCompactionEntry extends LocalTranscriptEntryBase {
+  type: "compaction";
+  summary: string;
+  firstKeptEntryId: string | null;
+  tokensBefore: number;
+  message: LocalMessage;
+  details?: {
+    stats?: LocalCompactionStats;
+  };
 }
 
 type LocalTranscriptSessionEntry =
   | LocalTranscriptSessionHeader
-  | LocalTranscriptSessionMessageEntry;
+  | LocalTranscriptSessionMessageEntry
+  | LocalTranscriptCompactionEntry;
+
+type LocalTranscriptAppendEntry =
+  | LocalTranscriptSessionMessageEntry
+  | LocalTranscriptCompactionEntry;
+
+interface LocalTranscriptRowsResult {
+  messages: LocalMessage[];
+  entryIds: Set<string>;
+  entryIdByMessageId: Map<string, string>;
+  lastEntryId: string | null;
+  sourceStartIndex: number;
+}
 
 function isLocalTranscriptSessionMessageEntry(
   value: unknown,
@@ -685,6 +712,33 @@ function isLocalTranscriptSessionMessageEntry(
     typeof value.timestamp === "string" &&
     isRecord(value.message) &&
     typeof value.message.id === "string"
+  );
+}
+
+function isLocalTranscriptCompactionEntry(
+  value: unknown,
+): value is LocalTranscriptCompactionEntry {
+  return (
+    isRecord(value) &&
+    value.type === "compaction" &&
+    typeof value.id === "string" &&
+    (value.parentId === null || typeof value.parentId === "string") &&
+    typeof value.timestamp === "string" &&
+    typeof value.summary === "string" &&
+    (value.firstKeptEntryId === null ||
+      typeof value.firstKeptEntryId === "string") &&
+    typeof value.tokensBefore === "number" &&
+    isRecord(value.message) &&
+    typeof value.message.id === "string"
+  );
+}
+
+function isLocalTranscriptAppendEntry(
+  value: unknown,
+): value is LocalTranscriptAppendEntry {
+  return (
+    isLocalTranscriptSessionMessageEntry(value) ||
+    isLocalTranscriptCompactionEntry(value)
   );
 }
 
@@ -710,7 +764,7 @@ function localTranscriptSessionEntries(
     ...messages.map((message) => {
       const entry: LocalTranscriptSessionMessageEntry = {
         type: "message",
-        id: message.id,
+        id: randomUUID().slice(0, 8),
         parentId,
         timestamp: localMessageDate(message, currentIsoTimestamp()),
         message,
@@ -721,16 +775,66 @@ function localTranscriptSessionEntries(
   ];
 }
 
-function localMessagesFromTranscriptRows(
+function localTranscriptRowsResult(
   rows: readonly unknown[],
   messageFormat: LocalTranscriptMessageFormat,
-): LocalMessage[] {
-  if (messageFormat === LOCAL_TRANSCRIPT_MESSAGE_FORMAT) {
-    return rows
-      .filter(isLocalTranscriptSessionMessageEntry)
-      .map((entry) => entry.message);
+  activeMessageIds: readonly string[] = [],
+): LocalTranscriptRowsResult {
+  if (messageFormat === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) {
+    const allMessages = rows as LocalMessage[];
+    const messageById = new Map(
+      allMessages.map((message) => [message.id, message] as const),
+    );
+    const activeMessages = activeMessageIds.length
+      ? activeMessageIds
+          .map((id) => messageById.get(id))
+          .filter((message): message is LocalMessage => message !== undefined)
+      : allMessages;
+    const firstActiveId = activeMessages[0]?.id;
+    return {
+      messages: activeMessages,
+      entryIds: new Set(allMessages.map((message) => message.id)),
+      entryIdByMessageId: new Map(
+        allMessages.map((message) => [message.id, message.id] as const),
+      ),
+      lastEntryId: allMessages.at(-1)?.id ?? null,
+      sourceStartIndex: firstActiveId
+        ? Math.max(0, activeMessageIds.indexOf(firstActiveId))
+        : 0,
+    };
   }
-  return rows as LocalMessage[];
+
+  const entryIds = new Set<string>();
+  const entryIdByMessageId = new Map<string, string>();
+  const allMessages: LocalMessage[] = [];
+  const messageById = new Map<string, LocalMessage>();
+  let lastEntryId: string | null = null;
+
+  for (const row of rows) {
+    if (!isLocalTranscriptAppendEntry(row)) continue;
+    entryIds.add(row.id);
+    lastEntryId = row.id;
+    entryIdByMessageId.set(row.message.id, row.id);
+    allMessages.push(row.message);
+    messageById.set(row.message.id, row.message);
+  }
+
+  const activeMessages = activeMessageIds.length
+    ? activeMessageIds
+        .map((id) => messageById.get(id))
+        .filter((message): message is LocalMessage => message !== undefined)
+    : allMessages;
+  const firstActiveId = activeMessages[0]?.id;
+
+  return {
+    messages: activeMessages,
+    entryIds,
+    entryIdByMessageId,
+    lastEntryId,
+    sourceStartIndex: firstActiveId
+      ? Math.max(0, activeMessageIds.indexOf(firstActiveId))
+      : 0,
+  };
 }
 
 function createLocalTranscriptManifest(
@@ -819,8 +923,15 @@ interface LocalConversationTranscriptMetadata {
 }
 
 interface LocalTranscriptPersistOptions {
-  transcript?: "append" | "rewrite" | "skip";
+  transcript?: "append" | "append-compaction" | "rewrite" | "skip";
   message?: LocalMessage;
+  compaction?: {
+    summaryMessage: LocalMessage;
+    summary: string;
+    firstKeptMessageId?: string;
+    previousMessages?: readonly LocalMessage[];
+    stats?: LocalCompactionStats;
+  };
 }
 
 function fileIsoTimestamp(value: number | undefined): string | undefined {
@@ -955,9 +1066,13 @@ export class LocalStore {
     string,
     LocalConversationTranscriptMetadata
   >();
-  private readonly persistedSessionMessageIdsByConversationKey = new Map<
+  private readonly sessionEntryIdsByConversationKey = new Map<
     string,
     Set<string>
+  >();
+  private readonly sessionEntryIdByMessageIdByConversationKey = new Map<
+    string,
+    Map<string, string>
   >();
   private readonly lastSessionEntryIdByConversationKey = new Map<
     string,
@@ -1062,7 +1177,8 @@ export class LocalStore {
         this.localMessagesByConversationKey.delete(key);
         this.loadedConversationKeys.delete(key);
         this.transcriptMetadataByConversationKey.delete(key);
-        this.persistedSessionMessageIdsByConversationKey.delete(key);
+        this.sessionEntryIdsByConversationKey.delete(key);
+        this.sessionEntryIdByMessageIdByConversationKey.delete(key);
         this.lastSessionEntryIdByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
@@ -1658,7 +1774,14 @@ export class LocalStore {
     conversation.updated_at = date;
     this.conversations.set(key, conversation);
     this.persistConversationState(conversation.id, input.agentId, {
-      transcript: "rewrite",
+      transcript: "append-compaction",
+      compaction: {
+        summaryMessage,
+        summary: input.summary,
+        firstKeptMessageId: input.remainingMessages?.[0]?.id,
+        previousMessages,
+        ...(input.stats ? { stats: input.stats } : {}),
+      },
     });
     this.rebuildMessageIndex();
     return {
@@ -2256,29 +2379,25 @@ export class LocalStore {
         metadata.messagesPath,
         maxBytes,
       );
-      const localMessages = localMessagesFromTranscriptRows(
+      const conversation = this.conversations.get(key);
+      const transcript = localTranscriptRowsResult(
         tail.items,
         metadata.messageFormat,
+        conversation?.in_context_message_ids ?? [],
       );
       assertNoLegacyUiMessageRows(
-        localMessages,
+        transcript.messages,
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const normalizedMessages = localMessages.map(normalizeLocalMessageForPi);
-      const conversation = this.conversations.get(key);
-      const sourceStartIndex = tail.reachedStart
-        ? 0
-        : Math.max(
-            0,
-            (conversation?.in_context_message_ids.length ?? 0) -
-              normalizedMessages.length,
-          );
+      const normalizedMessages = transcript.messages.map(
+        normalizeLocalMessageForPi,
+      );
       const projected = this.projectLocalMessages(
         normalizedMessages,
         agentId,
         conversationId,
-        { sourceStartIndex },
+        { sourceStartIndex: transcript.sourceStartIndex },
       );
       const cursorFound =
         !before || projected.some((message) => message.id === before);
@@ -2384,28 +2503,24 @@ export class LocalStore {
         metadata.messagesPath,
         maxBytes,
       );
-      const localMessages = localMessagesFromTranscriptRows(
+      const transcript = localTranscriptRowsResult(
         tail.items,
         metadata.messageFormat,
+        conversation.in_context_message_ids,
       );
       assertNoLegacyUiMessageRows(
-        localMessages,
+        transcript.messages,
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const normalizedMessages = localMessages.map(normalizeLocalMessageForPi);
-      const sourceStartIndex = tail.reachedStart
-        ? 0
-        : Math.max(
-            0,
-            conversation.in_context_message_ids.length -
-              normalizedMessages.length,
-          );
+      const normalizedMessages = transcript.messages.map(
+        normalizeLocalMessageForPi,
+      );
       this.projectLocalMessages(
         normalizedMessages,
         conversation.agent_id,
         conversation.id,
-        { sourceStartIndex },
+        { sourceStartIndex: transcript.sourceStartIndex },
       );
       if ((this.messagesById.get(messageId) ?? []).length > 0) return true;
       if (tail.reachedStart) return false;
@@ -2443,20 +2558,21 @@ export class LocalStore {
     }
 
     const rawRows = readJsonlFile<unknown>(metadata.messagesPath);
-    const rawMessages = localMessagesFromTranscriptRows(
+    const conversation = this.conversations.get(key);
+    const transcript = localTranscriptRowsResult(
       rawRows,
       metadata.messageFormat,
+      conversation?.in_context_message_ids ?? [],
     );
     assertNoLegacyUiMessageRows(
-      rawMessages,
+      transcript.messages,
       this.storageDir ?? "",
       metadata.conversationDir,
     );
     const localMessages = repairSyntheticLocalMessageTimestamps(
-      rawMessages.map(normalizeLocalMessageForPi),
+      transcript.messages.map(normalizeLocalMessageForPi),
       metadata.timing,
     );
-    const conversation = this.conversations.get(key);
     if (conversation) {
       this.conversations.set(
         key,
@@ -2469,7 +2585,7 @@ export class LocalStore {
     }
     this.localMessagesByConversationKey.set(key, localMessages);
     this.loadedConversationKeys.add(key);
-    this.resetPersistedSessionState(key, metadata.messageFormat, localMessages);
+    this.resetPersistedSessionState(key, metadata.messageFormat, transcript);
     for (const message of localMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
@@ -2728,6 +2844,7 @@ export class LocalStore {
     this.persistConversationTranscript(
       key,
       conversation,
+      conversationDir,
       messagesPath,
       messageFormat,
       options,
@@ -2738,25 +2855,58 @@ export class LocalStore {
   private persistConversationTranscript(
     key: string,
     conversation: StoredConversation,
+    conversationDir: string,
     messagesPath: string,
     messageFormat: LocalTranscriptMessageFormat,
     options: LocalTranscriptPersistOptions,
   ): void {
     if (options.transcript === "skip") return;
     const messages = this.localMessagesByConversationKey.get(key) ?? [];
+    let activeMessageFormat = messageFormat;
     if (messageFormat === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) {
-      if (this.loadedConversationKeys.has(key) || !existsSync(messagesPath)) {
-        writeFileSync(messagesPath, jsonl(messages));
+      const upgradeMessages = options.compaction?.previousMessages ?? messages;
+      if (upgradeMessages.length === 0) return;
+      this.rewriteConversationSessionTranscript(
+        key,
+        conversation,
+        messagesPath,
+        upgradeMessages,
+      );
+      writeLocalTranscriptManifest(
+        conversationDir,
+        createLocalTranscriptManifest({
+          migratedFrom: "versioned-pi-ai-message-jsonl",
+        }),
+      );
+      const metadata = this.transcriptMetadataByConversationKey.get(key);
+      if (metadata) {
+        this.transcriptMetadataByConversationKey.set(key, {
+          ...metadata,
+          messageFormat: LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
+        });
       }
+      activeMessageFormat = LOCAL_TRANSCRIPT_MESSAGE_FORMAT;
+    }
+
+    if (activeMessageFormat !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT) return;
+
+    if (options.transcript === "append" && options.message) {
+      this.appendConversationSessionMessageEntry(
+        key,
+        conversation,
+        messagesPath,
+        options.message,
+      );
       return;
     }
 
-    if (
-      options.transcript === "append" &&
-      options.message &&
-      existsSync(messagesPath)
-    ) {
-      this.appendConversationSessionEntry(key, messagesPath, options.message);
+    if (options.transcript === "append-compaction" && options.compaction) {
+      this.appendConversationSessionCompactionEntry(
+        key,
+        conversation,
+        messagesPath,
+        options.compaction,
+      );
       return;
     }
 
@@ -2765,6 +2915,7 @@ export class LocalStore {
       this.loadedConversationKeys.has(key) ||
       !existsSync(messagesPath)
     ) {
+      if (messages.length === 0) return;
       this.rewriteConversationSessionTranscript(
         key,
         conversation,
@@ -2780,57 +2931,135 @@ export class LocalStore {
     messagesPath: string,
     messages: readonly LocalMessage[],
   ): void {
-    writeFileSync(
-      messagesPath,
-      jsonl(localTranscriptSessionEntries(conversation, messages)),
-    );
-    this.resetPersistedSessionState(
-      key,
-      LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
-      messages,
-    );
+    if (messages.length === 0) return;
+    const entries = localTranscriptSessionEntries(conversation, messages);
+    writeFileSync(messagesPath, jsonl(entries));
+    this.resetPersistedSessionStateFromEntries(key, entries);
+  }
+
+  private appendConversationSessionMessageEntry(
+    key: string,
+    conversation: StoredConversation,
+    messagesPath: string,
+    message: LocalMessage,
+  ): void {
+    const entryIdByMessageId = this.sessionEntryIdsByMessageId(key);
+    if (entryIdByMessageId.has(message.id)) return;
+
+    this.ensureConversationTranscriptHeader(conversation, messagesPath);
+    const parentId = this.lastSessionEntryIdByConversationKey.get(key) ?? null;
+    const entry: LocalTranscriptSessionMessageEntry = {
+      type: "message",
+      id: this.nextSessionEntryId(key),
+      parentId,
+      timestamp: localMessageDate(message, currentIsoTimestamp()),
+      message,
+    };
+    this.appendConversationSessionEntry(key, messagesPath, entry);
+  }
+
+  private appendConversationSessionCompactionEntry(
+    key: string,
+    conversation: StoredConversation,
+    messagesPath: string,
+    compaction: NonNullable<LocalTranscriptPersistOptions["compaction"]>,
+  ): void {
+    const entryIdByMessageId = this.sessionEntryIdsByMessageId(key);
+    if (entryIdByMessageId.has(compaction.summaryMessage.id)) return;
+
+    this.ensureConversationTranscriptHeader(conversation, messagesPath);
+    const parentId = this.lastSessionEntryIdByConversationKey.get(key) ?? null;
+    const entry: LocalTranscriptCompactionEntry = {
+      type: "compaction",
+      id: this.nextSessionEntryId(key),
+      parentId,
+      timestamp: localMessageDate(
+        compaction.summaryMessage,
+        currentIsoTimestamp(),
+      ),
+      summary: compaction.summary,
+      firstKeptEntryId: compaction.firstKeptMessageId
+        ? (entryIdByMessageId.get(compaction.firstKeptMessageId) ?? null)
+        : null,
+      tokensBefore: compaction.stats?.context_tokens_before ?? 0,
+      message: compaction.summaryMessage,
+      ...(compaction.stats ? { details: { stats: compaction.stats } } : {}),
+    };
+    this.appendConversationSessionEntry(key, messagesPath, entry);
   }
 
   private appendConversationSessionEntry(
     key: string,
     messagesPath: string,
-    message: LocalMessage,
+    entry: LocalTranscriptAppendEntry,
   ): void {
-    let persistedIds =
-      this.persistedSessionMessageIdsByConversationKey.get(key);
-    if (!persistedIds) {
-      persistedIds = new Set<string>();
-      this.persistedSessionMessageIdsByConversationKey.set(key, persistedIds);
-    }
-    if (persistedIds.has(message.id)) return;
-
-    const parentId = this.lastSessionEntryIdByConversationKey.get(key) ?? null;
-    const entry: LocalTranscriptSessionMessageEntry = {
-      type: "message",
-      id: message.id,
-      parentId,
-      timestamp: localMessageDate(message, currentIsoTimestamp()),
-      message,
-    };
     appendFileSync(messagesPath, `${JSON.stringify(entry)}\n`);
-    persistedIds.add(message.id);
+    this.sessionEntryIds(key).add(entry.id);
+    this.sessionEntryIdsByMessageId(key).set(entry.message.id, entry.id);
     this.lastSessionEntryIdByConversationKey.set(key, entry.id);
+  }
+
+  private ensureConversationTranscriptHeader(
+    conversation: StoredConversation,
+    messagesPath: string,
+  ): void {
+    if (existsSync(messagesPath) && statSync(messagesPath).size > 0) return;
+    writeFileSync(
+      messagesPath,
+      `${JSON.stringify(createLocalTranscriptSessionHeader(conversation))}\n`,
+    );
   }
 
   private resetPersistedSessionState(
     key: string,
     messageFormat: LocalTranscriptMessageFormat,
-    messages: readonly LocalMessage[],
+    transcript: LocalTranscriptRowsResult,
   ): void {
     if (messageFormat !== LOCAL_TRANSCRIPT_MESSAGE_FORMAT) return;
-    this.persistedSessionMessageIdsByConversationKey.set(
+    this.sessionEntryIdsByConversationKey.set(key, transcript.entryIds);
+    this.sessionEntryIdByMessageIdByConversationKey.set(
       key,
-      new Set(messages.map((message) => message.id)),
+      transcript.entryIdByMessageId,
     );
-    this.lastSessionEntryIdByConversationKey.set(
+    this.lastSessionEntryIdByConversationKey.set(key, transcript.lastEntryId);
+  }
+
+  private resetPersistedSessionStateFromEntries(
+    key: string,
+    entries: readonly LocalTranscriptSessionEntry[],
+  ): void {
+    this.resetPersistedSessionState(
       key,
-      messages.at(-1)?.id ?? null,
+      LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
+      localTranscriptRowsResult(entries, LOCAL_TRANSCRIPT_MESSAGE_FORMAT),
     );
+  }
+
+  private sessionEntryIds(key: string): Set<string> {
+    let entryIds = this.sessionEntryIdsByConversationKey.get(key);
+    if (!entryIds) {
+      entryIds = new Set<string>();
+      this.sessionEntryIdsByConversationKey.set(key, entryIds);
+    }
+    return entryIds;
+  }
+
+  private sessionEntryIdsByMessageId(key: string): Map<string, string> {
+    let entryIds = this.sessionEntryIdByMessageIdByConversationKey.get(key);
+    if (!entryIds) {
+      entryIds = new Map<string, string>();
+      this.sessionEntryIdByMessageIdByConversationKey.set(key, entryIds);
+    }
+    return entryIds;
+  }
+
+  private nextSessionEntryId(key: string): string {
+    const entryIds = this.sessionEntryIds(key);
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const id = randomUUID().slice(0, 8);
+      if (!entryIds.has(id)) return id;
+    }
+    return randomUUID();
   }
 
   private persistCompiledSystemPrompt(

--- a/src/backend/local/transcript-migration.ts
+++ b/src/backend/local/transcript-migration.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   copyFileSync,
   existsSync,
@@ -84,7 +85,7 @@ function writeSessionEntryJsonl(
     ...messages.map((message) => {
       const entry = {
         type: "message",
-        id: message.id,
+        id: randomUUID().slice(0, 8),
         parentId,
         timestamp:
           message.metadata?.created_at ??

--- a/src/backend/local/transcript-migration.ts
+++ b/src/backend/local/transcript-migration.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { isRecord } from "@/utils/type-guards";
 import { emptyLocalUsage, type LocalMessage } from "./local-message";
 import {
+  LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT,
   LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
   LOCAL_TRANSCRIPT_PROVIDER_STACK,
   LOCAL_TRANSCRIPT_SCHEMA_VERSION,
@@ -64,6 +65,37 @@ function writeJsonl(path: string, items: unknown[]): void {
     path,
     `${items.map((item) => JSON.stringify(item)).join("\n")}\n`,
   );
+}
+
+function writeSessionEntryJsonl(
+  path: string,
+  messages: LocalMessage[],
+  input: { conversationId: string; createdAt?: string },
+): void {
+  let parentId: string | null = null;
+  const entries = [
+    {
+      type: "session",
+      version: 3,
+      id: input.conversationId,
+      timestamp: input.createdAt ?? new Date().toISOString(),
+      cwd: process.cwd(),
+    },
+    ...messages.map((message) => {
+      const entry = {
+        type: "message",
+        id: message.id,
+        parentId,
+        timestamp:
+          message.metadata?.created_at ??
+          new Date(message.timestamp).toISOString(),
+        message,
+      };
+      parentId = entry.id;
+      return entry;
+    }),
+  ];
+  writeJsonl(path, entries);
 }
 
 function timestampForLegacy(message: Record<string, unknown>): number {
@@ -404,9 +436,23 @@ export function migrateLocalBackendTranscripts(input: {
     const messagesPath = join(conversationDir, "messages.jsonl");
     const manifestPath = join(conversationDir, "manifest.json");
     const hasManifest = existsSync(manifestPath);
+    const existingManifest = hasManifest
+      ? (() => {
+          try {
+            return JSON.parse(readFileSync(manifestPath, "utf8")) as {
+              message_format?: unknown;
+            };
+          } catch {
+            return undefined;
+          }
+        })()
+      : undefined;
+    const hasLegacyPiManifest =
+      existingManifest?.message_format ===
+      LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
     const legacyMessages = readJsonl(messagesPath);
     const hasLegacyUiRows = legacyMessages.some(isLegacyUiMessage);
-    if (hasManifest && !hasLegacyUiRows) {
+    if (hasManifest && !hasLegacyUiRows && !hasLegacyPiManifest) {
       result.skipped.push({ conversationDir, reason: "already-versioned" });
       continue;
     }
@@ -421,7 +467,8 @@ export function migrateLocalBackendTranscripts(input: {
       }
       continue;
     }
-    const repairVersioned = hasManifest && hasLegacyUiRows;
+    const repairVersioned =
+      hasManifest && (hasLegacyUiRows || hasLegacyPiManifest);
 
     // Compute the max numeric ID across all messages so that step-split
     // messages get fresh, non-colliding sequential IDs. We check both
@@ -448,16 +495,28 @@ export function migrateLocalBackendTranscripts(input: {
     const backupPath = `${messagesPath}.pre-pi-backup-${timestampSuffix()}`;
     if (!input.dryRun) {
       copyFileSync(messagesPath, backupPath);
-      writeJsonl(messagesPath, converted);
+      const conversationPath = join(conversationDir, "conversation.json");
+      let conversation: Record<string, unknown> | undefined;
+      if (existsSync(conversationPath)) {
+        try {
+          conversation = JSON.parse(readFileSync(conversationPath, "utf8"));
+        } catch {
+          conversation = undefined;
+        }
+      }
+      writeSessionEntryJsonl(messagesPath, converted, {
+        conversationId:
+          typeof conversation?.id === "string" ? conversation.id : name,
+        createdAt:
+          typeof conversation?.created_at === "string"
+            ? conversation.created_at
+            : undefined,
+      });
 
       // Remap in_context_message_ids in conversation.json for any
       // legacy assistant messages that were split into multiple messages.
-      const conversationPath = join(conversationDir, "conversation.json");
-      if (existsSync(conversationPath) && idRemapping.size > 0) {
+      if (conversation && idRemapping.size > 0) {
         try {
-          const conversation = JSON.parse(
-            readFileSync(conversationPath, "utf8"),
-          );
           if (Array.isArray(conversation.in_context_message_ids)) {
             const remapped: string[] = [];
             for (const id of conversation.in_context_message_ids) {
@@ -489,7 +548,9 @@ export function migrateLocalBackendTranscripts(input: {
           manifest({
             backupPath,
             migratedFrom: repairVersioned
-              ? "versioned-pi-transcript-with-legacy-ui-message-rows"
+              ? hasLegacyUiRows
+                ? "versioned-pi-transcript-with-legacy-ui-message-rows"
+                : "versioned-pi-ai-message-jsonl"
               : undefined,
           }),
           null,


### PR DESCRIPTION
## Summary
- Introduce local transcript schema v2: `schema_version: 2` with `message_format: "pi-session-entry-jsonl"`.
- Store new local transcripts as pi-tui-style session-entry JSONL: a `session` header plus immutable `message` and `compaction` entries.
- Keep `messages.jsonl` non-lossy: normal turns append completed messages, compaction appends a `compaction` entry instead of rewriting away historical rows.
- Keep transcript entry IDs separate from local message IDs; `parentId` / `firstKeptEntryId` reference transcript entries, while `conversation.json.in_context_message_ids` remains the active-context source of truth using local message IDs.
- Avoid header-only transcript files: `conversation.json` / `manifest.json` may be created eagerly, but `messages.jsonl` is written lazily when the first transcript entry is appended.
- Preserve upgrade paths: v1 `pi-ai-message-jsonl` transcripts remain readable, are lazily upgraded to v2 on write, and `migrate-transcripts` converts legacy/unversioned transcripts to v2 with backups.

## Format
New v2 transcript example:

```jsonl
{"type":"session","version":3,"id":"local-conv-1","timestamp":"...","cwd":"..."}
{"type":"message","id":"entry-a","parentId":null,"timestamp":"...","message":{"id":"ui-msg-1","role":"user",...}}
{"type":"message","id":"entry-b","parentId":"entry-a","timestamp":"...","message":{"id":"ui-msg-2","role":"assistant",...}}
{"type":"compaction","id":"entry-c","parentId":"entry-b","timestamp":"...","summary":"...","firstKeptEntryId":null,"tokensBefore":123,"message":{"id":"ui-msg-3","role":"user",...}}
```

## Test plan
- [x] `bun test src/backend/local-backend.test.ts src/agent/check-approval-resume-data.test.ts src/backend/fake-headless-backend.test.ts src/backend/local-compaction-parity.test.ts`
- [x] `bun run typecheck`
- [x] pre-commit `tsc --noEmit`

👾 Generated with [Letta Code](https://letta.com)