### PR TITLE
feat(listener): add typed Letta Code upgrade command

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -685,6 +685,10 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             sessionLog.log(`status: ${status}`);
             console.log(`[${formatTimestamp()}] status: ${status}`);
           },
+          onLog: (message) => {
+            sessionLog.log(message);
+            console.log(`[${formatTimestamp()}] ${message}`);
+          },
           onConnected: () => {
             sessionLog.log("Connected. Awaiting instructions.");
             console.log(
@@ -774,6 +778,10 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
             sessionLog.log(`status: ${status}`);
             clearRetryStatusCallback?.();
             updateStatusCallback?.(status);
+          },
+          onLog: (message) => {
+            sessionLog.log(message);
+            console.log(`[${formatTimestamp()}] ${message}`);
           },
           onConnected: () => {
             sessionLog.log("Connected. Awaiting instructions.");

--- a/src/updater/auto-update.test.ts
+++ b/src/updater/auto-update.test.ts
@@ -7,6 +7,7 @@ import {
   buildLatestVersionUrl,
   checkForUpdate,
   detectPackageManager,
+  getSelfUpdateStatus,
   resolveUpdateInstallRegistryUrl,
   resolveUpdatePackageName,
   resolveUpdateRegistryBaseUrl,
@@ -220,6 +221,52 @@ describe("detectPackageManager", () => {
     process.argv[1] =
       "/usr/local/lib/node_modules/@letta-ai/letta-code/dist/index.js";
     expect(detectPackageManager()).toBe("npm");
+  });
+});
+
+describe("getSelfUpdateStatus", () => {
+  let originalArgv1: string;
+  let originalDesktopManaged: string | undefined;
+
+  beforeEach(() => {
+    originalArgv1 = process.argv[1] || "";
+    originalDesktopManaged = process.env.LETTA_CODE_DESKTOP_MANAGED;
+    delete process.env.LETTA_CODE_DESKTOP_MANAGED;
+  });
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+    if (originalDesktopManaged !== undefined) {
+      process.env.LETTA_CODE_DESKTOP_MANAGED = originalDesktopManaged;
+    } else {
+      delete process.env.LETTA_CODE_DESKTOP_MANAGED;
+    }
+  });
+
+  test("disables self-update for packaged Desktop runtimes", () => {
+    process.argv[1] =
+      "/Applications/Letta.app/Contents/Resources/app.asar.unpacked/node_modules/@letta-ai/letta-code/letta.js";
+
+    const status = getSelfUpdateStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.writable).toBe(false);
+    expect(status.reason).toContain("managed by Letta Code Desktop");
+    expect(status.manual_command).toBe(
+      "Update Letta Code Desktop to upgrade the bundled Letta Code runtime.",
+    );
+  });
+
+  test("disables self-update when Desktop marks the runtime as managed", () => {
+    process.env.LETTA_CODE_DESKTOP_MANAGED = "1";
+    process.argv[1] =
+      "/Users/test/.nvm/versions/node/v20.10.0/lib/node_modules/@letta-ai/letta-code/dist/index.js";
+
+    const status = getSelfUpdateStatus();
+
+    expect(status.supported).toBe(false);
+    expect(status.writable).toBe(false);
+    expect(status.reason).toContain("managed by Letta Code Desktop");
   });
 });
 

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -32,6 +32,7 @@ const DEFAULT_UPDATE_REGISTRY_BASE_URL = "https://registry.npmjs.org";
 const UPDATE_PACKAGE_NAME_ENV = "LETTA_UPDATE_PACKAGE_NAME";
 const UPDATE_REGISTRY_BASE_URL_ENV = "LETTA_UPDATE_REGISTRY_BASE_URL";
 const UPDATE_INSTALL_REGISTRY_URL_ENV = "LETTA_UPDATE_INSTALL_REGISTRY_URL";
+const DESKTOP_MANAGED_ENV = "LETTA_CODE_DESKTOP_MANAGED";
 
 const INSTALL_ARG_PREFIX: Record<PackageManager, string[]> = {
   npm: ["install", "-g"],
@@ -142,10 +143,29 @@ function canWritePath(path: string): boolean {
   }
 }
 
