### PR TITLE
fix(headless): handle bidirectional interrupts

### DIFF
--- a/src/headless-interrupt-latch.test.ts
+++ b/src/headless-interrupt-latch.test.ts
@@ -143,5 +143,10 @@ describe("headless interrupt latch wiring", () => {
     expect(source).toContain(
       "// Controller now exists — close the pre-controller race window.",
     );
+    // Interrupts must wake permission/external-tool waits that are blocked in
+    // getNextLine(), otherwise the fast path consumes the interrupt and hangs.
+    expect(source).toContain(
+      "Wake that waiter so the aborted turn can unwind.",
+    );
   });
 });

--- a/src/headless-interrupt-latch.test.ts
+++ b/src/headless-interrupt-latch.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { decideInterruptAction } from "@/headless";
+
+describe("decideInterruptAction", () => {
+  test("aborts the active turn when a controller exists", () => {
+    expect(
+      decideInterruptAction({ hasActiveController: true, turnStarting: false }),
+    ).toBe("abort-active");
+    // An active controller takes precedence even mid-startup.
+    expect(
+      decideInterruptAction({ hasActiveController: true, turnStarting: true }),
+    ).toBe("abort-active");
+  });
+
+  test("latches when a turn is starting but its controller does not exist yet", () => {
+    // Narrow pre-controller race: a user message was just dispatched.
+    expect(
+      decideInterruptAction({ hasActiveController: false, turnStarting: true }),
+    ).toBe("latch");
+  });
+
+  test("is a no-op when idle (no active or starting turn)", () => {
+    // The regression: an idle interrupt must NOT latch, or it poisons the
+    // next user turn.
+    expect(
+      decideInterruptAction({
+        hasActiveController: false,
+        turnStarting: false,
+      }),
+    ).toBe("noop");
+  });
+});
+
+/**
+ * Lifecycle simulation mirroring the headless main loop's interrupt handling,
+ * driven purely by decideInterruptAction. Proves the two behaviors cpacker
+ * asked us to cover in PR #2631:
+ *   1. an idle interrupt does not abort the next user message
+ *   2. an interrupt immediately after a user message still aborts that turn
+ */
+class TurnSim {
+  hasActiveController = false;
+  turnStarting = false;
+  pendingInterrupt = false;
+  aborted = false;
+
+  /** A user message is handed to the (idle) main loop. */
+  dispatchUserMessage() {
+    this.turnStarting = true;
+  }
+
+  /** An incoming control_request:interrupt, handled by the fast path. */
+  interrupt() {
+    const action = decideInterruptAction({
+      hasActiveController: this.hasActiveController,
+      turnStarting: this.turnStarting,
+    });
+    if (action === "abort-active") {
+      this.aborted = true;
+    } else if (action === "latch") {
+      this.pendingInterrupt = true;
+    }
+    // "noop": respond success, change nothing.
+  }
+
+  /** The main loop creates the AbortController for the dispatched turn. */
+  createController() {
+    this.hasActiveController = true;
+    if (this.pendingInterrupt) {
+      this.pendingInterrupt = false;
+      this.aborted = true;
+    }
+    this.turnStarting = false;
+  }
+
+  /** The turn finishes and the loop returns to idle. */
+  endTurn() {
+    this.hasActiveController = false;
+    this.aborted = false;
+  }
+}
+
+describe("headless interrupt latch lifecycle", () => {
+  test("idle interrupt does not abort the next user message", () => {
+    const sim = new TurnSim();
+
+    // Interrupt arrives while idle (no turn running or starting).
+    sim.interrupt();
+    expect(sim.pendingInterrupt).toBe(false);
+
+    // A later, unrelated user message must run normally.
+    sim.dispatchUserMessage();
+    sim.createController();
+    expect(sim.aborted).toBe(false);
+  });
+
+  test("interrupt immediately after a user message still aborts that turn", () => {
+    const sim = new TurnSim();
+
+    // User message dispatched, then interrupt arrives in the same stdin burst
+    // before the controller is created.
+    sim.dispatchUserMessage();
+    sim.interrupt();
+    expect(sim.pendingInterrupt).toBe(true);
+
+    // The imminent turn aborts via the drained latch.
+    sim.createController();
+    expect(sim.aborted).toBe(true);
+  });
+
+  test("idle interrupt then a turn then another idle interrupt stays clean", () => {
+    const sim = new TurnSim();
+
+    sim.interrupt(); // idle: noop
+    sim.dispatchUserMessage();
+    sim.createController();
+    expect(sim.aborted).toBe(false);
+    sim.endTurn();
+
+    sim.interrupt(); // idle again: noop
+    sim.dispatchUserMessage();
+    sim.createController();
+    expect(sim.aborted).toBe(false);
+  });
+});
+
+describe("headless interrupt latch wiring", () => {
+  test("source gates the latch on turnStarting and closes the window after controller creation", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("./headless.ts", import.meta.url)),
+      "utf-8",
+    );
+
+    // The fast path routes through the shared decision function.
+    expect(source).toContain("decideInterruptAction({");
+    // turnStarting is opened only for user-message delivery...
+    expect(source).toContain(
+      'if (parsedLine?.type === "user") turnStarting = true;',
+    );
+    // ...and closed once the controller exists.
+    expect(source).toContain(
+      "// Controller now exists — close the pre-controller race window.",
+    );
+  });
+});

