### PR TITLE
feat(settings): add shared conversation pins

### DIFF
--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1816,3 +1816,46 @@ describe("Settings Manager - Conversation Goals", () => {
     ).toBe(false);
   });
 });
+
+describe("Settings Manager - Conversation Pins", () => {
+  async function initPinTest() {
+    await settingsManager.initialize();
+    await settingsManager.loadLocalProjectSettings(testProjectDir);
+  }
+
+  test("pins conversations globally and locally per agent", async () => {
+    await initPinTest();
+
+    settingsManager.pinConversationGlobal("agent-1", "conv-1");
+    settingsManager.pinConversationLocal("agent-1", "conv-2", testProjectDir);
+
+    expect(settingsManager.getGlobalPinnedConversations("agent-1")).toEqual([
+      "conv-1",
+    ]);
+    expect(
+      settingsManager.getLocalPinnedConversations("agent-1", testProjectDir),
+    ).toEqual(["conv-2"]);
+    expect(
+      settingsManager.getMergedPinnedConversations("agent-1", testProjectDir),
+    ).toEqual([
+      { conversationId: "conv-2", isLocal: true },
+      { conversationId: "conv-1", isLocal: false },
+    ]);
+  });
+
+  test("conversation pins are scoped by local backend storage dir", async () => {
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+    process.env.LETTA_LOCAL_BACKEND_DIR = join(testHomeDir, "local-store-a");
+    await initPinTest();
+
+    settingsManager.pinConversationGlobal("local-agent-1", "conv-a");
+    expect(
+      settingsManager.getGlobalPinnedConversations("local-agent-1"),
+    ).toEqual(["conv-a"]);
+
+    process.env.LETTA_LOCAL_BACKEND_DIR = join(testHomeDir, "local-store-b");
+    expect(
+      settingsManager.getGlobalPinnedConversations("local-agent-1"),
+    ).toEqual([]);
+  });
+});

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -104,6 +104,7 @@ export interface Settings {
   // Server-indexed settings (agent IDs are server-specific)
   sessionsByServer?: Record<string, SessionRef>; // key = normalized base URL (e.g., "api.letta.com", "localhost:8283")
   pinnedAgentsByServer?: Record<string, string[]>; // DEPRECATED: use agents array
+  pinnedConversationsByServer?: Record<string, Record<string, string[]>>; // server -> agentId -> conversation IDs
   // Unified agent settings array (replaces pinnedAgentsByServer)
   agents?: AgentSettings[];
   // Letta Cloud OAuth token management (stored separately in secrets)
@@ -148,6 +149,7 @@ export interface LocalProjectSettings {
   // Server-indexed settings (agent IDs are server-specific)
   sessionsByServer?: Record<string, SessionRef>; // key = normalized base URL
   pinnedAgentsByServer?: Record<string, string[]>; // key = normalized base URL
+  pinnedConversationsByServer?: Record<string, Record<string, string[]>>; // server -> agentId -> conversation IDs
   listenerEnvName?: string; // Saved environment name for listener connections (project-specific)
   conversationGoalsByServer?: Record<string, Record<string, ConversationGoal>>;
   conversationGoalToolsByServer?: Record<string, Record<string, boolean>>;
@@ -1686,6 +1688,152 @@ class SettingsManager {
     }
 
     return result;
+  }
+
+  /**
+   * Get globally pinned conversation IDs for an agent on the current server.
+   */
+  getGlobalPinnedConversations(agentId: string): string[] {
+    const settings = this.getSettings();
+    const serverKey = getCurrentServerKey(settings);
+    return settings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
+  }
+
+  /**
+   * Get locally pinned conversation IDs for an agent on the current server.
+   */
+  getLocalPinnedConversations(
+    agentId: string,
+    workingDirectory: string = process.cwd(),
+  ): string[] {
+    const globalSettings = this.getSettings();
+    const serverKey = getCurrentServerKey(globalSettings);
+    const localSettings = this.getLocalProjectSettings(workingDirectory);
+    return (
+      localSettings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? []
+    );
+  }
+
+  /**
+   * Get merged pinned conversation IDs for an agent (local first, then global).
+   */
+  getMergedPinnedConversations(
+    agentId: string,
+    workingDirectory: string = process.cwd(),
+  ): Array<{ conversationId: string; isLocal: boolean }> {
+    const localConversations = this.getLocalPinnedConversations(
+      agentId,
+      workingDirectory,
+    );
+    const globalConversations = this.getGlobalPinnedConversations(agentId);
+
+    const result: Array<{ conversationId: string; isLocal: boolean }> = [];
+    const seenConversationIds = new Set<string>();
+
+    for (const conversationId of localConversations) {
+      result.push({ conversationId, isLocal: true });
+      seenConversationIds.add(conversationId);
+    }
+
+    for (const conversationId of globalConversations) {
+      if (!seenConversationIds.has(conversationId)) {
+        result.push({ conversationId, isLocal: false });
+        seenConversationIds.add(conversationId);
+      }
+    }
+
+    return result;
+  }
+
+  pinConversationGlobal(agentId: string, conversationId: string): void {
+    const settings = this.getSettings();
+    const serverKey = getCurrentServerKey(settings);
+    const current = this.getGlobalPinnedConversations(agentId);
+    if (current.includes(conversationId)) return;
+
+    this.updateSettings({
+      pinnedConversationsByServer: {
+        ...settings.pinnedConversationsByServer,
+        [serverKey]: {
+          ...(settings.pinnedConversationsByServer?.[serverKey] ?? {}),
+          [agentId]: [...current, conversationId],
+        },
+      },
+    });
+  }
+
+  unpinConversationGlobal(agentId: string, conversationId: string): void {
+    const settings = this.getSettings();
+    const serverKey = getCurrentServerKey(settings);
+    const current = this.getGlobalPinnedConversations(agentId);
+
+    this.updateSettings({
+      pinnedConversationsByServer: {
+        ...settings.pinnedConversationsByServer,
+        [serverKey]: {
+          ...(settings.pinnedConversationsByServer?.[serverKey] ?? {}),
+          [agentId]: current.filter((id) => id !== conversationId),
+        },
+      },
+    });
+  }
+
+  pinConversationLocal(
+    agentId: string,
+    conversationId: string,
+    workingDirectory: string = process.cwd(),
+  ): void {
+    const globalSettings = this.getSettings();
+    const serverKey = getCurrentServerKey(globalSettings);
+    const localSettings = this.getLocalProjectSettings(workingDirectory);
+    const current = this.getLocalPinnedConversations(agentId, workingDirectory);
+    if (current.includes(conversationId)) return;
+
+    this.updateLocalProjectSettings(
+      {
+        pinnedConversationsByServer: {
+          ...localSettings.pinnedConversationsByServer,
+          [serverKey]: {
+            ...(localSettings.pinnedConversationsByServer?.[serverKey] ?? {}),
+            [agentId]: [...current, conversationId],
+          },
+        },
+      },
+      workingDirectory,
+    );
+  }
+
+  unpinConversationLocal(
+    agentId: string,
+    conversationId: string,
+    workingDirectory: string = process.cwd(),
+  ): void {
+    const globalSettings = this.getSettings();
+    const serverKey = getCurrentServerKey(globalSettings);
+    const localSettings = this.getLocalProjectSettings(workingDirectory);
+    const current = this.getLocalPinnedConversations(agentId, workingDirectory);
+
+    this.updateLocalProjectSettings(
+      {
+        pinnedConversationsByServer: {
+          ...localSettings.pinnedConversationsByServer,
+          [serverKey]: {
+            ...(localSettings.pinnedConversationsByServer?.[serverKey] ?? {}),
+            [agentId]: current.filter((id) => id !== conversationId),
+          },
+        },
+      },
+      workingDirectory,
+    );
+  }
+
+  unpinConversationBoth(
+    agentId: string,
+    conversationId: string,
+    workingDirectory: string = process.cwd(),
+  ): void {
+    this.unpinConversationLocal(agentId, conversationId, workingDirectory);
+    this.unpinConversationGlobal(agentId, conversationId);
   }
 
   // DEPRECATED: Keep for backwards compatibility

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1091,6 +1091,42 @@ export interface GetCwdMapResponseMessage {
   error?: string;
 }
 
+export type ConversationPinScope = "global" | "local_project" | "both";
+export type ConversationPinAction = "pin" | "unpin" | "toggle";
+
+export interface ListConversationPinsCommand {
+  type: "list_conversation_pins";
+  request_id: string;
+  runtime: RuntimeScope;
+}
+
+export interface ListConversationPinsResponseMessage {
+  type: "list_conversation_pins_response";
+  request_id: string;
+  success: boolean;
+  pins: Array<{ conversation_id: string; is_local: boolean }>;
+  error?: string;
+}
+
+export interface SetConversationPinCommand {
+  type: "set_conversation_pin";
+  request_id: string;
+  runtime: RuntimeScope;
+  conversation_id: string;
+  action: ConversationPinAction;
+  scope?: ConversationPinScope;
+}
+
+export interface SetConversationPinResponseMessage {
+  type: "set_conversation_pin_response";
+  request_id: string;
+  success: boolean;
+  conversation_id: string;
+  pinned: boolean;
+  pins: Array<{ conversation_id: string; is_local: boolean }>;
+  error?: string;
+}
+
 export interface GetReflectionSettingsCommand {
   type: "get_reflection_settings";
   /** Echoed back in the response for request correlation. */
@@ -1785,6 +1821,8 @@ export type WsProtocolCommand =
   | SkillDisableCommand
   | CreateAgentCommand
   | GetCwdMapCommand
+  | ListConversationPinsCommand
+  | SetConversationPinCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
   | GetExperimentsCommand
@@ -1827,6 +1865,8 @@ export type WsProtocolMessage =
   | UpdateToolsetResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
+  | ListConversationPinsResponseMessage
+  | SetConversationPinResponseMessage
   | ChannelsListResponseMessage
   | ChannelAccountsListResponseMessage
   | ChannelAccountCreateResponseMessage

--- a/src/websocket/listener/commands/settings.ts
+++ b/src/websocket/listener/commands/settings.ts
@@ -219,9 +219,12 @@ export async function handleConversationPinCommand(
         parsed.conversation_id,
         workingDirectory,
       );
-    }
-  } else if (scope === "both") {
-    if (shouldPin) {
+      settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
+      settingsManager.pinConversationLocal(
+        agentId,
+        parsed.conversation_id,
+        workingDirectory,
+      );
       settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
     } else {
       settingsManager.unpinConversationBoth(

--- a/src/websocket/listener/commands/settings.ts
+++ b/src/websocket/listener/commands/settings.ts
@@ -219,7 +219,9 @@ export async function handleConversationPinCommand(
         parsed.conversation_id,
         workingDirectory,
       );
-      settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
+    }
+  } else if (scope === "both") {
+    if (shouldPin) {
       settingsManager.pinConversationLocal(
         agentId,
         parsed.conversation_id,

--- a/src/websocket/listener/commands/settings.ts
+++ b/src/websocket/listener/commands/settings.ts
@@ -4,11 +4,16 @@ import {
   persistReflectionSettingsForAgent,
 } from "@/cli/helpers/memory-reminder";
 import { experimentManager } from "@/experiments/manager";
+import { settingsManager } from "@/settings-manager";
 import type {
   GetExperimentsCommand,
   GetExperimentsResponseMessage,
   GetReflectionSettingsCommand,
+  ListConversationPinsCommand,
+  ListConversationPinsResponseMessage,
   ReflectionSettingsScope,
+  SetConversationPinCommand,
+  SetConversationPinResponseMessage,
   SetExperimentCommand,
   SetExperimentResponseMessage,
   SetReflectionSettingsCommand,
@@ -17,6 +22,8 @@ import { getConversationWorkingDirectory } from "@/websocket/listener/cwd";
 import {
   isGetExperimentsCommand,
   isGetReflectionSettingsCommand,
+  isListConversationPinsCommand,
+  isSetConversationPinCommand,
   isSetExperimentCommand,
   isSetReflectionSettingsCommand,
 } from "@/websocket/listener/protocol-inbound";
@@ -29,6 +36,10 @@ export type ReflectionSettingsCommand =
   | SetReflectionSettingsCommand;
 
 export type ExperimentCommand = GetExperimentsCommand | SetExperimentCommand;
+
+export type ConversationPinCommand =
+  | ListConversationPinsCommand
+  | SetConversationPinCommand;
 
 type SettingsCommandContext = {
   socket: WebSocket;
@@ -135,6 +146,111 @@ export async function handleExperimentCommand(
     );
   }
 
+  return true;
+}
+
+function toConversationPinResponseItems(
+  agentId: string,
+  workingDirectory: string,
+): Array<{ conversation_id: string; is_local: boolean }> {
+  return settingsManager
+    .getMergedPinnedConversations(agentId, workingDirectory)
+    .map((pin) => ({
+      conversation_id: pin.conversationId,
+      is_local: pin.isLocal,
+    }));
+}
+
+export async function handleConversationPinCommand(
+  parsed: ConversationPinCommand,
+  socket: WebSocket,
+  listener: ListenerRuntime,
+  safeSocketSend: SafeSocketSend,
+): Promise<boolean> {
+  const agentId = parsed.runtime.agent_id;
+  const workingDirectory = getConversationWorkingDirectory(
+    listener,
+    parsed.runtime.agent_id,
+    parsed.runtime.conversation_id,
+  );
+
+  if (parsed.type === "list_conversation_pins") {
+    const response: ListConversationPinsResponseMessage = {
+      type: "list_conversation_pins_response",
+      request_id: parsed.request_id,
+      success: true,
+      pins: toConversationPinResponseItems(agentId, workingDirectory),
+    };
+    safeSocketSend(
+      socket,
+      response,
+      "listener_conversation_pins_send_failed",
+      "listener_conversation_pins",
+    );
+    return true;
+  }
+
+  const scope = parsed.scope ?? "global";
+  const localPinned = settingsManager
+    .getLocalPinnedConversations(agentId, workingDirectory)
+    .includes(parsed.conversation_id);
+  const globalPinned = settingsManager
+    .getGlobalPinnedConversations(agentId)
+    .includes(parsed.conversation_id);
+  const currentlyPinned =
+    scope === "local_project"
+      ? localPinned
+      : scope === "global"
+        ? globalPinned
+        : localPinned || globalPinned;
+  const shouldPin =
+    parsed.action === "toggle" ? !currentlyPinned : parsed.action === "pin";
+
+  if (scope === "local_project") {
+    if (shouldPin) {
+      settingsManager.pinConversationLocal(
+        agentId,
+        parsed.conversation_id,
+        workingDirectory,
+      );
+    } else {
+      settingsManager.unpinConversationLocal(
+        agentId,
+        parsed.conversation_id,
+        workingDirectory,
+      );
+    }
+  } else if (scope === "both") {
+    if (shouldPin) {
+      settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
+    } else {
+      settingsManager.unpinConversationBoth(
+        agentId,
+        parsed.conversation_id,
+        workingDirectory,
+      );
+    }
+  } else if (shouldPin) {
+    settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
+  } else {
+    settingsManager.unpinConversationGlobal(agentId, parsed.conversation_id);
+  }
+
+  const pins = toConversationPinResponseItems(agentId, workingDirectory);
+  const response: SetConversationPinResponseMessage = {
+    type: "set_conversation_pin_response",
+    request_id: parsed.request_id,
+    success: true,
+    conversation_id: parsed.conversation_id,
+    pinned: pins.some((pin) => pin.conversation_id === parsed.conversation_id),
+    pins,
+  };
+  safeSocketSend(
+    socket,
+    response,
+    "listener_conversation_pins_send_failed",
+    "listener_conversation_pins",
+  );
   return true;
 }
 
@@ -249,6 +365,21 @@ export function handleSettingsProtocolCommand(
   if (isGetExperimentsCommand(parsed) || isSetExperimentCommand(parsed)) {
     runDetachedListenerTask("experiment_command", async () => {
       await handleExperimentCommand(parsed, socket, runtime, safeSocketSend);
+    });
+    return true;
+  }
+
+  if (
+    isListConversationPinsCommand(parsed) ||
+    isSetConversationPinCommand(parsed)
+  ) {
+    runDetachedListenerTask("conversation_pin_command", async () => {
+      await handleConversationPinCommand(
+        parsed,
+        socket,
+        runtime,
+        safeSocketSend,
+      );
     });
     return true;
   }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -43,6 +43,7 @@ import type {
   GetTreeCommand,
   GrepInFilesCommand,
   InputCommand,
+  ListConversationPinsCommand,
   ListInDirectoryCommand,
   ListMemoryCommand,
   ListModelsCommand,
@@ -57,6 +58,7 @@ import type {
   SearchFilesCommand,
   SecretApplyCommand,
   SecretListCommand,
+  SetConversationPinCommand,
   SetExperimentCommand,
   SetReflectionSettingsCommand,
   SkillDisableCommand,
@@ -868,6 +870,47 @@ export function isCreateAgentCommand(
   );
 }
 
+export function isListConversationPinsCommand(
+  value: unknown,
+): value is ListConversationPinsCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    runtime?: unknown;
+  };
+  return (
+    c.type === "list_conversation_pins" &&
+    typeof c.request_id === "string" &&
+    isRuntimeScope(c.runtime)
+  );
+}
+
+export function isSetConversationPinCommand(
+  value: unknown,
+): value is SetConversationPinCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    runtime?: unknown;
+    conversation_id?: unknown;
+    action?: unknown;
+    scope?: unknown;
+  };
+  return (
+    c.type === "set_conversation_pin" &&
+    typeof c.request_id === "string" &&
+    isRuntimeScope(c.runtime) &&
+    typeof c.conversation_id === "string" &&
+    (c.action === "pin" || c.action === "unpin" || c.action === "toggle") &&
+    (c.scope === undefined ||
+      c.scope === "global" ||
+      c.scope === "local_project" ||
+      c.scope === "both")
+  );
+}
+
 export function isGetReflectionSettingsCommand(
   value: unknown,
 ): value is GetReflectionSettingsCommand {
@@ -1615,6 +1658,8 @@ export function parseServerMessage(
       isGetCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||
+      isListConversationPinsCommand(parsed) ||
+      isSetConversationPinCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||
       isSetReflectionSettingsCommand(parsed) ||
       isChannelsListCommand(parsed) ||


### PR DESCRIPTION
## Summary
- Add server/agent-scoped shared conversation pin storage to global and local settings
- Add listener protocol commands for listing and mutating conversation pins
- Cover global/local merge behavior and local backend scoping in settings tests

## Test plan
- [x] bunx --bun @biomejs/biome@2.2.5 check --write src/settings-manager.ts src/settings-manager.test.ts src/types/protocol_v2.ts src/websocket/listener/commands/settings.ts src/websocket/listener/protocol-inbound.ts
- [x] bun run typecheck
- [x] bun test src/settings-manager.test.ts