### PR TITLE
feat(reflection): support manual multi-transcript reflection

### DIFF
--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -29,7 +29,12 @@ You can create, delete, or modify files (contents, names, descriptions). You can
 
 ## Memory Reflection
 
-Your job is to review the recent conversation and update the primary agent's memory files to capture any durable learnings. Follow the phases below in order.
+Your job is to review the recent conversation payload and update the primary agent's memory files to capture any durable learnings. The payload is at `$TRANSCRIPT_PATH`. It may be either:
+
+1. a JSON message array for one conversation, or
+2. a `multi_transcript_reflection_payload` manifest. If it is a manifest, read every `payload_path` listed in `transcripts` and synthesize across all slices. Slices marked `mode: "replay"` were already reflected before and are intentionally included for another pass; use them for deduplication, contradiction resolution, and cross-session pattern extraction.
+
+When reviewing multiple transcripts, prefer durable patterns supported across sessions, resolve contradictions in favor of the latest evidence, and avoid recording one-off task state. Follow the phases below in order.
 
 ---
 

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -53,4 +53,11 @@ describe("app URL helpers", () => {
       "\x1b]8;;https://app.letta.com/chat/agent-abc\x1b\\agent-abc\x1b]8;;\x1b\\",
     );
   });
+
+  test("buildAgentTerminalLink supports a custom label with the same chat URL target", () => {
+    const targetUrl = buildChatUrl("agent-abc");
+    expect(buildAgentTerminalLink("agent-abc", undefined, "memories")).toBe(
+      `\x1b]8;;${targetUrl}\x1b\\memories\x1b]8;;\x1b\\`,
+    );
+  });
 });

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -22,6 +22,7 @@ import {
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
 } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
