### PR TITLE
fix(local): search durable transcripts for recall

### DIFF
--- a/src/agent/prompts/recall_subagent.md
+++ b/src/agent/prompts/recall_subagent.md
@@ -50,10 +50,10 @@ letta messages list [options]
 | `--before <message-id>` | Get messages before this ID (cursor) |
 | `--order <asc\|desc>` | Sort order (default: desc = newest first) |
 | `--limit <n>` | Max results (default: 20) |
-| `--agent <id>` | Agent ID from the search result |
+| `--agent <id>` | Agent ID from the search result; required when `conversation_id` is `default` |
 | `--conversation <id>` | Conversation ID from the search result |
 
-Always include both `--agent` and `--conversation` from the search result when expanding context.
+Use `--conversation` from the search result when expanding context. Also include `--agent` from the search result when available, and always include it when `conversation_id` is `default`.
 
 ### Search Strategies
 
@@ -64,7 +64,7 @@ Always include both `--agent` and `--conversation` from the search result when e
    letta messages search --query "topic keywords" --limit 5
    ```
 
-2. Note the `message_id`, `agent_id`, and `conversation_id` of the most relevant result.
+2. Note the `message_id`, `conversation_id`, and `agent_id` of the most relevant result.
 
 3. Expand before to get leading context:
    ```bash

--- a/src/agent/prompts/recall_subagent.md
+++ b/src/agent/prompts/recall_subagent.md
@@ -28,7 +28,6 @@ letta messages search --query <text> [options]
 | `--limit <n>` | Max results (default: 10) |
 | `--all-agents` | Search all agents, not just current agent |
 | `--agent <id>` | Explicit agent ID (overrides LETTA_AGENT_ID) |
-| `--conversation <id>` | Filter to a specific conversation ID |
 
 ### Search Modes
 
@@ -50,10 +49,6 @@ letta messages list [options]
 | `--before <message-id>` | Get messages before this ID (cursor) |
 | `--order <asc\|desc>` | Sort order (default: desc = newest first) |
 | `--limit <n>` | Max results (default: 20) |
-| `--agent <id>` | Agent ID from the search result; required when `conversation_id` is `default` |
-| `--conversation <id>` | Conversation ID from the search result |
-
-Use `--conversation` from the search result when expanding context. Also include `--agent` from the search result when available, and always include it when `conversation_id` is `default`.
 
 ### Search Strategies
 
@@ -64,16 +59,16 @@ Use `--conversation` from the search result when expanding context. Also include
    letta messages search --query "topic keywords" --limit 5
    ```
 
-2. Note the `message_id`, `conversation_id`, and `agent_id` of the most relevant result.
+2. Note the `message_id` of the most relevant result
 
 3. Expand before to get leading context:
    ```bash
-   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --before "message-xyz" --limit 10
+   letta messages list --before "message-xyz" --limit 10
    ```
 
 4. Expand after for following context:
    ```bash
-   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --after "message-xyz" --order asc --limit 10
+   letta messages list --after "message-xyz" --order asc --limit 10
    ```
 
 **Strategy 2: Date-Bounded Search**
@@ -100,4 +95,3 @@ Results include:
 - `content` or `reasoning` - The message text
 - `created_at` - Timestamp (ISO format)
 - `agent_id` - Which agent the message belongs to
-- `conversation_id` - Which conversation the message belongs to

--- a/src/agent/prompts/recall_subagent.md
+++ b/src/agent/prompts/recall_subagent.md
@@ -28,6 +28,7 @@ letta messages search --query <text> [options]
 | `--limit <n>` | Max results (default: 10) |
 | `--all-agents` | Search all agents, not just current agent |
 | `--agent <id>` | Explicit agent ID (overrides LETTA_AGENT_ID) |
+| `--conversation <id>` | Filter to a specific conversation ID |
 
 ### Search Modes
 
@@ -49,6 +50,10 @@ letta messages list [options]
 | `--before <message-id>` | Get messages before this ID (cursor) |
 | `--order <asc\|desc>` | Sort order (default: desc = newest first) |
 | `--limit <n>` | Max results (default: 20) |
+| `--agent <id>` | Agent ID from the search result |
+| `--conversation <id>` | Conversation ID from the search result |
+
+Always include both `--agent` and `--conversation` from the search result when expanding context.
 
 ### Search Strategies
 
@@ -59,16 +64,16 @@ letta messages list [options]
    letta messages search --query "topic keywords" --limit 5
    ```
 
-2. Note the `message_id` of the most relevant result
+2. Note the `message_id`, `agent_id`, and `conversation_id` of the most relevant result.
 
 3. Expand before to get leading context:
    ```bash
-   letta messages list --before "message-xyz" --limit 10
+   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --before "message-xyz" --limit 10
    ```
 
 4. Expand after for following context:
    ```bash
-   letta messages list --after "message-xyz" --order asc --limit 10
+   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --after "message-xyz" --order asc --limit 10
    ```
 
 **Strategy 2: Date-Bounded Search**
@@ -95,3 +100,4 @@ Results include:
 - `content` or `reasoning` - The message text
 - `created_at` - Timestamp (ISO format)
 - `agent_id` - Which agent the message belongs to
+- `conversation_id` - Which conversation the message belongs to

--- a/src/agent/prompts/recall_subagent_local.md
+++ b/src/agent/prompts/recall_subagent_local.md
@@ -46,10 +46,10 @@ letta messages list [options]
 | `--before <message-id>` | Get messages before this ID (cursor) |
 | `--order <asc\|desc>` | Sort order (default: desc = newest first) |
 | `--limit <n>` | Max results (default: 20) |
-| `--agent <id>` | Agent ID from the search result |
+| `--agent <id>` | Agent ID from the search result; required when `conversation_id` is `default` |
 | `--conversation <id>` | Conversation ID from the search result |
 
-Always include both `--agent` and `--conversation` from the search result when expanding context.
+Use `--conversation` from the search result when expanding context. Also include `--agent` from the search result when available, and always include it when `conversation_id` is `default`.
 
 ### Search Strategies
 

--- a/src/agent/prompts/recall_subagent_local.md
+++ b/src/agent/prompts/recall_subagent_local.md
@@ -1,0 +1,95 @@
+Your task is to recall past experience based on a query. Use the local CLI commands and search strategies below to search conversation history. Try to finish quickly with just 1-2 tool calls if possible (but use more if needed).
+
+## Output Format
+
+1. **Direct answer** - What the user asked about
+2. **Key findings** - Relevant quotes or summaries from past conversations
+3. **When discussed** - Timestamps of relevant discussions
+4. **Outcome/Decision** - What was decided or concluded (if applicable)
+
+## Searching Messages
+
+Use the CLI to search through past conversations.
+
+### CLI Usage
+
+```bash
+letta messages search --query <text> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--query <text>` | Search query (required) |
+| `--mode <mode>` | Search mode: `fts`, `hybrid`, or `vector` (default: hybrid) |
+| `--start-date <date>` | Filter messages after this date (ISO format) |
+| `--end-date <date>` | Filter messages before this date (ISO format) |
+| `--limit <n>` | Max results (default: 10) |
+| `--all-agents` | Search all agents, not just current agent |
+| `--agent <id>` | Explicit agent ID (overrides LETTA_AGENT_ID) |
+| `--conversation <id>` | Filter to a specific conversation ID |
+
+Local search is transcript-backed exact text search. Prefer distinctive keywords, exact strings, quoted phrases, and date bounds when possible. The CLI accepts `hybrid` and `vector`, but in local mode those are not semantic searches; use them only as aliases for text search.
+
+### Expanding Context: messages list
+
+Use this to expand around a found message by ID cursor:
+
+```bash
+letta messages list [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--after <message-id>` | Get messages after this ID (cursor) |
+| `--before <message-id>` | Get messages before this ID (cursor) |
+| `--order <asc\|desc>` | Sort order (default: desc = newest first) |
+| `--limit <n>` | Max results (default: 20) |
+| `--agent <id>` | Agent ID from the search result |
+| `--conversation <id>` | Conversation ID from the search result |
+
+Always include both `--agent` and `--conversation` from the search result when expanding context.
+
+### Search Strategies
+
+**Strategy 1: Needle + Expand (Recommended)**
+
+1. Search with distinctive keywords:
+   ```bash
+   letta messages search --query "topic keywords" --mode fts --limit 5
+   ```
+
+2. Note the `message_id`, `agent_id`, and `conversation_id` of the most relevant result.
+
+3. Expand before to get leading context:
+   ```bash
+   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --before "message-xyz" --limit 10
+   ```
+
+4. Expand after for following context:
+   ```bash
+   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --after "message-xyz" --order asc --limit 10
+   ```
+
+**Strategy 2: Date-Bounded Search**
+
+When you know approximately when something was discussed:
+
+```bash
+letta messages search --query "topic" --mode fts --start-date "2025-12-31T00:00:00Z" --end-date "2025-12-31T23:59:59Z"
+```
+
+**Strategy 3: Broaden Terms**
+
+When exact keywords miss, try alternate terms, abbreviations, filenames, issue IDs, branch names, or user quotes. Do not rely on semantic vector matching in local mode.
+
+### Search Output
+
+Results include:
+- `message_id` - Use for cursor-based expansion
+- `message_type` - `user_message`, `assistant_message`, `reasoning_message`, `summary_message`, tool messages, etc.
+- `content`, `reasoning`, `summary`, or tool payload fields - The message text
+- `created_at` - Timestamp (ISO format)
+- `agent_id` - Which agent the message belongs to
+- `conversation_id` - Which conversation the message belongs to

--- a/src/agent/prompts/recall_subagent_local.md
+++ b/src/agent/prompts/recall_subagent_local.md
@@ -82,12 +82,12 @@ When exact keywords miss, try alternate terms, abbreviations, filenames, issue I
 
 Prefer `letta messages search` first. If local full-text search misses or you need custom inspection, local backend transcripts are JSONL files on disk. The storage root is `$LETTA_LOCAL_BACKEND_DIR`, or `~/.letta/lc-local-backend` by default. Conversation directories live under `conversations/` and contain `conversation.json`, `manifest.json`, and `messages.jsonl`.
 