--- a/src/headless-interrupt-recovery.test.ts
+++ b/src/headless-interrupt-recovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression guard for the post-interrupt approval recovery (PR #2631).
+ *
+ * A turn cancelled mid-tool-call (while a tool awaited approval) leaves the
+ * Letta agent in `requires_approval` with a dangling approval. Before this fix
+ * the next in-session user turn was sent against that stale state and the run
+ * errored — surfaced downstream (in the ACP adapter) as a bare "refusal" with
+ * no visible output. The fix records that the prior turn was interrupted and
+ * clears pending approvals (reusing resolveAllPendingApprovals) at the start of
+ * the next turn, before sending.
+ *
+ * The behavior itself is backend-coupled and proven by scripts/cancel-tool-smoke.ts
+ * (turn 2 recovers to end_turn instead of refusal). These assertions lock the
+ * wiring so the recovery can't silently regress.
+ */
+describe("headless post-interrupt approval recovery wiring", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL("./headless.ts", import.meta.url)),
+    "utf-8",
+  );
+
+  test("tracks whether the prior turn was interrupted", () => {
+    expect(source).toContain("let priorTurnInterrupted = false;");
+    // The epilogue records the interrupted state from the abort controller.
+    expect(source).toContain(
+      "priorTurnInterrupted = currentAbortController?.signal.aborted === true;",
+    );
+  });
+
+  test("clears dangling approvals before the next turn when interrupted", () => {
+    expect(source).toContain("if (priorTurnInterrupted) {");
+    // It consumes the flag and runs the shared recovery primitive.
+    const idx = source.indexOf("if (priorTurnInterrupted) {");
+    const block = source.slice(idx, idx + 400);
+    expect(block).toContain("priorTurnInterrupted = false;");
+    expect(block).toContain("resolveAllPendingApprovals()");
+  });
+});

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -3784,6 +3784,11 @@ async function runBidirectionalMode(
   };
 
   let turnInProgress = false;
