### PR TITLE
docs: add skill install source table

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ See the full list of slash commands in our [documentation](https://docs.letta.co
 
 Install skills into a specific agent's MemFS with `letta install <skill> --agent <agent-id>`.
 
-| Source | Example | How it resolves |
-|---|---|---|
-| Hermes official optional skills | `official/finance/stocks` | `https://github.com/NousResearch/hermes-agent.git`, subdirectory `optional-skills/finance/stocks` |
-| GitHub repositories/directories | `https://github.com/owner/repo`, `https://github.com/owner/repo/tree/main/path/to/skill`, `https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md`, `owner/repo/path/to/skill` | Uses the repository or skill directory; branch/path ambiguity is handled by checking remote branch names first |
-| ClawHub registry skills | `clawhub/<slug>`, `clawhub:<slug>`, `clawhub:<slug>@<version>`, `https://clawhub.ai/skills/<slug>` | Reads metadata from `https://clawhub.ai/api/v1/skills/<slug>`, uses `latestVersion.version`/`tags.latest` when no version is specified, then downloads from `/api/v1/download` |
-
+| Source | Example |
+|---|---|
+| GitHub repositories/directories | `https://github.com/owner/repo`, `https://github.com/owner/repo/tree/main/path/to/skill`, `https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md`, `owner/repo/path/to/skill` | 
+| [ClawHub](https://clawhub.ai/)  | `clawhub/<slug>`, `clawhub:<slug>`, `clawhub:<slug>@<version>`, `https://clawhub.ai/skills/<slug>` | 
+| Hermes | `hermes skills install {skill_path}` -> `letta skills install {skill_path}` | 
 ## Get started
 
 Install the package via [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):

--- a/README.md
+++ b/README.md
@@ -35,15 +35,6 @@ Letta Code is a frontier coding agent and can also be used as a long-lived perso
 
 See the full list of slash commands in our [documentation](https://docs.letta.com/letta-code/slash-commands).
 
-## Skills
-
-Install skills into a specific agent's MemFS with `letta install <skill> --agent <agent-id>`.
-
-| Source | Example |
-|---|---|
-| GitHub repositories/directories | `https://github.com/owner/repo`, `https://github.com/owner/repo/tree/main/path/to/skill`, `https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md`, `owner/repo/path/to/skill` | 
-| [ClawHub](https://clawhub.ai/)  | `clawhub/<slug>`, `clawhub:<slug>`, `clawhub:<slug>@<version>`, `https://clawhub.ai/skills/<slug>` | 
-| Hermes | `hermes skills install {skill_path}` -> `letta skills install {skill_path}` | 
 ## Get started
 
 Install the package via [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):
@@ -135,6 +126,18 @@ letta server --env-name "work-laptop"
 ```
 
 See our guides for using [Railway](https://docs.letta.com/letta-code/remote#railway), [DigitalOcean](https://docs.letta.com/letta-code/remote#digitalocean), and [Fly.io](https://docs.letta.com/letta-code/remote#flyio) as remote environments.
+
+## Installing Skills
+
+Install skills into a specific agent's memory with `letta skills install <skill>`: 
+
+| Source | Example |
+|---|---|
+| GitHub repositories/directories | `letta skills install https://github.com/owner/repo`<br>`letta skills install https://github.com/owner/repo/tree/main/path/to/skill`<br>`letta skills install https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md` |
+| [ClawHub](https://clawhub.ai/) | `openclaw skills install <skill-slug>` → `letta skills install <skill-slug>` |
+| [Hermes Skills Hub](https://hermes-agent.nousresearch.com/docs/skills/) | `hermes skills install <skill-path>` → `letta skills install <skill-path>` |
+
+To view skills run `letta skills list --agent <agent-id>`, and delete skills with `letta skills delete <skill-name> --agent <agent-id>`.
 
 ## Research
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Letta Code is a frontier coding agent and can also be used as a long-lived perso
 
 See the full list of slash commands in our [documentation](https://docs.letta.com/letta-code/slash-commands).
 
+## Skills
+
+Install skills into a specific agent's MemFS with `letta install <skill> --agent <agent-id>`.
+
+| Source | Example | How it resolves |
+|---|---|---|
+| Hermes official optional skills | `official/finance/stocks` | `https://github.com/NousResearch/hermes-agent.git`, subdirectory `optional-skills/finance/stocks` |
+| GitHub repositories/directories | `https://github.com/owner/repo`, `https://github.com/owner/repo/tree/main/path/to/skill`, `https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md`, `owner/repo/path/to/skill` | Uses the repository or skill directory; branch/path ambiguity is handled by checking remote branch names first |
+| ClawHub registry skills | `clawhub/<slug>`, `clawhub:<slug>`, `clawhub:<slug>@<version>`, `https://clawhub.ai/skills/<slug>` | Reads metadata from `https://clawhub.ai/api/v1/skills/<slug>`, uses `latestVersion.version`/`tags.latest` when no version is specified, then downloads from `/api/v1/download` |
+
 ## Get started
 
 Install the package via [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm):

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ letta server --env-name "work-laptop"
 
 See our guides for using [Railway](https://docs.letta.com/letta-code/remote#railway), [DigitalOcean](https://docs.letta.com/letta-code/remote#digitalocean), and [Fly.io](https://docs.letta.com/letta-code/remote#flyio) as remote environments.
 
-## Installing Skills
+## Installing external skills
 
 Install skills into a specific agent's memory with `letta skills install <skill>`: 
 


### PR DESCRIPTION
## Summary
- Add a short README section explaining how to install skills into a specific agent MemFS.
- Document supported source formats for Hermes official optional skills, GitHub directories, and ClawHub registry skills.

## Test plan
- Not run; docs-only change.

👾 Generated with [Letta Code](https://letta.com)