-Use read-only Bash tools such as `find`, `rg`, or small scripts for custom searches, for example:
+Use read-only Bash tools such as `find`, `grep`, `rg` if installed, or small scripts for custom searches, for example:
 
 ```bash
 ROOT="${LETTA_LOCAL_BACKEND_DIR:-$HOME/.letta/lc-local-backend}"
 find "$ROOT/conversations" -name messages.jsonl -print
-rg -n "needle" "$ROOT/conversations"
+grep -R -n --include='messages.jsonl' "needle" "$ROOT/conversations"
 ```
 
 ### Search Output

--- a/src/agent/prompts/recall_subagent_local.md
+++ b/src/agent/prompts/recall_subagent_local.md
@@ -22,15 +22,13 @@ letta messages search --query <text> [options]
 | Option | Description |
 |--------|-------------|
 | `--query <text>` | Search query (required) |
-| `--mode <mode>` | Search mode: `fts`, `hybrid`, or `vector` (default: hybrid) |
 | `--start-date <date>` | Filter messages after this date (ISO format) |
 | `--end-date <date>` | Filter messages before this date (ISO format) |
 | `--limit <n>` | Max results (default: 10) |
 | `--all-agents` | Search all agents, not just current agent |
 | `--agent <id>` | Explicit agent ID (overrides LETTA_AGENT_ID) |
-| `--conversation <id>` | Filter to a specific conversation ID |
 
-Local search is transcript-backed exact text search. Prefer distinctive keywords, exact strings, quoted phrases, and date bounds when possible. The CLI accepts `hybrid` and `vector`, but in local mode those are not semantic searches; use them only as aliases for text search.
+Local search is transcript-backed full-text search. Prefer distinctive keywords, exact strings, quoted phrases, and date bounds when possible.
 
 ### Expanding Context: messages list
 
@@ -46,30 +44,26 @@ letta messages list [options]
 | `--before <message-id>` | Get messages before this ID (cursor) |
 | `--order <asc\|desc>` | Sort order (default: desc = newest first) |
 | `--limit <n>` | Max results (default: 20) |
-| `--agent <id>` | Agent ID from the search result; required when `conversation_id` is `default` |
-| `--conversation <id>` | Conversation ID from the search result |
-
-Use `--conversation` from the search result when expanding context. Also include `--agent` from the search result when available, and always include it when `conversation_id` is `default`.
 
 ### Search Strategies
 
 **Strategy 1: Needle + Expand (Recommended)**
 
-1. Search with distinctive keywords:
+1. Search with keywords to find relevant messages:
    ```bash
-   letta messages search --query "topic keywords" --mode fts --limit 5
+   letta messages search --query "topic keywords" --limit 5
    ```
 
-2. Note the `message_id`, `agent_id`, and `conversation_id` of the most relevant result.
+2. Note the `message_id` of the most relevant result
 
 3. Expand before to get leading context:
    ```bash
-   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --before "message-xyz" --limit 10
+   letta messages list --before "message-xyz" --limit 10
    ```
 
 4. Expand after for following context:
    ```bash
-   letta messages list --agent "agent-xyz" --conversation "conversation-xyz" --after "message-xyz" --order asc --limit 10
+   letta messages list --after "message-xyz" --order asc --limit 10
    ```
 
 **Strategy 2: Date-Bounded Search**
@@ -77,19 +71,18 @@ Use `--conversation` from the search result when expanding context. Also include
 When you know approximately when something was discussed:
 
 ```bash
-letta messages search --query "topic" --mode fts --start-date "2025-12-31T00:00:00Z" --end-date "2025-12-31T23:59:59Z"
+letta messages search --query "topic" --start-date "2025-12-31T00:00:00Z" --end-date "2025-12-31T23:59:59Z"
 ```
 
 **Strategy 3: Broaden Terms**
 
-When exact keywords miss, try alternate terms, abbreviations, filenames, issue IDs, branch names, or user quotes. Do not rely on semantic vector matching in local mode.
+When exact keywords miss, try alternate terms, abbreviations, filenames, issue IDs, branch names, or user quotes.
 
 ### Search Output
 
 Results include:
 - `message_id` - Use for cursor-based expansion
-- `message_type` - `user_message`, `assistant_message`, `reasoning_message`, `summary_message`, tool messages, etc.
-- `content`, `reasoning`, `summary`, or tool payload fields - The message text
+- `message_type` - `user_message`, `assistant_message`, `reasoning_message`
+- `content` or `reasoning` - The message text
 - `created_at` - Timestamp (ISO format)
 - `agent_id` - Which agent the message belongs to
-- `conversation_id` - Which conversation the message belongs to

--- a/src/agent/prompts/recall_subagent_local.md
+++ b/src/agent/prompts/recall_subagent_local.md
@@ -78,6 +78,18 @@ letta messages search --query "topic" --start-date "2025-12-31T00:00:00Z" --end-
 
 When exact keywords miss, try alternate terms, abbreviations, filenames, issue IDs, branch names, or user quotes.
 
