### PR TITLE
fix(codex): discourage early exec yielding for one-shot commands

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -300,15 +300,28 @@ function getCatalogModel(
   oauthCredentials?: OAuthCredentials,
 ): Model<Api> | undefined {
   const spec = getPiProviderSpec(provider);
-  if (!spec.piProvider) return undefined;
-  const model = getModels(spec.piProvider).find(
-    (model) => model.id === modelId,
-  ) as Model<Api> | undefined;
+  const piProvider = spec.piProvider;
+  if (!piProvider) return undefined;
+  const catalog = getModels(piProvider);
+  const fallbackModelId = fallbackCatalogModelId(piProvider, modelId);
+  const model = (catalog.find((model) => model.id === modelId) ??
+    catalog.find((model) => model.id === fallbackModelId)) as
+    | Model<Api>
+    | undefined;
   if (!model || !oauthCredentials) return model;
 
-  const oauthProvider = getOAuthProvider(spec.piProvider);
+  const oauthProvider = getOAuthProvider(piProvider);
   return (oauthProvider?.modifyModels?.([model], oauthCredentials)[0] ??
     model) as Model<Api>;
+}
+
+function fallbackCatalogModelId(
+  provider: string,
+  modelId: string,
+): string | undefined {
+  if (provider !== "openai") return undefined;
+  const withoutReleaseDate = modelId.replace(/-\d{4}-\d{2}-\d{2}$/, "");
+  return withoutReleaseDate === modelId ? undefined : withoutReleaseDate;
 }
 
 function customOpenAICompatibleModel(input: {

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -257,6 +257,16 @@ describe("pi model factory", () => {
     expect(resolved.model.reasoning).toBe(true);
   });
 
+  test("resolves dated OpenAI registry handles to local Pi catalog aliases", async () => {
+    const resolved = await resolvePiModelForAgent(
+      "openai/gpt-5-mini-2025-08-07",
+      { provider_type: "openai" },
+    );
+
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model.id).toBe("gpt-5-mini");
+  });
+
   test("maps local Bedrock profile records to pi provider options", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-bedrock-profile-"));
     try {

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -37,6 +37,8 @@ describe("Codex unified exec toolset", () => {
     const execCommandDescription = [
       "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
       "",
+      "For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.",
+      "",
       extractCommitGuidance(ShellDescription),
     ].join("\n");
 

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -1,5 +1,7 @@
 Runs a command in a PTY, returning output or a session ID for ongoing interaction.
 
+For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.
+
 # Committing changes with git
 
 Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:


### PR DESCRIPTION
## Summary
- Adds a short Letta-specific guidance sentence to `exec_command` so ordinary one-shot commands omit `yield_time_ms` and wait for completion.
- Updates the unified exec description alignment test to document the intentional deviation from the upstream Codex wording.
- Fixes local backend OpenAI model resolution for release-dated registry handles like `openai/gpt-5-mini-2025-08-07`, which the Pi OpenAI catalog exposes as undated ids like `gpt-5-mini`.

## Why
Upstream Codex exposes `yield_time_ms` tersely as a wait-before-yield knob. In Letta Code we observed GPT-5.5 applying `yield_time_ms: 1000` to ordinary `gh run view ... --json jobs --jq ...` commands. Because those commands often take ~1.5s, each one returned `Process running with session ID ...`, then the next model turn issued empty `write_stdin` polls. In the three-command reproduction this produced three background sessions plus three follow-up polls for commands that would have completed inline with the default wait.

This intentionally strays from the source/reference tool description by adding model-facing guidance while preserving the Codex-compatible schema and runtime behavior.

The local CI failure was a separate model-catalog mismatch exposed by this PR run: `gpt-5-mini-medium` resolves through `models.json` to `openai/gpt-5-mini-2025-08-07`, but the local Pi OpenAI catalog exposes `gpt-5-mini`. Local backend model resolution now falls back from OpenAI release-dated ids to the undated catalog id when the exact id is absent.

## Test plan
- `bun test src/tools/codex-unified-exec-toolset.test.ts`
- `bun test src/backend/pi-model-factory.test.ts`
- `bun run check`
- `bun run src/test-utils/headless-scenario.ts --backend local --model gpt-5-mini-medium --output text --parallel on` (local run skipped because this environment lacks `OPENAI_API_KEY`; CI will exercise it with secrets)
- Local model probe with Big Chungus the 3rd (`agent-local-c47c57d5-72c5-4f23-baea-3fb1d441273e`) on the exact three Caren screenshot commands:
  - Before this description guidance: local transcript showed three `exec_command` calls with `yield_time_ms: 1000`, three `Process running with session ID ...` results, and three empty `write_stdin` polls.
  - After the longer additive guidance and after this shorter guidance: local transcripts showed three `exec_command` calls with no `yield_time_ms`, no `write_stdin` polls, and inline completion in ~1.4-1.6s each.

👾 Generated with [Letta Code](https://letta.com)