### PR TITLE
fix(ui): show dreaming agent link in tmux

### DIFF
--- a/src/cli/components/ProductStatusRow.tsx
+++ b/src/cli/components/ProductStatusRow.tsx
@@ -80,6 +80,7 @@ function renderDreamingStatus(agent: SubagentState): ReactNode {
   const elapsedS = Math.round((Date.now() - agent.startTime) / 1000);
   const typeLabel = typeLabelForBackgroundAgent(agent);
   const chatUrl = chatUrlForBackgroundAgent(agent);
+  const isTmux = Boolean(process.env.TMUX);
 
   return (
     <Text>
@@ -89,7 +90,12 @@ function renderDreamingStatus(agent: SubagentState): ReactNode {
         marginRight={0}
         pulseIntervalMs={400}
       />
-      {chatUrl ? (
+      {chatUrl && isTmux ? (
+        <>
+          <Text color={colors.bgSubagent.label}>{typeLabel}</Text>
+          <Text dimColor>: {chatUrl}</Text>
+        </>
+      ) : chatUrl ? (
         <Link url={chatUrl} fallback={false}>
           <Text color={colors.bgSubagent.label}>{typeLabel}</Text>
         </Link>


### PR DESCRIPTION
## Summary
- render the background dreaming/reflection agent URL as plain text when running inside tmux
- keep the existing clickable terminal link outside tmux

## Test plan
- `bun run check`