### PR TITLE
feat(extensions): add startup disable switch

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -330,6 +330,7 @@ export function App({
   releaseNotes = null,
   updateNotification = null,
   systemInfoReminderEnabled = true,
+  extensionsDisabled = false,
   onReload,
 }: AppProps) {
   // Warm the model-access cache in the background so /model is fast on first open.
@@ -2287,7 +2288,9 @@ export function App({
       statusLinePayload,
     ],
   );
-  const extensionRuntime = useLocalExtensionRuntime(extensionContext);
+  const extensionRuntime = useLocalExtensionRuntime(extensionContext, {
+    disabled: extensionsDisabled,
+  });
 
   useEffect(() => {
     extensionRuntimeRef.current = extensionRuntime;

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -47,6 +47,7 @@ export type AppProps = {
   releaseNotes?: string | null; // Markdown release notes to display above header
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;
+  extensionsDisabled?: boolean;
   /** Callback to soft-restart the TUI (re-runs startup path, remounts App). */
   onReload?: (agentId: string, conversationId: string) => Promise<void>;
 };

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -49,12 +49,16 @@ describe("shared CLI arg schema", () => {
     expect(interactiveFlags).not.toContain("memfs-startup");
     expect(headlessFlags).toContain("agent");
     expect(interactiveFlags).toContain("agent");
+    expect(headlessFlags).toContain("no-extensions");
+    expect(interactiveFlags).toContain("no-extensions");
   });
 
   test("rendered OPTIONS help is generated from catalog metadata", () => {
     const help = renderCliOptionsHelp();
     expect(help).toContain("-h, --help");
     expect(help).toContain("--backend <mode>");
+    expect(help).toContain("--no-extensions");
+    expect(help).toContain("LETTA_DISABLE_EXTENSIONS=1 letta");
     expect(help).toContain("--memfs-startup <m>");
     expect(help).toContain("Default: text");
     expect(help).not.toContain("--run");
@@ -131,6 +135,14 @@ describe("shared CLI arg schema", () => {
       true,
     );
     expect(parsed.values["disable-memory-guard"]).toBe(true);
+  });
+
+  test("recognizes no-extensions as a boolean recovery flag", () => {
+    const parsed = parseCliArgs(
+      preprocessCliArgs(["node", "script", "--no-extensions", "-p", "hi"]),
+      true,
+    );
+    expect(parsed.values["no-extensions"]).toBe(true);
   });
 
   test("validates backend mode values", () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -266,6 +266,14 @@ export const CLI_FLAG_CATALOG = {
         "Disable first-turn environment reminder (device/git/cwd context)",
     },
   },
+  "no-extensions": {
+    parser: { type: "boolean" },
+    mode: "both",
+    help: {
+      description: "Disable local extensions for this session",
+      continuationLines: ["Recovery alias: LETTA_DISABLE_EXTENSIONS=1 letta"],
+    },
+  },
   "reflection-trigger": {
     parser: { type: "string" },
     mode: "both",

--- a/src/cli/extensions/use-local-extension-runtime.ts
+++ b/src/cli/extensions/use-local-extension-runtime.ts
@@ -64,11 +64,13 @@ function createExtensionBackendApi(
 
 export function useLocalExtensionRuntime(
   initialContext: ExtensionContext,
+  options: { disabled?: boolean } = {},
 ): LocalExtensionRuntime {
   // biome-ignore lint/correctness/useExhaustiveDependencies: the runtime is process-local; context updates are pushed through updateContext below.
   const runtime = useMemo(
     () =>
       createExtensionRuntime({
+        disabled: options.disabled,
         getBackendApi: () => createExtensionBackendApi(getBackend()),
         getClient,
         initialContext,

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -16,6 +16,22 @@ export const DEFAULT_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   },
 };
 
+export const DISABLED_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: false,
+  commands: false,
+  events: {
+    lifecycle: false,
+    tools: false,
+    turns: false,
+  },
+  providers: false,
+  ui: {
+    panels: false,
+    statusValues: false,
+    customStatuslineRenderer: false,
+  },
+};
+
 export function cloneExtensionCapabilities(
   capabilities: ExtensionCapabilities,
 ): ExtensionCapabilities {

--- a/src/extensions/disable.test.ts
+++ b/src/extensions/disable.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  areExtensionsDisabled,
+  LETTA_DISABLE_EXTENSIONS_ENV,
+  shouldDisableExtensions,
+} from "@/extensions/disable";
+
+describe("extension disable switch", () => {
+  test("recognizes CLI flag and common truthy env values", () => {
+    expect(shouldDisableExtensions({ cliFlag: true, env: {} })).toBe(true);
+    expect(shouldDisableExtensions({ cliFlag: false, env: {} })).toBe(false);
+
+    for (const value of ["1", "true", "TRUE", "yes", "on"] as const) {
+      expect(
+        areExtensionsDisabled({ [LETTA_DISABLE_EXTENSIONS_ENV]: value }),
+      ).toBe(true);
+    }
+
+    for (const value of ["", "0", "false", "off", "no"] as const) {
+      expect(
+        areExtensionsDisabled({ [LETTA_DISABLE_EXTENSIONS_ENV]: value }),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/extensions/disable.ts
+++ b/src/extensions/disable.ts
@@ -1,0 +1,26 @@
+export const LETTA_DISABLE_EXTENSIONS_ENV = "LETTA_DISABLE_EXTENSIONS";
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(normalized);
+}
+
+export function areExtensionsDisabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isTruthyEnvFlag(env[LETTA_DISABLE_EXTENSIONS_ENV]);
+}
+
+export function shouldDisableExtensions(options?: {
+  cliFlag?: boolean;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  return Boolean(
+    options?.cliFlag || areExtensionsDisabled(options?.env ?? process.env),
+  );
+}
+
+export function disableExtensionsForProcess(): void {
+  process.env[LETTA_DISABLE_EXTENSIONS_ENV] = "1";
+}

--- a/src/extensions/event-emitter.ts
+++ b/src/extensions/event-emitter.ts
@@ -17,7 +17,7 @@ export type ExtensionEventEmitter = {
   getSnapshot: () => ExtensionRuntimeEventSnapshot;
 };
 
-function emptyEventEmissionResult<TName extends ExtensionEventName>(
+export function emptyEventEmissionResult<TName extends ExtensionEventName>(
   name: TName,
 ): ExtensionEventEmissionResult<TName> {
   return { diagnostics: [], handlerCount: 0, name, results: [] };

--- a/src/extensions/extension-runtime.test.ts
+++ b/src/extensions/extension-runtime.test.ts
@@ -103,6 +103,7 @@ describe("extension runtime", () => {
   test("disabled runtime does not load extensions or expose extension capabilities", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ExtensionRuntimeTestGlobal;
+    const originalDisableEnv = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
 
     try {
       const extensionDir = path.join(root, "global-extensions");
@@ -179,6 +180,24 @@ describe("extension runtime", () => {
         globalExtensionsDirectory: extensionDir,
         initialContext: createExtensionContext(),
       });
+      registerExtensionTool({
+        activationSignal: new AbortController().signal,
+        description: "Post-disable tool",
+        getContext: () => createExtensionContext(),
+        isAvailable: () => true,
+        name: "post_disabled_extension_tool",
+        owner: {
+          generation: 0,
+          id: "test:post-disabled",
+          path: "post-disabled.ts",
+          scope: "global",
+        },
+        parameters: { type: "object", properties: {} },
+        parallelSafe: false,
+        path: "post-disabled.ts",
+        requiresApproval: false,
+        run: () => "post-disabled",
+      });
 
       expect(runtime.getSnapshot()).toMatchObject({
         hadStatuslineRenderer: false,
@@ -208,11 +227,20 @@ describe("extension runtime", () => {
       expect(
         getExtensionToolDefinition("stale_extension_tool"),
       ).toBeUndefined();
+      expect(
+        getExtensionToolDefinition("post_disabled_extension_tool"),
+      ).toBeUndefined();
+      expect(process.env[LETTA_DISABLE_EXTENSIONS_ENV]).toBe("1");
       expect(listRegisteredPiProviders()).toEqual([]);
     } finally {
       delete testGlobal.__lettaDisabledExtensionLoaded;
       clearExtensionTools();
       clearRegisteredPiProviders();
+      if (originalDisableEnv === undefined) {
+        delete process.env[LETTA_DISABLE_EXTENSIONS_ENV];
+      } else {
+        process.env[LETTA_DISABLE_EXTENSIONS_ENV] = originalDisableEnv;
+      }
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/extensions/extension-runtime.test.ts
+++ b/src/extensions/extension-runtime.test.ts
@@ -3,7 +3,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
+import {
+  clearRegisteredPiProviders,
+  listRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-extension-registry";
+import { DISABLED_EXTENSION_CAPABILITIES } from "@/extensions/capabilities";
+import { LETTA_DISABLE_EXTENSIONS_ENV } from "@/extensions/disable";
 import { createExtensionRuntime } from "@/extensions/extension-runtime";
+import {
+  clearExtensionTools,
+  getExtensionToolDefinition,
+  registerExtensionTool,
+} from "@/extensions/tool-registry";
 import type {
   ExtensionContext,
   ExtensionRuntimeBackendApi,
@@ -11,6 +23,7 @@ import type {
 
 type ExtensionRuntimeTestGlobal = typeof globalThis & {
   __lettaRuntimeEvents?: string[];
+  __lettaDisabledExtensionLoaded?: boolean;
 };
 
 function createTempDir(): string {
@@ -62,6 +75,148 @@ function createExtensionContext(agentName = "Amelia"): ExtensionContext {
 }
 
 describe("extension runtime", () => {
+  test("LETTA_DISABLE_EXTENSIONS disables the runtime", () => {
+    const original = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
+    try {
+      process.env[LETTA_DISABLE_EXTENSIONS_ENV] = "1";
+      const runtime = createExtensionRuntime({
+        getClient: async () => ({}) as unknown as Letta,
+        initialContext: createExtensionContext(),
+      });
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        hasExtensionSources: false,
+        isLoading: false,
+      });
+      expect(runtime.getSnapshot().registry.capabilities).toEqual(
+        DISABLED_EXTENSION_CAPABILITIES,
+      );
+    } finally {
+      if (original === undefined) {
+        delete process.env[LETTA_DISABLE_EXTENSIONS_ENV];
+      } else {
+        process.env[LETTA_DISABLE_EXTENSIONS_ENV] = original;
+      }
+    }
+  });
+
+  test("disabled runtime does not load extensions or expose extension capabilities", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ExtensionRuntimeTestGlobal;
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "disabled.ts"),
+        `export default function(letta) {
+          globalThis.__lettaDisabledExtensionLoaded = true;
+          letta.tools.register({
+            name: "disabled_tool",
+            description: "Should not load",
+            parameters: { type: "object", properties: {} },
+            run() { return "loaded"; },
+          });
+          letta.providers.register("disabled-provider", {
+            api: "openai-completions",
+            baseUrl: "http://localhost:8000/v1",
+            apiKey: "not-needed",
+            models: [{
+              id: "disabled-model",
+              name: "Disabled Model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 1000,
+              maxTokens: 1000,
+            }],
+          });
+        }`,
+      );
+      registerExtensionTool({
+        activationSignal: new AbortController().signal,
+        description: "Stale tool",
+        getContext: () => createExtensionContext(),
+        isAvailable: () => true,
+        name: "stale_extension_tool",
+        owner: {
+          generation: 0,
+          id: "test:stale",
+          path: "stale.ts",
+          scope: "global",
+        },
+        parameters: { type: "object", properties: {} },
+        parallelSafe: false,
+        path: "stale.ts",
+        requiresApproval: false,
+        run: () => "stale",
+      });
+      registerPiProvider("stale-provider", {
+        api: "openai-completions",
+        apiKey: "not-needed",
+        baseUrl: "http://localhost:8000/v1",
+        models: [
+          {
+            id: "stale-model",
+            name: "Stale Model",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 1000,
+            maxTokens: 1000,
+          },
+        ],
+      });
+
+      const runtime = createExtensionRuntime({
+        cacheDirectory: path.join(root, "extension-cache"),
+        disabled: true,
+        getClient: async () => {
+          throw new Error(
+            "client should not initialize when extensions are disabled",
+          );
+        },
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      expect(runtime.getSnapshot()).toMatchObject({
+        hadStatuslineRenderer: false,
+        hasExtensionSources: false,
+        isLoading: false,
+      });
+      expect(runtime.getSnapshot().registry.capabilities).toEqual(
+        DISABLED_EXTENSION_CAPABILITIES,
+      );
+      expect(runtime.getSnapshot().registry.sources).toEqual([]);
+
+      await runtime.reload();
+      const result = await runtime.emitEvent("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+
+      expect(result.handlerCount).toBe(0);
+      expect(testGlobal.__lettaDisabledExtensionLoaded).toBeUndefined();
+      expect(runtime.getSnapshot().registry.loadedPaths).toEqual([]);
+      expect(runtime.getSnapshot().registry.commands).toEqual({});
+      expect(runtime.getSnapshot().registry.tools).toEqual({});
+      expect(runtime.getSnapshot().registry.ui.panels).toEqual({});
+      expect(runtime.getSnapshot().registry.ui.statuslineRenderer).toBeNull();
+      expect(
+        getExtensionToolDefinition("stale_extension_tool"),
+      ).toBeUndefined();
+      expect(listRegisteredPiProviders()).toEqual([]);
+    } finally {
+      delete testGlobal.__lettaDisabledExtensionLoaded;
+      clearExtensionTools();
+      clearRegisteredPiProviders();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("loads extensions and dispatches events with fresh context and backend", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ExtensionRuntimeTestGlobal;

--- a/src/extensions/extension-runtime.ts
+++ b/src/extensions/extension-runtime.ts
@@ -4,7 +4,10 @@ import {
   cloneExtensionCapabilities,
   DISABLED_EXTENSION_CAPABILITIES,
 } from "@/extensions/capabilities";
-import { areExtensionsDisabled } from "@/extensions/disable";
+import {
+  areExtensionsDisabled,
+  disableExtensionsForProcess,
+} from "@/extensions/disable";
 import {
   type ExtensionEventEmitter,
   emptyEventEmissionResult,
@@ -198,6 +201,10 @@ function createLazyRuntimeBackendApi(
 export function createExtensionRuntime(
   options: CreateExtensionRuntimeOptions,
 ): ExtensionRuntime {
+  if (options.disabled) {
+    disableExtensionsForProcess();
+  }
+
   if (options.disabled || areExtensionsDisabled()) {
     return createDisabledExtensionRuntime(options);
   }

--- a/src/extensions/extension-runtime.ts
+++ b/src/extensions/extension-runtime.ts
@@ -1,11 +1,22 @@
 import type Letta from "@letta-ai/letta-client";
-import type { ExtensionEventEmitter } from "@/extensions/event-emitter";
+import { clearRegisteredPiProviders } from "@/backend/dev/pi-provider-extension-registry";
+import {
+  cloneExtensionCapabilities,
+  DISABLED_EXTENSION_CAPABILITIES,
+} from "@/extensions/capabilities";
+import { areExtensionsDisabled } from "@/extensions/disable";
+import {
+  type ExtensionEventEmitter,
+  emptyEventEmissionResult,
+} from "@/extensions/event-emitter";
 import {
   type CreateExtensionHostOptions,
   createExtensionHost,
   type ExtensionHost,
+  type LocalExtensionRegistry,
   resolveLocalExtensionSources,
 } from "@/extensions/extension-host";
+import { clearExtensionTools } from "@/extensions/tool-registry";
 import type {
   ExtensionContext,
   ExtensionEventEmissionResult,
@@ -27,9 +38,105 @@ export interface ExtensionRuntimeSnapshot extends ExtensionRuntimeLoadState {
 
 export interface CreateExtensionRuntimeOptions
   extends Omit<CreateExtensionHostOptions, "backend" | "getContext"> {
+  disabled?: boolean;
   getBackendApi?: () => ExtensionRuntimeBackendApi | undefined;
   getClient: () => Promise<Letta>;
   initialContext: ExtensionContext;
+}
+
+function createDisabledExtensionRegistry(): LocalExtensionRegistry {
+  return {
+    capabilities: cloneExtensionCapabilities(DISABLED_EXTENSION_CAPABILITIES),
+    commands: {},
+    diagnostics: [],
+    disposers: [],
+    errors: [],
+    events: {},
+    generation: 0,
+    loadedPaths: [],
+    ownerAbortControllers: {},
+    owners: {},
+    sources: [],
+    tools: {},
+    ui: {
+      panels: {},
+      statuslineRenderer: null,
+      statusOwners: {},
+      statusValues: {},
+    },
+  };
+}
+
+function createDisabledExtensionHost(
+  registry: LocalExtensionRegistry,
+): ExtensionHost {
+  return {
+    dispose() {},
+    emitEvent(name) {
+      return Promise.resolve(emptyEventEmissionResult(name));
+    },
+    getSnapshot() {
+      return registry;
+    },
+    reload() {
+      return Promise.resolve();
+    },
+    subscribe() {
+      return () => undefined;
+    },
+  };
+}
+
+function createDisabledExtensionRuntime(
+  options: CreateExtensionRuntimeOptions,
+): ExtensionRuntime {
+  clearExtensionTools();
+  clearRegisteredPiProviders();
+
+  let context = options.initialContext;
+  const registry = createDisabledExtensionRegistry();
+  const host = createDisabledExtensionHost(registry);
+  const snapshot: ExtensionRuntimeSnapshot = {
+    hadStatuslineRenderer: false,
+    hasExtensionSources: false,
+    isLoading: false,
+    registry,
+  };
+  const eventEmitter: ExtensionEventEmitter = {
+    emitEvent(name) {
+      return Promise.resolve(emptyEventEmissionResult(name));
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+  };
+
+  return {
+    dispose() {},
+    emitEvent(name) {
+      return Promise.resolve(emptyEventEmissionResult(name));
+    },
+    eventEmitter,
+    getBackendApi() {
+      return undefined;
+    },
+    getContext() {
+      return context;
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+    host,
+    reload() {
+      return Promise.resolve();
+    },
+    subscribe() {
+      return () => undefined;
+    },
+    updateContext(nextContext) {
+      context = nextContext;
+    },
+  };
 }
 
 export interface ExtensionRuntime {
@@ -91,6 +198,10 @@ function createLazyRuntimeBackendApi(
 export function createExtensionRuntime(
   options: CreateExtensionRuntimeOptions,
 ): ExtensionRuntime {
+  if (options.disabled || areExtensionsDisabled()) {
+    return createDisabledExtensionRuntime(options);
+  }
+
   const {
     getBackendApi: resolveBackendApi,
     initialContext,

--- a/src/extensions/tool-registry.ts
+++ b/src/extensions/tool-registry.ts
@@ -4,6 +4,7 @@ import type {
   ExtensionToolRunContext,
   ExtensionToolRunResult,
 } from "@/extensions/types";
+import { areExtensionsDisabled } from "./disable";
 
 const EXTENSION_TOOLS_KEY = Symbol.for("@letta/extensionTools");
 
@@ -32,6 +33,8 @@ export function getAvailableExtensionToolsRegistry(): Map<
   string,
   ExtensionToolDefinition
 > {
+  if (areExtensionsDisabled()) return new Map();
+
   return new Map(
     Array.from(getMutableExtensionToolsRegistry().entries()).filter(
       ([, tool]) => {
@@ -47,6 +50,7 @@ export function getAvailableExtensionToolsRegistry(): Map<
 }
 
 export function registerExtensionTool(tool: ExtensionToolDefinition): void {
+  if (areExtensionsDisabled()) return;
   getMutableExtensionToolsRegistry().set(tool.name, tool);
 }
 
@@ -81,6 +85,7 @@ export function getExtensionToolDefinition(
     ExtensionToolDefinition
   > = getMutableExtensionToolsRegistry(),
 ): ExtensionToolDefinition | undefined {
+  if (areExtensionsDisabled()) return undefined;
   return registry.get(name);
 }
 
@@ -91,6 +96,7 @@ export function extensionToolRequiresApproval(
     ExtensionToolDefinition
   > = getMutableExtensionToolsRegistry(),
 ): boolean | undefined {
+  if (areExtensionsDisabled()) return undefined;
   return registry.get(name)?.requiresApproval;
 }
 
@@ -101,6 +107,7 @@ export function isExtensionToolParallelSafe(
     ExtensionToolDefinition
   > = getMutableExtensionToolsRegistry(),
 ): boolean {
+  if (areExtensionsDisabled()) return false;
   return registry.get(name)?.parallelSafe === true;
 }
 

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Backend } from "@/backend";
+import { LETTA_DISABLE_EXTENSIONS_ENV } from "@/extensions/disable";
 import {
   clearExtensionTools,
   getExtensionToolDefinition,
@@ -205,6 +206,7 @@ describe("headless extension runtime", () => {
     const root = mkdtempSync(
       path.join(tmpdir(), "letta-headless-ext-disabled-"),
     );
+    const originalDisableEnv = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
     const extensionDir = path.join(root, "global-extensions");
     const toolName = "disabled_headless_tool";
     const agent = {
@@ -255,9 +257,15 @@ describe("headless extension runtime", () => {
       expect(snapshot.registry.tools).toEqual({});
       expect(snapshot.registry.ui.statuslineRenderer).toBeNull();
       expect(getExtensionToolDefinition(toolName)).toBeUndefined();
+      expect(process.env[LETTA_DISABLE_EXTENSIONS_ENV]).toBe("1");
 
       runtime.dispose();
     } finally {
+      if (originalDisableEnv === undefined) {
+        delete process.env[LETTA_DISABLE_EXTENSIONS_ENV];
+      } else {
+        process.env[LETTA_DISABLE_EXTENSIONS_ENV] = originalDisableEnv;
+      }
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -201,6 +201,67 @@ describe("headless extension runtime", () => {
     }
   });
 
+  test("disabled headless runtime skips extension loading", async () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), "letta-headless-ext-disabled-"),
+    );
+    const extensionDir = path.join(root, "global-extensions");
+    const toolName = "disabled_headless_tool";
+    const agent = {
+      id: "agent-1",
+      name: "Amelia",
+      llm_config: { model: "anthropic/claude-sonnet-4" },
+    } as AgentState;
+    const backend = {
+      forkConversation: async () => ({ id: "forked" }),
+      sendMessageStream: async () => (async function* () {})(),
+    } as unknown as Backend;
+
+    try {
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "headless-tool.ts"),
+        `export default function activate(letta) {
+          letta.tools.register({
+            name: "${toolName}",
+            description: "Should not load",
+            parameters: { type: "object", properties: {} },
+            run() { return "loaded"; },
+          });
+          letta.commands.register({
+            id: "hidden_disabled_command",
+            description: "Should not load",
+            run() { return { type: "handled" }; },
+          });
+          letta.ui.setStatuslineRenderer(() => "hidden");
+        }`,
+      );
+
+      const runtime = createHeadlessExtensionRuntime({
+        agent,
+        backend,
+        cacheDirectory: path.join(root, "extension-cache"),
+        conversationId: "default",
+        disabled: true,
+        globalExtensionsDirectory: extensionDir,
+      });
+
+      await runtime.reload();
+      const snapshot = runtime.getSnapshot();
+
+      expect(snapshot.hasExtensionSources).toBe(false);
+      expect(snapshot.registry.loadedPaths).toEqual([]);
+      expect(snapshot.registry.commands).toEqual({});
+      expect(snapshot.registry.tools).toEqual({});
+      expect(snapshot.registry.ui.statuslineRenderer).toBeNull();
+      expect(getExtensionToolDefinition(toolName)).toBeUndefined();
+
+      runtime.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("emits tool_start before built-in tool execution", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "letta-headless-tool-start-"));
     const extensionDir = path.join(root, "global-extensions");

--- a/src/headless-extension-runtime.ts
+++ b/src/headless-extension-runtime.ts
@@ -164,6 +164,7 @@ export function createHeadlessExtensionRuntime(options: {
   backend: Backend;
   cacheDirectory?: string;
   conversationId: string;
+  disabled?: boolean;
   globalExtensionsDirectory?: string;
   permissionMode?: string | null;
   reflectionSettings?: ReflectionSettings;
@@ -174,6 +175,7 @@ export function createHeadlessExtensionRuntime(options: {
       ? { cacheDirectory: options.cacheDirectory }
       : {}),
     capabilities: HEADLESS_EXTENSION_CAPABILITIES,
+    disabled: options.disabled,
     getBackendApi: () => createHeadlessExtensionBackendApi(options.backend),
     getClient,
     ...(options.globalExtensionsDirectory

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -106,6 +106,10 @@ import {
   validateRegistryHandleOrThrow,
 } from "./cli/startup-flag-validation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
+import {
+  disableExtensionsForProcess,
+  shouldDisableExtensions,
+} from "./extensions/disable";
 import type { ExtensionRuntime } from "./extensions/extension-runtime";
 import type { ExtensionConversationOpenReason } from "./extensions/types";
 import {
@@ -549,6 +553,12 @@ export async function handleHeadlessCommand(
 ) {
   const { values, positionals } = parsedArgs;
   telemetry.setSurface(getTerminalTelemetrySurface(true));
+  const extensionsDisabled = shouldDisableExtensions({
+    cliFlag: values["no-extensions"],
+  });
+  if (extensionsDisabled) {
+    disableExtensionsForProcess();
+  }
 
   // Set tool filter if provided (controls which tools are loaded)
   if (values.tools !== undefined) {
@@ -1675,6 +1685,7 @@ export async function handleHeadlessCommand(
     permissionMode: headlessPermissionMode,
     reflectionSettings: effectiveReflectionSettings,
     sessionStats,
+    disabled: extensionsDisabled,
   });
   await headlessExtensionRuntime.reload();
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,10 @@ import {
 } from "./cli/startup-flag-validation";
 import { runSubcommand } from "./cli/subcommands/router";
 import {
+  disableExtensionsForProcess,
+  shouldDisableExtensions,
+} from "./extensions/disable";
+import {
   migratePermissionMode,
   permissionMode,
   VALID_PERMISSION_MODES,
@@ -847,6 +851,12 @@ async function main(): Promise<void> {
   const noBundledSkillsFlag = values["no-bundled-skills"];
   const skillSourcesRaw = values["skill-sources"];
   const noSystemInfoReminderFlag = values["no-system-info-reminder"];
+  const extensionsDisabled = shouldDisableExtensions({
+    cliFlag: values["no-extensions"],
+  });
+  if (extensionsDisabled) {
+    disableExtensionsForProcess();
+  }
   const resolvedSkillSources = (() => {
     try {
       return resolveSkillSourcesSelection({
@@ -2798,6 +2808,7 @@ async function main(): Promise<void> {
         startupHasAvailableLocalModels,
         releaseNotes,
         systemInfoReminderEnabled: !noSystemInfoReminderFlag,
+        extensionsDisabled,
       });
     }
 
@@ -2821,6 +2832,7 @@ async function main(): Promise<void> {
       releaseNotes,
       updateNotification,
       systemInfoReminderEnabled: !noSystemInfoReminderFlag,
+      extensionsDisabled,
       onReload: handleReload,
     });
   }

--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -44,7 +44,7 @@ Default to a **tool** when the model should decide when to use the capability. D
 5. Write a single-file extension unless the user asks for something larger.
 6. Return disposers for registered commands/tools/events, timers, subscriptions, and panels that should close on reload.
 7. Do a basic review: valid names, descriptions present, schemas are object schemas, optional capabilities guarded, scoped APIs used, cleanup returned.
-8. Tell the user the absolute file path changed and to run `/reload`.
+8. Tell the user the absolute file path changed and to run `/reload`. If an extension breaks startup or command handling, recover with `letta --no-extensions` or `LETTA_DISABLE_EXTENSIONS=1 letta`.
 
 ## Core extension shape
 


### PR DESCRIPTION
## Summary
- add `--no-extensions` and `LETTA_DISABLE_EXTENSIONS=1` as startup-level recovery switches
- bypass extension source resolution/loading with an empty no-op runtime when extensions are disabled
- disable extension tools, commands, providers, events, panels, status values, and statusline renderer
- make the runtime disabled option activate the same process-wide disable flag used by extension registries
- gate the extension tool registry so stale or post-disable extension tools do not appear while disabled
- document the recovery path in the extension authoring skill

## Tests
- `bun test src/extensions/disable.test.ts src/extensions/extension-runtime.test.ts src/headless-extension-lifecycle.test.ts src/cli/args.test.ts`
- `bun test src/cli/extensions/local-extension-loader.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/extensions/disable.ts src/extensions/disable.test.ts src/extensions/capabilities.ts src/extensions/event-emitter.ts src/extensions/extension-runtime.ts src/extensions/extension-runtime.test.ts src/extensions/tool-registry.ts src/cli/args.ts src/cli/args.test.ts src/index.ts src/headless.ts src/headless-extension-runtime.ts src/headless-extension-lifecycle.test.ts src/cli/extensions/use-local-extension-runtime.ts src/cli/app/AppCoordinator.tsx src/cli/app/types.ts src/skills/builtin/creating-extensions/SKILL.md`
- `bun run check:cycles`
- `bun run check:boundaries`
- `bun run check:exported-functions`
- `git diff --check`

Note: full `bun run typecheck` is currently blocked by existing unrelated `@pierre/diffs` errors in `src/web/generate-diff-viewer.ts`.