### PR TITLE
fix(telemetry): use correct relative import and add lint rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,15 @@
     "rules": {
       "recommended": true,
       "style": {
-        "noDefaultExport": "error"
+        "noDefaultExport": "error",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "./telemetry": "Use @/telemetry instead of a relative import — relative paths cause the bundler to emit duplicate module copies, breaking the singleton."
+            }
+          }
+        }
       }
     }
   },

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -129,9 +129,9 @@ import {
 import { getCurrentWorkingDirectory } from "./runtime-context";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
 import { writeWireMessage, writeWireMessageAsync } from "./stream-json-writer";
-import { getTerminalTelemetrySurface, telemetry } from "./telemetry";
-import { trackBoundaryError } from "./telemetry/error-reporting";
-import { extractTelemetryInputText } from "./telemetry/input";
+import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { extractTelemetryInputText } from "@/telemetry/input";
 import { isInteractiveApprovalTool } from "./tools/interactive-policy";
 import {
   type ExternalToolDefinition,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -6,6 +6,9 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { extractTelemetryInputText } from "@/telemetry/input";
 import {
   type QueuedMessage,
   setMessageQueueAdder,
@@ -129,9 +132,6 @@ import {
 import { getCurrentWorkingDirectory } from "./runtime-context";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
 import { writeWireMessage, writeWireMessageAsync } from "./stream-json-writer";
-import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
-import { trackBoundaryError } from "@/telemetry/error-reporting";
-import { extractTelemetryInputText } from "@/telemetry/input";
 import { isInteractiveApprovalTool } from "./tools/interactive-policy";
 import {
   type ExternalToolDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { hostname } from "node:os";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { ensureFileIndex } from "@/utils/file-index";
 import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import {
@@ -82,8 +84,6 @@ import {
   shouldPersistSessionState,
 } from "./settings-manager";
 import { startStartupAutoUpdateCheck } from "./startup-auto-update";
-import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
-import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { loadTools } from "./tools/manager";
 import { clearPersistedClientToolRules } from "./tools/toolset";
 import { debugLog, debugWarn, isDebugEnabled } from "./utils/debug";

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,8 @@ import {
   shouldPersistSessionState,
 } from "./settings-manager";
 import { startStartupAutoUpdateCheck } from "./startup-auto-update";
-import { getTerminalTelemetrySurface, telemetry } from "./telemetry";
-import { trackBoundaryError } from "./telemetry/error-reporting";
+import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { loadTools } from "./tools/manager";
 import { clearPersistedClientToolRules } from "./tools/toolset";
 import { debugLog, debugWarn, isDebugEnabled } from "./utils/debug";

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -763,5 +763,20 @@ class TelemetryManager {
   }
 }
 
-// Export singleton instance
-export const telemetry = new TelemetryManager();
+// Export singleton instance.
+//
+// Stash on globalThis so accidental module duplication (e.g. a stray
+// relative-vs-aliased import causing the bundler to emit two copies of
+// this module) still yields a single TelemetryManager. Without this
+// guard, one copy gets init()'d while another receives track() calls,
+// producing events with deviceId="" and silent 400s from the metadata
+// endpoint ("Organization ID is required for telemetry events.").
+const TELEMETRY_GLOBAL_KEY = "__lettaCodeTelemetrySingleton" as const;
+type GlobalWithTelemetry = typeof globalThis & {
+  [TELEMETRY_GLOBAL_KEY]?: TelemetryManager;
+};
+const globalScope = globalThis as GlobalWithTelemetry;
+if (!globalScope[TELEMETRY_GLOBAL_KEY]) {
+  globalScope[TELEMETRY_GLOBAL_KEY] = new TelemetryManager();
+}
+export const telemetry: TelemetryManager = globalScope[TELEMETRY_GLOBAL_KEY];

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -763,20 +763,5 @@ class TelemetryManager {
   }
 }
 
-// Export singleton instance.
-//
-// Stash on globalThis so accidental module duplication (e.g. a stray
-// relative-vs-aliased import causing the bundler to emit two copies of
-// this module) still yields a single TelemetryManager. Without this
-// guard, one copy gets init()'d while another receives track() calls,
-// producing events with deviceId="" and silent 400s from the metadata
-// endpoint ("Organization ID is required for telemetry events.").
-const TELEMETRY_GLOBAL_KEY = "__lettaCodeTelemetrySingleton" as const;
-type GlobalWithTelemetry = typeof globalThis & {
-  [TELEMETRY_GLOBAL_KEY]?: TelemetryManager;
-};
-const globalScope = globalThis as GlobalWithTelemetry;
-if (!globalScope[TELEMETRY_GLOBAL_KEY]) {
-  globalScope[TELEMETRY_GLOBAL_KEY] = new TelemetryManager();
-}
-export const telemetry: TelemetryManager = globalScope[TELEMETRY_GLOBAL_KEY];
+// Export singleton instance
+export const telemetry = new TelemetryManager();


### PR DESCRIPTION
## Summary
- The bundler emits two copies of the telemetry module because entry points (`index.ts`, `headless.ts`) use relative `./telemetry` imports while the rest of the codebase uses `@/telemetry`. One copy gets `init()` (sets `deviceId`), the other receives `track()` calls (`deviceId` stays null → sent as `""` → API 400: "Organization ID is required").
- Normalize the two relative imports to `@/telemetry` as belt-and-suspenders

## Test plan
- [ ] Verify `[TELEM-SEND]` logs no longer show `deviceId=EMPTY`
- [ ] Verify telemetry events flush successfully (no 400 errors)
- [ ] Run existing telemetry tests (`bun test src/telemetry/`)

🤖 Generated with [Letta Code](https://letta.com)