### PR TITLE
feat(local): support OAuth extension providers

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -544,6 +544,22 @@ export async function resolvePiModelForAgent(
     oauthCredentials = oauth?.credentials;
   }
 
+  if (
+    connection.record?.auth.type === "oauth" &&
+    registeredProvider?.config.oauth
+  ) {
+    const oauth = await getLocalOAuthApiKey({
+      providerId: registeredProvider.providerName,
+      providerNames: registeredProviderLocalNames(registeredProvider),
+      storageDir,
+    });
+    connection = {
+      ...connection,
+      apiKey: oauth?.apiKey,
+    };
+    oauthCredentials = oauth?.credentials;
+  }
+
   if (provider === "amazon-bedrock") {
     const bedrock = bedrockLocalProviderOptions(connection.record);
     providerOptions = bedrock.providerOptions;
@@ -575,19 +591,24 @@ export async function resolvePiModelForAgent(
     : baseURL;
   let model: Model<Api>;
   if (registeredModel && registeredProvider) {
-    model = withOverrides(
-      registeredModelToPiModel({
-        providerName: provider,
-        config: registeredProvider.config,
-        model: registeredModel,
-        baseURL: normalizedBaseURL,
-        headers: mergeHeaders(headers, registeredModel.headers),
-      }),
-      {
-        contextWindow,
-        maxTokens,
-      },
-    );
+    const baseModel = registeredModelToPiModel({
+      providerName: provider,
+      config: registeredProvider.config,
+      model: registeredModel,
+      baseURL: normalizedBaseURL,
+      headers: mergeHeaders(headers, registeredModel.headers),
+    });
+    const oauthModel =
+      oauthCredentials && registeredProvider.config.oauth?.modifyModels
+        ? (registeredProvider.config.oauth.modifyModels(
+            [baseModel],
+            oauthCredentials,
+          )[0] ?? baseModel)
+        : baseModel;
+    model = withOverrides(oauthModel, {
+      contextWindow,
+      maxTokens,
+    });
   } else if (!spec) {
     throw new Error(
       `Unknown model "${modelId}" for provider "${provider}". ` +

--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -54,7 +54,8 @@ export interface PiProviderOAuthDeviceCodeInfo {
   expiresInSeconds?: number;
 }
 
-export interface PiProviderOAuthLoginCallbacks extends OAuthLoginCallbacks {
+export interface PiProviderOAuthLoginCallbacks
+  extends Omit<OAuthLoginCallbacks, "onDeviceCode"> {
   onDeviceCode?: (info: PiProviderOAuthDeviceCodeInfo) => void;
 }
 

--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -1,4 +1,10 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+  type OAuthCredentials,
+  type OAuthLoginCallbacks,
+  registerOAuthProvider,
+  unregisterOAuthProvider,
+} from "@earendil-works/pi-ai/oauth";
 
 export type PiProviderInputType = "text" | "image";
 
@@ -41,6 +47,30 @@ export interface PiProviderConnectConfig {
   fields?: PiProviderConnectField[];
 }
 
+export interface PiProviderOAuthDeviceCodeInfo {
+  verificationUri: string;
+  userCode: string;
+  intervalSeconds?: number;
+  expiresInSeconds?: number;
+}
+
+export interface PiProviderOAuthLoginCallbacks extends OAuthLoginCallbacks {
+  onDeviceCode?: (info: PiProviderOAuthDeviceCodeInfo) => void;
+}
+
+export interface PiProviderOAuthConfig {
+  name?: string;
+  login: (
+    callbacks: PiProviderOAuthLoginCallbacks,
+  ) => Promise<OAuthCredentials>;
+  refreshToken: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
+  getApiKey: (credentials: OAuthCredentials) => string;
+  modifyModels?: (
+    models: Model<Api>[],
+    credentials: OAuthCredentials,
+  ) => Model<Api>[];
+}
+
 export interface PiProviderRegistration {
   name?: string;
   description?: string;
@@ -54,6 +84,7 @@ export interface PiProviderRegistration {
     connection: PiProviderConnection,
   ) => Promise<PiProviderModelRegistration[]> | PiProviderModelRegistration[];
   connect?: boolean | PiProviderConnectConfig;
+  oauth?: PiProviderOAuthConfig;
 }
 
 export interface RegisteredPiProvider {
@@ -256,6 +287,34 @@ function validateConnectConfig(
   }
 }
 
+function validateOAuthConfig(
+  providerName: string,
+  oauth: PiProviderRegistration["oauth"],
+): void {
+  if (oauth === undefined) return;
+  if (!oauth || typeof oauth !== "object" || Array.isArray(oauth)) {
+    throw new Error(`Provider ${providerName}.oauth must be an object`);
+  }
+  if (oauth.name !== undefined && typeof oauth.name !== "string") {
+    throw new Error(`Provider ${providerName}.oauth.name must be a string`);
+  }
+  for (const key of ["login", "refreshToken", "getApiKey"] as const) {
+    if (typeof oauth[key] !== "function") {
+      throw new Error(
+        `Provider ${providerName}.oauth.${key} must be a function`,
+      );
+    }
+  }
+  if (
+    oauth.modifyModels !== undefined &&
+    typeof oauth.modifyModels !== "function"
+  ) {
+    throw new Error(
+      `Provider ${providerName}.oauth.modifyModels must be a function`,
+    );
+  }
+}
+
 function validateProviderConfig(
   providerName: string,
   config: PiProviderRegistration,
@@ -263,6 +322,7 @@ function validateProviderConfig(
   validateProviderName(providerName);
   validateHeaders(config.headers, `Provider ${providerName}.headers`);
   validateConnectConfig(providerName, config.connect);
+  validateOAuthConfig(providerName, config.oauth);
   if (
     config.listModels !== undefined &&
     typeof config.listModels !== "function"
@@ -292,6 +352,45 @@ function validateProviderConfig(
   }
 }
 
+function registerPiOAuthProvider(
+  providerName: string,
+  config: PiProviderRegistration,
+): void {
+  unregisterOAuthProvider(providerName);
+  if (!config.oauth) return;
+  registerOAuthProvider({
+    id: providerName,
+    name: config.oauth.name ?? config.name ?? providerName,
+    login: (callbacks) =>
+      config.oauth?.login(callbacks as PiProviderOAuthLoginCallbacks) ??
+      Promise.reject(
+        new Error(`Provider "${providerName}" OAuth is not registered`),
+      ),
+    refreshToken: (credentials) => {
+      if (!config.oauth) {
+        throw new Error(`Provider "${providerName}" OAuth is not registered`);
+      }
+      return config.oauth.refreshToken(credentials);
+    },
+    getApiKey: (credentials) => {
+      if (!config.oauth) {
+        throw new Error(`Provider "${providerName}" OAuth is not registered`);
+      }
+      return config.oauth.getApiKey(credentials);
+    },
+    ...(config.oauth.modifyModels
+      ? {
+          modifyModels: (models, credentials) =>
+            config.oauth?.modifyModels?.(models, credentials) ?? models,
+        }
+      : {}),
+  });
+}
+
+function unregisterPiOAuthProvider(providerName: string): void {
+  unregisterOAuthProvider(providerName);
+}
+
 export function registerPiProvider(
   providerName: string,
   config: PiProviderRegistration,
@@ -305,6 +404,7 @@ export function registerPiProvider(
     ...(owner?.path ? { path: owner.path } : {}),
   };
   registeredProviders.set(providerName, registered);
+  registerPiOAuthProvider(providerName, registered.config);
   notifyRegistryListeners();
   return getRegisteredPiProvider(providerName) as RegisteredPiProvider;
 }
@@ -317,6 +417,7 @@ export function unregisterPiProvider(
   if (!existing) return;
   if (ownerId && existing.ownerId && existing.ownerId !== ownerId) return;
   registeredProviders.delete(providerName);
+  unregisterPiOAuthProvider(providerName);
   notifyRegistryListeners();
 }
 
@@ -325,6 +426,7 @@ export function unregisterPiProvidersForOwner(ownerId: string): void {
   for (const [providerName, provider] of registeredProviders.entries()) {
     if (provider.ownerId === ownerId) {
       registeredProviders.delete(providerName);
+      unregisterPiOAuthProvider(providerName);
       changed = true;
     }
   }
@@ -333,6 +435,9 @@ export function unregisterPiProvidersForOwner(ownerId: string): void {
 
 export function clearRegisteredPiProviders(): void {
   if (registeredProviders.size === 0) return;
+  for (const providerName of registeredProviders.keys()) {
+    unregisterPiOAuthProvider(providerName);
+  }
   registeredProviders.clear();
   notifyRegistryListeners();
 }

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -25,6 +25,7 @@ import {
   stripProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-registry";
 import {
+  getLocalOAuthApiKey,
   type LocalProviderRecord,
   listLocalProviderRecords,
   localProviderApiKeyFromRecord,
@@ -250,16 +251,26 @@ function registeredProviderRecordFor(
   return records.find((record) => providerNames.includes(record.name));
 }
 
-function registeredProviderConnection(
+async function registeredProviderConnection(
   provider: RegisteredPiProvider,
   records: readonly LocalProviderRecord[],
-): PiProviderConnection {
+  storageDir?: string,
+): Promise<PiProviderConnection> {
   const record = registeredProviderRecordFor(provider, records);
+  const oauth =
+    record?.auth.type === "oauth" && provider.config.oauth
+      ? await getLocalOAuthApiKey({
+          providerId: provider.providerName,
+          providerNames: registeredProviderLocalNames(provider),
+          storageDir,
+        })
+      : undefined;
   return {
     id: provider.providerName,
     providerName: provider.providerName,
     baseUrl: record?.base_url ?? provider.config.baseUrl,
     apiKey:
+      oauth?.apiKey ??
       localProviderApiKeyFromRecord(record) ??
       resolveRegisteredPiProviderApiKey(provider.config.apiKey),
     headers: resolveRegisteredPiProviderHeaders(provider.config.headers),
@@ -282,9 +293,10 @@ function isRegisteredProviderConfigured(
 async function listRegisteredProviderModels(
   provider: RegisteredPiProvider,
   records: readonly LocalProviderRecord[],
+  storageDir?: string,
 ): Promise<PiProviderModelRegistration[]> {
   const listed = await provider.config.listModels?.(
-    registeredProviderConnection(provider, records),
+    await registeredProviderConnection(provider, records, storageDir),
   );
   return listed ?? provider.config.models ?? [];
 }
@@ -422,6 +434,7 @@ export async function listLocalModels(
       for (const model of await listRegisteredProviderModels(
         provider,
         records,
+        storageDir,
       )) {
         addModel(provider.providerName, model.id, {
           handle: `${provider.providerName}/${model.id}`,

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getModels } from "@earendil-works/pi-ai";
+import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import {
   applyPiEnvOverrides,
   resolvePiModelForAgent,
@@ -394,6 +395,79 @@ describe("pi model factory", () => {
           headers: { "X-Kilo": "header" },
         },
       ]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses extension OAuth credentials at turn time", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-kilo-oauth-"));
+    try {
+      const refreshes: unknown[] = [];
+      registerPiProvider("kilo", {
+        baseUrl: "https://api.kilo.dev/v1",
+        api: "openai-completions",
+        authHeader: true,
+        oauth: {
+          name: "Kilo",
+          login: async () => ({
+            access: "login-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          }),
+          refreshToken: async (credentials) => {
+            refreshes.push(credentials);
+            return {
+              ...credentials,
+              access: "refreshed-token",
+              expires: Date.now() + 60_000,
+            };
+          },
+          getApiKey: (credentials) => `oauth:${credentials.access}`,
+          modifyModels: (models, credentials) =>
+            models.map((model) => ({
+              ...model,
+              baseUrl: `https://${credentials.access}.kilo.dev/v1`,
+            })),
+        },
+        models: [
+          {
+            id: "kilo-code",
+            name: "Kilo Code",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      });
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "kilo",
+        providerType: "kilo",
+        auth: localOAuthAuthFromCredentials({
+          access: "expired-token",
+          refresh: "refresh-token",
+          expires: Date.now() - 1,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "kilo/kilo-code",
+        {},
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+      expect(refreshes).toHaveLength(1);
+      expect(resolved.apiKey).toBe("oauth:refreshed-token");
+      expect(resolved.model).toMatchObject({
+        id: "kilo-code",
+        provider: "kilo",
+        baseUrl: "https://refreshed-token.kilo.dev/v1",
+        headers: { Authorization: "Bearer oauth:refreshed-token" },
+      });
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -323,28 +323,33 @@ function localOAuthConfigId(providerId: string): string {
 }
 
 function localOAuthProviderConfigs(): ByokProvider[] {
-  return getOAuthProviders().map((provider) => {
-    const spec = PI_PROVIDER_SPECS.find(
-      (candidate) => candidate.piProvider === provider.id,
-    );
-    const providerName =
-      provider.id === "openai-codex"
-        ? "chatgpt-plus-pro"
-        : (spec?.localProviderNames[0] ?? provider.id);
-    return {
-      id: localOAuthConfigId(provider.id),
-      displayName: provider.name,
-      description: "Connect a subscription account",
-      providerType: spec?.providerTypes[0] ?? provider.id,
-      providerName,
-      providerNames:
+  const registeredProviderIds = new Set(
+    listRegisteredPiProviders().map((provider) => provider.providerName),
+  );
+  return getOAuthProviders()
+    .filter((provider) => !registeredProviderIds.has(provider.id))
+    .map((provider) => {
+      const spec = PI_PROVIDER_SPECS.find(
+        (candidate) => candidate.piProvider === provider.id,
+      );
+      const providerName =
         provider.id === "openai-codex"
-          ? [providerName, "openai-codex"]
-          : spec?.localProviderNames,
-      isOAuth: true,
-      oauthProviderId: provider.id,
-    };
-  });
+          ? "chatgpt-plus-pro"
+          : (spec?.localProviderNames[0] ?? provider.id);
+      return {
+        id: localOAuthConfigId(provider.id),
+        displayName: provider.name,
+        description: "Connect a subscription account",
+        providerType: spec?.providerTypes[0] ?? provider.id,
+        providerName,
+        providerNames:
+          provider.id === "openai-codex"
+            ? [providerName, "openai-codex"]
+            : spec?.localProviderNames,
+        isOAuth: true,
+        oauthProviderId: provider.id,
+      };
+    });
 }
 
 function localApiKeyProviderIds(): string[] {
@@ -382,25 +387,29 @@ function byokProviderFromRegisteredProvider(
       ? provider.config.connect
       : undefined;
   const defaultApiKey = extensionProviderEnvApiKey(provider.config.apiKey);
-  return {
+  const displayName =
+    provider.config.name ?? displayNameForLocalProvider(provider.providerName);
+  const baseConfig: ByokProvider = {
     id: provider.providerName,
-    displayName:
-      provider.config.name ??
-      displayNameForLocalProvider(provider.providerName),
-    description:
-      provider.config.description ??
-      `Connect ${provider.config.name ?? displayNameForLocalProvider(provider.providerName)}`,
+    displayName,
+    description: provider.config.description ?? `Connect ${displayName}`,
     providerType: provider.providerName,
     providerName: provider.providerName,
     providerNames: [provider.providerName],
+  };
+  if (provider.config.oauth) {
+    return {
+      ...baseConfig,
+      isOAuth: true,
+      oauthProviderId: provider.providerName,
+      requiresApiKey: false,
+    };
+  }
+  return {
+    ...baseConfig,
     requiresApiKey: defaultApiKey === undefined,
     ...(defaultApiKey ? { defaultApiKey } : {}),
-    fields:
-      connect?.fields ??
-      defaultExtensionProviderFields(
-        provider.config.name ??
-          displayNameForLocalProvider(provider.providerName),
-      ),
+    fields: connect?.fields ?? defaultExtensionProviderFields(displayName),
   };
 }
 

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getModels, getProviders } from "@earendil-works/pi-ai";
-import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import {
+  getOAuthProvider,
+  getOAuthProviders,
+} from "@earendil-works/pi-ai/oauth";
 import {
   clearRegisteredPiProviders,
   registerPiProvider,
@@ -13,7 +16,11 @@ import {
   resolveProviderFromProviderType,
 } from "@/backend/dev/pi-provider-registry";
 import { listLocalModels } from "@/backend/local/local-model-config";
-import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+import {
+  createOrUpdateLocalProvider,
+  localOAuthAuthFromCredentials,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
 import { getProviderConfigs } from "@/providers/byok-providers";
 
 describe("local pi provider catalog", () => {
@@ -124,6 +131,90 @@ describe("local pi provider catalog", () => {
     });
   });
 
+  test("local /connect configs include registered extension OAuth providers", () => {
+    registerPiProvider("kilo", {
+      name: "Kilo",
+      description: "Connect Kilo account",
+      baseUrl: "https://api.kilo.dev/v1",
+      api: "openai-completions",
+      oauth: {
+        name: "Kilo",
+        login: async () => ({
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+        refreshToken: async (credentials) => credentials,
+        getApiKey: (credentials) => String(credentials.access),
+      },
+      models: [
+        {
+          id: "kilo-code",
+          name: "Kilo Code",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+
+    expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+
+    const provider = getProviderConfigs("local").find(
+      (candidate) => candidate.id === "kilo",
+    );
+
+    expect(provider).toMatchObject({
+      id: "kilo",
+      displayName: "Kilo",
+      description: "Connect Kilo account",
+      providerType: "kilo",
+      providerName: "kilo",
+      providerNames: ["kilo"],
+      isOAuth: true,
+      oauthProviderId: "kilo",
+      requiresApiKey: false,
+    });
+    expect(provider?.fields).toBeUndefined();
+  });
+
+  test("local /connect configs respect connect false for registered extension OAuth providers", () => {
+    registerPiProvider("kilo", {
+      name: "Kilo",
+      baseUrl: "https://api.kilo.dev/v1",
+      api: "openai-completions",
+      connect: false,
+      oauth: {
+        name: "Kilo",
+        login: async () => ({
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+        refreshToken: async (credentials) => credentials,
+        getApiKey: (credentials) => String(credentials.access),
+      },
+      models: [
+        {
+          id: "kilo-code",
+          name: "Kilo Code",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+
+    expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+    expect(
+      getProviderConfigs("local").some((provider) => provider.id === "kilo"),
+    ).toBe(false);
+  });
+
   test("local model listing includes dynamic extension provider models when configured", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-kilo-provider-"));
     try {
@@ -169,6 +260,70 @@ describe("local pi provider catalog", () => {
           providerName: "kilo",
           baseUrl: "https://custom.kilo/v1",
           apiKey: "kilo-key",
+          headers: undefined,
+        },
+      ]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("local model listing passes extension OAuth api keys to listModels", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-kilo-oauth-"));
+    try {
+      const connections: unknown[] = [];
+      registerPiProvider("kilo", {
+        baseUrl: "https://api.kilo.dev/v1",
+        api: "openai-completions",
+        oauth: {
+          login: async () => ({
+            access: "login-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          }),
+          refreshToken: async (credentials) => credentials,
+          getApiKey: (credentials) => `oauth:${credentials.access}`,
+        },
+        listModels(connection) {
+          connections.push(connection);
+          return [
+            {
+              id: "oauth-kilo-code",
+              name: "OAuth Kilo Code",
+              reasoning: true,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 8192,
+            },
+          ];
+        },
+      });
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "kilo",
+        providerType: "kilo",
+        auth: localOAuthAuthFromCredentials({
+          access: "stored-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const models = await listLocalModels(storageDir);
+
+      expect(models).toContainEqual({
+        handle: "kilo/oauth-kilo-code",
+        max_context_window: 128000,
+        model: "kilo/oauth-kilo-code",
+        model_endpoint_type: "kilo",
+      });
+      expect(connections).toEqual([
+        {
+          id: "kilo",
+          providerName: "kilo",
+          baseUrl: "https://api.kilo.dev/v1",
+          apiKey: "oauth:stored-token",
           headers: undefined,
         },
       ]);


### PR DESCRIPTION
## Summary
- add oauth config support to registered extension providers and bridge it into pi-ai OAuth registry
- surface extension OAuth providers through local /connect using the existing OAuth flow
- pass OAuth-derived API keys to dynamic model discovery and turn-time model resolution, including refresh, auth headers, and modifyModels

## Tests
- bun test src/backend/pi-model-factory.test.ts src/providers/local-pi-provider-catalog.test.ts src/extensions/extension-host.test.ts src/cli/components/provider-selector.test.ts src/cli/connect-normalize.test.ts
- bun run lint
- bun run check:boundaries
- bun run check:exported-functions
- bun run check:filename-casing
- bun run check:cycles
- bun run check:test-mock-isolation
- git diff --check

Note: bun run typecheck is still blocked by existing unrelated src/web/generate-diff-viewer.ts @pierre/diffs type resolution errors.