### PR TITLE
fix(sync): allow forced device status replay

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -635,6 +635,11 @@ export interface SyncCommand {
    * set this false and only replay in-memory listener state.
    */
   recover_approvals?: boolean;
+  /**
+   * Force the sync replay to include update_device_status even when the
+   * listener's last device-status snapshot for this socket/scope is unchanged.
+   */
+  force_device_status?: boolean;
 }
 
 export interface TerminalSpawnCommand {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -3379,11 +3379,7 @@ describe("listen-client v2 status builders", () => {
       socket.sentPayloads
         .map((payload) => JSON.parse(payload as string))
         .map((message) => message.type),
-    ).toEqual([
-      "update_loop_status",
-      "update_queue",
-      "update_subagent_state",
-    ]);
+    ).toEqual(["update_loop_status", "update_queue", "update_subagent_state"]);
 
     socket.sentPayloads = [];
     __listenClientTestUtils.emitStateSync(

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -409,6 +409,7 @@ describe("listen-client parseServerMessage", () => {
           type: "sync",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
           recover_approvals: false,
+          force_device_status: true,
         }),
       ),
     );
@@ -417,6 +418,7 @@ describe("listen-client parseServerMessage", () => {
       throw new Error("expected sync command");
     }
     expect(sync.recover_approvals).toBe(false);
+    expect(sync.force_device_status).toBe(true);
   });
 
   test("parses cron CRUD commands", () => {
@@ -3348,6 +3350,58 @@ describe("listen-client v2 status builders", () => {
         client_message_id: "cm-1",
         kind: "message",
       }),
+    ]);
+  });
+
+  test("sync can force update_device_status even when cached", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+    const scope = { agent_id: "agent-1", conversation_id: "default" };
+
+    __listenClientTestUtils.emitStateSync(
+      socket as unknown as WebSocket,
+      runtime,
+      scope,
+    );
+    socket.sentPayloads = [];
+
+    __listenClientTestUtils.emitStateSync(
+      socket as unknown as WebSocket,
+      runtime,
+      scope,
+    );
+    expect(
+      socket.sentPayloads
+        .map((payload) => JSON.parse(payload as string))
+        .map((message) => message.type),
+    ).toEqual([
+      "update_loop_status",
+      "update_queue",
+      "update_subagent_state",
+    ]);
+
+    socket.sentPayloads = [];
+    __listenClientTestUtils.emitStateSync(
+      socket as unknown as WebSocket,
+      runtime,
+      scope,
+      { forceDeviceStatus: true },
+    );
+
+    expect(
+      socket.sentPayloads
+        .map((payload) => JSON.parse(payload as string))
+        .map((message) => message.type),
+    ).toEqual([
+      "update_device_status",
+      "update_loop_status",
+      "update_queue",
+      "update_subagent_state",
     ]);
   });
 

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -541,6 +541,7 @@ export const __listenClientTestUtils = {
         runtime: ListenerRuntime,
         scope: { agent_id: string; conversation_id: string },
       ) => void;
+      forceDeviceStatus?: boolean;
     },
   ) =>
     replaySyncStateForRuntime(runtime, socket, scope, {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -207,6 +207,7 @@ export async function replaySyncStateForRuntime(
       runtime: ListenerRuntime,
       scope: { agent_id: string; conversation_id: string },
     ) => void;
+    forceDeviceStatus?: boolean;
   },
 ): Promise<void> {
   const syncScopedRuntime = getOrCreateScopedRuntime(
@@ -232,7 +233,9 @@ export async function replaySyncStateForRuntime(
     }
   }
 
-  emitStateSync(socket, listenerRuntime, scope);
+  emitStateSync(socket, listenerRuntime, scope, {
+    forceDeviceStatus: opts?.forceDeviceStatus,
+  });
   (opts?.scheduleWarmupsAfterSync ?? scheduleListenerWarmupsAfterSync)(
     listenerRuntime,
     scope,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -107,7 +107,7 @@ type MessageRouterParams = {
     listenerRuntime: ListenerRuntime,
     socket: WebSocket,
     scope: RuntimeScope,
-    opts?: { recoverApprovals?: boolean },
+    opts?: { recoverApprovals?: boolean; forceDeviceStatus?: boolean },
   ) => Promise<void>;
   getOrCreateScopedRuntime: (
     listener: ListenerRuntime,
@@ -236,6 +236,7 @@ export function createListenerMessageHandler(
         }
         await replaySyncStateForRuntime(runtime, socket, parsed.runtime, {
           recoverApprovals: parsed.recover_approvals !== false,
+          forceDeviceStatus: parsed.force_device_status === true,
         });
         return;
       }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -288,12 +288,15 @@ function isSyncCommand(value: unknown): value is SyncCommand {
     type?: unknown;
     runtime?: unknown;
     recover_approvals?: unknown;
+    force_device_status?: unknown;
   };
   return (
     candidate.type === "sync" &&
     isRuntimeScope(candidate.runtime) &&
     (candidate.recover_approvals === undefined ||
-      typeof candidate.recover_approvals === "boolean")
+      typeof candidate.recover_approvals === "boolean") &&
+    (candidate.force_device_status === undefined ||
+      typeof candidate.force_device_status === "boolean")
   );
 }
 

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -924,11 +924,10 @@ export function emitQueueUpdateIfOpen(
 
 /**
  * Per-transport, per-scope cache of the last emitted device-status JSON.
- * When a periodic sync produces the exact same status as the previous one
- * (common when idle), we skip the WS send entirely — avoiding redundant
- * JSON serialization, WS framing, and Redis pub/sub in the cloud relay
- * path. Keyed by transport (WeakMap) so cache is naturally cleaned up when
- * the socket closes and gets GC'd. (LET-8948)
+ * Periodic syncs can opt into this cache to avoid redundant device-status
+ * frames when idle, while recovery/visibility syncs can force a full replay.
+ * Keyed by transport (WeakMap) so cache is naturally cleaned up when the
+ * socket closes and gets GC'd. (LET-8948)
  */
 const lastSyncDeviceStatusByTransport = new WeakMap<
   ListenerTransport,
@@ -939,6 +938,7 @@ export function emitStateSync(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope: RuntimeScope,
+  options?: { forceDeviceStatus?: boolean },
 ): void {
   const deviceStatus = buildDeviceStatus(runtime, scope);
   const deviceStatusJson = JSON.stringify(deviceStatus);
@@ -951,7 +951,7 @@ export function emitStateSync(
   }
   const prev = scopeCache.get(cacheKey);
 
-  if (deviceStatusJson !== prev) {
+  if (options?.forceDeviceStatus || deviceStatusJson !== prev) {
     scopeCache.set(cacheKey, deviceStatusJson);
     const message: Omit<
       DeviceStatusUpdateMessage,


### PR DESCRIPTION
Add an explicit sync flag for clients that need update_device_status even when the listener would otherwise suppress an unchanged cached snapshot, preserving the idle sync optimization for routine polling.

👾 Generated with [Letta Code](https://letta.com)