+import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import {
   ensureMemoryFilesystemDirs,
   getScopedMemoryFilesystemRoot,
@@ -31,7 +32,6 @@ import {
   isActiveMemfsEnabled,
   isLocalMemfsActive,
 } from "@/agent/memory-runtime";
-import { sendMessageStreamWithBackend } from "@/agent/message";
 import {
   detectPersonalityFromPersonaFile,
   type PersonalityId,
@@ -40,9 +40,20 @@ import { recordSessionEnd } from "@/agent/session-history";
 import type { SessionStats } from "@/agent/stats";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
-import type { CustomCommand } from "@/cli/commands/custom";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
+import {
+  buildExtensionCommandPrompt,
+  parseExtensionCommandArgv,
+  parseExtensionSlashCommand,
+  runExtensionCommandWithTimeout,
+} from "@/cli/extensions/command-runtime";
+import type {
+  ExtensionCommand,
+  ExtensionCommandContext,
+  ExtensionConversationCloseReason,
+} from "@/cli/extensions/types";
+import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import {
@@ -70,6 +81,7 @@ import {
 } from "@/cli/helpers/init-command";
 import { buildLogoutSuccessMessage } from "@/cli/helpers/logout-message";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
+import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
 import {
   buildMessageContentFromDisplay,
   clearPlaceholdersInText,
@@ -78,7 +90,18 @@ import { resolveReasoningTabToggleCommand } from "@/cli/helpers/reasoning-tab-to
 import {
   AUTO_REFLECTION_DESCRIPTION,
   launchReflectionSubagent,
+  releaseReflectionLaunch,
+  tryReserveReflectionLaunch,
 } from "@/cli/helpers/reflection-launcher";
+import {
+  buildMultiReflectionPayload,
+  buildParentMemorySnapshot,
+  buildReflectionAutoPayload,
+  buildReflectionSelectorPrompt,
+  buildReflectionSubagentPrompt,
+  finalizeMultiReflectionPayload,
+  readReflectionAutoSelection,
+} from "@/cli/helpers/reflection-transcript";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import {
   estimateSystemTokens,
@@ -86,29 +109,18 @@ import {
 } from "@/cli/helpers/system-prompt-warning.ts";
 import { getRandomThinkingVerb } from "@/cli/helpers/thinking-messages";
 import {
-  buildModCommandPrompt,
-  parseModCommandArgv,
-  parseModSlashCommand,
-  runModCommandWithTimeout,
-} from "@/cli/mods/command-runtime";
-import type {
-  ModCommandContext,
-  ModConversationCloseReason,
-} from "@/cli/mods/types";
-import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
-import {
   DEFAULT_SUMMARIZATION_MODEL,
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
+import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
 import { goalLoopMode } from "@/goal-loop-mode";
 import {
   runPreCompactHooks,
   runSessionStartHooks,
   runUserPromptSubmitHooks,
 } from "@/hooks";
-import { createModConversationHandle } from "@/mods/conversation-handle";
 import type { PermissionMode } from "@/permissions/mode";
 import { permissionMode } from "@/permissions/mode";
 import type { QueueRuntime } from "@/queue/queue-runtime";
@@ -116,20 +128,18 @@ import {
   buildSharedReminderParts,
   prependReminderPartsToContent,
 } from "@/reminders/engine";
-import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import {
-  enqueueMemoryGitSyncReminder,
   type SharedReminderState,
+  syncReminderStateFromContextTracker,
 } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog, debugWarn } from "@/utils/debug";
-import { detectShellContext } from "@/utils/shell-context";
 import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
 import { switchCurrentRuntimeWorkingDirectory } from "@/websocket/listener/cwd-change";
 
-import { shouldSlashCommandBypassQueue } from "./command-routing";
+import { isInteractiveCommand, isNonStateCommand } from "./command-routing";
 import { buildTextParts } from "./content-parts";
 import { buildGoalPrompt } from "./goal-loop";
 import { appendOptimisticUserLine, createClientOtid, uid } from "./ids";
@@ -171,11 +181,9 @@ type ModelSelectorOptions = {
   forceRefresh?: boolean;
 };
 
-async function findCustomCommandByName(
-  commandName: string,
-): Promise<CustomCommand | undefined> {
+async function hasCustomCommand(commandName: string): Promise<boolean> {
   const { findCustomCommand } = await import("@/cli/commands/custom.js");
-  return findCustomCommand(commandName);
+  return Boolean(await findCustomCommand(commandName));
 }
 
 type SubmitHandlerContext = {
@@ -208,7 +216,7 @@ type SubmitHandlerContext = {
   currentModelProvider: string | null;
   effectiveContextWindowSize: number | undefined;
   emittedIdsRef: MutableRefObject<Set<string>>;
-  modAdapter: LocalModAdapter;
+  extensionRuntime: LocalExtensionRuntime;
   firstUserQueryRef: MutableRefObject<string | null>;
   flushPendingReasoningEffort: () => Promise<void>;
   generateConversationDescription: (options?: {
@@ -254,7 +262,7 @@ type SubmitHandlerContext = {
   resetDeferredToolCallCommits: () => void;
   resetPendingReasoningCycle: () => void;
   resetTrajectoryBases: () => void;
-  runEndHooks: (reason?: ModConversationCloseReason) => Promise<void>;
+  runEndHooks: (reason?: ExtensionConversationCloseReason) => Promise<void>;
   sessionHooksRanRef: MutableRefObject<boolean>;
   sessionStartFeedbackRef: MutableRefObject<string[]>;
   sessionStatsRef: MutableRefObject<SessionStats>;
@@ -323,8 +331,130 @@ type SubmitHandlerContext = {
     keepRunning?: boolean,
   ) => void;
   userCancelledRef: MutableRefObject<boolean>;
-  onReload?: () => Promise<void>;
+  onReload?: (agentId: string, conversationId: string) => Promise<void>;
 };
+
+type ReflectCommandArgs =
+  | { instruction?: string; kind: "single" }
+  | { instruction?: string; kind: "recent"; limit: number }
+  | { conversationIds: string[]; instruction?: string; kind: "conversations" }
+  | { instruction?: string; kind: "auto" };
+
+function isReflectCommandFlag(value: string): boolean {
+  return (
+    value === "--" ||
+    value === "--auto" ||
+    value === "--conversation" ||
+    value === "--instruction" ||
+    value === "--instructions" ||
+    value === "--recent" ||
+    value === "-i" ||
+    value.startsWith("--instruction=")
+  );
+}
+
+function parseReflectCommandArgs(input: string): ReflectCommandArgs {
+  const trimmed = input.trim();
+  const command = trimmed.split(/\s+/, 1)[0] ?? "/reflect";
+  const parts = parseExtensionCommandArgv(trimmed.slice(command.length).trim());
+  if (parts.length === 0) {
+    return { kind: "single" };
+  }
+
+  let recentLimit: number | null = null;
+  const conversationIds: string[] = [];
+  const instructions: string[] = [];
+  let auto = false;
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (!part) continue;
+    if (
+      part === "--instruction" ||
+      part === "--instructions" ||
+      part === "-i"
+    ) {
+      let instructionEnd = index + 1;
+      while (instructionEnd < parts.length) {
+        const instructionPart = parts[instructionEnd];
+        if (!instructionPart || isReflectCommandFlag(instructionPart)) break;
+        instructionEnd += 1;
+      }
+      const instruction = parts
+        .slice(index + 1, instructionEnd)
+        .join(" ")
+        .trim();
+      if (!instruction?.trim()) {
+        throw new Error("Usage: /reflect --instruction <instruction>");
+      }
+      instructions.push(instruction);
+      index = instructionEnd - 1;
+      continue;
+    }
+    if (part.startsWith("--instruction=")) {
+      const instruction = part.slice("--instruction=".length).trim();
+      if (!instruction) {
+        throw new Error("Usage: /reflect --instruction <instruction>");
+      }
+      instructions.push(instruction);
+      continue;
+    }
+    if (part === "--") {
+      const instruction = parts
+        .slice(index + 1)
+        .join(" ")
+        .trim();
+      if (!instruction) {
+        throw new Error("Usage: /reflect -- <instruction>");
+      }
+      instructions.push(instruction);
+      break;
+    }
+    if (part === "--auto") {
+      auto = true;
+      continue;
+    }
+    if (part === "--recent") {
+      const raw = parts[index + 1];
+      const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error("Usage: /reflect --recent <positive integer>");
+      }
+      recentLimit = parsed;
+      index += 1;
+      continue;
+    }
+    if (part === "--conversation") {
+      const conversationId = parts[index + 1];
+      if (!conversationId) {
+        throw new Error("Usage: /reflect --conversation <conversation-id>");
+      }
+      conversationIds.push(conversationId);
+      index += 1;
+      continue;
+    }
+    throw new Error(
+      "Usage: /reflect [--recent N | --conversation <id> ... | --auto] [--instruction <instruction>]",
+    );
+  }
+
+  const instruction = instructions.join("\n").trim() || undefined;
+  const modes = [recentLimit !== null, conversationIds.length > 0, auto].filter(
+    Boolean,
+  ).length;
+  if (modes > 1) {
+    throw new Error("Use only one of --recent, --conversation, or --auto.");
+  }
+  if (auto) {
+    return { instruction, kind: "auto" };
+  }
+  if (recentLimit !== null) {
+    return { instruction, kind: "recent", limit: recentLimit };
+  }
+  if (conversationIds.length > 0) {
+    return { conversationIds, instruction, kind: "conversations" };
+  }
+  return { instruction, kind: "single" };
+}
 
 export function useSubmitHandler(ctx: SubmitHandlerContext) {
   const {
@@ -353,7 +483,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
-    modAdapter,
+    extensionRuntime,
     firstUserQueryRef,
     flushPendingReasoningEffort,
     generateConversationDescription,
@@ -579,24 +709,24 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       }
 
       const isSlashCommand = userTextForInput.startsWith("/");
-      const parsedModCommand = isSlashCommand
-        ? parseModSlashCommand(userTextForInput.trim())
+      const parsedExtensionCommand = isSlashCommand
+        ? parseExtensionSlashCommand(userTextForInput.trim())
         : null;
-      const parsedSlashCommandName = parsedModCommand?.command ?? null;
-      const matchedCustomCommand = parsedSlashCommandName
-        ? await findCustomCommandByName(parsedSlashCommandName)
+      const queueBypassExtensionCommand = parsedExtensionCommand
+        ? extensionRuntime.registry?.commands[parsedExtensionCommand.command]
         : undefined;
-      const matchedModCommand = parsedSlashCommandName
-        ? modAdapter.registry?.commands[parsedSlashCommandName]
-        : undefined;
+      const isExtensionCommandShadowedByCustom =
+        isAgentBusy() && queueBypassExtensionCommand?.runWhenBusy === true
+          ? await hasCustomCommand(parsedExtensionCommand?.command ?? "")
+          : false;
       // Interactive/non-state slash commands bypass queueing so menus stay responsive
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
-        shouldSlashCommandBypassQueue(userTextForInput, {
-          hasCustomCommand: Boolean(matchedCustomCommand),
-          ...(matchedModCommand ? { modCommand: matchedModCommand } : {}),
-        });
+        (isInteractiveCommand(userTextForInput) ||
+          isNonStateCommand(userTextForInput) ||
+          (queueBypassExtensionCommand?.runWhenBusy === true &&
+            !isExtensionCommandShadowedByCustom));
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
@@ -628,169 +758,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       // Handle commands (messages starting with "/")
       if (aliasedMsg.startsWith("/")) {
         const trimmed = aliasedMsg.trim();
-
-        // Custom commands and mod commands override built-ins.
-        if (matchedCustomCommand) {
-          const { substituteArguments, expandBashCommands } = await import(
-            "@/cli/commands/custom.js"
-          );
-          const cmd = commandRunner.start(
-            trimmed,
-            `Running /${matchedCustomCommand.id}...`,
-          );
-
-          // Check for pending approvals before sending
-          const approvalCheck = await checkPendingApprovalsForSlashCommand();
-          if (approvalCheck.blocked) {
-            cmd.fail(
-              `Pending approval(s). Resolve approvals before running /${matchedCustomCommand.id}.`,
-            );
-            return { submitted: false }; // Keep custom command in input box, user handles approval first
-          }
-
-          // Extract arguments (everything after command name)
-          const args = trimmed
-            .slice(`/${matchedCustomCommand.id}`.length)
-            .trim();
-
-          // Build prompt: 1) substitute args, 2) expand bash commands
-          let prompt = substituteArguments(matchedCustomCommand.content, args);
-          prompt = await expandBashCommands(prompt);
-
-          // Show command in transcript (running phase for visual feedback)
-          setCommandRunning(true);
-
-          try {
-            // Mark command as finished BEFORE sending to agent
-            // (matches /remember pattern - command succeeded in triggering agent)
-            cmd.finish("Running custom command...", true);
-
-            // Send prompt to agent
-            // NOTE: Unlike /remember, we DON'T append args separately because
-            // they're already substituted into the prompt via $ARGUMENTS
-            await processConversationWithQueuedApprovals([
-              {
-                type: "message",
-                role: "user",
-                content: buildTextParts(
-                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
-                ),
-                otid: randomUUID(),
-              },
-            ]);
-          } catch (error) {
-            // Only catch errors from processConversation setup, not agent execution
-            const errorDetails = formatErrorDetails(error, agentId);
-            cmd.fail(`Failed to run command: ${errorDetails}`);
-          } finally {
-            setCommandRunning(false);
-          }
-
-          return { submitted: true };
-        }
-
-        if (parsedModCommand && matchedModCommand) {
-          const showInTranscript = matchedModCommand.showInTranscript;
-          const shouldLockCommand = !matchedModCommand.runWhenBusy;
-          const cmd = showInTranscript
-            ? commandRunner.start(
-                trimmed,
-                `Running /${matchedModCommand.id}...`,
-              )
-            : null;
-          const getFeedbackCommand = () =>
-            cmd ??
-            commandRunner.start(trimmed, `Running /${matchedModCommand.id}...`);
-          if (shouldLockCommand) {
-            setCommandRunning(true);
-          }
-
-          try {
-            const modContext = modAdapter.context;
-            const cwd = getCurrentWorkingDirectory();
-            const conversation = createModConversationHandle({
-              agentId,
-              backend: modAdapter.getBackend(),
-              conversationId: conversationIdRef.current,
-              sendMessageStream: sendMessageStreamWithBackend,
-              workingDirectory: cwd,
-            });
-            const commandContext: ModCommandContext = {
-              ...modContext,
-              args: parsedModCommand.args,
-              argv: parseModCommandArgv(parsedModCommand.args),
-              command: parsedModCommand.command,
-              conversation: { ...conversation, id: conversationIdRef.current },
-              cwd,
-              model: {
-                ...modContext.model,
-                id:
-                  currentModelId ??
-                  llmConfigRef.current?.model ??
-                  modContext.model.id,
-              },
-              permissionMode: modContext.permissionMode,
-              rawInput: trimmed,
-            };
-            const result = await runModCommandWithTimeout(
-              matchedModCommand,
-              commandContext,
-            );
-
-            if (result.type === "prompt") {
-              if (!showInTranscript) {
-                getFeedbackCommand().fail(
-                  `/${matchedModCommand.id} returned a prompt with showInTranscript: false. Hidden mod commands must return output or handled and own their UI.`,
-                );
-                return { submitted: true };
-              }
-
-              if (matchedModCommand.runWhenBusy && isAgentBusy()) {
-                getFeedbackCommand().fail(
-                  `/${matchedModCommand.id} returned a prompt while the agent is running. Busy-safe mod commands must handle their own SDK calls or return output.`,
-                );
-                return { submitted: true };
-              }
-
-              const approvalCheck =
-                await checkPendingApprovalsForSlashCommand();
-              if (approvalCheck.blocked) {
-                getFeedbackCommand().fail(
-                  `Pending approval(s). Resolve approvals before running /${matchedModCommand.id}.`,
-                );
-                return { submitted: false };
-              }
-
-              cmd?.finish(`Running /${matchedModCommand.id}...`, true);
-              await processConversationWithQueuedApprovals([
-                {
-                  type: "message",
-                  role: "user",
-                  content: buildTextParts(buildModCommandPrompt(result)),
-                  otid: randomUUID(),
-                },
-              ]);
-            } else if (result.type === "output") {
-              getFeedbackCommand().finish(
-                result.output,
-                result.success ?? true,
-              );
-            } else {
-              cmd?.finish("Handled.", true, true);
-            }
-          } catch (error) {
-            const errorDetails = formatErrorDetails(error, agentId);
-            getFeedbackCommand().fail(
-              `Failed to run /${matchedModCommand.id}: ${errorDetails}`,
-            );
-          } finally {
-            if (shouldLockCommand) {
-              setCommandRunning(false);
-            }
-          }
-
-          return { submitted: true };
-        }
 
         // Special handling for /model command - opens selector
         if (trimmed === "/model") {
@@ -973,23 +940,30 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           if (onReload) {
             const cmd = commandRunner.start(
               "/reload",
-              "Reloading settings and local mods...",
+              "Reloading settings and restarting TUI effects...",
             );
-            setCommandRunning(true);
+            cmd.finish("Reloading...", true);
+            try {
+              const { refreshCustomCommands } = await import(
+                "@/cli/commands/custom.js"
+              );
+              refreshCustomCommands();
+            } catch (error) {
+              debugLog(
+                "commands",
+                "refreshCustomCommands failed during /reload: %s",
+                error instanceof Error ? error.message : String(error),
+              );
+            }
             // Defer the reload to let the command UI render first
-            setTimeout(() => {
-              void (async () => {
-                try {
-                  await onReload();
-                  cmd.finish("Reloaded settings and local mods", true);
-                } catch (error) {
-                  const errorDetails = formatErrorDetails(error, agentId);
-                  cmd.fail(`Failed: ${errorDetails}`);
-                } finally {
-                  setCommandRunning(false);
-                }
-              })();
-            }, 0);
+            setTimeout(
+              () =>
+                onReload(
+                  agentIdRef.current,
+                  conversationIdRef.current ?? "default",
+                ),
+              0,
+            );
           } else {
             const cmd = commandRunner.start("/reload", "Reload not available");
             cmd.fail("Reload is not available in this context");
@@ -1250,7 +1224,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               },
             );
             const request = args
-              ? `The user ran \`/statusline ${args}\`. Use the loaded skill to help them create, edit, or migrate their Letta Code statusline mod.`
+              ? `The user ran \`/statusline ${args}\`. Use the loaded skill to help them create, edit, or migrate their Letta Code statusline extension.`
               : "The user ran `/statusline` without arguments. Use the loaded skill's bare `/statusline` behavior.";
 
             cmd.finish("Running statusline setup...", true);
@@ -1584,6 +1558,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation for the current agent
             const conversation = await backend.createConversation({
               agent_id: agentId,
+              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
               ...(conversationName && { summary: conversationName }),
             });
 
@@ -1624,17 +1599,13 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void modAdapter.events.emit(
-              "conversation_open",
-              {
-                agentId,
-                agentName: agentName ?? null,
-                conversationId: conversation.id,
-                previousConversationId: prevConversationId ?? null,
-                reason: "new",
-              },
-              modAdapter.context,
-            );
+            void extensionRuntime.emitEvent("conversation_open", {
+              agentId,
+              agentName: agentName ?? null,
+              conversationId: conversation.id,
+              previousConversationId: prevConversationId ?? null,
+              reason: "new",
+            });
 
             // Update command with success
             cmd.finish(
@@ -1726,17 +1697,13 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void modAdapter.events.emit(
-              "conversation_open",
-              {
-                agentId,
-                agentName: agentName ?? null,
-                conversationId: forked.id,
-                previousConversationId: forkPrevConversationId ?? null,
-                reason: "fork",
-              },
-              modAdapter.context,
-            );
+            void extensionRuntime.emitEvent("conversation_open", {
+              agentId,
+              agentName: agentName ?? null,
+              conversationId: forked.id,
+              previousConversationId: forkPrevConversationId ?? null,
+              reason: "fork",
+            });
 
             cmd.finish(
               "Forked conversation (use /resume to switch back)",
@@ -1810,6 +1777,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation
             const conversation = await backend.createConversation({
               agent_id: agentId,
+              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
             });
 
             setConversationAutoTitleEligibility(true);
@@ -1845,17 +1813,13 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void modAdapter.events.emit(
-              "conversation_open",
-              {
-                agentId,
-                agentName: agentName ?? null,
-                conversationId: conversation.id,
-                previousConversationId: clearPrevConversationId ?? null,
-                reason: "new",
-              },
-              modAdapter.context,
-            );
+            void extensionRuntime.emitEvent("conversation_open", {
+              agentId,
+              agentName: agentName ?? null,
+              conversationId: conversation.id,
+              previousConversationId: clearPrevConversationId ?? null,
+              reason: "new",
+            });
 
             // Update command with success
             cmd.finish(
@@ -2150,46 +2114,9 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Update command with success
             cmd.finish(outputLines.join("\n"), true);
 
-            // Manual /compact bypasses stream compaction events, so launch
-            // post-compaction reflection directly instead of waiting for the
-            // next turn's post-turn trigger evaluation. Best-effort — never
-            // fail the /compact itself.
-            try {
-              if (
-                getReflectionSettings(agentId).trigger === "compaction-event" &&
-                isActiveMemfsEnabled(agentId)
-              ) {
-                void launchReflectionSubagent({
-                  agentId,
-                  conversationId: compactConversationId,
-                  memfsEnabled: isActiveMemfsEnabled(agentId),
-                  triggerSource: "compaction-event",
-                  description: AUTO_REFLECTION_DESCRIPTION,
-                  completionConversationId: () => conversationIdRef.current,
-                  recompileByConversation:
-                    systemPromptRecompileByConversationRef.current,
-                  recompileQueuedByConversation:
-                    queuedSystemPromptRecompileByConversationRef.current,
-                  onCompletionMessage: (completionMessage) => {
-                    appendTaskNotificationEvents([completionMessage]);
-                  },
-                  feedbackContext: {
-                    parentAgentName: agentName,
-                    parentAgentDescription: agentDescription,
-                    surface: "letta_code_tui",
-                    model: currentModelId,
-                  },
-                });
-              }
-            } catch (reflectionError) {
-              debugLog(
-                "memory",
-                "Skipping post-compaction reflection:",
-                reflectionError instanceof Error
-                  ? reflectionError.message
-                  : String(reflectionError),
-              );
-            }
+            // Manual /compact bypasses stream compaction events, so trigger
+            // post-compaction reflection reminder/auto-launch on the next user turn.
+            contextTrackerRef.current.pendingReflectionTrigger = true;
             void generateConversationDescription({ force: true });
           } catch (error) {
             const apiError = error as {
@@ -2413,7 +2340,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         const profileCommandResult = await handleProfileCommand(msg, trimmed, {
           agentId,
           agentName,
-          conversationId,
           buffersRef,
           commandRunner,
           handleAgentSelect,
@@ -2947,7 +2873,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         }
 
         // Special handling for /reflect command - manually launch reflection subagent
-        if (trimmed === "/reflect") {
+        if (trimmed === "/reflect" || trimmed.startsWith("/reflect ")) {
           const cmd = commandRunner.start(msg, "Launching reflection agent...");
 
           if (!isActiveMemfsEnabled(agentId)) {
@@ -2957,57 +2883,360 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             return { submitted: true };
           }
 
+          let reflectionReserved = false;
+          let reflectionReservationDelegated = false;
+          const releaseReflectionReservation = () => {
+            if (!reflectionReserved) return;
+            releaseReflectionLaunch(agentId);
+            reflectionReserved = false;
+          };
+
           try {
+            const reflectArgs = parseReflectCommandArgs(trimmed);
             const reflectionConversationId =
               conversationIdRef.current ?? "default";
-            const result = await launchReflectionSubagent({
-              agentId,
-              conversationId: reflectionConversationId,
-              memfsEnabled: isActiveMemfsEnabled(agentId),
-              triggerSource: "manual",
-              description: "Reflecting on conversation",
-              completionConversationId: () => conversationIdRef.current,
-              recompileByConversation:
-                systemPromptRecompileByConversationRef.current,
-              recompileQueuedByConversation:
-                queuedSystemPromptRecompileByConversationRef.current,
-              onCompletionMessage: (completionMessage) => {
-                appendTaskNotificationEvents([completionMessage]);
-              },
-              feedbackContext: {
-                parentAgentName: agentName,
-                parentAgentDescription: agentDescription,
-                surface: "letta_code_tui",
-                model: currentModelId,
-              },
-            });
 
-            if (!result.launched) {
-              if (result.reason === "already_active") {
-                cmd.fail(
-                  "A reflection agent is already running in the background.",
-                );
-              } else if (result.reason === "no_payload") {
-                cmd.fail("No new transcript content to reflect on.");
-              } else if (result.reason === "memfs_disabled") {
-                cmd.fail(
-                  "Memory filesystem is not enabled. Use /remember instead.",
-                );
-              } else {
-                const errorDetails = formatErrorDetails(
-                  result.error ?? "Unknown error",
-                  agentId,
-                );
-                cmd.fail(`Failed to start reflection agent: ${errorDetails}`);
+            if (reflectArgs.kind === "single") {
+              const result = await launchReflectionSubagent({
+                agentId,
+                conversationId: reflectionConversationId,
+                memfsEnabled: isActiveMemfsEnabled(agentId),
+                triggerSource: "manual",
+                description: AUTO_REFLECTION_DESCRIPTION,
+                instruction: reflectArgs.instruction,
+                completionConversationId: () => conversationIdRef.current,
+                recompileByConversation:
+                  systemPromptRecompileByConversationRef.current,
+                recompileQueuedByConversation:
+                  queuedSystemPromptRecompileByConversationRef.current,
+                onCompletionMessage: (completionMessage) => {
+                  appendTaskNotificationEvents([completionMessage]);
+                },
+              });
+
+              if (!result.launched) {
+                if (result.reason === "already_active") {
+                  cmd.fail(
+                    "A reflection agent is already running in the background.",
+                  );
+                } else if (result.reason === "no_payload") {
+                  cmd.fail("No new transcript content to reflect on.");
+                } else if (result.reason === "memfs_disabled") {
+                  cmd.fail(
+                    "Memory filesystem is not enabled. Use /remember instead.",
+                  );
+                } else {
+                  const errorDetails = formatErrorDetails(
+                    result.error ?? "Unknown error",
+                    agentId,
+                  );
+                  cmd.fail(`Failed to start reflection agent: ${errorDetails}`);
+                }
+                return { submitted: true };
               }
+
+              cmd.finish(
+                `Reflecting on the recent conversation. View the transcript here: ${result.payloadPath}`,
+                true,
+              );
               return { submitted: true };
             }
 
+            if (!tryReserveReflectionLaunch(agentId)) {
+              cmd.fail(
+                "A reflection agent is already running in the background.",
+              );
+              return { submitted: true };
+            }
+            reflectionReserved = true;
+
+            // Fetch the agent's system prompt so multi-transcript reflection
+            // payloads include the core behavioural instructions (filtered to
+            // strip dynamic content).
+            let systemPrompt: string | undefined;
+            try {
+              const agent = await getBackend().retrieveAgent(agentId);
+              systemPrompt = agent.system ?? undefined;
+            } catch {
+              // Non-fatal — the reflection payload will just omit the system prompt.
+            }
+
+            if (reflectArgs.kind === "auto") {
+              const autoPayload = await buildReflectionAutoPayload({
+                agentId,
+                currentConversationId: reflectionConversationId,
+                instruction: reflectArgs.instruction,
+              });
+              if (!autoPayload) {
+                releaseReflectionReservation();
+                cmd.fail("No transcript candidates found for auto selection.");
+                return { submitted: true };
+              }
+
+              const { spawnBackgroundSubagentTask } = await import(
+                "@/tools/impl/task"
+              );
+              const { subagentId: selectorSubagentId } =
+                spawnBackgroundSubagentTask({
+                  subagentType: "reflection",
+                  prompt: buildReflectionSelectorPrompt({
+                    instruction: reflectArgs.instruction,
+                  }),
+                  description: "Selecting reflection transcripts",
+                  silentCompletion: true,
+                  transcriptPath: autoPayload.candidatesPath,
+                  parentScope: {
+                    agentId,
+                    conversationId: reflectionConversationId,
+                  },
+                  onComplete: async ({ success, error, report }) => {
+                    if (!success) {
+                      releaseReflectionReservation();
+                      appendTaskNotificationEvents([
+                        `Automatic reflection selection failed: ${error ?? "selector failed"}`,
+                      ]);
+                      return;
+                    }
+
+                    let finalReflectionSpawned = false;
+                    try {
+                      const selectedConversations =
+                        await readReflectionAutoSelection({
+                          selectionReport: report,
+                          candidates: autoPayload.candidates,
+                        });
+                      if (selectedConversations.length === 0) {
+                        releaseReflectionReservation();
+                        appendTaskNotificationEvents([
+                          "Automatic reflection selected no transcript candidates.",
+                        ]);
+                        return;
+                      }
+
+                      const autoReflectionPayload =
+                        await buildMultiReflectionPayload({
+                          agentId,
+                          selectionPolicy: {
+                            mode: "auto-selected",
+                            selectedConversations,
+                            candidatesPath: autoPayload.candidatesPath,
+                          },
+                          instruction: reflectArgs.instruction,
+                          systemPrompt,
+                        });
+                      if (!autoReflectionPayload) {
+                        releaseReflectionReservation();
+                        appendTaskNotificationEvents([
+                          "Automatic reflection selected transcript candidates, but no transcript content was available.",
+                        ]);
+                        return;
+                      }
+
+                      const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+                      const parentMemory =
+                        await buildParentMemorySnapshot(memoryDir);
+                      const reflectionPrompt = buildReflectionSubagentPrompt({
+                        instruction: reflectArgs.instruction,
+                        memoryDir,
+                        parentMemory,
+                      });
+
+                      spawnBackgroundSubagentTask({
+                        subagentType: "reflection",
+                        prompt: reflectionPrompt,
+                        description: "Reflecting on auto-selected transcripts",
+                        silentCompletion: true,
+                        transcriptPath: autoReflectionPayload.payloadPath,
+                        parentScope: {
+                          agentId,
+                          conversationId: reflectionConversationId,
+                        },
+                        onComplete: async ({
+                          success: reflectionSuccess,
+                          error: reflectionError,
+                          agentId: reflectionAgentId,
+                        }) => {
+                          try {
+                            telemetry.trackReflectionEnd(
+                              "manual",
+                              reflectionSuccess,
+                              {
+                                subagentId: reflectionAgentId ?? undefined,
+                                conversationId: reflectionConversationId,
+                                error: reflectionError,
+                              },
+                            );
+                            await finalizeMultiReflectionPayload(
+                              agentId,
+                              autoReflectionPayload.manifest,
+                              reflectionSuccess,
+                            );
+                            const msg = await handleMemorySubagentCompletion(
+                              {
+                                agentId,
+                                conversationId: conversationIdRef.current,
+                                subagentType: "reflection",
+                                success: reflectionSuccess,
+                                error: reflectionError,
+                                subagentAgentId: reflectionAgentId ?? undefined,
+                              },
+                              {
+                                recompileByConversation:
+                                  systemPromptRecompileByConversationRef.current,
+                                recompileQueuedByConversation:
+                                  queuedSystemPromptRecompileByConversationRef.current,
+                                logRecompileFailure: (message) =>
+                                  debugWarn("memory", message),
+                              },
+                            );
+                            appendTaskNotificationEvents([msg]);
+                          } finally {
+                            releaseReflectionReservation();
+                          }
+                        },
+                      });
+                      reflectionReservationDelegated = true;
+                      finalReflectionSpawned = true;
+
+                      telemetry.trackReflectionStart("manual", {
+                        conversationId: reflectionConversationId,
+                        startMessageId: autoReflectionPayload.startMessageId,
+                        endMessageId: autoReflectionPayload.endMessageId,
+                      });
+                      appendTaskNotificationEvents([
+                        `Automatic reflection selected ${selectedConversations.length} transcript(s); launched reflection. Payload: ${autoReflectionPayload.payloadPath}`,
+                      ]);
+                    } catch (selectionError) {
+                      if (!finalReflectionSpawned) {
+                        releaseReflectionReservation();
+                      }
+                      const errorDetails = formatErrorDetails(
+                        selectionError,
+                        agentId,
+                      );
+                      appendTaskNotificationEvents([
+                        `Automatic reflection failed after selection: ${errorDetails}`,
+                      ]);
+                    }
+                  },
+                });
+              reflectionReservationDelegated = true;
+
+              telemetry.trackReflectionStart("manual", {
+                subagentId: selectorSubagentId,
+                conversationId: reflectionConversationId,
+              });
+              cmd.finish(
+                `Reviewing ${autoPayload.candidates.candidates.length} candidate transcript(s) for reflection. View the transcript candidates here: ${autoPayload.candidatesPath}`,
+                true,
+              );
+              return { submitted: true };
+            }
+
+            const reflectionPayload = await buildMultiReflectionPayload({
+              agentId,
+              selectionPolicy:
+                reflectArgs.kind === "recent"
+                  ? { mode: "recent", limit: reflectArgs.limit }
+                  : {
+                      mode: "explicit-conversations",
+                      conversationIds: reflectArgs.conversationIds,
+                    },
+              instruction: reflectArgs.instruction,
+              systemPrompt,
+            });
+
+            if (!reflectionPayload) {
+              releaseReflectionReservation();
+              cmd.fail(
+                "No transcript content found for the selected conversations.",
+              );
+              return { submitted: true };
+            }
+
+            const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+            const parentMemory = await buildParentMemorySnapshot(memoryDir);
+            const reflectionPrompt = buildReflectionSubagentPrompt({
+              instruction: reflectArgs.instruction,
+              memoryDir,
+              parentMemory,
+            });
+
+            const {
+              spawnBackgroundSubagentTask,
+              waitForBackgroundSubagentAgentId,
+            } = await import("@/tools/impl/task");
+            const { subagentId } = spawnBackgroundSubagentTask({
+              subagentType: "reflection",
+              prompt: reflectionPrompt,
+              description: "Reflecting on conversation",
+              silentCompletion: true,
+              transcriptPath: reflectionPayload.payloadPath,
+              parentScope: {
+                agentId,
+                conversationId: reflectionConversationId,
+              },
+              onComplete: async ({
+                success,
+                error,
+                agentId: reflectionAgentId,
+              }) => {
+                try {
+                  telemetry.trackReflectionEnd("manual", success, {
+                    subagentId: reflectionAgentId ?? undefined,
+                    conversationId: reflectionConversationId,
+                    error,
+                  });
+                  await finalizeMultiReflectionPayload(
+                    agentId,
+                    reflectionPayload.manifest,
+                    success,
+                  );
+
+                  const msg = await handleMemorySubagentCompletion(
+                    {
+                      agentId,
+                      conversationId: conversationIdRef.current,
+                      subagentType: "reflection",
+                      success,
+                      error,
+                      subagentAgentId: reflectionAgentId ?? undefined,
+                    },
+                    {
+                      recompileByConversation:
+                        systemPromptRecompileByConversationRef.current,
+                      recompileQueuedByConversation:
+                        queuedSystemPromptRecompileByConversationRef.current,
+                      logRecompileFailure: (message) =>
+                        debugWarn("memory", message),
+                    },
+                  );
+                  appendTaskNotificationEvents([msg]);
+                } finally {
+                  releaseReflectionReservation();
+                }
+              },
+            });
+            reflectionReservationDelegated = true;
+            const reflectionAgentId = await waitForBackgroundSubagentAgentId(
+              subagentId,
+              1000,
+            );
+            telemetry.trackReflectionStart("manual", {
+              subagentId: reflectionAgentId ?? undefined,
+              conversationId: reflectionConversationId,
+              startMessageId: reflectionPayload.startMessageId,
+              endMessageId: reflectionPayload.endMessageId,
+            });
+
             cmd.finish(
-              `Reflecting on the recent conversation. View the transcript here: ${result.payloadPath}`,
+              `Reflecting on ${reflectionPayload.manifest.transcripts.length} transcript(s). View the payload here: ${reflectionPayload.payloadPath}`,
               true,
             );
           } catch (error) {
+            if (!reflectionReservationDelegated) {
+              releaseReflectionReservation();
+            }
             const errorDetails = formatErrorDetails(error, agentId);
             cmd.fail(`Failed to start reflection agent: ${errorDetails}`);
           }
@@ -3203,6 +3432,181 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
+        // === Custom command handling ===
+        // Check BEFORE falling through to executeCommand()
+        const { findCustomCommand, substituteArguments, expandBashCommands } =
+          await import("@/cli/commands/custom.js");
+        const customCommandName = trimmed.split(/\s+/)[0]?.slice(1) || ""; // e.g., "review" from "/review arg"
+        const matchedCustom = await findCustomCommand(customCommandName);
+
+        if (matchedCustom) {
+          const cmd = commandRunner.start(
+            trimmed,
+            `Running /${matchedCustom.id}...`,
+          );
+
+          // Check for pending approvals before sending
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              `Pending approval(s). Resolve approvals before running /${matchedCustom.id}.`,
+            );
+            return { submitted: false }; // Keep custom command in input box, user handles approval first
+          }
+
+          // Extract arguments (everything after command name)
+          const args = trimmed.slice(`/${matchedCustom.id}`.length).trim();
+
+          // Build prompt: 1) substitute args, 2) expand bash commands
+          let prompt = substituteArguments(matchedCustom.content, args);
+          prompt = await expandBashCommands(prompt);
+
+          // Show command in transcript (running phase for visual feedback)
+          setCommandRunning(true);
+
+          try {
+            // Mark command as finished BEFORE sending to agent
+            // (matches /remember pattern - command succeeded in triggering agent)
+            cmd.finish("Running custom command...", true);
+
+            // Send prompt to agent
+            // NOTE: Unlike /remember, we DON'T append args separately because
+            // they're already substituted into the prompt via $ARGUMENTS
+            await processConversationWithQueuedApprovals([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(
+                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
+                ),
+                otid: randomUUID(),
+              },
+            ]);
+          } catch (error) {
+            // Only catch errors from processConversation setup, not agent execution
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to run command: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+        // === END custom command handling ===
+
+        const matchedExtensionCommand: ExtensionCommand | undefined =
+          parsedExtensionCommand
+            ? extensionRuntime.registry?.commands[
+                parsedExtensionCommand.command
+              ]
+            : undefined;
+
+        if (parsedExtensionCommand && matchedExtensionCommand) {
+          const showInTranscript = matchedExtensionCommand.showInTranscript;
+          const shouldLockCommand = !matchedExtensionCommand.runWhenBusy;
+          const cmd = showInTranscript
+            ? commandRunner.start(
+                trimmed,
+                `Running /${matchedExtensionCommand.id}...`,
+              )
+            : null;
+          const getFeedbackCommand = () =>
+            cmd ??
+            commandRunner.start(
+              trimmed,
+              `Running /${matchedExtensionCommand.id}...`,
+            );
+          if (shouldLockCommand) {
+            setCommandRunning(true);
+          }
+
+          try {
+            const extensionContext = extensionRuntime.getContext();
+            const cwd = getCurrentWorkingDirectory();
+            const conversation = createExtensionConversationHandle({
+              agentId,
+              backend: extensionRuntime.getBackendApi(),
+              conversationId: conversationIdRef.current,
+              workingDirectory: cwd,
+            });
+            const commandContext: ExtensionCommandContext = {
+              agent: { id: agentId, name: agentName },
+              args: parsedExtensionCommand.args,
+              argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
+              command: parsedExtensionCommand.command,
+              conversation: { ...conversation, id: conversationIdRef.current },
+              cwd,
+              getContext: extensionRuntime.getContext,
+              model: {
+                id:
+                  currentModelId ??
+                  llmConfigRef.current?.model ??
+                  extensionContext.model.id,
+                displayName: extensionContext.model.displayName,
+              },
+              permissionMode: extensionContext.permissionMode,
+              rawInput: trimmed,
+            };
+            const result = await runExtensionCommandWithTimeout(
+              matchedExtensionCommand,
+              commandContext,
+            );
+
+            if (result.type === "prompt") {
+              if (!showInTranscript) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt with showInTranscript: false. Hidden extension commands must return output or handled and own their UI.`,
+                );
+                return { submitted: true };
+              }
+
+              if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
+                );
+                return { submitted: true };
+              }
+
+              const approvalCheck =
+                await checkPendingApprovalsForSlashCommand();
+              if (approvalCheck.blocked) {
+                getFeedbackCommand().fail(
+                  `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
+                );
+                return { submitted: false };
+              }
+
+              cmd?.finish(`Running /${matchedExtensionCommand.id}...`, true);
+              await processConversationWithQueuedApprovals([
+                {
+                  type: "message",
+                  role: "user",
+                  content: buildTextParts(buildExtensionCommandPrompt(result)),
+                  otid: randomUUID(),
+                },
+              ]);
+            } else if (result.type === "output") {
+              getFeedbackCommand().finish(
+                result.output,
+                result.success ?? true,
+              );
+            } else {
+              cmd?.finish("Handled.", true, true);
+            }
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            getFeedbackCommand().fail(
+              `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
+            );
+          } finally {
+            if (shouldLockCommand) {
+              setCommandRunning(false);
+            }
+          }
+
+          return { submitted: true };
+        }
+
         // Check if this is a known command before treating it as a slash command
         const { commands, executeCommand } = await import(
           "@/cli/commands/registry"
@@ -3353,6 +3757,9 @@ ${SYSTEM_REMINDER_CLOSE}
         bashCommandCacheRef.current = [];
       }
 
+      const reflectionSettings = getReflectionSettings(agentId);
+      const memfsEnabledForAgent = isActiveMemfsEnabled(agentId);
+
       // Build git memory sync reminder if uncommitted changes or unpushed commits
       let memoryGitReminder = "";
       const gitStatus = pendingGitReminderRef.current;
@@ -3360,8 +3767,8 @@ ${SYSTEM_REMINDER_CLOSE}
         const memoryDir = getScopedMemoryFilesystemRoot(agentId);
         const localMemfs = isLocalMemfsActive();
         const syncInstructions = localMemfs
-          ? `Commit memory changes locally when appropriate. Inspect with:\n\`\`\`bash\ngit -C ${JSON.stringify(memoryDir)} status\n\`\`\``
-          : `Inspect and fix the memory repository when appropriate. Commit any intended memory changes locally; the harness pushes clean committed memory changes automatically after turns.\n\`\`\`bash\ngit -C ${JSON.stringify(memoryDir)} status\n\`\`\``;
+          ? `Commit when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\n\`\`\``
+          : `Sync when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\ngit push\n\`\`\``;
         memoryGitReminder = `${SYSTEM_REMINDER_OPEN}
 ${localMemfs ? "MEMORY COMMIT" : "MEMORY SYNC"}: Your memory directory has uncommitted changes${localMemfs ? "." : " or is ahead of the remote."}
 
@@ -3384,6 +3791,31 @@ ${SYSTEM_REMINDER_CLOSE}
         if (!text) return;
         reminderParts.push({ type: "text", text });
       };
+      const maybeLaunchReflectionSubagent = async (
+        triggerSource: "step-count" | "compaction-event",
+      ) => {
+        const reflectionConversationId = conversationIdRef.current ?? "default";
+        const result = await launchReflectionSubagent({
+          agentId,
+          conversationId: reflectionConversationId,
+          memfsEnabled: memfsEnabledForAgent,
+          triggerSource,
+          description: AUTO_REFLECTION_DESCRIPTION,
+          completionConversationId: () => conversationIdRef.current,
+          recompileByConversation:
+            systemPromptRecompileByConversationRef.current,
+          recompileQueuedByConversation:
+            queuedSystemPromptRecompileByConversationRef.current,
+          onCompletionMessage: (completionMessage) => {
+            appendTaskNotificationEvents([completionMessage]);
+          },
+        });
+        return result.launched;
+      };
+      syncReminderStateFromContextTracker(
+        sharedReminderStateRef.current,
+        contextTrackerRef.current,
+      );
       const { getSkillSources } = await import("@/agent/context");
       const { parts: sharedReminderParts } = await buildSharedReminderParts({
         mode: "interactive",
@@ -3398,8 +3830,9 @@ ${SYSTEM_REMINDER_CLOSE}
         conversationBootstrapContent:
           contentParts as unknown as MessageCreate["content"],
         systemInfoReminderEnabled,
+        reflectionSettings,
         skillSources: getSkillSources(),
-        shellContext: detectShellContext(),
+        maybeLaunchReflectionSubagent,
       });
       for (const part of sharedReminderParts) {
         reminderParts.push(part);
@@ -3515,17 +3948,6 @@ ${SYSTEM_REMINDER_CLOSE}
         transcriptStartLineIndex,
       });
 
-      await runPostTurnMemorySync({
-        agentId,
-        isEnabled: isActiveMemfsEnabled,
-        debugLabel: "Post-turn memory sync",
-        enqueueReminder: (text) => {
-          enqueueMemoryGitSyncReminder(sharedReminderStateRef.current, {
-            text,
-          });
-        },
-      });
-
       // Clean up placeholders after submission
       clearPlaceholdersInText(msg);
 
@@ -3543,7 +3965,7 @@ ${SYSTEM_REMINDER_CLOSE}
       conversationId,
       currentModelHandle,
       currentModelId,
-      modAdapter,
+      extensionRuntime,
       effectiveContextWindowSize,
       commandRunner,
       handleExit,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -22,7 +22,6 @@ import {
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
 } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import {
   ensureMemoryFilesystemDirs,
   getScopedMemoryFilesystemRoot,
@@ -32,6 +31,7 @@ import {
   isActiveMemfsEnabled,
   isLocalMemfsActive,
 } from "@/agent/memory-runtime";
+import { sendMessageStreamWithBackend } from "@/agent/message";
 import {
   detectPersonalityFromPersonaFile,
   type PersonalityId,
@@ -40,20 +40,9 @@ import { recordSessionEnd } from "@/agent/session-history";
 import type { SessionStats } from "@/agent/stats";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
+import type { CustomCommand } from "@/cli/commands/custom";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
-import {
-  buildExtensionCommandPrompt,
-  parseExtensionCommandArgv,
-  parseExtensionSlashCommand,
-  runExtensionCommandWithTimeout,
-} from "@/cli/extensions/command-runtime";
-import type {
-  ExtensionCommand,
-  ExtensionCommandContext,
-  ExtensionConversationCloseReason,
-} from "@/cli/extensions/types";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import {
@@ -109,18 +98,29 @@ import {
 } from "@/cli/helpers/system-prompt-warning.ts";
 import { getRandomThinkingVerb } from "@/cli/helpers/thinking-messages";
 import {
+  buildModCommandPrompt,
+  parseModCommandArgv,
+  parseModSlashCommand,
+  runModCommandWithTimeout,
+} from "@/cli/mods/command-runtime";
+import type {
+  ModCommandContext,
+  ModConversationCloseReason,
+} from "@/cli/mods/types";
+import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
+import {
   DEFAULT_SUMMARIZATION_MODEL,
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
-import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
 import { goalLoopMode } from "@/goal-loop-mode";
 import {
   runPreCompactHooks,
   runSessionStartHooks,
   runUserPromptSubmitHooks,
 } from "@/hooks";
+import { createModConversationHandle } from "@/mods/conversation-handle";
 import type { PermissionMode } from "@/permissions/mode";
 import { permissionMode } from "@/permissions/mode";
 import type { QueueRuntime } from "@/queue/queue-runtime";
@@ -128,18 +128,20 @@ import {
   buildSharedReminderParts,
   prependReminderPartsToContent,
 } from "@/reminders/engine";
+import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import {
+  enqueueMemoryGitSyncReminder,
   type SharedReminderState,
-  syncReminderStateFromContextTracker,
 } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog, debugWarn } from "@/utils/debug";
+import { detectShellContext } from "@/utils/shell-context";
 import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
 import { switchCurrentRuntimeWorkingDirectory } from "@/websocket/listener/cwd-change";
 
-import { isInteractiveCommand, isNonStateCommand } from "./command-routing";
+import { shouldSlashCommandBypassQueue } from "./command-routing";
 import { buildTextParts } from "./content-parts";
 import { buildGoalPrompt } from "./goal-loop";
 import { appendOptimisticUserLine, createClientOtid, uid } from "./ids";
@@ -181,9 +183,11 @@ type ModelSelectorOptions = {
   forceRefresh?: boolean;
 };
 
-async function hasCustomCommand(commandName: string): Promise<boolean> {
+async function findCustomCommandByName(
+  commandName: string,
+): Promise<CustomCommand | undefined> {
   const { findCustomCommand } = await import("@/cli/commands/custom.js");
-  return Boolean(await findCustomCommand(commandName));
+  return findCustomCommand(commandName);
 }
 
 type SubmitHandlerContext = {
@@ -216,7 +220,7 @@ type SubmitHandlerContext = {
   currentModelProvider: string | null;
   effectiveContextWindowSize: number | undefined;
   emittedIdsRef: MutableRefObject<Set<string>>;
-  extensionRuntime: LocalExtensionRuntime;
+  modAdapter: LocalModAdapter;
   firstUserQueryRef: MutableRefObject<string | null>;
   flushPendingReasoningEffort: () => Promise<void>;
   generateConversationDescription: (options?: {
@@ -262,7 +266,7 @@ type SubmitHandlerContext = {
   resetDeferredToolCallCommits: () => void;
   resetPendingReasoningCycle: () => void;
   resetTrajectoryBases: () => void;
-  runEndHooks: (reason?: ExtensionConversationCloseReason) => Promise<void>;
+  runEndHooks: (reason?: ModConversationCloseReason) => Promise<void>;
   sessionHooksRanRef: MutableRefObject<boolean>;
   sessionStartFeedbackRef: MutableRefObject<string[]>;
   sessionStatsRef: MutableRefObject<SessionStats>;
@@ -331,7 +335,7 @@ type SubmitHandlerContext = {
     keepRunning?: boolean,
   ) => void;
   userCancelledRef: MutableRefObject<boolean>;
-  onReload?: (agentId: string, conversationId: string) => Promise<void>;
+  onReload?: () => Promise<void>;
 };
 
 type ReflectCommandArgs =
@@ -356,7 +360,7 @@ function isReflectCommandFlag(value: string): boolean {
 function parseReflectCommandArgs(input: string): ReflectCommandArgs {
   const trimmed = input.trim();
   const command = trimmed.split(/\s+/, 1)[0] ?? "/reflect";
-  const parts = parseExtensionCommandArgv(trimmed.slice(command.length).trim());
+  const parts = parseModCommandArgv(trimmed.slice(command.length).trim());
   if (parts.length === 0) {
     return { kind: "single" };
   }
@@ -383,7 +387,7 @@ function parseReflectCommandArgs(input: string): ReflectCommandArgs {
         .slice(index + 1, instructionEnd)
         .join(" ")
         .trim();
-      if (!instruction?.trim()) {
+      if (!instruction) {
         throw new Error("Usage: /reflect --instruction <instruction>");
       }
       instructions.push(instruction);
@@ -483,7 +487,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
-    extensionRuntime,
+    modAdapter,
     firstUserQueryRef,
     flushPendingReasoningEffort,
     generateConversationDescription,
@@ -709,24 +713,24 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       }
 
       const isSlashCommand = userTextForInput.startsWith("/");
-      const parsedExtensionCommand = isSlashCommand
-        ? parseExtensionSlashCommand(userTextForInput.trim())
+      const parsedModCommand = isSlashCommand
+        ? parseModSlashCommand(userTextForInput.trim())
         : null;
-      const queueBypassExtensionCommand = parsedExtensionCommand
-        ? extensionRuntime.registry?.commands[parsedExtensionCommand.command]
+      const parsedSlashCommandName = parsedModCommand?.command ?? null;
+      const matchedCustomCommand = parsedSlashCommandName
+        ? await findCustomCommandByName(parsedSlashCommandName)
         : undefined;
-      const isExtensionCommandShadowedByCustom =
-        isAgentBusy() && queueBypassExtensionCommand?.runWhenBusy === true
-          ? await hasCustomCommand(parsedExtensionCommand?.command ?? "")
-          : false;
+      const matchedModCommand = parsedSlashCommandName
+        ? modAdapter.registry?.commands[parsedSlashCommandName]
+        : undefined;
       // Interactive/non-state slash commands bypass queueing so menus stay responsive
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
-        (isInteractiveCommand(userTextForInput) ||
-          isNonStateCommand(userTextForInput) ||
-          (queueBypassExtensionCommand?.runWhenBusy === true &&
-            !isExtensionCommandShadowedByCustom));
+        shouldSlashCommandBypassQueue(userTextForInput, {
+          hasCustomCommand: Boolean(matchedCustomCommand),
+          ...(matchedModCommand ? { modCommand: matchedModCommand } : {}),
+        });
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
@@ -758,6 +762,169 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       // Handle commands (messages starting with "/")
       if (aliasedMsg.startsWith("/")) {
         const trimmed = aliasedMsg.trim();
+
+        // Custom commands and mod commands override built-ins.
+        if (matchedCustomCommand) {
+          const { substituteArguments, expandBashCommands } = await import(
+            "@/cli/commands/custom.js"
+          );
+          const cmd = commandRunner.start(
+            trimmed,
+            `Running /${matchedCustomCommand.id}...`,
+          );
+
+          // Check for pending approvals before sending
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              `Pending approval(s). Resolve approvals before running /${matchedCustomCommand.id}.`,
+            );
+            return { submitted: false }; // Keep custom command in input box, user handles approval first
+          }
+
+          // Extract arguments (everything after command name)
+          const args = trimmed
+            .slice(`/${matchedCustomCommand.id}`.length)
+            .trim();
+
+          // Build prompt: 1) substitute args, 2) expand bash commands
+          let prompt = substituteArguments(matchedCustomCommand.content, args);
+          prompt = await expandBashCommands(prompt);
+
+          // Show command in transcript (running phase for visual feedback)
+          setCommandRunning(true);
+
+          try {
+            // Mark command as finished BEFORE sending to agent
+            // (matches /remember pattern - command succeeded in triggering agent)
+            cmd.finish("Running custom command...", true);
+
+            // Send prompt to agent
+            // NOTE: Unlike /remember, we DON'T append args separately because
+            // they're already substituted into the prompt via $ARGUMENTS
+            await processConversationWithQueuedApprovals([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(
+                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
+                ),
+                otid: randomUUID(),
+              },
+            ]);
+          } catch (error) {
+            // Only catch errors from processConversation setup, not agent execution
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to run command: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+
+        if (parsedModCommand && matchedModCommand) {
+          const showInTranscript = matchedModCommand.showInTranscript;
+          const shouldLockCommand = !matchedModCommand.runWhenBusy;
+          const cmd = showInTranscript
+            ? commandRunner.start(
+                trimmed,
+                `Running /${matchedModCommand.id}...`,
+              )
+            : null;
+          const getFeedbackCommand = () =>
+            cmd ??
+            commandRunner.start(trimmed, `Running /${matchedModCommand.id}...`);
+          if (shouldLockCommand) {
+            setCommandRunning(true);
+          }
+
+          try {
+            const modContext = modAdapter.context;
+            const cwd = getCurrentWorkingDirectory();
+            const conversation = createModConversationHandle({
+              agentId,
+              backend: modAdapter.getBackend(),
+              conversationId: conversationIdRef.current,
+              sendMessageStream: sendMessageStreamWithBackend,
+              workingDirectory: cwd,
+            });
+            const commandContext: ModCommandContext = {
+              ...modContext,
+              args: parsedModCommand.args,
+              argv: parseModCommandArgv(parsedModCommand.args),
+              command: parsedModCommand.command,
+              conversation: { ...conversation, id: conversationIdRef.current },
+              cwd,
+              model: {
+                ...modContext.model,
+                id:
+                  currentModelId ??
+                  llmConfigRef.current?.model ??
+                  modContext.model.id,
+              },
+              permissionMode: modContext.permissionMode,
+              rawInput: trimmed,
+            };
+            const result = await runModCommandWithTimeout(
+              matchedModCommand,
+              commandContext,
+            );
+
+            if (result.type === "prompt") {
+              if (!showInTranscript) {
+                getFeedbackCommand().fail(
+                  `/${matchedModCommand.id} returned a prompt with showInTranscript: false. Hidden mod commands must return output or handled and own their UI.`,
+                );
+                return { submitted: true };
+              }
+
+              if (matchedModCommand.runWhenBusy && isAgentBusy()) {
+                getFeedbackCommand().fail(
+                  `/${matchedModCommand.id} returned a prompt while the agent is running. Busy-safe mod commands must handle their own SDK calls or return output.`,
+                );
+                return { submitted: true };
+              }
+
+              const approvalCheck =
+                await checkPendingApprovalsForSlashCommand();
+              if (approvalCheck.blocked) {
+                getFeedbackCommand().fail(
+                  `Pending approval(s). Resolve approvals before running /${matchedModCommand.id}.`,
+                );
+                return { submitted: false };
+              }
+
+              cmd?.finish(`Running /${matchedModCommand.id}...`, true);
+              await processConversationWithQueuedApprovals([
+                {
+                  type: "message",
+                  role: "user",
+                  content: buildTextParts(buildModCommandPrompt(result)),
+                  otid: randomUUID(),
+                },
+              ]);
+            } else if (result.type === "output") {
+              getFeedbackCommand().finish(
+                result.output,
+                result.success ?? true,
+              );
+            } else {
+              cmd?.finish("Handled.", true, true);
+            }
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            getFeedbackCommand().fail(
+              `Failed to run /${matchedModCommand.id}: ${errorDetails}`,
+            );
+          } finally {
+            if (shouldLockCommand) {
+              setCommandRunning(false);
+            }
+          }
+
+          return { submitted: true };
+        }
 
         // Special handling for /model command - opens selector
         if (trimmed === "/model") {
@@ -940,30 +1107,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           if (onReload) {
             const cmd = commandRunner.start(
               "/reload",
-              "Reloading settings and restarting TUI effects...",
+              "Reloading settings and local mods...",
             );
-            cmd.finish("Reloading...", true);
-            try {
-              const { refreshCustomCommands } = await import(
-                "@/cli/commands/custom.js"
-              );
-              refreshCustomCommands();
-            } catch (error) {
-              debugLog(
-                "commands",
-                "refreshCustomCommands failed during /reload: %s",
-                error instanceof Error ? error.message : String(error),
-              );
-            }
+            setCommandRunning(true);
             // Defer the reload to let the command UI render first
-            setTimeout(
-              () =>
-                onReload(
-                  agentIdRef.current,
-                  conversationIdRef.current ?? "default",
-                ),
-              0,
-            );
+            setTimeout(() => {
+              void (async () => {
+                try {
+                  await onReload();
+                  cmd.finish("Reloaded settings and local mods", true);
+                } catch (error) {
+                  const errorDetails = formatErrorDetails(error, agentId);
+                  cmd.fail(`Failed: ${errorDetails}`);
+                } finally {
+                  setCommandRunning(false);
+                }
+              })();
+            }, 0);
           } else {
             const cmd = commandRunner.start("/reload", "Reload not available");
             cmd.fail("Reload is not available in this context");
@@ -1224,7 +1384,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               },
             );
             const request = args
-              ? `The user ran \`/statusline ${args}\`. Use the loaded skill to help them create, edit, or migrate their Letta Code statusline extension.`
+              ? `The user ran \`/statusline ${args}\`. Use the loaded skill to help them create, edit, or migrate their Letta Code statusline mod.`
               : "The user ran `/statusline` without arguments. Use the loaded skill's bare `/statusline` behavior.";
 
             cmd.finish("Running statusline setup...", true);
@@ -1558,7 +1718,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation for the current agent
             const conversation = await backend.createConversation({
               agent_id: agentId,
-              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
               ...(conversationName && { summary: conversationName }),
             });
 
@@ -1599,13 +1758,17 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
-              agentId,
-              agentName: agentName ?? null,
-              conversationId: conversation.id,
-              previousConversationId: prevConversationId ?? null,
-              reason: "new",
-            });
+            void modAdapter.events.emit(
+              "conversation_open",
+              {
+                agentId,
+                agentName: agentName ?? null,
+                conversationId: conversation.id,
+                previousConversationId: prevConversationId ?? null,
+                reason: "new",
+              },
+              modAdapter.context,
+            );
 
             // Update command with success
             cmd.finish(
@@ -1697,13 +1860,17 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
-              agentId,
-              agentName: agentName ?? null,
-              conversationId: forked.id,
-              previousConversationId: forkPrevConversationId ?? null,
-              reason: "fork",
-            });
+            void modAdapter.events.emit(
+              "conversation_open",
+              {
+                agentId,
+                agentName: agentName ?? null,
+                conversationId: forked.id,
+                previousConversationId: forkPrevConversationId ?? null,
+                reason: "fork",
+              },
+              modAdapter.context,
+            );
 
             cmd.finish(
               "Forked conversation (use /resume to switch back)",
@@ -1777,7 +1944,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation
             const conversation = await backend.createConversation({
               agent_id: agentId,
-              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
             });
 
             setConversationAutoTitleEligibility(true);
@@ -1813,13 +1979,17 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
-              agentId,
-              agentName: agentName ?? null,
-              conversationId: conversation.id,
-              previousConversationId: clearPrevConversationId ?? null,
-              reason: "new",
-            });
+            void modAdapter.events.emit(
+              "conversation_open",
+              {
+                agentId,
+                agentName: agentName ?? null,
+                conversationId: conversation.id,
+                previousConversationId: clearPrevConversationId ?? null,
+                reason: "new",
+              },
+              modAdapter.context,
+            );
 
             // Update command with success
             cmd.finish(
@@ -2114,9 +2284,46 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Update command with success
             cmd.finish(outputLines.join("\n"), true);
 
-            // Manual /compact bypasses stream compaction events, so trigger
-            // post-compaction reflection reminder/auto-launch on the next user turn.
-            contextTrackerRef.current.pendingReflectionTrigger = true;
+            // Manual /compact bypasses stream compaction events, so launch
+            // post-compaction reflection directly instead of waiting for the
+            // next turn's post-turn trigger evaluation. Best-effort — never
+            // fail the /compact itself.
+            try {
+              if (
+                getReflectionSettings(agentId).trigger === "compaction-event" &&
+                isActiveMemfsEnabled(agentId)
+              ) {
+                void launchReflectionSubagent({
+                  agentId,
+                  conversationId: compactConversationId,
+                  memfsEnabled: isActiveMemfsEnabled(agentId),
+                  triggerSource: "compaction-event",
+                  description: AUTO_REFLECTION_DESCRIPTION,
+                  completionConversationId: () => conversationIdRef.current,
+                  recompileByConversation:
+                    systemPromptRecompileByConversationRef.current,
+                  recompileQueuedByConversation:
+                    queuedSystemPromptRecompileByConversationRef.current,
+                  onCompletionMessage: (completionMessage) => {
+                    appendTaskNotificationEvents([completionMessage]);
+                  },
+                  feedbackContext: {
+                    parentAgentName: agentName,
+                    parentAgentDescription: agentDescription,
+                    surface: "letta_code_tui",
+                    model: currentModelId,
+                  },
+                });
+              }
+            } catch (reflectionError) {
+              debugLog(
+                "memory",
+                "Skipping post-compaction reflection:",
+                reflectionError instanceof Error
+                  ? reflectionError.message
+                  : String(reflectionError),
+              );
+            }
             void generateConversationDescription({ force: true });
           } catch (error) {
             const apiError = error as {
@@ -2340,6 +2547,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         const profileCommandResult = await handleProfileCommand(msg, trimmed, {
           agentId,
           agentName,
+          conversationId,
           buffersRef,
           commandRunner,
           handleAgentSelect,
@@ -2912,6 +3120,12 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 onCompletionMessage: (completionMessage) => {
                   appendTaskNotificationEvents([completionMessage]);
                 },
+                feedbackContext: {
+                  parentAgentName: agentName,
+                  parentAgentDescription: agentDescription,
+                  surface: "letta_code_tui",
+                  model: currentModelId,
+                },
               });
 
               if (!result.launched) {
@@ -3432,181 +3646,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           return { submitted: true };
         }
 
-        // === Custom command handling ===
-        // Check BEFORE falling through to executeCommand()
-        const { findCustomCommand, substituteArguments, expandBashCommands } =
-          await import("@/cli/commands/custom.js");
-        const customCommandName = trimmed.split(/\s+/)[0]?.slice(1) || ""; // e.g., "review" from "/review arg"
-        const matchedCustom = await findCustomCommand(customCommandName);
-
-        if (matchedCustom) {
-          const cmd = commandRunner.start(
-            trimmed,
-            `Running /${matchedCustom.id}...`,
-          );
-
-          // Check for pending approvals before sending
-          const approvalCheck = await checkPendingApprovalsForSlashCommand();
-          if (approvalCheck.blocked) {
-            cmd.fail(
-              `Pending approval(s). Resolve approvals before running /${matchedCustom.id}.`,
-            );
-            return { submitted: false }; // Keep custom command in input box, user handles approval first
-          }
-
-          // Extract arguments (everything after command name)
-          const args = trimmed.slice(`/${matchedCustom.id}`.length).trim();
-
-          // Build prompt: 1) substitute args, 2) expand bash commands
-          let prompt = substituteArguments(matchedCustom.content, args);
-          prompt = await expandBashCommands(prompt);
-
-          // Show command in transcript (running phase for visual feedback)
-          setCommandRunning(true);
-
-          try {
-            // Mark command as finished BEFORE sending to agent
-            // (matches /remember pattern - command succeeded in triggering agent)
-            cmd.finish("Running custom command...", true);
-
-            // Send prompt to agent
-            // NOTE: Unlike /remember, we DON'T append args separately because
-            // they're already substituted into the prompt via $ARGUMENTS
-            await processConversationWithQueuedApprovals([
-              {
-                type: "message",
-                role: "user",
-                content: buildTextParts(
-                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
-                ),
-                otid: randomUUID(),
-              },
-            ]);
-          } catch (error) {
-            // Only catch errors from processConversation setup, not agent execution
-            const errorDetails = formatErrorDetails(error, agentId);
-            cmd.fail(`Failed to run command: ${errorDetails}`);
-          } finally {
-            setCommandRunning(false);
-          }
-
-          return { submitted: true };
-        }
-        // === END custom command handling ===
-
-        const matchedExtensionCommand: ExtensionCommand | undefined =
-          parsedExtensionCommand
-            ? extensionRuntime.registry?.commands[
-                parsedExtensionCommand.command
-              ]
-            : undefined;
-
-        if (parsedExtensionCommand && matchedExtensionCommand) {
-          const showInTranscript = matchedExtensionCommand.showInTranscript;
-          const shouldLockCommand = !matchedExtensionCommand.runWhenBusy;
-          const cmd = showInTranscript
-            ? commandRunner.start(
-                trimmed,
-                `Running /${matchedExtensionCommand.id}...`,
-              )
-            : null;
-          const getFeedbackCommand = () =>
-            cmd ??
-            commandRunner.start(
-              trimmed,
-              `Running /${matchedExtensionCommand.id}...`,
-            );
-          if (shouldLockCommand) {
-            setCommandRunning(true);
-          }
-
-          try {
-            const extensionContext = extensionRuntime.getContext();
-            const cwd = getCurrentWorkingDirectory();
-            const conversation = createExtensionConversationHandle({
-              agentId,
-              backend: extensionRuntime.getBackendApi(),
-              conversationId: conversationIdRef.current,
-              workingDirectory: cwd,
-            });
-            const commandContext: ExtensionCommandContext = {
-              agent: { id: agentId, name: agentName },
-              args: parsedExtensionCommand.args,
-              argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
-              command: parsedExtensionCommand.command,
-              conversation: { ...conversation, id: conversationIdRef.current },
-              cwd,
-              getContext: extensionRuntime.getContext,
-              model: {
-                id:
-                  currentModelId ??
-                  llmConfigRef.current?.model ??
-                  extensionContext.model.id,
-                displayName: extensionContext.model.displayName,
-              },
-              permissionMode: extensionContext.permissionMode,
-              rawInput: trimmed,
-            };
-            const result = await runExtensionCommandWithTimeout(
-              matchedExtensionCommand,
-              commandContext,
-            );
-
-            if (result.type === "prompt") {
-              if (!showInTranscript) {
-                getFeedbackCommand().fail(
-                  `/${matchedExtensionCommand.id} returned a prompt with showInTranscript: false. Hidden extension commands must return output or handled and own their UI.`,
-                );
-                return { submitted: true };
-              }
-
-              if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
-                getFeedbackCommand().fail(
-                  `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
-                );
-                return { submitted: true };
-              }
-
-              const approvalCheck =
-                await checkPendingApprovalsForSlashCommand();
-              if (approvalCheck.blocked) {
-                getFeedbackCommand().fail(
-                  `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
-                );
-                return { submitted: false };
-              }
-
-              cmd?.finish(`Running /${matchedExtensionCommand.id}...`, true);
-              await processConversationWithQueuedApprovals([
-                {
-                  type: "message",
-                  role: "user",
-                  content: buildTextParts(buildExtensionCommandPrompt(result)),
-                  otid: randomUUID(),
-                },
-              ]);
-            } else if (result.type === "output") {
-              getFeedbackCommand().finish(
-                result.output,
-                result.success ?? true,
-              );
-            } else {
-              cmd?.finish("Handled.", true, true);
-            }
-          } catch (error) {
-            const errorDetails = formatErrorDetails(error, agentId);
-            getFeedbackCommand().fail(
-              `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
-            );
-          } finally {
-            if (shouldLockCommand) {
-              setCommandRunning(false);
-            }
-          }
-
-          return { submitted: true };
-        }
-
         // Check if this is a known command before treating it as a slash command
         const { commands, executeCommand } = await import(
           "@/cli/commands/registry"
@@ -3757,9 +3796,6 @@ ${SYSTEM_REMINDER_CLOSE}
         bashCommandCacheRef.current = [];
       }
 
-      const reflectionSettings = getReflectionSettings(agentId);
-      const memfsEnabledForAgent = isActiveMemfsEnabled(agentId);
-
       // Build git memory sync reminder if uncommitted changes or unpushed commits
       let memoryGitReminder = "";
       const gitStatus = pendingGitReminderRef.current;
@@ -3767,8 +3803,8 @@ ${SYSTEM_REMINDER_CLOSE}
         const memoryDir = getScopedMemoryFilesystemRoot(agentId);
         const localMemfs = isLocalMemfsActive();
         const syncInstructions = localMemfs
-          ? `Commit when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\n\`\`\``
-          : `Sync when convenient by running these commands:\n\`\`\`bash\ncd ${JSON.stringify(memoryDir)}\ngit add system/\ngit commit -m "<type>: <what changed>"\ngit push\n\`\`\``;
+          ? `Commit memory changes locally when appropriate. Inspect with:\n\`\`\`bash\ngit -C ${JSON.stringify(memoryDir)} status\n\`\`\``
+          : `Inspect and fix the memory repository when appropriate. Commit any intended memory changes locally; the harness pushes clean committed memory changes automatically after turns.\n\`\`\`bash\ngit -C ${JSON.stringify(memoryDir)} status\n\`\`\``;
         memoryGitReminder = `${SYSTEM_REMINDER_OPEN}
 ${localMemfs ? "MEMORY COMMIT" : "MEMORY SYNC"}: Your memory directory has uncommitted changes${localMemfs ? "." : " or is ahead of the remote."}
 
@@ -3791,31 +3827,6 @@ ${SYSTEM_REMINDER_CLOSE}
         if (!text) return;
         reminderParts.push({ type: "text", text });
       };
-      const maybeLaunchReflectionSubagent = async (
-        triggerSource: "step-count" | "compaction-event",
-      ) => {
-        const reflectionConversationId = conversationIdRef.current ?? "default";
-        const result = await launchReflectionSubagent({
-          agentId,
-          conversationId: reflectionConversationId,
-          memfsEnabled: memfsEnabledForAgent,
-          triggerSource,
-          description: AUTO_REFLECTION_DESCRIPTION,
-          completionConversationId: () => conversationIdRef.current,
-          recompileByConversation:
-            systemPromptRecompileByConversationRef.current,
-          recompileQueuedByConversation:
-            queuedSystemPromptRecompileByConversationRef.current,
-          onCompletionMessage: (completionMessage) => {
-            appendTaskNotificationEvents([completionMessage]);
-          },
-        });
-        return result.launched;
-      };
-      syncReminderStateFromContextTracker(
-        sharedReminderStateRef.current,
-        contextTrackerRef.current,
-      );
       const { getSkillSources } = await import("@/agent/context");
       const { parts: sharedReminderParts } = await buildSharedReminderParts({
         mode: "interactive",
@@ -3830,9 +3841,8 @@ ${SYSTEM_REMINDER_CLOSE}
         conversationBootstrapContent:
           contentParts as unknown as MessageCreate["content"],
         systemInfoReminderEnabled,
-        reflectionSettings,
         skillSources: getSkillSources(),
-        maybeLaunchReflectionSubagent,
+        shellContext: detectShellContext(),
       });
       for (const part of sharedReminderParts) {
         reminderParts.push(part);
@@ -3948,6 +3958,17 @@ ${SYSTEM_REMINDER_CLOSE}
         transcriptStartLineIndex,
       });
 
+      await runPostTurnMemorySync({
+        agentId,
+        isEnabled: isActiveMemfsEnabled,
+        debugLabel: "Post-turn memory sync",
+        enqueueReminder: (text) => {
+          enqueueMemoryGitSyncReminder(sharedReminderStateRef.current, {
+            text,
+          });
+        },
+      });
+
       // Clean up placeholders after submission
       clearPlaceholdersInText(msg);
 
@@ -3965,7 +3986,7 @@ ${SYSTEM_REMINDER_CLOSE}
       conversationId,
       currentModelHandle,
       currentModelId,
-      extensionRuntime,
+      modAdapter,
       effectiveContextWindowSize,
       commandRunner,
       handleExit,

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -70,8 +70,8 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reflect": {
-    desc: "Launch reflection (/reflect [transcript_file])",
-    args: "[transcript_file]",
+    desc: "Launch reflection (/reflect [--recent N | --conversation ID ...])",
+    args: "[--recent N | --conversation ID ...]",
     order: 50,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -70,8 +70,8 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reflect": {
-    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --auto])",
-    args: "[--recent N | --conversation ID ... | --auto]",
+    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --auto] [--instruction TEXT])",
+    args: "[--recent N | --conversation ID ... | --auto] [--instruction TEXT]",
     order: 50,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -70,8 +70,8 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reflect": {
-    desc: "Launch reflection (/reflect [--recent N | --conversation ID ...])",
-    args: "[--recent N | --conversation ID ...]",
+    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --discover])",
+    args: "[--recent N | --conversation ID ... | --discover]",
     order: 50,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -70,8 +70,8 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reflect": {
-    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --discover])",
-    args: "[--recent N | --conversation ID ... | --discover]",
+    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --wander])",
+    args: "[--recent N | --conversation ID ... | --wander]",
     order: 50,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -70,8 +70,8 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reflect": {
-    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --wander])",
-    args: "[--recent N | --conversation ID ... | --wander]",
+    desc: "Launch reflection (/reflect [--recent N | --conversation ID ... | --auto])",
+    args: "[--recent N | --conversation ID ... | --auto]",
     order: 50,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/components/ProductStatusRow.tsx
+++ b/src/cli/components/ProductStatusRow.tsx
@@ -80,7 +80,6 @@ function renderDreamingStatus(agent: SubagentState): ReactNode {
   const elapsedS = Math.round((Date.now() - agent.startTime) / 1000);
   const typeLabel = typeLabelForBackgroundAgent(agent);
   const chatUrl = chatUrlForBackgroundAgent(agent);
-  const isTmux = Boolean(process.env.TMUX);
 
   return (
     <Text>
@@ -90,12 +89,7 @@ function renderDreamingStatus(agent: SubagentState): ReactNode {
         marginRight={0}
         pulseIntervalMs={400}
       />
-      {chatUrl && isTmux ? (
-        <>
-          <Text color={colors.bgSubagent.label}>{typeLabel}</Text>
-          <Text dimColor>: {chatUrl}</Text>
-        </>
-      ) : chatUrl ? (
+      {chatUrl ? (
         <Link url={chatUrl} fallback={false}>
           <Text color={colors.bgSubagent.label}>{typeLabel}</Text>
         </Link>

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -56,13 +56,14 @@ export function buildAgentReference(
 export function buildAgentTerminalLink(
   agentId: string,
   options?: Parameters<typeof buildChatUrl>[1],
+  label: string = agentId,
 ): string {
   if (isLocalAgentId(agentId)) {
     return agentId;
   }
 
   const url = buildChatUrl(agentId, options);
-  return `\x1b]8;;${url}\x1b\\${agentId}\x1b]8;;\x1b\\`;
+  return `\x1b]8;;${url}\x1b\\${label}\x1b]8;;\x1b\\`;
 }
 
 /**

--- a/src/cli/helpers/memory-subagent-completion.ts
+++ b/src/cli/helpers/memory-subagent-completion.ts
@@ -1,5 +1,6 @@
 import { recompileAgentSystemPrompt } from "@/agent/modify";
 import { isDebugEnabled } from "@/utils/debug";
+import { buildAgentTerminalLink, isLocalAgentId } from "./app-urls";
 import {
   estimateSystemTokens,
   setSystemPromptDoctorState,
@@ -19,6 +20,7 @@ export interface MemorySubagentCompletionArgs {
   subagentType: MemorySubagentType;
   success: boolean;
   error?: string;
+  subagentAgentId?: string;
 }
 
 export interface MemorySubagentCompletionDeps {
@@ -37,6 +39,12 @@ export async function handleMemorySubagentCompletion(
   deps: MemorySubagentCompletionDeps,
 ): Promise<string> {
   const { agentId, conversationId, subagentType, success, error } = args;
+  const subagentLink = args.subagentAgentId
+    ? buildAgentTerminalLink(args.subagentAgentId, undefined, "Dreamed")
+    : null;
+  const canLinkSubagent = args.subagentAgentId
+    ? !isLocalAgentId(args.subagentAgentId)
+    : false;
   const recompileAgentSystemPromptFn =
     deps.recompileAgentSystemPromptImpl ?? recompileAgentSystemPrompt;
   let recompileError: string | null = null;
@@ -90,10 +98,14 @@ export async function handleMemorySubagentCompletion(
     return `Memory initialization failed: ${normalizedError}`;
   }
 
-  const baseMessage =
+  let baseMessage =
     subagentType === "reflection"
-      ? "Reflected on /palace, the halls remember more now."
+      ? "Dreamed and made some memories."
       : "Built a memory palace of you. Visit it with /palace.";
+
+  if (subagentType === "reflection" && subagentLink && canLinkSubagent) {
+    baseMessage = `${subagentLink} and made some memories.`;
+  }
 
   if (!recompileError) {
     return baseMessage;

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -3,7 +3,6 @@ import { getSubagents } from "@/agent/subagent-state";
 import { getBackend } from "@/backend";
 import type { ReflectionTrigger } from "@/cli/helpers/memory-reminder";
 import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
-import { isReflectionSubagentActive } from "@/cli/helpers/reflection-gate";
 import {
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
@@ -11,13 +10,11 @@ import {
   finalizeAutoReflectionPayload,
 } from "@/cli/helpers/reflection-transcript";
 import { telemetry } from "@/telemetry";
-import { maybeSendReflectionThresholdFeedback } from "@/telemetry/reflection-threshold-feedback";
 import { debugLog, debugWarn } from "@/utils/debug";
 
 export const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
 
-/** Max background wait for the reflection subagent's agent ID before emitting `reflection_start` (previously 1s inline, timed out ~100% of the time). */
-export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;
+const reservedReflectionAgentIds = new Set<string>();
 
 export type ReflectionLaunchTriggerSource =
   | "manual"
@@ -28,15 +25,6 @@ export type ReflectionLaunchSkippedReason =
   | "already_active"
   | "no_payload"
   | "error";
-
-function drainReflectionTelemetry(): void {
-  telemetry.drain().catch((error) => {
-    debugWarn(
-      "telemetry",
-      `Failed to flush reflection telemetry: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  });
-}
 
 export type ReflectionLaunchResult =
   | {
@@ -72,12 +60,6 @@ export interface ReflectionLaunchOptions {
       reflectionAgentId?: string;
     },
   ) => void | Promise<void>;
-  feedbackContext?: {
-    parentAgentName?: string | null;
-    parentAgentDescription?: string | null;
-    model?: string | null;
-    surface?: string;
-  };
 }
 
 async function resolveSystemPrompt(
@@ -110,6 +92,33 @@ function resolveCompletionConversationId(
   return completionConversationId ?? fallback;
 }
 
+function isReflectionSubagentActiveForAgent(agentId: string): boolean {
+  return getSubagents().some((agent) => {
+    if (agent.type.toLowerCase() !== "reflection") {
+      return false;
+    }
+    if (agent.status !== "pending" && agent.status !== "running") {
+      return false;
+    }
+    return agent.parentAgentId === agentId;
+  });
+}
+
+export function tryReserveReflectionLaunch(agentId: string): boolean {
+  if (reservedReflectionAgentIds.has(agentId)) {
+    return false;
+  }
+  if (isReflectionSubagentActiveForAgent(agentId)) {
+    return false;
+  }
+  reservedReflectionAgentIds.add(agentId);
+  return true;
+}
+
+export function releaseReflectionLaunch(agentId: string): void {
+  reservedReflectionAgentIds.delete(agentId);
+}
+
 export async function launchReflectionSubagent(
   options: ReflectionLaunchOptions,
 ): Promise<ReflectionLaunchResult> {
@@ -128,7 +137,7 @@ export async function launchReflectionSubagent(
     return { launched: false, reason: "memfs_disabled" };
   }
 
-  if (isReflectionSubagentActive(getSubagents(), agentId, conversationId)) {
+  if (!tryReserveReflectionLaunch(agentId)) {
     debugLog(
       "memory",
       `Skipping reflection launch (${triggerSource}) because one is already active`,
@@ -136,6 +145,7 @@ export async function launchReflectionSubagent(
     return { launched: false, reason: "already_active" };
   }
 
+  let releaseOnComplete = false;
   try {
     const systemPrompt = await resolveSystemPrompt(
       agentId,
@@ -151,6 +161,7 @@ export async function launchReflectionSubagent(
         "memory",
         `Skipping reflection launch (${triggerSource}) because transcript has no new content`,
       );
+      releaseReflectionLaunch(agentId);
       return { launched: false, reason: "no_payload" };
     }
 
@@ -164,18 +175,6 @@ export async function launchReflectionSubagent(
 
     const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
       await import("@/tools/impl/task");
-
-    // Defer `reflection_start` until the agent ID resolves (background, bounded by REFLECTION_AGENT_ID_WAIT_MS).
-    const emitReflectionStart = (resolvedAgentId: string | null) => {
-      telemetry.trackReflectionStart(triggerSource, {
-        subagentId: resolvedAgentId ?? undefined,
-        conversationId,
-        startMessageId: autoPayload.startMessageId,
-        endMessageId: autoPayload.endMessageId,
-      });
-      drainReflectionTelemetry();
-    };
-
     const { subagentId } = spawnBackgroundSubagentTask({
       subagentType: "reflection",
       prompt: reflectionPrompt,
@@ -183,96 +182,74 @@ export async function launchReflectionSubagent(
       silentCompletion: true,
       transcriptPath: autoPayload.payloadPath,
       parentScope: { agentId, conversationId },
-      onComplete: async ({
-        success,
-        error,
-        agentId: reflectionAgentId,
-        stepCount,
-        durationMs,
-      }) => {
-        telemetry.trackReflectionEnd(triggerSource, success, {
-          subagentId: reflectionAgentId ?? undefined,
-          conversationId,
-          error,
-          stepCount,
-          durationMs,
-        });
-        drainReflectionTelemetry();
-        maybeSendReflectionThresholdFeedback({
-          parentAgentId: agentId,
-          parentAgentName: options.feedbackContext?.parentAgentName,
-          parentAgentDescription:
-            options.feedbackContext?.parentAgentDescription,
-          reflectionSubagentId: reflectionAgentId ?? undefined,
-          conversationId,
-          triggerSource,
-          success,
-          error,
-          stepCount,
-          durationMs,
-          surface: options.feedbackContext?.surface,
-          model: options.feedbackContext?.model,
-        });
-        await finalizeAutoReflectionPayload(
-          agentId,
-          conversationId,
-          autoPayload.payloadPath,
-          autoPayload.endSnapshotLine,
-          success,
-        );
-
-        const completionMessage = await handleMemorySubagentCompletion(
-          {
+      onComplete: async ({ success, error, agentId: reflectionAgentId }) => {
+        try {
+          telemetry.trackReflectionEnd(triggerSource, success, {
+            subagentId: reflectionAgentId ?? undefined,
+            conversationId,
+            error,
+          });
+          await finalizeAutoReflectionPayload(
             agentId,
-            conversationId: resolveCompletionConversationId(
-              options.completionConversationId,
-              conversationId,
-            ),
-            subagentType: "reflection",
+            conversationId,
+            autoPayload.payloadPath,
+            autoPayload.endSnapshotLine,
+            success,
+          );
+
+          const completionMessage = await handleMemorySubagentCompletion(
+            {
+              agentId,
+              conversationId: resolveCompletionConversationId(
+                options.completionConversationId,
+                conversationId,
+              ),
+              subagentType: "reflection",
+              success,
+              error,
+              subagentAgentId: reflectionAgentId ?? undefined,
+            },
+            {
+              recompileByConversation,
+              recompileQueuedByConversation,
+              logRecompileFailure: (message) => debugWarn("memory", message),
+            },
+          );
+          await onCompletionMessage?.(completionMessage, {
             success,
             error,
-          },
-          {
-            recompileByConversation,
-            recompileQueuedByConversation,
-            logRecompileFailure: (message) => debugWarn("memory", message),
-          },
-        );
-        await onCompletionMessage?.(completionMessage, {
-          success,
-          error,
-          reflectionAgentId: reflectionAgentId ?? undefined,
-        });
+            reflectionAgentId: reflectionAgentId ?? undefined,
+          });
+        } finally {
+          releaseReflectionLaunch(agentId);
+        }
       },
     });
-    // Fire-and-forget: emit `reflection_start` when the agent ID resolves or after timeout.
-    void waitForBackgroundSubagentAgentId(
+    releaseOnComplete = true;
+    const reflectionAgentId = await waitForBackgroundSubagentAgentId(
       subagentId,
-      REFLECTION_AGENT_ID_WAIT_MS,
-    )
-      .then((resolvedAgentId) => {
-        emitReflectionStart(resolvedAgentId);
-      })
-      .catch((err) => {
-        // Worst case — still emit with no subagent_id so we don't lose the event.
-        debugWarn(
-          "memory",
-          `Failed waiting for reflection agent ID: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-        emitReflectionStart(null);
-      });
+      1000,
+    );
+    telemetry.trackReflectionStart(triggerSource, {
+      subagentId: reflectionAgentId ?? undefined,
+      conversationId,
+      startMessageId: autoPayload.startMessageId,
+      endMessageId: autoPayload.endMessageId,
+    });
 
     debugLog("memory", `Launched reflection subagent (${triggerSource})`);
     return {
       launched: true,
       payloadPath: autoPayload.payloadPath,
       subagentId,
+      reflectionAgentId: reflectionAgentId ?? undefined,
       startMessageId: autoPayload.startMessageId,
       endMessageId: autoPayload.endMessageId,
     };
   } catch (error) {
+    if (!releaseOnComplete) {
+      releaseReflectionLaunch(agentId);
+    }
     debugWarn(
       "memory",
       `Failed to launch reflection subagent (${triggerSource}): ${

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -10,9 +10,13 @@ import {
   finalizeAutoReflectionPayload,
 } from "@/cli/helpers/reflection-transcript";
 import { telemetry } from "@/telemetry";
+import { maybeSendReflectionThresholdFeedback } from "@/telemetry/reflection-threshold-feedback";
 import { debugLog, debugWarn } from "@/utils/debug";
 
 export const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
+
+/** Max background wait for the reflection subagent's agent ID before emitting `reflection_start` (previously 1s inline, timed out ~100% of the time). */
+export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;
 
 const reservedReflectionAgentIds = new Set<string>();
 
@@ -25,6 +29,15 @@ export type ReflectionLaunchSkippedReason =
   | "already_active"
   | "no_payload"
   | "error";
+
+function drainReflectionTelemetry(): void {
+  telemetry.drain().catch((error) => {
+    debugWarn(
+      "telemetry",
+      `Failed to flush reflection telemetry: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}
 
 export type ReflectionLaunchResult =
   | {
@@ -60,6 +73,39 @@ export interface ReflectionLaunchOptions {
       reflectionAgentId?: string;
     },
   ) => void | Promise<void>;
+  feedbackContext?: {
+    parentAgentName?: string | null;
+    parentAgentDescription?: string | null;
+    model?: string | null;
+    surface?: string;
+  };
+}
+
+function isReflectionSubagentActiveForAgent(agentId: string): boolean {
+  return getSubagents().some((agent) => {
+    if (agent.type.toLowerCase() !== "reflection") {
+      return false;
+    }
+    if (agent.status !== "pending" && agent.status !== "running") {
+      return false;
+    }
+    return agent.parentAgentId === agentId;
+  });
+}
+
+export function tryReserveReflectionLaunch(agentId: string): boolean {
+  if (reservedReflectionAgentIds.has(agentId)) {
+    return false;
+  }
+  if (isReflectionSubagentActiveForAgent(agentId)) {
+    return false;
+  }
+  reservedReflectionAgentIds.add(agentId);
+  return true;
+}
+
+export function releaseReflectionLaunch(agentId: string): void {
+  reservedReflectionAgentIds.delete(agentId);
 }
 
 async function resolveSystemPrompt(
@@ -90,33 +136,6 @@ function resolveCompletionConversationId(
     return completionConversationId();
   }
   return completionConversationId ?? fallback;
-}
-
-function isReflectionSubagentActiveForAgent(agentId: string): boolean {
-  return getSubagents().some((agent) => {
-    if (agent.type.toLowerCase() !== "reflection") {
-      return false;
-    }
-    if (agent.status !== "pending" && agent.status !== "running") {
-      return false;
-    }
-    return agent.parentAgentId === agentId;
-  });
-}
-
-export function tryReserveReflectionLaunch(agentId: string): boolean {
-  if (reservedReflectionAgentIds.has(agentId)) {
-    return false;
-  }
-  if (isReflectionSubagentActiveForAgent(agentId)) {
-    return false;
-  }
-  reservedReflectionAgentIds.add(agentId);
-  return true;
-}
-
-export function releaseReflectionLaunch(agentId: string): void {
-  reservedReflectionAgentIds.delete(agentId);
 }
 
 export async function launchReflectionSubagent(
@@ -175,6 +194,18 @@ export async function launchReflectionSubagent(
 
     const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
       await import("@/tools/impl/task");
+
+    // Defer `reflection_start` until the agent ID resolves (background, bounded by REFLECTION_AGENT_ID_WAIT_MS).
+    const emitReflectionStart = (resolvedAgentId: string | null) => {
+      telemetry.trackReflectionStart(triggerSource, {
+        subagentId: resolvedAgentId ?? undefined,
+        conversationId,
+        startMessageId: autoPayload.startMessageId,
+        endMessageId: autoPayload.endMessageId,
+      });
+      drainReflectionTelemetry();
+    };
+
     const { subagentId } = spawnBackgroundSubagentTask({
       subagentType: "reflection",
       prompt: reflectionPrompt,
@@ -182,12 +213,36 @@ export async function launchReflectionSubagent(
       silentCompletion: true,
       transcriptPath: autoPayload.payloadPath,
       parentScope: { agentId, conversationId },
-      onComplete: async ({ success, error, agentId: reflectionAgentId }) => {
+      onComplete: async ({
+        success,
+        error,
+        agentId: reflectionAgentId,
+        stepCount,
+        durationMs,
+      }) => {
         try {
           telemetry.trackReflectionEnd(triggerSource, success, {
             subagentId: reflectionAgentId ?? undefined,
             conversationId,
             error,
+            stepCount,
+            durationMs,
+          });
+          drainReflectionTelemetry();
+          maybeSendReflectionThresholdFeedback({
+            parentAgentId: agentId,
+            parentAgentName: options.feedbackContext?.parentAgentName,
+            parentAgentDescription:
+              options.feedbackContext?.parentAgentDescription,
+            reflectionSubagentId: reflectionAgentId ?? undefined,
+            conversationId,
+            triggerSource,
+            success,
+            error,
+            stepCount,
+            durationMs,
+            surface: options.feedbackContext?.surface,
+            model: options.feedbackContext?.model,
           });
           await finalizeAutoReflectionPayload(
             agentId,
@@ -226,23 +281,30 @@ export async function launchReflectionSubagent(
       },
     });
     releaseOnComplete = true;
-    const reflectionAgentId = await waitForBackgroundSubagentAgentId(
+    // Fire-and-forget: emit `reflection_start` when the agent ID resolves or after timeout.
+    void waitForBackgroundSubagentAgentId(
       subagentId,
-      1000,
-    );
-    telemetry.trackReflectionStart(triggerSource, {
-      subagentId: reflectionAgentId ?? undefined,
-      conversationId,
-      startMessageId: autoPayload.startMessageId,
-      endMessageId: autoPayload.endMessageId,
-    });
+      REFLECTION_AGENT_ID_WAIT_MS,
+    )
+      .then((resolvedAgentId) => {
+        emitReflectionStart(resolvedAgentId);
+      })
+      .catch((err) => {
+        // Worst case — still emit with no subagent_id so we don't lose the event.
+        debugWarn(
+          "memory",
+          `Failed waiting for reflection agent ID: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        emitReflectionStart(null);
+      });
 
     debugLog("memory", `Launched reflection subagent (${triggerSource})`);
     return {
       launched: true,
       payloadPath: autoPayload.payloadPath,
       subagentId,
-      reflectionAgentId: reflectionAgentId ?? undefined,
       startMessageId: autoPayload.startMessageId,
       endMessageId: autoPayload.endMessageId,
     };

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -59,6 +59,7 @@ export interface ReflectionLaunchOptions {
   memfsEnabled: boolean;
   triggerSource: ReflectionLaunchTriggerSource;
   description: string;
+  instruction?: string;
   systemPrompt?: string;
   completionConversationId?: string | (() => string);
   recompileByConversation: Map<string, Promise<void>>;
@@ -156,6 +157,7 @@ export async function launchReflectionSubagent(
     const memoryDir = getScopedMemoryFilesystemRoot(agentId);
     const parentMemory = await buildParentMemorySnapshot(memoryDir);
     const reflectionPrompt = buildReflectionSubagentPrompt({
+      instruction: options.instruction,
       memoryDir,
       parentMemory,
     });

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  stat,
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -78,6 +79,50 @@ export interface AutoReflectionPayload {
   endSnapshotLine: number;
 }
 
+export type ReflectionSliceMode = "unreflected" | "replay";
+
+export interface MultiReflectionTranscriptSlice {
+  conversation_id: string;
+  mode: ReflectionSliceMode;
+  payload_path: string;
+  start_message_id: string;
+  end_message_id: string;
+  start_line: number;
+  end_line: number;
+  end_snapshot_line: number;
+  completed_turns: number;
+  approx_chars: number;
+  last_updated_at?: string;
+}
+
+export interface MultiReflectionManifest {
+  schema_version: 1;
+  type: "multi_transcript_reflection_payload";
+  agent_id: string;
+  created_at: string;
+  selection_policy:
+    | { mode: "recent"; limit: number }
+    | { mode: "explicit-conversations"; conversation_ids: string[] };
+  transcripts: MultiReflectionTranscriptSlice[];
+}
+
+export interface MultiReflectionPayload {
+  payloadPath: string;
+  manifest: MultiReflectionManifest;
+  startMessageId?: string;
+  endMessageId?: string;
+}
+
+export interface ReflectionTranscriptCandidate {
+  conversationId: string;
+  transcriptPath: string;
+  statePath: string;
+  lastUpdatedAt?: string;
+  totalCompletedTurns: number;
+  reflectedCompletedTurns: number;
+  turnsSinceLastSuccessfulReflection: number;
+}
+
 export interface ReflectionPromptInput {
   memoryDir: string;
   parentMemory?: string;
@@ -89,7 +134,10 @@ export function buildReflectionSubagentPrompt(
   const lines: string[] = [];
 
   lines.push(
-    "Review the conversation transcript and update memory files. The current conversation transcript path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Edit/Read/Write `file_path` is literal and does NOT expand env vars.",
+    "Review the conversation transcript payload and update memory files. The payload path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Edit/Read/Write `file_path` is literal and does NOT expand env vars.",
+    "",
+    'The payload may be either a JSON message array for one conversation or a `multi_transcript_reflection_payload` manifest. If it is a manifest, read each `payload_path` listed in `transcripts` and synthesize across all conversations. Entries with `mode: "replay"` were already reflected before and are included intentionally for re-review/deduplication; do not ignore them just because they are replay slices.',
+    "When reviewing multiple transcripts, prefer durable patterns and latest evidence across sessions. Resolve contradictions by updating stale memory at the source, deduplicate repeated facts, and avoid storing one-off task state.",
     "",
     `The primary agent's memory filesystem is located at: ${input.memoryDir}`,
     "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the parent agent's system prompt.",
@@ -851,9 +899,16 @@ async function writeState(
   );
 }
 
-function buildPayloadPath(rootDir: string, kind: "auto" | "remember"): string {
+function buildPayloadPath(
+  rootDir: string,
+  kind: "auto" | "remember" | "multi" | "slice",
+): string {
   const nonce = Math.random().toString(36).slice(2, 8);
   return join(rootDir, `payload-${kind}-${nonce}.json`);
+}
+
+function getAgentTranscriptRoot(agentId: string): string {
+  return join(getTranscriptRoot(), sanitizePathSegment(agentId));
 }
 
 export function getReflectionTranscriptPaths(
@@ -996,6 +1051,118 @@ function entriesForSelection(
     .map((row) => row.entry);
 }
 
+function selectReplayTranscriptRange(
+  rows: ParsedTranscriptRow[],
+  maxTurns: number,
+): TranscriptSelection | null {
+  if (rows.length === 0 || maxTurns <= 0) {
+    return null;
+  }
+
+  const endRow = rows.findLast((row) => isEligibleCanonicalEntry(row.entry));
+  if (!endRow || !isEligibleCanonicalEntry(endRow.entry)) {
+    return null;
+  }
+
+  let usersSeen = 0;
+  let startLineIndex = 0;
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (!row) continue;
+    if (row.lineIndex > endRow.lineIndex) continue;
+    startLineIndex = row.lineIndex;
+    if (row.entry.kind === "user") {
+      usersSeen += 1;
+      if (usersSeen >= maxTurns) {
+        break;
+      }
+    }
+  }
+
+  const startRow = rows.find(
+    (row) =>
+      row.lineIndex >= startLineIndex &&
+      row.lineIndex <= endRow.lineIndex &&
+      isEligibleCanonicalEntry(row.entry),
+  );
+  if (!startRow || !isEligibleCanonicalEntry(startRow.entry)) {
+    return null;
+  }
+
+  return {
+    startLineIndex,
+    endLineIndex: endRow.lineIndex,
+    startMessageId: startRow.entry.source_message_id,
+    endMessageId: endRow.entry.source_message_id,
+  };
+}
+
+async function getTranscriptLastUpdatedAt(
+  paths: ReflectionTranscriptPaths,
+): Promise<string | undefined> {
+  try {
+    const info = await stat(paths.transcriptPath);
+    return info.mtime.toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function ensureAgentPayloadRoot(agentId: string): Promise<string> {
+  const root = join(
+    getAgentTranscriptRoot(agentId),
+    "multi-reflection-payloads",
+  );
+  await mkdir(root, { recursive: true });
+  return root;
+}
+
+export async function listReflectionTranscriptCandidates(
+  agentId: string,
+): Promise<ReflectionTranscriptCandidate[]> {
+  const agentRoot = getAgentTranscriptRoot(agentId);
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(agentRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: ReflectionTranscriptCandidate[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === "multi-reflection-payloads") {
+      continue;
+    }
+    const conversationId = entry.name;
+    const paths = getReflectionTranscriptPaths(agentId, conversationId);
+    const lines = await readTranscriptLines(paths);
+    if (lines.length === 0) {
+      continue;
+    }
+    const rows = parseTranscriptRows(lines);
+    if (!rows.some((row) => isEligibleCanonicalEntry(row.entry))) {
+      continue;
+    }
+    const state = await readState(paths);
+    candidates.push({
+      conversationId,
+      transcriptPath: paths.transcriptPath,
+      statePath: paths.statePath,
+      lastUpdatedAt: await getTranscriptLastUpdatedAt(paths),
+      totalCompletedTurns: state.total_completed_turns,
+      reflectedCompletedTurns: state.reflected_completed_turns,
+      turnsSinceLastSuccessfulReflection:
+        state.turns_since_last_successful_reflection,
+    });
+  }
+
+  return candidates.sort((a, b) => {
+    const aTime = a.lastUpdatedAt ? Date.parse(a.lastUpdatedAt) : 0;
+    const bTime = b.lastUpdatedAt ? Date.parse(b.lastUpdatedAt) : 0;
+    return bTime - aTime || a.conversationId.localeCompare(b.conversationId);
+  });
+}
+
 export async function getReflectionTranscriptState(
   agentId: string,
   conversationId: string,
@@ -1051,6 +1218,160 @@ export async function buildAutoReflectionPayload(
   });
 }
 
+type MultiReflectionSelectionPolicy =
+  | { mode: "recent"; limit: number }
+  | { mode: "explicit-conversations"; conversationIds: string[] };
+
+export interface BuildMultiReflectionPayloadOptions {
+  agentId: string;
+  selectionPolicy: MultiReflectionSelectionPolicy;
+  systemPrompt?: string;
+  maxReplayTurnsPerConversation?: number;
+  maxTotalChars?: number;
+}
+
+async function resolveMultiReflectionConversationIds(
+  agentId: string,
+  selectionPolicy: MultiReflectionSelectionPolicy,
+): Promise<string[]> {
+  if (selectionPolicy.mode === "explicit-conversations") {
+    return Array.from(new Set(selectionPolicy.conversationIds));
+  }
+
+  const candidates = await listReflectionTranscriptCandidates(agentId);
+  return candidates
+    .slice(0, Math.max(0, selectionPolicy.limit))
+    .map((candidate) => candidate.conversationId);
+}
+
+function manifestSelectionPolicy(
+  selectionPolicy: MultiReflectionSelectionPolicy,
+): MultiReflectionManifest["selection_policy"] {
+  if (selectionPolicy.mode === "recent") {
+    return { mode: "recent", limit: selectionPolicy.limit };
+  }
+  return {
+    mode: "explicit-conversations",
+    conversation_ids: selectionPolicy.conversationIds,
+  };
+}
+
+export async function buildMultiReflectionPayload(
+  options: BuildMultiReflectionPayloadOptions,
+): Promise<MultiReflectionPayload | null> {
+  const {
+    agentId,
+    selectionPolicy,
+    systemPrompt,
+    maxReplayTurnsPerConversation = 50,
+    maxTotalChars = 150_000,
+  } = options;
+  const conversationIds = await resolveMultiReflectionConversationIds(
+    agentId,
+    selectionPolicy,
+  );
+  if (conversationIds.length === 0) {
+    return null;
+  }
+
+  const payloadRoot = await ensureAgentPayloadRoot(agentId);
+  const filteredSystemPrompt = systemPrompt
+    ? filterSystemPromptForReflection(systemPrompt) || undefined
+    : undefined;
+  const transcripts: MultiReflectionTranscriptSlice[] = [];
+  let totalChars = 0;
+  let firstMessageId: string | undefined;
+  let lastMessageId: string | undefined;
+
+  for (const conversationId of conversationIds) {
+    const slice = await withStateLock(agentId, conversationId, async () => {
+      const paths = getReflectionTranscriptPaths(agentId, conversationId);
+      await ensurePaths(paths);
+      const lines = await readTranscriptLines(paths);
+      const rows = parseTranscriptRows(lines);
+      const state = await readState(paths);
+      const unreflectedSelection = selectUnreflectedTranscriptRange(
+        rows,
+        state.reflected_through_message_id,
+      );
+      const mode: ReflectionSliceMode = unreflectedSelection
+        ? "unreflected"
+        : "replay";
+      const selection =
+        unreflectedSelection ??
+        selectReplayTranscriptRange(rows, maxReplayTurnsPerConversation);
+      if (!selection) {
+        return null;
+      }
+
+      const entries = entriesForSelection(rows, selection);
+      const transcript = formatTaggedTranscript(entries, filteredSystemPrompt);
+      if (!transcript || transcript === "[]") {
+        return null;
+      }
+      const approxChars = transcript.length;
+      if (transcripts.length > 0 && totalChars + approxChars > maxTotalChars) {
+        return null;
+      }
+
+      const payloadPath = buildPayloadPath(payloadRoot, "slice");
+      await writeFile(payloadPath, transcript, "utf-8");
+      state.last_reflection_started_at = new Date().toISOString();
+      await writeState(paths, state);
+
+      return {
+        conversation_id: conversationId,
+        mode,
+        payload_path: payloadPath,
+        start_message_id: selection.startMessageId,
+        end_message_id: selection.endMessageId,
+        start_line: selection.startLineIndex,
+        end_line: selection.endLineIndex,
+        end_snapshot_line: selection.endLineIndex + 1,
+        completed_turns: countUserRows(entries),
+        approx_chars: approxChars,
+        last_updated_at: await getTranscriptLastUpdatedAt(paths),
+      } satisfies MultiReflectionTranscriptSlice;
+    });
+
+    if (!slice) {
+      continue;
+    }
+    if (!firstMessageId) {
+      firstMessageId = slice.start_message_id;
+    }
+    lastMessageId = slice.end_message_id;
+    totalChars += slice.approx_chars;
+    transcripts.push(slice);
+  }
+
+  if (transcripts.length === 0) {
+    return null;
+  }
+
+  const manifest: MultiReflectionManifest = {
+    schema_version: 1,
+    type: "multi_transcript_reflection_payload",
+    agent_id: agentId,
+    created_at: new Date().toISOString(),
+    selection_policy: manifestSelectionPolicy(selectionPolicy),
+    transcripts,
+  };
+  const payloadPath = buildPayloadPath(payloadRoot, "multi");
+  await writeFile(
+    payloadPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf-8",
+  );
+
+  return {
+    payloadPath,
+    manifest,
+    startMessageId: firstMessageId,
+    endMessageId: lastMessageId,
+  };
+}
+
 export async function finalizeAutoReflectionPayload(
   agentId: string,
   conversationId: string,
@@ -1084,4 +1405,27 @@ export async function finalizeAutoReflectionPayload(
     }
     await writeState(paths, state);
   });
+}
+
+export async function finalizeMultiReflectionPayload(
+  agentId: string,
+  manifest: MultiReflectionManifest,
+  success: boolean,
+): Promise<void> {
+  if (!success) {
+    return;
+  }
+
+  for (const slice of manifest.transcripts) {
+    if (slice.mode !== "unreflected") {
+      continue;
+    }
+    await finalizeAutoReflectionPayload(
+      agentId,
+      slice.conversation_id,
+      slice.payload_path,
+      slice.end_snapshot_line,
+      true,
+    );
+  }
 }

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -1662,10 +1662,10 @@ export async function listReflectionTranscriptCandidates(
       transcriptPath: paths.transcriptPath,
       statePath: paths.statePath,
       lastUpdatedAt: await getTranscriptLastUpdatedAt(paths),
-      totalCompletedTurns: state.total_completed_turns,
-      reflectedCompletedTurns: state.reflected_completed_turns,
+      totalCompletedTurns: state.total_completed_steps,
+      reflectedCompletedTurns: state.reflected_completed_steps,
       turnsSinceLastSuccessfulReflection:
-        state.turns_since_last_successful_reflection,
+        state.steps_since_last_successful_reflection,
     });
   }
 
@@ -1883,7 +1883,7 @@ export async function buildMultiReflectionPayload(
         start_line: selection.startLineIndex,
         end_line: selection.endLineIndex,
         end_snapshot_line: selection.endLineIndex + 1,
-        completed_turns: countUserRows(entries),
+        completed_turns: countAssistantRows(entries),
         approx_chars: approxChars,
         last_updated_at: await getTranscriptLastUpdatedAt(paths),
       } satisfies MultiReflectionTranscriptSlice;

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -1292,6 +1292,35 @@ function scoreAutoCandidate(candidate: ReflectionAutoCandidate): number {
   );
 }
 
+function hasSearchHit(candidate: ReflectionAutoCandidate): boolean {
+  return candidate.search_scores.length > 0;
+}
+
+function hasSummary(candidate: ReflectionAutoCandidate): boolean {
+  return Boolean(candidate.summary?.trim());
+}
+
+function shouldKeepAutoCandidate(candidate: ReflectionAutoCandidate): boolean {
+  if (candidate.is_current_conversation) {
+    return candidate.has_unreflected_content || hasSearchHit(candidate);
+  }
+
+  if (!candidate.has_unreflected_content && !hasSearchHit(candidate)) {
+    return false;
+  }
+
+  if (
+    candidate.turns_since_last_successful_reflection <= 1 &&
+    candidate.total_completed_turns < 3 &&
+    !hasSearchHit(candidate) &&
+    !hasSummary(candidate)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function buildReflectionAutoPayload(options: {
   agentId: string;
   currentConversationId?: string;
@@ -1434,6 +1463,7 @@ export async function buildReflectionAutoPayload(options: {
   }
 
   const sortedCandidates = Array.from(candidates.values())
+    .filter(shouldKeepAutoCandidate)
     .map((candidate) => ({
       ...candidate,
       sources: [...candidate.sources].sort(),

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -91,7 +91,7 @@ export interface MultiReflectionTranscriptSlice {
   mode: ReflectionSliceMode;
   payload_path: string;
   selection_reason?: string;
-  selection_priority?: ReflectionWanderPriority;
+  selection_priority?: ReflectionAutoPriority;
   start_message_id: string;
   end_message_id: string;
   start_line: number;
@@ -111,9 +111,9 @@ export interface MultiReflectionManifest {
     | { mode: "recent"; limit: number }
     | { mode: "explicit-conversations"; conversation_ids: string[] }
     | {
-        mode: "wandered";
-        selected_conversations: ReflectionWanderSelectedConversation[];
-        catalog_path?: string;
+        mode: "auto-selected";
+        selected_conversations: ReflectionAutoSelectedConversation[];
+        candidates_path?: string;
       };
   transcripts: MultiReflectionTranscriptSlice[];
 }
@@ -135,21 +135,21 @@ export interface ReflectionTranscriptCandidate {
   turnsSinceLastSuccessfulReflection: number;
 }
 
-export type ReflectionWanderPriority = "high" | "medium" | "low";
+export type ReflectionAutoPriority = "high" | "medium" | "low";
 
-export interface ReflectionWanderSelectedConversation {
+export interface ReflectionAutoSelectedConversation {
   conversation_id: string;
   reason: string;
-  priority?: ReflectionWanderPriority;
+  priority?: ReflectionAutoPriority;
 }
 
-export interface ReflectionWanderSearchScore {
+export interface ReflectionAutoSearchScore {
   query: string;
   rrf_score: number;
   normalized_score: number;
 }
 
-export interface ReflectionWanderCandidate {
+export interface ReflectionAutoCandidate {
   conversation_id: string;
   summary?: string;
   description?: string;
@@ -160,28 +160,28 @@ export interface ReflectionWanderCandidate {
   has_unreflected_content: boolean;
   is_current_conversation: boolean;
   sources: string[];
-  search_scores: ReflectionWanderSearchScore[];
+  search_scores: ReflectionAutoSearchScore[];
   heuristic_score: number;
 }
 
-export interface ReflectionWanderCatalog {
+export interface ReflectionAutoCandidates {
   schema_version: 1;
-  type: "reflection_wander_catalog";
+  type: "auto_transcript_reflection_candidates";
   agent_id: string;
   current_conversation_id?: string;
   created_at: string;
   max_selected: number;
   instructions: string;
-  candidates: ReflectionWanderCandidate[];
+  candidates: ReflectionAutoCandidate[];
 }
 
-export interface ReflectionWanderSelection {
-  selected_conversations: ReflectionWanderSelectedConversation[];
+export interface ReflectionAutoSelection {
+  selected_conversations: ReflectionAutoSelectedConversation[];
 }
 
-export interface ReflectionWanderPayload {
-  catalogPath: string;
-  catalog: ReflectionWanderCatalog;
+export interface ReflectionAutoPayload {
+  candidatesPath: string;
+  candidates: ReflectionAutoCandidates;
 }
 
 export interface ReflectionPromptInput {
@@ -214,9 +214,9 @@ export function buildReflectionSubagentPrompt(
 
 export function buildReflectionSelectorPrompt(): string {
   return [
-    "You are selecting conversation transcripts for memory reflection. The wander catalog path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
+    "You are selecting conversation transcripts for memory reflection. The transcript candidates path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
     "",
-    "The payload is a `reflection_wander_catalog` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
+    "The payload is `auto_transcript_reflection_candidates` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
     "",
     "Select up to `max_selected` conversations. Prefer candidates likely to contain durable memory updates: explicit user corrections, repeated preferences, coding/review/commit style preferences, repo or workflow gotchas, durable facts about people/projects, contradictions with current memory, or repeated agent failures.",
     "Avoid one-off debugging, transient task status, duplicated/redundant candidates, and conversations already fully reflected unless they are useful for deduplication or contradiction resolution.",
@@ -978,7 +978,7 @@ async function writeState(
 
 function buildPayloadPath(
   rootDir: string,
-  kind: "auto" | "wander" | "multi" | "remember" | "slice",
+  kind: "auto" | "candidates" | "multi" | "remember" | "slice",
 ): string {
   const nonce = Math.random().toString(36).slice(2, 8);
   return join(rootDir, `payload-${kind}-${nonce}.json`);
@@ -1194,7 +1194,7 @@ async function ensureAgentPayloadRoot(agentId: string): Promise<string> {
   return root;
 }
 
-const REFLECTION_WANDER_QUERIES = [
+const REFLECTION_AUTO_QUERIES = [
   {
     id: "user-corrections",
     query:
@@ -1220,11 +1220,11 @@ const REFLECTION_WANDER_QUERIES = [
   },
 ] as const;
 
-const REFLECTION_WANDER_RECENT_LIMIT = 20;
-const REFLECTION_WANDER_UNREFLECTED_LIMIT = 20;
-const REFLECTION_WANDER_SEARCH_LIMIT_PER_QUERY = 10;
-const REFLECTION_WANDER_MAX_CATALOG_CANDIDATES = 30;
-export const REFLECTION_WANDER_MAX_SELECTED_TRANSCRIPTS = 5;
+const REFLECTION_AUTO_RECENT_LIMIT = 20;
+const REFLECTION_AUTO_UNREFLECTED_LIMIT = 20;
+const REFLECTION_AUTO_SEARCH_LIMIT_PER_QUERY = 10;
+const REFLECTION_AUTO_MAX_CATALOG_CANDIDATES = 30;
+export const REFLECTION_AUTO_MAX_SELECTED_TRANSCRIPTS = 5;
 
 function pageItems<T>(page: unknown): T[] {
   if (Array.isArray(page)) return page as T[];
@@ -1243,7 +1243,7 @@ function pageItems<T>(page: unknown): T[] {
   return [];
 }
 
-function addSource(candidate: ReflectionWanderCandidate, source: string): void {
+function addSource(candidate: ReflectionAutoCandidate, source: string): void {
   if (!candidate.sources.includes(source)) {
     candidate.sources.push(source);
   }
@@ -1261,7 +1261,7 @@ function recencyScore(lastUpdatedAt?: string): number {
   return 0;
 }
 
-function scoreWanderCandidate(candidate: ReflectionWanderCandidate): number {
+function scoreAutoCandidate(candidate: ReflectionAutoCandidate): number {
   const bestNormalizedSearch = Math.max(
     0,
     ...candidate.search_scores.map((score) => score.normalized_score),
@@ -1292,17 +1292,17 @@ function scoreWanderCandidate(candidate: ReflectionWanderCandidate): number {
   );
 }
 
-export async function buildReflectionWanderPayload(options: {
+export async function buildReflectionAutoPayload(options: {
   agentId: string;
   currentConversationId?: string;
   maxSelected?: number;
   maxCatalogCandidates?: number;
-}): Promise<ReflectionWanderPayload | null> {
+}): Promise<ReflectionAutoPayload | null> {
   const {
     agentId,
     currentConversationId,
-    maxSelected = REFLECTION_WANDER_MAX_SELECTED_TRANSCRIPTS,
-    maxCatalogCandidates = REFLECTION_WANDER_MAX_CATALOG_CANDIDATES,
+    maxSelected = REFLECTION_AUTO_MAX_SELECTED_TRANSCRIPTS,
+    maxCatalogCandidates = REFLECTION_AUTO_MAX_CATALOG_CANDIDATES,
   } = options;
   const transcriptCandidates =
     await listReflectionTranscriptCandidates(agentId);
@@ -1310,7 +1310,7 @@ export async function buildReflectionWanderPayload(options: {
     return null;
   }
 
-  const candidates = new Map<string, ReflectionWanderCandidate>();
+  const candidates = new Map<string, ReflectionAutoCandidate>();
   const ensureCandidate = (conversationId: string) => {
     const existing = candidates.get(conversationId);
     if (existing) return existing;
@@ -1318,7 +1318,7 @@ export async function buildReflectionWanderPayload(options: {
       (candidate) => candidate.conversationId === conversationId,
     );
     if (!transcriptCandidate) return null;
-    const candidate: ReflectionWanderCandidate = {
+    const candidate: ReflectionAutoCandidate = {
       conversation_id: conversationId,
       last_updated_at: transcriptCandidate.lastUpdatedAt,
       total_completed_turns: transcriptCandidate.totalCompletedTurns,
@@ -1338,10 +1338,10 @@ export async function buildReflectionWanderPayload(options: {
 
   for (const candidate of transcriptCandidates.slice(
     0,
-    REFLECTION_WANDER_RECENT_LIMIT,
+    REFLECTION_AUTO_RECENT_LIMIT,
   )) {
-    const wanderCandidate = ensureCandidate(candidate.conversationId);
-    if (wanderCandidate) addSource(wanderCandidate, "recent");
+    const autoCandidate = ensureCandidate(candidate.conversationId);
+    if (autoCandidate) addSource(autoCandidate, "recent");
   }
 
   for (const candidate of transcriptCandidates
@@ -1352,14 +1352,14 @@ export async function buildReflectionWanderPayload(options: {
           a.turnsSinceLastSuccessfulReflection ||
         Date.parse(b.lastUpdatedAt ?? "") - Date.parse(a.lastUpdatedAt ?? ""),
     )
-    .slice(0, REFLECTION_WANDER_UNREFLECTED_LIMIT)) {
-    const wanderCandidate = ensureCandidate(candidate.conversationId);
-    if (wanderCandidate) addSource(wanderCandidate, "unreflected");
+    .slice(0, REFLECTION_AUTO_UNREFLECTED_LIMIT)) {
+    const autoCandidate = ensureCandidate(candidate.conversationId);
+    if (autoCandidate) addSource(autoCandidate, "unreflected");
   }
 
   if (currentConversationId) {
-    const wanderCandidate = ensureCandidate(currentConversationId);
-    if (wanderCandidate) addSource(wanderCandidate, "current");
+    const autoCandidate = ensureCandidate(currentConversationId);
+    if (autoCandidate) addSource(autoCandidate, "current");
   }
 
   const transcriptConversationIds = new Set(
@@ -1383,17 +1383,17 @@ export async function buildReflectionWanderPayload(options: {
       }
     }
   } catch {
-    // Summaries are helpful metadata but not required for wandering.
+    // Summaries are helpful metadata but not required for auto selection.
   }
 
   const searchResultsByQuery = await Promise.allSettled(
-    REFLECTION_WANDER_QUERIES.map(async ({ id, query }) => {
+    REFLECTION_AUTO_QUERIES.map(async ({ id, query }) => {
       const results = await searchConversationsForBackend({
         agent_id: agentId,
         query,
         search_mode: "hybrid",
         search_target: "description",
-        limit: REFLECTION_WANDER_SEARCH_LIMIT_PER_QUERY,
+        limit: REFLECTION_AUTO_SEARCH_LIMIT_PER_QUERY,
       });
       return { id, query, results };
     }),
@@ -1410,14 +1410,14 @@ export async function buildReflectionWanderPayload(options: {
       ...eligibleResults.map((result) => result.rrf_score),
     );
     for (const result of eligibleResults) {
-      const wanderCandidate = ensureCandidate(result.conversation.id);
-      if (!wanderCandidate) continue;
-      addSource(wanderCandidate, `search:${id}`);
+      const autoCandidate = ensureCandidate(result.conversation.id);
+      if (!autoCandidate) continue;
+      addSource(autoCandidate, `search:${id}`);
       const summary = result.conversation.summary?.trim();
-      if (summary) wanderCandidate.summary = summary;
+      if (summary) autoCandidate.summary = summary;
       const description = result.embedded_text.trim();
-      if (description) wanderCandidate.description = description;
-      wanderCandidate.search_scores.push({
+      if (description) autoCandidate.description = description;
+      autoCandidate.search_scores.push({
         query,
         rrf_score: result.rrf_score,
         normalized_score:
@@ -1440,7 +1440,7 @@ export async function buildReflectionWanderPayload(options: {
       search_scores: [...candidate.search_scores].sort(
         (a, b) => b.normalized_score - a.normalized_score,
       ),
-      heuristic_score: scoreWanderCandidate(candidate),
+      heuristic_score: scoreAutoCandidate(candidate),
     }))
     .sort(
       (a, b) =>
@@ -1456,9 +1456,9 @@ export async function buildReflectionWanderPayload(options: {
   }
 
   const payloadRoot = await ensureAgentPayloadRoot(agentId);
-  const catalog: ReflectionWanderCatalog = {
+  const candidateSet: ReflectionAutoCandidates = {
     schema_version: 1,
-    type: "reflection_wander_catalog",
+    type: "auto_transcript_reflection_candidates",
     agent_id: agentId,
     current_conversation_id: currentConversationId,
     created_at: new Date().toISOString(),
@@ -1467,33 +1467,33 @@ export async function buildReflectionWanderPayload(options: {
       "Choose conversations likely to contain durable memory updates. Prefer explicit corrections, repeated preferences, project conventions, and contradictions; avoid one-off debugging and transient task state.",
     candidates: sortedCandidates,
   };
-  const catalogPath = buildPayloadPath(payloadRoot, "wander");
+  const candidatesPath = buildPayloadPath(payloadRoot, "candidates");
   await writeFile(
-    catalogPath,
-    `${JSON.stringify(catalog, null, 2)}\n`,
+    candidatesPath,
+    `${JSON.stringify(candidateSet, null, 2)}\n`,
     "utf-8",
   );
 
-  return { catalogPath, catalog };
+  return { candidatesPath, candidates: candidateSet };
 }
 
-function isReflectionWanderPriority(
+function isReflectionAutoPriority(
   value: unknown,
-): value is ReflectionWanderPriority {
+): value is ReflectionAutoPriority {
   return value === "high" || value === "medium" || value === "low";
 }
 
-export async function readReflectionWanderSelection(options: {
+export async function readReflectionAutoSelection(options: {
   selectionOutputPath?: string;
   selectionReport?: string;
-  catalog: ReflectionWanderCatalog;
-}): Promise<ReflectionWanderSelectedConversation[]> {
+  candidates: ReflectionAutoCandidates;
+}): Promise<ReflectionAutoSelectedConversation[]> {
   const raw =
     options.selectionReport ??
     (options.selectionOutputPath
       ? await readFile(options.selectionOutputPath, "utf-8")
       : "");
-  const parsed = parseReflectionWanderSelectionJson(raw);
+  const parsed = parseReflectionAutoSelectionJson(raw);
   if (!parsed || typeof parsed !== "object") {
     throw new Error("Reflection selector did not return valid JSON.");
   }
@@ -1506,10 +1506,10 @@ export async function readReflectionWanderSelection(options: {
   }
 
   const allowedIds = new Set(
-    options.catalog.candidates.map((candidate) => candidate.conversation_id),
+    options.candidates.candidates.map((candidate) => candidate.conversation_id),
   );
   const seenIds = new Set<string>();
-  const validated: ReflectionWanderSelectedConversation[] = [];
+  const validated: ReflectionAutoSelectedConversation[] = [];
   for (const item of selected) {
     if (!item || typeof item !== "object") continue;
     const record = item as Record<string, unknown>;
@@ -1526,16 +1526,16 @@ export async function readReflectionWanderSelection(options: {
     const reason =
       typeof record.reason === "string" && record.reason.trim()
         ? record.reason.trim()
-        : "Selected by reflection wandering.";
+        : "Selected by automatic reflection.";
     validated.push({
       conversation_id: conversationId,
       reason,
-      ...(isReflectionWanderPriority(record.priority)
+      ...(isReflectionAutoPriority(record.priority)
         ? { priority: record.priority }
         : {}),
     });
     seenIds.add(conversationId);
-    if (validated.length >= options.catalog.max_selected) {
+    if (validated.length >= options.candidates.max_selected) {
       break;
     }
   }
@@ -1543,7 +1543,7 @@ export async function readReflectionWanderSelection(options: {
   return validated;
 }
 
-function parseReflectionWanderSelectionJson(raw: string): unknown {
+function parseReflectionAutoSelectionJson(raw: string): unknown {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
@@ -1670,9 +1670,9 @@ type MultiReflectionSelectionPolicy =
   | { mode: "recent"; limit: number }
   | { mode: "explicit-conversations"; conversationIds: string[] }
   | {
-      mode: "wandered";
-      selectedConversations: ReflectionWanderSelectedConversation[];
-      catalogPath?: string;
+      mode: "auto-selected";
+      selectedConversations: ReflectionAutoSelectedConversation[];
+      candidatesPath?: string;
     };
 
 export interface BuildMultiReflectionPayloadOptions {
@@ -1687,7 +1687,7 @@ async function resolveMultiReflectionConversationIds(
   agentId: string,
   selectionPolicy: MultiReflectionSelectionPolicy,
 ): Promise<string[]> {
-  if (selectionPolicy.mode === "wandered") {
+  if (selectionPolicy.mode === "auto-selected") {
     return Array.from(
       new Set(
         selectionPolicy.selectedConversations.map(
@@ -1713,11 +1713,11 @@ function manifestSelectionPolicy(
   if (selectionPolicy.mode === "recent") {
     return { mode: "recent", limit: selectionPolicy.limit };
   }
-  if (selectionPolicy.mode === "wandered") {
+  if (selectionPolicy.mode === "auto-selected") {
     return {
-      mode: "wandered",
+      mode: "auto-selected",
       selected_conversations: selectionPolicy.selectedConversations,
-      catalog_path: selectionPolicy.catalogPath,
+      candidates_path: selectionPolicy.candidatesPath,
     };
   }
   return {
@@ -1726,10 +1726,10 @@ function manifestSelectionPolicy(
   };
 }
 
-function wanderSelectionByConversationId(
+function autoSelectionByConversationId(
   selectionPolicy: MultiReflectionSelectionPolicy,
-): Map<string, ReflectionWanderSelectedConversation> {
-  if (selectionPolicy.mode !== "wandered") {
+): Map<string, ReflectionAutoSelectedConversation> {
+  if (selectionPolicy.mode !== "auto-selected") {
     return new Map();
   }
 
@@ -1767,7 +1767,7 @@ export async function buildMultiReflectionPayload(
   let totalChars = 0;
   let firstMessageId: string | undefined;
   let lastMessageId: string | undefined;
-  const wanderSelections = wanderSelectionByConversationId(selectionPolicy);
+  const autoSelections = autoSelectionByConversationId(selectionPolicy);
 
   for (const conversationId of conversationIds) {
     const slice = await withStateLock(agentId, conversationId, async () => {
@@ -1809,8 +1809,8 @@ export async function buildMultiReflectionPayload(
         conversation_id: conversationId,
         mode,
         payload_path: payloadPath,
-        selection_reason: wanderSelections.get(conversationId)?.reason,
-        selection_priority: wanderSelections.get(conversationId)?.priority,
+        selection_reason: autoSelections.get(conversationId)?.reason,
+        selection_priority: autoSelections.get(conversationId)?.priority,
         start_message_id: selection.startMessageId,
         end_message_id: selection.endMessageId,
         start_line: selection.startLineIndex,

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -11,6 +11,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { MEMORY_SYSTEM_DIR } from "@/agent/memory-filesystem";
 import { REFLECTION_PARENT_MEMORY_SNAPSHOT_CHAR_LIMIT } from "@/agent/subagents/context-budget";
+import { getBackend } from "@/backend";
+import {
+  type ConversationSearchResult,
+  searchConversationsForBackend,
+} from "@/backend/conversation-search";
 import { getDirectoryLimits } from "@/utils/directory-limits";
 import { withFileLock } from "@/utils/file-lock";
 import { parseFrontmatter } from "@/utils/frontmatter";
@@ -85,6 +90,8 @@ export interface MultiReflectionTranscriptSlice {
   conversation_id: string;
   mode: ReflectionSliceMode;
   payload_path: string;
+  selection_reason?: string;
+  selection_priority?: ReflectionDiscoveryPriority;
   start_message_id: string;
   end_message_id: string;
   start_line: number;
@@ -102,7 +109,12 @@ export interface MultiReflectionManifest {
   created_at: string;
   selection_policy:
     | { mode: "recent"; limit: number }
-    | { mode: "explicit-conversations"; conversation_ids: string[] };
+    | { mode: "explicit-conversations"; conversation_ids: string[] }
+    | {
+        mode: "discovered";
+        selected_conversations: ReflectionDiscoverySelectedConversation[];
+        catalog_path?: string;
+      };
   transcripts: MultiReflectionTranscriptSlice[];
 }
 
@@ -121,6 +133,57 @@ export interface ReflectionTranscriptCandidate {
   totalCompletedTurns: number;
   reflectedCompletedTurns: number;
   turnsSinceLastSuccessfulReflection: number;
+}
+
+export type ReflectionDiscoveryPriority = "high" | "medium" | "low";
+
+export interface ReflectionDiscoverySelectedConversation {
+  conversation_id: string;
+  reason: string;
+  priority?: ReflectionDiscoveryPriority;
+}
+
+export interface ReflectionDiscoverySearchScore {
+  query: string;
+  rrf_score: number;
+  normalized_score: number;
+}
+
+export interface ReflectionDiscoveryCandidate {
+  conversation_id: string;
+  summary?: string;
+  description?: string;
+  last_updated_at?: string;
+  total_completed_turns: number;
+  reflected_completed_turns: number;
+  turns_since_last_successful_reflection: number;
+  has_unreflected_content: boolean;
+  is_current_conversation: boolean;
+  sources: string[];
+  search_scores: ReflectionDiscoverySearchScore[];
+  heuristic_score: number;
+}
+
+export interface ReflectionDiscoveryCatalog {
+  schema_version: 1;
+  type: "reflection_discovery_catalog";
+  agent_id: string;
+  current_conversation_id?: string;
+  created_at: string;
+  max_selected: number;
+  selection_output_path: string;
+  instructions: string;
+  candidates: ReflectionDiscoveryCandidate[];
+}
+
+export interface ReflectionDiscoverySelection {
+  selected_conversations: ReflectionDiscoverySelectedConversation[];
+}
+
+export interface ReflectionDiscoveryPayload {
+  catalogPath: string;
+  selectionOutputPath: string;
+  catalog: ReflectionDiscoveryCatalog;
 }
 
 export interface ReflectionPromptInput {
@@ -149,6 +212,22 @@ export function buildReflectionSubagentPrompt(
     lines.push(input.parentMemory);
   }
   return lines.join("\n");
+}
+
+export function buildReflectionSelectorPrompt(): string {
+  return [
+    "You are selecting conversation transcripts for memory reflection. The discovery catalog path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
+    "",
+    "The payload is a `reflection_discovery_catalog` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
+    "",
+    "Select up to `max_selected` conversations. Prefer candidates likely to contain durable memory updates: explicit user corrections, repeated preferences, coding/review/commit style preferences, repo or workflow gotchas, durable facts about people/projects, contradictions with current memory, or repeated agent failures.",
+    "Avoid one-off debugging, transient task status, duplicated/redundant candidates, and conversations already fully reflected unless they are useful for deduplication or contradiction resolution.",
+    "Treat summaries/descriptions as weak internal metadata, not confirmed facts. The final reflection pass will verify against the actual transcript before writing memory.",
+    "",
+    "Write strict JSON to the catalog's `selection_output_path` with this shape:",
+    '{"selected_conversations":[{"conversation_id":"conv-...","reason":"durable reason for selecting this transcript","priority":"high"}]}',
+    'Use priority values `high`, `medium`, or `low`. If nothing looks memory-worthy, write `{"selected_conversations":[]}`.',
+  ].join("\n");
 }
 
 interface ParentMemoryFile {
@@ -901,7 +980,7 @@ async function writeState(
 
 function buildPayloadPath(
   rootDir: string,
-  kind: "auto" | "remember" | "multi" | "slice",
+  kind: "auto" | "discover" | "multi" | "remember" | "selected" | "slice",
 ): string {
   const nonce = Math.random().toString(36).slice(2, 8);
   return join(rootDir, `payload-${kind}-${nonce}.json`);
@@ -1117,6 +1196,357 @@ async function ensureAgentPayloadRoot(agentId: string): Promise<string> {
   return root;
 }
 
+const REFLECTION_DISCOVERY_QUERIES = [
+  {
+    id: "user-corrections",
+    query:
+      "user corrections and preferences repeated mistakes durable feedback",
+  },
+  {
+    id: "coding-style",
+    query: "coding style preferences review commit testing branch conventions",
+  },
+  {
+    id: "collaboration",
+    query:
+      "collaboration communication style team preferences durable workflow",
+  },
+  {
+    id: "repo-gotchas",
+    query: "repo conventions project gotchas durable implementation details",
+  },
+  {
+    id: "long-term-facts",
+    query:
+      "long term facts about people projects workflows memory worthy context",
+  },
+] as const;
+
+const REFLECTION_DISCOVERY_RECENT_LIMIT = 20;
+const REFLECTION_DISCOVERY_UNREFLECTED_LIMIT = 20;
+const REFLECTION_DISCOVERY_SEARCH_LIMIT_PER_QUERY = 10;
+const REFLECTION_DISCOVERY_MAX_CATALOG_CANDIDATES = 30;
+export const REFLECTION_DISCOVERY_MAX_SELECTED_TRANSCRIPTS = 5;
+
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+function addSource(
+  candidate: ReflectionDiscoveryCandidate,
+  source: string,
+): void {
+  if (!candidate.sources.includes(source)) {
+    candidate.sources.push(source);
+  }
+}
+
+function recencyScore(lastUpdatedAt?: string): number {
+  if (!lastUpdatedAt) return 0;
+  const parsed = Date.parse(lastUpdatedAt);
+  if (!Number.isFinite(parsed)) return 0;
+  const ageMs = Date.now() - parsed;
+  const dayMs = 24 * 60 * 60 * 1000;
+  if (ageMs <= dayMs) return 8;
+  if (ageMs <= 7 * dayMs) return 5;
+  if (ageMs <= 30 * dayMs) return 2;
+  return 0;
+}
+
+function scoreDiscoveryCandidate(
+  candidate: ReflectionDiscoveryCandidate,
+): number {
+  const bestNormalizedSearch = Math.max(
+    0,
+    ...candidate.search_scores.map((score) => score.normalized_score),
+  );
+  const searchScore = 50 * bestNormalizedSearch;
+  const turns = candidate.turns_since_last_successful_reflection;
+  const unreflectedScore = turns > 0 ? 15 + Math.min(turns, 10) : 0;
+  const sourceScore = Math.min(candidate.sources.length, 4);
+  const sizeScore =
+    candidate.total_completed_turns >= 3
+      ? 4
+      : candidate.total_completed_turns >= 1
+        ? 1
+        : 0;
+  const currentConversationScore =
+    candidate.is_current_conversation && turns > 0 ? 8 : 0;
+  const alreadyReflectedPenalty =
+    turns === 0 && candidate.search_scores.length === 0 ? 8 : 0;
+
+  return (
+    searchScore +
+    unreflectedScore +
+    recencyScore(candidate.last_updated_at) +
+    sourceScore +
+    sizeScore +
+    currentConversationScore -
+    alreadyReflectedPenalty
+  );
+}
+
+export async function buildReflectionDiscoveryPayload(options: {
+  agentId: string;
+  currentConversationId?: string;
+  maxSelected?: number;
+  maxCatalogCandidates?: number;
+}): Promise<ReflectionDiscoveryPayload | null> {
+  const {
+    agentId,
+    currentConversationId,
+    maxSelected = REFLECTION_DISCOVERY_MAX_SELECTED_TRANSCRIPTS,
+    maxCatalogCandidates = REFLECTION_DISCOVERY_MAX_CATALOG_CANDIDATES,
+  } = options;
+  const transcriptCandidates =
+    await listReflectionTranscriptCandidates(agentId);
+  if (transcriptCandidates.length === 0) {
+    return null;
+  }
+
+  const candidates = new Map<string, ReflectionDiscoveryCandidate>();
+  const ensureCandidate = (conversationId: string) => {
+    const existing = candidates.get(conversationId);
+    if (existing) return existing;
+    const transcriptCandidate = transcriptCandidates.find(
+      (candidate) => candidate.conversationId === conversationId,
+    );
+    if (!transcriptCandidate) return null;
+    const candidate: ReflectionDiscoveryCandidate = {
+      conversation_id: conversationId,
+      last_updated_at: transcriptCandidate.lastUpdatedAt,
+      total_completed_turns: transcriptCandidate.totalCompletedTurns,
+      reflected_completed_turns: transcriptCandidate.reflectedCompletedTurns,
+      turns_since_last_successful_reflection:
+        transcriptCandidate.turnsSinceLastSuccessfulReflection,
+      has_unreflected_content:
+        transcriptCandidate.turnsSinceLastSuccessfulReflection > 0,
+      is_current_conversation: conversationId === currentConversationId,
+      sources: [],
+      search_scores: [],
+      heuristic_score: 0,
+    };
+    candidates.set(conversationId, candidate);
+    return candidate;
+  };
+
+  for (const candidate of transcriptCandidates.slice(
+    0,
+    REFLECTION_DISCOVERY_RECENT_LIMIT,
+  )) {
+    const discoveryCandidate = ensureCandidate(candidate.conversationId);
+    if (discoveryCandidate) addSource(discoveryCandidate, "recent");
+  }
+
+  for (const candidate of transcriptCandidates
+    .filter((item) => item.turnsSinceLastSuccessfulReflection > 0)
+    .sort(
+      (a, b) =>
+        b.turnsSinceLastSuccessfulReflection -
+          a.turnsSinceLastSuccessfulReflection ||
+        Date.parse(b.lastUpdatedAt ?? "") - Date.parse(a.lastUpdatedAt ?? ""),
+    )
+    .slice(0, REFLECTION_DISCOVERY_UNREFLECTED_LIMIT)) {
+    const discoveryCandidate = ensureCandidate(candidate.conversationId);
+    if (discoveryCandidate) addSource(discoveryCandidate, "unreflected");
+  }
+
+  if (currentConversationId) {
+    const discoveryCandidate = ensureCandidate(currentConversationId);
+    if (discoveryCandidate) addSource(discoveryCandidate, "current");
+  }
+
+  const transcriptConversationIds = new Set(
+    transcriptCandidates.map((candidate) => candidate.conversationId),
+  );
+  const conversationSummaries = new Map<string, string>();
+  try {
+    for (const conversation of pageItems<{
+      id: string;
+      summary?: string | null;
+    }>(
+      await getBackend().listConversations({
+        agent_id: agentId,
+        limit: 100,
+        order: "desc",
+        order_by: "last_message_at",
+      } as never),
+    )) {
+      if (conversation.summary?.trim()) {
+        conversationSummaries.set(conversation.id, conversation.summary.trim());
+      }
+    }
+  } catch {
+    // Summaries are helpful metadata but not required for discovery.
+  }
+
+  const searchResultsByQuery = await Promise.allSettled(
+    REFLECTION_DISCOVERY_QUERIES.map(async ({ id, query }) => {
+      const results = await searchConversationsForBackend({
+        agent_id: agentId,
+        query,
+        search_mode: "hybrid",
+        search_target: "description",
+        limit: REFLECTION_DISCOVERY_SEARCH_LIMIT_PER_QUERY,
+      });
+      return { id, query, results };
+    }),
+  );
+
+  for (const queryResult of searchResultsByQuery) {
+    if (queryResult.status !== "fulfilled") continue;
+    const { id, query, results } = queryResult.value;
+    const eligibleResults = results.filter((result: ConversationSearchResult) =>
+      transcriptConversationIds.has(result.conversation.id),
+    );
+    const bestRrfScore = Math.max(
+      0,
+      ...eligibleResults.map((result) => result.rrf_score),
+    );
+    for (const result of eligibleResults) {
+      const discoveryCandidate = ensureCandidate(result.conversation.id);
+      if (!discoveryCandidate) continue;
+      addSource(discoveryCandidate, `search:${id}`);
+      const summary = result.conversation.summary?.trim();
+      if (summary) discoveryCandidate.summary = summary;
+      const description = result.embedded_text.trim();
+      if (description) discoveryCandidate.description = description;
+      discoveryCandidate.search_scores.push({
+        query,
+        rrf_score: result.rrf_score,
+        normalized_score:
+          bestRrfScore > 0 ? result.rrf_score / bestRrfScore : 0,
+      });
+    }
+  }
+
+  for (const [conversationId, summary] of conversationSummaries) {
+    const candidate = candidates.get(conversationId);
+    if (candidate && !candidate.summary) {
+      candidate.summary = summary;
+    }
+  }
+
+  const sortedCandidates = Array.from(candidates.values())
+    .map((candidate) => ({
+      ...candidate,
+      sources: [...candidate.sources].sort(),
+      search_scores: [...candidate.search_scores].sort(
+        (a, b) => b.normalized_score - a.normalized_score,
+      ),
+      heuristic_score: scoreDiscoveryCandidate(candidate),
+    }))
+    .sort(
+      (a, b) =>
+        b.heuristic_score - a.heuristic_score ||
+        (b.last_updated_at ? Date.parse(b.last_updated_at) : 0) -
+          (a.last_updated_at ? Date.parse(a.last_updated_at) : 0) ||
+        a.conversation_id.localeCompare(b.conversation_id),
+    )
+    .slice(0, Math.max(1, maxCatalogCandidates));
+
+  if (sortedCandidates.length === 0) {
+    return null;
+  }
+
+  const payloadRoot = await ensureAgentPayloadRoot(agentId);
+  const selectionOutputPath = buildPayloadPath(payloadRoot, "selected");
+  const catalog: ReflectionDiscoveryCatalog = {
+    schema_version: 1,
+    type: "reflection_discovery_catalog",
+    agent_id: agentId,
+    current_conversation_id: currentConversationId,
+    created_at: new Date().toISOString(),
+    max_selected: maxSelected,
+    selection_output_path: selectionOutputPath,
+    instructions:
+      "Choose conversations likely to contain durable memory updates. Prefer explicit corrections, repeated preferences, project conventions, and contradictions; avoid one-off debugging and transient task state.",
+    candidates: sortedCandidates,
+  };
+  const catalogPath = buildPayloadPath(payloadRoot, "discover");
+  await writeFile(
+    catalogPath,
+    `${JSON.stringify(catalog, null, 2)}\n`,
+    "utf-8",
+  );
+
+  return { catalogPath, selectionOutputPath, catalog };
+}
+
+function isReflectionDiscoveryPriority(
+  value: unknown,
+): value is ReflectionDiscoveryPriority {
+  return value === "high" || value === "medium" || value === "low";
+}
+
+export async function readReflectionDiscoverySelection(options: {
+  selectionOutputPath: string;
+  catalog: ReflectionDiscoveryCatalog;
+}): Promise<ReflectionDiscoverySelectedConversation[]> {
+  const raw = await readFile(options.selectionOutputPath, "utf-8");
+  const parsed = safeJsonParseOr<unknown>(raw, null);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Reflection selector did not write valid JSON.");
+  }
+  const selected = (parsed as { selected_conversations?: unknown })
+    .selected_conversations;
+  if (!Array.isArray(selected)) {
+    throw new Error(
+      'Reflection selector JSON must include a "selected_conversations" array.',
+    );
+  }
+
+  const allowedIds = new Set(
+    options.catalog.candidates.map((candidate) => candidate.conversation_id),
+  );
+  const seenIds = new Set<string>();
+  const validated: ReflectionDiscoverySelectedConversation[] = [];
+  for (const item of selected) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const conversationId =
+      typeof record.conversation_id === "string"
+        ? record.conversation_id.trim()
+        : "";
+    if (!conversationId || seenIds.has(conversationId)) continue;
+    if (!allowedIds.has(conversationId)) {
+      throw new Error(
+        `Reflection selector chose unknown conversation: ${conversationId}`,
+      );
+    }
+    const reason =
+      typeof record.reason === "string" && record.reason.trim()
+        ? record.reason.trim()
+        : "Selected by reflection discovery.";
+    validated.push({
+      conversation_id: conversationId,
+      reason,
+      ...(isReflectionDiscoveryPriority(record.priority)
+        ? { priority: record.priority }
+        : {}),
+    });
+    seenIds.add(conversationId);
+    if (validated.length >= options.catalog.max_selected) {
+      break;
+    }
+  }
+
+  return validated;
+}
+
 export async function listReflectionTranscriptCandidates(
   agentId: string,
 ): Promise<ReflectionTranscriptCandidate[]> {
@@ -1220,7 +1650,12 @@ export async function buildAutoReflectionPayload(
 
 type MultiReflectionSelectionPolicy =
   | { mode: "recent"; limit: number }
-  | { mode: "explicit-conversations"; conversationIds: string[] };
+  | { mode: "explicit-conversations"; conversationIds: string[] }
+  | {
+      mode: "discovered";
+      selectedConversations: ReflectionDiscoverySelectedConversation[];
+      catalogPath?: string;
+    };
 
 export interface BuildMultiReflectionPayloadOptions {
   agentId: string;
@@ -1234,6 +1669,16 @@ async function resolveMultiReflectionConversationIds(
   agentId: string,
   selectionPolicy: MultiReflectionSelectionPolicy,
 ): Promise<string[]> {
+  if (selectionPolicy.mode === "discovered") {
+    return Array.from(
+      new Set(
+        selectionPolicy.selectedConversations.map(
+          (selection) => selection.conversation_id,
+        ),
+      ),
+    );
+  }
+
   if (selectionPolicy.mode === "explicit-conversations") {
     return Array.from(new Set(selectionPolicy.conversationIds));
   }
@@ -1250,10 +1695,32 @@ function manifestSelectionPolicy(
   if (selectionPolicy.mode === "recent") {
     return { mode: "recent", limit: selectionPolicy.limit };
   }
+  if (selectionPolicy.mode === "discovered") {
+    return {
+      mode: "discovered",
+      selected_conversations: selectionPolicy.selectedConversations,
+      catalog_path: selectionPolicy.catalogPath,
+    };
+  }
   return {
     mode: "explicit-conversations",
     conversation_ids: selectionPolicy.conversationIds,
   };
+}
+
+function discoverySelectionByConversationId(
+  selectionPolicy: MultiReflectionSelectionPolicy,
+): Map<string, ReflectionDiscoverySelectedConversation> {
+  if (selectionPolicy.mode !== "discovered") {
+    return new Map();
+  }
+
+  return new Map(
+    selectionPolicy.selectedConversations.map((selection) => [
+      selection.conversation_id,
+      selection,
+    ]),
+  );
 }
 
 export async function buildMultiReflectionPayload(
@@ -1282,6 +1749,8 @@ export async function buildMultiReflectionPayload(
   let totalChars = 0;
   let firstMessageId: string | undefined;
   let lastMessageId: string | undefined;
+  const discoverySelections =
+    discoverySelectionByConversationId(selectionPolicy);
 
   for (const conversationId of conversationIds) {
     const slice = await withStateLock(agentId, conversationId, async () => {
@@ -1323,6 +1792,8 @@ export async function buildMultiReflectionPayload(
         conversation_id: conversationId,
         mode,
         payload_path: payloadPath,
+        selection_reason: discoverySelections.get(conversationId)?.reason,
+        selection_priority: discoverySelections.get(conversationId)?.priority,
         start_message_id: selection.startMessageId,
         end_message_id: selection.endMessageId,
         start_line: selection.startLineIndex,

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -91,7 +91,7 @@ export interface MultiReflectionTranscriptSlice {
   mode: ReflectionSliceMode;
   payload_path: string;
   selection_reason?: string;
-  selection_priority?: ReflectionDiscoveryPriority;
+  selection_priority?: ReflectionWanderPriority;
   start_message_id: string;
   end_message_id: string;
   start_line: number;
@@ -111,8 +111,8 @@ export interface MultiReflectionManifest {
     | { mode: "recent"; limit: number }
     | { mode: "explicit-conversations"; conversation_ids: string[] }
     | {
-        mode: "discovered";
-        selected_conversations: ReflectionDiscoverySelectedConversation[];
+        mode: "wandered";
+        selected_conversations: ReflectionWanderSelectedConversation[];
         catalog_path?: string;
       };
   transcripts: MultiReflectionTranscriptSlice[];
@@ -135,21 +135,21 @@ export interface ReflectionTranscriptCandidate {
   turnsSinceLastSuccessfulReflection: number;
 }
 
-export type ReflectionDiscoveryPriority = "high" | "medium" | "low";
+export type ReflectionWanderPriority = "high" | "medium" | "low";
 
-export interface ReflectionDiscoverySelectedConversation {
+export interface ReflectionWanderSelectedConversation {
   conversation_id: string;
   reason: string;
-  priority?: ReflectionDiscoveryPriority;
+  priority?: ReflectionWanderPriority;
 }
 
-export interface ReflectionDiscoverySearchScore {
+export interface ReflectionWanderSearchScore {
   query: string;
   rrf_score: number;
   normalized_score: number;
 }
 
-export interface ReflectionDiscoveryCandidate {
+export interface ReflectionWanderCandidate {
   conversation_id: string;
   summary?: string;
   description?: string;
@@ -160,28 +160,28 @@ export interface ReflectionDiscoveryCandidate {
   has_unreflected_content: boolean;
   is_current_conversation: boolean;
   sources: string[];
-  search_scores: ReflectionDiscoverySearchScore[];
+  search_scores: ReflectionWanderSearchScore[];
   heuristic_score: number;
 }
 
-export interface ReflectionDiscoveryCatalog {
+export interface ReflectionWanderCatalog {
   schema_version: 1;
-  type: "reflection_discovery_catalog";
+  type: "reflection_wander_catalog";
   agent_id: string;
   current_conversation_id?: string;
   created_at: string;
   max_selected: number;
   instructions: string;
-  candidates: ReflectionDiscoveryCandidate[];
+  candidates: ReflectionWanderCandidate[];
 }
 
-export interface ReflectionDiscoverySelection {
-  selected_conversations: ReflectionDiscoverySelectedConversation[];
+export interface ReflectionWanderSelection {
+  selected_conversations: ReflectionWanderSelectedConversation[];
 }
 
-export interface ReflectionDiscoveryPayload {
+export interface ReflectionWanderPayload {
   catalogPath: string;
-  catalog: ReflectionDiscoveryCatalog;
+  catalog: ReflectionWanderCatalog;
 }
 
 export interface ReflectionPromptInput {
@@ -214,9 +214,9 @@ export function buildReflectionSubagentPrompt(
 
 export function buildReflectionSelectorPrompt(): string {
   return [
-    "You are selecting conversation transcripts for memory reflection. The discovery catalog path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
+    "You are selecting conversation transcripts for memory reflection. The wander catalog path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
     "",
-    "The payload is a `reflection_discovery_catalog` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
+    "The payload is a `reflection_wander_catalog` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
     "",
     "Select up to `max_selected` conversations. Prefer candidates likely to contain durable memory updates: explicit user corrections, repeated preferences, coding/review/commit style preferences, repo or workflow gotchas, durable facts about people/projects, contradictions with current memory, or repeated agent failures.",
     "Avoid one-off debugging, transient task status, duplicated/redundant candidates, and conversations already fully reflected unless they are useful for deduplication or contradiction resolution.",
@@ -978,7 +978,7 @@ async function writeState(
 
 function buildPayloadPath(
   rootDir: string,
-  kind: "auto" | "discover" | "multi" | "remember" | "slice",
+  kind: "auto" | "wander" | "multi" | "remember" | "slice",
 ): string {
   const nonce = Math.random().toString(36).slice(2, 8);
   return join(rootDir, `payload-${kind}-${nonce}.json`);
@@ -1194,7 +1194,7 @@ async function ensureAgentPayloadRoot(agentId: string): Promise<string> {
   return root;
 }
 
-const REFLECTION_DISCOVERY_QUERIES = [
+const REFLECTION_WANDER_QUERIES = [
   {
     id: "user-corrections",
     query:
@@ -1220,11 +1220,11 @@ const REFLECTION_DISCOVERY_QUERIES = [
   },
 ] as const;
 
-const REFLECTION_DISCOVERY_RECENT_LIMIT = 20;
-const REFLECTION_DISCOVERY_UNREFLECTED_LIMIT = 20;
-const REFLECTION_DISCOVERY_SEARCH_LIMIT_PER_QUERY = 10;
-const REFLECTION_DISCOVERY_MAX_CATALOG_CANDIDATES = 30;
-export const REFLECTION_DISCOVERY_MAX_SELECTED_TRANSCRIPTS = 5;
+const REFLECTION_WANDER_RECENT_LIMIT = 20;
+const REFLECTION_WANDER_UNREFLECTED_LIMIT = 20;
+const REFLECTION_WANDER_SEARCH_LIMIT_PER_QUERY = 10;
+const REFLECTION_WANDER_MAX_CATALOG_CANDIDATES = 30;
+export const REFLECTION_WANDER_MAX_SELECTED_TRANSCRIPTS = 5;
 
 function pageItems<T>(page: unknown): T[] {
   if (Array.isArray(page)) return page as T[];
@@ -1243,10 +1243,7 @@ function pageItems<T>(page: unknown): T[] {
   return [];
 }
 
-function addSource(
-  candidate: ReflectionDiscoveryCandidate,
-  source: string,
-): void {
+function addSource(candidate: ReflectionWanderCandidate, source: string): void {
   if (!candidate.sources.includes(source)) {
     candidate.sources.push(source);
   }
@@ -1264,9 +1261,7 @@ function recencyScore(lastUpdatedAt?: string): number {
   return 0;
 }
 
-function scoreDiscoveryCandidate(
-  candidate: ReflectionDiscoveryCandidate,
-): number {
+function scoreWanderCandidate(candidate: ReflectionWanderCandidate): number {
   const bestNormalizedSearch = Math.max(
     0,
     ...candidate.search_scores.map((score) => score.normalized_score),
@@ -1297,17 +1292,17 @@ function scoreDiscoveryCandidate(
   );
 }
 
-export async function buildReflectionDiscoveryPayload(options: {
+export async function buildReflectionWanderPayload(options: {
   agentId: string;
   currentConversationId?: string;
   maxSelected?: number;
   maxCatalogCandidates?: number;
-}): Promise<ReflectionDiscoveryPayload | null> {
+}): Promise<ReflectionWanderPayload | null> {
   const {
     agentId,
     currentConversationId,
-    maxSelected = REFLECTION_DISCOVERY_MAX_SELECTED_TRANSCRIPTS,
-    maxCatalogCandidates = REFLECTION_DISCOVERY_MAX_CATALOG_CANDIDATES,
+    maxSelected = REFLECTION_WANDER_MAX_SELECTED_TRANSCRIPTS,
+    maxCatalogCandidates = REFLECTION_WANDER_MAX_CATALOG_CANDIDATES,
   } = options;
   const transcriptCandidates =
     await listReflectionTranscriptCandidates(agentId);
@@ -1315,7 +1310,7 @@ export async function buildReflectionDiscoveryPayload(options: {
     return null;
   }
 
-  const candidates = new Map<string, ReflectionDiscoveryCandidate>();
+  const candidates = new Map<string, ReflectionWanderCandidate>();
   const ensureCandidate = (conversationId: string) => {
     const existing = candidates.get(conversationId);
     if (existing) return existing;
@@ -1323,7 +1318,7 @@ export async function buildReflectionDiscoveryPayload(options: {
       (candidate) => candidate.conversationId === conversationId,
     );
     if (!transcriptCandidate) return null;
-    const candidate: ReflectionDiscoveryCandidate = {
+    const candidate: ReflectionWanderCandidate = {
       conversation_id: conversationId,
       last_updated_at: transcriptCandidate.lastUpdatedAt,
       total_completed_turns: transcriptCandidate.totalCompletedTurns,
@@ -1343,10 +1338,10 @@ export async function buildReflectionDiscoveryPayload(options: {
 
   for (const candidate of transcriptCandidates.slice(
     0,
-    REFLECTION_DISCOVERY_RECENT_LIMIT,
+    REFLECTION_WANDER_RECENT_LIMIT,
   )) {
-    const discoveryCandidate = ensureCandidate(candidate.conversationId);
-    if (discoveryCandidate) addSource(discoveryCandidate, "recent");
+    const wanderCandidate = ensureCandidate(candidate.conversationId);
+    if (wanderCandidate) addSource(wanderCandidate, "recent");
   }
 
   for (const candidate of transcriptCandidates
@@ -1357,14 +1352,14 @@ export async function buildReflectionDiscoveryPayload(options: {
           a.turnsSinceLastSuccessfulReflection ||
         Date.parse(b.lastUpdatedAt ?? "") - Date.parse(a.lastUpdatedAt ?? ""),
     )
-    .slice(0, REFLECTION_DISCOVERY_UNREFLECTED_LIMIT)) {
-    const discoveryCandidate = ensureCandidate(candidate.conversationId);
-    if (discoveryCandidate) addSource(discoveryCandidate, "unreflected");
+    .slice(0, REFLECTION_WANDER_UNREFLECTED_LIMIT)) {
+    const wanderCandidate = ensureCandidate(candidate.conversationId);
+    if (wanderCandidate) addSource(wanderCandidate, "unreflected");
   }
 
   if (currentConversationId) {
-    const discoveryCandidate = ensureCandidate(currentConversationId);
-    if (discoveryCandidate) addSource(discoveryCandidate, "current");
+    const wanderCandidate = ensureCandidate(currentConversationId);
+    if (wanderCandidate) addSource(wanderCandidate, "current");
   }
 
   const transcriptConversationIds = new Set(
@@ -1388,17 +1383,17 @@ export async function buildReflectionDiscoveryPayload(options: {
       }
     }
   } catch {
-    // Summaries are helpful metadata but not required for discovery.
+    // Summaries are helpful metadata but not required for wandering.
   }
 
   const searchResultsByQuery = await Promise.allSettled(
-    REFLECTION_DISCOVERY_QUERIES.map(async ({ id, query }) => {
+    REFLECTION_WANDER_QUERIES.map(async ({ id, query }) => {
       const results = await searchConversationsForBackend({
         agent_id: agentId,
         query,
         search_mode: "hybrid",
         search_target: "description",
-        limit: REFLECTION_DISCOVERY_SEARCH_LIMIT_PER_QUERY,
+        limit: REFLECTION_WANDER_SEARCH_LIMIT_PER_QUERY,
       });
       return { id, query, results };
     }),
@@ -1415,14 +1410,14 @@ export async function buildReflectionDiscoveryPayload(options: {
       ...eligibleResults.map((result) => result.rrf_score),
     );
     for (const result of eligibleResults) {
-      const discoveryCandidate = ensureCandidate(result.conversation.id);
-      if (!discoveryCandidate) continue;
-      addSource(discoveryCandidate, `search:${id}`);
+      const wanderCandidate = ensureCandidate(result.conversation.id);
+      if (!wanderCandidate) continue;
+      addSource(wanderCandidate, `search:${id}`);
       const summary = result.conversation.summary?.trim();
-      if (summary) discoveryCandidate.summary = summary;
+      if (summary) wanderCandidate.summary = summary;
       const description = result.embedded_text.trim();
-      if (description) discoveryCandidate.description = description;
-      discoveryCandidate.search_scores.push({
+      if (description) wanderCandidate.description = description;
+      wanderCandidate.search_scores.push({
         query,
         rrf_score: result.rrf_score,
         normalized_score:
@@ -1445,7 +1440,7 @@ export async function buildReflectionDiscoveryPayload(options: {
       search_scores: [...candidate.search_scores].sort(
         (a, b) => b.normalized_score - a.normalized_score,
       ),
-      heuristic_score: scoreDiscoveryCandidate(candidate),
+      heuristic_score: scoreWanderCandidate(candidate),
     }))
     .sort(
       (a, b) =>
@@ -1461,9 +1456,9 @@ export async function buildReflectionDiscoveryPayload(options: {
   }
 
   const payloadRoot = await ensureAgentPayloadRoot(agentId);
-  const catalog: ReflectionDiscoveryCatalog = {
+  const catalog: ReflectionWanderCatalog = {
     schema_version: 1,
-    type: "reflection_discovery_catalog",
+    type: "reflection_wander_catalog",
     agent_id: agentId,
     current_conversation_id: currentConversationId,
     created_at: new Date().toISOString(),
@@ -1472,7 +1467,7 @@ export async function buildReflectionDiscoveryPayload(options: {
       "Choose conversations likely to contain durable memory updates. Prefer explicit corrections, repeated preferences, project conventions, and contradictions; avoid one-off debugging and transient task state.",
     candidates: sortedCandidates,
   };
-  const catalogPath = buildPayloadPath(payloadRoot, "discover");
+  const catalogPath = buildPayloadPath(payloadRoot, "wander");
   await writeFile(
     catalogPath,
     `${JSON.stringify(catalog, null, 2)}\n`,
@@ -1482,23 +1477,23 @@ export async function buildReflectionDiscoveryPayload(options: {
   return { catalogPath, catalog };
 }
 
-function isReflectionDiscoveryPriority(
+function isReflectionWanderPriority(
   value: unknown,
-): value is ReflectionDiscoveryPriority {
+): value is ReflectionWanderPriority {
   return value === "high" || value === "medium" || value === "low";
 }
 
-export async function readReflectionDiscoverySelection(options: {
+export async function readReflectionWanderSelection(options: {
   selectionOutputPath?: string;
   selectionReport?: string;
-  catalog: ReflectionDiscoveryCatalog;
-}): Promise<ReflectionDiscoverySelectedConversation[]> {
+  catalog: ReflectionWanderCatalog;
+}): Promise<ReflectionWanderSelectedConversation[]> {
   const raw =
     options.selectionReport ??
     (options.selectionOutputPath
       ? await readFile(options.selectionOutputPath, "utf-8")
       : "");
-  const parsed = parseReflectionDiscoverySelectionJson(raw);
+  const parsed = parseReflectionWanderSelectionJson(raw);
   if (!parsed || typeof parsed !== "object") {
     throw new Error("Reflection selector did not return valid JSON.");
   }
@@ -1514,7 +1509,7 @@ export async function readReflectionDiscoverySelection(options: {
     options.catalog.candidates.map((candidate) => candidate.conversation_id),
   );
   const seenIds = new Set<string>();
-  const validated: ReflectionDiscoverySelectedConversation[] = [];
+  const validated: ReflectionWanderSelectedConversation[] = [];
   for (const item of selected) {
     if (!item || typeof item !== "object") continue;
     const record = item as Record<string, unknown>;
@@ -1531,11 +1526,11 @@ export async function readReflectionDiscoverySelection(options: {
     const reason =
       typeof record.reason === "string" && record.reason.trim()
         ? record.reason.trim()
-        : "Selected by reflection discovery.";
+        : "Selected by reflection wandering.";
     validated.push({
       conversation_id: conversationId,
       reason,
-      ...(isReflectionDiscoveryPriority(record.priority)
+      ...(isReflectionWanderPriority(record.priority)
         ? { priority: record.priority }
         : {}),
     });
@@ -1548,7 +1543,7 @@ export async function readReflectionDiscoverySelection(options: {
   return validated;
 }
 
-function parseReflectionDiscoverySelectionJson(raw: string): unknown {
+function parseReflectionWanderSelectionJson(raw: string): unknown {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
@@ -1675,8 +1670,8 @@ type MultiReflectionSelectionPolicy =
   | { mode: "recent"; limit: number }
   | { mode: "explicit-conversations"; conversationIds: string[] }
   | {
-      mode: "discovered";
-      selectedConversations: ReflectionDiscoverySelectedConversation[];
+      mode: "wandered";
+      selectedConversations: ReflectionWanderSelectedConversation[];
       catalogPath?: string;
     };
 
@@ -1692,7 +1687,7 @@ async function resolveMultiReflectionConversationIds(
   agentId: string,
   selectionPolicy: MultiReflectionSelectionPolicy,
 ): Promise<string[]> {
-  if (selectionPolicy.mode === "discovered") {
+  if (selectionPolicy.mode === "wandered") {
     return Array.from(
       new Set(
         selectionPolicy.selectedConversations.map(
@@ -1718,9 +1713,9 @@ function manifestSelectionPolicy(
   if (selectionPolicy.mode === "recent") {
     return { mode: "recent", limit: selectionPolicy.limit };
   }
-  if (selectionPolicy.mode === "discovered") {
+  if (selectionPolicy.mode === "wandered") {
     return {
-      mode: "discovered",
+      mode: "wandered",
       selected_conversations: selectionPolicy.selectedConversations,
       catalog_path: selectionPolicy.catalogPath,
     };
@@ -1731,10 +1726,10 @@ function manifestSelectionPolicy(
   };
 }
 
-function discoverySelectionByConversationId(
+function wanderSelectionByConversationId(
   selectionPolicy: MultiReflectionSelectionPolicy,
-): Map<string, ReflectionDiscoverySelectedConversation> {
-  if (selectionPolicy.mode !== "discovered") {
+): Map<string, ReflectionWanderSelectedConversation> {
+  if (selectionPolicy.mode !== "wandered") {
     return new Map();
   }
 
@@ -1772,8 +1767,7 @@ export async function buildMultiReflectionPayload(
   let totalChars = 0;
   let firstMessageId: string | undefined;
   let lastMessageId: string | undefined;
-  const discoverySelections =
-    discoverySelectionByConversationId(selectionPolicy);
+  const wanderSelections = wanderSelectionByConversationId(selectionPolicy);
 
   for (const conversationId of conversationIds) {
     const slice = await withStateLock(agentId, conversationId, async () => {
@@ -1815,8 +1809,8 @@ export async function buildMultiReflectionPayload(
         conversation_id: conversationId,
         mode,
         payload_path: payloadPath,
-        selection_reason: discoverySelections.get(conversationId)?.reason,
-        selection_priority: discoverySelections.get(conversationId)?.priority,
+        selection_reason: wanderSelections.get(conversationId)?.reason,
+        selection_priority: wanderSelections.get(conversationId)?.priority,
         start_message_id: selection.startMessageId,
         end_message_id: selection.endMessageId,
         start_line: selection.startLineIndex,

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -107,6 +107,7 @@ export interface MultiReflectionManifest {
   type: "multi_transcript_reflection_payload";
   agent_id: string;
   created_at: string;
+  user_instruction?: string;
   selection_policy:
     | { mode: "recent"; limit: number }
     | { mode: "explicit-conversations"; conversation_ids: string[] }
@@ -171,6 +172,7 @@ export interface ReflectionAutoCandidates {
   current_conversation_id?: string;
   created_at: string;
   max_selected: number;
+  user_instruction?: string;
   instructions: string;
   candidates: ReflectionAutoCandidate[];
 }
@@ -185,6 +187,7 @@ export interface ReflectionAutoPayload {
 }
 
 export interface ReflectionPromptInput {
+  instruction?: string;
   memoryDir: string;
   parentMemory?: string;
 }
@@ -206,17 +209,44 @@ export function buildReflectionSubagentPrompt(
     "",
   );
 
+  if (input.instruction?.trim()) {
+    lines.push(
+      "Additional user-provided reflection instruction:",
+      input.instruction.trim(),
+      "",
+      "Use this instruction to focus what you look for, but still only persist durable memory-worthy learnings and do not store transient task state.",
+      "",
+    );
+  }
+
   if (input.parentMemory) {
     lines.push(input.parentMemory);
   }
   return lines.join("\n");
 }
 
-export function buildReflectionSelectorPrompt(): string {
-  return [
+export function buildReflectionSelectorPrompt(options?: {
+  instruction?: string;
+}): string {
+  const lines = [
     "You are selecting conversation transcripts for memory reflection. The transcript candidates path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Read/Edit file_path is literal and does NOT expand env vars.",
     "",
     "The payload is `auto_transcript_reflection_candidates` with compact metadata about candidate conversations. Your job is only to choose which conversations should be opened for a full reflection pass. Do not edit memory files. Do not commit anything.",
+    "",
+  ];
+
+  if (options?.instruction?.trim()) {
+    lines.push(
+      "Additional user-provided reflection instruction:",
+      options.instruction.trim(),
+      "",
+      "Prefer transcript candidates that help satisfy this instruction, while still avoiding transient or low-signal conversations.",
+      "",
+    );
+  }
+
+  lines.push(
+    "If the candidates payload includes `user_instruction`, use it as the requested focus for selection.",
     "",
     "Select up to `max_selected` conversations. Prefer candidates likely to contain durable memory updates: explicit user corrections, repeated preferences, coding/review/commit style preferences, repo or workflow gotchas, durable facts about people/projects, contradictions with current memory, or repeated agent failures.",
     "Avoid one-off debugging, transient task status, duplicated/redundant candidates, and conversations already fully reflected unless they are useful for deduplication or contradiction resolution.",
@@ -225,7 +255,9 @@ export function buildReflectionSelectorPrompt(): string {
     "Return strict JSON as your final response with this shape:",
     '{"selected_conversations":[{"conversation_id":"conv-...","reason":"durable reason for selecting this transcript","priority":"high"}]}',
     'Use priority values `high`, `medium`, or `low`. If nothing looks memory-worthy, write `{"selected_conversations":[]}`.',
-  ].join("\n");
+  );
+
+  return lines.join("\n");
 }
 
 interface ParentMemoryFile {
@@ -1324,12 +1356,14 @@ function shouldKeepAutoCandidate(candidate: ReflectionAutoCandidate): boolean {
 export async function buildReflectionAutoPayload(options: {
   agentId: string;
   currentConversationId?: string;
+  instruction?: string;
   maxSelected?: number;
   maxCatalogCandidates?: number;
 }): Promise<ReflectionAutoPayload | null> {
   const {
     agentId,
     currentConversationId,
+    instruction,
     maxSelected = REFLECTION_AUTO_MAX_SELECTED_TRANSCRIPTS,
     maxCatalogCandidates = REFLECTION_AUTO_MAX_CATALOG_CANDIDATES,
   } = options;
@@ -1493,6 +1527,7 @@ export async function buildReflectionAutoPayload(options: {
     current_conversation_id: currentConversationId,
     created_at: new Date().toISOString(),
     max_selected: maxSelected,
+    user_instruction: instruction?.trim() || undefined,
     instructions:
       "Choose conversations likely to contain durable memory updates. Prefer explicit corrections, repeated preferences, project conventions, and contradictions; avoid one-off debugging and transient task state.",
     candidates: sortedCandidates,
@@ -1707,6 +1742,7 @@ type MultiReflectionSelectionPolicy =
 
 export interface BuildMultiReflectionPayloadOptions {
   agentId: string;
+  instruction?: string;
   selectionPolicy: MultiReflectionSelectionPolicy;
   systemPrompt?: string;
   maxReplayTurnsPerConversation?: number;
@@ -1776,6 +1812,7 @@ export async function buildMultiReflectionPayload(
 ): Promise<MultiReflectionPayload | null> {
   const {
     agentId,
+    instruction,
     selectionPolicy,
     systemPrompt,
     maxReplayTurnsPerConversation = 50,
@@ -1872,6 +1909,7 @@ export async function buildMultiReflectionPayload(
     type: "multi_transcript_reflection_payload",
     agent_id: agentId,
     created_at: new Date().toISOString(),
+    user_instruction: instruction?.trim() || undefined,
     selection_policy: manifestSelectionPolicy(selectionPolicy),
     transcripts,
   };

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -171,7 +171,6 @@ export interface ReflectionDiscoveryCatalog {
   current_conversation_id?: string;
   created_at: string;
   max_selected: number;
-  selection_output_path: string;
   instructions: string;
   candidates: ReflectionDiscoveryCandidate[];
 }
@@ -182,7 +181,6 @@ export interface ReflectionDiscoverySelection {
 
 export interface ReflectionDiscoveryPayload {
   catalogPath: string;
-  selectionOutputPath: string;
   catalog: ReflectionDiscoveryCatalog;
 }
 
@@ -224,7 +222,7 @@ export function buildReflectionSelectorPrompt(): string {
     "Avoid one-off debugging, transient task status, duplicated/redundant candidates, and conversations already fully reflected unless they are useful for deduplication or contradiction resolution.",
     "Treat summaries/descriptions as weak internal metadata, not confirmed facts. The final reflection pass will verify against the actual transcript before writing memory.",
     "",
-    "Write strict JSON to the catalog's `selection_output_path` with this shape:",
+    "Return strict JSON as your final response with this shape:",
     '{"selected_conversations":[{"conversation_id":"conv-...","reason":"durable reason for selecting this transcript","priority":"high"}]}',
     'Use priority values `high`, `medium`, or `low`. If nothing looks memory-worthy, write `{"selected_conversations":[]}`.',
   ].join("\n");
@@ -980,7 +978,7 @@ async function writeState(
 
 function buildPayloadPath(
   rootDir: string,
-  kind: "auto" | "discover" | "multi" | "remember" | "selected" | "slice",
+  kind: "auto" | "discover" | "multi" | "remember" | "slice",
 ): string {
   const nonce = Math.random().toString(36).slice(2, 8);
   return join(rootDir, `payload-${kind}-${nonce}.json`);
@@ -1463,7 +1461,6 @@ export async function buildReflectionDiscoveryPayload(options: {
   }
 
   const payloadRoot = await ensureAgentPayloadRoot(agentId);
-  const selectionOutputPath = buildPayloadPath(payloadRoot, "selected");
   const catalog: ReflectionDiscoveryCatalog = {
     schema_version: 1,
     type: "reflection_discovery_catalog",
@@ -1471,7 +1468,6 @@ export async function buildReflectionDiscoveryPayload(options: {
     current_conversation_id: currentConversationId,
     created_at: new Date().toISOString(),
     max_selected: maxSelected,
-    selection_output_path: selectionOutputPath,
     instructions:
       "Choose conversations likely to contain durable memory updates. Prefer explicit corrections, repeated preferences, project conventions, and contradictions; avoid one-off debugging and transient task state.",
     candidates: sortedCandidates,
@@ -1483,7 +1479,7 @@ export async function buildReflectionDiscoveryPayload(options: {
     "utf-8",
   );
 
-  return { catalogPath, selectionOutputPath, catalog };
+  return { catalogPath, catalog };
 }
 
 function isReflectionDiscoveryPriority(
@@ -1493,13 +1489,18 @@ function isReflectionDiscoveryPriority(
 }
 
 export async function readReflectionDiscoverySelection(options: {
-  selectionOutputPath: string;
+  selectionOutputPath?: string;
+  selectionReport?: string;
   catalog: ReflectionDiscoveryCatalog;
 }): Promise<ReflectionDiscoverySelectedConversation[]> {
-  const raw = await readFile(options.selectionOutputPath, "utf-8");
-  const parsed = safeJsonParseOr<unknown>(raw, null);
+  const raw =
+    options.selectionReport ??
+    (options.selectionOutputPath
+      ? await readFile(options.selectionOutputPath, "utf-8")
+      : "");
+  const parsed = parseReflectionDiscoverySelectionJson(raw);
   if (!parsed || typeof parsed !== "object") {
-    throw new Error("Reflection selector did not write valid JSON.");
+    throw new Error("Reflection selector did not return valid JSON.");
   }
   const selected = (parsed as { selected_conversations?: unknown })
     .selected_conversations;
@@ -1545,6 +1546,28 @@ export async function readReflectionDiscoverySelection(options: {
   }
 
   return validated;
+}
+
+function parseReflectionDiscoverySelectionJson(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const direct = safeJsonParseOr<unknown>(trimmed, null);
+  if (direct) return direct;
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+  if (fenced) {
+    const parsed = safeJsonParseOr<unknown>(fenced, null);
+    if (parsed) return parsed;
+  }
+
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    return safeJsonParseOr<unknown>(trimmed.slice(start, end + 1), null);
+  }
+
+  return null;
 }
 
 export async function listReflectionTranscriptCandidates(

--- a/src/cli/memory-subagent-recompile.test.ts
+++ b/src/cli/memory-subagent-recompile.test.ts
@@ -138,15 +138,9 @@ describe("memory subagent recompile handling", () => {
       second,
       third,
     ]);
-    expect(firstMessage).toBe(
-      "Reflected on /palace, the halls remember more now.",
-    );
-    expect(secondMessage).toBe(
-      "Reflected on /palace, the halls remember more now.",
-    );
-    expect(thirdMessage).toBe(
-      "Reflected on /palace, the halls remember more now.",
-    );
+    expect(firstMessage).toBe("Dreamed and made some memories.");
+    expect(secondMessage).toBe("Dreamed and made some memories.");
+    expect(thirdMessage).toBe("Dreamed and made some memories.");
     expect(recompileByConversation.size).toBe(0);
     expect(recompileQueuedByConversation.size).toBe(0);
   });
@@ -179,12 +173,8 @@ describe("memory subagent recompile handling", () => {
       ),
     ]);
 
-    expect(firstMessage).toBe(
-      "Reflected on /palace, the halls remember more now.",
-    );
-    expect(secondMessage).toBe(
-      "Reflected on /palace, the halls remember more now.",
-    );
+    expect(firstMessage).toBe("Dreamed and made some memories.");
+    expect(secondMessage).toBe("Dreamed and made some memories.");
     expect(recompileAgentSystemPromptMock).toHaveBeenCalledTimes(2);
     expect(recompileAgentSystemPromptMock).toHaveBeenCalledWith(
       "conv-a",
@@ -193,6 +183,27 @@ describe("memory subagent recompile handling", () => {
     expect(recompileAgentSystemPromptMock).toHaveBeenCalledWith(
       "conv-b",
       "agent-shared",
+    );
+  });
+
+  test("links the word memories to the reflection subagent", async () => {
+    const message = await handleMemorySubagentCompletion(
+      {
+        agentId: "agent-parent",
+        conversationId: "conv-parent",
+        subagentType: "reflection",
+        success: true,
+        subagentAgentId: "agent-reflection",
+      },
+      {
+        recompileByConversation: new Map(),
+        recompileQueuedByConversation: new Set(),
+        recompileAgentSystemPromptImpl: recompileAgentSystemPromptMock,
+      },
+    );
+
+    expect(message).toBe(
+      "\x1b]8;;https://app.letta.com/chat/agent-reflection\x1b\\Dreamed\x1b]8;;\x1b\\ and made some memories.",
     );
   });
 });

--- a/src/cli/reflection-scope-gate.test.ts
+++ b/src/cli/reflection-scope-gate.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
+import { clearAllSubagents, registerSubagent } from "@/agent/subagent-state";
 import { isReflectionSubagentActive } from "@/cli/helpers/reflection-gate";
+import {
+  releaseReflectionLaunch,
+  tryReserveReflectionLaunch,
+} from "@/cli/helpers/reflection-launcher";
 
 type Row = {
   type: string;
@@ -10,6 +15,12 @@ type Row = {
 };
 
 describe("isReflectionSubagentActive", () => {
+  afterEach(() => {
+    releaseReflectionLaunch("agent-me");
+    releaseReflectionLaunch("agent-other");
+    clearAllSubagents();
+  });
+
   test("returns false when no subagents are present", () => {
     expect(isReflectionSubagentActive([], "agent-me", "conv-me")).toBe(false);
   });
@@ -147,5 +158,39 @@ describe("isReflectionSubagentActive", () => {
       },
     ];
     expect(isReflectionSubagentActive(rows, "agent-me", "conv-me")).toBe(true);
+  });
+});
+
+describe("reflection launch reservation", () => {
+  afterEach(() => {
+    releaseReflectionLaunch("agent-me");
+    releaseReflectionLaunch("agent-other");
+    clearAllSubagents();
+  });
+
+  test("serializes reflection launches per agent", () => {
+    expect(tryReserveReflectionLaunch("agent-me")).toBe(true);
+    expect(tryReserveReflectionLaunch("agent-me")).toBe(false);
+
+    releaseReflectionLaunch("agent-me");
+    expect(tryReserveReflectionLaunch("agent-me")).toBe(true);
+  });
+
+  test("blocks when any reflection is active for the same agent", () => {
+    registerSubagent(
+      "subagent-a",
+      "reflection",
+      "reflecting",
+      undefined,
+      true,
+      true,
+      {
+        agentId: "agent-me",
+        conversationId: "conv-other",
+      },
+    );
+
+    expect(tryReserveReflectionLaunch("agent-me")).toBe(false);
+    expect(tryReserveReflectionLaunch("agent-other")).toBe(true);
   });
 });

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -13,6 +13,7 @@ import {
   buildAutoReflectionPayload,
   buildMultiReflectionPayload,
   buildParentMemorySnapshot,
+  buildReflectionSelectorPrompt,
   buildReflectionSubagentPrompt,
   filterSystemPromptForReflection,
   finalizeAutoReflectionPayload,
@@ -21,6 +22,7 @@ import {
   getReflectionTranscriptState,
   listReflectionTranscriptCandidates,
   REFLECTION_STATE_SCHEMA_VERSION,
+  readReflectionDiscoverySelection,
 } from "@/cli/helpers/reflection-transcript";
 import { DIRECTORY_LIMIT_ENV } from "@/utils/directory-limits";
 
@@ -1013,5 +1015,72 @@ describe("reflectionTranscript helper", () => {
     expect(filtered).not.toContain("pinned into your prompt");
     expect(filtered).not.toContain("Syncing");
     expect(filtered).not.toContain("git push");
+  });
+
+  test("reflection selector prompt describes discovery-only mode", () => {
+    const prompt = buildReflectionSelectorPrompt();
+    expect(prompt).toContain("reflection_discovery_catalog");
+    expect(prompt).toContain("Do not edit memory files");
+    expect(prompt).toContain("selection_output_path");
+  });
+
+  test("readReflectionDiscoverySelection validates and caps selector output", async () => {
+    const selectionOutputPath = join(testRoot, "selected.json");
+    await writeFile(
+      selectionOutputPath,
+      JSON.stringify({
+        selected_conversations: [
+          { conversation_id: "conv-a", reason: "correction", priority: "high" },
+          { conversation_id: "conv-a", reason: "duplicate", priority: "low" },
+          {
+            conversation_id: "conv-b",
+            reason: "repo gotcha",
+            priority: "medium",
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const selected = await readReflectionDiscoverySelection({
+      selectionOutputPath,
+      catalog: {
+        schema_version: 1,
+        type: "reflection_discovery_catalog",
+        agent_id: agentId,
+        created_at: new Date().toISOString(),
+        max_selected: 1,
+        selection_output_path: selectionOutputPath,
+        instructions: "select",
+        candidates: [
+          {
+            conversation_id: "conv-a",
+            total_completed_turns: 3,
+            reflected_completed_turns: 0,
+            turns_since_last_successful_reflection: 3,
+            has_unreflected_content: true,
+            is_current_conversation: false,
+            sources: ["unreflected"],
+            search_scores: [],
+            heuristic_score: 10,
+          },
+          {
+            conversation_id: "conv-b",
+            total_completed_turns: 3,
+            reflected_completed_turns: 3,
+            turns_since_last_successful_reflection: 0,
+            has_unreflected_content: false,
+            is_current_conversation: false,
+            sources: ["search:coding-style"],
+            search_scores: [],
+            heuristic_score: 8,
+          },
+        ],
+      },
+    });
+
+    expect(selected).toEqual([
+      { conversation_id: "conv-a", reason: "correction", priority: "high" },
+    ]);
   });
 });

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -22,7 +22,7 @@ import {
   getReflectionTranscriptState,
   listReflectionTranscriptCandidates,
   REFLECTION_STATE_SCHEMA_VERSION,
-  readReflectionDiscoverySelection,
+  readReflectionWanderSelection,
 } from "@/cli/helpers/reflection-transcript";
 import { DIRECTORY_LIMIT_ENV } from "@/utils/directory-limits";
 
@@ -1017,15 +1017,15 @@ describe("reflectionTranscript helper", () => {
     expect(filtered).not.toContain("git push");
   });
 
-  test("reflection selector prompt describes discovery-only mode", () => {
+  test("reflection selector prompt describes wander-only mode", () => {
     const prompt = buildReflectionSelectorPrompt();
-    expect(prompt).toContain("reflection_discovery_catalog");
+    expect(prompt).toContain("reflection_wander_catalog");
     expect(prompt).toContain("Do not edit memory files");
     expect(prompt).toContain("Return strict JSON");
   });
 
-  test("readReflectionDiscoverySelection validates and caps selector report", async () => {
-    const selected = await readReflectionDiscoverySelection({
+  test("readReflectionWanderSelection validates and caps selector report", async () => {
+    const selected = await readReflectionWanderSelection({
       selectionReport: JSON.stringify({
         selected_conversations: [
           { conversation_id: "conv-a", reason: "correction", priority: "high" },
@@ -1039,7 +1039,7 @@ describe("reflectionTranscript helper", () => {
       }),
       catalog: {
         schema_version: 1,
-        type: "reflection_discovery_catalog",
+        type: "reflection_wander_catalog",
         agent_id: agentId,
         created_at: new Date().toISOString(),
         max_selected: 1,
@@ -1076,13 +1076,13 @@ describe("reflectionTranscript helper", () => {
     ]);
   });
 
-  test("readReflectionDiscoverySelection accepts fenced selector JSON", async () => {
-    const selected = await readReflectionDiscoverySelection({
+  test("readReflectionWanderSelection accepts fenced selector JSON", async () => {
+    const selected = await readReflectionWanderSelection({
       selectionReport:
         '```json\n{"selected_conversations":[{"conversation_id":"conv-a","reason":"correction"}]}\n```',
       catalog: {
         schema_version: 1,
-        type: "reflection_discovery_catalog",
+        type: "reflection_wander_catalog",
         agent_id: agentId,
         created_at: new Date().toISOString(),
         max_selected: 5,

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -1021,14 +1021,12 @@ describe("reflectionTranscript helper", () => {
     const prompt = buildReflectionSelectorPrompt();
     expect(prompt).toContain("reflection_discovery_catalog");
     expect(prompt).toContain("Do not edit memory files");
-    expect(prompt).toContain("selection_output_path");
+    expect(prompt).toContain("Return strict JSON");
   });
 
-  test("readReflectionDiscoverySelection validates and caps selector output", async () => {
-    const selectionOutputPath = join(testRoot, "selected.json");
-    await writeFile(
-      selectionOutputPath,
-      JSON.stringify({
+  test("readReflectionDiscoverySelection validates and caps selector report", async () => {
+    const selected = await readReflectionDiscoverySelection({
+      selectionReport: JSON.stringify({
         selected_conversations: [
           { conversation_id: "conv-a", reason: "correction", priority: "high" },
           { conversation_id: "conv-a", reason: "duplicate", priority: "low" },
@@ -1039,18 +1037,12 @@ describe("reflectionTranscript helper", () => {
           },
         ],
       }),
-      "utf-8",
-    );
-
-    const selected = await readReflectionDiscoverySelection({
-      selectionOutputPath,
       catalog: {
         schema_version: 1,
         type: "reflection_discovery_catalog",
         agent_id: agentId,
         created_at: new Date().toISOString(),
         max_selected: 1,
-        selection_output_path: selectionOutputPath,
         instructions: "select",
         candidates: [
           {
@@ -1081,6 +1073,38 @@ describe("reflectionTranscript helper", () => {
 
     expect(selected).toEqual([
       { conversation_id: "conv-a", reason: "correction", priority: "high" },
+    ]);
+  });
+
+  test("readReflectionDiscoverySelection accepts fenced selector JSON", async () => {
+    const selected = await readReflectionDiscoverySelection({
+      selectionReport:
+        '```json\n{"selected_conversations":[{"conversation_id":"conv-a","reason":"correction"}]}\n```',
+      catalog: {
+        schema_version: 1,
+        type: "reflection_discovery_catalog",
+        agent_id: agentId,
+        created_at: new Date().toISOString(),
+        max_selected: 5,
+        instructions: "select",
+        candidates: [
+          {
+            conversation_id: "conv-a",
+            total_completed_turns: 3,
+            reflected_completed_turns: 0,
+            turns_since_last_successful_reflection: 3,
+            has_unreflected_content: true,
+            is_current_conversation: false,
+            sources: ["unreflected"],
+            search_scores: [],
+            heuristic_score: 10,
+          },
+        ],
+      },
+    });
+
+    expect(selected).toEqual([
+      { conversation_id: "conv-a", reason: "correction" },
     ]);
   });
 });

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -562,10 +562,14 @@ describe("reflectionTranscript helper", () => {
 
     const multi = await buildMultiReflectionPayload({
       agentId,
+      instruction: "Focus on cross-session coding preferences.",
       selectionPolicy: { mode: "recent", limit: 10 },
     });
     expect(multi).not.toBeNull();
     if (!multi) return;
+    expect(multi.manifest.user_instruction).toBe(
+      "Focus on cross-session coding preferences.",
+    );
     expect(multi.manifest.transcripts).toHaveLength(2);
     expect(multi.manifest.transcripts.every((t) => t.mode === "replay")).toBe(
       true,
@@ -804,6 +808,7 @@ describe("reflectionTranscript helper", () => {
 
   test("buildReflectionSubagentPrompt uses expanded reflection instructions", () => {
     const prompt = buildReflectionSubagentPrompt({
+      instruction: "Focus on repo gotchas.",
       memoryDir: "/tmp/memory",
       parentMemory: "<parent_memory>snapshot</parent_memory>",
     });
@@ -824,6 +829,8 @@ describe("reflectionTranscript helper", () => {
     expect(prompt).toContain(
       "Additional memory files (such as skills and external memory) may also be read and modified.",
     );
+    expect(prompt).toContain("Additional user-provided reflection instruction");
+    expect(prompt).toContain("Focus on repo gotchas.");
     expect(prompt).toContain("<parent_memory>snapshot</parent_memory>");
   });
 
@@ -1018,10 +1025,13 @@ describe("reflectionTranscript helper", () => {
   });
 
   test("reflection selector prompt describes auto-only mode", () => {
-    const prompt = buildReflectionSelectorPrompt();
+    const prompt = buildReflectionSelectorPrompt({
+      instruction: "Find repeated mistakes.",
+    });
     expect(prompt).toContain("auto_transcript_reflection_candidates");
     expect(prompt).toContain("Do not edit memory files");
     expect(prompt).toContain("Return strict JSON");
+    expect(prompt).toContain("Find repeated mistakes.");
   });
 
   test("readReflectionAutoSelection validates and caps selector report", async () => {

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -11,12 +11,15 @@ import {
 import {
   appendTranscriptDeltaJsonl,
   buildAutoReflectionPayload,
+  buildMultiReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
   filterSystemPromptForReflection,
   finalizeAutoReflectionPayload,
+  finalizeMultiReflectionPayload,
   getReflectionTranscriptPaths,
   getReflectionTranscriptState,
+  listReflectionTranscriptCandidates,
   REFLECTION_STATE_SCHEMA_VERSION,
 } from "@/cli/helpers/reflection-transcript";
 import { DIRECTORY_LIMIT_ENV } from "@/utils/directory-limits";
@@ -518,6 +521,169 @@ describe("reflectionTranscript helper", () => {
     expect(state.total_completed_steps).toBe(5);
   });
 
+  test("multi payload recent uses replay slices when conversations are already reflected", async () => {
+    const convA = "conv-a";
+    const convB = "conv-b";
+    await appendTranscriptDeltaJsonl(agentId, convA, [
+      { kind: "user", id: "u-a", text: "alpha", messageId: "u-a" },
+      {
+        kind: "assistant",
+        id: "a-a",
+        text: "alpha response",
+        phase: "finished",
+        messageId: "a-a",
+      },
+    ]);
+    await appendTranscriptDeltaJsonl(agentId, convB, [
+      { kind: "user", id: "u-b", text: "beta", messageId: "u-b" },
+      {
+        kind: "assistant",
+        id: "a-b",
+        text: "beta response",
+        phase: "finished",
+        messageId: "a-b",
+      },
+    ]);
+
+    for (const conv of [convA, convB]) {
+      const payload = await buildAutoReflectionPayload(agentId, conv);
+      expect(payload).not.toBeNull();
+      if (!payload) return;
+      await finalizeAutoReflectionPayload(
+        agentId,
+        conv,
+        payload.payloadPath,
+        payload.endSnapshotLine,
+        true,
+      );
+    }
+
+    const multi = await buildMultiReflectionPayload({
+      agentId,
+      selectionPolicy: { mode: "recent", limit: 10 },
+    });
+    expect(multi).not.toBeNull();
+    if (!multi) return;
+    expect(multi.manifest.transcripts).toHaveLength(2);
+    expect(multi.manifest.transcripts.every((t) => t.mode === "replay")).toBe(
+      true,
+    );
+
+    const manifestText = await readFile(multi.payloadPath, "utf-8");
+    expect(JSON.parse(manifestText).type).toBe(
+      "multi_transcript_reflection_payload",
+    );
+    for (const slice of multi.manifest.transcripts) {
+      const payloadText = await readFile(slice.payload_path, "utf-8");
+      const messages = JSON.parse(payloadText);
+      expect(messages.some((m: { role: string }) => m.role === "user")).toBe(
+        true,
+      );
+    }
+  });
+
+  test("multi finalizer advances only unreflected slices", async () => {
+    const replayConv = "conv-replay";
+    const freshConv = "conv-fresh";
+    await appendTranscriptDeltaJsonl(agentId, replayConv, [
+      { kind: "user", id: "u-r", text: "old", messageId: "u-r" },
+      {
+        kind: "assistant",
+        id: "a-r",
+        text: "old response",
+        phase: "finished",
+        messageId: "a-r",
+      },
+    ]);
+    await appendTranscriptDeltaJsonl(agentId, freshConv, [
+      { kind: "user", id: "u-f", text: "new", messageId: "u-f" },
+      {
+        kind: "assistant",
+        id: "a-f",
+        text: "new response",
+        phase: "finished",
+        messageId: "a-f",
+      },
+    ]);
+
+    const replayPayload = await buildAutoReflectionPayload(agentId, replayConv);
+    expect(replayPayload).not.toBeNull();
+    if (!replayPayload) return;
+    await finalizeAutoReflectionPayload(
+      agentId,
+      replayConv,
+      replayPayload.payloadPath,
+      replayPayload.endSnapshotLine,
+      true,
+    );
+
+    const multi = await buildMultiReflectionPayload({
+      agentId,
+      selectionPolicy: {
+        mode: "explicit-conversations",
+        conversationIds: [replayConv, freshConv],
+      },
+    });
+    expect(multi).not.toBeNull();
+    if (!multi) return;
+    expect(
+      multi.manifest.transcripts.map((slice) => [
+        slice.conversation_id,
+        slice.mode,
+      ]),
+    ).toEqual([
+      [replayConv, "replay"],
+      [freshConv, "unreflected"],
+    ]);
+
+    await finalizeMultiReflectionPayload(agentId, multi.manifest, true);
+
+    const replayState = await getReflectionTranscriptState(agentId, replayConv);
+    const freshState = await getReflectionTranscriptState(agentId, freshConv);
+    expect(replayState.reflected_through_message_id).toBe("a-r");
+    expect(replayState.turns_since_last_successful_reflection).toBe(0);
+    expect(freshState.reflected_through_message_id).toBe("a-f");
+    expect(freshState.turns_since_last_successful_reflection).toBe(0);
+  });
+
+  test("multi finalizer leaves cursors unchanged on failure", async () => {
+    const conv = "conv-failure";
+    await appendTranscriptDeltaJsonl(agentId, conv, [
+      { kind: "user", id: "u1", text: "new", messageId: "u1" },
+    ]);
+    const multi = await buildMultiReflectionPayload({
+      agentId,
+      selectionPolicy: {
+        mode: "explicit-conversations",
+        conversationIds: [conv],
+      },
+    });
+    expect(multi).not.toBeNull();
+    if (!multi) return;
+
+    await finalizeMultiReflectionPayload(agentId, multi.manifest, false);
+
+    const state = await getReflectionTranscriptState(agentId, conv);
+    expect(state.reflected_through_message_id).toBeUndefined();
+    expect(state.turns_since_last_successful_reflection).toBe(1);
+  });
+
+  test("listReflectionTranscriptCandidates orders by recent transcript mtime", async () => {
+    await appendTranscriptDeltaJsonl(agentId, "older", [
+      { kind: "user", id: "u-old", text: "old", messageId: "u-old" },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await appendTranscriptDeltaJsonl(agentId, "newer", [
+      { kind: "user", id: "u-new", text: "new", messageId: "u-new" },
+    ]);
+
+    const candidates = await listReflectionTranscriptCandidates(agentId);
+    expect(candidates.map((candidate) => candidate.conversationId)).toEqual([
+      "newer",
+      "older",
+    ]);
+  });
+
   test("buildParentMemorySnapshot renders tree descriptions and system <memory> blocks", async () => {
     const memoryDir = join(testRoot, "memory");
     const normalizedMemoryDir = memoryDir.replace(/\\/g, "/");
@@ -642,9 +808,9 @@ describe("reflectionTranscript helper", () => {
 
     expect(prompt).toContain("Review the conversation transcript");
     expect(prompt).not.toContain("Your current working directory is:");
-    expect(prompt).toContain(
-      "The current conversation transcript path is available as the",
-    );
+    expect(prompt).toContain("The payload path is available as the");
+    expect(prompt).toContain("multi_transcript_reflection_payload");
+    expect(prompt).toContain('mode: "replay"');
     // Prompt references the $TRANSCRIPT_PATH env var (resolved via Bash),
     // not a literal absolute path.
     expect(prompt).toContain("$TRANSCRIPT_PATH");

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -647,9 +647,9 @@ describe("reflectionTranscript helper", () => {
     const replayState = await getReflectionTranscriptState(agentId, replayConv);
     const freshState = await getReflectionTranscriptState(agentId, freshConv);
     expect(replayState.reflected_through_message_id).toBe("a-r");
-    expect(replayState.turns_since_last_successful_reflection).toBe(0);
+    expect(replayState.steps_since_last_successful_reflection).toBe(0);
     expect(freshState.reflected_through_message_id).toBe("a-f");
-    expect(freshState.turns_since_last_successful_reflection).toBe(0);
+    expect(freshState.steps_since_last_successful_reflection).toBe(0);
   });
 
   test("multi finalizer leaves cursors unchanged on failure", async () => {
@@ -671,7 +671,7 @@ describe("reflectionTranscript helper", () => {
 
     const state = await getReflectionTranscriptState(agentId, conv);
     expect(state.reflected_through_message_id).toBeUndefined();
-    expect(state.turns_since_last_successful_reflection).toBe(1);
+    expect(state.steps_since_last_successful_reflection).toBe(0);
   });
 
   test("listReflectionTranscriptCandidates orders by recent transcript mtime", async () => {

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -22,7 +22,7 @@ import {
   getReflectionTranscriptState,
   listReflectionTranscriptCandidates,
   REFLECTION_STATE_SCHEMA_VERSION,
-  readReflectionWanderSelection,
+  readReflectionAutoSelection,
 } from "@/cli/helpers/reflection-transcript";
 import { DIRECTORY_LIMIT_ENV } from "@/utils/directory-limits";
 
@@ -1017,15 +1017,15 @@ describe("reflectionTranscript helper", () => {
     expect(filtered).not.toContain("git push");
   });
 
-  test("reflection selector prompt describes wander-only mode", () => {
+  test("reflection selector prompt describes auto-only mode", () => {
     const prompt = buildReflectionSelectorPrompt();
-    expect(prompt).toContain("reflection_wander_catalog");
+    expect(prompt).toContain("auto_transcript_reflection_candidates");
     expect(prompt).toContain("Do not edit memory files");
     expect(prompt).toContain("Return strict JSON");
   });
 
-  test("readReflectionWanderSelection validates and caps selector report", async () => {
-    const selected = await readReflectionWanderSelection({
+  test("readReflectionAutoSelection validates and caps selector report", async () => {
+    const selected = await readReflectionAutoSelection({
       selectionReport: JSON.stringify({
         selected_conversations: [
           { conversation_id: "conv-a", reason: "correction", priority: "high" },
@@ -1037,9 +1037,9 @@ describe("reflectionTranscript helper", () => {
           },
         ],
       }),
-      catalog: {
+      candidates: {
         schema_version: 1,
-        type: "reflection_wander_catalog",
+        type: "auto_transcript_reflection_candidates",
         agent_id: agentId,
         created_at: new Date().toISOString(),
         max_selected: 1,
@@ -1076,13 +1076,13 @@ describe("reflectionTranscript helper", () => {
     ]);
   });
 
-  test("readReflectionWanderSelection accepts fenced selector JSON", async () => {
-    const selected = await readReflectionWanderSelection({
+  test("readReflectionAutoSelection accepts fenced selector JSON", async () => {
+    const selected = await readReflectionAutoSelection({
       selectionReport:
         '```json\n{"selected_conversations":[{"conversation_id":"conv-a","reason":"correction"}]}\n```',
-      catalog: {
+      candidates: {
         schema_version: 1,
-        type: "reflection_wander_catalog",
+        type: "auto_transcript_reflection_candidates",
         agent_id: agentId,
         created_at: new Date().toISOString(),
         max_selected: 5,

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -114,6 +114,8 @@ export interface SpawnBackgroundSubagentTaskArgs {
    * Called after the subagent finishes (success or failure).
    * Runs regardless of `silentCompletion` and is awaited before
    * completion notifications/hooks continue.
+   * `report` is the raw final subagent report and may be large; callbacks
+   * should parse/summarize it rather than injecting it directly into context.
    */
   onComplete?: (result: {
     success: boolean;
@@ -122,6 +124,7 @@ export interface SpawnBackgroundSubagentTaskArgs {
     conversationId?: string;
     stepCount?: number;
     durationMs?: number;
+    report?: string;
   }) => void | Promise<void>;
   /**
    * Optional dependency overrides for tests.
@@ -433,6 +436,7 @@ export function spawnBackgroundSubagentTask(
           conversationId: result.conversationId,
           stepCount: result.stepCount,
           durationMs: result.durationMs,
+          report: result.report,
         });
       } catch (error) {
         const errorMessage =


### PR DESCRIPTION
## Summary
- add manual multi-transcript reflection with `/reflect --recent N` and repeated `/reflect --conversation <id>`
- add `/reflect --auto`, which builds transcript candidates, asks a selector reflection subagent to choose relevant conversations, then launches one multi-transcript reflection pass
- support focused reflection instructions via `--instruction` / `-i` / `--`, threading the user instruction through auto candidate selection, multi-reflection manifests, and final reflection prompts
- build multi-transcript manifests with unreflected/replay slices, selector reasons, auto-selected candidate metadata, and optional `user_instruction`
- advance cursors only for unreflected slices after successful multi-reflection
- teach reflection subagents to read multi-transcript manifests and auto transcript candidate manifests
- filter weak `/reflect --auto` candidates so one-turn leftovers and reflected recent-only transcripts do not dominate selection

## Test plan
- `bun test src/cli/reflection-transcript.test.ts`
- `bun run check`
