### PR TITLE
fix(cli): correct TUI diff tab rendering

### DIFF
--- a/src/cli/components/AdvancedDiffRenderer.test.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.test.tsx
@@ -6,6 +6,7 @@ import type { AdvancedDiffSuccess } from "@/cli/helpers/diff";
 import {
   AdvancedDiffRenderer,
   buildAdvancedDiffRows,
+  exceedsAdvancedDiffHighlightLimits,
 } from "./AdvancedDiffRenderer";
 
 class CaptureStream extends Writable {
@@ -129,4 +130,16 @@ test("advanced diff renderer expands tabs before writing terminal rows", async (
   expect(output).not.toContain("\t");
   expect(output).toContain("-     const before = true;");
   expect(output).toContain("+     const after = true;");
+});
+
+test("advanced diff syntax highlighting uses Codex-sized safety limits", () => {
+  expect(
+    exceedsAdvancedDiffHighlightLimits([
+      {
+        oldStart: 1,
+        newStart: 1,
+        lines: Array.from({ length: 10_001 }, () => ({ raw: " const x = 1;" })),
+      },
+    ]),
+  ).toBe(true);
 });

--- a/src/cli/components/AdvancedDiffRenderer.test.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.test.tsx
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import type { AdvancedDiffSuccess } from "@/cli/helpers/diff";
+import {
+  AdvancedDiffRenderer,
+  buildAdvancedDiffRows,
+} from "./AdvancedDiffRenderer";
+
+class CaptureStream extends Writable {
+  columns = 80;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderAdvancedDiff(
+  precomputed: AdvancedDiffSuccess,
+): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(
+    <AdvancedDiffRenderer
+      kind="edit"
+      filePath="/tmp/example.ts"
+      oldString="old"
+      newString="new"
+      showHeader={false}
+      precomputed={precomputed}
+    />,
+    {
+      stdout,
+      stdin: createInputStream(),
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("advanced diff rows number added lines from the new file", () => {
+  const rows = buildAdvancedDiffRows([
+    {
+      oldStart: 1,
+      newStart: 1,
+      lines: [
+        { raw: " export function f() {" },
+        { raw: "-\tconst customTool = tools.find(isCustomTool);" },
+        { raw: "-" },
+        { raw: "-\tif (customTool) {" },
+        { raw: "+\tconst functionTools = [];" },
+        { raw: "+\tfor (const tool of tools) {" },
+        { raw: "+\t\tif (isCustomTool(tool)) {" },
+        { raw: ' \t\t\tthrow new Error("x");' },
+        { raw: " \t\t}" },
+        { raw: "-\treturn tools;" },
+        { raw: "+\t\tfunctionTools.push(tool);" },
+        { raw: " \t}" },
+        { raw: "+\treturn functionTools;" },
+        { raw: "+}" },
+      ],
+    },
+  ]);
+
+  const signForKind = { context: " ", remove: "-", add: "+" } as const;
+
+  expect(rows.map((row) => `${row.displayNo}${signForKind[row.kind]}`)).toEqual(
+    [
+      "1 ",
+      "2-",
+      "3-",
+      "4-",
+      "2+",
+      "3+",
+      "4+",
+      "5 ",
+      "6 ",
+      "7-",
+      "7+",
+      "8 ",
+      "9+",
+      "10+",
+    ],
+  );
+});
+
+test("advanced diff renderer expands tabs before writing terminal rows", async () => {
+  const output = await renderAdvancedDiff({
+    mode: "advanced",
+    fileName: "example.ts",
+    oldStr: "",
+    newStr: "",
+    hunks: [
+      {
+        oldStart: 1,
+        newStart: 1,
+        lines: [
+          { raw: "-\tconst before = true;" },
+          { raw: "+\tconst after = true;" },
+        ],
+      },
+    ],
+  });
+
+  expect(output).not.toContain("\t");
+  expect(output).toContain("-     const before = true;");
+  expect(output).toContain("+     const after = true;");
+});

--- a/src/cli/components/AdvancedDiffRenderer.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.tsx
@@ -1,6 +1,7 @@
 import { relative } from "node:path";
 import { Box } from "ink";
 import { useMemo } from "react";
+import stringWidth from "string-width";
 import {
   ADV_DIFF_CONTEXT_LINES,
   type AdvancedDiffSuccess,
@@ -101,6 +102,42 @@ export function exceedsAdvancedDiffHighlightLimits(
   return false;
 }
 
+function takePrefixByDisplayWidth(
+  text: string,
+  maxWidth: number,
+): { prefix: string; rest: string; width: number } {
+  if (maxWidth <= 0) {
+    return { prefix: "", rest: text, width: 0 };
+  }
+
+  let prefix = "";
+  let width = 0;
+
+  for (const char of text) {
+    const charWidth = stringWidth(char);
+    if (width + charWidth > maxWidth) {
+      break;
+    }
+    prefix += char;
+    width += charWidth;
+  }
+
+  return { prefix, rest: text.slice(prefix.length), width };
+}
+
+function takeFirstCharacter(text: string): {
+  prefix: string;
+  rest: string;
+  width: number;
+} {
+  const prefix = Array.from(text)[0] ?? "";
+  return {
+    prefix,
+    rest: text.slice(prefix.length),
+    width: stringWidth(prefix),
+  };
+}
+
 // Split styled chunks into rows of exactly `cols` characters, padding the last row.
 // Continuation rows start with a blank indent of `contIndent` characters
 // (matching Codex's empty-gutter + 2-space continuation, diff_render.rs:922-929).
@@ -112,30 +149,41 @@ function buildPaddedRows(
   if (cols <= 0) return [chunks];
   const rows: StyledChunk[][] = [];
   let row: StyledChunk[] = [];
-  let len = 0;
+  let width = 0;
   for (const chunk of chunks) {
     let rem = chunk.text;
     while (rem.length > 0) {
-      const space = cols - len;
-      if (rem.length <= space) {
+      if (width >= cols) {
+        rows.push(row);
+        row = [{ text: " ".repeat(contIndent) }];
+        width = contIndent;
+      }
+
+      const space = Math.max(1, cols - width);
+      if (stringWidth(rem) <= space) {
         row.push({ text: rem, color: chunk.color, dimColor: chunk.dimColor });
-        len += rem.length;
+        width += stringWidth(rem);
         rem = "";
       } else {
+        let next = takePrefixByDisplayWidth(rem, space);
+        if (!next.prefix) {
+          next = takeFirstCharacter(rem);
+        }
         row.push({
-          text: rem.slice(0, space),
+          text: next.prefix,
           color: chunk.color,
           dimColor: chunk.dimColor,
         });
+        width += next.width;
+        rem = next.rest;
         rows.push(row);
         // Start continuation row with blank gutter indent
         row = [{ text: " ".repeat(contIndent) }];
-        len = contIndent;
-        rem = rem.slice(space);
+        width = contIndent;
       }
     }
   }
-  if (len < cols) row.push({ text: " ".repeat(cols - len) });
+  if (width < cols) row.push({ text: " ".repeat(cols - width) });
   if (row.length > 0) rows.push(row);
   return rows;
 }

--- a/src/cli/components/AdvancedDiffRenderer.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.tsx
@@ -18,6 +18,8 @@ import {
 import { Text } from "./Text";
 
 const TAB_WIDTH = 4;
+const HIGHLIGHT_MAX_BYTES = 512 * 1024;
+const HIGHLIGHT_MAX_LINES = 10_000;
 
 type EditItem = {
   old_string: string;
@@ -73,6 +75,30 @@ export type AdvancedDiffRenderRow = {
 
 export function expandTabsForDiffDisplay(text: string): string {
   return text.replaceAll("\t", " ".repeat(TAB_WIDTH));
+}
+
+export function exceedsAdvancedDiffHighlightLimits(
+  hunks: AdvancedDiffSuccess["hunks"],
+): boolean {
+  let totalBytes = 0;
+  let totalLines = 0;
+
+  for (const hunk of hunks) {
+    for (const line of hunk.lines) {
+      const raw = line.raw || "";
+      if (raw.charAt(0) === "\\") continue;
+      totalBytes += Buffer.byteLength(raw.slice(1), "utf8");
+      totalLines += 1;
+      if (
+        totalBytes > HIGHLIGHT_MAX_BYTES ||
+        totalLines > HIGHLIGHT_MAX_LINES
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 // Split styled chunks into rows of exactly `cols` characters, padding the last row.
@@ -344,6 +370,7 @@ export function AdvancedDiffRenderer(
   // Syntax-highlight all hunk content at once per hunk (preserves parser state
   // across consecutive lines, like Codex's hunk-level highlighting approach).
   const lang = languageFromPath(filePath);
+  const shouldHighlight = lang && !exceedsAdvancedDiffHighlightLimits(hunks);
   const hunkSyntaxLines: (StyledSpan[] | undefined)[][] = [];
   for (const h of hunks) {
     // Concatenate all displayable lines in the hunk for a single highlight pass.
@@ -355,9 +382,13 @@ export function AdvancedDiffRenderer(
       textLines.push(raw.slice(1));
     }
     const block = textLines.join("\n");
-    const highlighted = lang ? highlightCode(block, lang) : undefined;
+    const highlighted = shouldHighlight
+      ? highlightCode(block, lang)
+      : undefined;
+    const syntaxLines =
+      highlighted?.length === textLines.length ? highlighted : undefined;
     // Map highlighted per-line spans back; undefined when highlighting failed.
-    hunkSyntaxLines.push(textLines.map((_, i) => highlighted?.[i]));
+    hunkSyntaxLines.push(textLines.map((_, i) => syntaxLines?.[i]));
   }
 
   const rows = buildAdvancedDiffRows(hunks, hunkSyntaxLines);

--- a/src/cli/components/AdvancedDiffRenderer.tsx
+++ b/src/cli/components/AdvancedDiffRenderer.tsx
@@ -17,6 +17,8 @@ import {
 } from "./SyntaxHighlightedCommand";
 import { Text } from "./Text";
 
+const TAB_WIDTH = 4;
+
 type EditItem = {
   old_string: string;
   new_string: string;
@@ -61,6 +63,17 @@ function padLeft(n: number, width: number): string {
 
 // A styled text chunk with optional color/dim for row-splitting.
 type StyledChunk = { text: string; color?: string; dimColor?: boolean };
+
+export type AdvancedDiffRenderRow = {
+  kind: "context" | "remove" | "add";
+  displayNo: number;
+  text: string;
+  syntaxSpans?: StyledSpan[];
+};
+
+export function expandTabsForDiffDisplay(text: string): string {
+  return text.replaceAll("\t", " ".repeat(TAB_WIDTH));
+}
 
 // Split styled chunks into rows of exactly `cols` characters, padding the last row.
 // Continuation rows start with a blank indent of `contIndent` characters
@@ -144,10 +157,13 @@ function Line({
   chunks.push({ text: " " });
   if (syntaxSpans && syntaxSpans.length > 0) {
     for (const span of syntaxSpans) {
-      chunks.push({ text: span.text, color: span.color });
+      chunks.push({
+        text: expandTabsForDiffDisplay(span.text),
+        color: span.color,
+      });
     }
   } else {
-    chunks.push({ text });
+    chunks.push({ text: expandTabsForDiffDisplay(text) });
   }
 
   // Continuation indent = indent + gutter + sign + space (blank, same width)
@@ -169,6 +185,75 @@ function Line({
       ))}
     </>
   );
+}
+
+export function buildAdvancedDiffRows(
+  hunks: AdvancedDiffSuccess["hunks"],
+  hunkSyntaxLines: (StyledSpan[] | undefined)[][] = [],
+): AdvancedDiffRenderRow[] {
+  const rows: AdvancedDiffRenderRow[] = [];
+
+  for (let hIdx = 0; hIdx < hunks.length; hIdx++) {
+    const h = hunks[hIdx];
+    if (!h) {
+      continue;
+    }
+
+    const syntaxForHunk = hunkSyntaxLines[hIdx] ?? [];
+    let oldNo = h.oldStart;
+    let newNo = h.newStart;
+    let displayLineIdx = 0; // index into syntaxForHunk
+    for (let i = 0; i < h.lines.length; i++) {
+      const line = h.lines[i];
+      if (!line) continue;
+      const raw = line.raw || "";
+      const ch = raw.charAt(0);
+      const body = raw.slice(1);
+      // Skip meta lines (e.g., "\ No newline at end of file")
+      if (ch === "\\") continue;
+
+      const spans = syntaxForHunk[displayLineIdx];
+      displayLineIdx++;
+
+      if (ch === " ") {
+        rows.push({
+          kind: "context",
+          displayNo: newNo,
+          text: body,
+          syntaxSpans: spans,
+        });
+        oldNo++;
+        newNo++;
+      } else if (ch === "-") {
+        rows.push({
+          kind: "remove",
+          displayNo: oldNo,
+          text: body,
+          syntaxSpans: spans,
+        });
+        oldNo++;
+      } else if (ch === "+") {
+        rows.push({
+          kind: "add",
+          displayNo: newNo,
+          text: body,
+          syntaxSpans: spans,
+        });
+        newNo++;
+      } else {
+        rows.push({
+          kind: "context",
+          displayNo: newNo,
+          text: raw,
+          syntaxSpans: spans,
+        });
+        oldNo++;
+        newNo++;
+      }
+    }
+  }
+
+  return rows;
 }
 
 export function AdvancedDiffRenderer(
@@ -275,74 +360,7 @@ export function AdvancedDiffRenderer(
     hunkSyntaxLines.push(textLines.map((_, i) => highlighted?.[i]));
   }
 
-  // Prepare display rows with shared-line-number behavior.
-  type Row = {
-    kind: "context" | "remove" | "add";
-    displayNo: number;
-    text: string;
-    syntaxSpans?: StyledSpan[];
-  };
-  const rows: Row[] = [];
-  for (let hIdx = 0; hIdx < hunks.length; hIdx++) {
-    const h = hunks[hIdx];
-    if (!h) {
-      continue;
-    }
-
-    const syntaxForHunk = hunkSyntaxLines[hIdx] ?? [];
-    let oldNo = h.oldStart;
-    let newNo = h.newStart;
-    let lastRemovalNo: number | null = null;
-    let displayLineIdx = 0; // index into syntaxForHunk
-    for (let i = 0; i < h.lines.length; i++) {
-      const line = h.lines[i];
-      if (!line) continue;
-      const raw = line.raw || "";
-      const ch = raw.charAt(0);
-      const body = raw.slice(1);
-      // Skip meta lines (e.g., "\ No newline at end of file")
-      if (ch === "\\") continue;
-
-      const spans = syntaxForHunk[displayLineIdx];
-      displayLineIdx++;
-
-      if (ch === " ") {
-        rows.push({
-          kind: "context",
-          displayNo: oldNo,
-          text: body,
-          syntaxSpans: spans,
-        });
-        oldNo++;
-        newNo++;
-        lastRemovalNo = null;
-      } else if (ch === "-") {
-        rows.push({
-          kind: "remove",
-          displayNo: oldNo,
-          text: body,
-          syntaxSpans: spans,
-        });
-        lastRemovalNo = oldNo;
-        oldNo++;
-      } else if (ch === "+") {
-        const displayNo = lastRemovalNo !== null ? lastRemovalNo : newNo;
-        rows.push({ kind: "add", displayNo, text: body, syntaxSpans: spans });
-        newNo++;
-        lastRemovalNo = null;
-      } else {
-        rows.push({
-          kind: "context",
-          displayNo: oldNo,
-          text: raw,
-          syntaxSpans: spans,
-        });
-        oldNo++;
-        newNo++;
-        lastRemovalNo = null;
-      }
-    }
-  }
+  const rows = buildAdvancedDiffRows(hunks, hunkSyntaxLines);
   // Compute gutter width based on the maximum display number we will render,
   // so multi-digit line numbers (e.g., 10) never wrap.
   const maxDisplayNo = rows.reduce((m, r) => Math.max(m, r.displayNo), 1);

--- a/src/cli/helpers/diff.test.ts
+++ b/src/cli/helpers/diff.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { computeAdvancedDiff } from "@/cli/helpers/diff";
+
+describe("computeAdvancedDiff", () => {
+  test("shows whitespace-only tab/space edits", () => {
+    const result = computeAdvancedDiff(
+      {
+        kind: "write",
+        filePath: "/tmp/example.ts",
+        content: "  foo();\n",
+      },
+      { oldStrOverride: "\tfoo();\n" },
+    );
+
+    expect(result.mode).toBe("advanced");
+    if (result.mode !== "advanced") throw new Error("unreachable");
+
+    expect(result.hunks).toHaveLength(1);
+    expect(result.hunks[0]?.lines).toEqual([
+      { raw: "-\tfoo();" },
+      { raw: "+  foo();" },
+    ]);
+  });
+});

--- a/src/cli/helpers/diff.ts
+++ b/src/cli/helpers/diff.ts
@@ -2,7 +2,7 @@ import { basename } from "node:path";
 import * as Diff from "diff";
 
 export const ADV_DIFF_CONTEXT_LINES = 1; // easy to adjust later
-export const ADV_DIFF_IGNORE_WHITESPACE = true; // easy to flip later
+export const ADV_DIFF_IGNORE_WHITESPACE = false; // previews must show exact edits, including tab/space-only changes
 
 export type AdvancedDiffVariant = "write" | "edit" | "multi_edit";
 


### PR DESCRIPTION
## Summary
- Make advanced diff previews whitespace-sensitive so tab/space-only edits render instead of appearing unchanged.
- Expand tabs to fixed-width spaces before TUI row wrapping and use new-file line numbers for added/context rows, matching Codex diff semantics.
- Add regression coverage for whitespace-only diffs, tab rendering, and added-line numbering.

👾 Generated with [Letta Code](https://letta.com)