### PR TITLE
fix(auth): fix stale credential reauth flow

### DIFF
--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -84,10 +84,7 @@ export function ConstellationLoginView({
 
         const now = Date.now();
         settingsManager.updateSettings({
-          env: {
-            ...settingsManager.getSettings().env,
-            LETTA_API_KEY: tokens.access_token,
-          },
+          env: { LETTA_API_KEY: tokens.access_token },
           refreshToken: tokens.refresh_token,
           tokenExpiresAt: now + tokens.expires_in * 1000,
           preferredBackendMode: "api",

--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -8,14 +8,14 @@ import { pollForToken, requestDeviceCode } from "./oauth";
 
 interface ConstellationLoginViewProps {
   onComplete?: () => void;
-  onAlreadyLoggedIn?: () => void;
   onCancel?: () => void;
+  successMessage?: string;
 }
 
 export function ConstellationLoginView({
   onComplete,
-  onAlreadyLoggedIn,
   onCancel,
+  successMessage = "Signed in to Constellation. Switch to a Constellation agent with /agents.",
 }: ConstellationLoginViewProps) {
   const [error, setError] = useState<string | null>(null);
   const [doneMessage, setDoneMessage] = useState<string | null>(null);
@@ -25,10 +25,8 @@ export function ConstellationLoginView({
   const cancelledRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const onCompleteRef = useRef(onComplete);
-  const onAlreadyLoggedInRef = useRef(onAlreadyLoggedIn);
 
   onCompleteRef.current = onComplete;
-  onAlreadyLoggedInRef.current = onAlreadyLoggedIn;
 
   useInput((input, key) => {
     if (key.escape || (key.ctrl && input === "c")) {
@@ -45,13 +43,10 @@ export function ConstellationLoginView({
 
     const run = async () => {
       try {
-        const currentSettings =
-          await settingsManager.getSettingsWithSecureTokens();
-        const hasApiKey =
-          process.env.LETTA_API_KEY || currentSettings.env?.LETTA_API_KEY;
-
-        if (hasApiKey) {
-          onAlreadyLoggedInRef.current?.();
+        if (process.env.LETTA_API_KEY) {
+          setError(
+            "LETTA_API_KEY is set in your environment, so OAuth login cannot replace the credential Letta Code is using. Unset LETTA_API_KEY and try again.",
+          );
           return;
         }
 
@@ -100,9 +95,7 @@ export function ConstellationLoginView({
         await settingsManager.flush();
         configureBackendMode("api");
 
-        setDoneMessage(
-          "Signed in to Constellation. Switch to a Constellation agent with /agents.",
-        );
+        setDoneMessage(successMessage);
         setTimeout(() => onCompleteRef.current?.(), 500);
       } catch (err) {
         if (
@@ -120,7 +113,7 @@ export function ConstellationLoginView({
       cancelledRef.current = true;
       abortControllerRef.current?.abort();
     };
-  }, []);
+  }, [successMessage]);
 
   if (doneMessage) {
     return (
@@ -135,6 +128,15 @@ export function ConstellationLoginView({
     return (
       <Box flexDirection="column">
         <Text color="red">✗ Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  if (!userCode || !verificationUri) {
+    return (
+      <Box flexDirection="column">
+        <Text dimColor>Requesting authorization code...</Text>
+        <Text dimColor>Press Esc to cancel</Text>
       </Box>
     );
   }

--- a/src/auth/oauth-network-errors.test.ts
+++ b/src/auth/oauth-network-errors.test.ts
@@ -3,6 +3,7 @@ import {
   pollForToken,
   refreshAccessToken,
   requestDeviceCode,
+  validateCredentialsWithResult,
 } from "@/auth/oauth";
 
 const originalFetch = globalThis.fetch;
@@ -71,6 +72,28 @@ describe("OAuth network errors", () => {
     ).rejects.toThrow(
       "Failed to refresh access token from app.letta.com: certificate has expired (CERT_HAS_EXPIRED).",
     );
+  });
+
+  test("validateCredentialsWithResult classifies authentication failures", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ message: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await validateCredentialsWithResult(
+      "https://api.letta.com",
+      "bad-key",
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "invalid_credentials",
+      status: 401,
+    });
   });
 
   test("pollForToken preserves non-network OAuth errors", async () => {

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -4,6 +4,7 @@
  */
 
 import Letta from "@letta-ai/letta-client";
+import { APIError } from "@letta-ai/letta-client/core/error";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 
 export const LETTA_CLOUD_API_URL = "https://api.letta.com";
@@ -36,6 +37,21 @@ export interface OAuthError {
   error: string;
   error_description?: string;
 }
+
+export type CredentialValidationFailureReason =
+  | "invalid_credentials"
+  | "network_error"
+  | "server_unreachable"
+  | "unknown";
+
+export type CredentialValidationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: CredentialValidationFailureReason;
+      message: string;
+      status?: number;
+    };
 
 function getOAuthAuthHost(): string {
   try {
@@ -356,14 +372,28 @@ export async function revokeToken(refreshToken: string): Promise<void> {
 }
 
 /**
- * Validate credentials by checking health endpoint
- * Validate credentials by checking an authenticated endpoint
- * Uses SDK's agents.list() which requires valid authentication
+ * Validate credentials by checking an authenticated endpoint.
+ * Uses SDK's agents.list() which requires valid authentication.
  */
 export async function validateCredentials(
   baseUrl: string,
   apiKey: string,
 ): Promise<boolean> {
+  return (await validateCredentialsWithResult(baseUrl, apiKey)).ok;
+}
+
+export async function validateCredentialsWithResult(
+  baseUrl: string,
+  apiKey: string,
+): Promise<CredentialValidationResult> {
+  if (!apiKey.trim()) {
+    return {
+      ok: false,
+      reason: "invalid_credentials",
+      message: "Missing API key.",
+    };
+  }
+
   try {
     // Create a temporary client to test authentication
     const client = new Letta({
@@ -375,8 +405,51 @@ export async function validateCredentials(
     // Try to list agents - this requires valid authentication
     await client.agents.list({ limit: 1 });
 
-    return true;
-  } catch {
-    return false;
+    return { ok: true };
+  } catch (error) {
+    return classifyCredentialValidationError(error);
   }
+}
+
+function classifyCredentialValidationError(
+  error: unknown,
+): CredentialValidationResult {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (error instanceof APIError) {
+    if (error.status === 401 || error.status === 403) {
+      return {
+        ok: false,
+        reason: "invalid_credentials",
+        message,
+        status: error.status,
+      };
+    }
+
+    if (error.status >= 500) {
+      return {
+        ok: false,
+        reason: "server_unreachable",
+        message,
+        status: error.status,
+      };
+    }
+
+    return {
+      ok: false,
+      reason: "unknown",
+      message,
+      status: error.status,
+    };
+  }
+
+  if (
+    error instanceof TypeError ||
+    message.toLowerCase().includes("fetch failed") ||
+    message.toLowerCase().includes("network")
+  ) {
+    return { ok: false, reason: "network_error", message };
+  }
+
+  return { ok: false, reason: "unknown", message };
 }

--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -2,7 +2,7 @@
  * Ink UI components for OAuth setup flow
  */
 
-import { Box, useApp, useInput } from "ink";
+import { Box, useInput } from "ink";
 import { useState } from "react";
 import { configureBackendMode } from "@/backend";
 import { AnimatedLogo } from "@/cli/components/AnimatedLogo";
@@ -12,23 +12,33 @@ import { settingsManager } from "@/settings-manager";
 import { ConstellationLoginView } from "./ConstellationLoginView";
 
 type SetupMode = "menu" | "device-code" | "auth-code" | "self-host" | "done";
+export type SetupInitialMode = "menu" | "device-code";
+export type SetupResult =
+  | { kind: "cloud-login" }
+  | { kind: "local" }
+  | { kind: "cancelled" };
 
 const AUTH_LOGIN_LABEL = "Login to Constellation";
 const LOCAL_MODE_LABEL = "Proceed locally";
 const AUTH_LOGO_ANIMATE = false;
 
 interface SetupUIProps {
-  onComplete: () => void;
+  onComplete: (result: SetupResult) => void;
+  onCancel: () => void;
+  initialMode?: SetupInitialMode;
 }
 
-export function SetupUI({ onComplete }: SetupUIProps) {
-  const [mode, setMode] = useState<SetupMode>("menu");
-  const [selectedOption, setSelectedOption] = useState(1);
+export function SetupUI({
+  onComplete,
+  onCancel,
+  initialMode = "menu",
+}: SetupUIProps) {
+  const [mode, setMode] = useState<SetupMode>(initialMode);
+  const [selectedOption, setSelectedOption] = useState(
+    initialMode === "device-code" ? 0 : 1,
+  );
   const [error, setError] = useState<string | null>(null);
   const [doneMessage, setDoneMessage] = useState("Starting Letta Code...");
-
-  const { exit } = useApp();
-
   // Handle menu navigation
   useInput(
     (_input, key) => {
@@ -44,7 +54,7 @@ export function SetupUI({ onComplete }: SetupUIProps) {
           } else if (selectedOption === 1) {
             proceedLocally();
           } else if (selectedOption === 2) {
-            exit();
+            onCancel();
           }
         }
       }
@@ -61,7 +71,7 @@ export function SetupUI({ onComplete }: SetupUIProps) {
         "Local mode enabled. Agents you create now will be stored on this device. To sign into Letta Cloud later, run `letta setup` or `letta backend api`.",
       );
       setMode("done");
-      setTimeout(() => onComplete(), 500);
+      setTimeout(() => onComplete({ kind: "local" }), 500);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -96,8 +106,9 @@ export function SetupUI({ onComplete }: SetupUIProps) {
         <Text bold>{AUTH_LOGIN_LABEL}</Text>
         <Text> </Text>
         <ConstellationLoginView
-          onComplete={onComplete}
-          onAlreadyLoggedIn={onComplete}
+          onComplete={() => onComplete({ kind: "cloud-login" })}
+          onCancel={() => setMode("menu")}
+          successMessage="Signed in to Constellation. Starting Letta Code..."
         />
       </Box>
     );

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -4,25 +4,45 @@
 
 import { render } from "ink";
 import React from "react";
-import { SetupUI } from "./setup-ui";
+import { type SetupInitialMode, type SetupResult, SetupUI } from "./setup-ui";
+
+interface RunSetupOptions {
+  initialMode?: SetupInitialMode;
+}
 
 /**
  * Run the setup flow
  * Returns a promise that resolves when setup is complete
  */
-export async function runSetup(): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const { waitUntilExit } = render(
+export async function runSetup(
+  options: RunSetupOptions = {},
+): Promise<SetupResult> {
+  return new Promise<SetupResult>((resolve) => {
+    let settled = false;
+    let instance: ReturnType<typeof render>;
+    const settle = (result: SetupResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      instance.unmount();
+      resolve(result);
+    };
+
+    instance = render(
       React.createElement(SetupUI, {
-        onComplete: () => {
-          resolve();
-        },
+        initialMode: options.initialMode,
+        onComplete: settle,
+        onCancel: () => settle({ kind: "cancelled" }),
       }),
     );
 
-    waitUntilExit().catch((error) => {
-      console.error("Setup failed:", error);
-      process.exit(1);
-    });
+    instance
+      .waitUntilExit()
+      .then(() => settle({ kind: "cancelled" }))
+      .catch((error) => {
+        console.error("Setup failed:", error);
+        process.exit(1);
+      });
   });
 }

--- a/src/backend/api/client.ts
+++ b/src/backend/api/client.ts
@@ -209,7 +209,7 @@ export async function getClient() {
 
         // Update settings with new token (secrets handles secure storage automatically)
         settingsManager.updateSettings({
-          env: { ...settings.env, LETTA_API_KEY: tokens.access_token },
+          env: { LETTA_API_KEY: tokens.access_token },
           refreshToken: tokens.refresh_token || settings.refreshToken,
           tokenExpiresAt: now + tokens.expires_in * 1000,
         });

--- a/src/cli/components/ConstellationLoginOverlay.tsx
+++ b/src/cli/components/ConstellationLoginOverlay.tsx
@@ -1,5 +1,13 @@
+import { useInput } from "ink";
+import { useEffect, useRef, useState } from "react";
 import { ConstellationLoginView } from "@/auth/ConstellationLoginView";
+import {
+  LETTA_CLOUD_API_URL,
+  validateCredentialsWithResult,
+} from "@/auth/oauth";
 import { OverlayShell } from "@/cli/components/OverlayShell";
+import { Text } from "@/cli/components/Text";
+import { settingsManager } from "@/settings-manager";
 
 interface ConstellationLoginOverlayProps {
   onComplete: () => void;
@@ -12,13 +20,117 @@ export function ConstellationLoginOverlay({
   onAlreadyLoggedIn,
   onCancel,
 }: ConstellationLoginOverlayProps) {
+  const onAlreadyLoggedInRef = useRef(onAlreadyLoggedIn);
+  const onCancelRef = useRef(onCancel);
+  onAlreadyLoggedInRef.current = onAlreadyLoggedIn;
+  onCancelRef.current = onCancel;
+
+  const [preflight, setPreflight] = useState<
+    | { status: "checking" }
+    | { status: "login" }
+    | { status: "error"; message: string }
+  >({ status: "checking" });
+
+  useInput(
+    (input, key) => {
+      if (key.escape || (key.ctrl && input === "c")) {
+        onCancelRef.current();
+      }
+    },
+    { isActive: preflight.status !== "login" },
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const runPreflight = async () => {
+      try {
+        const currentSettings =
+          await settingsManager.getSettingsWithSecureTokens();
+        const envApiKey = process.env.LETTA_API_KEY;
+        const storedApiKey = currentSettings.env?.LETTA_API_KEY;
+        const apiKey = envApiKey || storedApiKey;
+
+        if (!apiKey) {
+          if (!cancelled) {
+            setPreflight({ status: "login" });
+          }
+          return;
+        }
+
+        const baseURL =
+          process.env.LETTA_BASE_URL ||
+          currentSettings.env?.LETTA_BASE_URL ||
+          LETTA_CLOUD_API_URL;
+        const validation = await validateCredentialsWithResult(baseURL, apiKey);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (validation.ok) {
+          onAlreadyLoggedInRef.current();
+          return;
+        }
+
+        if (envApiKey) {
+          setPreflight({
+            status: "error",
+            message:
+              "LETTA_API_KEY is set in your environment but is not valid. Unset or update LETTA_API_KEY, then run /login again.",
+          });
+          return;
+        }
+
+        if (
+          validation.reason === "network_error" ||
+          validation.reason === "server_unreachable"
+        ) {
+          setPreflight({
+            status: "error",
+            message: `Could not verify current credentials: ${validation.message}`,
+          });
+          return;
+        }
+
+        setPreflight({ status: "login" });
+      } catch (error) {
+        if (!cancelled) {
+          setPreflight({
+            status: "error",
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    };
+
+    void runPreflight();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (preflight.status === "checking") {
+    return (
+      <OverlayShell command="/login" title="Login to Constellation">
+        <Text dimColor>Checking current credentials...</Text>
+      </OverlayShell>
+    );
+  }
+
+  if (preflight.status === "error") {
+    return (
+      <OverlayShell command="/login" title="Login to Constellation">
+        <Text color="red">✗ Error: {preflight.message}</Text>
+        <Text dimColor>Press Esc to cancel</Text>
+      </OverlayShell>
+    );
+  }
+
   return (
     <OverlayShell command="/login" title="Login to Constellation">
-      <ConstellationLoginView
-        onComplete={onComplete}
-        onAlreadyLoggedIn={onAlreadyLoggedIn}
-        onCancel={onCancel}
-      />
+      <ConstellationLoginView onComplete={onComplete} onCancel={onCancel} />
     </OverlayShell>
   );
 }

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -74,6 +74,10 @@ describe("local-first setup wiring", () => {
       'initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu"',
     );
     expect(indexSource).toContain('setupResult.kind === "cancelled"');
+    expect(indexSource).toContain("const shouldValidateCredentials =");
+    expect(indexSource).toContain(
+      "baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey)",
+    );
   });
 
   test("startup auto-enters local mode for credentialless new users while honoring saved local preference", () => {

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -13,9 +13,7 @@ describe("local-first setup wiring", () => {
     expect(source).toContain(
       'const AUTH_LOGIN_LABEL = "Login to Constellation"',
     );
-    expect(source).toContain(
-      "const [selectedOption, setSelectedOption] = useState(1)",
-    );
+    expect(source).toContain('initialMode === "device-code" ? 0 : 1');
     expect(source).toContain('configureBackendMode("local")');
     expect(source).toContain(
       'settingsManager.updateSettings({ preferredBackendMode: "local" })',
@@ -39,6 +37,43 @@ describe("local-first setup wiring", () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     expect(source.slice(start, end)).toContain('preferredBackendMode: "api"');
+  });
+
+  test("reauthentication starts a fresh device-code login instead of trusting stale stored credentials", () => {
+    const loginSource = readSource("../auth/ConstellationLoginView.tsx");
+    const setupSource = readSource("../auth/setup-ui.tsx");
+    const setupRunnerSource = readSource("../auth/setup.ts");
+    const overlaySource = readSource(
+      "./components/ConstellationLoginOverlay.tsx",
+    );
+    const indexSource = readSource("../index.ts");
+
+    expect(loginSource).not.toContain("onAlreadyLoggedIn");
+    expect(loginSource).not.toContain("currentSettings.env?.LETTA_API_KEY");
+    expect(loginSource).toContain("Requesting authorization code...");
+    expect(loginSource).toContain(
+      "LETTA_API_KEY is set in your environment, so OAuth login cannot replace the credential Letta Code is using.",
+    );
+
+    expect(setupSource).toContain('initialMode === "device-code" ? 0 : 1');
+    expect(setupSource).toContain('onCancel={() => setMode("menu")}');
+    expect(setupRunnerSource).toContain("initialMode?: SetupInitialMode");
+    expect(setupRunnerSource).toContain("Promise<SetupResult>");
+    expect(setupRunnerSource).toContain('settle({ kind: "cancelled" })');
+    expect(setupRunnerSource).toContain("instance.unmount()");
+
+    expect(overlaySource).toContain(
+      "validateCredentialsWithResult(baseURL, apiKey)",
+    );
+    expect(overlaySource).toContain("onAlreadyLoggedInRef.current()");
+    expect(overlaySource).toContain("Could not verify current credentials");
+    expect(indexSource).toContain(
+      "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
+    );
+    expect(indexSource).toContain(
+      'initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu"',
+    );
+    expect(indexSource).toContain('setupResult.kind === "cancelled"');
   });
 
   test("startup auto-enters local mode for credentialless new users while honoring saved local preference", () => {

--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -157,7 +157,6 @@ describe("listen subcommand auth resolution", () => {
     expect(updateSettingsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         env: {
-          SOME_FLAG: "1",
           LETTA_API_KEY: "refreshed-key",
         },
         refreshToken: "new-refresh-token",
@@ -219,7 +218,6 @@ describe("listen subcommand auth resolution", () => {
     expect(updateSettingsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         env: {
-          SOME_FLAG: "1",
           LETTA_API_KEY: "oauth-key",
         },
         refreshToken: "oauth-refresh",

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -178,10 +178,7 @@ async function refreshListenerAccessToken(
   );
 
   settingsManager.updateSettings({
-    env: {
-      ...settings.env,
-      LETTA_API_KEY: tokens.access_token,
-    },
+    env: { LETTA_API_KEY: tokens.access_token },
     tokenExpiresAt: now + tokens.expires_in * 1000,
     ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
   });
@@ -193,7 +190,6 @@ async function refreshListenerAccessToken(
 }
 
 async function runListenerOAuthLogin(
-  currentEnv: Record<string, string> | undefined,
   deviceId: string,
   connectionName: string,
 ): Promise<string> {
@@ -218,10 +214,7 @@ async function runListenerOAuthLogin(
   const now = Date.now();
 
   settingsManager.updateSettings({
-    env: {
-      ...currentEnv,
-      LETTA_API_KEY: tokens.access_token,
-    },
+    env: { LETTA_API_KEY: tokens.access_token },
     tokenExpiresAt: now + tokens.expires_in * 1000,
     ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
   });
@@ -275,11 +268,7 @@ async function resolveListenerRegistrationOptions(
     }
 
     if (!apiKey) {
-      apiKey = await runListenerOAuthLogin(
-        settings.env,
-        deviceId,
-        connectionName,
-      );
+      apiKey = await runListenerOAuthLogin(deviceId, connectionName);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ async function refreshStartupOAuthToken(
     );
 
     settingsManager.updateSettings({
-      env: { ...settings.env, LETTA_API_KEY: tokens.access_token },
+      env: { LETTA_API_KEY: tokens.access_token },
       refreshToken: tokens.refresh_token || settings.refreshToken,
       tokenExpiresAt: now + tokens.expires_in * 1000,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -696,14 +696,6 @@ async function main(): Promise<void> {
   const settings = await settingsManager.getSettingsWithSecureTokens();
   markMilestone("SETTINGS_LOADED");
 
-  // Bootstrap base tools for subcommands that have LETTA_API_KEY set (e.g., remote via code-desktop)
-  if (process.env.LETTA_API_KEY) {
-    const { bootstrapBaseToolsIfNeeded } = await import(
-      "@/agent/bootstrap-tools"
-    );
-    await bootstrapBaseToolsIfNeeded();
-  }
-
   // Initialize LSP infrastructure for type checking
   if (process.env.LETTA_ENABLE_LSP) {
     try {
@@ -1226,7 +1218,10 @@ async function main(): Promise<void> {
     ) {
       // For interactive mode, show setup flow
       const { runSetup } = await import("@/auth/setup");
-      await runSetup();
+      const setupResult = await runSetup();
+      if (setupResult.kind === "cancelled") {
+        process.exit(0);
+      }
       // After setup, restart main flow
       return main().catch((err: unknown) => {
         // Handle top-level errors gracefully without raw stack traces
@@ -1245,7 +1240,10 @@ async function main(): Promise<void> {
       // For interactive mode, show setup flow
       console.log("No credentials found. Let's get you set up!\n");
       const { runSetup } = await import("@/auth/setup");
-      await runSetup();
+      const setupResult = await runSetup();
+      if (setupResult.kind === "cancelled") {
+        process.exit(0);
+      }
       // After setup, restart main flow
       return main();
     }
@@ -1260,9 +1258,13 @@ async function main(): Promise<void> {
       apiKey = (await refreshStartupOAuthToken(settings)) ?? apiKey;
     }
 
-    // Validate credentials by checking health endpoint
-    const { validateCredentials } = await import("@/auth/oauth");
-    let isValid = await validateCredentials(baseURL, apiKey ?? "");
+    // Validate credentials by checking an authenticated endpoint.
+    const { validateCredentialsWithResult } = await import("@/auth/oauth");
+    let credentialValidation = await validateCredentialsWithResult(
+      baseURL,
+      apiKey ?? "",
+    );
+    let isValid = credentialValidation.ok;
 
     if (
       !isValid &&
@@ -1273,7 +1275,11 @@ async function main(): Promise<void> {
       const refreshedApiKey = await refreshStartupOAuthToken(settings);
       if (refreshedApiKey) {
         apiKey = refreshedApiKey;
-        isValid = await validateCredentials(baseURL, apiKey);
+        credentialValidation = await validateCredentialsWithResult(
+          baseURL,
+          apiKey,
+        );
+        isValid = credentialValidation.ok;
       }
     }
     markMilestone("CREDENTIALS_VALIDATED");
@@ -1288,6 +1294,10 @@ async function main(): Promise<void> {
     }
 
     if (!isValid) {
+      const validationFailure = credentialValidation.ok
+        ? null
+        : credentialValidation;
+
       // For headless mode, error out with helpful message
       if (isHeadless) {
         console.error("Failed to connect to Letta server");
@@ -1295,9 +1305,16 @@ async function main(): Promise<void> {
         console.error(
           "Your credentials may be invalid or the server may be unreachable.",
         );
-        console.error(
-          "Delete ~/.letta/settings.json then run 'letta' to re-authenticate",
-        );
+        if (validationFailure?.message) {
+          console.error(`Details: ${validationFailure.message}`);
+        }
+        if (process.env.LETTA_API_KEY) {
+          console.error(
+            "LETTA_API_KEY is set in your environment. Unset or update LETTA_API_KEY, then run `letta` again.",
+          );
+        } else {
+          console.error("Run `letta setup` to re-authenticate.");
+        }
         process.exit(1);
       }
 
@@ -1307,9 +1324,37 @@ async function main(): Promise<void> {
       console.log(
         "Your credentials may be invalid or the server may be unreachable.",
       );
-      console.log("Let's reconfigure your setup.\n");
+      if (process.env.LETTA_API_KEY) {
+        console.log(
+          "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
+        );
+        console.log(
+          "Unset LETTA_API_KEY or update it with a valid API key, then run `letta` again.",
+        );
+        process.exit(1);
+      }
+
+      if (
+        validationFailure?.reason === "network_error" ||
+        validationFailure?.reason === "server_unreachable"
+      ) {
+        if (validationFailure.message) {
+          console.log(`Details: ${validationFailure.message}`);
+        }
+        console.log(
+          "Setup cannot fix a server reachability problem. Check your network or try again later.",
+        );
+        process.exit(1);
+      }
+
+      console.log("Let's reauthenticate your setup.\n");
       const { runSetup } = await import("@/auth/setup");
-      await runSetup();
+      const setupResult = await runSetup({
+        initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
+      });
+      if (setupResult.kind === "cancelled") {
+        process.exit(0);
+      }
       // After setup, restart main flow
       return main();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1258,105 +1258,114 @@ async function main(): Promise<void> {
       apiKey = (await refreshStartupOAuthToken(settings)) ?? apiKey;
     }
 
-    // Validate credentials by checking an authenticated endpoint.
-    const { validateCredentialsWithResult } = await import("@/auth/oauth");
-    let credentialValidation = await validateCredentialsWithResult(
-      baseURL,
-      apiKey ?? "",
-    );
-    let isValid = credentialValidation.ok;
+    // Cloud always requires credentials. Self-hosted/local API servers may be
+    // intentionally unauthenticated, so only validate them when a key is present.
+    const shouldValidateCredentials =
+      baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey);
 
-    if (
-      !isValid &&
-      !process.env.LETTA_API_KEY &&
-      baseURL === LETTA_CLOUD_API_URL &&
-      settings.refreshToken
-    ) {
-      const refreshedApiKey = await refreshStartupOAuthToken(settings);
-      if (refreshedApiKey) {
-        apiKey = refreshedApiKey;
-        credentialValidation = await validateCredentialsWithResult(
-          baseURL,
-          apiKey,
-        );
-        isValid = credentialValidation.ok;
-      }
-    }
-    markMilestone("CREDENTIALS_VALIDATED");
-
-    // Ensure base tools exist on the server (first-run-per-machine, non-blocking).
-    // Must run after credentials are validated so OAuth tokens are available.
-    if (isValid) {
-      const { bootstrapBaseToolsIfNeeded } = await import(
-        "@/agent/bootstrap-tools"
+    if (shouldValidateCredentials) {
+      // Validate credentials by checking an authenticated endpoint.
+      const { validateCredentialsWithResult } = await import("@/auth/oauth");
+      let credentialValidation = await validateCredentialsWithResult(
+        baseURL,
+        apiKey ?? "",
       );
-      await bootstrapBaseToolsIfNeeded();
-    }
-
-    if (!isValid) {
-      const validationFailure = credentialValidation.ok
-        ? null
-        : credentialValidation;
-
-      // For headless mode, error out with helpful message
-      if (isHeadless) {
-        console.error("Failed to connect to Letta server");
-        console.error(`Base URL: ${baseURL}`);
-        console.error(
-          "Your credentials may be invalid or the server may be unreachable.",
-        );
-        if (validationFailure?.message) {
-          console.error(`Details: ${validationFailure.message}`);
-        }
-        if (process.env.LETTA_API_KEY) {
-          console.error(
-            "LETTA_API_KEY is set in your environment. Unset or update LETTA_API_KEY, then run `letta` again.",
-          );
-        } else {
-          console.error("Run `letta setup` to re-authenticate.");
-        }
-        process.exit(1);
-      }
-
-      // For interactive mode, show setup flow
-      console.log("Failed to connect to Letta server.");
-      console.log(`Base URL: ${baseURL}\n`);
-      console.log(
-        "Your credentials may be invalid or the server may be unreachable.",
-      );
-      if (process.env.LETTA_API_KEY) {
-        console.log(
-          "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
-        );
-        console.log(
-          "Unset LETTA_API_KEY or update it with a valid API key, then run `letta` again.",
-        );
-        process.exit(1);
-      }
+      let isValid = credentialValidation.ok;
 
       if (
-        validationFailure?.reason === "network_error" ||
-        validationFailure?.reason === "server_unreachable"
+        !isValid &&
+        !process.env.LETTA_API_KEY &&
+        baseURL === LETTA_CLOUD_API_URL &&
+        settings.refreshToken
       ) {
-        if (validationFailure.message) {
-          console.log(`Details: ${validationFailure.message}`);
+        const refreshedApiKey = await refreshStartupOAuthToken(settings);
+        if (refreshedApiKey) {
+          apiKey = refreshedApiKey;
+          credentialValidation = await validateCredentialsWithResult(
+            baseURL,
+            apiKey,
+          );
+          isValid = credentialValidation.ok;
         }
-        console.log(
-          "Setup cannot fix a server reachability problem. Check your network or try again later.",
+      }
+      markMilestone("CREDENTIALS_VALIDATED");
+
+      // Ensure base tools exist on the server (first-run-per-machine, non-blocking).
+      // Must run after credentials are validated so OAuth tokens are available.
+      if (isValid) {
+        const { bootstrapBaseToolsIfNeeded } = await import(
+          "@/agent/bootstrap-tools"
         );
-        process.exit(1);
+        await bootstrapBaseToolsIfNeeded();
       }
 
-      console.log("Let's reauthenticate your setup.\n");
-      const { runSetup } = await import("@/auth/setup");
-      const setupResult = await runSetup({
-        initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
-      });
-      if (setupResult.kind === "cancelled") {
-        process.exit(0);
+      if (!isValid) {
+        const validationFailure = credentialValidation.ok
+          ? null
+          : credentialValidation;
+
+        // For headless mode, error out with helpful message
+        if (isHeadless) {
+          console.error("Failed to connect to Letta server");
+          console.error(`Base URL: ${baseURL}`);
+          console.error(
+            "Your credentials may be invalid or the server may be unreachable.",
+          );
+          if (validationFailure?.message) {
+            console.error(`Details: ${validationFailure.message}`);
+          }
+          if (process.env.LETTA_API_KEY) {
+            console.error(
+              "LETTA_API_KEY is set in your environment. Unset or update LETTA_API_KEY, then run `letta` again.",
+            );
+          } else {
+            console.error("Run `letta setup` to re-authenticate.");
+          }
+          process.exit(1);
+        }
+
+        // For interactive mode, show setup flow
+        console.log("Failed to connect to Letta server.");
+        console.log(`Base URL: ${baseURL}\n`);
+        console.log(
+          "Your credentials may be invalid or the server may be unreachable.",
+        );
+        if (process.env.LETTA_API_KEY) {
+          console.log(
+            "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
+          );
+          console.log(
+            "Unset LETTA_API_KEY or update it with a valid API key, then run `letta` again.",
+          );
+          process.exit(1);
+        }
+
+        if (
+          validationFailure?.reason === "network_error" ||
+          validationFailure?.reason === "server_unreachable"
+        ) {
+          if (validationFailure.message) {
+            console.log(`Details: ${validationFailure.message}`);
+          }
+          console.log(
+            "Setup cannot fix a server reachability problem. Check your network or try again later.",
+          );
+          process.exit(1);
+        }
+
+        console.log("Let's reauthenticate your setup.\n");
+        const { runSetup } = await import("@/auth/setup");
+        const setupResult = await runSetup({
+          initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
+        });
+        if (setupResult.kind === "cancelled") {
+          process.exit(0);
+        }
+        // After setup, restart main flow
+        return main();
       }
-      // After setup, restart main flow
-      return main();
+    } else {
+      markMilestone("CREDENTIALS_VALIDATED");
     }
   } else {
     markMilestone("CREDENTIALS_VALIDATED");

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1541,6 +1541,51 @@ describe("Settings Manager - Managed Keys Preservation", () => {
       );
     }
   });
+
+  test("Auth-only token updates preserve unrelated env settings", async () => {
+    const previousSkipKeychain = process.env.LETTA_SKIP_KEYCHAIN_CHECK;
+    process.env.LETTA_SKIP_KEYCHAIN_CHECK = "1";
+
+    try {
+      const { writeFile, readFile, mkdir } = await import("@/utils/fs.js");
+      const settingsDir = join(testHomeDir, ".letta");
+      const settingsPath = join(settingsDir, "settings.json");
+      await mkdir(settingsDir, { recursive: true });
+
+      await writeFile(
+        settingsPath,
+        JSON.stringify({
+          env: { SOME_FLAG: "1" },
+          tokenStreaming: true,
+        }),
+      );
+
+      await settingsManager.initialize();
+      settingsManager.updateSettings({
+        env: { LETTA_API_KEY: "sk-auth-only" },
+        refreshToken: "rt-auth-only",
+        tokenExpiresAt: 123,
+      });
+      await settingsManager.flush();
+
+      const raw = JSON.parse(await readFile(settingsPath)) as Record<
+        string,
+        unknown
+      >;
+      expect(raw.env).toEqual({
+        SOME_FLAG: "1",
+        LETTA_API_KEY: "sk-auth-only",
+      });
+      expect(raw.refreshToken).toBe("rt-auth-only");
+      expect(raw.tokenExpiresAt).toBe(123);
+    } finally {
+      if (previousSkipKeychain === undefined) {
+        delete process.env.LETTA_SKIP_KEYCHAIN_CHECK;
+      } else {
+        process.env.LETTA_SKIP_KEYCHAIN_CHECK = previousSkipKeychain;
+      }
+    }
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Separate OAuth device-code login from the "already signed in" check so startup reauth can replace stale stored credentials.
- Start failed cloud startup auth directly in device-code reauth, while explicitly blocking invalid `LETTA_API_KEY` env overrides and server reachability failures.
- Add loading/cancel states around device-code setup and regression coverage for the stale-credential path.

## Test plan
- [x] `bun test src/cli/local-first-setup-wiring.test.ts src/auth/oauth-network-errors.test.ts`
- [x] `bun run check`
- [x] Manual headless invalid env check: `LETTA_API_KEY=bad ... letta -p hello`

👾 Generated with [Letta Code](https://letta.com)