### PR TITLE
fix(ci): stabilize flaky test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,10 @@ jobs:
 
       - name: Run integration tests (API)
         # Only run on push to main or non-Dependabot PRs from the same repo
-        # (fork and Dependabot PRs cannot access secrets).
-        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        # (fork and Dependabot PRs cannot access secrets). Live API integration
+        # tests exercise API/client behavior, not OS-specific packaging, so run
+        # them once instead of multiplying provider load across the full matrix.
+        if: ${{ matrix.name == 'Linux x64 (ubuntu-24.04)' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)) }}
         env:
           LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
         run: bun test src/integration-tests --timeout 15000

--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -57,7 +57,20 @@ const channelTestFiles = findTestFiles("src/channels", [
   "src/channels/slack-media.test.ts",
 ]);
 
-const opts = { stdio: "inherit", shell: process.platform === "win32" };
+const testEnv = {
+  ...process.env,
+  // Unit tests should not touch the OS keychain. On hosted macOS runners,
+  // Bun.secrets can report available and then hang on set/delete operations,
+  // causing unrelated channel tests to hit Bun's per-test timeout and leaving
+  // live handles that keep the whole job open until the GitHub step timeout.
+  LETTA_SKIP_KEYCHAIN_CHECK: process.env.LETTA_SKIP_KEYCHAIN_CHECK ?? "1",
+};
+
+const opts = {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+  env: testEnv,
+};
 let exitCode = 0;
 
 // Run slack-media in isolation first (clean module registry)

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { createAuthenticatedCliTestEnv } from "@/test-utils/test-process-env";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 import type {
   ResultMessage,
   StreamEvent,
   SystemInitMessage,
 } from "@/types/protocol";
