### PR TITLE
refactor(perf): fix resume startup tail loading

### DIFF
--- a/docs/plans/resume-tail-fast-path.md
+++ b/docs/plans/resume-tail-fast-path.md
@@ -1,0 +1,44 @@
+# Resume tail fast path plan
+
+## Contract
+
+Boot/resume should use one small-tail algorithm for local and API backends:
+
+1. Resolve the active agent and conversation using existing Letta CLI behavior.
+2. If resuming, fetch a bounded tail for that exact conversation.
+3. Convert that tail into TUI buffer lines.
+4. Detect pending approvals from the literal tail.
+5. Render the tail and show either the approval UI or the normal input.
+
+Default Letta behavior stays stateful: normal startup resumes the default/last conversation.
+
+## Backend boundary
+
+Add a backend-level resume-tail operation, conceptually:
+
+```ts
+type ResumeTail = {
+  messages: Message[];
+  pendingApprovals: ApprovalRequest[];
+};
+
+getConversationResumeTail(agentId: string, conversationId: string, limit: number): Promise<ResumeTail>;
+```
+
+- API backend: uses bounded conversation message APIs and any required conversation metadata lookup.
+- Local backend: reads only the active conversation transcript tail from local storage.
+- Selectors/search may enumerate conversations; normal boot must not.
+
+## Decisions
+
+- Tail size should be small and bounded. Start with the existing visual target: enough for recent context, not hundreds of raw messages.
+- Pending approval is determined by unresolved approval/tool-call state in the tail: approval request exists and no matching tool result/approval response follows it.
+- The UI should not become `ready` and then do an expensive post-ready transcript replay.
+- The local fast path must not call APIs that rebuild global message indexes or scan unrelated conversations.
+- Keep existing hosted/API semantics, but route them through the same tail contract.
+
+## Non-goals
+
+- Do not change default resume semantics.
+- Do not change conversation selectors/search behavior except to keep enumeration out of boot.
+- Do not rewrite the transcript storage format in this PR.

