### PR TITLE
feat(cli): add skill management commands

### DIFF
--- a/src/cli/agent-selector-shortcuts.test.ts
+++ b/src/cli/agent-selector-shortcuts.test.ts
@@ -9,10 +9,10 @@ describe("agent selector shortcuts", () => {
     );
     const source = readFileSync(selectorPath, "utf-8");
 
-    expect(source).toContain('} else if (input === "D") {');
+    expect(source).toContain('allowDelete && input === "D"');
     expect(source).not.toContain('input === "d" || input === "D"');
 
-    const deleteShortcutIndex = source.indexOf('} else if (input === "D") {');
+    const deleteShortcutIndex = source.indexOf('allowDelete && input === "D"');
     const searchTypingIndex = source.indexOf(
       '} else if (activeTab !== "pinned" && input && !key.ctrl && !key.meta) {',
     );

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -28,6 +28,14 @@ interface AgentSelectorProps {
   onCreateNewAgent?: (name: string, backendMode: AgentBackendMode) => void;
   /** The command that triggered this selector (e.g., "/agents" or "/resume") */
   command?: string;
+  /** Override the overlay title. */
+  title?: string;
+  /** Whether to show the New tab and N shortcut. */
+  showNewTab?: boolean;
+  /** Whether Shift+D can delete agents from the selector. */
+  allowDelete?: boolean;
+  /** Whether Shift+P can unpin agents from the selector. */
+  allowPinActions?: boolean;
 }
 
 type TabId = "pinned" | "local" | "constellation" | "new";
@@ -154,6 +162,10 @@ export function AgentSelector({
   onLogin,
   onCreateNewAgent,
   command = "/agents",
+  title = "Swap to a different agent",
+  showNewTab = true,
+  allowDelete = true,
+  allowPinActions = true,
 }: AgentSelectorProps) {
   const terminalWidth = useTerminalWidth();
 
@@ -169,8 +181,13 @@ export function AgentSelector({
 
   // Compute visible tabs — Local tab only shown when there are local agents
   const visibleTabs = useMemo(
-    () => ALL_TABS.filter((t) => t.id !== "local" || hasLocalAgents),
-    [hasLocalAgents],
+    () =>
+      ALL_TABS.filter(
+        (t) =>
+          (showNewTab || t.id !== "new") &&
+          (t.id !== "local" || hasLocalAgents),
+      ),
+    [hasLocalAgents, showNewTab],
   );
 
   const [activeTab, setActiveTab] = useState<TabId>("pinned");
@@ -179,8 +196,10 @@ export function AgentSelector({
   useEffect(() => {
     if (activeTab === "local" && !hasLocalAgents) {
       setActiveTab("constellation");
+    } else if (activeTab === "new" && !showNewTab) {
+      setActiveTab("pinned");
     }
-  }, [activeTab, hasLocalAgents]);
+  }, [activeTab, hasLocalAgents, showNewTab]);
 
   // Pinned tab state
   const [pinnedAgents, setPinnedAgents] = useState<PinnedAgentData[]>([]);
@@ -706,7 +725,11 @@ export function AgentSelector({
           setConstellationSelectedIndex(0);
         }
       }
-    } else if (activeTab === "pinned" && (input === "p" || input === "P")) {
+    } else if (
+      allowPinActions &&
+      activeTab === "pinned" &&
+      (input === "p" || input === "P")
+    ) {
       // Unpin from current scope (pinned tab only)
       const selected = pinnedPageAgents[pinnedSelectedIndex];
       if (selected) {
@@ -717,7 +740,7 @@ export function AgentSelector({
         }
         loadPinnedAgents();
       }
-    } else if (input === "D") {
+    } else if (allowDelete && input === "D") {
       // Delete agent - open confirmation
       let selectedAgent: AgentState | null = null;
       let selectedAgentId: string | null = null;
@@ -750,7 +773,7 @@ export function AgentSelector({
         });
         setDeleteConfirmInput("");
       }
-    } else if (input === "n" || input === "N") {
+    } else if (showNewTab && (input === "n" || input === "N")) {
       // Switch to New tab
       setActiveTab("new");
     } else if (activeTab !== "pinned" && input && !key.ctrl && !key.meta) {
@@ -931,7 +954,7 @@ export function AgentSelector({
   return (
     <OverlayShell
       command={command}
-      title="Swap to a different agent"
+      title={title}
       footer={
         activeTab !== "new" &&
         !currentLoading &&
@@ -962,8 +985,12 @@ export function AgentSelector({
                   : activeTab === "local"
                     ? `Page ${localPage + 1}/${localTotalPages || 1}`
                     : `Page ${constellationPage + 1}${constellationHasMore ? "+" : `/${constellationTotalPages || 1}`}${constellationLoadingMore ? " (loading...)" : ""}`;
-              const pinnedHint = " · Shift+P unpin";
-              const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch · Shift+D delete${activeTab === "pinned" ? pinnedHint : ""} · Esc cancel`;
+              const deleteHint = allowDelete ? " · Shift+D delete" : "";
+              const pinnedHint =
+                allowPinActions && activeTab === "pinned"
+                  ? " · Shift+P unpin"
+                  : "";
+              const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch${deleteHint}${pinnedHint} · Esc cancel`;
 
               return (
                 <Box flexDirection="column">

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -8,7 +8,7 @@ import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
 import { runSetupSubcommand } from "./setup";
-import { runSkillsSubcommand } from "./skills";
+import { runInstallSubcommand, runSkillsSubcommand } from "./skills";
 
 async function runUpdateSubcommand(): Promise<number> {
   const { manualUpdate } = await import("@/updater/auto-update");
@@ -44,6 +44,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runBackendSubcommand(rest);
     case "setup":
       return runSetupSubcommand(rest);
+    case "install":
+      return runInstallSubcommand(rest);
     case "skills":
       return runSkillsSubcommand(rest);
     case "cron":

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -8,6 +8,7 @@ import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
 import { runSetupSubcommand } from "./setup";
+import { runSkillsSubcommand } from "./skills";
 
 async function runUpdateSubcommand(): Promise<number> {
   const { manualUpdate } = await import("@/updater/auto-update");
@@ -43,6 +44,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runBackendSubcommand(rest);
     case "setup":
       return runSetupSubcommand(rest);
+    case "skills":
+      return runSkillsSubcommand(rest);
     case "cron":
       return runCronSubcommand(rest);
     case "channels":

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  deleteSkillDirectory,
   installSkillDirectory,
+  listSkillDirectories,
   parseClawHubSpecifier,
   parseGitHubSpecifier,
 } from "./skills";
@@ -72,6 +74,46 @@ describe("skills subcommand", () => {
       expect(
         await readFile(join(result.path, "scripts", "client.py"), "utf8"),
       ).toBe("print('ok')\n");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("lists installed skill directories with frontmatter metadata", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-skills-test-"));
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      const skillDir = join(memoryDir, "skills", "stocks");
+      await mkdir(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, "SKILL.md"),
+        "---\nname: stocks\ndescription: Stock quotes\n---\n\n# Stocks\n",
+      );
+
+      expect(await listSkillDirectories({ memoryDir })).toEqual([
+        {
+          name: "stocks",
+          description: "Stock quotes",
+          path: skillDir,
+        },
+      ]);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("deletes an installed skill directory", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-skills-test-"));
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      const skillDir = join(memoryDir, "skills", "stocks");
+      await mkdir(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, "SKILL.md"), "# Stocks\n");
+
+      const result = await deleteSkillDirectory({ memoryDir, name: "stocks" });
+
+      expect(result).toEqual({ name: "stocks", path: skillDir });
+      expect(existsSync(skillDir)).toBe(false);
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  installSkillDirectory,
+  parseClawHubSpecifier,
+  parseGitHubSpecifier,
+} from "./skills";
+
+describe("skills subcommand", () => {
+  test("parses GitHub tree URLs", () => {
+    expect(
+      parseGitHubSpecifier(
+        "https://github.com/owner/repo/tree/main/path/to/skill",
+      ),
+    ).toEqual({
+      repoUrl: "https://github.com/owner/repo.git",
+      branch: null,
+      subdir: "main/path/to/skill",
+    });
+  });
+
+  test("parses GitHub blob SKILL.md URLs as their containing skill directory", () => {
+    expect(
+      parseGitHubSpecifier(
+        "https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md",
+      ),
+    ).toEqual({
+      repoUrl: "https://github.com/owner/repo.git",
+      branch: null,
+      subdir: "main/path/to/skill",
+    });
+  });
+
+  test("parses ClawHub specifiers", () => {
+    expect(parseClawHubSpecifier("clawhub/nano-banana-pro")).toEqual({
+      slug: "nano-banana-pro",
+      version: null,
+    });
+    expect(parseClawHubSpecifier("clawhub:nano-banana-pro@1.0.1")).toEqual({
+      slug: "nano-banana-pro",
+      version: "1.0.1",
+    });
+    expect(
+      parseClawHubSpecifier("https://clawhub.ai/skills/nano-banana-pro"),
+    ).toEqual({
+      slug: "nano-banana-pro",
+      version: null,
+    });
+  });
+
+  test("installs a skill directory into memfs skills using frontmatter name", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-skills-test-"));
+    try {
+      const sourceDir = join(tempRoot, "source", "finance", "stocks");
+      const memoryDir = join(tempRoot, "memory");
+      await mkdir(join(sourceDir, "scripts"), { recursive: true });
+      writeFileSync(
+        join(sourceDir, "SKILL.md"),
+        "---\nname: market-data\ndescription: test\n---\n\n# Market Data\n",
+      );
+      writeFileSync(join(sourceDir, "scripts", "client.py"), "print('ok')\n");
+
+      const result = await installSkillDirectory({ sourceDir, memoryDir });
+
+      expect(result.name).toBe("market-data");
+      expect(await readFile(join(result.path, "SKILL.md"), "utf8")).toContain(
+        "# Market Data",
+      );
+      expect(
+        await readFile(join(result.path, "scripts", "client.py"), "utf8"),
+      ).toBe("print('ok')\n");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -41,7 +41,7 @@ function printUsage(): void {
   console.log(
     `
 Usage:
-  letta skills install <skill> [--agent <id> | -n <name>] [--force]
+  letta install <skill> [--agent <id> | -n <name>] [--force]
 
 Sources:
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
@@ -546,7 +546,7 @@ async function installSkill(
   }
 }
 
-export async function runSkillsSubcommand(argv: string[]): Promise<number> {
+async function runInstall(argv: string[]): Promise<number> {
   let parsed: ReturnType<typeof parseSkillsArgs>;
   try {
     parsed = parseSkillsArgs(argv);
@@ -558,20 +558,14 @@ export async function runSkillsSubcommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const [action, specifier] = parsed.positionals;
-  if (parsed.values.help || !action || action === "help") {
+  const [specifier] = parsed.positionals;
+  if (parsed.values.help || !specifier || specifier === "help") {
     printUsage();
     return 0;
   }
 
-  if (action !== "install") {
-    console.error(`Unknown action: ${action}`);
-    printUsage();
-    return 1;
-  }
-
-  if (!specifier) {
-    console.error("Missing skill identifier or GitHub URL.");
+  if (parsed.positionals.length > 1) {
+    console.error(`Unexpected argument: ${parsed.positionals[1]}`);
     printUsage();
     return 1;
   }
@@ -591,4 +585,22 @@ export async function runSkillsSubcommand(argv: string[]): Promise<number> {
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
+}
+
+export async function runInstallSubcommand(argv: string[]): Promise<number> {
+  return runInstall(argv);
+}
+
+export async function runSkillsSubcommand(argv: string[]): Promise<number> {
+  const [action, ...rest] = argv;
+  if (action === "install") {
+    return runInstall(rest);
+  }
+  if (!action || action === "help" || action === "--help" || action === "-h") {
+    printUsage();
+    return 0;
+  }
+  console.error(`Unknown action: ${action}`);
+  printUsage();
+  return 1;
 }

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -29,6 +29,8 @@ interface InstallResult {
   name: string;
   path: string;
   source: string;
+  committed?: boolean;
+  commitSha?: string;
 }
 
 interface SkillListItem {
@@ -42,6 +44,8 @@ interface DeleteResult {
   name: string;
   path: string;
   deleted: true;
+  committed?: boolean;
+  commitSha?: string;
 }
 
 interface ClawHubSourceLocation {
@@ -633,7 +637,19 @@ async function installSkill(
       throw new Error(`Skill path not found: ${missingPath}`);
     }
     const result = await installSkillDirectory({ sourceDir, memoryDir, force });
-    return { agentId, source: specifier, ...result };
+    const commit = await commitSkillMemoryChange({
+      agentId,
+      memoryDir,
+      skillName: result.name,
+      reason: `chore(skills): install ${result.name}`,
+    });
+    return {
+      agentId,
+      source: specifier,
+      ...result,
+      committed: commit.committed,
+      commitSha: commit.sha,
+    };
   } finally {
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -656,6 +672,40 @@ async function getAgentMemoryDir(agentId: string): Promise<string> {
   return getScopedMemoryFilesystemRoot(agentId);
 }
 
+async function commitSkillMemoryChange(params: {
+  agentId: string;
+  memoryDir: string;
+  skillName: string;
+  reason: string;
+}): Promise<{ committed: boolean; sha?: string }> {
+  const { commitAndSyncMemoryWrite } = await import("@/agent/memory-git");
+  const { getBackend } = await import("@/backend");
+
+  let authorName = "Letta Code";
+  try {
+    const agent = await getBackend().retrieveAgent(params.agentId);
+    if (agent.name?.trim()) {
+      authorName = agent.name.trim();
+    }
+  } catch {
+    // Best effort only; committing should not depend on fetching display name.
+  }
+
+  const result = await commitAndSyncMemoryWrite({
+    memoryDir: params.memoryDir,
+    pathspecs: [`skills/${params.skillName}`],
+    reason: params.reason,
+    author: {
+      agentId: params.agentId,
+      authorName,
+      authorEmail: `${params.agentId}@letta.com`,
+    },
+    syncMode: isLocalAgentId(params.agentId) ? "local" : "remote",
+  });
+
+  return { committed: result.committed, sha: result.sha };
+}
+
 async function listSkills(agentId: string): Promise<{
   agentId: string;
   skills: SkillListItem[];
@@ -671,7 +721,19 @@ async function deleteSkill(
 ): Promise<DeleteResult> {
   const memoryDir = await getAgentMemoryDir(agentId);
   const result = await deleteSkillDirectory({ memoryDir, name: skillName });
-  return { agentId, deleted: true, ...result };
+  const commit = await commitSkillMemoryChange({
+    agentId,
+    memoryDir,
+    skillName: result.name,
+    reason: `chore(skills): delete ${result.name}`,
+  });
+  return {
+    agentId,
+    deleted: true,
+    ...result,
+    committed: commit.committed,
+    commitSha: commit.sha,
+  };
 }
 
 async function initializeAndResolveAgent(

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -63,7 +63,7 @@ function printUsage(): void {
 Usage:
   letta install <skill> [--agent <id> | -n <agent name>] [--force]
   letta skills list [--agent <id> | -n <agent name>]
-  letta skills delete <skill_name> [--agent <id> | -n <agent name>]
+  letta skills delete <skill_name> --agent <id>
 
 Sources:
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
@@ -100,6 +100,15 @@ function parseSkillsArgs(argv: string[]) {
 
 function isAgentId(value: string): boolean {
   return value.startsWith("agent-") || value.startsWith("agent_");
+}
+
+function getExplicitAgentId(
+  values: ReturnType<typeof parseSkillsArgs>["values"],
+): string | null {
+  const explicitAgent = values.agent || values["agent-id"];
+  return typeof explicitAgent === "string" && explicitAgent.trim()
+    ? explicitAgent.trim()
+    : null;
 }
 
 function paginatedItems<T>(page: unknown): T[] {
@@ -199,10 +208,8 @@ async function resolveAgentId(
   values: ReturnType<typeof parseSkillsArgs>["values"],
   promptStatusMessage = "Working...",
 ): Promise<string> {
-  const explicitAgent = values.agent || values["agent-id"];
-  if (typeof explicitAgent === "string" && explicitAgent.trim()) {
-    return explicitAgent.trim();
-  }
+  const explicitAgent = getExplicitAgentId(values);
+  if (explicitAgent) return explicitAgent;
 
   if (typeof values.name === "string" && values.name.trim()) {
     const nameOrId = values.name.trim();
@@ -859,11 +866,24 @@ async function runDelete(argv: string[]): Promise<number> {
     return 1;
   }
 
-  try {
-    const agentId = await initializeAndResolveAgent(
-      parsed.values,
-      `Deleting ${skillName}...`,
+  const agentId = getExplicitAgentId(parsed.values);
+  if (!agentId) {
+    console.error(
+      "Deleting a skill requires an explicit agent id. Re-run with --agent <id> or --agent-id <id>.",
     );
+    return 1;
+  }
+
+  if (skillName.includes("/")) {
+    console.error(
+      `Invalid installed skill name "${skillName}". Delete expects the installed directory name, e.g. "meme-generation", not a source specifier like "official/creative/meme-generation".`,
+    );
+    return 1;
+  }
+
+  try {
+    const { settingsManager } = await import("@/settings-manager");
+    await settingsManager.initialize();
     const result = await deleteSkill(skillName, agentId);
     stopAgentPromptStatus();
     console.log(JSON.stringify(result, null, 2));

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -129,46 +129,41 @@ async function resolveAgentByName(name: string): Promise<string> {
   return id;
 }
 
-async function listSelectableAgents(): Promise<AgentState[]> {
-  const { getBackend } = await import("@/backend");
-  const backend = getBackend();
-  const page = await backend.listAgents({ limit: 100 } as never);
-  return paginatedItems<AgentState>(page).filter((agent) => Boolean(agent.id));
-}
-
 async function promptForAgent(): Promise<string> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Missing agent id. Pass --agent <id> or -n <agent name>.");
   }
 
-  const agents = await listSelectableAgents();
-  if (agents.length === 0) {
-    throw new Error(
-      "No agents found. Pass --agent <id> if the agent is hidden.",
+  const { render } = await import("ink");
+  const React = await import("react");
+  const { AgentSelector } = await import("@/cli/components/AgentSelector");
+
+  return new Promise<string>((resolveAgent, rejectAgent) => {
+    let settled = false;
+    const { unmount } = render(
+      React.createElement(AgentSelector, {
+        currentAgentId:
+          process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "",
+        command: "letta skills",
+        title: "Select an agent",
+        showNewTab: false,
+        allowDelete: false,
+        allowPinActions: false,
+        onSelect: (agentId: string) => {
+          if (settled) return;
+          settled = true;
+          unmount();
+          resolveAgent(agentId);
+        },
+        onCancel: () => {
+          if (settled) return;
+          settled = true;
+          unmount();
+          rejectAgent(new Error("Agent selection cancelled."));
+        },
+      }),
     );
-  }
-
-  console.log("Select an agent:");
-  agents.forEach((agent, index) => {
-    console.log(`  ${index + 1}. ${agent.name || "Unnamed"} (${agent.id})`);
   });
-  process.stdout.write("Enter number: ");
-
-  const answer = await new Promise<string>((resolveAnswer) => {
-    process.stdin.setEncoding("utf8");
-    process.stdin.resume();
-    process.stdin.once("data", (chunk) => {
-      process.stdin.pause();
-      resolveAnswer(String(chunk).trim());
-    });
-  });
-
-  const index = Number.parseInt(answer, 10) - 1;
-  const selected = agents[index];
-  if (!selected?.id) {
-    throw new Error("Invalid agent selection.");
-  }
-  return selected.id;
 }
 
 async function resolveAgentId(

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -1,0 +1,594 @@
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, normalize, resolve, sep } from "node:path";
+import { parseArgs } from "node:util";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { parseFrontmatter } from "@/utils/frontmatter";
+
+const HERMES_REPO_URL = "https://github.com/NousResearch/hermes-agent.git";
+const HERMES_OPTIONAL_SKILLS_DIR = "optional-skills";
+
+interface SkillSourceLocation {
+  repoUrl: string;
+  branch: string | null;
+  subdir: string | null;
+}
+
+interface InstallResult {
+  agentId: string;
+  name: string;
+  path: string;
+  source: string;
+}
+
+interface ClawHubSourceLocation {
+  slug: string;
+  version: string | null;
+}
+
+const CLAWHUB_API_BASE_URL = "https://clawhub.ai/api/v1";
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta skills install <skill> [--agent <id> | -n <name>] [--force]
+
+Sources:
+  official/<path>         Hermes official optional skill, e.g. official/finance/stocks
+  clawhub/<slug>          ClawHub registry skill, e.g. clawhub/nano-banana-pro
+  clawhub:<slug>          ClawHub registry skill, optionally <slug>@<version>
+  https://github.com/...  GitHub repository, tree URL, or SKILL.md blob URL
+  owner/repo/path         GitHub repo/path shorthand
+
+Options:
+  --agent <id>            Install into this agent's memfs repository
+  --agent-id <id>         Alias for --agent
+  -n, --name <name>       Install into the agent with this exact name
+  --force                 Replace an existing skill with the same name
+`.trim(),
+  );
+}
+
+const SKILLS_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  agent: { type: "string" },
+  "agent-id": { type: "string" },
+  name: { type: "string", short: "n" },
+  force: { type: "boolean" },
+} as const;
+
+function parseSkillsArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: SKILLS_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function isAgentId(value: string): boolean {
+  return value.startsWith("agent-") || value.startsWith("agent_");
+}
+
+function paginatedItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  const items = (page as { items?: unknown }).items;
+  return Array.isArray(items) ? (items as T[]) : [];
+}
+
+async function findAgentsByName(name: string): Promise<AgentState[]> {
+  const { getBackend } = await import("@/backend");
+  const backend = getBackend();
+  const page = await backend.listAgents({
+    query_text: name,
+    limit: 100,
+  } as never);
+  const normalizedName = name.toLowerCase();
+  return paginatedItems<AgentState>(page).filter(
+    (agent) => agent.name?.toLowerCase() === normalizedName,
+  );
+}
+
+async function resolveAgentByName(name: string): Promise<string> {
+  const matches = await findAgentsByName(name);
+  if (matches.length === 0) {
+    throw new Error(`No agent found with name "${name}".`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple agents found with name "${name}". Pass --agent with an agent id instead.`,
+    );
+  }
+  const id = matches[0]?.id;
+  if (!id) throw new Error(`Agent "${name}" did not include an id.`);
+  return id;
+}
+
+async function listSelectableAgents(): Promise<AgentState[]> {
+  const { getBackend } = await import("@/backend");
+  const backend = getBackend();
+  const page = await backend.listAgents({ limit: 100 } as never);
+  return paginatedItems<AgentState>(page).filter((agent) => Boolean(agent.id));
+}
+
+async function promptForAgent(): Promise<string> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("Missing agent id. Pass --agent <id> or -n <agent name>.");
+  }
+
+  const agents = await listSelectableAgents();
+  if (agents.length === 0) {
+    throw new Error(
+      "No agents found. Pass --agent <id> if the agent is hidden.",
+    );
+  }
+
+  console.log("Select an agent:");
+  agents.forEach((agent, index) => {
+    console.log(`  ${index + 1}. ${agent.name || "Unnamed"} (${agent.id})`);
+  });
+  process.stdout.write("Enter number: ");
+
+  const answer = await new Promise<string>((resolveAnswer) => {
+    process.stdin.setEncoding("utf8");
+    process.stdin.resume();
+    process.stdin.once("data", (chunk) => {
+      process.stdin.pause();
+      resolveAnswer(String(chunk).trim());
+    });
+  });
+
+  const index = Number.parseInt(answer, 10) - 1;
+  const selected = agents[index];
+  if (!selected?.id) {
+    throw new Error("Invalid agent selection.");
+  }
+  return selected.id;
+}
+
+async function resolveAgentId(
+  values: ReturnType<typeof parseSkillsArgs>["values"],
+): Promise<string> {
+  const explicitAgent = values.agent || values["agent-id"];
+  if (typeof explicitAgent === "string" && explicitAgent.trim()) {
+    return explicitAgent.trim();
+  }
+
+  if (typeof values.name === "string" && values.name.trim()) {
+    const nameOrId = values.name.trim();
+    if (isAgentId(nameOrId)) return nameOrId;
+    return resolveAgentByName(nameOrId);
+  }
+
+  const envAgent = process.env.LETTA_AGENT_ID || process.env.AGENT_ID;
+  if (envAgent?.trim()) return envAgent.trim();
+
+  return promptForAgent();
+}
+
+export function parseGitHubSpecifier(
+  input: string,
+): SkillSourceLocation | null {
+  const trimmed = input.trim();
+
+  if (
+    trimmed.startsWith("https://github.com/") ||
+    trimmed.startsWith("http://github.com/")
+  ) {
+    const url = new URL(trimmed);
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const [owner, repoWithSuffix] = parts;
+    const repo = repoWithSuffix?.replace(/\.git$/, "");
+    if (!owner || !repo) return null;
+    const repoUrl = `https://github.com/${owner}/${repo}.git`;
+    const marker = parts[2];
+    if ((marker === "tree" || marker === "blob") && parts.length >= 4) {
+      const treePath = parts.slice(3).join("/");
+      return {
+        repoUrl,
+        branch: null,
+        subdir: marker === "blob" ? dirname(treePath) : treePath,
+      };
+    }
+    return { repoUrl, branch: null, subdir: null };
+  }
+
+  const shorthand = trimmed.split("/").filter(Boolean);
+  if (shorthand.length >= 3 && shorthand[0] !== "official") {
+    return {
+      repoUrl: `https://github.com/${shorthand[0]}/${shorthand[1]}.git`,
+      branch: null,
+      subdir: shorthand.slice(2).join("/"),
+    };
+  }
+
+  if (shorthand.length === 2 && shorthand[0] !== "official") {
+    return {
+      repoUrl: `https://github.com/${shorthand[0]}/${shorthand[1]}.git`,
+      branch: null,
+      subdir: null,
+    };
+  }
+
+  return null;
+}
+
+export function parseClawHubSpecifier(
+  input: string,
+): ClawHubSourceLocation | null {
+  const trimmed = input.trim();
+  let identifier: string | null = null;
+
+  if (trimmed.startsWith("clawhub:")) {
+    identifier = trimmed.slice("clawhub:".length);
+  } else if (trimmed.startsWith("clawhub/")) {
+    identifier = trimmed.slice("clawhub/".length);
+  } else if (
+    trimmed.startsWith("https://clawhub.ai/") ||
+    trimmed.startsWith("http://clawhub.ai/")
+  ) {
+    const url = new URL(trimmed);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const skillIndex = parts.indexOf("skills");
+    const skillSlug = parts[skillIndex + 1];
+    if (skillIndex >= 0 && skillSlug) {
+      identifier = skillSlug;
+    } else {
+      identifier = parts.at(-1) ?? null;
+    }
+    const version = url.searchParams.get("version");
+    if (identifier && version) identifier = `${identifier}@${version}`;
+  }
+
+  if (!identifier) return null;
+  const cleaned = identifier.replace(/^\/+|\/+$/g, "");
+  const finalSegment = cleaned.split("/").filter(Boolean).at(-1);
+  if (!finalSegment) return null;
+
+  const atIndex = finalSegment.lastIndexOf("@");
+  const slug = atIndex >= 0 ? finalSegment.slice(0, atIndex) : finalSegment;
+  const version = atIndex >= 0 ? finalSegment.slice(atIndex + 1) : null;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(slug)) return null;
+  if (version !== null && !/^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(version)) {
+    return null;
+  }
+  return { slug, version: version || null };
+}
+
+function parseOfficialSpecifier(input: string): SkillSourceLocation | null {
+  if (!input.startsWith("official/")) return null;
+  const relativePath = input
+    .slice("official/".length)
+    .replace(/^\/+|\/+$/g, "");
+  if (!relativePath || relativePath.includes("..")) return null;
+  return {
+    repoUrl: HERMES_REPO_URL,
+    branch: null,
+    subdir: `${HERMES_OPTIONAL_SKILLS_DIR}/${relativePath}`,
+  };
+}
+
+async function execFile(
+  command: string,
+  args: string[],
+  options: { cwd?: string; timeout?: number } = {},
+) {
+  const { execFile: execFileCb } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  return promisify(execFileCb)(command, args, options);
+}
+
+async function resolveBranchAndSubdir(
+  location: SkillSourceLocation,
+): Promise<SkillSourceLocation> {
+  if (!location.subdir) return location;
+
+  const { stdout } = await execFile(
+    "git",
+    ["ls-remote", "--heads", location.repoUrl],
+    {
+      timeout: 60_000,
+    },
+  );
+  const branches = stdout
+    .split("\n")
+    .map((line) => line.match(/refs\/heads\/(.+)$/)?.[1])
+    .filter((branch): branch is string => Boolean(branch))
+    .sort((a, b) => b.length - a.length);
+
+  for (const branch of branches) {
+    if (location.subdir === branch) {
+      return { ...location, branch, subdir: null };
+    }
+    if (location.subdir.startsWith(`${branch}/`)) {
+      return {
+        ...location,
+        branch,
+        subdir: location.subdir.slice(branch.length + 1),
+      };
+    }
+  }
+
+  return location;
+}
+
+async function cloneSkillSource(
+  location: SkillSourceLocation,
+): Promise<{ tmpDir: string; sourceDir: string }> {
+  const resolvedLocation = await resolveBranchAndSubdir(location);
+  const tmpDir = mkdtempSync(join(tmpdir(), "letta-skill-install-"));
+  const args = ["clone", "--depth", "1"];
+  if (resolvedLocation.branch) {
+    args.push("--branch", resolvedLocation.branch);
+  }
+  args.push(resolvedLocation.repoUrl, tmpDir);
+  await execFile("git", args, { timeout: 120_000 });
+
+  const sourceDir = resolvedLocation.subdir
+    ? join(tmpDir, resolvedLocation.subdir)
+    : tmpDir;
+  return { tmpDir, sourceDir };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function resolveClawHubVersion(
+  location: ClawHubSourceLocation,
+): Promise<string> {
+  if (location.version) return location.version;
+
+  const skillData = await fetchJson(
+    `${CLAWHUB_API_BASE_URL}/skills/${encodeURIComponent(location.slug)}`,
+  );
+  if (!skillData || typeof skillData !== "object") {
+    throw new Error(`ClawHub skill not found: ${location.slug}`);
+  }
+
+  const data = skillData as {
+    latestVersion?: { version?: unknown };
+    skill?: { latestVersion?: { version?: unknown }; tags?: unknown };
+    tags?: unknown;
+  };
+  const latestVersion = data.latestVersion ?? data.skill?.latestVersion;
+  if (typeof latestVersion?.version === "string" && latestVersion.version) {
+    return latestVersion.version;
+  }
+
+  const tags = data.skill?.tags ?? data.tags;
+  if (
+    tags &&
+    typeof tags === "object" &&
+    typeof (tags as { latest?: unknown }).latest === "string"
+  ) {
+    return (tags as { latest: string }).latest;
+  }
+
+  throw new Error(
+    `Could not resolve latest ClawHub version for ${location.slug}`,
+  );
+}
+
+function assertSafeZipMember(name: string): void {
+  const normalized = name.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter(Boolean);
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    parts.length === 0 ||
+    parts.some((part) => part === "..") ||
+    /^[A-Za-z]:$/.test(parts[0] ?? "")
+  ) {
+    throw new Error(`Unsafe path in ClawHub ZIP: ${name}`);
+  }
+}
+
+async function downloadClawHubSkillSource(
+  location: ClawHubSourceLocation,
+): Promise<{ tmpDir: string; sourceDir: string }> {
+  const version = await resolveClawHubVersion(location);
+  const tmpDir = mkdtempSync(join(tmpdir(), "letta-clawhub-skill-"));
+  const zipPath = join(tmpDir, "skill.zip");
+  const sourceDir = join(tmpDir, "skill");
+  await mkdir(sourceDir, { recursive: true });
+
+  const url = new URL(`${CLAWHUB_API_BASE_URL}/download`);
+  url.searchParams.set("slug", location.slug);
+  url.searchParams.set("version", version);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `ClawHub download failed for ${location.slug}@${version}: ${response.status}`,
+    );
+  }
+  writeFileSync(zipPath, Buffer.from(await response.arrayBuffer()));
+
+  const { stdout } = await execFile("unzip", ["-Z1", zipPath], {
+    timeout: 30_000,
+  });
+  const members = stdout.split("\n").filter(Boolean);
+  if (members.length === 0) {
+    throw new Error(
+      `ClawHub download was empty for ${location.slug}@${version}`,
+    );
+  }
+  members.forEach(assertSafeZipMember);
+
+  await execFile("unzip", ["-q", zipPath, "-d", sourceDir], {
+    timeout: 30_000,
+  });
+
+  return { tmpDir, sourceDir };
+}
+
+function assertInside(parent: string, child: string): void {
+  const parentPath = resolve(parent);
+  const childPath = resolve(child);
+  if (
+    childPath !== parentPath &&
+    !childPath.startsWith(`${parentPath}${sep}`)
+  ) {
+    throw new Error(`Resolved path is outside target directory: ${child}`);
+  }
+}
+
+function sanitizeSkillName(name: string): string {
+  const trimmed = name.trim();
+  if (
+    !/^[A-Za-z0-9._-]+$/.test(trimmed) ||
+    trimmed === "." ||
+    trimmed === ".."
+  ) {
+    throw new Error(`Invalid skill name "${name}".`);
+  }
+  return trimmed;
+}
+
+function getSkillName(sourceDir: string): string {
+  const skillMd = readFileSync(join(sourceDir, "SKILL.md"), "utf8");
+  const { frontmatter } = parseFrontmatter(skillMd);
+  const frontmatterName = frontmatter.name;
+  const name =
+    typeof frontmatterName === "string" && frontmatterName.trim()
+      ? frontmatterName
+      : basename(sourceDir);
+  return sanitizeSkillName(name);
+}
+
+export async function installSkillDirectory(params: {
+  sourceDir: string;
+  memoryDir: string;
+  force?: boolean;
+}): Promise<{ name: string; path: string }> {
+  const sourceDir = resolve(params.sourceDir);
+  const memoryDir = resolve(params.memoryDir);
+  const skillMdPath = join(sourceDir, "SKILL.md");
+  if (!existsSync(skillMdPath)) {
+    throw new Error("No SKILL.md found in the skill directory.");
+  }
+  if (!statSync(sourceDir).isDirectory()) {
+    throw new Error(`Skill source is not a directory: ${sourceDir}`);
+  }
+
+  const name = getSkillName(sourceDir);
+  const skillsDir = join(memoryDir, "skills");
+  const targetPath = join(skillsDir, name);
+  assertInside(skillsDir, targetPath);
+
+  if (existsSync(targetPath)) {
+    if (!params.force) {
+      throw new Error(
+        `Skill "${name}" already exists at ${targetPath}. Re-run with --force to replace it.`,
+      );
+    }
+    rmSync(targetPath, { recursive: true, force: true });
+  }
+
+  await mkdir(skillsDir, { recursive: true });
+  cpSync(sourceDir, targetPath, {
+    recursive: true,
+    filter: (source) => basename(source) !== ".git",
+  });
+  return { name, path: normalize(targetPath) };
+}
+
+async function installSkill(
+  specifier: string,
+  agentId: string,
+  force: boolean,
+): Promise<InstallResult> {
+  const clawHubSource = parseClawHubSpecifier(specifier);
+  const gitSource = clawHubSource
+    ? null
+    : (parseOfficialSpecifier(specifier) ?? parseGitHubSpecifier(specifier));
+  if (!gitSource && !clawHubSource) {
+    throw new Error(`Unsupported skill source: ${specifier}`);
+  }
+
+  const { ensureLocalMemfsCheckout, getScopedMemoryFilesystemRoot } =
+    await import("@/agent/memory-filesystem");
+  await ensureLocalMemfsCheckout(agentId);
+  const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+  let tmpDir: string | null = null;
+  try {
+    const downloaded = gitSource
+      ? await cloneSkillSource(gitSource)
+      : await downloadClawHubSkillSource(
+          clawHubSource as ClawHubSourceLocation,
+        );
+    tmpDir = downloaded.tmpDir;
+    const sourceDir = resolve(downloaded.sourceDir);
+    assertInside(tmpDir, sourceDir);
+    if (!existsSync(sourceDir)) {
+      const missingPath = gitSource?.subdir || clawHubSource?.slug || ".";
+      throw new Error(`Skill path not found: ${missingPath}`);
+    }
+    const result = await installSkillDirectory({ sourceDir, memoryDir, force });
+    return { agentId, source: specifier, ...result };
+  } finally {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+export async function runSkillsSubcommand(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseSkillsArgs>;
+  try {
+    parsed = parseSkillsArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  const [action, specifier] = parsed.positionals;
+  if (parsed.values.help || !action || action === "help") {
+    printUsage();
+    return 0;
+  }
+
+  if (action !== "install") {
+    console.error(`Unknown action: ${action}`);
+    printUsage();
+    return 1;
+  }
+
+  if (!specifier) {
+    console.error("Missing skill identifier or GitHub URL.");
+    printUsage();
+    return 1;
+  }
+
+  try {
+    const { settingsManager } = await import("@/settings-manager");
+    await settingsManager.initialize();
+    const agentId = await resolveAgentId(parsed.values);
+    const result = await installSkill(
+      specifier,
+      agentId,
+      Boolean(parsed.values.force),
+    );
+    console.log(JSON.stringify(result, null, 2));
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -7,7 +7,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, normalize, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
@@ -30,6 +30,19 @@ interface InstallResult {
   source: string;
 }
 
+interface SkillListItem {
+  name: string;
+  path: string;
+  description?: string;
+}
+
+interface DeleteResult {
+  agentId: string;
+  name: string;
+  path: string;
+  deleted: true;
+}
+
 interface ClawHubSourceLocation {
   slug: string;
   version: string | null;
@@ -41,7 +54,9 @@ function printUsage(): void {
   console.log(
     `
 Usage:
-  letta install <skill> [--agent <id> | -n <name>] [--force]
+  letta install <skill> [--agent <id> | -n <agent name>] [--force]
+  letta skills list [--agent <id> | -n <agent name>]
+  letta skills delete <skill_name> [--agent <id> | -n <agent name>]
 
 Sources:
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
@@ -508,6 +523,66 @@ export async function installSkillDirectory(params: {
   return { name, path: normalize(targetPath) };
 }
 
+export async function listSkillDirectories(params: {
+  memoryDir: string;
+}): Promise<SkillListItem[]> {
+  const memoryDir = resolve(params.memoryDir);
+  const skillsDir = join(memoryDir, "skills");
+  if (!existsSync(skillsDir)) return [];
+
+  const entries = await readdir(skillsDir, { withFileTypes: true });
+  const skills: SkillListItem[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillDir = join(skillsDir, entry.name);
+    const skillMdPath = join(skillDir, "SKILL.md");
+    if (!existsSync(skillMdPath)) continue;
+
+    let name = entry.name;
+    let description: string | undefined;
+    try {
+      const skillMd = readFileSync(skillMdPath, "utf8");
+      const { frontmatter } = parseFrontmatter(skillMd);
+      if (typeof frontmatter.name === "string" && frontmatter.name.trim()) {
+        name = frontmatter.name.trim();
+      }
+      if (
+        typeof frontmatter.description === "string" &&
+        frontmatter.description.trim()
+      ) {
+        description = frontmatter.description.trim();
+      }
+    } catch {
+      // Keep listing valid skill directories even if their frontmatter is malformed.
+    }
+
+    skills.push({ name, path: normalize(skillDir), description });
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function deleteSkillDirectory(params: {
+  memoryDir: string;
+  name: string;
+}): Promise<{ name: string; path: string }> {
+  const memoryDir = resolve(params.memoryDir);
+  const skillsDir = join(memoryDir, "skills");
+  const name = sanitizeSkillName(params.name);
+  const targetPath = join(skillsDir, name);
+  assertInside(skillsDir, targetPath);
+
+  if (!existsSync(targetPath)) {
+    throw new Error(`Skill "${name}" is not installed at ${targetPath}.`);
+  }
+  if (!statSync(targetPath).isDirectory()) {
+    throw new Error(`Skill path is not a directory: ${targetPath}`);
+  }
+
+  rmSync(targetPath, { recursive: true, force: true });
+  return { name, path: normalize(targetPath) };
+}
+
 async function installSkill(
   specifier: string,
   agentId: string,
@@ -521,10 +596,7 @@ async function installSkill(
     throw new Error(`Unsupported skill source: ${specifier}`);
   }
 
-  const { ensureLocalMemfsCheckout, getScopedMemoryFilesystemRoot } =
-    await import("@/agent/memory-filesystem");
-  await ensureLocalMemfsCheckout(agentId);
-  const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+  const memoryDir = await getAgentMemoryDir(agentId);
   let tmpDir: string | null = null;
   try {
     const downloaded = gitSource
@@ -544,6 +616,39 @@ async function installSkill(
   } finally {
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
   }
+}
+
+async function getAgentMemoryDir(agentId: string): Promise<string> {
+  const { ensureLocalMemfsCheckout, getScopedMemoryFilesystemRoot } =
+    await import("@/agent/memory-filesystem");
+  await ensureLocalMemfsCheckout(agentId);
+  return getScopedMemoryFilesystemRoot(agentId);
+}
+
+async function listSkills(agentId: string): Promise<{
+  agentId: string;
+  skills: SkillListItem[];
+}> {
+  const memoryDir = await getAgentMemoryDir(agentId);
+  const skills = await listSkillDirectories({ memoryDir });
+  return { agentId, skills };
+}
+
+async function deleteSkill(
+  skillName: string,
+  agentId: string,
+): Promise<DeleteResult> {
+  const memoryDir = await getAgentMemoryDir(agentId);
+  const result = await deleteSkillDirectory({ memoryDir, name: skillName });
+  return { agentId, deleted: true, ...result };
+}
+
+async function initializeAndResolveAgent(
+  values: ReturnType<typeof parseSkillsArgs>["values"],
+): Promise<string> {
+  const { settingsManager } = await import("@/settings-manager");
+  await settingsManager.initialize();
+  return resolveAgentId(values);
 }
 
 async function runInstall(argv: string[]): Promise<number> {
@@ -571,9 +676,7 @@ async function runInstall(argv: string[]): Promise<number> {
   }
 
   try {
-    const { settingsManager } = await import("@/settings-manager");
-    await settingsManager.initialize();
-    const agentId = await resolveAgentId(parsed.values);
+    const agentId = await initializeAndResolveAgent(parsed.values);
     const result = await installSkill(
       specifier,
       agentId,
@@ -591,16 +694,91 @@ export async function runInstallSubcommand(argv: string[]): Promise<number> {
   return runInstall(argv);
 }
 
-export async function runSkillsSubcommand(argv: string[]): Promise<number> {
-  const [action, ...rest] = argv;
-  if (action === "install") {
-    return runInstall(rest);
+async function runList(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseSkillsArgs>;
+  try {
+    parsed = parseSkillsArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
   }
-  if (!action || action === "help" || action === "--help" || action === "-h") {
+
+  if (parsed.values.help) {
     printUsage();
     return 0;
   }
-  console.error(`Unknown action: ${action}`);
-  printUsage();
-  return 1;
+  if (parsed.positionals.length > 0) {
+    console.error(`Unexpected argument: ${parsed.positionals[0]}`);
+    printUsage();
+    return 1;
+  }
+
+  try {
+    const agentId = await initializeAndResolveAgent(parsed.values);
+    console.log(JSON.stringify(await listSkills(agentId), null, 2));
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+async function runDelete(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseSkillsArgs>;
+  try {
+    parsed = parseSkillsArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  const [skillName] = parsed.positionals;
+  if (parsed.values.help || !skillName || skillName === "help") {
+    printUsage();
+    return 0;
+  }
+  if (parsed.positionals.length > 1) {
+    console.error(`Unexpected argument: ${parsed.positionals[1]}`);
+    printUsage();
+    return 1;
+  }
+
+  try {
+    const agentId = await initializeAndResolveAgent(parsed.values);
+    console.log(JSON.stringify(await deleteSkill(skillName, agentId), null, 2));
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function runSkillsSubcommand(argv: string[]): Promise<number> {
+  const [action, ...rest] = argv;
+  switch (action) {
+    case "install":
+      return runInstall(rest);
+    case "list":
+      return runList(rest);
+    case "delete":
+    case "remove":
+    case "rm":
+      return runDelete(rest);
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      printUsage();
+      return 0;
+    default:
+      console.error(`Unknown action: ${action}`);
+      printUsage();
+      return 1;
+  }
 }

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, normalize, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { isLocalAgentId } from "@/agent/agent-id";
 import { parseFrontmatter } from "@/utils/frontmatter";
 
 const HERMES_REPO_URL = "https://github.com/NousResearch/hermes-agent.git";
@@ -614,6 +615,16 @@ async function installSkill(
 }
 
 async function getAgentMemoryDir(agentId: string): Promise<string> {
+  if (isLocalAgentId(agentId)) {
+    const { getLocalBackendMemoryFilesystemRoot } = await import(
+      "@/backend/local/paths"
+    );
+    const { initializeLocalMemoryRepo } = await import("@/agent/memory-git");
+    const memoryDir = getLocalBackendMemoryFilesystemRoot(agentId);
+    await initializeLocalMemoryRepo({ memoryDir, agentId, files: [] });
+    return memoryDir;
+  }
+
   const { ensureLocalMemfsCheckout, getScopedMemoryFilesystemRoot } =
     await import("@/agent/memory-filesystem");
   await ensureLocalMemfsCheckout(agentId);

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -51,6 +51,8 @@ interface ClawHubSourceLocation {
 
 const CLAWHUB_API_BASE_URL = "https://clawhub.ai/api/v1";
 
+let activeAgentPromptStatus: { stop: () => void } | null = null;
+
 function printUsage(): void {
   console.log(
     `
@@ -130,18 +132,30 @@ async function resolveAgentByName(name: string): Promise<string> {
   return id;
 }
 
-async function promptForAgent(): Promise<string> {
+async function promptForAgent(statusMessage: string): Promise<string> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Missing agent id. Pass --agent <id> or -n <agent name>.");
   }
 
-  const { render } = await import("ink");
+  const { Box, render } = await import("ink");
+  const Spinner = (await import("ink-spinner")).default;
   const React = await import("react");
   const { AgentSelector } = await import("@/cli/components/AgentSelector");
+  const { Text } = await import("@/cli/components/Text");
 
   return new Promise<string>((resolveAgent, rejectAgent) => {
     let settled = false;
-    const { unmount } = render(
+    const statusView = React.createElement(
+      Box,
+      { paddingX: 1, paddingY: 1 },
+      React.createElement(
+        Text,
+        null,
+        React.createElement(Spinner, { type: "dots" }),
+        ` ${statusMessage}`,
+      ),
+    );
+    const instance = render(
       React.createElement(AgentSelector, {
         currentAgentId:
           process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "",
@@ -153,13 +167,23 @@ async function promptForAgent(): Promise<string> {
         onSelect: (agentId: string) => {
           if (settled) return;
           settled = true;
-          unmount();
-          resolveAgent(agentId);
+          instance.rerender(statusView);
+          activeAgentPromptStatus = {
+            stop: () => {
+              instance.unmount();
+              instance.clear?.();
+              if (activeAgentPromptStatus?.stop) {
+                activeAgentPromptStatus = null;
+              }
+            },
+          };
+          setTimeout(() => resolveAgent(agentId), 0);
         },
         onCancel: () => {
           if (settled) return;
           settled = true;
-          unmount();
+          instance.unmount();
+          instance.clear?.();
           rejectAgent(new Error("Agent selection cancelled."));
         },
       }),
@@ -169,6 +193,7 @@ async function promptForAgent(): Promise<string> {
 
 async function resolveAgentId(
   values: ReturnType<typeof parseSkillsArgs>["values"],
+  promptStatusMessage = "Working...",
 ): Promise<string> {
   const explicitAgent = values.agent || values["agent-id"];
   if (typeof explicitAgent === "string" && explicitAgent.trim()) {
@@ -184,7 +209,7 @@ async function resolveAgentId(
   const envAgent = process.env.LETTA_AGENT_ID || process.env.AGENT_ID;
   if (envAgent?.trim()) return envAgent.trim();
 
-  return promptForAgent();
+  return promptForAgent(promptStatusMessage);
 }
 
 export function parseGitHubSpecifier(
@@ -651,10 +676,16 @@ async function deleteSkill(
 
 async function initializeAndResolveAgent(
   values: ReturnType<typeof parseSkillsArgs>["values"],
+  promptStatusMessage?: string,
 ): Promise<string> {
   const { settingsManager } = await import("@/settings-manager");
   await settingsManager.initialize();
-  return resolveAgentId(values);
+  return resolveAgentId(values, promptStatusMessage);
+}
+
+function stopAgentPromptStatus(): void {
+  activeAgentPromptStatus?.stop();
+  activeAgentPromptStatus = null;
 }
 
 async function runInstall(argv: string[]): Promise<number> {
@@ -682,15 +713,20 @@ async function runInstall(argv: string[]): Promise<number> {
   }
 
   try {
-    const agentId = await initializeAndResolveAgent(parsed.values);
+    const agentId = await initializeAndResolveAgent(
+      parsed.values,
+      `Installing ${specifier}...`,
+    );
     const result = await installSkill(
       specifier,
       agentId,
       Boolean(parsed.values.force),
     );
+    stopAgentPromptStatus();
     console.log(JSON.stringify(result, null, 2));
     return 0;
   } catch (error) {
+    stopAgentPromptStatus();
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
@@ -723,10 +759,16 @@ async function runList(argv: string[]): Promise<number> {
   }
 
   try {
-    const agentId = await initializeAndResolveAgent(parsed.values);
-    console.log(JSON.stringify(await listSkills(agentId), null, 2));
+    const agentId = await initializeAndResolveAgent(
+      parsed.values,
+      "Loading skills...",
+    );
+    const result = await listSkills(agentId);
+    stopAgentPromptStatus();
+    console.log(JSON.stringify(result, null, 2));
     return 0;
   } catch (error) {
+    stopAgentPromptStatus();
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
@@ -756,10 +798,16 @@ async function runDelete(argv: string[]): Promise<number> {
   }
 
   try {
-    const agentId = await initializeAndResolveAgent(parsed.values);
-    console.log(JSON.stringify(await deleteSkill(skillName, agentId), null, 2));
+    const agentId = await initializeAndResolveAgent(
+      parsed.values,
+      `Deleting ${skillName}...`,
+    );
+    const result = await deleteSkill(skillName, agentId);
+    stopAgentPromptStatus();
+    console.log(JSON.stringify(result, null, 2));
     return 0;
   } catch (error) {
+    stopAgentPromptStatus();
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ USAGE
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
-  letta skills ...      Install skills into an agent memfs repository
+  letta install ...     Install a skill into an agent memfs repository
 
 OPTIONS
 ${renderCliOptionsHelp()}
@@ -206,7 +206,7 @@ SUBCOMMANDS
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
   letta connect <provider> [options]
-  letta skills install <skill> [--agent <id> | -n <name>]
+  letta install <skill> [--agent <id> | -n <name>]
   letta backend [api|local]
   letta local-backend migrate-transcripts [--storage-dir <path>] [--dry-run]
 
@@ -228,7 +228,7 @@ EXAMPLES
   letta                    # Show profile selector or create new
   letta --new              # Create new conversation
   letta --agent agent_123  # Open specific agent
-  letta skills install official/finance/stocks --agent agent-123
+  letta install official/finance/stocks --agent agent-123
 
   # inside the interactive session
   /profile save MyAgent    # Save current agent as profile

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ SUBCOMMANDS
   letta connect <provider> [options]
   letta install <skill> [--agent <id> | -n <name>]
   letta skills list [--agent <id> | -n <name>]
-  letta skills delete <skill_name> [--agent <id> | -n <name>]
+  letta skills delete <skill_name> --agent <id>
   letta backend [api|local]
   letta local-backend migrate-transcripts [--storage-dir <path>] [--dry-run]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,7 @@ USAGE
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
+  letta skills ...      Install skills into an agent memfs repository
 
 OPTIONS
 ${renderCliOptionsHelp()}
@@ -205,6 +206,7 @@ SUBCOMMANDS
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
   letta connect <provider> [options]
+  letta skills install <skill> [--agent <id> | -n <name>]
   letta backend [api|local]
   letta local-backend migrate-transcripts [--storage-dir <path>] [--dry-run]
 
@@ -226,6 +228,7 @@ EXAMPLES
   letta                    # Show profile selector or create new
   letta --new              # Create new conversation
   letta --agent agent_123  # Open specific agent
+  letta skills install official/finance/stocks --agent agent-123
 
   # inside the interactive session
   /profile save MyAgent    # Save current agent as profile

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ USAGE
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
   letta install ...     Install a skill into an agent memfs repository
+  letta skills ...      List or delete installed agent skills
 
 OPTIONS
 ${renderCliOptionsHelp()}
@@ -207,6 +208,8 @@ SUBCOMMANDS
   letta messages transcript --conversation <id> [--out <path>]
   letta connect <provider> [options]
   letta install <skill> [--agent <id> | -n <name>]
+  letta skills list [--agent <id> | -n <name>]
+  letta skills delete <skill_name> [--agent <id> | -n <name>]
   letta backend [api|local]
   letta local-backend migrate-transcripts [--storage-dir <path>] [--dry-run]
 


### PR DESCRIPTION
## Summary
- Add `letta install <skill>` to install skill folders into an agent memfs repository under `memory/skills/<skill-name>`.
- Add `letta skills list` and `letta skills delete <skill_name>` for installed agent skills.
- Reuse the interactive `/agents` selector UI for install/list when no agent id/name is provided, instead of dumping a numbered 100-agent list.
- Require an explicit `--agent`/`--agent-id` for destructive `skills delete` and emit a clear error if the user passes a source specifier instead of an installed skill directory name.
- Add compatibility source parsing for Hermes-style official skills, GitHub skill directories, and ClawHub registry skills.
- Support both cloud agents and local agents; local agent IDs install into the local backend memfs path instead of trying to clone a cloud git repo.

## Syntax and compatibility layer
The command intentionally mirrors the simple Hermes/OpenClaw skill-install shape while targeting Letta Code agent memory:

```bash
letta install <skill> [--agent <id> | --agent-id <id> | -n <agent name>] [--force]
letta skills list [--agent <id> | --agent-id <id> | -n <agent name>]
letta skills delete <skill_name> --agent <id>
```

Install/list resolve the target agent by explicit `--agent`/`--agent-id`, exact `-n/--name`, env (`LETTA_AGENT_ID`/`AGENT_ID`), then the shared Ink-based agent selector. The selector uses the same pinned/local/constellation tab UI as `/agents`, with skill-command-specific affordances: no New tab, no delete-agent shortcut, and no unpin shortcut.

Delete intentionally requires explicit `--agent`/`--agent-id`; it does not use env or selector fallback because it is destructive. Delete also expects the installed skill directory name (for example `meme-generation`), not an install source specifier like `official/creative/meme-generation`.

Supported install source syntaxes:

- Hermes official optional skills:
  - `official/finance/stocks`
  - Resolves to `https://github.com/NousResearch/hermes-agent.git`, subdirectory `optional-skills/finance/stocks`.
- GitHub repositories/directories:
  - `https://github.com/owner/repo`
  - `https://github.com/owner/repo/tree/main/path/to/skill`
  - `https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md`
  - `owner/repo/path/to/skill`
  - Branch/path ambiguity is handled by checking remote branch names before choosing the skill subdirectory.
- ClawHub registry skills:
  - `clawhub/<slug>`
  - `clawhub:<slug>`
  - `clawhub:<slug>@<version>`
  - `https://clawhub.ai/skills/<slug>`
  - Resolves metadata from `https://clawhub.ai/api/v1/skills/<slug>`, picks `latestVersion.version`/`tags.latest` when no version is specified, then downloads the ZIP bundle from `/api/v1/download`.

After fetching any supported source, the installer normalizes everything into the same compatibility layer: a temporary local directory containing `SKILL.md` and supporting files. The final install path is determined from `SKILL.md` frontmatter `name` when available, falling back to the source directory name. This keeps the memfs layout source-agnostic and allows existing skills to be replaced only with `--force`.

Cloud agents use the git-backed cloud memfs checkout. Local agents use `~/.letta/lc-local-backend/memfs/<agent-id>/memory`, initializing a local memory repo if needed, so `agent-local-*` IDs do not hit the cloud git endpoint.

`letta skills list` reads installed directories under `memory/skills`, parses `SKILL.md` frontmatter when available, and emits JSON with names, descriptions, and paths. `letta skills delete <skill_name> --agent <id>` removes the matching `memory/skills/<skill_name>` directory after validating the skill name and path containment.

Note: the old nested `letta skills install ...` route is still accepted as a compatibility alias, but help text and examples advertise `letta install ...`.

## Test plan
- [x] `bun test src/cli/subcommands/skills.test.ts`
- [x] `bun run check`
- [x] `letta skills delete official/creative/meme-generation` fails before selecting an agent and asks for `--agent`.
- [x] `letta skills delete official/creative/meme-generation --agent <id>` fails with a clear installed-name-vs-source-specifier error.
- [x] Live-installed `official/finance/stocks` via `letta install ...` into a cloud agent memfs and verified `skills/stocks/SKILL.md` plus script files.
- [x] Live-installed `official/finance/stocks` via `letta install ...` into `agent-local-59e6bd2b-0696-4b8a-92bf-2e6e2ffbfb40` and verified it writes to the local backend memfs path.
- [x] Live-installed `clawhub/nano-banana-pro` into agent memfs and verified `skills/nano-banana-pro/SKILL.md`, `_meta.json`, `skill-card.md`, and script files.
- [x] Live-ran `letta skills list --agent <id>` and verified installed skills are returned as JSON.

👾 Generated with [Letta Code](https://letta.com)