-import {
-  formatAttemptDiagnostics,
-  formatCapturedOutput,
-} from "./process-diagnostics";
+import { formatCapturedOutput } from "./process-diagnostics";
 
 /**
  * Tests for stream-json output format.
@@ -19,69 +19,56 @@ import {
 async function runHeadlessCommandOnce(
   prompt: string,
   extraArgs: string[] = [],
-  timeoutMs = 90000, // Keep two retry attempts within Bun's 200s test timeout
+  timeoutMs = 15000,
 ): Promise<{
   lines: string[];
   stdout: string;
   stderr: string;
 }> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(
-      "bun",
-      [
-        "run",
-        "dev",
-        "--new-agent",
-        "--no-memfs",
-        "-p",
-        prompt,
-        "--output-format",
-        "stream-json",
-        "--yolo",
-        "-m",
-        "sonnet-4.6-low",
-        ...extraArgs,
-      ],
-      {
-        cwd: process.cwd(),
-        env: createAuthenticatedCliTestEnv(),
-      },
-    );
-
-    let stdout = "";
-    let stderr = "";
-
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-
-    // Safety timeout for CI
-    const timeout = setTimeout(() => {
-      proc.kill();
-      reject(
-        new Error(
-          `Process timeout after ${timeoutMs}ms.\n${formatCapturedOutput({
-            stdout,
-            stderr,
-            extra: {
-              args: extraArgs.join(" "),
-              saw_result_event: stdout.includes('"type":"result"'),
-            },
-          })}`,
-        ),
+  const devBackendDir = await mkdtemp(join(tmpdir(), "letta-stream-json-"));
+  try {
+    return await new Promise((resolve, reject) => {
+      const proc = spawn(
+        "bun",
+        [
+          "run",
+          "dev",
+          "--dev-backend",
+          "fake-headless",
+          "--new-agent",
+          "--no-memfs",
+          "-p",
+          prompt,
+          "--output-format",
+          "stream-json",
+          "--yolo",
+          ...extraArgs,
+        ],
+        {
+          cwd: process.cwd(),
+          env: createIsolatedCliTestEnv({
+            LETTA_CODE_DEV_BACKEND_DIR: devBackendDir,
+          }),
+        },
       );
-    }, timeoutMs);
 
-    proc.on("close", (code) => {
-      clearTimeout(timeout);
-      if (code !== 0 && !stdout.includes('"type":"result"')) {
+      let stdout = "";
+      let stderr = "";
+
+      proc.stdout.on("data", (data) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      // Safety timeout for CI
+      const timeout = setTimeout(() => {
+        proc.kill();
         reject(
           new Error(
-            `Process exited with code ${code}.\n${formatCapturedOutput({
+            `Process timeout after ${timeoutMs}ms.\n${formatCapturedOutput({
               stdout,
               stderr,
               extra: {
@@ -91,102 +78,76 @@ async function runHeadlessCommandOnce(
             })}`,
           ),
         );
-      } else {
-        // Parse line-delimited JSON
-        const lines = stdout
-          .split("\n")
-          .filter((line) => line.trim())
-          .filter((line) => {
-            try {
-              JSON.parse(line);
-              return true;
-            } catch {
-              return false;
-            }
-          });
-        resolve({ lines, stdout, stderr });
-      }
+      }, timeoutMs);
+
+      proc.on("close", (code) => {
+        clearTimeout(timeout);
+        if (code !== 0 && !stdout.includes('"type":"result"')) {
+          reject(
+            new Error(
+              `Process exited with code ${code}.\n${formatCapturedOutput({
+                stdout,
+                stderr,
+                extra: {
+                  args: extraArgs.join(" "),
+                  saw_result_event: stdout.includes('"type":"result"'),
+                },
+              })}`,
+            ),
+          );
+        } else {
+          // Parse line-delimited JSON
+          const lines = stdout
+            .split("\n")
+            .filter((line) => line.trim())
+            .filter((line) => {
+              try {
+                JSON.parse(line);
+                return true;
+              } catch {
+                return false;
+              }
+            });
+          resolve({ lines, stdout, stderr });
+        }
+      });
     });
-  });
+  } finally {
+    await rm(devBackendDir, { recursive: true, force: true });
+  }
 }
 
 async function runHeadlessCommand(
   prompt: string,
   extraArgs: string[] = [],
-  timeoutMs = 90000,
+  timeoutMs = 15000,
 ): Promise<string[]> {
-  const maxRetries = 1;
-  const failedAttempts: Array<{ attempt: number; message: string }> = [];
-
-  for (let attempt = 0; ; attempt += 1) {
-    let result: Awaited<ReturnType<typeof runHeadlessCommandOnce>>;
+  const result = await runHeadlessCommandOnce(prompt, extraArgs, timeoutMs);
+  const hasResultLine = result.lines.some((line) => {
     try {
-      result = await runHeadlessCommandOnce(prompt, extraArgs, timeoutMs);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      failedAttempts.push({
-        attempt: attempt + 1,
-        message,
-      });
-
-      const isRetriableError =
-        error instanceof Error &&
-        (error.message.includes("Process timeout after") ||
-          error.message.includes("without a result envelope"));
-
-      if (!isRetriableError || attempt >= maxRetries) {
-        throw new Error(
-          failedAttempts.length === 1
-            ? message
-            : `${message}\n${formatAttemptDiagnostics(
-                failedAttempts.slice(0, -1),
-              )}`,
-        );
-      }
-
-      console.warn(
-        `[headless-stream-json] retrying after transient/incomplete run (${attempt + 1}/${maxRetries})`,
-      );
-      continue;
+      const obj = JSON.parse(line);
+      return obj.type === "result";
+    } catch {
+      return false;
     }
+  });
 
-    const hasResultLine = result.lines.some((line) => {
-      try {
-        const obj = JSON.parse(line);
-        return obj.type === "result";
-      } catch {
-        return false;
-      }
-    });
-
-    if (hasResultLine) {
-      return result.lines;
-    }
-
-    failedAttempts.push({
-      attempt: attempt + 1,
-      message: formatCapturedOutput({
-        stdout: result.stdout,
-        stderr: result.stderr,
-        extra: {
-          args: extraArgs.join(" ") || "(none)",
-          saw_result_event: result.stdout.includes('"type":"result"'),
+  if (!hasResultLine) {
+    throw new Error(
+      `Headless command completed without a result envelope.\n${formatCapturedOutput(
+        {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          extra: {
+            args: extraArgs.join(" ") || "(none)",
+            saw_result_event: result.stdout.includes('"type":"result"'),
+          },
         },
-      }),
-    });
-
-    if (attempt >= maxRetries) {
-      throw new Error(
-        `Headless command completed without a result envelope after ${attempt + 1} attempt(s).\n${formatAttemptDiagnostics(
-          failedAttempts,
-        )}`,
-      );
-    }
-
-    console.warn(
-      `[headless-stream-json] retrying after missing result envelope (${attempt + 1}/${maxRetries})`,
+      )}`,
     );
   }
+
+  return result.lines;
 }
 
 // Prescriptive prompt to ensure single-step response without tool use

--- a/src/integration-tests/headless-stream-json-format.test.ts
+++ b/src/integration-tests/headless-stream-json-format.test.ts
@@ -19,7 +19,7 @@ import {
 async function runHeadlessCommandOnce(
   prompt: string,
   extraArgs: string[] = [],
-  timeoutMs = 180000, // 180s timeout - CI can be very slow
+  timeoutMs = 90000, // Keep two retry attempts within Bun's 200s test timeout
 ): Promise<{
   lines: string[];
   stdout: string;
@@ -113,13 +113,43 @@ async function runHeadlessCommandOnce(
 async function runHeadlessCommand(
   prompt: string,
   extraArgs: string[] = [],
-  timeoutMs = 180000,
+  timeoutMs = 90000,
 ): Promise<string[]> {
   const maxRetries = 1;
   const failedAttempts: Array<{ attempt: number; message: string }> = [];
 
   for (let attempt = 0; ; attempt += 1) {
-    const result = await runHeadlessCommandOnce(prompt, extraArgs, timeoutMs);
+    let result: Awaited<ReturnType<typeof runHeadlessCommandOnce>>;
+    try {
+      result = await runHeadlessCommandOnce(prompt, extraArgs, timeoutMs);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failedAttempts.push({
+        attempt: attempt + 1,
+        message,
+      });
+
+      const isRetriableError =
+        error instanceof Error &&
+        (error.message.includes("Process timeout after") ||
+          error.message.includes("without a result envelope"));
+
+      if (!isRetriableError || attempt >= maxRetries) {
+        throw new Error(
+          failedAttempts.length === 1
+            ? message
+            : `${message}\n${formatAttemptDiagnostics(
+                failedAttempts.slice(0, -1),
+              )}`,
+        );
+      }
+
+      console.warn(
+        `[headless-stream-json] retrying after transient/incomplete run (${attempt + 1}/${maxRetries})`,
+      );
+      continue;
+    }
+
     const hasResultLine = result.lines.some((line) => {
       try {
         const obj = JSON.parse(line);

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { createAuthenticatedCliTestEnv } from "@/test-utils/test-process-env";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createAuthenticatedCliTestEnv,
+  createIsolatedCliTestEnv,
+} from "@/test-utils/test-process-env";
 import {
   formatAttemptDiagnostics,
   formatCapturedOutput,
@@ -14,8 +20,8 @@ import {
  */
 
 const projectRoot = process.cwd();
