### PR TITLE
fix(local): restore default conversation auto-titles

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -198,7 +198,29 @@ describe("local backend pi transcript", () => {
     }
   });
 
-  test("rejects updates to the virtual default conversation", async () => {
+  test("allows title updates to the virtual default conversation", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-default-conversation-title-update-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+
+      const updated = await backend.updateConversation("default", {
+        summary: "First user request",
+      } as never);
+
+      expect(updated.summary).toBe("First user request");
+      await expect(
+        backend.retrieveConversation("default"),
+      ).resolves.toMatchObject({
+        summary: "First user request",
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects non-title updates to the virtual default conversation", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-default-conversation-update-"),
     );
@@ -207,9 +229,9 @@ describe("local backend pi transcript", () => {
 
       expect(() =>
         backend.updateConversation("default", {
-          summary: "Default rename",
+          archived: true,
         } as never),
-      ).toThrow("Default conversation cannot be updated");
+      ).toThrow("Default conversation only supports title updates");
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -209,6 +209,13 @@ function createLocalConversationRecord(
   } as StoredConversation;
 }
 
+function isDefaultConversationTitleUpdate(
+  body: ConversationUpdateBody,
+): boolean {
+  const keys = Object.keys(body as Record<string, unknown>);
+  return keys.length > 0 && keys.every((key) => key === "summary");
+}
+
 function updateLocalConversationRecord(
   current: StoredConversation,
   body: ConversationUpdateBody,
@@ -1210,13 +1217,16 @@ export class LocalStore {
     conversationId: string,
     body: ConversationUpdateBody,
   ): Conversation {
-    if (conversationId === "default") {
-      throw new Error("Default conversation cannot be updated");
+    if (
+      conversationId === "default" &&
+      !isDefaultConversationTitleUpdate(body)
+    ) {
+      throw new Error("Default conversation only supports title updates");
     }
 
     const current = this.findConversation(conversationId);
     if (!current) {
-      if (this.strictConversationAccess) {
+      if (this.strictConversationAccess && conversationId !== "default") {
         throw new LocalBackendNotFoundError("Conversation", conversationId);
       }
       const created = this.ensureConversation(conversationId);

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -51,6 +51,7 @@ import {
 } from "@/cli/helpers/accumulator";
 import { classifyApprovals } from "@/cli/helpers/approval-classification";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
+import { shouldPersistAutoConversationTitle } from "@/cli/helpers/conversation-title";
 import {
   type AdvancedDiffSuccess,
   computeAdvancedDiff,
@@ -108,7 +109,6 @@ import { analyzeToolApproval, type ToolExecutionResult } from "@/tools/manager";
 import type { PreparedScopeToolContext } from "@/tools/toolset";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
-
 import {
   CONVERSATION_BUSY_MAX_RETRIES,
   EAGER_CANCEL,
@@ -1657,7 +1657,10 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             if (
               shouldAutoGenerateConversationTitleRef.current &&
               !isAutoConversationTitleInFlightRef.current &&
-              conversationIdRef.current !== "default"
+              shouldPersistAutoConversationTitle(
+                conversationIdRef.current,
+                getBackend().capabilities,
+              )
             ) {
               isAutoConversationTitleInFlightRef.current = true;
               const conversationTitle = await generateConversationTitle();

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -2064,6 +2064,11 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
             try {
               const backend = getBackend();
+              if (conversationId === "default" && !shouldAutoGenerate) {
+                cmd.fail("Default conversation cannot be manually renamed");
+                return { submitted: true };
+              }
+
               if (shouldAutoGenerate) {
                 const conversationTitle = await generateConversationTitle();
                 if (!conversationTitle) {

--- a/src/cli/helpers/conversation-title.test.ts
+++ b/src/cli/helpers/conversation-title.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeConversationTitle,
+  shouldPersistAutoConversationTitle,
+} from "./conversation-title";
+
+describe("conversation title helpers", () => {
+  test("uses normalized first user text as a fallback title", () => {
+    expect(normalizeConversationTitle("  fix   the default title bug  ")).toBe(
+      "fix the default title bug",
+    );
+  });
+
+  test("allows auto-title persistence for local default conversations", () => {
+    expect(
+      shouldPersistAutoConversationTitle("default", {
+        localModelCatalog: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("skips auto-title persistence for hosted default conversations", () => {
+    expect(
+      shouldPersistAutoConversationTitle("default", {
+        localModelCatalog: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -41,6 +41,21 @@ const CONVERSATION_TITLE_USER_PROMPT =
  * Strip whitespace, surrounding quotes, and clamp to {@link CONVERSATION_TITLE_MAX_LENGTH}.
  * Returns null when the input doesn't yield a usable title (empty, slash command, etc.).
  */
+
+export function shouldPersistAutoConversationTitle(
+  conversationId: string | null | undefined,
+  backendCapabilities: { localModelCatalog?: boolean },
+): boolean {
+  if (!conversationId) {
+    return false;
+  }
+
+  return (
+    conversationId !== "default" ||
+    backendCapabilities.localModelCatalog === true
+  );
+}
+
 export function normalizeConversationTitle(value: string): string | null {
   let normalized = value.replace(/\s+/g, " ").trim();
 


### PR DESCRIPTION
## Summary
- Restore local default conversation auto-title persistence for first-user-message fallback titles.
- Keep non-title mutations blocked on the virtual default conversation.
- Add CI-covered tests for default title persistence and hosted/default gating.

## Test plan
- [x] bun test src/cli/helpers/conversation-title.test.ts src/backend/local-backend.test.ts --timeout 15000
- [x] bun run check