### PR TITLE
fix(cli): ensure fd for file autocomplete

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -330,6 +330,7 @@ export function App({
   agentProvenance = null,
   startupHasCloudCredentials = false,
   startupHasAvailableLocalModels = true,
+  fileAutocompleteFdPath = null,
   releaseNotes = null,
   updateNotification = null,
   systemInfoReminderEnabled = true,
@@ -4858,6 +4859,7 @@ export function App({
       modelSelectorOptions={modelSelectorOptions}
       networkPhase={networkPhase}
       executionPhase={executionPhase}
+      fileAutocompleteFdPath={fileAutocompleteFdPath}
       onSubmit={onSubmit}
       pendingApprovals={pendingApprovals}
       pendingConversationSwitchRef={pendingConversationSwitchRef}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -320,6 +320,7 @@ type AppViewProps = {
   statusLinePayload: StatusLinePayload;
   statusLinePrompt: string;
   extensionRuntime: LocalExtensionRuntime;
+  fileAutocompleteFdPath?: string | null;
   streaming: boolean;
   stubDescriptions: Map<string, string>;
   thinkingMessage: string;
@@ -419,6 +420,7 @@ export function AppView(props: AppViewProps) {
     modelSelectorOptions,
     networkPhase,
     executionPhase,
+    fileAutocompleteFdPath,
     onSubmit,
     pendingApprovals,
     pendingConversationSwitchRef,
@@ -725,6 +727,7 @@ export function AppView(props: AppViewProps) {
                 isLocalBackend={isLocalBackend}
                 hasTemporaryModelOverride={hasTemporaryModelOverride}
                 currentReasoningEffort={currentReasoningEffort}
+                fileAutocompleteFdPath={fileAutocompleteFdPath}
                 messageQueue={queueDisplay}
                 onQueueEdit={handleQueueEdit}
                 onEscapeCancel={

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -45,6 +45,7 @@ export type AppProps = {
   agentProvenance?: AgentProvenance | null;
   startupHasCloudCredentials?: boolean;
   startupHasAvailableLocalModels?: boolean;
+  fileAutocompleteFdPath?: string | null;
   releaseNotes?: string | null; // Markdown release notes to display above header
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;

--- a/src/cli/components/FileAutocomplete.tsx
+++ b/src/cli/components/FileAutocomplete.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   applyPiFileCompletion,
   type FileAutocompleteItem,
   FileAutocompleteProvider,
   type FileAutocompleteSuggestions,
-  resolveFdPath,
 } from "@/cli/helpers/file-autocomplete";
 import { useAutocompleteNavigation } from "@/cli/hooks/use-autocomplete-navigation";
 import { AutocompleteBox, AutocompleteItem } from "./Autocomplete";
@@ -14,12 +13,11 @@ import { Text } from "./Text";
 interface FileAutocompleteProps {
   currentInput: string;
   cursorPosition: number;
+  fdPath?: string | null;
   workingDirectory?: string;
   onApplyCompletion: (value: string, cursorPosition: number) => void;
   onActiveChange?: (isActive: boolean) => void;
 }
-
-const fdPath = resolveFdPath();
 
 function isDirectoryItem(item: FileAutocompleteItem): boolean {
   return item.label.endsWith("/");
@@ -28,6 +26,7 @@ function isDirectoryItem(item: FileAutocompleteItem): boolean {
 export function FileAutocomplete({
   currentInput,
   cursorPosition,
+  fdPath,
   workingDirectory,
   onApplyCompletion,
   onActiveChange,
@@ -37,12 +36,6 @@ export function FileAutocomplete({
   const [isLoading, setIsLoading] = useState(false);
   const searchGenRef = useRef(0);
   const abortControllerRef = useRef<AbortController | null>(null);
-
-  const provider = useMemo(
-    () =>
-      new FileAutocompleteProvider(workingDirectory ?? process.cwd(), fdPath),
-    [workingDirectory],
-  );
   const matches = suggestions?.items ?? [];
 
   const applyItem = (item: FileAutocompleteItem) => {
@@ -65,6 +58,13 @@ export function FileAutocomplete({
   });
 
   useEffect(() => {
+    if (!currentInput.includes("@")) {
+      abortControllerRef.current?.abort();
+      setSuggestions(null);
+      setIsLoading(false);
+      return;
+    }
+
     abortControllerRef.current?.abort();
     const gen = ++searchGenRef.current;
     const controller = new AbortController();
@@ -72,27 +72,44 @@ export function FileAutocomplete({
     setIsLoading(true);
     onActiveChange?.(true);
 
-    provider
-      .getSuggestions(currentInput, cursorPosition, {
-        signal: controller.signal,
-      })
-      .then((nextSuggestions) => {
-        if (searchGenRef.current !== gen) return;
-        setSuggestions(nextSuggestions);
-        setIsLoading(false);
-        onActiveChange?.((nextSuggestions?.items.length ?? 0) > 0);
-      })
-      .catch(() => {
-        if (searchGenRef.current !== gen) return;
+    async function search() {
+      if (!fdPath) {
         setSuggestions(null);
         setIsLoading(false);
         onActiveChange?.(false);
-      });
+        return;
+      }
+
+      const provider = new FileAutocompleteProvider(
+        workingDirectory ?? process.cwd(),
+        fdPath,
+      );
+      const nextSuggestions = await provider.getSuggestions(
+        currentInput,
+        cursorPosition,
+        {
+          signal: controller.signal,
+        },
+      );
+
+      if (searchGenRef.current !== gen || controller.signal.aborted) return;
+
+      setSuggestions(nextSuggestions);
+      setIsLoading(false);
+      onActiveChange?.((nextSuggestions?.items.length ?? 0) > 0);
+    }
+
+    search().catch(() => {
+      if (searchGenRef.current !== gen) return;
+      setSuggestions(null);
+      setIsLoading(false);
+      onActiveChange?.(false);
+    });
 
     return () => {
       controller.abort();
     };
-  }, [currentInput, cursorPosition, onActiveChange, provider]);
+  }, [currentInput, cursorPosition, fdPath, onActiveChange, workingDirectory]);
 
   if (!currentInput.includes("@")) return null;
   if (matches.length === 0 && !isLoading) return null;

--- a/src/cli/components/InputAssist.tsx
+++ b/src/cli/components/InputAssist.tsx
@@ -9,6 +9,7 @@ import type { ExtensionCommandAutocompleteItem } from "./types/autocomplete";
 interface InputAssistProps {
   currentInput: string;
   cursorPosition: number;
+  fdPath?: string | null;
   onFileAutocompleteApply: (value: string, cursorPosition: number) => void;
   onCommandSelect: (command: string) => void;
   onCommandAutocomplete: (command: string) => void;
@@ -32,6 +33,7 @@ interface InputAssistProps {
 export function InputAssist({
   currentInput,
   cursorPosition,
+  fdPath,
   onFileAutocompleteApply,
   onCommandSelect,
   onCommandAutocomplete,
@@ -65,6 +67,7 @@ export function InputAssist({
       <FileAutocomplete
         currentInput={currentInput}
         cursorPosition={cursorPosition}
+        fdPath={fdPath}
         onApplyCompletion={onFileAutocompleteApply}
         onActiveChange={onAutocompleteActiveChange}
         workingDirectory={workingDirectory}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -912,6 +912,7 @@ export function Input({
   isLocalBackend = false,
   hasTemporaryModelOverride = false,
   currentReasoningEffort,
+  fileAutocompleteFdPath,
   messageQueue,
   onQueueEdit,
   onEscapeCancel,
@@ -964,6 +965,7 @@ export function Input({
   isLocalBackend?: boolean;
   hasTemporaryModelOverride?: boolean;
   currentReasoningEffort?: ModelReasoningEffort | null;
+  fileAutocompleteFdPath?: string | null;
   messageQueue?: QueuedMessage[];
   onQueueEdit?: () => string;
   onEscapeCancel?: () => void;
@@ -1998,6 +2000,7 @@ export function Input({
               <InputAssist
                 currentInput={value}
                 cursorPosition={currentCursorPosition}
+                fdPath={fileAutocompleteFdPath}
                 onFileAutocompleteApply={handleFileAutocompleteApply}
                 onCommandSelect={handleCommandSelect}
                 onCommandAutocomplete={handleCommandAutocomplete}
@@ -2076,6 +2079,7 @@ export function Input({
     goalLoopActive,
     currentModel,
     currentReasoningEffort,
+    fileAutocompleteFdPath,
     currentModelProvider,
     hasTemporaryModelOverride,
     hideFooter,

--- a/src/cli/helpers/file-autocomplete.ts
+++ b/src/cli/helpers/file-autocomplete.ts
@@ -1,7 +1,18 @@
 import { spawn, spawnSync } from "node:child_process";
-import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import {
+  chmodSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { arch, homedir, platform } from "node:os";
 import { basename, join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 // Ported from Pi TUI packages/tui/src/autocomplete.ts.
 // Keep behavior aligned with Pi's fd-backed @ file autocomplete.
@@ -262,19 +273,293 @@ export interface AppliedFileCompletion {
   cursorPosition: number;
 }
 
-export function resolveFdPath(): string | null {
-  for (const binaryName of ["fd", "fdfind"]) {
-    try {
-      const result = spawnSync(binaryName, ["--version"], { stdio: "pipe" });
-      if (!result.error) {
-        return binaryName;
+const FD_TOOLS_DIR = join(homedir(), ".letta", "bin");
+const FD_BINARY_NAME = platform() === "win32" ? "fd.exe" : "fd";
+const FD_LOCAL_PATH = join(FD_TOOLS_DIR, FD_BINARY_NAME);
+const FD_DOWNLOAD_REPO = "sharkdp/fd";
+const FD_DOWNLOAD_TIMEOUT_MS = 120_000;
+const FD_NETWORK_TIMEOUT_MS = 10_000;
+
+let cachedFdPath: string | null | undefined;
+let pendingFdPath: Promise<string | null> | null = null;
+
+function commandExists(command: string): boolean {
+  try {
+    const result = spawnSync(command, ["--version"], { stdio: "pipe" });
+    return result.error === undefined || result.error === null;
+  } catch {
+    return false;
+  }
+}
+
+function getFdAssetName(version: string): string | null {
+  const plat = platform();
+  const architecture = arch();
+  const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
+
+  if (plat === "darwin") {
+    return `fd-v${version}-${archStr}-apple-darwin.tar.gz`;
+  }
+  if (plat === "linux") {
+    return `fd-v${version}-${archStr}-unknown-linux-gnu.tar.gz`;
+  }
+  if (plat === "win32") {
+    return `fd-v${version}-${archStr}-pc-windows-msvc.zip`;
+  }
+  return null;
+}
+
+async function getLatestFdVersion(): Promise<string> {
+  const response = await fetch(
+    `https://api.github.com/repos/${FD_DOWNLOAD_REPO}/releases/latest`,
+    {
+      headers: { "User-Agent": "letta-code" },
+      signal: AbortSignal.timeout(FD_NETWORK_TIMEOUT_MS),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { tag_name: string };
+  return data.tag_name.replace(/^v/, "");
+}
+
+async function downloadFile(url: string, destination: string): Promise<void> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(FD_DOWNLOAD_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download fd: ${response.status}`);
+  }
+  if (!response.body) {
+    throw new Error("Failed to download fd: empty response body");
+  }
+
+  await pipeline(
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(destination),
+  );
+}
+
+function formatSpawnFailure(result: ReturnType<typeof spawnSync>): string {
+  if (result.error?.message) {
+    return result.error.message;
+  }
+  const stderr = result.stderr?.toString().trim();
+  if (stderr) {
+    return stderr;
+  }
+  const stdout = result.stdout?.toString().trim();
+  if (stdout) {
+    return stdout;
+  }
+  return `exit status ${result.status ?? "unknown"}`;
+}
+
+function runExtractionCommand(command: string, args: string[]): string | null {
+  const result = spawnSync(command, args, { stdio: "pipe" });
+  if (!result.error && result.status === 0) {
+    return null;
+  }
+  return `${command}: ${formatSpawnFailure(result)}`;
+}
+
+function extractTarGzArchive(archivePath: string, extractDir: string): void {
+  const failure = runExtractionCommand("tar", [
+    "xzf",
+    archivePath,
+    "-C",
+    extractDir,
+  ]);
+  if (failure) {
+    throw new Error(`Failed to extract fd: ${failure}`);
+  }
+}
+
+function getWindowsTarCommand(): string {
+  const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
+  if (systemRoot) {
+    const systemTar = join(systemRoot, "System32", "tar.exe");
+    if (existsSync(systemTar)) {
+      return systemTar;
+    }
+  }
+  return "tar.exe";
+}
+
+function extractZipArchive(archivePath: string, extractDir: string): void {
+  const failures: string[] = [];
+
+  if (platform() === "win32") {
+    const tarFailure = runExtractionCommand(getWindowsTarCommand(), [
+      "xf",
+      archivePath,
+      "-C",
+      extractDir,
+    ]);
+    if (!tarFailure) return;
+    failures.push(tarFailure);
+
+    const script =
+      "& { param($archive, $destination) $ErrorActionPreference = 'Stop'; Expand-Archive -LiteralPath $archive -DestinationPath $destination -Force }";
+    const powershellFailure = runExtractionCommand("powershell.exe", [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      script,
+      archivePath,
+      extractDir,
+    ]);
+    if (!powershellFailure) return;
+    failures.push(powershellFailure);
+  } else {
+    const unzipFailure = runExtractionCommand("unzip", [
+      "-q",
+      archivePath,
+      "-d",
+      extractDir,
+    ]);
+    if (!unzipFailure) return;
+    failures.push(unzipFailure);
+
+    const tarFailure = runExtractionCommand("tar", [
+      "xf",
+      archivePath,
+      "-C",
+      extractDir,
+    ]);
+    if (!tarFailure) return;
+    failures.push(tarFailure);
+  }
+
+  throw new Error(`Failed to extract fd: ${failures.join("; ")}`);
+}
+
+function findBinaryRecursively(
+  rootDir: string,
+  binaryName: string,
+): string | null {
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+    if (!currentDir) continue;
+
+    for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = join(currentDir, entry.name);
+      if (entry.isFile() && entry.name === binaryName) {
+        return fullPath;
       }
-    } catch {
-      // Try the next binary name.
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      }
     }
   }
 
   return null;
+}
+
+async function downloadFd(): Promise<string> {
+  let version = await getLatestFdVersion();
+  if (platform() === "darwin" && arch() === "x64") {
+    version = "10.3.0";
+  }
+
+  const assetName = getFdAssetName(version);
+  if (!assetName) {
+    throw new Error(`Unsupported platform: ${platform()}/${arch()}`);
+  }
+
+  mkdirSync(FD_TOOLS_DIR, { recursive: true });
+  const archivePath = join(FD_TOOLS_DIR, assetName);
+  const extractDir = join(
+    FD_TOOLS_DIR,
+    `extract_tmp_fd_${process.pid}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+  );
+  mkdirSync(extractDir, { recursive: true });
+
+  try {
+    await downloadFile(
+      `https://github.com/${FD_DOWNLOAD_REPO}/releases/download/v${version}/${assetName}`,
+      archivePath,
+    );
+
+    if (assetName.endsWith(".tar.gz")) {
+      extractTarGzArchive(archivePath, extractDir);
+    } else if (assetName.endsWith(".zip")) {
+      extractZipArchive(archivePath, extractDir);
+    } else {
+      throw new Error(`Unsupported fd archive format: ${assetName}`);
+    }
+
+    const extractedBinary = findBinaryRecursively(extractDir, FD_BINARY_NAME);
+    if (!extractedBinary) {
+      throw new Error(`fd binary not found in archive: ${assetName}`);
+    }
+
+    renameSync(extractedBinary, FD_LOCAL_PATH);
+    if (platform() !== "win32") {
+      chmodSync(FD_LOCAL_PATH, 0o755);
+    }
+  } finally {
+    rmSync(archivePath, { force: true });
+    rmSync(extractDir, { recursive: true, force: true });
+  }
+
+  return FD_LOCAL_PATH;
+}
+
+export function resolveFdPath(): string | null {
+  if (cachedFdPath !== undefined) {
+    return cachedFdPath;
+  }
+
+  if (existsSync(FD_LOCAL_PATH)) {
+    cachedFdPath = FD_LOCAL_PATH;
+    return cachedFdPath;
+  }
+
+  for (const binaryName of ["fd", "fdfind"]) {
+    if (commandExists(binaryName)) {
+      cachedFdPath = binaryName;
+      return cachedFdPath;
+    }
+  }
+
+  cachedFdPath = null;
+  return null;
+}
+
+export async function ensureFdPath(): Promise<string | null> {
+  const existingPath = resolveFdPath();
+  if (existingPath) {
+    return existingPath;
+  }
+
+  if (pendingFdPath) {
+    return pendingFdPath;
+  }
+
+  pendingFdPath = downloadFd()
+    .then((downloadedPath) => {
+      cachedFdPath = downloadedPath;
+      return downloadedPath;
+    })
+    .catch(() => {
+      cachedFdPath = null;
+      return null;
+    })
+    .finally(() => {
+      pendingFdPath = null;
+    });
+
+  return pendingFdPath;
 }
 
 export function applyPiFileCompletion(

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
   resolveImportFlagAlias,
 } from "./cli/flag-utils";
 import { formatErrorDetails } from "./cli/helpers/error-formatter";
+import { ensureFdPath, resolveFdPath } from "./cli/helpers/file-autocomplete";
 import type { ApprovalRequest } from "./cli/helpers/stream";
 import { initTerminalTheme } from "./cli/helpers/terminal-theme";
 import { ProfileSelectionInline } from "./cli/profile-selection";
@@ -1563,6 +1564,9 @@ async function main(): Promise<void> {
     const startupCreatedAgentRef = useRef<AgentState | null>(null);
     const [startupHasCloudCredentials, setStartupHasCloudCredentials] =
       useState(Boolean(settings.refreshToken || apiKey));
+    const [fileAutocompleteFdPath, setFileAutocompleteFdPath] = useState<
+      string | null
+    >(() => resolveFdPath());
     const [startupHasAvailableLocalModels, setStartupHasAvailableLocalModels] =
       useState(true);
     // Cache agent object from Phase 1 validation to avoid redundant re-fetch in Phase 2
@@ -2618,6 +2622,9 @@ async function main(): Promise<void> {
           }
         }
 
+        const fdPath = await ensureFdPath();
+        setFileAutocompleteFdPath(fdPath);
+
         // Ensure secrets cache is populated (non-fatal).
         try {
           await secretsInitPromise;
@@ -2806,6 +2813,7 @@ async function main(): Promise<void> {
         releaseNotes,
         systemInfoReminderEnabled: !noSystemInfoReminderFlag,
         extensionsDisabled,
+        fileAutocompleteFdPath,
       });
     }
 
@@ -2830,6 +2838,7 @@ async function main(): Promise<void> {
       updateNotification,
       systemInfoReminderEnabled: !noSystemInfoReminderFlag,
       extensionsDisabled,
+      fileAutocompleteFdPath,
       onReload: handleReload,
     });
   }


### PR DESCRIPTION
## Summary
- Ensure/download `fd` during TUI startup using Pi-style platform asset handling for macOS, Linux, and Windows.
- Pass the resolved `fdPath` down into the file autocomplete provider instead of resolving it at component module load.
- Keep `@` autocomplete behavior aligned with the Pi TUI port while making it work on machines without a system `fd` install.

## Test plan
- [x] `bunx --bun @biomejs/biome@2.2.5 check --write src/index.ts src/cli/app/types.ts src/cli/app/AppCoordinator.tsx src/cli/app/AppView.tsx src/cli/components/FileAutocomplete.tsx src/cli/components/InputAssist.tsx src/cli/components/InputRich.tsx src/cli/helpers/file-autocomplete.ts`
- [x] `bun run typecheck --pretty false`
- [x] `bun test src/cli/file-autocomplete.test.ts`
- [x] Manual provider smoke test: `ensureFdPath()` resolves `~/.letta/bin/fd` and `@` returns suggestions

👾 Generated with [Letta Code](https://letta.com)