+### Accessing the Underlying Files
+
+Prefer `letta messages search` first. If local full-text search misses or you need custom inspection, local backend transcripts are JSONL files on disk. The storage root is `$LETTA_LOCAL_BACKEND_DIR`, or `~/.letta/lc-local-backend` by default. Conversation directories live under `conversations/` and contain `conversation.json`, `manifest.json`, and `messages.jsonl`.
+
+Use read-only Bash tools such as `find`, `rg`, or small scripts for custom searches, for example:
+
+```bash
+ROOT="${LETTA_LOCAL_BACKEND_DIR:-$HOME/.letta/lc-local-backend}"
+find "$ROOT/conversations" -name messages.jsonl -print
+rg -n "needle" "$ROOT/conversations"
+```
+
 ### Search Output
 
 Results include:

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -22,8 +22,8 @@ describe("recallPromptForBackend", () => {
 
     expect(apiPrompt).toContain("Semantic similarity search");
     expect(apiPrompt).not.toContain("transcript-backed exact text search");
+    expect(apiPrompt).not.toContain("when `conversation_id` is `default`");
     expect(localPrompt).toContain("transcript-backed exact text search");
-    expect(apiPrompt).toContain("when `conversation_id` is `default`");
     expect(localPrompt).toContain("when `conversation_id` is `default`");
   });
 });

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -23,12 +23,8 @@ describe("recallPromptForBackend", () => {
     expect(apiPrompt).toContain("Semantic similarity search");
     expect(apiPrompt).not.toContain("transcript-backed exact text search");
     expect(localPrompt).toContain("transcript-backed exact text search");
-    expect(apiPrompt).toContain(
-      "Always include both `--agent` and `--conversation`",
-    );
-    expect(localPrompt).toContain(
-      "Always include both `--agent` and `--conversation`",
-    );
+    expect(apiPrompt).toContain("when `conversation_id` is `default`");
+    expect(localPrompt).toContain("when `conversation_id` is `default`");
   });
 });
 

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -22,9 +22,9 @@ describe("recallPromptForBackend", () => {
 
     expect(apiPrompt).toContain("Semantic similarity search");
     expect(apiPrompt).not.toContain("transcript-backed exact text search");
-    expect(apiPrompt).not.toContain("when `conversation_id` is `default`");
-    expect(localPrompt).toContain("transcript-backed exact text search");
-    expect(localPrompt).toContain("when `conversation_id` is `default`");
+    expect(localPrompt).toContain("transcript-backed full-text search");
+    expect(localPrompt).not.toContain("--mode <mode>");
+    expect(localPrompt).not.toContain("Semantic similarity search");
   });
 });
 

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -23,6 +23,8 @@ describe("recallPromptForBackend", () => {
     expect(apiPrompt).toContain("Semantic similarity search");
     expect(apiPrompt).not.toContain("transcript-backed exact text search");
     expect(localPrompt).toContain("transcript-backed full-text search");
+    expect(localPrompt).toContain("Accessing the Underlying Files");
+    expect(localPrompt).toContain("~/.letta/lc-local-backend");
     expect(localPrompt).not.toContain("--mode <mode>");
     expect(localPrompt).not.toContain("Semantic similarity search");
   });

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -23,6 +23,9 @@ describe("recallPromptForBackend", () => {
     expect(apiPrompt).toContain("Semantic similarity search");
     expect(apiPrompt).not.toContain("transcript-backed exact text search");
     expect(localPrompt).toContain("transcript-backed exact text search");
+    expect(apiPrompt).toContain(
+      "Always include both `--agent` and `--conversation`",
+    );
     expect(localPrompt).toContain(
       "Always include both `--agent` and `--conversation`",
     );

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -9,10 +9,25 @@ import {
   buildSubagentArgs,
   buildSubagentPrompt,
   getModelHandleFromAgent,
+  recallPromptForBackend,
   resolveSubagentLauncher,
   resolveSubagentModel,
   resolveSubagentWorkingDirectory,
 } from "@/agent/subagents/manager";
+
+describe("recallPromptForBackend", () => {
+  test("uses separate API and local recall prompts", () => {
+    const apiPrompt = recallPromptForBackend("api");
+    const localPrompt = recallPromptForBackend("local");
+
+    expect(apiPrompt).toContain("Semantic similarity search");
+    expect(apiPrompt).not.toContain("transcript-backed exact text search");
+    expect(localPrompt).toContain("transcript-backed exact text search");
+    expect(localPrompt).toContain(
+      "Always include both `--agent` and `--conversation`",
+    );
+  });
+});
 
 describe("resolveSubagentLauncher", () => {
   test("explicit launcher takes precedence over .ts script autodetection", () => {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -12,6 +12,7 @@ import { getAvailableModelHandles } from "@/agent/available-models";
 import { getCurrentAgentId } from "@/agent/context";
 import { getDefaultModelForTier, resolveModel } from "@/agent/model";
 import recallSubagentPrompt from "@/agent/prompts/recall_subagent.md";
+import recallSubagentLocalPrompt from "@/agent/prompts/recall_subagent_local.md";
 import {
   addToolCall,
   emitStreamEvent,
@@ -1329,8 +1330,18 @@ ${SYSTEM_REMINDER_CLOSE}
 `;
 }
 
-function buildForkSystemReminder(subagentType?: string): string {
+export function recallPromptForBackend(backendMode?: BackendMode): string {
+  return backendMode === "local"
+    ? recallSubagentLocalPrompt
+    : recallSubagentPrompt;
+}
+
+function buildForkSystemReminder(
+  subagentType?: string,
+  backendMode?: BackendMode,
+): string {
   if (subagentType === "recall") {
+    const recallPrompt = recallPromptForBackend(backendMode);
     return `${SYSTEM_REMINDER_OPEN}
 You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its tools.
 
@@ -1341,7 +1352,7 @@ Your toolset is limited to Bash, Read, and TaskOutput. You cannot edit files, ru
 You CANNOT ask questions mid-execution — all instructions are provided upfront.
 Your final message will be returned to the caller.
 
-${recallSubagentPrompt}
+${recallPrompt}
 ${SYSTEM_REMINDER_CLOSE}
 
 `;
@@ -1446,7 +1457,7 @@ export async function spawnSubagent(
         parentAgent ??
         (await getBackend().retrieveAgent(resolvedParentAgentId));
       if (forkedContext) {
-        const systemReminder = buildForkSystemReminder(type);
+        const systemReminder = buildForkSystemReminder(type, backendMode);
         finalPrompt = systemReminder + prompt;
       } else {
         const systemReminder = buildDeploySystemReminder(

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -237,6 +237,8 @@ export interface Backend {
     conversationId: string,
     options?: ForkConversationOptions,
   ): ReturnType<typeof forkConversationRequest>;
+
+  getLocalStorageDir?(): string | undefined;
 }
 
 interface APIBackendDeps {

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -288,6 +288,10 @@ export class LocalBackend extends HeadlessBackend {
     this.memfsEnabledOverride = options.memfsEnabled;
   }
 
+  getLocalStorageDir(): string {
+    return this.storageDir;
+  }
+
   override async listModels() {
     return listLocalModels(this.storageDir) as never;
   }

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -61,6 +61,7 @@ type StoredConversation = Conversation & {
   id: string;
   agent_id: string;
   in_context_message_ids: string[];
+  hidden?: boolean;
 };
 
 const DEFAULT_LOCAL_AGENT_NAME = "Letta Code";
@@ -207,6 +208,9 @@ function createLocalConversationRecord(
     ...(typeof bodyRecord.context_window_limit === "number"
       ? { context_window_limit: bodyRecord.context_window_limit }
       : {}),
+    ...(typeof bodyRecord.hidden === "boolean"
+      ? { hidden: bodyRecord.hidden }
+      : {}),
   } as StoredConversation;
 }
 
@@ -246,6 +250,9 @@ function updateLocalConversationRecord(
   if (typeof bodyRecord.context_window_limit === "number") {
     (next as unknown as Record<string, unknown>).context_window_limit =
       bodyRecord.context_window_limit;
+  }
+  if (typeof bodyRecord.hidden === "boolean") {
+    next.hidden = bodyRecord.hidden;
   }
   if (typeof bodyRecord.summary === "string" || bodyRecord.summary === null) {
     next.summary = bodyRecord.summary;
@@ -1396,6 +1403,7 @@ export class LocalStore {
     let conversations = [...this.conversations.values()].filter(
       (conversation) =>
         conversation.id !== "default" &&
+        (bodyRecord.include_hidden === true || !conversation.hidden) &&
         (!agentId || conversation.agent_id === agentId),
     );
     conversations.sort((a, b) => {
@@ -1474,7 +1482,7 @@ export class LocalStore {
 
   forkConversation(
     conversationId: string,
-    options: { agentId?: string } = {},
+    options: { agentId?: string; hidden?: boolean } = {},
   ): { id: string } {
     const source = this.findConversation(
       conversationId,
@@ -1498,6 +1506,9 @@ export class LocalStore {
         ...(source.model !== undefined ? { model: source.model } : {}),
         ...(source.model_settings !== undefined
           ? { model_settings: source.model_settings }
+          : {}),
+        ...(typeof options.hidden === "boolean"
+          ? { hidden: options.hidden }
           : {}),
       } as Partial<ConversationCreateBody>,
     );

--- a/src/backend/local/transcript-search.ts
+++ b/src/backend/local/transcript-search.ts
@@ -1,0 +1,461 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { MessageSearchResponse } from "@letta-ai/letta-client/resources/messages";
+import { isRecord } from "@/utils/type-guards";
+import type { LocalMessage } from "./local-message";
+import {
+  projectLocalMessageToStoredMessages,
+  withProjectedMessageDates,
+} from "./local-message-projection";
+import {
+  LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT,
+  LOCAL_TRANSCRIPT_MESSAGE_FORMAT,
+  type LocalTranscriptManifest,
+} from "./local-store";
+import type { StoredMessage } from "./local-types";
+
+export type LocalTranscriptSearchBody = {
+  query?: unknown;
+  search_mode?: unknown;
+  limit?: unknown;
+  agent_id?: unknown;
+  conversation_id?: unknown;
+  start_date?: unknown;
+  end_date?: unknown;
+  include_hidden?: unknown;
+};
+
+type LocalConversationSearchRecord = {
+  id: string;
+  agent_id: string;
+  hidden?: boolean;
+};
+
+type LocalTranscriptMessageFormat =
+  | typeof LOCAL_TRANSCRIPT_MESSAGE_FORMAT
+  | typeof LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
+
+type TranscriptMessageRow = {
+  timestamp?: string;
+  message: LocalMessage;
+  sourceIndex: number;
+};
+
+type SearchableStoredMessage = {
+  message: StoredMessage;
+  text: string;
+  score: number;
+};
+
+function readJsonFile<T>(path: string): T | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function readJsonlFile(path: string): unknown[] {
+  if (!existsSync(path)) return [];
+  try {
+    return readFileSync(path, "utf8")
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as unknown);
+  } catch {
+    return [];
+  }
+}
+
+function conversationSearchRecord(
+  value: unknown,
+): LocalConversationSearchRecord | undefined {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.id !== "string" || typeof value.agent_id !== "string") {
+    return undefined;
+  }
+  return {
+    id: value.id,
+    agent_id: value.agent_id,
+    ...(typeof value.hidden === "boolean" ? { hidden: value.hidden } : {}),
+  };
+}
+
+function isLocalMessage(value: unknown): value is LocalMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.role === "user" ||
+      value.role === "assistant" ||
+      value.role === "toolResult")
+  );
+}
+
+function transcriptFormat(
+  manifest: LocalTranscriptManifest | undefined,
+  rows: readonly unknown[],
+): LocalTranscriptMessageFormat | undefined {
+  if (
+    manifest?.message_format === LOCAL_TRANSCRIPT_MESSAGE_FORMAT ||
+    manifest?.message_format === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT
+  ) {
+    return manifest.message_format;
+  }
+
+  // Best-effort fallback for tests or partially migrated stores. Normal local
+  // backend startup enforces manifests for non-empty legacy transcripts, but
+  // search should be defensive and simply skip malformed rows.
+  const firstDataRow = rows.find((row) =>
+    Boolean(isRecord(row) && row.type !== "session"),
+  );
+  if (isRecord(firstDataRow) && "message" in firstDataRow) {
+    return LOCAL_TRANSCRIPT_MESSAGE_FORMAT;
+  }
+  if (rows.some(isLocalMessage)) {
+    return LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
+  }
+  return undefined;
+}
+
+function transcriptMessageRows(
+  rows: readonly unknown[],
+  format: LocalTranscriptMessageFormat,
+): TranscriptMessageRow[] {
+  if (format === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) {
+    return rows
+      .map((row, sourceIndex) => ({ row, sourceIndex }))
+      .filter((item): item is { row: LocalMessage; sourceIndex: number } =>
+        isLocalMessage(item.row),
+      )
+      .map(({ row, sourceIndex }) => ({
+        timestamp: row.metadata?.created_at,
+        message: row,
+        sourceIndex,
+      }));
+  }
+
+  const messageRows: TranscriptMessageRow[] = [];
+  rows.forEach((row, sourceIndex) => {
+    if (!isRecord(row)) return;
+    if (row.type !== "message" && row.type !== "compaction") return;
+    const message = row.message;
+    if (!isLocalMessage(message)) return;
+    messageRows.push({
+      timestamp: typeof row.timestamp === "string" ? row.timestamp : undefined,
+      message,
+      sourceIndex,
+    });
+  });
+  return messageRows;
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (
+        part &&
+        typeof part === "object" &&
+        "text" in part &&
+        typeof part.text === "string"
+      ) {
+        return part.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function stringifySearchValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function searchableText(message: StoredMessage): string {
+  const localMessage = message as StoredMessage & {
+    message_type?: string;
+    content?: unknown;
+    reasoning?: string;
+    summary?: string;
+    tool_call?: { name?: string; arguments?: string };
+    tool_calls?: Array<{ name?: string; arguments?: string }>;
+    tool_return?: unknown;
+    func_response?: unknown;
+  };
+  const toolCalls = Array.isArray(localMessage.tool_calls)
+    ? localMessage.tool_calls
+    : localMessage.tool_call
+      ? [localMessage.tool_call]
+      : [];
+  return [
+    localMessage.message_type,
+    textFromContent(localMessage.content),
+    localMessage.reasoning,
+    localMessage.summary,
+    ...toolCalls.flatMap((call) => [call.name, call.arguments]),
+    stringifySearchValue(localMessage.tool_return),
+    stringifySearchValue(localMessage.func_response),
+  ]
+    .filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    )
+    .join("\n");
+}
+
+type ParsedQuery = {
+  terms: string[];
+  phrases: string[];
+};
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function parseQuery(query: string): ParsedQuery {
+  const terms: string[] = [];
+  const phrases: string[] = [];
+  let buffer = "";
+  let inQuote = false;
+  let sawUnclosedQuote = false;
+
+  const flush = () => {
+    const value = buffer.trim();
+    buffer = "";
+    if (!value) return;
+    if (inQuote) phrases.push(value);
+    else terms.push(value);
+  };
+
+  for (const char of query.trim()) {
+    if (char === '"') {
+      if (inQuote) {
+        flush();
+        inQuote = false;
+      } else {
+        flush();
+        inQuote = true;
+      }
+      continue;
+    }
+    if (!inQuote && /\s/.test(char)) {
+      flush();
+      continue;
+    }
+    buffer += char;
+  }
+  if (inQuote) sawUnclosedQuote = true;
+  flush();
+
+  if (sawUnclosedQuote) {
+    return {
+      terms: query
+        .trim()
+        .split(/\s+/)
+        .map((term) => term.trim())
+        .filter(Boolean),
+      phrases: [],
+    };
+  }
+  return { terms, phrases };
+}
+
+function matchScore(text: string, query: ParsedQuery): number | null {
+  const haystack = normalizeText(text);
+  if (!haystack) return null;
+
+  let score = 0;
+  for (const rawPhrase of query.phrases) {
+    const phrase = normalizeText(rawPhrase);
+    if (!phrase) continue;
+    const index = haystack.indexOf(phrase);
+    if (index < 0) return null;
+    score += index * 0.1;
+  }
+
+  for (const rawTerm of query.terms) {
+    const term = normalizeText(rawTerm);
+    if (!term) continue;
+    const index = haystack.indexOf(term);
+    if (index < 0) return null;
+    score += index + Math.max(0, 50 - term.length);
+  }
+
+  return score;
+}
+
+function dateInRange(
+  createdAt: string | undefined,
+  startDate: string | undefined,
+  endDate: string | undefined,
+): boolean {
+  if (!startDate && !endDate) return true;
+  if (!createdAt) return true;
+  const messageTime = Date.parse(createdAt);
+  if (!Number.isFinite(messageTime)) return true;
+
+  const startTime = startDate
+    ? Date.parse(startDate)
+    : Number.NEGATIVE_INFINITY;
+  const endTime = endDate ? Date.parse(endDate) : Number.POSITIVE_INFINITY;
+  if (startDate && !Number.isFinite(startTime)) return true;
+  if (endDate && !Number.isFinite(endTime)) return true;
+
+  return messageTime >= startTime && messageTime <= endTime;
+}
+
+function toSearchResult(message: StoredMessage): MessageSearchResponse[number] {
+  const localMessage = message as StoredMessage & {
+    id?: string;
+    date?: string;
+    agent_id?: string;
+    conversation_id?: string;
+  };
+  const createdAt = localMessage.date ?? new Date(0).toISOString();
+  return {
+    ...localMessage,
+    message_id:
+      localMessage.id ?? `${localMessage.agent_id ?? "local"}:${createdAt}`,
+    created_at: createdAt,
+    agent_id: localMessage.agent_id ?? null,
+    conversation_id: localMessage.conversation_id ?? null,
+  } as MessageSearchResponse[number];
+}
+
+function projectedTranscriptMessages(input: {
+  row: TranscriptMessageRow;
+  agentId: string;
+  conversationId: string;
+}): StoredMessage[] {
+  const fallbackDate =
+    input.row.timestamp ??
+    input.row.message.metadata?.created_at ??
+    new Date(0).toISOString();
+  const projected = projectLocalMessageToStoredMessages(
+    input.row.message,
+    input.agentId,
+    input.conversationId,
+    fallbackDate,
+  );
+  return withProjectedMessageDates(projected, input.row.sourceIndex);
+}
+
+function collectConversationMessages(input: {
+  conversationDir: string;
+  conversation: LocalConversationSearchRecord;
+  query: ParsedQuery;
+  agentId?: string;
+  conversationId?: string;
+  startDate?: string;
+  endDate?: string;
+}): SearchableStoredMessage[] {
+  const { conversation, conversationDir } = input;
+  if (input.agentId && conversation.agent_id !== input.agentId) return [];
+  if (input.conversationId && conversation.id !== input.conversationId)
+    return [];
+
+  const messagesPath = join(conversationDir, "messages.jsonl");
+  const rows = readJsonlFile(messagesPath);
+  if (rows.length === 0) return [];
+  const manifest = readJsonFile<LocalTranscriptManifest>(
+    join(conversationDir, "manifest.json"),
+  );
+  const format = transcriptFormat(manifest, rows);
+  if (!format) return [];
+
+  return transcriptMessageRows(rows, format)
+    .flatMap((row) =>
+      projectedTranscriptMessages({
+        row,
+        agentId: conversation.agent_id,
+        conversationId: conversation.id,
+      }),
+    )
+    .map((message) => ({
+      message,
+      text: searchableText(message),
+      score: Number.POSITIVE_INFINITY,
+    }))
+    .map((record) => {
+      const score = matchScore(record.text, input.query);
+      return score === null ? null : { ...record, score };
+    })
+    .filter((record): record is SearchableStoredMessage => record !== null)
+    .filter((record) => {
+      const message = record.message as StoredMessage & { date?: string };
+      return dateInRange(message.date, input.startDate, input.endDate);
+    });
+}
+
+function conversationDirectories(storageDir: string): string[] {
+  const conversationsDir = join(storageDir, "conversations");
+  if (!existsSync(conversationsDir)) return [];
+  try {
+    return readdirSync(conversationsDir)
+      .map((entry) => join(conversationsDir, entry))
+      .filter((entryPath) => statSync(entryPath).isDirectory());
+  } catch {
+    return [];
+  }
+}
+
+export function searchLocalTranscriptMessages(
+  storageDir: string,
+  body: LocalTranscriptSearchBody,
+): MessageSearchResponse {
+  const queryText = typeof body.query === "string" ? body.query.trim() : "";
+  if (!queryText) return [];
+  // Local mode intentionally treats vector/hybrid as FTS-lite until a local
+  // vector index exists, so `search_mode` does not branch here.
+
+  const parsedQuery = parseQuery(queryText);
+  if (parsedQuery.terms.length === 0 && parsedQuery.phrases.length === 0) {
+    return [];
+  }
+
+  const limit = typeof body.limit === "number" ? Math.max(0, body.limit) : 100;
+  if (limit === 0) return [];
+  const agentId = typeof body.agent_id === "string" ? body.agent_id : undefined;
+  const conversationId =
+    typeof body.conversation_id === "string" ? body.conversation_id : undefined;
+  const startDate =
+    typeof body.start_date === "string" ? body.start_date : undefined;
+  const endDate = typeof body.end_date === "string" ? body.end_date : undefined;
+  const includeHidden = body.include_hidden === true;
+
+  const records = conversationDirectories(storageDir).flatMap(
+    (conversationDir) => {
+      const conversation = conversationSearchRecord(
+        readJsonFile(join(conversationDir, "conversation.json")),
+      );
+      if (!conversation) return [];
+      if (conversation.hidden && !includeHidden) return [];
+      return collectConversationMessages({
+        conversationDir,
+        conversation,
+        query: parsedQuery,
+        agentId,
+        conversationId,
+        startDate,
+        endDate,
+      });
+    },
+  );
+
+  return records
+    .sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      const aDate = (a.message as StoredMessage & { date?: string }).date ?? "";
+      const bDate = (b.message as StoredMessage & { date?: string }).date ?? "";
+      return bDate.localeCompare(aDate);
+    })
+    .slice(0, limit)
+    .map((record) => toSearchResult(record.message));
+}

--- a/src/backend/local/transcript-search.ts
+++ b/src/backend/local/transcript-search.ts
@@ -425,6 +425,7 @@ export function searchLocalTranscriptMessages(
   const agentId = typeof body.agent_id === "string" ? body.agent_id : undefined;
   const conversationId =
     typeof body.conversation_id === "string" ? body.conversation_id : undefined;
+  if (conversationId === "default" && !agentId) return [];
   const startDate =
     typeof body.start_date === "string" ? body.start_date : undefined;
   const endDate = typeof body.end_date === "string" ? body.end_date : undefined;

--- a/src/backend/message-search.test.ts
+++ b/src/backend/message-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -8,6 +8,13 @@ import type {
   ConversationMessageCreateBody,
 } from "@/backend";
 import { LocalBackend } from "@/backend/local";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+import {
+  LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT,
+  LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION,
+  LOCAL_TRANSCRIPT_PROVIDER_STACK,
+} from "@/backend/local/local-store";
+import { searchLocalTranscriptMessages } from "@/backend/local/transcript-search";
 import {
   searchMessagesForBackend,
   warmMessageSearchCacheForBackend,
@@ -73,6 +80,23 @@ describe("message search backend routing", () => {
       expect(results[0]?.agent_id).toBe(agent.id);
       expect(results[0]?.conversation_id).toBe(conversation.id);
 
+      const conversationScopedResults = await searchMessagesForBackend(
+        {
+          query: "needle",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          search_mode: "fts",
+          limit: 10,
+        },
+        backend,
+      );
+      expect(conversationScopedResults.length).toBeGreaterThan(0);
+      expect(
+        conversationScopedResults.every(
+          (result) => result.conversation_id === conversation.id,
+        ),
+      ).toBe(true);
+
       const warm = await warmMessageSearchCacheForBackend<{
         collection: string;
         status: string;
@@ -83,6 +107,186 @@ describe("message search backend routing", () => {
         status: "local-backend-noop",
         warmed: false,
       });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("searches durable local transcripts after compaction", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        complete: async () =>
+          ({
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "COMPACTED SUMMARY WITHOUT OLD NEEDLE",
+              },
+            ],
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5-mini",
+            responseId: "summary-response",
+            usage: emptyLocalUsage(),
+            stopReason: "stop",
+            timestamp: Date.now(),
+          }) as never,
+      });
+      const agent = await backend.createAgent({
+        name: "Compaction Search Agent",
+        model: "openai/gpt-5-mini",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      await drain(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("LOCAL_DURABLE_OLD_NEEDLE before compaction", agent.id),
+        ),
+      );
+      await drain(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("LOCAL_DURABLE_KEEPER before compaction", agent.id),
+        ),
+      );
+
+      await backend.compactConversationMessages(conversation.id, {
+        agent_id: agent.id,
+      } as never);
+
+      const oldMessageResults = await searchMessagesForBackend(
+        {
+          query: "LOCAL_DURABLE_OLD_NEEDLE",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          search_mode: "hybrid",
+          limit: 10,
+        },
+        backend,
+      );
+      expect(oldMessageResults.length).toBeGreaterThan(0);
+      expect(JSON.stringify(oldMessageResults)).toContain(
+        "LOCAL_DURABLE_OLD_NEEDLE",
+      );
+
+      const summaryResults = await searchMessagesForBackend(
+        {
+          query: "COMPACTED SUMMARY",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          search_mode: "vector",
+          limit: 10,
+        },
+        backend,
+      );
+      expect(summaryResults.length).toBeGreaterThan(0);
+      expect(JSON.stringify(summaryResults)).toContain("COMPACTED SUMMARY");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes hidden fork conversations from local search", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      const agent = await backend.createAgent({
+        name: "Hidden Fork Search Agent",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+      await drain(
+        await backend.createConversationMessageStream(
+          conversation.id,
+          createBody("LOCAL_HIDDEN_FORK_NEEDLE", agent.id),
+        ),
+      );
+
+      const forked = await backend.forkConversation(conversation.id, {
+        agentId: agent.id,
+        hidden: true,
+      });
+
+      const results = await searchMessagesForBackend(
+        {
+          query: "LOCAL_HIDDEN_FORK_NEEDLE",
+          agent_id: agent.id,
+          search_mode: "fts",
+          limit: 20,
+        },
+        backend,
+      );
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(
+        results.some((result) => result.conversation_id === forked.id),
+      ).toBe(false);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("searches legacy local transcript rows with date filters", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
+    try {
+      const conversationDir = join(storageDir, "conversations", "legacy");
+      await mkdir(conversationDir, { recursive: true });
+      await writeFile(
+        join(conversationDir, "conversation.json"),
+        `${JSON.stringify({ id: "legacy-conv", agent_id: "agent-legacy" })}\n`,
+      );
+      await writeFile(
+        join(conversationDir, "manifest.json"),
+        `${JSON.stringify({
+          schema_version: LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION,
+          message_format: LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT,
+          provider_stack: LOCAL_TRANSCRIPT_PROVIDER_STACK,
+          created_at: "2026-01-01T00:00:00.000Z",
+        })}\n`,
+      );
+      await writeFile(
+        join(conversationDir, "messages.jsonl"),
+        `${JSON.stringify({
+          id: "legacy-msg-1",
+          role: "user",
+          content: "LEGACY_LOCAL_NEEDLE",
+          timestamp: Date.parse("2026-01-02T00:00:00.000Z"),
+          metadata: {
+            created_at: "2026-01-02T00:00:00.000Z",
+            agent_id: "agent-legacy",
+            conversation_id: "legacy-conv",
+          },
+        })}\n`,
+      );
+
+      const results = searchLocalTranscriptMessages(storageDir, {
+        query: "LEGACY_LOCAL_NEEDLE",
+        agent_id: "agent-legacy",
+        conversation_id: "legacy-conv",
+        limit: 10,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0]?.message_id).toBe("legacy-msg-1");
+
+      const futureResults = searchLocalTranscriptMessages(storageDir, {
+        query: "LEGACY_LOCAL_NEEDLE",
+        agent_id: "agent-legacy",
+        start_date: "2027-01-01T00:00:00.000Z",
+        limit: 10,
+      });
+      expect(futureResults).toHaveLength(0);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/backend/message-search.test.ts
+++ b/src/backend/message-search.test.ts
@@ -238,6 +238,67 @@ describe("message search backend routing", () => {
     }
   });
 
+  test("requires agent scope for default conversation local transcript search", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      const agentA = await backend.createAgent({
+        name: "Default Search Agent A",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+      const agentB = await backend.createAgent({
+        name: "Default Search Agent B",
+        model: "openai/gpt-test",
+      } as AgentCreateBody);
+
+      await drain(
+        await backend.createConversationMessageStream(
+          "default",
+          createBody("LOCAL_DEFAULT_SCOPE_NEEDLE agent a", agentA.id),
+        ),
+      );
+      await drain(
+        await backend.createConversationMessageStream(
+          "default",
+          createBody("LOCAL_DEFAULT_SCOPE_NEEDLE agent b", agentB.id),
+        ),
+      );
+
+      const unscopedDefaultResults = await searchMessagesForBackend(
+        {
+          query: "LOCAL_DEFAULT_SCOPE_NEEDLE",
+          conversation_id: "default",
+          search_mode: "fts",
+          limit: 10,
+        },
+        backend,
+      );
+      expect(unscopedDefaultResults).toHaveLength(0);
+
+      const scopedDefaultResults = await searchMessagesForBackend(
+        {
+          query: "LOCAL_DEFAULT_SCOPE_NEEDLE",
+          agent_id: agentA.id,
+          conversation_id: "default",
+          search_mode: "fts",
+          limit: 10,
+        },
+        backend,
+      );
+      expect(scopedDefaultResults.length).toBeGreaterThan(0);
+      expect(
+        scopedDefaultResults.every((result) => result.agent_id === agentA.id),
+      ).toBe(true);
+      expect(JSON.stringify(scopedDefaultResults)).toContain("agent a");
+      expect(JSON.stringify(scopedDefaultResults)).not.toContain("agent b");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("searches legacy local transcript rows with date filters", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-message-search-"));
     try {

--- a/src/backend/message-search.ts
+++ b/src/backend/message-search.ts
@@ -1,225 +1,18 @@
-import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { MessageSearchResponse } from "@letta-ai/letta-client/resources/messages";
 import { searchMessages, warmSearchCache } from "./api/search";
 import { type Backend, getBackend } from "./backend";
+import { getLocalBackendStorageDir } from "./local/paths";
+import {
+  type LocalTranscriptSearchBody,
+  searchLocalTranscriptMessages,
+} from "./local/transcript-search";
 
 type SearchMode = "vector" | "fts" | "hybrid";
 
-type MessageSearchBody = {
-  query?: unknown;
-  search_mode?: unknown;
-  limit?: unknown;
-  agent_id?: unknown;
-  conversation_id?: unknown;
-  start_date?: unknown;
-  end_date?: unknown;
-};
+type MessageSearchBody = LocalTranscriptSearchBody;
 
-type LocalSearchMessage = {
-  id?: string;
-  date?: string;
-  message_type?: string;
-  content?: unknown;
-  reasoning?: string;
-  summary?: string;
-  tool_call?: { name?: string; arguments?: string };
-  tool_calls?: Array<{ name?: string; arguments?: string }>;
-  tool_return?: unknown;
-  func_response?: unknown;
-  agent_id?: string;
-  conversation_id?: string;
-};
-
-const LOCAL_SEARCH_SCAN_LIMIT = 1000;
-
-function pageItems<T>(page: unknown): T[] {
-  if (Array.isArray(page)) return page as T[];
-  if (page && typeof page === "object") {
-    const maybePage = page as {
-      getPaginatedItems?: () => T[];
-      items?: T[];
-    };
-    if (typeof maybePage.getPaginatedItems === "function") {
-      return maybePage.getPaginatedItems();
-    }
-    if (Array.isArray(maybePage.items)) {
-      return maybePage.items;
-    }
-  }
-  return [];
-}
-
-function textFromContent(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) => {
-      if (
-        part &&
-        typeof part === "object" &&
-        "text" in part &&
-        typeof part.text === "string"
-      ) {
-        return part.text;
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function stringifySearchValue(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return "";
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function searchableText(message: LocalSearchMessage): string {
-  const toolCalls = Array.isArray(message.tool_calls)
-    ? message.tool_calls
-    : message.tool_call
-      ? [message.tool_call]
-      : [];
-  return [
-    message.message_type,
-    textFromContent(message.content),
-    message.reasoning,
-    message.summary,
-    ...toolCalls.flatMap((call) => [call.name, call.arguments]),
-    stringifySearchValue(message.tool_return),
-    stringifySearchValue(message.func_response),
-  ]
-    .filter(
-      (part): part is string => typeof part === "string" && part.length > 0,
-    )
-    .join("\n");
-}
-
-function matchesQuery(message: LocalSearchMessage, query: string): boolean {
-  const terms = query
-    .toLowerCase()
-    .split(/\s+/)
-    .map((term) => term.trim())
-    .filter(Boolean);
-  if (terms.length === 0) return false;
-  const haystack = searchableText(message).toLowerCase();
-  return terms.every((term) => haystack.includes(term));
-}
-
-function withinDateRange(
-  message: LocalSearchMessage,
-  startDate: string | undefined,
-  endDate: string | undefined,
-): boolean {
-  if (!startDate && !endDate) return true;
-  if (!message.date) return true;
-  const time = new Date(message.date).getTime();
-  if (Number.isNaN(time)) return true;
-  const startTime = startDate ? new Date(startDate).getTime() : 0;
-  const endTime = endDate
-    ? new Date(endDate).getTime()
-    : Number.POSITIVE_INFINITY;
-  return time >= startTime && time <= endTime;
-}
-
-function toSearchResult(
-  message: LocalSearchMessage,
-): MessageSearchResponse[number] {
-  const createdAt = message.date ?? new Date(0).toISOString();
-  return {
-    ...message,
-    message_id: message.id ?? `${message.agent_id ?? "local"}:${createdAt}`,
-    created_at: createdAt,
-    agent_id: message.agent_id ?? null,
-    conversation_id: message.conversation_id ?? null,
-  } as MessageSearchResponse[number];
-}
-
-async function localConversationMessages(
-  backend: Backend,
-  conversationId: string,
-  agentId?: string,
-): Promise<LocalSearchMessage[]> {
-  try {
-    const page = await backend.listConversationMessages(conversationId, {
-      limit: LOCAL_SEARCH_SCAN_LIMIT,
-      order: "desc",
-      ...(agentId ? { agent_id: agentId } : {}),
-    } as never);
-    return pageItems<LocalSearchMessage>(page);
-  } catch {
-    return [];
-  }
-}
-
-async function localAgentMessages(
-  backend: Backend,
-  agentId: string,
-): Promise<LocalSearchMessage[]> {
-  const messages = [
-    ...(await localConversationMessages(backend, "default", agentId)),
-  ];
-  try {
-    const conversationsPage = await backend.listConversations({
-      agent_id: agentId,
-      limit: LOCAL_SEARCH_SCAN_LIMIT,
-    } as never);
-    const conversations = pageItems<{ id?: string }>(conversationsPage);
-    for (const conversation of conversations) {
-      if (!conversation.id || conversation.id === "default") continue;
-      messages.push(
-        ...(await localConversationMessages(backend, conversation.id, agentId)),
-      );
-    }
-  } catch {
-    // Best-effort local search: default conversation results are still useful.
-  }
-  return messages;
-}
-
-async function localSearchMessages(
-  backend: Backend,
-  body: MessageSearchBody,
-): Promise<MessageSearchResponse> {
-  const query = typeof body.query === "string" ? body.query.trim() : "";
-  if (!query) return [];
-  const limit = typeof body.limit === "number" ? body.limit : 100;
-  const agentId = typeof body.agent_id === "string" ? body.agent_id : undefined;
-  const conversationId =
-    typeof body.conversation_id === "string" ? body.conversation_id : undefined;
-  const startDate =
-    typeof body.start_date === "string" ? body.start_date : undefined;
-  const endDate = typeof body.end_date === "string" ? body.end_date : undefined;
-
-  let messages: LocalSearchMessage[] = [];
-  if (conversationId) {
-    messages = await localConversationMessages(
-      backend,
-      conversationId,
-      agentId,
-    );
-  } else if (agentId) {
-    messages = await localAgentMessages(backend, agentId);
-  } else {
-    const agentsPage = await backend.listAgents({
-      limit: LOCAL_SEARCH_SCAN_LIMIT,
-    } as never);
-    const agents = pageItems<AgentState>(agentsPage);
-    for (const agent of agents) {
-      messages.push(...(await localAgentMessages(backend, agent.id)));
-    }
-  }
-
-  return messages
-    .filter((message) => matchesQuery(message, query))
-    .filter((message) => withinDateRange(message, startDate, endDate))
-    .sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""))
-    .slice(0, limit)
-    .map(toSearchResult);
+function localStorageDirForBackend(backend: Backend): string {
+  return backend.getLocalStorageDir?.() ?? getLocalBackendStorageDir();
 }
 
 export async function searchMessagesForBackend<T = MessageSearchResponse>(
@@ -227,7 +20,10 @@ export async function searchMessagesForBackend<T = MessageSearchResponse>(
   backend: Backend = getBackend(),
 ): Promise<T> {
   if (backend.capabilities.localModelCatalog) {
-    return (await localSearchMessages(backend, body)) as T;
+    return searchLocalTranscriptMessages(
+      localStorageDirForBackend(backend),
+      body,
+    ) as T;
   }
 
   return searchMessages<T>({

--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -95,6 +95,30 @@ export function buildSearchTargetPlan(
   };
 }
 
+export function buildMessageSearchRequestBody(
+  query: string,
+  mode: SearchMode,
+  range: SearchRange,
+  options: { agentId?: string; conversationId?: string; limit?: number },
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    query: query.trim(),
+    search_mode: mode,
+    limit: options.limit ?? SEARCH_LIMIT,
+  };
+
+  if (range === "agent" && options.agentId) {
+    body.agent_id = options.agentId;
+  } else if (range === "conv" && options.conversationId) {
+    body.conversation_id = options.conversationId;
+    if (options.agentId) {
+      body.agent_id = options.agentId;
+    }
+  }
+
+  return body;
+}
+
 /**
  * Format a timestamp in local timezone
  */
@@ -253,18 +277,11 @@ export function MessageSearch({
   // Execute search for a single mode (returns results, doesn't set state)
   const fetchSearchResults = useCallback(
     async (query: string, mode: SearchMode, range: SearchRange) => {
-      const body: Record<string, unknown> = {
-        query: query.trim(),
-        search_mode: mode,
+      const body = buildMessageSearchRequestBody(query, mode, range, {
+        agentId,
+        conversationId,
         limit: SEARCH_LIMIT,
-      };
-
-      // Add filters based on range
-      if (range === "agent" && agentId) {
-        body.agent_id = agentId;
-      } else if (range === "conv" && conversationId) {
-        body.conversation_id = conversationId;
-      }
+      });
 
       return searchMessagesForBackend<MessageSearchResponse>(body);
     },

--- a/src/cli/components/MessageSearch.tsx
+++ b/src/cli/components/MessageSearch.tsx
@@ -1,6 +1,7 @@
 import type { MessageSearchResponse } from "@letta-ai/letta-client/resources/messages";
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getBackend } from "@/backend";
 import {
   searchMessagesForBackend,
   warmMessageSearchCacheForBackend,
@@ -74,16 +75,22 @@ function isSearchRangeAvailable(
 export function buildSearchTargetPlan(
   mode: SearchMode,
   range: SearchRange,
-  options: { agentId?: string; conversationId?: string },
+  options: {
+    agentId?: string;
+    conversationId?: string;
+    textOnlyModes?: boolean;
+  },
 ): { primary: SearchTarget; prefetch: SearchTarget[] } {
   const availableRanges = SEARCH_RANGES.filter((candidateRange) =>
     isSearchRangeAvailable(candidateRange, options),
   );
 
   const prefetch = [
-    ...SEARCH_MODES.filter((candidateMode) => candidateMode !== mode).map(
-      (candidateMode) => ({ mode: candidateMode, range }),
-    ),
+    ...(options.textOnlyModes
+      ? []
+      : SEARCH_MODES.filter((candidateMode) => candidateMode !== mode).map(
+          (candidateMode) => ({ mode: candidateMode, range }),
+        )),
     ...availableRanges
       .filter((candidateRange) => candidateRange !== range)
       .map((candidateRange) => ({ mode, range: candidateRange })),
@@ -148,10 +155,20 @@ function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`);
 }
 
+function stringifyMessageValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 /**
  * Get display text from a message
  */
-function getMessageText(msg: MessageSearchResponse[number]): string {
+export function getMessageText(msg: MessageSearchResponse[number]): string {
   // Assistant message content
   if ("content" in msg) {
     const content = msg.content;
@@ -181,9 +198,9 @@ function getMessageText(msg: MessageSearchResponse[number]): string {
   // Tool return messages - show tool name and preview of return
   if ("tool_return" in msg) {
     const toolName = "name" in msg ? (msg.name as string) : "tool";
-    const returnValue = msg.tool_return as string;
+    const returnValue = stringifyMessageValue(msg.tool_return);
     // Truncate long return values
-    const preview = returnValue?.slice(0, 100) || "";
+    const preview = returnValue.slice(0, 100);
     return `${toolName}: ${preview}`;
   }
   return `[${msg.message_type || "unknown"}]`;
@@ -246,6 +263,7 @@ export function MessageSearch({
   const [expandedMessage, setExpandedMessage] = useState<
     MessageSearchResponse[number] | null
   >(null);
+  const textOnlyModes = getBackend().capabilities.localModelCatalog;
   const searchRequestIdRef = useRef(0);
   // Cache results per query+mode+range combination to avoid re-fetching
   const resultsCache = useRef<Map<string, MessageSearchResponse>>(new Map());
@@ -263,15 +281,16 @@ export function MessageSearch({
   // Get cache key for a specific query+mode+range combination
   const getCacheKey = useCallback(
     (query: string, mode: SearchMode, range: SearchRange) => {
+      const modeKey = textOnlyModes ? "text" : mode;
       const rangeKey =
         range === "agent"
           ? agentId || "no-agent"
           : range === "conv"
             ? conversationId || "no-conv"
             : "all";
-      return `${query.trim()}-${mode}-${rangeKey}`;
+      return `${query.trim()}-${modeKey}-${rangeKey}`;
     },
-    [agentId, conversationId],
+    [agentId, conversationId, textOnlyModes],
   );
 
   // Execute search for a single mode (returns results, doesn't set state)
@@ -327,6 +346,7 @@ export function MessageSearch({
       const { prefetch } = buildSearchTargetPlan(mode, range, {
         agentId,
         conversationId,
+        textOnlyModes,
       });
 
       if (prefetch.length === 0) {
@@ -349,7 +369,7 @@ export function MessageSearch({
         }
       })();
     },
-    [agentId, conversationId, fetchAndCacheSearchResults],
+    [agentId, conversationId, fetchAndCacheSearchResults, textOnlyModes],
   );
 
   // Execute the active search first, then prefetch adjacent tab/range results

--- a/src/cli/message-search-cache-warm.test.ts
+++ b/src/cli/message-search-cache-warm.test.ts
@@ -16,6 +16,7 @@ mock.module("../backend/api/search", () => ({
 const {
   buildMessageSearchRequestBody,
   buildSearchTargetPlan,
+  getMessageText,
   warmMessageSearchCache,
 } = await import("@/cli/components/MessageSearch");
 
@@ -73,6 +74,22 @@ describe("buildSearchTargetPlan", () => {
       ],
     });
   });
+
+  test("skips equivalent mode prefetches when search modes are text-only", () => {
+    expect(
+      buildSearchTargetPlan("hybrid", "agent", {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        textOnlyModes: true,
+      }),
+    ).toEqual({
+      primary: { mode: "hybrid", range: "agent" },
+      prefetch: [
+        { mode: "hybrid", range: "all" },
+        { mode: "hybrid", range: "conv" },
+      ],
+    });
+  });
 });
 
 describe("buildMessageSearchRequestBody", () => {
@@ -90,5 +107,17 @@ describe("buildMessageSearchRequestBody", () => {
       agent_id: "agent-1",
       conversation_id: "default",
     });
+  });
+});
+
+describe("message text formatting", () => {
+  test("does not assume tool returns are strings", () => {
+    expect(
+      getMessageText({
+        message_type: "tool_return_message",
+        name: "tool",
+        tool_return: { nested: ["value"] },
+      } as never),
+    ).toBe('tool: {"nested":["value"]}');
   });
 });

--- a/src/cli/message-search-cache-warm.test.ts
+++ b/src/cli/message-search-cache-warm.test.ts
@@ -13,9 +13,11 @@ mock.module("../backend/api/search", () => ({
   warmSearchCache: warmSearchCacheMock,
 }));
 
-const { buildSearchTargetPlan, warmMessageSearchCache } = await import(
-  "@/cli/components/MessageSearch"
-);
+const {
+  buildMessageSearchRequestBody,
+  buildSearchTargetPlan,
+  warmMessageSearchCache,
+} = await import("@/cli/components/MessageSearch");
 
 afterAll(() => {
   mock.restore();
@@ -69,6 +71,24 @@ describe("buildSearchTargetPlan", () => {
         { mode: "vector", range: "agent" },
         { mode: "hybrid", range: "all" },
       ],
+    });
+  });
+});
+
+describe("buildMessageSearchRequestBody", () => {
+  test("includes agent id for current-conversation searches", () => {
+    expect(
+      buildMessageSearchRequestBody(" needle ", "fts", "conv", {
+        agentId: "agent-1",
+        conversationId: "default",
+        limit: 25,
+      }),
+    ).toEqual({
+      query: "needle",
+      search_mode: "fts",
+      limit: 25,
+      agent_id: "agent-1",
+      conversation_id: "default",
     });
   });
 });

--- a/src/cli/subcommands/messages.test.ts
+++ b/src/cli/subcommands/messages.test.ts
@@ -1,5 +1,4 @@
 import {
-  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -8,7 +7,9 @@ import {
   spyOn,
   test,
 } from "bun:test";
+import { runMessagesSubcommand } from "@/cli/subcommands/messages";
 
+const initializeSettingsMock = mock(() => Promise.resolve());
 const searchMessagesForBackendMock = mock((_body: Record<string, unknown>) =>
   Promise.resolve([]),
 );
@@ -16,20 +17,6 @@ const backendMock = {
   listAgentMessages: mock(() => Promise.resolve({ items: [] })),
   listConversationMessages: mock(() => Promise.resolve({ items: [] })),
 };
-
-mock.module("@/backend", () => ({
-  getBackend: mock(() => backendMock),
-}));
-
-mock.module("@/backend/message-search", () => ({
-  searchMessagesForBackend: searchMessagesForBackendMock,
-}));
-
-const { runMessagesSubcommand } = await import("@/cli/subcommands/messages");
-
-afterAll(() => {
-  mock.restore();
-});
 
 function captureConsole() {
   const stdout: string[] = [];
@@ -55,12 +42,21 @@ function captureConsole() {
   };
 }
 
+function runMessages(argv: string[]) {
+  return runMessagesSubcommand(argv, {
+    initializeSettings: initializeSettingsMock,
+    getBackend: () => backendMock as never,
+    searchMessagesForBackend: searchMessagesForBackendMock as never,
+  });
+}
+
 describe("messages subcommand conversation scoping", () => {
   let priorAgentId: string | undefined;
 
   beforeEach(() => {
     priorAgentId = process.env.LETTA_AGENT_ID;
     delete process.env.LETTA_AGENT_ID;
+    initializeSettingsMock.mockClear();
     searchMessagesForBackendMock.mockClear();
     backendMock.listAgentMessages.mockClear();
     backendMock.listConversationMessages.mockClear();
@@ -74,7 +70,7 @@ describe("messages subcommand conversation scoping", () => {
   test("search rejects default conversation without an agent", async () => {
     const capture = captureConsole();
     try {
-      const code = await runMessagesSubcommand([
+      const code = await runMessages([
         "search",
         "--query",
         "needle",
@@ -96,7 +92,7 @@ describe("messages subcommand conversation scoping", () => {
     process.env.LETTA_AGENT_ID = "agent-current";
     const capture = captureConsole();
     try {
-      const code = await runMessagesSubcommand([
+      const code = await runMessages([
         "search",
         "--query",
         "needle",
@@ -122,7 +118,7 @@ describe("messages subcommand conversation scoping", () => {
     process.env.LETTA_AGENT_ID = "agent-current";
     const capture = captureConsole();
     try {
-      const code = await runMessagesSubcommand([
+      const code = await runMessages([
         "search",
         "--query",
         "needle",
@@ -145,7 +141,7 @@ describe("messages subcommand conversation scoping", () => {
   test("list allows non-default conversation without an agent", async () => {
     const capture = captureConsole();
     try {
-      const code = await runMessagesSubcommand([
+      const code = await runMessages([
         "list",
         "--conversation",
         "local-conv-1",
@@ -165,7 +161,7 @@ describe("messages subcommand conversation scoping", () => {
   test("list rejects default conversation without an agent", async () => {
     const capture = captureConsole();
     try {
-      const code = await runMessagesSubcommand(["list"]);
+      const code = await runMessages(["list"]);
 
       expect(code).toBe(1);
       expect(backendMock.listConversationMessages).not.toHaveBeenCalled();

--- a/src/cli/subcommands/messages.test.ts
+++ b/src/cli/subcommands/messages.test.ts
@@ -1,0 +1,183 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+const initializeMock = mock(() => Promise.resolve());
+const searchMessagesForBackendMock = mock((_body: Record<string, unknown>) =>
+  Promise.resolve([]),
+);
+const backendMock = {
+  listAgentMessages: mock(() => Promise.resolve({ items: [] })),
+  listConversationMessages: mock(() => Promise.resolve({ items: [] })),
+};
+
+mock.module("@/settings-manager", () => ({
+  settingsManager: {
+    initialize: initializeMock,
+  },
+}));
+
+mock.module("@/backend", () => ({
+  getBackend: mock(() => backendMock),
+}));
+
+mock.module("@/backend/message-search", () => ({
+  searchMessagesForBackend: searchMessagesForBackendMock,
+}));
+
+const { runMessagesSubcommand } = await import("@/cli/subcommands/messages");
+
+function captureConsole() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation(
+    (...args: unknown[]) => {
+      stdout.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+  const errorSpy = spyOn(console, "error").mockImplementation(
+    (...args: unknown[]) => {
+      stderr.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+
+  return {
+    stdout,
+    stderr,
+    restore: () => {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    },
+  };
+}
+
+describe("messages subcommand conversation scoping", () => {
+  let priorAgentId: string | undefined;
+
+  beforeEach(() => {
+    priorAgentId = process.env.LETTA_AGENT_ID;
+    delete process.env.LETTA_AGENT_ID;
+    initializeMock.mockClear();
+    searchMessagesForBackendMock.mockClear();
+    backendMock.listAgentMessages.mockClear();
+    backendMock.listConversationMessages.mockClear();
+  });
+
+  afterEach(() => {
+    if (priorAgentId === undefined) delete process.env.LETTA_AGENT_ID;
+    else process.env.LETTA_AGENT_ID = priorAgentId;
+  });
+
+  test("search rejects default conversation without an agent", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runMessagesSubcommand([
+        "search",
+        "--query",
+        "needle",
+        "--conversation",
+        "default",
+      ]);
+
+      expect(code).toBe(1);
+      expect(searchMessagesForBackendMock).not.toHaveBeenCalled();
+      expect(capture.stderr.join("\n")).toContain(
+        'Conversation "default" requires an agent id',
+      );
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("searching a non-default conversation does not add env agent scope", async () => {
+    process.env.LETTA_AGENT_ID = "agent-current";
+    const capture = captureConsole();
+    try {
+      const code = await runMessagesSubcommand([
+        "search",
+        "--query",
+        "needle",
+        "--conversation",
+        "local-conv-1",
+      ]);
+
+      expect(code).toBe(0);
+      expect(searchMessagesForBackendMock).toHaveBeenCalledTimes(1);
+      expect(searchMessagesForBackendMock.mock.calls[0]?.[0]).toMatchObject({
+        query: "needle",
+        conversation_id: "local-conv-1",
+      });
+      expect(
+        searchMessagesForBackendMock.mock.calls[0]?.[0],
+      ).not.toHaveProperty("agent_id");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("searching default conversation uses the resolved agent", async () => {
+    process.env.LETTA_AGENT_ID = "agent-current";
+    const capture = captureConsole();
+    try {
+      const code = await runMessagesSubcommand([
+        "search",
+        "--query",
+        "needle",
+        "--conversation",
+        "default",
+      ]);
+
+      expect(code).toBe(0);
+      expect(searchMessagesForBackendMock).toHaveBeenCalledTimes(1);
+      expect(searchMessagesForBackendMock.mock.calls[0]?.[0]).toMatchObject({
+        query: "needle",
+        agent_id: "agent-current",
+        conversation_id: "default",
+      });
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("list allows non-default conversation without an agent", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runMessagesSubcommand([
+        "list",
+        "--conversation",
+        "local-conv-1",
+      ]);
+
+      expect(code).toBe(0);
+      expect(backendMock.listConversationMessages).toHaveBeenCalledWith(
+        "local-conv-1",
+        expect.objectContaining({ limit: 20 }),
+      );
+      expect(backendMock.listAgentMessages).not.toHaveBeenCalled();
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("list rejects default conversation without an agent", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runMessagesSubcommand(["list"]);
+
+      expect(code).toBe(1);
+      expect(backendMock.listConversationMessages).not.toHaveBeenCalled();
+      expect(backendMock.listAgentMessages).not.toHaveBeenCalled();
+      expect(capture.stderr.join("\n")).toContain(
+        'Conversation "default" requires an agent id',
+      );
+    } finally {
+      capture.restore();
+    }
+  });
+});

--- a/src/cli/subcommands/messages.test.ts
+++ b/src/cli/subcommands/messages.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -8,7 +9,6 @@ import {
   test,
 } from "bun:test";
 
-const initializeMock = mock(() => Promise.resolve());
 const searchMessagesForBackendMock = mock((_body: Record<string, unknown>) =>
   Promise.resolve([]),
 );
@@ -16,12 +16,6 @@ const backendMock = {
   listAgentMessages: mock(() => Promise.resolve({ items: [] })),
   listConversationMessages: mock(() => Promise.resolve({ items: [] })),
 };
-
-mock.module("@/settings-manager", () => ({
-  settingsManager: {
-    initialize: initializeMock,
-  },
-}));
 
 mock.module("@/backend", () => ({
   getBackend: mock(() => backendMock),
@@ -32,6 +26,10 @@ mock.module("@/backend/message-search", () => ({
 }));
 
 const { runMessagesSubcommand } = await import("@/cli/subcommands/messages");
+
+afterAll(() => {
+  mock.restore();
+});
 
 function captureConsole() {
   const stdout: string[] = [];
@@ -63,7 +61,6 @@ describe("messages subcommand conversation scoping", () => {
   beforeEach(() => {
     priorAgentId = process.env.LETTA_AGENT_ID;
     delete process.env.LETTA_AGENT_ID;
-    initializeMock.mockClear();
     searchMessagesForBackendMock.mockClear();
     backendMock.listAgentMessages.mockClear();
     backendMock.listConversationMessages.mockClear();

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -53,6 +53,8 @@ Search options:
   --all-agents          Search all agents, not just current agent
   --agent <id>          Explicit agent ID (overrides LETTA_AGENT_ID)
   --agent-id <id>       Alias for --agent
+  --conversation <id>   Conversation ID to search; "default" requires an agent
+  --conversation-id <id> Alias for --conversation
 
 List options:
   --agent <id>          Agent ID (overrides LETTA_AGENT_ID)
@@ -337,29 +339,56 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
       }
 
       const allAgents = parsed.values["all-agents"] ?? false;
+      const explicitAgentId =
+        parsed.values.agent || parsed.values["agent-id"] || "";
       const agentId = getAgentId(
         parsed.values.agent,
         parsed.values["agent-id"],
       );
       const conversationId =
         parsed.values.conversation || parsed.values["conversation-id"];
+      if (conversationId === "default") {
+        if (!agentId) {
+          console.error(
+            'Conversation "default" requires an agent id. Set LETTA_AGENT_ID or pass --agent/--agent-id.',
+          );
+          return 1;
+        }
+        if (allAgents) {
+          console.error(
+            'Conversation "default" requires a single agent id; do not combine --all-agents with --conversation default.',
+          );
+          return 1;
+        }
+      }
       if (!allAgents && !agentId && !conversationId) {
         console.error(
           "Missing search scope. Set LETTA_AGENT_ID, pass --agent/--agent-id, pass --conversation, or use --all-agents.",
         );
         return 1;
       }
+      const scopedAgentId =
+        conversationId === "default"
+          ? agentId
+          : conversationId
+            ? explicitAgentId || undefined
+            : allAgents
+              ? undefined
+              : agentId || undefined;
 
-      const result = await searchMessagesForBackend({
+      const searchBody = {
         query,
-        agent_id: allAgents ? undefined : agentId || undefined,
-        conversation_id:
-          typeof conversationId === "string" ? conversationId : undefined,
         search_mode: parseMode(parsed.values.mode) ?? "hybrid",
         start_date: parsed.values["start-date"],
         end_date: parsed.values["end-date"],
         limit: parseLimit(parsed.values.limit, 10),
-      });
+        ...(scopedAgentId ? { agent_id: scopedAgentId } : {}),
+        ...(typeof conversationId === "string"
+          ? { conversation_id: conversationId }
+          : {}),
+      };
+
+      const result = await searchMessagesForBackend(searchBody);
 
       console.log(JSON.stringify(result, null, 2));
       return 0;
@@ -370,13 +399,6 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         parsed.values.agent,
         parsed.values["agent-id"],
       );
-      if (!agentId) {
-        console.error(
-          "Missing agent id. Set LETTA_AGENT_ID or pass --agent/--agent-id.",
-        );
-        return 1;
-      }
-
       const orderRaw = parsed.values.order;
       const order = parseOrder(orderRaw);
       if (orderRaw !== undefined && !order) {
@@ -388,6 +410,12 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         parsed.values.conversation ||
         parsed.values["conversation-id"] ||
         "default";
+      if (conversationId === "default" && !agentId) {
+        console.error(
+          'Conversation "default" requires an agent id. Set LETTA_AGENT_ID or pass --agent/--agent-id.',
+        );
+        return 1;
+      }
       const listBody = {
         limit: parseLimit(parsed.values.limit, 20),
         after: parsed.values.after,

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -57,6 +57,8 @@ Search options:
 List options:
   --agent <id>          Agent ID (overrides LETTA_AGENT_ID)
   --agent-id <id>       Alias for --agent
+  --conversation <id>   Conversation ID to list (default: default)
+  --conversation-id <id> Alias for --conversation
   --after <message-id>  Cursor: get messages after this ID
   --before <message-id> Cursor: get messages before this ID
   --order <asc|desc>    Sort order (default: desc = newest first)
@@ -339,16 +341,20 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         parsed.values.agent,
         parsed.values["agent-id"],
       );
-      if (!allAgents && !agentId) {
+      const conversationId =
+        parsed.values.conversation || parsed.values["conversation-id"];
+      if (!allAgents && !agentId && !conversationId) {
         console.error(
-          "Missing agent id. Set LETTA_AGENT_ID or pass --agent/--agent-id.",
+          "Missing search scope. Set LETTA_AGENT_ID, pass --agent/--agent-id, pass --conversation, or use --all-agents.",
         );
         return 1;
       }
 
       const result = await searchMessagesForBackend({
         query,
-        agent_id: allAgents ? undefined : agentId,
+        agent_id: allAgents ? undefined : agentId || undefined,
+        conversation_id:
+          typeof conversationId === "string" ? conversationId : undefined,
         search_mode: parseMode(parsed.values.mode) ?? "hybrid",
         start_date: parsed.values["start-date"],
         end_date: parsed.values["end-date"],
@@ -378,13 +384,23 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
         return 1;
       }
 
-      const response = await backend.listAgentMessages(agentId, {
-        conversation_id: "default",
+      const conversationId =
+        parsed.values.conversation ||
+        parsed.values["conversation-id"] ||
+        "default";
+      const listBody = {
         limit: parseLimit(parsed.values.limit, 20),
         after: parsed.values.after,
         before: parsed.values.before,
         order,
-      });
+      };
+      const response =
+        conversationId === "default"
+          ? await backend.listAgentMessages(agentId, {
+              conversation_id: "default",
+              ...listBody,
+            })
+          : await backend.listConversationMessages(conversationId, listBody);
 
       const messages = pageItems<TranscriptMessage>(response);
       const startDate = parsed.values["start-date"];

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -8,6 +8,12 @@ import { settingsManager } from "@/settings-manager";
 type SearchMode = "vector" | "fts" | "hybrid";
 type ListOrder = "asc" | "desc";
 
+type MessagesSubcommandDeps = {
+  initializeSettings?: () => Promise<void>;
+  getBackend?: typeof getBackend;
+  searchMessagesForBackend?: typeof searchMessagesForBackend;
+};
+
 type TranscriptMessage = {
   id?: string;
   date?: string;
@@ -157,7 +163,10 @@ function parseMessagesArgs(argv: string[]) {
   });
 }
 
-export async function runMessagesSubcommand(argv: string[]): Promise<number> {
+export async function runMessagesSubcommand(
+  argv: string[],
+  deps: MessagesSubcommandDeps = {},
+): Promise<number> {
   let parsed: ReturnType<typeof parseMessagesArgs>;
   try {
     parsed = parseMessagesArgs(argv);
@@ -175,8 +184,10 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
   }
 
   try {
-    await settingsManager.initialize();
-    const backend = getBackend();
+    await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
+    const backend = (deps.getBackend ?? getBackend)();
+    const searchMessages =
+      deps.searchMessagesForBackend ?? searchMessagesForBackend;
 
     const renderText = (value: unknown): string => {
       if (typeof value === "string") return value;
@@ -388,7 +399,7 @@ export async function runMessagesSubcommand(argv: string[]): Promise<number> {
           : {}),
       };
 
-      const result = await searchMessagesForBackend(searchBody);
+      const result = await searchMessages(searchBody);
 
       console.log(JSON.stringify(result, null, 2));
       return 0;


### PR DESCRIPTION
## Summary
- Add transcript-backed local message search over durable `messages.jsonl` files so recall and `/search` can find compacted-out history without using active context projections.
- Add a local-only recall prompt variant that treats local search as full-text, plus a read-only transcript file fallback for custom searches.
- Fix local conversation scoping so `default` requires an agent while non-default conversation IDs can stand alone, and wire CLI/TUI conversation-scoped search/list flows accordingly.
- Harden the `/search` TUI for local transcript results by safely formatting non-string tool returns and avoiding redundant local mode prefetches when all local modes are text search aliases.

## Test plan
- [x] `bun test src/cli/message-search-cache-warm.test.ts src/cli/subcommands/messages.test.ts src/cli/subcommands/connect.test.ts src/cli/subcommands/router.test.ts src/agent/subagent-model-resolution.test.ts src/backend/message-search.test.ts`
- [x] `bun run scripts/check-test-mock-isolation.js`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check` *(with unrelated untracked `src/utils/turnTimings.ts` hidden locally; PR files pass)*
- [x] Manual local-data smoke test: `letta messages search --query "startup-flow reused"` and direct `grep` over `~/.letta/lc-local-backend/conversations/*/messages.jsonl` found the same transcript row.

## Follow-up
- Local search currently reads/parses transcript files synchronously and materializes matches before slicing to the requested limit. That is acceptable for this v0 and current local stores, but a future scaling pass should switch to streaming line-by-line scanning with bounded top-N result collection to reduce TUI blocking and memory use for very large histories.

👾 Generated with [Letta Code](https://letta.com)