--- a/src/agent/check-approval-prepare-message.test.ts
+++ b/src/agent/check-approval-prepare-message.test.ts
@@ -79,6 +79,7 @@ describe("prepareMessageHistory", () => {
     const base = 1_700_000_000_000;
     const messages: Message[] = [
       msg("tool_return_message", "tr1", base + 1),
+      msg("tool_return_message", "tr2", base + 2),
       msg("assistant_message", "a1", base + 2),
     ];
 

--- a/src/agent/check-approval-prepare-message.test.ts
+++ b/src/agent/check-approval-prepare-message.test.ts
@@ -60,8 +60,6 @@ describe("prepareMessageHistory", () => {
 
     const out = prepareMessageHistory(messages);
     expect(out.map((m) => m.id)).toEqual([
-      "u3",
-      "u4",
       "u5",
       "u6",
       "u7",

--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -12,7 +12,50 @@ type ResumeAgentState = AgentState & {
 };
 
 function installBackend(overrides: Record<string, unknown>): void {
-  __testSetBackend(overrides as unknown as Backend);
+  const getConversationResumeTail = mock(
+    async (
+      agentId: string,
+      conversationId: string,
+      options: { limit: number; includeReturnMessageTypes?: string[] },
+    ) => {
+      if (conversationId && conversationId !== "default") {
+        const conversation = await (
+          overrides.retrieveConversation as (
+            conversationId: string,
+          ) => Promise<unknown>
+        )?.(conversationId);
+        const page = await (
+          overrides.listConversationMessages as (
+            conversationId: string,
+            body: Record<string, unknown>,
+          ) => Promise<{ getPaginatedItems: () => Message[] }>
+        )?.(conversationId, {
+          limit: options.limit,
+          order: "desc",
+          include_return_message_types: options.includeReturnMessageTypes,
+        });
+        return { conversation, messages: page?.getPaginatedItems() ?? [] };
+      }
+
+      const page = await (
+        overrides.listAgentMessages as (
+          agentId: string,
+          body: Record<string, unknown>,
+        ) => Promise<{ getPaginatedItems: () => Message[] }>
+      )?.(agentId, {
+        conversation_id: "default",
+        limit: options.limit,
+        order: "desc",
+        include_return_message_types: options.includeReturnMessageTypes,
+      });
+      return { messages: page?.getPaginatedItems() ?? [] };
+    },
+  );
+
+  __testSetBackend({
+    getConversationResumeTail,
+    ...overrides,
+  } as unknown as Backend);
 }
 
 const DEFAULT_RESUME_MESSAGE_TYPES: MessageType[] = [
@@ -253,12 +296,39 @@ describe("getResumeData", () => {
     expect(agentsList).toHaveBeenCalledTimes(1);
     expect(agentsList).toHaveBeenCalledWith("agent-test", {
       conversation_id: "default",
-      limit: 200,
+      limit: 50,
       order: "desc",
       include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
     });
     expect(resume.pendingApprovals).toHaveLength(0);
     expect(resume.messageHistory.length).toBeGreaterThan(0);
+  });
+
+  test("uses resume tail for pending approval without retrieving last message", async () => {
+    const getConversationResumeTail = mock(async () => ({
+      messages: [
+        makeUserMessage("msg-user"),
+        makeApprovalMessage("msg-live:tool:tool-1:request"),
+      ],
+    }));
+    const messagesRetrieve = mock(async () => [
+      makeApprovalMessage("msg-live:tool:tool-1:request"),
+    ]);
+
+    installBackend({
+      getConversationResumeTail,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeDataFromBackend(
+      makeAgent({ in_context_message_ids: ["msg-live"] }),
+      "default",
+    );
+
+    expect(getConversationResumeTail).toHaveBeenCalledTimes(1);
+    expect(messagesRetrieve).toHaveBeenCalledTimes(0);
+    expect(resume.pendingApprovals).toHaveLength(1);
+    expect(resume.pendingApprovals[0]?.toolCallId).toBe("tool-1");
   });
 
   test("explicit conversation backfill requests and preserves tool messages", async () => {
@@ -309,7 +379,7 @@ describe("getResumeData", () => {
     const resume = await getResumeDataFromBackend(makeAgent(), "conv-abc");
 
     expect(conversationsList).toHaveBeenCalledWith("conv-abc", {
-      limit: 200,
+      limit: 50,
       order: "desc",
       include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
     });

--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -265,6 +265,12 @@ describe("getResumeData", () => {
 
     expect(messagesRetrieve).toHaveBeenCalledTimes(0);
     expect(agentsList).toHaveBeenCalledTimes(1);
+    expect(agentsList).toHaveBeenCalledWith("agent-test", {
+      conversation_id: "default",
+      limit: 1,
+      order: "desc",
+      include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
+    });
     expect(resume.pendingApprovals).toHaveLength(1);
     expect(resume.pendingApprovals[0]?.toolCallId).toBe("tool-1");
   });
@@ -304,7 +310,7 @@ describe("getResumeData", () => {
     expect(resume.messageHistory.length).toBeGreaterThan(0);
   });
 
-  test("uses resume tail for pending approval without retrieving last message", async () => {
+  test("uses resume tail for pending approval without retrieving last message when source variants are complete", async () => {
     const getConversationResumeTail = mock(async () => ({
       messages: [
         makeUserMessage("msg-user"),
@@ -329,6 +335,40 @@ describe("getResumeData", () => {
     expect(messagesRetrieve).toHaveBeenCalledTimes(0);
     expect(resume.pendingApprovals).toHaveLength(1);
     expect(resume.pendingApprovals[0]?.toolCallId).toBe("tool-1");
+  });
+
+  test("verifies pending approval when bounded tail may contain partial source variants", async () => {
+    const getConversationResumeTail = mock(async () => ({
+      messages: [makeApprovalMessage("msg-live:tool:tool-1:request")],
+    }));
+    const messagesRetrieve = mock(async () => [
+      makeApprovalMessage("msg-live:tool:tool-1:request"),
+      datedMessage(
+        "msg-live:tool:tool-1:return",
+        "tool_return_message",
+        "2026-01-01T00:00:02.000Z",
+        {
+          tool_call_id: "tool-1",
+          status: "success",
+          tool_return: "ok",
+        },
+      ),
+    ]);
+
+    installBackend({
+      getConversationResumeTail,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeDataFromBackend(
+      makeAgent({ in_context_message_ids: ["msg-live"] }),
+      "default",
+    );
+
+    expect(getConversationResumeTail).toHaveBeenCalledTimes(1);
+    expect(messagesRetrieve).toHaveBeenCalledWith("msg-live");
+    expect(messagesRetrieve).toHaveBeenCalledTimes(1);
+    expect(resume.pendingApprovals).toEqual([]);
   });
 
   test("explicit conversation backfill requests and preserves tool messages", async () => {

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -7,27 +7,18 @@ import type {
   Message,
   MessageType,
 } from "@letta-ai/letta-client/resources/agents/messages";
-import {
-  type AgentMessageListBody,
-  type ConversationMessageListBody,
-  getBackend,
-} from "@/backend";
+import { getBackend } from "@/backend";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
 
 // Backfill should feel like "the last turn(s)", not "the last N raw messages".
 // Fetch every renderable message type so the TUI can reconstruct the transcript.
-const BACKFILL_PRIMARY_MESSAGE_LIMIT = 12; // user/assistant/reasoning/event/summary
-const BACKFILL_MAX_RENDERABLE_MESSAGES = 80; // safety cap
-
-// Stop fetching once we have enough actual conversational anchors.
-// Reasoning can be extremely tool-step heavy, so anchor on user/assistant.
-const BACKFILL_ANCHOR_MESSAGE_LIMIT = 6;
+const BACKFILL_PRIMARY_MESSAGE_LIMIT = 10; // user/assistant/reasoning/event/summary
+const BACKFILL_MAX_RENDERABLE_MESSAGES = 40; // safety cap
 
 // We fetch more than we render so tool-heavy turns don't push the last
 // user-visible assistant message out of the backfill window.
-const BACKFILL_PAGE_LIMIT = 200;
-const BACKFILL_MAX_PAGES = 25; // 5k messages max
+const BACKFILL_PAGE_LIMIT = 50;
 const BACKFILL_MIN_ASSISTANT = 1;
 
 const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
@@ -40,12 +31,6 @@ const RESUME_BACKFILL_MESSAGE_TYPES: MessageType[] = [
   "tool_return_message",
   "approval_response_message",
 ];
-
-const DEFAULT_RESUME_MESSAGE_TYPES = RESUME_BACKFILL_MESSAGE_TYPES;
-
-function isAnchorMessageType(messageType: string | undefined): boolean {
-  return messageType === "user_message" || messageType === "assistant_message";
-}
 
 /**
  * Check if message backfilling is enabled via LETTA_BACKFILL env var.
@@ -212,6 +197,57 @@ function pendingApprovalsFromMessageVariants(messages: Message[]): {
   };
 }
 
+function sourceMessageIdFromVariant(messageId: string): string {
+  const variantSeparator = messageId.search(/:(assistant|reasoning|tool):/);
+  return variantSeparator >= 0
+    ? messageId.slice(0, variantSeparator)
+    : messageId;
+}
+
+function messageMatchesSourceId(message: Message, sourceId: string): boolean {
+  return (
+    message.id === sourceId ||
+    sourceMessageIdFromVariant(message.id) === sourceId
+  );
+}
+
+function pendingApprovalsFromTail(
+  messages: Message[],
+  lastInContextId?: string | null,
+): ReturnType<typeof pendingApprovalsFromMessageVariants> {
+  if (messages.length === 0) {
+    return {
+      messageToCheck: undefined,
+      pendingApproval: null,
+      pendingApprovals: [],
+    };
+  }
+
+  if (lastInContextId) {
+    const variants = messages.filter((message) =>
+      messageMatchesSourceId(message, lastInContextId),
+    );
+    if (variants.length > 0) {
+      return pendingApprovalsFromMessageVariants(variants);
+    }
+    return {
+      messageToCheck: undefined,
+      pendingApproval: null,
+      pendingApprovals: [],
+    };
+  }
+
+  const latestSourceId = sourceMessageIdFromVariant(
+    messages[messages.length - 1]?.id ?? "",
+  );
+  const latestVariants = latestSourceId
+    ? messages.filter((message) =>
+        messageMatchesSourceId(message, latestSourceId),
+      )
+    : [messages[messages.length - 1]].filter((msg): msg is Message => !!msg);
+  return pendingApprovalsFromMessageVariants(latestVariants);
+}
+
 /**
  * Prepare message history for backfill, trimming orphaned tool returns.
  * Messages should already be in chronological order (oldest first).
@@ -320,60 +356,26 @@ function sortChronological(messages: Message[]): Message[] {
   });
 }
 
-async function fetchConversationBackfillMessages(
-  conversationId: string,
-): Promise<Message[]> {
-  const collected: Message[] = [];
-  // Messages can have multiple variants with the same id (e.g. approval_request + reasoning).
-  // Dedupe using a key that preserves distinct variants while still preventing
-  // overlap across pagination pages.
+function collectResumeTailMessages(tailMessages: Message[]): Message[] {
   const seen = new Set<string>();
-
-  let cursorBefore: string | null = null;
   let assistantCount = 0;
-  let anchorCount = 0;
+  const collected: Message[] = [];
 
-  for (let pageIndex = 0; pageIndex < BACKFILL_MAX_PAGES; pageIndex += 1) {
-    const page = await getBackend().listConversationMessages(conversationId, {
-      limit: BACKFILL_PAGE_LIMIT,
-      order: "desc",
-      include_return_message_types: RESUME_BACKFILL_MESSAGE_TYPES,
-      ...(cursorBefore ? { before: cursorBefore } : {}),
-    } as unknown as ConversationMessageListBody);
-    const items = page.getPaginatedItems();
-    if (items.length === 0) break;
+  for (const m of tailMessages) {
+    if (!m?.id) continue;
 
-    // items are newest->oldest; use the last item as our "before" cursor.
-    cursorBefore = items[items.length - 1]?.id ?? null;
+    // Prefer otid when available (it is unique across variants). Otherwise,
+    // include message_type to avoid dropping variants that share ids.
+    const key =
+      "otid" in m && (m as { otid?: unknown }).otid
+        ? `otid:${String((m as { otid?: unknown }).otid)}`
+        : `id:${m.id}:${m.message_type ?? ""}`;
 
-    for (const m of items) {
-      if (!m?.id) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    collected.push(m);
 
-      // Prefer otid when available (it is unique across variants). Otherwise,
-      // include message_type to avoid dropping variants that share ids.
-      const key =
-        "otid" in m && (m as { otid?: unknown }).otid
-          ? `otid:${String((m as { otid?: unknown }).otid)}`
-          : `id:${m.id}:${m.message_type ?? ""}`;
-
-      if (seen.has(key)) continue;
-      seen.add(key);
-      collected.push(m);
-
-      if (m.message_type === "assistant_message") assistantCount += 1;
-      if (isAnchorMessageType(m.message_type)) anchorCount += 1;
-    }
-
-    // Stop once we can confidently show a good recent slice.
-    if (
-      assistantCount >= BACKFILL_MIN_ASSISTANT &&
-      anchorCount >= BACKFILL_ANCHOR_MESSAGE_LIMIT
-    ) {
-      break;
-    }
-
-    // If the server returned fewer than requested, we're likely at the end.
-    if (items.length < BACKFILL_PAGE_LIMIT) break;
+    if (m.message_type === "assistant_message") assistantCount += 1;
   }
 
   if (assistantCount < BACKFILL_MIN_ASSISTANT) {
@@ -384,6 +386,38 @@ async function fetchConversationBackfillMessages(
   }
 
   return sortChronological(collected);
+}
+
+async function fetchResumeTail(
+  agentId: string,
+  conversationId: string,
+): Promise<{
+  conversation?: { in_context_message_ids?: string[] | null };
+  messages: Message[];
+}> {
+  const tail = await getBackend().getConversationResumeTail(
+    agentId,
+    conversationId,
+    {
+      limit: BACKFILL_PAGE_LIMIT,
+      includeReturnMessageTypes: RESUME_BACKFILL_MESSAGE_TYPES,
+    },
+  );
+  return {
+    conversation: tail.conversation,
+    messages: collectResumeTailMessages(tail.messages),
+  };
+}
+
+async function pendingApprovalsFromTailOrRetrieve(
+  messages: Message[],
+  lastInContextId?: string | null,
+): Promise<ReturnType<typeof pendingApprovalsFromMessageVariants>> {
+  const tailCheck = pendingApprovalsFromTail(messages, lastInContextId);
+  if (tailCheck.messageToCheck || !lastInContextId) return tailCheck;
+
+  const retrievedMessages = await getBackend().retrieveMessage(lastInContextId);
+  return pendingApprovalsFromMessageVariants(retrievedMessages);
 }
 
 /**
@@ -404,184 +438,43 @@ export async function getResumeDataFromBackend(
 ): Promise<ResumeData> {
   try {
     const includeMessageHistory = options.includeMessageHistory ?? true;
+    const shouldFetchTail = includeMessageHistory && isBackfillEnabled();
     const agentWithInContext = agent as AgentState & {
       in_context_message_ids?: string[] | null;
     };
+    const activeConversationId = conversationId ?? "default";
+    const useConversationsApi =
+      activeConversationId && activeConversationId !== "default";
+
     let inContextMessageIds: string[] | null | undefined;
     let messages: Message[] = [];
 
-    // Use conversations API for explicit conversations,
-    // use agents API for "default" or no conversationId (agent's primary message history)
-    const useConversationsApi = conversationId && conversationId !== "default";
-
     if (useConversationsApi) {
-      // Get conversation to access in_context_message_ids (source of truth)
-      const conversation =
-        await getBackend().retrieveConversation(conversationId);
-      inContextMessageIds = conversation.in_context_message_ids;
+      if (shouldFetchTail) {
+        try {
+          const tail = await fetchResumeTail(agent.id, activeConversationId);
+          messages = tail.messages;
+          inContextMessageIds = tail.conversation?.in_context_message_ids;
+        } catch (backfillError) {
+          debugWarn(
+            "check-approval",
+            `Failed to load message history: ${backfillError instanceof Error ? backfillError.message : String(backfillError)}`,
+          );
+        }
+      }
 
-      if (!inContextMessageIds || inContextMessageIds.length === 0) {
+      if (!inContextMessageIds) {
+        const conversation =
+          await getBackend().retrieveConversation(activeConversationId);
+        inContextMessageIds = conversation.in_context_message_ids;
+      }
+
+      const lastInContextId = inContextMessageIds?.at(-1);
+      if (!lastInContextId) {
         debugWarn(
           "check-approval",
           "No in-context messages - no pending approvals",
         );
-        if (includeMessageHistory && isBackfillEnabled()) {
-          try {
-            const backfill =
-              await fetchConversationBackfillMessages(conversationId);
-            return {
-              pendingApproval: null,
-              pendingApprovals: [],
-              messageHistory: prepareMessageHistory(backfill),
-            };
-          } catch (backfillError) {
-            debugWarn(
-              "check-approval",
-              `Failed to load message history: ${backfillError instanceof Error ? backfillError.message : String(backfillError)}`,
-            );
-          }
-        }
-        return {
-          pendingApproval: null,
-          pendingApprovals: [],
-          messageHistory: [],
-        };
-      }
-
-      // Fetch the last in-context message directly by ID
-      // (We already checked inContextMessageIds.length > 0 above)
-      const lastInContextId = inContextMessageIds.at(-1);
-      if (!lastInContextId) {
-        throw new Error("Expected at least one in-context message");
-      }
-      const retrievedMessages =
-        await getBackend().retrieveMessage(lastInContextId);
-
-      // Fetch message history separately for backfill (desc then reverse for last N chronological)
-      // Wrapped in try/catch so backfill failures don't crash the CLI
-      if (includeMessageHistory && isBackfillEnabled()) {
-        try {
-          messages = await fetchConversationBackfillMessages(conversationId);
-        } catch (backfillError) {
-          debugWarn(
-            "check-approval",
-            `Failed to load message history: ${backfillError instanceof Error ? backfillError.message : String(backfillError)}`,
-          );
-        }
-      }
-
-      // Find the approval_request_message variant if it exists, but only treat
-      // it as pending when no matching tool result/approval response has been
-      // projected from the same underlying message.
-      const { messageToCheck, pendingApproval, pendingApprovals } =
-        pendingApprovalsFromMessageVariants(retrievedMessages);
-
-      if (messageToCheck) {
-        const logFoundMessage =
-          pendingApprovals.length > 0 ? debugWarn : debugLog;
-        logFoundMessage(
-          "check-approval",
-          `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
-            (retrievedMessages.length > 1
-              ? ` - had ${retrievedMessages.length} variants`
-              : ""),
-        );
-
-        // Check for pending approval(s) inline since we already have the message
-        if (pendingApprovals.length > 0) {
-          return {
-            pendingApproval,
-            pendingApprovals,
-            messageHistory: prepareMessageHistory(messages),
-          };
-        }
-      } else {
-        debugWarn(
-          "check-approval",
-          `Last in-context message ${lastInContextId} not found via retrieve`,
-        );
-      }
-
-      return {
-        pendingApproval: null,
-        pendingApprovals: [],
-        messageHistory: prepareMessageHistory(messages),
-      };
-    } else {
-      // For the default conversation, use the agent's in-context message IDs as
-      // the primary anchor, mirroring the explicit-conversation path. Hosted
-      // AgentState exposes this as message_ids; local compatibility shims may
-      // expose in_context_message_ids. Fall back to the message stream only when
-      // neither anchor is available, and keep using the stream for backfill/history.
-      inContextMessageIds =
-        agentWithInContext.in_context_message_ids ?? agent.message_ids;
-      const lastInContextId = inContextMessageIds?.at(-1);
-      let defaultConversationMessages: Message[] = [];
-      if ((includeMessageHistory && isBackfillEnabled()) || !lastInContextId) {
-        const listLimit =
-          includeMessageHistory && isBackfillEnabled()
-            ? BACKFILL_PAGE_LIMIT
-            : 1;
-        try {
-          const messagesPage = await getBackend().listAgentMessages(agent.id, {
-            conversation_id: "default",
-            limit: listLimit,
-            order: "desc",
-            include_return_message_types: DEFAULT_RESUME_MESSAGE_TYPES,
-          } as unknown as AgentMessageListBody);
-          defaultConversationMessages = sortChronological(
-            messagesPage.getPaginatedItems(),
-          );
-          if (includeMessageHistory && isBackfillEnabled()) {
-            messages = defaultConversationMessages;
-          }
-          if (isDebugEnabled()) {
-            debugLog(
-              "check-approval",
-              "conversations.messages.list(default, agent_id=%s) returned %d messages",
-              agent.id,
-              defaultConversationMessages.length,
-            );
-          }
-        } catch (backfillError) {
-          debugWarn(
-            "check-approval",
-            `Failed to load message history: ${backfillError instanceof Error ? backfillError.message : String(backfillError)}`,
-          );
-        }
-      }
-
-      if (lastInContextId) {
-        const retrievedMessages =
-          await getBackend().retrieveMessage(lastInContextId);
-        const { messageToCheck, pendingApproval, pendingApprovals } =
-          pendingApprovalsFromMessageVariants(retrievedMessages);
-
-        if (messageToCheck) {
-          const logFoundMessage =
-            pendingApprovals.length > 0 ? debugWarn : debugLog;
-          logFoundMessage(
-            "check-approval",
-            `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
-              (retrievedMessages.length > 1
-                ? ` - had ${retrievedMessages.length} variants`
-                : ""),
-          );
-
-          if (pendingApprovals.length > 0) {
-            return {
-              pendingApproval,
-              pendingApprovals,
-              messageHistory: prepareMessageHistory(messages),
-            };
-          }
-        } else {
-          debugWarn(
-            "check-approval",
-            `Last in-context message ${lastInContextId} not found via retrieve`,
-          );
-        }
-
         return {
           pendingApproval: null,
           pendingApprovals: [],
@@ -589,80 +482,69 @@ export async function getResumeDataFromBackend(
         };
       }
 
-      if (isDebugEnabled()) {
-        debugLog(
-          "check-approval",
-          "default conversation message stream returned %d messages for agent_id=%s",
-          defaultConversationMessages.length,
-          agent.id,
-        );
-      }
-
-      if (defaultConversationMessages.length === 0) {
-        debugWarn(
-          "check-approval",
-          "No messages in default conversation stream - no pending approvals",
-        );
-        return {
-          pendingApproval: null,
-          pendingApprovals: [],
-          messageHistory: [],
-        };
-      }
-
-      const lastDefaultMessage =
-        defaultConversationMessages[defaultConversationMessages.length - 1];
-      const latestMessageId = lastDefaultMessage?.id;
-      const latestMessageVariants = latestMessageId
-        ? defaultConversationMessages.filter(
-            (msg) => msg.id === latestMessageId,
-          )
-        : [];
-      const fallbackPendingCheck = pendingApprovalsFromMessageVariants(
-        latestMessageVariants.length > 0
-          ? latestMessageVariants
-          : [lastDefaultMessage].filter((msg): msg is Message => !!msg),
-      );
-      const { messageToCheck, pendingApproval, pendingApprovals } =
-        fallbackPendingCheck.messageToCheck
-          ? fallbackPendingCheck
-          : {
-              messageToCheck: lastDefaultMessage,
-              pendingApproval: null,
-              pendingApprovals: [],
-            };
-
-      if (messageToCheck) {
-        const logFoundMessage =
-          pendingApprovals.length > 0 ? debugWarn : debugLog;
-        logFoundMessage(
-          "check-approval",
-          `Found last in-context message: ${messageToCheck.id} (type: ${messageToCheck.message_type})` +
-            (latestMessageVariants.length > 1
-              ? ` - had ${latestMessageVariants.length} variants`
-              : ""),
-        );
-
-        if (pendingApprovals.length > 0) {
-          return {
-            pendingApproval,
-            pendingApprovals,
-            messageHistory: prepareMessageHistory(messages),
-          };
-        }
-      } else {
-        debugWarn(
-          "check-approval",
-          "Last default conversation message not found after list()",
-        );
-      }
-
+      const { pendingApproval, pendingApprovals } =
+        await pendingApprovalsFromTailOrRetrieve(messages, lastInContextId);
       return {
-        pendingApproval: null,
-        pendingApprovals: [],
+        pendingApproval,
+        pendingApprovals,
         messageHistory: prepareMessageHistory(messages),
       };
     }
+
+    inContextMessageIds =
+      agentWithInContext.in_context_message_ids ?? agent.message_ids;
+    const lastInContextId = inContextMessageIds?.at(-1);
+
+    if (shouldFetchTail || !lastInContextId) {
+      try {
+        messages = (await fetchResumeTail(agent.id, "default")).messages;
+        if (isDebugEnabled()) {
+          debugLog(
+            "check-approval",
+            "resume tail(default, agent_id=%s) returned %d messages",
+            agent.id,
+            messages.length,
+          );
+        }
+      } catch (backfillError) {
+        debugWarn(
+          "check-approval",
+          `Failed to load message history: ${backfillError instanceof Error ? backfillError.message : String(backfillError)}`,
+        );
+      }
+    }
+
+    if (lastInContextId) {
+      const { pendingApproval, pendingApprovals } =
+        await pendingApprovalsFromTailOrRetrieve(messages, lastInContextId);
+      return {
+        pendingApproval,
+        pendingApprovals,
+        messageHistory: prepareMessageHistory(messages),
+      };
+    }
+
+    if (messages.length === 0) {
+      debugWarn(
+        "check-approval",
+        "No messages in default conversation stream - no pending approvals",
+      );
+      return {
+        pendingApproval: null,
+        pendingApprovals: [],
+        messageHistory: [],
+      };
+    }
+
+    const { pendingApproval, pendingApprovals } = pendingApprovalsFromTail(
+      messages,
+      null,
+    );
+    return {
+      pendingApproval,
+      pendingApprovals,
+      messageHistory: prepareMessageHistory(messages),
+    };
   } catch (error) {
     // Re-throw "not found" errors (404/422) so callers can handle appropriately
     // (e.g., /resume command should fail for non-existent conversations)

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -248,6 +248,14 @@ function pendingApprovalsFromTail(
   return pendingApprovalsFromMessageVariants(latestVariants);
 }
 
+function tailStartsInsideSourceMessage(
+  messages: Message[],
+  sourceId: string,
+): boolean {
+  const firstMessage = messages[0];
+  return firstMessage ? messageMatchesSourceId(firstMessage, sourceId) : false;
+}
+
 /**
  * Prepare message history for backfill, trimming orphaned tool returns.
  * Messages should already be in chronological order (oldest first).
@@ -308,8 +316,8 @@ export function prepareMessageHistory(messages: Message[]): Message[] {
     messageHistory = messageHistory.slice(-BACKFILL_MAX_RENDERABLE_MESSAGES);
   }
 
-  // Skip if starts with orphaned tool_return (incomplete turn)
-  if (messageHistory[0]?.message_type === "tool_return_message") {
+  // Skip any leading orphaned tool returns (incomplete turn after tail clipping).
+  while (messageHistory[0]?.message_type === "tool_return_message") {
     messageHistory = messageHistory.slice(1);
   }
 
@@ -391,6 +399,7 @@ function collectResumeTailMessages(tailMessages: Message[]): Message[] {
 async function fetchResumeTail(
   agentId: string,
   conversationId: string,
+  limit = BACKFILL_PAGE_LIMIT,
 ): Promise<{
   conversation?: { in_context_message_ids?: string[] | null };
   messages: Message[];
@@ -399,7 +408,7 @@ async function fetchResumeTail(
     agentId,
     conversationId,
     {
-      limit: BACKFILL_PAGE_LIMIT,
+      limit,
       includeReturnMessageTypes: RESUME_BACKFILL_MESSAGE_TYPES,
     },
   );
@@ -414,6 +423,15 @@ async function pendingApprovalsFromTailOrRetrieve(
   lastInContextId?: string | null,
 ): Promise<ReturnType<typeof pendingApprovalsFromMessageVariants>> {
   const tailCheck = pendingApprovalsFromTail(messages, lastInContextId);
+  if (
+    lastInContextId &&
+    tailCheck.pendingApprovals.length > 0 &&
+    tailStartsInsideSourceMessage(messages, lastInContextId)
+  ) {
+    const retrievedMessages =
+      await getBackend().retrieveMessage(lastInContextId);
+    return pendingApprovalsFromMessageVariants(retrievedMessages);
+  }
   if (tailCheck.messageToCheck || !lastInContextId) return tailCheck;
 
   const retrievedMessages = await getBackend().retrieveMessage(lastInContextId);
@@ -497,7 +515,9 @@ export async function getResumeDataFromBackend(
 
     if (shouldFetchTail || !lastInContextId) {
       try {
-        messages = (await fetchResumeTail(agent.id, "default")).messages;
+        const tailLimit = shouldFetchTail ? BACKFILL_PAGE_LIMIT : 1;
+        messages = (await fetchResumeTail(agent.id, "default", tailLimit))
+          .messages;
         if (isDebugEnabled()) {
           debugLog(
             "check-approval",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import type { getClient } from "./api/client";
 import type {
   ForkConversationOptions,
@@ -107,6 +108,16 @@ export type MessageRetrieveOptions = MessageRetrieveParams[1];
 export type ModelsListParams = Parameters<APIClient["models"]["list"]>;
 export type ModelsListOptions = ModelsListParams[0];
 
+export interface ConversationResumeTailOptions {
+  limit: number;
+  includeReturnMessageTypes?: string[];
+}
+
+export interface ConversationResumeTail {
+  conversation?: Awaited<ReturnType<APIClient["conversations"]["retrieve"]>>;
+  messages: Message[];
+}
+
 export interface BackendCapabilities {
   remoteMemfs: boolean;
   serverSideToolManagement: boolean;
@@ -198,6 +209,12 @@ export interface Backend {
     messageId: string,
     options?: MessageRetrieveOptions,
   ): Promise<Awaited<ReturnType<APIClient["messages"]["retrieve"]>>>;
+
+  getConversationResumeTail(
+    agentId: string,
+    conversationId: string,
+    options: ConversationResumeTailOptions,
+  ): Promise<ConversationResumeTail>;
 
   listModels(
     options?: ModelsListOptions,
@@ -374,6 +391,35 @@ export class APIBackend implements Backend {
   async retrieveMessage(messageId: string, options?: MessageRetrieveOptions) {
     const client = await this.getClient();
     return client.messages.retrieve(messageId, options);
+  }
+
+  async getConversationResumeTail(
+    agentId: string,
+    conversationId: string,
+    options: ConversationResumeTailOptions,
+  ): Promise<ConversationResumeTail> {
+    const body = {
+      limit: options.limit,
+      order: "desc",
+      include_return_message_types: options.includeReturnMessageTypes,
+    };
+
+    if (conversationId && conversationId !== "default") {
+      const [conversation, page] = await Promise.all([
+        this.retrieveConversation(conversationId),
+        this.listConversationMessages(
+          conversationId,
+          body as ConversationMessageListBody,
+        ),
+      ]);
+      return { conversation, messages: page.getPaginatedItems() };
+    }
+
+    const page = await this.listAgentMessages(agentId, {
+      ...body,
+      conversation_id: "default",
+    } as AgentMessageListBody);
+    return { messages: page.getPaginatedItems() };
   }
 
   async listModels(options?: ModelsListOptions) {

--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -11,6 +11,8 @@ import type {
   ConversationMessageCreateBody,
   ConversationMessageListBody,
   ConversationMessageStreamBody,
+  ConversationResumeTail,
+  ConversationResumeTailOptions,
   RunMessageStreamBody,
 } from "@/backend/backend";
 import {
@@ -302,6 +304,39 @@ export class HeadlessBackend implements Backend {
   ): ReturnType<Backend["retrieveMessage"]> {
     const [messageId] = args;
     return this.store.retrieveMessage(messageId) as never;
+  }
+
+  async getConversationResumeTail(
+    agentId: string,
+    conversationId: string,
+    options: ConversationResumeTailOptions,
+  ): Promise<ConversationResumeTail> {
+    const body = {
+      limit: options.limit,
+      order: "desc",
+      include_return_message_types: options.includeReturnMessageTypes,
+    } as ConversationMessageListBody;
+
+    if (conversationId && conversationId !== "default") {
+      const conversation = this.store.retrieveConversation(
+        conversationId,
+        agentId,
+      );
+      return {
+        conversation,
+        messages: this.store.listConversationMessages(conversation.id, {
+          ...body,
+          agent_id: agentId,
+        } as ConversationMessageListBody) as never,
+      };
+    }
+
+    return {
+      messages: this.store.listAgentMessages(agentId, {
+        ...body,
+        conversation_id: "default",
+      } as never) as never,
+    };
   }
 
   async listModels(): ReturnType<Backend["listModels"]> {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -9,6 +9,7 @@ import type { LlmConfig } from "@letta-ai/letta-client/resources/models/models";
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -2789,8 +2790,9 @@ export function App({
     eagerCommittedPreviewsRef.current.add(toolCallId);
   }, [currentApproval, currentApprovalShouldCommitPreview]);
 
-  // Backfill message history when resuming (only once)
-  useEffect(() => {
+  // Backfill message history when resuming (only once). Use layout timing so
+  // the ready input is not painted before the resumed transcript.
+  useLayoutEffect(() => {
     if (
       loadingState === "ready" &&
       messageHistory.length > 0 &&

--- a/src/headless-backend-lifecycle.test.ts
+++ b/src/headless-backend-lifecycle.test.ts
@@ -37,8 +37,7 @@ describe("headless backend lifecycle wiring", () => {
     const source = readSource("./agent/check-approval.ts");
 
     expect(source).toContain("getBackend().retrieveConversation");
-    expect(source).toContain("getBackend().listConversationMessages");
-    expect(source).toContain("getBackend().listAgentMessages");
+    expect(source).toContain("getBackend().getConversationResumeTail");
     expect(source).toContain("getBackend().retrieveMessage");
 
     expect(source).not.toContain("client.conversations.");


### PR DESCRIPTION
## Summary
- Add a backend resume-tail contract so startup uses one bounded active-conversation tail for API and local backends.
- Resolve pending approvals from that tail before falling back to direct message retrieval.
- Keep resume history small and replay it before the ready input is painted.

## Test plan
- [x] bun install
- [x] bun test src/agent/check-approval-resume-data.test.ts
- [x] bun test src/backend/local-backend.test.ts
- [x] bun run check
- [x] bun run build

👾 Generated with [Letta Code](https://letta.com)