### PR TITLE
fix: hide auto-approved listener approval deltas

### DIFF
--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -40,6 +40,17 @@ type DrainResult = {
   apiDurationMs: number;
 };
 
+type DrainHook = (ctx: {
+  chunk: Record<string, unknown>;
+  shouldOutput: boolean;
+  errorInfo?: unknown;
+  updatedApproval?: {
+    toolCallId: string;
+    toolName: string;
+    toolArgs: string;
+  };
+}) => Promise<{ shouldOutput?: boolean } | undefined>;
+
 const defaultDrainResult: DrainResult = {
   stopReason: "end_turn",
   approvals: [],
@@ -83,7 +94,10 @@ const sendMessageStreamMock = mock(
 const getStreamToolContextIdMock = mock(() => null);
 const drainHandlers = new Map<
   string,
-  (abortSignal?: AbortSignal) => Promise<DrainResult>
+  (
+    abortSignal?: AbortSignal,
+    onChunkProcessed?: DrainHook,
+  ) => Promise<DrainResult>
 >();
 const drainStreamWithResumeMock = mock(
   async (
@@ -91,10 +105,12 @@ const drainStreamWithResumeMock = mock(
     _buffers: unknown,
     _refresh: () => void,
     abortSignal?: AbortSignal,
+    _onFirstMessage?: unknown,
+    onChunkProcessed?: DrainHook,
   ) => {
     const handler = drainHandlers.get(stream.conversationId);
     if (handler) {
-      return handler(abortSignal);
+      return handler(abortSignal, onChunkProcessed);
     }
     return defaultDrainResult;
   },
@@ -2261,6 +2277,110 @@ describe("listen-client multi-worker concurrency", () => {
       type: "approval",
       otid: expect.any(String),
     });
+  });
+
+  test("unrestricted mode suppresses streamed approval request deltas for auto-approved tools", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-auto",
+    );
+    const socket = new MockSocket();
+    const approval = {
+      toolCallId: "tc-auto-bash",
+      toolName: "Bash",
+      toolArgs: '{"command":"gh pr status"}',
+    };
+    const approvalChunk = {
+      message_type: "approval_request_message",
+      run_id: "run-auto-bash",
+      tool_call: {
+        tool_call_id: approval.toolCallId,
+        name: approval.toolName,
+        arguments: approval.toolArgs,
+      },
+    };
+    let drainCount = 0;
+
+    await __listenClientTestUtils.handleChangeDeviceStateInput(listener, {
+      command: {
+        type: "change_device_state",
+        runtime: { agent_id: "agent-1", conversation_id: "conv-auto" },
+        payload: { mode: "unrestricted" },
+      },
+      socket: socket as unknown as WebSocket,
+      opts: {},
+      processQueuedTurn: async () => {},
+    });
+
+    // biome-ignore lint/suspicious/noExplicitAny: mock method access
+    (classifyApprovalsMock as any).mockImplementation(
+      async (approvals: Array<typeof approval>) => ({
+        autoAllowed: approvals.map((entry: typeof approval) => ({
+          approval: entry,
+          permission: {
+            decision: "allow",
+            reason: "Permission mode: unrestricted",
+            matchedRule: "unrestricted mode",
+          },
+          context: null,
+          parsedArgs: { command: "gh pr status" },
+        })),
+        autoDenied: [],
+        needsUserInput: [],
+      }),
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: mock method access
+    (executeApprovalBatchMock as any).mockResolvedValueOnce([
+      {
+        type: "tool",
+        tool_call_id: approval.toolCallId,
+        status: "success",
+        tool_return: "ok",
+      },
+    ]);
+
+    drainHandlers.set("conv-auto", async (_abortSignal, onChunkProcessed) => {
+      if (drainCount === 0) {
+        drainCount += 1;
+        const hookResult = await onChunkProcessed?.({
+          chunk: approvalChunk,
+          shouldOutput: true,
+          updatedApproval: approval,
+        });
+        expect(hookResult?.shouldOutput).toBe(false);
+        return {
+          stopReason: "requires_approval",
+          approvals: [approval],
+          apiDurationMs: 0,
+        };
+      }
+      drainCount += 1;
+      return defaultDrainResult;
+    });
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-1", "conv-auto", "check the PR"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    const sentPayloads = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload),
+    );
+    expect(
+      sentPayloads.some(
+        (payload) =>
+          payload.type === "stream_delta" &&
+          payload.delta?.message_type === "approval_request_message",
+      ),
+    ).toBe(false);
+    expect(
+      sentPayloads.some((payload) => payload.type === "control_request"),
+    ).toBe(false);
+    expect(executeApprovalBatchMock).toHaveBeenCalledTimes(1);
   });
 
   test("change_device_state does not prune default-state entry mid-turn", async () => {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -32,6 +32,7 @@ import {
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
 import { createBuffers, toLines } from "@/cli/helpers/accumulator";
+import { classifyApprovals } from "@/cli/helpers/approval-classification";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import {
@@ -63,6 +64,7 @@ import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { extractTelemetryInputText } from "@/telemetry/input";
+import { isInteractiveApprovalTool } from "@/tools/interactive-policy";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
@@ -748,10 +750,11 @@ export async function handleIncomingMessage(
         () => {},
         turnAbortSignal,
         undefined,
-        ({ chunk, shouldOutput, errorInfo }) => {
+        async ({ chunk, shouldOutput, errorInfo, updatedApproval }) => {
           if (runtime.cancelRequested) {
             return undefined;
           }
+          let shouldForwardChunk = shouldOutput;
           const maybeRunId = (chunk as { run_id?: unknown }).run_id;
           if (typeof maybeRunId === "string") {
             runId = maybeRunId;
@@ -799,7 +802,32 @@ export async function handleIncomingMessage(
             }
           }
 
-          if (shouldOutput) {
+          if (updatedApproval && shouldForwardChunk) {
+            try {
+              const { autoAllowed } = await classifyApprovals(
+                [updatedApproval],
+                {
+                  alwaysRequiresUserInput: isInteractiveApprovalTool,
+                  requireArgsForAutoApprove: true,
+                  missingNameReason: "Tool call incomplete - missing name",
+                  workingDirectory: turnWorkingDirectory,
+                  permissionModeState: turnPermissionModeState,
+                  agentId,
+                },
+              );
+              if (autoAllowed.length > 0) {
+                shouldForwardChunk = false;
+              }
+            } catch (error) {
+              debugWarn(
+                "listener",
+                "Failed to pre-classify streamed approval chunk: %s",
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+          }
+
+          if (shouldForwardChunk) {
             const normalizedChunk = normalizeToolReturnWireMessage(
               chunk as unknown as Record<string, unknown>,
             );
@@ -819,7 +847,7 @@ export async function handleIncomingMessage(
             }
           }
 
-          return undefined;
+          return { shouldOutput: shouldForwardChunk };
         },
         runtime.contextTracker,
       );


### PR DESCRIPTION
## Summary
- pre-classify streamed listener approval chunks with the scoped permission mode before forwarding them to the UI
- suppress user-visible approval request deltas when the tool is already auto-approved, while still collecting the approval internally for execution/continuation
- add regression coverage for unrestricted mode auto-approving a streamed Bash/gh command without emitting an approval request or control request

## Tests
- `bun test src/websocket/listen-client-concurrency.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/turn.ts src/websocket/listen-client-concurrency.test.ts`
- `bun run typecheck`
- `git diff --check -- src/websocket/listener/turn.ts src/websocket/listen-client-concurrency.test.ts`
