### PR TITLE
fix(connect): manage disconnects through provider selector

### DIFF
--- a/src/cli/app/submit-connection-commands.ts
+++ b/src/cli/app/submit-connection-commands.ts
@@ -170,26 +170,6 @@ export async function handleConnectionCommand(
     return { submitted: true };
   }
 
-  if (trimmed.startsWith("/disconnect")) {
-    const cmd = commandRunner.start(msg, "Disconnecting...");
-    const { handleDisconnect, setActiveCommandId: setActiveConnectCommandId } =
-      await import("@/cli/commands/connect");
-    setActiveConnectCommandId(cmd.id);
-    try {
-      await handleDisconnect(
-        {
-          buffersRef,
-          refreshDerived,
-          setCommandRunning,
-        },
-        msg,
-      );
-    } finally {
-      setActiveConnectCommandId(null);
-    }
-    return { submitted: true };
-  }
-
   // Special handling for /server command (alias: /remote)
   if (
     trimmed === "/server" ||

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -14,15 +14,11 @@ import {
   getProviderByName,
   type ProviderStorageTarget,
   providerStorageTargetLabel,
-  removeProviderByName,
 } from "@/providers/byok-providers";
 import {
   createOrUpdateOpenAICodexProvider,
-  deleteOpenAICodexProvider,
   getOpenAICodexProvider,
-  listProviders,
   OPENAI_CODEX_PROVIDER_NAME,
-  removeOpenAICodexProvider,
 } from "@/providers/openai-codex-provider";
 import { getErrorMessage } from "@/utils/error";
 import { runLocalOAuthConnectFlow } from "./connect-local-oauth";
@@ -359,7 +355,7 @@ async function handleConnectChatGPT(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      "Already connected to ChatGPT via OAuth.\n\nUse /disconnect chatgpt (or /disconnect codex) to remove the current connection first.",
+      "Already connected to ChatGPT via OAuth.\n\nOpen /connect and select ChatGPT / Codex plan in the current tab to disconnect or re-authenticate.",
       false,
     );
     return;
@@ -447,7 +443,7 @@ async function handleConnectLocalOAuthProvider(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      `Already connected to ${provider.byokProvider.displayName}. Disconnect first if you want to re-authenticate.`,
+      `Already connected to ${provider.byokProvider.displayName}.\n\nOpen /connect and select it in the Local tab to disconnect or re-authenticate.`,
       false,
     );
     return;
@@ -805,270 +801,4 @@ export async function handleConnect(
       timeout: parsed.timeout,
     });
   }
