### PR TITLE
fix(toolsets): use Codex tools for local ChatGPT OAuth models

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1568,6 +1568,7 @@ export function isOpenAIModel(modelIdentifier: string): boolean {
   if (info?.handle && typeof info.handle === "string") {
     return (
       info.handle.startsWith("openai/") ||
+      info.handle.startsWith("openai-codex/") ||
       info.handle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`) ||
       info.handle.startsWith("chatgpt_oauth/")
     );
@@ -1576,6 +1577,7 @@ export function isOpenAIModel(modelIdentifier: string): boolean {
   // and ChatGPT OAuth Codex provider handles.
   return (
     modelIdentifier.startsWith("openai/") ||
+    modelIdentifier.startsWith("openai-codex/") ||
     modelIdentifier.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`) ||
     modelIdentifier.startsWith("chatgpt_oauth/")
   );

--- a/src/tools/model-provider-detection.test.ts
+++ b/src/tools/model-provider-detection.test.ts
@@ -17,6 +17,10 @@ describe("isOpenAIModel", () => {
     expect(isOpenAIModel("chatgpt_oauth/gpt-5.3-codex")).toBe(true);
   });
 
+  test("detects local ChatGPT OAuth handles", () => {
+    expect(isOpenAIModel("openai-codex/gpt-5.5")).toBe(true);
+  });
+
   test("detects chatgpt-plus-pro model ids via models.json metadata", () => {
     expect(isOpenAIModel("gpt-5.3-codex-plus-pro-high")).toBe(true);
   });
@@ -36,6 +40,10 @@ describe("isOpenAIModel", () => {
 describe("deriveToolsetFromModel", () => {
   test("maps chatgpt_oauth handles to codex toolset", () => {
     expect(deriveToolsetFromModel("chatgpt_oauth/gpt-5.3-codex")).toBe("codex");
+  });
+
+  test("maps local ChatGPT OAuth handles to codex toolset", () => {
+    expect(deriveToolsetFromModel("openai-codex/gpt-5.5")).toBe("codex");
   });
 
   test("maps Gemini models to default (anthropic) toolset", () => {


### PR DESCRIPTION
## Summary
- Treat local `openai-codex/*` ChatGPT OAuth handles as OpenAI-family models for auto toolset derivation.
- Add regression coverage so selecting local GPT-5.5 maps to the Codex toolset instead of Claude/default.

## Test plan
- [x] `bun test src/tools/model-provider-detection.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)