### PR TITLE
fix(local): keep provider registry replacement semantics

### DIFF
--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -298,12 +298,6 @@ export function registerPiProvider(
   owner?: { id?: string; path?: string },
 ): RegisteredPiProvider {
   validateProviderConfig(providerName, config);
-  const existing = registeredProviders.get(providerName);
-  if (existing && existing.ownerId !== owner?.id) {
-    throw new Error(
-      `Provider "${providerName}" is already registered${existing.path ? ` by ${existing.path}` : ""}`,
-    );
-  }
   const registered: RegisteredPiProvider = {
     providerName,
     config: cloneConfig(config),


### PR DESCRIPTION
## Summary
- remove owner-based conflicts from the local provider extension registry
- keep replacement semantics aligned with main/pre-provider-extension behavior and pi-ai registry behavior

## Tests
- bun test src/backend/pi-model-factory.test.ts src/extensions/extension-host.test.ts