### PR TITLE
feat(recovery): resume busy conversations using reported blocking run id

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -27,6 +27,7 @@ export {
   buildFreshDenialApprovals,
   classifyPreStreamConflict,
   extractConflictDetail,
+  extractConversationBusyRunId,
   getPreStreamErrorAction,
   getRetryDelayMs,
   getTransientRetryDelayMs,

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -17,6 +17,7 @@ import {
 import { executeAutoAllowedTools } from "@/agent/approval-execution";
 import {
   extractConflictDetail,
+  extractConversationBusyRunId,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
   getRetryDelayMs,
@@ -923,6 +924,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             }
 
             // Check for 409 "conversation busy" error - retry with exponential backoff
+            const blockingRunId = extractConversationBusyRunId(errorDetail);
             if (preStreamAction === "retry_conversation_busy") {
               conversationBusyRetriesRef.current += 1;
               const retryDelayMs = getRetryDelayMs({
@@ -947,7 +949,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               );
 
               // Attempt to resume the in-flight run via the conversation stream endpoint.
-              // Server resolves: (1) otid lookup, (2) active run fallback.
+              // Prefer the blocking run_id from 409s; otherwise use OTID recovery.
               try {
                 const backend = getBackend();
                 const messageOtid = currentInput
@@ -955,7 +957,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                   .find((v): v is string => typeof v === "string");
                 debugLog(
                   "stream",
-                  "Conversation busy: resuming via stream endpoint (otid=%s)",
+                  "Conversation busy: resuming via stream endpoint (run_id=%s, otid=%s)",
+                  blockingRunId ?? "none",
                   messageOtid ?? "none",
                 );
 
@@ -977,7 +980,9 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                       conversationId === "default"
                         ? (agentIdRef.current ?? undefined)
                         : undefined,
-                    otid: messageOtid ?? undefined,
+                    ...(blockingRunId
+                      ? { run_id: blockingRunId }
+                      : { otid: messageOtid ?? undefined }),
                     starting_after: 0,
                     batch_size: 1000,
                   } as unknown as ConversationMessageStreamBody,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -18,6 +18,7 @@ import type { ApprovalResult } from "./agent/approval-execution";
 import {
   buildFreshDenialApprovals,
   extractConflictDetail,
+  extractConversationBusyRunId,
   fetchRunErrorDetail,
   getPreStreamErrorAction,
   getRetryDelayMs,
@@ -2181,9 +2182,9 @@ ${SYSTEM_REMINDER_CLOSE}
         }
 
         // Check for 409 "conversation busy" - resume via conversation stream endpoint.
-        // Server resolves: (1) otid lookup, (2) active run fallback.
-        // OTID lookup provides server-side request ownership validation.
+        // Prefer the blocking run_id from 409s; otherwise use OTID recovery.
         // Falls back to exponential backoff retry if the endpoint fails.
+        const blockingRunId = extractConversationBusyRunId(errorDetail);
         if (preStreamAction === "retry_conversation_busy") {
           const messageOtid = currentInput
             .map((item) => (item as Record<string, unknown>).otid)
@@ -2198,7 +2199,9 @@ ${SYSTEM_REMINDER_CLOSE}
                   conversationId === "default"
                     ? (agent?.id ?? undefined)
                     : undefined,
-                otid: messageOtid ?? undefined,
+                ...(blockingRunId
+                  ? { run_id: blockingRunId }
+                  : { otid: messageOtid ?? undefined }),
                 starting_after: 0,
                 batch_size: 1000,
               } as unknown as ConversationMessageStreamBody,

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -136,6 +136,7 @@ const conversationMessagesStreamMock = mock(
     _params?: {
       agent_id?: string;
       otid?: string;
+      run_id?: string;
       starting_after?: number;
       batch_size?: number;
     },
@@ -2335,6 +2336,60 @@ describe("listen-client multi-worker concurrency", () => {
       starting_after: 0,
       batch_size: 1000,
     });
+
+    await turnPromise;
+  });
+
+  test("pre-stream 409 resumes via reported blocking run id", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-409-run-id",
+      "conv-409-run-id",
+    );
+    const socket = new MockSocket();
+    const blockingRunId = "run-blocking-stream-123";
+
+    sendMessageStreamMock.mockRejectedValueOnce(
+      new APIError(
+        409,
+        {
+          error: {
+            detail: `Cannot send a new message: Another request (run_id=${blockingRunId}) is currently being processed for this conversation. Please wait for it to complete.`,
+          },
+        },
+        undefined,
+        new Headers(),
+      ),
+    );
+
+    const turnPromise = __listenClientTestUtils.handleIncomingMessage(
+      {
+        type: "message",
+        agentId: "agent-409-run-id",
+        conversationId: "conv-409-run-id",
+        messages: [
+          {
+            role: "user",
+            content: "hello",
+            otid: "new-message-otid",
+          } as unknown as IncomingMessage["messages"][number],
+        ],
+      },
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    await waitFor(() => conversationMessagesStreamMock.mock.calls.length === 1);
+
+    const [, resumeParams] = conversationMessagesStreamMock.mock.calls[0] ?? [];
+    expect(resumeParams).toMatchObject({
+      agent_id: undefined,
+      run_id: blockingRunId,
+      starting_after: 0,
+      batch_size: 1000,
+    });
+    expect(resumeParams).not.toHaveProperty("otid");
 
     await turnPromise;
   });

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -213,11 +213,18 @@ async function tryResumeBusyConversationStream(params: {
   conversationId: string;
   messages: Parameters<typeof sendMessageStream>[1];
   runtime: ConversationRuntime;
+  blockingRunId?: string | null;
   abortSignal?: AbortSignal;
   debugMessage: string;
 }): Promise<MessageStreamResult | null> {
-  const { conversationId, messages, runtime, abortSignal, debugMessage } =
-    params;
+  const {
+    conversationId,
+    messages,
+    runtime,
+    blockingRunId,
+    abortSignal,
+    debugMessage,
+  } = params;
 
   try {
     const backend = getBackend();
@@ -238,7 +245,9 @@ async function tryResumeBusyConversationStream(params: {
             conversationId === "default"
               ? (runtime.agentId ?? undefined)
               : undefined,
-          otid: messageOtid ?? undefined,
+          ...(blockingRunId
+            ? { run_id: blockingRunId }
+            : { otid: messageOtid ?? undefined }),
           starting_after: 0,
           batch_size: 1000,
         } as unknown as ConversationMessageStreamBody,
@@ -592,6 +601,7 @@ export async function sendMessageStreamWithRetry(
           conversationId,
           messages,
           runtime,
+          blockingRunId,
           abortSignal,
           debugMessage:
             "[Listen] Pre-stream resume failed, falling back to wait/retry:",
@@ -831,6 +841,7 @@ export async function sendApprovalContinuationWithRetry(
           conversationId,
           messages,
           runtime,
+          blockingRunId,
           abortSignal,
           debugMessage:
             "[Listen] Approval continuation pre-stream resume failed, falling back to wait/retry:",


### PR DESCRIPTION
## Summary
- Extracts the blocking `run_id` from 409 "conversation busy" conflict details.
- Leverages the extracted `run_id` to directly resume the conversation stream via the stream endpoint, bypassing message OTID constraints when the client has the specific blocking run context.
- Implements this logic consistently in TUI app loops (`use-conversation-loop.ts`), Headless mode (`headless.ts`), and the WebSocket listener (`websocket/listener/send.ts`).

## Test plan
- Added unit test `pre-stream 409 resumes via reported blocking run id` in `listen-client-concurrency.test.ts`.
- Verified that all 33 concurrency tests under `listen-client-concurrency.test.ts` pass cleanly.

👾 Generated with [Letta Code](https://letta.com)