+function isDesktopManagedRuntime(resolvedEntrypoint: string): boolean {
+  return (
+    process.env[DESKTOP_MANAGED_ENV] === "1" ||
+    resolvedEntrypoint.includes("app.asar.unpacked")
+  );
+}
+
 export function getSelfUpdateStatus(): SelfUpdateStatus {
   const pm = detectPackageManager();
   const manualCommand = buildInstallCommand(pm);
   const resolvedEntrypoint = getResolvedEntrypoint();
+
+  if (isDesktopManagedRuntime(resolvedEntrypoint)) {
+    return {
+      supported: false,
+      writable: false,
+      reason:
+        "Self-update is disabled because this Letta Code runtime is managed by Letta Code Desktop.",
+      manual_command:
+        "Update Letta Code Desktop to upgrade the bundled Letta Code runtime.",
+    };
+  }
+
   const installPath = findInstalledPackagePath(resolvedEntrypoint);
 
   if (!installPath) {

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -301,10 +301,14 @@ async function performUpdate(): Promise<{
 
   try {
     debugLog(`Running ${installCmd}...`);
+    console.log(`Running update command: ${installCmd}`);
     await execFileAsync(pm, installArgs, { timeout: 60000 });
     debugLog("Update completed successfully");
+    console.log("Update command completed successfully.");
     return { success: true };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Update command failed: ${message}`);
     trackBoundaryError({
       errorType: "auto_update_install_failed",
       error,

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -278,7 +278,7 @@ async function cleanupOrphanedDirs(globalPath: string): Promise<void> {
   }
 }
 
-async function performUpdate(): Promise<{
+async function performUpdate(progressLog?: (message: string) => void): Promise<{
   success: boolean;
   error?: string;
   enotemptyFailed?: boolean;
@@ -301,14 +301,14 @@ async function performUpdate(): Promise<{
 
   try {
     debugLog(`Running ${installCmd}...`);
-    console.log(`Running update command: ${installCmd}`);
+    progressLog?.(`Running update command: ${installCmd}`);
     await execFileAsync(pm, installArgs, { timeout: 60000 });
     debugLog("Update completed successfully");
-    console.log("Update command completed successfully.");
+    progressLog?.("Update command completed successfully.");
     return { success: true };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`Update command failed: ${message}`);
+    progressLog?.(`Update command failed: ${message}`);
     trackBoundaryError({
       errorType: "auto_update_install_failed",
       error,
@@ -440,7 +440,9 @@ export async function checkAndAutoUpdate(): Promise<
   return undefined;
 }
 
-export async function manualUpdate(): Promise<{
+export async function manualUpdate(options?: {
+  progressLog?: (message: string) => void;
+}): Promise<{
   success: boolean;
   message: string;
 }> {
@@ -467,11 +469,12 @@ export async function manualUpdate(): Promise<{
     };
   }
 
-  console.log(
+  const progressLog = options?.progressLog ?? console.log;
+  progressLog(
     `Updating from ${result.currentVersion} to ${result.latestVersion}...`,
   );
 
-  const updateResult = await performUpdate();
+  const updateResult = await performUpdate(progressLog);
 
   if (updateResult.success) {
     return {

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { accessSync, constants, realpathSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { getVersion } from "@/version";
@@ -41,6 +41,14 @@ const INSTALL_ARG_PREFIX: Record<PackageManager, string[]> = {
 
 const VALID_PACKAGE_MANAGERS = new Set<string>(Object.keys(INSTALL_ARG_PREFIX));
 type FetchImpl = typeof fetch;
+
+export interface SelfUpdateStatus {
+  supported: boolean;
+  writable: boolean;
+  reason?: string;
+  install_path?: string;
+  manual_command: string;
+}
 
 function normalizeUpdatePackageName(raw: string | undefined): string | null {
   if (!raw) return null;
@@ -107,6 +115,61 @@ export function buildInstallCommand(
   return `${pm} ${buildInstallArgs(pm, env).join(" ")}`;
 }
 
+function getResolvedEntrypoint(): string {
+  const argv = process.argv[1] || "";
+  try {
+    return realpathSync(argv);
+  } catch {
+    return argv;
+  }
+}
+
+function findInstalledPackagePath(resolvedPath: string): string | null {
+  const marker = `${join("node_modules", "@letta-ai", "letta-code")}`;
+  const index = resolvedPath.lastIndexOf(marker);
+  if (index === -1) {
+    return null;
+  }
+  return resolvedPath.slice(0, index + marker.length);
+}
+
+function canWritePath(path: string): boolean {
+  try {
+    accessSync(path, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getSelfUpdateStatus(): SelfUpdateStatus {
+  const pm = detectPackageManager();
+  const manualCommand = buildInstallCommand(pm);
+  const resolvedEntrypoint = getResolvedEntrypoint();
+  const installPath = findInstalledPackagePath(resolvedEntrypoint);
+
+  if (!installPath) {
+    return {
+      supported: false,
+      writable: false,
+      reason: "Self-update is disabled for development/source checkouts.",
+      manual_command: manualCommand,
+    };
+  }
+
+  const packageParentPath = dirname(installPath);
+  const writable = canWritePath(installPath) && canWritePath(packageParentPath);
+  return {
+    supported: true,
+    writable,
+    reason: writable
+      ? undefined
+      : `Self-update requires write access to ${packageParentPath}. Run ${manualCommand} manually or reinstall Letta Code in a user-writable npm prefix.`,
+    install_path: installPath,
+    manual_command: manualCommand,
+  };
+}
+
 export function buildInstallArgs(
   pm: PackageManager,
   env: NodeJS.ProcessEnv = process.env,
@@ -136,13 +199,7 @@ export function detectPackageManager(): PackageManager {
     );
   }
 
-  const argv = process.argv[1] || "";
-  let resolvedPath = argv;
-  try {
-    resolvedPath = realpathSync(argv);
-  } catch {
-    // If realpath fails, use original path
-  }
+  const resolvedPath = getResolvedEntrypoint();
 
   if (/[/\\]\.bun[/\\]/.test(resolvedPath)) {
     debugLog("Detected package manager from path: bun");
@@ -163,16 +220,7 @@ function isAutoUpdateEnabled(): boolean {
 
 function isRunningLocally(): boolean {
   const argv = process.argv[1] || "";
-
-  // Resolve symlinks to get the real path
-  // npm creates symlinks in /bin/ that point to /lib/node_modules/
-  // Without resolving, argv would be like ~/.nvm/.../bin/letta (no node_modules)
-  let resolvedPath = argv;
-  try {
-    resolvedPath = realpathSync(argv);
-  } catch {
-    // If realpath fails (file doesn't exist), use original path
-  }
+  const resolvedPath = getResolvedEntrypoint();
 
   debugLog("argv[1]:", argv);
   debugLog("resolved path:", resolvedPath);

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -3,6 +3,7 @@
  * Owns the HTTP request contract and error handling; callers own UX strings and logging.
  */
 import { getVersion } from "@/version.ts";
+import { SUPPORTED_REMOTE_COMMANDS } from "./listener/listener-constants";
 
 export interface RegisterResult {
   connectionId: string;
@@ -92,6 +93,7 @@ export async function registerWithCloud(
         lettaCodeVersion: getVersion(),
         os: process.platform,
         nodeVersion: process.version,
+        supported_commands: SUPPORTED_REMOTE_COMMANDS,
       },
     }),
   }).catch((fetchError: unknown) => {

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -2,6 +2,8 @@
  * Shared registration helper for letta server / /server command.
  * Owns the HTTP request contract and error handling; callers own UX strings and logging.
  */
+
+import { getSelfUpdateStatus } from "@/updater/auto-update";
 import { getVersion } from "@/version.ts";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener/listener-constants";
 
@@ -94,6 +96,7 @@ export async function registerWithCloud(
         os: process.platform,
         nodeVersion: process.version,
         supported_commands: SUPPORTED_REMOTE_COMMANDS,
+        self_update: getSelfUpdateStatus(),
       },
     }),
   }).catch((fetchError: unknown) => {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -67,6 +67,7 @@ export async function handleExecuteCommand(
   conversationRuntime: ConversationRuntime,
   opts: {
     onStatusChange?: StartListenerOptions["onStatusChange"];
+    onLog?: StartListenerOptions["onLog"];
     connectionId?: string;
     connectionName?: string;
   },
@@ -191,30 +192,59 @@ export async function handleExecuteCommand(
 }
 
 async function handleUpgradeLettaCodeCommand(opts: {
+  onLog?: StartListenerOptions["onLog"];
   connectionName?: string;
 }): Promise<string> {
+  const log = (message: string) => {
+    const line = `[upgrade-letta-code] ${message}`;
+    if (opts.onLog) {
+      opts.onLog(line);
+    } else {
+      console.log(line);
+    }
+  };
+
+  log(
+    `command received (connectionName=${opts.connectionName ?? "unknown"}, execPath=${process.execPath}, entrypoint=${process.argv[1] ?? "unknown"})`,
+  );
   const { manualUpdate } = await import("@/updater/auto-update");
+  log("starting manualUpdate()");
   const result = await manualUpdate();
+  log(
+    `manualUpdate() completed: success=${result.success}; message=${result.message}`,
+  );
 
   if (!result.success) {
+    log(`upgrade failed: ${result.message}`);
     throw new Error(result.message);
   }
 
   if (!result.message.startsWith("Updated to ")) {
+    log("no restart scheduled because no update was installed");
     return result.message;
   }
 
-  scheduleRemoteRestart(opts.connectionName);
+  scheduleRemoteRestart(opts.connectionName, log);
   return `${result.message}\nRestarting remote listener...`;
 }
 
-function scheduleRemoteRestart(connectionName: string | undefined): void {
+function scheduleRemoteRestart(
+  connectionName: string | undefined,
+  log: (message: string) => void,
+): void {
   const entrypoint = process.argv[1];
   if (!entrypoint || !connectionName) {
+    log(
+      `restart skipped (entrypoint=${entrypoint ?? "missing"}, connectionName=${connectionName ?? "missing"})`,
+    );
     return;
   }
 
+  log(`scheduling remote listener restart for env ${connectionName}`);
   setTimeout(() => {
+    log(
+      `spawning replacement listener: ${process.execPath} ${entrypoint} remote --env-name ${connectionName}`,
+    );
     const child = spawn(
       process.execPath,
       [entrypoint, "remote", "--env-name", connectionName],
@@ -224,6 +254,9 @@ function scheduleRemoteRestart(connectionName: string | undefined): void {
         env: process.env,
         stdio: "ignore",
       },
+    );
+    log(
+      `spawned replacement listener pid=${child.pid ?? "unknown"}; exiting current listener`,
     );
     child.unref();
     process.exit(0);

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import type WebSocket from "ws";
 import { regenerateConversationDescription } from "@/agent/conversation-description";
 import {
@@ -67,6 +68,7 @@ export async function handleExecuteCommand(
   opts: {
     onStatusChange?: StartListenerOptions["onStatusChange"];
     connectionId?: string;
+    connectionName?: string;
   },
 ): Promise<void> {
   const scope = {
@@ -147,6 +149,10 @@ export async function handleExecuteCommand(
         );
         break;
 
+      case "upgrade-letta-code":
+        output = await handleUpgradeLettaCodeCommand(opts);
+        break;
+
       default:
         emitSlashCommandEnd(socket, conversationRuntime, scope, {
           command_id: command.command_id,
@@ -182,6 +188,46 @@ export async function handleExecuteCommand(
     // "interrupt_in_progress"). Reset it so subsequent user messages drain.
     conversationRuntime.cancelRequested = false;
   }
+}
+
+async function handleUpgradeLettaCodeCommand(opts: {
+  connectionName?: string;
+}): Promise<string> {
+  const { manualUpdate } = await import("@/updater/auto-update");
+  const result = await manualUpdate();
+
+  if (!result.success) {
+    throw new Error(result.message);
+  }
+
+  if (!result.message.startsWith("Updated to ")) {
+    return result.message;
+  }
+
+  scheduleRemoteRestart(opts.connectionName);
+  return `${result.message}\nRestarting remote listener...`;
+}
+
+function scheduleRemoteRestart(connectionName: string | undefined): void {
+  const entrypoint = process.argv[1];
+  if (!entrypoint || !connectionName) {
+    return;
+  }
+
+  setTimeout(() => {
+    const child = spawn(
+      process.execPath,
+      [entrypoint, "remote", "--env-name", connectionName],
+      {
+        cwd: process.cwd(),
+        detached: true,
+        env: process.env,
+        stdio: "ignore",
+      },
+    );
+    child.unref();
+    process.exit(0);
+  }, 1000).unref();
 }
 
 function emitSlashCommandEnd(

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -209,7 +209,7 @@ async function handleUpgradeLettaCodeCommand(opts: {
   );
   const { manualUpdate } = await import("@/updater/auto-update");
   log("starting manualUpdate()");
-  const result = await manualUpdate();
+  const result = await manualUpdate({ progressLog: log });
   log(
     `manualUpdate() completed: success=${result.success}; message=${result.message}`,
   );

--- a/src/websocket/listener/listener-constants.ts
+++ b/src/websocket/listener/listener-constants.ts
@@ -14,6 +14,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "compact",
   "context-limit",
   "channels",
+  "upgrade-letta-code",
   "toolset",
   // /secret opens the EditSecretsDialog and routes reads/writes through the
   // dedicated secret_list / secret_apply WS commands — not via

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -588,6 +588,7 @@ export function createListenerMessageHandler(
           await handleExecuteCommand(parsed, socket, scopedRuntime, {
             onStatusChange: opts.onStatusChange,
             connectionId: opts.connectionId,
+            connectionName: opts.connectionName,
           });
         });
         return;

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -587,6 +587,7 @@ export function createListenerMessageHandler(
         runDetachedListenerTask("execute_command", async () => {
           await handleExecuteCommand(parsed, socket, scopedRuntime, {
             onStatusChange: opts.onStatusChange,
+            onLog: opts.onLog,
             connectionId: opts.connectionId,
             connectionName: opts.connectionName,
           });

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -40,6 +40,7 @@ export interface StartListenerOptions {
     status: "idle" | "receiving" | "processing",
     connectionId: string,
   ) => void;
+  onLog?: (message: string) => void;
   onRetrying?: (
     attempt: number,
     maxAttempts: number,


### PR DESCRIPTION
## Summary
- Add an allowlisted `upgrade-letta-code` remote command advertised through listener supported commands.
- Run the existing manual updater inside the listener, then restart `letta remote` with the same environment name after a successful update.
- Include supported command metadata at environment registration so clients can capability-gate upgrade affordances.

## Test plan
- [x] `git diff --check`
- [x] `npm run typecheck`

👾 Generated with [Letta Code](https://letta.com)