+  // Set when a turn ends interrupted (aborted mid-flight). A cancel during a
+  // tool's approval gate leaves the agent in `requires_approval` with a
+  // dangling approval; the next user turn must clear it before sending or the
+  // run errors on stale state (surfaces downstream as a bare "refusal").
+  let priorTurnInterrupted = false;
 
   const msgQueueRuntime = new QueueRuntime({
     callbacks: {
@@ -4624,6 +4629,28 @@ async function runBidirectionalMode(
         }
         currentInput = turnStartEmission.input;
 
+        // If the previous turn was interrupted mid-tool-call, the agent may be
+        // left in `requires_approval` with a dangling approval. Sending this
+        // fresh turn against that stale state makes the run error (a silent
+        // "refusal" downstream). Clear it first, reusing the same recovery the
+        // resume path uses. Best-effort: a recovery failure must not abort the
+        // new turn. (PR #2631 — handle interrupts.)
+        if (priorTurnInterrupted) {
+          priorTurnInterrupted = false;
+          try {
+            await resolveAllPendingApprovals();
+          } catch (recoveryError) {
+            debugWarn(
+              "approval",
+              `Post-interrupt approval recovery failed: ${
+                recoveryError instanceof Error
+                  ? recoveryError.message
+                  : String(recoveryError)
+              }`,
+            );
+          }
+        }
+
         // Approval handling loop - continue until end_turn or error
         while (true) {
           numTurns++;
@@ -5125,6 +5152,9 @@ async function runBidirectionalMode(
         });
         turnInProgress = false;
         blockedEmittedThisTurn = false;
+        // Remember whether this turn was interrupted so the next user turn can
+        // clear any dangling approval before sending (see priorTurnInterrupted).
+        priorTurnInterrupted = currentAbortController?.signal.aborted === true;
         currentAbortController = null;
       }
       continue;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -4223,10 +4223,13 @@ async function runBidirectionalMode(
         };
         writeWireMessage(initResponse);
       } else if (subtype === "interrupt") {
-        // Abort current operation if any
+        // Abort current operation if any. Do NOT null the controller — the
+        // turn's epilogue (line ~4415) reads currentAbortController?.signal.aborted
+        // to classify the result as "interrupted" vs "error", and the
+        // user-message branch's `finally` is what owns nulling. Mirrors the
+        // fast path in rl.on("line", ...).
         if (currentAbortController !== null) {
           (currentAbortController as AbortController).abort();
-          currentAbortController = null;
         }
         const interruptResponse: ControlResponse = {
           type: "control_response",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -3954,6 +3954,14 @@ async function runBidirectionalMode(
         // to classify the result as "interrupted" vs "error". The `finally`
         // block at the bottom of the user-message branch is what owns nulling.
         (currentAbortController as AbortController).abort();
+        if (lineResolver) {
+          // If the turn is blocked waiting for a permission/external-tool
+          // response, the fast path consumed this interrupt before getNextLine()
+          // could see it. Wake that waiter so the aborted turn can unwind.
+          const resolve = lineResolver;
+          lineResolver = null;
+          resolve(null);
+        }
       } else if (action === "latch") {
         // Narrow pre-controller race: a user message was just dispatched but
         // its AbortController isn't created yet. Latch so the imminent turn

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -3618,6 +3618,12 @@ async function runBidirectionalMode(
 
   // Track current operation for interrupt support
   let currentAbortController: AbortController | null = null;
+  // Latch: an interrupt may arrive on stdin between the user message and
+  // when the abort controller for that turn is created (the gap is small but
+  // real — readline fires the next line before the main loop's microtask
+  // creating the controller runs). When that happens, set this flag so the
+  // turn aborts immediately after creation.
+  let pendingInterrupt = false;
   const reminderContextTracker = createContextTracker();
   const sharedReminderState = createSharedReminderState();
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
@@ -3883,6 +3889,46 @@ async function runBidirectionalMode(
   // Feed lines into queue or resolver
   rl.on("line", (line) => {
     maybeNotifyBlocked(line);
+    // Fast path: handle control_request:interrupt synchronously so we can
+    // abort an in-flight drain without waiting for the main loop to dequeue.
+    // Without this, a runaway thinking turn never sees the interrupt because
+    // `getNextLine()` isn't called until the current drain returns.
+    let interruptRequestId: string | null = null;
+    try {
+      const parsed = JSON.parse(line);
+      if (
+        parsed?.type === "control_request" &&
+        parsed?.request?.subtype === "interrupt"
+      ) {
+        interruptRequestId = String(parsed.request_id ?? "");
+      }
+    } catch {
+      // Not JSON / not a control_request — ignore here, the main loop will
+      // surface the parse error.
+    }
+    if (interruptRequestId !== null) {
+      if (currentAbortController !== null) {
+        // Abort the in-flight turn. Do NOT null the controller here — the
+        // turn's epilogue (line ~4275) reads currentAbortController?.signal.aborted
+        // to classify the result as "interrupted" vs "error". The `finally`
+        // block at the bottom of the user-message branch is what owns nulling.
+        (currentAbortController as AbortController).abort();
+      } else {
+        // No active turn yet — latch the interrupt for the next one.
+        pendingInterrupt = true;
+      }
+      const interruptResponse: ControlResponse = {
+        type: "control_response",
+        response: {
+          subtype: "success",
+          request_id: interruptRequestId,
+        },
+        session_id: sessionId,
+        uuid: randomUUID(),
+      };
+      writeWireMessage(interruptResponse);
+      return;
+    }
     if (lineResolver) {
       const resolve = lineResolver;
       lineResolver = null;
@@ -4441,8 +4487,15 @@ async function runBidirectionalMode(
         continue;
       }
 
-      // Create abort controller for this operation
+      // Create abort controller for this operation.  Drain any latched
+      // interrupt that arrived before the controller existed (race between
+      // the readline 'line' event and the microtask that creates the
+      // controller — see rl.on("line", ...) above).
       currentAbortController = new AbortController();
+      if (pendingInterrupt) {
+        pendingInterrupt = false;
+        currentAbortController.abort();
+      }
 
       turnInProgress = true;
       try {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -320,6 +320,31 @@ function toBidirectionalQueuedInput(
   };
 }
 
+/**
+ * Decide what an incoming `control_request: interrupt` should do, given the
+ * current turn state. Extracted as a pure function so the policy is unit-
+ * testable and shared between the fast-path (`rl.on("line", ...)`) and the
+ * main-loop interrupt handlers.
+ *
+ * - `abort-active`: a turn is running — abort its AbortController now.
+ * - `latch`: no controller exists yet, but a user message has just been
+ *   dispatched and its controller is about to be created (the narrow
+ *   pre-controller race). Latch so the imminent turn aborts immediately.
+ * - `noop`: the session is idle (no active or starting turn). Respond success
+ *   but do NOT latch — latching here would poison the next user turn, which
+ *   would create a controller and immediately abort itself.
+ */
+export type InterruptAction = "abort-active" | "latch" | "noop";
+
+export function decideInterruptAction(state: {
+  hasActiveController: boolean;
+  turnStarting: boolean;
+}): InterruptAction {
+  if (state.hasActiveController) return "abort-active";
+  if (state.turnStarting) return "latch";
+  return "noop";
+}
+
 export const __headlessTestUtils = {
   trackTelemetryUserInputFromContent,
   shouldTrackTelemetryForQueuedMessage,
@@ -3624,6 +3649,11 @@ async function runBidirectionalMode(
   // creating the controller runs). When that happens, set this flag so the
   // turn aborts immediately after creation.
   let pendingInterrupt = false;
+  // True only in the narrow window between a user message being handed to the
+  // main loop and its AbortController being created. Gates `pendingInterrupt`
+  // so an *idle* interrupt (no turn running or starting) is a no-op success
+  // instead of poisoning the next user turn. See decideInterruptAction.
+  let turnStarting = false;
   const reminderContextTracker = createContextTracker();
   const sharedReminderState = createSharedReminderState();
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
@@ -3893,28 +3923,37 @@ async function runBidirectionalMode(
     // abort an in-flight drain without waiting for the main loop to dequeue.
     // Without this, a runaway thinking turn never sees the interrupt because
     // `getNextLine()` isn't called until the current drain returns.
-    let interruptRequestId: string | null = null;
+    let parsedLine: {
+      type?: string;
+      request?: { subtype?: string };
+      request_id?: string | number;
+    } | null = null;
     try {
-      const parsed = JSON.parse(line);
-      if (
-        parsed?.type === "control_request" &&
-        parsed?.request?.subtype === "interrupt"
-      ) {
-        interruptRequestId = String(parsed.request_id ?? "");
-      }
+      parsedLine = JSON.parse(line);
     } catch {
-      // Not JSON / not a control_request — ignore here, the main loop will
-      // surface the parse error.
+      // Not JSON — the main loop will surface the parse error.
     }
+    const interruptRequestId =
+      parsedLine?.type === "control_request" &&
+      parsedLine?.request?.subtype === "interrupt"
+        ? String(parsedLine.request_id ?? "")
+        : null;
     if (interruptRequestId !== null) {
-      if (currentAbortController !== null) {
+      const action = decideInterruptAction({
+        hasActiveController: currentAbortController !== null,
+        turnStarting,
+      });
+      if (action === "abort-active") {
         // Abort the in-flight turn. Do NOT null the controller here — the
         // turn's epilogue (line ~4275) reads currentAbortController?.signal.aborted
         // to classify the result as "interrupted" vs "error". The `finally`
         // block at the bottom of the user-message branch is what owns nulling.
         (currentAbortController as AbortController).abort();
-      } else {
-        // No active turn yet — latch the interrupt for the next one.
+      } else if (action === "latch") {
+        // Narrow pre-controller race: a user message was just dispatched but
+        // its AbortController isn't created yet. Latch so the imminent turn
+        // aborts. An idle interrupt ("noop") must NOT latch — that would
+        // poison the next user turn.
         pendingInterrupt = true;
       }
       const interruptResponse: ControlResponse = {
@@ -3930,6 +3969,10 @@ async function runBidirectionalMode(
       return;
     }
     if (lineResolver) {
+      // Handing a user message to a waiting main loop opens the pre-controller
+      // race window: mark turnStarting so an interrupt arriving in the same
+      // stdin burst (before the controller exists) latches via "latch" above.
+      if (parsedLine?.type === "user") turnStarting = true;
       const resolve = lineResolver;
       lineResolver = null;
       resolve(line);
@@ -4228,7 +4271,13 @@ async function runBidirectionalMode(
         // to classify the result as "interrupted" vs "error", and the
         // user-message branch's `finally` is what owns nulling. Mirrors the
         // fast path in rl.on("line", ...).
-        if (currentAbortController !== null) {
+        if (
+          currentAbortController !== null &&
+          decideInterruptAction({
+            hasActiveController: true,
+            turnStarting,
+          }) === "abort-active"
+        ) {
           (currentAbortController as AbortController).abort();
         }
         const interruptResponse: ControlResponse = {
@@ -4487,6 +4536,10 @@ async function runBidirectionalMode(
 
       const userContent = mergeBidirectionalQueuedInput(queuedInputs);
       if (userContent === null) {
+        // No turn will start — clear the pre-controller window so a latched
+        // interrupt doesn't carry over to a later, unrelated turn.
+        turnStarting = false;
+        pendingInterrupt = false;
         continue;
       }
 
@@ -4499,6 +4552,8 @@ async function runBidirectionalMode(
         pendingInterrupt = false;
         currentAbortController.abort();
       }
+      // Controller now exists — close the pre-controller race window.
+      turnStarting = false;
 
       turnInProgress = true;
       try {


### PR DESCRIPTION
## Summary

Fixes interrupt handling in bidirectional headless `stream-json` mode:

- Handles `control_request: interrupt` synchronously in the readline handler so long-running turns can be cancelled while the main loop is blocked draining the model/tool stream.
- Latches interrupts that arrive in the narrow window after a user message is handed to the main loop but before the turn AbortController exists.
- Avoids latching idle interrupts, so an interrupt sent between turns does not poison the next user message.
- Wakes pending `getNextLine()` waiters after fast-path interrupt aborts an active turn, so interrupts during `can_use_tool` permission waits do not hang.
- Clears dangling pending approvals before the next turn if the prior turn ended interrupted.

## Verification

- `bun test src/headless-interrupt-latch.test.ts src/headless-interrupt-recovery.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/headless.ts src/headless-interrupt-latch.test.ts`
- `bun run typecheck`
- Live smoke: headless bidirectional `--permission-mode standard`, Bash tool triggers `can_use_tool`; sending `control_request: interrupt` during the permission wait returns `result.subtype = "interrupted"` and does not execute the tool.

👾 Generated with [Letta Code](https://letta.com)