### PR TITLE
fix: make Ctrl+U kill current line instead of entire input

### DIFF
--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -154,11 +154,17 @@ function TextInput({ value: originalValue, placeholder = '', focus = true, mask,
             }
         }
         else if (key.ctrl && input === 'u') {
-            // CTRL-U: kill from beginning to cursor
+            // CTRL-U: kill from line start to cursor. At line start, kill the
+            // preceding newline to join with the previous line.
             if (cursorOffset > 0) {
-                nextKillBuffer = originalValue.slice(0, cursorOffset);
-                nextValue = originalValue.slice(cursorOffset);
-                nextCursorOffset = 0;
+                let lineStart = originalValue.lastIndexOf('\n', cursorOffset - 1) + 1;
+                if (lineStart === cursorOffset && cursorOffset > 0) {
+                    // Cursor at start of line — kill the preceding newline
+                    lineStart = cursorOffset - 1;
+                }
+                nextKillBuffer = originalValue.slice(lineStart, cursorOffset);
+                nextValue = originalValue.slice(0, lineStart) + originalValue.slice(cursorOffset);
+                nextCursorOffset = lineStart;
             }
         }
         else if (key.ctrl && input === 'y') {


### PR DESCRIPTION
I think this better matches what most software does with Ctrl-U for multi-line input. Without this my muscle memory makes me constantly delete my whole prompt when I'm trying to change a line, so I assume some others might have experienced this too.

If you press it at the start of a line it deletes the new line, so you can still delete the whole prompt with multiple presses or by holding.