-}
-
-function formatDisconnectHelp(): string {
-  return [
-    "/disconnect help",
-    "",
-    "Disconnect an existing account.",
-    "",
-    "USAGE",
-    "  /disconnect <provider>   — disconnect a provider",
-    "  /disconnect help         — show this help",
-    "",
-    "PROVIDERS",
-    `  ${listConnectProvidersForHelp().join(", ")}, claude (legacy)`,
-  ].join("\n");
-}
-
-async function handleDisconnectChatGPT(
-  ctx: ConnectCommandContext,
-  msg: string,
-): Promise<void> {
-  const existingProvider = await getOpenAICodexProvider({
-    target: ctx.target,
-  });
-  if (!existingProvider) {
-    addCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      msg,
-      "Not currently connected to ChatGPT via OAuth.\n\nUse /connect chatgpt (or /connect codex) to authenticate.",
-      false,
-    );
-    return;
-  }
-
-  const cmdId = addCommandResult(
-    ctx.buffersRef,
-    ctx.refreshDerived,
-    msg,
-    "Disconnecting from ChatGPT OAuth...",
-    true,
-    "running",
-  );
-
-  ctx.setCommandRunning(true);
-  try {
-    await removeOpenAICodexProvider({ target: ctx.target });
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      `✓ Disconnected from ChatGPT OAuth.\n\n` +
-        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' removed from ${providerStorageTargetLabel(ctx.target)}.`,
-      true,
-      "finished",
-    );
-  } catch (error) {
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      `✗ Failed to disconnect from ChatGPT: ${getErrorMessage(error)}`,
-      false,
-      "finished",
-    );
-  } finally {
-    ctx.setCommandRunning(false);
-  }
-}
-
-async function handleDisconnectByokProvider(
-  ctx: ConnectCommandContext,
-  msg: string,
-  provider: ResolvedConnectProvider,
-): Promise<void> {
-  const existing = await getProviderByName(provider.byokProvider.providerName, {
-    target: provider.target,
-  });
-  const authMatches =
-    provider.target !== "local" || !existing?.auth_type
-      ? true
-      : provider.byokProvider.isOAuth
-        ? existing.auth_type === "oauth"
-        : existing.auth_type !== "oauth";
-  if (!existing || !authMatches) {
-    addCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      msg,
-      `Not currently connected to ${provider.byokProvider.displayName}.\n\nUse /connect ${provider.canonical} to connect.`,
-      false,
-    );
-    return;
-  }
-
-  const cmdId = addCommandResult(
-    ctx.buffersRef,
-    ctx.refreshDerived,
-    msg,
-    `Disconnecting from ${provider.byokProvider.displayName}...`,
-    true,
-    "running",
-  );
-
-  ctx.setCommandRunning(true);
-  try {
-    await removeProviderByName(provider.byokProvider.providerName, {
-      target: provider.target,
-    });
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      `✓ Disconnected from ${provider.byokProvider.displayName}.\n\n` +
-        `Provider '${provider.byokProvider.providerName}' removed from ${providerStorageTargetLabel(provider.target)}.`,
-      true,
-      "finished",
-    );
-  } catch (error) {
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      `✗ Failed to disconnect from ${provider.byokProvider.displayName}: ${getErrorMessage(error)}`,
-      false,
-      "finished",
-    );
-  } finally {
-    ctx.setCommandRunning(false);
-  }
-}
-
-async function handleDisconnectClaude(
-  ctx: ConnectCommandContext,
-  msg: string,
-): Promise<void> {
-  const CLAUDE_PROVIDER_NAME = "claude-pro-max";
-
-  const cmdId = addCommandResult(
-    ctx.buffersRef,
-    ctx.refreshDerived,
-    msg,
-    "Checking for Claude provider...",
-    true,
-    "running",
-  );
-
-  ctx.setCommandRunning(true);
-
-  try {
-    const providers = await listProviders({ target: ctx.target });
-    const claudeProvider = providers.find(
-      (provider) => provider.name === CLAUDE_PROVIDER_NAME,
-    );
-
-    if (!claudeProvider) {
-      updateCommandResult(
-        ctx.buffersRef,
-        ctx.refreshDerived,
-        cmdId,
-        msg,
-        `No Claude provider found.\n\nThe '${CLAUDE_PROVIDER_NAME}' provider does not exist in your Letta account.`,
-        false,
-        "finished",
-      );
-      return;
-    }
-
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      "Removing Claude provider...",
-      true,
-      "running",
-    );
-
-    await deleteOpenAICodexProvider(claudeProvider.id, { target: ctx.target });
-
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      "✓ Disconnected from Claude.\n\n" +
-        `Provider '${CLAUDE_PROVIDER_NAME}' has been removed from Letta.\n\n` +
-        "Note: /connect claude has been replaced by /connect chatgpt (alias: /connect codex).",
-      true,
-      "finished",
-    );
-  } catch (error) {
-    updateCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      cmdId,
-      msg,
-      `✗ Failed to disconnect from Claude: ${getErrorMessage(error)}`,
-      false,
-      "finished",
-    );
-  } finally {
-    ctx.setCommandRunning(false);
-  }
-}
-
-export async function handleDisconnect(
-  ctx: ConnectCommandContext,
-  msg: string,
-): Promise<void> {
-  const parts = parseArgs(msg);
-  const providerToken = parts[1]?.toLowerCase();
-
-  if (providerToken === "help") {
-    addCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      msg,
-      formatDisconnectHelp(),
-      true,
-    );
-    return;
-  }
-
-  if (!providerToken) {
-    addCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      msg,
-      "Usage: /disconnect <provider>",
-      false,
-    );
-    return;
-  }
-
-  if (providerToken === "claude") {
-    await handleDisconnectClaude(ctx, msg);
-    return;
-  }
-
-  const provider = resolveConnectProvider(providerToken, ctx.target);
-  if (!provider) {
-    addCommandResult(
-      ctx.buffersRef,
-      ctx.refreshDerived,
-      msg,
-      `Unknown provider: "${providerToken}". Run /disconnect help for usage.`,
-      false,
-    );
-    return;
-  }
-
-  if (isConnectOAuthProvider(provider)) {
-    if (provider.target === "local") {
-      await handleDisconnectByokProvider(ctx, msg, provider);
-    } else {
-      await handleDisconnectChatGPT(ctx, msg);
-    }
-    return;
-  }
-
-  await handleDisconnectByokProvider(ctx, msg, provider);
 }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -518,14 +518,6 @@ export const commands: Record<string, Command> = {
   },
 
   // === Session management (order 40-49) ===
