### PR TITLE
docs(tools): clarify ViewImage description

### DIFF
--- a/src/tools/descriptions/ViewImage.md
+++ b/src/tools/descriptions/ViewImage.md
@@ -1,1 +1,1 @@
-View a local image from the filesystem (only use if given a full filepath by the user, and the image isn't already attached to the thread context within <image ...> tags).
+View a local image file from the filesystem when visual inspection is needed. Use this for images already available on disk.


### PR DESCRIPTION
## Summary
- align the ViewImage tool description with upstream Codex wording from rust-v0.135.0
- clarify that the tool is for visually inspecting image files already available on disk

Closes #2579

## Test plan
- bun test src/tools/view-image.test.ts
- bun run typecheck