-const STARTUP_FLOW_CLI_TIMEOUT_MS = 60000;
-const STARTUP_FLOW_TEST_TIMEOUT_MS = 200000;
+const DEV_BACKEND_CLI_TIMEOUT_MS = 15000;
+const DEV_BACKEND_TEST_TIMEOUT_MS = 30000;
 
 async function runCli(
   args: string[],
@@ -23,18 +29,38 @@ async function runCli(
     timeoutMs?: number;
     expectExit?: number;
     retryOnTimeouts?: number;
+    devBackend?: string;
+    env?: NodeJS.ProcessEnv;
   } = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
-  const { timeoutMs = 30000, expectExit, retryOnTimeouts = 1 } = options;
+  const {
+    timeoutMs = 30000,
+    expectExit,
+    retryOnTimeouts = 1,
+    devBackend,
+    env: extraEnv = {},
+  } = options;
   const failedAttempts: Array<{ attempt: number; message: string }> = [];
 
   const runOnce = () =>
     new Promise<{ stdout: string; stderr: string; exitCode: number | null }>(
       (resolve, reject) => {
-        const proc = spawn("bun", ["run", "dev", "--no-memfs", ...args], {
-          cwd: projectRoot,
-          env: createAuthenticatedCliTestEnv(),
-        });
+        const proc = spawn(
+          "bun",
+          [
+            "run",
+            "dev",
+            ...(devBackend ? ["--dev-backend", devBackend] : []),
+            "--no-memfs",
+            ...args,
+          ],
+          {
+            cwd: projectRoot,
+            env: devBackend
+              ? createIsolatedCliTestEnv(extraEnv)
+              : createAuthenticatedCliTestEnv(extraEnv),
+          },
+        );
 
         let stdout = "";
         let stderr = "";
@@ -140,6 +166,8 @@ async function runCliJson(
     timeoutMs?: number;
     retryOnTimeouts?: number;
     retryOnParseErrors?: number;
+    devBackend?: string;
+    env?: NodeJS.ProcessEnv;
   } = {},
 ): Promise<{
   stdout: string;
@@ -227,11 +255,33 @@ describe("Startup Flow - Invalid Inputs", () => {
 });
 
 // ============================================================================
-// Integration Tests (require API access, create real agents)
+// Startup routing tests. These use the deterministic dev backend because the
+// assertions are about CLI startup/argument routing, not live provider behavior.
 // ============================================================================
 
 describe("Startup Flow - Integration", () => {
   let testAgentId: string | null = null;
+  let devBackendDir = "";
+
+  beforeAll(async () => {
+    devBackendDir = await mkdtemp(join(tmpdir(), "letta-startup-flow-"));
+  });
+
+  afterAll(async () => {
+    if (devBackendDir) {
+      await rm(devBackendDir, { recursive: true, force: true });
+    }
+  });
+
+  function devBackendOptions() {
+    return {
+      devBackend: "fake-headless",
+      env: { LETTA_CODE_DEV_BACKEND_DIR: devBackendDir },
+      timeoutMs: DEV_BACKEND_CLI_TIMEOUT_MS,
+      retryOnTimeouts: 0,
+      retryOnParseErrors: 0,
+    };
+  }
 
   test(
     "--new-agent creates agent and responds",
@@ -239,14 +289,12 @@ describe("Startup Flow - Integration", () => {
       const result = await runCliJson(
         [
           "--new-agent",
-          "-m",
-          "sonnet-4.6-low",
           "-p",
           "Say OK and nothing else",
           "--output-format",
           "json",
         ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        devBackendOptions(),
       );
 
       expect(result.exitCode).toBe(0);
@@ -256,7 +304,7 @@ describe("Startup Flow - Integration", () => {
 
       testAgentId = String(output.agent_id);
     },
-    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
+    { timeout: DEV_BACKEND_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -268,24 +316,15 @@ describe("Startup Flow - Integration", () => {
       }
 
       const result = await runCliJson(
-        [
-          "--agent",
-          testAgentId,
-          "-m",
-          "sonnet-4.6-low",
-          "-p",
-          "Say OK",
-          "--output-format",
-          "json",
-        ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        ["--agent", testAgentId, "-p", "Say OK", "--output-format", "json"],
+        devBackendOptions(),
       );
 
       expect(result.exitCode).toBe(0);
       const output = result.output;
       expect(output.agent_id).toBe(testAgentId);
     },
-    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
+    { timeout: DEV_BACKEND_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -302,14 +341,12 @@ describe("Startup Flow - Integration", () => {
           "--agent",
           testAgentId,
           "--new",
-          "-m",
-          "sonnet-4.6-low",
           "-p",
           "Say CREATED",
           "--output-format",
           "json",
         ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        devBackendOptions(),
       );
       expect(createResult.exitCode).toBe(0);
       const realConversationId = createResult.output.conversation_id;
@@ -324,14 +361,12 @@ describe("Startup Flow - Integration", () => {
         [
           "--conversation",
           realConversationId,
-          "-m",
-          "sonnet-4.6-low",
           "-p",
           "Say OK",
           "--output-format",
           "json",
         ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        devBackendOptions(),
       );
 
       expect(result.exitCode).toBe(0);
@@ -339,7 +374,7 @@ describe("Startup Flow - Integration", () => {
       expect(output.agent_id).toBe(testAgentId);
       expect(output.conversation_id).toBe(realConversationId);
     },
-    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
+    { timeout: DEV_BACKEND_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -348,16 +383,8 @@ describe("Startup Flow - Integration", () => {
       let agentIdForTest = testAgentId;
       if (!agentIdForTest) {
         const bootstrapResult = await runCliJson(
-          [
-            "--new-agent",
-            "-m",
-            "sonnet-4.6-low",
-            "-p",
-            "Say OK",
-            "--output-format",
-            "json",
-          ],
-          { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+          ["--new-agent", "-p", "Say OK", "--output-format", "json"],
+          devBackendOptions(),
         );
         expect(bootstrapResult.exitCode).toBe(0);
         agentIdForTest = String(bootstrapResult.output.agent_id);
@@ -370,14 +397,12 @@ describe("Startup Flow - Integration", () => {
           agentIdForTest,
           "--conversation",
           "default",
-          "-m",
-          "sonnet-4.6-low",
           "-p",
           "Say OK",
           "--output-format",
           "json",
         ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        devBackendOptions(),
       );
 
       expect(result.exitCode).toBe(0);
@@ -385,7 +410,7 @@ describe("Startup Flow - Integration", () => {
       expect(output.agent_id).toBe(agentIdForTest);
       expect(output.conversation_id).toBe("default");
     },
-    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
+    { timeout: DEV_BACKEND_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -396,20 +421,18 @@ describe("Startup Flow - Integration", () => {
           "--new-agent",
           "--init-blocks",
           "none",
-          "-m",
-          "sonnet-4.6-low",
           "-p",
           "Say OK",
           "--output-format",
           "json",
         ],
-        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
+        devBackendOptions(),
       );
 
       expect(result.exitCode).toBe(0);
       const output = result.output;
       expect(output.agent_id).toBeDefined();
     },
-    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
+    { timeout: DEV_BACKEND_TEST_TIMEOUT_MS },
   );
 });

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -14,6 +14,8 @@ import {
  */
 
 const projectRoot = process.cwd();
+const STARTUP_FLOW_CLI_TIMEOUT_MS = 60000;
+const STARTUP_FLOW_TEST_TIMEOUT_MS = 200000;
 
 async function runCli(
   args: string[],
@@ -244,7 +246,7 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
 
       expect(result.exitCode).toBe(0);
@@ -254,7 +256,7 @@ describe("Startup Flow - Integration", () => {
 
       testAgentId = String(output.agent_id);
     },
-    { timeout: 190000 },
+    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -276,14 +278,14 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
 
       expect(result.exitCode).toBe(0);
       const output = result.output;
       expect(output.agent_id).toBe(testAgentId);
     },
-    { timeout: 190000 },
+    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -307,7 +309,7 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
       expect(createResult.exitCode).toBe(0);
       const realConversationId = createResult.output.conversation_id;
@@ -329,7 +331,7 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
 
       expect(result.exitCode).toBe(0);
@@ -337,7 +339,7 @@ describe("Startup Flow - Integration", () => {
       expect(output.agent_id).toBe(testAgentId);
       expect(output.conversation_id).toBe(realConversationId);
     },
-    { timeout: 180000 },
+    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -355,7 +357,7 @@ describe("Startup Flow - Integration", () => {
             "--output-format",
             "json",
           ],
-          { timeoutMs: 180000 },
+          { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
         );
         expect(bootstrapResult.exitCode).toBe(0);
         agentIdForTest = String(bootstrapResult.output.agent_id);
@@ -375,7 +377,7 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
 
       expect(result.exitCode).toBe(0);
@@ -383,7 +385,7 @@ describe("Startup Flow - Integration", () => {
       expect(output.agent_id).toBe(agentIdForTest);
       expect(output.conversation_id).toBe("default");
     },
-    { timeout: 190000 },
+    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
   );
 
   test(
@@ -401,13 +403,13 @@ describe("Startup Flow - Integration", () => {
           "--output-format",
           "json",
         ],
-        { timeoutMs: 180000 },
+        { timeoutMs: STARTUP_FLOW_CLI_TIMEOUT_MS },
       );
 
       expect(result.exitCode).toBe(0);
       const output = result.output;
       expect(output.agent_id).toBeDefined();
     },
-    { timeout: 190000 },
+    { timeout: STARTUP_FLOW_TEST_TIMEOUT_MS },
   );
 });

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -37,11 +37,44 @@ function isDuplicateKeychainItemError(error: unknown): boolean {
   );
 }
 
+function shouldSkipKeychain(): boolean {
+  return process.env.LETTA_SKIP_KEYCHAIN_CHECK === "1";
+}
+
+function warnSecretReadFailure(
+  name: string,
+  label: string,
+  error: unknown,
+): void {
+  const message = `Failed to retrieve ${label} from secrets: ${error}`;
+  if (!warnedSecretReadFailures.has(name)) {
+    warnedSecretReadFailures.add(name);
+    console.warn(message);
+  } else {
+    debugWarn("secrets", message);
+  }
+}
+
 export async function getSecretValue(
   name: string,
   label: string,
 ): Promise<string | null> {
-  if (!secretsAvailable && !secretGetOverrideForTests) {
+  if (secretGetOverrideForTests) {
+    try {
+      const options = {
+        service: SERVICE_NAME,
+        name,
+      };
+      const value = await secretGetOverrideForTests(options);
+      warnedSecretReadFailures.delete(name);
+      return value;
+    } catch (error) {
+      warnSecretReadFailure(name, label, error);
+      return null;
+    }
+  }
+
+  if (shouldSkipKeychain() || !secretsAvailable) {
     return null;
   }
 
@@ -50,19 +83,11 @@ export async function getSecretValue(
       service: SERVICE_NAME,
       name,
     };
-    const value = secretGetOverrideForTests
-      ? await secretGetOverrideForTests(options)
-      : await secrets.get(options);
+    const value = await secrets.get(options);
     warnedSecretReadFailures.delete(name);
     return value;
   } catch (error) {
-    const message = `Failed to retrieve ${label} from secrets: ${error}`;
-    if (!warnedSecretReadFailures.has(name)) {
-      warnedSecretReadFailures.add(name);
-      console.warn(message);
-    } else {
-      debugWarn("secrets", message);
-    }
+    warnSecretReadFailure(name, label, error);
     return null;
   }
 }
@@ -71,7 +96,7 @@ export async function setSecretValue(
   name: string,
   value: string,
 ): Promise<void> {
-  if (!secretsAvailable) {
+  if (shouldSkipKeychain() || !secretsAvailable) {
     throw new Error("Secrets API unavailable");
   }
 
@@ -106,7 +131,7 @@ export async function setSecretValue(
 }
 
 export async function deleteSecretValue(name: string): Promise<boolean> {
-  if (!secretsAvailable) {
+  if (shouldSkipKeychain() || !secretsAvailable) {
     return false;
   }
 
@@ -266,7 +291,7 @@ export async function deleteSecureTokens(): Promise<void> {
  */
 export async function isKeychainAvailable(): Promise<boolean> {
   // Skip keychain check in test/CI environments to avoid error dialogs
-  if (process.env.LETTA_SKIP_KEYCHAIN_CHECK === "1") {
+  if (shouldSkipKeychain()) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Prevent unit tests from touching OS keychains by defaulting `scripts/run-unit-tests.cjs` to `LETTA_SKIP_KEYCHAIN_CHECK=1`. Hosted macOS runners can report `Bun.secrets` as available and then hang on keychain writes/deletes, which made unrelated channel tests time out.
- Make the secrets helpers honor the keychain skip flag for get/set/delete operations, not just the availability probe, while still allowing explicit test overrides.
- Move startup routing and stream-json wire-format assertions onto the deterministic `fake-headless` dev backend with isolated temp storage. These tests assert client behavior, and live provider runs were leaving orphaned server work that caused missing result envelopes and 409 busy retries.
- Run the live API integration suite only once on Linux x64 instead of across the full OS matrix; OS-specific coverage still comes from unit tests, build/package smoke tests, and platform-specific steps.