-  "/disconnect": {
-    desc: "Disconnect an existing account (/disconnect codex|claude|zai)",
-    order: 41,
-    handler: () => {
-      // Handled specially in App.tsx
-      return "Disconnecting...";
-    },
-  },
   "/bg": {
     desc: "Show background shell processes",
     order: 42,

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -42,6 +42,10 @@ type ProviderSelectionFlow =
   | "multiInput"
   | "input";
 
+type ConnectedProvidersByTarget = Partial<
+  Record<ProviderStorageTarget, Map<string, ProviderResponse>>
+>;
+
 interface ProviderSelectorProps {
   onCancel: () => void;
   /** Called when an OAuth flow should start */
@@ -110,6 +114,17 @@ export function providerSelectionFlow(
   return "input";
 }
 
+export function isProviderTargetLoading(input: {
+  selectedTarget: ProviderStorageTarget;
+  connectedProvidersByTarget: ConnectedProvidersByTarget;
+  showProviderStoreTabs: boolean;
+}): boolean {
+  return (
+    input.connectedProvidersByTarget[input.selectedTarget] === undefined &&
+    (input.selectedTarget === "local" || input.showProviderStoreTabs)
+  );
+}
+
 export function ProviderSelector({
   onCancel,
   onStartOAuth,
@@ -124,10 +139,11 @@ export function ProviderSelector({
   const [hasConstellationCredentials, setHasConstellationCredentials] =
     useState<boolean | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [connectedProviders, setConnectedProviders] = useState<
-    Map<string, ProviderResponse>
-  >(new Map());
-  const [isLoading, setIsLoading] = useState(true);
+  const [connectedProvidersByTarget, setConnectedProvidersByTarget] =
+    useState<ConnectedProvidersByTarget>({});
+  const [loadingTargets, setLoadingTargets] = useState<
+    Set<ProviderStorageTarget>
+  >(new Set());
   const [viewState, setViewState] = useState<ViewState>({ type: "list" });
   const [searchQuery, setSearchQuery] = useState("");
   const [apiKeyInput, setApiKeyInput] = useState("");
@@ -155,6 +171,15 @@ export function ProviderSelector({
   const showProviderStoreTabs = shouldShowProviderStoreTabs(
     hasConstellationCredentials,
   );
+  const connectedProviders = useMemo(
+    () => connectedProvidersByTarget[selectedTarget] ?? new Map(),
+    [connectedProvidersByTarget, selectedTarget],
+  );
+  const isLoading = isProviderTargetLoading({
+    selectedTarget,
+    connectedProvidersByTarget,
+    showProviderStoreTabs,
+  });
   const selectableProviders = filteredProviders;
   const providerStartIndex = useMemo(() => {
     if (selectedIndex < VISIBLE_PROVIDERS) return 0;
@@ -204,30 +229,75 @@ export function ProviderSelector({
     };
   }, []);
 
-  // Load connected providers on mount and when switching targets.
-  useEffect(() => {
-    if (selectedTarget === "api" && !showProviderStoreTabs) {
-      setIsLoading(false);
-      return;
-    }
+  const setConnectedProvidersForTarget = useCallback(
+    (
+      target: ProviderStorageTarget,
+      providers: Map<string, ProviderResponse>,
+    ) => {
+      setConnectedProvidersByTarget((previous) => ({
+        ...previous,
+        [target]: providers,
+      }));
+    },
+    [],
+  );
 
-    setIsLoading(true);
-    (async () => {
+  const refreshConnectedProviders = useCallback(
+    async (target: ProviderStorageTarget) => {
+      setLoadingTargets((previous) => new Set(previous).add(target));
       try {
-        const providers = await getConnectedProviders({
-          target: selectedTarget,
-        });
+        const providers = await getConnectedProviders({ target });
         if (mountedRef.current) {
-          setConnectedProviders(providers);
-          setIsLoading(false);
+          setConnectedProvidersForTarget(target, providers);
         }
       } catch {
         if (mountedRef.current) {
-          setIsLoading(false);
+          setConnectedProvidersForTarget(target, new Map());
+        }
+      } finally {
+        if (mountedRef.current) {
+          setLoadingTargets((previous) => {
+            const next = new Set(previous);
+            next.delete(target);
+            return next;
+          });
         }
       }
-    })();
-  }, [selectedTarget, showProviderStoreTabs]);
+    },
+    [setConnectedProvidersForTarget],
+  );
+
+  // Load connected providers once per target while the overlay is mounted.
+  useEffect(() => {
+    if (selectedTarget === "api" && !showProviderStoreTabs) return;
+    if (connectedProvidersByTarget[selectedTarget]) return;
+    if (loadingTargets.has(selectedTarget)) return;
+    void refreshConnectedProviders(selectedTarget);
+  }, [
+    connectedProvidersByTarget,
+    loadingTargets,
+    refreshConnectedProviders,
+    selectedTarget,
+    showProviderStoreTabs,
+  ]);
+
+  // When both tabs are available, prefetch the inactive tab so switching tabs
+  // can render from overlay-local cache instead of flashing a loading state.
+  useEffect(() => {
+    if (!showProviderStoreTabs) return;
+    for (const target of ["local", "api"] as const) {
+      if (target === selectedTarget) continue;
+      if (connectedProvidersByTarget[target]) continue;
+      if (loadingTargets.has(target)) continue;
+      void refreshConnectedProviders(target);
+    }
+  }, [
+    connectedProvidersByTarget,
+    loadingTargets,
+    refreshConnectedProviders,
+    selectedTarget,
+    showProviderStoreTabs,
+  ]);
 
   useEffect(() => {
     if (!showProviderStoreTabs && selectedTarget !== "local") {
@@ -436,7 +506,7 @@ export function ProviderSelector({
           target: selectedTarget,
         });
         if (mountedRef.current) {
-          setConnectedProviders(providers);
+          setConnectedProvidersForTarget(selectedTarget, providers);
           setViewState({ type: "list" });
           setApiKeyInput("");
           setValidationState("idle");
@@ -476,7 +546,13 @@ export function ProviderSelector({
         );
       }
     }
-  }, [viewState, apiKeyInput, validationState, selectedTarget]);
+  }, [
+    viewState,
+    apiKeyInput,
+    validationState,
+    selectedTarget,
+    setConnectedProvidersForTarget,
+  ]);
 
   // Handle multi-field validation and saving (for providers like Bedrock)
   const handleMultiFieldValidateAndSave = useCallback(async () => {
@@ -519,7 +595,7 @@ export function ProviderSelector({
           target: selectedTarget,
         });
         if (mountedRef.current) {
-          setConnectedProviders(providers);
+          setConnectedProvidersForTarget(selectedTarget, providers);
           setViewState({ type: "list" });
           setFieldValues({});
           setValidationState("idle");
@@ -559,7 +635,13 @@ export function ProviderSelector({
         );
       }
     }
-  }, [viewState, fieldValues, validationState, selectedTarget]);
+  }, [
+    viewState,
+    fieldValues,
+    validationState,
+    selectedTarget,
+    setConnectedProvidersForTarget,
+  ]);
 
   // Handle disconnect
   const handleDisconnect = useCallback(async () => {
@@ -577,13 +659,18 @@ export function ProviderSelector({
       // Refresh connected providers
       const providers = await getConnectedProviders({ target: selectedTarget });
       if (mountedRef.current) {
-        setConnectedProviders(providers);
+        setConnectedProvidersForTarget(selectedTarget, providers);
         setViewState({ type: "list" });
       }
     } catch {
       // Silently fail, stay on options view
     }
-  }, [viewState, selectedTarget, getConnectedProviderName]);
+  }, [
+    viewState,
+    selectedTarget,
+    getConnectedProviderName,
+    setConnectedProvidersForTarget,
+  ]);
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -110,10 +110,6 @@ export function providerSelectionFlow(
   return "input";
 }
 
-function targetLabel(target: ProviderStorageTarget): string {
-  return target === "local" ? "Local" : "Constellation";
-}
-
 export function ProviderSelector({
   onCancel,
   onStartOAuth,
@@ -1252,16 +1248,13 @@ export function ProviderSelector({
   const renderOptionsView = () => {
     if (viewState.type !== "options") return null;
     const { provider } = viewState;
-    const options = [`Disconnect from ${targetLabel(selectedTarget)}`, "Back"];
+    const options = ["Disconnect provider", "Back"];
 
     return (
       <>
         <Box flexDirection="column" marginBottom={1}>
           <Text bold color={colors.selector.title}>
             Disconnect {provider.displayName}
-          </Text>
-          <Text dimColor>
-            This removes only the {targetLabel(selectedTarget)} connection.
           </Text>
           <Box height={1} />
           <Box flexDirection="row">

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -31,9 +31,16 @@ type ViewState =
   | { type: "multiInput"; provider: ByokProvider; authMethod?: AuthMethod }
   | { type: "methodSelect"; provider: ByokProvider }
   | { type: "profileSelect"; provider: ByokProvider }
-  | { type: "options"; provider: ByokProvider; providerId: string };
+  | { type: "options"; provider: ByokProvider };
 
 type ValidationState = "idle" | "validating" | "valid" | "invalid" | "saving";
+
+type ProviderSelectionFlow =
+  | "options"
+  | "oauth"
+  | "methodSelect"
+  | "multiInput"
+  | "input";
 
 interface ProviderSelectorProps {
   onCancel: () => void;
@@ -90,6 +97,21 @@ export function filterProviderConfigs(
       .toLowerCase();
     return searchable.includes(normalized);
   });
+}
+
+export function providerSelectionFlow(
+  provider: ByokProvider,
+  connectedProviderId?: string,
+): ProviderSelectionFlow {
+  if (connectedProviderId) return "options";
+  if (provider.isOAuth) return "oauth";
+  if ("authMethods" in provider && provider.authMethods) return "methodSelect";
+  if ("fields" in provider && provider.fields) return "multiInput";
+  return "input";
+}
+
+function targetLabel(target: ProviderStorageTarget): string {
+  return target === "local" ? "Local" : "Constellation";
 }
 
 export function ProviderSelector({
@@ -289,7 +311,16 @@ export function ProviderSelector({
   // Handle selecting a provider from the list
   const handleSelectProvider = useCallback(
     (provider: ByokProvider) => {
-      if ("isOAuth" in provider && provider.isOAuth) {
+      const providerId = getProviderId(provider);
+      const flow = providerSelectionFlow(provider, providerId);
+
+      if (flow === "options") {
+        setViewState({ type: "options", provider });
+        setOptionIndex(0);
+        return;
+      }
+
+      if (flow === "oauth") {
         // OAuth provider - trigger OAuth flow
         if (onStartOAuth) {
           onStartOAuth(provider, selectedTarget);
@@ -297,19 +328,11 @@ export function ProviderSelector({
         return;
       }
 
-      const connected = isConnected(provider);
-      if (connected) {
-        // Show options for connected provider
-        const providerId = getProviderId(provider);
-        if (providerId) {
-          setViewState({ type: "options", provider, providerId });
-          setOptionIndex(0);
-        }
-      } else if ("authMethods" in provider && provider.authMethods) {
+      if (flow === "methodSelect") {
         // Provider with multiple auth methods - show method selection
         setViewState({ type: "methodSelect", provider });
         setMethodIndex(0);
-      } else if ("fields" in provider && provider.fields) {
+      } else if (flow === "multiInput") {
         // Multi-field provider - show multi-input view
         setViewState({ type: "multiInput", provider });
         setFieldValues({});
@@ -324,7 +347,7 @@ export function ProviderSelector({
         setValidationError(null);
       }
     },
-    [isConnected, getProviderId, onStartOAuth, selectedTarget],
+    [getProviderId, onStartOAuth, selectedTarget],
   );
 
   // Handle selecting an auth method
@@ -554,6 +577,7 @@ export function ProviderSelector({
           target: selectedTarget,
         },
       );
+      clearAvailableModelsCache();
       // Refresh connected providers
       const providers = await getConnectedProviders({ target: selectedTarget });
       if (mountedRef.current) {
@@ -1228,11 +1252,18 @@ export function ProviderSelector({
   const renderOptionsView = () => {
     if (viewState.type !== "options") return null;
     const { provider } = viewState;
-    const options = ["Disconnect", "Back"];
+    const options = [`Disconnect from ${targetLabel(selectedTarget)}`, "Back"];
 
     return (
       <>
         <Box flexDirection="column" marginBottom={1}>
+          <Text bold color={colors.selector.title}>
+            Disconnect {provider.displayName}
+          </Text>
+          <Text dimColor>
+            This removes only the {targetLabel(selectedTarget)} connection.
+          </Text>
+          <Box height={1} />
           <Box flexDirection="row">
             <Text>{"  "}</Text>
             <Text color="green">[✓]</Text>
@@ -1269,7 +1300,7 @@ export function ProviderSelector({
         </Box>
 
         <Box marginTop={1}>
-          <Text dimColor>{"  "}Enter select · ↑↓ navigate · Esc back</Text>
+          <Text dimColor>{"  "}Enter confirm · ↑↓ navigate · Esc back</Text>
         </Box>
       </>
     );

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -3,6 +3,7 @@ import { commands } from "@/cli/commands/registry";
 import {
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
+  isProviderTargetLoading,
   providerApiKeyFromInput,
   providerSelectionFlow,
   shouldShowProviderStoreTabs,
@@ -196,5 +197,23 @@ describe("ProviderSelector connected provider actions", () => {
 
   test("removes the legacy slash disconnect command from discovery", () => {
     expect(commands["/disconnect"]).toBeUndefined();
+  });
+
+  test("does not show loading when switching to a cached provider tab", () => {
+    expect(
+      isProviderTargetLoading({
+        selectedTarget: "api",
+        connectedProvidersByTarget: { api: new Map() },
+        showProviderStoreTabs: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      isProviderTargetLoading({
+        selectedTarget: "api",
+        connectedProvidersByTarget: {},
+        showProviderStoreTabs: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { commands } from "@/cli/commands/registry";
 import {
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
   providerApiKeyFromInput,
+  providerSelectionFlow,
   shouldShowProviderStoreTabs,
 } from "@/cli/components/ProviderSelector";
 import {
@@ -168,5 +170,31 @@ describe("ProviderSelector provider filtering", () => {
     expect(filterProviderConfigs(providers, "   ").length).toBe(
       providers.length,
     );
+  });
+});
+
+describe("ProviderSelector connected provider actions", () => {
+  test("opens options for connected OAuth providers before starting OAuth", () => {
+    const codex = getProviderConfigs("api").find(
+      (provider) => provider.id === "codex",
+    );
+    if (!codex) throw new Error("Expected codex provider config");
+
+    expect(providerSelectionFlow(codex)).toBe("oauth");
+    expect(providerSelectionFlow(codex, "provider-1")).toBe("options");
+  });
+
+  test("opens options for connected API-key providers", () => {
+    const openai = getProviderConfigs("api").find(
+      (provider) => provider.id === "openai",
+    );
+    if (!openai) throw new Error("Expected openai provider config");
+
+    expect(providerSelectionFlow(openai)).toBe("input");
+    expect(providerSelectionFlow(openai, "provider-2")).toBe("options");
+  });
+
+  test("removes the legacy slash disconnect command from discovery", () => {
+    expect(commands["/disconnect"]).toBeUndefined();
   });
 });

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -228,7 +228,7 @@ export async function runConnectSubcommand(
 
         if (await io.isChatGPTOAuthConnected()) {
           io.stdout(
-            "Already connected to ChatGPT via OAuth. Disconnect first if you want to re-authenticate.",
+            "Already connected to ChatGPT via OAuth. Use /connect in the TUI and select ChatGPT / Codex plan to disconnect or re-authenticate.",
           );
           return 0;
         }

--- a/src/providers/openai-codex-provider.ts
+++ b/src/providers/openai-codex-provider.ts
@@ -7,7 +7,6 @@
 import { getBalanceMetadata } from "@/backend/api/metadata";
 import {
   createProvider,
-  deleteProvider,
   getProviderByName,
   listProviders,
   type ProviderOperationOptions,
@@ -99,16 +98,6 @@ export async function updateOpenAICodexProvider(
 }
 
 /**
- * Delete the ChatGPT OAuth provider
- */
-export async function deleteOpenAICodexProvider(
-  providerId: string,
-  options: ProviderOperationOptions = {},
-): Promise<void> {
-  await deleteProvider(providerId, options);
-}
-
-/**
  * Create or update the ChatGPT OAuth provider
  * This is the main function called after successful /connect codex
  *
@@ -130,18 +119,6 @@ export async function createOrUpdateOpenAICodexProvider(
   }
 
   return createOpenAICodexProvider(config, options);
-}
-
-/**
- * Remove the ChatGPT OAuth provider (called on /disconnect)
- */
-export async function removeOpenAICodexProvider(
-  options: ProviderOperationOptions = {},
-): Promise<void> {
-  const existing = await getOpenAICodexProvider(options);
-  if (existing) {
-    await deleteOpenAICodexProvider(existing.id, options);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Route connected providers in `/connect` to a disconnect view before starting any new connection flow.
- Remove the legacy `/disconnect` slash command surface and stale guidance that pointed users to it.
- Cache connected provider state per Local/Constellation tab while the `/connect` selector is open, and prefetch the inactive tab to reduce loading flicker when switching tabs.

## Test plan
- [x] `bun test src/cli/components/provider-selector.test.ts src/cli/subcommands/connect.test.ts src/cli/subcommands/router.test.ts src/cli/context-limit-command.test.ts src/cli/connect-oauth-core.test.ts src/cli/connect-normalize.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check` with unrelated untracked `src/utils/turnTimings.ts` hidden locally

👾 Generated with [Letta Code](https://letta.com)