### PR TITLE
fix(import): fail fast for missing agent files

### DIFF
--- a/src/agent/import.ts
+++ b/src/agent/import.ts
@@ -2,7 +2,7 @@
  * Import an agent from an AgentFile (.af) template
  */
 import { createReadStream } from "node:fs";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getBackend } from "@/backend";
@@ -35,8 +35,14 @@ export async function importAgentFromFile(
   if (!getBackend().capabilities.agentFileImportExport) {
     throw new Error("Agent file import is not supported by this backend yet");
   }
-  const client = await getClient();
   const resolvedPath = resolve(options.filePath);
+  try {
+    await access(resolvedPath);
+  } catch {
+    throw new Error(`AgentFile not found: ${resolvedPath}`);
+  }
+
+  const client = await getClient();
 
   // Create a file stream for the API (compatible with Node.js and Bun)
   const file = createReadStream(resolvedPath);


### PR DESCRIPTION
## Summary
- Validate local AgentFile paths before opening the upload stream for `--import`.
- Return a deterministic `AgentFile not found: ...` error for missing files instead of constructing a `createReadStream` for a nonexistent path.

## Why
Main has been flaking in the Linux x64 integration job on `Startup Flow - Invalid Inputs > --import with nonexistent file shows error`. The job log showed this was not a normal assertion failure: the spawned `bun run dev --no-memfs --import /nonexistent/path/agent.af -p test` process hit a Bun 1.3.0 SIGILL/segfault after constructing the missing-file stream, then the test timed out and Bun reported a dangling child process.

The import path previously created a `createReadStream(resolvedPath)` and passed it into the API import call without checking that the file existed. For missing files, Node/Bun streams report `ENOENT` asynchronously; in CI this sometimes exercised a Bun crash path. Failing before `createReadStream` avoids that flake and gives users a clearer error.

## Test plan
- `bun test src/integration-tests/startup-flow.integration.test.ts -t "--import with nonexistent file shows error"`
- `bun run dev --no-memfs --import /nonexistent/path/agent.af -p test` exits 1 with `Error: AgentFile not found: /nonexistent/path/agent.af`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)